### PR TITLE
feat(web): select GitHub repo for chat context

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.test.ts
@@ -1,5 +1,7 @@
 import "dotenv/config";
 
+import { randomInt } from "node:crypto";
+
 import { eq } from "drizzle-orm";
 import { testClient } from "hono/testing";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
@@ -7,6 +9,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 import { createApp } from "@/api/app";
 import { db, schema } from "@/lib/database";
 import type { FileStorageAdapter } from "@/lib/file-storage";
+import { getWebConversationRepositorySession } from "@/lib/agent-runtime/loops/conversation-repository-session";
 import { createMemoryFileStorageAdapter } from "../file/file.fixture";
 import { createProjectTestFixture } from "../project/project.fixture";
 
@@ -43,6 +46,41 @@ const app = createApp({ fileStorageAdapter: createMemoryFileStorageAdapter() });
 const client = testClient(app);
 const { authHeadersFor, cleanup, createProjectViaApi, createWorkosIdentity } =
   createProjectTestFixture(client);
+
+async function createGithubRepositoryFixture(input: {
+  organizationId: string;
+  enabled?: boolean;
+  fullName?: string;
+}) {
+  const suffix = randomInt(100_000, 999_999);
+  const githubInstallationId = `98${suffix}`;
+  const githubRepositoryId = `10${suffix}`;
+  const fullName = input.fullName ?? "hyperlocalise/hyperlocalise-web";
+  const [owner, name] = fullName.split("/");
+
+  await db.insert(schema.githubInstallations).values({
+    organizationId: input.organizationId,
+    githubInstallationId,
+    githubAppId: "123",
+    accountLogin: owner ?? "hyperlocalise",
+    accountType: "Organization",
+  });
+
+  await db.insert(schema.githubInstallationRepositories).values({
+    organizationId: input.organizationId,
+    githubInstallationId,
+    githubRepositoryId,
+    owner: owner ?? "hyperlocalise",
+    name: name ?? "hyperlocalise-web",
+    fullName,
+    private: true,
+    archived: false,
+    defaultBranch: "main",
+    enabled: input.enabled ?? true,
+  });
+
+  return { githubInstallationId, githubRepositoryId, fullName };
+}
 
 beforeAll(async () => {
   await db.$client.query("select 1");
@@ -133,6 +171,65 @@ describe("conversation creation", () => {
     ]);
   });
 
+  it("seeds selected GitHub repository context when creating a chat UI conversation", async () => {
+    const identity = createWorkosIdentity();
+    const headers = await authHeadersFor(identity);
+    const organizationId = globalThis.__testApiAuthContext?.activeOrganization.localOrganizationId;
+    if (!organizationId) {
+      throw new Error("Expected test auth context to include an active organization");
+    }
+    const repository = await createGithubRepositoryFixture({ organizationId });
+    const formData = new FormData();
+    formData.set("text", "Review the repository localization setup");
+    formData.set("repositoryFullName", repository.fullName);
+
+    const response = await app.request(`/api/orgs/${identity.organization.slug}/conversations`, {
+      method: "POST",
+      headers,
+      body: formData,
+    });
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as {
+      conversation: { id: string };
+    };
+    const session = getWebConversationRepositorySession(body.conversation.id);
+    expect(session?.session.repositoryGitHubContext).toMatchObject({
+      resolved: true,
+      installationId: Number(repository.githubInstallationId),
+      repositoryFullName: repository.fullName,
+      branch: "main",
+    });
+  });
+
+  it("rejects a selected GitHub repository that is not enabled", async () => {
+    const identity = createWorkosIdentity();
+    const headers = await authHeadersFor(identity);
+    const organizationId = globalThis.__testApiAuthContext?.activeOrganization.localOrganizationId;
+    if (!organizationId) {
+      throw new Error("Expected test auth context to include an active organization");
+    }
+    const repository = await createGithubRepositoryFixture({
+      organizationId,
+      enabled: false,
+      fullName: "hyperlocalise/disabled-repo",
+    });
+    const formData = new FormData();
+    formData.set("text", "Review the repository localization setup");
+    formData.set("repositoryFullName", repository.fullName);
+
+    const response = await app.request(`/api/orgs/${identity.organization.slug}/conversations`, {
+      method: "POST",
+      headers,
+      body: formData,
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "github_repository_not_available",
+    });
+  });
+
   it("stores reply attachment URLs with an encoded organization slug", async () => {
     const identity = createWorkosIdentity();
     identity.organization.slug = "example org+東京";
@@ -180,6 +277,51 @@ describe("conversation creation", () => {
         url: `/api/orgs/${encodedOrganizationSlug}/files/${replyBody.message.attachments[0]!.id}`,
       }),
     ]);
+  });
+
+  it("seeds selected GitHub repository context when replying to a chat UI conversation", async () => {
+    const identity = createWorkosIdentity();
+    const headers = await authHeadersFor(identity);
+    const organizationId = globalThis.__testApiAuthContext?.activeOrganization.localOrganizationId;
+    if (!organizationId) {
+      throw new Error("Expected test auth context to include an active organization");
+    }
+    const repository = await createGithubRepositoryFixture({ organizationId });
+    const conversationFormData = new FormData();
+    conversationFormData.set("text", "Start a repository task");
+    const conversationResponse = await app.request(
+      `/api/orgs/${identity.organization.slug}/conversations`,
+      {
+        method: "POST",
+        headers,
+        body: conversationFormData,
+      },
+    );
+    expect(conversationResponse.status).toBe(201);
+    const conversationBody = (await conversationResponse.json()) as {
+      conversation: { id: string };
+    };
+    const replyFormData = new FormData();
+    replyFormData.set("text", "Use the selected repository for this task");
+    replyFormData.set("repositoryFullName", repository.fullName);
+
+    const replyResponse = await app.request(
+      `/api/orgs/${identity.organization.slug}/conversations/${conversationBody.conversation.id}/messages`,
+      {
+        method: "POST",
+        headers,
+        body: replyFormData,
+      },
+    );
+
+    expect(replyResponse.status).toBe(201);
+    const session = getWebConversationRepositorySession(conversationBody.conversation.id);
+    expect(session?.session.repositoryGitHubContext).toMatchObject({
+      resolved: true,
+      installationId: Number(repository.githubInstallationId),
+      repositoryFullName: repository.fullName,
+      branch: "main",
+    });
   });
 
   it("does not leave an inbox conversation when initial file upload fails", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
@@ -72,6 +72,15 @@ function buildOrganizationFileUrl(organizationSlug: string, fileId: string) {
   return `/api/orgs/${encodeURIComponent(organizationSlug)}/files/${fileId}`;
 }
 
+function normalizeRepositoryFullName(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const normalized = value.trim().slice(0, 255);
+  return normalized || undefined;
+}
+
 function seedConversationRepositorySession(
   conversationId: string,
   repositoryGitHubContext: RepositoryAgentGitHubContext,
@@ -461,7 +470,7 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
         const normalizedProjectId = normalizeProjectId(asString(body.projectId));
         const requestedProjectId =
           typeof normalizedProjectId === "string" ? normalizedProjectId : undefined;
-        const repositoryFullName = asString(body.repositoryFullName);
+        const repositoryFullName = normalizeRepositoryFullName(asString(body.repositoryFullName));
 
         if (!text.trim() && files.length === 0) {
           return invalidMessagePayloadResponse(c);
@@ -543,6 +552,10 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
             : new Error("failed to store uploaded file");
         }
 
+        if (repositoryGitHubContext) {
+          seedConversationRepositorySession(conversationId, repositoryGitHubContext);
+        }
+
         let message;
         try {
           message = await addInteractionMessage({
@@ -559,9 +572,6 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
                 : (file.downloadUrl ?? file.storageUrl),
             })),
           });
