### PR TITLE
ci(web): cache Next.js builds and add Vercel ignore

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -115,7 +115,7 @@ jobs:
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: apps/hyperlocalise-web/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('apps/hyperlocalise-web/pnpm-lock.yaml', 'apps/hyperlocalise-web/package.json') }}-${{ hashFiles('apps/hyperlocalise-web/**/*.ts', 'apps/hyperlocalise-web/**/*.tsx', 'apps/hyperlocalise-web/**/*.js', 'apps/hyperlocalise-web/**/*.jsx', 'apps/hyperlocalise-web/**/*.mjs', 'apps/hyperlocalise-web/**/*.cjs') }}
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('apps/hyperlocalise-web/pnpm-lock.yaml', 'apps/hyperlocalise-web/package.json') }}-${{ hashFiles('apps/hyperlocalise-web/src/**/*.ts', 'apps/hyperlocalise-web/src/**/*.tsx', 'apps/hyperlocalise-web/src/**/*.js', 'apps/hyperlocalise-web/src/**/*.jsx', 'apps/hyperlocalise-web/next.config.*', 'apps/hyperlocalise-web/postcss.config.*') }}
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('apps/hyperlocalise-web/pnpm-lock.yaml', 'apps/hyperlocalise-web/package.json') }}-
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -111,5 +111,13 @@ jobs:
       - name: Test hyperlocalise-web
         run: vp test
 
+      - name: Cache Next.js build
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: apps/hyperlocalise-web/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('apps/hyperlocalise-web/pnpm-lock.yaml', 'apps/hyperlocalise-web/package.json') }}-${{ hashFiles('apps/hyperlocalise-web/**/*.ts', 'apps/hyperlocalise-web/**/*.tsx', 'apps/hyperlocalise-web/**/*.js', 'apps/hyperlocalise-web/**/*.jsx', 'apps/hyperlocalise-web/**/*.mjs', 'apps/hyperlocalise-web/**/*.cjs') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('apps/hyperlocalise-web/pnpm-lock.yaml', 'apps/hyperlocalise-web/package.json') }}-
+
       - name: Build hyperlocalise-web
         run: vp run build

--- a/apps/hyperlocalise-web/.vercelignore
+++ b/apps/hyperlocalise-web/.vercelignore
@@ -1,0 +1,24 @@
+# Exclude dev-only files from Vercel uploads.
+# See https://vercel.com/docs/deployments/vercel-ignore
+# Vercel already ignores node_modules, .next, .git, and .env* by default.
+
+# Storybook
+.storybook
+storybook-static
+
+# Tests, fixtures, and stories (not imported by production code)
+**/*.test.ts
+**/*.test.tsx
+**/*.fixture.ts
+**/*.stories.ts
+**/*.stories.tsx
+
+# Test output
+coverage
+
+# MSW worker used by Storybook/local dev only
+public/mockServiceWorker.js
+
+# Agent/editor docs
+AGENTS.md
+CLAUDE.md

--- a/apps/hyperlocalise-web/.vercelignore
+++ b/apps/hyperlocalise-web/.vercelignore
@@ -9,9 +9,14 @@ storybook-static
 # Tests, fixtures, and stories (not imported by production code)
 **/*.test.ts
 **/*.test.tsx
+**/*.test.js
+**/*.test.jsx
 **/*.fixture.ts
+**/*.fixture.js
 **/*.stories.ts
 **/*.stories.tsx
+**/*.stories.js
+**/*.stories.jsx
 
 # Test output
 coverage


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

### CI: Next.js build cache
Adds a `actions/cache@v5` step to the web CI workflow to persist `apps/hyperlocalise-web/.next/cache` between runs. This is the cache Next.js uses to speed up production builds and removes the "No build cache found" warning.

On Blacksmith runners, `actions/cache` is automatically routed to their colocated cache backend — no `useblacksmith/cache` fork needed.

### Vercel: `.vercelignore`
Adds `apps/hyperlocalise-web/.vercelignore` to exclude dev-only files from deployment uploads ([Vercel docs](https://vercel.com/docs/deployments/vercel-ignore)):

- Storybook (`.storybook/`, `storybook-static`, `*.stories.*`)
- Tests and fixtures (`*.test.*`, `*.fixture.*`)
- Coverage output and MSW dev worker
- Agent docs (`AGENTS.md`, `CLAUDE.md`)

Vercel already ignores `node_modules`, `.next`, `.git`, and `.env*` by default — those are not duplicated here.

## How to test

**CI cache**
1. Run the web CI workflow twice on the same branch.
2. On the second run, confirm the "Cache Next.js build" step reports a cache hit and the build is faster.

**Vercel ignore**
1. Deploy to Vercel and confirm the build succeeds.
2. Verify upload size is reduced (fewer test/storybook files uploaded).

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-271ffe64-0861-4166-b83f-11d9104ef61d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-271ffe64-0861-4166-b83f-11d9104ef61d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

