### PR TITLE
feat(cat): validate segments with Go service

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-validation.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-validation.test.ts
@@ -77,6 +77,32 @@ describe("fetchCatSegmentValidation", () => {
     );
   });
 
+  it("omits maxLength when the segment has no positive limit", async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ checks: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await fetchCatSegmentValidation(
+      {
+        sourceText: "Hello",
+        targetText: "Bonjour",
+        sourcePath: "/messages/en.json",
+      },
+      fetcher,
+    );
+
+    const request = fetcher.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(request.body as string)).toEqual({
+      sourceText: "Hello",
+      targetText: "Bonjour",
+      sourcePath: "/messages/en.json",
+      modes: ["not_localized", "whitespace_only", "same_as_source"],
+    });
+  });
+
   it("returns an aborted result when the request is cancelled", async () => {
     const abortController = new AbortController();
     const fetcher = vi.fn().mockImplementation(async (_url, init: RequestInit) => {

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-validation.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-validation.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { fetchCatSegmentValidation } from "./project-file-cat-validation";
+
+describe("fetchCatSegmentValidation", () => {
+  it("posts the segment and all QA modes to go-svc", async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          checks: [
+            {
+              id: "format-parity",
+              label: "Placeholders & ICU",
+              status: "pass",
+              message: "Target keeps the required placeholders and ICU structure.",
+              category: "placeholder",
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const result = await fetchCatSegmentValidation(
+      {
+        sourceText: "Hello {name}",
+        targetText: "Bonjour {name}",
+        sourcePath: "/messages/en.json",
+        maxLength: 40,
+      },
+      fetcher,
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: true,
+        value: [expect.objectContaining({ id: "format-parity", status: "pass" })],
+      }),
+    );
+    expect(fetcher).toHaveBeenCalledWith(
+      "/api/go-svc/v1/validate/segment",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "same-origin",
+        body: JSON.stringify({
+          sourceText: "Hello {name}",
+          targetText: "Bonjour {name}",
+          sourcePath: "/messages/en.json",
+          maxLength: 40,
+          modes: ["not_localized", "whitespace_only", "same_as_source"],
+        }),
+      }),
+    );
+  });
+
+  it("rejects malformed service responses", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ checks: [{ status: "unknown" }] }), { status: 200 }),
+      );
+
+    const result = await fetchCatSegmentValidation(
+      {
+        sourceText: "Hello",
+        targetText: "Bonjour",
+        sourcePath: "/messages/en.json",
+      },
+      fetcher,
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: expect.objectContaining({ code: "invalid_response" }),
+      }),
+    );
+  });
+
+  it("returns an aborted result when the request is cancelled", async () => {
+    const abortController = new AbortController();
+    const fetcher = vi.fn().mockImplementation(async (_url, init: RequestInit) => {
+      abortController.abort();
+      init.signal?.throwIfAborted();
+      return new Response();
+    });
+
+    const result = await fetchCatSegmentValidation(
+      {
+        sourceText: "Hello",
+        targetText: "Bonjour",
+        sourcePath: "/messages/en.json",
+        signal: abortController.signal,
+      },
+      fetcher,
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: { code: "aborted" },
+      }),
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-validation.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-validation.ts
@@ -47,7 +47,7 @@ export async function fetchCatSegmentValidation(
         sourceText: input.sourceText,
         targetText: input.targetText,
         sourcePath: input.sourcePath,
-        maxLength: input.maxLength ?? 0,
+        ...(input.maxLength != null && input.maxLength > 0 ? { maxLength: input.maxLength } : {}),
         modes: CAT_SEGMENT_QA_MODES,
       }),
       signal: input.signal,

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-validation.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-validation.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+
+import type { CatFormatCheck } from "@/components/cat/shared/types";
+import { readApiError } from "@/lib/api-error";
+import { err, fromThrowableAsync, isErr, ok, type Result } from "@/lib/primitives/result/results";
+
+const catFormatCheckSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  status: z.enum(["pass", "warn", "fail"]),
+  message: z.string(),
+  category: z
+    .enum(["length", "placeholder", "icu", "syntax", "terminology", "glossary", "qa"])
+    .optional(),
+  relatedTokens: z.array(z.string()).optional(),
+});
+
+const catSegmentValidationResponseSchema = z.object({
+  checks: z.array(catFormatCheckSchema),
+});
+
+export const CAT_SEGMENT_QA_MODES = ["not_localized", "whitespace_only", "same_as_source"] as const;
+
+export type CatSegmentValidationError =
+  | { code: "aborted" }
+  | { code: "invalid_response"; message: string }
+  | { code: "service_error"; message: string };
+
+export async function fetchCatSegmentValidation(
+  input: {
+    sourceText: string;
+    targetText: string;
+    sourcePath: string;
+    maxLength?: number;
+    signal?: AbortSignal;
+  },
+  fetcher: typeof fetch = fetch,
+): Promise<Result<CatFormatCheck[], CatSegmentValidationError>> {
+  const responseResult = await fromThrowableAsync(
+    fetcher("/api/go-svc/v1/validate/segment", {
+      method: "POST",
+      credentials: "same-origin",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        sourceText: input.sourceText,
+        targetText: input.targetText,
+        sourcePath: input.sourcePath,
+        maxLength: input.maxLength ?? 0,
+        modes: CAT_SEGMENT_QA_MODES,
+      }),
+      signal: input.signal,
+    }),
+  );
+
+  if (isErr(responseResult)) {
+    if (input.signal?.aborted) {
+      return err({ code: "aborted" });
+    }
+
+    return err({
+      code: "service_error",
+      message:
+        responseResult.error instanceof Error
+          ? responseResult.error.message
+          : "Segment validation request failed.",
+    });
+  }
+
+  const response = responseResult.value;
+  if (!response.ok) {
+    return err({
+      code: "service_error",
+      message: await readApiError(response, "Segment validation request failed"),
+    });
+  }
+
+  const bodyResult = await fromThrowableAsync(response.json());
+  if (isErr(bodyResult)) {
+    return err({
+      code: "invalid_response",
+      message: "Segment validation returned invalid JSON.",
+    });
+  }
+
+  const parsed = catSegmentValidationResponseSchema.safeParse(bodyResult.value);
+  if (!parsed.success) {
+    return err({
+      code: "invalid_response",
+      message: "Segment validation returned an invalid response.",
+    });
+  }
+
+  return ok(parsed.data.checks);
+}

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
@@ -23,6 +23,7 @@ import { mapCatConcordanceForAiRecommendation } from "@/lib/translation/map-cat-
 import { cn } from "@/lib/primitives/cn";
 
 import { resolveAvailableCatQueueFilters } from "@/components/cat/queue/cat-queue-filter";
