### PR TITLE
feat(web): localise integrations page components

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const workspaceAutomationFormMessages = defineMessages({
+  scheduledTriggerHourly: {
+    defaultMessage: "Every hour · {timezone}",
+    id: "SlPmp40QPZ",
+    description: "Summary for a scheduled automation that runs every hour",
+  },
+  scheduledTriggerDaily: {
+    defaultMessage: "Every day at {time} · {timezone}",
+    id: "TEXn81XSVY",
+    description: "Summary for a scheduled automation that runs daily at a specific hour",
+  },
+  scheduledTriggerWeekly: {
+    defaultMessage: "Every {weekday} at {time} · {timezone}",
+    id: "8d4Iw9Q9DE",
+    description: "Summary for a scheduled automation that runs weekly on a specific day and hour",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -59,7 +59,8 @@ import {
   AUTOMATION_WEEKDAY_OPTIONS,
   addBranchPattern,
 } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model";
-import { AUTOMATION_WEEKDAY_MESSAGE_BY_VALUE } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-panel.messages";
+import { AUTOMATION_WEEKDAY_MESSAGE_BY_VALUE } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model.messages";
+import { workspaceAutomationFormMessages } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages";
 import { getLocaleLabel } from "@/lib/i18n/locales";
 import type { WorkspaceAutomationFormState } from "@/lib/agents/workspace-automation-view-model";
 import { workspaceAutomationFormCanActivate } from "@/lib/agents/workspace-automation-view-model";
@@ -223,7 +224,9 @@ function triggerSummary(
 ) {
   if (form.triggerMode === "scheduled") {
     if (form.scheduledCadence === "hourly") {
-      return `Every hour · ${form.scheduledTimezone}`;
+      return intl.formatMessage(workspaceAutomationFormMessages.scheduledTriggerHourly, {
+        timezone: form.scheduledTimezone,
+      });
     }
 
     if (form.scheduledCadence === "weekly") {
@@ -234,10 +237,17 @@ function triggerSummary(
       const weekday = weekdayMessage
         ? intl.formatMessage(weekdayMessage)
         : intl.formatMessage(AUTOMATION_WEEKDAY_MESSAGE_BY_VALUE[1]);
-      return `Every ${weekday} at ${formatHour(form.scheduledHourUtc)} · ${form.scheduledTimezone}`;
+      return intl.formatMessage(workspaceAutomationFormMessages.scheduledTriggerWeekly, {
+        weekday,
+        time: formatHour(form.scheduledHourUtc),
+        timezone: form.scheduledTimezone,
+      });
     }
 
-    return `Every day at ${formatHour(form.scheduledHourUtc)} · ${form.scheduledTimezone}`;
+    return intl.formatMessage(workspaceAutomationFormMessages.scheduledTriggerDaily, {
+      time: formatHour(form.scheduledHourUtc),
+      timezone: form.scheduledTimezone,
+    });
   }
 
   if (form.triggerMode === "github") {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -13,6 +13,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useQuery } from "@tanstack/react-query";
 import { ClockIcon, MailIcon, SearchIcon, Trash2Icon } from "lucide-react";
+import { useIntl, type IntlShape } from "react-intl";
 import type { SimpleIcon } from "simple-icons";
 import {
   siGoogle,
@@ -58,6 +59,7 @@ import {
   AUTOMATION_WEEKDAY_OPTIONS,
   addBranchPattern,
 } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model";
+import { AUTOMATION_WEEKDAY_MESSAGE_BY_VALUE } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-panel.messages";
 import { getLocaleLabel } from "@/lib/i18n/locales";
 import type { WorkspaceAutomationFormState } from "@/lib/agents/workspace-automation-view-model";
 import { workspaceAutomationFormCanActivate } from "@/lib/agents/workspace-automation-view-model";
@@ -214,6 +216,7 @@ function formatHour(hourUtc: number) {
 }
 
 function triggerSummary(
+  intl: IntlShape,
   form: WorkspaceAutomationFormState,
   repositories: GithubRepositoryOption[] = [],
   projects: ProjectOption[] = [],
@@ -224,9 +227,13 @@ function triggerSummary(
     }
 
     if (form.scheduledCadence === "weekly") {
-      const weekday =
-        AUTOMATION_WEEKDAY_OPTIONS.find((option) => option.value === form.scheduledDayOfWeek)
-          ?.label ?? "Monday";
+      const weekdayMessage =
+        AUTOMATION_WEEKDAY_MESSAGE_BY_VALUE[
+          form.scheduledDayOfWeek as keyof typeof AUTOMATION_WEEKDAY_MESSAGE_BY_VALUE
+        ];
+      const weekday = weekdayMessage
+        ? intl.formatMessage(weekdayMessage)
+        : intl.formatMessage(AUTOMATION_WEEKDAY_MESSAGE_BY_VALUE[1]);
       return `Every ${weekday} at ${formatHour(form.scheduledHourUtc)} · ${form.scheduledTimezone}`;
     }
 
@@ -477,11 +484,12 @@ function BranchPatternSelector({
   error?: string;
   onChange: (branches: string[]) => void;
 }) {
+  const intl = useIntl();
   const [branchInput, setBranchInput] = useState("");
   const [inputError, setInputError] = useState<string | undefined>();
 
   function handleAdd() {
-    const result = addBranchPattern(branches, branchInput);
+    const result = addBranchPattern(intl, branches, branchInput);
     if (result.error) {
       setInputError(result.error);
       return;
@@ -722,6 +730,8 @@ function TriggerSettings({
   onChange: (next: WorkspaceAutomationFormState) => void;
   repositories: GithubRepositoryOption[];
 }) {
+  const intl = useIntl();
+
   return (
     <EditorSection title="Triggers">
       <EditorPanel>
@@ -767,7 +777,7 @@ function TriggerSettings({
                     <SelectContent>
                       {AUTOMATION_WEEKDAY_OPTIONS.map((option) => (
                         <SelectItem key={option.value} value={String(option.value)}>
-                          {option.label}
+                          {intl.formatMessage(AUTOMATION_WEEKDAY_MESSAGE_BY_VALUE[option.value])}
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -1752,6 +1762,7 @@ export function WorkspaceAutomationEditor({
   organizationSlug: string;
   runHistory?: WorkspaceAutomationRunRecord[];
 }) {
+  const intl = useIntl();
   const [activeTab, setActiveTab] = useState<AutomationEditorTab>("settings");
 
   const projectsQuery = useQuery({
@@ -1926,7 +1937,7 @@ export function WorkspaceAutomationEditor({
           {form.triggerMode !== "manual" ? (
             <>
               <span className="text-border">|</span>
-              <span>{triggerSummary(form, repositories, projectsQuery.data ?? [])}</span>
+              <span>{triggerSummary(intl, form, repositories, projectsQuery.data ?? [])}</span>
             </>
           ) : null}
           <span className="text-border">|</span>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/agent-integrations-section.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/agent-integrations-section.messages.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const agentIntegrationsSectionMessages = defineMessages({
+  sourceControlCategory: {
+    defaultMessage: "Source control",
+    id: "z6J/H68BKd",
+    description: "Integrations page section heading for source control providers",
+  },
+  collaborationCategory: {
+    defaultMessage: "Collaboration",
+    id: "SRrmrnZCsA",
+    description: "Integrations page section heading for collaboration tools",
+  },
+  gitlabName: {
+    defaultMessage: "GitLab",
+    id: "ufjLSLmtEV",
+    description: "GitLab integration name on the integrations page",
+  },
+  gitlabDescription: {
+    defaultMessage:
+      "Connect GitLab so Hyperlocalise can inspect localized strings, review merge requests, and open localization fixes.",
+    id: "ezhaX1jR0b",
+    description: "GitLab integration description on the integrations page",
+  },
+  microsoftTeamsName: {
+    defaultMessage: "Microsoft Teams",
+    id: "Brot+npjjF",
+    description: "Microsoft Teams integration name on the integrations page",
+  },
+  microsoftTeamsDescription: {
+    defaultMessage: "Coordinate localization reviews from Microsoft Teams workspaces.",
+    id: "hMoO98tftt",
+    description: "Microsoft Teams integration description on the integrations page",
+  },
+  linearName: {
+    defaultMessage: "Linear",
+    id: "NJJU5P3v/j",
+    description: "Linear integration name on the integrations page",
+  },
+  linearDescription: {
+    defaultMessage: "Create issues from translation blockers and keep launch tasks in sync.",
+    id: "rponYzKMZ3",
+    description: "Linear integration description on the integrations page",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/agent-integrations-section.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/agent-integrations-section.tsx
@@ -4,7 +4,9 @@ import { MicrosoftIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { SimpleIcon } from "simple-icons";
 import { siGitlab, siLinear } from "simple-icons";
+import { FormattedMessage, useIntl, type MessageDescriptor } from "react-intl";
 
+import { agentIntegrationsSectionMessages } from "./agent-integrations-section.messages";
 import { EmailIntegrationRow } from "./email-integration-row";
 import { GitHubIntegrationRow } from "./github-integration-row";
 import {
@@ -21,42 +23,44 @@ type AgentIntegrationsSectionProps = {
 };
 
 type ComingSoonAgent = {
-  name: string;
-  description: string;
+  nameMessage: MessageDescriptor;
+  descriptionMessage: MessageDescriptor;
   icon?: SimpleIcon;
   fallbackIcon?: typeof MicrosoftIcon;
 };
 
 const comingSoonCollaborationAgents: readonly ComingSoonAgent[] = [
   {
-    name: "Microsoft Teams",
-    description: "Coordinate localization reviews from Microsoft Teams workspaces.",
+    nameMessage: agentIntegrationsSectionMessages.microsoftTeamsName,
+    descriptionMessage: agentIntegrationsSectionMessages.microsoftTeamsDescription,
     fallbackIcon: MicrosoftIcon,
   },
   {
-    name: "Linear",
-    description: "Create issues from translation blockers and keep launch tasks in sync.",
+    nameMessage: agentIntegrationsSectionMessages.linearName,
+    descriptionMessage: agentIntegrationsSectionMessages.linearDescription,
     icon: siLinear,
   },
 ] as const;
 
 function ComingSoonIntegrationRow({
-  name,
-  description,
+  nameMessage,
+  descriptionMessage,
   icon,
   fallbackIcon,
   isLast,
 }: {
-  name: string;
-  description: string;
+  nameMessage: MessageDescriptor;
+  descriptionMessage: MessageDescriptor;
   icon?: SimpleIcon;
   fallbackIcon?: typeof MicrosoftIcon;
   isLast?: boolean;
 }) {
+  const intl = useIntl();
+
   return (
     <IntegrationRow
-      name={name}
-      description={description}
+      name={intl.formatMessage(nameMessage)}
+      description={intl.formatMessage(descriptionMessage)}
       icon={
         icon ? (
           <SimpleBrandIcon icon={icon} colored={false} />
@@ -77,12 +81,14 @@ export function SourceControlIntegrationsSection({
 }: AgentIntegrationsSectionProps) {
   return (
     <section className="flex flex-col gap-3">
-      <IntegrationCategoryLabel>Source control</IntegrationCategoryLabel>
+      <IntegrationCategoryLabel>
+        <FormattedMessage {...agentIntegrationsSectionMessages.sourceControlCategory} />
+      </IntegrationCategoryLabel>
       <IntegrationCategoryCard>
         <GitHubIntegrationRow organizationSlug={organizationSlug} userCanManage={userCanManage} />
         <ComingSoonIntegrationRow
-          name="GitLab"
-          description="Connect GitLab so Hyperlocalise can inspect localized strings, review merge requests, and open localization fixes."
+          nameMessage={agentIntegrationsSectionMessages.gitlabName}
+          descriptionMessage={agentIntegrationsSectionMessages.gitlabDescription}
           icon={siGitlab}
           isLast
         />
@@ -97,15 +103,17 @@ export function CollaborationIntegrationsSection({
 }: AgentIntegrationsSectionProps) {
   return (
     <section className="flex flex-col gap-3">
-      <IntegrationCategoryLabel>Collaboration</IntegrationCategoryLabel>
+      <IntegrationCategoryLabel>
+        <FormattedMessage {...agentIntegrationsSectionMessages.collaborationCategory} />
+      </IntegrationCategoryLabel>
       <IntegrationCategoryCard>
         <SlackIntegrationRow organizationSlug={organizationSlug} userCanManage={userCanManage} />
         <EmailIntegrationRow organizationSlug={organizationSlug} userCanManage={userCanManage} />
         {comingSoonCollaborationAgents.map((agent, index) => (
           <ComingSoonIntegrationRow
-            key={agent.name}
-            name={agent.name}
-            description={agent.description}
+            key={index}
+            nameMessage={agent.nameMessage}
+            descriptionMessage={agent.descriptionMessage}
             icon={agent.icon}
             fallbackIcon={agent.fallbackIcon}
             isLast={index === comingSoonCollaborationAgents.length - 1}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/contentful-connection-panel.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/contentful-connection-panel.messages.ts
@@ -1,0 +1,200 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const contentfulConnectionPanelMessages = defineMessages({
+  fetchConnectionsFailed: {
+    defaultMessage: "Failed to fetch Contentful connections",
+    id: "6ilKS2sOmJ",
+    description: "Error when the Contentful connections list fails to load",
+  },
+  loadMetadataFailed: {
+    defaultMessage: "Unable to load Contentful metadata",
+    id: "DeRSeFizML",
+    description: "Fallback error when Contentful space discovery fails",
+  },
+  saveConnectionFailed: {
+    defaultMessage: "Unable to save Contentful connection",
+    id: "EQuzSP+RiS",
+    description: "Fallback error when saving a Contentful connection fails",
+  },
+  connectionSavedToast: {
+    defaultMessage: "Contentful connection saved",
+    id: "V8Rg1mvKHG",
+    description: "Toast after successfully saving a Contentful connection",
+  },
+  webhookRegisteredToastTitle: {
+    defaultMessage: "Contentful webhook registered",
+    id: "IypYQDIY3f",
+    description: "Toast title when a Contentful webhook is created",
+  },
+  webhookRegisteredToastDescription: {
+    defaultMessage:
+      "Hyperlocalise created the Contentful webhook automatically. Save the secret below if you need to re-register manually.",
+    id: "ZNrsvoazsU",
+    description: "Toast description when a Contentful webhook is created",
+  },
+  webhookSyncedToastTitle: {
+    defaultMessage: "Contentful webhook synced",
+    id: "W3/qvnQA3o",
+    description: "Toast title when an existing Contentful webhook is updated",
+  },
+  webhookSyncedToastDescription: {
+    defaultMessage: "Hyperlocalise updated the Contentful webhook configuration.",
+    id: "Oiey9nLAFp",
+    description: "Toast description when an existing Contentful webhook is updated",
+  },
+  webhookNeedsAttentionToastTitle: {
+    defaultMessage: "Contentful webhook needs attention",
+    id: "dJURPyuGPM",
+    description: "Toast title when Contentful webhook registration failed",
+  },
+  tokenGuidance: {
+    defaultMessage:
+      "Use a Content Management API personal access token from Contentful Settings → Content management tokens. Do not use Content Delivery or Preview API keys — those are read-only and cannot write draft translations or register webhooks.",
+    id: "YnIu9s0qeQ",
+    description: "Guidance for choosing a Contentful Management API token",
+  },
+  enterCredentialsForContentTypes: {
+    defaultMessage:
+      "Enter your Space ID and Content Management API token to load content types from Contentful.",
+    id: "Iy7BBXsi+j",
+    description: "Hint before credentials are entered for content type discovery",
+  },
+  loadingContentTypes: {
+    defaultMessage: "Loading content types…",
+    id: "lT0LhQ0lGx",
+    description: "Loading state while fetching Contentful content types",
+  },
+  noContentTypesFound: {
+    defaultMessage: "No content types found in this space.",
+    id: "u5hy7XQ9he",
+    description: "Empty state when Contentful returns no content types",
+  },
+  tokenBadge: {
+    defaultMessage: "Token …{suffix}",
+    id: "7+phzkP936",
+    description: "Badge showing the masked suffix of a stored Contentful token",
+  },
+  displayNameLabel: {
+    defaultMessage: "Display name",
+    id: "i9ZZoI20Cm",
+    description: "Label for the Contentful connection display name field",
+  },
+  displayNamePlaceholder: {
+    defaultMessage: "Contentful Help Center",
+    id: "A+IsVf0TGL",
+    description: "Placeholder for the Contentful connection display name field",
+  },
+  spaceIdLabel: {
+    defaultMessage: "Space ID",
+    id: "wtxoYMaNGy",
+    description: "Label for the Contentful space ID field",
+  },
+  environmentIdLabel: {
+    defaultMessage: "Environment ID",
+    id: "kw9ywOaVL3",
+    description: "Label for the Contentful environment ID field",
+  },
+  environmentIdPlaceholder: {
+    defaultMessage: "master",
+    id: "F+43ZMkvwH",
+    description: "Placeholder for the Contentful environment ID field",
+  },
+  cmaTokenLabel: {
+    defaultMessage: "Content Management API token",
+    id: "7QQUiWq0U1",
+    description: "Label for the Contentful Management API token field",
+  },
+  cancel: {
+    defaultMessage: "Cancel",
+    id: "wSu0+cW+hv",
+    description: "Button to cancel replacing a stored Contentful token",
+  },
+  replaceToken: {
+    defaultMessage: "Replace token",
+    id: "zjfCQW7GjW",
+    description: "Button to start replacing a stored Contentful token",
+  },
+  contentTypesLabel: {
+    defaultMessage: "Content types",
+    id: "akKSazt0o+",
+    description: "Label for the Contentful content type picker field",
+  },
+  webhookHeading: {
+    defaultMessage: "Webhook",
+    id: "6DqYm4cuZL",
+    description: "Heading for Contentful webhook status section",
+  },
+  webhookDescription: {
+    defaultMessage:
+      "Hyperlocalise registers a Contentful webhook for entry publish events when you save or validate this connection. Automations with a Contentful trigger use it to start translation runs.",
+    id: "bCzZNsSN41",
+    description: "Explains how Contentful webhooks are used",
+  },
+  registrationLabel: {
+    defaultMessage: "Registration:",
+    id: "8vYRLImWYG",
+    description: "Label prefix for webhook registration status",
+  },
+  registrationRegistered: {
+    defaultMessage: "Registered in Contentful",
+    id: "GRJxQXl5PH",
+    description: "Webhook registration status when registered",
+  },
+  registrationNotRegistered: {
+    defaultMessage: "Not registered",
+    id: "z48kpV5sye",
+    description: "Webhook registration status when registration failed",
+  },
+  registrationPending: {
+    defaultMessage: "Pending registration",
+    id: "304a0qYa4S",
+    description: "Webhook registration status before registration completes",
+  },
+  webhookUrl: {
+    defaultMessage: "URL: {url}",
+    id: "y+0ftMWpAa",
+    description: "Contentful webhook callback URL display",
+  },
+  webhookUrlUnset: {
+    defaultMessage: "Set HYPERLOCALISE_PUBLIC_APP_URL",
+    id: "OS+T5iqT3s",
+    description: "Placeholder when webhook URL env var is not configured",
+  },
+  contentfulWebhookId: {
+    defaultMessage: "Contentful webhook ID: {webhookId}",
+    id: "cOeHLAqsSE",
+    description: "Displays the provider-assigned Contentful webhook ID",
+  },
+  webhookSecret: {
+    defaultMessage: "Secret: {secret}",
+    id: "hj7GTNbnw4",
+    description: "Displays the Contentful webhook signing secret",
+  },
+  lastDeliveryAt: {
+    defaultMessage: "Last delivery: {timestamp}",
+    id: "5KdZWVlAAs",
+    description: "Shows when the Contentful webhook last delivered an event",
+  },
+  lastDeliveryNone: {
+    defaultMessage: "Last delivery: No deliveries yet",
+    id: "T7ocGbiped",
+    description: "Shown when the Contentful webhook has not delivered events",
+  },
+  saving: {
+    defaultMessage: "Saving…",
+    id: "uF3cBjB2oQ",
+    description: "Save button label while a Contentful connection is saving",
+  },
+  updateConnection: {
+    defaultMessage: "Update connection",
+    id: "CQCxmYWm3f",
+    description: "Save button label when editing an existing Contentful connection",
+  },
+  saveConnection: {
+    defaultMessage: "Save connection",
+    id: "DxmswO0BaI",
+    description: "Save button label when creating a new Contentful connection",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/contentful-connection-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/contentful-connection-panel.tsx
@@ -4,8 +4,10 @@ import { useEffect, useId, useMemo, useState } from "react";
 import { SaveIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
 
+import { contentfulConnectionPanelMessages } from "./contentful-connection-panel.messages";
 import { createApiClient } from "@/lib/api-client";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -71,6 +73,8 @@ type SaveContentfulConnectionPayload =
     });
 
 export function useContentfulConnections(organizationSlug: string) {
+  const intl = useIntl();
+
   return useQuery({
     queryKey: ["contentful-connections", organizationSlug],
     queryFn: async () => {
@@ -78,7 +82,9 @@ export function useContentfulConnections(organizationSlug: string) {
         param: { organizationSlug },
       });
       if (!res.ok) {
-        throw new Error("Failed to fetch Contentful connections");
+        throw new Error(
+          intl.formatMessage(contentfulConnectionPanelMessages.fetchConnectionsFailed),
+        );
       }
       const data = await res.json();
       return data.contentfulConnections as ContentfulConnectionSummary[];
@@ -94,6 +100,7 @@ function useDiscoverContentfulSpace(input: {
   connectionId?: string;
   enabled: boolean;
 }) {
+  const intl = useIntl();
   const trimmedSpaceId = input.spaceId.trim();
   const trimmedEnvironmentId = input.environmentId.trim() || "master";
   const trimmedAccessToken = input.accessToken.trim();
@@ -124,9 +131,10 @@ function useDiscoverContentfulSpace(input: {
         },
       });
       if (!res.ok) {
-        const error = await res
-          .json()
-          .catch(() => ({ message: "Unable to load Contentful metadata" }));
+        const fallbackMessage = intl.formatMessage(
+          contentfulConnectionPanelMessages.loadMetadataFailed,
+        );
+        const error = await res.json().catch(() => ({ message: fallbackMessage }));
         const message =
           typeof error === "object" &&
           error !== null &&
@@ -139,7 +147,7 @@ function useDiscoverContentfulSpace(input: {
                 "error" in error &&
                 typeof error.error === "string"
               ? error.error.replaceAll("_", " ")
-              : "Unable to load Contentful metadata";
+              : fallbackMessage;
         throw new Error(message);
       }
       const data = await res.json();
@@ -153,6 +161,7 @@ function useDiscoverContentfulSpace(input: {
 }
 
 export function useSaveContentfulConnection(organizationSlug: string) {
+  const intl = useIntl();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -193,7 +202,9 @@ export function useSaveContentfulConnection(organizationSlug: string) {
       if (!res.ok) {
         const error = await res.json().catch(() => ({ error: "contentful_connection_failed" }));
         throw new Error(
-          "message" in error ? String(error.message) : "Unable to save Contentful connection",
+          "message" in error
+            ? String(error.message)
+            : intl.formatMessage(contentfulConnectionPanelMessages.saveConnectionFailed),
         );
       }
       return res.json();
@@ -202,20 +213,32 @@ export function useSaveContentfulConnection(organizationSlug: string) {
       await queryClient.invalidateQueries({
         queryKey: ["contentful-connections", organizationSlug],
       });
-      toast.success("Contentful connection saved");
+      toast.success(intl.formatMessage(contentfulConnectionPanelMessages.connectionSavedToast));
       if (result.webhookSecret) {
-        toast.message("Contentful webhook registered", {
-          description:
-            "Hyperlocalise created the Contentful webhook automatically. Save the secret below if you need to re-register manually.",
-        });
+        toast.message(
+          intl.formatMessage(contentfulConnectionPanelMessages.webhookRegisteredToastTitle),
+          {
+            description: intl.formatMessage(
+              contentfulConnectionPanelMessages.webhookRegisteredToastDescription,
+            ),
+          },
+        );
       } else if (result.contentfulConnection.webhook?.providerWebhookId) {
-        toast.message("Contentful webhook synced", {
-          description: "Hyperlocalise updated the Contentful webhook configuration.",
-        });
+        toast.message(
+          intl.formatMessage(contentfulConnectionPanelMessages.webhookSyncedToastTitle),
+          {
+            description: intl.formatMessage(
+              contentfulConnectionPanelMessages.webhookSyncedToastDescription,
+            ),
+          },
+        );
       } else if (result.contentfulConnection.webhook?.lastError) {
-        toast.message("Contentful webhook needs attention", {
-          description: result.contentfulConnection.webhook.lastError,
-        });
+        toast.message(
+          intl.formatMessage(contentfulConnectionPanelMessages.webhookNeedsAttentionToastTitle),
+          {
+            description: result.contentfulConnection.webhook.lastError,
+          },
+        );
       }
     },
     onError: (error) => {
@@ -227,9 +250,7 @@ export function useSaveContentfulConnection(organizationSlug: string) {
 function ContentfulTokenGuidance() {
   return (
     <FieldDescription>
-      Use a Content Management API personal access token from Contentful Settings → Content
-      management tokens. Do not use Content Delivery or Preview API keys — those are read-only and
-      cannot write draft translations or register webhooks.
+      <FormattedMessage {...contentfulConnectionPanelMessages.tokenGuidance} />
     </FieldDescription>
   );
 }
@@ -266,13 +287,17 @@ function ContentTypePicker({
   if (requiresCredentials) {
     return (
       <p className="text-sm text-muted-foreground">
-        Enter your Space ID and Content Management API token to load content types from Contentful.
+        <FormattedMessage {...contentfulConnectionPanelMessages.enterCredentialsForContentTypes} />
       </p>
     );
   }
 
   if (isLoading) {
-    return <p className="text-sm text-muted-foreground">Loading content types...</p>;
+    return (
+      <p className="text-sm text-muted-foreground">
+        <FormattedMessage {...contentfulConnectionPanelMessages.loadingContentTypes} />
+      </p>
+    );
   }
 
   if (loadError) {
@@ -280,7 +305,11 @@ function ContentTypePicker({
   }
 
   if (contentTypes.length === 0) {
-    return <p className="text-sm text-muted-foreground">No content types found in this space.</p>;
+    return (
+      <p className="text-sm text-muted-foreground">
+        <FormattedMessage {...contentfulConnectionPanelMessages.noContentTypesFound} />
+      </p>
+    );
   }
 
   return (
@@ -324,6 +353,7 @@ export function ContentfulConnectionPanel({
   onFormChange: (form: ContentfulConnectionForm) => void;
   organizationSlug: string;
 }) {
+  const intl = useIntl();
   const contentTypesFieldId = useId();
   const [isReplacingToken, setIsReplacingToken] = useState(false);
   const tokenRequired = !connection || isReplacingToken;
@@ -370,7 +400,11 @@ export function ContentfulConnectionPanel({
     <div className="flex flex-col gap-5">
       {connection ? (
         <div className="flex flex-wrap gap-2 text-xs">
-          <Badge variant="outline">Token ...{connection.maskedTokenSuffix}</Badge>
+          <Badge variant="outline">
+            {intl.formatMessage(contentfulConnectionPanelMessages.tokenBadge, {
+              suffix: connection.maskedTokenSuffix,
+            })}
+          </Badge>
           <Badge variant="outline">
             {connection.spaceId}/{connection.environmentId}
           </Badge>
@@ -379,16 +413,22 @@ export function ContentfulConnectionPanel({
 
       <div className="grid gap-4 lg:grid-cols-2">
         <Field className="gap-2 lg:col-span-2">
-          <FieldLabel>Display name</FieldLabel>
+          <FieldLabel>
+            {intl.formatMessage(contentfulConnectionPanelMessages.displayNameLabel)}
+          </FieldLabel>
           <Input
             value={form.displayName}
             disabled={disabled}
-            placeholder="Contentful Help Center"
+            placeholder={intl.formatMessage(
+              contentfulConnectionPanelMessages.displayNamePlaceholder,
+            )}
             onChange={(event) => onFormChange({ ...form, displayName: event.target.value })}
           />
         </Field>
         <Field className="gap-2">
-          <FieldLabel>Space ID</FieldLabel>
+          <FieldLabel>
+            {intl.formatMessage(contentfulConnectionPanelMessages.spaceIdLabel)}
+          </FieldLabel>
           <Input
             value={form.spaceId}
             disabled={disabled}
@@ -396,17 +436,23 @@ export function ContentfulConnectionPanel({
           />
         </Field>
         <Field className="gap-2">
-          <FieldLabel>Environment ID</FieldLabel>
+          <FieldLabel>
+            {intl.formatMessage(contentfulConnectionPanelMessages.environmentIdLabel)}
+          </FieldLabel>
           <Input
             value={form.environmentId}
             disabled={disabled}
-            placeholder="master"
+            placeholder={intl.formatMessage(
+              contentfulConnectionPanelMessages.environmentIdPlaceholder,
+            )}
             onChange={(event) => onFormChange({ ...form, environmentId: event.target.value })}
           />
         </Field>
         {!connection || isReplacingToken ? (
           <Field className="gap-2 lg:col-span-2">
-            <FieldLabel>Content Management API token</FieldLabel>
+            <FieldLabel>
+              {intl.formatMessage(contentfulConnectionPanelMessages.cmaTokenLabel)}
+            </FieldLabel>
             <ContentfulTokenGuidance />
             <div className="flex gap-2">
               <Input
@@ -426,14 +472,16 @@ export function ContentfulConnectionPanel({
                     onFormChange({ ...form, accessToken: "" });
                   }}
                 >
-                  Cancel
+                  {intl.formatMessage(contentfulConnectionPanelMessages.cancel)}
                 </Button>
               ) : null}
             </div>
           </Field>
         ) : (
           <Field className="gap-2 lg:col-span-2">
-            <FieldLabel>Content Management API token</FieldLabel>
+            <FieldLabel>
+              {intl.formatMessage(contentfulConnectionPanelMessages.cmaTokenLabel)}
+            </FieldLabel>
             <ContentfulTokenGuidance />
             <Button
               type="button"
@@ -442,12 +490,14 @@ export function ContentfulConnectionPanel({
               className="justify-start"
               onClick={() => setIsReplacingToken(true)}
             >
-              Replace token
+              {intl.formatMessage(contentfulConnectionPanelMessages.replaceToken)}
             </Button>
           </Field>
         )}
         <Field className="gap-2 lg:col-span-2">
-          <FieldLabel id={contentTypesFieldId}>Content types</FieldLabel>
+          <FieldLabel id={contentTypesFieldId}>
+            {intl.formatMessage(contentfulConnectionPanelMessages.contentTypesLabel)}
+          </FieldLabel>
           <ContentTypePicker
             contentTypes={discoveredContentTypes}
             disabled={disabled}
@@ -463,36 +513,54 @@ export function ContentfulConnectionPanel({
 
       {connection?.webhook ? (
         <div className="text-sm">
-          <h4 className="font-medium">Webhook</h4>
+          <h4 className="font-medium">
+            <FormattedMessage {...contentfulConnectionPanelMessages.webhookHeading} />
+          </h4>
           <p className="mt-1 text-xs text-muted-foreground">
-            Hyperlocalise registers a Contentful webhook for entry publish events when you save or
-            validate this connection. Automations with a Contentful trigger use it to start
-            translation runs.
+            <FormattedMessage {...contentfulConnectionPanelMessages.webhookDescription} />
           </p>
           <div className="mt-3 grid gap-2 rounded-lg bg-muted/50 p-3 text-xs">
             <span>
-              Registration:{" "}
-              {connection.webhook.providerWebhookId
-                ? "Registered in Contentful"
-                : connection.webhook.lastError
-                  ? "Not registered"
-                  : "Pending registration"}
+              {intl.formatMessage(contentfulConnectionPanelMessages.registrationLabel)}{" "}
+              {intl.formatMessage(
+                connection.webhook.providerWebhookId
+                  ? contentfulConnectionPanelMessages.registrationRegistered
+                  : connection.webhook.lastError
+                    ? contentfulConnectionPanelMessages.registrationNotRegistered
+                    : contentfulConnectionPanelMessages.registrationPending,
+              )}
             </span>
             <span className="font-mono break-all">
-              URL: {connection.webhook.url ?? "Set HYPERLOCALISE_PUBLIC_APP_URL"}
+              {intl.formatMessage(contentfulConnectionPanelMessages.webhookUrl, {
+                url:
+                  connection.webhook.url ??
+                  intl.formatMessage(contentfulConnectionPanelMessages.webhookUrlUnset),
+              })}
             </span>
             {connection.webhook.providerWebhookId ? (
               <span className="font-mono break-all">
-                Contentful webhook ID: {connection.webhook.providerWebhookId}
+                {intl.formatMessage(contentfulConnectionPanelMessages.contentfulWebhookId, {
+                  webhookId: connection.webhook.providerWebhookId,
+                })}
               </span>
             ) : null}
             {lastWebhookSecret ? (
-              <span className="font-mono break-all">Secret: {lastWebhookSecret}</span>
+              <span className="font-mono break-all">
+                {intl.formatMessage(contentfulConnectionPanelMessages.webhookSecret, {
+                  secret: lastWebhookSecret,
+                })}
+              </span>
             ) : null}
             {connection.webhook.lastError ? (
               <span className="text-destructive">{connection.webhook.lastError}</span>
             ) : null}
-            <span>Last delivery: {connection.webhook.lastDeliveredAt ?? "No deliveries yet"}</span>
+            <span>
+              {connection.webhook.lastDeliveredAt
+                ? intl.formatMessage(contentfulConnectionPanelMessages.lastDeliveryAt, {
+                    timestamp: connection.webhook.lastDeliveredAt,
+                  })
+                : intl.formatMessage(contentfulConnectionPanelMessages.lastDeliveryNone)}
+            </span>
           </div>
         </div>
       ) : null}
@@ -504,7 +572,11 @@ export function ContentfulConnectionPanel({
           onClick={onSave}
         >
           <HugeiconsIcon icon={SaveIcon} strokeWidth={1.8} />
-          {isSaving ? "Saving..." : connection ? "Update connection" : "Save connection"}
+          {isSaving
+            ? intl.formatMessage(contentfulConnectionPanelMessages.saving)
+            : connection
+              ? intl.formatMessage(contentfulConnectionPanelMessages.updateConnection)
+              : intl.formatMessage(contentfulConnectionPanelMessages.saveConnection)}
         </Button>
       </div>
     </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/email-integration-row.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/email-integration-row.messages.ts
@@ -1,0 +1,94 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const emailIntegrationRowMessages = defineMessages({
+  name: {
+    defaultMessage: "Email",
+    id: "b+pVg94kFI",
+    description: "Email agent integration name on the integrations page",
+  },
+  descriptionReady: {
+    defaultMessage:
+      "Inbound address ready. Send files or images with a target language to translate by email.",
+    id: "lWsEWOz8r0",
+    description: "Email integration description when an inbound address exists",
+  },
+  descriptionNotReady: {
+    defaultMessage:
+      "Enable the email agent to receive a unique workspace address for translation requests.",
+    id: "vd4gOsmpWc",
+    description: "Email integration description before an inbound address is generated",
+  },
+  panelInstructions: {
+    defaultMessage:
+      "Send documents, spreadsheets, JSON, text files, or images with a target language. Source language is optional, and style notes apply to file translations.",
+    id: "a917ExUu0o",
+    description: "Instructions in the email agent settings panel",
+  },
+  enableEmailAgentAriaLabel: {
+    defaultMessage: "Enable email agent",
+    id: "Ubm7I3eMos",
+    description: "Aria label for the email agent enable switch",
+  },
+  loadError: {
+    defaultMessage: "Unable to load email agent settings right now.",
+    id: "WnNeQt1daO",
+    description: "Error message when email agent settings fail to load",
+  },
+  intakeAddressAriaLabel: {
+    defaultMessage: "Email agent intake address",
+    id: "EyTy76luBD",
+    description: "Aria label for the read-only inbound email address field",
+  },
+  placeholderUnavailable: {
+    defaultMessage: "Email agent settings unavailable",
+    id: "GM92+KcSLv",
+    description: "Placeholder when email agent settings failed to load",
+  },
+  placeholderEnable: {
+    defaultMessage: "Enable email agent to generate inbox address",
+    id: "I7LI9gWPKv",
+    description: "Placeholder before the email agent is enabled",
+  },
+  copiedAriaLabel: {
+    defaultMessage: "Copied!",
+    id: "H7MZFgXFSw",
+    description: "Aria label after copying the inbound email address",
+  },
+  copyAriaLabel: {
+    defaultMessage: "Copy email address",
+    id: "2jyWXfstrf",
+    description: "Aria label for the copy inbound email address button",
+  },
+  copiedTooltip: {
+    defaultMessage: "Copied!",
+    id: "uPLvPG1gYg",
+    description: "Tooltip after copying the inbound email address",
+  },
+  copyTooltip: {
+    defaultMessage: "Copy email address",
+    id: "Y+UFarvRd2",
+    description: "Tooltip for the copy inbound email address button",
+  },
+  inboundEmailCopiedToast: {
+    defaultMessage: "Inbound email copied",
+    id: "kod/dgRhlc",
+    description: "Toast after copying the email agent inbound address",
+  },
+  enabledToast: {
+    defaultMessage: "Email agent enabled",
+    id: "Z3S7OrVNyY",
+    description: "Toast after enabling the email agent",
+  },
+  disabledToast: {
+    defaultMessage: "Email agent disabled",
+    id: "bW5VkndWCk",
+    description: "Toast after disabling the email agent",
+  },
+  updateFailedToast: {
+    defaultMessage: "Unable to update email agent right now",
+    id: "dCPFe2ny4S",
+    description: "Toast when enabling or disabling the email agent fails",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/email-integration-row.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/email-integration-row.tsx
@@ -5,8 +5,10 @@ import { Copy01Icon, Tick02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { siGmail } from "simple-icons";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useIntl } from "react-intl";
 import { toast } from "sonner";
 
+import { emailIntegrationRowMessages } from "./email-integration-row.messages";
 import { IntegrationRow } from "./integration-row";
 import { SimpleBrandIcon } from "./simple-brand-icon";
 import {
@@ -80,6 +82,7 @@ export function EmailIntegrationRow({
   isLast = false,
   userCanManage,
 }: EmailIntegrationRowProps) {
+  const intl = useIntl();
   const [expanded, setExpanded] = useState(false);
   const { data: emailAgent, isLoading, isError } = useEmailAgentState(organizationSlug);
   const updateEmailAgentState = useUpdateEmailAgentState(organizationSlug);
@@ -95,7 +98,7 @@ export function EmailIntegrationRow({
 
     await navigator.clipboard.writeText(emailAddress);
     setCopied(true);
-    toast.success("Inbound email copied");
+    toast.success(intl.formatMessage(emailIntegrationRowMessages.inboundEmailCopiedToast));
 
     if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
     copyTimeoutRef.current = setTimeout(() => setCopied(false), 5000);
@@ -111,19 +114,25 @@ export function EmailIntegrationRow({
   const toggleEnabled = async (enabled: boolean) => {
     try {
       await updateEmailAgentState.mutateAsync(enabled);
-      toast.success(enabled ? "Email agent enabled" : "Email agent disabled");
+      toast.success(
+        intl.formatMessage(
+          enabled
+            ? emailIntegrationRowMessages.enabledToast
+            : emailIntegrationRowMessages.disabledToast,
+        ),
+      );
       if (enabled) {
         setExpanded(true);
       }
     } catch {
-      toast.error("Unable to update email agent right now");
+      toast.error(intl.formatMessage(emailIntegrationRowMessages.updateFailedToast));
     }
   };
 
   const hasAddress = Boolean(emailAgent?.inboundEmailAddress);
   const description = hasAddress
-    ? `Inbound address ready. Send files or images with a target language to translate by email.`
-    : "Enable the email agent to receive a unique workspace address for translation requests.";
+    ? intl.formatMessage(emailIntegrationRowMessages.descriptionReady)
+    : intl.formatMessage(emailIntegrationRowMessages.descriptionNotReady);
 
   const action = !userCanManage
     ? "view-only"
@@ -133,7 +142,7 @@ export function EmailIntegrationRow({
 
   return (
     <IntegrationRow
-      name="Email"
+      name={intl.formatMessage(emailIntegrationRowMessages.name)}
       description={description}
       icon={<SimpleBrandIcon icon={siGmail} colored={hasAddress} />}
       iconMuted={!hasAddress}
@@ -148,20 +157,19 @@ export function EmailIntegrationRow({
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-3 rounded-lg border border-border bg-background/70 p-3 sm:flex-row sm:items-center sm:justify-between">
           <TypographyP className="text-sm leading-6 text-muted-foreground">
-            Send documents, spreadsheets, JSON, text files, or images with a target language. Source
-            language is optional, and style notes apply to file translations.
+            {intl.formatMessage(emailIntegrationRowMessages.panelInstructions)}
           </TypographyP>
           <Switch
             checked={emailAgent?.enabled ?? false}
             onCheckedChange={toggleEnabled}
-            aria-label="Enable email agent"
+            aria-label={intl.formatMessage(emailIntegrationRowMessages.enableEmailAgentAriaLabel)}
             disabled={isLoading || isError || updateEmailAgentState.isPending || !userCanManage}
           />
         </div>
 
         {isError ? (
           <TypographyP className="text-sm text-destructive">
-            Unable to load email agent settings right now.
+            {intl.formatMessage(emailIntegrationRowMessages.loadError)}
           </TypographyP>
         ) : null}
 
@@ -174,13 +182,13 @@ export function EmailIntegrationRow({
             <InputGroupInput
               readOnly
               value={emailAddress}
-              aria-label="Email agent intake address"
+              aria-label={intl.formatMessage(emailIntegrationRowMessages.intakeAddressAriaLabel)}
               className="truncate text-sm"
               disabled={!emailAgent?.enabled}
               placeholder={
                 isError
-                  ? "Email agent settings unavailable"
-                  : "Enable email agent to generate inbox address"
+                  ? intl.formatMessage(emailIntegrationRowMessages.placeholderUnavailable)
+                  : intl.formatMessage(emailIntegrationRowMessages.placeholderEnable)
               }
             />
           )}
@@ -193,13 +201,23 @@ export function EmailIntegrationRow({
                     size="icon-sm"
                     onClick={copyEmailAddress}
                     disabled={!emailAgent?.enabled || !emailAddress}
-                    aria-label={copied ? "Copied!" : "Copy email address"}
+                    aria-label={intl.formatMessage(
+                      copied
+                        ? emailIntegrationRowMessages.copiedAriaLabel
+                        : emailIntegrationRowMessages.copyAriaLabel,
+                    )}
                   >
                     <HugeiconsIcon icon={copied ? Tick02Icon : Copy01Icon} strokeWidth={1.8} />
                   </InputGroupButton>
                 }
               />
-              <TooltipContent>{copied ? "Copied!" : "Copy email address"}</TooltipContent>
+              <TooltipContent>
+                {intl.formatMessage(
+                  copied
+                    ? emailIntegrationRowMessages.copiedTooltip
+                    : emailIntegrationRowMessages.copyTooltip,
+                )}
+              </TooltipContent>
             </Tooltip>
           </InputGroupAddon>
         </InputGroup>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-integration-row.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-integration-row.messages.ts
@@ -1,0 +1,246 @@
+"use client";
+
+import { defineMessages, type IntlShape, type MessageDescriptor } from "react-intl";
+
+export const githubIntegrationRowMessages = defineMessages({
+  name: {
+    defaultMessage: "GitHub",
+    id: "9phIm1BV0j",
+    description: "GitHub integration name on the integrations page",
+  },
+  disconnectedDescription: {
+    defaultMessage:
+      "Connect GitHub for pull request reviews, localization fixes, and repository context.",
+    id: "+xOXD4ARmA",
+    description: "GitHub integration description before the app is connected",
+  },
+  repoSummary: {
+    defaultMessage: "{enabledCount} of {totalCount} repositories enabled.",
+    id: "MZotM1J5qc",
+    description: "Summary of enabled vs total GitHub repositories",
+  },
+  connectedAsDescription: {
+    defaultMessage: "Connected as {accountLogin}. {repoSummary}",
+    id: "rqH4qSNbvK",
+    description: "GitHub integration description when connected with a known account login",
+  },
+  connectedDescription: {
+    defaultMessage: "Connected. {repoSummary}",
+    id: "4Ot6qB+D/E",
+    description: "GitHub integration description when connected without a known account login",
+  },
+  loadError: {
+    defaultMessage: "Unable to load GitHub installation status right now.",
+    id: "3M+guxg4Ll",
+    description: "Error message when GitHub installation status fails to load",
+  },
+  retry: {
+    defaultMessage: "Retry",
+    id: "bHpDk7ICgp",
+    description: "Button label to retry loading GitHub installation status",
+  },
+  manageAccessOnGitHub: {
+    defaultMessage: "Manage access on GitHub",
+    id: "M3bbV5wmi2",
+    description: "Button label to open GitHub installation settings",
+  },
+  refreshRepoListTitle: {
+    defaultMessage:
+      "Refresh the repository list and metadata from GitHub. This does not push or pull translations.",
+    id: "WA49vhY6w5",
+    description: "Tooltip for the refresh repository list button",
+  },
+  refreshingRepoList: {
+    defaultMessage: "Refreshing…",
+    id: "gg+xut28LR",
+    description: "Refresh repository list button label while syncing",
+  },
+  refreshRepoList: {
+    defaultMessage: "Refresh repo list",
+    id: "bubst9Dzg+",
+    description: "Refresh repository list button label",
+  },
+  disconnecting: {
+    defaultMessage: "Disconnecting…",
+    id: "JEdlCIcj1G",
+    description: "Disconnect button label while GitHub is being disconnected",
+  },
+  disconnect: {
+    defaultMessage: "Disconnect",
+    id: "ljEJGwxPd/",
+    description: "Button label to disconnect GitHub",
+  },
+  searchRepositoriesPlaceholder: {
+    defaultMessage: "Search repositories",
+    id: "f0pASu5TFR",
+    description: "Placeholder for the GitHub repository search input",
+  },
+  searchRepositoriesAriaLabel: {
+    defaultMessage: "Search repositories",
+    id: "Zq6yckXsZ1",
+    description: "Aria label for the GitHub repository search input",
+  },
+  enableSelected: {
+    defaultMessage: "Enable {count}",
+    id: "Lps9d8jAkf",
+    description: "Button label to enable the selected GitHub repositories",
+  },
+  enableAll: {
+    defaultMessage: "Enable all",
+    id: "/cgIKQ7r8o",
+    description: "Button label to enable all GitHub repositories",
+  },
+  enabledColumnSrOnly: {
+    defaultMessage: "Enabled",
+    id: "zztNzAuBoJ",
+    description: "Screen reader label for the repository enabled checkbox column",
+  },
+  repositoriesColumn: {
+    defaultMessage: "Repositories",
+    id: "/d8vf0Z+2x",
+    description: "Table header for GitHub repository names",
+  },
+  branchColumn: {
+    defaultMessage: "Branch",
+    id: "5AkeE7XWLR",
+    description: "Table header for default branch names",
+  },
+  actionColumn: {
+    defaultMessage: "Action",
+    id: "M1dHMgqYPX",
+    description: "Table header for per-repository actions",
+  },
+  enableRepositoryAriaLabel: {
+    defaultMessage: "Enable {repositoryFullName}",
+    id: "VpKHsNzJ6d",
+    description: "Aria label for a repository enable checkbox",
+  },
+  privateBadge: {
+    defaultMessage: "Private",
+    id: "mMp/zOre+X",
+    description: "Badge label for a private GitHub repository",
+  },
+  archivedBadge: {
+    defaultMessage: "Archived",
+    id: "+3ic9geD5G",
+    description: "Badge label for an archived GitHub repository",
+  },
+  defaultBranchFallback: {
+    defaultMessage: "default",
+    id: "wUKFu5cEaD",
+    description: "Fallback label when a repository has no default branch name",
+  },
+  noRepositoriesAvailable: {
+    defaultMessage: "No repositories are available to this GitHub App installation.",
+    id: "PRbdh+Ryiw",
+    description: "Empty state when the GitHub App installation exposes no repositories",
+  },
+  noRepositoriesMatchSearch: {
+    defaultMessage: "No repositories match this search.",
+    id: "Co6OZgcHjk",
+    description: "Empty state when repository search returns no results",
+  },
+  repositoryListRefreshedToast: {
+    defaultMessage: "GitHub repository list refreshed",
+    id: "YfETsADG9Z",
+    description: "Toast after syncing the GitHub repository list",
+  },
+  enabledRepositoriesUpdatedToast: {
+    defaultMessage: "Enabled repositories updated",
+    id: "zM/fYyJiHY",
+    description: "Toast after updating enabled GitHub repositories",
+  },
+  disconnectedToast: {
+    defaultMessage: "GitHub disconnected",
+    id: "3ml8Juvu7i",
+    description: "Toast after disconnecting GitHub",
+  },
+  connectedToast: {
+    defaultMessage: "GitHub connected",
+    id: "pj6HuYI/BY",
+    description: "Toast after returning from successful GitHub App installation",
+  },
+  installUrlFailedToast: {
+    defaultMessage: "Failed to generate GitHub install URL",
+    id: "9pmdbGAxZ4",
+    description: "Toast when GitHub App install URL generation fails",
+  },
+  connectFailedFallback: {
+    defaultMessage: "GitHub App connection failed. Try connecting again.",
+    id: "/5pMziffIK",
+    description: "Fallback toast when GitHub App connection fails with an unknown error code",
+  },
+  missingCallbackParams: {
+    defaultMessage:
+      "GitHub did not return installation_id on the Setup URL callback. Confirm the GitHub App Setup URL points to this app and try connecting again.",
+    id: "udWuegdP+q",
+    description: "GitHub connect error when callback params are missing",
+  },
+  invalidState: {
+    defaultMessage:
+      "The GitHub install link expired or was already used. Click Connect again from this page.",
+    id: "nwJGCHKaPx",
+    description: "GitHub connect error when OAuth state is invalid or expired",
+  },
+  githubInstallPendingApproval: {
+    defaultMessage:
+      "GitHub is waiting for an org owner to approve this app install. Approve it on GitHub, then connect again.",
+    id: "pdHOl1weOs",
+    description: "GitHub connect error when installation awaits org owner approval",
+  },
+  githubAppNotConfigured: {
+    defaultMessage: "GitHub App integration is not configured for this environment.",
+    id: "7BA/WdUPFq",
+    description: "GitHub connect error when GitHub App credentials are not configured",
+  },
+  githubAppPrivateKeyInvalid: {
+    defaultMessage:
+      "GitHub rejected the app credentials in this environment. Set GITHUB_APP_ID to the App ID from GitHub App settings and GITHUB_APP_PRIVATE_KEY to the matching PEM (use literal \\n line breaks or base64-encode the whole file).",
+    id: "adEnn5Hnc9",
+    description: "GitHub connect error when GitHub App private key is invalid",
+  },
+  githubInstallationInvalid: {
+    defaultMessage:
+      "GitHub rejected the installation ID. Confirm the app is installed on the expected account.",
+    id: "5nl3kRCtNh",
+    description: "GitHub connect error when installation ID is invalid",
+  },
+  githubInstallationAlreadyLinked: {
+    defaultMessage:
+      "That GitHub installation is already linked to another Hyperlocalise organization.",
+    id: "glSxg8oQcE",
+    description: "GitHub connect error when installation is linked to another organization",
+  },
+  organizationNotFound: {
+    defaultMessage: "The organization for this install request could not be found.",
+    id: "P4BtYAEPF2",
+    description: "GitHub connect error when organization cannot be resolved",
+  },
+  githubUseSetupUrl: {
+    defaultMessage:
+      'GitHub returned a user OAuth code instead of an installation ID. In GitHub App settings, turn off "Request user authorization (OAuth) during installation" and set the Setup URL to this app\'s /auth/github/callback.',
+    id: "SBi1hajIEG",
+    description: "GitHub connect error when OAuth code is returned instead of installation ID",
+  },
+});
+
+const GITHUB_CONNECT_ERROR_MESSAGES: Record<string, MessageDescriptor> = {
+  missing_callback_params: githubIntegrationRowMessages.missingCallbackParams,
+  invalid_state: githubIntegrationRowMessages.invalidState,
+  github_install_pending_approval: githubIntegrationRowMessages.githubInstallPendingApproval,
+  github_app_not_configured: githubIntegrationRowMessages.githubAppNotConfigured,
+  github_app_private_key_invalid: githubIntegrationRowMessages.githubAppPrivateKeyInvalid,
+  github_installation_invalid: githubIntegrationRowMessages.githubInstallationInvalid,
+  github_installation_already_linked: githubIntegrationRowMessages.githubInstallationAlreadyLinked,
+  organization_not_found: githubIntegrationRowMessages.organizationNotFound,
+  github_use_setup_url: githubIntegrationRowMessages.githubUseSetupUrl,
+};
+
+export function getGithubConnectErrorMessage(intl: IntlShape, errorCode: string): string {
+  const message = GITHUB_CONNECT_ERROR_MESSAGES[errorCode];
+  if (message) {
+    return intl.formatMessage(message);
+  }
+
+  return intl.formatMessage(githubIntegrationRowMessages.connectFailedFallback);
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-integration-row.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-integration-row.tsx
@@ -6,8 +6,13 @@ import { GitBranchIcon, Refresh01Icon, Search01Icon } from "@hugeicons/core-free
 import { HugeiconsIcon } from "@hugeicons/react";
 import { siGithub } from "simple-icons";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
 import { toast } from "sonner";
 
+import {
+  getGithubConnectErrorMessage,
+  githubIntegrationRowMessages,
+} from "./github-integration-row.messages";
 import { IntegrationRow } from "./integration-row";
 import { RepositoryAutomationSettingsAction } from "./repository-automation-settings-action";
 import { SimpleBrandIcon } from "./simple-brand-icon";
@@ -19,25 +24,6 @@ import { cn } from "@/lib/primitives/cn";
 import { TypographyP } from "@/components/ui/typography";
 
 const api = createApiClient();
-
-const GITHUB_CONNECT_ERROR_MESSAGES: Record<string, string> = {
-  missing_callback_params:
-    "GitHub did not return installation_id on the Setup URL callback. Confirm the GitHub App Setup URL points to this app and try connecting again.",
-  invalid_state:
-    "The GitHub install link expired or was already used. Click Connect again from this page.",
-  github_install_pending_approval:
-    "GitHub is waiting for an org owner to approve this app install. Approve it on GitHub, then connect again.",
-  github_app_not_configured: "GitHub App integration is not configured for this environment.",
-  github_app_private_key_invalid:
-    "GitHub rejected the app credentials in this environment. Set GITHUB_APP_ID to the App ID from GitHub App settings and GITHUB_APP_PRIVATE_KEY to the matching PEM (use literal \\n line breaks or base64-encode the whole file).",
-  github_installation_invalid:
-    "GitHub rejected the installation ID. Confirm the app is installed on the expected account.",
-  github_installation_already_linked:
-    "That GitHub installation is already linked to another Hyperlocalise organization.",
-  organization_not_found: "The organization for this install request could not be found.",
-  github_use_setup_url:
-    'GitHub returned a user OAuth code instead of an installation ID. In GitHub App settings, turn off "Request user authorization (OAuth) during installation" and set the Setup URL to this app\'s /auth/github/callback.',
-};
 
 type GitHubIntegrationRowProps = {
   organizationSlug: string;
@@ -117,7 +103,7 @@ function useInstallUrl(organizationSlug: string) {
   });
 }
 
-function useSyncRepositories(organizationSlug: string) {
+function useSyncRepositories(organizationSlug: string, intl: IntlShape) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -140,7 +126,7 @@ function useSyncRepositories(organizationSlug: string) {
           queryKey: ["github-installation-repositories", organizationSlug],
         }),
       ]);
-      toast.success("GitHub repository list refreshed");
+      toast.success(intl.formatMessage(githubIntegrationRowMessages.repositoryListRefreshedToast));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -148,7 +134,7 @@ function useSyncRepositories(organizationSlug: string) {
   });
 }
 
-function useUpdateRepositories(organizationSlug: string) {
+function useUpdateRepositories(organizationSlug: string, intl: IntlShape) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -173,7 +159,9 @@ function useUpdateRepositories(organizationSlug: string) {
           queryKey: ["github-installation-repositories", organizationSlug],
         }),
       ]);
-      toast.success("Enabled repositories updated");
+      toast.success(
+        intl.formatMessage(githubIntegrationRowMessages.enabledRepositoriesUpdatedToast),
+      );
     },
     onError: (error) => {
       toast.error(error.message);
@@ -181,7 +169,7 @@ function useUpdateRepositories(organizationSlug: string) {
   });
 }
 
-function useDisconnectInstallation(organizationSlug: string) {
+function useDisconnectInstallation(organizationSlug: string, intl: IntlShape) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -201,7 +189,7 @@ function useDisconnectInstallation(organizationSlug: string) {
           queryKey: ["github-installation-repositories", organizationSlug],
         }),
       ]);
-      toast.success("GitHub disconnected");
+      toast.success(intl.formatMessage(githubIntegrationRowMessages.disconnectedToast));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -214,6 +202,7 @@ export function GitHubIntegrationRow({
   isLast = false,
   userCanManage,
 }: GitHubIntegrationRowProps) {
+  const intl = useIntl();
   const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const [expanded, setExpanded] = useState(false);
@@ -240,11 +229,8 @@ export function GitHubIntegrationRow({
     url.searchParams.delete("error");
     window.history.replaceState(null, "", url.toString());
 
-    const message =
-      GITHUB_CONNECT_ERROR_MESSAGES[errorCode] ??
-      "GitHub App connection failed. Try connecting again.";
-    toast.error(message);
-  }, [searchParams]);
+    toast.error(getGithubConnectErrorMessage(intl, errorCode));
+  }, [intl, searchParams]);
 
   useEffect(() => {
     if (searchParams.get("github_connected") !== "1" || handledGithubConnectedRef.current) {
@@ -263,9 +249,9 @@ export function GitHubIntegrationRow({
         queryKey: ["github-installation-repositories", organizationSlug],
       });
       setExpanded(true);
-      toast.success("GitHub connected");
+      toast.success(intl.formatMessage(githubIntegrationRowMessages.connectedToast));
     })();
-  }, [organizationSlug, queryClient, refetchInstallation, searchParams]);
+  }, [intl, organizationSlug, queryClient, refetchInstallation, searchParams]);
 
   const { data: repositories = [], isLoading: isLoadingRepositories } = useGitHubRepositories(
     organizationSlug,
@@ -273,9 +259,9 @@ export function GitHubIntegrationRow({
   );
   const { refetch: getInstallUrl, isFetching: isCreatingInstallUrl } =
     useInstallUrl(organizationSlug);
-  const syncRepositories = useSyncRepositories(organizationSlug);
-  const updateRepositories = useUpdateRepositories(organizationSlug);
-  const disconnect = useDisconnectInstallation(organizationSlug);
+  const syncRepositories = useSyncRepositories(organizationSlug, intl);
+  const updateRepositories = useUpdateRepositories(organizationSlug, intl);
+  const disconnect = useDisconnectInstallation(organizationSlug, intl);
   const [query, setQuery] = useState("");
   const [selectedRepositoryIds, setSelectedRepositoryIds] = useState<Set<string> | null>(null);
 
@@ -315,9 +301,9 @@ export function GitHubIntegrationRow({
     if (url) {
       window.location.href = url;
     } else {
-      toast.error("Failed to generate GitHub install URL");
+      toast.error(intl.formatMessage(githubIntegrationRowMessages.installUrlFailedToast));
     }
-  }, [getInstallUrl]);
+  }, [getInstallUrl, intl]);
 
   const toggleRepository = useCallback(
     (repositoryId: string) => {
@@ -355,17 +341,24 @@ export function GitHubIntegrationRow({
   const hasEnabledRepositories =
     (installation?.enabledRepositoryCount ??
       repositories.filter((repository) => repository.enabled).length) > 0;
-  const description = (() => {
+
+  const description = useMemo(() => {
     if (!installation) {
-      return "Connect GitHub for pull request reviews, localization fixes, and repository context.";
+      return intl.formatMessage(githubIntegrationRowMessages.disconnectedDescription);
     }
 
-    const repoSummary = `${installation.enabledRepositoryCount ?? 0} of ${installation.repositoryCount ?? repositories.length} repositories enabled.`;
+    const repoSummary = intl.formatMessage(githubIntegrationRowMessages.repoSummary, {
+      enabledCount: installation.enabledRepositoryCount ?? 0,
+      totalCount: installation.repositoryCount ?? repositories.length,
+    });
 
     return installation.accountLogin
-      ? `Connected as ${installation.accountLogin}. ${repoSummary}`
-      : `Connected. ${repoSummary}`;
-  })();
+      ? intl.formatMessage(githubIntegrationRowMessages.connectedAsDescription, {
+          accountLogin: installation.accountLogin,
+          repoSummary,
+        })
+      : intl.formatMessage(githubIntegrationRowMessages.connectedDescription, { repoSummary });
+  }, [installation, intl, repositories.length]);
 
   const action = !userCanManage
     ? connected
@@ -377,7 +370,7 @@ export function GitHubIntegrationRow({
 
   return (
     <IntegrationRow
-      name="GitHub"
+      name={intl.formatMessage(githubIntegrationRowMessages.name)}
       description={description}
       icon={<SimpleBrandIcon icon={siGithub} colored={hasEnabledRepositories} />}
       iconMuted={!hasEnabledRepositories}
@@ -396,10 +389,10 @@ export function GitHubIntegrationRow({
           <TypographyP className="text-sm text-destructive">
             {error instanceof Error
               ? error.message
-              : "Unable to load GitHub installation status right now."}
+              : intl.formatMessage(githubIntegrationRowMessages.loadError)}
           </TypographyP>
           <Button variant="outline" size="sm" onClick={() => void refetchInstallation()}>
-            Retry
+            <FormattedMessage {...githubIntegrationRowMessages.retry} />
           </Button>
         </div>
       ) : connected ? (
@@ -413,7 +406,7 @@ export function GitHubIntegrationRow({
                   <a href={installationSettingsUrl} target="_blank" rel="noopener noreferrer" />
                 }
               >
-                Manage access on GitHub
+                <FormattedMessage {...githubIntegrationRowMessages.manageAccessOnGitHub} />
               </Button>
             ) : null}
             <Button
@@ -421,10 +414,14 @@ export function GitHubIntegrationRow({
               size="sm"
               onClick={() => syncRepositories.mutate()}
               disabled={syncRepositories.isPending}
-              title="Refresh the repository list and metadata from GitHub. This does not push or pull translations."
+              title={intl.formatMessage(githubIntegrationRowMessages.refreshRepoListTitle)}
             >
               <HugeiconsIcon icon={Refresh01Icon} strokeWidth={1.8} className="size-4" />
-              {syncRepositories.isPending ? "Refreshing..." : "Refresh repo list"}
+              {syncRepositories.isPending ? (
+                <FormattedMessage {...githubIntegrationRowMessages.refreshingRepoList} />
+              ) : (
+                <FormattedMessage {...githubIntegrationRowMessages.refreshRepoList} />
+              )}
             </Button>
             <Button
               variant="outline"
@@ -436,7 +433,11 @@ export function GitHubIntegrationRow({
               }
               disabled={disconnect.isPending}
             >
-              {disconnect.isPending ? "Disconnecting..." : "Disconnect"}
+              {disconnect.isPending ? (
+                <FormattedMessage {...githubIntegrationRowMessages.disconnecting} />
+              ) : (
+                <FormattedMessage {...githubIntegrationRowMessages.disconnect} />
+              )}
             </Button>
           </div>
 
@@ -451,8 +452,12 @@ export function GitHubIntegrationRow({
                 <input
                   value={query}
                   onChange={(event) => setQuery(event.target.value)}
-                  placeholder="Search repositories"
-                  aria-label="Search repositories"
+                  placeholder={intl.formatMessage(
+                    githubIntegrationRowMessages.searchRepositoriesPlaceholder,
+                  )}
+                  aria-label={intl.formatMessage(
+                    githubIntegrationRowMessages.searchRepositoriesAriaLabel,
+                  )}
                   className="h-9 w-full rounded-lg border border-border bg-background px-9 text-sm text-foreground transition-all outline-none placeholder:text-muted-foreground focus:border-input focus:ring-[3px] focus:ring-border"
                 />
               </div>
@@ -463,7 +468,10 @@ export function GitHubIntegrationRow({
                   onClick={handleEnableSelected}
                   disabled={updateRepositories.isPending || repositories.length === 0}
                 >
-                  Enable {effectiveSelection.size}
+                  <FormattedMessage
+                    {...githubIntegrationRowMessages.enableSelected}
+                    values={{ count: effectiveSelection.size }}
+                  />
                 </Button>
               ) : null}
               <Button
@@ -476,17 +484,25 @@ export function GitHubIntegrationRow({
                   effectiveSelection.size === repositories.length
                 }
               >
-                Enable all
+                <FormattedMessage {...githubIntegrationRowMessages.enableAll} />
               </Button>
             </div>
             <div className="overflow-hidden rounded-lg border border-border bg-card">
               <div className="grid grid-cols-[48px_minmax(0,1fr)_120px_260px] border-b border-border bg-muted/40 text-xs font-medium tracking-wide text-muted-foreground uppercase">
                 <div className="px-4 py-3">
-                  <span className="sr-only">Enabled</span>
+                  <span className="sr-only">
+                    <FormattedMessage {...githubIntegrationRowMessages.enabledColumnSrOnly} />
+                  </span>
                 </div>
-                <div className="px-4 py-3">Repositories</div>
-                <div className="px-4 py-3">Branch</div>
-                <div className="px-4 py-3 text-right">Action</div>
+                <div className="px-4 py-3">
+                  <FormattedMessage {...githubIntegrationRowMessages.repositoriesColumn} />
+                </div>
+                <div className="px-4 py-3">
+                  <FormattedMessage {...githubIntegrationRowMessages.branchColumn} />
+                </div>
+                <div className="px-4 py-3 text-right">
+                  <FormattedMessage {...githubIntegrationRowMessages.actionColumn} />
+                </div>
               </div>
               {isLoadingRepositories ? (
                 <div className="p-4">
@@ -509,7 +525,10 @@ export function GitHubIntegrationRow({
                           checked={checked}
                           onChange={() => toggleRepository(repository.githubRepositoryId)}
                           className="size-4 rounded border-input accent-foreground"
-                          aria-label={`Enable ${repository.fullName}`}
+                          aria-label={intl.formatMessage(
+                            githubIntegrationRowMessages.enableRepositoryAriaLabel,
+                            { repositoryFullName: repository.fullName },
+                          )}
                         />
                       </div>
                       <div className="min-w-0 px-4">
@@ -525,7 +544,7 @@ export function GitHubIntegrationRow({
                               variant="outline"
                               className="border-border bg-secondary text-secondary-foreground"
                             >
-                              Private
+                              <FormattedMessage {...githubIntegrationRowMessages.privateBadge} />
                             </Badge>
                           ) : null}
                           {repository.archived ? (
@@ -533,14 +552,17 @@ export function GitHubIntegrationRow({
                               variant="outline"
                               className="border-border bg-accent text-accent-foreground"
                             >
-                              Archived
+                              <FormattedMessage {...githubIntegrationRowMessages.archivedBadge} />
                             </Badge>
                           ) : null}
                         </div>
                       </div>
                       <div className="flex min-w-0 items-center gap-2 px-4 text-muted-foreground">
                         <HugeiconsIcon icon={GitBranchIcon} strokeWidth={1.8} className="size-4" />
-                        <span className="truncate">{repository.defaultBranch ?? "default"}</span>
+                        <span className="truncate">
+                          {repository.defaultBranch ??
+                            intl.formatMessage(githubIntegrationRowMessages.defaultBranchFallback)}
+                        </span>
                       </div>
                       <div
                         className="px-4"
@@ -563,9 +585,11 @@ export function GitHubIntegrationRow({
                 })
               ) : (
                 <div className="px-4 py-6 text-sm text-muted-foreground">
-                  {repositories.length === 0
-                    ? "No repositories are available to this GitHub App installation."
-                    : "No repositories match this search."}
+                  {repositories.length === 0 ? (
+                    <FormattedMessage {...githubIntegrationRowMessages.noRepositoriesAvailable} />
+                  ) : (
+                    <FormattedMessage {...githubIntegrationRowMessages.noRepositoriesMatchSearch} />
+                  )}
                 </div>
               )}
             </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model.messages.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const githubRepositoryAutomationViewModelMessages = defineMessages({
+  pushSourceProjectRequired: {
+    defaultMessage: "Choose a Hyperlocalise project for push source.",
+    id: "g2W3opbod8",
+    description: "Validation error when push source workflow has no project selected",
+  },
+  pullTranslationsProjectRequired: {
+    defaultMessage: "Choose a Hyperlocalise project for pull translations.",
+    id: "NxMkWJ+eS3",
+    description: "Validation error when pull translations workflow has no project selected",
+  },
+  triggerRequired: {
+    defaultMessage: "Choose push or scheduled triggers when workflows are enabled.",
+    id: "dmWGvUNewd",
+    description: "Validation error when workflows are enabled but no trigger mode is selected",
+  },
+  automationTriggerRequired: {
+    defaultMessage: "Enable at least one workflow and choose when automation should run.",
+    id: "/TZx8A/JWk",
+    description: "API error when automation has workflows but no trigger configuration",
+  },
+  pushTriggerRequiresBranches: {
+    defaultMessage: "Add at least one branch pattern for push triggers.",
+    id: "l5r0xPEJDX",
+    description: "API error when push trigger has no branch patterns",
+  },
+  weeklyScheduleRequiresDayOfWeek: {
+    defaultMessage: "Choose a day of the week for weekly schedules.",
+    id: "pCwlsos9AL",
+    description: "API error when weekly schedule has an invalid day of week",
+  },
+  invalidAutomationTimezone: {
+    defaultMessage: "Enter a valid IANA timezone such as UTC or America/New_York.",
+    id: "muwnlAh1Hy",
+    description: "API error when scheduled automation timezone is invalid",
+  },
+  githubRepositoryNotEnabled: {
+    defaultMessage: "Enable this repository before configuring automation.",
+    id: "nwEXrsmZmr",
+    description: "API error when configuring automation on a disabled repository",
+  },
+  githubRepositoryArchived: {
+    defaultMessage: "Archived repositories cannot use translation automation.",
+    id: "ULAiYLTSMp",
+    description: "API error when configuring automation on an archived repository",
+  },
+  invalidBranchPattern: {
+    defaultMessage: "Branch patterns may only use letters, numbers, ., _, -, /, *, and ?.",
+    id: "FSI9rZSdBy",
+    description: "Validation error when a branch pattern contains invalid characters",
+  },
+  saveFailed: {
+    defaultMessage: "Could not save automation settings.",
+    id: "0xs+BR2vTX",
+    description: "Fallback error when automation settings save fails without a specific message",
+  },
+  enterBranchPattern: {
+    defaultMessage: "Enter a branch pattern.",
+    id: "8RC2xeVGMi",
+    description: "Validation error when adding an empty branch pattern",
+  },
+  branchPatternAlreadyListed: {
+    defaultMessage: "That branch pattern is already listed.",
+    id: "8Gb40LZzb8",
+    description: "Validation error when adding a duplicate branch pattern",
+  },
+  maxBranchPatterns: {
+    defaultMessage: "You can add up to {max} branch patterns.",
+    id: "88mR250rV4",
+    description: "Validation error when the branch pattern limit is reached",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model.messages.ts
@@ -73,4 +73,49 @@ export const githubRepositoryAutomationViewModelMessages = defineMessages({
     id: "88mR250rV4",
     description: "Validation error when the branch pattern limit is reached",
   },
+  weekdaySunday: {
+    defaultMessage: "Sunday",
+    id: "oQckCPSvLu",
+    description: "Weekday option for scheduled automation",
+  },
+  weekdayMonday: {
+    defaultMessage: "Monday",
+    id: "qxBrl7Yxqo",
+    description: "Weekday option for scheduled automation",
+  },
+  weekdayTuesday: {
+    defaultMessage: "Tuesday",
+    id: "WCzohOaFyx",
+    description: "Weekday option for scheduled automation",
+  },
+  weekdayWednesday: {
+    defaultMessage: "Wednesday",
+    id: "/bH75mQmVa",
+    description: "Weekday option for scheduled automation",
+  },
+  weekdayThursday: {
+    defaultMessage: "Thursday",
+    id: "1ESwnn506c",
+    description: "Weekday option for scheduled automation",
+  },
+  weekdayFriday: {
+    defaultMessage: "Friday",
+    id: "0XCfYzdREi",
+    description: "Weekday option for scheduled automation",
+  },
+  weekdaySaturday: {
+    defaultMessage: "Saturday",
+    id: "Cv5dtJ6iTe",
+    description: "Weekday option for scheduled automation",
+  },
 });
+
+export const AUTOMATION_WEEKDAY_MESSAGE_BY_VALUE = {
+  0: githubRepositoryAutomationViewModelMessages.weekdaySunday,
+  1: githubRepositoryAutomationViewModelMessages.weekdayMonday,
+  2: githubRepositoryAutomationViewModelMessages.weekdayTuesday,
+  3: githubRepositoryAutomationViewModelMessages.weekdayWednesday,
+  4: githubRepositoryAutomationViewModelMessages.weekdayThursday,
+  5: githubRepositoryAutomationViewModelMessages.weekdayFriday,
+  6: githubRepositoryAutomationViewModelMessages.weekdaySaturday,
+} as const;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model.test.ts
@@ -8,6 +8,10 @@ import {
   validateAutomationFormState,
 } from "./github-repository-automation-view-model";
 import { DEFAULT_GITHUB_REPOSITORY_AUTOMATION_SETTINGS } from "@/lib/agents/github/github-repository-automation-settings";
+import { getIntlShape } from "@/lib/app-i18n/intl";
+import type { IntlShape } from "react-intl";
+
+const intl = getIntlShape("en") as IntlShape;
 
 describe("github-repository-automation-view-model", () => {
   it("maps stored settings into form state", () => {
@@ -37,7 +41,7 @@ describe("github-repository-automation-view-model", () => {
   });
 
   it("requires a trigger when workflows are enabled", () => {
-    const errors = validateAutomationFormState({
+    const errors = validateAutomationFormState(intl, {
       ...createAutomationFormStateFromSettings(DEFAULT_GITHUB_REPOSITORY_AUTOMATION_SETTINGS),
       pushSourceEnabled: true,
       pushSourceProjectId: "project-1",
@@ -71,21 +75,21 @@ describe("github-repository-automation-view-model", () => {
   });
 
   it("maps API validation codes to field errors", () => {
-    expect(mapAutomationApiErrorToFieldErrors("push_trigger_requires_branches")).toEqual({
+    expect(mapAutomationApiErrorToFieldErrors(intl, "push_trigger_requires_branches")).toEqual({
       pushBranches: expect.stringContaining("branch pattern"),
     });
   });
 
   it("deduplicates branch patterns and enforces limits", () => {
-    const first = addBranchPattern([], "main");
-    const duplicate = addBranchPattern(first.branches, "main");
+    const first = addBranchPattern(intl, [], "main");
+    const duplicate = addBranchPattern(intl, first.branches, "main");
 
     expect(first.branches).toEqual(["main"]);
     expect(duplicate.error).toMatch(/already listed/i);
   });
 
   it("rejects invalid weekly day-of-week values", () => {
-    const errors = validateAutomationFormState({
+    const errors = validateAutomationFormState(intl, {
       ...createAutomationFormStateFromSettings(DEFAULT_GITHUB_REPOSITORY_AUTOMATION_SETTINGS),
       pushSourceEnabled: true,
       pushSourceProjectId: "project-1",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model.ts
@@ -1,3 +1,5 @@
+import type { IntlShape } from "react-intl";
+
 import {
   DEFAULT_GITHUB_REPOSITORY_AUTOMATION_SETTINGS,
   type GithubRepositoryAutomationSettings,
@@ -5,6 +7,8 @@ import {
   hasEnabledGithubRepoAutomationWorkflow,
   validateGithubRepositoryAutomationSettings,
 } from "@/lib/agents/github/github-repository-automation-settings";
+
+import { githubRepositoryAutomationViewModelMessages } from "./github-repository-automation-view-model.messages";
 
 export type GithubAutomationTriggerMode = "none" | "push" | "scheduled";
 
@@ -43,25 +47,47 @@ export const MAX_AUTOMATION_BRANCH_PATTERNS = 32;
 const BRANCH_PATTERN_REGEX = /^[A-Za-z0-9._\-/*?]+$/;
 
 export const AUTOMATION_WEEKDAY_OPTIONS = [
-  { value: 0, label: "Sunday" },
-  { value: 1, label: "Monday" },
-  { value: 2, label: "Tuesday" },
-  { value: 3, label: "Wednesday" },
-  { value: 4, label: "Thursday" },
-  { value: 5, label: "Friday" },
-  { value: 6, label: "Saturday" },
+  { value: 0 },
+  { value: 1 },
+  { value: 2 },
+  { value: 3 },
+  { value: 4 },
+  { value: 5 },
+  { value: 6 },
 ] as const;
 
-export const AUTOMATION_API_ERROR_MESSAGES: Record<string, string> = {
-  automation_trigger_required:
-    "Enable at least one workflow and choose when automation should run.",
-  push_trigger_requires_branches: "Add at least one branch pattern for push triggers.",
-  weekly_schedule_requires_day_of_week: "Choose a day of the week for weekly schedules.",
-  invalid_automation_timezone: "Enter a valid IANA timezone such as UTC or America/New_York.",
-  github_repository_not_enabled: "Enable this repository before configuring automation.",
-  github_repository_archived: "Archived repositories cannot use translation automation.",
-  invalid_branch_pattern: "Branch patterns may only use letters, numbers, ., _, -, /, *, and ?.",
-};
+function getAutomationApiErrorMessage(intl: IntlShape, errorCode: string) {
+  switch (errorCode) {
+    case "automation_trigger_required":
+      return intl.formatMessage(
+        githubRepositoryAutomationViewModelMessages.automationTriggerRequired,
+      );
+    case "push_trigger_requires_branches":
+      return intl.formatMessage(
+        githubRepositoryAutomationViewModelMessages.pushTriggerRequiresBranches,
+      );
+    case "weekly_schedule_requires_day_of_week":
+      return intl.formatMessage(
+        githubRepositoryAutomationViewModelMessages.weeklyScheduleRequiresDayOfWeek,
+      );
+    case "invalid_automation_timezone":
+      return intl.formatMessage(
+        githubRepositoryAutomationViewModelMessages.invalidAutomationTimezone,
+      );
+    case "github_repository_not_enabled":
+      return intl.formatMessage(
+        githubRepositoryAutomationViewModelMessages.githubRepositoryNotEnabled,
+      );
+    case "github_repository_archived":
+      return intl.formatMessage(
+        githubRepositoryAutomationViewModelMessages.githubRepositoryArchived,
+      );
+    case "invalid_branch_pattern":
+      return intl.formatMessage(githubRepositoryAutomationViewModelMessages.invalidBranchPattern);
+    default:
+      return undefined;
+  }
+}
 
 export function createDefaultAutomationFormState(): GithubRepositoryAutomationFormState {
   const defaults = DEFAULT_GITHUB_REPOSITORY_AUTOMATION_SETTINGS;
@@ -187,17 +213,22 @@ export function formStateToAutomationSettingsPayload(
 }
 
 export function validateAutomationFormState(
+  intl: IntlShape,
   form: GithubRepositoryAutomationFormState,
 ): GithubRepositoryAutomationFieldErrors {
   const errors: GithubRepositoryAutomationFieldErrors = {};
   const hasWorkflow = hasAnyAutomationWorkflowEnabled(form);
 
   if (form.pushSourceEnabled && !form.pushSourceProjectId.trim()) {
-    errors.pushSourceProjectId = "Choose a Hyperlocalise project for push source.";
+    errors.pushSourceProjectId = intl.formatMessage(
+      githubRepositoryAutomationViewModelMessages.pushSourceProjectRequired,
+    );
   }
 
   if (form.pullTranslationsEnabled && !form.pullTranslationsProjectId.trim()) {
-    errors.pullTranslationsProjectId = "Choose a Hyperlocalise project for pull translations.";
+    errors.pullTranslationsProjectId = intl.formatMessage(
+      githubRepositoryAutomationViewModelMessages.pullTranslationsProjectRequired,
+    );
   }
 
   if (!hasWorkflow) {
@@ -205,19 +236,25 @@ export function validateAutomationFormState(
   }
 
   if (form.triggerMode === "none") {
-    errors.trigger = "Choose push or scheduled triggers when workflows are enabled.";
+    errors.trigger = intl.formatMessage(
+      githubRepositoryAutomationViewModelMessages.triggerRequired,
+    );
     return errors;
   }
 
   if (form.triggerMode === "push") {
     if (form.pushBranches.length === 0) {
-      errors.pushBranches = AUTOMATION_API_ERROR_MESSAGES.push_trigger_requires_branches;
+      errors.pushBranches = intl.formatMessage(
+        githubRepositoryAutomationViewModelMessages.pushTriggerRequiresBranches,
+      );
     } else {
       const invalidPattern = form.pushBranches.find(
         (branch) => !BRANCH_PATTERN_REGEX.test(branch.trim()),
       );
       if (invalidPattern) {
-        errors.pushBranches = AUTOMATION_API_ERROR_MESSAGES.invalid_branch_pattern;
+        errors.pushBranches = intl.formatMessage(
+          githubRepositoryAutomationViewModelMessages.invalidBranchPattern,
+        );
       }
     }
   }
@@ -227,15 +264,18 @@ export function validateAutomationFormState(
       form.scheduledCadence === "weekly" &&
       (form.scheduledDayOfWeek < 0 || form.scheduledDayOfWeek > 6)
     ) {
-      errors.scheduledDayOfWeek =
-        AUTOMATION_API_ERROR_MESSAGES.weekly_schedule_requires_day_of_week;
+      errors.scheduledDayOfWeek = intl.formatMessage(
+        githubRepositoryAutomationViewModelMessages.weeklyScheduleRequiresDayOfWeek,
+      );
     }
 
     const timezone = form.scheduledTimezone.trim() || "UTC";
     try {
       Intl.DateTimeFormat("en-US", { timeZone: timezone });
     } catch {
-      errors.scheduledTimezone = AUTOMATION_API_ERROR_MESSAGES.invalid_automation_timezone;
+      errors.scheduledTimezone = intl.formatMessage(
+        githubRepositoryAutomationViewModelMessages.invalidAutomationTimezone,
+      );
     }
   }
 
@@ -243,7 +283,7 @@ export function validateAutomationFormState(
     formStateToAutomationSettings(form),
   );
   if (validationError) {
-    const mapped = mapAutomationApiErrorToFieldErrors(validationError);
+    const mapped = mapAutomationApiErrorToFieldErrors(intl, validationError);
     return { ...errors, ...mapped };
   }
 
@@ -251,10 +291,11 @@ export function validateAutomationFormState(
 }
 
 export function mapAutomationApiErrorToFieldErrors(
+  intl: IntlShape,
   errorCode: string,
   message?: string,
 ): GithubRepositoryAutomationFieldErrors {
-  const fallbackMessage = message ?? AUTOMATION_API_ERROR_MESSAGES[errorCode];
+  const fallbackMessage = message ?? getAutomationApiErrorMessage(intl, errorCode);
 
   switch (errorCode) {
     case "automation_trigger_required":
@@ -269,7 +310,11 @@ export function mapAutomationApiErrorToFieldErrors(
     case "github_repository_archived":
       return { form: fallbackMessage };
     default:
-      return { form: fallbackMessage ?? "Could not save automation settings." };
+      return {
+        form:
+          fallbackMessage ??
+          intl.formatMessage(githubRepositoryAutomationViewModelMessages.saveFailed),
+      };
   }
 }
 
@@ -278,27 +323,41 @@ export function normalizeBranchPatternInput(value: string) {
 }
 
 export function addBranchPattern(
+  intl: IntlShape,
   branches: string[],
   rawPattern: string,
 ): { branches: string[]; error?: string } {
   const pattern = normalizeBranchPatternInput(rawPattern);
 
   if (!pattern) {
-    return { branches, error: "Enter a branch pattern." };
+    return {
+      branches,
+      error: intl.formatMessage(githubRepositoryAutomationViewModelMessages.enterBranchPattern),
+    };
   }
 
   if (!BRANCH_PATTERN_REGEX.test(pattern)) {
-    return { branches, error: AUTOMATION_API_ERROR_MESSAGES.invalid_branch_pattern };
+    return {
+      branches,
+      error: intl.formatMessage(githubRepositoryAutomationViewModelMessages.invalidBranchPattern),
+    };
   }
 
   if (branches.includes(pattern)) {
-    return { branches, error: "That branch pattern is already listed." };
+    return {
+      branches,
+      error: intl.formatMessage(
+        githubRepositoryAutomationViewModelMessages.branchPatternAlreadyListed,
+      ),
+    };
   }
 
   if (branches.length >= MAX_AUTOMATION_BRANCH_PATTERNS) {
     return {
       branches,
-      error: `You can add up to ${MAX_AUTOMATION_BRANCH_PATTERNS} branch patterns.`,
+      error: intl.formatMessage(githubRepositoryAutomationViewModelMessages.maxBranchPatterns, {
+        max: MAX_AUTOMATION_BRANCH_PATTERNS,
+      }),
     };
   }
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integration-row.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integration-row.messages.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const integrationRowMessages = defineMessages({
+  comingSoon: {
+    defaultMessage: "Coming soon",
+    id: "2Wk4xEwU1H",
+    description: "Disabled button label for integrations not yet available",
+  },
+  adminsCanConnect: {
+    defaultMessage: "Admins can connect",
+    id: "D9igbLAS2O",
+    description: "Hint shown when the user lacks permission to connect an integration",
+  },
+  connecting: {
+    defaultMessage: "Connecting…",
+    id: "pfwX+wkDSM",
+    description: "Connect button label while an OAuth or install flow is starting",
+  },
+  connect: {
+    defaultMessage: "Connect",
+    id: "jLjTPaf/u5",
+    description: "Button label to start connecting an integration",
+  },
+  manage: {
+    defaultMessage: "Manage",
+    id: "V5IhYqq1Fk",
+    description: "Button label to expand integration settings",
+  },
+  viewOnly: {
+    defaultMessage: "View only",
+    id: "PLauAF+cPB",
+    description: "Badge shown when the user can view but not manage a connected integration",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integration-row.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integration-row.tsx
@@ -2,6 +2,9 @@
 
 import type { ReactNode } from "react";
 import { ArrowUpRightIcon, ChevronDownIcon } from "lucide-react";
+import { FormattedMessage } from "react-intl";
+
+import { integrationRowMessages } from "./integration-row.messages";
 
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
@@ -109,10 +112,12 @@ export function IntegrationRow({
             <Skeleton className="h-8 w-[5.75rem] rounded-md" aria-hidden />
           ) : action === "coming-soon" ? (
             <Button type="button" variant="outline" size="sm" disabled>
-              Coming soon
+              <FormattedMessage {...integrationRowMessages.comingSoon} />
             </Button>
           ) : action === "view-only" ? (
-            <span className="text-sm text-muted-foreground">Admins can connect</span>
+            <span className="text-sm text-muted-foreground">
+              <FormattedMessage {...integrationRowMessages.adminsCanConnect} />
+            </span>
           ) : action === "connect" ? (
             <Button
               type="button"
@@ -122,14 +127,18 @@ export function IntegrationRow({
               disabled={isConnecting}
               className={activeStyle.button}
             >
-              {isConnecting ? "Connecting..." : "Connect"}
+              {isConnecting ? (
+                <FormattedMessage {...integrationRowMessages.connecting} />
+              ) : (
+                <FormattedMessage {...integrationRowMessages.connect} />
+              )}
               <ArrowUpRightIcon className="size-3.5" strokeWidth={2} />
             </Button>
           ) : showPanel ? (
             <CollapsibleTrigger
               render={
                 <Button type="button" variant="outline" size="sm">
-                  Manage
+                  <FormattedMessage {...integrationRowMessages.manage} />
                   <ChevronDownIcon
                     className={cn("size-3.5 transition-transform", expanded && "rotate-180")}
                     strokeWidth={2}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.messages.ts
@@ -1,0 +1,281 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const integrationsPageContentMessages = defineMessages({
+  pageTitle: {
+    defaultMessage: "Integrations",
+    id: "9glYgHRgqB",
+    description: "Integrations page heading",
+  },
+  workspaceLevelBadge: {
+    defaultMessage: "Workspace level",
+    id: "rywDd6XWpM",
+    description: "Badge indicating integrations apply to the whole workspace",
+  },
+  tmsCategory: {
+    defaultMessage: "Translation Management System",
+    id: "AvXpNmaez+",
+    description: "Integrations page section heading for TMS providers",
+  },
+  cmsCategory: {
+    defaultMessage: "Content Management System",
+    id: "dWHU+zjwUO",
+    description: "Integrations page section heading for CMS connectors",
+  },
+  modelProviderCategory: {
+    defaultMessage: "Model provider",
+    id: "E6HRzAiOt0",
+    description: "Integrations page section heading for LLM providers",
+  },
+  hyperlocaliseGoLabel: {
+    defaultMessage: "Hyperlocalise GO",
+    id: "Qkra2VNwUo",
+    description: "Managed Hyperlocalise model provider name",
+  },
+  hyperlocaliseGoDescription: {
+    defaultMessage: "Managed by Hyperlocalise",
+    id: "tHJT8VDfIn",
+    description: "Managed Hyperlocalise model provider description",
+  },
+  openAiLabel: {
+    defaultMessage: "Open AI",
+    id: "0kqhhOMa9k",
+    description: "OpenAI BYOK provider name on the integrations page",
+  },
+  openAiDescription: {
+    defaultMessage: "Connect your OpenAI account",
+    id: "QmXtxyLvCd",
+    description: "OpenAI BYOK provider description on the integrations page",
+  },
+  anthropicLabel: {
+    defaultMessage: "Anthropic",
+    id: "1VNZg9UkcM",
+    description: "Anthropic BYOK provider name on the integrations page",
+  },
+  anthropicDescription: {
+    defaultMessage: "Connect your Anthropic account",
+    id: "4tP9x2ODN4",
+    description: "Anthropic BYOK provider description on the integrations page",
+  },
+  geminiLabel: {
+    defaultMessage: "Google Gemini",
+    id: "l0d6YXPPZ9",
+    description: "Google Gemini BYOK provider name on the integrations page",
+  },
+  geminiDescription: {
+    defaultMessage: "Connect your Gemini account",
+    id: "R+hZLscXuo",
+    description: "Google Gemini BYOK provider description on the integrations page",
+  },
+  tmsNativeName: {
+    defaultMessage: "Hyperlocalise Native",
+    id: "Ij4qN1o4kr",
+    description: "Built-in TMS integration name on the integrations page",
+  },
+  tmsNativeDetail: {
+    defaultMessage:
+      "Built-in TMS for projects, jobs, files, and translation memories. No external provider required.",
+    id: "ayMjHyvmox",
+    description: "Built-in TMS integration description on the integrations page",
+  },
+  tmsCrowdinName: {
+    defaultMessage: "Crowdin",
+    id: "b1aqjjuIqX",
+    description: "Crowdin TMS integration name on the integrations page",
+  },
+  tmsCrowdinDetail: {
+    defaultMessage:
+      "Connect to browse Crowdin projects alongside native Hyperlocalise projects. Project and job data is read live from Crowdin when you open it.",
+    id: "F63lYTb8dq",
+    description: "Crowdin TMS integration description on the integrations page",
+  },
+  tmsLokaliseName: {
+    defaultMessage: "Lokalise",
+    id: "7bhDbepHzq",
+    description: "Lokalise TMS integration name on the integrations page",
+  },
+  tmsLokaliseDetail: {
+    defaultMessage:
+      "Connect to browse Lokalise projects, tasks, glossaries, and translation memories with user OAuth.",
+    id: "KsWSfbuaLd",
+    description: "Lokalise TMS integration description on the integrations page",
+  },
+  tmsPhraseName: {
+    defaultMessage: "Phrase",
+    id: "PNU13RfDla",
+    description: "Phrase TMS integration name on the integrations page",
+  },
+  tmsPhraseDetail: {
+    defaultMessage: "Connect to browse Phrase projects and jobs with user OAuth.",
+    id: "HsI1Rbh6Cp",
+    description: "Phrase TMS integration description on the integrations page",
+  },
+  tmsSmartlingName: {
+    defaultMessage: "Smartling",
+    id: "7nMUUnudcv",
+    description: "Smartling TMS integration name on the integrations page",
+  },
+  tmsSmartlingDetail: {
+    defaultMessage: "Connect enterprise localization programs.",
+    id: "4HsCO20k/1",
+    description: "Smartling TMS integration description on the integrations page",
+  },
+  contentfulName: {
+    defaultMessage: "Contentful",
+    id: "msm7HmNNfJ",
+    description: "Contentful CMS integration name on the integrations page",
+  },
+  contentfulDetail: {
+    defaultMessage: "CMS connector for agentic article translation and draft writeback.",
+    id: "YrDOYyksrv",
+    description: "Contentful CMS integration description on the integrations page",
+  },
+  viewProjects: {
+    defaultMessage: "View projects",
+    id: "umhjXIiCiC",
+    description: "Button label linking to native TMS projects",
+  },
+  disconnectTmsTooltip: {
+    defaultMessage: "Disconnect the current TMS to switch providers.",
+    id: "tSnciLV1cq",
+    description: "Tooltip when another TMS provider blocks connecting this one",
+  },
+  providerSavedToast: {
+    defaultMessage: "{providerLabel} provider saved",
+    id: "nmfgIZNX5m",
+    description: "Toast after saving a BYOK LLM provider credential",
+  },
+  llmProviderDisconnectedToast: {
+    defaultMessage: "LLM provider disconnected",
+    id: "kDfywMCo7J",
+    description: "Toast after disconnecting the workspace LLM provider",
+  },
+  externalTmsConnectedToast: {
+    defaultMessage: "{displayName} connected",
+    id: "V1BIkH6W+O",
+    description: "Toast after connecting an external TMS provider",
+  },
+  crowdinPatSavedConnectTokenToast: {
+    defaultMessage: "{displayName} saved. Connect your Crowdin token to continue.",
+    id: "/0FWG2SoFG",
+    description: "Toast after saving Crowdin PAT settings when user token is still required",
+  },
+  settingsSavedToast: {
+    defaultMessage: "{displayName} settings saved",
+    id: "nDPeOs1MH9",
+    description: "Toast after saving TMS OAuth or PAT settings",
+  },
+  crowdinOAuthSavedConnectAccountToast: {
+    defaultMessage: "{displayName} saved. Connect your Crowdin account to continue.",
+    id: "C+9nUAd/Jd",
+    description: "Toast after saving Crowdin OAuth app when user OAuth is still required",
+  },
+  phraseOAuthSavedConnectAccountToast: {
+    defaultMessage: "{displayName} saved. Connect your Phrase account to continue.",
+    id: "C7FCjLc6gc",
+    description: "Toast after saving Phrase OAuth app when user OAuth is still required",
+  },
+  lokaliseOAuthSavedConnectAccountToast: {
+    defaultMessage: "{displayName} saved. Connect your Lokalise account to continue.",
+    id: "4DV7znCLLI",
+    description: "Toast after saving Lokalise OAuth app when user OAuth is still required",
+  },
+  providerDisconnectedToast: {
+    defaultMessage: "Provider disconnected",
+    id: "rO3KPnsZEO",
+    description: "Toast after disconnecting an external TMS provider",
+  },
+  switchToManagedFooter: {
+    defaultMessage: "Switch to managed",
+    id: "CIdkhlQIV6",
+    description: "Footer label on managed model provider card when BYOK is active",
+  },
+  configureFooter: {
+    defaultMessage: "Configure",
+    id: "If/xnDCxst",
+    description: "Footer label on BYOK model provider cards",
+  },
+  configureDialogTitle: {
+    defaultMessage: "Configure {providerLabel}",
+    id: "Y7XT7zpg39",
+    description: "Title for the BYOK model provider configuration dialog",
+  },
+  configureDialogDescription: {
+    defaultMessage:
+      "Save one shared provider key for this workspace. Saving validates the key, encrypts it at rest, and replaces the current provider.",
+    id: "uMS3Md9f77",
+    description: "Description for the BYOK model provider configuration dialog",
+  },
+  defaultModelLabel: {
+    defaultMessage: "Default model",
+    id: "BsIdlB/bdk",
+    description: "Label for the default model select field",
+  },
+  apiKeyLabel: {
+    defaultMessage: "API key",
+    id: "znjMm102W+",
+    description: "Label for the provider API key input",
+  },
+  apiKeyPlaceholder: {
+    defaultMessage: "Enter {providerLabel} API key",
+    id: "tlMl5v6nnm",
+    description: "Placeholder for the provider API key input",
+  },
+  hideApiKeyAriaLabel: {
+    defaultMessage: "Hide API key",
+    id: "98mLYv90ox",
+    description: "Aria label for the button that hides the API key input",
+  },
+  showApiKeyAriaLabel: {
+    defaultMessage: "Show API key",
+    id: "2BaYUyVX1c",
+    description: "Aria label for the button that reveals the API key input",
+  },
+  disconnecting: {
+    defaultMessage: "Disconnecting…",
+    id: "ntvyMHkHZg",
+    description: "Button label while disconnecting a provider",
+  },
+  disconnect: {
+    defaultMessage: "Disconnect",
+    id: "PJoDNnwjRj",
+    description: "Button label to disconnect a provider",
+  },
+  validating: {
+    defaultMessage: "Validating…",
+    id: "2BoI5eES6X",
+    description: "Button label while validating a provider credential",
+  },
+  saveProvider: {
+    defaultMessage: "Save provider",
+    id: "NBLnrSCLwC",
+    description: "Button label to save a BYOK provider credential",
+  },
+  disconnectTmsDialogTitle: {
+    defaultMessage: "Disconnect {providerName}?",
+    id: "BX0DlJwbY+",
+    description: "Title for the external TMS disconnect confirmation dialog",
+  },
+  disconnectTmsDialogTitleFallback: {
+    defaultMessage: "TMS provider",
+    id: "dY8L59VF27",
+    description: "Fallback provider name in the TMS disconnect dialog title",
+  },
+  disconnectTmsDialogDescription: {
+    defaultMessage:
+      "This removes the saved encrypted provider credentials. Reconnecting this provider will require entering the secret again.",
+    id: "pM8pgX4u47",
+    description: "Description for the external TMS disconnect confirmation dialog",
+  },
+  cancel: {
+    defaultMessage: "Cancel",
+    id: "wIG4YNHURU",
+    description: "Cancel button in the TMS disconnect confirmation dialog",
+  },
+  contentfulHelpCenterDefaultName: {
+    defaultMessage: "Contentful Help Center",
+    id: "w9jgu/gyZT",
+    description: "Default display name for a new Contentful CMS connection",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useId, useState, type ReactNode } from "react";
+import { useEffect, useId, useMemo, useState, type ReactNode } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { Alert02Icon, Delete02Icon, Key01Icon, SaveIcon } from "@hugeicons/core-free-icons";
@@ -9,6 +9,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import type { SimpleIcon } from "simple-icons";
 import { siAnthropic, siContentful, siCrowdin, siGooglegemini } from "simple-icons";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
 import { toast } from "sonner";
 
 import type { LlmProvider } from "@/lib/database/types";
@@ -70,6 +71,8 @@ import {
   useContentfulConnections,
   useSaveContentfulConnection,
 } from "./contentful-connection-panel";
+import { integrationRowMessages } from "./integration-row.messages";
+import { integrationsPageContentMessages } from "./integrations-page-content.messages";
 import { IntegrationCategoryLabel, integrationConnectButtonClassName } from "./integration-row";
 import { ModelProviderCard, type ModelProviderCardConfig } from "./model-provider-card";
 import { SimpleBrandIcon } from "./simple-brand-icon";
@@ -104,46 +107,28 @@ type ProviderCredentialSummary = {
 type ManagedProviderId = "hyperlocalise-go";
 type ProviderOptionId = LlmProvider | ManagedProviderId;
 
-const hyperlocaliseGoProvider = {
-  id: "hyperlocalise-go",
-  label: "Hyperlocalise GO",
-  description: "Managed by Hyperlocalise",
-  logo: "/images/logo.png",
-} as const;
+const hyperlocaliseGoProviderId = "hyperlocalise-go" as const satisfies ManagedProviderId;
 
-const byokProviders = [
+const byokProviderMeta = [
   {
     id: "openai",
-    label: "Open AI",
-    description: "Connect your OpenAI account",
     logo: "/images/openai-old-logo.webp",
   },
   {
     id: "anthropic",
-    label: "Anthropic",
-    description: "Connect your Anthropic account",
     logo: "/images/claude.png",
     icon: siAnthropic,
   },
   {
     id: "gemini",
-    label: "Google Gemini",
-    description: "Connect your Gemini account",
     logo: "/images/gemini.webp",
     icon: siGooglegemini,
   },
 ] as const satisfies readonly {
   id: LlmProvider;
-  label: string;
-  description: string;
   logo: string;
   icon?: SimpleIcon;
 }[];
-
-const modelProviderCards: readonly ModelProviderCardConfig[] = [
-  hyperlocaliseGoProvider,
-  ...byokProviders,
-];
 
 type TmsIntegrationConfig =
   | {
@@ -162,49 +147,34 @@ type TmsIntegrationConfig =
       comingSoon?: boolean;
     };
 
-const tmsIntegrations: readonly TmsIntegrationConfig[] = [
+const tmsIntegrationMeta = [
   {
-    name: "Hyperlocalise Native",
-    providerKind: "native",
+    providerKind: "native" as const,
     logo: "/images/logo.png",
-    included: true,
-    detail:
-      "Built-in TMS for projects, jobs, files, and translation memories. No external provider required.",
+    included: true as const,
   },
   {
-    name: "Crowdin",
-    providerKind: "crowdin",
+    providerKind: "crowdin" as const,
     logo: "/images/tms/crowdin.png",
     icon: siCrowdin,
-    detail:
-      "Connect to browse Crowdin projects alongside native Hyperlocalise projects. Project and job data is read live from Crowdin when you open it.",
   },
   {
-    name: "Lokalise",
     providerKind: "lokalise" as const,
     logo: "/images/tms/lokalise.webp",
-    detail:
-      "Connect to browse Lokalise projects, tasks, glossaries, and translation memories with user OAuth.",
   },
   {
-    name: "Phrase",
     providerKind: "phrase" as const,
     logo: "/images/tms/phrase.png",
-    detail: "Connect to browse Phrase projects and jobs with user OAuth.",
   },
   {
-    name: "Smartling",
     providerKind: "smartling" as const,
     logo: "/images/tms/smartling.png",
-    detail: "Connect enterprise localization programs.",
-    comingSoon: true,
+    comingSoon: true as const,
   },
 ] as const;
 
-const contentfulIntegration = {
-  name: "Contentful",
+const contentfulIntegrationMeta = {
   icon: siContentful,
-  detail: "CMS connector for agentic article translation and draft writeback.",
 } as const;
 
 function useProviderCredential(organizationSlug: string) {
@@ -224,7 +194,7 @@ function useProviderCredential(organizationSlug: string) {
   });
 }
 
-function useSaveProviderCredential(organizationSlug: string) {
+function useSaveProviderCredential(organizationSlug: string, intl: IntlShape) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -251,7 +221,11 @@ function useSaveProviderCredential(organizationSlug: string) {
     },
     onSuccess: async (_, payload) => {
       await queryClient.invalidateQueries({ queryKey: ["provider-credential", organizationSlug] });
-      toast.success(`${llmProviderCatalog[payload.provider].label} provider saved`);
+      toast.success(
+        intl.formatMessage(integrationsPageContentMessages.providerSavedToast, {
+          providerLabel: llmProviderCatalog[payload.provider].label,
+        }),
+      );
     },
     onError: (error) => {
       toast.error(error.message);
@@ -259,7 +233,7 @@ function useSaveProviderCredential(organizationSlug: string) {
   });
 }
 
-function useDeleteProviderCredential(organizationSlug: string) {
+function useDeleteProviderCredential(organizationSlug: string, intl: IntlShape) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -274,7 +248,9 @@ function useDeleteProviderCredential(organizationSlug: string) {
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ["provider-credential", organizationSlug] });
-      toast.success("LLM provider disconnected");
+      toast.success(
+        intl.formatMessage(integrationsPageContentMessages.llmProviderDisconnectedToast),
+      );
     },
     onError: (error) => {
       toast.error(error.message);
@@ -304,7 +280,7 @@ function useExternalTmsCredentials(organizationSlug: string) {
   });
 }
 
-function useSaveExternalTmsCredential(organizationSlug: string) {
+function useSaveExternalTmsCredential(organizationSlug: string, intl: IntlShape) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -342,7 +318,11 @@ function useSaveExternalTmsCredential(organizationSlug: string) {
           queryKey: ["tms-provider-connection", organizationSlug],
         }),
       ]);
-      toast.success(`${payload.displayName} connected`);
+      toast.success(
+        intl.formatMessage(integrationsPageContentMessages.externalTmsConnectedToast, {
+          displayName: payload.displayName,
+        }),
+      );
     },
     onError: (error) => {
       toast.error(error.message);
@@ -380,7 +360,7 @@ function buildTmsOAuthAppPayload(input: {
   return payload;
 }
 
-function useSaveCrowdinPatSetup(organizationSlug: string) {
+function useSaveCrowdinPatSetup(organizationSlug: string, intl: IntlShape) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -418,10 +398,18 @@ function useSaveCrowdinPatSetup(organizationSlug: string) {
         }),
       ]);
       if (result.shouldConnectCrowdinUser) {
-        toast.success(`${payload.displayName} saved. Connect your Crowdin token to continue.`);
+        toast.success(
+          intl.formatMessage(integrationsPageContentMessages.crowdinPatSavedConnectTokenToast, {
+            displayName: payload.displayName,
+          }),
+        );
         return;
       }
-      toast.success(`${payload.displayName} settings saved`);
+      toast.success(
+        intl.formatMessage(integrationsPageContentMessages.settingsSavedToast, {
+          displayName: payload.displayName,
+        }),
+      );
     },
     onError: (error) => {
       toast.error(error.message);
@@ -429,7 +417,7 @@ function useSaveCrowdinPatSetup(organizationSlug: string) {
   });
 }
 
-function useSaveCrowdinOAuthApp(organizationSlug: string) {
+function useSaveCrowdinOAuthApp(organizationSlug: string, intl: IntlShape) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -472,10 +460,18 @@ function useSaveCrowdinOAuthApp(organizationSlug: string) {
         }),
       ]);
       if (result.shouldConnectCrowdinUser) {
-        toast.success(`${payload.displayName} saved. Connect your Crowdin account to continue.`);
+        toast.success(
+          intl.formatMessage(integrationsPageContentMessages.crowdinOAuthSavedConnectAccountToast, {
+            displayName: payload.displayName,
+          }),
+        );
         return;
       }
-      toast.success(`${payload.displayName} settings saved`);
+      toast.success(
+        intl.formatMessage(integrationsPageContentMessages.settingsSavedToast, {
+          displayName: payload.displayName,
+        }),
+      );
     },
     onError: (error) => {
       toast.error(error.message);
@@ -483,7 +479,7 @@ function useSaveCrowdinOAuthApp(organizationSlug: string) {
   });
 }
 
-function useSavePhraseOAuthApp(organizationSlug: string) {
+function useSavePhraseOAuthApp(organizationSlug: string, intl: IntlShape) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -526,10 +522,18 @@ function useSavePhraseOAuthApp(organizationSlug: string) {
         }),
       ]);
       if (result.shouldConnectPhraseUser) {
-        toast.success(`${payload.displayName} saved. Connect your Phrase account to continue.`);
+        toast.success(
+          intl.formatMessage(integrationsPageContentMessages.phraseOAuthSavedConnectAccountToast, {
+            displayName: payload.displayName,
+          }),
+        );
         return;
       }
-      toast.success(`${payload.displayName} settings saved`);
+      toast.success(
+        intl.formatMessage(integrationsPageContentMessages.settingsSavedToast, {
+          displayName: payload.displayName,
+        }),
+      );
     },
     onError: (error) => {
       toast.error(error.message);
@@ -537,7 +541,7 @@ function useSavePhraseOAuthApp(organizationSlug: string) {
   });
 }
 
-function useSaveLokaliseOAuthApp(organizationSlug: string) {
+function useSaveLokaliseOAuthApp(organizationSlug: string, intl: IntlShape) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -580,10 +584,21 @@ function useSaveLokaliseOAuthApp(organizationSlug: string) {
         }),
       ]);
       if (result.shouldConnectLokaliseUser) {
-        toast.success(`${payload.displayName} saved. Connect your Lokalise account to continue.`);
+        toast.success(
+          intl.formatMessage(
+            integrationsPageContentMessages.lokaliseOAuthSavedConnectAccountToast,
+            {
+              displayName: payload.displayName,
+            },
+          ),
+        );
         return;
       }
-      toast.success(`${payload.displayName} settings saved`);
+      toast.success(
+        intl.formatMessage(integrationsPageContentMessages.settingsSavedToast, {
+          displayName: payload.displayName,
+        }),
+      );
     },
     onError: (error) => {
       toast.error(error.message);
@@ -612,6 +627,7 @@ function TmsIntegrationRow({
   isLast: boolean;
   children?: ReactNode;
 }) {
+  const intl = useIntl();
   const isIncluded = integration.providerKind === "native";
   const isConnected = isIncluded || !!credential;
   const isComingSoon = !isIncluded && Boolean(integration.comingSoon);
@@ -679,22 +695,24 @@ function TmsIntegrationRow({
               nativeButton={false}
               render={<Link href={`/org/${organizationSlug}/projects`} />}
             >
-              View projects
+              {intl.formatMessage(integrationsPageContentMessages.viewProjects)}
             </Button>
           ) : isComingSoon ? (
             <Button type="button" variant="outline" size="sm" disabled>
-              Coming soon
+              <FormattedMessage {...integrationRowMessages.comingSoon} />
             </Button>
           ) : isBlockedByActiveProvider ? (
             <Tooltip>
               <TooltipTrigger
                 render={
                   <Button type="button" variant="outline" size="sm" disabled>
-                    Connect
+                    <FormattedMessage {...integrationRowMessages.connect} />
                   </Button>
                 }
               />
-              <TooltipContent>Disconnect the current TMS to switch providers.</TooltipContent>
+              <TooltipContent>
+                {intl.formatMessage(integrationsPageContentMessages.disconnectTmsTooltip)}
+              </TooltipContent>
             </Tooltip>
           ) : userIsAdmin && showPanel ? (
             <CollapsibleTrigger
@@ -705,7 +723,11 @@ function TmsIntegrationRow({
                   size="sm"
                   className={isConnected ? undefined : integrationConnectButtonClassName}
                 >
-                  {isConnected ? "Manage" : "Connect"}
+                  {isConnected ? (
+                    <FormattedMessage {...integrationRowMessages.manage} />
+                  ) : (
+                    <FormattedMessage {...integrationRowMessages.connect} />
+                  )}
                   <ChevronDownIcon
                     className={cn("size-3.5 transition-transform", expanded && "rotate-180")}
                     strokeWidth={2}
@@ -714,9 +736,13 @@ function TmsIntegrationRow({
               }
             />
           ) : isConnected ? (
-            <Badge variant="outline">View only</Badge>
+            <Badge variant="outline">
+              <FormattedMessage {...integrationRowMessages.viewOnly} />
+            </Badge>
           ) : (
-            <span className="text-sm text-muted-foreground">Admins can connect</span>
+            <span className="text-sm text-muted-foreground">
+              <FormattedMessage {...integrationRowMessages.adminsCanConnect} />
+            </span>
           )}
         </div>
       </div>
@@ -731,12 +757,14 @@ function TmsIntegrationRow({
 }
 
 function CmsIntegrationRow({
+  integration,
   connection,
   userIsAdmin,
   expanded,
   onExpandedChange,
   children,
 }: {
+  integration: { name: string; detail: string; icon: SimpleIcon };
   connection?: ContentfulConnectionSummary;
   userIsAdmin: boolean;
   expanded: boolean;
@@ -766,16 +794,14 @@ function CmsIntegrationRow({
               : "border-border bg-muted/50 text-muted-foreground",
           )}
         >
-          <SimpleBrandIcon icon={contentfulIntegration.icon} colored={isConnected} />
+          <SimpleBrandIcon icon={integration.icon} colored={isConnected} />
         </div>
 
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-2">
-            <p className="text-base font-medium text-foreground">{contentfulIntegration.name}</p>
+            <p className="text-base font-medium text-foreground">{integration.name}</p>
           </div>
-          <p className="mt-0.5 text-sm leading-6 text-muted-foreground">
-            {contentfulIntegration.detail}
-          </p>
+          <p className="mt-0.5 text-sm leading-6 text-muted-foreground">{integration.detail}</p>
         </div>
 
         <div className="shrink-0">
@@ -788,7 +814,11 @@ function CmsIntegrationRow({
                   size="sm"
                   className={isConnected ? undefined : integrationConnectButtonClassName}
                 >
-                  {isConnected ? "Manage" : "Connect"}
+                  {isConnected ? (
+                    <FormattedMessage {...integrationRowMessages.manage} />
+                  ) : (
+                    <FormattedMessage {...integrationRowMessages.connect} />
+                  )}
                   <ChevronDownIcon
                     className={cn("size-3.5 transition-transform", expanded && "rotate-180")}
                     strokeWidth={2}
@@ -797,9 +827,13 @@ function CmsIntegrationRow({
               }
             />
           ) : isConnected ? (
-            <Badge variant="outline">View only</Badge>
+            <Badge variant="outline">
+              <FormattedMessage {...integrationRowMessages.viewOnly} />
+            </Badge>
           ) : (
-            <span className="text-sm text-muted-foreground">Admins can connect</span>
+            <span className="text-sm text-muted-foreground">
+              <FormattedMessage {...integrationRowMessages.adminsCanConnect} />
+            </span>
           )}
         </div>
       </div>
@@ -813,7 +847,7 @@ function CmsIntegrationRow({
   );
 }
 
-function useDeleteExternalTmsCredential(organizationSlug: string) {
+function useDeleteExternalTmsCredential(organizationSlug: string, intl: IntlShape) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -837,7 +871,7 @@ function useDeleteExternalTmsCredential(organizationSlug: string) {
           queryKey: ["tms-provider-connection", organizationSlug],
         }),
       ]);
-      toast.success("Provider disconnected");
+      toast.success(intl.formatMessage(integrationsPageContentMessages.providerDisconnectedToast));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -851,10 +885,11 @@ export function IntegrationsPageContent({
   canManageProviderIntegrations,
   errorCode,
 }: IntegrationsPageContentProps) {
+  const intl = useIntl();
   const integrationError = getTmsUserOAuthErrorCopy(errorCode ?? null);
   const { data: credential, isLoading } = useProviderCredential(organizationSlug);
-  const saveCredential = useSaveProviderCredential(organizationSlug);
-  const deleteCredential = useDeleteProviderCredential(organizationSlug);
+  const saveCredential = useSaveProviderCredential(organizationSlug, intl);
+  const deleteCredential = useDeleteProviderCredential(organizationSlug, intl);
   const [selectedProvider, setSelectedProvider] = useState<ProviderOptionId | null>(null);
   const [selectedModel, setSelectedModel] = useState(defaultModelByProvider.openai);
   const [apiKey, setApiKey] = useState("");
@@ -871,13 +906,13 @@ export function IntegrationsPageContent({
   const activeExternalTmsProviderCredential = externalTmsCredentialState?.activeCredential ?? null;
   const { data: contentfulConnections, isLoading: isLoadingContentful } =
     useContentfulConnections(organizationSlug);
-  const saveExternalTms = useSaveExternalTmsCredential(organizationSlug);
-  const saveCrowdinOAuthApp = useSaveCrowdinOAuthApp(organizationSlug);
-  const saveCrowdinPatSetup = useSaveCrowdinPatSetup(organizationSlug);
-  const savePhraseOAuthApp = useSavePhraseOAuthApp(organizationSlug);
-  const saveLokaliseOAuthApp = useSaveLokaliseOAuthApp(organizationSlug);
+  const saveExternalTms = useSaveExternalTmsCredential(organizationSlug, intl);
+  const saveCrowdinOAuthApp = useSaveCrowdinOAuthApp(organizationSlug, intl);
+  const saveCrowdinPatSetup = useSaveCrowdinPatSetup(organizationSlug, intl);
+  const savePhraseOAuthApp = useSavePhraseOAuthApp(organizationSlug, intl);
+  const saveLokaliseOAuthApp = useSaveLokaliseOAuthApp(organizationSlug, intl);
   const saveContentfulConnection = useSaveContentfulConnection(organizationSlug);
-  const deleteExternalTms = useDeleteExternalTmsCredential(organizationSlug);
+  const deleteExternalTms = useDeleteExternalTmsCredential(organizationSlug, intl);
   const [expandedTmsProvider, setExpandedTmsProvider] = useState<ExternalTmsProviderKind | null>(
     null,
   );
@@ -893,7 +928,9 @@ export function IntegrationsPageContent({
   const [disconnectingTmsProvider, setDisconnectingTmsProvider] =
     useState<ExternalTmsProviderKind | null>(null);
   const [contentfulForm, setContentfulForm] = useState<ContentfulConnectionForm>({
-    displayName: "Contentful Help Center",
+    displayName: intl.formatMessage(
+      integrationsPageContentMessages.contentfulHelpCenterDefaultName,
+    ),
     spaceId: "",
     environmentId: "master",
     contentTypeIds: [],
@@ -911,6 +948,108 @@ export function IntegrationsPageContent({
   const userIsAdmin = canManageIntegrations(membershipRole);
   const userCanManageAgents = canManageAgents(membershipRole);
 
+  const hyperlocaliseGoProvider = useMemo(
+    () => ({
+      id: hyperlocaliseGoProviderId,
+      label: intl.formatMessage(integrationsPageContentMessages.hyperlocaliseGoLabel),
+      description: intl.formatMessage(integrationsPageContentMessages.hyperlocaliseGoDescription),
+      logo: "/images/logo.png",
+    }),
+    [intl],
+  );
+
+  const byokProviders = useMemo(
+    () =>
+      byokProviderMeta.map((provider) => {
+        const copyById = {
+          openai: {
+            label: integrationsPageContentMessages.openAiLabel,
+            description: integrationsPageContentMessages.openAiDescription,
+          },
+          anthropic: {
+            label: integrationsPageContentMessages.anthropicLabel,
+            description: integrationsPageContentMessages.anthropicDescription,
+          },
+          gemini: {
+            label: integrationsPageContentMessages.geminiLabel,
+            description: integrationsPageContentMessages.geminiDescription,
+          },
+        } as const;
+
+        const copy = copyById[provider.id];
+
+        return {
+          ...provider,
+          label: intl.formatMessage(copy.label),
+          description: intl.formatMessage(copy.description),
+        };
+      }),
+    [intl],
+  );
+
+  const modelProviderCards = useMemo<readonly ModelProviderCardConfig[]>(
+    () => [hyperlocaliseGoProvider, ...byokProviders],
+    [byokProviders, hyperlocaliseGoProvider],
+  );
+
+  const tmsIntegrations = useMemo<readonly TmsIntegrationConfig[]>(
+    () =>
+      tmsIntegrationMeta.map((integration) => {
+        const copyByKind = {
+          native: {
+            name: integrationsPageContentMessages.tmsNativeName,
+            detail: integrationsPageContentMessages.tmsNativeDetail,
+          },
+          crowdin: {
+            name: integrationsPageContentMessages.tmsCrowdinName,
+            detail: integrationsPageContentMessages.tmsCrowdinDetail,
+          },
+          lokalise: {
+            name: integrationsPageContentMessages.tmsLokaliseName,
+            detail: integrationsPageContentMessages.tmsLokaliseDetail,
+          },
+          phrase: {
+            name: integrationsPageContentMessages.tmsPhraseName,
+            detail: integrationsPageContentMessages.tmsPhraseDetail,
+          },
+          smartling: {
+            name: integrationsPageContentMessages.tmsSmartlingName,
+            detail: integrationsPageContentMessages.tmsSmartlingDetail,
+          },
+        } as const;
+
+        const copy = copyByKind[integration.providerKind];
+
+        if (integration.providerKind === "native") {
+          return {
+            ...integration,
+            name: intl.formatMessage(copy.name),
+            detail: intl.formatMessage(copy.detail),
+          };
+        }
+
+        return {
+          ...integration,
+          name: intl.formatMessage(copy.name),
+          detail: intl.formatMessage(copy.detail),
+        };
+      }),
+    [intl],
+  );
+
+  const contentfulIntegration = useMemo(
+    () => ({
+      ...contentfulIntegrationMeta,
+      name: intl.formatMessage(integrationsPageContentMessages.contentfulName),
+      detail: intl.formatMessage(integrationsPageContentMessages.contentfulDetail),
+    }),
+    [intl],
+  );
+
+  const contentfulHelpCenterDefaultName = intl.formatMessage(
+    integrationsPageContentMessages.contentfulHelpCenterDefaultName,
+  );
+
   useEffect(() => {
     if (!credential || selectedProvider !== credential.provider) {
       return;
@@ -920,7 +1059,7 @@ export function IntegrationsPageContent({
   }, [credential, selectedProvider]);
 
   useEffect(() => {
-    if (!selectedProvider || selectedProvider === hyperlocaliseGoProvider.id) {
+    if (!selectedProvider || selectedProvider === hyperlocaliseGoProviderId) {
       return;
     }
 
@@ -932,7 +1071,7 @@ export function IntegrationsPageContent({
   }, [selectedModel, selectedProvider]);
 
   const selectedByokProvider =
-    selectedProvider && selectedProvider !== hyperlocaliseGoProvider.id ? selectedProvider : null;
+    selectedProvider && selectedProvider !== hyperlocaliseGoProviderId ? selectedProvider : null;
   const selectedProviderConfig = selectedByokProvider
     ? llmProviderCatalog[selectedByokProvider]
     : null;
@@ -964,7 +1103,7 @@ export function IntegrationsPageContent({
 
   function loadContentfulForm(existingConnection?: ContentfulConnectionSummary) {
     setContentfulForm({
-      displayName: existingConnection?.displayName ?? "Contentful Help Center",
+      displayName: existingConnection?.displayName ?? contentfulHelpCenterDefaultName,
       spaceId: existingConnection?.spaceId ?? "",
       environmentId: existingConnection?.environmentId ?? "master",
       contentTypeIds: existingConnection?.contentTypeIds ?? [],
@@ -1001,10 +1140,10 @@ export function IntegrationsPageContent({
     <main className="space-y-5">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <TypographyH1 className="font-heading text-2xl font-medium text-foreground md:text-2xl">
-          Integrations
+          <FormattedMessage {...integrationsPageContentMessages.pageTitle} />
         </TypographyH1>
         <Badge variant="outline" className="rounded-full lg:self-start">
-          Workspace level
+          <FormattedMessage {...integrationsPageContentMessages.workspaceLevelBadge} />
         </Badge>
       </div>
 
@@ -1029,7 +1168,9 @@ export function IntegrationsPageContent({
       {canManageProviderIntegrations ? (
         <>
           <section className="flex flex-col gap-3">
-            <IntegrationCategoryLabel>Translation Management System</IntegrationCategoryLabel>
+            <IntegrationCategoryLabel>
+              <FormattedMessage {...integrationsPageContentMessages.tmsCategory} />
+            </IntegrationCategoryLabel>
 
             {isLoadingExternalTms ? (
               <div className="overflow-hidden rounded-lg border border-border bg-card text-card-foreground">
@@ -1190,7 +1331,9 @@ export function IntegrationsPageContent({
           </section>
 
           <section className="flex flex-col gap-3">
-            <IntegrationCategoryLabel>Content Management System</IntegrationCategoryLabel>
+            <IntegrationCategoryLabel>
+              <FormattedMessage {...integrationsPageContentMessages.cmsCategory} />
+            </IntegrationCategoryLabel>
             {isLoadingContentful ? (
               <div className="overflow-hidden rounded-lg border border-border bg-card text-card-foreground">
                 <div className="px-5 py-4">
@@ -1200,6 +1343,7 @@ export function IntegrationsPageContent({
             ) : (
               <div className="overflow-hidden rounded-lg border border-border bg-card text-card-foreground">
                 <CmsIntegrationRow
+                  integration={contentfulIntegration}
                   connection={contentfulConnections?.[0]}
                   userIsAdmin={userIsAdmin}
                   expanded={expandedContentful}
@@ -1256,7 +1400,9 @@ export function IntegrationsPageContent({
       {canManageProviderIntegrations ? (
         <>
           <section className="flex flex-col gap-3">
-            <IntegrationCategoryLabel>Model provider</IntegrationCategoryLabel>
+            <IntegrationCategoryLabel>
+              <FormattedMessage {...integrationsPageContentMessages.modelProviderCategory} />
+            </IntegrationCategoryLabel>
 
             {isLoading ? (
               <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
@@ -1267,7 +1413,7 @@ export function IntegrationsPageContent({
             ) : (
               <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
                 {modelProviderCards.map((provider) => {
-                  const isManaged = provider.id === hyperlocaliseGoProvider.id;
+                  const isManaged = provider.id === hyperlocaliseGoProviderId;
                   const isByok = !isManaged;
                   const isConfigured = isByok && credential?.provider === provider.id;
                   const isActive = isManaged ? !credential : isConfigured;
@@ -1279,7 +1425,13 @@ export function IntegrationsPageContent({
                       isActive={isActive}
                       isManaged={isManaged}
                       footerLabel={
-                        isManaged ? (isActive ? undefined : "Switch to managed") : "Configure"
+                        isManaged
+                          ? isActive
+                            ? undefined
+                            : intl.formatMessage(
+                                integrationsPageContentMessages.switchToManagedFooter,
+                              )
+                          : intl.formatMessage(integrationsPageContentMessages.configureFooter)
                       }
                       disabled={
                         isManaged && isActive ? true : isManaged && deleteCredential.isPending
@@ -1313,10 +1465,13 @@ export function IntegrationsPageContent({
           <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
             <DialogContent>
               <DialogHeader>
-                <DialogTitle>Configure {selectedProviderLabel}</DialogTitle>
+                <DialogTitle>
+                  {intl.formatMessage(integrationsPageContentMessages.configureDialogTitle, {
+                    providerLabel: selectedProviderLabel ?? "",
+                  })}
+                </DialogTitle>
                 <DialogDescription>
-                  Save one shared provider key for this workspace. Saving validates the key,
-                  encrypts it at rest, and replaces the current provider.
+                  {intl.formatMessage(integrationsPageContentMessages.configureDialogDescription)}
                 </DialogDescription>
               </DialogHeader>
 
@@ -1342,7 +1497,9 @@ export function IntegrationsPageContent({
                   }}
                 >
                   <Field className="gap-2">
-                    <FieldLabel htmlFor={modelFieldId}>Default model</FieldLabel>
+                    <FieldLabel htmlFor={modelFieldId}>
+                      {intl.formatMessage(integrationsPageContentMessages.defaultModelLabel)}
+                    </FieldLabel>
                     <Select
                       value={selectedModel}
                       onValueChange={(value) => setSelectedModel(value ?? "")}
@@ -1361,7 +1518,9 @@ export function IntegrationsPageContent({
                   </Field>
 
                   <Field className="gap-2">
-                    <FieldLabel htmlFor={apiKeyFieldId}>API key</FieldLabel>
+                    <FieldLabel htmlFor={apiKeyFieldId}>
+                      {intl.formatMessage(integrationsPageContentMessages.apiKeyLabel)}
+                    </FieldLabel>
                     <div className="relative">
                       <HugeiconsIcon
                         icon={Key01Icon}
@@ -1374,14 +1533,21 @@ export function IntegrationsPageContent({
                         autoComplete="off"
                         value={apiKey}
                         onChange={(event) => setApiKey(event.target.value)}
-                        placeholder={`Enter ${selectedProviderLabel} API key`}
+                        placeholder={intl.formatMessage(
+                          integrationsPageContentMessages.apiKeyPlaceholder,
+                          { providerLabel: selectedProviderLabel ?? "" },
+                        )}
                         className="ps-9 pe-9"
                       />
                       <button
                         type="button"
                         onClick={() => setShowApiKey(!showApiKey)}
                         className="absolute top-1/2 right-3 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
-                        aria-label={showApiKey ? "Hide API key" : "Show API key"}
+                        aria-label={intl.formatMessage(
+                          showApiKey
+                            ? integrationsPageContentMessages.hideApiKeyAriaLabel
+                            : integrationsPageContentMessages.showApiKeyAriaLabel,
+                        )}
                       >
                         {showApiKey ? <EyeOffIcon size={16} /> : <EyeIcon size={16} />}
                       </button>
@@ -1396,11 +1562,15 @@ export function IntegrationsPageContent({
                       disabled={!credential || deleteCredential.isPending}
                     >
                       <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
-                      {deleteCredential.isPending ? "Disconnecting..." : "Disconnect"}
+                      {deleteCredential.isPending
+                        ? intl.formatMessage(integrationsPageContentMessages.disconnecting)
+                        : intl.formatMessage(integrationsPageContentMessages.disconnect)}
                     </Button>
                     <Button type="submit" disabled={!apiKey.trim() || saveCredential.isPending}>
                       <HugeiconsIcon icon={SaveIcon} strokeWidth={1.8} />
-                      {saveCredential.isPending ? "Validating..." : "Save provider"}
+                      {saveCredential.isPending
+                        ? intl.formatMessage(integrationsPageContentMessages.validating)
+                        : intl.formatMessage(integrationsPageContentMessages.saveProvider)}
                     </Button>
                   </DialogFooter>
                 </form>
@@ -1419,15 +1589,24 @@ export function IntegrationsPageContent({
             <AlertDialogContent>
               <AlertDialogHeader>
                 <AlertDialogTitle>
-                  Disconnect {disconnectingTmsProviderName ?? "TMS provider"}?
+                  {intl.formatMessage(integrationsPageContentMessages.disconnectTmsDialogTitle, {
+                    providerName:
+                      disconnectingTmsProviderName ??
+                      intl.formatMessage(
+                        integrationsPageContentMessages.disconnectTmsDialogTitleFallback,
+                      ),
+                  })}
                 </AlertDialogTitle>
                 <AlertDialogDescription>
-                  This removes the saved encrypted provider credentials. Reconnecting this provider
-                  will require entering the secret again.
+                  {intl.formatMessage(
+                    integrationsPageContentMessages.disconnectTmsDialogDescription,
+                  )}
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>
-                <AlertDialogCancel disabled={deleteExternalTms.isPending}>Cancel</AlertDialogCancel>
+                <AlertDialogCancel disabled={deleteExternalTms.isPending}>
+                  {intl.formatMessage(integrationsPageContentMessages.cancel)}
+                </AlertDialogCancel>
                 <Button
                   type="button"
                   variant="destructive"
@@ -1451,7 +1630,9 @@ export function IntegrationsPageContent({
                   }}
                 >
                   <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
-                  {deleteExternalTms.isPending ? "Disconnecting..." : "Disconnect"}
+                  {deleteExternalTms.isPending
+                    ? intl.formatMessage(integrationsPageContentMessages.disconnecting)
+                    : intl.formatMessage(integrationsPageContentMessages.disconnect)}
                 </Button>
               </AlertDialogFooter>
             </AlertDialogContent>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/model-provider-card.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/model-provider-card.messages.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const modelProviderCardMessages = defineMessages({
+  activeBadge: {
+    defaultMessage: "Active",
+    id: "D6hzyJl9hV",
+    description: "Badge on the workspace’s currently selected model provider card",
+  },
+  managedBadge: {
+    defaultMessage: "Managed",
+    id: "jBITE1qEv6",
+    description: "Badge on Hyperlocalise-managed model provider cards",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/model-provider-card.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/model-provider-card.tsx
@@ -4,9 +4,11 @@ import Image from "next/image";
 import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { SimpleIcon } from "simple-icons";
+import { FormattedMessage } from "react-intl";
 
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/primitives/cn";
+import { modelProviderCardMessages } from "./model-provider-card.messages";
 import { SimpleBrandIcon } from "./simple-brand-icon";
 
 export type ModelProviderCardConfig = {
@@ -51,7 +53,7 @@ export function ModelProviderCard({
             "border-grove-500/35 bg-grove-100 text-grove-900 dark:border-grove-300/20 dark:bg-grove-300/10 dark:text-grove-300",
           )}
         >
-          Active
+          <FormattedMessage {...modelProviderCardMessages.activeBadge} />
         </Badge>
       ) : null}
 
@@ -78,7 +80,7 @@ export function ModelProviderCard({
         <span className="text-base font-medium text-foreground">{provider.label}</span>
         {isManaged ? (
           <Badge variant="outline" className="text-[10px]">
-            Managed
+            <FormattedMessage {...modelProviderCardMessages.managedBadge} />
           </Badge>
         ) : null}
       </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-action.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-action.messages.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const repositoryAutomationSettingsActionMessages = defineMessages({
+  automationButton: {
+    defaultMessage: "Automation",
+    id: "8MEkOXiww5",
+    description: "Button label to open repository automation settings",
+  },
+  sheetTitle: {
+    defaultMessage: "Repository automation",
+    id: "Q2zZo/5fFx",
+    description: "Sheet title for repository automation settings",
+  },
+  sheetDescription: {
+    defaultMessage:
+      "Push source, pull translations, and publish localization checks for this repository.",
+    id: "Vb+OMqzvaE",
+    description: "Sheet description for repository automation settings",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-action.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-action.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useState } from "react";
+import { FormattedMessage } from "react-intl";
 
 import { RepositoryAutomationSettingsPanel } from "./repository-automation-settings-panel";
+import { repositoryAutomationSettingsActionMessages } from "./repository-automation-settings-action.messages";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
@@ -41,13 +43,15 @@ export function RepositoryAutomationSettingsAction({
       <SheetTrigger
         render={<Button type="button" variant="outline" size="sm" className="whitespace-nowrap" />}
       >
-        Automation
+        <FormattedMessage {...repositoryAutomationSettingsActionMessages.automationButton} />
       </SheetTrigger>
       <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-xl">
         <SheetHeader>
-          <SheetTitle>Repository automation</SheetTitle>
+          <SheetTitle>
+            <FormattedMessage {...repositoryAutomationSettingsActionMessages.sheetTitle} />
+          </SheetTitle>
           <SheetDescription>
-            Push source, pull translations, and publish localization checks for this repository.
+            <FormattedMessage {...repositoryAutomationSettingsActionMessages.sheetDescription} />
           </SheetDescription>
         </SheetHeader>
         <div className="px-6 pb-6">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-panel.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-panel.messages.ts
@@ -1,0 +1,368 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const repositoryAutomationSettingsPanelMessages = defineMessages({
+  selectProjectPlaceholder: {
+    defaultMessage: "Select a project",
+    id: "heSbClUFGX",
+    description: "Placeholder for Hyperlocalise project select fields",
+  },
+  loadSettingsFailed: {
+    defaultMessage: "Failed to load automation settings",
+    id: "dYBH3h8+RK",
+    description: "Error when repository automation settings fail to load",
+  },
+  loadProjectsFailed: {
+    defaultMessage: "Failed to load projects",
+    id: "mMsPU5+otj",
+    description: "Error when organization projects fail to load for automation settings",
+  },
+  saveFailedToast: {
+    defaultMessage: "Could not save automation settings",
+    id: "Y3BPUJdmMR",
+    description: "Toast when repository automation settings save fails",
+  },
+  saveSuccessToast: {
+    defaultMessage: "Automation settings saved",
+    id: "lO+u6H8vSf",
+    description: "Toast after repository automation settings are saved",
+  },
+  resetFailed: {
+    defaultMessage: "Failed to reset automation settings",
+    id: "9Ixpy5poXF",
+    description: "Error when repository automation settings reset fails",
+  },
+  resetSuccessToast: {
+    defaultMessage: "Automation settings reset",
+    id: "MR4r0hcWXP",
+    description: "Toast after repository automation settings are reset",
+  },
+  triggerOff: {
+    defaultMessage: "Off",
+    id: "sp82GiYbAh",
+    description: "Trigger mode option when automation triggers are disabled",
+  },
+  triggerOnPush: {
+    defaultMessage: "On push",
+    id: "2kT6l4vS6b",
+    description: "Trigger mode option when automation runs on git push",
+  },
+  triggerScheduled: {
+    defaultMessage: "Scheduled",
+    id: "Up6UMTbrGA",
+    description: "Trigger mode option when automation runs on a schedule",
+  },
+  enableRepositoryHint: {
+    defaultMessage: "Enable this repository to configure translation automation.",
+    id: "JUWqOD5PWj",
+    description:
+      "Hint shown when repository automation cannot be configured because repo is disabled",
+  },
+  archivedRepositoryHint: {
+    defaultMessage: "Archived repositories cannot use translation automation.",
+    id: "UP0P0zCDA/",
+    description:
+      "Hint shown when repository automation cannot be configured because repo is archived",
+  },
+  loadError: {
+    defaultMessage: "Unable to load automation settings.",
+    id: "kvuiTkSvGX",
+    description: "Error message when automation settings query fails",
+  },
+  retry: {
+    defaultMessage: "Retry",
+    id: "YPUY3Uik30",
+    description: "Button label to retry loading automation settings",
+  },
+  intro: {
+    defaultMessage:
+      "Configure how Hyperlocalise syncs source strings and translations for <repositoryName>{repositoryFullName}</repositoryName>.",
+    id: "hSh2lnNLxs",
+    description: "Introduction text for repository automation settings",
+  },
+  openFullPageEditor: {
+    defaultMessage: "Open full-page editor",
+    id: "VdjibQd9gV",
+    description: "Link to open repository automation settings on a dedicated page",
+  },
+  workflowsTitle: {
+    defaultMessage: "Workflows",
+    id: "J5QEeAEILc",
+    description: "Section heading for automation workflow toggles",
+  },
+  workflowsDescription: {
+    defaultMessage: "Choose which automation jobs run for this repository.",
+    id: "uUnWGsYCBS",
+    description: "Section description for automation workflow toggles",
+  },
+  pushSourceLabel: {
+    defaultMessage: "Push source to Hyperlocalise",
+    id: "9KmYVi7cCO",
+    description: "Label for the push source workflow toggle",
+  },
+  pushSourceDescription: {
+    defaultMessage: "Import source strings from GitHub into your TMS project.",
+    id: "xkkgs3AOHS",
+    description: "Description for the push source workflow toggle",
+  },
+  hyperlocaliseProjectLabel: {
+    defaultMessage: "Hyperlocalise project",
+    id: "F60WBL3vGu",
+    description: "Label for project select fields in automation settings",
+  },
+  pushSourceProjectDescription: {
+    defaultMessage: "Source strings are pushed into this project.",
+    id: "6xwxjrmrdy",
+    description: "Description for the push source project select field",
+  },
+  pullTranslationsLabel: {
+    defaultMessage: "Pull translations to GitHub",
+    id: "4Qb5sAFHM8",
+    description: "Label for the pull translations workflow toggle",
+  },
+  pullTranslationsDescription: {
+    defaultMessage: "Opens a pull request with updated translation files when sync succeeds.",
+    id: "33ZcrkXcDM",
+    description: "Description for the pull translations workflow toggle",
+  },
+  pullTranslationsProjectDescription: {
+    defaultMessage: "Translations are read from this project before opening the pull request.",
+    id: "n+jmfgFlG0",
+    description: "Description for the pull translations project select field",
+  },
+  validationLabel: {
+    defaultMessage: "Localization check",
+    id: "BjoXu+/Pje",
+    description: "Label for the localization validation workflow toggle",
+  },
+  validationDescription: {
+    defaultMessage: "Runs <command>hl check</command> against repository translation files.",
+    id: "yXOtXZjqsN",
+    description: "Description for the localization validation workflow toggle",
+  },
+  validationBlockLabel: {
+    defaultMessage: "Block on failure",
+    id: "477uPaXfz1",
+    description: "Label for blocking automation when localization check fails",
+  },
+  validationBlockDescription: {
+    defaultMessage: "Fail the automation run when the localization check reports errors.",
+    id: "cjBFGkHog4",
+    description: "Description for blocking automation when localization check fails",
+  },
+  triggerTitle: {
+    defaultMessage: "Trigger",
+    id: "WuN0lCA6yk",
+    description: "Section heading for automation trigger settings",
+  },
+  triggerDescription: {
+    defaultMessage: "Push and scheduled triggers are mutually exclusive.",
+    id: "mE9BVZ+4OT",
+    description: "Section description for automation trigger settings",
+  },
+  branchPatternsLabel: {
+    defaultMessage: "Branch patterns",
+    id: "dW35I3VMSZ",
+    description: "Label for branch pattern input in push trigger settings",
+  },
+  branchPatternsDescription: {
+    defaultMessage:
+      "Use glob patterns such as <mainExample>main</mainExample> or <releaseExample>release/*</releaseExample>. Up to 32 patterns.",
+    id: "3AEM15DaMz",
+    description: "Description for branch pattern input in push trigger settings",
+  },
+  branchPatternPlaceholder: {
+    defaultMessage: "main",
+    id: "vK7GusCjy3",
+    description: "Placeholder for branch pattern input",
+  },
+  addBranchPattern: {
+    defaultMessage: "Add",
+    id: "xovEZE5T2r",
+    description: "Button label to add a branch pattern",
+  },
+  removeBranchPatternAriaLabel: {
+    defaultMessage: "Remove {branch}",
+    id: "g5YfEeVlsF",
+    description: "Aria label for removing a branch pattern badge",
+  },
+  cadenceLabel: {
+    defaultMessage: "Cadence",
+    id: "usZU30knmw",
+    description: "Label for scheduled automation cadence select",
+  },
+  cadenceHourly: {
+    defaultMessage: "Hourly",
+    id: "TR2IFwpfx/",
+    description: "Scheduled cadence option for hourly runs",
+  },
+  cadenceDaily: {
+    defaultMessage: "Daily",
+    id: "1V22/7VZBT",
+    description: "Scheduled cadence option for daily runs",
+  },
+  cadenceWeekly: {
+    defaultMessage: "Weekly",
+    id: "Y19LAzxjpx",
+    description: "Scheduled cadence option for weekly runs",
+  },
+  scheduledHourLabel: {
+    defaultMessage: "Hour (UTC)",
+    id: "BrsVyR4Efb",
+    description: "Label for scheduled automation hour select",
+  },
+  scheduledHourOption: {
+    defaultMessage: "{hour}:00 UTC",
+    id: "6xU6c/eKvO",
+    description: "Option label for a scheduled automation hour in UTC",
+  },
+  scheduledDayLabel: {
+    defaultMessage: "Day of week",
+    id: "wBNC3JBHju",
+    description: "Label for scheduled automation day-of-week select",
+  },
+  scheduledTimezoneLabel: {
+    defaultMessage: "Timezone",
+    id: "XMHsfUaoDt",
+    description: "Label for scheduled automation timezone input",
+  },
+  scheduledTimezonePlaceholder: {
+    defaultMessage: "UTC",
+    id: "Zy8ZOSNNhB",
+    description: "Placeholder for scheduled automation timezone input",
+  },
+  weekdaySunday: {
+    defaultMessage: "Sunday",
+    id: "oQckCPSvLu",
+    description: "Weekday option for scheduled automation",
+  },
+  weekdayMonday: {
+    defaultMessage: "Monday",
+    id: "qxBrl7Yxqo",
+    description: "Weekday option for scheduled automation",
+  },
+  weekdayTuesday: {
+    defaultMessage: "Tuesday",
+    id: "WCzohOaFyx",
+    description: "Weekday option for scheduled automation",
+  },
+  weekdayWednesday: {
+    defaultMessage: "Wednesday",
+    id: "/bH75mQmVa",
+    description: "Weekday option for scheduled automation",
+  },
+  weekdayThursday: {
+    defaultMessage: "Thursday",
+    id: "1ESwnn506c",
+    description: "Weekday option for scheduled automation",
+  },
+  weekdayFriday: {
+    defaultMessage: "Friday",
+    id: "0XCfYzdREi",
+    description: "Weekday option for scheduled automation",
+  },
+  weekdaySaturday: {
+    defaultMessage: "Saturday",
+    id: "Cv5dtJ6iTe",
+    description: "Weekday option for scheduled automation",
+  },
+  statusCheckTitle: {
+    defaultMessage: "GitHub status check",
+    id: "WZko2fwHOK",
+    description: "Section heading for GitHub status check settings",
+  },
+  statusCheckDescription: {
+    defaultMessage:
+      "Publish a check run so teams can see localization results on commits and pull requests.",
+    id: "lmsnisjyr6",
+    description: "Section description for GitHub status check settings",
+  },
+  statusCheckEnabledLabel: {
+    defaultMessage: "Enable check run",
+    id: "NPcxGbshkv",
+    description: "Label for enabling GitHub status checks",
+  },
+  statusCheckEnabledDescription: {
+    defaultMessage: "Shows localization automation status in GitHub Checks.",
+    id: "+WcpU6CzaH",
+    description: "Description for enabling GitHub status checks",
+  },
+  statusCheckModeLabel: {
+    defaultMessage: "Check mode",
+    id: "rhfG3eu2aR",
+    description: "Label for GitHub status check mode select",
+  },
+  statusCheckAdvisory: {
+    defaultMessage: "Advisory",
+    id: "3gBCC4Vt7Q",
+    description: "GitHub status check mode that reports results without blocking",
+  },
+  statusCheckBlocking: {
+    defaultMessage: "Blocking",
+    id: "/9tSalqpWn",
+    description: "GitHub status check mode that can block pull requests",
+  },
+  statusCheckBlockingDescription: {
+    defaultMessage:
+      "Blocking checks can fail pull requests when combined with <link>branch protection rules</link>.",
+    id: "orN5K1E2Yc",
+    description: "Description for blocking GitHub status check mode",
+  },
+  configVersion: {
+    defaultMessage: "Config version: <version>{configVersion}</version>",
+    id: "3r10YA/kX+",
+    description: "Metadata label showing saved automation config version",
+  },
+  nextScheduledRun: {
+    defaultMessage: "Next scheduled run: <time>{nextRunAt}</time>",
+    id: "L7iavACo3u",
+    description: "Metadata label showing next scheduled automation run time",
+  },
+  resetSettings: {
+    defaultMessage: "Reset settings",
+    id: "EZ0iYWNVvs",
+    description: "Button label to reset repository automation settings",
+  },
+  saveSettings: {
+    defaultMessage: "Save settings",
+    id: "U7qjKZzoBx",
+    description: "Button label to save repository automation settings",
+  },
+  savingSettings: {
+    defaultMessage: "Saving...",
+    id: "nJUCs4vSKi",
+    description: "Button label while repository automation settings are saving",
+  },
+  resetDialogTitle: {
+    defaultMessage: "Reset automation settings?",
+    id: "TpaF4AqL/5",
+    description: "Confirmation dialog title for resetting automation settings",
+  },
+  resetDialogDescription: {
+    defaultMessage:
+      "This clears saved workflows, triggers, and status check settings for this repository. GitHub metadata sync is not affected.",
+    id: "G8MBSDjILS",
+    description: "Confirmation dialog description for resetting automation settings",
+  },
+  cancel: {
+    defaultMessage: "Cancel",
+    id: "ODcZRmwDmR",
+    description: "Cancel button label in reset automation settings dialog",
+  },
+  resettingSettings: {
+    defaultMessage: "Resetting...",
+    id: "ALRaijWLiy",
+    description: "Button label while repository automation settings are resetting",
+  },
+});
+
+export const AUTOMATION_WEEKDAY_MESSAGE_BY_VALUE = {
+  0: repositoryAutomationSettingsPanelMessages.weekdaySunday,
+  1: repositoryAutomationSettingsPanelMessages.weekdayMonday,
+  2: repositoryAutomationSettingsPanelMessages.weekdayTuesday,
+  3: repositoryAutomationSettingsPanelMessages.weekdayWednesday,
+  4: repositoryAutomationSettingsPanelMessages.weekdayThursday,
+  5: repositoryAutomationSettingsPanelMessages.weekdayFriday,
+  6: repositoryAutomationSettingsPanelMessages.weekdaySaturday,
+} as const;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-panel.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-panel.messages.ts
@@ -232,41 +232,6 @@ export const repositoryAutomationSettingsPanelMessages = defineMessages({
     id: "Zy8ZOSNNhB",
     description: "Placeholder for scheduled automation timezone input",
   },
-  weekdaySunday: {
-    defaultMessage: "Sunday",
-    id: "oQckCPSvLu",
-    description: "Weekday option for scheduled automation",
-  },
-  weekdayMonday: {
-    defaultMessage: "Monday",
-    id: "qxBrl7Yxqo",
-    description: "Weekday option for scheduled automation",
-  },
-  weekdayTuesday: {
-    defaultMessage: "Tuesday",
-    id: "WCzohOaFyx",
-    description: "Weekday option for scheduled automation",
-  },
-  weekdayWednesday: {
-    defaultMessage: "Wednesday",
-    id: "/bH75mQmVa",
-    description: "Weekday option for scheduled automation",
-  },
-  weekdayThursday: {
-    defaultMessage: "Thursday",
-    id: "1ESwnn506c",
-    description: "Weekday option for scheduled automation",
-  },
-  weekdayFriday: {
-    defaultMessage: "Friday",
-    id: "0XCfYzdREi",
-    description: "Weekday option for scheduled automation",
-  },
-  weekdaySaturday: {
-    defaultMessage: "Saturday",
-    id: "Cv5dtJ6iTe",
-    description: "Weekday option for scheduled automation",
-  },
   statusCheckTitle: {
     defaultMessage: "GitHub status check",
     id: "WZko2fwHOK",
@@ -356,13 +321,3 @@ export const repositoryAutomationSettingsPanelMessages = defineMessages({
     description: "Button label while repository automation settings are resetting",
   },
 });
-
-export const AUTOMATION_WEEKDAY_MESSAGE_BY_VALUE = {
-  0: repositoryAutomationSettingsPanelMessages.weekdaySunday,
-  1: repositoryAutomationSettingsPanelMessages.weekdayMonday,
-  2: repositoryAutomationSettingsPanelMessages.weekdayTuesday,
-  3: repositoryAutomationSettingsPanelMessages.weekdayWednesday,
-  4: repositoryAutomationSettingsPanelMessages.weekdayThursday,
-  5: repositoryAutomationSettingsPanelMessages.weekdayFriday,
-  6: repositoryAutomationSettingsPanelMessages.weekdaySaturday,
-} as const;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-panel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
 
 import {
@@ -17,6 +18,10 @@ import {
   mapAutomationApiErrorToFieldErrors,
   validateAutomationFormState,
 } from "./github-repository-automation-view-model";
+import {
+  AUTOMATION_WEEKDAY_MESSAGE_BY_VALUE,
+  repositoryAutomationSettingsPanelMessages,
+} from "./repository-automation-settings-panel.messages";
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -88,6 +93,7 @@ function ProjectSelectField({
   id,
   label,
   description,
+  placeholder,
   value,
   projects,
   disabled,
@@ -97,6 +103,7 @@ function ProjectSelectField({
   id: string;
   label: string;
   description: string;
+  placeholder: string;
   value: string;
   projects: ProjectOption[];
   disabled: boolean;
@@ -117,7 +124,7 @@ function ProjectSelectField({
         disabled={disabled}
       >
         <SelectTrigger id={id} className="w-full">
-          <SelectValue placeholder="Select a project" />
+          <SelectValue placeholder={placeholder} />
         </SelectTrigger>
         <SelectContent>
           {projects.map((project) => (
@@ -142,6 +149,7 @@ export function RepositoryAutomationSettingsPanel({
   showFullPageLink = false,
   onSaved,
 }: RepositoryAutomationSettingsPanelProps) {
+  const intl = useIntl();
   const queryClient = useQueryClient();
   const [form, setForm] = useState<GithubRepositoryAutomationFormState | null>(null);
   const [fieldErrors, setFieldErrors] = useState<GithubRepositoryAutomationFieldErrors>({});
@@ -167,7 +175,9 @@ export function RepositoryAutomationSettingsPanel({
       if (!res.ok) {
         const error = await res.json().catch(() => ({ error: "load_failed" }));
         throw new Error(
-          "error" in error ? String(error.error) : "Failed to load automation settings",
+          "error" in error
+            ? String(error.error)
+            : intl.formatMessage(repositoryAutomationSettingsPanelMessages.loadSettingsFailed),
         );
       }
 
@@ -185,7 +195,9 @@ export function RepositoryAutomationSettingsPanel({
       });
 
       if (res.status !== 200) {
-        throw new Error("Failed to load projects");
+        throw new Error(
+          intl.formatMessage(repositoryAutomationSettingsPanelMessages.loadProjectsFailed),
+        );
       }
 
       const data = await res.json();
@@ -246,8 +258,11 @@ export function RepositoryAutomationSettingsPanel({
     },
     onSuccess: (result) => {
       if (!result.ok) {
-        setFieldErrors(mapAutomationApiErrorToFieldErrors(result.code, result.message));
-        toast.error(result.message ?? "Could not save automation settings");
+        setFieldErrors(mapAutomationApiErrorToFieldErrors(intl, result.code, result.message));
+        toast.error(
+          result.message ??
+            intl.formatMessage(repositoryAutomationSettingsPanelMessages.saveFailedToast),
+        );
         return;
       }
 
@@ -261,7 +276,7 @@ export function RepositoryAutomationSettingsPanel({
         ["github-repository-automation-settings", organizationSlug, githubRepositoryId],
         result.record,
       );
-      toast.success("Automation settings saved");
+      toast.success(intl.formatMessage(repositoryAutomationSettingsPanelMessages.saveSuccessToast));
       onSaved?.();
     },
     onError: (error) => {
@@ -280,7 +295,9 @@ export function RepositoryAutomationSettingsPanel({
       if (!res.ok) {
         const error = await res.json().catch(() => ({ error: "reset_failed" }));
         throw new Error(
-          "error" in error ? String(error.error) : "Failed to reset automation settings",
+          "error" in error
+            ? String(error.error)
+            : intl.formatMessage(repositoryAutomationSettingsPanelMessages.resetFailed),
         );
       }
 
@@ -299,7 +316,9 @@ export function RepositoryAutomationSettingsPanel({
         ["github-repository-automation-settings", organizationSlug, githubRepositoryId],
         record,
       );
-      toast.success("Automation settings reset");
+      toast.success(
+        intl.formatMessage(repositoryAutomationSettingsPanelMessages.resetSuccessToast),
+      );
       onSaved?.();
     },
     onError: (error) => {
@@ -316,11 +335,20 @@ export function RepositoryAutomationSettingsPanel({
 
   const triggerChoices = useMemo(
     () => [
-      { value: "none", label: "Off" },
-      { value: "push", label: "On push" },
-      { value: "scheduled", label: "Scheduled" },
+      {
+        value: "none",
+        label: intl.formatMessage(repositoryAutomationSettingsPanelMessages.triggerOff),
+      },
+      {
+        value: "push",
+        label: intl.formatMessage(repositoryAutomationSettingsPanelMessages.triggerOnPush),
+      },
+      {
+        value: "scheduled",
+        label: intl.formatMessage(repositoryAutomationSettingsPanelMessages.triggerScheduled),
+      },
     ],
-    [],
+    [intl],
   );
 
   function updateForm(patch: Partial<GithubRepositoryAutomationFormState>) {
@@ -339,7 +367,7 @@ export function RepositoryAutomationSettingsPanel({
       return;
     }
 
-    const errors = validateAutomationFormState(form);
+    const errors = validateAutomationFormState(intl, form);
     if (Object.keys(errors).length > 0) {
       setFieldErrors(errors);
       return;
@@ -353,7 +381,7 @@ export function RepositoryAutomationSettingsPanel({
       return;
     }
 
-    const result = addBranchPattern(form.pushBranches, branchInput);
+    const result = addBranchPattern(intl, form.pushBranches, branchInput);
     if (result.error) {
       setBranchInputError(result.error);
       return;
@@ -371,7 +399,7 @@ export function RepositoryAutomationSettingsPanel({
   if (!repositoryEnabled) {
     return (
       <p className="text-sm text-muted-foreground">
-        Enable this repository to configure translation automation.
+        <FormattedMessage {...repositoryAutomationSettingsPanelMessages.enableRepositoryHint} />
       </p>
     );
   }
@@ -379,7 +407,7 @@ export function RepositoryAutomationSettingsPanel({
   if (repositoryArchived) {
     return (
       <p className="text-sm text-muted-foreground">
-        Archived repositories cannot use translation automation.
+        <FormattedMessage {...repositoryAutomationSettingsPanelMessages.archivedRepositoryHint} />
       </p>
     );
   }
@@ -400,10 +428,10 @@ export function RepositoryAutomationSettingsPanel({
         <p className="text-sm text-destructive">
           {settingsQuery.error instanceof Error
             ? settingsQuery.error.message
-            : "Unable to load automation settings."}
+            : intl.formatMessage(repositoryAutomationSettingsPanelMessages.loadError)}
         </p>
         <Button variant="outline" size="sm" onClick={() => void settingsQuery.refetch()}>
-          Retry
+          <FormattedMessage {...repositoryAutomationSettingsPanelMessages.retry} />
         </Button>
       </div>
     );
@@ -414,15 +442,22 @@ export function RepositoryAutomationSettingsPanel({
       <div className="flex flex-col gap-6">
         <div className="flex flex-col gap-2">
           <p className="text-sm text-muted-foreground">
-            Configure how Hyperlocalise syncs source strings and translations for{" "}
-            <span className="font-medium text-foreground">{repositoryFullName}</span>.
+            <FormattedMessage
+              {...repositoryAutomationSettingsPanelMessages.intro}
+              values={{
+                repositoryFullName,
+                repositoryName: (chunks) => (
+                  <span className="font-medium text-foreground">{chunks}</span>
+                ),
+              }}
+            />
           </p>
           {showFullPageLink ? (
             <Link
               href={automationPath}
               className="text-xs text-primary underline-offset-4 hover:underline"
             >
-              Open full-page editor
+              <FormattedMessage {...repositoryAutomationSettingsPanelMessages.openFullPageEditor} />
             </Link>
           ) : null}
           {fieldErrors.form ? <FieldError message={fieldErrors.form} /> : null}
@@ -430,16 +465,24 @@ export function RepositoryAutomationSettingsPanel({
 
         <section className="flex flex-col gap-4 rounded-lg border border-border p-4">
           <SectionHeading
-            title="Workflows"
-            description="Choose which automation jobs run for this repository."
+            title={intl.formatMessage(repositoryAutomationSettingsPanelMessages.workflowsTitle)}
+            description={intl.formatMessage(
+              repositoryAutomationSettingsPanelMessages.workflowsDescription,
+            )}
           />
 
           <div className="flex flex-col gap-4">
             <div className="flex items-start justify-between gap-4">
               <div className="flex flex-col gap-1">
-                <Label htmlFor="push-source-enabled">Push source to Hyperlocalise</Label>
+                <Label htmlFor="push-source-enabled">
+                  <FormattedMessage
+                    {...repositoryAutomationSettingsPanelMessages.pushSourceLabel}
+                  />
+                </Label>
                 <p className="text-xs text-muted-foreground">
-                  Import source strings from GitHub into your TMS project.
+                  <FormattedMessage
+                    {...repositoryAutomationSettingsPanelMessages.pushSourceDescription}
+                  />
                 </p>
               </div>
               <Switch
@@ -452,8 +495,15 @@ export function RepositoryAutomationSettingsPanel({
             {form.pushSourceEnabled ? (
               <ProjectSelectField
                 id="push-source-project"
-                label="Hyperlocalise project"
-                description="Source strings are pushed into this project."
+                label={intl.formatMessage(
+                  repositoryAutomationSettingsPanelMessages.hyperlocaliseProjectLabel,
+                )}
+                description={intl.formatMessage(
+                  repositoryAutomationSettingsPanelMessages.pushSourceProjectDescription,
+                )}
+                placeholder={intl.formatMessage(
+                  repositoryAutomationSettingsPanelMessages.selectProjectPlaceholder,
+                )}
                 value={form.pushSourceProjectId}
                 projects={projects}
                 disabled={formDisabled || projectsQuery.isLoading}
@@ -464,9 +514,15 @@ export function RepositoryAutomationSettingsPanel({
 
             <div className="flex items-start justify-between gap-4">
               <div className="flex flex-col gap-1">
-                <Label htmlFor="pull-translations-enabled">Pull translations to GitHub</Label>
+                <Label htmlFor="pull-translations-enabled">
+                  <FormattedMessage
+                    {...repositoryAutomationSettingsPanelMessages.pullTranslationsLabel}
+                  />
+                </Label>
                 <p className="text-xs text-muted-foreground">
-                  Opens a pull request with updated translation files when sync succeeds.
+                  <FormattedMessage
+                    {...repositoryAutomationSettingsPanelMessages.pullTranslationsDescription}
+                  />
                 </p>
               </div>
               <Switch
@@ -479,8 +535,15 @@ export function RepositoryAutomationSettingsPanel({
             {form.pullTranslationsEnabled ? (
               <ProjectSelectField
                 id="pull-translations-project"
-                label="Hyperlocalise project"
-                description="Translations are read from this project before opening the pull request."
+                label={intl.formatMessage(
+                  repositoryAutomationSettingsPanelMessages.hyperlocaliseProjectLabel,
+                )}
+                description={intl.formatMessage(
+                  repositoryAutomationSettingsPanelMessages.pullTranslationsProjectDescription,
+                )}
+                placeholder={intl.formatMessage(
+                  repositoryAutomationSettingsPanelMessages.selectProjectPlaceholder,
+                )}
                 value={form.pullTranslationsProjectId}
                 projects={projects}
                 disabled={formDisabled || projectsQuery.isLoading}
@@ -491,10 +554,18 @@ export function RepositoryAutomationSettingsPanel({
 
             <div className="flex items-start justify-between gap-4">
               <div className="flex flex-col gap-1">
-                <Label htmlFor="validation-enabled">Localization check</Label>
+                <Label htmlFor="validation-enabled">
+                  <FormattedMessage
+                    {...repositoryAutomationSettingsPanelMessages.validationLabel}
+                  />
+                </Label>
                 <p className="text-xs text-muted-foreground">
-                  Runs <code className="text-xs">hl check</code> against repository translation
-                  files.
+                  <FormattedMessage
+                    {...repositoryAutomationSettingsPanelMessages.validationDescription}
+                    values={{
+                      command: (chunks) => <code className="text-xs">{chunks}</code>,
+                    }}
+                  />
                 </p>
               </div>
               <Switch
@@ -507,9 +578,15 @@ export function RepositoryAutomationSettingsPanel({
             {form.validationEnabled ? (
               <div className="flex items-start justify-between gap-4 ps-2">
                 <div className="flex flex-col gap-1">
-                  <Label htmlFor="validation-block">Block on failure</Label>
+                  <Label htmlFor="validation-block">
+                    <FormattedMessage
+                      {...repositoryAutomationSettingsPanelMessages.validationBlockLabel}
+                    />
+                  </Label>
                   <p className="text-xs text-muted-foreground">
-                    Fail the automation run when the localization check reports errors.
+                    <FormattedMessage
+                      {...repositoryAutomationSettingsPanelMessages.validationBlockDescription}
+                    />
                   </p>
                 </div>
                 <Switch
@@ -525,8 +602,10 @@ export function RepositoryAutomationSettingsPanel({
 
         <section className="flex flex-col gap-4 rounded-lg border border-border p-4">
           <SectionHeading
-            title="Trigger"
-            description="Push and scheduled triggers are mutually exclusive."
+            title={intl.formatMessage(repositoryAutomationSettingsPanelMessages.triggerTitle)}
+            description={intl.formatMessage(
+              repositoryAutomationSettingsPanelMessages.triggerDescription,
+            )}
           />
 
           <div className="flex flex-wrap gap-2">
@@ -551,10 +630,19 @@ export function RepositoryAutomationSettingsPanel({
 
           {form.triggerMode === "push" ? (
             <div className="flex flex-col gap-3">
-              <Label htmlFor="branch-pattern-input">Branch patterns</Label>
+              <Label htmlFor="branch-pattern-input">
+                <FormattedMessage
+                  {...repositoryAutomationSettingsPanelMessages.branchPatternsLabel}
+                />
+              </Label>
               <p className="text-xs text-muted-foreground">
-                Use glob patterns such as <code className="text-xs">main</code> or{" "}
-                <code className="text-xs">release/*</code>. Up to 32 patterns.
+                <FormattedMessage
+                  {...repositoryAutomationSettingsPanelMessages.branchPatternsDescription}
+                  values={{
+                    mainExample: (chunks) => <code className="text-xs">{chunks}</code>,
+                    releaseExample: (chunks) => <code className="text-xs">{chunks}</code>,
+                  }}
+                />
               </p>
               <div className="flex gap-2">
                 <input
@@ -565,7 +653,9 @@ export function RepositoryAutomationSettingsPanel({
                     setBranchInputError(undefined);
                   }}
                   disabled={formDisabled}
-                  placeholder="main"
+                  placeholder={intl.formatMessage(
+                    repositoryAutomationSettingsPanelMessages.branchPatternPlaceholder,
+                  )}
                   className="h-9 min-w-0 flex-1 rounded-lg border border-border bg-background px-3 text-sm outline-none focus:border-primary/40 focus:ring-[3px] focus:ring-primary/20"
                   onKeyDown={(event) => {
                     if (event.key === "Enter") {
@@ -581,7 +671,9 @@ export function RepositoryAutomationSettingsPanel({
                   disabled={formDisabled}
                   onClick={handleAddBranchPattern}
                 >
-                  Add
+                  <FormattedMessage
+                    {...repositoryAutomationSettingsPanelMessages.addBranchPattern}
+                  />
                 </Button>
               </div>
               <FieldError message={branchInputError ?? fieldErrors.pushBranches} />
@@ -594,7 +686,10 @@ export function RepositoryAutomationSettingsPanel({
                         type="button"
                         className="rounded-full px-1 text-muted-foreground hover:text-foreground"
                         disabled={formDisabled}
-                        aria-label={`Remove ${branch}`}
+                        aria-label={intl.formatMessage(
+                          repositoryAutomationSettingsPanelMessages.removeBranchPatternAriaLabel,
+                          { branch },
+                        )}
                         onClick={() =>
                           updateForm({
                             pushBranches: form.pushBranches.filter((value) => value !== branch),
@@ -613,7 +708,9 @@ export function RepositoryAutomationSettingsPanel({
           {form.triggerMode === "scheduled" ? (
             <div className="grid gap-4 sm:grid-cols-2">
               <div className="flex flex-col gap-2">
-                <Label htmlFor="scheduled-cadence">Cadence</Label>
+                <Label htmlFor="scheduled-cadence">
+                  <FormattedMessage {...repositoryAutomationSettingsPanelMessages.cadenceLabel} />
+                </Label>
                 <Select
                   value={form.scheduledCadence}
                   onValueChange={(value) =>
@@ -628,16 +725,32 @@ export function RepositoryAutomationSettingsPanel({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="hourly">Hourly</SelectItem>
-                    <SelectItem value="daily">Daily</SelectItem>
-                    <SelectItem value="weekly">Weekly</SelectItem>
+                    <SelectItem value="hourly">
+                      <FormattedMessage
+                        {...repositoryAutomationSettingsPanelMessages.cadenceHourly}
+                      />
+                    </SelectItem>
+                    <SelectItem value="daily">
+                      <FormattedMessage
+                        {...repositoryAutomationSettingsPanelMessages.cadenceDaily}
+                      />
+                    </SelectItem>
+                    <SelectItem value="weekly">
+                      <FormattedMessage
+                        {...repositoryAutomationSettingsPanelMessages.cadenceWeekly}
+                      />
+                    </SelectItem>
                   </SelectContent>
                 </Select>
               </div>
 
               {form.scheduledCadence !== "hourly" ? (
                 <div className="flex flex-col gap-2">
-                  <Label htmlFor="scheduled-hour">Hour (UTC)</Label>
+                  <Label htmlFor="scheduled-hour">
+                    <FormattedMessage
+                      {...repositoryAutomationSettingsPanelMessages.scheduledHourLabel}
+                    />
+                  </Label>
                   <Select
                     value={String(form.scheduledHourUtc)}
                     onValueChange={(value) => updateForm({ scheduledHourUtc: Number(value) })}
@@ -649,7 +762,10 @@ export function RepositoryAutomationSettingsPanel({
                     <SelectContent>
                       {Array.from({ length: 24 }, (_, hour) => (
                         <SelectItem key={hour} value={String(hour)}>
-                          {String(hour).padStart(2, "0")}:00 UTC
+                          {intl.formatMessage(
+                            repositoryAutomationSettingsPanelMessages.scheduledHourOption,
+                            { hour: String(hour).padStart(2, "0") },
+                          )}
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -659,7 +775,11 @@ export function RepositoryAutomationSettingsPanel({
 
               {form.scheduledCadence === "weekly" ? (
                 <div className="flex flex-col gap-2 sm:col-span-2">
-                  <Label htmlFor="scheduled-day">Day of week</Label>
+                  <Label htmlFor="scheduled-day">
+                    <FormattedMessage
+                      {...repositoryAutomationSettingsPanelMessages.scheduledDayLabel}
+                    />
+                  </Label>
                   <Select
                     value={String(form.scheduledDayOfWeek)}
                     onValueChange={(value) => updateForm({ scheduledDayOfWeek: Number(value) })}
@@ -671,7 +791,7 @@ export function RepositoryAutomationSettingsPanel({
                     <SelectContent>
                       {AUTOMATION_WEEKDAY_OPTIONS.map((option) => (
                         <SelectItem key={option.value} value={String(option.value)}>
-                          {option.label}
+                          {intl.formatMessage(AUTOMATION_WEEKDAY_MESSAGE_BY_VALUE[option.value])}
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -681,13 +801,19 @@ export function RepositoryAutomationSettingsPanel({
               ) : null}
 
               <div className="flex flex-col gap-2 sm:col-span-2">
-                <Label htmlFor="scheduled-timezone">Timezone</Label>
+                <Label htmlFor="scheduled-timezone">
+                  <FormattedMessage
+                    {...repositoryAutomationSettingsPanelMessages.scheduledTimezoneLabel}
+                  />
+                </Label>
                 <input
                   id="scheduled-timezone"
                   value={form.scheduledTimezone}
                   onChange={(event) => updateForm({ scheduledTimezone: event.target.value })}
                   disabled={formDisabled}
-                  placeholder="UTC"
+                  placeholder={intl.formatMessage(
+                    repositoryAutomationSettingsPanelMessages.scheduledTimezonePlaceholder,
+                  )}
                   className="h-9 rounded-lg border border-border bg-background px-3 text-sm outline-none focus:border-primary/40 focus:ring-[3px] focus:ring-primary/20"
                 />
                 <FieldError message={fieldErrors.scheduledTimezone} />
@@ -698,15 +824,23 @@ export function RepositoryAutomationSettingsPanel({
 
         <section className="flex flex-col gap-4 rounded-lg border border-border p-4">
           <SectionHeading
-            title="GitHub status check"
-            description="Publish a check run so teams can see localization results on commits and pull requests."
+            title={intl.formatMessage(repositoryAutomationSettingsPanelMessages.statusCheckTitle)}
+            description={intl.formatMessage(
+              repositoryAutomationSettingsPanelMessages.statusCheckDescription,
+            )}
           />
 
           <div className="flex items-start justify-between gap-4">
             <div className="flex flex-col gap-1">
-              <Label htmlFor="status-check-enabled">Enable check run</Label>
+              <Label htmlFor="status-check-enabled">
+                <FormattedMessage
+                  {...repositoryAutomationSettingsPanelMessages.statusCheckEnabledLabel}
+                />
+              </Label>
               <p className="text-xs text-muted-foreground">
-                Shows localization automation status in GitHub Checks.
+                <FormattedMessage
+                  {...repositoryAutomationSettingsPanelMessages.statusCheckEnabledDescription}
+                />
               </p>
             </div>
             <Switch
@@ -719,7 +853,11 @@ export function RepositoryAutomationSettingsPanel({
 
           {form.statusCheckEnabled ? (
             <div className="flex flex-col gap-2">
-              <Label htmlFor="status-check-mode">Check mode</Label>
+              <Label htmlFor="status-check-mode">
+                <FormattedMessage
+                  {...repositoryAutomationSettingsPanelMessages.statusCheckModeLabel}
+                />
+              </Label>
               <Select
                 value={form.statusCheckMode}
                 onValueChange={(value) =>
@@ -734,21 +872,34 @@ export function RepositoryAutomationSettingsPanel({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="advisory">Advisory</SelectItem>
-                  <SelectItem value="blocking">Blocking</SelectItem>
+                  <SelectItem value="advisory">
+                    <FormattedMessage
+                      {...repositoryAutomationSettingsPanelMessages.statusCheckAdvisory}
+                    />
+                  </SelectItem>
+                  <SelectItem value="blocking">
+                    <FormattedMessage
+                      {...repositoryAutomationSettingsPanelMessages.statusCheckBlocking}
+                    />
+                  </SelectItem>
                 </SelectContent>
               </Select>
               <p className="text-xs text-muted-foreground">
-                Blocking checks can fail pull requests when combined with{" "}
-                <a
-                  href="https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-status-checks"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary underline-offset-4 hover:underline"
-                >
-                  branch protection rules
-                </a>
-                .
+                <FormattedMessage
+                  {...repositoryAutomationSettingsPanelMessages.statusCheckBlockingDescription}
+                  values={{
+                    link: (chunks) => (
+                      <a
+                        href="https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-status-checks"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary underline-offset-4 hover:underline"
+                      >
+                        {chunks}
+                      </a>
+                    ),
+                  }}
+                />
               </p>
             </div>
           ) : null}
@@ -758,14 +909,26 @@ export function RepositoryAutomationSettingsPanel({
           <div className="rounded-lg border border-dashed border-border bg-muted/30 px-4 py-3 text-xs text-muted-foreground">
             {metadata.configVersion > 0 ? (
               <p>
-                Config version:{" "}
-                <span className="font-medium text-foreground">{metadata.configVersion}</span>
+                <FormattedMessage
+                  {...repositoryAutomationSettingsPanelMessages.configVersion}
+                  values={{
+                    configVersion: metadata.configVersion,
+                    version: (chunks) => (
+                      <span className="font-medium text-foreground">{chunks}</span>
+                    ),
+                  }}
+                />
               </p>
             ) : null}
             {formattedNextRun ? (
               <p className={cn(metadata.configVersion > 0 && "mt-1")}>
-                Next scheduled run:{" "}
-                <span className="font-medium text-foreground">{formattedNextRun}</span>
+                <FormattedMessage
+                  {...repositoryAutomationSettingsPanelMessages.nextScheduledRun}
+                  values={{
+                    nextRunAt: formattedNextRun,
+                    time: (chunks) => <span className="font-medium text-foreground">{chunks}</span>,
+                  }}
+                />
               </p>
             ) : null}
           </div>
@@ -778,7 +941,7 @@ export function RepositoryAutomationSettingsPanel({
             disabled={formDisabled || resetSettings.isPending}
             onClick={() => setResetDialogOpen(true)}
           >
-            Reset settings
+            <FormattedMessage {...repositoryAutomationSettingsPanelMessages.resetSettings} />
           </Button>
           <Button
             type="button"
@@ -786,7 +949,11 @@ export function RepositoryAutomationSettingsPanel({
             onClick={handleSave}
             className="bg-primary text-primary-foreground hover:bg-primary/80"
           >
-            {saveSettings.isPending ? "Saving..." : "Save settings"}
+            {saveSettings.isPending ? (
+              <FormattedMessage {...repositoryAutomationSettingsPanelMessages.savingSettings} />
+            ) : (
+              <FormattedMessage {...repositoryAutomationSettingsPanelMessages.saveSettings} />
+            )}
           </Button>
         </div>
       </div>
@@ -794,21 +961,32 @@ export function RepositoryAutomationSettingsPanel({
       <AlertDialog open={resetDialogOpen} onOpenChange={setResetDialogOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Reset automation settings?</AlertDialogTitle>
+            <AlertDialogTitle>
+              <FormattedMessage {...repositoryAutomationSettingsPanelMessages.resetDialogTitle} />
+            </AlertDialogTitle>
             <AlertDialogDescription>
-              This clears saved workflows, triggers, and status check settings for this repository.
-              GitHub metadata sync is not affected.
+              <FormattedMessage
+                {...repositoryAutomationSettingsPanelMessages.resetDialogDescription}
+              />
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={resetSettings.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogCancel disabled={resetSettings.isPending}>
+              <FormattedMessage {...repositoryAutomationSettingsPanelMessages.cancel} />
+            </AlertDialogCancel>
             <Button
               type="button"
               variant="destructive"
               disabled={resetSettings.isPending}
               onClick={() => resetSettings.mutate()}
             >
-              {resetSettings.isPending ? "Resetting..." : "Reset settings"}
+              {resetSettings.isPending ? (
+                <FormattedMessage
+                  {...repositoryAutomationSettingsPanelMessages.resettingSettings}
+                />
+              ) : (
+                <FormattedMessage {...repositoryAutomationSettingsPanelMessages.resetSettings} />
+              )}
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-panel.tsx
@@ -18,10 +18,8 @@ import {
   mapAutomationApiErrorToFieldErrors,
   validateAutomationFormState,
 } from "./github-repository-automation-view-model";
-import {
-  AUTOMATION_WEEKDAY_MESSAGE_BY_VALUE,
-  repositoryAutomationSettingsPanelMessages,
-} from "./repository-automation-settings-panel.messages";
+import { AUTOMATION_WEEKDAY_MESSAGE_BY_VALUE } from "./github-repository-automation-view-model.messages";
+import { repositoryAutomationSettingsPanelMessages } from "./repository-automation-settings-panel.messages";
 import {
   AlertDialog,
   AlertDialogCancel,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/slack-agent-view-model.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/slack-agent-view-model.messages.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const slackAgentViewModelMessages = defineMessages({
+  connectedBadge: {
+    defaultMessage: "Connected",
+    id: "ZmMPE/eod1",
+    description: "Slack integration badge when a workspace is linked",
+  },
+  availableBadge: {
+    defaultMessage: "Available",
+    id: "PvWb6LSHFM",
+    description: "Slack integration badge when no workspace is linked yet",
+  },
+  enabledStatus: {
+    defaultMessage: "Enabled",
+    id: "gq9Z4S47VX",
+    description: "Slack agent status title when connected and enabled",
+  },
+  disabledStatus: {
+    defaultMessage: "Disabled",
+    id: "8nYNjmNA8P",
+    description: "Slack agent status title when connected but disabled",
+  },
+  notConnectedStatus: {
+    defaultMessage: "Not connected",
+    id: "W3mkNKamaw",
+    description: "Slack agent status title when no workspace is linked",
+  },
+  statusDescriptionConnected: {
+    defaultMessage: "Installed on {workspace}",
+    id: "N564Eak7tL",
+    description: "Slack integration description when a workspace is linked",
+  },
+  slackWorkspaceFallback: {
+    defaultMessage: "Slack workspace",
+    id: "JcGQchl/ia",
+    description: "Fallback workspace name in Slack status when team name is missing",
+  },
+  statusDescriptionNotConnected: {
+    defaultMessage:
+      "Connect a Slack workspace to let Hyperlocalise respond to mentions, DMs, and subscribed threads.",
+    id: "DeMAC4mdid",
+    description: "Slack integration description before OAuth connection",
+  },
+  reconnectSlack: {
+    defaultMessage: "Reconnect Slack",
+    id: "SAjiqcjzOx",
+    description: "Primary action label when Slack is already connected",
+  },
+  connectSlack: {
+    defaultMessage: "Connect Slack",
+    id: "F/3zp/X191",
+    description: "Primary action label to start Slack OAuth",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/slack-agent-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/slack-agent-view-model.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vite-plus/test";
 
+import { getIntlShape } from "@/lib/app-i18n/intl";
+import type { IntlShape } from "react-intl";
+
 import { getSlackAgentViewModel, type SlackAgentState } from "./slack-agent-view-model";
+
+const intl = getIntlShape("en") as IntlShape;
 
 function createSlackAgent(overrides: Partial<SlackAgentState> = {}): SlackAgentState {
   return {
@@ -13,7 +18,7 @@ function createSlackAgent(overrides: Partial<SlackAgentState> = {}): SlackAgentS
 
 describe("getSlackAgentViewModel", () => {
   it("shows a connected and enabled Slack workspace", () => {
-    const viewModel = getSlackAgentViewModel(createSlackAgent());
+    const viewModel = getSlackAgentViewModel(createSlackAgent(), intl);
 
     expect(viewModel).toEqual({
       connected: true,
@@ -27,7 +32,7 @@ describe("getSlackAgentViewModel", () => {
   });
 
   it("keeps connected workspaces manageable when disabled", () => {
-    const viewModel = getSlackAgentViewModel(createSlackAgent({ enabled: false }));
+    const viewModel = getSlackAgentViewModel(createSlackAgent({ enabled: false }), intl);
 
     expect(viewModel.connected).toBe(true);
     expect(viewModel.enabled).toBe(false);
@@ -37,11 +42,14 @@ describe("getSlackAgentViewModel", () => {
   });
 
   it("requires OAuth connection before enabling Slack", () => {
-    const viewModel = getSlackAgentViewModel({
-      enabled: true,
-      teamId: null,
-      teamName: null,
-    });
+    const viewModel = getSlackAgentViewModel(
+      {
+        enabled: true,
+        teamId: null,
+        teamName: null,
+      },
+      intl,
+    );
 
     expect(viewModel.connected).toBe(false);
     expect(viewModel.enabled).toBe(false);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/slack-agent-view-model.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/slack-agent-view-model.ts
@@ -1,22 +1,38 @@
+import type { IntlShape } from "react-intl";
+
+import { slackAgentViewModelMessages } from "./slack-agent-view-model.messages";
+
 export type SlackAgentState = {
   enabled: boolean;
   teamId: string | null;
   teamName: string | null;
 };
 
-export function getSlackAgentViewModel(slackAgent: SlackAgentState | undefined) {
+export function getSlackAgentViewModel(slackAgent: SlackAgentState | undefined, intl: IntlShape) {
   const connected = Boolean(slackAgent?.teamId);
   const enabled = connected && Boolean(slackAgent?.enabled);
+  const workspace =
+    slackAgent?.teamName ??
+    slackAgent?.teamId ??
+    intl.formatMessage(slackAgentViewModelMessages.slackWorkspaceFallback);
 
   return {
     connected,
     enabled,
-    badgeLabel: connected ? "Connected" : "Available",
-    statusTitle: connected ? (enabled ? "Enabled" : "Disabled") : "Not connected",
+    badgeLabel: connected
+      ? intl.formatMessage(slackAgentViewModelMessages.connectedBadge)
+      : intl.formatMessage(slackAgentViewModelMessages.availableBadge),
+    statusTitle: connected
+      ? enabled
+        ? intl.formatMessage(slackAgentViewModelMessages.enabledStatus)
+        : intl.formatMessage(slackAgentViewModelMessages.disabledStatus)
+      : intl.formatMessage(slackAgentViewModelMessages.notConnectedStatus),
     statusDescription: connected
-      ? `Installed on ${slackAgent?.teamName ?? slackAgent?.teamId ?? "Slack workspace"}`
-      : "Connect a Slack workspace to let Hyperlocalise respond to mentions, DMs, and subscribed threads.",
-    primaryActionLabel: connected ? "Reconnect Slack" : "Connect Slack",
+      ? intl.formatMessage(slackAgentViewModelMessages.statusDescriptionConnected, { workspace })
+      : intl.formatMessage(slackAgentViewModelMessages.statusDescriptionNotConnected),
+    primaryActionLabel: connected
+      ? intl.formatMessage(slackAgentViewModelMessages.reconnectSlack)
+      : intl.formatMessage(slackAgentViewModelMessages.connectSlack),
     toggleDisabled: !connected,
   };
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/slack-integration-row.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/slack-integration-row.messages.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const slackIntegrationRowMessages = defineMessages({
+  name: {
+    defaultMessage: "Slack",
+    id: "A6g1n+wasr",
+    description: "Slack integration name on the integrations page",
+  },
+  loadErrorDescription: {
+    defaultMessage: "Unable to load Slack settings right now.",
+    id: "5bWs0pTrNJ",
+    description: "Slack integration row description when settings fail to load",
+  },
+  disconnectedDescription: {
+    defaultMessage:
+      "Coordinate localization reviews from Slack mentions, DMs, and subscribed threads.",
+    id: "0bosLZsKFI",
+    description: "Slack integration description before OAuth connection",
+  },
+  settingsUnavailable: {
+    defaultMessage: "Settings unavailable",
+    id: "k0oDzsZOu6",
+    description: "Slack agent panel title when settings failed to load",
+  },
+  workspaceId: {
+    defaultMessage: "Workspace ID: {teamId}",
+    id: "goHDd0IC3Q",
+    description: "Slack workspace identifier shown in the agent settings panel",
+  },
+  enableSlackAgentAriaLabel: {
+    defaultMessage: "Enable Slack agent",
+    id: "rYXZcW+sgJ",
+    description: "Aria label for the Slack agent enable switch",
+  },
+  openingSlack: {
+    defaultMessage: "Opening Slack…",
+    id: "uGl99aLDiP",
+    description: "Primary action label while redirecting to Slack OAuth",
+  },
+  updating: {
+    defaultMessage: "Updating…",
+    id: "OY8OoRp1g9",
+    description: "Disable button label while Slack agent state is saving",
+  },
+  disable: {
+    defaultMessage: "Disable",
+    id: "RBvXfLqDOK",
+    description: "Button label to disable the Slack agent",
+  },
+  installUrlFailedToast: {
+    defaultMessage: "Failed to generate Slack install URL",
+    id: "b1jBVJ44Vr",
+    description: "Toast when Slack OAuth install URL generation fails",
+  },
+  connectedToast: {
+    defaultMessage: "Slack connected",
+    id: "k8bxVI/FQf",
+    description: "Toast after returning from successful Slack OAuth",
+  },
+  enabledToast: {
+    defaultMessage: "Slack agent enabled",
+    id: "/zPj/3x/+q",
+    description: "Toast after enabling the Slack agent",
+  },
+  disabledToast: {
+    defaultMessage: "Slack agent disabled",
+    id: "gso6nAA1gq",
+    description: "Toast after disabling the Slack agent",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/slack-integration-row.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/slack-integration-row.tsx
@@ -5,9 +5,11 @@ import { useSearchParams } from "next/navigation";
 import { SlackIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useIntl, type IntlShape } from "react-intl";
 import { toast } from "sonner";
 
 import { getSlackAgentViewModel } from "./slack-agent-view-model";
+import { slackIntegrationRowMessages } from "./slack-integration-row.messages";
 import { IntegrationRow } from "./integration-row";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -61,7 +63,7 @@ function useSlackInstallUrl(organizationSlug: string) {
   });
 }
 
-function useUpdateSlackAgentState(organizationSlug: string) {
+function useUpdateSlackAgentState(organizationSlug: string, intl: IntlShape) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -81,7 +83,13 @@ function useUpdateSlackAgentState(organizationSlug: string) {
     },
     onSuccess: async (_data, enabled) => {
       await queryClient.invalidateQueries({ queryKey: ["slack-agent", organizationSlug] });
-      toast.success(enabled ? "Slack agent enabled" : "Slack agent disabled");
+      toast.success(
+        intl.formatMessage(
+          enabled
+            ? slackIntegrationRowMessages.enabledToast
+            : slackIntegrationRowMessages.disabledToast,
+        ),
+      );
     },
     onError: (error) => {
       toast.error(error.message);
@@ -94,6 +102,7 @@ export function SlackIntegrationRow({
   isLast = false,
   userCanManage,
 }: SlackIntegrationRowProps) {
+  const intl = useIntl();
   const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const [expanded, setExpanded] = useState(false);
@@ -102,8 +111,8 @@ export function SlackIntegrationRow({
   const { data: slackAgent, isLoading, isError } = useSlackAgentState(organizationSlug);
   const { refetch: getInstallUrl, isFetching: isCreatingInstallUrl } =
     useSlackInstallUrl(organizationSlug);
-  const updateSlackAgentState = useUpdateSlackAgentState(organizationSlug);
-  const viewModel = getSlackAgentViewModel(slackAgent);
+  const updateSlackAgentState = useUpdateSlackAgentState(organizationSlug, intl);
+  const viewModel = getSlackAgentViewModel(slackAgent, intl);
 
   useEffect(() => {
     if (searchParams.get("slack_connected") !== "1" || handledSlackConnectedRef.current) {
@@ -118,9 +127,9 @@ export function SlackIntegrationRow({
 
     void queryClient.invalidateQueries({ queryKey: ["slack-agent", organizationSlug] }).then(() => {
       setExpanded(true);
-      toast.success("Slack connected");
+      toast.success(intl.formatMessage(slackIntegrationRowMessages.connectedToast));
     });
-  }, [organizationSlug, queryClient, searchParams]);
+  }, [intl, organizationSlug, queryClient, searchParams]);
 
   const handleConnect = useCallback(async () => {
     try {
@@ -130,23 +139,23 @@ export function SlackIntegrationRow({
         return;
       }
 
-      toast.error("Failed to generate Slack install URL");
+      toast.error(intl.formatMessage(slackIntegrationRowMessages.installUrlFailedToast));
     } catch (installError) {
       toast.error(installError instanceof Error ? installError.message : "Unable to connect Slack");
     }
-  }, [getInstallUrl]);
+  }, [getInstallUrl, intl]);
 
   const action = !userCanManage ? "view-only" : viewModel.connected ? "manage" : "connect";
 
   return (
     <IntegrationRow
-      name="Slack"
+      name={intl.formatMessage(slackIntegrationRowMessages.name)}
       description={
         isError
-          ? "Unable to load Slack settings right now."
+          ? intl.formatMessage(slackIntegrationRowMessages.loadErrorDescription)
           : viewModel.connected
             ? viewModel.statusDescription
-            : "Coordinate localization reviews from Slack mentions, DMs, and subscribed threads."
+            : intl.formatMessage(slackIntegrationRowMessages.disconnectedDescription)
       }
       icon={<HugeiconsIcon icon={SlackIcon} strokeWidth={1.8} className="size-5 text-current" />}
       iconMuted={!viewModel.enabled}
@@ -165,18 +174,22 @@ export function SlackIntegrationRow({
           <div className="flex flex-col gap-3 rounded-lg border border-border bg-background/70 p-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <TypographyP className="text-sm font-medium text-foreground">
-                {isError ? "Settings unavailable" : viewModel.statusTitle}
+                {isError
+                  ? intl.formatMessage(slackIntegrationRowMessages.settingsUnavailable)
+                  : viewModel.statusTitle}
               </TypographyP>
               {slackAgent?.teamId ? (
                 <TypographyP className="mt-1 text-xs text-muted-foreground">
-                  Workspace ID: {slackAgent.teamId}
+                  {intl.formatMessage(slackIntegrationRowMessages.workspaceId, {
+                    teamId: slackAgent.teamId,
+                  })}
                 </TypographyP>
               ) : null}
             </div>
             <Switch
               checked={viewModel.enabled}
               onCheckedChange={(enabled) => updateSlackAgentState.mutate(enabled)}
-              aria-label="Enable Slack agent"
+              aria-label={intl.formatMessage(slackIntegrationRowMessages.enableSlackAgentAriaLabel)}
               disabled={
                 viewModel.toggleDisabled ||
                 isError ||
@@ -188,7 +201,9 @@ export function SlackIntegrationRow({
           </div>
           <div className="flex flex-wrap gap-2">
             <Button size="sm" onClick={() => void handleConnect()} disabled={isCreatingInstallUrl}>
-              {isCreatingInstallUrl ? "Opening Slack..." : viewModel.primaryActionLabel}
+              {isCreatingInstallUrl
+                ? intl.formatMessage(slackIntegrationRowMessages.openingSlack)
+                : viewModel.primaryActionLabel}
             </Button>
             {viewModel.connected ? (
               <Button
@@ -197,7 +212,9 @@ export function SlackIntegrationRow({
                 onClick={() => updateSlackAgentState.mutate(false)}
                 disabled={!viewModel.enabled || updateSlackAgentState.isPending}
               >
-                {updateSlackAgentState.isPending ? "Updating..." : "Disable"}
+                {updateSlackAgentState.isPending
+                  ? intl.formatMessage(slackIntegrationRowMessages.updating)
+                  : intl.formatMessage(slackIntegrationRowMessages.disable)}
               </Button>
             ) : null}
           </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/tms-provider-credential-panel.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/tms-provider-credential-panel.messages.ts
@@ -1,0 +1,283 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const tmsProviderCredentialPanelMessages = defineMessages({
+  oauthCallbackUrlLabel: {
+    defaultMessage: "OAuth callback URL",
+    id: "vLTwfBOTEg",
+    description: "Label for the OAuth callback URL field in TMS provider setup",
+  },
+  oauthCallbackUrlAriaLabel: {
+    defaultMessage: "OAuth callback URL",
+    id: "2yOh43qm8U",
+    description: "Aria label for the read-only OAuth callback URL field",
+  },
+  copiedOAuthCallbackUrlAriaLabel: {
+    defaultMessage: "Copied OAuth callback URL",
+    id: "naWIsHiFkQ",
+    description: "Aria label after copying the OAuth callback URL",
+  },
+  copyOAuthCallbackUrlAriaLabel: {
+    defaultMessage: "Copy OAuth callback URL",
+    id: "t6Jk21Xb6m",
+    description: "Aria label for the copy OAuth callback URL button",
+  },
+  copiedTooltip: {
+    defaultMessage: "Copied!",
+    id: "qMoIwNM0g+",
+    description: "Tooltip after copying the OAuth callback URL",
+  },
+  copyOAuthCallbackUrlTooltip: {
+    defaultMessage: "Copy OAuth callback URL",
+    id: "hdt51o9xzu",
+    description: "Tooltip for the copy OAuth callback URL button",
+  },
+  requiredOAuthScopesTitle: {
+    defaultMessage: "Required OAuth scopes",
+    id: "2zhZzc+gaw",
+    description: "Heading for the OAuth scope checklist in TMS provider setup",
+  },
+  crowdinOAuthScopesDescription: {
+    defaultMessage:
+      "In your Crowdin OAuth App, enable every scope below. Hyperlocalise requests the same list when you connect Crowdin.",
+    id: "E5p3SqvCuO",
+    description: "Intro text for Crowdin OAuth scope requirements",
+  },
+  phraseOAuthScopesDescription: {
+    defaultMessage:
+      "Phrase TMS OAuth uses the scope below when Hyperlocalise requests an authorization code and exchanges it for a user bearer token.",
+    id: "SQRLgyMjtO",
+    description: "Intro text for Phrase OAuth scope requirements",
+  },
+  oauthClientIdLabel: {
+    defaultMessage: "OAuth client ID",
+    id: "uBs3qiwQrd",
+    description: "Label for the OAuth client ID field",
+  },
+  oauthClientIdPlaceholderKeep: {
+    defaultMessage: "Leave blank to keep existing client ID",
+    id: "v9ol+HRqV1",
+    description: "Placeholder when updating OAuth credentials without changing client ID",
+  },
+  oauthClientIdPlaceholderNew: {
+    defaultMessage: "{providerName} OAuth App client ID",
+    id: "vWISliHekQ",
+    description: "Placeholder for a new OAuth client ID",
+  },
+  oauthClientSecretLabel: {
+    defaultMessage: "OAuth client secret",
+    id: "wc8eM+CF/N",
+    description: "Label for the OAuth client secret field",
+  },
+  oauthClientSecretPlaceholderKeep: {
+    defaultMessage: "Leave blank to keep existing client secret",
+    id: "NMG/zBLWDQ",
+    description: "Placeholder when updating OAuth credentials without changing client secret",
+  },
+  oauthClientSecretPlaceholderNew: {
+    defaultMessage: "{providerName} OAuth App client secret",
+    id: "Zgi1lh5USb",
+    description: "Placeholder for a new OAuth client secret",
+  },
+  hideSecretAriaLabel: {
+    defaultMessage: "Hide secret",
+    id: "VSVVptSaLR",
+    description: "Aria label for hiding a credential secret field",
+  },
+  showSecretAriaLabel: {
+    defaultMessage: "Show secret",
+    id: "2IX5Zk4LCM",
+    description: "Aria label for revealing a credential secret field",
+  },
+  baseUrlGuidanceCrowdin: {
+    defaultMessage:
+      "Leave blank for Crowdin.com. For Crowdin Enterprise, use your organization API URL including /api/v2, for example https://yourorg.api.crowdin.com/api/v2. A trailing slash is optional.",
+    id: "LCvdY0etjh",
+    description: "Guidance for the Crowdin API base URL field",
+  },
+  baseUrlGuidancePhrase: {
+    defaultMessage:
+      "Leave blank for Phrase Cloud. For a custom Phrase TMS host, enter the full web API base URL, for example https://cloud.memsource.com/web.",
+    id: "NuOuhehPIz",
+    description: "Guidance for the Phrase API base URL field",
+  },
+  baseUrlGuidanceLokalise: {
+    defaultMessage:
+      "Leave blank for the standard Lokalise API. For a custom host, include the /api2 path, for example https://api.lokalise.com/api2.",
+    id: "hvxzMXw+ek",
+    description: "Guidance for the Lokalise API base URL field",
+  },
+  baseUrlGuidanceSmartling: {
+    defaultMessage:
+      "Leave blank for the standard Smartling API. For a custom host, include the auth API path, for example https://api.smartling.com/auth-api/v2.",
+    id: "anZVyDdEfq",
+    description: "Guidance for the Smartling API base URL field",
+  },
+  baseUrlPlaceholderCrowdin: {
+    defaultMessage: "https://yourorg.api.crowdin.com/api/v2",
+    id: "NagMPC+eb9",
+    description: "Example placeholder for the Crowdin API base URL field",
+  },
+  baseUrlPlaceholderPhrase: {
+    defaultMessage: "https://cloud.memsource.com/web",
+    id: "9hphmwIx1l",
+    description: "Example placeholder for the Phrase API base URL field",
+  },
+  baseUrlPlaceholderLokalise: {
+    defaultMessage: "https://api.lokalise.com/api2",
+    id: "y7TyDgtZHB",
+    description: "Example placeholder for the Lokalise API base URL field",
+  },
+  baseUrlPlaceholderSmartling: {
+    defaultMessage: "https://api.smartling.com/auth-api/v2",
+    id: "aGXP2V6FOj",
+    description: "Example placeholder for the Smartling API base URL field",
+  },
+  oauthConnectedTitle: {
+    defaultMessage: "{providerName} is connected via OAuth",
+    id: "YvOtHkprF2",
+    description: "Status heading when a TMS provider is connected with OAuth",
+  },
+  oauthConnectedDescription: {
+    defaultMessage:
+      "Each workspace member connects their own {providerName} account. Projects, jobs, glossaries, and translation memories load live from {providerName} when you open those pages.",
+    id: "QfmZdcP/TR",
+    description: "Status description when a TMS provider is connected with OAuth",
+  },
+  accessTokenExpires: {
+    defaultMessage: "Access token expires {expiresAt}",
+    id: "nJvRveEDal",
+    description: "Shows when the stored OAuth access token expires",
+  },
+  patConnectedTitle: {
+    defaultMessage: "{providerName} is ready for member tokens",
+    id: "svD7SMchJb",
+    description: "Status heading when Crowdin PAT mode is configured",
+  },
+  patConnectedDescription: {
+    defaultMessage:
+      "The API base URL is saved for this workspace. Each member connects with their own Crowdin personal access token—no OAuth app required.",
+    id: "J/94oLjLEp",
+    description: "Status description when Crowdin PAT mode is configured",
+  },
+  authenticationMethodLabel: {
+    defaultMessage: "Authentication method",
+    id: "8bpns6mW0p",
+    description: "Label for the Crowdin authentication method selector",
+  },
+  authenticationMethodDescription: {
+    defaultMessage:
+      "OAuth works when your Enterprise OAuth app is configured. Personal access tokens let each member paste a token from Crowdin without OAuth setup.",
+    id: "CzW/0u2+bW",
+    description: "Description for the Crowdin authentication method selector",
+  },
+  oauthAppRecommended: {
+    defaultMessage: "OAuth app (recommended)",
+    id: "TOuqvBUuy6",
+    description: "Crowdin authentication option for OAuth apps",
+  },
+  personalAccessTokenOption: {
+    defaultMessage: "Personal access token (per member)",
+    id: "3zJmjtu7XF",
+    description: "Crowdin authentication option for personal access tokens",
+  },
+  connectOAuthIntro: {
+    defaultMessage:
+      "Connect {providerName} with an OAuth App. Each member links their own account before using {providerName} data in Hyperlocalise.",
+    id: "mDYRJWtk3P",
+    description: "Intro text before connecting an OAuth-based TMS provider",
+  },
+  crowdinPatIntro: {
+    defaultMessage:
+      "Set the Crowdin API base URL once for this workspace. After you save, members connect by pasting their own personal access token—nothing else to configure.",
+    id: "p0T+Rt+a+4",
+    description: "Intro text before enabling Crowdin personal access token mode",
+  },
+  saveCredentialsIntro: {
+    defaultMessage:
+      "Save credentials to connect {providerName}. The secret is encrypted at rest and used to sync projects, files, and jobs into the workspace.",
+    id: "YOCao9EtJ4",
+    description: "Intro text before saving API token credentials for a TMS provider",
+  },
+  displayNameLabel: {
+    defaultMessage: "Display name",
+    id: "ACud1VtN9i",
+    description: "Label for the TMS provider credential display name field",
+  },
+  displayNamePlaceholder: {
+    defaultMessage: "e.g. Crowdin Production",
+    id: "wYUzxhVyTO",
+    description: "Placeholder for the TMS provider credential display name field",
+  },
+  apiBaseUrlLabel: {
+    defaultMessage: "API base URL",
+    id: "ggrU8wuuic",
+    description: "Label for the required API base URL field in Crowdin PAT mode",
+  },
+  reconnectOAuthApp: {
+    defaultMessage: "Reconnect with a different OAuth app",
+    id: "tQNKmwbVHc",
+    description: "Collapsible trigger to replace OAuth app credentials",
+  },
+  apiTokenSecretLabel: {
+    defaultMessage: "API token / secret",
+    id: "yHXzQ/SrSE",
+    description: "Label for the API token or secret field",
+  },
+  apiTokenPlaceholder: {
+    defaultMessage: "Enter provider API token",
+    id: "BVsezPmDFQ",
+    description: "Placeholder for the API token or secret field",
+  },
+  advancedSettings: {
+    defaultMessage: "Advanced settings",
+    id: "3lnMAqI5qB",
+    description: "Collapsible trigger for optional TMS provider settings",
+  },
+  baseUrlOptionalLabel: {
+    defaultMessage: "Base URL (optional)",
+    id: "iIDH8DJhzI",
+    description: "Label for the optional API base URL field",
+  },
+  disconnect: {
+    defaultMessage: "Disconnect",
+    id: "ljCRNx6fjZ",
+    description: "Button to remove a stored TMS provider credential",
+  },
+  saving: {
+    defaultMessage: "Saving…",
+    id: "NjO8LhO0p7",
+    description: "Save button label while TMS provider credentials are saving",
+  },
+  saveProviderSettings: {
+    defaultMessage: "Save {providerName} settings",
+    id: "XIKJG5Q5Cf",
+    description: "Save button label when updating an existing TMS provider connection",
+  },
+  enableProviderTokens: {
+    defaultMessage: "Enable {providerName} tokens",
+    id: "5A/N2rMBQL",
+    description: "Save button label when enabling Crowdin personal access token mode",
+  },
+  updateProvider: {
+    defaultMessage: "Update {providerName}",
+    id: "cgwAYz/R89",
+    description: "Save button label when reconnecting with new OAuth credentials",
+  },
+  saveProvider: {
+    defaultMessage: "Save {providerName}",
+    id: "ajjoHt03BE",
+    description: "Save button label when connecting a new OAuth-based TMS provider",
+  },
+  saveProviderGeneric: {
+    defaultMessage: "Save provider",
+    id: "bqM/HZdSBC",
+    description: "Save button label for non-OAuth TMS providers",
+  },
+  oauthCallbackUrlCopiedToast: {
+    defaultMessage: "OAuth callback URL copied",
+    id: "z4vfspWg4+",
+    description: "Toast after copying the OAuth callback URL",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/tms-provider-credential-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/tms-provider-credential-panel.tsx
@@ -10,8 +10,10 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ChevronDownIcon, EyeIcon, EyeOffIcon } from "lucide-react";
+import { FormattedMessage, useIntl, type IntlShape, type MessageDescriptor } from "react-intl";
 import { toast } from "sonner";
 
+import { tmsProviderCredentialPanelMessages } from "./tms-provider-credential-panel.messages";
 import type { ExternalTmsProviderCredentialListItem } from "@/lib/providers/contracts/external-tms-provider-credential";
 import type { ExternalTmsProviderKind } from "@/lib/providers/contracts/external-tms-provider-kind";
 import {
@@ -39,6 +41,28 @@ import {
 } from "@/components/ui/input-group";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/primitives/cn";
+
+const baseUrlGuidanceMessages = {
+  crowdin: tmsProviderCredentialPanelMessages.baseUrlGuidanceCrowdin,
+  phrase: tmsProviderCredentialPanelMessages.baseUrlGuidancePhrase,
+  lokalise: tmsProviderCredentialPanelMessages.baseUrlGuidanceLokalise,
+  smartling: tmsProviderCredentialPanelMessages.baseUrlGuidanceSmartling,
+} satisfies Record<ExternalTmsProviderKind, MessageDescriptor>;
+
+const baseUrlPlaceholderMessages = {
+  crowdin: tmsProviderCredentialPanelMessages.baseUrlPlaceholderCrowdin,
+  phrase: tmsProviderCredentialPanelMessages.baseUrlPlaceholderPhrase,
+  lokalise: tmsProviderCredentialPanelMessages.baseUrlPlaceholderLokalise,
+  smartling: tmsProviderCredentialPanelMessages.baseUrlPlaceholderSmartling,
+} satisfies Record<ExternalTmsProviderKind, MessageDescriptor>;
+
+function getTmsBaseUrlGuidance(intl: IntlShape, providerKind: ExternalTmsProviderKind): string {
+  return intl.formatMessage(baseUrlGuidanceMessages[providerKind]);
+}
+
+function getTmsBaseUrlPlaceholder(intl: IntlShape, providerKind: ExternalTmsProviderKind): string {
+  return intl.formatMessage(baseUrlPlaceholderMessages[providerKind]);
+}
 
 function CrowdinOAuthSetupFields({
   providerKind,
@@ -73,17 +97,23 @@ function CrowdinOAuthSetupFields({
   onToggleShowSecret: () => void;
   allowExistingCredentials?: boolean;
 }) {
+  const intl = useIntl();
+
   return (
     <>
       <Field className="gap-2">
-        <FieldLabel htmlFor={redirectUriFieldId}>OAuth callback URL</FieldLabel>
+        <FieldLabel htmlFor={redirectUriFieldId}>
+          {intl.formatMessage(tmsProviderCredentialPanelMessages.oauthCallbackUrlLabel)}
+        </FieldLabel>
         <InputGroup className="h-10 bg-muted/30">
           <InputGroupInput
             id={redirectUriFieldId}
             readOnly
             tabIndex={-1}
             value={crowdinRedirectUri}
-            aria-label="OAuth callback URL"
+            aria-label={intl.formatMessage(
+              tmsProviderCredentialPanelMessages.oauthCallbackUrlAriaLabel,
+            )}
             className="truncate text-sm cursor-default"
           />
           <InputGroupAddon align="inline-end">
@@ -95,9 +125,11 @@ function CrowdinOAuthSetupFields({
                     size="icon-sm"
                     onClick={onCopyRedirectUri}
                     disabled={!crowdinRedirectUri}
-                    aria-label={
-                      redirectUriCopied ? "Copied OAuth callback URL" : "Copy OAuth callback URL"
-                    }
+                    aria-label={intl.formatMessage(
+                      redirectUriCopied
+                        ? tmsProviderCredentialPanelMessages.copiedOAuthCallbackUrlAriaLabel
+                        : tmsProviderCredentialPanelMessages.copyOAuthCallbackUrlAriaLabel,
+                    )}
                   >
                     <HugeiconsIcon
                       icon={redirectUriCopied ? Tick02Icon : Copy01Icon}
@@ -107,7 +139,11 @@ function CrowdinOAuthSetupFields({
                 }
               />
               <TooltipContent>
-                {redirectUriCopied ? "Copied!" : "Copy OAuth callback URL"}
+                {intl.formatMessage(
+                  redirectUriCopied
+                    ? tmsProviderCredentialPanelMessages.copiedTooltip
+                    : tmsProviderCredentialPanelMessages.copyOAuthCallbackUrlTooltip,
+                )}
               </TooltipContent>
             </Tooltip>
           </InputGroupAddon>
@@ -116,11 +152,15 @@ function CrowdinOAuthSetupFields({
 
       <div className="space-y-3 rounded-lg border border-border bg-muted/30 p-4">
         <div>
-          <p className="text-sm font-medium text-foreground">Required OAuth scopes</p>
+          <p className="text-sm font-medium text-foreground">
+            <FormattedMessage {...tmsProviderCredentialPanelMessages.requiredOAuthScopesTitle} />
+          </p>
           <p className="mt-1 text-sm leading-6 text-muted-foreground">
-            {providerKind === "crowdin"
-              ? "In your Crowdin OAuth App, enable every scope below. Hyperlocalise requests the same list when you connect Crowdin."
-              : "Phrase TMS OAuth uses the scope below when Hyperlocalise requests an authorization code and exchanges it for a user bearer token."}
+            <FormattedMessage
+              {...(providerKind === "crowdin"
+                ? tmsProviderCredentialPanelMessages.crowdinOAuthScopesDescription
+                : tmsProviderCredentialPanelMessages.phraseOAuthScopesDescription)}
+            />
           </p>
         </div>
         {providerKind === "crowdin" || providerKind === "phrase" ? (
@@ -141,22 +181,27 @@ function CrowdinOAuthSetupFields({
       </div>
 
       <Field className="gap-2">
-        <FieldLabel htmlFor={oauthClientIdFieldId}>OAuth client ID</FieldLabel>
+        <FieldLabel htmlFor={oauthClientIdFieldId}>
+          {intl.formatMessage(tmsProviderCredentialPanelMessages.oauthClientIdLabel)}
+        </FieldLabel>
         <Input
           id={oauthClientIdFieldId}
           value={oauthClientId}
           onChange={(event) => onOauthClientIdChange(event.target.value)}
           autoComplete="off"
-          placeholder={
+          placeholder={intl.formatMessage(
             allowExistingCredentials
-              ? "Leave blank to keep existing client ID"
-              : `${providerName} OAuth App client ID`
-          }
+              ? tmsProviderCredentialPanelMessages.oauthClientIdPlaceholderKeep
+              : tmsProviderCredentialPanelMessages.oauthClientIdPlaceholderNew,
+            { providerName },
+          )}
         />
       </Field>
 
       <Field className="gap-2">
-        <FieldLabel htmlFor={oauthClientSecretFieldId}>OAuth client secret</FieldLabel>
+        <FieldLabel htmlFor={oauthClientSecretFieldId}>
+          {intl.formatMessage(tmsProviderCredentialPanelMessages.oauthClientSecretLabel)}
+        </FieldLabel>
         <div className="relative">
           <HugeiconsIcon
             icon={Key01Icon}
@@ -169,18 +214,23 @@ function CrowdinOAuthSetupFields({
             autoComplete="off"
             value={oauthClientSecret}
             onChange={(event) => onOauthClientSecretChange(event.target.value)}
-            placeholder={
+            placeholder={intl.formatMessage(
               allowExistingCredentials
-                ? "Leave blank to keep existing client secret"
-                : `${providerName} OAuth App client secret`
-            }
+                ? tmsProviderCredentialPanelMessages.oauthClientSecretPlaceholderKeep
+                : tmsProviderCredentialPanelMessages.oauthClientSecretPlaceholderNew,
+              { providerName },
+            )}
             className="ps-9 pe-9"
           />
           <button
             type="button"
             onClick={onToggleShowSecret}
             className="absolute top-1/2 right-3 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
-            aria-label={showSecret ? "Hide secret" : "Show secret"}
+            aria-label={intl.formatMessage(
+              showSecret
+                ? tmsProviderCredentialPanelMessages.hideSecretAriaLabel
+                : tmsProviderCredentialPanelMessages.showSecretAriaLabel,
+            )}
           >
             {showSecret ? <EyeOffIcon size={16} /> : <EyeIcon size={16} />}
           </button>
@@ -188,32 +238,6 @@ function CrowdinOAuthSetupFields({
       </Field>
     </>
   );
-}
-
-function getTmsBaseUrlGuidance(providerKind: ExternalTmsProviderKind): string {
-  switch (providerKind) {
-    case "crowdin":
-      return "Leave blank for Crowdin.com. For Crowdin Enterprise, use your organization API URL including /api/v2, for example https://yourorg.api.crowdin.com/api/v2. A trailing slash is optional.";
-    case "phrase":
-      return "Leave blank for Phrase Cloud. For a custom Phrase TMS host, enter the full web API base URL, for example https://cloud.memsource.com/web.";
-    case "lokalise":
-      return "Leave blank for the standard Lokalise API. For a custom host, include the /api2 path, for example https://api.lokalise.com/api2.";
-    case "smartling":
-      return "Leave blank for the standard Smartling API. For a custom host, include the auth API path, for example https://api.smartling.com/auth-api/v2.";
-  }
-}
-
-function getTmsBaseUrlPlaceholder(providerKind: ExternalTmsProviderKind): string {
-  switch (providerKind) {
-    case "crowdin":
-      return "https://yourorg.api.crowdin.com/api/v2";
-    case "phrase":
-      return "https://cloud.memsource.com/web";
-    case "lokalise":
-      return "https://api.lokalise.com/api2";
-    case "smartling":
-      return "https://api.smartling.com/auth-api/v2";
-  }
 }
 
 type CrowdinAuthMode = typeof OAUTH_AUTH_MODE | typeof PAT_AUTH_MODE;
@@ -283,6 +307,7 @@ export function TmsProviderCredentialPanel({
   baseUrlFieldId,
   crowdinAuthModeFieldId,
 }: TmsProviderCredentialPanelProps) {
+  const intl = useIntl();
   const isCrowdin = providerKind === "crowdin";
   const isCrowdinOAuthMode = isCrowdin && crowdinAuthMode === OAUTH_AUTH_MODE;
   const isCrowdinPatMode = isCrowdin && crowdinAuthMode === PAT_AUTH_MODE;
@@ -311,7 +336,9 @@ export function TmsProviderCredentialPanel({
 
     await navigator.clipboard.writeText(oauthRedirectUri);
     setRedirectUriCopied(true);
-    toast.success("OAuth callback URL copied");
+    toast.success(
+      intl.formatMessage(tmsProviderCredentialPanelMessages.oauthCallbackUrlCopiedToast),
+    );
 
     if (redirectUriCopyTimeoutRef.current) {
       clearTimeout(redirectUriCopyTimeoutRef.current);
@@ -354,15 +381,23 @@ export function TmsProviderCredentialPanel({
     >
       {isOAuthProvider && isOAuthConnected ? (
         <div className="space-y-2 rounded-lg border border-border bg-muted/30 p-4 text-sm">
-          <p className="font-medium text-foreground">{providerName} is connected via OAuth</p>
+          <p className="font-medium text-foreground">
+            <FormattedMessage
+              {...tmsProviderCredentialPanelMessages.oauthConnectedTitle}
+              values={{ providerName }}
+            />
+          </p>
           <p className="leading-6 text-muted-foreground">
-            Each workspace member connects their own {providerName} account. Projects, jobs,
-            glossaries, and translation memories load live from {providerName} when you open those
-            pages.
+            <FormattedMessage
+              {...tmsProviderCredentialPanelMessages.oauthConnectedDescription}
+              values={{ providerName }}
+            />
           </p>
           {credential.oauthExpiresAt ? (
             <p className="text-xs text-muted-foreground">
-              Access token expires {new Date(credential.oauthExpiresAt).toLocaleString()}
+              {intl.formatMessage(tmsProviderCredentialPanelMessages.accessTokenExpires, {
+                expiresAt: new Date(credential.oauthExpiresAt).toLocaleString(),
+              })}
             </p>
           ) : null}
         </div>
@@ -370,20 +405,27 @@ export function TmsProviderCredentialPanel({
 
       {isPatConnected ? (
         <div className="space-y-2 rounded-lg border border-border bg-muted/30 p-4 text-sm">
-          <p className="font-medium text-foreground">{providerName} is ready for member tokens</p>
+          <p className="font-medium text-foreground">
+            <FormattedMessage
+              {...tmsProviderCredentialPanelMessages.patConnectedTitle}
+              values={{ providerName }}
+            />
+          </p>
           <p className="leading-6 text-muted-foreground">
-            The API base URL is saved for this workspace. Each member connects with their own
-            Crowdin personal access token—no OAuth app required.
+            <FormattedMessage {...tmsProviderCredentialPanelMessages.patConnectedDescription} />
           </p>
         </div>
       ) : null}
 
       {isCrowdin && onCrowdinAuthModeChange && crowdinAuthModeFieldId ? (
         <Field className="gap-2">
-          <FieldLabel htmlFor={crowdinAuthModeFieldId}>Authentication method</FieldLabel>
+          <FieldLabel htmlFor={crowdinAuthModeFieldId}>
+            {intl.formatMessage(tmsProviderCredentialPanelMessages.authenticationMethodLabel)}
+          </FieldLabel>
           <FieldDescription>
-            OAuth works when your Enterprise OAuth app is configured. Personal access tokens let
-            each member paste a token from Crowdin without OAuth setup.
+            <FormattedMessage
+              {...tmsProviderCredentialPanelMessages.authenticationMethodDescription}
+            />
           </FieldDescription>
           <Select
             value={crowdinAuthMode}
@@ -397,8 +439,12 @@ export function TmsProviderCredentialPanel({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value={OAUTH_AUTH_MODE}>OAuth app (recommended)</SelectItem>
-              <SelectItem value={PAT_AUTH_MODE}>Personal access token (per member)</SelectItem>
+              <SelectItem value={OAUTH_AUTH_MODE}>
+                {intl.formatMessage(tmsProviderCredentialPanelMessages.oauthAppRecommended)}
+              </SelectItem>
+              <SelectItem value={PAT_AUTH_MODE}>
+                {intl.formatMessage(tmsProviderCredentialPanelMessages.personalAccessTokenOption)}
+              </SelectItem>
             </SelectContent>
           </Select>
         </Field>
@@ -406,39 +452,49 @@ export function TmsProviderCredentialPanel({
 
       {isOAuthProvider && !isOAuthConnected ? (
         <p className="text-sm leading-6 text-muted-foreground">
-          {`Connect ${providerName} with an OAuth App. Each member links their own account before using ${providerName} data in Hyperlocalise.`}
+          <FormattedMessage
+            {...tmsProviderCredentialPanelMessages.connectOAuthIntro}
+            values={{ providerName }}
+          />
         </p>
       ) : isCrowdinPatMode && !isPatConnected ? (
         <p className="text-sm leading-6 text-muted-foreground">
-          Set the Crowdin API base URL once for this workspace. After you save, members connect by
-          pasting their own personal access token—nothing else to configure.
+          <FormattedMessage {...tmsProviderCredentialPanelMessages.crowdinPatIntro} />
         </p>
       ) : !isOAuthProvider ? (
         <p className="text-sm leading-6 text-muted-foreground">
-          Save credentials to connect {providerName}. The secret is encrypted at rest and used to
-          sync projects, files, and jobs into the workspace.
+          <FormattedMessage
+            {...tmsProviderCredentialPanelMessages.saveCredentialsIntro}
+            values={{ providerName }}
+          />
         </p>
       ) : null}
 
       <Field className="gap-2">
-        <FieldLabel htmlFor={displayNameFieldId}>Display name</FieldLabel>
+        <FieldLabel htmlFor={displayNameFieldId}>
+          {intl.formatMessage(tmsProviderCredentialPanelMessages.displayNameLabel)}
+        </FieldLabel>
         <Input
           id={displayNameFieldId}
           value={displayName}
           onChange={(event) => onDisplayNameChange(event.target.value)}
-          placeholder="e.g. Crowdin Production"
+          placeholder={intl.formatMessage(
+            tmsProviderCredentialPanelMessages.displayNamePlaceholder,
+          )}
         />
       </Field>
 
       {isCrowdinPatMode ? (
         <Field className="gap-2">
-          <FieldLabel htmlFor={baseUrlFieldId}>API base URL</FieldLabel>
-          <FieldDescription>{getTmsBaseUrlGuidance(providerKind)}</FieldDescription>
+          <FieldLabel htmlFor={baseUrlFieldId}>
+            {intl.formatMessage(tmsProviderCredentialPanelMessages.apiBaseUrlLabel)}
+          </FieldLabel>
+          <FieldDescription>{getTmsBaseUrlGuidance(intl, providerKind)}</FieldDescription>
           <Input
             id={baseUrlFieldId}
             value={baseUrl}
             onChange={(event) => onBaseUrlChange(event.target.value)}
-            placeholder={getTmsBaseUrlPlaceholder(providerKind)}
+            placeholder={getTmsBaseUrlPlaceholder(intl, providerKind)}
           />
         </Field>
       ) : null}
@@ -453,7 +509,7 @@ export function TmsProviderCredentialPanel({
                 size="sm"
                 className="h-8 w-full justify-between px-2 text-muted-foreground hover:text-foreground"
               >
-                Reconnect with a different OAuth app
+                {intl.formatMessage(tmsProviderCredentialPanelMessages.reconnectOAuthApp)}
                 <ChevronDownIcon
                   className={cn(
                     "size-3.5 shrink-0 transition-transform",
@@ -511,7 +567,9 @@ export function TmsProviderCredentialPanel({
 
       {showOrgApiTokenField ? (
         <Field className="gap-2">
-          <FieldLabel htmlFor={secretFieldId}>API token / secret</FieldLabel>
+          <FieldLabel htmlFor={secretFieldId}>
+            {intl.formatMessage(tmsProviderCredentialPanelMessages.apiTokenSecretLabel)}
+          </FieldLabel>
           <div className="relative">
             <HugeiconsIcon
               icon={Key01Icon}
@@ -524,14 +582,20 @@ export function TmsProviderCredentialPanel({
               autoComplete="off"
               value={secret}
               onChange={(event) => onSecretChange(event.target.value)}
-              placeholder="Enter provider API token"
+              placeholder={intl.formatMessage(
+                tmsProviderCredentialPanelMessages.apiTokenPlaceholder,
+              )}
               className="ps-9 pe-9"
             />
             <button
               type="button"
               onClick={onToggleShowSecret}
               className="absolute top-1/2 right-3 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
-              aria-label={showSecret ? "Hide secret" : "Show secret"}
+              aria-label={intl.formatMessage(
+                showSecret
+                  ? tmsProviderCredentialPanelMessages.hideSecretAriaLabel
+                  : tmsProviderCredentialPanelMessages.showSecretAriaLabel,
+              )}
             >
               {showSecret ? <EyeOffIcon size={16} /> : <EyeIcon size={16} />}
             </button>
@@ -549,7 +613,7 @@ export function TmsProviderCredentialPanel({
                 size="sm"
                 className="h-8 w-full justify-between px-2 text-muted-foreground hover:text-foreground"
               >
-                Advanced settings
+                {intl.formatMessage(tmsProviderCredentialPanelMessages.advancedSettings)}
                 <ChevronDownIcon
                   className={cn(
                     "size-3.5 shrink-0 transition-transform",
@@ -562,13 +626,15 @@ export function TmsProviderCredentialPanel({
           />
           <CollapsibleContent className="pt-1">
             <Field className="gap-2">
-              <FieldLabel htmlFor={baseUrlFieldId}>Base URL (optional)</FieldLabel>
-              <FieldDescription>{getTmsBaseUrlGuidance(providerKind)}</FieldDescription>
+              <FieldLabel htmlFor={baseUrlFieldId}>
+                {intl.formatMessage(tmsProviderCredentialPanelMessages.baseUrlOptionalLabel)}
+              </FieldLabel>
+              <FieldDescription>{getTmsBaseUrlGuidance(intl, providerKind)}</FieldDescription>
               <Input
                 id={baseUrlFieldId}
                 value={baseUrl}
                 onChange={(event) => onBaseUrlChange(event.target.value)}
-                placeholder={getTmsBaseUrlPlaceholder(providerKind)}
+                placeholder={getTmsBaseUrlPlaceholder(intl, providerKind)}
               />
             </Field>
           </CollapsibleContent>
@@ -579,7 +645,7 @@ export function TmsProviderCredentialPanel({
         {credential && userIsAdmin ? (
           <Button type="button" variant="outline" onClick={onDisconnect} disabled={isDisconnecting}>
             <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
-            Disconnect
+            {intl.formatMessage(tmsProviderCredentialPanelMessages.disconnect)}
           </Button>
         ) : (
           <div />
@@ -587,18 +653,28 @@ export function TmsProviderCredentialPanel({
         <Button type="submit" disabled={!canSubmit || isSaving} className="sm:ms-auto">
           <HugeiconsIcon icon={SaveIcon} strokeWidth={1.8} />
           {isSaving
-            ? "Saving..."
+            ? intl.formatMessage(tmsProviderCredentialPanelMessages.saving)
             : isCrowdinPatMode
               ? isPatConnected
-                ? `Save ${providerName} settings`
-                : `Enable ${providerName} tokens`
+                ? intl.formatMessage(tmsProviderCredentialPanelMessages.saveProviderSettings, {
+                    providerName,
+                  })
+                : intl.formatMessage(tmsProviderCredentialPanelMessages.enableProviderTokens, {
+                    providerName,
+                  })
               : isOAuthProvider
                 ? isOAuthConnected && !oauthReconnectOpen
-                  ? `Save ${providerName} settings`
+                  ? intl.formatMessage(tmsProviderCredentialPanelMessages.saveProviderSettings, {
+                      providerName,
+                    })
                   : isOAuthConnected
-                    ? `Update ${providerName}`
-                    : `Save ${providerName}`
-                : "Save provider"}
+                    ? intl.formatMessage(tmsProviderCredentialPanelMessages.updateProvider, {
+                        providerName,
+                      })
+                    : intl.formatMessage(tmsProviderCredentialPanelMessages.saveProvider, {
+                        providerName,
+                      })
+                : intl.formatMessage(tmsProviderCredentialPanelMessages.saveProviderGeneric)}
         </Button>
       </div>
     </form>


### PR DESCRIPTION
## What changed

Localised hardcoded user-facing copy in the integrations `_components` folder using react-intl with colocated `defineMessages` modules.

Coverage includes:
- Shared integration row actions and section labels
- Agent integrations (GitHub, Slack, Email, coming-soon rows)
- TMS/CMS provider panels (Crowdin, Phrase, Lokalise, Contentful)
- Model provider cards and configure/disconnect dialogs
- Repository automation settings panel and sheet action
- View-model validation/error strings for GitHub repository automation

Also updates `workspace-automation-form.tsx` to use the localised weekday labels and the new `addBranchPattern(intl, …)` signature.

## How to test

- [ ] Open **Org → Integrations** and verify labels, buttons, toasts, and dialogs render correctly
- [ ] Connect/manage flows for GitHub, Slack, Email, TMS, Contentful, and model providers still work
- [ ] Expand repository automation settings from a GitHub repo row and save/reset settings
- [ ] Run `cd apps/hyperlocalise-web && vp check`
- [ ] Run `cd apps/hyperlocalise-web && vp test src/app/[lang]/\(authenticated\)/org/[organizationSlug]/integrations/_components/`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)