### PR TITLE
feat(cat): lazy load agent context

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -54,7 +54,10 @@ import {
   listFilteredProjectFiles,
 } from "@/lib/projects/files/project-file-service";
 import { enqueueSourceFileIngestAfterUpload } from "@/lib/projects/files/source-file-ingest";
-import { lookupProjectFileStringRepositoryContext } from "@/lib/projects/string-context/project-string-context-service";
+import {
+  lookupCachedProjectFileStringRepositoryContext,
+  lookupProjectFileStringRepositoryContext,
+} from "@/lib/projects/string-context/project-string-context-service";
 import {
   getRepositorySourceFileByPath,
   loadProjectTranslationsAsPrefilledEntries,
@@ -1288,6 +1291,43 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           return providerProjectUnavailableResponse(c, target);
         }
 
+        if (body.cachedOnly) {
+          const result = await lookupCachedProjectFileStringRepositoryContext({
+            organizationId: c.var.auth.organization.localOrganizationId,
+            projectId: params.projectId,
+            repositoryFullName: body.repositoryFullName ?? null,
+            sourcePath: body.sourcePath,
+            key: body.key,
+            text: body.text,
+          });
+
+          if (isErr(result)) {
+            stringContextRouteLogger.warn(
+              {
+                organizationId: c.var.auth.organization.localOrganizationId,
+                projectId: params.projectId,
+                stringKey: body.key,
+                code: result.error.code,
+              },
+              "project file string context lookup rejected",
+            );
+            return badRequestResponse(c, result.error.code, result.error.message);
+          }
+
+          stringContextRouteLogger.debug(
+            {
+              organizationId: c.var.auth.organization.localOrganizationId,
+              projectId: params.projectId,
+              stringKey: body.key,
+              cached: result.value.cached,
+              summaryLength: result.value.summary?.length ?? 0,
+            },
+            "project file string context lookup served",
+          );
+
+          return c.json({ stringContext: result.value }, 200);
+        }
+
         const result = await lookupProjectFileStringRepositoryContext({
           organizationId: c.var.auth.organization.localOrganizationId,
           projectId: params.projectId,
@@ -1322,7 +1362,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
             projectId: params.projectId,
             stringKey: body.key,
             cached: result.value.cached,
-            summaryLength: result.value.summary.length,
+            summaryLength: result.value.summary?.length ?? 0,
           },
           "project file string context lookup served",
         );

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -315,12 +315,13 @@ export const projectFileStringContextBodySchema = z.object({
   key: z.string().trim().min(1).max(2048),
   text: z.string().trim().max(16_384),
   context: z.string().trim().max(16_384).nullable().optional(),
+  cachedOnly: z.boolean().optional(),
   forceRefresh: z.boolean().optional(),
 });
 
 export const projectFileStringContextResponseSchema = z.object({
   stringContext: z.object({
-    summary: z.string(),
+    summary: z.string().nullable(),
     cached: z.boolean(),
   }),
 });

--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-panel.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-panel.test.tsx
@@ -115,4 +115,10 @@ describe("CatEditorPanel UI", () => {
     expect(screen.getByText("Length on mobile")).toBeInTheDocument();
     expect(screen.getByText("Translation exceeds 80 characters.")).toBeInTheDocument();
   });
+
+  it("shows the segment key above the source heading", () => {
+    renderEditorPanel();
+
+    expect(screen.getByText("dashboard.reviews.pending.card")).toBeInTheDocument();
+  });
 });

