### PR TITLE
feat(web): add zoomable lightbox for visual context screenshots

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-visual-context-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-visual-context-panel.tsx
@@ -2,6 +2,7 @@
 
 import { FormattedMessage, useIntl } from "react-intl";
 
+import { ImageLightbox } from "@/components/ui/image-lightbox/image-lightbox";
 import { Skeleton } from "@/components/ui/skeleton";
 import type {
   CatVisualContext,
@@ -20,8 +21,46 @@ function VisualContextSkeleton() {
   );
 }
 
+function VisualContextScreenshotPreview({
+  screenshot,
+  alt,
+}: {
+  screenshot: CatVisualContextScreenshot;
+  alt: string;
+}) {
+  return (
+    <>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={screenshot.imageUrl}
+        alt={alt}
+        className="block h-auto w-full"
+        loading="lazy"
+        decoding="async"
+      />
+      {screenshot.markers.map((marker, index) => (
+        <span
+          key={`${screenshot.id}-${index}`}
+          className={cn(
+            "pointer-events-none absolute rounded-sm border-2 border-grove-300/80 bg-grove-300/15",
+            "shadow-[0_0_0_1px_rgba(255,255,255,0.35)_inset]",
+          )}
+          style={{
+            left: `${marker.left}%`,
+            top: `${marker.top}%`,
+            width: `${marker.width}%`,
+            height: `${marker.height}%`,
+          }}
+        />
+      ))}
+    </>
+  );
+}
+
 function VisualContextScreenshotCard({ screenshot }: { screenshot: CatVisualContextScreenshot }) {
   const intl = useIntl();
+  const alt =
+    screenshot.name ?? intl.formatMessage(catVisualContextPanelMessages.screenshotAltFallback);
 
   return (
     <figure className="overflow-hidden rounded-xl border border-border bg-background">
@@ -30,34 +69,18 @@ function VisualContextScreenshotCard({ screenshot }: { screenshot: CatVisualCont
           {screenshot.name}
         </figcaption>
       ) : null}
-      <div className="relative bg-muted">
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          src={screenshot.imageUrl}
-          alt={
-            screenshot.name ??
-            intl.formatMessage(catVisualContextPanelMessages.screenshotAltFallback)
-          }
-          className="block h-auto w-full"
-          loading="lazy"
-          decoding="async"
-        />
-        {screenshot.markers.map((marker, index) => (
-          <span
-            key={`${screenshot.id}-${index}`}
-            className={cn(
-              "pointer-events-none absolute rounded-sm border-2 border-grove-300/80 bg-grove-300/15",
-              "shadow-[0_0_0_1px_rgba(255,255,255,0.35)_inset]",
-            )}
-            style={{
-              left: `${marker.left}%`,
-              top: `${marker.top}%`,
-              width: `${marker.width}%`,
-              height: `${marker.height}%`,
-            }}
-          />
-        ))}
-      </div>
+      <ImageLightbox
+        alt={alt}
+        imageUrl={screenshot.imageUrl}
+        markers={screenshot.markers}
+        title={screenshot.name}
+        trigger={
+          <div className="group relative bg-muted">
+            <VisualContextScreenshotPreview screenshot={screenshot} alt={alt} />
+            <div className="pointer-events-none absolute inset-0 bg-black/0 transition-colors group-hover:bg-black/10 group-focus-visible:bg-black/10" />
+          </div>
+        }
+      />
     </figure>
   );
 }

