### PR TITLE
ci(web): ignore MSW handler files in Vercel uploads

### DIFF
--- a/apps/hyperlocalise-web/.vercelignore
+++ b/apps/hyperlocalise-web/.vercelignore
@@ -6,13 +6,14 @@
 .storybook
 storybook-static
 
-# Tests, fixtures, and stories (not imported by production code)
+# Tests, fixtures, MSW handlers, and stories (not imported by production code)
 **/*.test.ts
 **/*.test.tsx
 **/*.test.js
 **/*.test.jsx
 **/*.fixture.ts
 **/*.fixture.js
+**/*-msw-handlers.ts
 **/*.stories.ts
 **/*.stories.tsx
 **/*.stories.js


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Added `**/*-msw-handlers.ts` to `apps/hyperlocalise-web/.vercelignore` so Storybook-only MSW handler files (like `automation-msw-handlers.ts`) are excluded from Vercel uploads, matching the existing pattern for `*.fixture.ts` files.

## How to test

- Confirm `automation-msw-handlers.ts` is only imported from `workspace-automation-editor.stories.tsx` (not production code).
- Verify the `.vercelignore` pattern matches `automation-msw-handlers.ts`.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87a57baf-df4e-4036-9298-fc788d56bc1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87a57baf-df4e-4036-9298-fc788d56bc1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