--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-panel.tsx
@@ -130,6 +130,7 @@ export function CatEditorPanel({
           <CatEditorSourceSection
             sourceText={segment.sourceText}
             sourceLocale={segment.sourceLocale}
+            segmentKey={segment.key}
           />
 
           <CatEditorTargetSection

--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-source-section.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-source-section.tsx
@@ -9,18 +9,28 @@ import { CatMessagePreview } from "./cat-target-editor";
 export function CatEditorSourceSection({
   sourceText,
   sourceLocale,
+  segmentKey,
 }: {
   sourceText: string;
   sourceLocale: string;
+  segmentKey: string;
 }) {
   return (
     <section className="space-y-3">
-      <h3 className="text-xs font-medium text-muted-foreground">
-        <FormattedMessage
-          {...catEditorPanelMessages.sourceHeading}
-          values={{ locale: sourceLocale }}
-        />
-      </h3>
+      <div className="space-y-1">
+        <p
+          className="truncate font-mono text-[11px] leading-5 text-muted-foreground"
+          title={segmentKey}
+        >
+          {segmentKey}
+        </p>
+        <h3 className="text-xs font-medium text-muted-foreground">
+          <FormattedMessage
+            {...catEditorPanelMessages.sourceHeading}
+            values={{ locale: sourceLocale }}
+          />
+        </h3>
+      </div>
       <p className="text-pretty text-base leading-relaxed text-foreground/92 lg:text-lg">
         <CatMessagePreview message={sourceText} />
       </p>

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.tsx
@@ -5,7 +5,7 @@ import {
   BulbIcon,
   AlertCircleIcon,
   CheckmarkCircle02Icon,
-  InformationCircleIcon,
+  RefreshIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -27,7 +27,10 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/primitives/cn";
 
-import { catIntelligencePanelMessages } from "@/components/cat/shared/cat.messages";
+import {
+  catEditorPanelMessages,
+  catIntelligencePanelMessages,
+} from "@/components/cat/shared/cat.messages";
 import type {
   CatGlossaryTerm,
   CatSegmentIntelligence,
@@ -39,34 +42,23 @@ import { containsGlossaryTerm } from "./cat-glossary-checks";
 import { requiresLowMatchConfirmation } from "./tm-match-quality";
 import { CatVisualContextPanel } from "./cat-visual-context-panel";
 
-function PanelSection({ title, children }: { title: string; children: ReactNode }) {
-  return (
-    <section className="space-y-3">
-      <h3 className="text-xs font-medium text-muted-foreground">{title}</h3>
-      {children}
-    </section>
-  );
-}
-
-function InsightCard({
-  icon,
-  label,
+function PanelSection({
+  title,
+  action,
   children,
 }: {
-  icon: ReactNode;
-  label: string;
+  title: string;
+  action?: ReactNode;
   children: ReactNode;
 }) {
   return (
-    <div className="rounded-2xl bg-foreground/3 p-3.5">
-      <div className="mb-2 flex items-center gap-2 text-xs font-medium text-muted-foreground">
-        <span className="flex size-6 items-center justify-center rounded-full bg-background text-foreground/70">
-          {icon}
-        </span>
-        {label}
+    <section className="space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="text-xs font-medium text-muted-foreground">{title}</h3>
+        {action}
       </div>
       {children}
-    </div>
+    </section>
   );
 }
 
@@ -219,6 +211,7 @@ export function CatIntelligencePanel({
   showAgentContext = false,
   showVisualContext = false,
   canEditTranslations = true,
+  onRefreshContext,
   onUseTmMatch,
   onUseGlossaryTerm,
 }: {
@@ -230,6 +223,7 @@ export function CatIntelligencePanel({
   showAgentContext?: boolean;
   showVisualContext?: boolean;
   canEditTranslations?: boolean;
+  onRefreshContext?: () => void;
   onUseTmMatch?: (match: CatTranslationMemoryMatch) => void;
   onUseGlossaryTerm?: (term: CatGlossaryTerm) => void;
 }) {
@@ -303,35 +297,45 @@ export function CatIntelligencePanel({
           {showAgentContext ? (
             <PanelSection
               title={intl.formatMessage(catIntelligencePanelMessages.agentContextTitle)}
+              action={
+                hasAgentInsight && onRefreshContext ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="-mr-2 size-8 p-0 text-muted-foreground hover:text-foreground"
+                    onClick={onRefreshContext}
+                    disabled={isLookingUpContext}
+                    title={intl.formatMessage(catEditorPanelMessages.refreshContextTitle)}
+                    aria-label={intl.formatMessage(catEditorPanelMessages.refreshContextTitle)}
+                  >
+                    <HugeiconsIcon icon={RefreshIcon} className="size-4" strokeWidth={1.8} />
+                  </Button>
+                ) : null
+              }
             >
               {isLookingUpContext ? (
                 <AgentContextSkeleton />
               ) : hasAgentContext ? (
                 <div className="space-y-3">
                   {hasAgentInsight ? (
-                    <InsightCard
-                      label={intl.formatMessage(catIntelligencePanelMessages.meaningInProduct)}
-                      icon={<HugeiconsIcon icon={InformationCircleIcon} className="size-3.5" />}
-                    >
-                      <div className="min-h-[1.25rem] space-y-2">
+                    <div className="min-h-[1.25rem] space-y-2">
+                      <MarkdownContent
+                        value={intelligence.agentContext ?? ""}
+                        contentClassName="min-h-[1.25rem] px-0 py-0 text-sm leading-relaxed text-foreground/88"
+                        ariaLabel={intl.formatMessage(
+                          catIntelligencePanelMessages.agentContextAria,
+                        )}
+                      />
+                      {intelligence.intent ? (
                         <MarkdownContent
-                          value={intelligence.agentContext ?? ""}
-                          contentClassName="min-h-[1.25rem] px-0 py-0 text-sm leading-relaxed text-foreground/88"
+                          value={intelligence.intent}
+                          contentClassName="min-h-[1rem] px-0 py-0 text-xs leading-relaxed text-muted-foreground"
                           ariaLabel={intl.formatMessage(
-                            catIntelligencePanelMessages.agentContextAria,
+                            catIntelligencePanelMessages.translationIntentAria,
                           )}
                         />
-                        {intelligence.intent ? (
-                          <MarkdownContent
-                            value={intelligence.intent}
-                            contentClassName="min-h-[1rem] px-0 py-0 text-xs leading-relaxed text-muted-foreground"
-                            ariaLabel={intl.formatMessage(
-                              catIntelligencePanelMessages.translationIntentAria,
-                            )}
-                          />
-                        ) : null}
-                      </div>
-                    </InsightCard>
+                      ) : null}
+                    </div>
                   ) : null}
                   {agentBadges.length > 0 ? (
                     <div className="flex flex-wrap gap-1.5">

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.tsx
@@ -236,7 +236,9 @@ export function CatIntelligencePanel({
     intelligence.filePath,
   ].filter(Boolean);
   const hasAgentInsight = Boolean(intelligence.agentContext?.trim());
+  const hasAttemptedAgentLookup = intelligence.agentContext !== undefined;
   const hasAgentContext = hasAgentInsight || agentBadges.length > 0;
+  const canRefreshAgentContext = hasAttemptedAgentLookup && onRefreshContext;
 
   function handleUseTmMatch(match: CatTranslationMemoryMatch) {
     if (!onUseTmMatch) {
@@ -298,7 +300,7 @@ export function CatIntelligencePanel({
             <PanelSection
               title={intl.formatMessage(catIntelligencePanelMessages.agentContextTitle)}
               action={
-                hasAgentInsight && onRefreshContext ? (
+                canRefreshAgentContext ? (
                   <Button
                     type="button"
                     variant="ghost"

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
@@ -312,7 +312,10 @@ export function ProjectFileCatWorkspace({
   }, []);
 
   const lookupSegmentContext = useCallback(
-    async (segment: CatSegment) => {
+    async (
+      segment: CatSegment,
+      options?: { cachedOnly?: boolean; forceRefresh?: boolean },
+    ): Promise<string | null> => {
       if (!repositoryFullName) {
         throw new Error("Select a GitHub repository before looking up string context.");
       }
@@ -327,6 +330,8 @@ export function ProjectFileCatWorkspace({
           key: segment.key,
           text: segment.sourceText,
           context: segment.contextLabel ?? null,
+          ...(options?.cachedOnly ? { cachedOnly: true } : {}),
+          ...(options?.forceRefresh ? { forceRefresh: true } : {}),
         },
       });
 
@@ -334,7 +339,7 @@ export function ProjectFileCatWorkspace({
         throw new Error(await readApiError(response, "Failed to look up repository context"));
       }
 
-      const body = (await response.json()) as { stringContext: { summary: string } };
+      const body = (await response.json()) as { stringContext: { summary: string | null } };
       return body.stringContext.summary;
     },
     [organizationSlug, projectId, repositoryFullName, sourcePath],

--- a/apps/hyperlocalise-web/src/components/cat/segment/cat-segment-status.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/segment/cat-segment-status.test.tsx
@@ -1,0 +1,16 @@
+// @vitest-environment happy-dom
+
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+
+import { renderWithCatProviders } from "@/components/cat/shared/cat-test-utils";
+
+import { QueueStatusDot } from "./cat-segment-status";
+
+describe("QueueStatusDot", () => {
+  it("uses yellow for segments that need review", () => {
+    renderWithCatProviders(<QueueStatusDot status="needs_review" />);
+
+    expect(screen.getByRole("img", { name: /Needs review/i })).toHaveClass("bg-beam-700");
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/segment/cat-segment-status.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/segment/cat-segment-status.test.tsx
@@ -5,12 +5,20 @@ import { describe, expect, it } from "vite-plus/test";
 
 import { renderWithCatProviders } from "@/components/cat/shared/cat-test-utils";
 
-import { QueueStatusDot } from "./cat-segment-status";
+import { QueueStatusDot, SegmentStatusBadge } from "./cat-segment-status";
 
 describe("QueueStatusDot", () => {
   it("uses yellow for segments that need review", () => {
     renderWithCatProviders(<QueueStatusDot status="needs_review" />);
 
     expect(screen.getByRole("img", { name: /Needs review/i })).toHaveClass("bg-beam-700");
+  });
+});
+
+describe("SegmentStatusBadge", () => {
+  it("uses yellow for segments that need review", () => {
+    renderWithCatProviders(<SegmentStatusBadge status="needs_review" />);
+
+    expect(screen.getByText("Needs review")).toHaveClass("text-beam-100");
   });
 });

--- a/apps/hyperlocalise-web/src/components/cat/segment/cat-segment-status.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/segment/cat-segment-status.tsx
@@ -30,7 +30,7 @@ function queueStatusDotClassName(status: CatSegmentStatus) {
   }
 
   if (status === "needs_review") {
-    return "size-2.5 rounded-full bg-bud-400";
+    return "size-2.5 rounded-full bg-beam-700";
   }
 
   return "size-2.5 rounded-full border border-foreground/25";

--- a/apps/hyperlocalise-web/src/components/cat/segment/cat-segment-status.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/segment/cat-segment-status.tsx
@@ -36,6 +36,14 @@ function queueStatusDotClassName(status: CatSegmentStatus) {
   return "size-2.5 rounded-full border border-foreground/25";
 }
 
+function segmentStatusBadgeClassName(status: CatSegmentStatus) {
+  if (status === "needs_review") {
+    return "border-beam-500/25 bg-beam-500/10 text-beam-100";
+  }
+
+  return catToneClass(segmentStatusTone(status));
+}
+
 export function QueueStatusDot({ status }: { status: CatSegmentStatus }) {
   const intl = useIntl();
   const statusLabel = intl.formatMessage(getSegmentStatusMessage(status));
@@ -53,7 +61,7 @@ export function QueueStatusDot({ status }: { status: CatSegmentStatus }) {
 
 export function SegmentStatusBadge({ status }: { status: CatSegmentStatus }) {
   return (
-    <Badge variant="outline" className={cn(catToneClass(segmentStatusTone(status)))}>
+    <Badge variant="outline" className={cn(segmentStatusBadgeClassName(status))}>
       <FormattedMessage {...getSegmentStatusMessage(status)} />
     </Badge>
   );

--- a/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
@@ -360,11 +360,6 @@ export const catIntelligencePanelMessages = defineMessages({
     id: "obaPDIKyjU",
     description: "Section heading for repository context discovered by an agent",
   },
-  meaningInProduct: {
-    defaultMessage: "Meaning in product",
-    id: "99wOujGZDN",
-    description: "Insight card label for agent-discovered product meaning",
-  },
   agentContextAria: {
     defaultMessage: "Agent context",
     id: "4lhHg5n2pX",
@@ -513,6 +508,11 @@ export const catEditorPanelMessages = defineMessages({
     defaultMessage: "Find context",
     id: "/MBsvL6JVH",
     description: "Button to look up repository context for the current string",
+  },
+  refreshContextTitle: {
+    defaultMessage: "Re-run repository context lookup for this string",
+    id: "746kT0UVrs",
+    description: "Tooltip for refreshing repository context for the current string",
   },
   previous: {
     defaultMessage: "Previous",

--- a/apps/hyperlocalise-web/src/components/cat/shared/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/dependencies.ts
@@ -49,7 +49,7 @@ export interface CatWorkspaceReview {
   ) => void | CatSegmentStatus | Promise<void | CatSegmentStatus>;
   onAddComment?: (segmentId: string, input: CatSegmentCommentInput) => void | Promise<void>;
   onResolveComment?: (segmentId: string, commentId: string) => void | Promise<void>;
-  onAskQuestion: (segmentId: string) => void | Promise<void>;
+  onAskQuestion: (segmentId: string, options?: { forceRefresh?: boolean }) => void | Promise<void>;
   onReviewWithAi: (segmentId: string) => void | Promise<void>;
   onSkip: (segmentId: string) => void;
   onBulkApprove?: (segmentIds: string[]) => void | Promise<void>;
@@ -63,7 +63,10 @@ export interface CatWorkspaceServices {
     glossaryTerms?: CatGlossaryTerm[],
   ) => Promise<CatFormatCheck[]>;
   runQaChecks?: (segment: CatSegment, value: string) => Promise<CatFormatCheck[]>;
-  lookupSegmentContext?: (segment: CatSegment) => Promise<string>;
+  lookupSegmentContext?: (
+    segment: CatSegment,
+    options?: { cachedOnly?: boolean; forceRefresh?: boolean },
+  ) => Promise<string | null>;
   lookupSegmentConcordance?: (segment: CatSegment) => Promise<CatSegmentConcordanceResult>;
   lookupSegmentVisualContext?: (segment: CatSegment) => Promise<CatSegmentVisualContextResult>;
   generateAiRecommendation?: (

--- a/apps/hyperlocalise-web/src/components/cat/shared/types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/types.ts
@@ -82,7 +82,7 @@ export interface CatSegmentIntelligence {
   filePath?: string;
   componentName?: string;
   productMeaning?: string;
-  agentContext?: string;
+  agentContext?: string | null;
   reviewerPreference?: string;
   constraints?: string;
   glossaryTerms: CatGlossaryTerm[];

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.stories.tsx
@@ -4,8 +4,8 @@ import { expect, userEvent, waitFor, within } from "storybook/test";
 
 import { CatWorkspaceContainer } from "./cat-workspace-container";
 import {
+  catIntelligenceFixture,
   catSegmentsFixture,
-  catWorkspaceFixture,
   createCatWorkspaceState,
   mockValidateFormat,
 } from "@/components/cat/shared/cat.fixture";
@@ -31,7 +31,15 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    initialState: catWorkspaceFixture,
+    initialState: createCatWorkspaceState({
+      segmentIntelligence: {
+        "seg-02": {
+          ...catIntelligenceFixture,
+          agentContext:
+            "Cached repository context: this card is rendered in the dashboard overview after a project sync.",
+        },
+      },
+    }),
     navigation: {
       onSelectSegment: fn(),
       onPreviousSegment: fn(),
@@ -48,6 +56,10 @@ export const Default: Story = {
     },
     services: {
       validateFormat: mockValidateFormat,
+      lookupSegmentContext: async (_segment, options) =>
+        options?.forceRefresh
+          ? "Refreshed repository context: the card lives in the dashboard review summary widget."
+          : "Cached repository context: this card is rendered in the dashboard overview after a project sync.",
     },
   },
   play: async ({ canvasElement }) => {
@@ -58,6 +70,19 @@ export const Default: Story = {
     await expect(canvas.getByText("Translation memory")).toBeInTheDocument();
     await expect(
       canvas.getByText("Dashboard card showing how many reviews still need approval."),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByText(
+        "“Review” refers to a human approval step for translated content, not a product rating.",
+      ),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByText(
+        "Cached repository context: this card is rendered in the dashboard overview after a project sync.",
+      ),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", { name: "Re-run repository context lookup for this string" }),
     ).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Approve" })).toBeInTheDocument();
     await expect(canvasElement.querySelectorAll('[data-slot="kbd"]')).toHaveLength(8);

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
@@ -292,6 +292,7 @@ export function CatWorkspaceView({
           showAgentContext={showAgentContext}
           showVisualContext={showVisualContext}
           canEditTranslations={fullState.canEditTranslations !== false}
+          onRefreshContext={() => review.onAskQuestion(selectedSegment.id, { forceRefresh: true })}
           onUseTmMatch={(match) => editing.onUseTmMatch(selectedSegment.id, match)}
           onUseGlossaryTerm={(term) =>
             editing.onUseGlossaryTerm(selectedSegment.id, term, selectedSegment.sourceText)

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.test.tsx
@@ -340,6 +340,52 @@ describe("useCatWorkspaceController", () => {
     });
   });
 
+  it("retries cached agent context lookup when the lookup function changes", async () => {
+    const lookupSegmentContext = vi.fn().mockResolvedValue(null);
+    const nextLookupSegmentContext = vi.fn().mockResolvedValue("Cached context from another repo.");
+    const services = { lookupSegmentContext };
+    const { rerender, store } = renderController(undefined, { services });
+
+    await waitFor(() => expect(lookupSegmentContext).toHaveBeenCalledTimes(1));
+
+    services.lookupSegmentContext = nextLookupSegmentContext;
+    rerender();
+
+    await waitFor(() =>
+      expect(store.segmentIntelligence["seg-02"]?.agentContext).toBe(
+        "Cached context from another repo.",
+      ),
+    );
+    expect(nextLookupSegmentContext).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "seg-02" }),
+      {
+        cachedOnly: true,
+      },
+    );
+  });
+
+  it("stores null from full agent context lookups as an attempted result", async () => {
+    const lookupSegmentContext = vi.fn().mockResolvedValue(null);
+    const nextLookupSegmentContext = vi
+      .fn()
+      .mockResolvedValue("Cached context from the repository.");
+    const services = { lookupSegmentContext };
+    const { result, rerender, store } = renderController(undefined, { services });
+
+    await act(async () => {
+      await result.current.dependencies.review.onAskQuestion("seg-02");
+    });
+
+    expect(store.segmentIntelligence["seg-02"]?.agentContext).toBeNull();
+
+    services.lookupSegmentContext = nextLookupSegmentContext;
+    rerender();
+
+    await Promise.resolve();
+
+    expect(nextLookupSegmentContext).not.toHaveBeenCalled();
+  });
+
   it("refreshes existing agent context when requested", async () => {
     const initialState = createCatWorkspaceState({
       selectedSegmentId: "seg-02",

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.test.tsx
@@ -364,7 +364,7 @@ describe("useCatWorkspaceController", () => {
     );
   });
 
-  it("stores null from full agent context lookups as an attempted result", async () => {
+  it("stores null from full agent context lookups and allows retry", async () => {
     const lookupSegmentContext = vi.fn().mockResolvedValue(null);
     const nextLookupSegmentContext = vi
       .fn()
@@ -381,9 +381,17 @@ describe("useCatWorkspaceController", () => {
     services.lookupSegmentContext = nextLookupSegmentContext;
     rerender();
 
-    await Promise.resolve();
+    await act(async () => {
+      await result.current.dependencies.review.onAskQuestion("seg-02");
+    });
 
-    expect(nextLookupSegmentContext).not.toHaveBeenCalled();
+    expect(nextLookupSegmentContext).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "seg-02" }),
+      { forceRefresh: false },
+    );
+    expect(store.segmentIntelligence["seg-02"]?.agentContext).toBe(
+      "Cached context from the repository.",
+    );
   });
 
   it("refreshes existing agent context when requested", async () => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.test.tsx
@@ -297,11 +297,19 @@ describe("useCatWorkspaceController", () => {
   });
 
   it("reveals agent context after a successful lookup", async () => {
+    const lookupSegmentContext = vi.fn().mockImplementation((_segment, options) => {
+      if (options?.cachedOnly) {
+        return Promise.resolve(null);
+      }
+      return Promise.resolve("Hero title on the sign-in page.");
+    });
     const { result, store } = renderController(undefined, {
       services: {
-        lookupSegmentContext: vi.fn().mockResolvedValue("Hero title on the sign-in page."),
+        lookupSegmentContext,
       },
     });
+
+    await waitFor(() => expect(store.segmentFormatChecks["seg-02"]?.length).toBeGreaterThan(0));
 
     await act(async () => {
       await result.current.dependencies.review.onAskQuestion("seg-02");
@@ -313,10 +321,62 @@ describe("useCatWorkspaceController", () => {
     );
   });
 
+  it("lazy-loads cached agent context for the selected segment", async () => {
+    const lookupSegmentContext = vi.fn().mockResolvedValue("Cached context from the repository.");
+    const { store } = renderController(undefined, {
+      services: {
+        lookupSegmentContext,
+      },
+    });
+
+    await waitFor(() =>
+      expect(store.segmentIntelligence["seg-02"]?.agentContext).toBe(
+        "Cached context from the repository.",
+      ),
+    );
+    expect(store.revealedAgentContextSegmentIds.has("seg-02")).toBe(true);
+    expect(lookupSegmentContext).toHaveBeenCalledWith(expect.objectContaining({ id: "seg-02" }), {
+      cachedOnly: true,
+    });
+  });
+
+  it("refreshes existing agent context when requested", async () => {
+    const initialState = createCatWorkspaceState({
+      selectedSegmentId: "seg-02",
+      segmentIntelligence: {
+        "seg-02": {
+          ...createCatWorkspaceState().intelligence,
+          agentContext: "Old context.",
+        },
+      },
+    });
+    const lookupSegmentContext = vi.fn().mockResolvedValue("Updated context.");
+    const { result, store } = renderController(initialState, {
+      services: {
+        lookupSegmentContext,
+      },
+    });
+
+    await act(async () => {
+      await result.current.dependencies.review.onAskQuestion("seg-02", { forceRefresh: true });
+    });
+
+    expect(lookupSegmentContext).toHaveBeenCalledWith(expect.objectContaining({ id: "seg-02" }), {
+      forceRefresh: true,
+    });
+    expect(store.segmentIntelligence["seg-02"]?.agentContext).toBe("Updated context.");
+  });
+
   it("records context lookup failures as format checks", async () => {
+    const lookupSegmentContext = vi.fn().mockImplementation((_segment, options) => {
+      if (options?.cachedOnly) {
+        return Promise.resolve(null);
+      }
+      return Promise.reject(new Error("Repository not selected."));
+    });
     const { result, store } = renderController(undefined, {
       services: {
-        lookupSegmentContext: vi.fn().mockRejectedValue(new Error("Repository not selected.")),
+        lookupSegmentContext,
       },
     });
 
@@ -326,13 +386,15 @@ describe("useCatWorkspaceController", () => {
       await result.current.dependencies.review.onAskQuestion("seg-02");
     });
 
-    expect(store.segmentFormatChecks["seg-02"]).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          id: "context-lookup-failed-seg-02",
-          message: "Repository not selected.",
-        }),
-      ]),
+    await waitFor(() =>
+      expect(store.segmentFormatChecks["seg-02"]).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "context-lookup-failed-seg-02",
+            message: "Repository not selected.",
+          }),
+        ]),
+      ),
     );
   });
 });

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.ts
@@ -389,6 +389,10 @@ export function useCatWorkspaceController({
   const cachedContextLookupAttemptedRef = useRef(new Set<string>());
 
   useEffect(() => {
+    cachedContextLookupAttemptedRef.current.clear();
+  }, [lookupSegmentContext]);
+
+  useEffect(() => {
     const segmentId = store.selectedSegmentId;
     if (!segmentId || !lookupSegmentContext) {
       return;
@@ -399,8 +403,11 @@ export function useCatWorkspaceController({
       return;
     }
 
-    const existingAgentContext = store.segmentIntelligence[segmentId]?.agentContext?.trim();
-    if (existingAgentContext || cachedContextLookupAttemptedRef.current.has(segmentId)) {
+    const existingAgentContext = store.segmentIntelligence[segmentId]?.agentContext;
+    if (
+      existingAgentContext !== undefined ||
+      cachedContextLookupAttemptedRef.current.has(segmentId)
+    ) {
       return;
     }
 
@@ -659,9 +666,9 @@ export function useCatWorkspaceController({
           return;
         }
 
-        const existingAgentContext = store.segmentIntelligence[segmentId]?.agentContext?.trim();
+        const existingAgentContext = store.segmentIntelligence[segmentId]?.agentContext;
         store.revealAgentContext(segmentId);
-        if (existingAgentContext && !options?.forceRefresh) {
+        if (existingAgentContext !== undefined && !options?.forceRefresh) {
           return;
         }
 
@@ -671,7 +678,7 @@ export function useCatWorkspaceController({
             forceRefresh: options?.forceRefresh === true,
           });
           store.removeFormatCheck(segmentId, `context-lookup-failed-${segmentId}`);
-          store.mergeSegmentIntelligence(segmentId, { agentContext: agentContext ?? "" });
+          store.mergeSegmentIntelligence(segmentId, { agentContext });
         } catch (error) {
           const message =
             error instanceof Error

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.ts
@@ -386,6 +386,44 @@ export function useCatWorkspaceController({
     void runSegmentReviewRef.current(segmentId, { includeAi: false });
   }, [canRunSegmentReview, store.selectedSegmentId]);
 
+  const cachedContextLookupAttemptedRef = useRef(new Set<string>());
+
+  useEffect(() => {
+    const segmentId = store.selectedSegmentId;
+    if (!segmentId || !lookupSegmentContext) {
+      return;
+    }
+
+    const segment = store.segments.find((item) => item.id === segmentId);
+    if (!segment) {
+      return;
+    }
+
+    const existingAgentContext = store.segmentIntelligence[segmentId]?.agentContext?.trim();
+    if (existingAgentContext || cachedContextLookupAttemptedRef.current.has(segmentId)) {
+      return;
+    }
+
+    cachedContextLookupAttemptedRef.current.add(segmentId);
+
+    let cancelled = false;
+    void lookupSegmentContext(segment, { cachedOnly: true })
+      .then((agentContext) => {
+        if (cancelled || !agentContext?.trim()) {
+          return;
+        }
+
+        store.mergeSegmentIntelligence(segmentId, { agentContext });
+        store.revealAgentContext(segmentId);
+        store.removeFormatCheck(segmentId, `context-lookup-failed-${segmentId}`);
+      })
+      .catch(() => undefined);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [lookupSegmentContext, store, store.selectedSegmentId]);
+
   useEffect(() => {
     const segmentId = store.selectedSegmentId;
     if (!segmentId || !lookupSegmentVisualContext || !canLoadVisualContext) {
@@ -610,8 +648,8 @@ export function useCatWorkspaceController({
           store.resolvingCommentId = null;
         }
       },
-      onAskQuestion: async (segmentId: string) => {
-        await onAskQuestion?.(segmentId);
+      onAskQuestion: async (segmentId: string, options?: { forceRefresh?: boolean }) => {
+        await onAskQuestion?.(segmentId, options);
         if (!lookupSegmentContext) {
           return;
         }
@@ -623,15 +661,17 @@ export function useCatWorkspaceController({
 
         const existingAgentContext = store.segmentIntelligence[segmentId]?.agentContext?.trim();
         store.revealAgentContext(segmentId);
-        if (existingAgentContext) {
+        if (existingAgentContext && !options?.forceRefresh) {
           return;
         }
 
         store.isLookingUpContext = true;
         try {
-          const agentContext = await lookupSegmentContext(segment);
+          const agentContext = await lookupSegmentContext(segment, {
+            forceRefresh: options?.forceRefresh === true,
+          });
           store.removeFormatCheck(segmentId, `context-lookup-failed-${segmentId}`);
-          store.mergeSegmentIntelligence(segmentId, { agentContext });
+          store.mergeSegmentIntelligence(segmentId, { agentContext: agentContext ?? "" });
         } catch (error) {
           const message =
             error instanceof Error

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.ts
@@ -668,7 +668,7 @@ export function useCatWorkspaceController({
 
         const existingAgentContext = store.segmentIntelligence[segmentId]?.agentContext;
         store.revealAgentContext(segmentId);
-        if (existingAgentContext !== undefined && !options?.forceRefresh) {
+        if (Boolean(existingAgentContext?.trim()) && !options?.forceRefresh) {
           return;
         }
 

--- a/apps/hyperlocalise-web/src/lib/projects/string-context/project-string-context-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/string-context/project-string-context-service.ts
@@ -474,6 +474,53 @@ export class ProjectStringContextService extends ProjectServiceBase {
       }
     }
   }
+
+  async lookupCached(input: {
+    organizationId: string;
+    projectId: string;
+    repositoryFullName: string | null;
+    sourcePath: string;
+    key: string;
+    text: string;
+  }): Promise<Result<{ summary: string | null; cached: true }, ProjectFileStringContextError>> {
+    const log = this.log.child({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      stringKey: input.key,
+    });
+    log.debug("project file string cached context lookup started");
+
+    const repositoryResult = await this.resolveRepositoryFullName({
+      organizationId: input.organizationId,
+      repositoryFullName: input.repositoryFullName,
+    });
+    if (isErr(repositoryResult)) {
+      log.warn(
+        { code: repositoryResult.error.code },
+        "project file string cached context repository resolution failed",
+      );
+      return repositoryResult;
+    }
+
+    const summary = await this.getCached({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      sourcePath: input.sourcePath,
+      stringKey: input.key,
+      repositoryFullName: repositoryResult.value,
+      sourceText: input.text,
+    });
+
+    log.debug(
+      {
+        cached: summary !== null,
+        summaryLength: summary?.length ?? 0,
+      },
+      "project file string cached context lookup completed",
+    );
+
+    return ok({ summary, cached: true });
+  }
 }
 
 export const projectStringContextService = new ProjectStringContextService();
@@ -500,3 +547,7 @@ export const resolveProjectFileStringRepositoryFullName = (
 export const lookupProjectFileStringRepositoryContext = (
   input: Parameters<ProjectStringContextService["lookup"]>[0],
 ) => projectStringContextService.lookup(input);
+
+export const lookupCachedProjectFileStringRepositoryContext = (
+  input: Parameters<ProjectStringContextService["lookupCached"]>[0],
+) => projectStringContextService.lookupCached(input);


### PR DESCRIPTION
## What changed

- Lazy-load cached agent context for the selected CAT segment instead of hydrating it in bulk.
- Add an explicit refresh action in the agent context panel to re-run repository lookup when needed.
- Show segment keys above source text and make needs-review queue dots yellow.

## How to test

- `vp test src/components/cat/segment/cat-segment-status.test.tsx src/components/cat/workspace/use-cat-workspace-controller.test.tsx src/components/cat/editor/cat-editor-panel.test.tsx`
- `vp check --fix` (passes with existing unrelated project-files story warnings)
- Full `vp test` was attempted but is blocked locally by an unrelated DB schema mismatch: `crowdin_user_connections.auth_mode` is missing.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)