### PR TITLE
fix(crowdin): add internalCode to Language model for API parity

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -209,3 +209,9 @@
 **Learning:** The Crowdin Tasks API v2 supports filtering by `creatorId` when listing project tasks and by `projectId` when listing user tasks. These parameters were missing from the SDK's `TasksListOptions` and `UserTasksListOptions` respectively.
 
 **Action:** Added `CreatorID` to `TasksListOptions` and `ProjectID` to `UserTasksListOptions` in `model/tasks.go`. Updated their `Values()` methods to correctly encode these parameters in query strings. Verified with updated unit tests in `tasks_test.go`.
+
+## 2026-07-07 - Add Language model parity for internalCode
+
+**Learning:** The Crowdin API v2 Language resource includes an `internalCode` field in its response, which was missing from the Go SDK's `Language` model. This field provides the internal Crowdin language code, which can differ from standard ISO codes.
+
+**Action:** Added `InternalCode` (string) to the `Language` struct in `model/languages.go`. Updated contract tests in `languages_test.go` to include the `internalCode` field in mock responses and verify correct unmarshaling across List, Get, and Add operations.

--- a/go.work
+++ b/go.work
@@ -1,3 +1,6 @@
 go 1.26.1
 
-use .
+use (
+	.
+	./third_party/crowdin-api-client-go
+)

--- a/third_party/crowdin-api-client-go/crowdin/languages_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/languages_test.go
@@ -38,7 +38,8 @@ func TestLanguageService_List(t *testing.T) {
 						"pluralRules": "(n != 1)",
 						"pluralExamples": ["0, 2-999; 1.2, 2.07..."],
 						"textDirection": "ltr",
-						"dialectOf": "es"
+						"dialectOf": "es",
+						"internalCode": "es"
 					}
 				},
 				{
@@ -56,7 +57,8 @@ func TestLanguageService_List(t *testing.T) {
 						"pluralRules": "(n != 1)",
 						"pluralExamples": ["0, 2-999; 1.2, 2.07..."],
 						"textDirection": "ltr",
-						"dialectOf": "uk"
+						"dialectOf": "uk",
+						"internalCode": "uk"
 					}
 				}
 			],
@@ -88,6 +90,7 @@ func TestLanguageService_List(t *testing.T) {
 			PluralExamples:      []string{"0, 2-999; 1.2, 2.07..."},
 			TextDirection:       "ltr",
 			DialectOf:           "es",
+			InternalCode:        "es",
 		},
 		{
 			ID:                  "uk",
@@ -104,6 +107,7 @@ func TestLanguageService_List(t *testing.T) {
 			PluralExamples:      []string{"0, 2-999; 1.2, 2.07..."},
 			TextDirection:       "ltr",
 			DialectOf:           "uk",
+			InternalCode:        "uk",
 		},
 	}
 	if !reflect.DeepEqual(languages, want) {
@@ -149,7 +153,8 @@ func TestLanguagesService_ListWithQueryParams(t *testing.T) {
 						"pluralRules": "(n != 1)",
 						"pluralExamples": ["0, 2-999; 1.2, 2.07..."],
 						"textDirection": "ltr",
-						"dialectOf": "uk"
+						"dialectOf": "uk",
+						"internalCode": "uk"
 					}
 				}
 			],
@@ -181,6 +186,7 @@ func TestLanguagesService_ListWithQueryParams(t *testing.T) {
 			PluralExamples:      []string{"0, 2-999; 1.2, 2.07..."},
 			TextDirection:       "ltr",
 			DialectOf:           "uk",
+			InternalCode:        "uk",
 		},
 	}
 	if !reflect.DeepEqual(languages, want) {
@@ -216,7 +222,8 @@ func TestLanguagesService_Get(t *testing.T) {
 				"pluralRules": "(n != 1)",
 				"pluralExamples": ["0, 2-999; 1.2, 2.07..."],
 				"textDirection": "ltr",
-				"dialectOf": "uk"
+				"dialectOf": "uk",
+				"internalCode": "uk"
 			}
 		}`)
 	})
@@ -241,6 +248,7 @@ func TestLanguagesService_Get(t *testing.T) {
 		PluralExamples:      []string{"0, 2-999; 1.2, 2.07..."},
 		TextDirection:       "ltr",
 		DialectOf:           "uk",
+		InternalCode:        "uk",
 	}
 	if !reflect.DeepEqual(language, want) {
 		t.Errorf("Languages.Get returned %+v, want %+v", language, want)
@@ -297,6 +305,7 @@ func TestLanguageService_Add(t *testing.T) {
 		PluralExamples:      []string{"0, 2-999; 1.2, 2.07..."},
 		TextDirection:       "ltr",
 		DialectOf:           "uk",
+		InternalCode:        "custom",
 	}
 
 	mux.HandleFunc("/api/v2/languages", func(w http.ResponseWriter, r *http.Request) {
@@ -320,7 +329,8 @@ func TestLanguageService_Add(t *testing.T) {
 				"pluralRules": "(n != 1)",
 				"pluralExamples": ["0, 2-999; 1.2, 2.07..."],
 				"textDirection": "ltr",
-				"dialectOf": "uk"
+				"dialectOf": "uk",
+				"internalCode": "custom"
 			}
 		}`)
 	})
@@ -368,7 +378,8 @@ func TestLanguagesService_Edit(t *testing.T) {
 				"pluralRules": "(n != 1)",
 				"pluralExamples": ["0, 2-999; 1.2, 2.07..."],
 				"textDirection": "ltr",
-				"dialectOf": "uk"
+				"dialectOf": "uk",
+				"internalCode": "custom"
 			}
 		}`)
 	})

--- a/third_party/crowdin-api-client-go/crowdin/model/languages.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/languages.go
@@ -21,6 +21,7 @@ type Language struct {
 	PluralExamples      []string `json:"pluralExamples"`
 	TextDirection       string   `json:"textDirection"`
 	DialectOf           string   `json:"dialectOf"`
+	InternalCode        string   `json:"internalCode"`
 }
 
 // LanguagesListResponse defines the structure of a response


### PR DESCRIPTION
This PR improves parity between the Hyperlocalise Crowdin fork and the official Crowdin API v2 by adding the missing `internalCode` field to the `Language` response model.

- **What**: Added `InternalCode` string field to the `Language` struct.
- **Why**: The `internalCode` field is part of the documented Crowdin API v2 response for languages but was absent from the SDK, preventing callers from accessing it.
- **Docs**: https://developer.crowdin.com/api/v2/#operation/api.languages.get
- **Scope**: `third_party/crowdin-api-client-go/crowdin/model/languages.go`, `third_party/crowdin-api-client-go/crowdin/languages_test.go`, `go.work`.
- **Tests**: Ran `go test -v ./third_party/crowdin-api-client-go/crowdin -run TestLanguage` and verified all tests pass.
- **Confidence**: High, as this is a non-breaking addition of a documented field verified with contract tests.

---
*PR created automatically by Jules for task [9857048385875931408](https://jules.google.com/task/9857048385875931408) started by @cungminh2710*