### PR TITLE
feat(web): default job CAT to untranslated queue filter

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.test.tsx
@@ -23,14 +23,17 @@ const {
     ({
       repositoryFullName,
       sourcePath,
+      initialQueueFilter,
     }: {
       repositoryFullName?: string | null;
       sourcePath: string;
+      initialQueueFilter?: string;
     }) => (
       <div
         data-testid="cat-workspace"
         data-repo={repositoryFullName ?? ""}
         data-source-path={sourcePath}
+        data-initial-queue-filter={initialQueueFilter ?? ""}
       />
     ),
   ),
@@ -82,8 +85,11 @@ vi.mock("@/lib/api-client-instance", () => ({
 }));
 
 vi.mock("@/components/cat/project-file/project-file-cat-workspace", () => ({
-  ProjectFileCatWorkspace: (props: { repositoryFullName?: string | null; sourcePath: string }) =>
-    ProjectFileCatWorkspaceMock(props),
+  ProjectFileCatWorkspace: (props: {
+    repositoryFullName?: string | null;
+    sourcePath: string;
+    initialQueueFilter?: string;
+  }) => ProjectFileCatWorkspaceMock(props),
 }));
 
 import { JobCatPageContent } from "./job-cat-page-content";
@@ -244,6 +250,10 @@ describe("JobCatPageContent CAT shell", () => {
       expect(screen.getByTestId("cat-workspace")).toHaveAttribute(
         "data-source-path",
         "crowdin/home.json",
+      );
+      expect(screen.getByTestId("cat-workspace")).toHaveAttribute(
+        "data-initial-queue-filter",
+        "untranslated",
       );
     });
   });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -37,6 +37,8 @@ import { ProjectFileCatWorkspace } from "@/components/cat/project-file/project-f
 
 import { JobCatSourceFilePicker } from "./job-cat-source-file-picker";
 
+const JOB_CAT_DEFAULT_QUEUE_FILTER = "untranslated" as const;
+
 type JobCatGithubRepository = {
   fullName: string;
   enabled: boolean;
@@ -403,6 +405,7 @@ export function JobCatPageContent({
               selectedRepositoryFullName,
             )}
             initialSegmentKey={initialSegmentKey}
+            initialQueueFilter={JOB_CAT_DEFAULT_QUEUE_FILTER}
             layout="fullscreen"
             className="min-h-0 flex-1"
           />
@@ -539,6 +542,7 @@ export function JobCatPageContent({
             selectedRepositoryFullName,
           )}
           initialSegmentKey={initialSegmentKey}
+          initialQueueFilter={JOB_CAT_DEFAULT_QUEUE_FILTER}
           layout="fullscreen"
           className="min-h-0 flex-1"
         />

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
@@ -22,7 +22,10 @@ import { apiClient } from "@/lib/api-client-instance";
 import { mapCatConcordanceForAiRecommendation } from "@/lib/translation/map-cat-concordance-for-ai-recommendation";
 import { cn } from "@/lib/primitives/cn";
 
-import { resolveAvailableCatQueueFilters } from "@/components/cat/queue/cat-queue-filter";
+import {
+  resolveAvailableCatQueueFilters,
+  type CatQueueFilter,
+} from "@/components/cat/queue/cat-queue-filter";
 import { glossaryFormatChecksForSegment } from "@/components/cat/intelligence/cat-glossary-checks";
 import { buildCatSegmentShareUrl } from "@/components/cat/segment/cat-segment-share-link";
 import type {
@@ -60,6 +63,7 @@ export function ProjectFileCatWorkspace({
   repositoryFullName = null,
   canLookupFreshContext = true,
   initialSegmentKey = null,
+  initialQueueFilter = "all",
   layout = "default",
   className,
 }: {
@@ -75,6 +79,7 @@ export function ProjectFileCatWorkspace({
   repositoryFullName?: string | null;
   canLookupFreshContext?: boolean;
   initialSegmentKey?: string | null;
+  initialQueueFilter?: CatQueueFilter;
   layout?: "default" | "fullscreen";
   className?: string;
 }) {
@@ -123,6 +128,7 @@ export function ProjectFileCatWorkspace({
     targetLocale,
     repositoryFullName,
     enabled: Boolean(targetLocale),
+    initialQueueFilter,
   });
 
   const availableQueueFilters = useMemo(

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-segment-query.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-segment-query.ts
@@ -44,11 +44,14 @@ export function useCatSegmentQuery(input: {
   targetLocale: string;
   repositoryFullName?: string | null;
   enabled?: boolean;
+  initialQueueFilter?: CatQueueFilter;
 }) {
   const queryClient = useQueryClient();
   const repositoryFullName = input.repositoryFullName ?? null;
   const [search, setSearch] = useState("");
-  const [queueFilter, setQueueFilter] = useState<CatQueueFilter>("all");
+  const [queueFilter, setQueueFilter] = useState<CatQueueFilter>(
+    () => input.initialQueueFilter ?? "all",
+  );
   const [limit] = useState(defaultCatPageLimit);
   const debouncedSearch = useDebouncedValue(search, 300);
   const isSearchPending = search !== debouncedSearch;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Opening the CAT workspace from a job detail page now defaults to the **Untranslated** queue filter instead of **All**. This applies to both provider-backed and native job CAT entry points.

The project file CAT workspace (opened from the files page) is unchanged and still defaults to **All**.

## How to test

1. Open a translation or review job detail page.
2. Click **View strings** (or open a source file in CAT).
3. Confirm the queue filter is set to **Untranslated** on load.
4. Open CAT from the project files page and confirm it still defaults to **All**.

Automated: `vp test src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.test.tsx`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f31d3-b225-79db-a8ee-a52390702849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f31d3-b225-79db-a8ee-a52390702849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

