### PR TITLE
fix(web): restore job source file actions and CAT context lookup

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.test.tsx
@@ -1,13 +1,38 @@
 // @vitest-environment happy-dom
 
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vite-plus/test";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { CatTestProviders } from "@/components/cat/shared/cat-test-utils";
 
-const { useProjectPageQueryMock, useAppShellSidebarMock } = vi.hoisted(() => ({
+import { createProjectFileRecord } from "./project-files.fixture";
+
+const {
+  useProjectPageQueryMock,
+  useAppShellSidebarMock,
+  fetchProjectFilesMock,
+  repositoriesGetMock,
+  ProjectFileCatWorkspaceMock,
+} = vi.hoisted(() => ({
   useProjectPageQueryMock: vi.fn(),
   useAppShellSidebarMock: vi.fn(),
+  fetchProjectFilesMock: vi.fn(),
+  repositoriesGetMock: vi.fn(),
+  ProjectFileCatWorkspaceMock: vi.fn(
+    ({
+      repositoryFullName,
+      sourcePath,
+    }: {
+      repositoryFullName?: string | null;
+      sourcePath: string;
+    }) => (
+      <div
+        data-testid="cat-workspace"
+        data-repo={repositoryFullName ?? ""}
+        data-source-path={sourcePath}
+      />
+    ),
+  ),
 }));
 
 vi.mock("../../_components/project-page-shell", async (importOriginal) => {
@@ -23,12 +48,86 @@ vi.mock("@/components/app-shell/store/use-app-shell-sidebar", () => ({
 }));
 
 vi.mock("./project-files-tree-panel", () => ({
-  fetchProjectFiles: vi.fn(),
+  fetchProjectFiles: (...args: unknown[]) => fetchProjectFilesMock(...args),
   findCachedProjectFiles: vi.fn(() => undefined),
   projectFilesQueryKey: () => ["project-files"],
+  sortFilesByPath: (files: unknown[]) => files,
+  PROJECT_FILES_MAX_LIMIT: 1000,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/api-client-instance", () => ({
+  apiClient: {
+    api: {
+      orgs: {
+        ":organizationSlug": {
+          "github-installation": {
+            repositories: {
+              $get: (...args: unknown[]) => repositoriesGetMock(...args),
+            },
+          },
+        },
+      },
+    },
+  },
+}));
+
+vi.mock("@/components/cat/project-file/project-file-cat-workspace", () => ({
+  ProjectFileCatWorkspace: (props: { repositoryFullName?: string | null; sourcePath: string }) =>
+    ProjectFileCatWorkspaceMock(props),
 }));
 
 import { ProjectFileCatPageContent } from "./project-file-cat-page-content";
+
+const enUsFile = createProjectFileRecord({
+  sourcePath: "en-US.json",
+  storedFileId: "file_en_us",
+  filename: "en-US.json",
+});
+
+const pricingFile = createProjectFileRecord({
+  sourcePath: "marketing/pricing.json",
+  storedFileId: "file_pricing",
+  filename: "pricing.json",
+});
+
+function createLocalStorageMock() {
+  const store = new Map<string, string>();
+
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    clear: () => {
+      store.clear();
+    },
+  };
+}
+
+function mockRepositories(
+  repositories: Array<{ fullName: string; enabled: boolean; archived: boolean }>,
+) {
+  repositoriesGetMock.mockResolvedValue({
+    ok: true,
+    json: async () => ({ repositories }),
+  });
+}
+
+function mockReadyProjectQuery() {
+  useProjectPageQueryMock.mockReturnValue({
+    isLoading: false,
+    isError: false,
+    isSuccess: true,
+    data: { sourceLocale: "en" },
+    error: null,
+  });
+}
 
 describe("ProjectFileCatPageContent guard ordering", () => {
   it("shows the select-a-file prompt when no source path is selected", () => {
@@ -84,6 +183,102 @@ describe("ProjectFileCatPageContent guard ordering", () => {
     expect(useProjectPageQueryMock).toHaveBeenCalledWith("acme", "proj_1", { enabled: false });
     expect(
       screen.queryByText("This project does not have a source locale."),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("ProjectFileCatPageContent CAT shell", () => {
+  beforeEach(() => {
+    mockReadyProjectQuery();
+    fetchProjectFilesMock.mockResolvedValue([enUsFile, pricingFile]);
+    mockRepositories([
+      { fullName: "acme/web", enabled: true, archived: false },
+      { fullName: "acme/docs", enabled: true, archived: false },
+    ]);
+    ProjectFileCatWorkspaceMock.mockClear();
+    vi.stubGlobal("localStorage", createLocalStorageMock());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders source file and GitHub repository selectors in the CAT header", async () => {
+    render(
+      <CatTestProviders>
+        <ProjectFileCatPageContent
+          organizationSlug="acme"
+          projectId="proj_1"
+          sourcePath="en-US.json"
+          highlightLocale="vi"
+        />
+      </CatTestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Source file")).toBeInTheDocument();
+      expect(screen.getByLabelText("GitHub repository")).toBeInTheDocument();
+    });
+  });
+
+  it("passes a saved repository preference into the CAT workspace", async () => {
+    localStorage.setItem("job-cat-repository:acme:proj_1:en-US.json", "acme/docs");
+
+    render(
+      <CatTestProviders>
+        <ProjectFileCatPageContent
+          organizationSlug="acme"
+          projectId="proj_1"
+          sourcePath="en-US.json"
+          highlightLocale="vi"
+        />
+      </CatTestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("cat-workspace")).toHaveAttribute("data-repo", "acme/docs");
+    });
+  });
+
+  it("prompts for a repository when multiple GitHub repos are enabled and none is selected", async () => {
+    render(
+      <CatTestProviders>
+        <ProjectFileCatPageContent
+          organizationSlug="acme"
+          projectId="proj_1"
+          sourcePath="en-US.json"
+          highlightLocale="vi"
+        />
+      </CatTestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Select a GitHub repository to look up string context."),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("cat-workspace")).toHaveAttribute("data-repo", "");
+  });
+
+  it("auto-selects the only enabled repository and passes it to the workspace", async () => {
+    mockRepositories([{ fullName: "acme/web", enabled: true, archived: false }]);
+
+    render(
+      <CatTestProviders>
+        <ProjectFileCatPageContent
+          organizationSlug="acme"
+          projectId="proj_1"
+          sourcePath="en-US.json"
+          highlightLocale="vi"
+        />
+      </CatTestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("cat-workspace")).toHaveAttribute("data-repo", "acme/web");
+    });
+    expect(
+      screen.queryByText("Select a GitHub repository to look up string context."),
     ).not.toBeInTheDocument();
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
@@ -1,24 +1,59 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
 import { ArrowLeftIcon } from "lucide-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { TypographyP } from "@/components/ui/typography";
 import { ProjectFileCatWorkspace } from "@/components/cat/project-file/project-file-cat-workspace";
 import { useAppShellSidebar } from "@/components/app-shell/store/use-app-shell-sidebar";
+import { apiClient } from "@/lib/api-client-instance";
 import { supportsProviderCatFile } from "@/lib/providers/provider-cat-capabilities";
-import { hasProjectFileCatIdentityFromUrl } from "@/lib/projects/project-file-cat-routing";
+import {
+  buildProjectFileCatHref,
+  canOpenProjectFileCat,
+  hasProjectFileCatIdentityFromUrl,
+} from "@/lib/projects/project-file-cat-routing";
 
 import { ProjectPageShell, useProjectPageQuery } from "../../_components/project-page-shell";
+import {
+  catFileRepositoryPreferenceKey,
+  readCatFileRepositoryPreference,
+  writeCatFileRepositoryPreference,
+} from "../../jobs/[jobId]/strings/_components/job-cat-repository-preference";
 import { selectJobCatTargetLocale } from "../../jobs/[jobId]/strings/_components/job-cat-target-locale";
+import {
+  canLookupFreshCatRepositoryContext,
+  selectJobCatRepository,
+} from "../../jobs/[jobId]/strings/_components/select-job-cat-repository";
 import {
   fetchProjectFiles,
   findCachedProjectFiles,
+  PROJECT_FILES_MAX_LIMIT,
   projectFilesQueryKey,
+  sortFilesByPath,
 } from "./project-files-tree-panel";
+
+type ProjectFileCatGithubRepository = {
+  fullName: string;
+  enabled: boolean;
+  archived: boolean;
+};
+
+function githubInstallationRepositoriesQueryKey(organizationSlug: string) {
+  return ["github-installation-repositories", organizationSlug] as const;
+}
 
 export function ProjectFileCatPageContent({
   organizationSlug,
@@ -28,6 +63,7 @@ export function ProjectFileCatPageContent({
   initialSegmentKey = null,
   externalResourceId = null,
   resourceType = null,
+  branch = null,
 }: {
   organizationSlug: string;
   projectId: string;
@@ -36,15 +72,30 @@ export function ProjectFileCatPageContent({
   initialSegmentKey?: string | null;
   externalResourceId?: string | null;
   resourceType?: "file" | "key" | null;
+  branch?: string | null;
 }) {
+  const router = useRouter();
   const queryClient = useQueryClient();
   const hasFileReference = Boolean(sourcePath);
   const projectQuery = useProjectPageQuery(organizationSlug, projectId, {
     enabled: hasFileReference,
   });
-  const filesHref = `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/files${
-    sourcePath ? `?sourcePath=${encodeURIComponent(sourcePath)}` : ""
-  }`;
+  const filesHref = useMemo(() => {
+    const params = new URLSearchParams();
+    if (sourcePath) {
+      params.set("sourcePath", sourcePath);
+    }
+    if (highlightLocale) {
+      params.set("locale", highlightLocale);
+    }
+    if (branch) {
+      params.set("branch", branch);
+    }
+    const query = params.toString();
+    return `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/files${
+      query ? `?${query}` : ""
+    }`;
+  }, [branch, highlightLocale, organizationSlug, projectId, sourcePath]);
   const canOpenFromUrlIdentity = hasProjectFileCatIdentityFromUrl({
     sourcePath,
     externalResourceId,
@@ -52,11 +103,67 @@ export function ProjectFileCatPageContent({
   });
 
   const filesQuery = useQuery({
-    queryKey: projectFilesQueryKey(organizationSlug, projectId),
-    queryFn: () => fetchProjectFiles(organizationSlug, projectId),
-    enabled: hasFileReference && !canOpenFromUrlIdentity,
-    placeholderData: () => findCachedProjectFiles(queryClient, organizationSlug, projectId),
+    queryKey: projectFilesQueryKey(organizationSlug, projectId, PROJECT_FILES_MAX_LIMIT, branch),
+    queryFn: () => fetchProjectFiles(organizationSlug, projectId, PROJECT_FILES_MAX_LIMIT, branch),
+    enabled: hasFileReference,
+    placeholderData: () => findCachedProjectFiles(queryClient, organizationSlug, projectId, branch),
   });
+
+  const repositoriesQuery = useQuery({
+    queryKey: githubInstallationRepositoriesQueryKey(organizationSlug),
+    enabled: hasFileReference,
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["github-installation"][
+        "repositories"
+      ].$get({
+        param: { organizationSlug },
+        query: {},
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to load GitHub repositories");
+      }
+
+      const body = (await response.json()) as { repositories: ProjectFileCatGithubRepository[] };
+      return body.repositories;
+    },
+  });
+
+  const catFiles = useMemo(
+    () => sortFilesByPath(filesQuery.data ?? []).filter((entry) => canOpenProjectFileCat(entry)),
+    [filesQuery.data],
+  );
+
+  const enabledRepositoryFullNames = useMemo(
+    () =>
+      (repositoriesQuery.data ?? [])
+        .filter((repository) => repository.enabled && !repository.archived)
+        .map((repository) => repository.fullName),
+    [repositoriesQuery.data],
+  );
+
+  const repositoryPreferenceKey = sourcePath
+    ? catFileRepositoryPreferenceKey(organizationSlug, projectId, sourcePath)
+    : null;
+
+  const [repositoryOverride, setRepositoryOverride] = useState<string | null>(null);
+
+  useEffect(() => {
+    setRepositoryOverride(null);
+  }, [repositoryPreferenceKey]);
+
+  const autoSelectedRepositoryFullName = useMemo(() => {
+    if (!repositoryPreferenceKey) {
+      return null;
+    }
+
+    return selectJobCatRepository({
+      enabledRepositoryFullNames,
+      savedRepositoryFullName: readCatFileRepositoryPreference(repositoryPreferenceKey),
+    });
+  }, [enabledRepositoryFullNames, repositoryPreferenceKey]);
+
+  const selectedRepositoryFullName = repositoryOverride ?? autoSelectedRepositoryFullName;
   useAppShellSidebar({
     forceCollapsed: hasFileReference,
     preferredOpen: hasFileReference ? false : null,
@@ -201,23 +308,114 @@ export function ProjectFileCatPageContent({
     );
   }
 
+  const handleFileChange = (nextSourcePath: string | null) => {
+    if (!nextSourcePath) {
+      return;
+    }
+
+    const nextFile = catFiles.find((entry) => entry.sourcePath === nextSourcePath);
+    if (!nextFile) {
+      return;
+    }
+
+    const href = buildProjectFileCatHref(
+      organizationSlug,
+      projectId,
+      nextFile,
+      highlightLocale,
+      branch,
+    );
+    if (href) {
+      router.push(href);
+    }
+  };
+
+  const handleRepositoryChange = (nextRepositoryFullName: string | null) => {
+    if (!nextRepositoryFullName || !repositoryPreferenceKey) {
+      return;
+    }
+
+    writeCatFileRepositoryPreference(repositoryPreferenceKey, nextRepositoryFullName);
+    setRepositoryOverride(nextRepositoryFullName);
+  };
+
   return (
     <main className="-mx-4 -my-5 flex min-h-[calc(100svh-var(--app-shell-header-height))] flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
-      <div className="flex shrink-0 flex-col gap-3 border-b border-border px-4 py-3 sm:px-6 lg:px-8">
-        <div className="flex min-w-0 items-center gap-3">
-          <Button variant="outline" size="sm" render={<Link href={filesHref} />}>
-            <ArrowLeftIcon />
-            Files
-          </Button>
-          <TypographyP className="truncate font-mono text-xs text-muted-foreground">
+      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 sm:px-4 lg:px-6">
+        <Button
+          variant="outline"
+          size="icon-sm"
+          className="size-8 shrink-0"
+          render={<Link href={filesHref} />}
+        >
+          <ArrowLeftIcon className="size-4" />
+        </Button>
+
+        {catFiles.length > 0 ? (
+          <Select value={sourcePath ?? ""} onValueChange={handleFileChange}>
+            <SelectTrigger
+              className="h-8 min-w-0 flex-1 basis-40 font-mono text-xs sm:max-w-xs"
+              aria-label="Source file"
+            >
+              <SelectValue placeholder="Source file" />
+            </SelectTrigger>
+            <SelectContent>
+              {catFiles.map((entry) => (
+                <SelectItem key={entry.sourcePath} value={entry.sourcePath}>
+                  {entry.sourcePath}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : (
+          <TypographyP className="min-w-0 truncate font-mono text-xs text-muted-foreground">
             {sourcePath}
           </TypographyP>
-        </div>
+        )}
+
+        {enabledRepositoryFullNames.length > 0 ? (
+          <Select value={selectedRepositoryFullName ?? ""} onValueChange={handleRepositoryChange}>
+            <SelectTrigger
+              className="h-8 min-w-0 flex-1 basis-40 font-mono text-xs sm:max-w-xs"
+              aria-label="GitHub repository"
+            >
+              <SelectValue placeholder="GitHub repo" />
+            </SelectTrigger>
+            <SelectContent>
+              {enabledRepositoryFullNames.map((repositoryFullName) => (
+                <SelectItem key={repositoryFullName} value={repositoryFullName}>
+                  {repositoryFullName}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : null}
+
+        {file?.provider ? (
+          <TypographyP className="hidden min-w-0 truncate text-xs text-muted-foreground sm:block lg:max-w-48">
+            {file.provider.kind} · {file.provider.format ?? "file"}
+          </TypographyP>
+        ) : null}
       </div>
 
-      <div className="flex min-h-0 flex-1 flex-col px-4 py-3 sm:px-6 lg:px-8">
+      {(repositoriesQuery.isError ||
+        (enabledRepositoryFullNames.length > 1 && !selectedRepositoryFullName)) && (
+        <div className="shrink-0 border-b border-border px-3 py-1.5 sm:px-4 lg:px-6">
+          {repositoriesQuery.isError ? (
+            <TypographyP className="text-xs text-muted-foreground">
+              GitHub repositories could not be loaded. Repository context lookup is unavailable.
+            </TypographyP>
+          ) : (
+            <TypographyP className="text-xs text-muted-foreground">
+              Select a GitHub repository to look up string context.
+            </TypographyP>
+          )}
+        </div>
+      )}
+
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 py-2 sm:px-4 lg:px-6">
         <ProjectFileCatWorkspace
-          key={`${sourcePath}:${resolvedExternalResourceId ?? "source-path"}:${targetLocale}`}
+          key={`${sourcePath}:${resolvedExternalResourceId ?? "source-path"}:${targetLocale}:${selectedRepositoryFullName ?? "default"}`}
           organizationSlug={organizationSlug}
           projectId={projectId}
           sourceLocale={sourceLocale}
@@ -227,8 +425,14 @@ export function ProjectFileCatPageContent({
           targetLocale={targetLocale}
           targetLocales={file?.provider?.targetLocales}
           highlightLocale={highlightLocale}
+          repositoryFullName={selectedRepositoryFullName}
+          canLookupFreshContext={canLookupFreshCatRepositoryContext(
+            enabledRepositoryFullNames,
+            selectedRepositoryFullName,
+          )}
           initialSegmentKey={initialSegmentKey}
           layout="fullscreen"
+          className="min-h-0 flex-1"
         />
       </div>
     </main>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.tsx
@@ -16,16 +16,24 @@ export function ProjectFileSelectionActions({
   projectId,
   file,
   highlightLocale,
+  branch = null,
   layout = "default",
 }: {
   organizationSlug: string;
   projectId: string;
   file: ProjectFileRecord;
   highlightLocale: string | null;
+  branch?: string | null;
   layout?: "default" | "compact";
 }) {
   const canOpenCat = canOpenProjectFileCat(file);
-  const catHref = buildProjectFileCatHref(organizationSlug, projectId, file, highlightLocale);
+  const catHref = buildProjectFileCatHref(
+    organizationSlug,
+    projectId,
+    file,
+    highlightLocale,
+    branch,
+  );
 
   if (layout === "compact") {
     return (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEffect, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { createProjectFileRecord } from "./project-files.fixture";
+
+const enUsFile = createProjectFileRecord({
+  sourcePath: "en-US.json",
+  storedFileId: "file_en_us",
+  filename: "en-US.json",
+});
+
+const { routerPushMock } = vi.hoisted(() => ({
+  routerPushMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/org/acme/projects/proj_1/files",
+  useRouter: () => ({
+    push: routerPushMock,
+    replace: vi.fn(),
+  }),
+  useSearchParams: () => new URLSearchParams("sourcePath=en-US.json&locale=vi"),
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useMutation: () => ({
+      mutate: vi.fn(),
+      isPending: false,
+    }),
+    useQueryClient: () => ({
+      invalidateQueries: vi.fn(),
+    }),
+  };
+});
+
+vi.mock("./project-files-tree-panel", () => ({
+  PROJECT_FILES_PAGE_SIZE: 50,
+  PROJECT_FILES_MAX_LIMIT: 1000,
+  projectFilesQueryKey: () => ["project-files"],
+  sortFilesByPath: (files: unknown[]) => files,
+  ProjectFilesTreePanel: ({
+    onActivateFile,
+    onLoadedFilesChange,
+    catOpenHint,
+    headerActions,
+  }: {
+    onActivateFile?: (sourcePath: string) => void;
+    onLoadedFilesChange?: (files: (typeof enUsFile)[]) => void;
+    catOpenHint?: string | null;
+    headerActions?: ReactNode;
+  }) => {
+    useEffect(() => {
+      onLoadedFilesChange?.([enUsFile]);
+    }, [onLoadedFilesChange]);
+
+    return (
+      <div>
+        {headerActions}
+        {catOpenHint ? <p>{catOpenHint}</p> : null}
+        <button type="button" onDoubleClick={() => onActivateFile?.("en-US.json")}>
+          en-US.json
+        </button>
+      </div>
+    );
+  },
+}));
+
+vi.mock("./project-files-branch-filter", () => ({
+  ProjectFilesBranchFilter: () => null,
+}));
+
+vi.mock("../../_components/project-page-shell", () => ({
+  ProjectPageShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ProjectSectionHeader: ({ section }: { section: string }) => <h2>{section}</h2>,
+  ProjectSectionTitle: ({ children }: { children: React.ReactNode }) => <h3>{children}</h3>,
+  useProjectPageQuery: () => ({
+    isLoading: false,
+    isError: false,
+    data: { sourceLocale: "en" },
+  }),
+}));
+
+import { ProjectFilesPageContent } from "./project-files-page-content";
+
+describe("ProjectFilesPageContent CAT entry UX", () => {
+  it("opens CAT when a project file is double-clicked", async () => {
+    const user = userEvent.setup();
+    routerPushMock.mockClear();
+
+    render(<ProjectFilesPageContent organizationSlug="acme" projectId="proj_1" />);
+
+    await user.dblClick(screen.getByRole("button", { name: "en-US.json" }));
+
+    expect(routerPushMock).toHaveBeenCalledWith(
+      "/org/acme/projects/proj_1/files/cat?sourcePath=en-US.json&locale=vi",
+    );
+  });
+
+  it("shows double-click guidance when a file is selected", () => {
+    render(<ProjectFilesPageContent organizationSlug="acme" projectId="proj_1" />);
+
+    expect(
+      screen.getByText(/Double-click a file or use View strings to open the CAT workspace for vi/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -16,6 +16,11 @@ import { Spinner } from "@/components/ui/spinner";
 import { TypographyP } from "@/components/ui/typography";
 import { readApiResponseError } from "@/lib/api-error";
 import { getProjectWorkspaceCapabilities } from "@/lib/projects/workspace-resource-capabilities";
+import {
+  buildProjectFileCatHref,
+  canOpenProjectFileCat,
+  resolveProjectFileCatTargetLocale,
+} from "@/lib/projects/project-file-cat-routing";
 
 import {
   ProjectPageShell,
@@ -198,6 +203,55 @@ export function ProjectFilesPageContent({
   const projectCapabilities = getProjectWorkspaceCapabilities({ projectId });
   const isProviderProject = projectCapabilities.isProviderProject;
 
+  const openFileInCat = useCallback(
+    (sourcePath: string) => {
+      const file = resolvedFiles.find((entry) => entry.sourcePath === sourcePath);
+      if (!file) {
+        return;
+      }
+
+      const targetLocale = resolveProjectFileCatTargetLocale(file, highlightLocale);
+      if (!canOpenProjectFileCat(file) || !targetLocale) {
+        toast.error(
+          targetLocale
+            ? "This file can't be opened in the CAT workspace."
+            : "No target locale is available for this file.",
+        );
+        return;
+      }
+
+      const href = buildProjectFileCatHref(
+        organizationSlug,
+        projectId,
+        file,
+        highlightLocale,
+        selectedBranch,
+      );
+      if (href) {
+        router.push(href);
+      }
+    },
+    [highlightLocale, organizationSlug, projectId, resolvedFiles, router, selectedBranch],
+  );
+
+  const selectedFileForTree = useMemo(
+    () => resolvedFiles.find((file) => file.sourcePath === selectedSourcePath) ?? null,
+    [resolvedFiles, selectedSourcePath],
+  );
+  const catOpenHint = selectedFileForTree
+    ? (() => {
+        const targetLocale = resolveProjectFileCatTargetLocale(
+          selectedFileForTree,
+          highlightLocale,
+        );
+        if (targetLocale) {
+          return `Double-click a file or use View strings to open the CAT workspace for ${targetLocale}.`;
+        }
+
+        return "No target locale is available for this file.";
+      })()
+    : null;
+
   return (
     <ProjectFilesPageContentView
       organizationSlug={organizationSlug}
@@ -224,6 +278,8 @@ export function ProjectFilesPageContent({
           selectedSourcePath={selectedSourcePath}
           onSelectSourcePath={setSelectedSourcePath}
           onLoadedFilesChange={setLoadedFiles}
+          onActivateFile={openFileInCat}
+          catOpenHint={catOpenHint}
           branch={selectedBranch}
           headerActions={
             <>
@@ -241,6 +297,7 @@ export function ProjectFilesPageContent({
                   projectId={projectId}
                   file={selectedFile}
                   highlightLocale={highlightLocale}
+                  branch={selectedBranch}
                   layout="compact"
                 />
               ) : null}
@@ -404,6 +461,7 @@ export function ProjectFilesPageContentView({
                 projectId={projectId}
                 file={selectedFile}
                 highlightLocale={highlightLocale}
+                branch={_selectedBranch}
               />
             ) : null}
             <header className="flex shrink-0 items-center justify-between gap-3 border-b border-border px-4 py-3">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.tsx
@@ -105,11 +105,15 @@ function ProjectFilesTreeBody({
   files,
   selectedSourcePath,
   onSelectSourcePath,
+  onActivateFile,
+  catOpenHint,
 }: {
   projectId: string;
   files: ProjectFileRecord[];
   selectedSourcePath: string | null;
   onSelectSourcePath: (sourcePath: string | null) => void;
+  onActivateFile?: (sourcePath: string) => void;
+  catOpenHint?: string | null;
 }) {
   const projectCapabilities = getProjectWorkspaceCapabilities({ projectId });
   const isProviderProject = projectCapabilities.isProviderProject;
@@ -128,12 +132,23 @@ function ProjectFilesTreeBody({
   }
 
   return (
-    <div className="min-h-0 flex-1 p-2">
-      <ProjectFilesTree
-        files={files}
-        selectedSourcePath={selectedSourcePath}
-        onSelectFile={onSelectSourcePath}
-      />
+    <div className="flex min-h-0 flex-1 flex-col gap-2 p-2">
+      {onActivateFile && selectedSourcePath && catOpenHint ? (
+        <div className="rounded-lg border border-border bg-background px-4 py-3">
+          <TypographyP className="truncate font-mono text-xs text-foreground">
+            {selectedSourcePath}
+          </TypographyP>
+          <TypographyP className="text-xs text-muted-foreground">{catOpenHint}</TypographyP>
+        </div>
+      ) : null}
+      <div className="min-h-0 flex-1">
+        <ProjectFilesTree
+          files={files}
+          selectedSourcePath={selectedSourcePath}
+          onSelectFile={onSelectSourcePath}
+          onActivateFile={onActivateFile}
+        />
+      </div>
     </div>
   );
 }
@@ -144,12 +159,16 @@ function ProjectFilesTreeQueryResult({
   files,
   selectedSourcePath,
   onSelectSourcePath,
+  onActivateFile,
+  catOpenHint,
 }: {
   error: unknown;
   projectId: string;
   files: ProjectFileRecord[];
   selectedSourcePath: string | null;
   onSelectSourcePath: (sourcePath: string | null) => void;
+  onActivateFile?: (sourcePath: string) => void;
+  catOpenHint?: string | null;
 }) {
   if (error) {
     throw error;
@@ -161,6 +180,8 @@ function ProjectFilesTreeQueryResult({
       files={files}
       selectedSourcePath={selectedSourcePath}
       onSelectSourcePath={onSelectSourcePath}
+      onActivateFile={onActivateFile}
+      catOpenHint={catOpenHint}
     />
   );
 }
@@ -171,6 +192,8 @@ export function ProjectFilesTreePanel({
   selectedSourcePath,
   onSelectSourcePath,
   onLoadedFilesChange,
+  onActivateFile,
+  catOpenHint = null,
   headerActions,
   branch = null,
 }: {
@@ -179,6 +202,8 @@ export function ProjectFilesTreePanel({
   selectedSourcePath: string | null;
   onSelectSourcePath: (sourcePath: string | null) => void;
   onLoadedFilesChange?: (files: ProjectFileRecord[]) => void;
+  onActivateFile?: (sourcePath: string) => void;
+  catOpenHint?: string | null;
   headerActions?: ReactNode;
   branch?: string | null;
 }) {
@@ -288,6 +313,8 @@ export function ProjectFilesTreePanel({
             files={files}
             selectedSourcePath={selectedSourcePath}
             onSelectSourcePath={onSelectSourcePath}
+            onActivateFile={onActivateFile}
+            catOpenHint={catOpenHint}
           />
           {hasMoreFiles ? (
             <div className="shrink-0 border-t border-border p-2">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
@@ -17,6 +17,8 @@ const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
 });
 
 const projectFilesTreeStyle = {
+  width: "100%",
+  minWidth: "100%",
   height: `${TREE_MIN_HEIGHT_PX}px`,
   backgroundColor: "transparent",
   color: "var(--foreground)",
@@ -58,18 +60,21 @@ export function ProjectFilesTree({
   files,
   selectedSourcePath,
   onSelectFile,
+  onActivateFile,
   ariaLabel = "Project files",
 }: {
   files: ProjectFileRecord[];
   selectedSourcePath: string | null;
   onSelectFile: (sourcePath: string) => void;
+  onActivateFile?: (sourcePath: string) => void;
   ariaLabel?: string;
 }) {
+  const containerRef = useRef<HTMLDivElement>(null);
   const paths = useMemo(() => files.map((file) => file.sourcePath), [files]);
   const fileByPath = useMemo(() => new Map(files.map((file) => [file.sourcePath, file])), [files]);
   const selectedPaths =
     selectedSourcePath && fileByPath.has(selectedSourcePath) ? [selectedSourcePath] : [];
-  const latestStateRef = useRef({ fileByPath, onSelectFile });
+  const latestStateRef = useRef({ fileByPath, onSelectFile, onActivateFile });
   const preloadedData = useMemo(
     () =>
       paths.length > 0
@@ -84,12 +89,40 @@ export function ProjectFilesTree({
   );
 
   useEffect(() => {
-    latestStateRef.current = { fileByPath, onSelectFile };
-  }, [fileByPath, onSelectFile]);
+    latestStateRef.current = { fileByPath, onSelectFile, onActivateFile };
+  }, [fileByPath, onActivateFile, onSelectFile]);
+
+  useEffect(() => {
+    if (!onActivateFile) {
+      return;
+    }
+
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    const handleDoubleClick = (event: MouseEvent) => {
+      const pathElement = event
+        .composedPath()
+        .find(
+          (node): node is HTMLElement =>
+            node instanceof HTMLElement && typeof node.dataset.itemPath === "string",
+        );
+      const path = pathElement?.dataset.itemPath;
+      if (!path || !latestStateRef.current.fileByPath.has(path)) {
+        return;
+      }
+
+      latestStateRef.current.onActivateFile?.(path);
+    };
+
+    container.addEventListener("dblclick", handleDoubleClick);
+    return () => container.removeEventListener("dblclick", handleDoubleClick);
+  }, [onActivateFile]);
 
   const { model } = useFileTree({
     id: "project-files-tree",
-    density: "compact",
     flattenEmptyDirectories: true,
     initialExpansion: "open",
     initialSelectedPaths: selectedPaths,
@@ -140,13 +173,15 @@ export function ProjectFilesTree({
   }
 
   return (
-    <PierreFileTree
-      aria-label={ariaLabel}
-      className="w-full border-0 bg-transparent"
-      id="project-files-tree"
-      model={model}
-      preloadedData={preloadedData ?? undefined}
-      style={projectFilesTreeStyle}
-    />
+    <div ref={containerRef} className="w-full min-w-0">
+      <PierreFileTree
+        aria-label={ariaLabel}
+        className="w-full min-w-0 border-0 bg-transparent"
+        id="project-files-tree"
+        model={model}
+        preloadedData={preloadedData ?? undefined}
+        style={projectFilesTreeStyle}
+      />
+    </div>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/cat/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/cat/page.tsx
@@ -14,6 +14,7 @@ export default async function ProjectFileCatPage({
     segment?: string;
     externalResourceId?: string;
     resourceType?: string;
+    branch?: string;
   }>;
 }) {
   const { organizationSlug, projectId } = await params;
@@ -29,6 +30,7 @@ export default async function ProjectFileCatPage({
       initialSegmentKey={parsedSearchParams.initialSegmentKey}
       externalResourceId={parsedSearchParams.externalResourceId}
       resourceType={parsedSearchParams.resourceType}
+      branch={parsedSearchParams.branch}
     />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { createProjectFileRecord } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files.fixture";
+
+const { routerPushMock, lastTreePropsRef } = vi.hoisted(() => ({
+  routerPushMock: vi.fn(),
+  lastTreePropsRef: { current: null as { onActivateFile?: (sourcePath: string) => void } | null },
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: routerPushMock,
+  }),
+}));
+
+vi.mock("../../../../files/_components/project-files-tree", () => ({
+  ProjectFilesTree: (props: {
+    files: Array<{ sourcePath: string }>;
+    onSelectFile: (sourcePath: string) => void;
+    onActivateFile?: (sourcePath: string) => void;
+  }) => {
+    lastTreePropsRef.current = props;
+
+    return (
+      <div>
+        {props.files.map((file) => (
+          <button
+            key={file.sourcePath}
+            type="button"
+            onClick={() => props.onSelectFile(file.sourcePath)}
+            onDoubleClick={() => props.onActivateFile?.(file.sourcePath)}
+          >
+            {file.sourcePath}
+          </button>
+        ))}
+      </div>
+    );
+  },
+}));
+
+import { JobSourceFilesPanel } from "./job-source-files-panel";
+
+const nativeFile = createProjectFileRecord({
+  sourcePath: "en-US.json",
+  storedFileId: "en-US.json",
+  filename: "en-US.json",
+});
+
+describe("JobSourceFilesPanel CAT entry UX", () => {
+  it("shows View strings when files are selected from the task detail panel", () => {
+    render(
+      <JobSourceFilesPanel
+        organizationSlug="acme"
+        projectId="proj_1"
+        encodedJobId="job_1"
+        files={[nativeFile]}
+        highlightLocale="vi"
+        openInCatOnSelect={false}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "View strings" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View strings" })).toHaveAttribute(
+      "href",
+      "/org/acme/projects/proj_1/jobs/job_1/strings?targetLocale=vi&storedFileId=en-US.json",
+    );
+    expect(
+      screen.getByText(/Double-click a file or use View strings to open the CAT workspace/i),
+    ).toBeInTheDocument();
+  });
+
+  it("opens CAT when a file is double-clicked from the task detail panel", async () => {
+    const user = userEvent.setup();
+    routerPushMock.mockClear();
+
+    render(
+      <JobSourceFilesPanel
+        organizationSlug="acme"
+        projectId="proj_1"
+        encodedJobId="job_1"
+        files={[nativeFile]}
+        highlightLocale="vi"
+        openInCatOnSelect={false}
+      />,
+    );
+
+    await user.dblClick(screen.getByRole("button", { name: "en-US.json" }));
+
+    expect(routerPushMock).toHaveBeenCalledWith(
+      "/org/acme/projects/proj_1/jobs/job_1/strings?targetLocale=vi&storedFileId=en-US.json",
+    );
+  });
+
+  it("opens CAT immediately when openInCatOnSelect is enabled", async () => {
+    const user = userEvent.setup();
+    routerPushMock.mockClear();
+
+    render(
+      <JobSourceFilesPanel
+        organizationSlug="acme"
+        projectId="proj_1"
+        encodedJobId="job_1"
+        files={[nativeFile]}
+        highlightLocale="vi"
+        openInCatOnSelect
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "en-US.json" }));
+
+    expect(routerPushMock).toHaveBeenCalledWith(
+      "/org/acme/projects/proj_1/jobs/job_1/strings?targetLocale=vi&storedFileId=en-US.json",
+    );
+    expect(screen.queryByRole("link", { name: "View strings" })).not.toBeInTheDocument();
+  });
+
+  it("does not wire onActivateFile when openInCatOnSelect is enabled", () => {
+    render(
+      <JobSourceFilesPanel
+        organizationSlug="acme"
+        projectId="proj_1"
+        encodedJobId="job_1"
+        files={[nativeFile]}
+        highlightLocale="vi"
+        openInCatOnSelect
+      />,
+    );
+
+    expect(lastTreePropsRef.current?.onActivateFile).toBeUndefined();
+  });
+
+  it("wires onActivateFile when openInCatOnSelect is disabled", () => {
+    render(
+      <JobSourceFilesPanel
+        organizationSlug="acme"
+        projectId="proj_1"
+        encodedJobId="job_1"
+        files={[nativeFile]}
+        highlightLocale="vi"
+        openInCatOnSelect={false}
+      />,
+    );
+
+    expect(lastTreePropsRef.current?.onActivateFile).toBeTypeOf("function");
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { ListIcon } from "lucide-react";
 
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { TypographyH4 } from "@/components/ui/typography";
+import { TypographyH4, TypographyP } from "@/components/ui/typography";
 import { supportsProviderCatFile } from "@/lib/providers/provider-cat-capabilities";
 import { toast } from "sonner";
 
@@ -110,11 +113,9 @@ export function JobSourceFilesPanel({
     sortedFiles.find((file) => file.sourcePath === selectedSourcePath) ?? sortedFiles[0] ?? null;
   const activeSourcePath = selectedFile?.sourcePath ?? null;
 
-  const handleSelectFile = useCallback(
+  const openFileInCat = useCallback(
     (sourcePath: string) => {
-      setSelectedSourcePath(sourcePath);
-
-      if (!openInCatOnSelect || !encodedJobId) {
+      if (!encodedJobId) {
         return;
       }
 
@@ -141,16 +142,42 @@ export function JobSourceFilesPanel({
         }),
       );
     },
-    [
-      encodedJobId,
-      highlightLocale,
-      openInCatOnSelect,
-      organizationSlug,
-      projectId,
-      router,
-      sortedFiles,
-    ],
+    [encodedJobId, highlightLocale, organizationSlug, projectId, router, sortedFiles],
   );
+
+  const handleSelectFile = useCallback(
+    (sourcePath: string) => {
+      setSelectedSourcePath(sourcePath);
+
+      if (!openInCatOnSelect || !encodedJobId) {
+        return;
+      }
+
+      openFileInCat(sourcePath);
+    },
+    [encodedJobId, openInCatOnSelect, openFileInCat],
+  );
+
+  const selectedTargetLocale = selectedFile
+    ? resolveTargetLocale(selectedFile, highlightLocale)
+    : null;
+  const canViewStrings = Boolean(
+    selectedFile &&
+    activeSourcePath &&
+    canOpenFileInCat(selectedFile, activeSourcePath, encodedJobId, selectedTargetLocale),
+  );
+  const stringsHrefForSelected =
+    canViewStrings && selectedFile && activeSourcePath && encodedJobId && selectedTargetLocale
+      ? stringsHref({
+          organizationSlug,
+          projectId,
+          encodedJobId,
+          targetLocale: selectedTargetLocale,
+          ...(supportsProviderCatFile(selectedFile)
+            ? { sourcePath: activeSourcePath }
+            : { storedFileId: selectedFile.storedFileId as string }),
+        })
+      : null;
 
   return (
     <section className="rounded-lg border border-border bg-card p-5">
@@ -173,13 +200,40 @@ export function JobSourceFilesPanel({
       ) : null}
 
       {!isLoading && !isError && sortedFiles.length > 0 ? (
-        <div className="mt-4 overflow-hidden rounded-lg border border-border bg-background p-2">
-          <ProjectFilesTree
-            ariaLabel="Job source files"
-            files={sortedFiles}
-            selectedSourcePath={activeSourcePath}
-            onSelectFile={handleSelectFile}
-          />
+        <div className="mt-4 space-y-2">
+          {!openInCatOnSelect && encodedJobId ? (
+            <div className="flex flex-col gap-2 rounded-lg border border-border bg-background px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="min-w-0">
+                <TypographyP className="truncate font-mono text-xs text-foreground">
+                  {selectedFile?.sourcePath}
+                </TypographyP>
+                <TypographyP className="text-xs text-muted-foreground">
+                  {selectedTargetLocale
+                    ? `Double-click a file or use View strings to open the CAT workspace for ${selectedTargetLocale}.`
+                    : "No target locale is available for this task file."}
+                </TypographyP>
+              </div>
+              <Button
+                type="button"
+                size="sm"
+                className="shrink-0"
+                disabled={!stringsHrefForSelected}
+                render={stringsHrefForSelected ? <Link href={stringsHrefForSelected} /> : undefined}
+              >
+                <ListIcon />
+                View strings
+              </Button>
+            </div>
+          ) : null}
+          <div className="overflow-hidden rounded-lg border border-border bg-background p-2">
+            <ProjectFilesTree
+              ariaLabel="Job source files"
+              files={sortedFiles}
+              selectedSourcePath={activeSourcePath}
+              onSelectFile={handleSelectFile}
+              onActivateFile={encodedJobId ? openFileInCat : undefined}
+            />
+          </div>
         </div>
       ) : null}
     </section>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.tsx
@@ -231,7 +231,7 @@ export function JobSourceFilesPanel({
               files={sortedFiles}
               selectedSourcePath={activeSourcePath}
               onSelectFile={handleSelectFile}
-              onActivateFile={encodedJobId ? openFileInCat : undefined}
+              onActivateFile={encodedJobId && !openInCatOnSelect ? openFileInCat : undefined}
             />
           </div>
         </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.test.tsx
@@ -1,13 +1,39 @@
 // @vitest-environment happy-dom
 
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vite-plus/test";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { CatTestProviders } from "@/components/cat/shared/cat-test-utils";
+import { createProjectFileRecord } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files.fixture";
 
-const { useProjectPageQueryMock, useAppShellSidebarMock } = vi.hoisted(() => ({
+const {
+  useProjectPageQueryMock,
+  useAppShellSidebarMock,
+  loadJobCatTargetFileMock,
+  loadJobCatProviderJobFilesMock,
+  repositoriesGetMock,
+  ProjectFileCatWorkspaceMock,
+} = vi.hoisted(() => ({
   useProjectPageQueryMock: vi.fn(),
   useAppShellSidebarMock: vi.fn(),
+  loadJobCatTargetFileMock: vi.fn(),
+  loadJobCatProviderJobFilesMock: vi.fn(),
+  repositoriesGetMock: vi.fn(),
+  ProjectFileCatWorkspaceMock: vi.fn(
+    ({
+      repositoryFullName,
+      sourcePath,
+    }: {
+      repositoryFullName?: string | null;
+      sourcePath: string;
+    }) => (
+      <div
+        data-testid="cat-workspace"
+        data-repo={repositoryFullName ?? ""}
+        data-source-path={sourcePath}
+      />
+    ),
+  ),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -35,11 +61,91 @@ vi.mock("./job-cat-source-file-picker", () => ({
 }));
 
 vi.mock("./load-job-cat-files", () => ({
-  loadJobCatTargetFile: vi.fn(),
-  loadJobCatProviderJobFiles: vi.fn(),
+  loadJobCatTargetFile: (...args: unknown[]) => loadJobCatTargetFileMock(...args),
+  loadJobCatProviderJobFiles: (...args: unknown[]) => loadJobCatProviderJobFilesMock(...args),
+}));
+
+vi.mock("@/lib/api-client-instance", () => ({
+  apiClient: {
+    api: {
+      orgs: {
+        ":organizationSlug": {
+          "github-installation": {
+            repositories: {
+              $get: (...args: unknown[]) => repositoriesGetMock(...args),
+            },
+          },
+        },
+      },
+    },
+  },
+}));
+
+vi.mock("@/components/cat/project-file/project-file-cat-workspace", () => ({
+  ProjectFileCatWorkspace: (props: { repositoryFullName?: string | null; sourcePath: string }) =>
+    ProjectFileCatWorkspaceMock(props),
 }));
 
 import { JobCatPageContent } from "./job-cat-page-content";
+
+const nativeFile = createProjectFileRecord({
+  sourcePath: "en-US.json",
+  storedFileId: "en-US.json",
+  filename: "en-US.json",
+});
+
+const providerFile = createProjectFileRecord({
+  origin: "provider",
+  sourcePath: "crowdin/home.json",
+  storedFileId: null,
+  provider: {
+    kind: "crowdin",
+    resourceType: "file",
+    externalProjectId: "project_website",
+    externalResourceId: "file_home_json",
+    externalUrl: null,
+    syncState: "synced",
+    sourceLocale: "en",
+    targetLocales: ["vi", "de-DE"],
+    localeReadiness: {},
+    revision: "1",
+    format: "json",
+    lastSyncedAt: new Date().toISOString(),
+  },
+});
+
+function createLocalStorageMock() {
+  const store = new Map<string, string>();
+
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    clear: () => {
+      store.clear();
+    },
+  };
+}
+
+function mockRepositories(
+  repositories: Array<{ fullName: string; enabled: boolean; archived: boolean }>,
+) {
+  repositoriesGetMock.mockResolvedValue({
+    ok: true,
+    json: async () => ({ repositories }),
+  });
+}
+
+function mockReadyProjectQuery() {
+  useProjectPageQueryMock.mockReturnValue({
+    isLoading: false,
+    isError: false,
+    isSuccess: true,
+    data: { sourceLocale: "en" },
+    error: null,
+  });
+}
 
 describe("JobCatPageContent guard ordering", () => {
   it("shows the source file picker when no file reference is present", () => {
@@ -98,5 +204,117 @@ describe("JobCatPageContent guard ordering", () => {
     expect(
       screen.queryByText("This project does not have a source locale."),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("JobCatPageContent CAT shell", () => {
+  beforeEach(() => {
+    mockReadyProjectQuery();
+    mockRepositories([
+      { fullName: "acme/web", enabled: true, archived: false },
+      { fullName: "acme/docs", enabled: true, archived: false },
+    ]);
+    ProjectFileCatWorkspaceMock.mockClear();
+    vi.stubGlobal("localStorage", createLocalStorageMock());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders provider task CAT with file and repository selectors", async () => {
+    loadJobCatTargetFileMock.mockResolvedValue({ status: "found", file: providerFile });
+    loadJobCatProviderJobFilesMock.mockResolvedValue([providerFile]);
+
+    render(
+      <CatTestProviders>
+        <JobCatPageContent
+          organizationSlug="acme"
+          projectId="proj_1"
+          jobId="job_1"
+          sourcePath="crowdin/home.json"
+          targetLocale="vi"
+        />
+      </CatTestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Source file")).toBeInTheDocument();
+      expect(screen.getByLabelText("GitHub repository")).toBeInTheDocument();
+      expect(screen.getByTestId("cat-workspace")).toHaveAttribute(
+        "data-source-path",
+        "crowdin/home.json",
+      );
+    });
+  });
+
+  it("passes a saved repository preference into provider task CAT", async () => {
+    localStorage.setItem("job-cat-repository:acme:proj_1:crowdin/home.json", "acme/docs");
+    loadJobCatTargetFileMock.mockResolvedValue({ status: "found", file: providerFile });
+    loadJobCatProviderJobFilesMock.mockResolvedValue([providerFile]);
+
+    render(
+      <CatTestProviders>
+        <JobCatPageContent
+          organizationSlug="acme"
+          projectId="proj_1"
+          jobId="job_1"
+          sourcePath="crowdin/home.json"
+          targetLocale="vi"
+        />
+      </CatTestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("cat-workspace")).toHaveAttribute("data-repo", "acme/docs");
+    });
+  });
+
+  it("renders native task CAT with a repository selector and passes the selection to the workspace", async () => {
+    localStorage.setItem("job-cat-repository:acme:proj_1:en-US.json", "acme/web");
+    loadJobCatTargetFileMock.mockResolvedValue({ status: "found", file: nativeFile });
+
+    render(
+      <CatTestProviders>
+        <JobCatPageContent
+          organizationSlug="acme"
+          projectId="proj_1"
+          jobId="job_1"
+          sourcePath={null}
+          storedFileId="en-US.json"
+          targetLocale="vi"
+        />
+      </CatTestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("GitHub repository")).toBeInTheDocument();
+      expect(screen.getByTestId("cat-workspace")).toHaveAttribute("data-repo", "acme/web");
+      expect(screen.getByTestId("cat-workspace")).toHaveAttribute("data-source-path", "en-US.json");
+    });
+    expect(screen.queryByLabelText("Source file")).not.toBeInTheDocument();
+  });
+
+  it("prompts for a repository on native task CAT when multiple repos are enabled", async () => {
+    loadJobCatTargetFileMock.mockResolvedValue({ status: "found", file: nativeFile });
+
+    render(
+      <CatTestProviders>
+        <JobCatPageContent
+          organizationSlug="acme"
+          projectId="proj_1"
+          jobId="job_1"
+          sourcePath={null}
+          storedFileId="en-US.json"
+          targetLocale="vi"
+        />
+      </CatTestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Select a GitHub repository to look up string context."),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -398,6 +398,10 @@ export function JobCatPageContent({
             targetLocale={targetLocale}
             highlightLocale={targetLocale}
             repositoryFullName={selectedRepositoryFullName}
+            canLookupFreshContext={canLookupFreshCatRepositoryContext(
+              enabledRepositoryFullNames,
+              selectedRepositoryFullName,
+            )}
             initialSegmentKey={initialSegmentKey}
             layout="fullscreen"
             className="min-h-0 flex-1"

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -28,7 +28,11 @@ import {
 } from "./job-cat-repository-preference";
 import { selectJobCatTargetLocale } from "./job-cat-target-locale";
 import { loadJobCatProviderJobFiles, loadJobCatTargetFile } from "./load-job-cat-files";
-import { selectJobCatRepository, sortJobCatProviderFiles } from "./select-job-cat-repository";
+import {
+  canLookupFreshCatRepositoryContext,
+  selectJobCatRepository,
+  sortJobCatProviderFiles,
+} from "./select-job-cat-repository";
 import { ProjectFileCatWorkspace } from "@/components/cat/project-file/project-file-cat-workspace";
 
 import { JobCatSourceFilePicker } from "./job-cat-source-file-picker";
@@ -144,7 +148,7 @@ export function JobCatPageContent({
 
   const repositoriesQuery = useQuery({
     queryKey: githubInstallationRepositoriesQueryKey(organizationSlug),
-    enabled: hasFileReference && !isNativeJob,
+    enabled: hasFileReference,
     queryFn: async () => {
       const response = await apiClient.api.orgs[":organizationSlug"]["github-installation"][
         "repositories"
@@ -298,38 +302,6 @@ export function JobCatPageContent({
     );
   }
 
-  if (isNativeFile) {
-    return (
-      <main className="-mx-4 -my-5 flex min-h-[calc(100svh-var(--app-shell-header-height))] flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
-        <div className="flex shrink-0 flex-col gap-3 border-b border-border px-4 py-3 sm:px-6 lg:px-8">
-          <div className="flex min-w-0 items-center gap-3">
-            <Button variant="outline" size="sm" render={<Link href={taskHref} />}>
-              <ArrowLeftIcon />
-              Task
-            </Button>
-            <TypographyP className="truncate font-mono text-xs text-muted-foreground">
-              {selectedFile.sourcePath}
-            </TypographyP>
-          </div>
-        </div>
-
-        <div className="flex min-h-0 flex-1 flex-col px-4 py-3 sm:px-6 lg:px-8">
-          <ProjectFileCatWorkspace
-            key={selectedFile.sourcePath}
-            organizationSlug={organizationSlug}
-            projectId={projectId}
-            sourceLocale={sourceLocale}
-            sourcePath={selectedFile.sourcePath}
-            targetLocale={targetLocale ?? undefined}
-            highlightLocale={targetLocale}
-            initialSegmentKey={initialSegmentKey}
-            layout="fullscreen"
-          />
-        </div>
-      </main>
-    );
-  }
-
   if (repositoriesQuery.isLoading) {
     return (
       <ProjectPageShell>
@@ -338,6 +310,100 @@ export function JobCatPageContent({
           <TypographyP className="text-sm text-muted-foreground">Loading workspace…</TypographyP>
         </div>
       </ProjectPageShell>
+    );
+  }
+
+  const handleRepositoryChange = (nextRepositoryFullName: string | null) => {
+    if (!nextRepositoryFullName || !repositoryPreferenceKey) {
+      return;
+    }
+
+    writeCatFileRepositoryPreference(repositoryPreferenceKey, nextRepositoryFullName);
+    setRepositoryOverride(nextRepositoryFullName);
+  };
+
+  const repositoryBanner =
+    repositoriesQuery.isError ||
+    (enabledRepositoryFullNames.length > 1 && !selectedRepositoryFullName) ? (
+      <div className="shrink-0 border-b border-border px-3 py-1.5 sm:px-4 lg:px-6">
+        {repositoriesQuery.isError ? (
+          <TypographyP className="text-xs text-muted-foreground">
+            GitHub repositories could not be loaded. Repository context lookup is unavailable.
+          </TypographyP>
+        ) : (
+          <TypographyP className="text-xs text-muted-foreground">
+            Select a GitHub repository to look up string context.
+          </TypographyP>
+        )}
+      </div>
+    ) : null;
+
+  if (isNativeFile) {
+    if (!targetLocale) {
+      return (
+        <ProjectPageShell>
+          <div className="rounded-lg border border-border bg-card p-5">
+            <TypographyP className="text-sm text-muted-foreground">
+              No target locale is available for this task file.
+            </TypographyP>
+          </div>
+        </ProjectPageShell>
+      );
+    }
+
+    return (
+      <main className="-mx-4 -my-5 flex min-h-[calc(100svh-var(--app-shell-header-height))] flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
+        <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 sm:px-4 lg:px-6">
+          <Button
+            variant="outline"
+            size="icon-sm"
+            className="size-8 shrink-0"
+            render={<Link href={taskHref} />}
+          >
+            <ArrowLeftIcon className="size-4" />
+          </Button>
+
+          <TypographyP className="min-w-0 truncate font-mono text-xs text-muted-foreground sm:max-w-xs">
+            {selectedFile.sourcePath}
+          </TypographyP>
+
+          {enabledRepositoryFullNames.length > 0 ? (
+            <Select value={selectedRepositoryFullName ?? ""} onValueChange={handleRepositoryChange}>
+              <SelectTrigger
+                className="h-8 min-w-0 flex-1 basis-40 font-mono text-xs sm:max-w-xs"
+                aria-label="GitHub repository"
+              >
+                <SelectValue placeholder="GitHub repo" />
+              </SelectTrigger>
+              <SelectContent>
+                {enabledRepositoryFullNames.map((repositoryFullName) => (
+                  <SelectItem key={repositoryFullName} value={repositoryFullName}>
+                    {repositoryFullName}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : null}
+        </div>
+
+        {repositoryBanner}
+
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 py-2 sm:px-4 lg:px-6">
+          <ProjectFileCatWorkspace
+            key={`${selectedFile.sourcePath}:${selectedRepositoryFullName ?? "default"}`}
+            organizationSlug={organizationSlug}
+            projectId={projectId}
+            sourceLocale={sourceLocale}
+            sourcePath={selectedFile.sourcePath}
+            targetLocale={targetLocale}
+            highlightLocale={targetLocale}
+            repositoryFullName={selectedRepositoryFullName}
+            initialSegmentKey={initialSegmentKey}
+            layout="fullscreen"
+            className="min-h-0 flex-1"
+          />
+        </div>
+      </main>
     );
   }
 
@@ -400,15 +466,6 @@ export function JobCatPageContent({
     );
   };
 
-  const handleRepositoryChange = (nextRepositoryFullName: string | null) => {
-    if (!nextRepositoryFullName || !repositoryPreferenceKey) {
-      return;
-    }
-
-    writeCatFileRepositoryPreference(repositoryPreferenceKey, nextRepositoryFullName);
-    setRepositoryOverride(nextRepositoryFullName);
-  };
-
   return (
     <main className="-mx-4 -my-5 flex h-[calc(100svh-var(--app-shell-header-height))] min-h-0 flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
       <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 sm:px-4 lg:px-6">
@@ -460,20 +517,7 @@ export function JobCatPageContent({
         </TypographyP>
       </div>
 
-      {(repositoriesQuery.isError ||
-        (enabledRepositoryFullNames.length > 1 && !selectedRepositoryFullName)) && (
-        <div className="shrink-0 border-b border-border px-3 py-1.5 sm:px-4 lg:px-6">
-          {repositoriesQuery.isError ? (
-            <TypographyP className="text-xs text-muted-foreground">
-              GitHub repositories could not be loaded. Repository context lookup is unavailable.
-            </TypographyP>
-          ) : (
-            <TypographyP className="text-xs text-muted-foreground">
-              Select a GitHub repository to look up string context.
-            </TypographyP>
-          )}
-        </div>
-      )}
+      {repositoryBanner}
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 py-2 sm:px-4 lg:px-6">
         <ProjectFileCatWorkspace
@@ -486,6 +530,10 @@ export function JobCatPageContent({
           resourceType={selectedFile.provider.resourceType}
           targetLocale={selectedTargetLocale}
           repositoryFullName={selectedRepositoryFullName}
+          canLookupFreshContext={canLookupFreshCatRepositoryContext(
+            enabledRepositoryFullNames,
+            selectedRepositoryFullName,
+          )}
           initialSegmentKey={initialSegmentKey}
           layout="fullscreen"
           className="min-h-0 flex-1"

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/select-job-cat-repository.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/select-job-cat-repository.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { selectJobCatRepository, sortJobCatProviderFiles } from "./select-job-cat-repository";
+import {
+  canLookupFreshCatRepositoryContext,
+  selectJobCatRepository,
+  sortJobCatProviderFiles,
+} from "./select-job-cat-repository";
 
 describe("selectJobCatRepository", () => {
   it("returns the saved repository when it is still enabled", () => {
@@ -37,6 +41,21 @@ describe("selectJobCatRepository", () => {
         savedRepositoryFullName: "acme/legacy",
       }),
     ).toBe("acme/web");
+  });
+});
+
+describe("canLookupFreshCatRepositoryContext", () => {
+  it("allows fresh lookup when a single repository is enabled", () => {
+    expect(canLookupFreshCatRepositoryContext(["acme/web"], null)).toBe(true);
+  });
+
+  it("requires an explicit repository choice when multiple repositories are enabled", () => {
+    expect(canLookupFreshCatRepositoryContext(["acme/web", "acme/docs"], null)).toBe(false);
+    expect(canLookupFreshCatRepositoryContext(["acme/web", "acme/docs"], "acme/docs")).toBe(true);
+  });
+
+  it("disables fresh lookup when no repositories are enabled", () => {
+    expect(canLookupFreshCatRepositoryContext([], null)).toBe(false);
   });
 });
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/select-job-cat-repository.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/select-job-cat-repository.ts
@@ -16,6 +16,16 @@ export function selectJobCatRepository({
   return null;
 }
 
+export function canLookupFreshCatRepositoryContext(
+  enabledRepositoryFullNames: readonly string[],
+  selectedRepositoryFullName: string | null,
+) {
+  return (
+    enabledRepositoryFullNames.length > 0 &&
+    (enabledRepositoryFullNames.length === 1 || selectedRepositoryFullName != null)
+  );
+}
+
 export function sortJobCatProviderFiles<T extends { sourcePath: string }>(files: readonly T[]) {
   return [...files].toSorted((left, right) =>
     left.sourcePath.localeCompare(right.sourcePath, undefined, { sensitivity: "base" }),

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.tsx
@@ -220,6 +220,7 @@ export function CatIntelligencePanel({
   showAgentContext = false,
   showVisualContext = false,
   canEditTranslations = true,
+  canLookupFreshContext = true,
   onRefreshContext,
   onUseTmMatch,
   onUseGlossaryTerm,
@@ -232,6 +233,7 @@ export function CatIntelligencePanel({
   showAgentContext?: boolean;
   showVisualContext?: boolean;
   canEditTranslations?: boolean;
+  canLookupFreshContext?: boolean;
   onRefreshContext?: () => void;
   onUseTmMatch?: (match: CatTranslationMemoryMatch) => void;
   onUseGlossaryTerm?: (term: CatGlossaryTerm) => void;
@@ -247,7 +249,8 @@ export function CatIntelligencePanel({
   const hasAgentInsight = Boolean(intelligence.agentContext?.trim());
   const hasAttemptedAgentLookup = intelligence.agentContext !== undefined;
   const hasAgentContext = hasAgentInsight || agentBadges.length > 0;
-  const canRefreshAgentContext = hasAttemptedAgentLookup && onRefreshContext;
+  const canRefreshAgentContext =
+    hasAttemptedAgentLookup && canLookupFreshContext && onRefreshContext;
 
   function handleUseTmMatch(match: CatTranslationMemoryMatch) {
     if (!onUseTmMatch) {

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
@@ -274,17 +274,13 @@ export function ProjectFileCatWorkspace({
       segment: CatSegment,
       options?: { cachedOnly?: boolean; forceRefresh?: boolean },
     ): Promise<string | null> => {
-      if (!repositoryFullName) {
-        throw new Error("Select a GitHub repository before looking up string context.");
-      }
-
       const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"].files[
         "string-context"
       ].$post({
         param: { organizationSlug, projectId },
         json: {
           sourcePath,
-          repositoryFullName,
+          ...(repositoryFullName ? { repositoryFullName } : {}),
           key: segment.key,
           text: segment.sourceText,
           context: segment.contextLabel ?? null,
@@ -485,12 +481,12 @@ export function ProjectFileCatWorkspace({
         services={{
           validateFormat,
           lookupSegmentConcordance,
+          lookupSegmentContext,
           lookupSegmentVisualContext:
             catFile?.provider?.kind && catFile.provider.kind !== "native"
               ? lookupSegmentVisualContext
               : undefined,
           generateAiRecommendation,
-          ...(repositoryFullName ? { lookupSegmentContext } : {}),
         }}
         review={{
           onApprove: handleApprove,

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
@@ -58,6 +58,7 @@ export function ProjectFileCatWorkspace({
   targetLocales,
   highlightLocale = null,
   repositoryFullName = null,
+  canLookupFreshContext = true,
   initialSegmentKey = null,
   layout = "default",
   className,
@@ -72,6 +73,7 @@ export function ProjectFileCatWorkspace({
   targetLocales?: string[];
   highlightLocale?: string | null;
   repositoryFullName?: string | null;
+  canLookupFreshContext?: boolean;
   initialSegmentKey?: string | null;
   layout?: "default" | "fullscreen";
   className?: string;
@@ -508,6 +510,7 @@ export function ProjectFileCatWorkspace({
         queuePagination={pagination}
         onLoadMoreQueue={loadNextPage}
         hasMoreQueue={pagination?.hasMore ?? false}
+        canLookupFreshContext={canLookupFreshContext}
       />
     </div>
   );

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
@@ -66,6 +66,7 @@ export interface CatWorkspaceContainerProps {
   initialSegmentKeyOrId?: string | null;
   buildSegmentShareUrl?: (segment: CatSegment) => string | null;
   tmAutoFillMinMatchPercent?: number;
+  canLookupFreshContext?: boolean;
 }
 
 const CatWorkspaceContainerObserver = observer(function CatWorkspaceContainerObserver({
@@ -92,6 +93,7 @@ const CatWorkspaceContainerObserver = observer(function CatWorkspaceContainerObs
   onLoadMoreQueue,
   buildSegmentShareUrl,
   tmAutoFillMinMatchPercent,
+  canLookupFreshContext,
 }: CatWorkspaceContainerProps & { store: CatWorkspaceOrchestrator }) {
   const controller = useCatWorkspaceRuntime({
     store,
@@ -104,6 +106,7 @@ const CatWorkspaceContainerObserver = observer(function CatWorkspaceContainerObs
     onQueueFilterChange,
     buildSegmentShareUrl,
     tmAutoFillMinMatchPercent,
+    canLookupFreshContext,
   });
 
   return (

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
@@ -328,6 +328,7 @@ export function CatWorkspaceView({
           showAgentContext={showAgentContext}
           showVisualContext={showVisualContext}
           canEditTranslations={shell.fileContext.canEditTranslations !== false}
+          canLookupFreshContext={canLookupContext}
           onRefreshContext={() => review.onAskQuestion(editorSegment.id, { forceRefresh: true })}
           onUseTmMatch={(match) => editing.onUseTmMatch(editorSegment.id, match)}
           onUseGlossaryTerm={(term) =>

--- a/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.test.ts
@@ -442,6 +442,29 @@ describe("CatIntelligenceController", () => {
       expect(lookupSegmentVisualContext).not.toHaveBeenCalled();
       expect(workspace.isLoadingVisualContext).toBe(false);
     });
+
+    it("loads cached agent context without requiring fresh lookup availability", async () => {
+      const lookupSegmentContext = vi.fn().mockResolvedValue("Cached repository context.");
+      const { controller, workspace } = createController(undefined, {
+        intl,
+        services: { lookupSegmentContext },
+      });
+
+      controller.panelVisible("seg-02");
+
+      await vi.waitFor(() =>
+        expect(lookupSegmentContext).toHaveBeenCalledWith(
+          expect.objectContaining({ id: "seg-02" }),
+          {
+            cachedOnly: true,
+          },
+        ),
+      );
+      expect(workspace.segmentIntelligence["seg-02"]?.agentContext).toBe(
+        "Cached repository context.",
+      );
+      expect(workspace.revealedAgentContextSegmentIds.has("seg-02")).toBe(true);
+    });
   });
 
   describe("askQuestion", () => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.test.tsx
@@ -818,6 +818,27 @@ describe("useCatWorkspaceRuntime", () => {
     });
   });
 
+  it("disables fresh context lookup while still loading cached context", async () => {
+    const lookupSegmentContext = vi.fn().mockResolvedValue("Cached context from the repository.");
+    const { result } = renderController(undefined, {
+      services: {
+        lookupSegmentContext,
+      },
+      canLookupFreshContext: false,
+    });
+
+    expect(result.current.canLookupContext).toBe(false);
+
+    act(() => {
+      result.current.handleIntelligencePanelVisible("seg-02");
+    });
+
+    await waitFor(() => expect(lookupSegmentContext).toHaveBeenCalledTimes(1));
+    expect(lookupSegmentContext).toHaveBeenCalledWith(expect.objectContaining({ id: "seg-02" }), {
+      cachedOnly: true,
+    });
+  });
+
   it("retries cached agent context lookup when the lookup function changes", async () => {
     const lookupSegmentContext = vi.fn().mockResolvedValue(null);
     const nextLookupSegmentContext = vi.fn().mockResolvedValue("Cached context from another repo.");

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.ts
@@ -69,6 +69,7 @@ export interface UseCatWorkspaceRuntimeInput {
   onQueueFilterChange?: (filter: CatQueueFilter) => void;
   buildSegmentShareUrl?: (segment: CatSegment) => string | null;
   tmAutoFillMinMatchPercent?: number;
+  canLookupFreshContext?: boolean;
 }
 
 export function useCatWorkspaceRuntime({
@@ -82,6 +83,7 @@ export function useCatWorkspaceRuntime({
   onQueueFilterChange,
   buildSegmentShareUrl,
   tmAutoFillMinMatchPercent = TM_AUTO_FILL_MIN_MATCH_PERCENT_DEFAULT,
+  canLookupFreshContext = true,
 }: UseCatWorkspaceRuntimeInput) {
   const intl = useIntl();
   const queueFilter = queueFilterProp ?? store.queueFilter;
@@ -102,7 +104,7 @@ export function useCatWorkspaceRuntime({
   const onSaveDraft = reviewOverrides?.onSaveDraft;
   const onAskQuestion = reviewOverrides?.onAskQuestion;
 
-  const canLookupContext = Boolean(lookupSegmentContext);
+  const canLookupContext = Boolean(lookupSegmentContext) && canLookupFreshContext;
   const canLoadVisualContext = Boolean(
     lookupSegmentVisualContext && store.providerKind && store.providerKind !== "native",
   );

--- a/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.test.ts
@@ -110,4 +110,14 @@ describe("buildProjectFileCatHref", () => {
       "/org/acme/projects/project_website/files/cat?sourcePath=marketing%2Fhome.json&locale=fr-FR",
     );
   });
+
+  it("preserves the provider branch filter in CAT hrefs", () => {
+    const file = createProjectFileRecord({
+      sourcePath: "marketing/home.json",
+    });
+
+    expect(buildProjectFileCatHref("acme", "project_website", file, "fr-FR", "main")).toBe(
+      "/org/acme/projects/project_website/files/cat?sourcePath=marketing%2Fhome.json&locale=fr-FR&branch=main",
+    );
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.ts
@@ -9,7 +9,10 @@ export function canOpenProjectFileCat(file: ProjectFileRecord) {
   return Boolean(file.storedFileId);
 }
 
-function resolveProjectFileTargetLocale(file: ProjectFileRecord, highlightLocale: string | null) {
+export function resolveProjectFileCatTargetLocale(
+  file: ProjectFileRecord,
+  highlightLocale: string | null,
+) {
   if (file.provider) {
     if (highlightLocale && file.provider.targetLocales.includes(highlightLocale)) {
       return highlightLocale;
@@ -21,12 +24,17 @@ function resolveProjectFileTargetLocale(file: ProjectFileRecord, highlightLocale
   return highlightLocale;
 }
 
+function resolveProjectFileTargetLocale(file: ProjectFileRecord, highlightLocale: string | null) {
+  return resolveProjectFileCatTargetLocale(file, highlightLocale);
+}
+
 export type ProjectFileCatUrlParams = {
   sourcePath: string;
   locale?: string | null;
   segment?: string | null;
   externalResourceId?: string | null;
   resourceType?: "file" | "key" | null;
+  branch?: string | null;
 };
 
 export function parseProjectFileCatSearchParams(searchParams: {
@@ -35,12 +43,14 @@ export function parseProjectFileCatSearchParams(searchParams: {
   segment?: string;
   externalResourceId?: string;
   resourceType?: string;
+  branch?: string;
 }): {
   sourcePath: string | null;
   highlightLocale: string | null;
   initialSegmentKey: string | null;
   externalResourceId: string | null;
   resourceType: "file" | "key" | null;
+  branch: string | null;
 } {
   const resourceType =
     searchParams.resourceType === "file" || searchParams.resourceType === "key"
@@ -55,6 +65,7 @@ export function parseProjectFileCatSearchParams(searchParams: {
       ? searchParams.externalResourceId.trim()
       : null,
     resourceType,
+    branch: searchParams.branch?.trim() ? searchParams.branch.trim() : null,
   };
 }
 
@@ -71,6 +82,7 @@ export function buildProjectFileCatHref(
   projectId: string,
   file: ProjectFileRecord,
   highlightLocale: string | null = null,
+  branch: string | null = null,
 ) {
   if (!canOpenProjectFileCat(file)) {
     return null;
@@ -83,6 +95,11 @@ export function buildProjectFileCatHref(
   const targetLocale = resolveProjectFileTargetLocale(file, highlightLocale);
   if (targetLocale) {
     params.set("locale", targetLocale);
+  }
+
+  const trimmedBranch = branch?.trim();
+  if (trimmedBranch) {
+    params.set("branch", trimmedBranch);
   }
 
   if (file.provider?.externalResourceId) {

--- a/apps/hyperlocalise-web/src/lib/projects/string-context/project-string-context-service.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/string-context/project-string-context-service.test.ts
@@ -32,7 +32,10 @@ import { createProjectTestFixture } from "@/api/routes/project/project.fixture";
 import { db, schema } from "@/lib/database";
 import { isErr } from "@/lib/primitives/result/results";
 
-import { lookupProjectFileStringRepositoryContext } from "./project-string-context-service";
+import {
+  lookupCachedProjectFileStringRepositoryContext,
+  lookupProjectFileStringRepositoryContext,
+} from "./project-string-context-service";
 
 const fixture = createProjectTestFixture();
 
@@ -277,5 +280,98 @@ describe("lookupProjectFileStringRepositoryContext", () => {
     });
     expect(resolveWebProjectRepositoryGitHubContextMock).not.toHaveBeenCalled();
     expect(runSubagentMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("lookupCachedProjectFileStringRepositoryContext", () => {
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await fixture.cleanup();
+  });
+
+  it("returns cached context without requiring a repository selection", async () => {
+    const { organization, project, user } = await fixture.createStoredProjectFixture();
+    await insertRepository({
+      organizationId: organization.id,
+      githubRepositoryId: "2001",
+      fullName: "hyperlocalise/first",
+    });
+    await insertRepository({
+      organizationId: organization.id,
+      githubRepositoryId: "2002",
+      fullName: "hyperlocalise/second",
+    });
+
+    const { saveProjectFileStringRepositoryContext } =
+      await import("./project-string-context-service");
+    await saveProjectFileStringRepositoryContext({
+      organizationId: organization.id,
+      projectId: project.id,
+      sourcePath: "locales/en.json",
+      stringKey: "home.hero.title",
+      repositoryFullName: "hyperlocalise/second",
+      sourceText: "Ship localized product experiences",
+      summary: "Cached hero headline context.",
+      createdByUserId: user.id,
+    });
+
+    const result = await lookupCachedProjectFileStringRepositoryContext(
+      baseInput({
+        organizationId: organization.id,
+        projectId: project.id,
+        localUserId: user.id,
+      }),
+    );
+
+    expect(isErr(result)).toBe(false);
+    if (!result.ok) {
+      throw new Error("expected cached lookup to succeed");
+    }
+    expect(result.value).toEqual({
+      summary: "Cached hero headline context.",
+      cached: true,
+    });
+  });
+
+  it("prefers the explicitly selected repository when multiple caches exist", async () => {
+    const { organization, project, user } = await fixture.createStoredProjectFixture();
+
+    const { saveProjectFileStringRepositoryContext } =
+      await import("./project-string-context-service");
+    await saveProjectFileStringRepositoryContext({
+      organizationId: organization.id,
+      projectId: project.id,
+      sourcePath: "locales/en.json",
+      stringKey: "home.hero.title",
+      repositoryFullName: "hyperlocalise/web",
+      sourceText: "Ship localized product experiences",
+      summary: "Web repository context.",
+      createdByUserId: user.id,
+    });
+    await saveProjectFileStringRepositoryContext({
+      organizationId: organization.id,
+      projectId: project.id,
+      sourcePath: "locales/en.json",
+      stringKey: "home.hero.title",
+      repositoryFullName: "hyperlocalise/legacy",
+      sourceText: "Ship localized product experiences",
+      summary: "Legacy repository context.",
+      createdByUserId: user.id,
+    });
+
+    const result = await lookupCachedProjectFileStringRepositoryContext({
+      ...baseInput({
+        organizationId: organization.id,
+        projectId: project.id,
+        localUserId: user.id,
+      }),
+      repositoryFullName: "hyperlocalise/web",
+    });
+
+    expect(isErr(result)).toBe(false);
+    if (!result.ok) {
+      throw new Error("expected cached lookup to succeed");
+    }
+    expect(result.value.summary).toBe("Web repository context.");
   });
 });

--- a/apps/hyperlocalise-web/src/lib/projects/string-context/project-string-context-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/string-context/project-string-context-service.ts
@@ -490,26 +490,16 @@ export class ProjectStringContextService extends ProjectServiceBase {
     });
     log.debug("project file string cached context lookup started");
 
-    const repositoryResult = await this.resolveRepositoryFullName({
-      organizationId: input.organizationId,
-      repositoryFullName: input.repositoryFullName,
-    });
-    if (isErr(repositoryResult)) {
-      log.warn(
-        { code: repositoryResult.error.code },
-        "project file string cached context repository resolution failed",
-      );
-      return repositoryResult;
-    }
-
-    const summary = await this.getCached({
+    const summaries = await this.listCached({
       organizationId: input.organizationId,
       projectId: input.projectId,
       sourcePath: input.sourcePath,
-      stringKey: input.key,
-      repositoryFullName: repositoryResult.value,
-      sourceText: input.text,
+      stringKeys: [input.key],
+      preferredRepositoryFullName: input.repositoryFullName,
+      sourceTextByKey: new Map([[input.key, input.text]]),
     });
+
+    const summary = summaries.get(input.key) ?? null;
 
     log.debug(
       {


### PR DESCRIPTION
## What changed

- Always wire CAT **Find context** lookup and let the API resolve the GitHub repository when none is pre-selected, so cached context can load and the action is clickable.
- Restore **View strings** on job source files and support double-click to open the CAT workspace from the file tree.
- Fix Pierre file tree layout: default density, full-width wrapper, and readable filenames after the tree-only refactor.

## How to test

1. Open a job detail page with linked source files.
2. Confirm the file tree shows full filenames (not crushed).
3. Double-click a file or click **View strings** to open the CAT workspace.
4. In CAT, select a segment and click **Find context** — it should be enabled and load cached context when available.

- [x] I ran relevant checks locally (`vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)