### PR TITLE
feat(dashboard): improve workspace overview

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-content.tsx
@@ -51,6 +51,9 @@ import { DashboardPageView } from "./dashboard-page-view";
 const api = createApiClient();
 const automationsApi = createAutomationsApi(api);
 
+/** Workspace jobs can include synced TMS rows; fetch extra so five native jobs remain after filtering. */
+const DASHBOARD_NATIVE_JOB_FETCH_LIMIT = "100";
+
 async function fetchAssignedJobs(organizationSlug: string) {
   const response = await api.api.orgs[":organizationSlug"].jobs.$get({
     param: { organizationSlug },
@@ -72,7 +75,7 @@ async function fetchLatestJobs(organizationSlug: string) {
   const response = await api.api.orgs[":organizationSlug"].jobs.$get({
     param: { organizationSlug },
     query: {
-      limit: "10",
+      limit: DASHBOARD_NATIVE_JOB_FETCH_LIMIT,
     },
   });
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -10,6 +10,9 @@ import { readApiResponseError } from "@/lib/api-error";
 import { createApiClient } from "@/lib/api-client";
 import { WORKSPACE_FEATURE_UNAVAILABLE_REASON } from "@/lib/flags/workos-flag-entities";
 import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-with-concurrency";
+import { isNativeWorkspaceJob } from "@/lib/projects/workspace-resource-capabilities";
+import { getTmsProviderBranding } from "@/lib/providers/tms-provider-branding";
+import { readTmsProviderListResponse } from "@/lib/providers/tms-provider-list-fetch";
 import type { WorkspaceAutomationRunRecord } from "@/lib/agents/workspace-automations";
 
 import { buildJobDetailHref } from "../../jobs/_components/jobs-view-helpers";
@@ -20,16 +23,25 @@ import {
   type JobRow,
 } from "../../jobs/_components/jobs-page-view";
 import { mapProjectToListRow, type ProjectListRow } from "../../projects/_components/project-list";
+import {
+  readRecentProjectVisits,
+  type RecentProjectVisit,
+} from "../../projects/_components/recent-projects";
+import { useActiveTmsProvider } from "../../_hooks/use-active-tms-provider";
+import { fetchTmsLiveProjects, tmsLiveProjectsQueryKey } from "../../_hooks/use-tms-live-projects";
 import { providerLabel } from "../../_components/workspace-files-shared";
 import { createAutomationsApi } from "../../automations/_components/automations-api";
 import {
   formatDashboardLocaleRoute,
   mapDashboardAutomationRuns,
+  mergeDashboardJobSources,
+  mergeDashboardProjectSources,
   resolveAutomationSnapshotStats,
   resolveDashboardHero,
   resolveDashboardIntegrations,
   resolveWorkspacePendingActionCount,
   sortDashboardJobs,
+  sortDashboardLatestJobs,
   sortDashboardProjects,
   type DashboardJobItem,
   type DashboardProjectItem,
@@ -56,7 +68,36 @@ async function fetchAssignedJobs(organizationSlug: string) {
   return body.jobs;
 }
 
-async function fetchProjects(organizationSlug: string) {
+async function fetchLatestJobs(organizationSlug: string) {
+  const response = await api.api.orgs[":organizationSlug"].jobs.$get({
+    param: { organizationSlug },
+    query: {
+      limit: "10",
+    },
+  });
+
+  if (!response.ok) {
+    throw await readApiResponseError(response, "Failed to load latest jobs");
+  }
+
+  const body = (await response.json()) as { jobs: JobRow[] };
+  return body.jobs;
+}
+
+async function fetchTmsJobs(organizationSlug: string, mine: boolean) {
+  const response = await api.api.orgs[":organizationSlug"]["tms-provider"].jobs.$get({
+    param: { organizationSlug },
+    query: { mine: mine ? "true" : "false" },
+  });
+
+  return readTmsProviderListResponse<JobRow>(
+    response,
+    "jobs",
+    mine ? "Failed to load assigned TMS jobs" : "Failed to load latest TMS jobs",
+  );
+}
+
+async function fetchNativeProjects(organizationSlug: string) {
   const response = await api.api.orgs[":organizationSlug"].projects.$get({
     param: { organizationSlug },
   });
@@ -95,22 +136,6 @@ async function fetchGithubConnected(organizationSlug: string) {
   return body.installation !== null;
 }
 
-async function fetchTmsConnected(organizationSlug: string, projectCount: number) {
-  const response = await api.api.orgs[":organizationSlug"]["tms-provider"].connection.$get({
-    param: { organizationSlug },
-  });
-
-  if (response.status === 404) {
-    return projectCount > 0;
-  }
-
-  if (!response.ok) {
-    throw new Error("Failed to load TMS connection");
-  }
-
-  return true;
-}
-
 async function fetchRecentAutomationRuns(
   organizationSlug: string,
   automationIds: string[],
@@ -134,8 +159,14 @@ async function fetchRecentAutomationRuns(
   return runsByAutomation.flat();
 }
 
-function mapDashboardJobs(organizationSlug: string, jobs: readonly JobRow[]): DashboardJobItem[] {
-  return sortDashboardJobs(jobs).map((job) => ({
+function mapDashboardJobs(
+  organizationSlug: string,
+  jobs: readonly JobRow[],
+  order: "priority" | "latest",
+): DashboardJobItem[] {
+  const sortedJobs = order === "priority" ? sortDashboardJobs(jobs) : sortDashboardLatestJobs(jobs);
+
+  return sortedJobs.slice(0, 5).map((job) => ({
     id: job.id,
     name: getJobName(job),
     projectName: job.projectName,
@@ -149,8 +180,9 @@ function mapDashboardJobs(organizationSlug: string, jobs: readonly JobRow[]): Da
 function mapDashboardProjects(
   organizationSlug: string,
   projects: readonly ProjectListRow[],
+  recentProjectVisits: readonly RecentProjectVisit[],
 ): DashboardProjectItem[] {
-  return sortDashboardProjects(projects)
+  return sortDashboardProjects(projects, recentProjectVisits)
     .slice(0, 5)
     .map((project) => ({
       id: project.id,
@@ -175,6 +207,7 @@ export function DashboardPageContent({
 }) {
   const searchParams = useSearchParams();
   const handledFeatureUnavailableRef = useRef(false);
+  const [recentProjectVisits, setRecentProjectVisits] = useState<RecentProjectVisit[] | null>(null);
 
   useEffect(() => {
     if (
@@ -193,18 +226,43 @@ export function DashboardPageContent({
     toast.error("This feature is not available for your workspace yet.");
   }, [searchParams]);
 
+  useEffect(() => {
+    setRecentProjectVisits(readRecentProjectVisits(organizationSlug));
+  }, [organizationSlug]);
+
   const integrationsHref = `/org/${organizationSlug}/integrations`;
   const myJobsHref = `/org/${organizationSlug}/my-jobs`;
   const newRequestHref = `/org/${organizationSlug}/chat`;
 
-  const projectsQuery = useQuery({
+  const activeTmsProviderQuery = useActiveTmsProvider(organizationSlug);
+  const activeTmsProvider = activeTmsProviderQuery.data;
+  const hasTmsConnection = Boolean(activeTmsProvider);
+
+  const nativeProjectsQuery = useQuery({
     queryKey: ["dashboard-projects", organizationSlug],
-    queryFn: () => fetchProjects(organizationSlug),
+    queryFn: () => fetchNativeProjects(organizationSlug),
   });
 
-  const jobsQuery = useQuery({
+  const assignedJobsQuery = useQuery({
     queryKey: ["dashboard-my-jobs", organizationSlug],
     queryFn: () => fetchAssignedJobs(organizationSlug),
+  });
+
+  const latestJobsQuery = useQuery({
+    queryKey: ["dashboard-latest-jobs", organizationSlug],
+    queryFn: () => fetchLatestJobs(organizationSlug),
+  });
+
+  const assignedTmsJobsQuery = useQuery({
+    queryKey: ["dashboard-my-jobs", organizationSlug, "tms-live"],
+    queryFn: () => fetchTmsJobs(organizationSlug, true),
+    enabled: hasTmsConnection,
+  });
+
+  const latestTmsJobsQuery = useQuery({
+    queryKey: ["dashboard-latest-jobs", organizationSlug, "tms-live"],
+    queryFn: () => fetchTmsJobs(organizationSlug, false),
+    enabled: hasTmsConnection,
   });
 
   const slackQuery = useQuery({
@@ -217,10 +275,11 @@ export function DashboardPageContent({
     queryFn: () => fetchGithubConnected(organizationSlug),
   });
 
-  const tmsQuery = useQuery({
-    queryKey: ["dashboard-tms-connected", organizationSlug, projectsQuery.data?.length ?? 0],
-    queryFn: () => fetchTmsConnected(organizationSlug, projectsQuery.data?.length ?? 0),
-    enabled: projectsQuery.isFetched,
+  const tmsProjectsQuery = useQuery({
+    queryKey: tmsLiveProjectsQueryKey(organizationSlug),
+    queryFn: () => fetchTmsLiveProjects(organizationSlug),
+    select: (projects) => projects.map(mapProjectToListRow),
+    enabled: hasTmsConnection,
   });
 
   const automationsQuery = useQuery({
@@ -251,46 +310,61 @@ export function DashboardPageContent({
     enabled: automationsEnabled && automationsQuery.isSuccess,
   });
 
-  const projects = projectsQuery.data ?? [];
-  const jobs = jobsQuery.data ?? [];
+  const allProjects = useMemo(
+    () => mergeDashboardProjectSources(nativeProjectsQuery.data ?? [], tmsProjectsQuery.data ?? []),
+    [nativeProjectsQuery.data, tmsProjectsQuery.data],
+  );
+  const assignedJobs = useMemo(
+    () =>
+      mergeDashboardJobSources(
+        (assignedJobsQuery.data ?? []).filter(isNativeWorkspaceJob),
+        assignedTmsJobsQuery.data ?? [],
+      ),
+    [assignedJobsQuery.data, assignedTmsJobsQuery.data],
+  );
+  const latestJobs = useMemo(
+    () => (latestJobsQuery.data ?? []).filter(isNativeWorkspaceJob),
+    [latestJobsQuery.data],
+  );
+  const tmsBranding = getTmsProviderBranding(activeTmsProvider?.providerKind);
   const integrations = useMemo(
     () =>
       resolveDashboardIntegrations({
-        tmsConnected: tmsQuery.data ?? false,
+        tmsConnected: hasTmsConnection,
+        tmsProviderKind: activeTmsProvider?.providerKind,
+        tmsProviderName: hasTmsConnection ? tmsBranding.name : undefined,
         githubConnected: githubQuery.data ?? false,
         slackConnected: slackQuery.data ?? false,
       }),
-    [githubQuery.data, slackQuery.data, tmsQuery.data],
+    [
+      activeTmsProvider?.providerKind,
+      githubQuery.data,
+      hasTmsConnection,
+      slackQuery.data,
+      tmsBranding.name,
+    ],
   );
 
   const pendingCount = useMemo(
     () =>
       resolveWorkspacePendingActionCount({
-        projects,
-        jobs: jobs as readonly ApiJob[],
+        projects: allProjects,
+        jobs: assignedJobs as readonly ApiJob[],
       }),
-    [jobs, projects],
+    [allProjects, assignedJobs],
   );
 
   const hero = useMemo(
     () =>
       resolveDashboardHero({
         integrations,
-        projectCount: projects.length,
+        projectCount: allProjects.length,
         pendingCount,
         integrationsHref,
         myJobsHref,
         newRequestHref,
       }),
-    [
-      integrations,
-      integrationsHref,
-      myJobsHref,
-      newRequestHref,
-      organizationSlug,
-      pendingCount,
-      projects.length,
-    ],
+    [allProjects.length, integrations, integrationsHref, myJobsHref, newRequestHref, pendingCount],
   );
 
   const automationStats = useMemo(
@@ -310,39 +384,90 @@ export function DashboardPageContent({
   );
 
   const mappedJobs = useMemo(
-    () => mapDashboardJobs(organizationSlug, jobs),
-    [organizationSlug, jobs],
+    () => mapDashboardJobs(organizationSlug, assignedJobs, "priority"),
+    [assignedJobs, organizationSlug],
+  );
+
+  const mappedLatestJobs = useMemo(
+    () => mapDashboardJobs(organizationSlug, latestJobs, "latest"),
+    [latestJobs, organizationSlug],
+  );
+
+  const mappedTmsJobs = useMemo(
+    () => mapDashboardJobs(organizationSlug, latestTmsJobsQuery.data ?? [], "latest"),
+    [latestTmsJobsQuery.data, organizationSlug],
   );
 
   const mappedProjects = useMemo(
-    () => mapDashboardProjects(organizationSlug, projects),
-    [organizationSlug, projects],
+    () =>
+      recentProjectVisits
+        ? mapDashboardProjects(
+            organizationSlug,
+            nativeProjectsQuery.data ?? [],
+            recentProjectVisits,
+          )
+        : [],
+    [nativeProjectsQuery.data, organizationSlug, recentProjectVisits],
   );
 
+  const mappedTmsProjects = useMemo(
+    () =>
+      recentProjectVisits
+        ? mapDashboardProjects(organizationSlug, tmsProjectsQuery.data ?? [], recentProjectVisits)
+        : [],
+    [organizationSlug, recentProjectVisits, tmsProjectsQuery.data],
+  );
+
+  const isSetupLoading =
+    nativeProjectsQuery.isLoading ||
+    activeTmsProviderQuery.isLoading ||
+    (hasTmsConnection && tmsProjectsQuery.isLoading) ||
+    slackQuery.isLoading ||
+    githubQuery.isLoading;
   return (
     <DashboardPageView
       organizationSlug={organizationSlug}
       hero={hero}
+      isHeroLoading={isSetupLoading}
       integrations={integrations}
       jobs={mappedJobs}
+      latestJobs={mappedLatestJobs}
       projects={mappedProjects}
+      showTmsSections={hasTmsConnection}
+      tmsProviderName={tmsBranding.name}
+      tmsJobs={mappedTmsJobs}
+      tmsProjects={mappedTmsProjects}
       automationStats={automationStats}
       automationRuns={automationRuns}
       automationsEnabled={automationsEnabled}
       isIntegrationsLoading={
-        slackQuery.isLoading ||
-        githubQuery.isLoading ||
-        tmsQuery.isLoading ||
-        projectsQuery.isLoading
+        slackQuery.isLoading || githubQuery.isLoading || activeTmsProviderQuery.isLoading
       }
-      isJobsLoading={jobsQuery.isLoading}
-      isJobsError={jobsQuery.isError}
-      isProjectsLoading={projectsQuery.isLoading}
-      isProjectsError={projectsQuery.isError}
+      isJobsLoading={
+        assignedJobsQuery.isLoading || (hasTmsConnection && assignedTmsJobsQuery.isLoading)
+      }
+      isJobsError={assignedJobsQuery.isError && (!hasTmsConnection || assignedTmsJobsQuery.isError)}
+      jobsWarning={
+        assignedTmsJobsQuery.isError && !assignedJobsQuery.isError
+          ? "Live TMS jobs could not be loaded."
+          : assignedJobsQuery.isError && assignedTmsJobsQuery.isSuccess
+            ? "Native workspace jobs could not be loaded."
+            : undefined
+      }
+      isLatestJobsLoading={latestJobsQuery.isLoading}
+      isLatestJobsError={latestJobsQuery.isError}
+      isProjectsLoading={nativeProjectsQuery.isLoading || recentProjectVisits === null}
+      isProjectsError={nativeProjectsQuery.isError}
+      isTmsJobsLoading={hasTmsConnection && latestTmsJobsQuery.isLoading}
+      isTmsJobsError={latestTmsJobsQuery.isError}
+      isTmsProjectsLoading={
+        hasTmsConnection && (tmsProjectsQuery.isLoading || recentProjectVisits === null)
+      }
+      isTmsProjectsError={tmsProjectsQuery.isError}
       isAutomationsLoading={automationsQuery.isLoading || automationRunsQuery.isLoading}
       isAutomationsError={automationsQuery.isError || automationRunsQuery.isError}
-      renderLink={({ href, className, children }) => (
-        <Link href={href} className={className}>
+      renderLink={({ href, className, children, onClick }) => (
+        <Link href={href} className={className} onClick={onClick}>
           {children}
         </Link>
       )}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view-model.test.ts
@@ -1,15 +1,47 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import type { ApiJob } from "../../jobs/_components/jobs-page-view";
+import type { ProjectListRow } from "../../projects/_components/project-list";
 import {
   isDashboardSetupComplete,
+  mergeDashboardJobSources,
+  mergeDashboardProjectSources,
   resolveDashboardHero,
   resolveDashboardIntegrations,
   resolveWorkspacePendingActionCount,
   sortDashboardJobs,
+  sortDashboardLatestJobs,
+  sortDashboardProjects,
 } from "./dashboard-page-view-model";
 
 describe("dashboard-page-view-model", () => {
+  it("merges native and live TMS jobs without duplicate resource IDs", () => {
+    const jobs = mergeDashboardJobSources(
+      [{ id: "native-job", updatedAt: "2026-03-18T00:00:00.000Z" }],
+      [
+        { id: "ext:crowdin:100:200", updatedAt: "2026-03-20T00:00:00.000Z" },
+        { id: "native-job", updatedAt: "2026-03-21T00:00:00.000Z" },
+      ],
+    );
+
+    expect(jobs).toEqual([
+      { id: "native-job", updatedAt: "2026-03-21T00:00:00.000Z" },
+      { id: "ext:crowdin:100:200", updatedAt: "2026-03-20T00:00:00.000Z" },
+    ]);
+  });
+
+  it("merges native and live TMS projects", () => {
+    const projects = mergeDashboardProjectSources(
+      [{ id: "native-project", source: "native" }] as ProjectListRow[],
+      [{ id: "ext:crowdin:100", source: "external_tms" }] as ProjectListRow[],
+    );
+
+    expect(projects.map((project) => [project.id, project.source])).toEqual([
+      ["native-project", "native"],
+      ["ext:crowdin:100", "external_tms"],
+    ]);
+  });
+
   it("prioritizes actionable jobs before succeeded work", () => {
     const jobs = sortDashboardJobs([
       { status: "succeeded", updatedAt: "2026-03-20T00:00:00.000Z" },
@@ -20,13 +52,51 @@ describe("dashboard-page-view-model", () => {
     expect(jobs.map((job) => job.status)).toEqual(["waiting_for_review", "failed", "succeeded"]);
   });
 
+  it("orders latest jobs by update time without status priority", () => {
+    const jobs = sortDashboardLatestJobs([
+      { status: "waiting_for_review", updatedAt: "2026-03-18T00:00:00.000Z" },
+      { status: "succeeded", updatedAt: "2026-03-20T00:00:00.000Z" },
+    ] as ApiJob[]);
+
+    expect(jobs.map((job) => job.status)).toEqual(["succeeded", "waiting_for_review"]);
+  });
+
+  it("puts locally visited projects before activity-ranked projects", () => {
+    const projects = sortDashboardProjects(
+      [
+        {
+          id: "busy",
+          openJobCount: 5,
+          updated: "Mar 20, 2026, 11:00 AM",
+          lastSyncedAt: null,
+        },
+        {
+          id: "visited",
+          openJobCount: 0,
+          updated: "Mar 18, 2026, 11:00 AM",
+          lastSyncedAt: null,
+        },
+      ] as unknown as ProjectListRow[],
+      [{ projectId: "visited", visitedAt: 100 }],
+    );
+
+    expect(projects.map((project) => project.id)).toEqual(["visited", "busy"]);
+  });
+
   it("treats setup as complete only when integrations and projects exist", () => {
     const integrations = resolveDashboardIntegrations({
       tmsConnected: true,
+      tmsProviderKind: "crowdin",
+      tmsProviderName: "Crowdin",
       githubConnected: true,
       slackConnected: true,
     });
 
+    expect(integrations[0]).toMatchObject({
+      label: "Crowdin",
+      providerKind: "crowdin",
+      connected: true,
+    });
     expect(isDashboardSetupComplete(integrations, 0)).toBe(false);
     expect(isDashboardSetupComplete(integrations, 2)).toBe(true);
   });
@@ -49,7 +119,8 @@ describe("dashboard-page-view-model", () => {
 
     expect(hero.mode).toBe("setup");
     if (hero.mode === "setup") {
-      expect(hero.connectedCount).toBe(0);
+      expect(hero.completedCount).toBe(0);
+      expect(hero.totalCount).toBe(4);
     }
   });
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view-model.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view-model.ts
@@ -5,6 +5,7 @@ import type {
 
 import type { ApiJob } from "../../jobs/_components/jobs-page-view";
 import type { ProjectListRow } from "../../projects/_components/project-list";
+import type { RecentProjectVisit } from "../../projects/_components/recent-projects";
 
 export type DashboardIntegrationId = "tms" | "github" | "slack";
 
@@ -13,6 +14,7 @@ export type DashboardIntegrationItem = {
   label: string;
   description: string;
   connected: boolean;
+  providerKind?: ProjectListRow["externalProviderKind"];
 };
 
 export type DashboardJobItem = {
@@ -50,7 +52,7 @@ export type DashboardHeroState =
       mode: "setup";
       title: string;
       description: string;
-      connectedCount: number;
+      completedCount: number;
       totalCount: number;
       ctaLabel: string;
       ctaHref: string;
@@ -73,6 +75,31 @@ const JOB_STATUS_PRIORITY: Record<ApiJob["status"], number> = {
   cancelled: 5,
 };
 
+function mergeDashboardSources<T extends { id: string }>(
+  primary: readonly T[],
+  secondary: readonly T[],
+) {
+  const itemsById = new Map(primary.map((item) => [item.id, item]));
+  for (const item of secondary) {
+    itemsById.set(item.id, item);
+  }
+  return [...itemsById.values()];
+}
+
+export function mergeDashboardJobSources<T extends Pick<ApiJob, "id">>(
+  nativeJobs: readonly T[],
+  tmsJobs: readonly T[],
+) {
+  return mergeDashboardSources(nativeJobs, tmsJobs);
+}
+
+export function mergeDashboardProjectSources(
+  nativeProjects: readonly ProjectListRow[],
+  tmsProjects: readonly ProjectListRow[],
+) {
+  return mergeDashboardSources(nativeProjects, tmsProjects);
+}
+
 export function formatDashboardLocaleRoute(
   sourceLocale: string | null,
   targetLocales: readonly string[],
@@ -89,15 +116,20 @@ export function formatDashboardLocaleRoute(
 
 export function resolveDashboardIntegrations(input: {
   tmsConnected: boolean;
+  tmsProviderKind?: ProjectListRow["externalProviderKind"];
+  tmsProviderName?: string;
   githubConnected: boolean;
   slackConnected: boolean;
 }): DashboardIntegrationItem[] {
   return [
     {
       id: "tms",
-      label: "Translation management",
-      description: "Connect Crowdin, Lokalise, Phrase, or use Hyperlocalise native projects.",
+      label: input.tmsProviderName ?? "Translation management",
+      description: input.tmsProviderName
+        ? `${input.tmsProviderName} projects and translation work are available.`
+        : "Connect Crowdin, Lokalise, Phrase, or Smartling.",
       connected: input.tmsConnected,
+      providerKind: input.tmsProviderKind,
     },
     {
       id: "github",
@@ -145,6 +177,7 @@ export function resolveDashboardHero(input: {
   newRequestHref: string;
 }): DashboardHeroState {
   const connectedCount = input.integrations.filter((item) => item.connected).length;
+  const completedCount = connectedCount + (input.projectCount > 0 ? 1 : 0);
   const setupComplete = isDashboardSetupComplete(input.integrations, input.projectCount);
 
   if (!setupComplete) {
@@ -153,8 +186,8 @@ export function resolveDashboardHero(input: {
       title: "Get your workspace ready",
       description:
         "Connect your tools and create a project so Hyperlocalise can route translation work to you.",
-      connectedCount,
-      totalCount: input.integrations.length,
+      completedCount,
+      totalCount: input.integrations.length + 1,
       ctaLabel: "Finish setup",
       ctaHref: input.integrationsHref,
     };
@@ -195,8 +228,34 @@ export function sortDashboardJobs<T extends Pick<ApiJob, "status" | "updatedAt">
   });
 }
 
-export function sortDashboardProjects(projects: readonly ProjectListRow[]) {
+export function sortDashboardLatestJobs<T extends Pick<ApiJob, "updatedAt">>(jobs: readonly T[]) {
+  return [...jobs].toSorted(
+    (left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime(),
+  );
+}
+
+export function sortDashboardProjects(
+  projects: readonly ProjectListRow[],
+  recentVisits: readonly RecentProjectVisit[] = [],
+) {
+  const visitedAtByProjectId = new Map(
+    recentVisits.map((visit) => [visit.projectId, visit.visitedAt]),
+  );
+
   return [...projects].toSorted((left, right) => {
+    const leftVisitedAt = visitedAtByProjectId.get(left.id);
+    const rightVisitedAt = visitedAtByProjectId.get(right.id);
+
+    if (leftVisitedAt !== undefined || rightVisitedAt !== undefined) {
+      if (leftVisitedAt === undefined) {
+        return 1;
+      }
+      if (rightVisitedAt === undefined) {
+        return -1;
+      }
+      return rightVisitedAt - leftVisitedAt;
+    }
+
     const pendingDelta = right.openJobCount - left.openJobCount;
     if (pendingDelta !== 0) {
       return pendingDelta;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.stories.tsx
@@ -50,6 +50,18 @@ const caughtUpHero = resolveDashboardHero({
   newRequestHref: `/org/${organizationSlug}/chat`,
 });
 
+const tmsJobsFixture = dashboardJobsFixture.slice(0, 2).map((job) => ({
+  ...job,
+  id: `tms_${job.id}`,
+  name: `Crowdin · ${job.name}`,
+}));
+
+const tmsProjectsFixture = dashboardProjectsItemsFixture.slice(0, 2).map((project) => ({
+  ...project,
+  id: `tms_${project.id}`,
+  name: `Crowdin · ${project.name}`,
+}));
+
 const meta = {
   title: "App/Dashboard/Page",
   component: DashboardPageView,
@@ -61,7 +73,12 @@ const meta = {
     hero: activeHero,
     integrations: dashboardIntegrationsCompleteFixture,
     jobs: dashboardJobsFixture,
+    latestJobs: [...dashboardJobsFixture].reverse(),
     projects: dashboardProjectsItemsFixture,
+    showTmsSections: true,
+    tmsProviderName: "Crowdin",
+    tmsJobs: tmsJobsFixture,
+    tmsProjects: tmsProjectsFixture,
     automationStats: resolveAutomationSnapshotStats(automationsFixture),
     automationRuns: dashboardAutomationRunsFixture,
     automationsEnabled: true,
@@ -82,7 +99,10 @@ export const Default: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("heading", { name: "Overview" })).toBeInTheDocument();
     await expect(canvas.getByText("My jobs")).toBeInTheDocument();
+    await expect(canvas.getByText("Latest jobs")).toBeInTheDocument();
     await expect(canvas.getByText("Recent projects")).toBeInTheDocument();
+    await expect(canvas.getByText("Crowdin jobs")).toBeInTheDocument();
+    await expect(canvas.getByText("Crowdin projects")).toBeInTheDocument();
     await expect(canvas.getByText("Integrations")).toBeInTheDocument();
     await expect(canvas.getByText("Automation runs")).toBeInTheDocument();
     await expect(canvas.getByText("Review: terminology consistency")).toBeInTheDocument();
@@ -95,7 +115,11 @@ export const SetupIncomplete: Story = {
     hero: setupHero,
     integrations: dashboardIntegrationsIncompleteFixture,
     jobs: [],
+    latestJobs: [],
     projects: [],
+    showTmsSections: false,
+    tmsJobs: [],
+    tmsProjects: [],
     automationRuns: [],
     automationStats: { total: 0, active: 0, paused: 0 },
   },
@@ -110,6 +134,7 @@ export const CaughtUp: Story = {
   args: {
     hero: caughtUpHero,
     jobs: dashboardJobsFixture.filter((job) => job.status === "succeeded").slice(0, 3),
+    latestJobs: dashboardJobsFixture.filter((job) => job.status === "succeeded").slice(0, 3),
     projects: dashboardProjectsItemsFixture.map((project) => ({
       ...project,
       pendingActionCount: 0,
@@ -133,12 +158,19 @@ export const AutomationsDisabled: Story = {
 export const Loading: Story = {
   args: {
     jobs: [],
+    latestJobs: [],
     projects: [],
+    tmsJobs: [],
+    tmsProjects: [],
     integrations: [],
     automationRuns: [],
+    isHeroLoading: true,
     isIntegrationsLoading: true,
     isJobsLoading: true,
+    isLatestJobsLoading: true,
     isProjectsLoading: true,
+    isTmsJobsLoading: true,
+    isTmsProjectsLoading: true,
     isAutomationsLoading: true,
   },
 };
@@ -147,7 +179,10 @@ export const Empty: Story = {
   args: {
     hero: caughtUpHero,
     jobs: [],
+    latestJobs: [],
     projects: [],
+    tmsJobs: [],
+    tmsProjects: [],
     automationRuns: [],
     automationStats: { total: 0, active: 0, paused: 0 },
   },
@@ -156,13 +191,20 @@ export const Empty: Story = {
 export const LoadError: Story = {
   args: {
     jobs: [],
+    latestJobs: [],
     projects: [],
+    tmsJobs: [],
+    tmsProjects: [],
     isJobsError: true,
+    isLatestJobsError: true,
     isProjectsError: true,
+    isTmsJobsError: true,
+    isTmsProjectsError: true,
     isAutomationsError: true,
   },
   play: async ({ canvas }) => {
     await expect(canvas.getByText("My jobs could not be loaded.")).toBeInTheDocument();
+    await expect(canvas.getByText("Latest jobs could not be loaded.")).toBeInTheDocument();
     await expect(canvas.getByText("Recent projects could not be loaded.")).toBeInTheDocument();
     await expect(canvas.getByText("Automation runs could not be loaded.")).toBeInTheDocument();
   },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import {
   AlertCircleIcon,
@@ -8,10 +9,13 @@ import {
   CheckmarkCircle02Icon,
   DashboardSquare01Icon,
   FolderKanbanIcon,
+  SlackIcon,
   TaskDone01Icon,
+  TranslationIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { ReactNode } from "react";
+import { siGithub } from "simple-icons";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -31,6 +35,9 @@ import {
 } from "../../_components/workspace-resource-shared";
 import { formatJobStatusLabel, jobTone } from "../../jobs/_components/jobs-page-view";
 import { formatPendingActionCount } from "../../_components/overview/overview-attention";
+import { SimpleBrandIcon } from "../../integrations/_components/simple-brand-icon";
+import { recordRecentProjectVisit } from "../../projects/_components/recent-projects";
+import { getTmsProviderBranding } from "@/lib/providers/tms-provider-branding";
 
 import type {
   DashboardAutomationRunItem,
@@ -44,11 +51,17 @@ export type DashboardLinkRenderer = (props: {
   href: string;
   className?: string;
   children: ReactNode;
+  onClick?: () => void;
 }) => ReactNode;
 
-function defaultRenderLink({ href, className, children }: Parameters<DashboardLinkRenderer>[0]) {
+function defaultRenderLink({
+  href,
+  className,
+  children,
+  onClick,
+}: Parameters<DashboardLinkRenderer>[0]) {
   return (
-    <Link href={href} className={className}>
+    <Link href={href} className={className} onClick={onClick}>
       {children}
     </Link>
   );
@@ -63,6 +76,7 @@ function DashboardPanel({
   isLoading,
   isError,
   errorMessage,
+  warningMessage,
   emptyMessage,
   isEmpty = false,
   children,
@@ -76,6 +90,7 @@ function DashboardPanel({
   isLoading?: boolean;
   isError?: boolean;
   errorMessage?: string;
+  warningMessage?: string;
   emptyMessage?: string;
   isEmpty?: boolean;
   children: ReactNode;
@@ -127,6 +142,18 @@ function DashboardPanel({
             ) : (
               <div className="grid gap-2">{children}</div>
             )}
+            {warningMessage ? (
+              <div className="mt-3 flex items-start gap-2 rounded-lg border border-warning/25 bg-warning/10 px-3 py-3">
+                <HugeiconsIcon
+                  icon={AlertCircleIcon}
+                  strokeWidth={1.8}
+                  className="mt-0.5 size-4 text-warning"
+                />
+                <TypographyP className="text-sm text-warning-foreground">
+                  {warningMessage}
+                </TypographyP>
+              </div>
+            ) : null}
           </>
         )}
 
@@ -155,7 +182,7 @@ function DashboardSetupHero({
   newRequestHref: string;
   renderLink?: DashboardLinkRenderer;
 }) {
-  const progressValue = Math.round((hero.connectedCount / hero.totalCount) * 100);
+  const progressValue = Math.round((hero.completedCount / hero.totalCount) * 100);
 
   return (
     <Card className="rounded-2xl border border-border bg-gradient-to-br from-amber-100 via-muted to-muted py-0 text-foreground ring-0 lg:col-span-2">
@@ -163,7 +190,7 @@ function DashboardSetupHero({
         <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,14rem)] lg:items-end">
           <div>
             <TypographyP className="text-sm font-medium text-subtle-foreground">
-              Workspace setup · {hero.connectedCount} of {hero.totalCount} connected
+              Workspace setup · {hero.completedCount} of {hero.totalCount} complete
             </TypographyP>
             <TypographyP className="mt-2 font-heading text-2xl font-medium text-foreground">
               {hero.title}
@@ -205,6 +232,56 @@ function DashboardSetupHero({
   );
 }
 
+function DashboardHeroSkeleton() {
+  return (
+    <Card
+      className="rounded-2xl border border-border bg-card py-0 ring-0 lg:col-span-2"
+      aria-busy="true"
+      aria-label="Loading workspace overview"
+    >
+      <CardContent className="grid min-h-52 gap-6 px-6 py-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,14rem)] lg:items-end">
+        <div className="flex flex-col gap-3">
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-8 w-72 max-w-full" />
+          <Skeleton className="h-4 w-full max-w-xl" />
+          <Skeleton className="h-4 w-4/5 max-w-lg" />
+          <div className="mt-2 flex gap-2">
+            <Skeleton className="h-9 w-32 rounded-full" />
+            <Skeleton className="h-9 w-32 rounded-full" />
+          </div>
+        </div>
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-3 w-full" />
+          <Skeleton className="h-2 w-full rounded-full" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function DashboardIntegrationMark({ item }: { item: DashboardIntegrationItem }) {
+  if (item.id === "github") {
+    return <SimpleBrandIcon icon={siGithub} colored={item.connected} />;
+  }
+
+  if (item.id === "slack") {
+    return <HugeiconsIcon icon={SlackIcon} strokeWidth={1.8} className="size-5" />;
+  }
+
+  if (item.providerKind) {
+    const branding = getTmsProviderBranding(item.providerKind);
+    if (branding.icon) {
+      return <SimpleBrandIcon icon={branding.icon} colored={item.connected} />;
+    }
+
+    return (
+      <Image src={branding.logo} alt="" width={24} height={24} className="size-6 object-contain" />
+    );
+  }
+
+  return <HugeiconsIcon icon={TranslationIcon} strokeWidth={1.8} className="size-5" />;
+}
+
 function DashboardIntegrationsSection({
   integrations,
   integrationsHref,
@@ -221,44 +298,67 @@ function DashboardIntegrationsSection({
   return (
     <section className="flex flex-col gap-4">
       <OverviewSectionHeader title="Integrations" count={integrations.length - connectedCount} />
-      <Card className="rounded-lg border border-border bg-muted py-0 ring-0">
-        <CardContent className="px-5 py-5">
+      <Card className="overflow-hidden rounded-lg border border-border bg-card py-0 ring-0">
+        <CardContent className="p-0">
           {isLoading ? (
-            <div className="grid gap-2" aria-busy="true" aria-label="Loading integrations">
+            <div
+              className="flex flex-col divide-y divide-border"
+              aria-busy="true"
+              aria-label="Loading integrations"
+            >
               {Array.from({ length: 3 }).map((_, index) => (
-                <Skeleton key={index} className="h-16 rounded-lg bg-muted" />
+                <div key={index} className="flex items-center gap-4 px-5 py-4">
+                  <Skeleton className="size-10 shrink-0 rounded-lg" />
+                  <div className="flex flex-1 flex-col gap-2">
+                    <Skeleton className="h-4 w-40" />
+                    <Skeleton className="h-3 w-64 max-w-full" />
+                  </div>
+                  <Skeleton className="h-5 w-20" />
+                </div>
               ))}
             </div>
           ) : (
-            <div className="grid gap-2">
+            <div className="divide-y divide-border">
               {integrations.map((item) => (
                 <div key={item.id}>
                   {renderLink({
                     href: integrationsHref,
                     className:
-                      "block rounded-lg border border-border px-4 py-4 transition-colors hover:bg-muted",
+                      "group grid grid-cols-[auto_minmax(0,1fr)] items-center gap-4 px-5 py-4 transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset sm:grid-cols-[auto_minmax(0,1fr)_auto]",
                     children: (
-                      <div className="flex items-start justify-between gap-4">
+                      <>
+                        <div className="flex size-10 items-center justify-center rounded-lg border border-border bg-background text-muted-foreground group-hover:text-foreground">
+                          <DashboardIntegrationMark item={item} />
+                        </div>
                         <div className="min-w-0">
                           <TypographyP className="text-sm font-medium text-foreground">
                             {item.label}
                           </TypographyP>
-                          <TypographyP className="mt-1 text-sm text-muted-foreground">
+                          <TypographyP className="mt-1 text-sm text-subtle-foreground">
                             {item.description}
                           </TypographyP>
                         </div>
-                        <Badge
-                          variant="outline"
-                          className={cn(
-                            "shrink-0 rounded-full",
-                            item.connected
-                              ? "border-grove-300/25 bg-grove-300/10 text-grove-300"
-                              : "border-border bg-muted text-muted-foreground",
-                          )}
-                        >
-                          {item.connected ? "Connected" : "Connect"}
-                        </Badge>
-                      </div>
+                        <div className="col-span-2 flex items-center justify-between gap-3 pl-14 sm:col-span-1 sm:pl-0">
+                          <Badge variant={item.connected ? "success" : "outline"}>
+                            {item.connected ? (
+                              <HugeiconsIcon
+                                icon={CheckmarkCircle02Icon}
+                                strokeWidth={2}
+                                data-icon="inline-start"
+                              />
+                            ) : null}
+                            {item.connected ? "Connected" : "Not connected"}
+                          </Badge>
+                          <span className="inline-flex items-center gap-1 text-sm font-medium text-foreground">
+                            {item.connected ? "Manage" : "Connect"}
+                            <HugeiconsIcon
+                              icon={ArrowRight01Icon}
+                              strokeWidth={1.8}
+                              className="size-4"
+                            />
+                          </span>
+                        </div>
+                      </>
                     ),
                   })}
                 </div>
@@ -371,43 +471,226 @@ function DashboardAutomationsSection({
   );
 }
 
+function DashboardJobsPanel({
+  title,
+  description,
+  jobs,
+  footerHref,
+  isLoading,
+  isError,
+  warningMessage,
+  emptyMessage,
+  renderLink,
+}: {
+  title: string;
+  description: string;
+  jobs: DashboardJobItem[];
+  footerHref: string;
+  isLoading: boolean;
+  isError: boolean;
+  warningMessage?: string;
+  emptyMessage: string;
+  renderLink: DashboardLinkRenderer;
+}) {
+  return (
+    <DashboardPanel
+      title={title}
+      description={description}
+      icon={TaskDone01Icon}
+      footerHref={footerHref}
+      footerLabel="View all jobs"
+      isLoading={isLoading}
+      isError={isError}
+      warningMessage={warningMessage}
+      isEmpty={jobs.length === 0}
+      emptyMessage={emptyMessage}
+      renderLink={renderLink}
+    >
+      {jobs.map((job) => {
+        const content = (
+          <div className="rounded-lg border border-border px-3 py-3 transition-colors hover:bg-muted">
+            <div className="flex flex-wrap items-center gap-2">
+              <TypographyP className="min-w-0 truncate text-sm font-medium text-foreground">
+                {job.name}
+              </TypographyP>
+              <Badge
+                variant="outline"
+                className={cn("rounded-full capitalize", toneClass(jobTone(job.status)))}
+              >
+                {formatJobStatusLabel(job.status)}
+              </Badge>
+            </div>
+            <TypographyP className="mt-1 text-xs text-muted-foreground">
+              {job.projectName ?? "Workspace"} · {job.kindLabel} · updated{" "}
+              {formatRelativeTimestamp(job.updatedAt)}
+            </TypographyP>
+          </div>
+        );
+
+        if (!job.href) {
+          return <div key={job.id}>{content}</div>;
+        }
+
+        return (
+          <div key={job.id}>
+            {renderLink({
+              href: job.href,
+              className: "block",
+              children: content,
+            })}
+          </div>
+        );
+      })}
+    </DashboardPanel>
+  );
+}
+
+function DashboardProjectsPanel({
+  organizationSlug,
+  title,
+  description,
+  projects,
+  footerHref,
+  isLoading,
+  isError,
+  emptyMessage,
+  renderLink,
+}: {
+  organizationSlug: string;
+  title: string;
+  description: string;
+  projects: DashboardProjectItem[];
+  footerHref: string;
+  isLoading: boolean;
+  isError: boolean;
+  emptyMessage: string;
+  renderLink: DashboardLinkRenderer;
+}) {
+  return (
+    <DashboardPanel
+      title={title}
+      description={description}
+      icon={FolderKanbanIcon}
+      footerHref={footerHref}
+      footerLabel="View all projects"
+      isLoading={isLoading}
+      isError={isError}
+      isEmpty={projects.length === 0}
+      emptyMessage={emptyMessage}
+      renderLink={renderLink}
+    >
+      {projects.map((project) => (
+        <div key={project.id}>
+          {renderLink({
+            href: project.href,
+            className:
+              "block rounded-lg border border-border px-3 py-3 transition-colors hover:bg-muted",
+            onClick: () => {
+              recordRecentProjectVisit(organizationSlug, project.id);
+            },
+            children: (
+              <>
+                <div className="flex flex-wrap items-center gap-2">
+                  <TypographyP className="min-w-0 truncate text-sm font-medium text-foreground">
+                    {project.name}
+                  </TypographyP>
+                  {project.pendingActionCount > 0 ? (
+                    <Badge
+                      variant="outline"
+                      className="rounded-full border-beam-500/30 bg-beam-500/15 text-beam-100"
+                    >
+                      {formatPendingActionCount(project.pendingActionCount)} open
+                    </Badge>
+                  ) : (
+                    <Badge variant="outline" className="rounded-full text-muted-foreground">
+                      <HugeiconsIcon
+                        icon={CheckmarkCircle02Icon}
+                        strokeWidth={1.7}
+                        className="mr-1 size-3.5"
+                      />
+                      Up to date
+                    </Badge>
+                  )}
+                </div>
+                <TypographyP className="mt-1 text-xs text-muted-foreground">
+                  {project.sourceLabel} · {project.localeRoute}
+                  {project.updatedAt
+                    ? ` · updated ${formatRelativeTimestamp(project.updatedAt)}`
+                    : ""}
+                </TypographyP>
+              </>
+            ),
+          })}
+        </div>
+      ))}
+    </DashboardPanel>
+  );
+}
+
 export function DashboardPageView({
   organizationSlug,
   hero,
+  isHeroLoading = false,
   integrations,
   jobs,
+  latestJobs,
   projects,
+  showTmsSections = false,
+  tmsProviderName = "TMS",
+  tmsJobs,
+  tmsProjects,
   automationStats,
   automationRuns,
   automationsEnabled = false,
   isIntegrationsLoading = false,
   isJobsLoading = false,
   isJobsError = false,
+  jobsWarning,
+  isLatestJobsLoading = false,
+  isLatestJobsError = false,
   isProjectsLoading = false,
   isProjectsError = false,
+  isTmsJobsLoading = false,
+  isTmsJobsError = false,
+  isTmsProjectsLoading = false,
+  isTmsProjectsError = false,
   isAutomationsLoading = false,
   isAutomationsError = false,
   renderLink = defaultRenderLink,
 }: {
   organizationSlug: string;
   hero: DashboardHeroState;
+  isHeroLoading?: boolean;
   integrations: DashboardIntegrationItem[];
   jobs: DashboardJobItem[];
+  latestJobs: DashboardJobItem[];
   projects: DashboardProjectItem[];
+  showTmsSections?: boolean;
+  tmsProviderName?: string;
+  tmsJobs: DashboardJobItem[];
+  tmsProjects: DashboardProjectItem[];
   automationStats: { total: number; active: number; paused: number };
   automationRuns: DashboardAutomationRunItem[];
   automationsEnabled?: boolean;
   isIntegrationsLoading?: boolean;
   isJobsLoading?: boolean;
   isJobsError?: boolean;
+  jobsWarning?: string;
+  isLatestJobsLoading?: boolean;
+  isLatestJobsError?: boolean;
   isProjectsLoading?: boolean;
   isProjectsError?: boolean;
+  isTmsJobsLoading?: boolean;
+  isTmsJobsError?: boolean;
+  isTmsProjectsLoading?: boolean;
+  isTmsProjectsError?: boolean;
   isAutomationsLoading?: boolean;
   isAutomationsError?: boolean;
   renderLink?: DashboardLinkRenderer;
 }) {
   const integrationsHref = `/org/${organizationSlug}/integrations`;
   const myJobsHref = `/org/${organizationSlug}/my-jobs`;
+  const jobsHref = `/org/${organizationSlug}/jobs`;
   const projectsHref = `/org/${organizationSlug}/projects`;
   const newRequestHref = `/org/${organizationSlug}/chat`;
 
@@ -417,11 +700,13 @@ export function DashboardPageView({
         icon={DashboardSquare01Icon}
         label="Workspace"
         title="Overview"
-        description="Your workspace at a glance — setup, assigned work, and recent projects."
+        description="Your workspace at a glance — assigned work, latest activity, and recent projects."
       />
 
       <section className="grid gap-4 lg:grid-cols-2">
-        {hero.mode === "setup" ? (
+        {isHeroLoading ? (
+          <DashboardHeroSkeleton />
+        ) : hero.mode === "setup" ? (
           <DashboardSetupHero hero={hero} newRequestHref={newRequestHref} renderLink={renderLink} />
         ) : (
           <>
@@ -461,110 +746,67 @@ export function DashboardPageView({
         )}
       </section>
 
-      <section className="grid gap-4 lg:grid-cols-2">
-        <DashboardPanel
+      <section className="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
+        <DashboardJobsPanel
           title="My jobs"
           description="The latest work assigned to you, prioritized by what needs action."
-          icon={TaskDone01Icon}
+          jobs={jobs}
           footerHref={myJobsHref}
-          footerLabel="View all jobs"
           isLoading={isJobsLoading}
           isError={isJobsError}
-          isEmpty={jobs.length === 0}
+          warningMessage={jobsWarning}
           emptyMessage="No jobs assigned to you yet."
           renderLink={renderLink}
-        >
-          {jobs.map((job) => {
-            const content = (
-              <div className="rounded-lg border border-border px-3 py-3 transition-colors hover:bg-muted">
-                <div className="flex flex-wrap items-center gap-2">
-                  <TypographyP className="min-w-0 truncate text-sm font-medium text-foreground">
-                    {job.name}
-                  </TypographyP>
-                  <Badge
-                    variant="outline"
-                    className={cn("rounded-full capitalize", toneClass(jobTone(job.status)))}
-                  >
-                    {formatJobStatusLabel(job.status)}
-                  </Badge>
-                </div>
-                <TypographyP className="mt-1 text-xs text-muted-foreground">
-                  {job.projectName ?? "Workspace"} · {job.kindLabel} · updated{" "}
-                  {formatRelativeTimestamp(job.updatedAt)}
-                </TypographyP>
-              </div>
-            );
+        />
 
-            if (!job.href) {
-              return <div key={job.id}>{content}</div>;
-            }
+        <DashboardJobsPanel
+          title="Latest jobs"
+          description="The most recently updated work across this workspace."
+          jobs={latestJobs}
+          footerHref={jobsHref}
+          isLoading={isLatestJobsLoading}
+          isError={isLatestJobsError}
+          emptyMessage="No workspace jobs yet."
+          renderLink={renderLink}
+        />
 
-            return (
-              <div key={job.id}>
-                {renderLink({
-                  href: job.href,
-                  className: "block",
-                  children: content,
-                })}
-              </div>
-            );
-          })}
-        </DashboardPanel>
-
-        <DashboardPanel
+        <DashboardProjectsPanel
+          organizationSlug={organizationSlug}
           title="Recent projects"
-          description="Projects with the most open work, plus your latest activity."
-          icon={FolderKanbanIcon}
+          description="Projects you opened recently, followed by active workspace projects."
+          projects={projects}
           footerHref={projectsHref}
-          footerLabel="View all projects"
           isLoading={isProjectsLoading}
           isError={isProjectsError}
-          isEmpty={projects.length === 0}
-          emptyMessage="No projects yet. Connect a TMS or create a native project to get started."
+          emptyMessage="No native projects yet. Create a project to get started."
           renderLink={renderLink}
-        >
-          {projects.map((project) => (
-            <div key={project.id}>
-              {renderLink({
-                href: project.href,
-                className:
-                  "block rounded-lg border border-border px-3 py-3 transition-colors hover:bg-muted",
-                children: (
-                  <>
-                    <div className="flex flex-wrap items-center gap-2">
-                      <TypographyP className="min-w-0 truncate text-sm font-medium text-foreground">
-                        {project.name}
-                      </TypographyP>
-                      {project.pendingActionCount > 0 ? (
-                        <Badge
-                          variant="outline"
-                          className="rounded-full border-beam-500/30 bg-beam-500/15 text-beam-100"
-                        >
-                          {formatPendingActionCount(project.pendingActionCount)} open
-                        </Badge>
-                      ) : (
-                        <Badge variant="outline" className="rounded-full text-muted-foreground">
-                          <HugeiconsIcon
-                            icon={CheckmarkCircle02Icon}
-                            strokeWidth={1.7}
-                            className="mr-1 size-3.5"
-                          />
-                          Up to date
-                        </Badge>
-                      )}
-                    </div>
-                    <TypographyP className="mt-1 text-xs text-muted-foreground">
-                      {project.sourceLabel} · {project.localeRoute}
-                      {project.updatedAt
-                        ? ` · updated ${formatRelativeTimestamp(project.updatedAt)}`
-                        : ""}
-                    </TypographyP>
-                  </>
-                ),
-              })}
-            </div>
-          ))}
-        </DashboardPanel>
+        />
+
+        {showTmsSections ? (
+          <>
+            <DashboardJobsPanel
+              title={`${tmsProviderName} jobs`}
+              description={`Live jobs fetched from ${tmsProviderName}.`}
+              jobs={tmsJobs}
+              footerHref={jobsHref}
+              isLoading={isTmsJobsLoading}
+              isError={isTmsJobsError}
+              emptyMessage={`No jobs found in ${tmsProviderName}.`}
+              renderLink={renderLink}
+            />
+            <DashboardProjectsPanel
+              organizationSlug={organizationSlug}
+              title={`${tmsProviderName} projects`}
+              description={`Live projects fetched from ${tmsProviderName}.`}
+              projects={tmsProjects}
+              footerHref={projectsHref}
+              isLoading={isTmsProjectsLoading}
+              isError={isTmsProjectsError}
+              emptyMessage={`No projects found in ${tmsProviderName}.`}
+              renderLink={renderLink}
+            />
+          </>
+        ) : null}
       </section>
 
       <DashboardIntegrationsSection

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-page-shell.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-page-shell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { cn } from "@/lib/primitives/cn";
@@ -13,13 +13,14 @@ import {
 } from "../../../_components/workspace-resource-shared";
 
 import { mapProjectToListRow } from "../../_components/project-list";
+import { recordRecentProjectVisit } from "../../_components/recent-projects";
 
 export function useProjectPageQuery(
   organizationSlug: string,
   projectId: string,
   options?: { enabled?: boolean },
 ) {
-  return useQuery({
+  const query = useQuery({
     queryKey: ["translation-project", organizationSlug, projectId],
     enabled: options?.enabled ?? true,
     queryFn: async () => {
@@ -33,6 +34,14 @@ export function useProjectPageQuery(
       return mapProjectToListRow(body.project);
     },
   });
+
+  useEffect(() => {
+    if (query.isSuccess) {
+      recordRecentProjectVisit(organizationSlug, projectId);
+    }
+  }, [organizationSlug, projectId, query.isSuccess]);
+
+  return query;
 }
 
 export function ProjectPageShell({

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 import type { ProjectListRow } from "./project-list";
+import { recordRecentProjectVisit } from "./recent-projects";
 import { TypographyH3, TypographyP } from "@/components/ui/typography";
 
 function ProviderBadge({
@@ -135,6 +136,9 @@ export function ProjectsTable({
                 <Link
                   href={`/org/${organizationSlug}/projects/${project.id}`}
                   className="min-w-0 flex-1"
+                  onClick={() => {
+                    recordRecentProjectVisit(organizationSlug, project.id);
+                  }}
                 >
                   <div className="flex items-center gap-2">
                     <TypographyH3 className="min-w-0 truncate text-base font-medium text-foreground md:text-base group-hover:text-foreground">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/recent-projects.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/recent-projects.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { readRecentProjectVisits, recordRecentProjectVisit } from "./recent-projects";
+
+function createStorage() {
+  const values = new Map<string, string>();
+  return {
+    getItem(key: string) {
+      return values.get(key) ?? null;
+    },
+    setItem(key: string, value: string) {
+      values.set(key, value);
+    },
+  };
+}
+
+describe("recent-projects", () => {
+  it("stores the latest visit first without duplicating a project", () => {
+    const storage = createStorage();
+
+    recordRecentProjectVisit("acme", "project_a", { storage, visitedAt: 10 });
+    recordRecentProjectVisit("acme", "project_b", { storage, visitedAt: 20 });
+    recordRecentProjectVisit("acme", "project_a", { storage, visitedAt: 30 });
+
+    expect(readRecentProjectVisits("acme", storage)).toEqual([
+      { projectId: "project_a", visitedAt: 30 },
+      { projectId: "project_b", visitedAt: 20 },
+    ]);
+  });
+
+  it("keeps organization histories separate and ignores invalid data", () => {
+    const storage = createStorage();
+    storage.setItem("hyperlocalise:recent-projects:v1:broken", "{");
+    recordRecentProjectVisit("acme", "project_a", { storage, visitedAt: 10 });
+
+    expect(readRecentProjectVisits("other", storage)).toEqual([]);
+    expect(readRecentProjectVisits("broken", storage)).toEqual([]);
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/recent-projects.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/recent-projects.ts
@@ -1,0 +1,94 @@
+const RECENT_PROJECTS_STORAGE_VERSION = 1;
+const RECENT_PROJECTS_LIMIT = 20;
+
+export type RecentProjectVisit = {
+  projectId: string;
+  visitedAt: number;
+};
+
+type RecentProjectsStorage = Pick<Storage, "getItem" | "setItem">;
+
+function recentProjectsStorageKey(organizationSlug: string) {
+  return `hyperlocalise:recent-projects:v${RECENT_PROJECTS_STORAGE_VERSION}:${organizationSlug}`;
+}
+
+function getBrowserStorage() {
+  try {
+    return typeof window === "undefined" ? undefined : window.localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+function isRecentProjectVisit(value: unknown): value is RecentProjectVisit {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const visit = value as Partial<RecentProjectVisit>;
+  return (
+    typeof visit.projectId === "string" &&
+    visit.projectId.length > 0 &&
+    typeof visit.visitedAt === "number" &&
+    Number.isFinite(visit.visitedAt)
+  );
+}
+
+export function readRecentProjectVisits(
+  organizationSlug: string,
+  storage: RecentProjectsStorage | undefined = getBrowserStorage(),
+): RecentProjectVisit[] {
+  if (!storage) {
+    return [];
+  }
+
+  try {
+    const value = storage.getItem(recentProjectsStorageKey(organizationSlug));
+    if (!value) {
+      return [];
+    }
+
+    const parsed: unknown = JSON.parse(value);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed
+      .filter(isRecentProjectVisit)
+      .toSorted((left, right) => right.visitedAt - left.visitedAt)
+      .slice(0, RECENT_PROJECTS_LIMIT);
+  } catch {
+    return [];
+  }
+}
+
+export function recordRecentProjectVisit(
+  organizationSlug: string,
+  projectId: string,
+  options?: {
+    storage?: RecentProjectsStorage;
+    visitedAt?: number;
+  },
+) {
+  const storage = options?.storage ?? getBrowserStorage();
+  if (!storage || !projectId) {
+    return;
+  }
+
+  const visits = readRecentProjectVisits(organizationSlug, storage).filter(
+    (visit) => visit.projectId !== projectId,
+  );
+  visits.unshift({
+    projectId,
+    visitedAt: options?.visitedAt ?? Date.now(),
+  });
+
+  try {
+    storage.setItem(
+      recentProjectsStorageKey(organizationSlug),
+      JSON.stringify(visits.slice(0, RECENT_PROJECTS_LIMIT)),
+    );
+  } catch {
+    // Recent history is an enhancement; navigation must still succeed.
+  }
+}

--- a/apps/hyperlocalise-web/src/components/ui/badge.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/badge.stories.tsx
@@ -11,6 +11,7 @@ const badgeVariants = [
   "outline",
   "ghost",
   "destructive",
+  "success",
   "warning",
   "link",
 ] as const;
@@ -40,7 +41,7 @@ export const Overview: Story = {
       <section className="flex flex-col gap-3">
         <h2 className="text-sm font-medium text-muted-foreground">States</h2>
         <div className="flex flex-wrap items-center gap-3">
-          <Badge>
+          <Badge variant="success">
             <HugeiconsIcon icon={CheckmarkCircle02Icon} strokeWidth={2} data-icon="inline-start" />
             Synced
           </Badge>

--- a/apps/hyperlocalise-web/src/components/ui/badge.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/badge.tsx
@@ -13,6 +13,8 @@ const badgeVariants = cva(
         secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
         destructive:
           "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        success:
+          "border-success bg-success text-success-foreground focus-visible:ring-success/25 [a]:hover:bg-success/90",
         warning:
           "border-warning/25 bg-warning/10 text-warning-foreground focus-visible:ring-warning/20 dark:bg-warning/20 dark:focus-visible:ring-warning/30 [a]:hover:bg-warning/20 dark:[a]:hover:bg-warning/30",
         outline:

--- a/docs/adr/2026-07-05-dashboard-overview-ux-design.md
+++ b/docs/adr/2026-07-05-dashboard-overview-ux-design.md
@@ -1,0 +1,38 @@
+# Dashboard overview UX design
+
+## Problem
+
+The dashboard exposes data as its requests settle. Setup progress jumps through
+intermediate percentages, connected integrations have weak visual hierarchy,
+live TMS projects do not appear in recent projects, and the jobs preview only
+shows assigned work.
+
+## Design
+
+- Keep the setup hero in a structural loading state until project and
+  integration checks finish. Render one final setup or workspace state.
+- Present integrations as one divided surface. Each row shows a recognizable
+  brand mark, a specific title and description, a high-contrast status badge,
+  and a clear manage affordance.
+- Store a versioned, organization-scoped list of recently opened project IDs
+  in local storage. Rank known projects by that history, then fall back to
+  server activity.
+- Show separate **My jobs** and **Latest jobs** panels. My jobs keeps assigned
+  relationship semantics; Latest jobs shows recent workspace activity.
+- When an active TMS integration exists, fetch live provider resources and add
+  dedicated **TMS jobs** and **TMS projects** panels. Do not query or render
+  those panels without an active connection.
+
+## Data and error behavior
+
+Local storage contains project IDs and visit timestamps only. Invalid or stale
+entries are ignored, and unavailable projects fall out when results are
+reconciled. If one project source succeeds, the dashboard shows that partial
+result instead of replacing it with a global error.
+
+## Verification
+
+Add focused tests for recent-project persistence and ranking, dashboard model
+mapping, stable loading states, integration hierarchy, and both job panels.
+Run the dashboard tests, then `vp test` and `vp check --fix` from
+`apps/hyperlocalise-web`.


### PR DESCRIPTION
## What changed

- prevent setup progress from showing intermediate values while dashboard data loads
- include the project requirement in setup completion
- redesign integration rows with provider icons, stronger connected badges, clearer contrast, and manage actions
- show separate My Jobs and Latest Jobs panels
- include live TMS projects in Recent Projects
- persist organization-scoped project history in local storage and prioritize recently opened projects
- add focused model, persistence, Storybook, and badge coverage
- document the dashboard UX decisions

## How to test

- Run:
  - `vp test run 'src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard' 'src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/recent-projects.test.ts'`
  - `vp check --fix`
- Open the dashboard and confirm:
  - setup progress appears only after connection and project checks finish
  - connected integrations have visible icons, badges, and manage actions
  - My Jobs contains assigned work
  - Latest Jobs contains recently updated workspace work
  - native and live TMS projects appear under Recent Projects
  - opening a project moves it to the front of Recent Projects
- `vp test` was attempted but requires PostgreSQL; it failed with `ECONNREFUSED` on port 5432.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review