### PR TITLE
fix(dashboard): color automation run status badges

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.tsx
@@ -14,7 +14,7 @@ import {
   TranslationIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import type { ReactNode } from "react";
+import type { ComponentProps, ReactNode } from "react";
 import { siGithub } from "simple-icons";
 
 import { Badge } from "@/components/ui/badge";
@@ -46,6 +46,18 @@ import type {
   DashboardJobItem,
   DashboardProjectItem,
 } from "./dashboard-page-view-model";
+
+type AutomationRunStatus = DashboardAutomationRunItem["status"];
+type AutomationRunBadgeVariant = NonNullable<ComponentProps<typeof Badge>["variant"]>;
+
+const AUTOMATION_RUN_BADGE_VARIANTS: Record<AutomationRunStatus, AutomationRunBadgeVariant> = {
+  queued: "warning",
+  running: "warning",
+  succeeded: "success",
+  failed: "destructive",
+  cancelled: "warning",
+  skipped: "warning",
+};
 
 export type DashboardLinkRenderer = (props: {
   href: string;
@@ -446,7 +458,10 @@ function DashboardAutomationsSection({
                               <TypographyP className="min-w-0 truncate text-sm font-medium text-foreground">
                                 {run.automationName}
                               </TypographyP>
-                              <Badge variant="outline" className="rounded-full capitalize">
+                              <Badge
+                                variant={AUTOMATION_RUN_BADGE_VARIANTS[run.status]}
+                                className="rounded-full capitalize"
+                              >
                                 {run.status}
                               </Badge>
                             </div>


### PR DESCRIPTION
## What changed

- Added a typed automation run status-to-badge-variant map for the dashboard automation runs list.
- Shows succeeded runs as success badges, failed runs as error badges, and queued/running/cancelled/skipped runs as warning badges.

## How to test

- `vp check --fix`
- `vp test "src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view-model.test.ts"`
- `vp test` was run, but existing API/MCP route tests failed with unexpected `401`/`403` responses unrelated to this dashboard badge change.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)