### PR TITLE
fix(web): guard live TMS memory and glossary IDs from DB lookups

### DIFF
--- a/apps/hyperlocalise-web/src/api/auth/team-access.ts
+++ b/apps/hyperlocalise-web/src/api/auth/team-access.ts
@@ -4,6 +4,10 @@ import { hasCapability } from "@/api/auth/policy";
 import type { ApiAuthContext } from "@/api/auth/workos";
 import { db, schema } from "@/lib/database";
 import { providerAssignedUsersMatch } from "@/lib/providers/tms-provider-assignee-match";
+import {
+  isLiveProviderGlossaryId,
+  isLiveProviderMemoryId,
+} from "@/lib/providers/tms-provider-resource-id";
 import { backfillOrganizationProjectTeams } from "@/lib/teams/default-workspace-team";
 
 export function hasOrganizationWideProjectAccess(auth: ApiAuthContext) {
@@ -250,6 +254,10 @@ export async function canAccessInteraction(auth: ApiAuthContext, interactionId: 
 }
 
 export async function canAccessGlossary(auth: ApiAuthContext, glossaryId: string) {
+  if (isLiveProviderGlossaryId(glossaryId)) {
+    return null;
+  }
+
   if (hasOrganizationWideProjectAccess(auth)) {
     const [glossary] = await db
       .select({ id: schema.glossaries.id })
@@ -324,6 +332,10 @@ export async function canAccessStoredFile(
 }
 
 export async function canAccessMemory(auth: ApiAuthContext, memoryId: string) {
+  if (isLiveProviderMemoryId(memoryId)) {
+    return null;
+  }
+
   if (hasOrganizationWideProjectAccess(auth)) {
     const [memory] = await db
       .select({ id: schema.memories.id })

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.tsx
@@ -12,9 +12,9 @@ import { Separator } from "@/components/ui/separator";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { TypographyP } from "@/components/ui/typography";
 
+import { isLiveProviderGlossaryId } from "@/lib/providers/tms-provider-resource-id";
 import { ProviderKindBadge, SyncStateBadge } from "../../_components/workspace-files-shared";
 import { toneClass } from "../../_components/workspace-resource-shared";
-import { isLiveProviderGlossaryId } from "@/lib/providers/tms-provider-resource-id";
 import type { GlossaryListRow } from "./glossary-list";
 import { providerLabel } from "./glossary-list";
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.tsx
@@ -14,6 +14,7 @@ import { TypographyP } from "@/components/ui/typography";
 
 import { ProviderKindBadge, SyncStateBadge } from "../../_components/workspace-files-shared";
 import { toneClass } from "../../_components/workspace-resource-shared";
+import { isLiveProviderGlossaryId } from "@/lib/providers/tms-provider-resource-id";
 import type { GlossaryListRow } from "./glossary-list";
 import { providerLabel } from "./glossary-list";
 
@@ -110,12 +111,16 @@ function GlossaryRow({
             strokeWidth={1.7}
             className="size-4 shrink-0 text-muted-foreground"
           />
-          <Link
-            href={`/org/${organizationSlug}/glossaries/${glossary.id}`}
-            className="truncate text-sm font-medium text-foreground underline-offset-2 hover:underline"
-          >
-            {glossary.name}
-          </Link>
+          {isLiveProviderGlossaryId(glossary.id) ? (
+            <span className="truncate text-sm font-medium text-foreground">{glossary.name}</span>
+          ) : (
+            <Link
+              href={`/org/${organizationSlug}/glossaries/${glossary.id}`}
+              className="truncate text-sm font-medium text-foreground underline-offset-2 hover:underline"
+            >
+              {glossary.name}
+            </Link>
+          )}
           <SourceLabel glossary={glossary} />
           <ResourceTypeBadge glossary={glossary} />
         </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-table.tsx
@@ -12,9 +12,9 @@ import { Separator } from "@/components/ui/separator";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { TypographyP } from "@/components/ui/typography";
 
+import { isLiveProviderMemoryId } from "@/lib/providers/tms-provider-resource-id";
 import { ProviderKindBadge, SyncStateBadge } from "../../_components/workspace-files-shared";
 import { toneClass } from "../../_components/workspace-resource-shared";
-import { isLiveProviderMemoryId } from "@/lib/providers/tms-provider-resource-id";
 import type { MemoryListRow } from "./memory-list";
 import { providerLabel } from "./memory-list";
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-table.tsx
@@ -14,6 +14,7 @@ import { TypographyP } from "@/components/ui/typography";
 
 import { ProviderKindBadge, SyncStateBadge } from "../../_components/workspace-files-shared";
 import { toneClass } from "../../_components/workspace-resource-shared";
+import { isLiveProviderMemoryId } from "@/lib/providers/tms-provider-resource-id";
 import type { MemoryListRow } from "./memory-list";
 import { providerLabel } from "./memory-list";
 
@@ -100,12 +101,16 @@ function MemoryRow({
             strokeWidth={1.7}
             className="size-4 shrink-0 text-muted-foreground"
           />
-          <Link
-            href={`/org/${organizationSlug}/translation-memories/${memory.id}`}
-            className="truncate text-sm font-medium text-foreground underline-offset-2 hover:underline"
-          >
-            {memory.name}
-          </Link>
+          {isLiveProviderMemoryId(memory.id) ? (
+            <span className="truncate text-sm font-medium text-foreground">{memory.name}</span>
+          ) : (
+            <Link
+              href={`/org/${organizationSlug}/translation-memories/${memory.id}`}
+              className="truncate text-sm font-medium text-foreground underline-offset-2 hover:underline"
+            >
+              {memory.name}
+            </Link>
+          )}
           <SourceLabel memory={memory} />
         </div>
         <TypographyP className="mt-1 text-xs text-muted-foreground">{sourceDetail}</TypographyP>

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/tool-access.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/tool-access.ts
@@ -14,7 +14,11 @@ import type { ApiAuthContext } from "@/api/auth/workos";
 import { schema } from "@/lib/database";
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 import { getTmsProviderLiveProject } from "@/lib/providers/tms-provider-live";
-import { parseProviderProjectId } from "@/lib/providers/tms-provider-resource-id";
+import {
+  isLiveProviderGlossaryId,
+  isLiveProviderMemoryId,
+  parseProviderProjectId,
+} from "@/lib/providers/tms-provider-resource-id";
 import { normalizeProjectId } from "@/lib/projects/identity/project-id";
 import { resolveOrganizationMembershipAccessSource } from "@/lib/workos/membership-access";
 
@@ -128,6 +132,10 @@ export function toolCanAccessMemory(ctx: ToolContext, memoryId: string) {
 
 /** Single-query glossary fetch with team scoping (replaces check + select). */
 export async function toolGetAccessibleGlossary(ctx: ToolContext, glossaryId: string) {
+  if (isLiveProviderGlossaryId(glossaryId)) {
+    return null;
+  }
+
   const [glossary] = await ctx.db
     .select()
     .from(schema.glossaries)
@@ -139,6 +147,10 @@ export async function toolGetAccessibleGlossary(ctx: ToolContext, glossaryId: st
 
 /** Single-query memory fetch with team scoping (replaces check + select). */
 export async function toolGetAccessibleMemory(ctx: ToolContext, memoryId: string) {
+  if (isLiveProviderMemoryId(memoryId)) {
+    return null;
+  }
+
   const [memory] = await ctx.db
     .select()
     .from(schema.memories)

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-resource-id.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-resource-id.test.ts
@@ -151,5 +151,7 @@ describe("tms-provider-resource-id", () => {
     expect(isLiveProviderResourceId("ext:crowdin:42")).toBe(false);
     expect(parseLiveProviderMemoryId("unknown:tm:1")).toBeNull();
     expect(parseLiveProviderMemoryId("crowdin:tm:")).toBeNull();
+    expect(parseLiveProviderGlossaryId("unknown:glossary:1")).toBeNull();
+    expect(parseLiveProviderGlossaryId("crowdin:glossary:")).toBeNull();
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-resource-id.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-resource-id.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   encodeProviderJobId,
   encodeProviderProjectId,
+  isLiveProviderResourceId,
+  parseLiveProviderGlossaryId,
+  parseLiveProviderMemoryId,
   parseProviderJobId,
   parseProviderProjectId,
   resolveEncodedProviderJobId,
@@ -132,5 +135,21 @@ describe("tms-provider-resource-id", () => {
     );
     expect(resolveJobProjectId(null, "ext:crowdin:902807:2001")).toBe("ext:crowdin:902807");
     expect(resolveJobProjectId(null, "job_native")).toBeNull();
+  });
+
+  it("parses live provider memory and glossary ids", () => {
+    expect(parseLiveProviderMemoryId("crowdin:tm:718373")).toEqual({
+      providerKind: "crowdin",
+      externalMemoryId: "718373",
+    });
+    expect(parseLiveProviderGlossaryId("smartling:glossary:term-base-1")).toEqual({
+      providerKind: "smartling",
+      externalGlossaryId: "term-base-1",
+    });
+    expect(isLiveProviderResourceId("crowdin:tm:718373")).toBe(true);
+    expect(isLiveProviderResourceId("crowdin:glossary:42")).toBe(true);
+    expect(isLiveProviderResourceId("ext:crowdin:42")).toBe(false);
+    expect(parseLiveProviderMemoryId("unknown:tm:1")).toBeNull();
+    expect(parseLiveProviderMemoryId("crowdin:tm:")).toBeNull();
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-resource-id.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-resource-id.ts
@@ -21,12 +21,90 @@ export type EncodedProviderJobId = EncodedProviderProjectId & {
   externalJobId: string;
 };
 
+export type LiveProviderMemoryId = {
+  providerKind: ExternalTmsProviderKind;
+  externalMemoryId: string;
+};
+
+export type LiveProviderGlossaryId = {
+  providerKind: ExternalTmsProviderKind;
+  externalGlossaryId: string;
+};
+
+export type LiveProviderResourceId = LiveProviderMemoryId | LiveProviderGlossaryId;
+
 export function encodeProviderProjectId(input: EncodedProviderProjectId) {
   return `ext:${input.providerKind}:${input.externalProjectId}`;
 }
 
 export function encodeProviderJobId(input: EncodedProviderJobId) {
   return `ext:${input.providerKind}:${input.externalProjectId}:${input.externalJobId}`;
+}
+
+function parseLiveProviderResourceIdParts(value: string, resourceKind: "tm" | "glossary") {
+  for (const providerKind of externalTmsProviderKinds) {
+    const prefix = `${providerKind}:${resourceKind}:`;
+    if (!value.startsWith(prefix)) {
+      continue;
+    }
+
+    const externalResourceId = value.slice(prefix.length);
+    if (!externalResourceId) {
+      return null;
+    }
+
+    return { providerKind, externalResourceId };
+  }
+
+  return null;
+}
+
+export function parseLiveProviderMemoryId(
+  value: string | null | undefined,
+): LiveProviderMemoryId | null {
+  if (typeof value !== "string" || value.length === 0) {
+    return null;
+  }
+
+  const parsed = parseLiveProviderResourceIdParts(value, "tm");
+  if (!parsed) {
+    return null;
+  }
+
+  return {
+    providerKind: parsed.providerKind,
+    externalMemoryId: parsed.externalResourceId,
+  };
+}
+
+export function parseLiveProviderGlossaryId(
+  value: string | null | undefined,
+): LiveProviderGlossaryId | null {
+  if (typeof value !== "string" || value.length === 0) {
+    return null;
+  }
+
+  const parsed = parseLiveProviderResourceIdParts(value, "glossary");
+  if (!parsed) {
+    return null;
+  }
+
+  return {
+    providerKind: parsed.providerKind,
+    externalGlossaryId: parsed.externalResourceId,
+  };
+}
+
+export function isLiveProviderMemoryId(value: string | null | undefined) {
+  return parseLiveProviderMemoryId(value) !== null;
+}
+
+export function isLiveProviderGlossaryId(value: string | null | undefined) {
+  return parseLiveProviderGlossaryId(value) !== null;
+}
+
+export function isLiveProviderResourceId(value: string | null | undefined) {
+  return isLiveProviderMemoryId(value) || isLiveProviderGlossaryId(value);
 }
 
 function parseProviderKindAndRemainder(value: string) {


### PR DESCRIPTION
## What changed

Live TMS translation memories and glossaries are listed via the provider API with synthetic IDs (e.g. `crowdin:tm:718373`), but detail and access-check paths still queried the native `memories` / `glossaries` tables where `id` is a UUID. That caused production API errors when users clicked a live provider row.

This PR adds parsers for live provider resource IDs, skips DB access checks for those IDs, and stops linking live list rows to native detail pages.

## How to test

- Connect an active TMS provider (e.g. Crowdin) and open Translation Memories or Glossaries.
- Confirm live provider rows load from the list API without errors.
- Click a live TM/glossary name — it should not navigate to a native detail page (plain text, not a link).
- Optionally hit `GET /api/orgs/:slug/translation-memories/crowdin:tm:<id>` directly — expect a clean 404, not an unhandled query error.
- Run `vp test src/lib/providers/tms-provider-resource-id.test.ts` and `vp check --fix`.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)