-          if (repositoryGitHubContext) {
-            seedConversationRepositorySession(conversationId, repositoryGitHubContext);
-          }
         } catch (error) {
           await cleanupStoredFiles(storedFiles, adapter);
           throw error;

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
@@ -15,6 +15,13 @@ import { createStoredFile } from "@/lib/file-storage/records";
 import { getOwnedProject } from "@/api/routes/project/project.shared";
 import { addInteractionMessage, createInteraction } from "@/lib/conversations/interactions";
 import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
+import type { RepositoryAgentGitHubContext } from "@/lib/agent-contracts/repository-task";
+import {
+  getRepositoryContextKey,
+  getWebConversationRepositorySession,
+  setWebConversationRepositorySession,
+} from "@/lib/agent-runtime/loops/conversation-repository-session";
+import { resolveWebProjectRepositoryGitHubContext } from "@/lib/agents/repository-context";
 
 import { createChatStreamRoutes } from "./chat-stream.route";
 import {
@@ -63,6 +70,52 @@ function tooManyFilesResponse(c: {
 
 function buildOrganizationFileUrl(organizationSlug: string, fileId: string) {
   return `/api/orgs/${encodeURIComponent(organizationSlug)}/files/${fileId}`;
+}
+
+function seedConversationRepositorySession(
+  conversationId: string,
+  repositoryGitHubContext: RepositoryAgentGitHubContext,
+) {
+  const repositoryContextKey = getRepositoryContextKey(repositoryGitHubContext);
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const current = getWebConversationRepositorySession(conversationId);
+    const repositorySandboxSession =
+      current?.session.repositorySandboxSession?.repositoryContextKey === repositoryContextKey
+        ? current.session.repositorySandboxSession
+        : undefined;
+
+    const committed = setWebConversationRepositorySession(conversationId, {
+      baseVersion: current?.version ?? null,
+      session: {
+        ...current?.session,
+        repositoryGitHubContext,
+        ...(repositorySandboxSession ? { repositorySandboxSession } : {}),
+      },
+    });
+
+    if (committed) {
+      return;
+    }
+  }
+
+  throw new Error("failed to seed repository context");
+}
+
+async function resolveSelectedRepositoryGitHubContext(input: {
+  organizationId: string;
+  repositoryFullName?: string;
+}) {
+  if (!input.repositoryFullName) {
+    return null;
+  }
+
+  const resolution = await resolveWebProjectRepositoryGitHubContext({
+    organizationId: input.organizationId,
+    repositoryFullName: input.repositoryFullName,
+  });
+
+  return resolution.status === "resolved" ? resolution.context : null;
 }
 
 const validateConversationParams = validator("param", (value, c) => {
@@ -207,6 +260,7 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
         const parsed = createConversationRequestSchema.safeParse({
           text: asString(body.text),
           projectId: asString(body.projectId),
+          repositoryFullName: asString(body.repositoryFullName),
         });
 
         if (!parsed.success) {
@@ -243,6 +297,18 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
         }
 
         const orgId = c.var.auth.activeOrganization.localOrganizationId;
+        const repositoryGitHubContext = await resolveSelectedRepositoryGitHubContext({
+          organizationId: orgId,
+          repositoryFullName: parsed.data.repositoryFullName,
+        });
+        if (parsed.data.repositoryFullName && !repositoryGitHubContext) {
+          return badRequestResponse(
+            c,
+            "github_repository_not_available",
+            "Selected GitHub repository is not enabled for this workspace.",
+          );
+        }
+
         const adapter = options.fileStorageAdapter ?? getFileStorageAdapter();
         const organizationSlug = c.var.auth.activeOrganization.slug ?? "";
 
@@ -288,6 +354,10 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
             projectId,
           });
           conversation = createdConversation;
+
+          if (repositoryGitHubContext) {
+            seedConversationRepositorySession(createdConversation.id, repositoryGitHubContext);
+          }
 
           if (storedFiles.length > 0) {
             await db
@@ -391,6 +461,7 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
         const normalizedProjectId = normalizeProjectId(asString(body.projectId));
         const requestedProjectId =
           typeof normalizedProjectId === "string" ? normalizedProjectId : undefined;
+        const repositoryFullName = asString(body.repositoryFullName);
 
         if (!text.trim() && files.length === 0) {
           return invalidMessagePayloadResponse(c);
@@ -402,6 +473,18 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
 
         if (conversation.source !== "chat_ui") {
           return c.json({ error: "conversation_not_replyable" }, 400);
+        }
+
+        const repositoryGitHubContext = await resolveSelectedRepositoryGitHubContext({
+          organizationId: orgId,
+          repositoryFullName,
+        });
+        if (repositoryFullName && !repositoryGitHubContext) {
+          return badRequestResponse(
+            c,
+            "github_repository_not_available",
+            "Selected GitHub repository is not enabled for this workspace.",
+          );
         }
 
         if (requestedProjectId && requestedProjectId !== conversation.projectId) {
@@ -476,6 +559,9 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
                 : (file.downloadUrl ?? file.storageUrl),
             })),
           });
+          if (repositoryGitHubContext) {
+            seedConversationRepositorySession(conversationId, repositoryGitHubContext);
+          }
         } catch (error) {
           await cleanupStoredFiles(storedFiles, adapter);
           throw error;

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.schema.ts
@@ -9,6 +9,7 @@ export const conversationIdParamsSchema = z.object({
 export const createConversationRequestSchema = z.object({
   text: z.string().trim().max(10000).default(""),
   projectId: optionalProjectIdSchema,
+  repositoryFullName: z.string().trim().min(1).max(255).optional(),
 });
 
 export const listConversationsQuerySchema = z.object({

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/github-repository.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/github-repository.ts
@@ -1,0 +1,10 @@
+export type GithubRepository = {
+  archived: boolean;
+  defaultBranch: string | null;
+  enabled: boolean;
+  fullName: string;
+  githubRepositoryId: string;
+  id: string;
+  name: string;
+  owner: string;
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/repository-selector.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/repository-selector.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { siGithub } from "simple-icons";
+
+import { PromptInputButton } from "@/components/ai-elements/prompt-input";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Skeleton } from "@/components/ui/skeleton";
+
+import { SimpleBrandIcon } from "../integrations/_components/simple-brand-icon";
+import type { GithubRepository } from "./github-repository";
+
+type RepositorySelectorTriggerStyle = "button" | "prompt-input";
+
+function RepositorySelectorTrigger({
+  children,
+  className,
+  disabled,
+  style,
+}: {
+  children: ReactNode;
+  className?: string;
+  disabled?: boolean;
+  style: RepositorySelectorTriggerStyle;
+}) {
+  if (style === "prompt-input") {
+    return (
+      <PromptInputButton className={className} size="sm" disabled={disabled}>
+        {children}
+      </PromptInputButton>
+    );
+  }
+
+  return (
+    <Button type="button" variant="ghost" size="sm" className={className} disabled={disabled}>
+      {children}
+    </Button>
+  );
+}
+
+export function RepositorySelector({
+  onSelectRepository,
+  repositories,
+  repositoriesIsError,
+  repositoriesIsLoading,
+  selectedRepositoryFullName,
+  triggerStyle,
+}: {
+  onSelectRepository: (fullName: string) => void;
+  repositories: GithubRepository[];
+  repositoriesIsError: boolean;
+  repositoriesIsLoading: boolean;
+  selectedRepositoryFullName: string;
+  triggerStyle: RepositorySelectorTriggerStyle;
+}) {
+  const disabledTriggerClassName =
+    triggerStyle === "prompt-input"
+      ? "inline-flex h-8 items-center gap-1 rounded-full px-2.5 text-sm font-medium text-muted-foreground"
+      : "rounded-full px-2.5 text-muted-foreground";
+  const interactiveTriggerClassName =
+    triggerStyle === "prompt-input"
+      ? "inline-flex h-8 max-w-56 items-center gap-1 rounded-full px-2.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent/20 hover:text-foreground"
+      : "rounded-full px-2.5 text-muted-foreground hover:bg-accent/20 hover:text-foreground";
+  const singleRepositoryTriggerClassName =
+    triggerStyle === "prompt-input"
+      ? "inline-flex h-8 max-w-56 items-center gap-1 rounded-full px-2.5 text-sm font-medium text-muted-foreground"
+      : "max-w-56 rounded-full px-2.5 text-muted-foreground";
+
+  if (repositoriesIsLoading) {
+    return (
+      <RepositorySelectorTrigger style={triggerStyle} className={disabledTriggerClassName} disabled>
+        <SimpleBrandIcon icon={siGithub} colored className="size-4" />
+        <Skeleton className="h-3.5 w-24 rounded-full bg-muted" />
+      </RepositorySelectorTrigger>
+    );
+  }
+
+  if (repositoriesIsError) {
+    return (
+      <RepositorySelectorTrigger style={triggerStyle} className={disabledTriggerClassName} disabled>
+        <SimpleBrandIcon icon={siGithub} colored className="size-4" />
+        Repos unavailable
+      </RepositorySelectorTrigger>
+    );
+  }
+
+  if (repositories.length === 0) {
+    return (
+      <RepositorySelectorTrigger style={triggerStyle} className={disabledTriggerClassName} disabled>
+        <SimpleBrandIcon icon={siGithub} colored className="size-4" />
+        No GitHub repos
+      </RepositorySelectorTrigger>
+    );
+  }
+
+  if (repositories.length === 1) {
+    return (
+      <RepositorySelectorTrigger
+        style={triggerStyle}
+        className={singleRepositoryTriggerClassName}
+        disabled
+      >
+        <SimpleBrandIcon icon={siGithub} colored className="size-4 shrink-0" />
+        <span className="truncate">{repositories[0]?.fullName}</span>
+      </RepositorySelectorTrigger>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <RepositorySelectorTrigger style={triggerStyle} className={interactiveTriggerClassName}>
+            <SimpleBrandIcon icon={siGithub} colored className="size-4 shrink-0" />
+            <span className="max-w-44 truncate">{selectedRepositoryFullName || "GitHub repo"}</span>
+            <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={1.8} className="size-3.5 shrink-0" />
+          </RepositorySelectorTrigger>
+        }
+      />
+      <DropdownMenuContent className="min-w-64" align="end">
+        <DropdownMenuGroup>
+          {repositories.map((repository) => (
+            <DropdownMenuItem
+              key={repository.id}
+              onClick={() => onSelectRepository(repository.fullName)}
+            >
+              <SimpleBrandIcon icon={siGithub} colored className="size-4" />
+              <span className="min-w-0 flex-1 truncate">{repository.fullName}</span>
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/chat/_components/chat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/chat/_components/chat-page-content.tsx
@@ -1,33 +1,27 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
-  Add01Icon,
-  AiImageIcon,
-  AiWebBrowsingIcon,
   ArrowDown01Icon,
   BubbleChatTranslateIcon,
   Cancel01Icon,
   SentIcon,
   CheckmarkCircle02Icon,
   FileAttachmentIcon,
-  FolderLibraryIcon,
   MailReceive01Icon,
   SparklesIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { siGithub } from "simple-icons";
 import { useMutation, useQuery } from "@tanstack/react-query";
 
 import { Button } from "@/components/ui/button";
 import {
-  ComingSoonBadge,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Kbd } from "@/components/ui/kbd";
@@ -38,6 +32,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { TypographyH2, TypographyMuted } from "@/components/ui/typography";
 import { readApiResponseError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
+
+import { SimpleBrandIcon } from "../../integrations/_components/simple-brand-icon";
 
 const suggestedRequests = [
   {
@@ -55,21 +51,6 @@ const suggestedRequests = [
   {
     icon: MailReceive01Icon,
     text: "Suggest glossary updates from this copy, including product terms and forbidden translations.",
-  },
-] as const;
-
-const attachOptions = [
-  {
-    icon: FileAttachmentIcon,
-    label: "Add source files",
-  },
-  {
-    icon: AiImageIcon,
-    label: "Create Image",
-  },
-  {
-    icon: AiWebBrowsingIcon,
-    label: "Research",
   },
 ] as const;
 
@@ -92,38 +73,161 @@ const translationSourceFileAccept = [
 ].join(",");
 const maxTranslationSourceFiles = 5;
 
+type ChatGithubRepository = {
+  archived: boolean;
+  defaultBranch: string | null;
+  enabled: boolean;
+  fullName: string;
+  githubRepositoryId: string;
+  id: string;
+  name: string;
+  owner: string;
+};
+
+function RepositorySelector({
+  repositories,
+  repositoriesIsError,
+  repositoriesIsLoading,
+  selectedRepositoryFullName,
+  onSelectRepository,
+}: {
+  repositories: ChatGithubRepository[];
+  repositoriesIsError: boolean;
+  repositoriesIsLoading: boolean;
+  selectedRepositoryFullName: string;
+  onSelectRepository: (fullName: string) => void;
+}) {
+  const triggerClassName =
+    "rounded-full px-2.5 text-muted-foreground hover:bg-accent/20 hover:text-foreground";
+
+  if (repositoriesIsLoading) {
+    return (
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="rounded-full px-2.5 text-muted-foreground"
+        disabled
+      >
+        <SimpleBrandIcon icon={siGithub} colored className="size-4" />
+        <Skeleton className="h-3.5 w-24 rounded-full bg-muted" />
+      </Button>
+    );
+  }
+
+  if (repositoriesIsError) {
+    return (
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="rounded-full px-2.5 text-muted-foreground"
+        disabled
+      >
+        <SimpleBrandIcon icon={siGithub} colored className="size-4" />
+        Repos unavailable
+      </Button>
+    );
+  }
+
+  if (repositories.length === 0) {
+    return (
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="rounded-full px-2.5 text-muted-foreground"
+        disabled
+      >
+        <SimpleBrandIcon icon={siGithub} colored className="size-4" />
+        No GitHub repos
+      </Button>
+    );
+  }
+
+  if (repositories.length === 1) {
+    return (
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="max-w-56 rounded-full px-2.5 text-muted-foreground"
+        disabled
+      >
+        <SimpleBrandIcon icon={siGithub} colored className="size-4 shrink-0" />
+        <span className="truncate">{repositories[0]?.fullName}</span>
+      </Button>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button type="button" variant="ghost" size="sm" className={triggerClassName}>
+            <SimpleBrandIcon icon={siGithub} colored className="size-4 shrink-0" />
+            <span className="max-w-44 truncate">{selectedRepositoryFullName || "GitHub repo"}</span>
+            <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={1.8} className="size-3.5" />
+          </Button>
+        }
+      />
+      <DropdownMenuContent className="min-w-64" align="end">
+        <DropdownMenuGroup>
+          {repositories.map((repository) => (
+            <DropdownMenuItem
+              key={repository.id}
+              onClick={() => onSelectRepository(repository.fullName)}
+            >
+              <SimpleBrandIcon icon={siGithub} colored className="size-4" />
+              <span className="min-w-0 flex-1 truncate">{repository.fullName}</span>
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 export function ChatPageContent({ organizationSlug }: { organizationSlug: string }) {
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [selectedProjectId, setSelectedProjectId] = useState<string>("");
+  const [selectedRepositoryFullName, setSelectedRepositoryFullName] = useState("");
   const [text, setText] = useState("");
   const [files, setFiles] = useState<File[]>([]);
-  const projectsQuery = useQuery({
-    queryKey: ["translation-projects", organizationSlug],
+  const repositoriesQuery = useQuery({
+    queryKey: ["github-repositories", organizationSlug],
     queryFn: async () => {
-      const response = await apiClient.api.orgs[":organizationSlug"].projects.$get({
-        param: { organizationSlug },
-      });
+      const response = await apiClient.api.orgs[":organizationSlug"]["github-installation"][
+        "repositories"
+      ].$get({ param: { organizationSlug }, query: {} });
 
       if (!response.ok) {
-        throw await readApiResponseError(response, "Failed to load projects");
+        throw await readApiResponseError(response, "Failed to load GitHub repositories");
       }
 
-      const body = await response.json();
-      return body.projects;
+      const body = (await response.json()) as { repositories: ChatGithubRepository[] };
+      return body.repositories.filter((repository) => repository.enabled && !repository.archived);
     },
   });
-  const projects = projectsQuery.data ?? [];
-  const selectedProject =
-    projects.find((project) => project.id === selectedProjectId) ?? projects[0] ?? null;
-  const projectTriggerLabel = selectedProject?.name ?? "Project";
+  const repositories = repositoriesQuery.data ?? [];
+  const resolvedRepositoryFullName =
+    selectedRepositoryFullName || (repositories.length === 1 ? repositories[0]?.fullName : "");
+
+  useEffect(() => {
+    if (
+      selectedRepositoryFullName &&
+      !repositories.some((repository) => repository.fullName === selectedRepositoryFullName)
+    ) {
+      setSelectedRepositoryFullName("");
+    }
+  }, [repositories, selectedRepositoryFullName]);
 
   const createConversationMutation = useMutation({
     mutationFn: async () => {
       const formData = new FormData();
       formData.set("text", text.trim() || "Please translate the attached source file.");
-      if (selectedProject?.id) {
-        formData.set("projectId", selectedProject.id);
+      if (resolvedRepositoryFullName) {
+        formData.set("repositoryFullName", resolvedRepositoryFullName);
       }
       for (const file of files) {
         formData.append("files", file);
@@ -235,118 +339,37 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
           ) : null}
           <div className="flex flex-wrap items-center justify-between gap-3 bg-background/70 px-4 py-3 sm:px-5">
             <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-              <DropdownMenu>
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <DropdownMenuTrigger
-                        render={
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="icon-sm"
-                            className="rounded-full text-muted-foreground hover:bg-accent/20 hover:text-foreground"
-                            aria-label="Add translation context"
-                          >
-                            <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} className="size-4" />
-                          </Button>
-                        }
-                      />
-                    }
-                  />
-                  <TooltipContent>Add translation context</TooltipContent>
-                </Tooltip>
-                <DropdownMenuContent className="min-w-52" align="start">
-                  <DropdownMenuGroup>
-                    <DropdownMenuItem
-                      closeOnClick={false}
-                      onClick={() => {
-                        fileInputRef.current?.click();
-                      }}
-                    >
-                      <HugeiconsIcon
-                        icon={attachOptions[0].icon}
-                        strokeWidth={1.8}
-                        className="size-4"
-                      />
-                      {attachOptions[0].label}
-                    </DropdownMenuItem>
-                  </DropdownMenuGroup>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuGroup>
-                    {attachOptions.slice(1).map((option) => (
-                      <DropdownMenuItem key={option.label} disabled>
-                        <HugeiconsIcon icon={option.icon} strokeWidth={1.8} className="size-4" />
-                        <span className="min-w-0 flex-1">{option.label}</span>
-                        <ComingSoonBadge />
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuGroup>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <DropdownMenu>
-                <DropdownMenuTrigger
+              <Tooltip>
+                <TooltipTrigger
                   render={
                     <Button
                       type="button"
                       variant="ghost"
-                      size="sm"
-                      className="rounded-full px-2.5 text-muted-foreground hover:bg-accent/20 hover:text-foreground"
-                    />
+                      size="icon-sm"
+                      className="rounded-full text-muted-foreground hover:bg-accent/20 hover:text-foreground"
+                      aria-label="Add source files"
+                      onClick={() => fileInputRef.current?.click()}
+                    >
+                      <HugeiconsIcon
+                        icon={FileAttachmentIcon}
+                        strokeWidth={1.8}
+                        className="size-4"
+                      />
+                    </Button>
                   }
-                >
-                  <HugeiconsIcon icon={FolderLibraryIcon} strokeWidth={1.8} className="size-4" />
-                  {projectsQuery.isLoading ? (
-                    <Skeleton className="h-3.5 w-24 rounded-full bg-muted" />
-                  ) : (
-                    projectTriggerLabel
-                  )}
-                  <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={1.8} className="size-3.5" />
-                </DropdownMenuTrigger>
-                <DropdownMenuContent className="min-w-56" align="end">
-                  <DropdownMenuGroup>
-                    <DropdownMenuLabel>Projects</DropdownMenuLabel>
-                    {projectsQuery.isLoading ? (
-                      <>
-                        <DropdownMenuItem disabled>
-                          <Skeleton className="size-4 rounded-md bg-muted" />
-                          <Skeleton className="h-3.5 w-28 rounded-full bg-muted" />
-                        </DropdownMenuItem>
-                        <DropdownMenuItem disabled>
-                          <Skeleton className="size-4 rounded-md bg-muted" />
-                          <Skeleton className="h-3.5 w-24 rounded-full bg-muted" />
-                        </DropdownMenuItem>
-                        <DropdownMenuItem disabled>
-                          <Skeleton className="size-4 rounded-md bg-muted" />
-                          <Skeleton className="h-3.5 w-32 rounded-full bg-muted" />
-                        </DropdownMenuItem>
-                      </>
-                    ) : null}
-                    {projectsQuery.isError ? (
-                      <DropdownMenuItem disabled>Unable to load projects</DropdownMenuItem>
-                    ) : null}
-                    {projectsQuery.isSuccess && projects.length === 0 ? (
-                      <DropdownMenuItem disabled>No projects found</DropdownMenuItem>
-                    ) : null}
-                    {projects.map((project) => (
-                      <DropdownMenuItem
-                        key={project.id}
-                        onClick={() => setSelectedProjectId(project.id)}
-                      >
-                        <HugeiconsIcon
-                          icon={FolderLibraryIcon}
-                          strokeWidth={1.8}
-                          className="size-4"
-                        />
-                        {project.name}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuGroup>
-                </DropdownMenuContent>
-              </DropdownMenu>
+                />
+                <TooltipContent>Add source files</TooltipContent>
+              </Tooltip>
+            </div>
+
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <RepositorySelector
+                repositories={repositories}
+                repositoriesIsError={repositoriesQuery.isError}
+                repositoriesIsLoading={repositoriesQuery.isLoading}
+                selectedRepositoryFullName={resolvedRepositoryFullName}
+                onSelectRepository={setSelectedRepositoryFullName}
+              />
               <Tooltip>
                 <TooltipTrigger
                   render={

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/chat/_components/chat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/chat/_components/chat-page-content.tsx
@@ -3,7 +3,6 @@
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import {
-  ArrowDown01Icon,
   BubbleChatTranslateIcon,
   Cancel01Icon,
   SentIcon,
@@ -13,27 +12,19 @@ import {
   SparklesIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { siGithub } from "simple-icons";
 import { useMutation, useQuery } from "@tanstack/react-query";
 
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { Kbd } from "@/components/ui/kbd";
 import { Separator } from "@/components/ui/separator";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { TypographyH2, TypographyMuted } from "@/components/ui/typography";
 import { readApiResponseError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
 
-import { SimpleBrandIcon } from "../../integrations/_components/simple-brand-icon";
+import type { GithubRepository } from "../../_components/github-repository";
+import { RepositorySelector } from "../../_components/repository-selector";
 
 const suggestedRequests = [
   {
@@ -73,121 +64,6 @@ const translationSourceFileAccept = [
 ].join(",");
 const maxTranslationSourceFiles = 5;
 
-type ChatGithubRepository = {
-  archived: boolean;
-  defaultBranch: string | null;
-  enabled: boolean;
-  fullName: string;
-  githubRepositoryId: string;
-  id: string;
-  name: string;
-  owner: string;
-};
-
-function RepositorySelector({
-  repositories,
-  repositoriesIsError,
-  repositoriesIsLoading,
-  selectedRepositoryFullName,
-  onSelectRepository,
-}: {
-  repositories: ChatGithubRepository[];
-  repositoriesIsError: boolean;
-  repositoriesIsLoading: boolean;
-  selectedRepositoryFullName: string;
-  onSelectRepository: (fullName: string) => void;
-}) {
-  const triggerClassName =
-    "rounded-full px-2.5 text-muted-foreground hover:bg-accent/20 hover:text-foreground";
-
-  if (repositoriesIsLoading) {
-    return (
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="rounded-full px-2.5 text-muted-foreground"
-        disabled
-      >
-        <SimpleBrandIcon icon={siGithub} colored className="size-4" />
-        <Skeleton className="h-3.5 w-24 rounded-full bg-muted" />
-      </Button>
-    );
-  }
-
-  if (repositoriesIsError) {
-    return (
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="rounded-full px-2.5 text-muted-foreground"
-        disabled
-      >
-        <SimpleBrandIcon icon={siGithub} colored className="size-4" />
-        Repos unavailable
-      </Button>
-    );
-  }
-
-  if (repositories.length === 0) {
-    return (
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="rounded-full px-2.5 text-muted-foreground"
-        disabled
-      >
-        <SimpleBrandIcon icon={siGithub} colored className="size-4" />
-        No GitHub repos
-      </Button>
-    );
-  }
-
-  if (repositories.length === 1) {
-    return (
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="max-w-56 rounded-full px-2.5 text-muted-foreground"
-        disabled
-      >
-        <SimpleBrandIcon icon={siGithub} colored className="size-4 shrink-0" />
-        <span className="truncate">{repositories[0]?.fullName}</span>
-      </Button>
-    );
-  }
-
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger
-        render={
-          <Button type="button" variant="ghost" size="sm" className={triggerClassName}>
-            <SimpleBrandIcon icon={siGithub} colored className="size-4 shrink-0" />
-            <span className="max-w-44 truncate">{selectedRepositoryFullName || "GitHub repo"}</span>
-            <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={1.8} className="size-3.5" />
-          </Button>
-        }
-      />
-      <DropdownMenuContent className="min-w-64" align="end">
-        <DropdownMenuGroup>
-          {repositories.map((repository) => (
-            <DropdownMenuItem
-              key={repository.id}
-              onClick={() => onSelectRepository(repository.fullName)}
-            >
-              <SimpleBrandIcon icon={siGithub} colored className="size-4" />
-              <span className="min-w-0 flex-1 truncate">{repository.fullName}</span>
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
-
 export function ChatPageContent({ organizationSlug }: { organizationSlug: string }) {
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -205,7 +81,7 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
         throw await readApiResponseError(response, "Failed to load GitHub repositories");
       }
 
-      const body = (await response.json()) as { repositories: ChatGithubRepository[] };
+      const body = (await response.json()) as { repositories: GithubRepository[] };
       return body.repositories.filter((repository) => repository.enabled && !repository.archived);
     },
   });
@@ -369,6 +245,7 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
                 repositoriesIsLoading={repositoriesQuery.isLoading}
                 selectedRepositoryFullName={resolvedRepositoryFullName}
                 onSelectRepository={setSelectedRepositoryFullName}
+                triggerStyle="button"
               />
               <Tooltip>
                 <TooltipTrigger

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.tsx
@@ -41,13 +41,17 @@ export function ConversationPanel({
   jobsIsLoading: boolean;
   messages: ConversationMessage[];
   messagesIsLoading: boolean;
-  onSendMessage: (text: string, files: File[], projectId?: string) => void | Promise<void>;
+  onSendMessage: (
+    text: string,
+    files: File[],
+    options?: { projectId?: string; repositoryFullName?: string },
+  ) => void | Promise<void>;
   organizationSlug: string;
   streamedAssistant: StreamedAssistantMessage | null;
 }) {
   if (!conversation) {
     return (
-      <section className="flex min-h-[50vh] flex-col bg-background lg:min-h-0">
+      <section className="flex min-h-0 min-w-0 flex-col overflow-hidden bg-background">
         <div className="flex flex-1 items-center justify-center text-muted-foreground">
           <TypographyMuted>Select a conversation to view details</TypographyMuted>
         </div>
@@ -59,10 +63,10 @@ export function ConversationPanel({
   const composerDisabled = isSending || isStreaming;
 
   return (
-    <section className="flex min-h-[50vh] min-w-0 flex-1 flex-col bg-background lg:min-h-0">
+    <section className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background">
       <ConversationHeader conversation={conversation} jobs={jobs} jobsIsLoading={jobsIsLoading} />
 
-      <div className="relative flex min-h-0 flex-1 flex-col lg:h-[calc(100svh-7.5rem)]">
+      <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
         <ConversationDetails
           conversation={conversation}
           jobs={jobs}
@@ -82,7 +86,6 @@ export function ConversationPanel({
 
           {isChatUi ? (
             <ReplyComposer
-              conversationProjectId={conversation.projectId}
               disabled={composerDisabled}
               isStreaming={isStreaming}
               onSend={onSendMessage}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.ts
@@ -1,18 +1,10 @@
 import type { createApiClient } from "@/lib/api-client";
 import { readApiResponseError } from "@/lib/api-error";
 
+import type { GithubRepository } from "../../_components/github-repository";
 import type { Conversation, ConversationMessage, LinkedJob } from "./inbox-types";
 
-export type InboxGithubRepository = {
-  archived: boolean;
-  defaultBranch: string | null;
-  enabled: boolean;
-  fullName: string;
-  githubRepositoryId: string;
-  id: string;
-  name: string;
-  owner: string;
-};
+export type InboxGithubRepository = GithubRepository;
 
 export type SendConversationMessageInput = {
   text: string;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.ts
@@ -1,22 +1,31 @@
-import type { ProjectsResponse } from "@/api/routes/project/project.schema";
 import type { createApiClient } from "@/lib/api-client";
 import { readApiResponseError } from "@/lib/api-error";
 
 import type { Conversation, ConversationMessage, LinkedJob } from "./inbox-types";
 
-export type InboxProjectSummary = ProjectsResponse["projects"][number];
+export type InboxGithubRepository = {
+  archived: boolean;
+  defaultBranch: string | null;
+  enabled: boolean;
+  fullName: string;
+  githubRepositoryId: string;
+  id: string;
+  name: string;
+  owner: string;
+};
 
 export type SendConversationMessageInput = {
   text: string;
   files: File[];
   projectId?: string;
+  repositoryFullName?: string;
 };
 
 export type InboxApi = {
   listConversations(organizationSlug: string, limit?: number): Promise<Conversation[]>;
   listMessages(organizationSlug: string, conversationId: string): Promise<ConversationMessage[]>;
   listLinkedJobs(organizationSlug: string, conversationId: string): Promise<LinkedJob[]>;
-  listProjects(organizationSlug: string): Promise<InboxProjectSummary[]>;
+  listGithubRepositories(organizationSlug: string): Promise<InboxGithubRepository[]>;
   sendMessage(
     organizationSlug: string,
     conversationId: string,
@@ -64,15 +73,18 @@ export function createInboxApi(client: ApiClient): InboxApi {
       return body.jobs;
     },
 
-    async listProjects(organizationSlug) {
-      const response = await client.api.orgs[":organizationSlug"].projects.$get({
+    async listGithubRepositories(organizationSlug) {
+      const response = await client.api.orgs[":organizationSlug"]["github-installation"][
+        "repositories"
+      ].$get({
         param: { organizationSlug },
+        query: {},
       });
       if (!response.ok) {
-        throw await readApiResponseError(response, "Failed to load projects");
+        throw await readApiResponseError(response, "Failed to load GitHub repositories");
       }
-      const body = (await response.json()) as ProjectsResponse;
-      return body.projects;
+      const body = (await response.json()) as { repositories: InboxGithubRepository[] };
+      return body.repositories.filter((repository) => repository.enabled && !repository.archived);
     },
 
     async sendMessage(organizationSlug, conversationId, input) {
@@ -80,6 +92,9 @@ export function createInboxApi(client: ApiClient): InboxApi {
       formData.append("text", input.text);
       if (input.projectId) {
         formData.append("projectId", input.projectId);
+      }
+      if (input.repositoryFullName) {
+        formData.append("repositoryFullName", input.repositoryFullName);
       }
       for (const file of input.files) {
         formData.append("files", file);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.tsx
@@ -32,7 +32,7 @@ export const InboxList = memo(function InboxList({
   selectedConversationId: string;
 }) {
   return (
-    <section className="flex max-h-[40vh] shrink-0 flex-col overflow-hidden border-border lg:max-h-none lg:min-h-0 lg:h-full lg:shrink lg:border-r">
+    <section className="flex max-h-[40svh] min-h-0 shrink-0 flex-col overflow-hidden border-border lg:h-full lg:max-h-none lg:shrink lg:border-r">
       <div className="min-h-0 flex-1 overflow-y-auto p-2">
         {isLoading ? (
           <ConversationListSkeleton />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-content.tsx
@@ -73,8 +73,12 @@ export function InboxPageContent({
   });
 
   const sendMessageMutation = useMutation({
-    mutationFn: (input: { text: string; files: File[]; projectId?: string }) =>
-      injectedInboxApi.sendMessage(organizationSlug, selectedConversationId, input),
+    mutationFn: (input: {
+      text: string;
+      files: File[];
+      projectId?: string;
+      repositoryFullName?: string;
+    }) => injectedInboxApi.sendMessage(organizationSlug, selectedConversationId, input),
     onSuccess: () => {
       void messagesQuery.refetch();
       void conversationsQuery.refetch();
@@ -83,8 +87,12 @@ export function InboxPageContent({
 
   const mutateAsync = sendMessageMutation.mutateAsync;
   const onSendMessage = useCallback(
-    async (text: string, files: File[], projectId?: string) => {
-      await mutateAsync({ text, files, projectId });
+    async (
+      text: string,
+      files: File[],
+      options?: { projectId?: string; repositoryFullName?: string },
+    ) => {
+      await mutateAsync({ text, files, ...options });
     },
     [mutateAsync],
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-view.tsx
@@ -43,7 +43,11 @@ export function InboxPageView({
   messages: ConversationMessage[];
   messagesIsLoading: boolean;
   onSelectConversation: (conversationId: string) => void;
-  onSendMessage: (text: string, files: File[], projectId?: string) => void | Promise<void>;
+  onSendMessage: (
+    text: string,
+    files: File[],
+    options?: { projectId?: string; repositoryFullName?: string },
+  ) => void | Promise<void>;
   organizationSlug: string;
   selectedConversation: Conversation | undefined;
   selectedConversationId: string;
@@ -52,11 +56,11 @@ export function InboxPageView({
   return (
     <main
       data-organization={organizationSlug}
-      className="-mx-4 -my-5 bg-background text-foreground sm:-mx-6 lg:-mx-8 lg:min-h-[calc(100svh-3.5rem)] lg:overflow-hidden"
+      className="-mx-4 -my-5 flex h-[calc(100svh-var(--app-shell-header-height))] min-h-0 flex-col overflow-hidden bg-background text-foreground sm:-mx-6 lg:-mx-8"
     >
       <div
         className={cn(
-          "grid grid-cols-1 lg:min-h-[calc(100svh-3.5rem)]",
+          "grid h-full min-h-0 grid-cols-1 grid-rows-[auto_minmax(0,1fr)] overflow-hidden lg:grid-rows-1",
           isSparseInbox
             ? "lg:grid-cols-[minmax(14rem,17rem)_minmax(0,1fr)]"
             : "lg:grid-cols-[minmax(20rem,24rem)_minmax(0,1fr)] xl:grid-cols-[minmax(22rem,26rem)_minmax(0,1fr)]",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox.fixture.ts
@@ -1,6 +1,6 @@
 import type { UIMessage } from "ai";
 
-import type { InboxProjectSummary } from "./inbox-api";
+import type { InboxGithubRepository } from "./inbox-api";
 import type {
   Conversation,
   ConversationMessage,
@@ -72,30 +72,18 @@ export function createLinkedJob(overrides: Partial<LinkedJob> = {}): LinkedJob {
   };
 }
 
-export function createProjectSummary(
-  overrides: Partial<InboxProjectSummary> = {},
-): InboxProjectSummary {
+export function createGithubRepository(
+  overrides: Partial<InboxGithubRepository> = {},
+): InboxGithubRepository {
   return {
-    id: "project_website",
-    organizationId: "org_001",
-    teamId: null,
-    createdByUserId: "user_001",
-    name: "Website",
-    description: "Marketing website localization",
-    translationContext: "Public marketing copy",
-    source: "native",
-    externalProviderKind: null,
-    externalProjectId: null,
-    sourceLocale: "en-US",
-    targetLocales: ["fr-FR", "de-DE"],
-    externalProjectUrl: null,
-    isActive: true,
-    lastSyncedAt: null,
-    lastSyncErrorAt: null,
-    lastSyncErrorMessage: null,
-    createdAt: iso(-604_800_000),
-    updatedAt: iso(-86_400_000),
-    openJobCount: 2,
+    id: "repo_website",
+    githubRepositoryId: "101",
+    owner: "hyperlocalise",
+    name: "hyperlocalise-web",
+    fullName: "hyperlocalise/hyperlocalise-web",
+    archived: false,
+    defaultBranch: "main",
+    enabled: true,
     ...overrides,
   };
 }
@@ -181,10 +169,12 @@ export const linkedJobsFixture: LinkedJob[] = [
   }),
 ];
 
-export const projectsFixture: InboxProjectSummary[] = [
-  createProjectSummary(),
-  createProjectSummary({
-    id: "project_mobile",
-    name: "Mobile app",
+export const repositoriesFixture: InboxGithubRepository[] = [
+  createGithubRepository(),
+  createGithubRepository({
+    id: "repo_mobile",
+    githubRepositoryId: "102",
+    name: "mobile-app",
+    fullName: "hyperlocalise/mobile-app",
   }),
 ];

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.stories.tsx
@@ -3,7 +3,7 @@ import { expect, fn } from "storybook/test";
 
 import { PromptInputProvider } from "@/components/ai-elements/prompt-input";
 
-import { projectsFixture } from "./inbox.fixture";
+import { repositoriesFixture } from "./inbox.fixture";
 import { ReplyComposerView } from "./reply-composer";
 
 const meta = {
@@ -22,12 +22,11 @@ const meta = {
     ),
   ],
   args: {
-    conversationProjectId: "project_website",
     disabled: false,
     isStreaming: false,
-    projects: projectsFixture,
-    projectsIsLoading: false,
-    projectsIsError: false,
+    repositories: repositoriesFixture,
+    repositoriesIsLoading: false,
+    repositoriesIsError: false,
     onSend: fn(),
   },
 } satisfies Meta<typeof ReplyComposerView>;
@@ -41,7 +40,7 @@ export const Default: Story = {
       canvas.getByPlaceholderText("Paste text or describe what to translate..."),
     ).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Send reply" })).toBeInTheDocument();
-    await expect(canvas.getByText("Website")).toBeInTheDocument();
+    await expect(canvas.getByText("GitHub repo")).toBeInTheDocument();
   },
 };
 
@@ -61,23 +60,28 @@ export const Disabled: Story = {
   },
 };
 
-export const LoadingProjects: Story = {
+export const LoadingRepositories: Story = {
   args: {
-    projects: [],
-    projectsIsLoading: true,
+    repositories: [],
+    repositoriesIsLoading: true,
   },
 };
 
-export const ProjectsLoadError: Story = {
+export const RepositoriesLoadError: Story = {
   args: {
-    projects: [],
-    projectsIsError: true,
+    repositories: [],
+    repositoriesIsError: true,
   },
 };
 
-export const NoProjects: Story = {
+export const NoRepositories: Story = {
   args: {
-    projects: [],
-    conversationProjectId: null,
+    repositories: [],
+  },
+};
+
+export const SingleRepository: Story = {
+  args: {
+    repositories: repositoriesFixture.slice(0, 1),
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
@@ -2,9 +2,8 @@
 
 import type { FileUIPart } from "ai";
 import { memo, useEffect, useState } from "react";
-import { ArrowDown01Icon, FileAttachmentIcon, SentIcon } from "@hugeicons/core-free-icons";
+import { FileAttachmentIcon, SentIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { siGithub } from "simple-icons";
 import { useQuery } from "@tanstack/react-query";
 
 import {
@@ -25,17 +24,9 @@ import {
   AttachmentRemove,
   Attachments,
 } from "@/components/ai-elements/attachments";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Skeleton } from "@/components/ui/skeleton";
 import { apiClient } from "@/lib/api-client-instance";
 
-import { SimpleBrandIcon } from "../../integrations/_components/simple-brand-icon";
+import { RepositorySelector } from "../../_components/repository-selector";
 import { createInboxApi, type InboxApi, type InboxGithubRepository } from "./inbox-api";
 
 const inboxApi = createInboxApi(apiClient);
@@ -67,102 +58,6 @@ type ReplyComposerViewProps = {
   repositoriesIsError: boolean;
   repositoriesIsLoading: boolean;
 };
-
-function RepositorySelector({
-  repositories,
-  repositoriesIsError,
-  repositoriesIsLoading,
-  selectedRepositoryFullName,
-  onSelectRepository,
-}: {
-  repositories: InboxGithubRepository[];
-  repositoriesIsError: boolean;
-  repositoriesIsLoading: boolean;
-  selectedRepositoryFullName: string;
-  onSelectRepository: (fullName: string) => void;
-}) {
-  if (repositoriesIsLoading) {
-    return (
-      <PromptInputButton
-        className="inline-flex h-8 items-center gap-1 rounded-full px-2.5 text-sm font-medium text-muted-foreground"
-        size="sm"
-        disabled
-      >
-        <SimpleBrandIcon icon={siGithub} colored className="size-4" />
-        <Skeleton className="h-3.5 w-24 rounded-full bg-muted" />
-      </PromptInputButton>
-    );
-  }
-
-  if (repositoriesIsError) {
-    return (
-      <PromptInputButton
-        className="inline-flex h-8 items-center gap-1 rounded-full px-2.5 text-sm font-medium text-muted-foreground"
-        size="sm"
-        disabled
-      >
-        <SimpleBrandIcon icon={siGithub} colored className="size-4" />
-        Repos unavailable
-      </PromptInputButton>
-    );
-  }
-
-  if (repositories.length === 0) {
-    return (
-      <PromptInputButton
-        className="inline-flex h-8 items-center gap-1 rounded-full px-2.5 text-sm font-medium text-muted-foreground"
-        size="sm"
-        disabled
-      >
-        <SimpleBrandIcon icon={siGithub} colored className="size-4" />
-        No GitHub repos
-      </PromptInputButton>
-    );
-  }
-
-  if (repositories.length === 1) {
-    return (
-      <PromptInputButton
-        className="inline-flex h-8 max-w-56 items-center gap-1 rounded-full px-2.5 text-sm font-medium text-muted-foreground"
-        size="sm"
-        disabled
-      >
-        <SimpleBrandIcon icon={siGithub} colored className="size-4 shrink-0" />
-        <span className="truncate">{repositories[0]?.fullName}</span>
-      </PromptInputButton>
-    );
-  }
-
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger
-        render={
-          <PromptInputButton
-            className="inline-flex h-8 max-w-56 items-center gap-1 rounded-full px-2.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent/20 hover:text-foreground"
-            size="sm"
-          >
-            <SimpleBrandIcon icon={siGithub} colored className="size-4 shrink-0" />
-            <span className="truncate">{selectedRepositoryFullName || "GitHub repo"}</span>
-            <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={1.8} className="size-3.5 shrink-0" />
-          </PromptInputButton>
-        }
-      />
-      <DropdownMenuContent className="min-w-64" align="end">
-        <DropdownMenuGroup>
-          {repositories.map((repository) => (
-            <DropdownMenuItem
-              key={repository.id}
-              onClick={() => onSelectRepository(repository.fullName)}
-            >
-              <SimpleBrandIcon icon={siGithub} colored className="size-4" />
-              <span className="min-w-0 flex-1 truncate">{repository.fullName}</span>
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
 
 export function ReplyComposerView({
   disabled,
@@ -261,6 +156,7 @@ export function ReplyComposerView({
                 repositoriesIsLoading={repositoriesIsLoading}
                 selectedRepositoryFullName={resolvedRepositoryFullName}
                 onSelectRepository={setSelectedRepositoryFullName}
+                triggerStyle="prompt-input"
               />
               <PromptInputSubmit
                 size="sm"

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
@@ -2,16 +2,9 @@
 
 import type { FileUIPart } from "ai";
 import { memo, useEffect, useState } from "react";
-import {
-  Add01Icon,
-  AiImageIcon,
-  AiWebBrowsingIcon,
-  ArrowDown01Icon,
-  FileAttachmentIcon,
-  FolderLibraryIcon,
-  SentIcon,
-} from "@hugeicons/core-free-icons";
+import { ArrowDown01Icon, FileAttachmentIcon, SentIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { siGithub } from "simple-icons";
 import { useQuery } from "@tanstack/react-query";
 
 import {
@@ -33,19 +26,17 @@ import {
   Attachments,
 } from "@/components/ai-elements/attachments";
 import {
-  ComingSoonBadge,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import { apiClient } from "@/lib/api-client-instance";
 
-import { createInboxApi, type InboxApi, type InboxProjectSummary } from "./inbox-api";
+import { SimpleBrandIcon } from "../../integrations/_components/simple-brand-icon";
+import { createInboxApi, type InboxApi, type InboxGithubRepository } from "./inbox-api";
 
 const inboxApi = createInboxApi(apiClient);
 
@@ -64,50 +55,137 @@ function dataUrlToFile(dataUrl: string, filename: string, mediaType?: string): F
   return new File([u8arr], filename, { type: mime });
 }
 
-const attachOptions = [
-  {
-    icon: FileAttachmentIcon,
-    label: "Add photos & files",
-  },
-  {
-    icon: AiImageIcon,
-    label: "Create Image",
-  },
-  {
-    icon: AiWebBrowsingIcon,
-    label: "Research",
-  },
-] as const;
-
 type ReplyComposerViewProps = {
-  conversationProjectId: string | null;
   disabled: boolean;
   isStreaming: boolean;
-  onSend: (text: string, files: File[], projectId?: string) => void | Promise<void>;
-  projects: InboxProjectSummary[];
-  projectsIsError: boolean;
-  projectsIsLoading: boolean;
+  onSend: (
+    text: string,
+    files: File[],
+    options?: { projectId?: string; repositoryFullName?: string },
+  ) => void | Promise<void>;
+  repositories: InboxGithubRepository[];
+  repositoriesIsError: boolean;
+  repositoriesIsLoading: boolean;
 };
 
+function RepositorySelector({
+  repositories,
+  repositoriesIsError,
+  repositoriesIsLoading,
+  selectedRepositoryFullName,
+  onSelectRepository,
+}: {
+  repositories: InboxGithubRepository[];
+  repositoriesIsError: boolean;
+  repositoriesIsLoading: boolean;
+  selectedRepositoryFullName: string;
+  onSelectRepository: (fullName: string) => void;
+}) {
+  if (repositoriesIsLoading) {
+    return (
+      <PromptInputButton
+        className="inline-flex h-8 items-center gap-1 rounded-full px-2.5 text-sm font-medium text-muted-foreground"
+        size="sm"
+        disabled
+      >
+        <SimpleBrandIcon icon={siGithub} colored className="size-4" />
+        <Skeleton className="h-3.5 w-24 rounded-full bg-muted" />
+      </PromptInputButton>
+    );
+  }
+
+  if (repositoriesIsError) {
+    return (
+      <PromptInputButton
+        className="inline-flex h-8 items-center gap-1 rounded-full px-2.5 text-sm font-medium text-muted-foreground"
+        size="sm"
+        disabled
+      >
+        <SimpleBrandIcon icon={siGithub} colored className="size-4" />
+        Repos unavailable
+      </PromptInputButton>
+    );
+  }
+
+  if (repositories.length === 0) {
+    return (
+      <PromptInputButton
+        className="inline-flex h-8 items-center gap-1 rounded-full px-2.5 text-sm font-medium text-muted-foreground"
+        size="sm"
+        disabled
+      >
+        <SimpleBrandIcon icon={siGithub} colored className="size-4" />
+        No GitHub repos
+      </PromptInputButton>
+    );
+  }
+
+  if (repositories.length === 1) {
+    return (
+      <PromptInputButton
+        className="inline-flex h-8 max-w-56 items-center gap-1 rounded-full px-2.5 text-sm font-medium text-muted-foreground"
+        size="sm"
+        disabled
+      >
+        <SimpleBrandIcon icon={siGithub} colored className="size-4 shrink-0" />
+        <span className="truncate">{repositories[0]?.fullName}</span>
+      </PromptInputButton>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <PromptInputButton
+            className="inline-flex h-8 max-w-56 items-center gap-1 rounded-full px-2.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent/20 hover:text-foreground"
+            size="sm"
+          >
+            <SimpleBrandIcon icon={siGithub} colored className="size-4 shrink-0" />
+            <span className="truncate">{selectedRepositoryFullName || "GitHub repo"}</span>
+            <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={1.8} className="size-3.5 shrink-0" />
+          </PromptInputButton>
+        }
+      />
+      <DropdownMenuContent className="min-w-64" align="end">
+        <DropdownMenuGroup>
+          {repositories.map((repository) => (
+            <DropdownMenuItem
+              key={repository.id}
+              onClick={() => onSelectRepository(repository.fullName)}
+            >
+              <SimpleBrandIcon icon={siGithub} colored className="size-4" />
+              <span className="min-w-0 flex-1 truncate">{repository.fullName}</span>
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 export function ReplyComposerView({
-  conversationProjectId,
   disabled,
   isStreaming,
   onSend,
-  projects,
-  projectsIsError,
-  projectsIsLoading,
+  repositories,
+  repositoriesIsError,
+  repositoriesIsLoading,
 }: ReplyComposerViewProps) {
   const [replyText, setReplyText] = useState("");
-  const [selectedProjectId, setSelectedProjectId] = useState(conversationProjectId ?? "");
+  const [selectedRepositoryFullName, setSelectedRepositoryFullName] = useState("");
 
   useEffect(() => {
-    setSelectedProjectId(conversationProjectId ?? "");
-  }, [conversationProjectId]);
+    if (
+      selectedRepositoryFullName &&
+      !repositories.some((repository) => repository.fullName === selectedRepositoryFullName)
+    ) {
+      setSelectedRepositoryFullName("");
+    }
+  }, [repositories, selectedRepositoryFullName]);
 
-  const selectedProject =
-    projects.find((project) => project.id === selectedProjectId) ?? projects[0] ?? null;
-  const projectTriggerLabel = selectedProject?.name ?? "Project";
+  const resolvedRepositoryFullName =
+    selectedRepositoryFullName || (repositories.length === 1 ? repositories[0]?.fullName : "");
 
   const attachments = usePromptInputAttachments();
 
@@ -119,11 +197,9 @@ export function ReplyComposerView({
       dataUrlToFile(file.url, file.filename || "untitled", file.mediaType),
     );
 
-    const projectIdForSend =
-      selectedProjectId && selectedProjectId !== conversationProjectId
-        ? selectedProjectId
-        : undefined;
-    await onSend(trimmedText, fileObjects, projectIdForSend);
+    await onSend(trimmedText, fileObjects, {
+      repositoryFullName: resolvedRepositoryFullName || undefined,
+    });
     setReplyText("");
     attachments.clear();
   };
@@ -167,111 +243,25 @@ export function ReplyComposerView({
           </PromptInputBody>
           <PromptInputFooter className="flex-wrap gap-3 border-t border-border bg-muted px-4 py-3 sm:px-5">
             <PromptInputTools className="flex-wrap gap-2 text-sm text-muted-foreground">
-              <DropdownMenu>
-                <DropdownMenuTrigger
-                  render={
-                    <PromptInputButton
-                      className="inline-flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent/20 hover:text-foreground"
-                      size="icon-sm"
-                      aria-label="Add translation context"
-                      tooltip="Add translation context"
-                    >
-                      <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} className="size-4" />
-                    </PromptInputButton>
-                  }
-                />
-                <DropdownMenuContent className="min-w-52" align="start">
-                  <DropdownMenuGroup>
-                    <DropdownMenuItem onClick={() => attachments.openFileDialog()}>
-                      <HugeiconsIcon
-                        icon={attachOptions[0].icon}
-                        strokeWidth={1.8}
-                        className="size-4"
-                      />
-                      {attachOptions[0].label}
-                    </DropdownMenuItem>
-                  </DropdownMenuGroup>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuGroup>
-                    {attachOptions.slice(1).map((option) => (
-                      <DropdownMenuItem key={option.label} disabled>
-                        <HugeiconsIcon icon={option.icon} strokeWidth={1.8} className="size-4" />
-                        <span className="min-w-0 flex-1">{option.label}</span>
-                        <ComingSoonBadge />
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuGroup>
-                </DropdownMenuContent>
-              </DropdownMenu>
+              <PromptInputButton
+                className="inline-flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent/20 hover:text-foreground"
+                size="icon-sm"
+                aria-label="Add photos and files"
+                tooltip="Add photos and files"
+                onClick={() => attachments.openFileDialog()}
+              >
+                <HugeiconsIcon icon={FileAttachmentIcon} strokeWidth={1.8} className="size-4" />
+              </PromptInputButton>
             </PromptInputTools>
 
             <PromptInputTools className="flex-wrap justify-end gap-2 text-sm text-muted-foreground">
-              <DropdownMenu>
-                <DropdownMenuTrigger
-                  render={
-                    <PromptInputButton
-                      className="inline-flex h-8 items-center gap-1 rounded-full px-2.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent/20 hover:text-foreground"
-                      size="sm"
-                    >
-                      <HugeiconsIcon
-                        icon={FolderLibraryIcon}
-                        strokeWidth={1.8}
-                        className="size-4"
-                      />
-                      {projectsIsLoading ? (
-                        <Skeleton className="h-3.5 w-24 rounded-full bg-muted" />
-                      ) : (
-                        projectTriggerLabel
-                      )}
-                      <HugeiconsIcon
-                        icon={ArrowDown01Icon}
-                        strokeWidth={1.8}
-                        className="size-3.5"
-                      />
-                    </PromptInputButton>
-                  }
-                />
-                <DropdownMenuContent className="min-w-56" align="end">
-                  <DropdownMenuGroup>
-                    <DropdownMenuLabel>Projects</DropdownMenuLabel>
-                    {projectsIsLoading ? (
-                      <>
-                        <DropdownMenuItem disabled>
-                          <Skeleton className="size-4 rounded-md bg-muted" />
-                          <Skeleton className="h-3.5 w-28 rounded-full bg-muted" />
-                        </DropdownMenuItem>
-                        <DropdownMenuItem disabled>
-                          <Skeleton className="size-4 rounded-md bg-muted" />
-                          <Skeleton className="h-3.5 w-24 rounded-full bg-muted" />
-                        </DropdownMenuItem>
-                        <DropdownMenuItem disabled>
-                          <Skeleton className="size-4 rounded-md bg-muted" />
-                          <Skeleton className="h-3.5 w-32 rounded-full bg-muted" />
-                        </DropdownMenuItem>
-                      </>
-                    ) : null}
-                    {projectsIsError ? (
-                      <DropdownMenuItem disabled>Unable to load projects</DropdownMenuItem>
-                    ) : null}
-                    {!projectsIsLoading && !projectsIsError && projects.length === 0 ? (
-                      <DropdownMenuItem disabled>No projects found</DropdownMenuItem>
-                    ) : null}
-                    {projects.map((project) => (
-                      <DropdownMenuItem
-                        key={project.id}
-                        onClick={() => setSelectedProjectId(project.id)}
-                      >
-                        <HugeiconsIcon
-                          icon={FolderLibraryIcon}
-                          strokeWidth={1.8}
-                          className="size-4"
-                        />
-                        {project.name}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuGroup>
-                </DropdownMenuContent>
-              </DropdownMenu>
+              <RepositorySelector
+                repositories={repositories}
+                repositoriesIsError={repositoriesIsError}
+                repositoriesIsLoading={repositoriesIsLoading}
+                selectedRepositoryFullName={resolvedRepositoryFullName}
+                onSelectRepository={setSelectedRepositoryFullName}
+              />
               <PromptInputSubmit
                 size="sm"
                 disabled={(!replyText.trim() && attachments.files.length === 0) || disabled}
@@ -295,7 +285,7 @@ export function ReplyComposerView({
 
 type ReplyComposerProps = Omit<
   ReplyComposerViewProps,
-  "projects" | "projectsIsError" | "projectsIsLoading"
+  "repositories" | "repositoriesIsError" | "repositoriesIsLoading"
 > & {
   organizationSlug: string;
   inboxApi?: InboxApi;
@@ -306,18 +296,18 @@ export const ReplyComposer = memo(function ReplyComposer({
   inboxApi: injectedInboxApi = inboxApi,
   ...viewProps
 }: ReplyComposerProps) {
-  const projectsQuery = useQuery({
-    queryKey: ["translation-projects", organizationSlug],
-    queryFn: () => injectedInboxApi.listProjects(organizationSlug),
+  const repositoriesQuery = useQuery({
+    queryKey: ["github-repositories", organizationSlug],
+    queryFn: () => injectedInboxApi.listGithubRepositories(organizationSlug),
   });
 
   return (
     <PromptInputProvider>
       <ReplyComposerView
         {...viewProps}
-        projects={projectsQuery.data ?? []}
-        projectsIsError={projectsQuery.isError}
-        projectsIsLoading={projectsQuery.isLoading}
+        repositories={repositoriesQuery.data ?? []}
+        repositoriesIsError={repositoriesQuery.isError}
+        repositoriesIsLoading={repositoriesQuery.isLoading}
       />
     </PromptInputProvider>
   );


### PR DESCRIPTION
## What changed

- Replaced chat and inbox composer project/context controls with enabled GitHub repository selection.
- Auto-selects a single enabled repository and sends `repositoryFullName` with chat create/reply requests.
- Validates selected repositories server-side and seeds the web conversation repository session for Hyperlocalise agent repo tools.

## How to test

- `vp check --fix`
- `vp test src/api/routes/conversation/conversation.route.test.ts`
- `vp test src/agents/hyperlocalise/agent/channels/web.test.ts`
- `vp test` currently still fails in unrelated public API/MCP auth tests with 403/401/400 status mismatches.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)