### PR TITLE
feat(web): replace files preview with View strings action

### DIFF
--- a/apps/hyperlocalise-web/.storybook/preview.tsx
+++ b/apps/hyperlocalise-web/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 import type { Preview } from "@storybook/nextjs-vite";
 import { Domine, Geist_Mono, Open_Sans } from "next/font/google";
 import { initialize, mswLoader } from "msw-storybook-addon";
+import "@pierre/trees/web-components";
 
 import "../src/app/globals.css";
 import { I18nProvider } from "../src/components/i18n/i18n-provider";

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeftIcon } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { TypographyP } from "@/components/ui/typography";
+import { ProjectFileCatWorkspace } from "@/components/cat/project-file/project-file-cat-workspace";
+import { supportsProviderCatFile } from "@/lib/providers/provider-cat-capabilities";
+
+import { ProjectPageShell } from "../../_components/project-page-shell";
+import { selectJobCatTargetLocale } from "../../jobs/[jobId]/strings/_components/job-cat-target-locale";
+import { fetchProjectFiles, projectFilesQueryKey } from "./project-files-tree-panel";
+
+export function ProjectFileCatPageContent({
+  organizationSlug,
+  projectId,
+  sourcePath,
+  highlightLocale,
+  initialSegmentKey = null,
+}: {
+  organizationSlug: string;
+  projectId: string;
+  sourcePath: string | null;
+  highlightLocale: string | null;
+  initialSegmentKey?: string | null;
+}) {
+  const filesHref = `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/files${
+    sourcePath ? `?sourcePath=${encodeURIComponent(sourcePath)}` : ""
+  }`;
+  const filesQuery = useQuery({
+    queryKey: projectFilesQueryKey(organizationSlug, projectId),
+    queryFn: () => fetchProjectFiles(organizationSlug, projectId),
+    enabled: Boolean(sourcePath),
+  });
+
+  if (!sourcePath) {
+    return (
+      <ProjectPageShell>
+        <div className="rounded-lg border border-border bg-card p-5">
+          <TypographyP className="text-sm text-muted-foreground">
+            Choose a source file from the project files list to open it in the CAT workspace.
+          </TypographyP>
+          <Button className="mt-4" variant="outline" size="sm" render={<Link href={filesHref} />}>
+            <ArrowLeftIcon />
+            Files
+          </Button>
+        </div>
+      </ProjectPageShell>
+    );
+  }
+
+  if (filesQuery.isLoading) {
+    return (
+      <ProjectPageShell>
+        <div className="flex min-h-48 items-center justify-center gap-2 rounded-lg border border-border bg-card p-5">
+          <Spinner />
+          <TypographyP className="text-sm text-muted-foreground">Loading file…</TypographyP>
+        </div>
+      </ProjectPageShell>
+    );
+  }
+
+  if (filesQuery.isError) {
+    return (
+      <ProjectPageShell>
+        <div className="rounded-lg border border-border bg-card p-5">
+          <TypographyP className="text-sm text-flame-100">
+            {filesQuery.error instanceof Error
+              ? filesQuery.error.message
+              : "Unable to load project files."}
+          </TypographyP>
+          <Button className="mt-4" variant="outline" size="sm" render={<Link href={filesHref} />}>
+            <ArrowLeftIcon />
+            Files
+          </Button>
+        </div>
+      </ProjectPageShell>
+    );
+  }
+
+  const file = filesQuery.data?.find((entry) => entry.sourcePath === sourcePath) ?? null;
+
+  if (!file) {
+    return (
+      <ProjectPageShell>
+        <div className="rounded-lg border border-border bg-card p-5">
+          <TypographyP className="font-mono text-sm text-foreground">{sourcePath}</TypographyP>
+          <TypographyP className="mt-2 text-sm text-muted-foreground">
+            This source file is not in the project file list anymore.
+          </TypographyP>
+          <Button className="mt-4" variant="outline" size="sm" render={<Link href={filesHref} />}>
+            <ArrowLeftIcon />
+            Files
+          </Button>
+        </div>
+      </ProjectPageShell>
+    );
+  }
+
+  if (file.provider && !supportsProviderCatFile(file)) {
+    return (
+      <ProjectPageShell>
+        <div className="rounded-lg border border-border bg-card p-5">
+          <TypographyP className="text-sm text-muted-foreground">
+            The CAT workspace is not available for this provider file type yet.
+          </TypographyP>
+          <Button className="mt-4" variant="outline" size="sm" render={<Link href={filesHref} />}>
+            <ArrowLeftIcon />
+            Files
+          </Button>
+        </div>
+      </ProjectPageShell>
+    );
+  }
+
+  const targetLocale = file.provider
+    ? selectJobCatTargetLocale({
+        requestedTargetLocale: highlightLocale,
+        providerTargetLocales: file.provider.targetLocales,
+      })
+    : highlightLocale;
+
+  return (
+    <main className="-mx-4 -my-5 flex min-h-[calc(100svh-var(--app-shell-header-height))] flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
+      <div className="flex shrink-0 flex-col gap-3 border-b border-border px-4 py-3 sm:px-6 lg:px-8">
+        <div className="flex min-w-0 items-center gap-3">
+          <Button variant="outline" size="sm" render={<Link href={filesHref} />}>
+            <ArrowLeftIcon />
+            Files
+          </Button>
+          <TypographyP className="truncate font-mono text-xs text-muted-foreground">
+            {file.sourcePath}
+          </TypographyP>
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col px-4 py-3 sm:px-6 lg:px-8">
+        <ProjectFileCatWorkspace
+          key={file.sourcePath}
+          organizationSlug={organizationSlug}
+          projectId={projectId}
+          sourcePath={file.sourcePath}
+          targetLocale={targetLocale ?? undefined}
+          targetLocales={file.provider?.targetLocales}
+          highlightLocale={highlightLocale}
+          initialSegmentKey={initialSegmentKey}
+          layout="fullscreen"
+        />
+      </div>
+    </main>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import Link from "next/link";
+import { ListIcon } from "lucide-react";
+
+import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+import { Button } from "@/components/ui/button";
+import { TypographyP } from "@/components/ui/typography";
+import {
+  buildProjectFileCatHref,
+  canOpenProjectFileCat,
+} from "@/lib/projects/project-file-cat-routing";
+
+export function ProjectFileSelectionActions({
+  organizationSlug,
+  projectId,
+  file,
+  highlightLocale,
+}: {
+  organizationSlug: string;
+  projectId: string;
+  file: ProjectFileRecord;
+  highlightLocale: string | null;
+}) {
+  const canOpenCat = canOpenProjectFileCat(file);
+  const catHref = buildProjectFileCatHref(organizationSlug, projectId, file, highlightLocale);
+
+  return (
+    <div className="flex shrink-0 flex-col gap-3 border-b border-foreground/8 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-w-0">
+        <TypographyP className="truncate font-mono text-sm text-foreground">
+          {file.sourcePath}
+        </TypographyP>
+        <TypographyP className="text-xs text-foreground/52">
+          {canOpenCat
+            ? "Open this file in the CAT workspace to review and edit translations."
+            : "The CAT workspace is not available for this file yet."}
+        </TypographyP>
+      </div>
+      <Button
+        type="button"
+        size="sm"
+        className="w-full shrink-0 sm:w-fit"
+        disabled={!canOpenCat || !catHref}
+        render={canOpenCat && catHref ? <Link href={catHref} /> : undefined}
+      >
+        <ListIcon />
+        View strings
+      </Button>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.stories.tsx
@@ -1,10 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { expect } from "storybook/test";
 
-import { ProjectFileDetailPanelView } from "./project-file-detail-panel";
 import { ProjectFilesPageContentView } from "./project-files-page-content";
 import {
-  createProjectFileDetail,
   createProjectFileRecord,
   projectFilesFixture,
   providerProjectFilesFixture,
@@ -12,7 +10,6 @@ import {
 } from "./project-files.fixture";
 
 const selectedFile = projectFilesFixture[0] ?? createProjectFileRecord();
-const selectedDetail = createProjectFileDetail(selectedFile);
 
 const meta = {
   title: "App/Project/Files/Page",
@@ -34,14 +31,6 @@ const meta = {
     onAddSelectedFiles: () => undefined,
     onRemoveSelectedFile: () => undefined,
     onUploadSelectedFiles: () => undefined,
-    renderDetailPanel: (props) => (
-      <ProjectFileDetailPanelView
-        {...props}
-        isLoading={false}
-        detail={props.file?.sourcePath === selectedDetail.sourcePath ? selectedDetail : undefined}
-        targetLocales={["fr-FR", "de-DE"]}
-      />
-    ),
   },
 } satisfies Meta<typeof ProjectFilesPageContentView>;
 
@@ -51,8 +40,9 @@ type Story = StoryObj<typeof meta>;
 export const RepositoryFiles: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("heading", { name: "Files" })).toBeInTheDocument();
-    await expect(canvas.getByText("Project files")).toBeInTheDocument();
+    await expect(canvas.getByRole("heading", { name: "Project files" })).toBeInTheDocument();
     await expect(canvas.getByText("marketing/home.json")).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "View strings" })).toBeInTheDocument();
   },
 };
 
