### PR TITLE
refactor(web): show source files as tree only

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-detail-panel.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-detail-panel.stories.tsx
@@ -35,8 +35,7 @@ export const MetadataOnly: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByText("marketing/home.json")).toBeInTheDocument();
     await expect(canvas.getByText("fr-FR")).toBeInTheDocument();
-    await expect(canvas.getByText("Source preview")).toBeInTheDocument();
-    await expect(canvas.getByText("hero.title")).toBeInTheDocument();
+    await expect(canvas.queryByText("Source preview")).not.toBeInTheDocument();
     await expect(canvas.queryByText("CAT workspace")).not.toBeInTheDocument();
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-detail-panel.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { ReactNode } from "react";
 import Link from "next/link";
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
@@ -10,7 +9,6 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import type {
   ProjectFileDetailResponse,
   ProjectFileRecord,
-  ProjectSourceStringsPreview,
 } from "@/api/routes/project/project.schema";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -18,12 +16,10 @@ import { Spinner } from "@/components/ui/spinner";
 import { TypographyP } from "@/components/ui/typography";
 import { readApiError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
-import { parseSourceStringsFromFileContent } from "@/lib/projects/files/project-file-content";
 import { cn } from "@/lib/primitives/cn";
 import { formatBytes } from "./project-files-shared";
 import { CreateTranslationJobDialog } from "./create-translation-job-dialog";
 import { ImportTranslationsDialog } from "./import-translations-dialog";
-import { ProjectFileSourceStringsPreview } from "./project-file-source-strings-preview";
 import {
   countReadyLocales,
   resolveFileLocaleReadiness,
@@ -32,16 +28,10 @@ import {
 
 type ProjectFileDetail = ProjectFileDetailResponse["file"];
 
-export type ProjectFileSourceStringsPreviewRenderer = (props: {
-  sourceStrings: ProjectSourceStringsPreview;
-}) => ReactNode;
-
 const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
   dateStyle: "medium",
   timeStyle: "short",
 });
-
-const MAX_PREVIEW_CHARS = 100_000;
 
 function projectFileDetailQueryKey(
   organizationSlug: string,
@@ -81,27 +71,6 @@ function fileMetadataLine(
   ]
     .filter(Boolean)
     .join(" · ");
-}
-
-function truncatePreview(text: string) {
-  if (text.length <= MAX_PREVIEW_CHARS) {
-    return { text, truncated: false };
-  }
-
-  return {
-    text: `${text.slice(0, MAX_PREVIEW_CHARS)}\n\n…`,
-    truncated: true,
-  };
-}
-
-function defaultRenderSourceStringsPreview({
-  sourceStrings,
-}: Parameters<ProjectFileSourceStringsPreviewRenderer>[0]) {
-  if (!sourceStrings) {
-    return null;
-  }
-
-  return <ProjectFileSourceStringsPreview sourceStrings={sourceStrings} />;
 }
 
 export function ProjectFileDetailPanel({
@@ -214,7 +183,6 @@ export function ProjectFileDetailPanelView({
   isLoading,
   error,
   detail,
-  renderSourceStringsPreview = defaultRenderSourceStringsPreview,
 }: {
   organizationSlug: string;
   projectId: string;
@@ -226,7 +194,6 @@ export function ProjectFileDetailPanelView({
   isLoading: boolean;
   error?: unknown;
   detail?: ProjectFileDetail;
-  renderSourceStringsPreview?: ProjectFileSourceStringsPreviewRenderer;
 }) {
   const [translateDialogOpen, setTranslateDialogOpen] = useState(false);
   const [importDialogOpen, setImportDialogOpen] = useState(false);
@@ -252,7 +219,7 @@ export function ProjectFileDetailPanelView({
       <div className="flex h-full min-h-48 flex-col items-center justify-center gap-2 px-6 py-10 text-center">
         <TypographyP className="text-sm font-medium text-foreground">Select a file</TypographyP>
         <TypographyP className="max-w-sm text-sm text-muted-foreground">
-          Choose a file from the list to preview its source content and related jobs.
+          Choose a file from the list to view its metadata and related jobs.
         </TypographyP>
       </div>
     );
@@ -278,10 +245,6 @@ export function ProjectFileDetailPanelView({
   }
 
   const latestVersion = detail?.versions[0];
-  const latestContent = latestVersion?.content ?? null;
-  const sourceStringsPreview = parseSourceStringsFromFileContent(latestContent);
-  const textPreview =
-    latestContent?.text && !sourceStringsPreview ? truncatePreview(latestContent.text) : null;
   const displayByteSize = latestVersion?.byteSize ?? file.byteSize;
   const provider = file.provider;
 
@@ -412,33 +375,6 @@ export function ProjectFileDetailPanelView({
           </div>
         ) : null}
       </header>
-
-      <section className="space-y-2">
-        <TypographyP className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
-          Source preview
-        </TypographyP>
-        {sourceStringsPreview ? (
-          renderSourceStringsPreview({
-            sourceStrings: sourceStringsPreview,
-          })
-        ) : textPreview ? (
-          <div className="overflow-hidden rounded-md border border-border bg-background">
-            <pre className="max-h-[min(24rem,50vh)] overflow-auto p-3 font-mono text-xs leading-relaxed whitespace-pre-wrap wrap-break-word text-foreground">
-              {textPreview.text}
-            </pre>
-            {textPreview.truncated ? (
-              <TypographyP className="border-t border-border px-3 py-2 text-xs text-muted-foreground">
-                Preview truncated. Download the full file from a completed job output when
-                available.
-              </TypographyP>
-            ) : null}
-          </div>
-        ) : (
-          <TypographyP className="text-sm text-muted-foreground">
-            No text preview is available for this file yet.
-          </TypographyP>
-        )}
-      </section>
 
       {orderedJobsByLocale.length > 0 ? (
         <section className="space-y-3">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.tsx
@@ -7,6 +7,7 @@ import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TypographyH4 } from "@/components/ui/typography";
 import { supportsProviderCatFile } from "@/lib/providers/provider-cat-capabilities";
+import { toast } from "sonner";
 
 import { ProjectFilesTree } from "../../../../files/_components/project-files-tree";
 
@@ -71,6 +72,14 @@ function canOpenFileInCat(
   return isNativeCatFile;
 }
 
+function catOpenUnavailableMessage(targetLocale: string | null) {
+  if (!targetLocale) {
+    return "No target locale is available for this task file.";
+  }
+
+  return "This file can't be opened in the CAT workspace.";
+}
+
 export function JobSourceFilesPanel({
   organizationSlug,
   projectId,
@@ -116,6 +125,7 @@ export function JobSourceFilesPanel({
 
       const targetLocale = resolveTargetLocale(file, highlightLocale);
       if (!canOpenFileInCat(file, sourcePath, encodedJobId, targetLocale)) {
+        toast.error(catOpenUnavailableMessage(targetLocale));
         return;
       }
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.tsx
@@ -1,17 +1,14 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import Link from "next/link";
-import { ListIcon } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
-import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { TypographyH4, TypographyP } from "@/components/ui/typography";
+import { TypographyH4 } from "@/components/ui/typography";
 import { supportsProviderCatFile } from "@/lib/providers/provider-cat-capabilities";
 
 import { ProjectFilesTree } from "../../../../files/_components/project-files-tree";
-import { ProjectFileDetailPanel } from "../../../../files/_components/project-file-detail-panel";
 
 function sortFilesByPath(files: ProjectFileRecord[]) {
   return [...files].toSorted((a, b) =>
@@ -42,6 +39,38 @@ function stringsHref(input: {
   return `/org/${input.organizationSlug}/projects/${encodeURIComponent(input.projectId)}/jobs/${encodeURIComponent(input.encodedJobId)}/strings?${params.toString()}`;
 }
 
+function resolveTargetLocale(file: ProjectFileRecord, highlightLocale: string | null) {
+  if (file.provider) {
+    if (highlightLocale && file.provider.targetLocales?.includes(highlightLocale)) {
+      return highlightLocale;
+    }
+
+    return file.provider.targetLocales?.[0] ?? highlightLocale;
+  }
+
+  return highlightLocale;
+}
+
+function canOpenFileInCat(
+  file: ProjectFileRecord,
+  sourcePath: string,
+  encodedJobId: string | null | undefined,
+  targetLocale: string | null,
+) {
+  if (!encodedJobId || !targetLocale) {
+    return false;
+  }
+
+  const isProviderCatFile = supportsProviderCatFile(file);
+  const isNativeCatFile = !file.provider && Boolean(file.storedFileId);
+
+  if (isProviderCatFile) {
+    return Boolean(sourcePath);
+  }
+
+  return isNativeCatFile;
+}
+
 export function JobSourceFilesPanel({
   organizationSlug,
   projectId,
@@ -52,6 +81,7 @@ export function JobSourceFilesPanel({
   errorMessage,
   emptyMessage = "No source files linked to this job.",
   highlightLocale = null,
+  openInCatOnSelect = false,
 }: {
   organizationSlug: string;
   projectId: string;
@@ -62,37 +92,63 @@ export function JobSourceFilesPanel({
   errorMessage?: string;
   emptyMessage?: string;
   highlightLocale?: string | null;
+  openInCatOnSelect?: boolean;
 }) {
+  const router = useRouter();
   const sortedFiles = useMemo(() => sortFilesByPath(files), [files]);
   const [selectedSourcePath, setSelectedSourcePath] = useState<string | null>(null);
   const selectedFile =
     sortedFiles.find((file) => file.sourcePath === selectedSourcePath) ?? sortedFiles[0] ?? null;
   const activeSourcePath = selectedFile?.sourcePath ?? null;
-  const targetLocale = selectedFile?.provider
-    ? highlightLocale && selectedFile.provider.targetLocales?.includes(highlightLocale)
-      ? highlightLocale
-      : (selectedFile.provider.targetLocales?.[0] ?? highlightLocale)
-    : highlightLocale;
-  const isProviderCatFile = Boolean(selectedFile && supportsProviderCatFile(selectedFile));
-  const isNativeCatFile = Boolean(
-    selectedFile && !selectedFile.provider && selectedFile.storedFileId,
+
+  const handleSelectFile = useCallback(
+    (sourcePath: string) => {
+      setSelectedSourcePath(sourcePath);
+
+      if (!openInCatOnSelect || !encodedJobId) {
+        return;
+      }
+
+      const file = sortedFiles.find((entry) => entry.sourcePath === sourcePath);
+      if (!file) {
+        return;
+      }
+
+      const targetLocale = resolveTargetLocale(file, highlightLocale);
+      if (!canOpenFileInCat(file, sourcePath, encodedJobId, targetLocale)) {
+        return;
+      }
+
+      router.push(
+        stringsHref({
+          organizationSlug,
+          projectId,
+          encodedJobId,
+          targetLocale: targetLocale as string,
+          ...(supportsProviderCatFile(file)
+            ? { sourcePath }
+            : { storedFileId: file.storedFileId as string }),
+        }),
+      );
+    },
+    [
+      encodedJobId,
+      highlightLocale,
+      openInCatOnSelect,
+      organizationSlug,
+      projectId,
+      router,
+      sortedFiles,
+    ],
   );
-  const canViewStrings = Boolean(
-    encodedJobId &&
-    selectedFile &&
-    targetLocale &&
-    ((isProviderCatFile && activeSourcePath) || isNativeCatFile),
-  );
-  const showStringsAction = isProviderCatFile || isNativeCatFile;
 
   return (
     <section className="rounded-lg border border-border bg-card p-5">
       <TypographyH4>Source files</TypographyH4>
 
       {isLoading ? (
-        <div className="mt-4 space-y-3">
-          <Skeleton className="h-10 w-full" />
-          <Skeleton className="h-48 w-full" />
+        <div className="mt-4">
+          <Skeleton className="h-80 w-full" />
         </div>
       ) : null}
 
@@ -107,62 +163,13 @@ export function JobSourceFilesPanel({
       ) : null}
 
       {!isLoading && !isError && sortedFiles.length > 0 ? (
-        <div className="mt-4 overflow-hidden rounded-lg border border-border bg-background lg:grid lg:grid-cols-[minmax(0,16rem)_minmax(0,1fr)]">
-          <aside className="min-h-80 border-b border-border p-2 lg:border-r lg:border-b-0">
-            <ProjectFilesTree
-              ariaLabel="Job source files"
-              files={sortedFiles}
-              selectedSourcePath={activeSourcePath}
-              onSelectFile={setSelectedSourcePath}
-            />
-          </aside>
-          <div className="min-h-[min(20rem,50vh)] overflow-y-auto">
-            {showStringsAction ? (
-              <div className="flex flex-col gap-2 border-b border-border px-5 py-3 sm:flex-row sm:items-center sm:justify-between">
-                <div>
-                  <TypographyP className="font-mono text-xs text-foreground">
-                    {selectedFile?.sourcePath}
-                  </TypographyP>
-                  <TypographyP className="text-xs text-muted-foreground">
-                    {targetLocale
-                      ? `Edit ${targetLocale} strings in the CAT workspace.`
-                      : "No target locale is available for this task file."}
-                  </TypographyP>
-                </div>
-                <Button
-                  type="button"
-                  size="sm"
-                  disabled={!canViewStrings}
-                  render={
-                    canViewStrings ? (
-                      <Link
-                        href={stringsHref({
-                          organizationSlug,
-                          projectId,
-                          encodedJobId: encodedJobId as string,
-                          targetLocale: targetLocale as string,
-                          ...(isProviderCatFile
-                            ? { sourcePath: activeSourcePath as string }
-                            : { storedFileId: selectedFile?.storedFileId as string }),
-                        })}
-                      />
-                    ) : undefined
-                  }
-                >
-                  <ListIcon />
-                  View strings
-                </Button>
-              </div>
-            ) : null}
-            <ProjectFileDetailPanel
-              organizationSlug={organizationSlug}
-              projectId={projectId}
-              encodedJobId={encodedJobId}
-              file={selectedFile}
-              requestedSourcePath={activeSourcePath}
-              highlightLocale={highlightLocale}
-            />
-          </div>
+        <div className="mt-4 overflow-hidden rounded-lg border border-border bg-background p-2">
+          <ProjectFilesTree
+            ariaLabel="Job source files"
+            files={sortedFiles}
+            selectedSourcePath={activeSourcePath}
+            onSelectFile={handleSelectFile}
+          />
         </div>
       ) : null}
     </section>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/tms-live-job-files-section.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/tms-live-job-files-section.tsx
@@ -17,11 +17,13 @@ export function TmsLiveJobFilesSection({
   projectId,
   encodedJobId,
   highlightLocale,
+  openInCatOnSelect = false,
 }: {
   organizationSlug: string;
   projectId: string;
   encodedJobId: string;
   highlightLocale?: string | null;
+  openInCatOnSelect?: boolean;
 }) {
   const filesQuery = useQuery({
     queryKey: tmsLiveJobFilesQueryKey(organizationSlug, encodedJobId),
@@ -56,6 +58,7 @@ export function TmsLiveJobFilesSection({
       }
       emptyMessage="No files are linked to this task."
       highlightLocale={highlightLocale ?? null}
+      openInCatOnSelect={openInCatOnSelect}
     />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-source-file-picker.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-source-file-picker.tsx
@@ -104,6 +104,7 @@ function NativeJobCatSourceFilePicker({
       files={[file]}
       highlightLocale={targetLocale}
       emptyMessage="No source file linked to this task."
+      openInCatOnSelect
     />
   );
 }
@@ -141,6 +142,7 @@ export function JobCatSourceFilePicker({
             projectId={projectId}
             encodedJobId={jobId}
             highlightLocale={targetLocale}
+            openInCatOnSelect
           />
         ) : (
           <NativeJobCatSourceFilePicker


### PR DESCRIPTION
## What changed

Job source files now render as a file tree only. The detail panel, metadata sidebar, and source preview UI were removed from `JobSourceFilesPanel`.

On the CAT source file picker page, selecting a file opens the CAT workspace directly instead of showing a preview and a separate "View strings" action.

The unused source preview section was also removed from `ProjectFileDetailPanel`.

## How to test

- Run `cd apps/hyperlocalise-web && vp check --fix`
- Open a task's source file picker (`/jobs/{id}/strings` without a selected file) and confirm only the file tree is shown
- Click a file in the tree and confirm it navigates to the CAT workspace
- Open a task detail page with source files and confirm the Files tab shows the tree without preview or detail panel

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)