### PR TITLE
refactor(cat): separate concordance lookup from segment review

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.test.tsx
@@ -284,6 +284,66 @@ describe("useCatWorkspaceController", () => {
     expect(lookupSegmentConcordance).toHaveBeenCalledTimes(1);
   });
 
+  it("invokes the onReviewWithAi review override before AI review", async () => {
+    const onReviewWithAi = vi.fn();
+    const generateAiRecommendation = vi.fn().mockResolvedValue({
+      aiSuggestion: "Suggestion IA",
+      aiReasoning: "Because TM",
+      formatChecks: [],
+    });
+    const { result } = renderController(undefined, {
+      review: { onReviewWithAi },
+      services: { generateAiRecommendation },
+    });
+
+    await act(async () => {
+      await result.current.dependencies.review.onReviewWithAi("seg-02");
+    });
+
+    expect(onReviewWithAi).toHaveBeenCalledWith("seg-02");
+    expect(generateAiRecommendation).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs generateAiRecommendation once when Review with AI is triggered twice during concordance", async () => {
+    let resolveConcordance: ((value: CatSegmentConcordanceResult) => void) | undefined;
+    const concordancePromise = new Promise<CatSegmentConcordanceResult>((resolve) => {
+      resolveConcordance = resolve;
+    });
+
+    const lookupSegmentConcordance = vi.fn().mockReturnValue(concordancePromise);
+    const generateAiRecommendation = vi.fn().mockResolvedValue({
+      aiSuggestion: "Suggestion IA",
+      aiReasoning: "Because TM",
+      formatChecks: [],
+    });
+
+    const { result } = renderController(undefined, {
+      services: {
+        lookupSegmentConcordance,
+        generateAiRecommendation,
+      },
+    });
+
+    act(() => {
+      result.current.handleIntelligencePanelVisible("seg-02");
+    });
+
+    await waitFor(() => expect(lookupSegmentConcordance).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      const firstReview = result.current.dependencies.review.onReviewWithAi("seg-02");
+      const secondReview = result.current.dependencies.review.onReviewWithAi("seg-02");
+      resolveConcordance?.({
+        glossaryTerms: [],
+        translationMemoryMatches: [],
+      });
+      await concordancePromise;
+      await Promise.all([firstReview, secondReview]);
+    });
+
+    expect(generateAiRecommendation).toHaveBeenCalledTimes(1);
+  });
+
   it("does not refetch concordance when AI review runs after intelligence panel loaded it", async () => {
     const lookupSegmentConcordance = vi.fn().mockResolvedValue({
       glossaryTerms: [

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { createCatWorkspaceState, mockValidateFormat } from "@/components/cat/shared/cat.fixture";
 import { CatTestProviders } from "@/components/cat/shared/cat-test-utils";
 import type { CatSegmentConcordanceResult } from "@/components/cat/shared/dependencies";
+import type { CatFormatCheck } from "@/components/cat/shared/types";
 
 import { createCatWorkspaceStore } from "./store/cat-workspace-store";
 import { useCatWorkspaceController } from "./use-cat-workspace-controller";
@@ -152,7 +153,7 @@ describe("useCatWorkspaceController", () => {
     expect(store.isLoadingConcordance).toBe(false);
   });
 
-  it("clears concordance loading when a concurrent review supersedes the sequence", async () => {
+  it("clears concordance loading when AI review runs during an in-flight lookup", async () => {
     let resolveConcordance: ((value: CatSegmentConcordanceResult) => void) | undefined;
     const concordancePromise = new Promise<CatSegmentConcordanceResult>((resolve) => {
       resolveConcordance = resolve;
@@ -172,10 +173,7 @@ describe("useCatWorkspaceController", () => {
     expect(store.isLoadingConcordance).toBe(true);
 
     await act(async () => {
-      await result.current.dependencies.review.onReviewWithAi("seg-02");
-    });
-
-    await act(async () => {
+      const reviewPromise = result.current.dependencies.review.onReviewWithAi("seg-02");
       resolveConcordance?.({
         glossaryTerms: [
           {
@@ -189,9 +187,62 @@ describe("useCatWorkspaceController", () => {
         translationMemoryMatches: [],
       });
       await concordancePromise;
+      await reviewPromise;
     });
 
     await waitFor(() => expect(store.isLoadingConcordance).toBe(false));
+    expect(store.segmentIntelligence["seg-02"]?.glossaryTerms).toEqual([
+      expect.objectContaining({ id: "term-1", target: "Deuxième" }),
+    ]);
+  });
+
+  it("keeps concordance results while format checks run in parallel", async () => {
+    let resolveConcordance: ((value: CatSegmentConcordanceResult) => void) | undefined;
+    const concordancePromise = new Promise<CatSegmentConcordanceResult>((resolve) => {
+      resolveConcordance = resolve;
+    });
+
+    const lookupSegmentConcordance = vi.fn().mockReturnValue(concordancePromise);
+    const validateFormat = vi
+      .fn()
+      .mockImplementation(
+        () => new Promise<CatFormatCheck[]>((resolve) => setTimeout(() => resolve([]), 50)),
+      );
+    const { result, store } = renderController(undefined, {
+      services: {
+        lookupSegmentConcordance,
+        validateFormat,
+      },
+    });
+
+    act(() => {
+      result.current.handleIntelligencePanelVisible("seg-02");
+    });
+
+    expect(store.isLoadingConcordance).toBe(true);
+    await waitFor(() => expect(lookupSegmentConcordance).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      resolveConcordance?.({
+        glossaryTerms: [],
+        translationMemoryMatches: [
+          {
+            id: "tm-1",
+            sourceText: "Second",
+            targetText: "Deuxième",
+            matchPercent: 100,
+            contextLabel: "Settings",
+          },
+        ],
+      });
+      await concordancePromise;
+    });
+
+    await waitFor(() =>
+      expect(store.segmentIntelligence["seg-02"]?.translationMemoryMatches).toEqual([
+        expect.objectContaining({ id: "tm-1", targetText: "Deuxième" }),
+      ]),
+    );
   });
 
   it("does not start a duplicate concordance lookup when AI review runs during an in-flight lookup", async () => {
@@ -221,18 +272,16 @@ describe("useCatWorkspaceController", () => {
     expect(store.isLoadingConcordance).toBe(true);
 
     await act(async () => {
-      await result.current.dependencies.review.onReviewWithAi("seg-02");
-    });
-
-    expect(lookupSegmentConcordance).toHaveBeenCalledTimes(1);
-
-    await act(async () => {
+      const reviewPromise = result.current.dependencies.review.onReviewWithAi("seg-02");
       resolveConcordance?.({
         glossaryTerms: [],
         translationMemoryMatches: [],
       });
       await concordancePromise;
+      await reviewPromise;
     });
+
+    expect(lookupSegmentConcordance).toHaveBeenCalledTimes(1);
   });
 
   it("does not refetch concordance when AI review runs after intelligence panel loaded it", async () => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.test.tsx
@@ -245,6 +245,50 @@ describe("useCatWorkspaceController", () => {
     );
   });
 
+  it("auto-fills when intelligence panel joins an in-flight AI review concordance lookup", async () => {
+    let resolveConcordance: ((value: CatSegmentConcordanceResult) => void) | undefined;
+    const concordancePromise = new Promise<CatSegmentConcordanceResult>((resolve) => {
+      resolveConcordance = resolve;
+    });
+
+    const lookupSegmentConcordance = vi.fn().mockReturnValue(concordancePromise);
+    const generateAiRecommendation = vi.fn().mockResolvedValue({
+      aiSuggestion: "Suggestion IA",
+      aiReasoning: "Because TM",
+      formatChecks: [],
+    });
+
+    const { result, store } = renderController(undefined, {
+      services: {
+        lookupSegmentConcordance,
+        generateAiRecommendation,
+      },
+    });
+
+    await act(async () => {
+      const reviewPromise = result.current.dependencies.review.onReviewWithAi("seg-02");
+      result.current.handleIntelligencePanelVisible("seg-02");
+      resolveConcordance?.({
+        glossaryTerms: [],
+        translationMemoryMatches: [
+          {
+            id: "tm-1",
+            sourceText: "Second",
+            targetText: "Deuxième",
+            matchPercent: 100,
+            contextLabel: "Settings",
+          },
+        ],
+      });
+      await concordancePromise;
+      await reviewPromise;
+    });
+
+    expect(lookupSegmentConcordance).toHaveBeenCalledTimes(1);
+    expect(store.getSegmentView("seg-02")?.targetText).toBe("Deuxième");
+    expect(store.autoFilledSegmentIds.has("seg-02")).toBe(true);
+  });
+
   it("does not start a duplicate concordance lookup when AI review runs during an in-flight lookup", async () => {
     let resolveConcordance: ((value: CatSegmentConcordanceResult) => void) | undefined;
     const concordancePromise = new Promise<CatSegmentConcordanceResult>((resolve) => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.ts
@@ -20,6 +20,7 @@ import {
 } from "@/components/cat/shared/cat.messages";
 import type {
   CatAiRecommendationResult,
+  CatSegmentConcordanceResult,
   CatWorkspaceDependencies,
   CatWorkspaceEditing,
   CatWorkspaceNavigation,
@@ -117,7 +118,6 @@ export function useCatWorkspaceController({
   const onAddComment = reviewOverrides?.onAddComment;
   const onResolveComment = reviewOverrides?.onResolveComment;
   const onAskQuestion = reviewOverrides?.onAskQuestion;
-  const onReviewWithAi = reviewOverrides?.onReviewWithAi;
   const onSkip = reviewOverrides?.onSkip;
   const onBulkApprove = reviewOverrides?.onBulkApprove;
   const onBulkSkip = reviewOverrides?.onBulkSkip;
@@ -209,9 +209,106 @@ export function useCatWorkspaceController({
   );
 
   const concordanceLoadedSegmentIdsRef = useRef(new Set<string>());
+  const concordanceInFlightRef = useRef(
+    new Map<string, Promise<CatSegmentConcordanceResult | undefined>>(),
+  );
+
+  const applyConcordanceResult = useCallback(
+    (segmentId: string, concordance: CatSegmentConcordanceResult, autoFill: boolean) => {
+      concordanceLoadedSegmentIdsRef.current.add(segmentId);
+      store.mergeSegmentIntelligence(segmentId, {
+        glossaryTerms: concordance.glossaryTerms,
+        translationMemoryMatches: concordance.translationMemoryMatches,
+      });
+
+      if (!autoFill) {
+        return;
+      }
+
+      const currentSegment = store.getSegmentView(segmentId);
+      const bestTmMatch = selectBestTmMatchForAutoFill(
+        concordance.translationMemoryMatches,
+        tmAutoFillMinMatchPercent,
+      );
+      if (
+        currentSegment &&
+        !currentSegment.targetText.trim() &&
+        bestTmMatch &&
+        !store.autoFilledSegmentIds.has(segmentId)
+      ) {
+        store.autoFilledSegmentIds = new Set([...store.autoFilledSegmentIds, segmentId]);
+        store.setTargetText(segmentId, bestTmMatch.targetText);
+        store.markSegmentSaved(segmentId, bestTmMatch.targetText);
+        onTargetChange?.(segmentId, bestTmMatch.targetText);
+      }
+    },
+    [onTargetChange, store, tmAutoFillMinMatchPercent],
+  );
+
+  const runConcordanceLookup = useCallback(
+    async (
+      segmentId: string,
+      options?: { autoFill?: boolean },
+    ): Promise<CatSegmentConcordanceResult | undefined> => {
+      if (!lookupSegmentConcordance) {
+        return undefined;
+      }
+
+      if (concordanceLoadedSegmentIdsRef.current.has(segmentId)) {
+        const intelligence = store.segmentIntelligence[segmentId] ?? store.intelligence;
+        return {
+          glossaryTerms: intelligence.glossaryTerms ?? [],
+          translationMemoryMatches: intelligence.translationMemoryMatches ?? [],
+        };
+      }
+
+      const inFlight = concordanceInFlightRef.current.get(segmentId);
+      if (inFlight) {
+        return inFlight;
+      }
+
+      const segment = store.getSegmentView(segmentId);
+      if (!segment) {
+        return undefined;
+      }
+
+      const autoFill = options?.autoFill !== false;
+      const lookupPromise = (async () => {
+        store.beginConcordanceLoad(segmentId);
+        try {
+          const concordance = await lookupSegmentConcordance(segment);
+          applyConcordanceResult(segmentId, concordance, autoFill);
+          return concordance;
+        } catch (error) {
+          const message =
+            error instanceof Error
+              ? error.message
+              : intl.formatMessage(catWorkspaceContainerMessages.concordanceSearchFailed);
+          store.upsertFormatCheck(segmentId, {
+            id: `concordance-failed-${segmentId}`,
+            label: intl.formatMessage(catWorkspaceContainerMessages.concordanceSearchLabel),
+            status: "fail",
+            message,
+            category: "qa",
+          });
+          return undefined;
+        } finally {
+          store.endConcordanceLoad(segmentId);
+          concordanceInFlightRef.current.delete(segmentId);
+        }
+      })();
+
+      concordanceInFlightRef.current.set(segmentId, lookupPromise);
+      return lookupPromise;
+    },
+    [applyConcordanceResult, intl, lookupSegmentConcordance, store],
+  );
+
+  const runConcordanceLookupRef = useRef(runConcordanceLookup);
+  runConcordanceLookupRef.current = runConcordanceLookup;
 
   const runSegmentReview = useCallback(
-    async (segmentId: string, options?: { includeAi?: boolean; includeConcordance?: boolean }) => {
+    async (segmentId: string, options?: { includeAi?: boolean }) => {
       const segment = store.getSegmentView(segmentId);
       if (!segment) {
         return;
@@ -219,171 +316,91 @@ export function useCatWorkspaceController({
 
       const includeAi = options?.includeAi === true && Boolean(generateAiRecommendation);
       const includeFormatChecks = Boolean(validateFormat || runQaChecks);
-      const includeConcordance =
-        Boolean(lookupSegmentConcordance) && (options?.includeConcordance === true || includeAi);
-      const shouldLookupConcordance =
-        includeConcordance &&
-        !concordanceLoadedSegmentIdsRef.current.has(segmentId) &&
-        store.concordanceLoadingSegmentId !== segmentId;
       const showFormatChecksLoading = includeFormatChecks && !includeAi;
 
-      if (!includeAi && !includeFormatChecks && !includeConcordance) {
+      if (!includeAi && !includeFormatChecks) {
         return;
       }
 
-      if (shouldLookupConcordance && lookupSegmentConcordance) {
-        store.beginConcordanceLoad(segmentId);
+      if (includeAi && lookupSegmentConcordance) {
+        await runConcordanceLookupRef.current(segmentId, { autoFill: false });
       }
 
+      const intelligenceForRecommendation =
+        store.segmentIntelligence[segmentId] ?? store.intelligence;
+
+      const sequence = store.beginReview({ includeAi, showFormatChecksLoading });
       try {
-        await onReviewWithAi?.(segmentId);
+        let recommendation: CatAiRecommendationResult | undefined;
+        let aiFailureCheck: CatFormatCheck | undefined;
 
-        const currentIntelligence = store.segmentIntelligence[segmentId] ?? store.intelligence;
+        const segmentForReview = store.getSegmentView(segmentId) ?? segment;
 
-        const sequence = store.beginReview({ includeAi, showFormatChecksLoading });
-        try {
-          let recommendation: CatAiRecommendationResult | undefined;
-          let aiFailureCheck: CatFormatCheck | undefined;
-          let intelligenceForRecommendation = currentIntelligence;
-
-          if (shouldLookupConcordance && lookupSegmentConcordance) {
-            try {
-              const concordance = await lookupSegmentConcordance(segment);
-              if (!store.isReviewCurrent(sequence)) {
-                return;
-              }
-
-              concordanceLoadedSegmentIdsRef.current.add(segmentId);
-
-              intelligenceForRecommendation = {
-                ...currentIntelligence,
-                glossaryTerms: concordance.glossaryTerms,
-                translationMemoryMatches: concordance.translationMemoryMatches,
-              };
-
-              store.mergeSegmentIntelligence(segmentId, {
-                glossaryTerms: concordance.glossaryTerms,
-                translationMemoryMatches: concordance.translationMemoryMatches,
-              });
-
-              const currentSegment = store.getSegmentView(segmentId);
-              const bestTmMatch = selectBestTmMatchForAutoFill(
-                concordance.translationMemoryMatches,
-                tmAutoFillMinMatchPercent,
-              );
-              if (
-                currentSegment &&
-                !currentSegment.targetText.trim() &&
-                bestTmMatch &&
-                !store.autoFilledSegmentIds.has(segmentId)
-              ) {
-                store.autoFilledSegmentIds = new Set([...store.autoFilledSegmentIds, segmentId]);
-                store.setTargetText(segmentId, bestTmMatch.targetText);
-                store.markSegmentSaved(segmentId, bestTmMatch.targetText);
-                onTargetChange?.(segmentId, bestTmMatch.targetText);
-              }
-            } catch (error) {
-              if (!store.isReviewCurrent(sequence)) {
-                return;
-              }
-
-              const message =
-                error instanceof Error
-                  ? error.message
-                  : intl.formatMessage(catWorkspaceContainerMessages.concordanceSearchFailed);
-              store.upsertFormatCheck(segmentId, {
-                id: `concordance-failed-${segmentId}`,
-                label: intl.formatMessage(catWorkspaceContainerMessages.concordanceSearchLabel),
-                status: "fail",
-                message,
-                category: "qa",
-              });
-            }
-          }
-
-          const segmentForReview = store.getSegmentView(segmentId) ?? segment;
-
-          if (includeAi && generateAiRecommendation) {
-            try {
-              recommendation = await generateAiRecommendation(
-                segmentForReview,
-                segmentForReview.targetText,
-                intelligenceForRecommendation,
-              );
-            } catch (error) {
-              if (!store.isReviewCurrent(sequence)) {
-                return;
-              }
-
-              const message =
-                error instanceof Error
-                  ? error.message
-                  : intl.formatMessage(catWorkspaceContainerMessages.aiRecommendationFailed);
-              aiFailureCheck = {
-                id: `ai-recommendation-failed-${segmentId}`,
-                label: intl.formatMessage(catWorkspaceContainerMessages.aiRecommendationLabel),
-                status: "fail",
-                message,
-                category: "qa",
-              };
-            }
-          }
-
-          if (includeFormatChecks || includeAi) {
-            const [formatChecks, qaChecks] = await Promise.all([
-              includeFormatChecks && validateFormat
-                ? validateFormat(
-                    segmentForReview,
-                    segmentForReview.targetText,
-                    intelligenceForRecommendation.glossaryTerms,
-                  )
-                : Promise.resolve([]),
-              includeFormatChecks && runQaChecks
-                ? runQaChecks(segmentForReview, segmentForReview.targetText)
-                : Promise.resolve([]),
-            ]);
+        if (includeAi && generateAiRecommendation) {
+          try {
+            recommendation = await generateAiRecommendation(
+              segmentForReview,
+              segmentForReview.targetText,
+              intelligenceForRecommendation,
+            );
+          } catch (error) {
             if (!store.isReviewCurrent(sequence)) {
               return;
             }
-            const withoutAiFailure = (segmentChecks: CatFormatCheck[]) =>
-              segmentChecks.filter((check) => check.id !== `ai-recommendation-failed-${segmentId}`);
-            const baseChecks = withoutAiFailure(
-              recommendation?.formatChecks ?? [...formatChecks, ...qaChecks],
-            );
-            const checks = aiFailureCheck
-              ? [aiFailureCheck, ...baseChecks.filter((check) => check.id !== aiFailureCheck.id)]
-              : baseChecks;
 
-            store.setFormatChecks(segmentId, checks, store.selectedSegmentId === segmentId);
-            if (recommendation) {
-              store.mergeSegmentIntelligence(segmentId, {
-                aiSuggestion: recommendation.aiSuggestion,
-                aiReasoning: recommendation.aiReasoning,
-              });
-            }
+            const message =
+              error instanceof Error
+                ? error.message
+                : intl.formatMessage(catWorkspaceContainerMessages.aiRecommendationFailed);
+            aiFailureCheck = {
+              id: `ai-recommendation-failed-${segmentId}`,
+              label: intl.formatMessage(catWorkspaceContainerMessages.aiRecommendationLabel),
+              status: "fail",
+              message,
+              category: "qa",
+            };
           }
-        } finally {
-          store.setReviewPhaseLoading(sequence, "ai", false);
-          store.setReviewPhaseLoading(sequence, "formatChecks", false);
+        }
+
+        if (includeFormatChecks || includeAi) {
+          const [formatChecks, qaChecks] = await Promise.all([
+            includeFormatChecks && validateFormat
+              ? validateFormat(
+                  segmentForReview,
+                  segmentForReview.targetText,
+                  intelligenceForRecommendation.glossaryTerms,
+                )
+              : Promise.resolve([]),
+            includeFormatChecks && runQaChecks
+              ? runQaChecks(segmentForReview, segmentForReview.targetText)
+              : Promise.resolve([]),
+          ]);
+          if (!store.isReviewCurrent(sequence)) {
+            return;
+          }
+          const withoutAiFailure = (segmentChecks: CatFormatCheck[]) =>
+            segmentChecks.filter((check) => check.id !== `ai-recommendation-failed-${segmentId}`);
+          const baseChecks = withoutAiFailure(
+            recommendation?.formatChecks ?? [...formatChecks, ...qaChecks],
+          );
+          const checks = aiFailureCheck
+            ? [aiFailureCheck, ...baseChecks.filter((check) => check.id !== aiFailureCheck.id)]
+            : baseChecks;
+
+          store.setFormatChecks(segmentId, checks, store.selectedSegmentId === segmentId);
+          if (recommendation) {
+            store.mergeSegmentIntelligence(segmentId, {
+              aiSuggestion: recommendation.aiSuggestion,
+              aiReasoning: recommendation.aiReasoning,
+            });
+          }
         }
       } finally {
-        if (shouldLookupConcordance && lookupSegmentConcordance) {
-          store.endConcordanceLoad(segmentId);
-        }
+        store.setReviewPhaseLoading(sequence, "ai", false);
+        store.setReviewPhaseLoading(sequence, "formatChecks", false);
       }
     },
-    [
-      generateAiRecommendation,
-      intl,
-      lookupSegmentConcordance,
-      onReviewWithAi,
-      onTargetChange,
-      runQaChecks,
-      runSegmentChecks,
-      store,
-      tmAutoFillMinMatchPercent,
-      validateFormat,
-    ],
+    [generateAiRecommendation, intl, lookupSegmentConcordance, runQaChecks, store, validateFormat],
   );
 
   const runSegmentReviewRef = useRef(runSegmentReview);
@@ -406,6 +423,7 @@ export function useCatWorkspaceController({
   useEffect(() => {
     concordanceLookupAttemptedRef.current.clear();
     concordanceLoadedSegmentIdsRef.current.clear();
+    concordanceInFlightRef.current.clear();
   }, [lookupSegmentConcordance]);
 
   useEffect(() => {
@@ -425,10 +443,7 @@ export function useCatWorkspaceController({
 
       if (lookupSegmentConcordance && !concordanceLookupAttemptedRef.current.has(segmentId)) {
         concordanceLookupAttemptedRef.current.add(segmentId);
-        void runSegmentReviewRef.current(segmentId, {
-          includeAi: false,
-          includeConcordance: true,
-        });
+        void runConcordanceLookupRef.current(segmentId);
       }
 
       if (lookupSegmentContext) {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.ts
@@ -211,7 +211,13 @@ export function useCatWorkspaceController({
 
   const concordanceLoadedSegmentIdsRef = useRef(new Set<string>());
   const concordanceInFlightRef = useRef(
-    new Map<string, Promise<CatSegmentConcordanceResult | undefined>>(),
+    new Map<
+      string,
+      {
+        autoFill: boolean;
+        promise: Promise<CatSegmentConcordanceResult | undefined>;
+      }
+    >(),
   );
 
   const applyConcordanceResult = useCallback(
@@ -265,7 +271,10 @@ export function useCatWorkspaceController({
 
       const inFlight = concordanceInFlightRef.current.get(segmentId);
       if (inFlight) {
-        return inFlight;
+        if (options?.autoFill !== false) {
+          inFlight.autoFill = true;
+        }
+        return inFlight.promise;
       }
 
       const segment = store.getSegmentView(segmentId);
@@ -273,34 +282,37 @@ export function useCatWorkspaceController({
         return undefined;
       }
 
-      const autoFill = options?.autoFill !== false;
-      const lookupPromise = (async () => {
-        store.beginConcordanceLoad(segmentId);
-        try {
-          const concordance = await lookupSegmentConcordance(segment);
-          applyConcordanceResult(segmentId, concordance, autoFill);
-          return concordance;
-        } catch (error) {
-          const message =
-            error instanceof Error
-              ? error.message
-              : intl.formatMessage(catWorkspaceContainerMessages.concordanceSearchFailed);
-          store.upsertFormatCheck(segmentId, {
-            id: `concordance-failed-${segmentId}`,
-            label: intl.formatMessage(catWorkspaceContainerMessages.concordanceSearchLabel),
-            status: "fail",
-            message,
-            category: "qa",
-          });
-          return undefined;
-        } finally {
-          store.endConcordanceLoad(segmentId);
-          concordanceInFlightRef.current.delete(segmentId);
-        }
-      })();
+      const inFlightEntry = {
+        autoFill: options?.autoFill !== false,
+        promise: (async () => {
+          store.beginConcordanceLoad(segmentId);
+          try {
+            const concordance = await lookupSegmentConcordance(segment);
+            const entry = concordanceInFlightRef.current.get(segmentId);
+            applyConcordanceResult(segmentId, concordance, entry?.autoFill ?? false);
+            return concordance;
+          } catch (error) {
+            const message =
+              error instanceof Error
+                ? error.message
+                : intl.formatMessage(catWorkspaceContainerMessages.concordanceSearchFailed);
+            store.upsertFormatCheck(segmentId, {
+              id: `concordance-failed-${segmentId}`,
+              label: intl.formatMessage(catWorkspaceContainerMessages.concordanceSearchLabel),
+              status: "fail",
+              message,
+              category: "qa",
+            });
+            return undefined;
+          } finally {
+            store.endConcordanceLoad(segmentId);
+            concordanceInFlightRef.current.delete(segmentId);
+          }
+        })(),
+      };
 
-      concordanceInFlightRef.current.set(segmentId, lookupPromise);
-      return lookupPromise;
+      concordanceInFlightRef.current.set(segmentId, inFlightEntry);
+      return inFlightEntry.promise;
     },
     [applyConcordanceResult, intl, lookupSegmentConcordance, store],
   );

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.ts
@@ -118,6 +118,7 @@ export function useCatWorkspaceController({
   const onAddComment = reviewOverrides?.onAddComment;
   const onResolveComment = reviewOverrides?.onResolveComment;
   const onAskQuestion = reviewOverrides?.onAskQuestion;
+  const onReviewWithAiOverride = reviewOverrides?.onReviewWithAi;
   const onSkip = reviewOverrides?.onSkip;
   const onBulkApprove = reviewOverrides?.onBulkApprove;
   const onBulkSkip = reviewOverrides?.onBulkSkip;
@@ -322,15 +323,20 @@ export function useCatWorkspaceController({
         return;
       }
 
-      if (includeAi && lookupSegmentConcordance) {
-        await runConcordanceLookupRef.current(segmentId, { autoFill: false });
-      }
-
-      const intelligenceForRecommendation =
-        store.segmentIntelligence[segmentId] ?? store.intelligence;
+      await onReviewWithAiOverride?.(segmentId);
 
       const sequence = store.beginReview({ includeAi, showFormatChecksLoading });
       try {
+        if (includeAi && lookupSegmentConcordance) {
+          await runConcordanceLookupRef.current(segmentId, { autoFill: false });
+          if (!store.isReviewCurrent(sequence)) {
+            return;
+          }
+        }
+
+        const intelligenceForRecommendation =
+          store.segmentIntelligence[segmentId] ?? store.intelligence;
+
         let recommendation: CatAiRecommendationResult | undefined;
         let aiFailureCheck: CatFormatCheck | undefined;
 
@@ -400,7 +406,15 @@ export function useCatWorkspaceController({
         store.setReviewPhaseLoading(sequence, "formatChecks", false);
       }
     },
-    [generateAiRecommendation, intl, lookupSegmentConcordance, runQaChecks, store, validateFormat],
+    [
+      generateAiRecommendation,
+      intl,
+      lookupSegmentConcordance,
+      onReviewWithAiOverride,
+      runQaChecks,
+      store,
+      validateFormat,
+    ],
   );
 
   const runSegmentReviewRef = useRef(runSegmentReview);


### PR DESCRIPTION
## What changed

Concordance (glossary + translation memory) was bundled into `runSegmentReview` and shared the same `reviewSequence` cancellation token as format checks and AI review. When the intelligence panel opened concordance at the same time as segment-select format checks, the faster review could invalidate the concordance run and discard TM/glossary results.

This PR extracts a dedicated `runConcordanceLookup` path with its own loading state and in-flight deduplication. `runSegmentReview` now handles format checks and AI recommendation only. AI review awaits cached or in-flight concordance before generating a suggestion, without triggering a duplicate API call.

## How to test

- [ ] Open a CAT file, select a segment, and confirm translation memory matches appear in the intelligence panel after concordance loads
- [ ] Switch segments quickly and confirm concordance results still appear (no silent drop)
- [ ] Click "Review with AI" while concordance is still loading — AI should wait for TM/glossary and only call concordance once
- [ ] Run `cd apps/hyperlocalise-web && vp test src/components/cat/workspace/use-cat-workspace-controller.test.tsx`
- [ ] Run `cd apps/hyperlocalise-web && vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)