@@ -79,13 +69,6 @@ export const ProviderFiles: Story = {
     files: providerProjectFilesFixture,
     selectedSourcePath: providerProjectFilesFixture[0]?.sourcePath ?? null,
     selectedFiles: [],
-    renderDetailPanel: (props) => (
-      <ProjectFileDetailPanelView
-        {...props}
-        isLoading={false}
-        detail={props.file ? createProjectFileDetail(props.file) : undefined}
-      />
-    ),
   },
 };
 
@@ -94,9 +77,6 @@ export const LoadingFiles: Story = {
     files: [],
     isFilesLoading: true,
     selectedSourcePath: null,
-    renderDetailPanel: (props) => (
-      <ProjectFileDetailPanelView {...props} isLoading={false} detail={undefined} />
-    ),
   },
 };
 
@@ -104,9 +84,6 @@ export const EmptyRepository: Story = {
   args: {
     files: [],
     selectedSourcePath: null,
-    renderDetailPanel: (props) => (
-      <ProjectFileDetailPanelView {...props} isLoading={false} detail={undefined} />
-    ),
   },
 };
 
@@ -115,8 +92,5 @@ export const LoadError: Story = {
     files: [],
     filesError: new Error("The files API returned a 500."),
     selectedSourcePath: null,
-    renderDetailPanel: (props) => (
-      <ProjectFileDetailPanelView {...props} isLoading={false} detail={undefined} />
-    ),
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.stories.tsx
@@ -1,7 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { expect } from "storybook/test";
 
+import { TypographyP } from "@/components/ui/typography";
+
+import { ProjectSectionTitle } from "../../_components/project-page-shell";
+import { ProjectFileSelectionActions } from "./project-file-selection-actions";
 import { ProjectFilesPageContentView } from "./project-files-page-content";
+import { ProjectFilesTree } from "./project-files-tree";
 import {
   createProjectFileRecord,
   projectFilesFixture,
@@ -10,6 +15,52 @@ import {
 } from "./project-files.fixture";
 
 const selectedFile = projectFilesFixture[0] ?? createProjectFileRecord();
+
+function storyFilesTree({
+  files,
+  selectedSourcePath,
+  onSelectSourcePath,
+  organizationSlug,
+  projectId,
+  highlightLocale,
+}: {
+  files: typeof projectFilesFixture;
+  selectedSourcePath: string | null;
+  onSelectSourcePath: (sourcePath: string | null) => void;
+  organizationSlug: string;
+  projectId: string;
+  highlightLocale: string | null;
+}) {
+  return (selectedFileRecord: ReturnType<typeof createProjectFileRecord> | null) => (
+    <>
+      <header className="flex shrink-0 items-center justify-between gap-3 border-b border-foreground/8 px-4 py-3">
+        <div>
+          <ProjectSectionTitle>Project files</ProjectSectionTitle>
+          <TypographyP className="mt-0.5 text-sm text-foreground/52">
+            {files.length} file{files.length === 1 ? "" : "s"}
+          </TypographyP>
+        </div>
+      </header>
+
+      {selectedFileRecord ? (
+        <ProjectFileSelectionActions
+          organizationSlug={organizationSlug}
+          projectId={projectId}
+          file={selectedFileRecord}
+          highlightLocale={highlightLocale}
+        />
+      ) : null}
+
+      <div className="min-h-0 flex-1 p-2">
+        <ProjectFilesTree
+          files={files}
+          selectedSourcePath={selectedSourcePath}
+          onSelectFile={(sourcePath) => onSelectSourcePath(sourcePath)}
+        />
+      </div>
+    </>
+  );
+}
 
 const meta = {
   title: "App/Project/Files/Page",
@@ -31,6 +82,14 @@ const meta = {
     onAddSelectedFiles: () => undefined,
     onRemoveSelectedFile: () => undefined,
     onUploadSelectedFiles: () => undefined,
+    filesTree: storyFilesTree({
+      files: projectFilesFixture,
+      selectedSourcePath: selectedFile.sourcePath,
+      onSelectSourcePath: () => undefined,
+      organizationSlug: "acme",
+      projectId: "project_website",
+      highlightLocale: "fr-FR",
+    }),
   },
 } satisfies Meta<typeof ProjectFilesPageContentView>;
 
@@ -41,7 +100,8 @@ export const RepositoryFiles: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("heading", { name: "Files" })).toBeInTheDocument();
     await expect(canvas.getByRole("heading", { name: "Project files" })).toBeInTheDocument();
-    await expect(canvas.getByText("marketing/home.json")).toBeInTheDocument();
+    await expect(canvas.getByRole("tree", { name: "Project files" })).toBeInTheDocument();
+    await expect(canvas.getAllByText("marketing/home.json").length).toBeGreaterThan(0);
     await expect(canvas.getByRole("link", { name: "View strings" })).toBeInTheDocument();
   },
 };
