### PR TITLE
fix(agents): stabilize due Contentful automation list test

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
@@ -309,35 +309,38 @@ describe("workspace automations", () => {
         timezone: "UTC",
       },
     };
+    const now = new Date("2099-06-15T12:00:00.000Z");
 
-    await createWorkspaceAutomation({
-      organizationId: scope.organizationId,
-      authorUserId: scope.userId,
-      name: "Due GitHub automation",
-      instructions: "Run GitHub automation first.",
-      repositoryTarget: {
-        kind: "github",
-        githubInstallationRepositoryId: scope.githubInstallationRepositoryId,
-      },
-      triggerConfig,
-      toolConfig: {
-        github: {
-          enabled: true,
-          mode: "sync",
-          projectId: scope.projectId,
-          pushSource: true,
-          pullTranslations: false,
-          validation: false,
-        },
-      },
-      nextRunAt: new Date("2026-06-01T08:00:00.000Z"),
-    });
-    const contentfulAutomation = expectOk(
+    const githubAutomation = expectOk(
       await createWorkspaceAutomation({
         organizationId: scope.organizationId,
         authorUserId: scope.userId,
-        name: "Due Contentful automation",
-        instructions: "Run Contentful automation second.",
+        name: "Due GitHub automation",
+        instructions: "Run GitHub automation first.",
+        repositoryTarget: {
+          kind: "github",
+          githubInstallationRepositoryId: scope.githubInstallationRepositoryId,
+        },
+        triggerConfig,
+        toolConfig: {
+          github: {
+            enabled: true,
+            mode: "sync",
+            projectId: scope.projectId,
+            pushSource: true,
+            pullTranslations: false,
+            validation: false,
+          },
+        },
+        nextRunAt: new Date("2099-06-15T08:00:00.000Z"),
+      }),
+    );
+    const earlierContentfulAutomation = expectOk(
+      await createWorkspaceAutomation({
+        organizationId: scope.organizationId,
+        authorUserId: scope.userId,
+        name: "Earlier due Contentful automation",
+        instructions: "Run Contentful automation first.",
         triggerConfig,
         toolConfig: {
           contentful: {
@@ -354,16 +357,55 @@ describe("workspace automations", () => {
             writeDrafts: true,
           },
         },
-        nextRunAt: new Date("2026-06-01T09:00:00.000Z"),
+        nextRunAt: new Date("2099-06-15T09:00:00.000Z"),
+      }),
+    );
+    const laterContentfulAutomation = expectOk(
+      await createWorkspaceAutomation({
+        organizationId: scope.organizationId,
+        authorUserId: scope.userId,
+        name: "Later due Contentful automation",
+        instructions: "Run Contentful automation second.",
+        triggerConfig,
+        toolConfig: {
+          contentful: {
+            enabled: true,
+            connectionId: crypto.randomUUID(),
+            projectId: scope.projectId,
+            sourceLocale: "en",
+            entryId: "entry-scheduled-2",
+            targetLocales: ["fr"],
+            contentTypeIds: [],
+            fieldMode: "auto",
+            overwriteDraftLocales: false,
+            runQa: true,
+            writeDrafts: true,
+          },
+        },
+        nextRunAt: new Date("2099-06-15T10:00:00.000Z"),
       }),
     );
 
     const dueAutomations = await listDueContentfulWorkspaceAutomations({
-      now: new Date("2026-06-01T10:00:00.000Z"),
+      now,
       limit: 1,
     });
 
-    expect(dueAutomations.map((automation) => automation.id)).toEqual([contentfulAutomation.id]);
+    expect(dueAutomations).toHaveLength(1);
+    expect(dueAutomations[0]?.id).not.toBe(githubAutomation.id);
+    expect(dueAutomations[0]?.toolConfig.contentful?.enabled).toBe(true);
+
+    const dueAutomationsForOrg = (
+      await listDueContentfulWorkspaceAutomations({
+        now,
+        limit: 100,
+      })
+    ).filter((automation) => automation.organizationId === scope.organizationId);
+
+    expect(dueAutomationsForOrg.map((automation) => automation.id)).toEqual([
+      earlierContentfulAutomation.id,
+      laterContentfulAutomation.id,
+    ]);
   });
 
   it("only versions config-changing automation updates", async () => {

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
@@ -311,7 +311,7 @@ describe("workspace automations", () => {
     };
     const now = new Date("2099-06-15T12:00:00.000Z");
 
-    const githubAutomation = expectOk(
+    expectOk(
       await createWorkspaceAutomation({
         organizationId: scope.organizationId,
         authorUserId: scope.userId,
@@ -389,20 +389,19 @@ describe("workspace automations", () => {
     const dueAutomations = await listDueContentfulWorkspaceAutomations({
       now,
       limit: 1,
+      organizationId: scope.organizationId,
     });
 
     expect(dueAutomations).toHaveLength(1);
-    expect(dueAutomations[0]?.id).not.toBe(githubAutomation.id);
-    expect(dueAutomations[0]?.toolConfig.contentful?.enabled).toBe(true);
+    expect(dueAutomations[0]?.id).toBe(earlierContentfulAutomation.id);
 
-    const dueAutomationsForOrg = (
-      await listDueContentfulWorkspaceAutomations({
-        now,
-        limit: 100,
-      })
-    ).filter((automation) => automation.organizationId === scope.organizationId);
+    const bothDueAutomations = await listDueContentfulWorkspaceAutomations({
+      now,
+      limit: 2,
+      organizationId: scope.organizationId,
+    });
 
-    expect(dueAutomationsForOrg.map((automation) => automation.id)).toEqual([
+    expect(bothDueAutomations.map((automation) => automation.id)).toEqual([
       earlierContentfulAutomation.id,
       laterContentfulAutomation.id,
     ]);

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNotNull, lte, sql } from "drizzle-orm";
+import { and, asc, desc, eq, isNotNull, lte, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { db, schema, type DatabaseClient } from "@/lib/database";
@@ -855,7 +855,7 @@ export async function listDueWorkspaceAutomations(input: {
         eq(schema.githubInstallationRepositories.archived, false),
       ),
     )
-    .orderBy(schema.workspaceAutomations.nextRunAt)
+    .orderBy(asc(schema.workspaceAutomations.nextRunAt), asc(schema.workspaceAutomations.id))
     .limit(limit);
 
   return rows.map(({ automation, repository }) => ({
@@ -883,7 +883,7 @@ export async function listDueContentfulWorkspaceAutomations(input: {
         sql`${schema.workspaceAutomations.toolConfig}->'contentful'->>'enabled' = 'true'`,
       ),
     )
-    .orderBy(schema.workspaceAutomations.nextRunAt)
+    .orderBy(asc(schema.workspaceAutomations.nextRunAt), asc(schema.workspaceAutomations.id))
     .limit(limit);
 
   return rows

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -867,6 +867,7 @@ export async function listDueWorkspaceAutomations(input: {
 export async function listDueContentfulWorkspaceAutomations(input: {
   now?: Date;
   limit?: number;
+  organizationId?: string;
 }): Promise<WorkspaceAutomationRecord[]> {
   const now = input.now ?? new Date();
   const limit = input.limit ?? 100;
@@ -881,6 +882,9 @@ export async function listDueContentfulWorkspaceAutomations(input: {
         lte(schema.workspaceAutomations.nextRunAt, now),
         sql`${schema.workspaceAutomations.triggerConfig}->>'mode' = 'scheduled'`,
         sql`${schema.workspaceAutomations.toolConfig}->'contentful'->>'enabled' = 'true'`,
+        ...(input.organizationId
+          ? [eq(schema.workspaceAutomations.organizationId, input.organizationId)]
+          : []),
       ),
     )
     .orderBy(asc(schema.workspaceAutomations.nextRunAt), asc(schema.workspaceAutomations.id))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a flaky integration test in `workspace-automations.test.ts` that asserted a specific automation ID from a global `limit: 1` query.

## Root cause

`listDueContentfulWorkspaceAutomations` queries across all organizations. The test used common `2026-06-01` timestamps and expected its own Contentful automation to be the sole `limit: 1` result. When other tests left earlier due Contentful automations in the shared database, ordering returned a different ID and the assertion failed.

## Changes

- Rework the test to use an isolated schedule window (`2099-06-15`) so it does not collide with other tests.
- Assert the limited result is Contentful (not the earlier-due GitHub automation), which is the behavior under test.
- Verify org-scoped ordering with a higher limit instead of relying on global uniqueness.
- Add deterministic secondary ordering by automation `id` in `listDueContentfulWorkspaceAutomations` and `listDueWorkspaceAutomations`.

## Testing

- `vp test src/lib/agents/workspace-automations.test.ts`
- `vp test src/lib/agents/workspace-automation-dispatcher.test.ts`
- `vp check --fix`
- Reproduced the original failure by seeding a polluting due Contentful row, then confirmed the updated test passes with that data present.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2a8c-c6b6-78a7-877c-4df3b0350aa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2a8c-c6b6-78a7-877c-4df3b0350aa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

