### PR TITLE
fix(web): set explicit height on Pierre file tree

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
@@ -17,8 +17,7 @@ const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
 });
 
 const projectFilesTreeStyle = {
-  height: "100%",
-  minHeight: `${TREE_MIN_HEIGHT_PX}px`,
+  height: `${TREE_MIN_HEIGHT_PX}px`,
   backgroundColor: "transparent",
   color: "var(--foreground)",
   borderColor: "var(--border)",
@@ -141,15 +140,13 @@ export function ProjectFilesTree({
   }
 
   return (
-    <div className="h-full min-h-80 w-full">
-      <PierreFileTree
-        aria-label={ariaLabel}
-        className="size-full border-0 bg-transparent"
-        id="project-files-tree"
-        model={model}
-        preloadedData={preloadedData ?? undefined}
-        style={projectFilesTreeStyle}
-      />
-    </div>
+    <PierreFileTree
+      aria-label={ariaLabel}
+      className="w-full border-0 bg-transparent"
+      id="project-files-tree"
+      model={model}
+      preloadedData={preloadedData ?? undefined}
+      style={projectFilesTreeStyle}
+    />
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the empty file tree in the CAT source file picker and Storybook by giving the `@pierre/trees` web component an explicit pixel height.

## Problem

`ProjectFilesTree` passed `height: 100%` to the Pierre `file-tree-container` host while its wrapper only had `min-h-80`. Percentage height does not resolve when the parent has no concrete height, so the virtualized tree rendered at 0px and showed no rows.

## Fix

- Set `height: 320px` on the Pierre FileTree host, matching the library's documented usage
- Remove the redundant wrapper div that relied on percentage-based sizing

## Verification

- `vp check --fix` passes
- Storybook `App/Project/Files/Tree` iframe now renders at 320px height with visible file rows
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec4a1659-62bb-4d49-bd17-cdc3e2ed5d37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec4a1659-62bb-4d49-bd17-cdc3e2ed5d37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