--- a/apps/hyperlocalise-web/src/components/ui/image-lightbox/image-lightbox-gestures.test.ts
+++ b/apps/hyperlocalise-web/src/components/ui/image-lightbox/image-lightbox-gestures.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  clampLightboxScale,
+  distanceBetweenPoints,
+  MAX_LIGHTBOX_SCALE,
+  MIN_LIGHTBOX_SCALE,
+  translateForZoom,
+} from "@/components/ui/image-lightbox/image-lightbox-gestures";
+
+describe("image-lightbox-gestures", () => {
+  it("clamps zoom scale within supported bounds", () => {
+    expect(clampLightboxScale(0.5)).toBe(MIN_LIGHTBOX_SCALE);
+    expect(clampLightboxScale(2)).toBe(2);
+    expect(clampLightboxScale(10)).toBe(MAX_LIGHTBOX_SCALE);
+  });
+
+  it("computes distance between two points", () => {
+    expect(distanceBetweenPoints({ x: 0, y: 0 }, { x: 3, y: 4 })).toBe(5);
+  });
+
+  it("keeps the zoom anchor fixed while scaling", () => {
+    const viewportRect = {
+      left: 0,
+      top: 0,
+      width: 200,
+      height: 200,
+      right: 200,
+      bottom: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect;
+
+    const nextTranslate = translateForZoom({
+      viewportRect,
+      anchor: { x: 150, y: 100 },
+      currentTranslate: { x: 0, y: 0 },
+      currentScale: 1,
+      nextScale: 2,
+    });
+
+    expect(nextTranslate.x).toBe(-50);
+    expect(nextTranslate.y).toBe(0);
+  });
+});

--- a/apps/hyperlocalise-web/src/components/ui/image-lightbox/image-lightbox-gestures.ts
+++ b/apps/hyperlocalise-web/src/components/ui/image-lightbox/image-lightbox-gestures.ts
@@ -1,0 +1,51 @@
+export const MIN_LIGHTBOX_SCALE = 1;
+export const MAX_LIGHTBOX_SCALE = 5;
+export const LIGHTBOX_ZOOM_STEP = 0.25;
+export const LIGHTBOX_DOUBLE_TAP_ZOOM = 2;
+
+export const TAP_MAX_DURATION_MS = 300;
+export const TAP_MAX_DISTANCE_PX = 12;
+export const DRAG_THRESHOLD_PX = 6;
+
+export type Point = {
+  x: number;
+  y: number;
+};
+
+export type Translate = Point;
+
+export function clampLightboxScale(value: number) {
+  return Math.min(MAX_LIGHTBOX_SCALE, Math.max(MIN_LIGHTBOX_SCALE, value));
+}
+
+export function distanceBetweenPoints(a: Point, b: Point) {
+  return Math.hypot(b.x - a.x, b.y - a.y);
+}
+
+export function centerBetweenPoints(a: Point, b: Point): Point {
+  return {
+    x: (a.x + b.x) / 2,
+    y: (a.y + b.y) / 2,
+  };
+}
+
+export function translateForZoom(input: {
+  viewportRect: DOMRect;
+  anchor: Point;
+  currentTranslate: Translate;
+  currentScale: number;
+  nextScale: number;
+}): Translate {
+  if (input.nextScale === MIN_LIGHTBOX_SCALE) {
+    return { x: 0, y: 0 };
+  }
+
+  const offsetX = input.anchor.x - input.viewportRect.left - input.viewportRect.width / 2;
+  const offsetY = input.anchor.y - input.viewportRect.top - input.viewportRect.height / 2;
+  const scaleRatio = input.nextScale / input.currentScale;
+
+  return {
+    x: input.currentTranslate.x - offsetX * (scaleRatio - 1),
+    y: input.currentTranslate.y - offsetY * (scaleRatio - 1),
+  };
+}

--- a/apps/hyperlocalise-web/src/components/ui/image-lightbox/image-lightbox.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ui/image-lightbox/image-lightbox.messages.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const imageLightboxMessages = defineMessages({
+  close: {
+    defaultMessage: "Close",
+    id: "KRRKR3H/tH",
+    description: "Accessible label for closing the image lightbox",
+  },
+  zoomIn: {
+    defaultMessage: "Zoom in",
+    id: "NERy9XM6Cd",
+    description: "Accessible label for zooming in within the image lightbox",
+  },
+  zoomOut: {
+    defaultMessage: "Zoom out",
+    id: "mSR1oODTzi",
+    description: "Accessible label for zooming out within the image lightbox",
+  },
+  resetZoom: {
+    defaultMessage: "Reset zoom",
+    id: "kIG+JJHbzJ",
+    description: "Accessible label for resetting zoom and pan in the image lightbox",
+  },
+  zoomLevel: {
+    defaultMessage: "{percent}%",
+    id: "xbAzhdR+Tu",
+    description: "Current zoom percentage shown in the image lightbox toolbar",
+  },
+  openPreview: {
+    defaultMessage: "Open screenshot preview",
+    id: "ODRuwyxRYT",
+    description: "Accessible label for opening a screenshot in the lightbox",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ui/image-lightbox/image-lightbox.test.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/image-lightbox/image-lightbox.test.tsx
@@ -1,25 +1,28 @@
 // @vitest-environment happy-dom
 
-import { screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vite-plus/test";
 
 import { renderWithCatProviders } from "@/components/cat/shared/cat-test-utils";
 import { ImageLightbox } from "@/components/ui/image-lightbox/image-lightbox";
 
+function renderLightbox() {
+  renderWithCatProviders(
+    <ImageLightbox
+      alt="Screenshot context"
+      imageUrl="https://example.com/screenshot.png"
+      markers={[{ left: 10, top: 20, width: 30, height: 15 }]}
+      title="Home screen"
+      trigger={<img src="https://example.com/screenshot.png" alt="Screenshot context" />}
+    />,
+  );
+}
+
 describe("ImageLightbox", () => {
   it("opens the lightbox and exposes zoom controls", async () => {
     const user = userEvent.setup();
-
-    renderWithCatProviders(
-      <ImageLightbox
-        alt="Screenshot context"
-        imageUrl="https://example.com/screenshot.png"
-        markers={[{ left: 10, top: 20, width: 30, height: 15 }]}
-        title="Home screen"
-        trigger={<img src="https://example.com/screenshot.png" alt="Screenshot context" />}
-      />,
-    );
+    renderLightbox();
 
     await user.click(screen.getByRole("button", { name: "Open screenshot preview" }));
 
@@ -27,6 +30,99 @@ describe("ImageLightbox", () => {
     expect(screen.getByRole("button", { name: "Zoom in" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Zoom out" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Reset zoom" })).toBeTruthy();
+    expect(screen.getByText("100%")).toBeTruthy();
+  });
+
+  it("supports pinch-to-zoom gestures on touch devices", async () => {
+    const user = userEvent.setup();
+    renderLightbox();
+
+    await user.click(screen.getByRole("button", { name: "Open screenshot preview" }));
+
+    const viewport = screen.getByTestId("image-lightbox-viewport");
+
+    fireEvent.pointerDown(viewport, {
+      pointerId: 1,
+      pointerType: "touch",
+      clientX: 100,
+      clientY: 100,
+    });
+    fireEvent.pointerDown(viewport, {
+      pointerId: 2,
+      pointerType: "touch",
+      clientX: 200,
+      clientY: 200,
+    });
+    fireEvent.pointerMove(viewport, {
+      pointerId: 2,
+      pointerType: "touch",
+      clientX: 260,
+      clientY: 260,
+    });
+
+    expect(screen.getByText("160%")).toBeTruthy();
+  });
+
+  it("supports double-tap zoom and reset on touch devices", async () => {
+    const user = userEvent.setup();
+    renderLightbox();
+
+    await user.click(screen.getByRole("button", { name: "Open screenshot preview" }));
+
+    const viewport = screen.getByTestId("image-lightbox-viewport");
+
+    fireEvent.pointerDown(viewport, {
+      pointerId: 3,
+      pointerType: "touch",
+      clientX: 120,
+      clientY: 120,
+    });
+    fireEvent.pointerUp(viewport, {
+      pointerId: 3,
+      pointerType: "touch",
+      clientX: 120,
+      clientY: 120,
+    });
+    fireEvent.pointerDown(viewport, {
+      pointerId: 4,
+      pointerType: "touch",
+      clientX: 122,
+      clientY: 121,
+    });
+    fireEvent.pointerUp(viewport, {
+      pointerId: 4,
+      pointerType: "touch",
+      clientX: 122,
+      clientY: 121,
+    });
+
+    expect(screen.getByText("200%")).toBeTruthy();
+
+    fireEvent.pointerDown(viewport, {
+      pointerId: 5,
+      pointerType: "touch",
+      clientX: 122,
+      clientY: 121,
+    });
+    fireEvent.pointerUp(viewport, {
+      pointerId: 5,
+      pointerType: "touch",
+      clientX: 122,
+      clientY: 121,
+    });
+    fireEvent.pointerDown(viewport, {
+      pointerId: 6,
+      pointerType: "touch",
+      clientX: 124,
+      clientY: 122,
+    });
+    fireEvent.pointerUp(viewport, {
+      pointerId: 6,
+      pointerType: "touch",
+      clientX: 124,
+      clientY: 122,
+    });
+
     expect(screen.getByText("100%")).toBeTruthy();
   });
 });

--- a/apps/hyperlocalise-web/src/components/ui/image-lightbox/image-lightbox.test.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/image-lightbox/image-lightbox.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment happy-dom
+
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vite-plus/test";
+
+import { renderWithCatProviders } from "@/components/cat/shared/cat-test-utils";
+import { ImageLightbox } from "@/components/ui/image-lightbox/image-lightbox";
+
+describe("ImageLightbox", () => {
+  it("opens the lightbox and exposes zoom controls", async () => {
+    const user = userEvent.setup();
+
+    renderWithCatProviders(
+      <ImageLightbox
+        alt="Screenshot context"
+        imageUrl="https://example.com/screenshot.png"
+        markers={[{ left: 10, top: 20, width: 30, height: 15 }]}
+        title="Home screen"
+        trigger={<img src="https://example.com/screenshot.png" alt="Screenshot context" />}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open screenshot preview" }));
+
+    expect(screen.getByText("Home screen")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Zoom in" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Zoom out" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Reset zoom" })).toBeTruthy();
+    expect(screen.getByText("100%")).toBeTruthy();
+  });
+});

--- a/apps/hyperlocalise-web/src/components/ui/image-lightbox/image-lightbox.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/image-lightbox/image-lightbox.tsx
@@ -177,6 +177,10 @@ function ImageLightboxViewport({ alt, imageUrl, markers = [] }: ImageLightboxVie
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+        return;
+      }
+
       if (event.key === "+" || event.key === "=") {
         event.preventDefault();
         zoomIn();
@@ -370,13 +374,6 @@ function ImageLightboxViewport({ alt, imageUrl, markers = [] }: ImageLightboxVie
     [toggleDoubleTapZoom],
   );
 
-  const handleDoubleClick = useCallback(
-    (event: React.MouseEvent<HTMLDivElement>) => {
-      toggleDoubleTapZoom({ x: event.clientX, y: event.clientY });
-    },
-    [toggleDoubleTapZoom],
-  );
-
   return (
     <>
       <div
@@ -391,7 +388,6 @@ function ImageLightboxViewport({ alt, imageUrl, markers = [] }: ImageLightboxVie
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
         onPointerCancel={handlePointerUp}
-        onDoubleClick={handleDoubleClick}
       >
         <div className="flex size-full items-center justify-center">
           <div

--- a/apps/hyperlocalise-web/src/components/ui/image-lightbox/image-lightbox.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/image-lightbox/image-lightbox.tsx
@@ -19,11 +19,22 @@ import { Dialog, DialogOverlay, DialogPortal, DialogTrigger } from "@/components
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/primitives/cn";
 
+import {
+  centerBetweenPoints,
+  clampLightboxScale,
+  distanceBetweenPoints,
+  DRAG_THRESHOLD_PX,
+  LIGHTBOX_DOUBLE_TAP_ZOOM,
+  LIGHTBOX_ZOOM_STEP,
+  MAX_LIGHTBOX_SCALE,
+  MIN_LIGHTBOX_SCALE,
+  TAP_MAX_DISTANCE_PX,
+  TAP_MAX_DURATION_MS,
+  translateForZoom,
+  type Point,
+  type Translate,
+} from "@/components/ui/image-lightbox/image-lightbox-gestures";
 import { imageLightboxMessages } from "@/components/ui/image-lightbox/image-lightbox.messages";
-
-const MIN_SCALE = 1;
-const MAX_SCALE = 5;
-const ZOOM_STEP = 0.25;
 
 export type ImageLightboxMarker = {
   left: number;
@@ -38,57 +49,131 @@ type ImageLightboxViewportProps = {
   markers?: ImageLightboxMarker[];
 };
 
-function clampScale(value: number) {
-  return Math.min(MAX_SCALE, Math.max(MIN_SCALE, value));
-}
+type PinchState = {
+  startDistance: number;
+  startScale: number;
+  startTranslate: Translate;
+  center: Point;
+};
+
+type TapState = {
+  time: number;
+  x: number;
+  y: number;
+};
 
 function ImageLightboxViewport({ alt, imageUrl, markers = [] }: ImageLightboxViewportProps) {
   const intl = useIntl();
   const viewportRef = useRef<HTMLDivElement>(null);
-  const [scale, setScale] = useState(MIN_SCALE);
-  const [translate, setTranslate] = useState({ x: 0, y: 0 });
-  const dragStateRef = useRef<{ pointerId: number; x: number; y: number } | null>(null);
+  const [scale, setScale] = useState(MIN_LIGHTBOX_SCALE);
+  const [translate, setTranslate] = useState<Translate>({ x: 0, y: 0 });
+  const [isGesturing, setIsGesturing] = useState(false);
 
-  const resetView = useCallback(() => {
-    setScale(MIN_SCALE);
-    setTranslate({ x: 0, y: 0 });
+  const scaleRef = useRef(scale);
+  const translateRef = useRef(translate);
+  const activePointersRef = useRef(new Map<number, Point>());
+  const dragPointerRef = useRef<{ pointerId: number; x: number; y: number } | null>(null);
+  const pinchStateRef = useRef<PinchState | null>(null);
+  const lastTapRef = useRef<TapState | null>(null);
+  const pointerStartRef = useRef<{ pointerId: number; x: number; y: number; time: number } | null>(
+    null,
+  );
+  const hasDraggedRef = useRef(false);
+
+  useEffect(() => {
+    scaleRef.current = scale;
+  }, [scale]);
+
+  useEffect(() => {
+    translateRef.current = translate;
+  }, [translate]);
+
+  const commitView = useCallback((nextScale: number, nextTranslate: Translate) => {
+    scaleRef.current = nextScale;
+    translateRef.current = nextTranslate;
+    setScale(nextScale);
+    setTranslate(nextTranslate);
   }, []);
 
+  const resetView = useCallback(() => {
+    commitView(MIN_LIGHTBOX_SCALE, { x: 0, y: 0 });
+  }, [commitView]);
+
   const applyZoom = useCallback(
-    (getNextScale: (currentScale: number) => number, anchor?: { x: number; y: number }) => {
-      setScale((currentScale) => {
-        const clampedScale = clampScale(getNextScale(currentScale));
-        if (clampedScale === currentScale) {
-          return currentScale;
-        }
+    (getNextScale: (currentScale: number) => number, anchor?: Point) => {
+      const currentScale = scaleRef.current;
+      const nextScale = clampLightboxScale(getNextScale(currentScale));
+      if (nextScale === currentScale) {
+        return;
+      }
 
-        if (anchor && viewportRef.current && clampedScale !== MIN_SCALE) {
-          const rect = viewportRef.current.getBoundingClientRect();
-          const offsetX = anchor.x - rect.left - rect.width / 2;
-          const offsetY = anchor.y - rect.top - rect.height / 2;
-          const scaleRatio = clampedScale / currentScale;
+      if (anchor && viewportRef.current) {
+        const nextTranslate = translateForZoom({
+          viewportRect: viewportRef.current.getBoundingClientRect(),
+          anchor,
+          currentTranslate: translateRef.current,
+          currentScale,
+          nextScale,
+        });
+        commitView(nextScale, nextTranslate);
+        return;
+      }
 
-          setTranslate((current) => ({
-            x: current.x - offsetX * (scaleRatio - 1),
-            y: current.y - offsetY * (scaleRatio - 1),
-          }));
-        } else if (clampedScale === MIN_SCALE) {
-          setTranslate({ x: 0, y: 0 });
-        }
-
-        return clampedScale;
-      });
+      commitView(
+        nextScale,
+        nextScale === MIN_LIGHTBOX_SCALE ? { x: 0, y: 0 } : translateRef.current,
+      );
     },
-    [],
+    [commitView],
   );
 
   const zoomIn = useCallback(() => {
-    applyZoom((currentScale) => currentScale + ZOOM_STEP);
+    applyZoom((currentScale) => currentScale + LIGHTBOX_ZOOM_STEP);
   }, [applyZoom]);
 
   const zoomOut = useCallback(() => {
-    applyZoom((currentScale) => currentScale - ZOOM_STEP);
+    applyZoom((currentScale) => currentScale - LIGHTBOX_ZOOM_STEP);
   }, [applyZoom]);
+
+  const toggleDoubleTapZoom = useCallback(
+    (anchor: Point) => {
+      if (scaleRef.current > MIN_LIGHTBOX_SCALE) {
+        resetView();
+        return;
+      }
+
+      applyZoom(() => LIGHTBOX_DOUBLE_TAP_ZOOM, anchor);
+    },
+    [applyZoom, resetView],
+  );
+
+  const updatePinch = useCallback(() => {
+    const pointers = [...activePointersRef.current.values()];
+    const pinchState = pinchStateRef.current;
+    const viewport = viewportRef.current;
+
+    if (pointers.length < 2 || !pinchState || !viewport) {
+      return;
+    }
+
+    const distance = distanceBetweenPoints(pointers[0]!, pointers[1]!);
+    if (distance <= 0 || pinchState.startDistance <= 0) {
+      return;
+    }
+
+    const nextScale = clampLightboxScale(
+      pinchState.startScale * (distance / pinchState.startDistance),
+    );
+    const nextTranslate = translateForZoom({
+      viewportRect: viewport.getBoundingClientRect(),
+      anchor: pinchState.center,
+      currentTranslate: pinchState.startTranslate,
+      currentScale: pinchState.startScale,
+      nextScale,
+    });
+
+    commitView(nextScale, nextTranslate);
+  }, [commitView]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -111,7 +196,7 @@ function ImageLightboxViewport({ alt, imageUrl, markers = [] }: ImageLightboxVie
   const handleWheel = useCallback(
     (event: ReactWheelEvent<HTMLDivElement>) => {
       event.preventDefault();
-      const direction = event.deltaY < 0 ? ZOOM_STEP : -ZOOM_STEP;
+      const direction = event.deltaY < 0 ? LIGHTBOX_ZOOM_STEP : -LIGHTBOX_ZOOM_STEP;
       applyZoom((currentScale) => currentScale + direction, {
         x: event.clientX,
         y: event.clientY,
@@ -120,74 +205,186 @@ function ImageLightboxViewport({ alt, imageUrl, markers = [] }: ImageLightboxVie
     [applyZoom],
   );
 
-  const handlePointerDown = useCallback(
+  const handlePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.pointerType === "mouse" && event.button !== 0) {
+      return;
+    }
+
+    activePointersRef.current.set(event.pointerId, {
+      x: event.clientX,
+      y: event.clientY,
+    });
+    setIsGesturing(true);
+
+    if (activePointersRef.current.size === 2) {
+      const [first, second] = [...activePointersRef.current.values()];
+      pinchStateRef.current = {
+        startDistance: distanceBetweenPoints(first!, second!),
+        startScale: scaleRef.current,
+        startTranslate: translateRef.current,
+        center: centerBetweenPoints(first!, second!),
+      };
+      dragPointerRef.current = null;
+      pointerStartRef.current = null;
+      hasDraggedRef.current = true;
+      return;
+    }
+
+    pointerStartRef.current = {
+      pointerId: event.pointerId,
+      x: event.clientX,
+      y: event.clientY,
+      time: Date.now(),
+    };
+    hasDraggedRef.current = false;
+  }, []);
+
+  const handlePointerMove = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
-      if (scale <= MIN_SCALE) {
+      if (!activePointersRef.current.has(event.pointerId)) {
         return;
       }
 
-      dragStateRef.current = {
+      activePointersRef.current.set(event.pointerId, {
+        x: event.clientX,
+        y: event.clientY,
+      });
+
+      if (activePointersRef.current.size >= 2) {
+        if (!pinchStateRef.current) {
+          const [first, second] = [...activePointersRef.current.values()];
+          pinchStateRef.current = {
+            startDistance: distanceBetweenPoints(first!, second!),
+            startScale: scaleRef.current,
+            startTranslate: translateRef.current,
+            center: centerBetweenPoints(first!, second!),
+          };
+        }
+
+        updatePinch();
+        return;
+      }
+
+      const pointerStart = pointerStartRef.current;
+      if (!pointerStart || pointerStart.pointerId !== event.pointerId) {
+        return;
+      }
+
+      const deltaX = event.clientX - pointerStart.x;
+      const deltaY = event.clientY - pointerStart.y;
+      const distanceMoved = Math.hypot(deltaX, deltaY);
+
+      if (!hasDraggedRef.current) {
+        if (distanceMoved < DRAG_THRESHOLD_PX || scaleRef.current <= MIN_LIGHTBOX_SCALE) {
+          return;
+        }
+
+        hasDraggedRef.current = true;
+        dragPointerRef.current = {
+          pointerId: event.pointerId,
+          x: event.clientX,
+          y: event.clientY,
+        };
+        event.currentTarget.setPointerCapture(event.pointerId);
+        return;
+      }
+
+      const dragPointer = dragPointerRef.current;
+      if (!dragPointer || dragPointer.pointerId !== event.pointerId) {
+        return;
+      }
+
+      const frameDeltaX = event.clientX - dragPointer.x;
+      const frameDeltaY = event.clientY - dragPointer.y;
+
+      dragPointerRef.current = {
         pointerId: event.pointerId,
         x: event.clientX,
         y: event.clientY,
       };
-      event.currentTarget.setPointerCapture(event.pointerId);
+
+      const nextTranslate = {
+        x: translateRef.current.x + frameDeltaX,
+        y: translateRef.current.y + frameDeltaY,
+      };
+      translateRef.current = nextTranslate;
+      setTranslate(nextTranslate);
     },
-    [scale],
+    [updatePinch],
   );
 
-  const handlePointerMove = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    const dragState = dragStateRef.current;
-    if (!dragState || dragState.pointerId !== event.pointerId) {
-      return;
-    }
+  const handlePointerUp = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const pointerStart = pointerStartRef.current;
+      const wasPinching = pinchStateRef.current != null;
 
-    const deltaX = event.clientX - dragState.x;
-    const deltaY = event.clientY - dragState.y;
+      activePointersRef.current.delete(event.pointerId);
 
-    dragStateRef.current = {
-      pointerId: event.pointerId,
-      x: event.clientX,
-      y: event.clientY,
-    };
+      if (activePointersRef.current.size < 2) {
+        pinchStateRef.current = null;
+      }
 
-    setTranslate((current) => ({
-      x: current.x + deltaX,
-      y: current.y + deltaY,
-    }));
-  }, []);
+      if (dragPointerRef.current?.pointerId === event.pointerId) {
+        dragPointerRef.current = null;
+        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+          event.currentTarget.releasePointerCapture(event.pointerId);
+        }
+      }
 
-  const handlePointerUp = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    const dragState = dragStateRef.current;
-    if (!dragState || dragState.pointerId !== event.pointerId) {
-      return;
-    }
+      if (
+        pointerStart?.pointerId === event.pointerId &&
+        !hasDraggedRef.current &&
+        !wasPinching &&
+        activePointersRef.current.size === 0
+      ) {
+        const now = Date.now();
+        const lastTap = lastTapRef.current;
+        const tapDistance = lastTap
+          ? Math.hypot(event.clientX - lastTap.x, event.clientY - lastTap.y)
+          : Number.POSITIVE_INFINITY;
 
-    dragStateRef.current = null;
-    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-      event.currentTarget.releasePointerCapture(event.pointerId);
-    }
-  }, []);
+        if (
+          lastTap &&
+          now - lastTap.time <= TAP_MAX_DURATION_MS &&
+          tapDistance <= TAP_MAX_DISTANCE_PX
+        ) {
+          lastTapRef.current = null;
+          toggleDoubleTapZoom({ x: event.clientX, y: event.clientY });
+        } else {
+          lastTapRef.current = {
+            time: now,
+            x: event.clientX,
+            y: event.clientY,
+          };
+        }
+      }
+
+      if (pointerStart?.pointerId === event.pointerId) {
+        pointerStartRef.current = null;
+      }
+
+      if (activePointersRef.current.size === 0) {
+        setIsGesturing(false);
+      }
+    },
+    [toggleDoubleTapZoom],
+  );
 
   const handleDoubleClick = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
-      if (scale > MIN_SCALE) {
-        resetView();
-        return;
-      }
-
-      applyZoom(() => 2, { x: event.clientX, y: event.clientY });
+      toggleDoubleTapZoom({ x: event.clientX, y: event.clientY });
     },
-    [applyZoom, resetView, scale],
+    [toggleDoubleTapZoom],
   );
 
   return (
     <>
       <div
         ref={viewportRef}
+        data-testid="image-lightbox-viewport"
         className={cn(
           "relative min-h-0 flex-1 touch-none overflow-hidden bg-black/40",
-          scale > MIN_SCALE ? "cursor-grab active:cursor-grabbing" : "cursor-zoom-in",
+          scale > MIN_LIGHTBOX_SCALE ? "cursor-grab active:cursor-grabbing" : "cursor-zoom-in",
         )}
         onWheel={handleWheel}
         onPointerDown={handlePointerDown}
@@ -198,7 +395,10 @@ function ImageLightboxViewport({ alt, imageUrl, markers = [] }: ImageLightboxVie
       >
         <div className="flex size-full items-center justify-center">
           <div
-            className="relative max-h-full max-w-full transition-transform duration-75 will-change-transform"
+            className={cn(
+              "relative max-h-full max-w-full will-change-transform",
+              !isGesturing && "transition-transform duration-75",
+            )}
             style={{
               transform: `translate(${translate.x}px, ${translate.y}px) scale(${scale})`,
             }}
@@ -207,7 +407,7 @@ function ImageLightboxViewport({ alt, imageUrl, markers = [] }: ImageLightboxVie
             <img
               src={imageUrl}
               alt={alt}
-              className="block max-h-[calc(100vh-7rem)] max-w-[calc(100vw-2rem)] object-contain select-none"
+              className="block max-h-[calc(100dvh-7rem-env(safe-area-inset-top)-env(safe-area-inset-bottom))] max-w-[calc(100vw-2rem)] object-contain select-none"
               draggable={false}
             />
             {markers.map((marker, index) => (
@@ -229,7 +429,7 @@ function ImageLightboxViewport({ alt, imageUrl, markers = [] }: ImageLightboxVie
         </div>
       </div>
 
-      <div className="flex items-center justify-center gap-1 border-t border-white/10 bg-black/60 px-3 py-2">
+      <div className="flex items-center justify-center gap-1 border-t border-white/10 bg-black/60 px-3 py-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]">
         <Tooltip>
           <TooltipTrigger
             render={
@@ -239,7 +439,7 @@ function ImageLightboxViewport({ alt, imageUrl, markers = [] }: ImageLightboxVie
                 size="icon-sm"
                 className="text-white hover:bg-white/10 hover:text-white"
                 onClick={zoomOut}
-                disabled={scale <= MIN_SCALE}
+                disabled={scale <= MIN_LIGHTBOX_SCALE}
                 aria-label={intl.formatMessage(imageLightboxMessages.zoomOut)}
               >
                 <HugeiconsIcon icon={ZoomOutAreaIcon} strokeWidth={2} />
@@ -257,7 +457,7 @@ function ImageLightboxViewport({ alt, imageUrl, markers = [] }: ImageLightboxVie
           size="sm"
           className="min-w-16 text-white hover:bg-white/10 hover:text-white"
           onClick={resetView}
-          disabled={scale === MIN_SCALE && translate.x === 0 && translate.y === 0}
+          disabled={scale === MIN_LIGHTBOX_SCALE && translate.x === 0 && translate.y === 0}
           aria-label={intl.formatMessage(imageLightboxMessages.resetZoom)}
         >
           <FormattedMessage
@@ -275,7 +475,7 @@ function ImageLightboxViewport({ alt, imageUrl, markers = [] }: ImageLightboxVie
                 size="icon-sm"
                 className="text-white hover:bg-white/10 hover:text-white"
                 onClick={zoomIn}
-                disabled={scale >= MAX_SCALE}
+                disabled={scale >= MAX_LIGHTBOX_SCALE}
                 aria-label={intl.formatMessage(imageLightboxMessages.zoomIn)}
               >
                 <HugeiconsIcon icon={ZoomInAreaIcon} strokeWidth={2} />
@@ -336,7 +536,7 @@ export function ImageLightbox({
           data-slot="dialog-content"
           className="fixed inset-0 z-50 flex flex-col outline-none data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0"
         >
-          <div className="flex items-center justify-between gap-3 border-b border-white/10 bg-black/60 px-4 py-3 text-white">
+          <div className="flex items-center justify-between gap-3 border-b border-white/10 bg-black/60 px-4 py-3 pt-[max(0.75rem,env(safe-area-inset-top))] text-white">
             <p className="truncate text-sm font-medium">{title ?? alt}</p>
             <Tooltip>
               <TooltipTrigger

--- a/apps/hyperlocalise-web/src/components/ui/image-lightbox/image-lightbox.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/image-lightbox/image-lightbox.tsx
@@ -1,0 +1,377 @@
+"use client";
+
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { Cancel01Icon, ZoomInAreaIcon, ZoomOutAreaIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+  type WheelEvent as ReactWheelEvent,
+} from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogOverlay, DialogPortal, DialogTrigger } from "@/components/ui/dialog";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/primitives/cn";
+
+import { imageLightboxMessages } from "@/components/ui/image-lightbox/image-lightbox.messages";
+
+const MIN_SCALE = 1;
+const MAX_SCALE = 5;
+const ZOOM_STEP = 0.25;
+
+export type ImageLightboxMarker = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+type ImageLightboxViewportProps = {
+  alt: string;
+  imageUrl: string;
+  markers?: ImageLightboxMarker[];
+};
+
+function clampScale(value: number) {
+  return Math.min(MAX_SCALE, Math.max(MIN_SCALE, value));
+}
+
+function ImageLightboxViewport({ alt, imageUrl, markers = [] }: ImageLightboxViewportProps) {
+  const intl = useIntl();
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(MIN_SCALE);
+  const [translate, setTranslate] = useState({ x: 0, y: 0 });
+  const dragStateRef = useRef<{ pointerId: number; x: number; y: number } | null>(null);
+
+  const resetView = useCallback(() => {
+    setScale(MIN_SCALE);
+    setTranslate({ x: 0, y: 0 });
+  }, []);
+
+  const applyZoom = useCallback(
+    (getNextScale: (currentScale: number) => number, anchor?: { x: number; y: number }) => {
+      setScale((currentScale) => {
+        const clampedScale = clampScale(getNextScale(currentScale));
+        if (clampedScale === currentScale) {
+          return currentScale;
+        }
+
+        if (anchor && viewportRef.current && clampedScale !== MIN_SCALE) {
+          const rect = viewportRef.current.getBoundingClientRect();
+          const offsetX = anchor.x - rect.left - rect.width / 2;
+          const offsetY = anchor.y - rect.top - rect.height / 2;
+          const scaleRatio = clampedScale / currentScale;
+
+          setTranslate((current) => ({
+            x: current.x - offsetX * (scaleRatio - 1),
+            y: current.y - offsetY * (scaleRatio - 1),
+          }));
+        } else if (clampedScale === MIN_SCALE) {
+          setTranslate({ x: 0, y: 0 });
+        }
+
+        return clampedScale;
+      });
+    },
+    [],
+  );
+
+  const zoomIn = useCallback(() => {
+    applyZoom((currentScale) => currentScale + ZOOM_STEP);
+  }, [applyZoom]);
+
+  const zoomOut = useCallback(() => {
+    applyZoom((currentScale) => currentScale - ZOOM_STEP);
+  }, [applyZoom]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "+" || event.key === "=") {
+        event.preventDefault();
+        zoomIn();
+      } else if (event.key === "-") {
+        event.preventDefault();
+        zoomOut();
+      } else if (event.key === "0") {
+        event.preventDefault();
+        resetView();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [resetView, zoomIn, zoomOut]);
+
+  const handleWheel = useCallback(
+    (event: ReactWheelEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      const direction = event.deltaY < 0 ? ZOOM_STEP : -ZOOM_STEP;
+      applyZoom((currentScale) => currentScale + direction, {
+        x: event.clientX,
+        y: event.clientY,
+      });
+    },
+    [applyZoom],
+  );
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (scale <= MIN_SCALE) {
+        return;
+      }
+
+      dragStateRef.current = {
+        pointerId: event.pointerId,
+        x: event.clientX,
+        y: event.clientY,
+      };
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+    [scale],
+  );
+
+  const handlePointerMove = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    const dragState = dragStateRef.current;
+    if (!dragState || dragState.pointerId !== event.pointerId) {
+      return;
+    }
+
+    const deltaX = event.clientX - dragState.x;
+    const deltaY = event.clientY - dragState.y;
+
+    dragStateRef.current = {
+      pointerId: event.pointerId,
+      x: event.clientX,
+      y: event.clientY,
+    };
+
+    setTranslate((current) => ({
+      x: current.x + deltaX,
+      y: current.y + deltaY,
+    }));
+  }, []);
+
+  const handlePointerUp = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    const dragState = dragStateRef.current;
+    if (!dragState || dragState.pointerId !== event.pointerId) {
+      return;
+    }
+
+    dragStateRef.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  }, []);
+
+  const handleDoubleClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (scale > MIN_SCALE) {
+        resetView();
+        return;
+      }
+
+      applyZoom(() => 2, { x: event.clientX, y: event.clientY });
+    },
+    [applyZoom, resetView, scale],
+  );
+
+  return (
+    <>
+      <div
+        ref={viewportRef}
+        className={cn(
+          "relative min-h-0 flex-1 touch-none overflow-hidden bg-black/40",
+          scale > MIN_SCALE ? "cursor-grab active:cursor-grabbing" : "cursor-zoom-in",
+        )}
+        onWheel={handleWheel}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        onDoubleClick={handleDoubleClick}
+      >
+        <div className="flex size-full items-center justify-center">
+          <div
+            className="relative max-h-full max-w-full transition-transform duration-75 will-change-transform"
+            style={{
+              transform: `translate(${translate.x}px, ${translate.y}px) scale(${scale})`,
+            }}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={imageUrl}
+              alt={alt}
+              className="block max-h-[calc(100vh-7rem)] max-w-[calc(100vw-2rem)] object-contain select-none"
+              draggable={false}
+            />
+            {markers.map((marker, index) => (
+              <span
+                key={`${marker.left}-${marker.top}-${index}`}
+                className={cn(
+                  "pointer-events-none absolute rounded-sm border-2 border-grove-300/90 bg-grove-300/20",
+                  "shadow-[0_0_0_1px_rgba(255,255,255,0.35)_inset]",
+                )}
+                style={{
+                  left: `${marker.left}%`,
+                  top: `${marker.top}%`,
+                  width: `${marker.width}%`,
+                  height: `${marker.height}%`,
+                }}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-center gap-1 border-t border-white/10 bg-black/60 px-3 py-2">
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="text-white hover:bg-white/10 hover:text-white"
+                onClick={zoomOut}
+                disabled={scale <= MIN_SCALE}
+                aria-label={intl.formatMessage(imageLightboxMessages.zoomOut)}
+              >
+                <HugeiconsIcon icon={ZoomOutAreaIcon} strokeWidth={2} />
+              </Button>
+            }
+          />
+          <TooltipContent side="top">
+            <FormattedMessage {...imageLightboxMessages.zoomOut} />
+          </TooltipContent>
+        </Tooltip>
+
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="min-w-16 text-white hover:bg-white/10 hover:text-white"
+          onClick={resetView}
+          disabled={scale === MIN_SCALE && translate.x === 0 && translate.y === 0}
+          aria-label={intl.formatMessage(imageLightboxMessages.resetZoom)}
+        >
+          <FormattedMessage
+            {...imageLightboxMessages.zoomLevel}
+            values={{ percent: Math.round(scale * 100) }}
+          />
+        </Button>
+
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="text-white hover:bg-white/10 hover:text-white"
+                onClick={zoomIn}
+                disabled={scale >= MAX_SCALE}
+                aria-label={intl.formatMessage(imageLightboxMessages.zoomIn)}
+              >
+                <HugeiconsIcon icon={ZoomInAreaIcon} strokeWidth={2} />
+              </Button>
+            }
+          />
+          <TooltipContent side="top">
+            <FormattedMessage {...imageLightboxMessages.zoomIn} />
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    </>
+  );
+}
+
+export type ImageLightboxProps = {
+  alt: string;
+  imageUrl: string;
+  markers?: ImageLightboxMarker[];
+  title?: string | null;
+  trigger: ReactNode;
+  triggerClassName?: string;
+};
+
+export function ImageLightbox({
+  alt,
+  imageUrl,
+  markers,
+  title,
+  trigger,
+  triggerClassName,
+}: ImageLightboxProps) {
+  const intl = useIntl();
+  const [open, setOpen] = useState(false);
+  const [viewportKey, setViewportKey] = useState(0);
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setViewportKey((current) => current + 1);
+    }
+  }, []);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger
+        className={cn(
+          "block w-full cursor-zoom-in text-start focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          triggerClassName,
+        )}
+        aria-label={intl.formatMessage(imageLightboxMessages.openPreview)}
+      >
+        {trigger}
+      </DialogTrigger>
+      <DialogPortal>
+        <DialogOverlay className="bg-black/85 dark:bg-black/90" />
+        <DialogPrimitive.Popup
+          data-slot="dialog-content"
+          className="fixed inset-0 z-50 flex flex-col outline-none data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0"
+        >
+          <div className="flex items-center justify-between gap-3 border-b border-white/10 bg-black/60 px-4 py-3 text-white">
+            <p className="truncate text-sm font-medium">{title ?? alt}</p>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <DialogPrimitive.Close
+                    render={
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        className="text-white hover:bg-white/10 hover:text-white"
+                        aria-label={intl.formatMessage(imageLightboxMessages.close)}
+                      >
+                        <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} />
+                      </Button>
+                    }
+                  />
+                }
+              />
+              <TooltipContent side="bottom" align="end">
+                <FormattedMessage {...imageLightboxMessages.close} />
+              </TooltipContent>
+            </Tooltip>
+          </div>
+
+          {open ? (
+            <ImageLightboxViewport
+              key={viewportKey}
+              alt={alt}
+              imageUrl={imageUrl}
+              markers={markers}
+            />
+          ) : null}
+        </DialogPrimitive.Popup>
+      </DialogPortal>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a fullscreen lightbox for CAT Visual Context screenshots so translators can inspect TMS images in detail.

- New reusable `ImageLightbox` with zoom in/out, drag-to-pan, scroll-wheel zoom, double-click/double-tap zoom/reset, and keyboard shortcuts (`+`/`-`/`0`)
- **Touch support:** pinch-to-zoom, one-finger pan when zoomed, double-tap zoom/reset
- Safe-area padding for notched mobile devices
- Segment highlight markers preserved inside the lightbox viewport
- Visual Context panel thumbnails open the lightbox on click

## Test plan

- [x] `vp check --fix`
- [x] `vp test src/components/ui/image-lightbox/`
- [ ] Manually open a TMS project segment with screenshot context on mobile, verify pinch/double-tap/pan

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76adef3c-fd89-41a1-b9ec-f8bcb9720dec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76adef3c-fd89-41a1-b9ec-f8bcb9720dec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

