### PR TITLE
fix(cat): improve ICU highlight contrast with theme-aware color tokens

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-target-editor.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-target-editor.tsx
@@ -19,6 +19,11 @@ import {
   type CatMessageAnalysis,
   type CatMessageToken,
 } from "@/components/cat/message-format/cat-message-format";
+import {
+  catMessageTokenMissingClass,
+  catMessageTokenToneClass,
+  type CatMessageTokenVisualKind,
+} from "@/components/cat/message-format/cat-message-token-styles";
 import { catTargetEditorMessages } from "@/components/cat/shared/cat.messages";
 
 function textDocFromValue(value: string) {
@@ -36,17 +41,22 @@ function editorText(editor: NonNullable<ReturnType<typeof useEditor>>) {
   return editor.getText({ blockSeparator: "\n" });
 }
 
-function tokenClassName(token: CatMessageToken) {
+function tokenVisualKind(token: CatMessageToken): CatMessageTokenVisualKind {
   switch (token.kind) {
     case "icu":
-      return "cat-mf-token cat-mf-icu";
+      return "icu";
     case "pound":
-      return "cat-mf-token cat-mf-pound";
+      return "pound";
     case "tag":
-      return "cat-mf-token cat-mf-tag";
+      return "tag";
     default:
-      return "cat-mf-token cat-mf-placeholder";
+      return "placeholder";
   }
+}
+
+function tokenClassName(token: CatMessageToken) {
+  const kind = tokenVisualKind(token);
+  return cn("cat-mf-token", `cat-mf-${kind}`, catMessageTokenToneClass(kind));
 }
 
 function decorationRangesForToken(
@@ -125,7 +135,11 @@ function createCatMessageFormatExtension() {
                   start: analysis.parseError.start,
                   end: analysis.parseError.end,
                 }).forEach(({ from, to }) => {
-                  decorations.push(Decoration.inline(from, to, { class: "cat-mf-error" }));
+                  decorations.push(
+                    Decoration.inline(from, to, {
+                      class: cn("cat-mf-error", catMessageTokenToneClass("error")),
+                    }),
+                  );
                 });
               }
 
@@ -208,9 +222,7 @@ export function CatMessagePreview({ message, className }: { message: string; cla
             key={part.key}
             className={cn(
               "rounded-md border px-1 py-0.5 font-mono text-[0.9em]",
-              part.token.kind === "icu"
-                ? "border-bud-500/25 bg-bud-500/10 text-bud-100"
-                : "border-dew-500/25 bg-dew-500/10 text-dew-100",
+              catMessageTokenToneClass(tokenVisualKind(part.token)),
             )}
           >
             {part.text}
@@ -237,7 +249,12 @@ export function CatIcuStructureSummary({ blocks }: { blocks: CatIcuBlockSummary[
         {blocks.map((block) => (
           <li key={block.id} className="space-y-1">
             <div className="flex flex-wrap items-center gap-1.5 text-xs">
-              <span className="rounded-md border border-bud-500/25 bg-bud-500/10 px-1.5 py-0.5 font-mono text-bud-100">
+              <span
+                className={cn(
+                  "rounded-md border px-1.5 py-0.5 font-mono",
+                  catMessageTokenToneClass("icu"),
+                )}
+              >
                 {block.arg}
               </span>
               <span className="text-muted-foreground">·</span>
@@ -352,11 +369,6 @@ export function CatTargetEditor({
           "rounded-2xl border border-border bg-background shadow-sm transition-colors",
           "focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50",
           "[&_.cat-mf-token]:rounded-md [&_.cat-mf-token]:px-1 [&_.cat-mf-token]:py-0.5 [&_.cat-mf-token]:font-mono [&_.cat-mf-token]:text-[0.9em]",
-          "[&_.cat-mf-placeholder]:bg-dew-500/10 [&_.cat-mf-placeholder]:text-dew-100",
-          "[&_.cat-mf-icu]:bg-bud-500/10 [&_.cat-mf-icu]:text-bud-100",
-          "[&_.cat-mf-pound]:bg-grove-500/10 [&_.cat-mf-pound]:text-grove-100",
-          "[&_.cat-mf-tag]:bg-skeleton [&_.cat-mf-tag]:text-foreground",
-          "[&_.cat-mf-error]:rounded-md [&_.cat-mf-error]:bg-flame-700/20 [&_.cat-mf-error]:text-flame-100",
           "[&_.tiptap_p.is-editor-empty:first-child::before]:text-muted-foreground",
           "[&_.tiptap_p.is-editor-empty:first-child::before]:content-[attr(data-placeholder)]",
           "[&_.tiptap_p.is-editor-empty:first-child::before]:float-left",
@@ -427,7 +439,7 @@ export function CatTargetEditor({
                 disabled={disabled}
                 className={cn(
                   "h-7 rounded-full px-2 font-mono text-xs",
-                  isMissing && "border-bud-500/40 bg-bud-500/10 text-bud-100",
+                  isMissing && catMessageTokenMissingClass,
                   isPresent && !isMissing && "text-muted-foreground",
                 )}
               >

--- a/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-token-styles.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-token-styles.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { catMessageTokenMissingClass, catMessageTokenToneClass } from "./cat-message-token-styles";
+
+describe("catMessageTokenToneClass", () => {
+  it("uses readable foreground tokens for ICU highlights in both themes", () => {
+    expect(catMessageTokenToneClass("icu")).toContain("text-bud-900");
+    expect(catMessageTokenToneClass("icu")).toContain("dark:text-bud-300");
+    expect(catMessageTokenToneClass("icu")).not.toContain("text-bud-100");
+  });
+
+  it("uses readable foreground tokens for placeholder highlights in both themes", () => {
+    expect(catMessageTokenToneClass("placeholder")).toContain("text-dew-900");
+    expect(catMessageTokenToneClass("placeholder")).toContain("dark:text-dew-100");
+    expect(catMessageTokenToneClass("placeholder")).not.toContain("text-dew-100 ");
+  });
+
+  it("uses readable foreground tokens for pound highlights in both themes", () => {
+    expect(catMessageTokenToneClass("pound")).toContain("text-grove-900");
+    expect(catMessageTokenToneClass("pound")).toContain("dark:text-grove-300");
+    expect(catMessageTokenToneClass("pound")).not.toContain("text-grove-100");
+  });
+});
+
+describe("catMessageTokenMissingClass", () => {
+  it("uses readable foreground tokens for missing ICU tokens", () => {
+    expect(catMessageTokenMissingClass).toContain("text-bud-900");
+    expect(catMessageTokenMissingClass).toContain("dark:text-bud-300");
+    expect(catMessageTokenMissingClass).not.toContain("text-bud-100");
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-token-styles.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-token-styles.test.ts
@@ -4,28 +4,54 @@ import { catMessageTokenMissingClass, catMessageTokenToneClass } from "./cat-mes
 
 describe("catMessageTokenToneClass", () => {
   it("uses readable foreground tokens for ICU highlights in both themes", () => {
-    expect(catMessageTokenToneClass("icu")).toContain("text-bud-900");
-    expect(catMessageTokenToneClass("icu")).toContain("dark:text-bud-300");
-    expect(catMessageTokenToneClass("icu")).not.toContain("text-bud-100");
+    const classes = catMessageTokenToneClass("icu").split(" ");
+
+    expect(classes).toContain("text-bud-900");
+    expect(classes).toContain("dark:text-bud-300");
+    expect(classes).not.toContain("text-bud-100");
   });
 
   it("uses readable foreground tokens for placeholder highlights in both themes", () => {
-    expect(catMessageTokenToneClass("placeholder")).toContain("text-dew-900");
-    expect(catMessageTokenToneClass("placeholder")).toContain("dark:text-dew-100");
-    expect(catMessageTokenToneClass("placeholder")).not.toContain("text-dew-100 ");
+    const classes = catMessageTokenToneClass("placeholder").split(" ");
+
+    expect(classes).toContain("text-dew-900");
+    expect(classes).toContain("dark:text-dew-100");
+    expect(classes).not.toContain("text-dew-100");
   });
 
   it("uses readable foreground tokens for pound highlights in both themes", () => {
-    expect(catMessageTokenToneClass("pound")).toContain("text-grove-900");
-    expect(catMessageTokenToneClass("pound")).toContain("dark:text-grove-300");
-    expect(catMessageTokenToneClass("pound")).not.toContain("text-grove-100");
+    const classes = catMessageTokenToneClass("pound").split(" ");
+
+    expect(classes).toContain("text-grove-900");
+    expect(classes).toContain("dark:text-grove-300");
+    expect(classes).not.toContain("text-grove-100");
+  });
+
+  it("styles tag highlights with semantic border and foreground tokens", () => {
+    const classes = catMessageTokenToneClass("tag").split(" ");
+
+    expect(classes).toContain("border-border");
+    expect(classes).toContain("bg-skeleton");
+    expect(classes).toContain("text-foreground");
+  });
+
+  it("styles error highlights with rounded corners and theme-aware flame tokens", () => {
+    const classes = catMessageTokenToneClass("error").split(" ");
+
+    expect(classes).toContain("rounded-md");
+    expect(classes).toContain("bg-flame-700/20");
+    expect(classes).toContain("text-flame-900");
+    expect(classes).toContain("dark:text-flame-100");
+    expect(classes).not.toContain("text-flame-100");
   });
 });
 
 describe("catMessageTokenMissingClass", () => {
   it("uses readable foreground tokens for missing ICU tokens", () => {
-    expect(catMessageTokenMissingClass).toContain("text-bud-900");
-    expect(catMessageTokenMissingClass).toContain("dark:text-bud-300");
-    expect(catMessageTokenMissingClass).not.toContain("text-bud-100");
+    const classes = catMessageTokenMissingClass.split(" ");
+
+    expect(classes).toContain("text-bud-900");
+    expect(classes).toContain("dark:text-bud-300");
+    expect(classes).not.toContain("text-bud-100");
   });
 });

--- a/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-token-styles.ts
+++ b/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-token-styles.ts
@@ -1,0 +1,19 @@
+export type CatMessageTokenVisualKind = "icu" | "placeholder" | "pound" | "tag" | "error";
+
+export function catMessageTokenToneClass(kind: CatMessageTokenVisualKind) {
+  switch (kind) {
+    case "icu":
+      return "border-bud-500/25 bg-bud-500/10 text-bud-900 dark:text-bud-300";
+    case "placeholder":
+      return "border-dew-500/25 bg-dew-500/10 text-dew-900 dark:text-dew-100";
+    case "pound":
+      return "border-grove-500/25 bg-grove-500/10 text-grove-900 dark:text-grove-300";
+    case "tag":
+      return "border-border bg-skeleton text-foreground";
+    case "error":
+      return "bg-flame-700/20 text-flame-900 dark:text-flame-100";
+  }
+}
+
+export const catMessageTokenMissingClass =
+  "border-bud-500/40 bg-bud-500/10 text-bud-900 dark:text-bud-300";

--- a/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-token-styles.ts
+++ b/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-token-styles.ts
@@ -11,7 +11,7 @@ export function catMessageTokenToneClass(kind: CatMessageTokenVisualKind) {
     case "tag":
       return "border-border bg-skeleton text-foreground";
     case "error":
-      return "bg-flame-700/20 text-flame-900 dark:text-flame-100";
+      return "rounded-md bg-flame-700/20 text-flame-900 dark:text-flame-100";
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

ICU, placeholder, and pound syntax highlights in the CAT editor and source preview used fixed light palette text colors (`text-bud-100`, `text-dew-100`, `text-grove-100`) that were nearly invisible on both light and dark backgrounds.

This adds shared theme-aware token styles and applies them across the target editor, source preview, ICU structure summary, and missing-token chips.

## How to test

1. Open a CAT segment with ICU plural syntax (for example `project.sidebar.files.count`).
2. Verify ICU blocks are readable in both light and dark mode in:
   - Source preview
   - Target editor inline highlights
   - Required token chips when missing
3. Run `vp test src/components/cat/message-format/cat-message-token-styles.test.ts`
4. Run `vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de7c8326-5354-4674-b265-088acac76108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de7c8326-5354-4674-b265-088acac76108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