@@ -69,6 +129,14 @@ export const ProviderFiles: Story = {
     files: providerProjectFilesFixture,
     selectedSourcePath: providerProjectFilesFixture[0]?.sourcePath ?? null,
     selectedFiles: [],
+    filesTree: storyFilesTree({
+      files: providerProjectFilesFixture,
+      selectedSourcePath: providerProjectFilesFixture[0]?.sourcePath ?? null,
+      onSelectSourcePath: () => undefined,
+      organizationSlug: "acme",
+      projectId: "crowdin:project_website",
+      highlightLocale: "fr-FR",
+    }),
   },
 };
 
@@ -77,6 +145,7 @@ export const LoadingFiles: Story = {
     files: [],
     isFilesLoading: true,
     selectedSourcePath: null,
+    filesTree: undefined,
   },
 };
 
@@ -84,6 +153,14 @@ export const EmptyRepository: Story = {
   args: {
     files: [],
     selectedSourcePath: null,
+    filesTree: storyFilesTree({
+      files: [],
+      selectedSourcePath: null,
+      onSelectSourcePath: () => undefined,
+      organizationSlug: "acme",
+      projectId: "project_website",
+      highlightLocale: null,
+    }),
   },
 };
 
@@ -92,5 +169,6 @@ export const LoadError: Story = {
     files: [],
     filesError: new Error("The files API returned a 500."),
     selectedSourcePath: null,
+    filesTree: undefined,
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { expect } from "storybook/test";
+import { expect, waitFor } from "storybook/test";
 
 import { TypographyP } from "@/components/ui/typography";
 
@@ -72,6 +72,7 @@ const meta = {
     organizationSlug: "acme",
     projectId: "project_website",
     files: projectFilesFixture,
+    resolvedFiles: projectFilesFixture,
     isFilesLoading: false,
     isFilesFetching: false,
     selectedSourcePath: selectedFile.sourcePath,
@@ -97,12 +98,15 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const RepositoryFiles: Story = {
-  play: async ({ canvas }) => {
+  play: async ({ canvas, canvasElement }) => {
     await expect(canvas.getByRole("heading", { name: "Files" })).toBeInTheDocument();
     await expect(canvas.getByRole("heading", { name: "Project files" })).toBeInTheDocument();
-    await expect(canvas.getByRole("tree", { name: "Project files" })).toBeInTheDocument();
+    await expect(canvas.getByText("3 files")).toBeInTheDocument();
     await expect(canvas.getAllByText("marketing/home.json").length).toBeGreaterThan(0);
     await expect(canvas.getByRole("link", { name: "View strings" })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(canvasElement.querySelector("file-tree-container")).toBeTruthy();
+    });
   },
 };
 
@@ -127,6 +131,7 @@ export const ProviderFiles: Story = {
   args: {
     projectId: "crowdin:project_website",
     files: providerProjectFilesFixture,
+    resolvedFiles: providerProjectFilesFixture,
     selectedSourcePath: providerProjectFilesFixture[0]?.sourcePath ?? null,
     selectedFiles: [],
     filesTree: storyFilesTree({

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -258,7 +258,7 @@ export function ProjectFilesPageContentView({
   filesTree?: (selectedFile: ProjectFileRecord | null) => ReactNode;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const displayFiles = filesTree ? (resolvedFiles ?? []) : files;
+  const displayFiles = filesTree ? (resolvedFiles ?? files) : files;
   const selectedFile = useMemo(
     () => displayFiles.find((file) => file.sourcePath === selectedSourcePath) ?? null,
     [displayFiles, selectedSourcePath],

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -22,8 +22,7 @@ import {
   ProjectSectionHeader,
   ProjectSectionTitle,
 } from "../../_components/project-page-shell";
-import { ProjectFileDetailPanel } from "./project-file-detail-panel";
-import { ProjectFilesErrorBoundary } from "./project-files-error-boundary";
+import { ProjectFileSelectionActions } from "./project-file-selection-actions";
 import {
   ProjectFilesTreePanel,
   projectFilesQueryKey,
@@ -55,14 +54,6 @@ export type ProjectFilesTreeRenderer = (props: {
   onSelectFile: (sourcePath: string | null) => void;
 }) => ReactNode;
 
-export type ProjectFilesDetailPanelRenderer = (props: {
-  organizationSlug: string;
-  projectId: string;
-  file: ProjectFileRecord | null;
-  requestedSourcePath: string | null;
-  highlightLocale: string | null;
-}) => ReactNode;
-
 export type ProjectFilesErrorRenderer = (props: {
   organizationSlug: string;
   error: unknown;
@@ -78,24 +69,6 @@ function defaultRenderFilesTree({
       files={files}
       selectedSourcePath={selectedSourcePath}
       onSelectFile={onSelectFile}
-    />
-  );
-}
-
-function defaultRenderDetailPanel({
-  organizationSlug,
-  projectId,
-  file,
-  requestedSourcePath,
-  highlightLocale,
-}: Parameters<ProjectFilesDetailPanelRenderer>[0]) {
-  return (
-    <ProjectFileDetailPanel
-      organizationSlug={organizationSlug}
-      projectId={projectId}
-      file={file}
-      requestedSourcePath={requestedSourcePath}
-      highlightLocale={highlightLocale}
     />
   );
 }
@@ -222,15 +195,25 @@ export function ProjectFilesPageContent({
       onAddSelectedFiles={addSelectedFiles}
       onRemoveSelectedFile={removeSelectedFile}
       onUploadSelectedFiles={() => uploadFiles.mutate(selectedFiles)}
-      filesTree={
+      filesTree={(selectedFile) => (
         <ProjectFilesTreePanel
           organizationSlug={organizationSlug}
           projectId={projectId}
           selectedSourcePath={selectedSourcePath}
           onSelectSourcePath={setSelectedSourcePath}
           onLoadedFilesChange={setLoadedFiles}
+          toolbar={
+            selectedFile ? (
+              <ProjectFileSelectionActions
+                organizationSlug={organizationSlug}
+                projectId={projectId}
+                file={selectedFile}
+                highlightLocale={highlightLocale}
+              />
+            ) : null
+          }
         />
-      }
+      )}
     />
   );
 }
@@ -251,7 +234,6 @@ export function ProjectFilesPageContentView({
   onAddSelectedFiles,
   onRemoveSelectedFile,
   onUploadSelectedFiles,
-  renderDetailPanel = defaultRenderDetailPanel,
   renderError = defaultRenderFilesError,
   renderFilesTree = defaultRenderFilesTree,
   filesTree,
@@ -271,10 +253,9 @@ export function ProjectFilesPageContentView({
   onAddSelectedFiles: (files: File[]) => void;
   onRemoveSelectedFile: (file: File) => void;
   onUploadSelectedFiles: () => void;
-  renderDetailPanel?: ProjectFilesDetailPanelRenderer;
   renderError?: ProjectFilesErrorRenderer;
   renderFilesTree?: ProjectFilesTreeRenderer;
-  filesTree?: ReactNode;
+  filesTree?: (selectedFile: ProjectFileRecord | null) => ReactNode;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
   const displayFiles = filesTree ? (resolvedFiles ?? []) : files;
@@ -293,8 +274,8 @@ export function ProjectFilesPageContentView({
         section="Files"
         description={
           isProviderProject
-            ? "Browse source files from the connected TMS provider, then select one to preview its source content when the provider exposes it."
-            : "Upload source files, then select one to preview its content and related translation jobs."
+            ? "Browse source files from the connected TMS provider, then open one in the CAT workspace when it is supported."
+            : "Upload source files, then open one in the CAT workspace to review and edit translations."
         }
         actions={
           canUploadFiles ? (
@@ -374,28 +355,17 @@ export function ProjectFilesPageContentView({
 
       <section className="flex min-h-[min(28rem,70vh)] flex-col overflow-hidden rounded-lg border border-foreground/8 bg-foreground/2.5">
         {filesTree ? (
-          <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(14rem,18rem)_minmax(0,1fr)]">
-            <aside className="flex min-h-0 flex-col border-foreground/8 lg:border-e">
-              {filesTree}
-            </aside>
-            <main className="min-h-0 overflow-y-auto bg-background/40">
-              <ProjectFilesErrorBoundary
-                organizationSlug={organizationSlug}
-                scope="detail"
-                resetKeys={[selectedSourcePath, highlightLocale, selectedFile?.sourcePath]}
-              >
-                {renderDetailPanel({
-                  organizationSlug,
-                  projectId,
-                  file: selectedFile,
-                  requestedSourcePath: selectedSourcePath,
-                  highlightLocale,
-                })}
-              </ProjectFilesErrorBoundary>
-            </main>
-          </div>
+          <div className="flex min-h-0 flex-1 flex-col">{filesTree(selectedFile)}</div>
         ) : (
           <>
+            {selectedFile ? (
+              <ProjectFileSelectionActions
+                organizationSlug={organizationSlug}
+                projectId={projectId}
+                file={selectedFile}
+                highlightLocale={highlightLocale}
+              />
+            ) : null}
             <header className="flex shrink-0 items-center justify-between gap-3 border-b border-foreground/8 px-4 py-3">
               <div>
                 <ProjectSectionTitle>Project files</ProjectSectionTitle>
@@ -410,45 +380,31 @@ export function ProjectFilesPageContentView({
               {isFilesFetching && !isFilesLoading ? <Spinner /> : null}
             </header>
 
-            <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(14rem,18rem)_minmax(0,1fr)]">
-              <aside className="flex min-h-0 flex-col border-foreground/8 lg:border-e">
-                {isFilesLoading ? (
-                  <TypographyP className="p-4 text-sm text-foreground/52">
-                    Loading files…
+            <div className="flex min-h-0 flex-1 flex-col">
+              {isFilesLoading ? (
+                <TypographyP className="p-4 text-sm text-foreground/52">Loading files…</TypographyP>
+              ) : filesError ? (
+                <div className="p-4">{renderError({ organizationSlug, error: filesError })}</div>
+              ) : files.length === 0 ? (
+                <div className="flex flex-col gap-2 p-4">
+                  <TypographyP className="text-sm font-medium text-foreground">
+                    No files yet
                   </TypographyP>
-                ) : filesError ? (
-                  <div className="p-4">{renderError({ organizationSlug, error: filesError })}</div>
-                ) : files.length === 0 ? (
-                  <div className="flex flex-col gap-2 p-4">
-                    <TypographyP className="text-sm font-medium text-foreground">
-                      No files yet
-                    </TypographyP>
-                    <TypographyP className="text-sm text-foreground/52">
-                      {isProviderProject
-                        ? "No provider files were found for this project."
-                        : "Use Add files above to upload JSON, YAML, XLIFF, PO, and other supported formats."}
-                    </TypographyP>
-                  </div>
-                ) : (
-                  <div className="min-h-0 flex-1 p-2">
-                    {renderFilesTree({
-                      files,
-                      selectedSourcePath,
-                      onSelectFile: onSelectSourcePath,
-                    })}
-                  </div>
-                )}
-              </aside>
-
-              <main className="min-h-0 overflow-y-auto bg-background/40">
-                {renderDetailPanel({
-                  organizationSlug,
-                  projectId,
-                  file: selectedFile,
-                  requestedSourcePath: selectedSourcePath,
-                  highlightLocale,
-                })}
-              </main>
+                  <TypographyP className="text-sm text-foreground/52">
+                    {isProviderProject
+                      ? "No provider files were found for this project."
+                      : "Use Add files above to upload JSON, YAML, XLIFF, PO, and other supported formats."}
+                  </TypographyP>
+                </div>
+              ) : (
+                <div className="min-h-0 flex-1 p-2">
+                  {renderFilesTree({
+                    files,
+                    selectedSourcePath,
+                    onSelectFile: onSelectSourcePath,
+                  })}
+                </div>
+              )}
             </div>
           </>
         )}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -121,12 +122,14 @@ export function ProjectFilesTreePanel({
   selectedSourcePath,
   onSelectSourcePath,
   onLoadedFilesChange,
+  toolbar,
 }: {
   organizationSlug: string;
   projectId: string;
   selectedSourcePath: string | null;
   onSelectSourcePath: (sourcePath: string | null) => void;
   onLoadedFilesChange?: (files: ProjectFileRecord[]) => void;
+  toolbar?: ReactNode;
 }) {
   const queryClient = useQueryClient();
   const [fileLimit, setFileLimit] = useState(PROJECT_FILES_PAGE_SIZE);
@@ -209,6 +212,8 @@ export function ProjectFilesTreePanel({
         </div>
         {filesQuery.isFetching && !filesQuery.isLoading ? <Spinner /> : null}
       </header>
+
+      {toolbar}
 
       {filesQuery.isLoading ? (
         <TypographyP className="p-4 text-sm text-foreground/52">Loading files…</TypographyP>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, fn, userEvent, waitFor } from "storybook/test";
+
+import { ProjectFilesTree } from "./project-files-tree";
+import { projectFilesFixture } from "./project-files.fixture";
+
+const meta = {
+  title: "App/Project/Files/Tree",
+  component: ProjectFilesTree,
+  parameters: {
+    layout: "padded",
+  },
+  args: {
+    files: projectFilesFixture,
+    selectedSourcePath: projectFilesFixture[0]?.sourcePath ?? null,
+    onSelectFile: fn(),
+  },
+} satisfies Meta<typeof ProjectFilesTree>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    await waitFor(() => {
+      expect(canvasElement.querySelector("file-tree-container")).toBeTruthy();
+    });
+  },
+};
+
+export const SelectFile: Story = {
+  play: async ({ canvasElement, args }) => {
+    await waitFor(() => {
+      expect(canvasElement.querySelector("file-tree-container")).toBeTruthy();
+    });
+
+    const treeContainer = canvasElement.querySelector("file-tree-container");
+    const pricingRow = treeContainer?.shadowRoot?.querySelector(
+      '[data-item-path="marketing/pricing.json"]',
+    );
+    if (!pricingRow) {
+      throw new Error("Expected pricing.json row in file tree");
+    }
+
+    await userEvent.click(pricingRow);
+    await expect(args.onSelectFile).toHaveBeenCalledWith("marketing/pricing.json");
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
@@ -9,31 +9,29 @@ import "@pierre/trees/web-components";
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
 import { formatBytes } from "./project-files-shared";
 
-const TREE_HEIGHT_PX = 320;
+const TREE_MIN_HEIGHT_PX = 320;
 
 const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
   dateStyle: "medium",
   timeStyle: "short",
 });
 
-function projectFilesTreeStyle(heightPx: number): CSSProperties {
-  return {
-    height: `${heightPx}px`,
-    minHeight: `${heightPx}px`,
-    backgroundColor: "transparent",
-    color: "var(--foreground)",
-    borderColor: "var(--border)",
-    "--trees-bg-override": "var(--background)",
-    "--trees-bg-muted-override": "var(--muted)",
-    "--trees-border-color-override": "var(--border)",
-    "--trees-fg-override": "var(--foreground)",
-    "--trees-fg-muted-override": "var(--muted-foreground)",
-    "--trees-focus-ring-color-override": "var(--ring)",
-    "--trees-selected-bg-override": "var(--muted)",
-    "--trees-selected-fg-override": "var(--foreground)",
-    "--trees-selected-focused-border-color-override": "var(--ring)",
-  } as CSSProperties;
-}
+const projectFilesTreeStyle = {
+  height: "100%",
+  minHeight: `${TREE_MIN_HEIGHT_PX}px`,
+  backgroundColor: "transparent",
+  color: "var(--foreground)",
+  borderColor: "var(--border)",
+  "--trees-bg-override": "var(--background)",
+  "--trees-bg-muted-override": "var(--muted)",
+  "--trees-border-color-override": "var(--border)",
+  "--trees-fg-override": "var(--foreground)",
+  "--trees-fg-muted-override": "var(--muted-foreground)",
+  "--trees-focus-ring-color-override": "var(--ring)",
+  "--trees-selected-bg-override": "var(--muted)",
+  "--trees-selected-fg-override": "var(--foreground)",
+  "--trees-selected-focused-border-color-override": "var(--ring)",
+} as CSSProperties;
 
 function formatNullableDate(value: string | null | undefined) {
   if (!value) return null;
@@ -69,7 +67,6 @@ export function ProjectFilesTree({
   ariaLabel?: string;
 }) {
   const paths = useMemo(() => files.map((file) => file.sourcePath), [files]);
-  const pathsKey = paths.join("\0");
   const fileByPath = useMemo(() => new Map(files.map((file) => [file.sourcePath, file])), [files]);
   const selectedPaths =
     selectedSourcePath && fileByPath.has(selectedSourcePath) ? [selectedSourcePath] : [];
@@ -84,7 +81,7 @@ export function ProjectFilesTree({
             initialVisibleRowCount: Math.max(paths.length, 8),
           })
         : null,
-    [pathsKey, paths],
+    [paths],
   );
 
   useEffect(() => {
@@ -144,14 +141,14 @@ export function ProjectFilesTree({
   }
 
   return (
-    <div className="w-full" style={{ height: TREE_HEIGHT_PX }}>
+    <div className="h-full min-h-80 w-full">
       <PierreFileTree
         aria-label={ariaLabel}
         className="size-full border-0 bg-transparent"
         id="project-files-tree"
         model={model}
         preloadedData={preloadedData ?? undefined}
-        style={projectFilesTreeStyle(TREE_HEIGHT_PX)}
+        style={projectFilesTreeStyle}
       />
     </div>
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
@@ -14,7 +14,7 @@ const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
 
 const projectFilesTreeStyle = {
   height: "100%",
-  minHeight: 0,
+  minHeight: "20rem",
   backgroundColor: "transparent",
   color: "var(--foreground)",
   borderColor: "var(--border)",
@@ -121,7 +121,7 @@ export function ProjectFilesTree({
   return (
     <PierreFileTree
       aria-label={ariaLabel}
-      className="h-full min-h-0 border-0 bg-transparent"
+      className="h-full min-h-80 border-0 bg-transparent"
       model={model}
       style={projectFilesTreeStyle}
     />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
@@ -3,31 +3,37 @@
 import { useEffect, useMemo, useRef, type CSSProperties } from "react";
 import type { FileTreeRowDecorationContext } from "@pierre/trees";
 import { FileTree as PierreFileTree, useFileTree } from "@pierre/trees/react";
+import { preloadFileTree } from "@pierre/trees/ssr";
+import "@pierre/trees/web-components";
 
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
 import { formatBytes } from "./project-files-shared";
+
+const TREE_HEIGHT_PX = 320;
 
 const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
   dateStyle: "medium",
   timeStyle: "short",
 });
 
-const projectFilesTreeStyle = {
-  height: "100%",
-  minHeight: "20rem",
-  backgroundColor: "transparent",
-  color: "var(--foreground)",
-  borderColor: "var(--border)",
-  "--trees-bg-override": "var(--background)",
-  "--trees-bg-muted-override": "var(--muted)",
-  "--trees-border-color-override": "var(--border)",
-  "--trees-fg-override": "var(--foreground)",
-  "--trees-fg-muted-override": "var(--muted-foreground)",
-  "--trees-focus-ring-color-override": "var(--ring)",
-  "--trees-selected-bg-override": "var(--muted)",
-  "--trees-selected-fg-override": "var(--foreground)",
-  "--trees-selected-focused-border-color-override": "var(--ring)",
-} as CSSProperties;
+function projectFilesTreeStyle(heightPx: number): CSSProperties {
+  return {
+    height: `${heightPx}px`,
+    minHeight: `${heightPx}px`,
+    backgroundColor: "transparent",
+    color: "var(--foreground)",
+    borderColor: "var(--border)",
+    "--trees-bg-override": "var(--background)",
+    "--trees-bg-muted-override": "var(--muted)",
+    "--trees-border-color-override": "var(--border)",
+    "--trees-fg-override": "var(--foreground)",
+    "--trees-fg-muted-override": "var(--muted-foreground)",
+    "--trees-focus-ring-color-override": "var(--ring)",
+    "--trees-selected-bg-override": "var(--muted)",
+    "--trees-selected-fg-override": "var(--foreground)",
+    "--trees-selected-focused-border-color-override": "var(--ring)",
+  } as CSSProperties;
+}
 
 function formatNullableDate(value: string | null | undefined) {
   if (!value) return null;
@@ -63,20 +69,35 @@ export function ProjectFilesTree({
   ariaLabel?: string;
 }) {
   const paths = useMemo(() => files.map((file) => file.sourcePath), [files]);
+  const pathsKey = paths.join("\0");
   const fileByPath = useMemo(() => new Map(files.map((file) => [file.sourcePath, file])), [files]);
   const selectedPaths =
     selectedSourcePath && fileByPath.has(selectedSourcePath) ? [selectedSourcePath] : [];
   const latestStateRef = useRef({ fileByPath, onSelectFile });
+  const preloadedData = useMemo(
+    () =>
+      paths.length > 0
+        ? preloadFileTree({
+            id: "project-files-tree",
+            initialExpansion: "open",
+            paths,
+            initialVisibleRowCount: Math.max(paths.length, 8),
+          })
+        : null,
+    [pathsKey, paths],
+  );
 
   useEffect(() => {
     latestStateRef.current = { fileByPath, onSelectFile };
   }, [fileByPath, onSelectFile]);
 
   const { model } = useFileTree({
+    id: "project-files-tree",
     density: "compact",
     flattenEmptyDirectories: true,
     initialExpansion: "open",
     initialSelectedPaths: selectedPaths,
+    initialVisibleRowCount: Math.max(paths.length, 8),
     paths,
     renderRowDecoration: (context: FileTreeRowDecorationContext) => {
       if (context.item.kind !== "file") {
@@ -118,12 +139,20 @@ export function ProjectFilesTree({
     model.scrollToPath(selectedSourcePath, { offset: "nearest" });
   }, [fileByPath, model, selectedSourcePath]);
 
+  if (paths.length === 0) {
+    return null;
+  }
+
   return (
-    <PierreFileTree
-      aria-label={ariaLabel}
-      className="h-full min-h-80 border-0 bg-transparent"
-      model={model}
-      style={projectFilesTreeStyle}
-    />
+    <div className="w-full" style={{ height: TREE_HEIGHT_PX }}>
+      <PierreFileTree
+        aria-label={ariaLabel}
+        className="size-full border-0 bg-transparent"
+        id="project-files-tree"
+        model={model}
+        preloadedData={preloadedData ?? undefined}
+        style={projectFilesTreeStyle(TREE_HEIGHT_PX)}
+      />
+    </div>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/cat/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/cat/page.tsx
@@ -1,0 +1,29 @@
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
+
+import { ProjectFileCatPageContent } from "../_components/project-file-cat-page-content";
+
+export default async function ProjectFileCatPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ organizationSlug: string; projectId: string }>;
+  searchParams: Promise<{
+    sourcePath?: string;
+    locale?: string;
+    segment?: string;
+  }>;
+}) {
+  const { organizationSlug, projectId } = await params;
+  const { sourcePath, locale, segment } = await searchParams;
+  await requireAppAuthContext({ organizationSlug });
+
+  return (
+    <ProjectFileCatPageContent
+      organizationSlug={organizationSlug}
+      projectId={projectId}
+      sourcePath={sourcePath ?? null}
+      highlightLocale={locale ?? null}
+      initialSegmentKey={segment ?? null}
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { createProjectFileRecord } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files.fixture";
+
+import { buildProjectFileCatHref, canOpenProjectFileCat } from "./project-file-cat-routing";
+
+describe("canOpenProjectFileCat", () => {
+  it("allows provider files supported by the live CAT workspace", () => {
+    expect(
+      canOpenProjectFileCat(
+        createProjectFileRecord({
+          origin: "provider",
+          storedFileId: null,
+          provider: {
+            kind: "crowdin",
+            resourceType: "file",
+            externalProjectId: "project_website",
+            externalResourceId: "file_home_json",
+            externalUrl: null,
+            syncState: "synced",
+            sourceLocale: "en",
+            targetLocales: ["fr-FR"],
+            localeReadiness: {},
+            revision: "1",
+            format: "json",
+            lastSyncedAt: new Date().toISOString(),
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("allows native files with a stored file id", () => {
+    expect(canOpenProjectFileCat(createProjectFileRecord())).toBe(true);
+  });
+
+  it("rejects native files without a stored file id", () => {
+    expect(
+      canOpenProjectFileCat(
+        createProjectFileRecord({
+          storedFileId: null,
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("buildProjectFileCatHref", () => {
+  it("builds provider CAT hrefs with locale and source path", () => {
+    const file = createProjectFileRecord({
+      origin: "provider",
+      sourcePath: "crowdin/home.json",
+      storedFileId: null,
+      provider: {
+        kind: "crowdin",
+        resourceType: "file",
+        externalProjectId: "project_website",
+        externalResourceId: "file_home_json",
+        externalUrl: null,
+        syncState: "synced",
+        sourceLocale: "en",
+        targetLocales: ["fr-FR", "de-DE"],
+        localeReadiness: {},
+        revision: "1",
+        format: "json",
+        lastSyncedAt: new Date().toISOString(),
+      },
+    });
+
+    expect(buildProjectFileCatHref("acme", "crowdin:project_website", file, "de-DE")).toBe(
+      "/org/acme/projects/crowdin%3Aproject_website/files/cat?sourcePath=crowdin%2Fhome.json&locale=de-DE",
+    );
+  });
+
+  it("builds native CAT hrefs with source path and optional locale", () => {
+    const file = createProjectFileRecord({
+      sourcePath: "marketing/home.json",
+    });
+
+    expect(buildProjectFileCatHref("acme", "project_website", file, "fr-FR")).toBe(
+      "/org/acme/projects/project_website/files/cat?sourcePath=marketing%2Fhome.json&locale=fr-FR",
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.ts
@@ -1,0 +1,45 @@
+import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+import { supportsProviderCatFile } from "@/lib/providers/provider-cat-capabilities";
+
+export function canOpenProjectFileCat(file: ProjectFileRecord) {
+  if (file.provider) {
+    return supportsProviderCatFile(file);
+  }
+
+  return Boolean(file.storedFileId);
+}
+
+function resolveProjectFileTargetLocale(file: ProjectFileRecord, highlightLocale: string | null) {
+  if (file.provider) {
+    if (highlightLocale && file.provider.targetLocales.includes(highlightLocale)) {
+      return highlightLocale;
+    }
+
+    return file.provider.targetLocales[0] ?? null;
+  }
+
+  return highlightLocale;
+}
+
+export function buildProjectFileCatHref(
+  organizationSlug: string,
+  projectId: string,
+  file: ProjectFileRecord,
+  highlightLocale: string | null = null,
+) {
+  if (!canOpenProjectFileCat(file)) {
+    return null;
+  }
+
+  const params = new URLSearchParams({
+    sourcePath: file.sourcePath,
+  });
+
+  const targetLocale = resolveProjectFileTargetLocale(file, highlightLocale);
+  if (targetLocale) {
+    params.set("locale", targetLocale);
+  }
+
+  const base = `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/files/cat`;
+  return `${base}?${params.toString()}`;
+}


### PR DESCRIPTION
## What changed

The project Files page no longer shows a source content preview pane. It now uses a full-width file tree, and selecting a file reveals a **View strings** action that opens the CAT workspace via a new `/files/cat` route.

## How to test

- Open a project Files page and confirm the tree uses the full width with no preview pane
- Select a supported file and click **View strings**
- Confirm the CAT workspace opens at `/files/cat?sourcePath=...`
- Run `cd apps/hyperlocalise-web && vp test src/lib/projects/project-file-cat-routing.test.ts`
- Run `cd apps/hyperlocalise-web && vp check`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)