### PR TITLE
feat(web): add projects UX utilities for avatars and recent tracking

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview.fixture.ts
@@ -20,6 +20,8 @@ export const projectOverviewFixture: ProjectListRow = {
   targetLocales: ["fr-FR", "de-DE", "es-ES"],
   externalProjectUrl: "https://crowdin.com/project/website",
   isActive: true,
+  logoUrl: null,
+  lastActivityAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
   lastSyncedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
   lastSyncErrorAt: null,
   lastSyncErrorMessage: null,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-avatar.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-avatar.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { cn } from "@/lib/primitives/cn";
+import { TmsProviderBrandMark } from "@/lib/providers/tms-provider-brand-mark";
+
+import type { ProjectListRow } from "./project-list";
+
+export function ProjectAvatar({
+  project,
+  className,
+  compact = false,
+}: {
+  project: Pick<ProjectListRow, "name" | "key" | "logoUrl" | "externalProviderKind" | "source">;
+  className?: string;
+  compact?: boolean;
+}) {
+  const sizeClass = compact ? "size-9 rounded-lg" : "size-10 rounded-lg";
+
+  return (
+    <span className={cn("relative shrink-0", className)}>
+      <Avatar className={cn(sizeClass, "after:rounded-lg")}>
+        {project.logoUrl ? (
+          <AvatarImage src={project.logoUrl} alt="" className="rounded-lg object-cover" />
+        ) : null}
+        <AvatarFallback className="rounded-lg bg-background text-xs font-medium text-foreground">
+          {project.key}
+        </AvatarFallback>
+      </Avatar>
+      {project.source === "external_tms" && project.externalProviderKind ? (
+        <span className="absolute -right-1 -bottom-1 rounded-md border border-border bg-background p-0.5 shadow-sm">
+          <TmsProviderBrandMark
+            providerKind={project.externalProviderKind}
+            compact
+            colored
+            className="size-4 rounded-md border-0 bg-transparent p-0"
+          />
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-list.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-list.test.ts
@@ -62,4 +62,18 @@ describe("mapProjectToListRow", () => {
     expect(row.created).toContain("2026");
     expect(row.updated).toContain("2026");
   });
+
+  it("maps logo and last activity fields for live TMS projects", () => {
+    const row = mapProjectToListRow(
+      createProject({
+        source: "external_tms",
+        externalProviderKind: "crowdin",
+        logoUrl: "data:image/png;base64,abc123",
+        lastActivityAt: "2026-04-30T03:20:00.000Z",
+      }),
+    );
+
+    expect(row.logoUrl).toBe("data:image/png;base64,abc123");
+    expect(row.lastActivityAt).toBe("2026-04-30T03:20:00.000Z");
+  });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-list.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-list.ts
@@ -14,6 +14,8 @@ export type ApiProject = {
   targetLocales?: string[];
   externalProjectUrl?: string | null;
   isActive?: boolean;
+  logoUrl?: string | null;
+  lastActivityAt?: string | Date | null;
   lastSyncedAt?: string | Date | null;
   lastSyncErrorAt?: string | Date | null;
   lastSyncErrorMessage?: string | null;
@@ -37,6 +39,8 @@ export type ProjectListRow = {
   targetLocales: string[];
   externalProjectUrl: string | null;
   isActive: boolean;
+  logoUrl: string | null;
+  lastActivityAt: string | null;
   lastSyncedAt: string | null;
   lastSyncErrorAt: string | null;
   lastSyncErrorMessage: string | null;
@@ -100,9 +104,38 @@ function createProjectKey(project: ApiProject) {
   );
 }
 
+function normalizeIsoTimestamp(value: string | Date | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date.toISOString();
+}
+
+export function formatProjectLocaleRoute(
+  sourceLocale: string | null,
+  targetLocales: readonly string[],
+) {
+  const source = sourceLocale ?? "—";
+  if (targetLocales.length === 0) {
+    return source;
+  }
+
+  const preview = targetLocales.slice(0, 2).join(", ");
+  const suffix = targetLocales.length > 2 ? ` +${targetLocales.length - 2}` : "";
+  return `${source} → ${preview}${suffix}`;
+}
+
 export function mapProjectToListRow(project: ApiProject): ProjectListRow {
   const descriptionValue = project.description?.trim() ?? "";
   const translationContextValue = project.translationContext?.trim() ?? "";
+  const lastActivityAt =
+    normalizeIsoTimestamp(project.lastActivityAt) ?? normalizeIsoTimestamp(project.updatedAt);
 
   return {
     id: project.id,
@@ -121,6 +154,8 @@ export function mapProjectToListRow(project: ApiProject): ProjectListRow {
     targetLocales: project.targetLocales ?? [],
     externalProjectUrl: sanitizeExternalUrl(project.externalProjectUrl),
     isActive: project.isActive ?? true,
+    logoUrl: project.logoUrl?.trim() || null,
+    lastActivityAt,
     lastSyncedAt: formatTimestampOrNull(project.lastSyncedAt),
     lastSyncErrorAt: formatTimestampOrNull(project.lastSyncErrorAt),
     lastSyncErrorMessage: project.lastSyncErrorMessage ?? null,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
@@ -260,16 +260,18 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
   );
 
   const hasAnyProjects = nativeProjects.length > 0 || tmsProjects.length > 0;
-  const hasFilteredResults = filteredNativeProjects.length > 0 || filteredTmsProjects.length > 0;
   const isTmsProjectsLoading = tmsProjectsQuery.isLoading || tmsProjectsQuery.isFetching;
-  const tmsProviderName = activeTmsProviderQuery.data
-    ? getTmsProviderBranding(activeTmsProviderQuery.data.providerKind).name
-    : "TMS";
-  const hasTmsPrimaryWorkflow = hasTmsConnection && tmsProjects.length > 0;
   const showTmsSection =
     (hasTmsConnection || isTmsProjectsLoading) &&
     (sourceFilter === "all" || sourceFilter === "tms");
   const showNativeSection = sourceFilter === "all" || sourceFilter === "native";
+  const hasFilteredResults =
+    (showNativeSection && filteredNativeProjects.length > 0) ||
+    (showTmsSection && filteredTmsProjects.length > 0);
+  const tmsProviderName = activeTmsProviderQuery.data
+    ? getTmsProviderBranding(activeTmsProviderQuery.data.providerKind).name
+    : "TMS";
+  const hasTmsPrimaryWorkflow = hasTmsConnection && tmsProjects.length > 0;
   const compactNativeEmpty = hasTmsPrimaryWorkflow && nativeProjects.length === 0;
 
   function openCreateProjectDialog() {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
@@ -302,7 +302,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
 
   const pageDescription = hasTmsConnection
     ? `Browse live ${tmsProviderName} projects and manage Hyperlocalise workspace projects.`
-    : "Browse Hyperlocalise projects and live TMS projects from your connected provider.";
+    : "Browse Hyperlocalise projects. Connect a TMS provider to view live provider projects alongside them.";
 
   const createProjectAction =
     hasTmsPrimaryWorkflow && nativeProjects.length === 0 ? (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Add01Icon, FolderKanbanIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { TypographyP } from "@/components/ui/typography";
 import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
@@ -31,9 +32,12 @@ import {
 import { ProjectDialog } from "./project-dialog";
 import { mapProjectToListRow, type ProjectListRow } from "./project-list";
 import { ProjectsTable } from "./projects-table";
+import { recordRecentProject, resolveRecentProjects } from "./recent-projects";
 
 const nativeProjectsQueryKey = (organizationSlug: string) =>
   ["translation-projects", organizationSlug, "native"] as const;
+
+type ProjectSourceFilter = "all" | "tms" | "native";
 
 function useProjectSearch(projects: ProjectListRow[]) {
   const [searchQuery, setSearchQuery] = useState("");
@@ -65,11 +69,55 @@ function ProjectsSectionHeader({ title, description }: { title: string; descript
   );
 }
 
+function RecentProjectsStrip({
+  organizationSlug,
+  projects,
+  onOpenProject,
+}: {
+  organizationSlug: string;
+  projects: Array<{ id: string; name: string }>;
+  onOpenProject: (projectId: string) => void;
+}) {
+  if (projects.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-3">
+      <TypographyP className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">
+        Recently opened
+      </TypographyP>
+      <div className="flex flex-wrap gap-2">
+        {projects.map((project) => (
+          <Button
+            key={project.id}
+            nativeButton={false}
+            render={
+              <Link
+                href={`/org/${organizationSlug}/projects/${project.id}`}
+                onClick={() => onOpenProject(project.id)}
+              />
+            }
+            variant="outline"
+            size="sm"
+            className="max-w-full"
+          >
+            <span className="truncate">{project.name}</span>
+          </Button>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 export function ProjectsPageContent({ organizationSlug }: { organizationSlug: string }) {
   const queryClient = useQueryClient();
   const [projectDialogMode, setProjectDialogMode] = useState<"create" | "edit" | null>(null);
   const [editingProject, setEditingProject] = useState<ProjectListRow | null>(null);
   const [deleteProject, setDeleteProject] = useState<ProjectListRow | null>(null);
+  const [sourceFilter, setSourceFilter] = useState<ProjectSourceFilter>("all");
+  const [recentProjects, setRecentProjects] = useState<Array<{ id: string; name: string }>>([]);
+
   const nativeProjectsQuery = useQuery({
     queryKey: nativeProjectsQueryKey(organizationSlug),
     queryFn: async () => {
@@ -165,6 +213,10 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
 
   const nativeProjects = nativeProjectsQuery.data ?? [];
   const tmsProjects = tmsProjectsQuery.data ?? [];
+  const allProjects = useMemo(
+    () => [...tmsProjects, ...nativeProjects],
+    [nativeProjects, tmsProjects],
+  );
   const {
     searchQuery,
     setSearchQuery,
@@ -180,6 +232,18 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
       return matchesName || matchesId;
     });
   }, [searchQuery, tmsProjects]);
+
+  const handleOpenProject = useCallback(
+    (projectId: string) => {
+      recordRecentProject(organizationSlug, projectId);
+      setRecentProjects(resolveRecentProjects(organizationSlug, allProjects));
+    },
+    [allProjects, organizationSlug],
+  );
+
+  useEffect(() => {
+    setRecentProjects(resolveRecentProjects(organizationSlug, allProjects));
+  }, [allProjects, organizationSlug]);
 
   const isSavingProject = createProject.isPending || updateProject.isPending;
   const projectDialogTitle = projectDialogMode === "edit" ? "Edit project" : "Create project";
@@ -201,6 +265,12 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
   const tmsProviderName = activeTmsProviderQuery.data
     ? getTmsProviderBranding(activeTmsProviderQuery.data.providerKind).name
     : "TMS";
+  const hasTmsPrimaryWorkflow = hasTmsConnection && tmsProjects.length > 0;
+  const showTmsSection =
+    (hasTmsConnection || isTmsProjectsLoading) &&
+    (sourceFilter === "all" || sourceFilter === "tms");
+  const showNativeSection = sourceFilter === "all" || sourceFilter === "native";
+  const compactNativeEmpty = hasTmsPrimaryWorkflow && nativeProjects.length === 0;
 
   function openCreateProjectDialog() {
     setEditingProject(null);
@@ -230,17 +300,93 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
     createProject.mutate(values);
   }
 
-  const createProjectAction = (
-    <Button
-      type="button"
-      onClick={openCreateProjectDialog}
-      className="w-full sm:w-fit"
-      disabled={isSavingProject}
-    >
-      <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
-      Create project
-    </Button>
-  );
+  const pageDescription = hasTmsConnection
+    ? `Browse live ${tmsProviderName} projects and manage Hyperlocalise workspace projects.`
+    : "Browse Hyperlocalise projects and live TMS projects from your connected provider.";
+
+  const createProjectAction =
+    hasTmsPrimaryWorkflow && nativeProjects.length === 0 ? (
+      <Button
+        type="button"
+        onClick={openCreateProjectDialog}
+        variant="outline"
+        className="w-full sm:w-fit"
+        disabled={isSavingProject}
+      >
+        <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
+        Create native project
+      </Button>
+    ) : (
+      <Button
+        type="button"
+        onClick={openCreateProjectDialog}
+        className="w-full sm:w-fit"
+        disabled={isSavingProject}
+      >
+        <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
+        Create project
+      </Button>
+    );
+
+  const tmsSection = showTmsSection ? (
+    <section className="space-y-4">
+      <ProjectsSectionHeader
+        title={`${tmsProviderName} projects`}
+        description="Live projects fetched from your connected TMS provider, ordered by recent activity."
+      />
+      <ProjectsTable
+        projects={filteredTmsProjects}
+        projectsQuery={tmsProjectsQuery}
+        isSavingProject={isSavingProject}
+        isDeletingProject={deleteProjectMutation.isPending}
+        organizationSlug={organizationSlug}
+        variant="tms"
+        onOpenProject={handleOpenProject}
+      />
+    </section>
+  ) : null;
+
+  const nativeSection = showNativeSection ? (
+    <section className="space-y-4">
+      <ProjectsSectionHeader
+        title="Hyperlocalise projects"
+        description="Projects created and managed in this workspace."
+      />
+      <ProjectsTable
+        projects={filteredNativeProjects}
+        projectsQuery={nativeProjectsQuery}
+        isSavingProject={isSavingProject}
+        isDeletingProject={deleteProjectMutation.isPending}
+        organizationSlug={organizationSlug}
+        variant="native"
+        compactEmptyNative={compactNativeEmpty}
+        onEditProject={openEditProjectDialog}
+        onDeleteProject={setDeleteProject}
+        onCreateProject={openCreateProjectDialog}
+        onOpenProject={handleOpenProject}
+      />
+    </section>
+  ) : null;
+
+  const connectTmsSection =
+    !hasTmsConnection && !isTmsProjectsLoading && activeTmsProviderQuery.isSuccess ? (
+      <section className="space-y-4">
+        <ProjectsSectionHeader
+          title="TMS projects"
+          description="Connect a TMS provider to browse live provider projects here."
+        />
+        <div className="max-w-xl py-4">
+          <Button
+            nativeButton={false}
+            render={<Link href={`/org/${organizationSlug}/integrations`} />}
+            variant="outline"
+            size="sm"
+          >
+            Connect a provider
+          </Button>
+        </div>
+      </section>
+    ) : null;
 
   return (
     <WorkspacePageShell>
@@ -248,21 +394,41 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
         icon={FolderKanbanIcon}
         label="Workspace"
         title="Projects"
-        description="Browse Hyperlocalise projects and live TMS projects from your connected provider."
+        description={pageDescription}
         actions={createProjectAction}
       />
 
       {hasAnyProjects ? (
-        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:gap-2">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
           <WorkspaceFilterField label="Search" className="w-full sm:max-w-xs">
             <Input
-              placeholder="Name or ID..."
+              placeholder="Search by name..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               className="w-full"
             />
           </WorkspaceFilterField>
+          {hasTmsConnection ? (
+            <Tabs
+              value={sourceFilter}
+              onValueChange={(value) => setSourceFilter(value as ProjectSourceFilter)}
+            >
+              <TabsList>
+                <TabsTrigger value="all">All</TabsTrigger>
+                <TabsTrigger value="tms">{tmsProviderName}</TabsTrigger>
+                <TabsTrigger value="native">Hyperlocalise</TabsTrigger>
+              </TabsList>
+            </Tabs>
+          ) : null}
         </div>
+      ) : null}
+
+      {hasAnyProjects ? (
+        <RecentProjectsStrip
+          organizationSlug={organizationSlug}
+          projects={recentProjects}
+          onOpenProject={handleOpenProject}
+        />
       ) : null}
 
       {hasAnyProjects && !hasFilteredResults ? (
@@ -279,56 +445,17 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
       ) : null}
 
       <div className="space-y-10">
-        <section className="space-y-4">
-          <ProjectsSectionHeader
-            title="Hyperlocalise projects"
-            description="Projects created and managed in this workspace."
-          />
-          <ProjectsTable
-            projects={filteredNativeProjects}
-            projectsQuery={nativeProjectsQuery}
-            isSavingProject={isSavingProject}
-            isDeletingProject={deleteProjectMutation.isPending}
-            organizationSlug={organizationSlug}
-            variant="native"
-            onEditProject={openEditProjectDialog}
-            onDeleteProject={setDeleteProject}
-          />
-        </section>
-
-        {hasTmsConnection || isTmsProjectsLoading ? (
-          <section className="space-y-4">
-            <ProjectsSectionHeader
-              title={`${tmsProviderName} projects`}
-              description="Live projects fetched from your connected TMS provider."
-            />
-            <ProjectsTable
-              projects={filteredTmsProjects}
-              projectsQuery={tmsProjectsQuery}
-              isSavingProject={isSavingProject}
-              isDeletingProject={deleteProjectMutation.isPending}
-              organizationSlug={organizationSlug}
-              variant="tms"
-            />
-          </section>
-        ) : activeTmsProviderQuery.isSuccess ? (
-          <section className="space-y-4">
-            <ProjectsSectionHeader
-              title="TMS projects"
-              description="Connect a TMS provider to browse live provider projects here."
-            />
-            <div className="max-w-xl py-4">
-              <Button
-                nativeButton={false}
-                render={<Link href={`/org/${organizationSlug}/integrations`} />}
-                variant="outline"
-                size="sm"
-              >
-                Connect a provider
-              </Button>
-            </div>
-          </section>
-        ) : null}
+        {hasTmsConnection ? (
+          <>
+            {tmsSection}
+            {nativeSection}
+          </>
+        ) : (
+          <>
+            {nativeSection}
+            {connectTmsSection}
+          </>
+        )}
       </div>
 
       <ProjectDialog

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
@@ -1,61 +1,264 @@
 import Link from "next/link";
 import {
+  ArrowRight01Icon,
+  ArrowUpRight01Icon,
   Delete02Icon,
   Edit02Icon,
-  ArrowRight01Icon,
-  TranslationIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { UseQueryResult } from "@tanstack/react-query";
 
 import { TmsUserConnectionErrorPanel } from "@/components/app-shell/tms-user-connection-prompt";
-import { isTmsUserConnectionRequiredError } from "@/lib/providers/tms-user-connection-shared";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-
-import type { ProjectListRow } from "./project-list";
 import { TypographyH3, TypographyP } from "@/components/ui/typography";
+import { cn } from "@/lib/primitives/cn";
+import { getTmsProviderBranding } from "@/lib/providers/tms-provider-branding";
+import { isTmsUserConnectionRequiredError } from "@/lib/providers/tms-user-connection-shared";
 
-function ProviderBadge({
-  externalProviderKind,
+import { formatRelativeTimestamp } from "../../_components/workspace-files-shared";
+import { ProjectAvatar } from "./project-avatar";
+import { formatProjectLocaleRoute, type ProjectListRow } from "./project-list";
+
+function NativeEmptyState({
+  compact,
+  onCreateProject,
 }: {
-  externalProviderKind: ProjectListRow["externalProviderKind"];
+  compact: boolean;
+  onCreateProject?: () => void;
 }) {
-  if (!externalProviderKind) return null;
-
-  const labels: Record<string, string> = {
-    crowdin: "Crowdin",
-    smartling: "Smartling",
-    phrase: "Phrase",
-    lokalise: "Lokalise",
-  };
+  if (compact) {
+    return (
+      <TypographyP className="text-sm leading-6 text-muted-foreground">
+        No Hyperlocalise projects yet.{" "}
+        {onCreateProject ? (
+          <button
+            type="button"
+            onClick={onCreateProject}
+            className="text-subtle-foreground underline hover:text-foreground"
+          >
+            Create one
+          </button>
+        ) : (
+          "Create one"
+        )}{" "}
+        to add translation context and job tracking.
+      </TypographyP>
+    );
+  }
 
   return (
-    <Badge variant="secondary" className="text-[10px]">
-      {labels[externalProviderKind] ?? externalProviderKind}
-    </Badge>
+    <div className="max-w-xl space-y-3 py-6">
+      <TypographyP className="text-sm font-medium text-foreground">
+        Create your first localization project
+      </TypographyP>
+      <TypographyP className="text-sm leading-6 text-muted-foreground">
+        Track source content, release ownership, and translation context before work moves into
+        translation jobs.
+      </TypographyP>
+    </div>
   );
 }
 
-function LocaleSummary({ project }: { project: ProjectListRow }) {
-  if (project.source === "native") return null;
-
-  const parts: string[] = [];
-  if (project.sourceLocale) {
-    parts.push(project.sourceLocale);
-  }
-  if (project.targetLocales.length > 0) {
-    parts.push(`${project.targetLocales.length} target`);
-  }
-
-  if (parts.length === 0) return null;
+function TmsProjectRow({
+  project,
+  organizationSlug,
+  onOpenProject,
+}: {
+  project: ProjectListRow;
+  organizationSlug: string;
+  onOpenProject?: (projectId: string) => void;
+}) {
+  const providerName = getTmsProviderBranding(project.externalProviderKind).name;
+  const localeRoute = formatProjectLocaleRoute(project.sourceLocale, project.targetLocales);
+  const activityLabel = project.lastActivityAt
+    ? formatRelativeTimestamp(project.lastActivityAt)
+    : null;
+  const metaParts = [
+    providerName,
+    localeRoute,
+    activityLabel ? `Active ${activityLabel}` : null,
+  ].filter(Boolean);
 
   return (
-    <div className="flex items-center gap-1 text-xs text-muted-foreground">
-      <HugeiconsIcon icon={TranslationIcon} strokeWidth={1.8} className="size-3.5" />
-      <span>{parts.join(" → ")}</span>
-    </div>
+    <article className="group min-w-0">
+      <div className="flex items-center gap-3 rounded-lg border border-border bg-muted px-3 py-3 transition-colors hover:border-beam-500/30 hover:bg-beam-500/5">
+        <ProjectAvatar project={project} compact />
+        <Link
+          href={`/org/${organizationSlug}/projects/${project.id}`}
+          onClick={() => onOpenProject?.(project.id)}
+          className="min-w-0 flex-1"
+        >
+          <div className="flex min-w-0 items-center gap-2">
+            <TypographyH3 className="min-w-0 truncate text-sm font-medium text-foreground">
+              {project.name}
+            </TypographyH3>
+            {!project.isActive ? (
+              <Badge variant="outline" className="text-[10px]">
+                Inactive
+              </Badge>
+            ) : null}
+          </div>
+          <TypographyP className="mt-1 truncate text-xs text-muted-foreground">
+            {metaParts.join(" · ")}
+          </TypographyP>
+          {project.descriptionValue ? (
+            <TypographyP className="mt-1 line-clamp-1 text-xs text-muted-foreground">
+              {project.descriptionValue}
+            </TypographyP>
+          ) : null}
+        </Link>
+
+        <div className="flex shrink-0 items-center gap-1">
+          {project.externalProjectUrl ? (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    type="button"
+                    size="icon-sm"
+                    variant="ghost"
+                    render={
+                      <a
+                        href={project.externalProjectUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      />
+                    }
+                    className="text-muted-foreground hover:text-foreground"
+                  >
+                    <HugeiconsIcon icon={ArrowUpRight01Icon} strokeWidth={1.8} />
+                    <span className="sr-only">Open {project.name} in provider</span>
+                  </Button>
+                }
+              />
+              <TooltipContent side="bottom" align="center">
+                Open in {providerName}
+              </TooltipContent>
+            </Tooltip>
+          ) : null}
+          <HugeiconsIcon
+            icon={ArrowRight01Icon}
+            strokeWidth={1.8}
+            className="size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground"
+          />
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function NativeProjectCard({
+  project,
+  organizationSlug,
+  isSavingProject,
+  isDeletingProject,
+  onEditProject,
+  onDeleteProject,
+  onOpenProject,
+}: {
+  project: ProjectListRow;
+  organizationSlug: string;
+  isSavingProject: boolean;
+  isDeletingProject: boolean;
+  onEditProject: (project: ProjectListRow) => void;
+  onDeleteProject: (project: ProjectListRow) => void;
+  onOpenProject?: (projectId: string) => void;
+}) {
+  return (
+    <article className="group min-w-0 rounded-lg border border-border bg-muted p-4 transition-colors hover:border-beam-500/30 hover:bg-beam-500/5">
+      <div className="flex items-start justify-between gap-4">
+        <Link
+          href={`/org/${organizationSlug}/projects/${project.id}`}
+          onClick={() => onOpenProject?.(project.id)}
+          className="min-w-0 flex flex-1 items-start gap-3"
+        >
+          <ProjectAvatar project={project} />
+          <div className="min-w-0 flex-1">
+            <TypographyH3 className="min-w-0 truncate text-base font-medium text-foreground">
+              {project.name}
+            </TypographyH3>
+            <TypographyP className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+              {project.descriptionValue || "No description yet"}
+            </TypographyP>
+          </div>
+        </Link>
+
+        <div className="flex shrink-0 items-center gap-1">
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  size="icon-sm"
+                  variant="ghost"
+                  onClick={() => onEditProject(project)}
+                  disabled={isSavingProject}
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  <HugeiconsIcon icon={Edit02Icon} strokeWidth={1.8} />
+                  <span className="sr-only">Edit {project.name}</span>
+                </Button>
+              }
+            />
+            <TooltipContent side="bottom" align="center">
+              Edit project
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  size="icon-sm"
+                  variant="ghost"
+                  onClick={() => onDeleteProject(project)}
+                  disabled={isDeletingProject || isSavingProject}
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
+                  <span className="sr-only">Delete {project.name}</span>
+                </Button>
+              }
+            />
+            <TooltipContent side="bottom" align="center">
+              Delete project
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+
+      <dl className="mt-5 grid gap-3 border-t border-border pt-4 sm:grid-cols-2">
+        <div className="min-w-0">
+          <dt className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">
+            Open jobs
+          </dt>
+          <dd className="mt-1 truncate text-sm text-muted-foreground">
+            {project.openJobCount > 0 ? (
+              <Link
+                href={`/org/${organizationSlug}/projects/${project.id}/jobs`}
+                className="text-subtle-foreground hover:text-foreground hover:underline"
+              >
+                {project.openJobCount} {project.openJobCount === 1 ? "job" : "jobs"}
+              </Link>
+            ) : (
+              <span>None</span>
+            )}
+          </dd>
+        </div>
+        <div className="min-w-0">
+          <dt className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">
+            Updated
+          </dt>
+          <dd className="mt-1 truncate text-sm text-muted-foreground">
+            {project.lastActivityAt
+              ? formatRelativeTimestamp(project.lastActivityAt)
+              : project.updated}
+          </dd>
+        </div>
+      </dl>
+    </article>
   );
 }
 
@@ -66,8 +269,11 @@ export function ProjectsTable({
   isDeletingProject,
   organizationSlug,
   variant,
+  compactEmptyNative = false,
   onEditProject,
   onDeleteProject,
+  onCreateProject,
+  onOpenProject,
 }: {
   projects: ProjectListRow[];
   projectsQuery: UseQueryResult<ProjectListRow[], Error>;
@@ -75,12 +281,12 @@ export function ProjectsTable({
   isDeletingProject: boolean;
   organizationSlug: string;
   variant: "native" | "tms";
+  compactEmptyNative?: boolean;
   onEditProject?: (project: ProjectListRow) => void;
   onDeleteProject?: (project: ProjectListRow) => void;
+  onCreateProject?: () => void;
+  onOpenProject?: (projectId: string) => void;
 }) {
-  const emptyNativeTitle = "Create your first localization project";
-  const emptyNativeDescription =
-    "Track source content, release ownership, and translation context before work moves into translation jobs.";
   const emptyTmsTitle = "No TMS projects found";
   const emptyTmsDescription =
     "Your provider connection is active, but no projects were returned from the live API.";
@@ -88,12 +294,12 @@ export function ProjectsTable({
   return (
     <section>
       {projectsQuery.isLoading ? (
-        <div className="border-t border-border px-1 py-8 text-sm text-muted-foreground">
+        <div className={cn("text-sm text-muted-foreground", variant === "tms" ? "py-4" : "py-8")}>
           Loading projects...
         </div>
       ) : null}
       {projectsQuery.isError ? (
-        <div className="border-t border-border px-1 py-8">
+        <div className={cn(variant === "tms" ? "py-4" : "py-8")}>
           {variant === "tms" && isTmsUserConnectionRequiredError(projectsQuery.error) ? (
             <TmsUserConnectionErrorPanel
               organizationSlug={organizationSlug}
@@ -115,146 +321,48 @@ export function ProjectsTable({
         </div>
       ) : null}
       {projectsQuery.isSuccess && projects.length === 0 ? (
-        <div className="max-w-xl space-y-3 py-6">
-          <TypographyP className="text-sm font-medium text-foreground">
-            {variant === "native" ? emptyNativeTitle : emptyTmsTitle}
-          </TypographyP>
-          <TypographyP className="text-sm leading-6 text-muted-foreground">
-            {variant === "native" ? emptyNativeDescription : emptyTmsDescription}
-          </TypographyP>
+        variant === "native" ? (
+          <NativeEmptyState compact={compactEmptyNative} onCreateProject={onCreateProject} />
+        ) : (
+          <div className="max-w-xl space-y-3 py-4">
+            <TypographyP className="text-sm font-medium text-foreground">
+              {emptyTmsTitle}
+            </TypographyP>
+            <TypographyP className="text-sm leading-6 text-muted-foreground">
+              {emptyTmsDescription}
+            </TypographyP>
+          </div>
+        )
+      ) : null}
+      {projectsQuery.isSuccess && projects.length > 0 && variant === "tms" ? (
+        <div className="grid gap-2">
+          {projects.map((project) => (
+            <TmsProjectRow
+              key={project.id}
+              project={project}
+              organizationSlug={organizationSlug}
+              onOpenProject={onOpenProject}
+            />
+          ))}
         </div>
       ) : null}
-      {projectsQuery.isSuccess && projects.length > 0 ? (
+      {projectsQuery.isSuccess &&
+      projects.length > 0 &&
+      variant === "native" &&
+      onEditProject &&
+      onDeleteProject ? (
         <div className="grid gap-3 lg:grid-cols-2">
           {projects.map((project) => (
-            <article
+            <NativeProjectCard
               key={project.id}
-              className="group min-w-0 rounded-lg border border-border bg-muted p-4 transition-colors hover:border-border hover:bg-muted"
-            >
-              <div className="flex items-start justify-between gap-4">
-                <Link
-                  href={`/org/${organizationSlug}/projects/${project.id}`}
-                  className="min-w-0 flex-1"
-                >
-                  <div className="flex items-center gap-2">
-                    <TypographyH3 className="min-w-0 truncate text-base font-medium text-foreground md:text-base group-hover:text-foreground">
-                      {project.name}
-                    </TypographyH3>
-                    <ProviderBadge externalProviderKind={project.externalProviderKind} />
-                    {variant === "tms" && !project.isActive ? (
-                      <Badge variant="outline" className="text-[10px]">
-                        Inactive
-                      </Badge>
-                    ) : null}
-                  </div>
-                  <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1">
-                    <TypographyP className="truncate text-xs text-muted-foreground">
-                      {project.id}
-                    </TypographyP>
-                    <LocaleSummary project={project} />
-                  </div>
-                </Link>
-
-                <div className="flex shrink-0 items-center gap-1">
-                  {variant === "native" && onEditProject && onDeleteProject ? (
-                    <>
-                      <Tooltip>
-                        <TooltipTrigger
-                          render={
-                            <Button
-                              type="button"
-                              size="icon-sm"
-                              variant="ghost"
-                              onClick={() => {
-                                onEditProject(project);
-                              }}
-                              disabled={isSavingProject}
-                              className="text-muted-foreground hover:text-foreground"
-                            >
-                              <HugeiconsIcon icon={Edit02Icon} strokeWidth={1.8} />
-                              <span className="sr-only">Edit {project.name}</span>
-                            </Button>
-                          }
-                        />
-                        <TooltipContent side="bottom" align="center">
-                          Edit project
-                        </TooltipContent>
-                      </Tooltip>
-                      <Tooltip>
-                        <TooltipTrigger
-                          render={
-                            <Button
-                              type="button"
-                              size="icon-sm"
-                              variant="ghost"
-                              onClick={() => {
-                                onDeleteProject(project);
-                              }}
-                              disabled={isDeletingProject || isSavingProject}
-                              className="text-muted-foreground hover:text-foreground"
-                            >
-                              <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
-                              <span className="sr-only">Delete {project.name}</span>
-                            </Button>
-                          }
-                        />
-                        <TooltipContent side="bottom" align="center">
-                          Delete project
-                        </TooltipContent>
-                      </Tooltip>
-                    </>
-                  ) : project.externalProjectUrl ? (
-                    <Tooltip>
-                      <TooltipTrigger
-                        render={
-                          <Button
-                            type="button"
-                            size="icon-sm"
-                            variant="ghost"
-                            render={
-                              <a
-                                href={project.externalProjectUrl}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                              />
-                            }
-                            className="text-muted-foreground hover:text-foreground"
-                          >
-                            <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={1.8} />
-                            <span className="sr-only">Open {project.name} in provider</span>
-                          </Button>
-                        }
-                      />
-                      <TooltipContent side="bottom" align="center">
-                        Open in provider
-                      </TooltipContent>
-                    </Tooltip>
-                  ) : null}
-                </div>
-              </div>
-
-              {variant === "native" ? (
-                <dl className="mt-6 grid gap-3 border-t border-border pt-4 sm:grid-cols-2">
-                  <div className="min-w-0">
-                    <dt className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">
-                      Open jobs
-                    </dt>
-                    <dd className="mt-1 truncate text-sm text-muted-foreground">
-                      {project.openJobCount > 0 ? (
-                        <Link
-                          href={`/org/${organizationSlug}/projects/${project.id}/jobs`}
-                          className="text-subtle-foreground hover:text-foreground hover:underline"
-                        >
-                          {project.openJobCount} {project.openJobCount === 1 ? "job" : "jobs"}
-                        </Link>
-                      ) : (
-                        <span>None</span>
-                      )}
-                    </dd>
-                  </div>
-                </dl>
-              ) : null}
-            </article>
+              project={project}
+              organizationSlug={organizationSlug}
+              isSavingProject={isSavingProject}
+              isDeletingProject={isDeletingProject}
+              onEditProject={onEditProject}
+              onDeleteProject={onDeleteProject}
+              onOpenProject={onOpenProject}
+            />
           ))}
         </div>
       ) : null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/recent-projects.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/recent-projects.test.ts
@@ -62,4 +62,18 @@ describe("recent-projects", () => {
       { id: "project_a", name: "Alpha" },
     ]);
   });
+
+  it("applies the limit after ignoring visits for unavailable projects", () => {
+    const storage = createStorage();
+
+    recordRecentProjectVisit("acme", "project_a", { storage, visitedAt: 10 });
+    recordRecentProjectVisit("acme", "deleted_project", { storage, visitedAt: 20 });
+
+    expect(
+      resolveRecentProjects("acme", [{ id: "project_a", name: "Alpha" }], {
+        storage,
+        limit: 1,
+      }),
+    ).toEqual([{ id: "project_a", name: "Alpha" }]);
+  });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/recent-projects.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/recent-projects.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  readRecentProjectIds,
+  recordRecentProject,
+  resolveRecentProjects,
+} from "./recent-projects";
+
+describe("recent-projects", () => {
+  const storage = new Map<string, string>();
+
+  beforeEach(() => {
+    storage.clear();
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storage.set(key, value);
+      },
+      removeItem: (key: string) => {
+        storage.delete(key);
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("records and resolves recent projects in recency order", () => {
+    recordRecentProject("acme", "project_b");
+    recordRecentProject("acme", "project_a");
+    recordRecentProject("acme", "project_c");
+
+    expect(readRecentProjectIds("acme")).toEqual(["project_c", "project_a", "project_b"]);
+    expect(
+      resolveRecentProjects("acme", [
+        { id: "project_a", name: "Alpha" },
+        { id: "project_c", name: "Charlie" },
+      ]),
+    ).toEqual([
+      { id: "project_c", name: "Charlie" },
+      { id: "project_a", name: "Alpha" },
+    ]);
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/recent-projects.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/recent-projects.ts
@@ -105,7 +105,7 @@ export function resolveRecentProjects(
   const limit = options?.limit ?? 5;
 
   return readRecentProjectVisits(organizationSlug, options?.storage)
-    .slice(0, limit)
     .map((visit) => projectsById.get(visit.projectId))
-    .filter((project): project is { id: string; name: string } => project !== undefined);
+    .filter((project): project is { id: string; name: string } => project !== undefined)
+    .slice(0, limit);
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/recent-projects.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/recent-projects.ts
@@ -1,0 +1,65 @@
+const RECENT_PROJECTS_STORAGE_VERSION = "v1";
+const MAX_RECENT_PROJECTS = 5;
+
+function storageKey(organizationSlug: string) {
+  return `recent-projects:${RECENT_PROJECTS_STORAGE_VERSION}:${organizationSlug}`;
+}
+
+function getBrowserStorage(): Storage | null {
+  if (typeof globalThis.localStorage === "undefined") {
+    return null;
+  }
+
+  return globalThis.localStorage;
+}
+
+export function readRecentProjectIds(organizationSlug: string): string[] {
+  const storage = getBrowserStorage();
+  if (!storage) {
+    return [];
+  }
+
+  try {
+    const raw = storage.getItem(storageKey(organizationSlug));
+    if (!raw) {
+      return [];
+    }
+
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed
+      .filter((value): value is string => typeof value === "string")
+      .slice(0, MAX_RECENT_PROJECTS);
+  } catch {
+    return [];
+  }
+}
+
+export function recordRecentProject(organizationSlug: string, projectId: string) {
+  const storage = getBrowserStorage();
+  if (!storage || !projectId.trim()) {
+    return;
+  }
+
+  try {
+    const existing = readRecentProjectIds(organizationSlug).filter((id) => id !== projectId);
+    const next = [projectId, ...existing].slice(0, MAX_RECENT_PROJECTS);
+    storage.setItem(storageKey(organizationSlug), JSON.stringify(next));
+  } catch {
+    // Ignore quota, private browsing, or disabled storage.
+  }
+}
+
+export function resolveRecentProjects(
+  organizationSlug: string,
+  projects: readonly { id: string; name: string }[],
+) {
+  const projectsById = new Map(projects.map((project) => [project.id, project]));
+
+  return readRecentProjectIds(organizationSlug)
+    .map((id) => projectsById.get(id))
+    .filter((project): project is { id: string; name: string } => project !== undefined);
+}

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -197,7 +197,7 @@ describe("CrowdinApiClient", () => {
     await client.listProjects();
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.crowdin.com/api/v2/projects?limit=500&offset=0",
+      "https://api.crowdin.com/api/v2/projects?limit=500&offset=0&orderBy=lastActivity%20desc",
       expect.anything(),
     );
   });
@@ -215,7 +215,7 @@ describe("CrowdinApiClient", () => {
     await client.listProjects();
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://enterprise.crowdin.com/api/v2/projects?limit=500&offset=0",
+      "https://enterprise.crowdin.com/api/v2/projects?limit=500&offset=0&orderBy=lastActivity%20desc",
       expect.anything(),
     );
   });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -15,6 +15,7 @@ const logger = createLogger("crowdin-api");
 
 export const CROWDIN_LIVE_TASK_LIST_LIMIT = 50;
 export const CROWDIN_LIVE_TASK_LIST_ORDER_BY = "createdAt desc";
+export const CROWDIN_PROJECT_LIST_ORDER_BY = "lastActivity desc";
 export const CROWDIN_SYNC_TASK_PAGE_LIMIT = 500;
 
 export type ListCrowdinTasksOptions = {
@@ -38,10 +39,13 @@ export interface CrowdinProject {
   id: number;
   name: string;
   identifier: string;
+  description?: string;
   sourceLanguageId: string;
   targetLanguageIds: string[];
   webUrl: string;
   isSuspended: boolean;
+  logo?: string;
+  lastActivity?: string;
 }
 
 export interface CrowdinBranch {
@@ -469,10 +473,11 @@ export class CrowdinApiClient {
     const projects: CrowdinProject[] = [];
     let offset = 0;
     const limit = 500;
+    const orderBy = encodeURIComponent(CROWDIN_PROJECT_LIST_ORDER_BY);
 
     while (true) {
       const response = await this.get<CrowdinListResponse<CrowdinProject>>(
-        `/projects?limit=${limit}&offset=${offset}`,
+        `/projects?limit=${limit}&offset=${offset}&orderBy=${orderBy}`,
       );
 
       const page = response.data.map((item) => item.data);

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-project-fetcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-project-fetcher.test.ts
@@ -58,10 +58,13 @@ describe("fetchCrowdinProjects", () => {
       {
         externalProjectId: "42",
         name: "Marketing",
+        description: null,
         sourceLocale: "en",
         targetLocales: ["fr"],
         externalProjectUrl: "https://crowdin.com/project/marketing",
         isActive: true,
+        logoUrl: null,
+        lastActivityAt: null,
         metadata: {
           identifier: "marketing",
         },

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-project-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-project-fetcher.ts
@@ -1,15 +1,19 @@
 import type { ExternalTmsProjectFetcher } from "@/lib/providers/tms-provider-types";
 
 import { CrowdinApiClient, CrowdinApiError, type CrowdinProject } from "./crowdin-api";
+import { sanitizeCrowdinProjectLogo } from "./crowdin-project-logo";
 
 export function mapCrowdinProjectToMetadata(project: CrowdinProject) {
   return {
     externalProjectId: String(project.id),
     name: project.name,
+    description: project.description?.trim() || null,
     sourceLocale: project.sourceLanguageId,
     targetLocales: project.targetLanguageIds,
     externalProjectUrl: project.webUrl,
     isActive: !project.isSuspended,
+    logoUrl: sanitizeCrowdinProjectLogo(project.logo),
+    lastActivityAt: project.lastActivity?.trim() || null,
     metadata: {
       identifier: project.identifier,
     },

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-project-logo.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-project-logo.test.ts
@@ -9,6 +9,10 @@ describe("sanitizeCrowdinProjectLogo", () => {
     );
   });
 
+  it("rejects data image URLs with whitespace in the base64 payload", () => {
+    expect(sanitizeCrowdinProjectLogo("data:image/png;base64,abc 123")).toBeNull();
+  });
+
   it("accepts https logo URLs", () => {
     expect(sanitizeCrowdinProjectLogo("https://crowdin.com/logo.png")).toBe(
       "https://crowdin.com/logo.png",

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-project-logo.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-project-logo.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { sanitizeCrowdinProjectLogo } from "./crowdin-project-logo";
+
+describe("sanitizeCrowdinProjectLogo", () => {
+  it("accepts safe data image URLs", () => {
+    expect(sanitizeCrowdinProjectLogo("data:image/png;base64,abc123+/=")).toBe(
+      "data:image/png;base64,abc123+/=",
+    );
+  });
+
+  it("accepts https logo URLs", () => {
+    expect(sanitizeCrowdinProjectLogo("https://crowdin.com/logo.png")).toBe(
+      "https://crowdin.com/logo.png",
+    );
+  });
+
+  it("rejects unsafe protocols", () => {
+    expect(sanitizeCrowdinProjectLogo("javascript:alert(1)")).toBeNull();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-project-logo.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-project-logo.ts
@@ -1,6 +1,6 @@
 import { sanitizeExternalUrl } from "@/lib/security/safe-external-url";
 
-const SAFE_DATA_IMAGE_PATTERN = /^data:image\/(png|jpeg|jpg|webp|gif);base64,[a-zA-Z0-9+/=\s]+$/i;
+const SAFE_DATA_IMAGE_PATTERN = /^data:image\/(png|jpeg|jpg|webp|gif);base64,[a-zA-Z0-9+/=]+$/i;
 
 export function sanitizeCrowdinProjectLogo(value: string | null | undefined): string | null {
   if (!value?.trim()) {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-project-logo.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-project-logo.ts
@@ -1,0 +1,16 @@
+import { sanitizeExternalUrl } from "@/lib/security/safe-external-url";
+
+const SAFE_DATA_IMAGE_PATTERN = /^data:image\/(png|jpeg|jpg|webp|gif);base64,[a-zA-Z0-9+/=\s]+$/i;
+
+export function sanitizeCrowdinProjectLogo(value: string | null | undefined): string | null {
+  if (!value?.trim()) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.startsWith("data:image/")) {
+    return SAFE_DATA_IMAGE_PATTERN.test(trimmed) ? trimmed : null;
+  }
+
+  return sanitizeExternalUrl(trimmed);
+}

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -25,6 +25,7 @@ import {
   type CrowdinSourceString,
   type CrowdinStringComment,
 } from "@/lib/providers/adapters/crowdin/crowdin-api";
+import { mapCrowdinProjectToMetadata } from "@/lib/providers/adapters/crowdin/crowdin-project-fetcher";
 import {
   fetchCrowdinUserJobTasks,
   mapCrowdinLanguageProgressToLocaleReadiness,
@@ -148,6 +149,8 @@ export type TmsProviderLiveProject = {
   targetLocales: string[];
   externalProjectUrl: string | null;
   isActive: boolean;
+  logoUrl?: string | null;
+  lastActivityAt?: string | null;
   metadata?: Record<string, unknown>;
 };
 
@@ -598,14 +601,16 @@ function mapLiveProject(
   const timestamp = new Date().toISOString();
   const sourceLocale = project.sourceLocale ?? "en";
   const targetLocales = project.targetLocales ?? [];
+  const lastActivityAt = normalizeExternalTimestamp(project.lastActivityAt);
+  const updatedAt = lastActivityAt ?? timestamp;
 
   return {
     id: encodeProviderProjectId({ providerKind, externalProjectId: project.externalProjectId }),
     name: project.name,
-    description: null,
+    description: project.description?.trim() || null,
     translationContext: null,
     createdAt: timestamp,
-    updatedAt: timestamp,
+    updatedAt,
     source: "external_tms",
     externalProviderKind: providerKind,
     externalProjectId: project.externalProjectId,
@@ -613,6 +618,8 @@ function mapLiveProject(
     targetLocales,
     externalProjectUrl: project.externalProjectUrl ?? null,
     isActive: project.isActive ?? true,
+    logoUrl: project.logoUrl ?? null,
+    lastActivityAt,
     metadata: project.metadata,
   };
 }
@@ -1576,17 +1583,7 @@ async function resolveLiveProjectMetadata(
 
     try {
       const project = await client.getProject(crowdinProjectId);
-      return {
-        externalProjectId: String(project.id),
-        name: project.name,
-        sourceLocale: project.sourceLanguageId,
-        targetLocales: project.targetLanguageIds,
-        externalProjectUrl: project.webUrl,
-        isActive: !project.isSuspended,
-        metadata: {
-          identifier: project.identifier,
-        },
-      };
+      return mapCrowdinProjectToMetadata(project);
     } catch (error) {
       if (error instanceof CrowdinApiError && error.status === 404) {
         return null;

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-types.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-types.ts
@@ -18,6 +18,9 @@ export type ExternalTmsProjectMetadata = {
   targetLocales?: string[];
   externalProjectUrl?: string | null;
   isActive?: boolean;
+  logoUrl?: string | null;
+  lastActivityAt?: string | null;
+  description?: string | null;
   metadata?: Record<string, unknown>;
 };
 


### PR DESCRIPTION
## What changed

This draft PR adds the foundational utilities for the projects page UX refresh:

- `ProjectAvatar` component for TMS/native project logos with provider badge overlay
- `recent-projects` helpers to persist and resolve recently opened projects per organization
- `sanitizeCrowdinProjectLogo` for safe Crowdin logo URLs (data URLs and https)

Follow-up commits will wire these into the projects page layout, Crowdin metadata mapping, and TMS sorting.

## How to test

- Run `vp test src/app/[lang]/\(authenticated\)/org/[organizationSlug]/projects/_components/recent-projects.test.ts`
- Run `vp test src/lib/providers/adapters/crowdin/crowdin-project-logo.test.ts`
- Verify `ProjectAvatar` renders initials fallback when `logoUrl` is absent

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)