### PR TITLE
feat(automations): expand Storybook coverage for editor and templates

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-editor.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-editor.fixture.ts
@@ -106,7 +106,7 @@ export const automationRunsFixture: WorkspaceAutomationRunRecord[] = [
   },
 ];
 
-export const createEmptyAutomationFormFixture = createDefaultWorkspaceAutomationFormState();
+export const createEmptyAutomationFormFixture = () => createDefaultWorkspaceAutomationFormState();
 
 export const createGithubAutomationFormFixture = () => {
   const form = createWorkspaceAutomationFormStateFromTemplate("validate-localisation-on-push");

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-editor.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-editor.fixture.ts
@@ -1,0 +1,130 @@
+import {
+  createDefaultWorkspaceAutomationFormState,
+  createWorkspaceAutomationFormStateFromRecord,
+  createWorkspaceAutomationFormStateFromTemplate,
+} from "@/lib/agents/workspace-automation-view-model";
+import type { WorkspaceAutomationRunRecord } from "@/lib/agents/workspace-automations";
+
+import { createAutomationSummary } from "./automations.fixture";
+
+export const automationEditorProjectsFixture = [
+  {
+    id: "project_website",
+    name: "Website",
+    source: "github",
+    sourceLocale: "en",
+    targetLocales: ["fr-FR", "de-DE", "ja-JP"],
+  },
+  {
+    id: "project_mobile",
+    name: "Mobile app",
+    source: "contentful",
+    sourceLocale: "en-US",
+    targetLocales: ["es-ES", "pt-BR"],
+  },
+];
+
+export const automationEditorRepositoriesFixture = [
+  {
+    id: "22222222-2222-4222-8222-222222222222",
+    fullName: "acme/website",
+    enabled: true,
+    archived: false,
+    defaultBranch: "main",
+  },
+  {
+    id: "55555555-5555-4555-8555-555555555555",
+    fullName: "acme/mobile",
+    enabled: true,
+    archived: false,
+    defaultBranch: "develop",
+  },
+];
+
+export const automationEditorSlackChannelsFixture = [
+  { id: "C01234567", name: "localization", private: false },
+  { id: "C07654321", name: "release-updates", private: true },
+];
+
+export const automationEditorContentfulConnectionsFixture = [
+  {
+    id: "contentful_conn_001",
+    displayName: "Marketing space",
+    contentTypeIds: ["article", "landingPage"],
+    enabled: true,
+  },
+];
+
+export const automationRunsFixture: WorkspaceAutomationRunRecord[] = [
+  {
+    id: "run_001",
+    automationId: "11111111-1111-4111-8111-111111111111",
+    organizationId: "org_001",
+    triggerSource: "github",
+    status: "succeeded",
+    idempotencyKey: null,
+    inputSnapshot: {},
+    outputSummary: { validatedFiles: 12 },
+    error: null,
+    githubRepositoryAutomationJobId: null,
+    startedAt: "2026-06-07T11:55:00.000Z",
+    completedAt: "2026-06-07T12:00:00.000Z",
+    createdAt: "2026-06-07T11:55:00.000Z",
+    updatedAt: "2026-06-07T12:00:00.000Z",
+  },
+  {
+    id: "run_002",
+    automationId: "11111111-1111-4111-8111-111111111111",
+    organizationId: "org_001",
+    triggerSource: "scheduled",
+    status: "failed",
+    idempotencyKey: null,
+    inputSnapshot: {},
+    outputSummary: {},
+    error: { message: "GitHub sync failed" },
+    githubRepositoryAutomationJobId: null,
+    startedAt: "2026-06-06T09:00:00.000Z",
+    completedAt: "2026-06-06T09:04:00.000Z",
+    createdAt: "2026-06-06T09:00:00.000Z",
+    updatedAt: "2026-06-06T09:04:00.000Z",
+  },
+  {
+    id: "run_003",
+    automationId: "11111111-1111-4111-8111-111111111111",
+    organizationId: "org_001",
+    triggerSource: "manual",
+    status: "running",
+    idempotencyKey: "manual-1",
+    inputSnapshot: {},
+    outputSummary: {},
+    error: null,
+    githubRepositoryAutomationJobId: null,
+    startedAt: "2026-06-05T14:00:00.000Z",
+    completedAt: null,
+    createdAt: "2026-06-05T14:00:00.000Z",
+    updatedAt: "2026-06-05T14:00:00.000Z",
+  },
+];
+
+export const createEmptyAutomationFormFixture = createDefaultWorkspaceAutomationFormState();
+
+export const createGithubAutomationFormFixture = () => {
+  const form = createWorkspaceAutomationFormStateFromTemplate("validate-localisation-on-push");
+  if (!form) {
+    throw new Error("validate-localisation-on-push template is missing");
+  }
+
+  return form;
+};
+
+export const createContentfulAutomationFormFixture = () => {
+  const form = createWorkspaceAutomationFormStateFromTemplate("translate-contentful-article");
+  if (!form) {
+    throw new Error("translate-contentful-article template is missing");
+  }
+
+  return form;
+};
+
+export const createDetailAutomationFormFixture = () =>
+  createWorkspaceAutomationFormStateFromRecord(createAutomationSummary());

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-msw-handlers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-msw-handlers.ts
@@ -53,6 +53,9 @@ export const automationEditorDisconnectedMswHandlers = [
   http.get("/api/orgs/:organizationSlug/github-installation", () =>
     HttpResponse.json({ installation: null }),
   ),
+  http.get("/api/orgs/:organizationSlug/github-installation/repositories", () =>
+    HttpResponse.json({ repositories: [] }),
+  ),
   http.get("/api/orgs/:organizationSlug/agent-slack", () =>
     HttpResponse.json({
       slackAgent: {
@@ -61,6 +64,9 @@ export const automationEditorDisconnectedMswHandlers = [
         teamName: null,
       },
     }),
+  ),
+  http.get("/api/orgs/:organizationSlug/agent-slack/channels", () =>
+    HttpResponse.json({ channels: [] }),
   ),
   http.get("/api/orgs/:organizationSlug/agent-email", () =>
     HttpResponse.json({

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-msw-handlers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-msw-handlers.ts
@@ -1,0 +1,76 @@
+import { http, HttpResponse } from "msw";
+
+import {
+  automationEditorContentfulConnectionsFixture,
+  automationEditorProjectsFixture,
+  automationEditorRepositoriesFixture,
+  automationEditorSlackChannelsFixture,
+} from "./automation-editor.fixture";
+
+export const automationEditorMswHandlers = [
+  http.get("/api/orgs/:organizationSlug/projects", () =>
+    HttpResponse.json({ projects: automationEditorProjectsFixture }),
+  ),
+  http.get("/api/orgs/:organizationSlug/github-installation", () =>
+    HttpResponse.json({
+      installation: {
+        githubInstallationId: "12345678",
+      },
+    }),
+  ),
+  http.get("/api/orgs/:organizationSlug/github-installation/repositories", () =>
+    HttpResponse.json({ repositories: automationEditorRepositoriesFixture }),
+  ),
+  http.get("/api/orgs/:organizationSlug/agent-slack", () =>
+    HttpResponse.json({
+      slackAgent: {
+        enabled: true,
+        teamId: "T01234567",
+        teamName: "Acme",
+      },
+    }),
+  ),
+  http.get("/api/orgs/:organizationSlug/agent-slack/channels", () =>
+    HttpResponse.json({ channels: automationEditorSlackChannelsFixture }),
+  ),
+  http.get("/api/orgs/:organizationSlug/agent-email", () =>
+    HttpResponse.json({
+      emailAgent: {
+        enabled: true,
+        inboundEmailAddress: "automation@inbound.hyperlocalise.test",
+      },
+    }),
+  ),
+  http.get("/api/orgs/:organizationSlug/contentful-connections", () =>
+    HttpResponse.json({ contentfulConnections: automationEditorContentfulConnectionsFixture }),
+  ),
+];
+
+export const automationEditorDisconnectedMswHandlers = [
+  http.get("/api/orgs/:organizationSlug/projects", () =>
+    HttpResponse.json({ projects: automationEditorProjectsFixture }),
+  ),
+  http.get("/api/orgs/:organizationSlug/github-installation", () =>
+    HttpResponse.json({ installation: null }),
+  ),
+  http.get("/api/orgs/:organizationSlug/agent-slack", () =>
+    HttpResponse.json({
+      slackAgent: {
+        enabled: false,
+        teamId: null,
+        teamName: null,
+      },
+    }),
+  ),
+  http.get("/api/orgs/:organizationSlug/agent-email", () =>
+    HttpResponse.json({
+      emailAgent: {
+        enabled: false,
+        inboundEmailAddress: null,
+      },
+    }),
+  ),
+  http.get("/api/orgs/:organizationSlug/contentful-connections", () =>
+    HttpResponse.json({ contentfulConnections: [] }),
+  ),
+];

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-template-flow.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-template-flow.stories.tsx
@@ -33,9 +33,7 @@ function templateStory(templateId: string): Story {
 export const GithubPushValidation: Story = {
   ...templateStory("validate-localisation-on-push"),
   play: async ({ canvas }) => {
-    await expect(
-      canvas.getByLabelText("GitHub push → Validation → Slack"),
-    ).toBeInTheDocument();
+    await expect(canvas.getByLabelText("GitHub push → Validation → Slack")).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-template-flow.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-template-flow.stories.tsx
@@ -58,7 +58,7 @@ export const ContentfulTranslation: Story = {
   },
 };
 
-export const TriggerOnly: Story = {
+export const ScheduledSummary: Story = {
   ...templateStory("summarize-changes-daily"),
   play: async ({ canvas }) => {
     await expect(canvas.getByLabelText("Daily → GitHub → Slack")).toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-template-flow.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-template-flow.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect } from "storybook/test";
+
+import { getWorkspaceAutomationTemplate } from "@/lib/agents/workspace-automation-templates";
+
+import { automationTemplatesFixture } from "./automations.fixture";
+import { AutomationTemplateFlow } from "./automation-template-flow";
+
+const meta = {
+  title: "App/Automations/TemplateFlow",
+  component: AutomationTemplateFlow,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof AutomationTemplateFlow>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function templateStory(templateId: string): Story {
+  const template = getWorkspaceAutomationTemplate(templateId, automationTemplatesFixture);
+  if (!template) {
+    throw new Error(`Template ${templateId} is missing from fixtures`);
+  }
+
+  return {
+    args: {
+      template,
+    },
+  };
+}
+
+export const GithubPushValidation: Story = {
+  ...templateStory("validate-localisation-on-push"),
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByLabelText("GitHub push → Validation → Slack"),
+    ).toBeInTheDocument();
+  },
+};
+
+export const ScheduledSync: Story = {
+  ...templateStory("pull-translations-daily"),
+  play: async ({ canvas }) => {
+    await expect(canvas.getByLabelText("Daily → Pull translations")).toBeInTheDocument();
+  },
+};
+
+export const ManualWorkflow: Story = {
+  ...templateStory("create-localisation-job-brief"),
+  play: async ({ canvas }) => {
+    await expect(canvas.getByLabelText("Manual → GitHub → Slack")).toBeInTheDocument();
+  },
+};
+
+export const ContentfulTranslation: Story = {
+  ...templateStory("translate-contentful-article"),
+  play: async ({ canvas }) => {
+    await expect(canvas.getByLabelText("Contentful webhook → Contentful")).toBeInTheDocument();
+  },
+};
+
+export const TriggerOnly: Story = {
+  ...templateStory("summarize-changes-daily"),
+  play: async ({ canvas }) => {
+    await expect(canvas.getByLabelText("Daily → GitHub → Slack")).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.stories.tsx
@@ -78,3 +78,29 @@ export const ActiveAndPaused: Story = {
     await expect(canvas.getByText("paused")).toBeInTheDocument();
   },
 };
+
+export const SingleAutomation: Story = {
+  args: {
+    automations: [automationsFixture[0]!],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Validate localisation on push")).toBeInTheDocument();
+    await expect(canvas.queryByText("Weekly translation sync")).not.toBeInTheDocument();
+    await expect(canvas.getByText("1")).toBeInTheDocument();
+  },
+};
+
+export const MarketingTemplates: Story = {
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("tab", { name: "Marketing" }));
+    await expect(canvas.getByText("Market messaging brief")).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Coming soon" })).toBeInTheDocument();
+  },
+};
+
+export const ActivatableTemplate: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Translate Contentful article")).toBeInTheDocument();
+    await expect(canvas.getAllByRole("button", { name: "Add" }).length).toBeGreaterThan(0);
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.stories.tsx
@@ -101,6 +101,6 @@ export const MarketingTemplates: Story = {
 export const ActivatableTemplate: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByText("Translate Contentful article")).toBeInTheDocument();
-    await expect(canvas.getAllByRole("button", { name: "Add" }).length).toBeGreaterThan(0);
+    await expect(canvas.getAllByRole("button", { name: "Add" })).not.toHaveLength(0);
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-editor.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-editor.stories.tsx
@@ -72,7 +72,7 @@ const meta = {
   args: {
     organizationSlug: "acme",
     mode: "create" as const,
-    form: createEmptyAutomationFormFixture,
+    form: createEmptyAutomationFormFixture(),
     errors: {},
     actions: (
       <Button type="button" onClick={fn()}>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-editor.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-editor.stories.tsx
@@ -134,9 +134,7 @@ export const CreateValidationErrors: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByText("Name is required.")).toBeInTheDocument();
     await expect(canvas.getByText("Instructions are required.")).toBeInTheDocument();
-    await expect(
-      canvas.getByText("Choose a Slack channel for notifications."),
-    ).toBeInTheDocument();
+    await expect(canvas.getByText("Choose a Slack channel for notifications.")).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-editor.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-editor.stories.tsx
@@ -1,0 +1,242 @@
+import { useState, type ReactNode } from "react";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, fn } from "storybook/test";
+
+import { Button } from "@/components/ui/button";
+import type { WorkspaceAutomationFormState } from "@/lib/agents/workspace-automation-view-model";
+
+import { WorkspacePageShell } from "../../_components/workspace-resource-shared";
+import {
+  automationRunsFixture,
+  createContentfulAutomationFormFixture,
+  createDetailAutomationFormFixture,
+  createEmptyAutomationFormFixture,
+  createGithubAutomationFormFixture,
+} from "./automation-editor.fixture";
+import { automationEditorMswHandlers } from "./automation-msw-handlers";
+import { WorkspaceAutomationEditor } from "./workspace-automation-form";
+
+function WorkspaceAutomationEditorStory({
+  actions,
+  disabled,
+  errors: initialErrors = {},
+  form: initialForm,
+  mode,
+  organizationSlug = "acme",
+  runHistory,
+}: {
+  actions?: ReactNode;
+  disabled?: boolean;
+  errors?: Record<string, string | undefined>;
+  form: WorkspaceAutomationFormState;
+  mode: "create" | "detail";
+  organizationSlug?: string;
+  runHistory?: typeof automationRunsFixture;
+}) {
+  const [form, setForm] = useState(initialForm);
+  const [errors, setErrors] = useState(initialErrors);
+
+  return (
+    <WorkspacePageShell className="max-w-5xl">
+      <WorkspaceAutomationEditor
+        actions={actions}
+        disabled={disabled}
+        errors={errors}
+        form={form}
+        mode={mode}
+        onChange={(next) => {
+          setForm(next);
+          setErrors({});
+        }}
+        organizationSlug={organizationSlug}
+        runHistory={runHistory}
+      />
+    </WorkspacePageShell>
+  );
+}
+
+const meta = {
+  title: "App/Automations/Editor",
+  component: WorkspaceAutomationEditorStory,
+  parameters: {
+    layout: "fullscreen",
+    msw: {
+      handlers: automationEditorMswHandlers,
+    },
+    nextjs: {
+      navigation: {
+        pathname: "/org/acme/automations/new",
+      },
+    },
+  },
+  args: {
+    organizationSlug: "acme",
+    mode: "create" as const,
+    form: createEmptyAutomationFormFixture,
+    errors: {},
+    actions: (
+      <Button type="button" onClick={fn()}>
+        Create automation
+      </Button>
+    ),
+  },
+} satisfies Meta<typeof WorkspaceAutomationEditorStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const CreateEmpty: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByPlaceholderText("Untitled automation")).toBeInTheDocument();
+    await expect(canvas.getByRole("tab", { name: "Settings" })).toBeInTheDocument();
+    await expect(canvas.queryByRole("tab", { name: "Run History" })).not.toBeInTheDocument();
+    await expect(
+      canvas.getByText("Add at least one supported tool to activate this automation."),
+    ).toBeInTheDocument();
+  },
+};
+
+export const CreateFromGithubTemplate: Story = {
+  args: {
+    form: createGithubAutomationFormFixture(),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByDisplayValue("Validate localisation on push")).toBeInTheDocument();
+    await expect(canvas.getByText("Active")).toBeInTheDocument();
+    await expect(canvas.getByText("2 tools")).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Create automation" })).toBeInTheDocument();
+  },
+};
+
+export const CreateFromContentfulTemplate: Story = {
+  args: {
+    form: createContentfulAutomationFormFixture(),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByDisplayValue("Translate Contentful article")).toBeInTheDocument();
+    await expect(canvas.getByText("Contentful")).toBeInTheDocument();
+  },
+};
+
+export const CreateValidationErrors: Story = {
+  args: {
+    form: {
+      ...createGithubAutomationFormFixture(),
+      name: "",
+      instructions: "",
+    },
+    errors: {
+      name: "Name is required.",
+      instructions: "Instructions are required.",
+      slackChannelId: "Choose a Slack channel for notifications.",
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Name is required.")).toBeInTheDocument();
+    await expect(canvas.getByText("Instructions are required.")).toBeInTheDocument();
+    await expect(
+      canvas.getByText("Choose a Slack channel for notifications."),
+    ).toBeInTheDocument();
+  },
+};
+
+export const DetailDefault: Story = {
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: "/org/acme/automations/11111111-1111-4111-8111-111111111111",
+      },
+    },
+  },
+  args: {
+    mode: "detail",
+    form: createDetailAutomationFormFixture(),
+    actions: (
+      <>
+        <Button type="button" variant="outline" onClick={fn()}>
+          Run now
+        </Button>
+        <Button type="button" onClick={fn()}>
+          Save changes
+        </Button>
+      </>
+    ),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByDisplayValue("Validate localisation on push")).toBeInTheDocument();
+    await expect(canvas.getByRole("tab", { name: "Run History" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Run now" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Save changes" })).toBeInTheDocument();
+  },
+};
+
+export const DetailPaused: Story = {
+  args: {
+    mode: "detail",
+    form: {
+      ...createDetailAutomationFormFixture(),
+      status: "paused",
+    },
+    actions: (
+      <Button type="button" onClick={fn()}>
+        Save changes
+      </Button>
+    ),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Paused")).toBeInTheDocument();
+  },
+};
+
+export const DetailRunHistory: Story = {
+  args: {
+    mode: "detail",
+    form: createDetailAutomationFormFixture(),
+    runHistory: automationRunsFixture,
+    actions: (
+      <Button type="button" onClick={fn()}>
+        Save changes
+      </Button>
+    ),
+  },
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("tab", { name: "Run History" }));
+    await expect(canvas.getByText("succeeded")).toBeInTheDocument();
+    await expect(canvas.getByText("failed")).toBeInTheDocument();
+    await expect(canvas.getByText("running")).toBeInTheDocument();
+  },
+};
+
+export const DetailRunHistoryEmpty: Story = {
+  args: {
+    mode: "detail",
+    form: createDetailAutomationFormFixture(),
+    runHistory: [],
+    actions: (
+      <Button type="button" onClick={fn()}>
+        Save changes
+      </Button>
+    ),
+  },
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("tab", { name: "Run History" }));
+    await expect(canvas.getByText("No runs yet.")).toBeInTheDocument();
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    mode: "detail",
+    form: createDetailAutomationFormFixture(),
+    disabled: true,
+    actions: (
+      <Button type="button" disabled>
+        Save changes
+      </Button>
+    ),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByPlaceholderText("Untitled automation")).toBeDisabled();
+    await expect(canvas.getByRole("button", { name: "Save changes" })).toBeDisabled();
+  },
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Automations feature only had Storybook coverage for the list page (`AutomationsPageView`). This adds stories for the editor, template flow icons, and additional list-page states so the full Automations UX can be reviewed in isolation.

## Changes

- **`automation-editor.fixture.ts`** — shared fixtures for projects, repositories, Slack channels, Contentful connections, run history, and form states
- **`automation-msw-handlers.ts`** — MSW handlers so `WorkspaceAutomationEditor` can load integration data in Storybook without a live API
- **`automation-template-flow.stories.tsx`** — 5 stories covering GitHub push, scheduled, manual, Contentful, and trigger-only template flows
- **`workspace-automation-editor.stories.tsx`** — 9 stories for create (empty, GitHub template, Contentful template, validation errors), detail (default, paused, run history, empty history), and read-only modes
- **`automations-page-view.stories.tsx`** — 3 additional list-page stories: single automation, marketing templates tab, and activatable template cards

## Storybook coverage after this PR

| Area | Before | After |
|------|--------|-------|
| List page | 5 stories | 8 stories |
| Template flow icons | 0 | 5 stories |
| Create/edit editor | 0 | 9 stories |

## Verification

- `vp check --fix` passes
- `vp run build-storybook` completes successfully
- `vp test` fails in this environment due to missing `.env` (pre-existing; unrelated to these changes)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2bf5-5264-734c-8f01-3bce59f2df9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2bf5-5264-734c-8f01-3bce59f2df9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

