### PR TITLE
feat(web): add MobX app shell store with substores

### DIFF
--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-breadcrumb.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-breadcrumb.tsx
@@ -4,6 +4,7 @@ import { Fragment } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
+import { observer } from "mobx-react-lite";
 
 import {
   Breadcrumb,
@@ -18,12 +19,16 @@ import { cn } from "@/lib/primitives/cn";
 
 import { getAppShellBreadcrumbs } from "./app-shell-title";
 import { parseProjectRoute } from "./navigation-config";
+import { useAppShellStore } from "./store/app-shell-store-context";
 
 type AppShellBreadcrumbProps = {
   organizationSlug: string;
 };
 
-export function AppShellBreadcrumb({ organizationSlug }: AppShellBreadcrumbProps) {
+export const AppShellBreadcrumb = observer(function AppShellBreadcrumb({
+  organizationSlug,
+}: AppShellBreadcrumbProps) {
+  const store = useAppShellStore();
   const pathname = usePathname();
   const projectRoute = parseProjectRoute(pathname);
   const resolvedOrganizationSlug = projectRoute?.organizationSlug ?? organizationSlug;
@@ -46,9 +51,11 @@ export function AppShellBreadcrumb({ organizationSlug }: AppShellBreadcrumbProps
     },
   });
 
-  const breadcrumbs = getAppShellBreadcrumbs(pathname, {
-    projectName: projectQuery.data?.name,
-  });
+  const breadcrumbs = store.breadcrumb.applyOverrides(
+    getAppShellBreadcrumbs(pathname, {
+      projectName: projectQuery.data?.name,
+    }),
+  );
 
   if (breadcrumbs.length === 1) {
     return (
@@ -92,4 +99,4 @@ export function AppShellBreadcrumb({ organizationSlug }: AppShellBreadcrumbProps
       </BreadcrumbList>
     </Breadcrumb>
   );
-}
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
@@ -15,8 +15,13 @@ import {
 } from "@/components/ui/sidebar";
 import ThemeToggle from "@/components/theme-toggle/theme-toggle";
 import { AppShellBreadcrumb } from "./app-shell-breadcrumb";
+import { AppShellNavigation } from "./app-shell-navigation";
 import { TmsUserConnectButton } from "./tms-user-connect-button";
 import { TmsUserOAuthErrorToast } from "./tms-user-oauth-error-toast";
+import type { NavigationGroup } from "./navigation-config";
+import { AppShellHeaderActions } from "./store/app-shell-header-actions";
+import { AppShellStoreProvider } from "./store/app-shell-store-context";
+import { SidebarStoreBridge } from "./store/sidebar-store-bridge";
 import type { TmsUserConnectCta } from "@/lib/providers/tms-user-connection-shared";
 import { useTmsUserConnectCta } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/_hooks/use-tms-user-connect-cta";
 import { NavUser } from "./nav-user";
@@ -26,7 +31,7 @@ import { TypographyP } from "@/components/ui/typography";
 type AppShellClientProps = {
   autumnConfigured?: boolean;
   children: ReactNode;
-  navigation: ReactNode;
+  navigationGroups: readonly NavigationGroup[];
   activeOrganization: {
     name: string;
     slug?: string | null;
@@ -48,7 +53,7 @@ type AppShellClientProps = {
 export function AppShellClient({
   autumnConfigured = false,
   children,
-  navigation,
+  navigationGroups,
   activeOrganization,
   organizations,
   tmsUserConnectCta = { showConnectCta: false },
@@ -65,13 +70,14 @@ export function AppShellClient({
   const resolvedTmsUserConnectCta = tmsUserConnectQuery.data ?? tmsUserConnectCta;
 
   return (
-    <>
+    <AppShellStoreProvider defaultNavigationGroups={navigationGroups}>
       <TmsUserOAuthErrorToast />
       <SidebarProvider
         defaultOpen
         style={{ "--sidebar-width": "15rem" } as CSSProperties}
         className="min-h-svh bg-background text-foreground"
       >
+        <SidebarStoreBridge />
         <Sidebar variant="sidebar" collapsible="icon">
           <SidebarHeader className="gap-3 border-b border-sidebar-border px-3 py-3 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:px-0">
             <div className="flex items-center gap-2.5 rounded-xl px-1 py-1 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
@@ -92,7 +98,7 @@ export function AppShellClient({
           </SidebarHeader>
 
           <SidebarContent className="gap-0 px-2 py-2">
-            {navigation}
+            <AppShellNavigation organizationSlug={organizationSlug} />
 
             {showBillingLink && autumnConfigured ? (
               <PlanUsageSidebarWidget organizationSlug={organizationSlug} />
@@ -114,6 +120,7 @@ export function AppShellClient({
                 <AppShellBreadcrumb organizationSlug={organizationSlug} />
               </div>
               <div className="flex shrink-0 items-center gap-2">
+                <AppShellHeaderActions />
                 {resolvedTmsUserConnectCta.showConnectCta && organizationSlug ? (
                   <TmsUserConnectButton
                     organizationSlug={organizationSlug}
@@ -139,6 +146,6 @@ export function AppShellClient({
           <div className="flex-1 px-4 py-5 sm:px-6 lg:px-8">{children}</div>
         </SidebarInset>
       </SidebarProvider>
-    </>
+    </AppShellStoreProvider>
   );
 }

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { ArrowDown01Icon, ArrowLeft01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useQuery } from "@tanstack/react-query";
+import { observer } from "mobx-react-lite";
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import {
@@ -27,15 +28,42 @@ import {
   type NavigationGroup,
   type NavigationItem,
 } from "./navigation-config";
+import { useAppShellStore } from "./store/app-shell-store-context";
 
 type AppShellNavigationProps = {
   organizationSlug: string;
-  groups: readonly NavigationGroup[];
 };
 
-export function AppShellNavigation({ organizationSlug, groups }: AppShellNavigationProps) {
+export const AppShellNavigation = observer(function AppShellNavigation({
+  organizationSlug,
+}: AppShellNavigationProps) {
+  const store = useAppShellStore();
   const pathname = usePathname();
   const projectRoute = parseProjectRoute(pathname);
+
+  if (store.navigation.mode === "custom" && store.navigation.customState) {
+    const customState = store.navigation.customState;
+
+    if (customState.projectContext) {
+      return (
+        <ProjectNavigation
+          organizationSlug={customState.projectContext.organizationSlug}
+          projectId={customState.projectContext.projectId}
+          pathname={pathname}
+          projectName={customState.projectContext.projectName}
+          items={customState.groups.flatMap((group) => group.items)}
+        />
+      );
+    }
+
+    return (
+      <GlobalNavigation
+        organizationSlug={organizationSlug}
+        groups={customState.groups}
+        pathname={pathname}
+      />
+    );
+  }
 
   if (projectRoute?.organizationSlug === organizationSlug) {
     return (
@@ -48,9 +76,13 @@ export function AppShellNavigation({ organizationSlug, groups }: AppShellNavigat
   }
 
   return (
-    <GlobalNavigation organizationSlug={organizationSlug} groups={groups} pathname={pathname} />
+    <GlobalNavigation
+      organizationSlug={organizationSlug}
+      groups={store.navigation.defaultNavigationGroups}
+      pathname={pathname}
+    />
   );
-}
+});
 
 function GlobalNavigation({
   organizationSlug,
@@ -104,13 +136,18 @@ function ProjectNavigation({
   organizationSlug,
   projectId,
   pathname,
+  projectName,
+  items,
 }: {
   organizationSlug: string;
   projectId: string;
   pathname: string;
+  projectName?: string;
+  items?: readonly NavigationItem[];
 }) {
   const projectQuery = useQuery({
     queryKey: ["translation-project", organizationSlug, projectId],
+    enabled: !projectName && !items,
     queryFn: async () => {
       const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"].$get({
         param: { organizationSlug, projectId },
@@ -123,7 +160,8 @@ function ProjectNavigation({
     },
   });
 
-  const items = buildProjectNavigationItems(organizationSlug, projectId);
+  const resolvedItems = items ?? buildProjectNavigationItems(organizationSlug, projectId);
+  const resolvedProjectName = projectName ?? projectQuery.data?.name ?? "Project";
   const projectsHref = buildOrganizationPath(organizationSlug, "projects");
 
   return (
@@ -150,16 +188,16 @@ function ProjectNavigation({
           Project
         </SidebarGroupLabel>
         <div className="px-3 pb-1 group-data-[collapsible=icon]:hidden">
-          {projectQuery.isLoading ? (
+          {!projectName && projectQuery.isLoading ? (
             <Skeleton className="h-5 w-4/5" />
           ) : (
             <p className="truncate text-sm font-medium text-sidebar-foreground">
-              {projectQuery.data?.name ?? "Project"}
+              {resolvedProjectName}
             </p>
           )}
         </div>
         <NavigationGroupItems
-          group={{ items }}
+          group={{ items: resolvedItems }}
           pathname={pathname}
           organizationSlug={organizationSlug}
           projectId={projectId}

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
@@ -2,7 +2,6 @@ import type { ReactNode } from "react";
 
 import { hasCapability } from "@/api/auth/policy";
 import { AppShellClient } from "@/components/app-shell/app-shell-client";
-import { AppShellNavigation } from "@/components/app-shell/app-shell-navigation";
 import { buildGlobalNavigationGroups } from "@/components/app-shell/navigation-config";
 import {
   evaluateWorkspaceFeatureFlags,
@@ -73,9 +72,7 @@ export async function AppShell({
         name: displayName,
         avatarUrl: auth.sessionUser.profilePictureUrl ?? undefined,
       }}
-      navigation={
-        <AppShellNavigation organizationSlug={activeOrganizationSlug} groups={navigationGroups} />
-      }
+      navigationGroups={navigationGroups}
     >
       <OrgTmsQueryProvider
         organizationSlug={activeOrganizationSlug}

--- a/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-header-actions.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-header-actions.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { Fragment } from "react";
+import { observer } from "mobx-react-lite";
+
+import { useAppShellStore } from "./app-shell-store-context";
+
+export const AppShellHeaderActions = observer(function AppShellHeaderActions() {
+  const store = useAppShellStore();
+
+  return (
+    <>
+      {store.headerActions.orderedSlots.map((slot) => (
+        <Fragment key={slot.id}>{slot.render()}</Fragment>
+      ))}
+    </>
+  );
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store-context.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store-context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import { createContext, useContext, useRef, useState, type ReactNode } from "react";
 import { usePathname } from "next/navigation";
 
 import type { NavigationGroup } from "@/components/app-shell/navigation-config";
@@ -18,10 +18,14 @@ export function AppShellStoreProvider({
 }) {
   const [store] = useState(() => createAppShellStore(defaultNavigationGroups));
   const pathname = usePathname();
+  const previousPathnameRef = useRef(pathname);
 
-  useEffect(() => {
+  // Reset during render, not in useEffect. Passive effects flush bottom-up, so a
+  // provider effect would run after page hooks register and immediately clear them.
+  if (previousPathnameRef.current !== pathname) {
     store.resetPageScope();
-  }, [pathname, store]);
+    previousPathnameRef.current = pathname;
+  }
 
   return <AppShellStoreContext.Provider value={store}>{children}</AppShellStoreContext.Provider>;
 }

--- a/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store-context.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store-context.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { createContext, useContext, useEffect, useMemo, type ReactNode } from "react";
+import { usePathname } from "next/navigation";
+
+import type { NavigationGroup } from "@/components/app-shell/navigation-config";
+
+import { AppShellStore, createAppShellStore } from "./app-shell-store";
+
+const AppShellStoreContext = createContext<AppShellStore | null>(null);
+
+export function AppShellStoreProvider({
+  defaultNavigationGroups,
+  children,
+}: {
+  defaultNavigationGroups: readonly NavigationGroup[];
+  children: ReactNode;
+}) {
+  const store = useMemo(
+    () => createAppShellStore(defaultNavigationGroups),
+    // Store is scoped to shell mount; navigation groups are stable for the org layout.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+  const pathname = usePathname();
+
+  useEffect(() => {
+    store.resetPageScope();
+  }, [pathname, store]);
+
+  return <AppShellStoreContext.Provider value={store}>{children}</AppShellStoreContext.Provider>;
+}
+
+export function useAppShellStore() {
+  const store = useContext(AppShellStoreContext);
+  if (!store) {
+    throw new Error("useAppShellStore must be used within AppShellStoreProvider");
+  }
+
+  return store;
+}
+
+export function useOptionalAppShellStore() {
+  return useContext(AppShellStoreContext);
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store-context.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store-context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useEffect, useMemo, type ReactNode } from "react";
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
 import { usePathname } from "next/navigation";
 
 import type { NavigationGroup } from "@/components/app-shell/navigation-config";
@@ -16,12 +16,7 @@ export function AppShellStoreProvider({
   defaultNavigationGroups: readonly NavigationGroup[];
   children: ReactNode;
 }) {
-  const store = useMemo(
-    () => createAppShellStore(defaultNavigationGroups),
-    // Store is scoped to shell mount; navigation groups are stable for the org layout.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  );
+  const [store] = useState(() => createAppShellStore(defaultNavigationGroups));
   const pathname = usePathname();
 
   useEffect(() => {

--- a/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { Chat01Icon } from "@hugeicons/core-free-icons";
+
+import { createAppShellStore } from "./app-shell-store";
+import type { SidebarApi } from "./sidebar-store";
+
+const sampleGroups = [
+  {
+    items: [
+      {
+        label: "Inbox",
+        href: "/org/acme/inbox",
+        icon: Chat01Icon,
+      },
+    ],
+  },
+] as const;
+
+function createSidebarApi(overrides: Partial<SidebarApi> = {}): SidebarApi {
+  return {
+    open: true,
+    openMobile: false,
+    isMobile: false,
+    state: "expanded",
+    setOpen: vi.fn(),
+    setOpenMobile: vi.fn(),
+    toggleSidebar: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("AppShellStore", () => {
+  it("registers header actions in order and filters hidden slots", () => {
+    const store = createAppShellStore(sampleGroups);
+
+    store.headerActions.register({
+      id: "b",
+      order: 20,
+      visible: true,
+      render: () => "B",
+    });
+    store.headerActions.register({
+      id: "a",
+      order: 10,
+      visible: true,
+      render: () => "A",
+    });
+    store.headerActions.register({
+      id: "hidden",
+      order: 0,
+      visible: false,
+      render: () => "Hidden",
+    });
+
+    expect(store.headerActions.orderedSlots.map((slot) => slot.id)).toEqual(["a", "b"]);
+  });
+
+  it("applies breadcrumb overrides and appends", () => {
+    const store = createAppShellStore(sampleGroups);
+    const base = [
+      { label: "Projects", href: "/org/acme/projects" },
+      { label: "proj_1", href: "/org/acme/projects/proj_1" },
+      { label: "Jobs" },
+    ];
+
+    store.breadcrumb.registerOverride({
+      id: "project-name",
+      matchSegment: "proj_1",
+      label: "Checkout",
+    });
+    store.breadcrumb.registerAppend({
+      id: "job-title",
+      label: "Translate to Vietnamese",
+    });
+
+    expect(store.breadcrumb.applyOverrides(base)).toEqual([
+      { label: "Projects", href: "/org/acme/projects" },
+      { label: "Checkout", href: "/org/acme/projects/proj_1" },
+      { label: "Jobs" },
+      { label: "Translate to Vietnamese", href: undefined },
+    ]);
+  });
+
+  it("switches navigation into custom mode", () => {
+    const store = createAppShellStore(sampleGroups);
+    const customGroups = [
+      {
+        label: "Custom",
+        items: [
+          {
+            label: "Wizard",
+            href: "/org/acme/wizard",
+            icon: Chat01Icon,
+          },
+        ],
+      },
+    ] as const;
+
+    store.navigation.setCustomNavigation(customGroups, {
+      organizationSlug: "acme",
+      projectId: "proj_1",
+      projectName: "Checkout",
+    });
+
+    expect(store.navigation.mode).toBe("custom");
+    expect(store.navigation.activeGroups).toEqual(customGroups);
+    expect(store.navigation.activeProjectContext).toEqual({
+      organizationSlug: "acme",
+      projectId: "proj_1",
+      projectName: "Checkout",
+    });
+  });
+
+  it("resets page-scoped shell state", () => {
+    const store = createAppShellStore(sampleGroups);
+
+    store.headerActions.register({
+      id: "save",
+      order: 0,
+      visible: true,
+      render: () => "Save",
+    });
+    store.breadcrumb.registerAppend({ id: "extra", label: "Detail" });
+    store.navigation.setCustomNavigation(sampleGroups);
+    store.sidebar.setForceCollapsed(true);
+    store.sidebar.setPreferredOpen(false);
+
+    store.resetPageScope();
+
+    expect(store.headerActions.orderedSlots).toEqual([]);
+    expect(store.breadcrumb.applyOverrides([{ label: "Inbox" }])).toEqual([{ label: "Inbox" }]);
+    expect(store.navigation.mode).toBe("route");
+    expect(store.sidebar.forceCollapsed).toBe(false);
+    expect(store.sidebar.preferredOpen).toBeNull();
+  });
+
+  it("bridges sidebar api and collapses when forced", () => {
+    const store = createAppShellStore(sampleGroups);
+    const api = createSidebarApi();
+
+    store.sidebar.bindSidebarApi(api);
+    store.sidebar.setForceCollapsed(true);
+
+    expect(api.setOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("uses preferred open state on mobile via setOpenMobile", () => {
+    const store = createAppShellStore(sampleGroups);
+    const api = createSidebarApi({ isMobile: true });
+
+    store.sidebar.bindSidebarApi(api);
+    store.sidebar.setPreferredOpen(true);
+
+    expect(api.setOpenMobile).toHaveBeenCalledWith(true);
+  });
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store.ts
@@ -1,0 +1,36 @@
+import { makeAutoObservable } from "mobx";
+
+import type { NavigationGroup } from "@/components/app-shell/navigation-config";
+
+import { BreadcrumbStore } from "./breadcrumb-store";
+import { HeaderActionsStore } from "./header-actions-store";
+import { NavigationStore } from "./navigation-store";
+import { SidebarStore } from "./sidebar-store";
+
+export class AppShellStore {
+  sidebar: SidebarStore;
+  navigation: NavigationStore;
+  breadcrumb: BreadcrumbStore;
+  headerActions: HeaderActionsStore;
+
+  constructor(defaultNavigationGroups: readonly NavigationGroup[]) {
+    this.sidebar = new SidebarStore();
+    this.navigation = new NavigationStore(defaultNavigationGroups);
+    this.breadcrumb = new BreadcrumbStore();
+    this.headerActions = new HeaderActionsStore();
+
+    makeAutoObservable(this, {}, { autoBind: true });
+  }
+
+  resetPageScope() {
+    this.breadcrumb.clearOverrides();
+    this.headerActions.clearAll();
+    this.navigation.clearCustomMode();
+    this.sidebar.setForceCollapsed(false);
+    this.sidebar.setPreferredOpen(null);
+  }
+}
+
+export function createAppShellStore(defaultNavigationGroups: readonly NavigationGroup[]) {
+  return new AppShellStore(defaultNavigationGroups);
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/store/breadcrumb-store.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/breadcrumb-store.ts
@@ -1,0 +1,80 @@
+import { makeAutoObservable } from "mobx";
+
+import type { AppShellBreadcrumb } from "@/components/app-shell/app-shell-title";
+
+export type BreadcrumbOverride = {
+  id: string;
+  index?: number;
+  matchSegment?: string;
+  label: string;
+  href?: string;
+};
+
+export type BreadcrumbAppend = {
+  id: string;
+  label: string;
+  href?: string;
+};
+
+export class BreadcrumbStore {
+  private overrides = new Map<string, BreadcrumbOverride>();
+  private appends = new Map<string, BreadcrumbAppend>();
+
+  constructor() {
+    makeAutoObservable(this, {}, { autoBind: true });
+  }
+
+  registerOverride(override: BreadcrumbOverride) {
+    this.overrides.set(override.id, override);
+  }
+
+  unregisterOverride(id: string) {
+    this.overrides.delete(id);
+  }
+
+  registerAppend(append: BreadcrumbAppend) {
+    this.appends.set(append.id, append);
+  }
+
+  unregisterAppend(id: string) {
+    this.appends.delete(id);
+  }
+
+  clearOverrides() {
+    this.overrides.clear();
+    this.appends.clear();
+  }
+
+  applyOverrides(base: readonly AppShellBreadcrumb[]): AppShellBreadcrumb[] {
+    const overridden = base.map((crumb, index) => {
+      for (const override of this.overrides.values()) {
+        if (override.index === index) {
+          return {
+            label: override.label,
+            href: override.href ?? crumb.href,
+          };
+        }
+
+        if (override.matchSegment) {
+          const matchesHref = crumb.href?.includes(override.matchSegment) ?? false;
+          const matchesLabel = crumb.label === override.matchSegment;
+          if (matchesHref || matchesLabel) {
+            return {
+              label: override.label,
+              href: override.href ?? crumb.href,
+            };
+          }
+        }
+      }
+
+      return crumb;
+    });
+
+    const appended = [...this.appends.values()].map((append) => ({
+      label: append.label,
+      href: append.href,
+    }));
+
+    return [...overridden, ...appended];
+  }
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/store/header-actions-store.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/header-actions-store.ts
@@ -1,0 +1,35 @@
+import { makeAutoObservable } from "mobx";
+import type { ReactNode } from "react";
+
+export type HeaderActionSlot = {
+  id: string;
+  order: number;
+  visible: boolean;
+  render: () => ReactNode;
+};
+
+export class HeaderActionsStore {
+  private slots = new Map<string, HeaderActionSlot>();
+
+  constructor() {
+    makeAutoObservable(this, {}, { autoBind: true });
+  }
+
+  register(slot: HeaderActionSlot) {
+    this.slots.set(slot.id, slot);
+  }
+
+  unregister(id: string) {
+    this.slots.delete(id);
+  }
+
+  clearAll() {
+    this.slots.clear();
+  }
+
+  get orderedSlots(): HeaderActionSlot[] {
+    return [...this.slots.values()]
+      .filter((slot) => slot.visible)
+      .sort((left, right) => left.order - right.order);
+  }
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/store/navigation-store.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/navigation-store.ts
@@ -1,0 +1,52 @@
+import { makeAutoObservable } from "mobx";
+
+import type { NavigationGroup } from "@/components/app-shell/navigation-config";
+
+export type NavigationProjectContext = {
+  organizationSlug: string;
+  projectId: string;
+  projectName?: string;
+};
+
+export type NavigationCustomState = {
+  groups: readonly NavigationGroup[];
+  projectContext?: NavigationProjectContext;
+};
+
+export class NavigationStore {
+  mode: "route" | "custom" = "route";
+  customState: NavigationCustomState | null = null;
+
+  constructor(private readonly defaultGroups: readonly NavigationGroup[]) {
+    makeAutoObservable(this, {}, { autoBind: true });
+  }
+
+  get defaultNavigationGroups(): readonly NavigationGroup[] {
+    return this.defaultGroups;
+  }
+
+  get activeGroups(): readonly NavigationGroup[] {
+    if (this.mode === "custom" && this.customState) {
+      return this.customState.groups;
+    }
+
+    return this.defaultGroups;
+  }
+
+  get activeProjectContext(): NavigationProjectContext | null {
+    return this.customState?.projectContext ?? null;
+  }
+
+  setCustomNavigation(
+    groups: readonly NavigationGroup[],
+    projectContext?: NavigationProjectContext,
+  ) {
+    this.mode = "custom";
+    this.customState = { groups, projectContext };
+  }
+
+  clearCustomMode() {
+    this.mode = "route";
+    this.customState = null;
+  }
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/store/sidebar-store-bridge.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/sidebar-store-bridge.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+import { observer } from "mobx-react-lite";
+
+import { useSidebar } from "@/components/ui/sidebar";
+
+import { useAppShellStore } from "./app-shell-store-context";
+
+export const SidebarStoreBridge = observer(function SidebarStoreBridge() {
+  const store = useAppShellStore();
+  const sidebar = useSidebar();
+  const { forceCollapsed, preferredOpen } = store.sidebar;
+
+  useEffect(() => {
+    store.sidebar.bindSidebarApi(sidebar);
+
+    return () => {
+      store.sidebar.unbindSidebarApi();
+    };
+  }, [store, sidebar]);
+
+  useEffect(() => {
+    store.sidebar.sync();
+  }, [store, sidebar, forceCollapsed, preferredOpen]);
+
+  return null;
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/store/sidebar-store-bridge.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/sidebar-store-bridge.tsx
@@ -22,7 +22,7 @@ export const SidebarStoreBridge = observer(function SidebarStoreBridge() {
 
   useEffect(() => {
     store.sidebar.sync();
-  }, [store, sidebar, forceCollapsed, preferredOpen]);
+  }, [store, forceCollapsed, preferredOpen]);
 
   return null;
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/store/sidebar-store.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/sidebar-store.ts
@@ -1,0 +1,106 @@
+import { makeAutoObservable } from "mobx";
+
+export type SidebarApi = {
+  open: boolean;
+  openMobile: boolean;
+  isMobile: boolean;
+  state: "expanded" | "collapsed";
+  setOpen: (open: boolean) => void;
+  setOpenMobile: (open: boolean) => void;
+  toggleSidebar: () => void;
+};
+
+export class SidebarStore {
+  preferredOpen: boolean | null = null;
+  forceCollapsed = false;
+
+  private api: SidebarApi | null = null;
+
+  constructor() {
+    makeAutoObservable(this, {}, { autoBind: true });
+  }
+
+  bindSidebarApi(api: SidebarApi) {
+    this.api = api;
+    this.sync();
+  }
+
+  unbindSidebarApi() {
+    this.api = null;
+  }
+
+  get isBound() {
+    return this.api !== null;
+  }
+
+  get isOpen() {
+    return this.api?.open ?? true;
+  }
+
+  get isMobile() {
+    return this.api?.isMobile ?? false;
+  }
+
+  get state(): "expanded" | "collapsed" {
+    return this.api?.state ?? "expanded";
+  }
+
+  setPreferredOpen(open: boolean | null) {
+    this.preferredOpen = open;
+    this.sync();
+  }
+
+  setForceCollapsed(force: boolean) {
+    this.forceCollapsed = force;
+    this.sync();
+  }
+
+  setOpen(open: boolean) {
+    if (!this.api) {
+      this.preferredOpen = open;
+      return;
+    }
+
+    if (this.api.isMobile) {
+      this.api.setOpenMobile(open);
+      return;
+    }
+
+    this.api.setOpen(open);
+  }
+
+  toggle() {
+    this.api?.toggleSidebar();
+  }
+
+  collapse() {
+    this.setOpen(false);
+  }
+
+  expand() {
+    this.setOpen(true);
+  }
+
+  sync() {
+    if (!this.api) {
+      return;
+    }
+
+    if (this.forceCollapsed) {
+      if (this.api.isMobile) {
+        this.api.setOpenMobile(false);
+      } else {
+        this.api.setOpen(false);
+      }
+      return;
+    }
+
+    if (this.preferredOpen !== null) {
+      if (this.api.isMobile) {
+        this.api.setOpenMobile(this.preferredOpen);
+      } else {
+        this.api.setOpen(this.preferredOpen);
+      }
+    }
+  }
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/store/use-app-shell-breadcrumb.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/use-app-shell-breadcrumb.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+
+import type { BreadcrumbAppend, BreadcrumbOverride } from "./breadcrumb-store";
+import { useAppShellStore } from "./app-shell-store-context";
+
+type BreadcrumbOverrideConfig = Omit<BreadcrumbOverride, "id"> & { id: string };
+type BreadcrumbAppendConfig = Omit<BreadcrumbAppend, "id"> & { id: string };
+
+export function useAppShellBreadcrumbOverride(config: BreadcrumbOverrideConfig) {
+  const store = useAppShellStore();
+  const { id, index, matchSegment, label, href } = config;
+
+  useEffect(() => {
+    store.breadcrumb.registerOverride({ id, index, matchSegment, label, href });
+
+    return () => {
+      store.breadcrumb.unregisterOverride(id);
+    };
+  }, [store, id, index, matchSegment, label, href]);
+}
+
+export function useAppShellBreadcrumbAppend(config: BreadcrumbAppendConfig) {
+  const store = useAppShellStore();
+  const { id, label, href } = config;
+
+  useEffect(() => {
+    store.breadcrumb.registerAppend({ id, label, href });
+
+    return () => {
+      store.breadcrumb.unregisterAppend(id);
+    };
+  }, [store, id, label, href]);
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/store/use-app-shell-header-action.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/use-app-shell-header-action.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { ReactNode } from "react";
+
+import type { HeaderActionSlot } from "./header-actions-store";
+import { useAppShellStore } from "./app-shell-store-context";
+
+type AppShellHeaderActionConfig = {
+  id: string;
+  order?: number;
+  visible?: boolean;
+  render: () => ReactNode;
+};
+
+export function useAppShellHeaderAction({
+  id,
+  order = 0,
+  visible = true,
+  render,
+}: AppShellHeaderActionConfig) {
+  const store = useAppShellStore();
+  const renderRef = useRef(render);
+  renderRef.current = render;
+
+  useEffect(() => {
+    const slot: HeaderActionSlot = {
+      id,
+      order,
+      visible,
+      render: () => renderRef.current(),
+    };
+
+    store.headerActions.register(slot);
+
+    return () => {
+      store.headerActions.unregister(id);
+    };
+  }, [store, id, order, visible]);
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/store/use-app-shell-navigation.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/use-app-shell-navigation.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import type { NavigationGroup } from "@/components/app-shell/navigation-config";
 
@@ -8,45 +8,42 @@ import type { NavigationProjectContext } from "./navigation-store";
 import { useAppShellStore } from "./app-shell-store-context";
 
 type AppShellNavigationCustomConfig = {
+  /**
+   * Navigation groups to render in custom mode. Pass a stable reference (module-level
+   * constant or `useMemo`) when the groups do not change for the lifetime of the page.
+   */
   groups: readonly NavigationGroup[];
   projectContext?: NavigationProjectContext;
 };
+
+function buildGroupsSignature(groups: readonly NavigationGroup[]) {
+  return groups
+    .flatMap((group) =>
+      group.items.map((item) => `${group.label ?? ""}:${item.href}:${item.label}`),
+    )
+    .join("\0");
+}
 
 export function useAppShellNavigationCustom({
   groups,
   projectContext,
 }: AppShellNavigationCustomConfig) {
   const store = useAppShellStore();
+  const groupsRef = useRef(groups);
+  const projectContextRef = useRef(projectContext);
+  groupsRef.current = groups;
+  projectContextRef.current = projectContext;
+
+  const groupsSignature = buildGroupsSignature(groups);
+  const organizationSlug = projectContext?.organizationSlug;
+  const projectId = projectContext?.projectId;
+  const projectName = projectContext?.projectName;
 
   useEffect(() => {
-    store.navigation.setCustomNavigation(groups, projectContext);
+    store.navigation.setCustomNavigation(groupsRef.current, projectContextRef.current);
 
     return () => {
       store.navigation.clearCustomMode();
     };
-  }, [store, groups, projectContext]);
-}
-
-type AppShellSidebarConfig = {
-  preferredOpen?: boolean | null;
-  forceCollapsed?: boolean;
-};
-
-export function useAppShellSidebar({
-  preferredOpen = null,
-  forceCollapsed = false,
-}: AppShellSidebarConfig = {}) {
-  const store = useAppShellStore();
-
-  useEffect(() => {
-    store.sidebar.setPreferredOpen(preferredOpen);
-    store.sidebar.setForceCollapsed(forceCollapsed);
-
-    return () => {
-      store.sidebar.setForceCollapsed(false);
-      store.sidebar.setPreferredOpen(null);
-    };
-  }, [store, preferredOpen, forceCollapsed]);
-
-  return store.sidebar;
+  }, [store, groupsSignature, organizationSlug, projectId, projectName]);
 }

--- a/apps/hyperlocalise-web/src/components/app-shell/store/use-app-shell-navigation.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/use-app-shell-navigation.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect } from "react";
+
+import type { NavigationGroup } from "@/components/app-shell/navigation-config";
+
+import type { NavigationProjectContext } from "./navigation-store";
+import { useAppShellStore } from "./app-shell-store-context";
+
+type AppShellNavigationCustomConfig = {
+  groups: readonly NavigationGroup[];
+  projectContext?: NavigationProjectContext;
+};
+
+export function useAppShellNavigationCustom({
+  groups,
+  projectContext,
+}: AppShellNavigationCustomConfig) {
+  const store = useAppShellStore();
+
+  useEffect(() => {
+    store.navigation.setCustomNavigation(groups, projectContext);
+
+    return () => {
+      store.navigation.clearCustomMode();
+    };
+  }, [store, groups, projectContext]);
+}
+
+type AppShellSidebarConfig = {
+  preferredOpen?: boolean | null;
+  forceCollapsed?: boolean;
+};
+
+export function useAppShellSidebar({
+  preferredOpen = null,
+  forceCollapsed = false,
+}: AppShellSidebarConfig = {}) {
+  const store = useAppShellStore();
+
+  useEffect(() => {
+    store.sidebar.setPreferredOpen(preferredOpen);
+    store.sidebar.setForceCollapsed(forceCollapsed);
+
+    return () => {
+      store.sidebar.setForceCollapsed(false);
+      store.sidebar.setPreferredOpen(null);
+    };
+  }, [store, preferredOpen, forceCollapsed]);
+
+  return store.sidebar;
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/store/use-app-shell-sidebar.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/use-app-shell-sidebar.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { useAppShellStore } from "./app-shell-store-context";
+
+type AppShellSidebarConfig = {
+  preferredOpen?: boolean | null;
+  forceCollapsed?: boolean;
+};
+
+export function useAppShellSidebar({
+  preferredOpen = null,
+  forceCollapsed = false,
+}: AppShellSidebarConfig = {}) {
+  const store = useAppShellStore();
+
+  useEffect(() => {
+    store.sidebar.setPreferredOpen(preferredOpen);
+    store.sidebar.setForceCollapsed(forceCollapsed);
+
+    return () => {
+      store.sidebar.setForceCollapsed(false);
+      store.sidebar.setPreferredOpen(null);
+    };
+  }, [store, preferredOpen, forceCollapsed]);
+
+  return store.sidebar;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds a MobX `AppShellStore` scoped to the authenticated org layout, with four substores:

- **SidebarStore** — bridges to `SidebarProvider` for imperative open/close, `forceCollapsed`, and `preferredOpen`
- **NavigationStore** — route-driven nav by default; pages can switch to custom nav groups via `useAppShellNavigationCustom`
- **BreadcrumbStore** — layers overrides/appends on top of URL-derived breadcrumbs from `getAppShellBreadcrumbs`
- **HeaderActionsStore** — slot registry for navbar actions rendered before TMS connect / theme / user menu

The store resets page-scoped state (actions, breadcrumb overrides, custom nav, sidebar preferences) on every route change.

### New hooks

| Hook | Purpose |
|------|---------|
| `useAppShellHeaderAction` | Register a navbar action slot |
| `useAppShellBreadcrumbOverride` | Replace a crumb by index or segment match |
| `useAppShellBreadcrumbAppend` | Append a trailing crumb |
| `useAppShellNavigationCustom` | Replace sidebar nav with custom groups |
| `useAppShellSidebar` | Control sidebar open state / force collapse |

### Architecture notes

- URL + React Query remain the source of truth for routing and server data; MobX coordinates page-driven shell customization only
- Store is created per layout mount (not a global singleton), matching the CAT workspace pattern
- `observer` is limited to shell chrome components (`AppShellBreadcrumb`, `AppShellNavigation`, `AppShellHeaderActions`, `SidebarStoreBridge`)

## How to test

```bash
cd apps/hyperlocalise-web
vp check --fix
vp test src/components/app-shell
```

Example page usage:

```tsx
useAppShellHeaderAction({
  id: "save",
  order: 10,
  render: () => <Button onClick={save}>Save</Button>,
});

useAppShellBreadcrumbOverride({
  id: "job-title",
  matchSegment: "jobs",
  label: job.title,
});

useAppShellSidebar({ forceCollapsed: true });
```

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test src/components/app-shell`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2a7f-ab1b-75dd-ab55-f24d1567cd25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2a7f-ab1b-75dd-ab55-f24d1567cd25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

