### PR TITLE
test(app-shell): expand unit test coverage and edge cases

### DIFF
--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
@@ -13,6 +13,12 @@ describe("getAppShellTitle", () => {
     ["/org/acme/projects/proj_1/files", "Files"],
     ["/org/acme/projects/proj_1/jobs", "Jobs"],
     ["/org/acme/projects/proj_1/agent-runs", "Agent Runs"],
+    ["/org/acme/projects/proj_1/activity", "Activity"],
+    ["/org/acme/projects/proj_1/context", "Context"],
+    ["/org/acme/projects/proj_1/locales", "Locales"],
+    ["/org/acme/projects/proj_1/qa", "QA"],
+    ["/org/acme/projects/proj_1/reviews", "Reviews"],
+    ["/org/acme/projects/proj_1/settings", "Settings"],
     ["/org/acme/my-work", "My Jobs"],
     ["/org/acme/my-jobs", "My Jobs"],
     ["/org/acme/knowledge", "Knowledge"],
@@ -32,7 +38,23 @@ describe("getAppShellTitle", () => {
 
   it("falls back to overview for unknown or empty paths", () => {
     expect(getAppShellTitle(null)).toBe("Overview");
+    expect(getAppShellTitle("")).toBe("Overview");
     expect(getAppShellTitle("/org/acme/unknown")).toBe("Overview");
+  });
+
+  it("falls back to overview when the org slug is missing", () => {
+    expect(getAppShellTitle("/org")).toBe("Overview");
+    expect(getAppShellTitle("/org/")).toBe("Overview");
+    expect(getAppShellTitle("/dashboard")).toBe("Overview");
+  });
+
+  it("resolves the title from locale-prefixed paths", () => {
+    expect(getAppShellTitle("/en/org/acme/inbox")).toBe("Inbox");
+    expect(getAppShellTitle("/en/org/acme/settings/billing")).toBe("Billing");
+  });
+
+  it("uses the project id as the title for unknown project sections", () => {
+    expect(getAppShellTitle("/org/acme/projects/proj_1/unknown-section")).toBe("proj_1");
   });
 });
 
@@ -85,6 +107,67 @@ describe("getAppShellBreadcrumbs", () => {
     expect(getAppShellBreadcrumbs("/org/acme/projects/proj_1")).toEqual([
       { label: "Projects", href: "/org/acme/projects" },
       { label: "proj_1" },
+    ]);
+  });
+
+  it("falls back to the dashboard crumb when there is no org route", () => {
+    expect(getAppShellBreadcrumbs(null)).toEqual([{ label: "Overview" }]);
+    expect(getAppShellBreadcrumbs("")).toEqual([{ label: "Overview" }]);
+    expect(getAppShellBreadcrumbs("/org")).toEqual([{ label: "Overview" }]);
+    expect(getAppShellBreadcrumbs("/dashboard")).toEqual([{ label: "Overview" }]);
+  });
+
+  it("resolves breadcrumbs from locale-prefixed paths", () => {
+    expect(getAppShellBreadcrumbs("/en/org/acme/settings/account")).toEqual([
+      { label: "Settings", href: "/org/acme/settings" },
+      { label: "Account" },
+    ]);
+  });
+
+  it("returns the settings section verbatim for unknown subsections", () => {
+    expect(getAppShellBreadcrumbs("/org/acme/settings/unknown")).toEqual([
+      { label: "Settings", href: "/org/acme/settings" },
+      { label: "unknown" },
+    ]);
+  });
+
+  it("decodes encoded team detail segments", () => {
+    expect(getAppShellBreadcrumbs("/org/acme/teams/team%20alpha")).toEqual([
+      { label: "Teams", href: "/org/acme/teams" },
+      { label: "team alpha" },
+    ]);
+  });
+
+  it("keeps a malformed team segment untouched when it cannot be decoded", () => {
+    expect(getAppShellBreadcrumbs("/org/acme/teams/%E0%A4%A")).toEqual([
+      { label: "Teams", href: "/org/acme/teams" },
+      { label: "%E0%A4%A" },
+    ]);
+  });
+
+  it("decodes encoded external project ids while keeping hrefs encoded", () => {
+    expect(getAppShellBreadcrumbs("/org/acme/projects/ext%3Acrowdin%3A902807/files")).toEqual([
+      { label: "Projects", href: "/org/acme/projects" },
+      { label: "ext:crowdin:902807", href: "/org/acme/projects/ext%3Acrowdin%3A902807" },
+      { label: "Files" },
+    ]);
+  });
+
+  it("ignores unknown project sections and keeps the project crumb", () => {
+    expect(
+      getAppShellBreadcrumbs("/org/acme/projects/proj_1/unknown-section", {
+        projectName: "Checkout",
+      }),
+    ).toEqual([{ label: "Projects", href: "/org/acme/projects" }, { label: "Checkout" }]);
+  });
+
+  it("falls back to the project id when the project name is only whitespace", () => {
+    expect(
+      getAppShellBreadcrumbs("/org/acme/projects/proj_1/files", { projectName: "   " }),
+    ).toEqual([
+      { label: "Projects", href: "/org/acme/projects" },
+      { label: "proj_1", href: "/org/acme/projects/proj_1" },
+      { label: "Files" },
     ]);
   });
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  WORKSPACE_AUTOMATIONS_FLAG,
+  WORKSPACE_KNOWLEDGE_FLAG,
+} from "@/lib/flags/workos-flag-entities";
+
+import {
+  buildGlobalNavigationGroups,
+  buildOrganizationPath,
+  buildProjectNavigationItems,
   buildProjectPath,
   isNavigationItemActive,
   parseProjectRoute,
@@ -115,5 +123,128 @@ describe("workspace people navigation", () => {
     expect(stripAppLocalePrefix(null)).toBe("/");
     expect(stripAppLocalePrefix(undefined)).toBe("/");
     expect(isNavigationItemActive(null, "/org/acme/teams")).toBe(false);
+    expect(isNavigationItemActive(undefined, "/org/acme/teams")).toBe(false);
+    expect(isNavigationItemActive("", "/org/acme/teams")).toBe(false);
+  });
+});
+
+describe("path builders", () => {
+  it("builds organization paths", () => {
+    expect(buildOrganizationPath("acme", "inbox")).toBe("/org/acme/inbox");
+  });
+
+  it("builds project paths with and without a section", () => {
+    expect(buildProjectPath("acme", "proj_1")).toBe("/org/acme/projects/proj_1");
+    expect(buildProjectPath("acme", "proj_1", "files")).toBe("/org/acme/projects/proj_1/files");
+  });
+
+  it("encodes reserved characters in the project id segment", () => {
+    expect(buildProjectPath("acme", "ext:crowdin:1", "jobs")).toBe(
+      "/org/acme/projects/ext%3Acrowdin%3A1/jobs",
+    );
+  });
+
+  it("builds global navigation groups scoped to the organization", () => {
+    const groups = buildGlobalNavigationGroups("acme");
+    const items = groups.flatMap((group) => group.items);
+    const byLabel = new Map(items.map((item) => [item.label, item]));
+
+    expect(byLabel.get("Inbox")?.href).toBe("/org/acme/inbox");
+    expect(byLabel.get("Projects")?.href).toBe("/org/acme/projects");
+    expect(byLabel.get("Automations")?.featureFlagKey).toBe(WORKSPACE_AUTOMATIONS_FLAG);
+    expect(byLabel.get("Knowledge")?.featureFlagKey).toBe(WORKSPACE_KNOWLEDGE_FLAG);
+  });
+
+  it("builds project navigation items scoped to the project", () => {
+    const items = buildProjectNavigationItems("acme", "proj_1");
+
+    expect(items.map((item) => [item.label, item.href])).toEqual([
+      ["Overview", "/org/acme/projects/proj_1"],
+      ["Files", "/org/acme/projects/proj_1/files"],
+      ["Jobs", "/org/acme/projects/proj_1/jobs"],
+      ["Settings", "/org/acme/projects/proj_1/settings"],
+    ]);
+  });
+});
+
+describe("stripAppLocalePrefix", () => {
+  it("removes a supported locale prefix", () => {
+    expect(stripAppLocalePrefix("/en/org/acme/inbox")).toBe("/org/acme/inbox");
+  });
+
+  it("collapses a locale-only path to root", () => {
+    expect(stripAppLocalePrefix("/en")).toBe("/");
+    expect(stripAppLocalePrefix("/en/")).toBe("/");
+  });
+
+  it("strips trailing slashes after removing the locale", () => {
+    expect(stripAppLocalePrefix("/en/org/acme/inbox/")).toBe("/org/acme/inbox");
+  });
+
+  it("leaves paths without a locale prefix untouched", () => {
+    expect(stripAppLocalePrefix("/org/acme/inbox")).toBe("/org/acme/inbox");
+    expect(stripAppLocalePrefix("/fr/org/acme/inbox")).toBe("/fr/org/acme/inbox");
+  });
+});
+
+describe("parseProjectRoute", () => {
+  it("returns null for empty and non-project routes", () => {
+    expect(parseProjectRoute(null)).toBeNull();
+    expect(parseProjectRoute("")).toBeNull();
+    expect(parseProjectRoute("/org/acme/inbox")).toBeNull();
+    expect(parseProjectRoute("/org/acme/projects")).toBeNull();
+  });
+
+  it("returns a null section for the project overview route", () => {
+    expect(parseProjectRoute("/org/acme/projects/proj_1")).toEqual({
+      organizationSlug: "acme",
+      projectId: "proj_1",
+      section: null,
+    });
+  });
+
+  it("only reports the first section segment for nested routes", () => {
+    expect(parseProjectRoute("/org/acme/projects/proj_1/jobs/job_1/strings")).toEqual({
+      organizationSlug: "acme",
+      projectId: "proj_1",
+      section: "jobs",
+    });
+  });
+});
+
+describe("isNavigationItemActive", () => {
+  it("matches exactly when the exact option is set", () => {
+    expect(isNavigationItemActive("/org/acme/inbox", "/org/acme/inbox", { exact: true })).toBe(
+      true,
+    );
+    expect(
+      isNavigationItemActive("/org/acme/inbox/thread_1", "/org/acme/inbox", { exact: true }),
+    ).toBe(false);
+  });
+
+  it("matches nested subpaths for non-exact items", () => {
+    expect(isNavigationItemActive("/org/acme/inbox/thread_1", "/org/acme/inbox")).toBe(true);
+  });
+
+  it("ignores the hash fragment on the item href", () => {
+    expect(isNavigationItemActive("/org/acme/settings", "/org/acme/settings#profile")).toBe(true);
+  });
+
+  it("keeps the projects list inactive on project detail routes", () => {
+    expect(isNavigationItemActive("/org/acme/projects", "/org/acme/projects")).toBe(true);
+    expect(isNavigationItemActive("/org/acme/projects/proj_1", "/org/acme/projects")).toBe(false);
+    expect(isNavigationItemActive("/org/acme/projects/proj_1/files", "/org/acme/projects")).toBe(
+      false,
+    );
+  });
+
+  it("treats my-work and my-jobs as the same destination", () => {
+    const myWorkHref = "/org/acme/my-work";
+
+    expect(isNavigationItemActive("/org/acme/my-work", myWorkHref)).toBe(true);
+    expect(isNavigationItemActive("/org/acme/my-jobs", myWorkHref)).toBe(true);
+    expect(isNavigationItemActive("/org/acme/my-jobs/job_1", myWorkHref)).toBe(true);
+    expect(isNavigationItemActive("/en/org/acme/my-jobs", myWorkHref)).toBe(true);
+    expect(isNavigationItemActive("/org/acme/inbox", myWorkHref)).toBe(false);
   });
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-hooks.test.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-hooks.test.tsx
@@ -1,13 +1,17 @@
 // @vitest-environment happy-dom
 
 import { isValidElement, type ReactNode } from "react";
-import { render, waitFor } from "@testing-library/react";
+import { render, renderHook, waitFor } from "@testing-library/react";
 import { Chat01Icon } from "@hugeicons/core-free-icons";
-import { describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import type { NavigationGroup } from "@/components/app-shell/navigation-config";
 
-import { AppShellStoreProvider, useAppShellStore } from "./app-shell-store-context";
+import {
+  AppShellStoreProvider,
+  useAppShellStore,
+  useOptionalAppShellStore,
+} from "./app-shell-store-context";
 import type { AppShellStore } from "./app-shell-store";
 import {
   useAppShellBreadcrumbAppend,
@@ -17,9 +21,16 @@ import { useAppShellHeaderAction } from "./use-app-shell-header-action";
 import { useAppShellNavigationCustom } from "./use-app-shell-navigation";
 import { useAppShellSidebar } from "./use-app-shell-sidebar";
 
+const DEFAULT_PATHNAME = "/org/acme/projects/proj_1/jobs";
+const navigationMock = vi.hoisted(() => ({ pathname: "/org/acme/projects/proj_1/jobs" }));
+
 vi.mock("next/navigation", () => ({
-  usePathname: () => "/org/acme/projects/proj_1/jobs",
+  usePathname: () => navigationMock.pathname,
 }));
+
+afterEach(() => {
+  navigationMock.pathname = DEFAULT_PATHNAME;
+});
 
 const defaultGroups = [
   {
@@ -241,5 +252,91 @@ describe("app shell page hooks", () => {
       expect(storeRef.current?.sidebar.forceCollapsed).toBe(false);
       expect(storeRef.current?.sidebar.preferredOpen).toBeNull();
     });
+  });
+
+  it("skips sidebar registration when no preference is provided", async () => {
+    const storeRef: { current: AppShellStore | null } = { current: null };
+
+    function NeutralSidebarDemo() {
+      useAppShellSidebar();
+      return null;
+    }
+
+    render(
+      <AppShellHookTestProvider onStore={(nextStore) => (storeRef.current = nextStore)}>
+        <NeutralSidebarDemo />
+      </AppShellHookTestProvider>,
+    );
+
+    await waitFor(() => expect(storeRef.current).not.toBeNull());
+    expect(storeRef.current?.sidebar.forceCollapsed).toBe(false);
+    expect(storeRef.current?.sidebar.preferredOpen).toBeNull();
+  });
+
+  it("resets page-scoped state when the pathname changes", async () => {
+    const storeRef: { current: AppShellStore | null } = { current: null };
+    const baseBreadcrumbs = [{ label: "Jobs", href: "/org/acme/projects/proj_1/jobs" }];
+
+    function BreadcrumbDemo() {
+      useAppShellBreadcrumbAppend({ id: "job-name", label: "Translate homepage" });
+      return null;
+    }
+
+    const view = render(
+      <AppShellHookTestProvider onStore={(nextStore) => (storeRef.current = nextStore)}>
+        <BreadcrumbDemo />
+      </AppShellHookTestProvider>,
+    );
+
+    await waitFor(() =>
+      expect(storeRef.current?.breadcrumb.applyOverrides(baseBreadcrumbs)).toEqual([
+        { label: "Jobs", href: "/org/acme/projects/proj_1/jobs" },
+        { label: "Translate homepage", href: undefined },
+      ]),
+    );
+
+    navigationMock.pathname = "/org/acme/inbox";
+    view.rerender(
+      <AppShellHookTestProvider onStore={(nextStore) => (storeRef.current = nextStore)}>
+        <BreadcrumbDemo />
+      </AppShellHookTestProvider>,
+    );
+
+    expect(storeRef.current?.breadcrumb.applyOverrides(baseBreadcrumbs)).toEqual(baseBreadcrumbs);
+  });
+});
+
+describe("app shell store context", () => {
+  it("throws when useAppShellStore is used outside the provider", () => {
+    expect(() => renderHook(() => useAppShellStore())).toThrow(
+      "useAppShellStore must be used within AppShellStoreProvider",
+    );
+  });
+
+  it("returns null from useOptionalAppShellStore outside the provider", () => {
+    const { result } = renderHook(() => useOptionalAppShellStore());
+
+    expect(result.current).toBeNull();
+  });
+
+  it("keeps the same store instance across rerenders", async () => {
+    const stores: AppShellStore[] = [];
+
+    const view = render(
+      <AppShellStoreProvider defaultNavigationGroups={defaultGroups}>
+        <StoreCapture onStore={(store) => stores.push(store)} />
+      </AppShellStoreProvider>,
+    );
+
+    await waitFor(() => expect(stores.length).toBeGreaterThan(0));
+    expect(stores[0]?.navigation.defaultNavigationGroups).toEqual(defaultGroups);
+
+    view.rerender(
+      <AppShellStoreProvider defaultNavigationGroups={defaultGroups}>
+        <StoreCapture onStore={(store) => stores.push(store)} />
+      </AppShellStoreProvider>,
+    );
+
+    expect(new Set(stores).size).toBe(1);
   });
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store.test.ts
@@ -242,3 +242,251 @@ describe("AppShellStore", () => {
     expect(api.setOpen).toHaveBeenCalledWith(false);
   });
 });
+
+describe("HeaderActionsStore", () => {
+  it("unregisters a single slot without affecting the others", () => {
+    const store = createAppShellStore(sampleGroups);
+
+    store.headerActions.register({ id: "a", order: 10, visible: true, render: () => "A" });
+    store.headerActions.register({ id: "b", order: 20, visible: true, render: () => "B" });
+    store.headerActions.unregister("a");
+
+    expect(store.headerActions.orderedSlots.map((slot) => slot.id)).toEqual(["b"]);
+  });
+
+  it("keeps stable ordering for slots that share an order", () => {
+    const store = createAppShellStore(sampleGroups);
+
+    store.headerActions.register({ id: "first", order: 5, visible: true, render: () => "1" });
+    store.headerActions.register({ id: "second", order: 5, visible: true, render: () => "2" });
+
+    expect(store.headerActions.orderedSlots.map((slot) => slot.id)).toEqual(["first", "second"]);
+  });
+
+  it("hides a slot when it is re-registered as not visible", () => {
+    const store = createAppShellStore(sampleGroups);
+
+    store.headerActions.register({ id: "save", order: 0, visible: true, render: () => "Save" });
+    expect(store.headerActions.orderedSlots).toHaveLength(1);
+
+    store.headerActions.register({ id: "save", order: 0, visible: false, render: () => "Save" });
+    expect(store.headerActions.orderedSlots).toEqual([]);
+  });
+});
+
+describe("BreadcrumbStore", () => {
+  it("overrides a crumb by index and preserves the original href", () => {
+    const store = createAppShellStore(sampleGroups);
+    const base = [
+      { label: "Projects", href: "/org/acme/projects" },
+      { label: "proj_1", href: "/org/acme/projects/proj_1" },
+    ];
+
+    store.breadcrumb.registerOverride({ id: "first", index: 0, label: "Workspace" });
+
+    expect(store.breadcrumb.applyOverrides(base)).toEqual([
+      { label: "Workspace", href: "/org/acme/projects" },
+      { label: "proj_1", href: "/org/acme/projects/proj_1" },
+    ]);
+  });
+
+  it("applies a custom href from an override", () => {
+    const store = createAppShellStore(sampleGroups);
+    const base = [{ label: "proj_1", href: "/org/acme/projects/proj_1" }];
+
+    store.breadcrumb.registerOverride({
+      id: "project-name",
+      matchSegment: "proj_1",
+      label: "Checkout",
+      href: "/org/acme/projects/proj_1/overview",
+    });
+
+    expect(store.breadcrumb.applyOverrides(base)).toEqual([
+      { label: "Checkout", href: "/org/acme/projects/proj_1/overview" },
+    ]);
+  });
+
+  it("removes overrides and appends when unregistered", () => {
+    const store = createAppShellStore(sampleGroups);
+    const base = [{ label: "proj_1", href: "/org/acme/projects/proj_1" }];
+
+    store.breadcrumb.registerOverride({ id: "name", matchSegment: "proj_1", label: "Checkout" });
+    store.breadcrumb.registerAppend({ id: "detail", label: "Detail" });
+    store.breadcrumb.unregisterOverride("name");
+    store.breadcrumb.unregisterAppend("detail");
+
+    expect(store.breadcrumb.applyOverrides(base)).toEqual(base);
+  });
+
+  it("returns the base crumbs when no overrides or appends are registered", () => {
+    const store = createAppShellStore(sampleGroups);
+    const base = [{ label: "Inbox" }];
+
+    expect(store.breadcrumb.applyOverrides(base)).toEqual(base);
+  });
+});
+
+describe("NavigationStore", () => {
+  it("exposes the default groups in route mode", () => {
+    const store = createAppShellStore(sampleGroups);
+
+    expect(store.navigation.mode).toBe("route");
+    expect(store.navigation.defaultNavigationGroups).toEqual(sampleGroups);
+    expect(store.navigation.activeGroups).toEqual(sampleGroups);
+    expect(store.navigation.activeProjectContext).toBeNull();
+  });
+
+  it("returns default groups after clearing custom mode", () => {
+    const store = createAppShellStore(sampleGroups);
+    const customGroups = [
+      { label: "Custom", items: [{ label: "Wizard", href: "/w", icon: Chat01Icon }] },
+    ] as const;
+
+    store.navigation.setCustomNavigation(customGroups, {
+      organizationSlug: "acme",
+      projectId: "proj_1",
+    });
+    store.navigation.clearCustomMode();
+
+    expect(store.navigation.mode).toBe("route");
+    expect(store.navigation.activeGroups).toEqual(sampleGroups);
+    expect(store.navigation.activeProjectContext).toBeNull();
+  });
+
+  it("enters custom mode without a project context", () => {
+    const store = createAppShellStore(sampleGroups);
+    const customGroups = [
+      { label: "Custom", items: [{ label: "Wizard", href: "/w", icon: Chat01Icon }] },
+    ] as const;
+
+    store.navigation.setCustomNavigation(customGroups);
+
+    expect(store.navigation.mode).toBe("custom");
+    expect(store.navigation.activeGroups).toEqual(customGroups);
+    expect(store.navigation.activeProjectContext).toBeNull();
+  });
+});
+
+describe("SidebarStore", () => {
+  it("reports default state before an api binds", () => {
+    const store = createAppShellStore(sampleGroups);
+
+    expect(store.sidebar.isBound).toBe(false);
+    expect(store.sidebar.isOpen).toBe(true);
+    expect(store.sidebar.isMobile).toBe(false);
+    expect(store.sidebar.state).toBe("expanded");
+  });
+
+  it("reflects the bound api state through getters", () => {
+    const store = createAppShellStore(sampleGroups);
+    const api = createSidebarApi({ open: false, isMobile: true, state: "collapsed" });
+
+    store.sidebar.bindSidebarApi(api);
+
+    expect(store.sidebar.isBound).toBe(true);
+    expect(store.sidebar.isOpen).toBe(false);
+    expect(store.sidebar.isMobile).toBe(true);
+    expect(store.sidebar.state).toBe("collapsed");
+  });
+
+  it("stores the open preference locally while unbound", () => {
+    const store = createAppShellStore(sampleGroups);
+
+    store.sidebar.setOpen(false);
+
+    expect(store.sidebar.preferredOpen).toBe(false);
+  });
+
+  it("routes open changes to the desktop api", () => {
+    const store = createAppShellStore(sampleGroups);
+    const api = createSidebarApi();
+
+    store.sidebar.bindSidebarApi(api);
+    store.sidebar.setOpen(false);
+
+    expect(api.setOpen).toHaveBeenCalledWith(false);
+    expect(api.setOpenMobile).not.toHaveBeenCalled();
+  });
+
+  it("routes open changes to the mobile api", () => {
+    const store = createAppShellStore(sampleGroups);
+    const api = createSidebarApi({ isMobile: true });
+
+    store.sidebar.bindSidebarApi(api);
+    store.sidebar.setOpen(true);
+
+    expect(api.setOpenMobile).toHaveBeenCalledWith(true);
+    expect(api.setOpen).not.toHaveBeenCalled();
+  });
+
+  it("collapses and expands through the api", () => {
+    const store = createAppShellStore(sampleGroups);
+    const api = createSidebarApi();
+
+    store.sidebar.bindSidebarApi(api);
+    store.sidebar.collapse();
+    store.sidebar.expand();
+
+    expect(api.setOpen).toHaveBeenNthCalledWith(1, false);
+    expect(api.setOpen).toHaveBeenNthCalledWith(2, true);
+  });
+
+  it("toggles the bound api", () => {
+    const store = createAppShellStore(sampleGroups);
+    const api = createSidebarApi();
+
+    store.sidebar.bindSidebarApi(api);
+    store.sidebar.toggle();
+
+    expect(api.toggleSidebar).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing on toggle while unbound", () => {
+    const store = createAppShellStore(sampleGroups);
+
+    expect(() => store.sidebar.toggle()).not.toThrow();
+  });
+
+  it("does not sync a neutral preference when binding", () => {
+    const store = createAppShellStore(sampleGroups);
+    const api = createSidebarApi();
+
+    store.sidebar.bindSidebarApi(api);
+
+    expect(api.setOpen).not.toHaveBeenCalled();
+    expect(api.setOpenMobile).not.toHaveBeenCalled();
+  });
+
+  it("stops syncing preferences after the api unbinds", () => {
+    const store = createAppShellStore(sampleGroups);
+    const api = createSidebarApi();
+
+    store.sidebar.bindSidebarApi(api);
+    store.sidebar.unbindSidebarApi();
+    store.sidebar.setPreferredOpen(false);
+
+    expect(store.sidebar.isBound).toBe(false);
+    expect(api.setOpen).not.toHaveBeenCalled();
+  });
+
+  it("forces a collapse on mobile through setOpenMobile", () => {
+    const store = createAppShellStore(sampleGroups);
+    const api = createSidebarApi({ isMobile: true });
+
+    store.sidebar.bindSidebarApi(api);
+    store.sidebar.setForceCollapsed(true);
+
+    expect(api.setOpenMobile).toHaveBeenCalledWith(false);
+  });
+
+  it("prefers the forced collapse over an open preference", () => {
+    const store = createAppShellStore(sampleGroups);
+    const api = createSidebarApi();
+
+    store.sidebar.setPreferredOpen(true);
+    store.sidebar.setForceCollapsed(true);
+    store.sidebar.bindSidebarApi(api);
+
+    expect(api.setOpen).toHaveBeenLastCalledWith(false);
+  });
+});


### PR DESCRIPTION
## What changed

Expanded unit test coverage for the app-shell module from 54 to 115 tests across four test files. No production code changes.

- **`app-shell-title.test.ts`**: locale-prefixed paths, empty/missing org routes, URL-decoded segments (encoded project ids, team names, malformed sequences), whitespace-only project names, unknown project/settings sections, and all project section titles.
- **`navigation-config.test.ts`**: path builders, global/project navigation group construction with feature flags, `stripAppLocalePrefix` edge cases, `parseProjectRoute` null/deep-route behavior, and `isNavigationItemActive` branches (exact match, hash stripping, projects-list exactness, my-work/my-jobs aliasing).
- **`app-shell-store.test.ts`**: direct store tests for header actions, breadcrumb overrides/appends, navigation mode transitions, and the full sidebar API surface (desktop/mobile routing, bind/unbind, force-collapse precedence).
- **`app-shell-hooks.test.tsx`**: provider context errors, optional store hook, neutral sidebar hook, pathname-change reset, and stable store instance across rerenders.

## How to test

```bash
cd apps/hyperlocalise-web
vp test src/components/app-shell
vp check --fix src/components/app-shell
```

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)