+import { glossaryFormatChecksForSegment } from "@/components/cat/intelligence/cat-glossary-checks";
 import { buildCatSegmentShareUrl } from "@/components/cat/segment/cat-segment-share-link";
 import type {
   CatGlossaryTerm,
@@ -33,7 +34,8 @@ import type {
 import { CatWorkspaceContainer } from "@/components/cat/workspace/cat-workspace-container";
 import { CatWorkspaceSkeleton } from "@/components/cat/workspace/cat-workspace-skeleton";
 
-import { projectFileCatToWorkspaceState, validateSegmentFormat } from "./project-file-cat-mapper";
+import { projectFileCatToWorkspaceState } from "./project-file-cat-mapper";
+import { fetchCatSegmentValidation } from "./project-file-cat-validation";
 import { useCatMutations } from "./use-cat-mutations";
 import { useCatSegmentQuery } from "./use-cat-segment-query";
 
@@ -153,9 +155,45 @@ export function ProjectFileCatWorkspace({
   }, [catFile, intl, sourceLocale]);
 
   const validateFormat = useCallback(
-    (segment: CatSegment, value: string, glossaryTerms: CatGlossaryTerm[] = []) =>
-      validateSegmentFormat(segment, value, intl, glossaryTerms),
-    [intl],
+    async (
+      segment: CatSegment,
+      value: string,
+      glossaryTerms: CatGlossaryTerm[] = [],
+      options?: { signal?: AbortSignal },
+    ) => {
+      const validation = await fetchCatSegmentValidation({
+        sourceText: segment.sourceText,
+        targetText: value,
+        sourcePath,
+        maxLength: segment.maxLength,
+        signal: options?.signal,
+      });
+
+      if (!validation.ok) {
+        if (validation.error.code === "aborted") {
+          const abortError = new Error("Segment validation aborted.");
+          abortError.name = "AbortError";
+          throw abortError;
+        }
+
+        return [
+          {
+            id: "validation-unavailable",
+            label: "Validation unavailable",
+            status: "warn" as const,
+            message: validation.error.message,
+            category: "qa" as const,
+          },
+          ...glossaryFormatChecksForSegment(segment.sourceText, value, glossaryTerms, intl),
+        ];
+      }
+
+      return [
+        ...validation.value,
+        ...glossaryFormatChecksForSegment(segment.sourceText, value, glossaryTerms, intl),
+      ];
+    },
+    [intl, sourcePath],
   );
 
   const isNativeProject = !catFile?.provider;

--- a/apps/hyperlocalise-web/src/components/cat/shared/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/dependencies.ts
@@ -61,6 +61,7 @@ export interface CatWorkspaceServices {
     segment: CatSegment,
     value: string,
     glossaryTerms?: CatGlossaryTerm[],
+    options?: { signal?: AbortSignal },
   ) => Promise<CatFormatCheck[]>;
   runQaChecks?: (segment: CatSegment, value: string) => Promise<CatFormatCheck[]>;
   lookupSegmentContext?: (

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.test.tsx
@@ -103,6 +103,39 @@ describe("useCatWorkspaceController", () => {
     expect(store.getSegmentView("seg-02")?.targetText).toBe("Deuxième");
   });
 
+  it("cancels the previous segment debounce when selection triggers direct validation", async () => {
+    const validateFormat = vi.fn(mockValidateFormat);
+    const { result, rerender, store } = renderController(undefined, {
+      services: { validateFormat },
+    });
+
+    await waitFor(() => expect(validateFormat).toHaveBeenCalled());
+    validateFormat.mockClear();
+
+    act(() => {
+      result.current.dependencies.editing.onTargetChange("seg-02", "Deuxième");
+      store.setSelectedSegmentId("seg-03");
+    });
+    rerender();
+
+    await waitFor(() =>
+      expect(validateFormat).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "seg-03" }),
+        "Troisième",
+        expect.any(Array),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      ),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 350));
+
+    expect(validateFormat).not.toHaveBeenCalledWith(
+      expect.objectContaining({ id: "seg-02" }),
+      "Deuxième",
+      expect.any(Array),
+      expect.any(Object),
+    );
+  });
+
   it("applies AI suggestions through the editing pipeline", () => {
     const initialState = createCatWorkspaceState({
       selectedSegmentId: "seg-02",
@@ -360,6 +393,57 @@ describe("useCatWorkspaceController", () => {
 
     expect(onReviewWithAi).toHaveBeenCalledWith("seg-02");
     expect(generateAiRecommendation).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts superseded format validation during AI review", async () => {
+    const signals: AbortSignal[] = [];
+    const resolvers: Array<(checks: CatFormatCheck[]) => void> = [];
+    const validateFormat = vi.fn(
+      (
+        _segment,
+        _value,
+        _glossaryTerms,
+        options?: {
+          signal?: AbortSignal;
+        },
+      ) =>
+        new Promise<CatFormatCheck[]>((resolve) => {
+          const signal = options?.signal;
+          if (signal) {
+            signals.push(signal);
+            signal.addEventListener("abort", () => resolve([]), { once: true });
+          }
+          resolvers.push(resolve);
+        }),
+    );
+    const { result } = renderController(undefined, {
+      services: { validateFormat },
+    });
+
+    await waitFor(() => expect(validateFormat).toHaveBeenCalled());
+    resolvers.shift()?.([]);
+    validateFormat.mockClear();
+    signals.length = 0;
+
+    let firstReview: Promise<void> | undefined;
+    act(() => {
+      firstReview = result.current.dependencies.review.onReviewWithAi("seg-02") as Promise<void>;
+    });
+    await waitFor(() => expect(validateFormat).toHaveBeenCalledTimes(1));
+
+    let secondReview: Promise<void> | undefined;
+    act(() => {
+      secondReview = result.current.dependencies.review.onReviewWithAi("seg-02") as Promise<void>;
+    });
+    await waitFor(() => expect(validateFormat).toHaveBeenCalledTimes(2));
+
+    expect(signals[0]?.aborted).toBe(true);
+    expect(signals[1]?.aborted).toBe(false);
+
+    resolvers.at(-1)?.([]);
+    await act(async () => {
+      await Promise.all([firstReview, secondReview]);
+    });
   });
 
   it("runs generateAiRecommendation once when Review with AI is triggered twice during concordance", async () => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.test.tsx
@@ -78,14 +78,28 @@ afterEach(() => {
 });
 
 describe("useCatWorkspaceController", () => {
-  it("runs format checks when the target text changes", async () => {
-    const { result, store } = renderController();
+  it("debounces format checks and validates the latest target text", async () => {
+    const validateFormat = vi.fn(mockValidateFormat);
+    const { result, store } = renderController(undefined, {
+      services: { validateFormat },
+    });
+
+    await waitFor(() => expect(validateFormat).toHaveBeenCalled());
+    validateFormat.mockClear();
 
     act(() => {
+      result.current.dependencies.editing.onTargetChange("seg-02", "Deux");
       result.current.dependencies.editing.onTargetChange("seg-02", "Deuxième");
     });
 
-    await waitFor(() => expect(store.segmentFormatChecks["seg-02"]?.length).toBeGreaterThan(0));
+    expect(validateFormat).not.toHaveBeenCalled();
+    await waitFor(() => expect(validateFormat).toHaveBeenCalledTimes(1));
+    expect(validateFormat).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "seg-02" }),
+      "Deuxième",
+      expect.any(Array),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
     expect(store.getSegmentView("seg-02")?.targetText).toBe("Deuxième");
   });
 

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.ts
@@ -189,6 +189,11 @@ export function useCatWorkspaceController({
 
   const runSegmentChecks = useCallback(
     async (segment: CatSegment, value: string, glossaryTermsOverride?: CatGlossaryTerm[]) => {
+      if (validationTimeoutRef.current) {
+        clearTimeout(validationTimeoutRef.current);
+        validationTimeoutRef.current = null;
+      }
+
       if (!validateFormat && !runQaChecks) {
         return;
       }
@@ -377,6 +382,14 @@ export function useCatWorkspaceController({
         return;
       }
 
+      if (validationTimeoutRef.current) {
+        clearTimeout(validationTimeoutRef.current);
+        validationTimeoutRef.current = null;
+      }
+      validationAbortControllerRef.current?.abort();
+      const abortController = new AbortController();
+      validationAbortControllerRef.current = abortController;
+
       await onReviewWithAiOverride?.(segmentId);
 
       const sequence = store.beginReview({ includeAi, showFormatChecksLoading });
@@ -429,13 +442,14 @@ export function useCatWorkspaceController({
                   segmentForReview,
                   segmentForReview.targetText,
                   intelligenceForRecommendation.glossaryTerms,
+                  { signal: abortController.signal },
                 )
               : Promise.resolve([]),
             includeFormatChecks && runQaChecks
               ? runQaChecks(segmentForReview, segmentForReview.targetText)
               : Promise.resolve([]),
           ]);
-          if (!store.isReviewCurrent(sequence)) {
+          if (abortController.signal.aborted || !store.isReviewCurrent(sequence)) {
             return;
           }
           const withoutAiFailure = (segmentChecks: CatFormatCheck[]) =>
@@ -455,7 +469,14 @@ export function useCatWorkspaceController({
             });
           }
         }
+      } catch (error) {
+        if (!abortController.signal.aborted && (error as Error)?.name !== "AbortError") {
+          throw error;
+        }
       } finally {
+        if (validationAbortControllerRef.current === abortController) {
+          validationAbortControllerRef.current = null;
+        }
         store.setReviewPhaseLoading(sequence, "ai", false);
         store.setReviewPhaseLoading(sequence, "formatChecks", false);
       }

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-controller.ts
@@ -44,6 +44,8 @@ import {
 } from "./store/cat-workspace-store-utils";
 import type { CatWorkspaceStore } from "./store/cat-workspace-store";
 
+const SEGMENT_VALIDATION_DEBOUNCE_MS = 300;
+
 function getSegmentQueueIndex(segments: Pick<CatSegment, "id" | "key">[], segmentIdOrKey: string) {
   const resolvedId = findSegmentIdByKeyOrIdInQueue(segments, segmentIdOrKey) ?? segmentIdOrKey;
   return segments.findIndex((segment) => segment.id === resolvedId);
@@ -131,6 +133,8 @@ export function useCatWorkspaceController({
   const canRunSegmentReview = Boolean(validateFormat || runQaChecks);
 
   const isInitialHydrationRef = useRef(true);
+  const validationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const validationAbortControllerRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     if (isInitialHydrationRef.current) {
@@ -189,24 +193,62 @@ export function useCatWorkspaceController({
         return;
       }
 
+      validationAbortControllerRef.current?.abort();
+      const abortController = new AbortController();
+      validationAbortControllerRef.current = abortController;
       const sequence = store.beginValidation();
       try {
         const glossaryTerms =
           glossaryTermsOverride ?? glossaryTermsForSegment(store.shellState, segment.id);
         const [formatChecks, qaChecks] = await Promise.all([
-          validateFormat ? validateFormat(segment, value, glossaryTerms) : Promise.resolve([]),
+          validateFormat
+            ? validateFormat(segment, value, glossaryTerms, {
+                signal: abortController.signal,
+              })
+            : Promise.resolve([]),
           runQaChecks ? runQaChecks(segment, value) : Promise.resolve([]),
         ]);
-        if (!store.isValidationCurrent(sequence)) {
+        if (abortController.signal.aborted || !store.isValidationCurrent(sequence)) {
           return;
         }
         const checks = [...formatChecks, ...qaChecks];
         store.setFormatChecks(segment.id, checks, store.selectedSegmentId === segment.id);
+      } catch (error) {
+        if (!abortController.signal.aborted && (error as Error)?.name !== "AbortError") {
+          throw error;
+        }
       } finally {
+        if (validationAbortControllerRef.current === abortController) {
+          validationAbortControllerRef.current = null;
+        }
         store.completeValidation(sequence);
       }
     },
     [runQaChecks, store, validateFormat],
+  );
+
+  const scheduleSegmentChecks = useCallback(
+    (segment: CatSegment, value: string) => {
+      if (validationTimeoutRef.current) {
+        clearTimeout(validationTimeoutRef.current);
+      }
+      validationAbortControllerRef.current?.abort();
+      validationTimeoutRef.current = setTimeout(() => {
+        validationTimeoutRef.current = null;
+        void runSegmentChecks(segment, value);
+      }, SEGMENT_VALIDATION_DEBOUNCE_MS);
+    },
+    [runSegmentChecks],
+  );
+
+  useEffect(
+    () => () => {
+      if (validationTimeoutRef.current) {
+        clearTimeout(validationTimeoutRef.current);
+      }
+      validationAbortControllerRef.current?.abort();
+    },
+    [],
   );
 
   const concordanceLoadedSegmentIdsRef = useRef(new Set<string>());
@@ -429,17 +471,17 @@ export function useCatWorkspaceController({
     ],
   );
 
-  const runSegmentReviewRef = useRef(runSegmentReview);
-  runSegmentReviewRef.current = runSegmentReview;
-
   useEffect(() => {
     const segmentId = store.selectedSegmentId;
     if (!segmentId || !canRunSegmentReview) {
       return;
     }
 
-    void runSegmentReviewRef.current(segmentId, { includeAi: false });
-  }, [canRunSegmentReview, store.selectedSegmentId]);
+    const segment = store.getSegmentView(segmentId);
+    if (segment) {
+      void runSegmentChecks(segment, segment.targetText);
+    }
+  }, [canRunSegmentReview, runSegmentChecks, store, store.selectedSegmentId]);
 
   const concordanceLookupAttemptedRef = useRef(new Set<string>());
   const cachedContextLookupAttemptedRef = useRef(new Set<string>());
@@ -548,7 +590,7 @@ export function useCatWorkspaceController({
         store.setTargetText(segmentId, value);
         const segmentToValidate = store.getSegmentView(segmentId);
         if (segmentToValidate) {
-          void runSegmentChecks(segmentToValidate, value);
+          scheduleSegmentChecks(segmentToValidate, value);
         }
         onTargetChange?.(segmentId, value);
       },
@@ -778,7 +820,7 @@ export function useCatWorkspaceController({
     onUseAiSuggestion,
     queueFilter,
     runQaChecks,
-    runSegmentChecks,
+    scheduleSegmentChecks,
     runSegmentReview,
     store,
     usesServerQueueFilter,

--- a/docs/adr/2026-07-05-cat-segment-validation-service-design.md
+++ b/docs/adr/2026-07-05-cat-segment-validation-service-design.md
@@ -1,0 +1,35 @@
+# CAT segment validation service integration
+
+## Goal
+
+Use the Go segment-validation service as the CAT editor's source of truth for format, length, and QA checks while preserving responsive live editing.
+
+## Architecture
+
+The CAT client posts directly to `/api/go-svc/v1/validate/segment`. The existing Vercel rewrite routes this same-origin request to `go-svc`, and the browser's WorkOS session cookie authenticates it.
+
+Each request includes the source text, current target text, source path, maximum length, and all supported QA modes:
+
+- `not_localized`
+- `whitespace_only`
+- `same_as_source`
+
+The client validates the response before mapping its checks to the existing `CatFormatCheck` type. The Go service owns format, length, and QA rules. Existing client-side glossary checks remain local because the Go endpoint does not accept glossary data.
+
+## Interaction
+
+The CAT workspace validates a newly selected segment immediately. Target edits schedule validation after a 300 ms debounce. A newer edit cancels the pending request and supersedes any in-flight response so stale checks cannot replace current results.
+
+Validation remains advisory. A network, authentication, or response-validation failure produces one `Validation unavailable` check and does not block editing, drafts, or approval.
+
+## Testing
+
+Focused tests cover:
+
+- The Go-service request payload and response mapping.
+- All QA modes in the request.
+- Glossary-check merging.
+- Invalid and unsuccessful responses.
+- Debounced edit validation and stale-request cancellation.
+
+Run the repository's required Go and web checks before finalizing.

--- a/docs/adr/2026-07-05-cat-segment-validation-service-design.md
+++ b/docs/adr/2026-07-05-cat-segment-validation-service-design.md
@@ -8,7 +8,7 @@ Use the Go segment-validation service as the CAT editor's source of truth for fo
 
 The CAT client posts directly to `/api/go-svc/v1/validate/segment`. The existing Vercel rewrite routes this same-origin request to `go-svc`, and the browser's WorkOS session cookie authenticates it.
 
-Each request includes the source text, current target text, source path, maximum length, and all supported QA modes:
+Each request includes the source text, current target text, source path, and all supported QA modes. It includes `maxLength` only when the segment defines a positive limit.
 
 - `not_localized`
 - `whitespace_only`


### PR DESCRIPTION
## What changed

- Call the Go segment-validation service from the CAT editor.
- Enable format, length, and all supported QA checks.
- Debounce live validation by 300 ms and cancel stale requests.
- Preserve local glossary checks and surface service failures without blocking edits.
- Add API contract and debounce tests.
- Document the integration design.

## How to test

- `vp test src/components/cat/project-file/project-file-cat-validation.test.ts src/components/cat/workspace/use-cat-workspace-controller.test.tsx`
- `vp check --fix`
- `vp test` — blocked by PostgreSQL being unavailable on port 5432 (`ECONNREFUSED`).

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review