### PR TITLE
refactor(app-shell): wire MobX shell hooks

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { TypographyP } from "@/components/ui/typography";
 import { ProjectFileCatWorkspace } from "@/components/cat/project-file/project-file-cat-workspace";
+import { useAppShellSidebar } from "@/components/app-shell/store/use-app-shell-sidebar";
 import { supportsProviderCatFile } from "@/lib/providers/provider-cat-capabilities";
 
 import { ProjectPageShell } from "../../_components/project-page-shell";
@@ -35,6 +36,7 @@ export function ProjectFileCatPageContent({
     queryFn: () => fetchProjectFiles(organizationSlug, projectId),
     enabled: Boolean(sourcePath),
   });
+  useAppShellSidebar({ forceCollapsed: Boolean(sourcePath) });
 
   if (!sourcePath) {
     return (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
@@ -36,7 +36,10 @@ export function ProjectFileCatPageContent({
     queryFn: () => fetchProjectFiles(organizationSlug, projectId),
     enabled: Boolean(sourcePath),
   });
-  useAppShellSidebar({ forceCollapsed: Boolean(sourcePath) });
+  useAppShellSidebar({
+    forceCollapsed: Boolean(sourcePath),
+    preferredOpen: sourcePath ? false : null,
+  });
 
   if (!sourcePath) {
     return (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-content.tsx
@@ -179,7 +179,7 @@ export function NativeJobDetailContent({
   const translateAction = job && isProviderBackedJob(job) ? providerTranslateAction(job) : null;
   useAppShellBreadcrumbAppend({
     id: "job-detail",
-    label: layout?.title ?? jobId,
+    label: layout?.title,
   });
 
   const headerActions = job ? (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-content.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useAppShellBreadcrumbAppend } from "@/components/app-shell/store/use-app-shell-breadcrumb";
 import { apiClient } from "@/lib/api-client-instance";
 import { buildJobCatHref, canOpenJobCat } from "@/lib/projects/job-cat-routing";
 
@@ -176,6 +177,10 @@ export function NativeJobDetailContent({
       ? (getProviderPayloadString(job.externalProviderPayload, "description") ?? "")
       : "";
   const translateAction = job && isProviderBackedJob(job) ? providerTranslateAction(job) : null;
+  useAppShellBreadcrumbAppend({
+    id: "job-detail",
+    label: layout?.title ?? jobId,
+  });
 
   const headerActions = job ? (
     <>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
@@ -3,6 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
+import { useAppShellBreadcrumbAppend } from "@/components/app-shell/store/use-app-shell-breadcrumb";
 import { apiClient } from "@/lib/api-client-instance";
 import { getJobProviderActionAvailability } from "@/lib/providers/job-provider-actions";
 import type { TmsProviderLiveJobDetail } from "@/lib/providers/tms-provider-live";
@@ -66,6 +67,10 @@ export function ProviderLiveJobDetailContent({
     providerKind: jobQuery.data?.externalProviderKind,
     providerPayload: jobQuery.data?.externalProviderPayload,
     enabled: Boolean(jobQuery.data),
+  });
+  useAppShellBreadcrumbAppend({
+    id: "job-detail",
+    label: jobQuery.data?.externalTitle ?? jobId,
   });
 
   const translateWithAgent = useMutation({

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
@@ -70,7 +70,7 @@ export function ProviderLiveJobDetailContent({
   });
   useAppShellBreadcrumbAppend({
     id: "job-detail",
-    label: jobQuery.data?.externalTitle ?? jobId,
+    label: jobQuery.data?.externalTitle,
   });
 
   const translateWithAgent = useMutation({

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -17,6 +17,7 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import { TypographyP } from "@/components/ui/typography";
 import { apiClient } from "@/lib/api-client-instance";
+import { useAppShellSidebar } from "@/components/app-shell/store/use-app-shell-sidebar";
 import { supportsProviderCatFile } from "@/lib/providers/provider-cat-capabilities";
 
 import { ProjectPageShell } from "../../../../_components/project-page-shell";
@@ -114,6 +115,7 @@ export function JobCatPageContent({
   const taskHref = `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(jobId)}`;
   const hasFileReference = Boolean(sourcePath || storedFileId);
   const isNativeJob = Boolean(storedFileId);
+  useAppShellSidebar({ forceCollapsed: hasFileReference });
   const targetFileQuery = useQuery({
     queryKey: projectJobCatTargetFileQueryKey(
       organizationSlug,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.tsx
@@ -15,6 +15,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { TypographyP } from "@/components/ui/typography";
 import { apiClient } from "@/lib/api-client-instance";
 import { sanitizeExternalUrl } from "@/lib/security/safe-external-url";
+import { useAppShellHeaderAction } from "@/components/app-shell/store/use-app-shell-header-action";
 
 import {
   createProjectFormFromRow,
@@ -175,6 +176,19 @@ export function ProjectSettingsPageContent({
     },
   });
 
+  const isSaving = updateProject.isPending;
+  const settingsEditable = project?.source === "native";
+  useAppShellHeaderAction({
+    id: "project-settings-save",
+    visible: Boolean(settingsEditable),
+    render: () => (
+      <Button type="submit" form="project-settings-form" disabled={isSaving}>
+        {isSaving ? <Spinner /> : <SaveIcon className="size-4" strokeWidth={2} />}
+        {isSaving ? "Saving..." : "Save settings"}
+      </Button>
+    ),
+  });
+
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (!values || !project) return;
@@ -211,9 +225,7 @@ export function ProjectSettingsPageContent({
     );
   }
 
-  const isSaving = updateProject.isPending;
   const localesEditable = project.source === "native";
-  const settingsEditable = project.source === "native";
 
   return (
     <ProjectPageShell>
@@ -224,14 +236,6 @@ export function ProjectSettingsPageContent({
           settingsEditable
             ? "Edit project metadata, translation guidance, locales, and source connection details."
             : "View provider-managed project metadata, locales, and source connection details."
-        }
-        actions={
-          settingsEditable ? (
-            <Button type="submit" form="project-settings-form" disabled={isSaving}>
-              {isSaving ? <Spinner /> : <SaveIcon className="size-4" strokeWidth={2} />}
-              {isSaving ? "Saving..." : "Save settings"}
-            </Button>
-          ) : null
         }
       />
 

--- a/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-hooks.test.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-hooks.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { isValidElement, type ReactNode } from "react";
-import { act, render, waitFor } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import { Chat01Icon } from "@hugeicons/core-free-icons";
 import { describe, expect, it, vi } from "vite-plus/test";
 
@@ -152,6 +152,42 @@ describe("app shell page hooks", () => {
     );
   });
 
+  it("skips breadcrumb appends until a label is available", async () => {
+    const storeRef: { current: AppShellStore | null } = { current: null };
+    const baseBreadcrumbs = [{ label: "Jobs", href: "/org/acme/projects/proj_1/jobs" }];
+
+    function BreadcrumbAppendDemo({ label }: { label?: string }) {
+      useAppShellBreadcrumbAppend({
+        id: "job-name",
+        label,
+      });
+      return null;
+    }
+
+    const view = render(
+      <AppShellHookTestProvider onStore={(nextStore) => (storeRef.current = nextStore)}>
+        <BreadcrumbAppendDemo />
+      </AppShellHookTestProvider>,
+    );
+
+    await waitFor(() =>
+      expect(storeRef.current?.breadcrumb.applyOverrides(baseBreadcrumbs)).toEqual(baseBreadcrumbs),
+    );
+
+    view.rerender(
+      <AppShellHookTestProvider onStore={(nextStore) => (storeRef.current = nextStore)}>
+        <BreadcrumbAppendDemo label="Translate homepage" />
+      </AppShellHookTestProvider>,
+    );
+
+    await waitFor(() =>
+      expect(storeRef.current?.breadcrumb.applyOverrides(baseBreadcrumbs)).toEqual([
+        { label: "Jobs", href: "/org/acme/projects/proj_1/jobs" },
+        { label: "Translate homepage", href: undefined },
+      ]),
+    );
+  });
+
   it("registers custom navigation and restores route mode on cleanup", async () => {
     const storeRef: { current: AppShellStore | null } = { current: null };
 
@@ -199,7 +235,7 @@ describe("app shell page hooks", () => {
       expect(storeRef.current?.sidebar.preferredOpen).toBe(false);
     });
 
-    act(() => view.unmount());
+    view.unmount();
 
     await waitFor(() => {
       expect(storeRef.current?.sidebar.forceCollapsed).toBe(false);

--- a/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-hooks.test.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-hooks.test.tsx
@@ -1,0 +1,209 @@
+// @vitest-environment happy-dom
+
+import { isValidElement, type ReactNode } from "react";
+import { act, render, waitFor } from "@testing-library/react";
+import { Chat01Icon } from "@hugeicons/core-free-icons";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import type { NavigationGroup } from "@/components/app-shell/navigation-config";
+
+import { AppShellStoreProvider, useAppShellStore } from "./app-shell-store-context";
+import type { AppShellStore } from "./app-shell-store";
+import {
+  useAppShellBreadcrumbAppend,
+  useAppShellBreadcrumbOverride,
+} from "./use-app-shell-breadcrumb";
+import { useAppShellHeaderAction } from "./use-app-shell-header-action";
+import { useAppShellNavigationCustom } from "./use-app-shell-navigation";
+import { useAppShellSidebar } from "./use-app-shell-sidebar";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/org/acme/projects/proj_1/jobs",
+}));
+
+const defaultGroups = [
+  {
+    items: [
+      {
+        label: "Inbox",
+        href: "/org/acme/inbox",
+        icon: Chat01Icon,
+      },
+    ],
+  },
+] as const satisfies readonly NavigationGroup[];
+
+const customGroups = [
+  {
+    label: "Project",
+    items: [
+      {
+        label: "Strings",
+        href: "/org/acme/projects/proj_1/jobs/job_1/strings",
+        icon: Chat01Icon,
+      },
+    ],
+  },
+] as const satisfies readonly NavigationGroup[];
+
+function AppShellHookTestProvider({
+  children,
+  onStore,
+}: {
+  children: ReactNode;
+  onStore: (store: AppShellStore) => void;
+}) {
+  return (
+    <AppShellStoreProvider defaultNavigationGroups={defaultGroups}>
+      <StoreCapture onStore={onStore} />
+      {children}
+    </AppShellStoreProvider>
+  );
+}
+
+function StoreCapture({ onStore }: { onStore: (store: AppShellStore) => void }) {
+  const store = useAppShellStore();
+  onStore(store);
+  return null;
+}
+
+function textFromReactNode(node: ReactNode) {
+  return isValidElement<{ children?: ReactNode }>(node) ? node.props.children : null;
+}
+
+describe("app shell page hooks", () => {
+  it("registers header actions and keeps the render callback fresh", async () => {
+    const storeRef: { current: AppShellStore | null } = { current: null };
+
+    function HeaderActionDemo({ label }: { label: string }) {
+      useAppShellHeaderAction({
+        id: "save",
+        order: 10,
+        render: () => <span>{label}</span>,
+      });
+      return null;
+    }
+
+    const view = render(
+      <AppShellHookTestProvider onStore={(nextStore) => (storeRef.current = nextStore)}>
+        <HeaderActionDemo label="Save" />
+      </AppShellHookTestProvider>,
+    );
+
+    await waitFor(() =>
+      expect(storeRef.current?.headerActions.orderedSlots.map((slot) => slot.id)).toEqual(["save"]),
+    );
+    expect(textFromReactNode(storeRef.current!.headerActions.orderedSlots[0]!.render())).toBe(
+      "Save",
+    );
+
+    view.rerender(
+      <AppShellHookTestProvider onStore={(nextStore) => (storeRef.current = nextStore)}>
+        <HeaderActionDemo label="Saving..." />
+      </AppShellHookTestProvider>,
+    );
+
+    expect(storeRef.current?.headerActions.orderedSlots).toHaveLength(1);
+    expect(textFromReactNode(storeRef.current!.headerActions.orderedSlots[0]!.render())).toBe(
+      "Saving...",
+    );
+
+    view.unmount();
+    await waitFor(() => expect(storeRef.current?.headerActions.orderedSlots).toEqual([]));
+  });
+
+  it("registers breadcrumb overrides and appends with cleanup", async () => {
+    const storeRef: { current: AppShellStore | null } = { current: null };
+    const baseBreadcrumbs = [
+      { label: "Projects", href: "/org/acme/projects" },
+      { label: "proj_1", href: "/org/acme/projects/proj_1" },
+    ];
+
+    function BreadcrumbDemo() {
+      useAppShellBreadcrumbOverride({
+        id: "project-name",
+        matchSegment: "proj_1",
+        label: "Checkout",
+      });
+      useAppShellBreadcrumbAppend({
+        id: "job-name",
+        label: "Translate homepage",
+      });
+      return null;
+    }
+
+    const view = render(
+      <AppShellHookTestProvider onStore={(nextStore) => (storeRef.current = nextStore)}>
+        <BreadcrumbDemo />
+      </AppShellHookTestProvider>,
+    );
+
+    await waitFor(() =>
+      expect(storeRef.current?.breadcrumb.applyOverrides(baseBreadcrumbs)).toEqual([
+        { label: "Projects", href: "/org/acme/projects" },
+        { label: "Checkout", href: "/org/acme/projects/proj_1" },
+        { label: "Translate homepage", href: undefined },
+      ]),
+    );
+
+    view.unmount();
+    await waitFor(() =>
+      expect(storeRef.current?.breadcrumb.applyOverrides(baseBreadcrumbs)).toEqual(baseBreadcrumbs),
+    );
+  });
+
+  it("registers custom navigation and restores route mode on cleanup", async () => {
+    const storeRef: { current: AppShellStore | null } = { current: null };
+
+    function NavigationDemo() {
+      useAppShellNavigationCustom({
+        groups: customGroups,
+        projectContext: {
+          organizationSlug: "acme",
+          projectId: "proj_1",
+          projectName: "Checkout",
+        },
+      });
+      return null;
+    }
+
+    const view = render(
+      <AppShellHookTestProvider onStore={(nextStore) => (storeRef.current = nextStore)}>
+        <NavigationDemo />
+      </AppShellHookTestProvider>,
+    );
+
+    await waitFor(() => expect(storeRef.current?.navigation.mode).toBe("custom"));
+    expect(storeRef.current?.navigation.activeGroups).toEqual(customGroups);
+
+    view.unmount();
+    await waitFor(() => expect(storeRef.current?.navigation.mode).toBe("route"));
+  });
+
+  it("applies sidebar preferences and clears them on cleanup", async () => {
+    const storeRef: { current: AppShellStore | null } = { current: null };
+
+    function SidebarDemo() {
+      useAppShellSidebar({ forceCollapsed: true, preferredOpen: false });
+      return null;
+    }
+
+    const view = render(
+      <AppShellHookTestProvider onStore={(nextStore) => (storeRef.current = nextStore)}>
+        <SidebarDemo />
+      </AppShellHookTestProvider>,
+    );
+
+    await waitFor(() => {
+      expect(storeRef.current?.sidebar.forceCollapsed).toBe(true);
+      expect(storeRef.current?.sidebar.preferredOpen).toBe(false);
+    });
+
+    act(() => view.unmount());
+
+    await waitFor(() => {
+      expect(storeRef.current?.sidebar.forceCollapsed).toBe(false);
+      expect(storeRef.current?.sidebar.preferredOpen).toBeNull();
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store.test.ts
@@ -56,6 +56,27 @@ describe("AppShellStore", () => {
     expect(store.headerActions.orderedSlots.map((slot) => slot.id)).toEqual(["a", "b"]);
   });
 
+  it("replaces header actions with the same id", () => {
+    const store = createAppShellStore(sampleGroups);
+
+    store.headerActions.register({
+      id: "save",
+      order: 20,
+      visible: true,
+      render: () => "Save",
+    });
+    store.headerActions.register({
+      id: "save",
+      order: 10,
+      visible: true,
+      render: () => "Save changes",
+    });
+
+    expect(store.headerActions.orderedSlots).toHaveLength(1);
+    expect(store.headerActions.orderedSlots[0]?.order).toBe(10);
+    expect(store.headerActions.orderedSlots[0]?.render()).toBe("Save changes");
+  });
+
   it("applies breadcrumb overrides and appends", () => {
     const store = createAppShellStore(sampleGroups);
     const base = [
@@ -79,6 +100,29 @@ describe("AppShellStore", () => {
       { label: "Checkout", href: "/org/acme/projects/proj_1" },
       { label: "Jobs" },
       { label: "Translate to Vietnamese", href: undefined },
+    ]);
+  });
+
+  it("replaces breadcrumb entries with the same id", () => {
+    const store = createAppShellStore(sampleGroups);
+    const base = [{ label: "Jobs", href: "/org/acme/projects/proj_1/jobs" }];
+
+    store.breadcrumb.registerAppend({ id: "job", label: "Old title" });
+    store.breadcrumb.registerAppend({ id: "job", label: "New title" });
+    store.breadcrumb.registerOverride({
+      id: "jobs-label",
+      matchSegment: "Jobs",
+      label: "Tasks",
+    });
+    store.breadcrumb.registerOverride({
+      id: "jobs-label",
+      matchSegment: "Jobs",
+      label: "Jobs",
+    });
+
+    expect(store.breadcrumb.applyOverrides(base)).toEqual([
+      { label: "Jobs", href: "/org/acme/projects/proj_1/jobs" },
+      { label: "New title", href: undefined },
     ]);
   });
 
@@ -109,6 +153,39 @@ describe("AppShellStore", () => {
       organizationSlug: "acme",
       projectId: "proj_1",
       projectName: "Checkout",
+    });
+  });
+
+  it("replaces custom navigation state", () => {
+    const store = createAppShellStore(sampleGroups);
+    const firstGroups = [
+      {
+        label: "First",
+        items: [{ label: "One", href: "/one", icon: Chat01Icon }],
+      },
+    ] as const;
+    const nextGroups = [
+      {
+        label: "Next",
+        items: [{ label: "Two", href: "/two", icon: Chat01Icon }],
+      },
+    ] as const;
+
+    store.navigation.setCustomNavigation(firstGroups, {
+      organizationSlug: "acme",
+      projectId: "proj_1",
+    });
+    store.navigation.setCustomNavigation(nextGroups, {
+      organizationSlug: "acme",
+      projectId: "proj_2",
+      projectName: "Checkout v2",
+    });
+
+    expect(store.navigation.activeGroups).toEqual(nextGroups);
+    expect(store.navigation.activeProjectContext).toEqual({
+      organizationSlug: "acme",
+      projectId: "proj_2",
+      projectName: "Checkout v2",
     });
   });
 
@@ -153,5 +230,15 @@ describe("AppShellStore", () => {
     store.sidebar.setPreferredOpen(true);
 
     expect(api.setOpenMobile).toHaveBeenCalledWith(true);
+  });
+
+  it("keeps sidebar preference until an api binds", () => {
+    const store = createAppShellStore(sampleGroups);
+    const api = createSidebarApi();
+
+    store.sidebar.setPreferredOpen(false);
+    store.sidebar.bindSidebarApi(api);
+
+    expect(api.setOpen).toHaveBeenCalledWith(false);
   });
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/store/use-app-shell-breadcrumb.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/use-app-shell-breadcrumb.ts
@@ -6,7 +6,10 @@ import type { BreadcrumbAppend, BreadcrumbOverride } from "./breadcrumb-store";
 import { useAppShellStore } from "./app-shell-store-context";
 
 type BreadcrumbOverrideConfig = Omit<BreadcrumbOverride, "id"> & { id: string };
-type BreadcrumbAppendConfig = Omit<BreadcrumbAppend, "id"> & { id: string };
+type BreadcrumbAppendConfig = Omit<BreadcrumbAppend, "id" | "label"> & {
+  id: string;
+  label?: string;
+};
 
 export function useAppShellBreadcrumbOverride(config: BreadcrumbOverrideConfig) {
   const store = useAppShellStore();
@@ -26,6 +29,10 @@ export function useAppShellBreadcrumbAppend(config: BreadcrumbAppendConfig) {
   const { id, label, href } = config;
 
   useEffect(() => {
+    if (label === undefined) {
+      return;
+    }
+
     store.breadcrumb.registerAppend({ id, label, href });
 
     return () => {

--- a/apps/hyperlocalise-web/src/components/app-shell/store/use-app-shell-sidebar.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/use-app-shell-sidebar.ts
@@ -16,6 +16,10 @@ export function useAppShellSidebar({
   const store = useAppShellStore();
 
   useEffect(() => {
+    if (!forceCollapsed && preferredOpen === null) {
+      return;
+    }
+
     store.sidebar.setPreferredOpen(preferredOpen);
     store.sidebar.setForceCollapsed(forceCollapsed);
 


### PR DESCRIPTION
## What changed

- Treat the app-shell MobX hooks as the page-facing API with focused coverage for header actions, breadcrumbs, custom navigation, and sidebar lifecycle cleanup.
- Collapse the app shell sidebar through `useAppShellSidebar` for fullscreen CAT workspace routes.
- Move project settings save into an app-shell header action and append loaded job titles to breadcrumbs from native/provider job detail flows.
- Harden app-shell store tests around replacement behavior and sidebar binding.

## How to test

- `vp test src/components/app-shell/store/app-shell-store.test.ts src/components/app-shell/store/app-shell-hooks.test.tsx`
- `vp check --fix` passes with existing `no-floating-promises` warnings in project file Storybook stories.
- `vp run db:migrate`
- `vp test` still fails in unrelated API/MCP/public API auth and fixture tests returning 401/403 plus duplicate membership fixture state.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)