### PR TITLE
fix(web): rename visual context label

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -1088,7 +1088,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           return badRequestResponse(
             c,
             "visual_context_unavailable",
-            "In-context preview is only available for connected TMS provider projects.",
+            "Visual Context is only available for connected TMS provider projects.",
           );
         }
 

--- a/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
@@ -719,7 +719,7 @@ export const catEditorPanelMessages = defineMessages({
 export const catVisualContextPanelMessages = defineMessages({
   title: {
     defaultMessage: "Visual Context",
-    id: "2W3toA+qRz",
+    id: "tJeeSJ6Rq1",
     description: "Section heading for TMS screenshot context in the CAT intelligence panel",
   },
   description: {

--- a/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
@@ -718,7 +718,7 @@ export const catEditorPanelMessages = defineMessages({
 
 export const catVisualContextPanelMessages = defineMessages({
   title: {
-    defaultMessage: "In-context preview",
+    defaultMessage: "Visual Context",
     id: "2W3toA+qRz",
     description: "Section heading for TMS screenshot context in the CAT intelligence panel",
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Renamed the CAT visual context panel title from "In-context preview" to "Visual Context" and aligned the matching unavailable-provider error message with the same feature name.

## How to test

- `vp test` — passed, 396 files / 2225 tests.
- `vp check --fix` — passed with 0 errors; reported 3 pre-existing `typescript(no-floating-promises)` warnings in unrelated project file Storybook stories.
- `rg "In-context preview" /workspace` — no matches.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-510b718d-c64b-4c52-9b1d-45b6de4eb799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-510b718d-c64b-4c52-9b1d-45b6de4eb799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

