### PR TITLE
fix(web): track chat agent usage

### DIFF
--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.test.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.test.ts
@@ -4,10 +4,14 @@ const {
   prepareConversationAgentTurnMock,
   getWebConversationRepositorySessionMock,
   setWebConversationRepositorySessionMock,
+  reserveAgentRuntimeUsageMock,
+  trackSucceededAgentRuntimeUsageMock,
 } = vi.hoisted(() => ({
   prepareConversationAgentTurnMock: vi.fn(),
   getWebConversationRepositorySessionMock: vi.fn(),
   setWebConversationRepositorySessionMock: vi.fn(),
+  reserveAgentRuntimeUsageMock: vi.fn(),
+  trackSucceededAgentRuntimeUsageMock: vi.fn(),
 }));
 
 vi.mock("@/lib/agent-runtime/loops/conversation-turn", () => ({
@@ -20,6 +24,11 @@ vi.mock("@/lib/agent-runtime/loops/conversation-repository-session", () => ({
   getWebConversationRepositorySession: getWebConversationRepositorySessionMock,
   setWebConversationRepositorySession: setWebConversationRepositorySessionMock,
   acquireWebRepositorySandboxLease: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/lib/billing/agent-runtime-usage", () => ({
+  reserveAgentRuntimeUsage: reserveAgentRuntimeUsageMock,
+  trackSucceededAgentRuntimeUsage: trackSucceededAgentRuntimeUsageMock,
 }));
 
 import { runWebChatAgentTurn } from "./web";
@@ -57,6 +66,8 @@ describe("runWebChatAgentTurn", () => {
       version: 1,
     });
     setWebConversationRepositorySessionMock.mockReturnValue(false);
+    reserveAgentRuntimeUsageMock.mockResolvedValue(true);
+    trackSucceededAgentRuntimeUsageMock.mockResolvedValue(undefined);
     prepareConversationAgentTurnMock.mockResolvedValue({
       classification: baseClassification,
       agent: { stream: vi.fn(async () => ({ textStream: (async function* () {})() })) },
@@ -145,5 +156,59 @@ describe("runWebChatAgentTurn", () => {
       "I'm still preparing repository access for this conversation. Please send your message again in a moment.",
     );
     expect(turn.textStream).toBeNull();
+    expect(reserveAgentRuntimeUsageMock).not.toHaveBeenCalled();
+    expect(trackSucceededAgentRuntimeUsageMock).not.toHaveBeenCalled();
+  });
+
+  it("tracks agent runtime usage after a successful response stream", async () => {
+    async function* textStream() {
+      yield "Done";
+    }
+
+    prepareConversationAgentTurnMock.mockResolvedValueOnce({
+      classification: baseClassification,
+      agent: { stream: vi.fn(async () => ({ textStream: textStream() })) },
+      chatMessages: [],
+      clarificationFollowUp: null,
+      updatedRepositorySession: null,
+      staleSandboxId: null,
+      repositorySandboxId: null,
+    });
+
+    const turn = await runWebChatAgentTurn({
+      conversationId: "conv_123",
+      messageText: "where is the login copy?",
+      toolContext: {
+        conversationId: "conv_123",
+        organizationId: "org_123",
+        localUserId: "user_123",
+        membershipRole: "admin",
+        projectId: null,
+        db: {} as never,
+      },
+      hasTranslationAttachments: false,
+      usageOperationKey: "chat-agent-turn:msg_123:agent_runs",
+    });
+
+    const chunks: string[] = [];
+    for await (const chunk of turn.textStream ?? []) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(["Done"]);
+    expect(reserveAgentRuntimeUsageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: "org_123",
+        operationKey: "chat-agent-turn:msg_123:agent_runs",
+        source: "chat_agent_turn",
+        interactionId: "conv_123",
+      }),
+    );
+    expect(trackSucceededAgentRuntimeUsageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: "org_123",
+        operationKey: "chat-agent-turn:msg_123:agent_runs",
+      }),
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.ts
@@ -1,6 +1,11 @@
+import { randomUUID } from "node:crypto";
 import type { Thread } from "chat";
 
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
+import {
+  reserveAgentRuntimeUsage,
+  trackSucceededAgentRuntimeUsage,
+} from "@/lib/billing/agent-runtime-usage";
 import { addInteractionMessage } from "@/lib/conversations/interactions";
 import {
   acquireWebRepositorySandboxLease,
@@ -44,6 +49,21 @@ async function* streamWithSandboxLeaseRelease(
   }
 }
 
+async function* streamWithUsageTracking(
+  stream: AsyncIterable<string>,
+  input: {
+    organizationId: string;
+    operationKey: string;
+    dimensions: Record<string, string | number | boolean | null>;
+  },
+) {
+  for await (const chunk of stream) {
+    yield chunk;
+  }
+
+  await trackSucceededAgentRuntimeUsage(input);
+}
+
 async function prepareAndCommitWebConversationTurn(
   conversationId: string,
   prepareInput: Omit<PrepareConversationAgentTurnInput, "repositorySession">,
@@ -84,6 +104,7 @@ export async function runWebChatAgentTurn(input: {
   messageText: string;
   toolContext: ToolContext;
   hasTranslationAttachments: boolean;
+  usageOperationKey?: string;
 }) {
   const prepared = await prepareAndCommitWebConversationTurn(input.conversationId, {
     surface: "web",
@@ -109,15 +130,36 @@ export async function runWebChatAgentTurn(input: {
   const releaseSandboxLease = prepared.repositorySandboxId
     ? acquireWebRepositorySandboxLease(prepared.repositorySandboxId)
     : null;
+  const usageOperationKey =
+    input.usageOperationKey ?? `chat-agent-turn:${input.conversationId}:${randomUUID()}`;
+  const usageDimensions = {
+    surface: "web",
+    agent_surface: "chat",
+    repository_tools: Boolean(prepared.repositorySandboxId),
+  };
 
   try {
+    await reserveAgentRuntimeUsage({
+      organizationId: input.toolContext.organizationId,
+      operationKey: usageOperationKey,
+      source: "chat_agent_turn",
+      interactionId: input.conversationId,
+      dimensions: usageDimensions,
+    });
+
     const result = await prepared.agent.stream({ messages: prepared.chatMessages });
+    const trackedStream = streamWithUsageTracking(result.textStream, {
+      organizationId: input.toolContext.organizationId,
+      operationKey: usageOperationKey,
+      dimensions: usageDimensions,
+    });
+
     return {
       classification: prepared.classification,
       clarificationFollowUp: null,
       textStream: releaseSandboxLease
-        ? streamWithSandboxLeaseRelease(result.textStream, releaseSandboxLease)
-        : result.textStream,
+        ? streamWithSandboxLeaseRelease(trackedStream, releaseSandboxLease)
+        : trackedStream,
     };
   } catch (error) {
     releaseSandboxLease?.();

--- a/apps/hyperlocalise-web/src/api/routes/conversation/chat-stream.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/chat-stream.route.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { and, desc, eq } from "drizzle-orm";
 import { createWebAdapter } from "@chat-adapter/web";
 import { createMemoryState } from "@chat-adapter/state-memory";
 import { Chat } from "chat";
@@ -14,7 +15,7 @@ import {
   postWebClarificationReply,
   runWebChatAgentTurn,
 } from "@/agents/hyperlocalise/agent/channels/web";
-import { db } from "@/lib/database";
+import { db, schema } from "@/lib/database";
 import {
   addInteractionMessage,
   interactionHasTranslationAttachments,
@@ -82,6 +83,17 @@ export function createChatStreamRoutes() {
           throw new Error("web_thread_conversation_mismatch");
         }
 
+        const [latestUserMessage] = await db
+          .select({ id: schema.interactionMessages.id })
+          .from(schema.interactionMessages)
+          .where(
+            and(
+              eq(schema.interactionMessages.interactionId, conversationId),
+              eq(schema.interactionMessages.senderType, "user"),
+            ),
+          )
+          .orderBy(desc(schema.interactionMessages.createdAt))
+          .limit(1);
         const hasTranslationAttachments =
           await interactionHasTranslationAttachments(conversationId);
 
@@ -97,6 +109,9 @@ export function createChatStreamRoutes() {
             db,
           },
           hasTranslationAttachments,
+          usageOperationKey: latestUserMessage
+            ? `chat-agent-turn:${latestUserMessage.id}:agent_runs`
+            : undefined,
         });
 
         if (turn.clarificationFollowUp) {

--- a/apps/hyperlocalise-web/src/lib/billing/agent-runtime-usage.test.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/agent-runtime-usage.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+const {
+  markUsageEventSucceededByOperationKeyMock,
+  reserveUsageEventMock,
+  trackUsageEventInAutumnByOperationKeyMock,
+} = vi.hoisted(() => ({
+  markUsageEventSucceededByOperationKeyMock: vi.fn(),
+  reserveUsageEventMock: vi.fn(),
+  trackUsageEventInAutumnByOperationKeyMock: vi.fn(),
+}));
+
+vi.mock("@/lib/billing/usage-control", () => ({
+  formatUsageControlError: (error: { code: string }) => error.code,
+  markUsageEventSucceededByOperationKey: markUsageEventSucceededByOperationKeyMock,
+  reserveUsageEvent: reserveUsageEventMock,
+  trackUsageEventInAutumnByOperationKey: trackUsageEventInAutumnByOperationKeyMock,
+  usageFeatureIds: {
+    agentRuns: "agent-runs",
+  },
+}));
+
+import {
+  reserveAgentRuntimeUsage,
+  trackSucceededAgentRuntimeUsage,
+} from "@/lib/billing/agent-runtime-usage";
+import { ok } from "@/lib/primitives/result/results";
+
+describe("agent-runtime-usage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("fails open when reserving usage throws", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    reserveUsageEventMock.mockRejectedValue(new Error("database unavailable"));
+
+    await expect(
+      reserveAgentRuntimeUsage({
+        organizationId: "org_123",
+        operationKey: "agent-run:test",
+        source: "chat_agent_turn",
+      }),
+    ).resolves.toBe(false);
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[agent-runtime-usage] usage event reservation threw",
+      expect.objectContaining({
+        organizationId: "org_123",
+        operationKey: "agent-run:test",
+        source: "chat_agent_turn",
+      }),
+    );
+  });
+
+  it("fails open when marking usage succeeded throws", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    markUsageEventSucceededByOperationKeyMock.mockRejectedValue(new Error("database unavailable"));
+
+    await expect(
+      trackSucceededAgentRuntimeUsage({
+        organizationId: "org_123",
+        operationKey: "agent-run:test",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(trackUsageEventInAutumnByOperationKeyMock).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(
+      "[agent-runtime-usage] usage event completion threw",
+      expect.objectContaining({
+        organizationId: "org_123",
+        operationKey: "agent-run:test",
+      }),
+    );
+  });
+
+  it("fails open when Autumn usage tracking throws", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    markUsageEventSucceededByOperationKeyMock.mockResolvedValue(ok(undefined));
+    trackUsageEventInAutumnByOperationKeyMock.mockRejectedValue(new Error("network unavailable"));
+
+    await expect(
+      trackSucceededAgentRuntimeUsage({
+        organizationId: "org_123",
+        operationKey: "agent-run:test",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[agent-runtime-usage] usage event completion threw",
+      expect.objectContaining({
+        organizationId: "org_123",
+        operationKey: "agent-run:test",
+      }),
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/billing/agent-runtime-usage.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/agent-runtime-usage.ts
@@ -1,0 +1,81 @@
+import {
+  formatUsageControlError,
+  markUsageEventSucceededByOperationKey,
+  reserveUsageEvent,
+  trackUsageEventInAutumnByOperationKey,
+  usageFeatureIds,
+} from "@/lib/billing/usage-control";
+import { isErr } from "@/lib/primitives/result/results";
+
+type AgentRuntimeUsageDimensions = Record<string, string | number | boolean | null>;
+
+function logAgentRuntimeUsageError(message: string, input: Record<string, unknown>) {
+  console.error(`[agent-runtime-usage] ${message}`, input);
+}
+
+export async function reserveAgentRuntimeUsage(input: {
+  organizationId: string;
+  operationKey: string;
+  source: string;
+  interactionId?: string | null;
+  dimensions?: AgentRuntimeUsageDimensions;
+}) {
+  const usageEventResult = await reserveUsageEvent({
+    organizationId: input.organizationId,
+    featureId: usageFeatureIds.agentRuns,
+    operationKey: input.operationKey,
+    source: input.source,
+    interactionId: input.interactionId ?? undefined,
+    quantity: 1,
+    dimensions: input.dimensions,
+  });
+
+  if (isErr(usageEventResult)) {
+    logAgentRuntimeUsageError("usage event reservation failed", {
+      organizationId: input.organizationId,
+      operationKey: input.operationKey,
+      source: input.source,
+      error: formatUsageControlError(usageEventResult.error),
+    });
+    return false;
+  }
+
+  return true;
+}
+
+export async function trackSucceededAgentRuntimeUsage(input: {
+  organizationId: string;
+  operationKey: string;
+  dimensions?: AgentRuntimeUsageDimensions;
+}) {
+  const markUsageResult = await markUsageEventSucceededByOperationKey({
+    operationKey: input.operationKey,
+    quantity: 1,
+    dimensions: {
+      ...input.dimensions,
+      autumn_event_name: "agent_run.completed",
+      unit: "run",
+    },
+  });
+
+  if (isErr(markUsageResult)) {
+    logAgentRuntimeUsageError("usage event completion failed", {
+      organizationId: input.organizationId,
+      operationKey: input.operationKey,
+      error: formatUsageControlError(markUsageResult.error),
+    });
+    return;
+  }
+
+  const trackUsageResult = await trackUsageEventInAutumnByOperationKey({
+    operationKey: input.operationKey,
+  });
+
+  if (isErr(trackUsageResult)) {
+    logAgentRuntimeUsageError("Autumn usage tracking failed", {
+      organizationId: input.organizationId,
+      operationKey: input.operationKey,
+      error: formatUsageControlError(trackUsageResult.error),
+    });
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/billing/agent-runtime-usage.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/agent-runtime-usage.ts
@@ -5,6 +5,7 @@ import {
   trackUsageEventInAutumnByOperationKey,
   usageFeatureIds,
 } from "@/lib/billing/usage-control";
+import { serializeErrorForLog } from "@/lib/log";
 import { isErr } from "@/lib/primitives/result/results";
 
 type AgentRuntimeUsageDimensions = Record<string, string | number | boolean | null>;
@@ -20,27 +21,37 @@ export async function reserveAgentRuntimeUsage(input: {
   interactionId?: string | null;
   dimensions?: AgentRuntimeUsageDimensions;
 }) {
-  const usageEventResult = await reserveUsageEvent({
-    organizationId: input.organizationId,
-    featureId: usageFeatureIds.agentRuns,
-    operationKey: input.operationKey,
-    source: input.source,
-    interactionId: input.interactionId ?? undefined,
-    quantity: 1,
-    dimensions: input.dimensions,
-  });
+  try {
+    const usageEventResult = await reserveUsageEvent({
+      organizationId: input.organizationId,
+      featureId: usageFeatureIds.agentRuns,
+      operationKey: input.operationKey,
+      source: input.source,
+      interactionId: input.interactionId ?? undefined,
+      quantity: 1,
+      dimensions: input.dimensions,
+    });
 
-  if (isErr(usageEventResult)) {
-    logAgentRuntimeUsageError("usage event reservation failed", {
+    if (isErr(usageEventResult)) {
+      logAgentRuntimeUsageError("usage event reservation failed", {
+        organizationId: input.organizationId,
+        operationKey: input.operationKey,
+        source: input.source,
+        error: formatUsageControlError(usageEventResult.error),
+      });
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    logAgentRuntimeUsageError("usage event reservation threw", {
       organizationId: input.organizationId,
       operationKey: input.operationKey,
       source: input.source,
-      error: formatUsageControlError(usageEventResult.error),
+      err: serializeErrorForLog(error),
     });
     return false;
   }
-
-  return true;
 }
 
 export async function trackSucceededAgentRuntimeUsage(input: {
@@ -48,34 +59,42 @@ export async function trackSucceededAgentRuntimeUsage(input: {
   operationKey: string;
   dimensions?: AgentRuntimeUsageDimensions;
 }) {
-  const markUsageResult = await markUsageEventSucceededByOperationKey({
-    operationKey: input.operationKey,
-    quantity: 1,
-    dimensions: {
-      ...input.dimensions,
-      autumn_event_name: "agent_run.completed",
-      unit: "run",
-    },
-  });
-
-  if (isErr(markUsageResult)) {
-    logAgentRuntimeUsageError("usage event completion failed", {
-      organizationId: input.organizationId,
+  try {
+    const markUsageResult = await markUsageEventSucceededByOperationKey({
       operationKey: input.operationKey,
-      error: formatUsageControlError(markUsageResult.error),
+      quantity: 1,
+      dimensions: {
+        ...input.dimensions,
+        autumn_event_name: "agent_run.completed",
+        unit: "run",
+      },
     });
-    return;
-  }
 
-  const trackUsageResult = await trackUsageEventInAutumnByOperationKey({
-    operationKey: input.operationKey,
-  });
+    if (isErr(markUsageResult)) {
+      logAgentRuntimeUsageError("usage event completion failed", {
+        organizationId: input.organizationId,
+        operationKey: input.operationKey,
+        error: formatUsageControlError(markUsageResult.error),
+      });
+      return;
+    }
 
-  if (isErr(trackUsageResult)) {
-    logAgentRuntimeUsageError("Autumn usage tracking failed", {
+    const trackUsageResult = await trackUsageEventInAutumnByOperationKey({
+      operationKey: input.operationKey,
+    });
+
+    if (isErr(trackUsageResult)) {
+      logAgentRuntimeUsageError("Autumn usage tracking failed", {
+        organizationId: input.organizationId,
+        operationKey: input.operationKey,
+        error: formatUsageControlError(trackUsageResult.error),
+      });
+    }
+  } catch (error) {
+    logAgentRuntimeUsageError("usage event completion threw", {
       organizationId: input.organizationId,
       operationKey: input.operationKey,
-      error: formatUsageControlError(trackUsageResult.error),
+      err: serializeErrorForLog(error),
     });
   }
 }

--- a/apps/hyperlocalise-web/src/lib/projects/string-context/project-string-context-service.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/string-context/project-string-context-service.test.ts
@@ -275,6 +275,39 @@ describe("lookupProjectFileStringRepositoryContext", () => {
     expect(stopRepositorySandboxMock).toHaveBeenCalledWith("sandbox-test");
   });
 
+  it("completes reserved usage when the repository agent returns only whitespace", async () => {
+    const { organization, project, user } = await fixture.createStoredProjectFixture();
+    runSubagentMock.mockResolvedValue({ text: " \n\t " });
+
+    const result = await lookupProjectFileStringRepositoryContext(
+      baseInput({
+        organizationId: organization.id,
+        projectId: project.id,
+        localUserId: user.id,
+        repositoryFullName: "hyperlocalise/explicit",
+      }),
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: expect.objectContaining({
+        code: "agent_failed",
+      }),
+    });
+    expect(reserveAgentRuntimeUsageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: organization.id,
+        source: "project_file_string_context_lookup",
+      }),
+    );
+    expect(trackSucceededAgentRuntimeUsageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: organization.id,
+      }),
+    );
+    expect(stopRepositorySandboxMock).toHaveBeenCalledWith("sandbox-test");
+  });
+
   it("returns repository_context_ambiguous when multiple enabled repositories match", async () => {
     const { organization, project, user } = await fixture.createStoredProjectFixture();
     await insertRepository({

--- a/apps/hyperlocalise-web/src/lib/projects/string-context/project-string-context-service.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/string-context/project-string-context-service.test.ts
@@ -5,11 +5,15 @@ const {
   resolveWebProjectRepositoryGitHubContextMock,
   runSubagentMock,
   stopRepositorySandboxMock,
+  reserveAgentRuntimeUsageMock,
+  trackSucceededAgentRuntimeUsageMock,
 } = vi.hoisted(() => ({
   createRepositorySandboxMock: vi.fn(),
   resolveWebProjectRepositoryGitHubContextMock: vi.fn(),
   runSubagentMock: vi.fn(),
   stopRepositorySandboxMock: vi.fn(),
+  reserveAgentRuntimeUsageMock: vi.fn(),
+  trackSucceededAgentRuntimeUsageMock: vi.fn(),
 }));
 
 vi.mock("@/lib/agents/repository-context", () => ({
@@ -26,6 +30,11 @@ vi.mock("@/lib/agent-runtime/workspaces/repository-sandbox", () => ({
 
 vi.mock("@/lib/agent-runtime/subagents/run-subagent", () => ({
   runSubagent: runSubagentMock,
+}));
+
+vi.mock("@/lib/billing/agent-runtime-usage", () => ({
+  reserveAgentRuntimeUsage: reserveAgentRuntimeUsageMock,
+  trackSucceededAgentRuntimeUsage: trackSucceededAgentRuntimeUsageMock,
 }));
 
 import { createProjectTestFixture } from "@/api/routes/project/project.fixture";
@@ -98,6 +107,8 @@ describe("lookupProjectFileStringRepositoryContext", () => {
     );
     runSubagentMock.mockResolvedValue({ text: "Found this key in the homepage hero." });
     stopRepositorySandboxMock.mockResolvedValue(undefined);
+    reserveAgentRuntimeUsageMock.mockResolvedValue(true);
+    trackSucceededAgentRuntimeUsageMock.mockResolvedValue(undefined);
   });
 
   afterEach(async () => {
@@ -144,6 +155,8 @@ describe("lookupProjectFileStringRepositoryContext", () => {
     });
     expect(resolveWebProjectRepositoryGitHubContextMock).not.toHaveBeenCalled();
     expect(runSubagentMock).not.toHaveBeenCalled();
+    expect(reserveAgentRuntimeUsageMock).not.toHaveBeenCalled();
+    expect(trackSucceededAgentRuntimeUsageMock).not.toHaveBeenCalled();
   });
 
   it("uses an explicit repository name without auto-selecting from enabled repositories", async () => {
@@ -178,6 +191,17 @@ describe("lookupProjectFileStringRepositoryContext", () => {
       }),
     );
     expect(stopRepositorySandboxMock).toHaveBeenCalledWith("sandbox-test");
+    expect(reserveAgentRuntimeUsageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: organization.id,
+        source: "project_file_string_context_lookup",
+      }),
+    );
+    expect(trackSucceededAgentRuntimeUsageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: organization.id,
+      }),
+    );
   });
 
   it("returns repository_not_enabled when no repository is specified and none are enabled", async () => {

--- a/apps/hyperlocalise-web/src/lib/projects/string-context/project-string-context-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/string-context/project-string-context-service.ts
@@ -460,6 +460,12 @@ export class ProjectStringContextService extends ProjectServiceBase {
 
       const summary = result.text.trim();
       if (!summary) {
+        await trackSucceededAgentRuntimeUsage({
+          organizationId: input.organizationId,
+          operationKey: usageOperationKey,
+          dimensions: usageDimensions,
+        });
+
         log.warn(
           { code: "agent_failed" },
           "project file string context agent returned empty summary",

--- a/apps/hyperlocalise-web/src/lib/projects/string-context/project-string-context-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/string-context/project-string-context-service.ts
@@ -8,6 +8,10 @@ import {
 } from "@/lib/agents/repository-context";
 import { runSubagent } from "@/lib/agent-runtime/subagents/run-subagent";
 import {
+  reserveAgentRuntimeUsage,
+  trackSucceededAgentRuntimeUsage,
+} from "@/lib/billing/agent-runtime-usage";
+import {
   createRepositorySandbox,
   stopRepositorySandbox,
 } from "@/lib/agent-runtime/workspaces/repository-sandbox";
@@ -386,6 +390,22 @@ export class ProjectStringContextService extends ProjectServiceBase {
     }
 
     const conversationId = `project-file-context:${randomUUID()}`;
+    const sourceTextHash = this.hashSourceText(input.text);
+    const usageOperationKey = `project-file-string-context:${this.hashSourceText(
+      [
+        input.organizationId,
+        input.projectId,
+        repositoryFullName,
+        input.sourcePath,
+        input.key,
+        sourceTextHash,
+      ].join("\0"),
+    )}:agent_runs`;
+    const usageDimensions = {
+      surface: "web",
+      agent_surface: "project_file_string_context",
+      subagent_type: "repository",
+    };
     const toolContext: ToolContext = {
       conversationId,
       agentSession: { todos: [] },
@@ -425,6 +445,13 @@ export class ProjectStringContextService extends ProjectServiceBase {
       .join("\n\n");
 
     try {
+      await reserveAgentRuntimeUsage({
+        organizationId: input.organizationId,
+        operationKey: usageOperationKey,
+        source: "project_file_string_context_lookup",
+        dimensions: usageDimensions,
+      });
+
       const result = await runSubagent("repository", {
         toolContext,
         task: `Find repository context for localization key "${input.key}".`,
@@ -452,6 +479,12 @@ export class ProjectStringContextService extends ProjectServiceBase {
         sourceText: input.text,
         summary,
         createdByUserId: input.localUserId,
+      });
+
+      await trackSucceededAgentRuntimeUsage({
+        organizationId: input.organizationId,
+        operationKey: usageOperationKey,
+        dimensions: usageDimensions,
       });
 
       log.info(


### PR DESCRIPTION
## What changed

- Track successful direct Hyperlocalise chat agent turns as `agent_runs` usage events in Autumn.
- Track successful live repository string-context lookups, while keeping cached lookups unbilled.
- Add focused tests for chat stream usage tracking and string-context usage tracking.

## How to test

- `vp test src/agents/hyperlocalise/agent/channels/web.test.ts src/lib/projects/string-context/project-string-context-service.test.ts src/lib/billing/usage-control.test.ts`
- `vp check --fix`
- `vp test` was run and currently fails in existing public API/MCP auth tests returning 403/401 instead of expected statuses.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)