### PR TITLE
feat(api): support TMS source file uploads via public files API

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/public-files/public-files.fixture.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-files/public-files.fixture.ts
@@ -3,6 +3,11 @@ import { createHash, randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
+import type { ExternalTmsProviderKind } from "@/lib/providers/contracts/external-tms-provider-kind";
+import {
+  encryptProviderCredential,
+  unwrapProviderCredentialCrypto,
+} from "@/lib/security/provider-credential-crypto";
 
 import { createMemoryFileStorageAdapter } from "../file/file.fixture";
 
@@ -69,6 +74,47 @@ export async function createPublicApiFixture() {
   });
 
   return { apiKey, project };
+}
+
+export async function createExternalTmsPublicApiFixture(
+  providerKind: ExternalTmsProviderKind = "phrase",
+) {
+  const fixture = await createPublicApiFixture();
+  const encrypted = unwrapProviderCredentialCrypto(encryptProviderCredential("provider-token"));
+  const [credential] = await db
+    .insert(schema.organizationExternalTmsProviderCredentials)
+    .values({
+      organizationId: fixture.project.organizationId,
+      createdByUserId: fixture.project.createdByUserId,
+      providerKind,
+      displayName: `${providerKind} test credential`,
+      authMode: "api_token",
+      encryptionAlgorithm: encrypted.algorithm,
+      ciphertext: encrypted.ciphertext,
+      iv: encrypted.iv,
+      authTag: encrypted.authTag,
+      keyVersion: encrypted.keyVersion,
+      maskedSecretSuffix: "token",
+    })
+    .returning();
+
+  const externalProjectId = "external-project-1";
+  const externalProjectCanonicalId = `ext:${providerKind}:${externalProjectId}`;
+  const [project] = await db
+    .update(schema.projects)
+    .set({
+      id: externalProjectCanonicalId,
+      source: "external_tms",
+      externalProviderKind: providerKind,
+      externalProviderCredentialId: credential.id,
+      externalProjectId,
+      sourceLocale: "en",
+      targetLocales: ["fr"],
+    })
+    .where(eq(schema.projects.id, fixture.project.id))
+    .returning();
+
+  return { ...fixture, project, credential, externalProjectId };
 }
 
 export async function cleanupPublicApiFixture() {

--- a/apps/hyperlocalise-web/src/api/routes/public-files/public-files.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-files/public-files.route.test.ts
@@ -16,11 +16,16 @@ import {
 
 const uploadSourceFileMock = vi.hoisted(() => vi.fn());
 
-vi.mock("@/lib/providers/adapters/tms-provider-adapter-registry", () => ({
-  getTmsProviderAdapter: () => ({
-    uploadSourceFile: uploadSourceFileMock,
-  }),
-}));
+vi.mock("@/lib/providers/adapters/tms-provider-adapter-registry", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/providers/adapters/tms-provider-adapter-registry")>();
+  return {
+    ...actual,
+    getTmsProviderAdapter: () => ({
+      uploadSourceFile: uploadSourceFileMock,
+    }),
+  };
+});
 
 const fileStorageAdapter = createMemoryFileStorageAdapter();
 const client = testClient(createApp({ fileStorageAdapter }));
@@ -69,7 +74,8 @@ describe("publicFileRoutes", () => {
   });
 
   it("uploads a source file to an external TMS project through the provider adapter", async () => {
-    const { apiKey, project, externalProjectId } = await createExternalTmsPublicApiFixture("phrase");
+    const { apiKey, project, externalProjectId } =
+      await createExternalTmsPublicApiFixture("phrase");
     uploadSourceFileMock.mockResolvedValue({
       sourcePath: "content/en/home.json",
       externalResourceId: "upload_1",

--- a/apps/hyperlocalise-web/src/api/routes/public-files/public-files.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-files/public-files.route.test.ts
@@ -2,16 +2,25 @@ import "dotenv/config";
 
 import { and, eq } from "drizzle-orm";
 import { testClient } from "hono/testing";
-import { afterEach, beforeAll, describe, expect, it } from "vite-plus/test";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
 import { createApp } from "@/api/app";
 import { db, schema } from "@/lib/database";
 
 import {
   createMemoryFileStorageAdapter,
+  createExternalTmsPublicApiFixture,
   createPublicApiFixture,
   cleanupPublicApiFixture,
 } from "./public-files.fixture";
+
+const uploadSourceFileMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/providers/adapters/tms-provider-adapter-registry", () => ({
+  getTmsProviderAdapter: () => ({
+    uploadSourceFile: uploadSourceFileMock,
+  }),
+}));
 
 const fileStorageAdapter = createMemoryFileStorageAdapter();
 const client = testClient(createApp({ fileStorageAdapter }));
@@ -21,6 +30,7 @@ beforeAll(async () => {
 });
 
 afterEach(async () => {
+  uploadSourceFileMock.mockReset();
   await cleanupPublicApiFixture();
 });
 
@@ -46,12 +56,82 @@ describe("publicFileRoutes", () => {
     );
 
     expect(uploadResponse.status).toBe(201);
+    const uploadBody = (await uploadResponse.json()) as {
+      file: { destination: "native" };
+    };
+    expect(uploadBody.file.destination).toBe("native");
     const [storedFile] = await db
       .select({ projectId: schema.storedFiles.projectId })
       .from(schema.storedFiles)
       .where(eq(schema.storedFiles.projectId, projectId))
       .limit(1);
     expect(storedFile?.projectId).toBe(projectId);
+  });
+
+  it("uploads a source file to an external TMS project through the provider adapter", async () => {
+    const { apiKey, project, externalProjectId } = await createExternalTmsPublicApiFixture("phrase");
+    uploadSourceFileMock.mockResolvedValue({
+      sourcePath: "content/en/home.json",
+      externalResourceId: "upload_1",
+      revision: "rev_1",
+      asyncOperation: null,
+      providerPayload: { state: "success" },
+    });
+
+    const uploadResponse = await client.api.v1.files.$post(
+      {
+        form: {
+          projectId: project.id,
+          sourcePath: "content/en/home.json",
+          sourceLocale: "en",
+          format: "json",
+          branch: "main",
+          file: new File([`{"hello":"Hello"}`], "home.json", { type: "application/json" }),
+        },
+      },
+      { headers: { "x-api-key": apiKey } },
+    );
+
+    expect(uploadResponse.status).toBe(201);
+    await expect(uploadResponse.json()).resolves.toEqual({
+      file: {
+        id: "upload_1",
+        destination: "external_tms",
+        sourcePath: "content/en/home.json",
+        providerKind: "phrase",
+        externalProjectId,
+        externalResourceId: "upload_1",
+        revision: "rev_1",
+        asyncOperation: null,
+        providerPayload: { state: "success" },
+      },
+    });
+
+    expect(uploadSourceFileMock).toHaveBeenCalledTimes(1);
+    const adapterInput = uploadSourceFileMock.mock.calls[0]?.[0];
+    expect(adapterInput).toEqual(
+      expect.objectContaining({
+        organizationId: project.organizationId,
+        projectId: project.id,
+        externalProjectId,
+        secretMaterial: "provider-token",
+        file: expect.objectContaining({
+          sourcePath: "content/en/home.json",
+          filename: "home.json",
+          contentType: "application/json",
+          sourceLocale: "en",
+          format: "json",
+          branch: "main",
+        }),
+      }),
+    );
+    expect(Buffer.from(adapterInput.file.content).toString("utf8")).toBe(`{"hello":"Hello"}`);
+
+    const storedFiles = await db
+      .select({ id: schema.storedFiles.id })
+      .from(schema.storedFiles)
+      .where(eq(schema.storedFiles.projectId, project.id));
+    expect(storedFiles).toHaveLength(0);
   });
 
   it("uploads and downloads a repository source file with an API key", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/public-files/public-files.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-files/public-files.route.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
 import { createApp } from "@/api/app";
 import { db, schema } from "@/lib/database";
+import { err, ok } from "@/lib/primitives/result/results";
 
 import {
   createMemoryFileStorageAdapter,
@@ -76,13 +77,15 @@ describe("publicFileRoutes", () => {
   it("uploads a source file to an external TMS project through the provider adapter", async () => {
     const { apiKey, project, externalProjectId } =
       await createExternalTmsPublicApiFixture("phrase");
-    uploadSourceFileMock.mockResolvedValue({
-      sourcePath: "content/en/home.json",
-      externalResourceId: "upload_1",
-      revision: "rev_1",
-      asyncOperation: null,
-      providerPayload: { state: "success" },
-    });
+    uploadSourceFileMock.mockResolvedValue(
+      ok({
+        sourcePath: "content/en/home.json",
+        externalResourceId: "upload_1",
+        revision: "rev_1",
+        asyncOperation: null,
+        providerPayload: { state: "success" },
+      }),
+    );
 
     const uploadResponse = await client.api.v1.files.$post(
       {
@@ -138,6 +141,29 @@ describe("publicFileRoutes", () => {
       .from(schema.storedFiles)
       .where(eq(schema.storedFiles.projectId, project.id));
     expect(storedFiles).toHaveLength(0);
+  });
+
+  it("maps typed provider upload errors without matching error messages", async () => {
+    const { apiKey, project } = await createExternalTmsPublicApiFixture("phrase");
+    uploadSourceFileMock.mockResolvedValue(err({ code: "phrase_source_locale_not_found" }));
+
+    const response = await client.api.v1.files.$post(
+      {
+        form: {
+          projectId: project.id,
+          sourcePath: "content/en/home.json",
+          branch: "missing",
+          file: new File([`{"hello":"Hello"}`], "home.json", { type: "application/json" }),
+        },
+      },
+      { headers: { "x-api-key": apiKey } },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_file_payload",
+      message: "phrase_source_locale_not_found",
+    });
   });
 
   it("uploads and downloads a repository source file with an API key", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/public-files/public-files.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-files/public-files.route.ts
@@ -11,12 +11,10 @@ import {
 import { canAccessStoredFile } from "@/api/auth/team-access";
 import { db, schema } from "@/lib/database";
 import { getFileStorageAdapter, type FileStorageAdapter } from "@/lib/file-storage";
-import { createRepositorySourceFileVersion, createStoredFile } from "@/lib/file-storage/records";
-import { enqueueSourceFileIngestAfterUpload } from "@/lib/projects/files/source-file-ingest";
-import { createLogger } from "@/lib/log";
+import { uploadSourceFile } from "@/lib/projects/files/source-file-upload-service";
 import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
 
-import { payloadTooLargeResponse } from "@/api/response.schema";
+import { badRequestResponse, payloadTooLargeResponse } from "@/api/response.schema";
 
 import { uploadBodySchema, fileParamsSchema, maxPublicUploadBytes } from "./public-files.schema";
 import {
@@ -25,8 +23,6 @@ import {
   fileNotFoundResponse,
   unsupportedFileResponse,
 } from "./public-files.shared";
-
-const logger = createLogger("public-files");
 
 function asString(value: unknown) {
   return typeof value === "string" ? value : undefined;
@@ -40,6 +36,33 @@ function asFile(value: unknown) {
 type CreatePublicFileRoutesOptions = {
   fileStorageAdapter?: FileStorageAdapter;
 };
+
+function sourceUploadErrorResponse(c: Parameters<typeof badRequestResponse>[0], error: unknown) {
+  const code = error instanceof Error ? error.message : "source_upload_failed";
+  switch (code) {
+    case "external_tms_project_not_found":
+      return projectNotFoundResponse(c);
+    case "provider_credential_not_found":
+      return badRequestResponse(c, "provider_credential_not_found");
+    case "crowdin_branch_not_found":
+    case "phrase_source_locale_not_found":
+    case "phrase_source_file_format_required":
+    case "lokalise_source_locale_required":
+    case "lokalise_source_file_format_required":
+    case "smartling_source_file_type_required":
+      return badRequestResponse(c, "invalid_file_payload", code);
+    case "source_upload_unsupported":
+      return badRequestResponse(c, "source_upload_unsupported");
+    default:
+      return c.json(
+        {
+          error: "source_upload_failed",
+          message: "External TMS source upload failed.",
+        },
+        502,
+      );
+  }
+}
 
 export function createPublicFileRoutes(options: CreatePublicFileRoutesOptions = {}) {
   return new Hono<{ Variables: ApiKeyAuthVariables }>()
@@ -59,6 +82,9 @@ export function createPublicFileRoutes(options: CreatePublicFileRoutesOptions = 
           sourceHash: asString(body.sourceHash),
           commitSha: asString(body.commitSha),
           workflowRunId: asString(body.workflowRunId),
+          sourceLocale: asString(body.sourceLocale),
+          format: asString(body.format),
+          branch: asString(body.branch),
         });
 
         if (!parsed.success) {
@@ -70,8 +96,8 @@ export function createPublicFileRoutes(options: CreatePublicFileRoutesOptions = 
           return invalidFilePayloadResponse(c);
         }
 
-        if (!inferSupportedFileTranslationFileFormat(file.name)) {
-          return unsupportedFileResponse(c, file.name);
+        if (!inferSupportedFileTranslationFileFormat(parsed.data.sourcePath)) {
+          return unsupportedFileResponse(c, parsed.data.sourcePath);
         }
 
         const organizationId = c.var.auth.organization.localOrganizationId;
@@ -84,81 +110,41 @@ export function createPublicFileRoutes(options: CreatePublicFileRoutesOptions = 
           return projectNotFoundResponse(c);
         }
 
-        const adapter = options.fileStorageAdapter ?? getFileStorageAdapter();
-        let uploadedFile: typeof schema.storedFiles.$inferSelect | null = null;
-
-        const { storedFile, version } = await db
-          .transaction(async (tx) => {
-            uploadedFile = await createStoredFile({
-              organizationId,
-              projectId: project.id,
-              role: "source",
-              sourceKind: "repository_file",
+        try {
+          const content = new Uint8Array(await file.arrayBuffer());
+          const result = await uploadSourceFile({
+            organizationId,
+            project,
+            file: {
               filename: file.name,
               contentType: file.type || "application/octet-stream",
-              content: await file.arrayBuffer(),
-              metadata: {
-                sourcePath: parsed.data.sourcePath,
-                sourceHash: parsed.data.sourceHash,
-                commitSha: parsed.data.commitSha,
-                workflowRunId: parsed.data.workflowRunId,
-                uploadSurface: "public_api",
-              },
-              adapter,
-              db: tx,
-            });
-
-            const version = await createRepositorySourceFileVersion({
-              storedFile: uploadedFile,
-              sourcePath: parsed.data.sourcePath,
-              sourceHash: parsed.data.sourceHash,
-              commitSha: parsed.data.commitSha,
-              workflowRunId: parsed.data.workflowRunId,
-              uploadedByApiKeyId: c.var.auth.apiKey.id,
-              uploadSurface: "public_api",
-              db: tx,
-            });
-
-            return { storedFile: uploadedFile, version };
-          })
-          .catch(async (error) => {
-            if (uploadedFile) {
-              await adapter.delete({ keyOrUrl: uploadedFile.storageKey }).catch(() => {});
-            }
-            throw error;
+              content,
+            },
+            sourcePath: parsed.data.sourcePath,
+            sourceHash: parsed.data.sourceHash,
+            commitSha: parsed.data.commitSha,
+            workflowRunId: parsed.data.workflowRunId,
+            sourceLocale: parsed.data.sourceLocale,
+            format: parsed.data.format,
+            branch: parsed.data.branch,
+            uploadSurface: "public_api",
+            uploadedByApiKeyId: c.var.auth.apiKey.id,
+            actorUserId: c.var.auth.teamAccess.user.localUserId,
+            fileStorageAdapter: options.fileStorageAdapter,
           });
 
-        void enqueueSourceFileIngestAfterUpload({
-          organizationId,
-          projectId: project.id,
-          storedFileId: storedFile.id,
-          sourceFileVersionId: version.id,
-          sourcePath: parsed.data.sourcePath,
-          sourceHash: parsed.data.sourceHash ?? storedFile.sha256,
-        }).catch((error) => {
-          logger.warn(
+          return c.json(
             {
-              projectId: project.id,
-              sourceFileVersionId: version.id,
-              error: error instanceof Error ? error.message : String(error),
+              file: {
+                ...result.file,
+                destination: result.destination,
+              },
             },
-            "public-files source ingest enqueue failed",
+            201,
           );
-        });
-
-        return c.json(
-          {
-            file: {
-              id: storedFile.id,
-              sourceFileVersionId: version.id,
-              filename: storedFile.filename,
-              contentType: storedFile.contentType,
-              byteSize: storedFile.byteSize,
-              sha256: storedFile.sha256,
-            },
-          },
-          201,
-        );
+        } catch (error) {
+          return sourceUploadErrorResponse(c, error);
+        }
       },
     )
     .get("/:fileId/download", requireApiKeyPermission("files:read"), async (c) => {

--- a/apps/hyperlocalise-web/src/api/routes/public-files/public-files.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-files/public-files.route.ts
@@ -11,7 +11,11 @@ import {
 import { canAccessStoredFile } from "@/api/auth/team-access";
 import { db, schema } from "@/lib/database";
 import { getFileStorageAdapter, type FileStorageAdapter } from "@/lib/file-storage";
-import { uploadSourceFile } from "@/lib/projects/files/source-file-upload-service";
+import {
+  uploadSourceFile,
+  type SourceFileUploadError,
+} from "@/lib/projects/files/source-file-upload-service";
+import { isErr } from "@/lib/primitives/result/results";
 import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
 
 import { badRequestResponse, payloadTooLargeResponse } from "@/api/response.schema";
@@ -37,23 +41,24 @@ type CreatePublicFileRoutesOptions = {
   fileStorageAdapter?: FileStorageAdapter;
 };
 
-function sourceUploadErrorResponse(c: Parameters<typeof badRequestResponse>[0], error: unknown) {
-  const code = error instanceof Error ? error.message : "source_upload_failed";
-  switch (code) {
+function sourceUploadErrorResponse(
+  c: Parameters<typeof badRequestResponse>[0],
+  error: SourceFileUploadError,
+) {
+  switch (error.code) {
     case "external_tms_project_not_found":
       return projectNotFoundResponse(c);
     case "provider_credential_not_found":
       return badRequestResponse(c, "provider_credential_not_found");
+    case "invalid_crowdin_project_id":
     case "crowdin_branch_not_found":
     case "phrase_source_locale_not_found":
     case "phrase_source_file_format_required":
     case "lokalise_source_locale_required":
     case "lokalise_source_file_format_required":
     case "smartling_source_file_type_required":
-      return badRequestResponse(c, "invalid_file_payload", code);
-    case "source_upload_unsupported":
-      return badRequestResponse(c, "source_upload_unsupported");
-    default:
+      return badRequestResponse(c, "invalid_file_payload", error.code);
+    case "source_upload_failed":
       return c.json(
         {
           error: "source_upload_failed",
@@ -110,41 +115,40 @@ export function createPublicFileRoutes(options: CreatePublicFileRoutesOptions = 
           return projectNotFoundResponse(c);
         }
 
-        try {
-          const content = new Uint8Array(await file.arrayBuffer());
-          const result = await uploadSourceFile({
-            organizationId,
-            project,
-            file: {
-              filename: file.name,
-              contentType: file.type || "application/octet-stream",
-              content,
-            },
-            sourcePath: parsed.data.sourcePath,
-            sourceHash: parsed.data.sourceHash,
-            commitSha: parsed.data.commitSha,
-            workflowRunId: parsed.data.workflowRunId,
-            sourceLocale: parsed.data.sourceLocale,
-            format: parsed.data.format,
-            branch: parsed.data.branch,
-            uploadSurface: "public_api",
-            uploadedByApiKeyId: c.var.auth.apiKey.id,
-            actorUserId: c.var.auth.teamAccess.user.localUserId,
-            fileStorageAdapter: options.fileStorageAdapter,
-          });
-
-          return c.json(
-            {
-              file: {
-                ...result.file,
-                destination: result.destination,
-              },
-            },
-            201,
-          );
-        } catch (error) {
-          return sourceUploadErrorResponse(c, error);
+        const content = new Uint8Array(await file.arrayBuffer());
+        const result = await uploadSourceFile({
+          organizationId,
+          project,
+          file: {
+            filename: file.name,
+            contentType: file.type || "application/octet-stream",
+            content,
+          },
+          sourcePath: parsed.data.sourcePath,
+          sourceHash: parsed.data.sourceHash,
+          commitSha: parsed.data.commitSha,
+          workflowRunId: parsed.data.workflowRunId,
+          sourceLocale: parsed.data.sourceLocale,
+          format: parsed.data.format,
+          branch: parsed.data.branch,
+          uploadSurface: "public_api",
+          uploadedByApiKeyId: c.var.auth.apiKey.id,
+          actorUserId: c.var.auth.teamAccess.user.localUserId,
+          fileStorageAdapter: options.fileStorageAdapter,
+        });
+        if (isErr(result)) {
+          return sourceUploadErrorResponse(c, result.error);
         }
+
+        return c.json(
+          {
+            file: {
+              ...result.value.file,
+              destination: result.value.destination,
+            },
+          },
+          201,
+        );
       },
     )
     .get("/:fileId/download", requireApiKeyPermission("files:read"), async (c) => {

--- a/apps/hyperlocalise-web/src/api/routes/public-files/public-files.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-files/public-files.schema.ts
@@ -10,6 +10,9 @@ export const uploadBodySchema = z.object({
   sourceHash: z.string().trim().min(1).max(256).optional(),
   commitSha: z.string().trim().min(1).max(256).optional(),
   workflowRunId: z.string().trim().min(1).max(256).optional(),
+  sourceLocale: z.string().trim().min(1).max(32).optional(),
+  format: z.string().trim().min(1).max(64).optional(),
+  branch: z.string().trim().min(1).max(256).optional(),
 });
 
 export const fileParamsSchema = z.object({

--- a/apps/hyperlocalise-web/src/lib/projects/files/source-file-upload-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/files/source-file-upload-service.ts
@@ -4,12 +4,17 @@ import { db, schema } from "@/lib/database";
 import type { FileStorageAdapter } from "@/lib/file-storage";
 import { getFileStorageAdapter } from "@/lib/file-storage";
 import { createRepositorySourceFileVersion, createStoredFile } from "@/lib/file-storage/records";
+import { createLogger } from "@/lib/log";
 import { getTmsProviderAdapter } from "@/lib/providers/adapters/tms-provider-adapter-registry";
 import type { ExternalTmsProviderKind } from "@/lib/providers/contracts/external-tms-provider-kind";
+import type { ExternalTmsSourceFileUploadError } from "@/lib/providers/tms-provider-types";
 import { resolveExternalTmsSecretMaterialForActor } from "@/lib/providers/tms-provider-content";
+import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 import { enqueueSourceFileIngestAfterUpload } from "./source-file-ingest";
 
 type ProjectRecord = typeof schema.projects.$inferSelect;
+
+const logger = createLogger("source-file-upload-service");
 
 export type SourceFileUploadInput = {
   organizationId: string;
@@ -63,14 +68,20 @@ export type SourceFileUploadResult =
   | NativeSourceFileUploadResult
   | ExternalTmsSourceFileUploadResult;
 
+export type SourceFileUploadError =
+  | { code: "external_tms_project_not_found" }
+  | { code: "provider_credential_not_found" }
+  | { code: "source_upload_failed" }
+  | ExternalTmsSourceFileUploadError;
+
 export async function uploadSourceFile(
   input: SourceFileUploadInput,
-): Promise<SourceFileUploadResult> {
+): Promise<Result<SourceFileUploadResult, SourceFileUploadError>> {
   if (input.project.source === "external_tms") {
     return uploadExternalTmsSourceFile(input);
   }
 
-  return uploadNativeSourceFile(input);
+  return ok(await uploadNativeSourceFile(input));
 }
 
 async function uploadNativeSourceFile(
@@ -129,7 +140,16 @@ async function uploadNativeSourceFile(
     sourceFileVersionId: version.id,
     sourcePath: input.sourcePath,
     sourceHash: input.sourceHash ?? storedFile.sha256,
-  }).catch(() => {});
+  }).catch((error) => {
+    logger.warn(
+      {
+        projectId: input.project.id,
+        sourceFileVersionId: version.id,
+        error: error instanceof Error ? error.message : "unknown",
+      },
+      "source-file-upload source ingest enqueue failed",
+    );
+  });
 
   return {
     destination: "native",
@@ -146,14 +166,14 @@ async function uploadNativeSourceFile(
 
 async function uploadExternalTmsSourceFile(
   input: SourceFileUploadInput,
-): Promise<ExternalTmsSourceFileUploadResult> {
+): Promise<Result<ExternalTmsSourceFileUploadResult, SourceFileUploadError>> {
   const providerKind = input.project.externalProviderKind as ExternalTmsProviderKind | null;
   const externalProjectId = input.project.externalProjectId?.trim();
   if (!providerKind || !externalProjectId) {
-    throw new Error("external_tms_project_not_found");
+    return err({ code: "external_tms_project_not_found" });
   }
   if (!input.project.externalProviderCredentialId) {
-    throw new Error("provider_credential_not_found");
+    return err({ code: "provider_credential_not_found" });
   }
 
   const [credential] = await db
@@ -172,44 +192,61 @@ async function uploadExternalTmsSourceFile(
     .limit(1);
 
   if (!credential) {
-    throw new Error("provider_credential_not_found");
+    return err({ code: "provider_credential_not_found" });
   }
 
-  const secretMaterial = await resolveExternalTmsSecretMaterialForActor({
-    credential,
-    organizationId: input.organizationId,
-    actorUserId: input.actorUserId,
-  });
-  const providerResult = await getTmsProviderAdapter(providerKind).uploadSourceFile({
-    organizationId: input.organizationId,
-    projectId: input.project.id,
-    externalProjectId,
-    credential,
-    project: input.project,
-    secretMaterial,
-    file: {
-      sourcePath: input.sourcePath,
-      filename: input.file.filename,
-      contentType: input.file.contentType,
-      content: input.file.content,
-      sourceHash: input.sourceHash ?? null,
-      sourceLocale: input.sourceLocale ?? input.project.sourceLocale ?? null,
-      format: input.format ?? null,
-      branch: input.branch ?? null,
-    },
-  });
+  let providerResult;
+  try {
+    const secretMaterial = await resolveExternalTmsSecretMaterialForActor({
+      credential,
+      organizationId: input.organizationId,
+      actorUserId: input.actorUserId,
+    });
+    providerResult = await getTmsProviderAdapter(providerKind).uploadSourceFile({
+      organizationId: input.organizationId,
+      projectId: input.project.id,
+      externalProjectId,
+      credential,
+      project: input.project,
+      secretMaterial,
+      file: {
+        sourcePath: input.sourcePath,
+        filename: input.file.filename,
+        contentType: input.file.contentType,
+        content: input.file.content,
+        sourceHash: input.sourceHash ?? null,
+        sourceLocale: input.sourceLocale ?? input.project.sourceLocale ?? null,
+        format: input.format ?? null,
+        branch: input.branch ?? null,
+      },
+    });
+  } catch (error) {
+    logger.warn(
+      {
+        projectId: input.project.id,
+        providerKind,
+        error: error instanceof Error ? error.message : "unknown",
+      },
+      "external TMS source upload failed",
+    );
+    return err({ code: "source_upload_failed" });
+  }
 
-  return {
+  if (isErr(providerResult)) {
+    return providerResult;
+  }
+
+  return ok({
     destination: "external_tms",
     file: {
-      id: providerResult.externalResourceId ?? null,
-      sourcePath: providerResult.sourcePath,
+      id: providerResult.value.externalResourceId ?? null,
+      sourcePath: providerResult.value.sourcePath,
       providerKind,
       externalProjectId,
-      externalResourceId: providerResult.externalResourceId ?? null,
-      revision: providerResult.revision ?? null,
-      asyncOperation: providerResult.asyncOperation ?? null,
-      providerPayload: providerResult.providerPayload ?? {},
+      externalResourceId: providerResult.value.externalResourceId ?? null,
+      revision: providerResult.value.revision ?? null,
+      asyncOperation: providerResult.value.asyncOperation ?? null,
+      providerPayload: providerResult.value.providerPayload ?? {},
     },
-  };
+  });
 }

--- a/apps/hyperlocalise-web/src/lib/projects/files/source-file-upload-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/files/source-file-upload-service.ts
@@ -63,7 +63,9 @@ export type SourceFileUploadResult =
   | NativeSourceFileUploadResult
   | ExternalTmsSourceFileUploadResult;
 
-export async function uploadSourceFile(input: SourceFileUploadInput): Promise<SourceFileUploadResult> {
+export async function uploadSourceFile(
+  input: SourceFileUploadInput,
+): Promise<SourceFileUploadResult> {
   if (input.project.source === "external_tms") {
     return uploadExternalTmsSourceFile(input);
   }
@@ -159,7 +161,10 @@ async function uploadExternalTmsSourceFile(
     .from(schema.organizationExternalTmsProviderCredentials)
     .where(
       and(
-        eq(schema.organizationExternalTmsProviderCredentials.id, input.project.externalProviderCredentialId),
+        eq(
+          schema.organizationExternalTmsProviderCredentials.id,
+          input.project.externalProviderCredentialId,
+        ),
         eq(schema.organizationExternalTmsProviderCredentials.organizationId, input.organizationId),
         eq(schema.organizationExternalTmsProviderCredentials.providerKind, providerKind),
       ),

--- a/apps/hyperlocalise-web/src/lib/projects/files/source-file-upload-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/files/source-file-upload-service.ts
@@ -1,0 +1,210 @@
+import { and, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import type { FileStorageAdapter } from "@/lib/file-storage";
+import { getFileStorageAdapter } from "@/lib/file-storage";
+import { createRepositorySourceFileVersion, createStoredFile } from "@/lib/file-storage/records";
+import { getTmsProviderAdapter } from "@/lib/providers/adapters/tms-provider-adapter-registry";
+import type { ExternalTmsProviderKind } from "@/lib/providers/contracts/external-tms-provider-kind";
+import { resolveExternalTmsSecretMaterialForActor } from "@/lib/providers/tms-provider-content";
+import { enqueueSourceFileIngestAfterUpload } from "./source-file-ingest";
+
+type ProjectRecord = typeof schema.projects.$inferSelect;
+
+export type SourceFileUploadInput = {
+  organizationId: string;
+  project: ProjectRecord;
+  file: {
+    filename: string;
+    contentType: string;
+    content: Uint8Array;
+  };
+  sourcePath: string;
+  sourceHash?: string | null;
+  commitSha?: string | null;
+  workflowRunId?: string | null;
+  sourceLocale?: string | null;
+  format?: string | null;
+  branch?: string | null;
+  uploadSurface: string;
+  uploadedByApiKeyId?: string | null;
+  uploadedByUserId?: string | null;
+  actorUserId?: string | null;
+  fileStorageAdapter?: FileStorageAdapter;
+};
+
+export type NativeSourceFileUploadResult = {
+  destination: "native";
+  file: {
+    id: string;
+    sourceFileVersionId: string;
+    filename: string;
+    contentType: string;
+    byteSize: number;
+    sha256: string;
+  };
+};
+
+export type ExternalTmsSourceFileUploadResult = {
+  destination: "external_tms";
+  file: {
+    id: string | null;
+    sourcePath: string;
+    providerKind: ExternalTmsProviderKind;
+    externalProjectId: string;
+    externalResourceId: string | null;
+    revision: string | null;
+    asyncOperation: Record<string, unknown> | null;
+    providerPayload: Record<string, unknown>;
+  };
+};
+
+export type SourceFileUploadResult =
+  | NativeSourceFileUploadResult
+  | ExternalTmsSourceFileUploadResult;
+
+export async function uploadSourceFile(input: SourceFileUploadInput): Promise<SourceFileUploadResult> {
+  if (input.project.source === "external_tms") {
+    return uploadExternalTmsSourceFile(input);
+  }
+
+  return uploadNativeSourceFile(input);
+}
+
+async function uploadNativeSourceFile(
+  input: SourceFileUploadInput,
+): Promise<NativeSourceFileUploadResult> {
+  const adapter = input.fileStorageAdapter ?? getFileStorageAdapter();
+  let uploadedFile: typeof schema.storedFiles.$inferSelect | null = null;
+
+  const { storedFile, version } = await db
+    .transaction(async (tx) => {
+      uploadedFile = await createStoredFile({
+        organizationId: input.organizationId,
+        projectId: input.project.id,
+        createdByUserId: input.uploadedByUserId ?? undefined,
+        role: "source",
+        sourceKind: "repository_file",
+        filename: input.file.filename,
+        contentType: input.file.contentType,
+        content: input.file.content,
+        metadata: {
+          sourcePath: input.sourcePath,
+          sourceHash: input.sourceHash ?? null,
+          commitSha: input.commitSha ?? null,
+          workflowRunId: input.workflowRunId ?? null,
+          uploadSurface: input.uploadSurface,
+        },
+        adapter,
+        db: tx,
+      });
+
+      const version = await createRepositorySourceFileVersion({
+        storedFile: uploadedFile,
+        sourcePath: input.sourcePath,
+        sourceHash: input.sourceHash ?? undefined,
+        commitSha: input.commitSha ?? undefined,
+        workflowRunId: input.workflowRunId ?? undefined,
+        uploadedByApiKeyId: input.uploadedByApiKeyId ?? undefined,
+        uploadedByUserId: input.uploadedByUserId ?? undefined,
+        uploadSurface: input.uploadSurface,
+        db: tx,
+      });
+
+      return { storedFile: uploadedFile, version };
+    })
+    .catch(async (error) => {
+      if (uploadedFile) {
+        await adapter.delete({ keyOrUrl: uploadedFile.storageKey }).catch(() => {});
+      }
+      throw error;
+    });
+
+  void enqueueSourceFileIngestAfterUpload({
+    organizationId: input.organizationId,
+    projectId: input.project.id,
+    storedFileId: storedFile.id,
+    sourceFileVersionId: version.id,
+    sourcePath: input.sourcePath,
+    sourceHash: input.sourceHash ?? storedFile.sha256,
+  }).catch(() => {});
+
+  return {
+    destination: "native",
+    file: {
+      id: storedFile.id,
+      sourceFileVersionId: version.id,
+      filename: storedFile.filename,
+      contentType: storedFile.contentType,
+      byteSize: storedFile.byteSize,
+      sha256: storedFile.sha256,
+    },
+  };
+}
+
+async function uploadExternalTmsSourceFile(
+  input: SourceFileUploadInput,
+): Promise<ExternalTmsSourceFileUploadResult> {
+  const providerKind = input.project.externalProviderKind as ExternalTmsProviderKind | null;
+  const externalProjectId = input.project.externalProjectId?.trim();
+  if (!providerKind || !externalProjectId) {
+    throw new Error("external_tms_project_not_found");
+  }
+  if (!input.project.externalProviderCredentialId) {
+    throw new Error("provider_credential_not_found");
+  }
+
+  const [credential] = await db
+    .select()
+    .from(schema.organizationExternalTmsProviderCredentials)
+    .where(
+      and(
+        eq(schema.organizationExternalTmsProviderCredentials.id, input.project.externalProviderCredentialId),
+        eq(schema.organizationExternalTmsProviderCredentials.organizationId, input.organizationId),
+        eq(schema.organizationExternalTmsProviderCredentials.providerKind, providerKind),
+      ),
+    )
+    .limit(1);
+
+  if (!credential) {
+    throw new Error("provider_credential_not_found");
+  }
+
+  const secretMaterial = await resolveExternalTmsSecretMaterialForActor({
+    credential,
+    organizationId: input.organizationId,
+    actorUserId: input.actorUserId,
+  });
+  const providerResult = await getTmsProviderAdapter(providerKind).uploadSourceFile({
+    organizationId: input.organizationId,
+    projectId: input.project.id,
+    externalProjectId,
+    credential,
+    project: input.project,
+    secretMaterial,
+    file: {
+      sourcePath: input.sourcePath,
+      filename: input.file.filename,
+      contentType: input.file.contentType,
+      content: input.file.content,
+      sourceHash: input.sourceHash ?? null,
+      sourceLocale: input.sourceLocale ?? input.project.sourceLocale ?? null,
+      format: input.format ?? null,
+      branch: input.branch ?? null,
+    },
+  });
+
+  return {
+    destination: "external_tms",
+    file: {
+      id: providerResult.externalResourceId ?? null,
+      sourcePath: providerResult.sourcePath,
+      providerKind,
+      externalProjectId,
+      externalResourceId: providerResult.externalResourceId ?? null,
+      revision: providerResult.revision ?? null,
+      asyncOperation: providerResult.asyncOperation ?? null,
+      providerPayload: providerResult.providerPayload ?? {},
+    },
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-adapter.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-adapter.ts
@@ -6,6 +6,7 @@ import { searchCrowdinGlossaryMatches } from "@/lib/providers/adapters/crowdin/c
 import { fetchCrowdinJobTasks } from "@/lib/providers/adapters/crowdin/crowdin-job-task-fetcher";
 import { fetchCrowdinProjects } from "@/lib/providers/adapters/crowdin/crowdin-project-fetcher";
 import { pullCrowdinProviderReview } from "@/lib/providers/adapters/crowdin/crowdin-review-puller";
+import { uploadCrowdinSourceFile } from "@/lib/providers/adapters/crowdin/crowdin-source-uploader";
 import { fetchCrowdinTranslationMemories } from "@/lib/providers/adapters/crowdin/crowdin-tm-fetcher";
 import { searchCrowdinTranslationMemoryMatches } from "@/lib/providers/adapters/crowdin/crowdin-tm-matcher";
 import { pushCrowdinTranslations } from "@/lib/providers/adapters/crowdin/crowdin-translation-pusher";
@@ -17,6 +18,7 @@ import {
   type TmsProviderProjectScope,
   type TmsProviderPullReviewScope,
   type TmsProviderPushTranslationsScope,
+  type TmsProviderSourceFileUploadScope,
 } from "@/lib/providers/contracts/tms-provider-adapter";
 import type { ExternalTmsGlossaryMatcherInput } from "@/lib/providers/contracts/glossary-matcher";
 import type { ExternalTmsTranslationMemoryMatcherInput } from "@/lib/providers/contracts/translation-memory-matcher";
@@ -46,6 +48,10 @@ export class CrowdinTmsAdapter extends TmsProviderAdapter {
 
   pullTaskContent(scope: TmsProviderJobScope) {
     return pullCrowdinTaskContent({ ...scope, providerKind: this.kind });
+  }
+
+  uploadSourceFile(scope: TmsProviderSourceFileUploadScope) {
+    return uploadCrowdinSourceFile({ ...scope, providerKind: this.kind });
   }
 
   pushTranslations(scope: TmsProviderPushTranslationsScope) {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -617,12 +617,15 @@ export class CrowdinApiClient {
       directoryId?: number | null;
     },
   ): Promise<CrowdinFile> {
-    const response = await this.post<CrowdinGetResponse<CrowdinFile>>(`/projects/${projectId}/files`, {
-      storageId: input.storageId,
-      name: input.name,
-      ...(input.directoryId ? { directoryId: input.directoryId } : {}),
-      ...(!input.directoryId && input.branchId ? { branchId: input.branchId } : {}),
-    });
+    const response = await this.post<CrowdinGetResponse<CrowdinFile>>(
+      `/projects/${projectId}/files`,
+      {
+        storageId: input.storageId,
+        name: input.name,
+        ...(input.directoryId ? { directoryId: input.directoryId } : {}),
+        ...(!input.directoryId && input.branchId ? { branchId: input.branchId } : {}),
+      },
+    );
 
     return response.data;
   }

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -80,6 +80,11 @@ export interface CrowdinFile {
   revisionId: number;
 }
 
+export interface CrowdinSourceFileUploadResult {
+  file: CrowdinFile;
+  storageId: number;
+}
+
 export interface CrowdinFileRevision {
   id: number;
   fileId: number;
@@ -585,6 +590,58 @@ export class CrowdinApiClient {
     }
 
     return files;
+  }
+
+  async addDirectory(
+    projectId: number,
+    input: { name: string; branchId?: number | null; directoryId?: number | null },
+  ): Promise<CrowdinDirectory> {
+    const response = await this.post<CrowdinGetResponse<CrowdinDirectory>>(
+      `/projects/${projectId}/directories`,
+      {
+        name: input.name,
+        ...(input.directoryId ? { directoryId: input.directoryId } : {}),
+        ...(!input.directoryId && input.branchId ? { branchId: input.branchId } : {}),
+      },
+    );
+
+    return response.data;
+  }
+
+  async addSourceFile(
+    projectId: number,
+    input: {
+      storageId: number;
+      name: string;
+      branchId?: number | null;
+      directoryId?: number | null;
+    },
+  ): Promise<CrowdinFile> {
+    const response = await this.post<CrowdinGetResponse<CrowdinFile>>(`/projects/${projectId}/files`, {
+      storageId: input.storageId,
+      name: input.name,
+      ...(input.directoryId ? { directoryId: input.directoryId } : {}),
+      ...(!input.directoryId && input.branchId ? { branchId: input.branchId } : {}),
+    });
+
+    return response.data;
+  }
+
+  async updateSourceFile(
+    projectId: number,
+    fileId: number,
+    input: { storageId: number; name: string },
+  ): Promise<CrowdinFile> {
+    const response = await this.put<CrowdinGetResponse<CrowdinFile>>(
+      `/projects/${projectId}/files/${fileId}`,
+      {
+        storageId: input.storageId,
+        name: input.name,
+        updateOption: "keep_translations_and_approvals",
+      },
+    );
+
+    return response.data;
   }
 
   /**
@@ -1647,6 +1704,14 @@ export class CrowdinApiClient {
   private async patch<T>(path: string, body: unknown): Promise<T> {
     return this.request<T>(path, {
       method: "PATCH",
+      headers: this.authHeaders(),
+      body: JSON.stringify(body),
+    });
+  }
+
+  private async put<T>(path: string, body: unknown): Promise<T> {
+    return this.request<T>(path, {
+      method: "PUT",
       headers: this.authHeaders(),
       body: JSON.stringify(body),
     });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-source-uploader.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-source-uploader.ts
@@ -1,5 +1,6 @@
 import type { ExternalTmsSourceFileUploader } from "@/lib/providers/tms-provider-types";
 
+import { err, ok, type Result } from "@/lib/primitives/result/results";
 import {
   providerFilename,
   providerSourcePath,
@@ -18,23 +19,27 @@ export const uploadCrowdinSourceFile: ExternalTmsSourceFileUploader = async ({
   });
   const projectId = Number(externalProjectId);
   if (!Number.isInteger(projectId) || projectId <= 0) {
-    throw new Error("invalid_crowdin_project_id");
+    return err({ code: "invalid_crowdin_project_id" });
   }
 
-  const branchId = await resolveCrowdinBranchId(client, projectId, file.branch);
+  const branchIdResult = await resolveCrowdinBranchId(client, projectId, file.branch);
+  if (!branchIdResult.ok) {
+    return branchIdResult;
+  }
+  const branchId = branchIdResult.value;
   const sourcePath = providerSourcePath(file);
   const pathSegments = sourcePath.split("/").filter(Boolean);
   const name = providerFilename(file);
   const directorySegments = pathSegments.length > 1 ? pathSegments.slice(0, -1) : [];
   const directoryId = await ensureCrowdinDirectory(client, projectId, branchId, directorySegments);
+  const files = await client.listFiles(projectId, branchId ?? undefined, directoryId ?? undefined);
+  const existing = files.find((item) => item.name === name);
   const storage = await client.addStorage({
     fileName: name,
     content: file.content,
     contentType: file.contentType,
   });
 
-  const files = await client.listFiles(projectId, branchId ?? undefined, directoryId ?? undefined);
-  const existing = files.find((item) => item.name === name);
   const uploaded = existing
     ? await client.updateSourceFile(projectId, existing.id, { storageId: storage.id, name })
     : await client.addSourceFile(projectId, {
@@ -44,7 +49,7 @@ export const uploadCrowdinSourceFile: ExternalTmsSourceFileUploader = async ({
         directoryId,
       });
 
-  return {
+  return ok({
     sourcePath,
     externalResourceId: String(uploaded.id),
     revision: String(uploaded.revisionId),
@@ -56,25 +61,25 @@ export const uploadCrowdinSourceFile: ExternalTmsSourceFileUploader = async ({
       path: uploaded.path,
       status: uploaded.status,
     },
-  };
+  });
 };
 
 async function resolveCrowdinBranchId(
   client: CrowdinApiClient,
   projectId: number,
   branch?: string | null,
-) {
+): Promise<Result<number | null, { code: "crowdin_branch_not_found" }>> {
   const normalizedBranch = branch?.trim();
   if (!normalizedBranch) {
-    return null;
+    return ok(null);
   }
 
   const branches = await client.listBranches(projectId);
   const match = branches.find((item) => item.name === normalizedBranch);
   if (!match) {
-    throw new Error("crowdin_branch_not_found");
+    return err({ code: "crowdin_branch_not_found" });
   }
-  return match.id;
+  return ok(match.id);
 }
 
 async function ensureCrowdinDirectory(

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-source-uploader.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-source-uploader.ts
@@ -33,11 +33,7 @@ export const uploadCrowdinSourceFile: ExternalTmsSourceFileUploader = async ({
     contentType: file.contentType,
   });
 
-  const files = await client.listFiles(
-    projectId,
-    branchId ?? undefined,
-    directoryId ?? undefined,
-  );
+  const files = await client.listFiles(projectId, branchId ?? undefined, directoryId ?? undefined);
   const existing = files.find((item) => item.name === name);
   const uploaded = existing
     ? await client.updateSourceFile(projectId, existing.id, { storageId: storage.id, name })

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-source-uploader.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-source-uploader.ts
@@ -1,0 +1,131 @@
+import type { ExternalTmsSourceFileUploader } from "@/lib/providers/tms-provider-types";
+
+import {
+  providerFilename,
+  providerSourcePath,
+} from "@/lib/providers/adapters/source-file-upload-shared";
+import { CrowdinApiClient, CrowdinApiError, type CrowdinDirectory } from "./crowdin-api";
+
+export const uploadCrowdinSourceFile: ExternalTmsSourceFileUploader = async ({
+  credential,
+  externalProjectId,
+  secretMaterial,
+  file,
+}) => {
+  const client = new CrowdinApiClient({
+    token: secretMaterial,
+    baseUrl: credential.baseUrl ?? undefined,
+  });
+  const projectId = Number(externalProjectId);
+  if (!Number.isInteger(projectId) || projectId <= 0) {
+    throw new Error("invalid_crowdin_project_id");
+  }
+
+  const branchId = await resolveCrowdinBranchId(client, projectId, file.branch);
+  const sourcePath = providerSourcePath(file);
+  const pathSegments = sourcePath.split("/").filter(Boolean);
+  const name = providerFilename(file);
+  const directorySegments = pathSegments.length > 1 ? pathSegments.slice(0, -1) : [];
+  const directoryId = await ensureCrowdinDirectory(client, projectId, branchId, directorySegments);
+  const storage = await client.addStorage({
+    fileName: name,
+    content: file.content,
+    contentType: file.contentType,
+  });
+
+  const files = await client.listFiles(
+    projectId,
+    branchId ?? undefined,
+    directoryId ?? undefined,
+  );
+  const existing = files.find((item) => item.name === name);
+  const uploaded = existing
+    ? await client.updateSourceFile(projectId, existing.id, { storageId: storage.id, name })
+    : await client.addSourceFile(projectId, {
+        storageId: storage.id,
+        name,
+        branchId,
+        directoryId,
+      });
+
+  return {
+    sourcePath,
+    externalResourceId: String(uploaded.id),
+    revision: String(uploaded.revisionId),
+    providerPayload: {
+      storageId: storage.id,
+      branchId: uploaded.branchId,
+      directoryId: uploaded.directoryId,
+      name: uploaded.name,
+      path: uploaded.path,
+      status: uploaded.status,
+    },
+  };
+};
+
+async function resolveCrowdinBranchId(
+  client: CrowdinApiClient,
+  projectId: number,
+  branch?: string | null,
+) {
+  const normalizedBranch = branch?.trim();
+  if (!normalizedBranch) {
+    return null;
+  }
+
+  const branches = await client.listBranches(projectId);
+  const match = branches.find((item) => item.name === normalizedBranch);
+  if (!match) {
+    throw new Error("crowdin_branch_not_found");
+  }
+  return match.id;
+}
+
+async function ensureCrowdinDirectory(
+  client: CrowdinApiClient,
+  projectId: number,
+  branchId: number | null,
+  segments: string[],
+) {
+  let parentId: number | null = null;
+  for (const segment of segments) {
+    const directories = await client.listDirectories(projectId, branchId ?? undefined);
+    const existing = findCrowdinDirectory(directories, parentId, segment);
+    if (existing) {
+      parentId = existing.id;
+      continue;
+    }
+
+    try {
+      const created = await client.addDirectory(projectId, {
+        name: segment,
+        branchId: parentId ? null : branchId,
+        directoryId: parentId,
+      });
+      parentId = created.id;
+    } catch (error) {
+      if (!(error instanceof CrowdinApiError) || error.status !== 409) {
+        throw error;
+      }
+      const refreshed = await client.listDirectories(projectId, branchId ?? undefined);
+      const existingAfterConflict = findCrowdinDirectory(refreshed, parentId, segment);
+      if (!existingAfterConflict) {
+        throw error;
+      }
+      parentId = existingAfterConflict.id;
+    }
+  }
+
+  return parentId;
+}
+
+function findCrowdinDirectory(
+  directories: CrowdinDirectory[],
+  parentId: number | null,
+  name: string,
+) {
+  return directories.find((directory) => {
+    const candidateParent = directory.directoryId ?? null;
+    return candidateParent === parentId && directory.name === name;
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-adapter.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-adapter.ts
@@ -6,6 +6,7 @@ import { searchLokaliseGlossaryMatches } from "@/lib/providers/adapters/lokalise
 import { fetchLokaliseJobTasks } from "@/lib/providers/adapters/lokalise/lokalise-job-task-fetcher";
 import { fetchLokaliseProjects } from "@/lib/providers/adapters/lokalise/lokalise-project-fetcher";
 import { pullLokaliseProviderReview } from "@/lib/providers/adapters/lokalise/lokalise-review-puller";
+import { uploadLokaliseSourceFile } from "@/lib/providers/adapters/lokalise/lokalise-source-uploader";
 import { searchLokaliseTranslationMemoryMatches } from "@/lib/providers/adapters/lokalise/lokalise-tm-matcher";
 import { fetchLokaliseTranslationMemories } from "@/lib/providers/adapters/lokalise/lokalise-translation-memory-fetcher";
 import { pushLokaliseTranslations } from "@/lib/providers/adapters/lokalise/lokalise-translation-pusher";
@@ -17,6 +18,7 @@ import {
   type TmsProviderProjectScope,
   type TmsProviderPullReviewScope,
   type TmsProviderPushTranslationsScope,
+  type TmsProviderSourceFileUploadScope,
 } from "@/lib/providers/contracts/tms-provider-adapter";
 import type { ExternalTmsGlossaryMatcherInput } from "@/lib/providers/contracts/glossary-matcher";
 import type { ExternalTmsTranslationMemoryMatcherInput } from "@/lib/providers/contracts/translation-memory-matcher";
@@ -46,6 +48,10 @@ export class LokaliseTmsAdapter extends TmsProviderAdapter {
 
   pullTaskContent(scope: TmsProviderJobScope) {
     return pullLokaliseTaskContent({ ...scope, providerKind: this.kind });
+  }
+
+  uploadSourceFile(scope: TmsProviderSourceFileUploadScope) {
+    return uploadLokaliseSourceFile({ ...scope, providerKind: this.kind });
   }
 
   pushTranslations(scope: TmsProviderPushTranslationsScope) {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-api.ts
@@ -154,6 +154,13 @@ export type LokaliseFileDownloadResult = {
   warning: string | null;
 };
 
+export type LokaliseSourceUploadResult = {
+  processId: string;
+  type: string | null;
+  status: string | null;
+  message: string | null;
+};
+
 export interface LokaliseComment {
   commentId: number;
   keyId: number;
@@ -529,6 +536,40 @@ export class LokaliseApiClient {
     return {
       bundleUrl,
       warning: response.warning?.trim() || null,
+    };
+  }
+
+  async uploadSourceFile(
+    projectId: string,
+    input: {
+      filename: string;
+      content: Uint8Array;
+      sourceLocale: string;
+      format: string;
+      branch?: string | null;
+    },
+  ): Promise<LokaliseSourceUploadResult> {
+    const response = await this.post<LokaliseFileUploadResponse>(
+      `/projects/${lokaliseProjectPathSegment(projectId, input.branch)}/files/upload`,
+      {
+        data: Buffer.from(input.content).toString("base64"),
+        filename: input.filename,
+        lang_iso: input.sourceLocale,
+        format: input.format,
+        queue: true,
+      },
+    );
+
+    const process = response.process;
+    if (!process?.process_id) {
+      throw new LokaliseApiError("Lokalise source upload response is missing a process id", 502, response);
+    }
+
+    return {
+      processId: process.process_id,
+      type: process.type ?? null,
+      status: process.status ?? null,
+      message: process.message ?? null,
     };
   }
 
@@ -1042,6 +1083,16 @@ type LokaliseFileDownloadResponse = {
   warning?: string | null;
 };
 
+type LokaliseFileUploadResponse = {
+  project_id?: string;
+  process?: {
+    process_id?: string;
+    type?: string | null;
+    status?: string | null;
+    message?: string | null;
+  };
+};
+
 type LokaliseTaskLanguageUserApiRecord = {
   user_id?: number;
   email?: string;
@@ -1343,6 +1394,12 @@ function normalizeLokaliseProject(record: LokaliseProjectApiRecord): LokalisePro
     baseLanguageIso: record.base_language_iso ?? null,
     createdAt: record.created_at ?? null,
   };
+}
+
+function lokaliseProjectPathSegment(projectId: string, branch?: string | null) {
+  const projectSegment = encodeURIComponent(projectId.trim());
+  const normalizedBranch = branch?.trim();
+  return normalizedBranch ? `${projectSegment}:${encodeURIComponent(normalizedBranch)}` : projectSegment;
 }
 
 function normalizeLokaliseLanguage(record: LokaliseLanguageApiRecord): LokaliseLanguage {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-api.ts
@@ -562,7 +562,11 @@ export class LokaliseApiClient {
 
     const process = response.process;
     if (!process?.process_id) {
-      throw new LokaliseApiError("Lokalise source upload response is missing a process id", 502, response);
+      throw new LokaliseApiError(
+        "Lokalise source upload response is missing a process id",
+        502,
+        response,
+      );
     }
 
     return {
@@ -1399,7 +1403,9 @@ function normalizeLokaliseProject(record: LokaliseProjectApiRecord): LokalisePro
 function lokaliseProjectPathSegment(projectId: string, branch?: string | null) {
   const projectSegment = encodeURIComponent(projectId.trim());
   const normalizedBranch = branch?.trim();
-  return normalizedBranch ? `${projectSegment}:${encodeURIComponent(normalizedBranch)}` : projectSegment;
+  return normalizedBranch
+    ? `${projectSegment}:${encodeURIComponent(normalizedBranch)}`
+    : projectSegment;
 }
 
 function normalizeLokaliseLanguage(record: LokaliseLanguageApiRecord): LokaliseLanguage {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-source-uploader.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-source-uploader.ts
@@ -1,0 +1,60 @@
+import type { ExternalTmsSourceFileUploader } from "@/lib/providers/tms-provider-types";
+
+import {
+  providerFileFormat,
+  providerFilename,
+  providerSourcePath,
+} from "@/lib/providers/adapters/source-file-upload-shared";
+import { LOKALISE_DEFAULT_BASE_URL, LokaliseApiClient } from "./lokalise-api";
+
+export const uploadLokaliseSourceFile: ExternalTmsSourceFileUploader = async ({
+  credential,
+  externalProjectId,
+  project,
+  secretMaterial,
+  file,
+}) => {
+  const client = new LokaliseApiClient({
+    token: secretMaterial,
+    baseUrl: credential.baseUrl ?? LOKALISE_DEFAULT_BASE_URL,
+  });
+  const sourcePath = providerSourcePath(file);
+  const format = providerFileFormat(file);
+  if (!format) {
+    throw new Error("lokalise_source_file_format_required");
+  }
+
+  const sourceLocale = file.sourceLocale?.trim() || project.sourceLocale?.trim();
+  if (!sourceLocale) {
+    throw new Error("lokalise_source_locale_required");
+  }
+
+  const result = await client.uploadSourceFile(externalProjectId, {
+    filename: providerFilename(file),
+    content: file.content,
+    sourceLocale,
+    format,
+    branch: file.branch,
+  });
+
+  return {
+    sourcePath,
+    externalResourceId: result.processId,
+    revision: null,
+    asyncOperation: {
+      provider: "lokalise",
+      processId: result.processId,
+      status: result.status,
+      type: result.type,
+    },
+    providerPayload: {
+      processId: result.processId,
+      status: result.status,
+      type: result.type,
+      message: result.message,
+      sourceLocale,
+      format,
+      branch: file.branch?.trim() || null,
+    },
+  };
+};

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-source-uploader.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-source-uploader.ts
@@ -1,5 +1,6 @@
 import type { ExternalTmsSourceFileUploader } from "@/lib/providers/tms-provider-types";
 
+import { err, ok } from "@/lib/primitives/result/results";
 import {
   providerFileFormat,
   providerFilename,
@@ -21,12 +22,12 @@ export const uploadLokaliseSourceFile: ExternalTmsSourceFileUploader = async ({
   const sourcePath = providerSourcePath(file);
   const format = providerFileFormat(file);
   if (!format) {
-    throw new Error("lokalise_source_file_format_required");
+    return err({ code: "lokalise_source_file_format_required" });
   }
 
   const sourceLocale = file.sourceLocale?.trim() || project.sourceLocale?.trim();
   if (!sourceLocale) {
-    throw new Error("lokalise_source_locale_required");
+    return err({ code: "lokalise_source_locale_required" });
   }
 
   const result = await client.uploadSourceFile(externalProjectId, {
@@ -37,7 +38,7 @@ export const uploadLokaliseSourceFile: ExternalTmsSourceFileUploader = async ({
     branch: file.branch,
   });
 
-  return {
+  return ok({
     sourcePath,
     externalResourceId: result.processId,
     revision: null,
@@ -56,5 +57,5 @@ export const uploadLokaliseSourceFile: ExternalTmsSourceFileUploader = async ({
       format,
       branch: file.branch?.trim() || null,
     },
-  };
+  });
 };

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-adapter.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-adapter.ts
@@ -4,6 +4,7 @@ import { fetchPhraseGlossaries } from "@/lib/providers/adapters/phrase/phrase-gl
 import { fetchPhraseJobTasks } from "@/lib/providers/adapters/phrase/phrase-job-task-fetcher";
 import { fetchPhraseProjects } from "@/lib/providers/adapters/phrase/phrase-project-fetcher";
 import { pullPhraseProviderReview } from "@/lib/providers/adapters/phrase/phrase-review-puller";
+import { uploadPhraseSourceFile } from "@/lib/providers/adapters/phrase/phrase-source-uploader";
 import { searchPhraseTranslationMemoryMatches } from "@/lib/providers/adapters/phrase/phrase-tm-matcher";
 import { fetchPhraseTranslationMemories } from "@/lib/providers/adapters/phrase/phrase-translation-memory-fetcher";
 import { pushPhraseTranslations } from "@/lib/providers/adapters/phrase/phrase-translation-pusher";
@@ -14,6 +15,7 @@ import {
   type TmsProviderProjectScope,
   type TmsProviderPullReviewScope,
   type TmsProviderPushTranslationsScope,
+  type TmsProviderSourceFileUploadScope,
 } from "@/lib/providers/contracts/tms-provider-adapter";
 import type { ExternalTmsTranslationMemoryMatcherInput } from "@/lib/providers/contracts/translation-memory-matcher";
 
@@ -42,6 +44,10 @@ export class PhraseTmsAdapter extends TmsProviderAdapter {
 
   pullTaskContent(scope: TmsProviderJobScope) {
     return pullPhraseTaskContent({ ...scope, providerKind: this.kind });
+  }
+
+  uploadSourceFile(scope: TmsProviderSourceFileUploadScope) {
+    return uploadPhraseSourceFile({ ...scope, providerKind: this.kind });
   }
 
   pushTranslations(scope: TmsProviderPushTranslationsScope) {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-api.ts
@@ -563,6 +563,36 @@ export class PhraseApiClient {
     });
   }
 
+  async uploadSourceFile(
+    projectId: string,
+    input: {
+      filename: string;
+      content: Uint8Array;
+      contentType: string;
+      fileFormat: string;
+      localeId: string;
+      branch?: string | null;
+    },
+  ): Promise<PhraseUpload> {
+    const form = new FormData();
+    form.append("file", new Blob([input.content], { type: input.contentType }), input.filename);
+    form.append("file_format", input.fileFormat);
+    form.append("locale_id", input.localeId);
+
+    const record = await this.request<PhraseUploadApiRecord>(
+      this.buildPath(`/projects/${encodeURIComponent(projectId)}/uploads`, {
+        branch: input.branch,
+      }),
+      {
+        method: "POST",
+        headers: this.authHeaders(),
+        body: form,
+      },
+    );
+
+    return normalizePhraseUpload(record);
+  }
+
   async createKey(
     projectId: string,
     input: {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-api.ts
@@ -575,7 +575,11 @@ export class PhraseApiClient {
     },
   ): Promise<PhraseUpload> {
     const form = new FormData();
-    form.append("file", new Blob([input.content], { type: input.contentType }), input.filename);
+    const content = input.content.buffer.slice(
+      input.content.byteOffset,
+      input.content.byteOffset + input.content.byteLength,
+    ) as ArrayBuffer;
+    form.append("file", new Blob([content], { type: input.contentType }), input.filename);
     form.append("file_format", input.fileFormat);
     form.append("locale_id", input.localeId);
 

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-source-uploader.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-source-uploader.ts
@@ -1,0 +1,86 @@
+import type {
+  ExternalTmsSourceFileUpload,
+  ExternalTmsSourceFileUploader,
+} from "@/lib/providers/tms-provider-types";
+
+import {
+  providerFileFormat,
+  providerFilename,
+  providerSourcePath,
+} from "@/lib/providers/adapters/source-file-upload-shared";
+import { PhraseApiClient, type PhraseLocale } from "./phrase-api";
+
+export const uploadPhraseSourceFile: ExternalTmsSourceFileUploader = async ({
+  credential,
+  externalProjectId,
+  project,
+  secretMaterial,
+  file,
+}) => {
+  const client = new PhraseApiClient({
+    token: secretMaterial,
+    region: credential.region,
+    baseUrl: credential.baseUrl,
+  });
+  const sourcePath = providerSourcePath(file);
+  const fileFormat = providerFileFormat(file);
+  if (!fileFormat) {
+    throw new Error("phrase_source_file_format_required");
+  }
+
+  const locales = await client.listLocales(externalProjectId, { branch: file.branch });
+  const sourceLocale = resolvePhraseSourceLocale(file, locales, project.sourceLocale);
+  if (!sourceLocale) {
+    throw new Error("phrase_source_locale_not_found");
+  }
+
+  const upload = await client.uploadSourceFile(externalProjectId, {
+    filename: providerFilename(file),
+    content: file.content,
+    contentType: file.contentType,
+    fileFormat,
+    localeId: sourceLocale.id,
+    branch: file.branch,
+  });
+
+  return {
+    sourcePath,
+    externalResourceId: upload.id,
+    revision: upload.updatedAt ?? upload.createdAt ?? null,
+    providerPayload: {
+      id: upload.id,
+      filename: upload.filename,
+      format: upload.format,
+      state: upload.state,
+      url: upload.url,
+      sourceLocale: {
+        id: sourceLocale.id,
+        name: sourceLocale.name,
+        code: sourceLocale.code,
+      },
+      branch: file.branch?.trim() || null,
+    },
+  };
+};
+
+function resolvePhraseSourceLocale(
+  file: ExternalTmsSourceFileUpload,
+  locales: PhraseLocale[],
+  projectSourceLocale: string | null,
+) {
+  const requested = file.sourceLocale?.trim() || projectSourceLocale?.trim() || "";
+  if (requested) {
+    const lower = requested.toLowerCase();
+    const match = locales.find(
+      (locale) =>
+        locale.id.toLowerCase() === lower ||
+        locale.name.toLowerCase() === lower ||
+        locale.code?.toLowerCase() === lower,
+    );
+    if (match) {
+      return match;
+    }
+  }
+
+  return locales.find((locale) => locale.default) ?? null;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-source-uploader.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-source-uploader.ts
@@ -3,6 +3,7 @@ import type {
   ExternalTmsSourceFileUploader,
 } from "@/lib/providers/tms-provider-types";
 
+import { err, ok } from "@/lib/primitives/result/results";
 import {
   providerFileFormat,
   providerFilename,
@@ -25,13 +26,13 @@ export const uploadPhraseSourceFile: ExternalTmsSourceFileUploader = async ({
   const sourcePath = providerSourcePath(file);
   const fileFormat = providerFileFormat(file);
   if (!fileFormat) {
-    throw new Error("phrase_source_file_format_required");
+    return err({ code: "phrase_source_file_format_required" });
   }
 
   const locales = await client.listLocales(externalProjectId, { branch: file.branch });
   const sourceLocale = resolvePhraseSourceLocale(file, locales, project.sourceLocale);
   if (!sourceLocale) {
-    throw new Error("phrase_source_locale_not_found");
+    return err({ code: "phrase_source_locale_not_found" });
   }
 
   const upload = await client.uploadSourceFile(externalProjectId, {
@@ -43,7 +44,7 @@ export const uploadPhraseSourceFile: ExternalTmsSourceFileUploader = async ({
     branch: file.branch,
   });
 
-  return {
+  return ok({
     sourcePath,
     externalResourceId: upload.id,
     revision: upload.updatedAt ?? upload.createdAt ?? null,
@@ -60,7 +61,7 @@ export const uploadPhraseSourceFile: ExternalTmsSourceFileUploader = async ({
       },
       branch: file.branch?.trim() || null,
     },
-  };
+  });
 };
 
 function resolvePhraseSourceLocale(

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/smartling/smartling-adapter.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/smartling/smartling-adapter.ts
@@ -5,6 +5,7 @@ import { fetchSmartlingGlossaries } from "@/lib/providers/adapters/smartling/sma
 import { searchSmartlingGlossaryMatches } from "@/lib/providers/adapters/smartling/smartling-glossary-matcher";
 import { fetchSmartlingJobTasks } from "@/lib/providers/adapters/smartling/smartling-job-fetcher";
 import { fetchSmartlingProjects } from "@/lib/providers/adapters/smartling/smartling-project-fetcher";
+import { uploadSmartlingSourceFile } from "@/lib/providers/adapters/smartling/smartling-source-uploader";
 import { searchSmartlingTranslationMemoryMatches } from "@/lib/providers/adapters/smartling/smartling-tm-matcher";
 import { fetchSmartlingTranslationMemories } from "@/lib/providers/adapters/smartling/smartling-translation-memory-fetcher";
 import { pushSmartlingTranslations } from "@/lib/providers/adapters/smartling/smartling-translation-pusher";
@@ -15,6 +16,7 @@ import {
   type TmsProviderJobScope,
   type TmsProviderProjectScope,
   type TmsProviderPushTranslationsScope,
+  type TmsProviderSourceFileUploadScope,
 } from "@/lib/providers/contracts/tms-provider-adapter";
 import type { ExternalTmsGlossaryMatcherInput } from "@/lib/providers/contracts/glossary-matcher";
 import type { ExternalTmsTranslationMemoryMatcherInput } from "@/lib/providers/contracts/translation-memory-matcher";
@@ -44,6 +46,10 @@ export class SmartlingTmsAdapter extends TmsProviderAdapter {
 
   pullTaskContent(scope: TmsProviderJobScope) {
     return pullSmartlingTaskContent({ ...scope, providerKind: this.kind });
+  }
+
+  uploadSourceFile(scope: TmsProviderSourceFileUploadScope) {
+    return uploadSmartlingSourceFile({ ...scope, providerKind: this.kind });
   }
 
   pushTranslations(scope: TmsProviderPushTranslationsScope) {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/smartling/smartling-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/smartling/smartling-api.ts
@@ -550,7 +550,11 @@ export class SmartlingApiClient {
     const form = new FormData();
     form.append("fileUri", input.fileUri);
     form.append("fileType", input.fileType);
-    form.append("file", new Blob([input.content], { type: input.contentType }), input.filename);
+    const content = input.content.buffer.slice(
+      input.content.byteOffset,
+      input.content.byteOffset + input.content.byteLength,
+    ) as ArrayBuffer;
+    form.append("file", new Blob([content], { type: input.contentType }), input.filename);
 
     const url = `${this.filesBaseUrl}/projects/${encodeURIComponent(projectId)}/file`;
     const response = await this.fetchFn(url, {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/smartling/smartling-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/smartling/smartling-api.ts
@@ -228,6 +228,13 @@ export interface SmartlingAsyncProcessStatus {
   percentComplete?: number;
 }
 
+export interface SmartlingSourceUploadResult {
+  fileUri: string;
+  fileType: string;
+  processUid: string | null;
+  providerPayload: Record<string, unknown>;
+}
+
 export interface SmartlingIssueStringReference {
   hashcode: string;
   localeId: string;
@@ -527,6 +534,41 @@ export class SmartlingApiClient {
     });
 
     return files;
+  }
+
+  async uploadSourceFile(
+    projectId: string,
+    input: {
+      fileUri: string;
+      fileType: string;
+      filename: string;
+      content: Uint8Array;
+      contentType: string;
+    },
+  ): Promise<SmartlingSourceUploadResult> {
+    const token = await this.getAccessToken();
+    const form = new FormData();
+    form.append("fileUri", input.fileUri);
+    form.append("fileType", input.fileType);
+    form.append("file", new Blob([input.content], { type: input.contentType }), input.filename);
+
+    const url = `${this.filesBaseUrl}/projects/${encodeURIComponent(projectId)}/file`;
+    const response = await this.fetchFn(url, {
+      method: "POST",
+      redirect: "error",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      body: form,
+    });
+
+    const payload = await parseSmartlingResponse<Record<string, unknown>>(response, url);
+    return {
+      fileUri: input.fileUri,
+      fileType: input.fileType,
+      processUid: typeof payload.processUid === "string" ? payload.processUid : null,
+      providerPayload: payload,
+    };
   }
 
   async getFileStatusForAllLocales(

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/smartling/smartling-source-uploader.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/smartling/smartling-source-uploader.ts
@@ -1,0 +1,52 @@
+import type { ExternalTmsSourceFileUploader } from "@/lib/providers/tms-provider-types";
+
+import {
+  providerFileFormat,
+  providerFilename,
+  providerSourcePath,
+} from "@/lib/providers/adapters/source-file-upload-shared";
+import { SmartlingApiClient } from "./smartling-api";
+import { parseSmartlingCredentials } from "./smartling-credentials";
+
+export const uploadSmartlingSourceFile: ExternalTmsSourceFileUploader = async ({
+  credential,
+  externalProjectId,
+  secretMaterial,
+  file,
+}) => {
+  const client = new SmartlingApiClient({
+    credentials: parseSmartlingCredentials(secretMaterial),
+    authBaseUrl: credential.baseUrl ?? undefined,
+  });
+  const sourcePath = providerSourcePath(file);
+  const fileType = providerFileFormat(file);
+  if (!fileType) {
+    throw new Error("smartling_source_file_type_required");
+  }
+
+  const result = await client.uploadSourceFile(externalProjectId, {
+    fileUri: sourcePath,
+    fileType,
+    filename: providerFilename(file),
+    content: file.content,
+    contentType: file.contentType,
+  });
+
+  return {
+    sourcePath,
+    externalResourceId: result.fileUri,
+    revision: null,
+    asyncOperation: result.processUid
+      ? {
+          provider: "smartling",
+          processUid: result.processUid,
+        }
+      : null,
+    providerPayload: {
+      fileUri: result.fileUri,
+      fileType: result.fileType,
+      processUid: result.processUid,
+      ...result.providerPayload,
+    },
+  };
+};

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/smartling/smartling-source-uploader.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/smartling/smartling-source-uploader.ts
@@ -1,5 +1,6 @@
 import type { ExternalTmsSourceFileUploader } from "@/lib/providers/tms-provider-types";
 
+import { err, ok } from "@/lib/primitives/result/results";
 import {
   providerFileFormat,
   providerFilename,
@@ -21,7 +22,7 @@ export const uploadSmartlingSourceFile: ExternalTmsSourceFileUploader = async ({
   const sourcePath = providerSourcePath(file);
   const fileType = providerFileFormat(file);
   if (!fileType) {
-    throw new Error("smartling_source_file_type_required");
+    return err({ code: "smartling_source_file_type_required" });
   }
 
   const result = await client.uploadSourceFile(externalProjectId, {
@@ -32,7 +33,7 @@ export const uploadSmartlingSourceFile: ExternalTmsSourceFileUploader = async ({
     contentType: file.contentType,
   });
 
-  return {
+  return ok({
     sourcePath,
     externalResourceId: result.fileUri,
     revision: null,
@@ -48,5 +49,5 @@ export const uploadSmartlingSourceFile: ExternalTmsSourceFileUploader = async ({
       processUid: result.processUid,
       ...result.providerPayload,
     },
-  };
+  });
 };

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/source-file-upload-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/source-file-upload-api.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { CrowdinApiClient } from "./crowdin/crowdin-api";
+import { LokaliseApiClient } from "./lokalise/lokalise-api";
+import { PhraseApiClient } from "./phrase/phrase-api";
+import { SmartlingApiClient } from "./smartling/smartling-api";
+
+describe("source file upload API clients", () => {
+  it("constructs Phrase multipart source uploads", async () => {
+    const fetchFn = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      const form = init?.body as FormData;
+      const file = form.get("file") as File;
+      expect(init?.method).toBe("POST");
+      expect(form.get("file_format")).toBe("json");
+      expect(form.get("locale_id")).toBe("locale-en");
+      expect(file.name).toBe("home.json");
+      expect(await file.text()).toBe(`{"hello":"Hello"}`);
+      return Response.json({
+        id: "upload-1",
+        filename: "home.json",
+        format: "json",
+        state: "success",
+        tags: [],
+      });
+    });
+    const client = new PhraseApiClient({
+      token: "token",
+      baseUrl: "https://api.phrase.test/api/v2",
+      fetchFn,
+    });
+
+    const result = await client.uploadSourceFile("project-1", {
+      filename: "home.json",
+      content: new TextEncoder().encode(`{"hello":"Hello"}`),
+      contentType: "application/json",
+      fileFormat: "json",
+      localeId: "locale-en",
+      branch: "main",
+    });
+
+    expect(String(fetchFn.mock.calls[0]?.[0])).toBe(
+      "https://api.phrase.test/api/v2/projects/project-1/uploads?branch=main",
+    );
+    expect(result.id).toBe("upload-1");
+  });
+
+  it("constructs Lokalise queued source imports", async () => {
+    const fetchFn = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      expect(init?.method).toBe("POST");
+      expect(body).toMatchObject({
+        filename: "home.json",
+        lang_iso: "en",
+        format: "json",
+        queue: true,
+      });
+      expect(Buffer.from(String(body.data), "base64").toString("utf8")).toBe(`{"hello":"Hello"}`);
+      return Response.json({
+        process: {
+          process_id: "process-1",
+          type: "file-import",
+          status: "queued",
+        },
+      });
+    });
+    const client = new LokaliseApiClient({
+      token: "token",
+      baseUrl: "https://api.lokalise.test/api2",
+      fetchFn,
+    });
+
+    const result = await client.uploadSourceFile("project-1", {
+      filename: "home.json",
+      content: new TextEncoder().encode(`{"hello":"Hello"}`),
+      sourceLocale: "en",
+      format: "json",
+      branch: "main",
+    });
+
+    expect(String(fetchFn.mock.calls[0]?.[0])).toBe(
+      "https://api.lokalise.test/api2/projects/project-1:main/files/upload",
+    );
+    expect(result.processId).toBe("process-1");
+  });
+
+  it("constructs Smartling multipart source uploads after auth", async () => {
+    const fetchFn = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      if (String(url).endsWith("/authenticate")) {
+        return Response.json({
+          response: {
+            code: "SUCCESS",
+            data: {
+              accessToken: "access-token",
+              refreshToken: "refresh-token",
+              expiresIn: 3600,
+            },
+          },
+        });
+      }
+
+      const form = init?.body as FormData;
+      const file = form.get("file") as File;
+      expect(init?.method).toBe("POST");
+      expect(form.get("fileUri")).toBe("content/en/home.json");
+      expect(form.get("fileType")).toBe("json");
+      expect(file.name).toBe("home.json");
+      expect(await file.text()).toBe(`{"hello":"Hello"}`);
+      return Response.json({
+        response: {
+          code: "SUCCESS",
+          data: {
+            processUid: "process-1",
+          },
+        },
+      });
+    });
+    const client = new SmartlingApiClient({
+      credentials: { userIdentifier: "user", userSecret: "secret" },
+      authBaseUrl: "https://api.smartling.test/auth-api/v2",
+      fetchFn,
+    });
+
+    const result = await client.uploadSourceFile("project-1", {
+      fileUri: "content/en/home.json",
+      fileType: "json",
+      filename: "home.json",
+      content: new TextEncoder().encode(`{"hello":"Hello"}`),
+      contentType: "application/json",
+    });
+
+    expect(String(fetchFn.mock.calls[1]?.[0])).toBe(
+      "https://api.smartling.test/files-api/v2/projects/project-1/file",
+    );
+    expect(result.processUid).toBe("process-1");
+  });
+
+  it("constructs Crowdin source file create requests", async () => {
+    const fetchFn = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      expect(init?.method).toBe("POST");
+      expect(JSON.parse(String(init?.body))).toEqual({
+        storageId: 7,
+        name: "home.json",
+        branchId: 3,
+      });
+      return Response.json({
+        data: {
+          id: 9,
+          branchId: 3,
+          directoryId: null,
+          name: "home.json",
+          title: null,
+          type: "json",
+          path: "/home.json",
+          status: "active",
+          revisionId: 2,
+        },
+      });
+    });
+    const client = new CrowdinApiClient({
+      token: "token",
+      baseUrl: "https://api.crowdin.test/api/v2",
+      fetchFn,
+    });
+
+    const result = await client.addSourceFile(123, {
+      storageId: 7,
+      name: "home.json",
+      branchId: 3,
+    });
+
+    expect(String(fetchFn.mock.calls[0]?.[0])).toBe(
+      "https://api.crowdin.test/api/v2/projects/123/files",
+    );
+    expect(result.id).toBe(9);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/source-file-upload-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/source-file-upload-api.test.ts
@@ -5,6 +5,18 @@ import { LokaliseApiClient } from "./lokalise/lokalise-api";
 import { PhraseApiClient } from "./phrase/phrase-api";
 import { SmartlingApiClient } from "./smartling/smartling-api";
 
+function requestUrl(input: RequestInfo | URL | undefined) {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  if (input instanceof Request) return input.url;
+  return "";
+}
+
+function requestBodyText(input: BodyInit | null | undefined) {
+  if (typeof input === "string") return input;
+  throw new Error("expected string request body");
+}
+
 describe("source file upload API clients", () => {
   it("constructs Phrase multipart source uploads", async () => {
     const fetchFn = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
@@ -38,7 +50,7 @@ describe("source file upload API clients", () => {
       branch: "main",
     });
 
-    expect(String(fetchFn.mock.calls[0]?.[0])).toBe(
+    expect(requestUrl(fetchFn.mock.calls[0]?.[0])).toBe(
       "https://api.phrase.test/api/v2/projects/project-1/uploads?branch=main",
     );
     expect(result.id).toBe("upload-1");
@@ -46,7 +58,7 @@ describe("source file upload API clients", () => {
 
   it("constructs Lokalise queued source imports", async () => {
     const fetchFn = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
-      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      const body = JSON.parse(requestBodyText(init?.body)) as Record<string, unknown>;
       expect(init?.method).toBe("POST");
       expect(body).toMatchObject({
         filename: "home.json",
@@ -77,7 +89,7 @@ describe("source file upload API clients", () => {
       branch: "main",
     });
 
-    expect(String(fetchFn.mock.calls[0]?.[0])).toBe(
+    expect(requestUrl(fetchFn.mock.calls[0]?.[0])).toBe(
       "https://api.lokalise.test/api2/projects/project-1:main/files/upload",
     );
     expect(result.processId).toBe("process-1");
@@ -85,7 +97,7 @@ describe("source file upload API clients", () => {
 
   it("constructs Smartling multipart source uploads after auth", async () => {
     const fetchFn = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
-      if (String(url).endsWith("/authenticate")) {
+      if (requestUrl(url).endsWith("/authenticate")) {
         return Response.json({
           response: {
             code: "SUCCESS",
@@ -128,7 +140,7 @@ describe("source file upload API clients", () => {
       contentType: "application/json",
     });
 
-    expect(String(fetchFn.mock.calls[1]?.[0])).toBe(
+    expect(requestUrl(fetchFn.mock.calls[1]?.[0])).toBe(
       "https://api.smartling.test/files-api/v2/projects/project-1/file",
     );
     expect(result.processUid).toBe("process-1");
@@ -137,7 +149,7 @@ describe("source file upload API clients", () => {
   it("constructs Crowdin source file create requests", async () => {
     const fetchFn = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
       expect(init?.method).toBe("POST");
-      expect(JSON.parse(String(init?.body))).toEqual({
+      expect(JSON.parse(requestBodyText(init?.body))).toEqual({
         storageId: 7,
         name: "home.json",
         branchId: 3,
@@ -168,7 +180,7 @@ describe("source file upload API clients", () => {
       branchId: 3,
     });
 
-    expect(String(fetchFn.mock.calls[0]?.[0])).toBe(
+    expect(requestUrl(fetchFn.mock.calls[0]?.[0])).toBe(
       "https://api.crowdin.test/api/v2/projects/123/files",
     );
     expect(result.id).toBe(9);

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/source-file-upload-shared.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/source-file-upload-shared.ts
@@ -1,0 +1,25 @@
+import type { ExternalTmsSourceFileUpload } from "@/lib/providers/tms-provider-types";
+
+export function providerSourcePath(file: ExternalTmsSourceFileUpload) {
+  return file.sourcePath.trim().replaceAll("\\", "/").replace(/^\/+/, "");
+}
+
+export function providerFilename(file: ExternalTmsSourceFileUpload) {
+  const sourcePath = providerSourcePath(file);
+  return file.filename.trim() || sourcePath.split("/").filter(Boolean).at(-1) || "source";
+}
+
+export function providerFileFormat(file: ExternalTmsSourceFileUpload) {
+  const explicit = file.format?.trim().replace(/^\./, "").toLowerCase();
+  if (explicit) {
+    return explicit;
+  }
+
+  const filename = providerFilename(file);
+  const match = /\.([a-z0-9][a-z0-9_-]*)$/i.exec(filename);
+  return match?.[1]?.toLowerCase() ?? null;
+}
+
+export function providerFileBase64(file: ExternalTmsSourceFileUpload) {
+  return Buffer.from(file.content).toString("base64");
+}

--- a/apps/hyperlocalise-web/src/lib/providers/contracts/tms-provider-adapter.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/contracts/tms-provider-adapter.ts
@@ -1,4 +1,5 @@
 import type { schema } from "@/lib/database";
+import type { Result } from "@/lib/primitives/result/results";
 import type { ProviderReviewReport } from "@/lib/providers/provider-job-review/types";
 import type {
   ExternalTmsApprovedTranslationUpload,
@@ -6,6 +7,7 @@ import type {
   ExternalTmsGlossaryMetadata,
   ExternalTmsJobTaskMetadata,
   ExternalTmsProjectMetadata,
+  ExternalTmsSourceFileUploadError,
   ExternalTmsSourceFileUpload,
   ExternalTmsSourceFileUploadResult,
   ExternalTmsTaskContent,
@@ -102,7 +104,7 @@ export abstract class TmsProviderAdapter {
 
   abstract uploadSourceFile(
     scope: TmsProviderSourceFileUploadScope,
-  ): Promise<ExternalTmsSourceFileUploadResult>;
+  ): Promise<Result<ExternalTmsSourceFileUploadResult, ExternalTmsSourceFileUploadError>>;
 
   abstract pushTranslations(
     scope: TmsProviderPushTranslationsScope,

--- a/apps/hyperlocalise-web/src/lib/providers/contracts/tms-provider-adapter.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/contracts/tms-provider-adapter.ts
@@ -6,6 +6,8 @@ import type {
   ExternalTmsGlossaryMetadata,
   ExternalTmsJobTaskMetadata,
   ExternalTmsProjectMetadata,
+  ExternalTmsSourceFileUpload,
+  ExternalTmsSourceFileUploadResult,
   ExternalTmsTaskContent,
   ExternalTmsTranslationMemoryMetadata,
 } from "@/lib/providers/tms-provider-types";
@@ -45,6 +47,10 @@ export type TmsProviderPushTranslationsScope = TmsProviderJobScope & {
 
 export type TmsProviderPullReviewScope = TmsProviderJobScope & {
   content: ExternalTmsTaskContent;
+};
+
+export type TmsProviderSourceFileUploadScope = TmsProviderProjectScope & {
+  file: ExternalTmsSourceFileUpload;
 };
 
 export type TmsProviderCommentPushScope = {
@@ -93,6 +99,10 @@ export abstract class TmsProviderAdapter {
   ): Promise<ExternalTmsTranslationMemoryMetadata[]>;
 
   abstract pullTaskContent(scope: TmsProviderJobScope): Promise<ExternalTmsTaskContent>;
+
+  abstract uploadSourceFile(
+    scope: TmsProviderSourceFileUploadScope,
+  ): Promise<ExternalTmsSourceFileUploadResult>;
 
   abstract pushTranslations(
     scope: TmsProviderPushTranslationsScope,

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-types.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-types.ts
@@ -60,6 +60,36 @@ export type ExternalTmsFileKeyFetcher = (input: {
   branch?: string | null;
 }) => Promise<ExternalTmsFileKeyMetadata[]>;
 
+export type ExternalTmsSourceFileUpload = {
+  sourcePath: string;
+  filename: string;
+  contentType: string;
+  content: Uint8Array;
+  sourceHash?: string | null;
+  sourceLocale?: string | null;
+  format?: string | null;
+  branch?: string | null;
+};
+
+export type ExternalTmsSourceFileUploadResult = {
+  sourcePath: string;
+  externalResourceId?: string | null;
+  revision?: string | null;
+  asyncOperation?: Record<string, unknown> | null;
+  providerPayload?: Record<string, unknown>;
+};
+
+export type ExternalTmsSourceFileUploader = (input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  externalProjectId: string;
+  credential: ExternalTmsCredential;
+  project: ExternalTmsProject;
+  secretMaterial: string;
+  file: ExternalTmsSourceFileUpload;
+}) => Promise<ExternalTmsSourceFileUploadResult>;
+
 export type ExternalTmsJobTaskMetadata = {
   externalJobId: string;
   externalTaskId?: string | null;

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-types.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-types.ts
@@ -1,5 +1,6 @@
 import type { JobKind } from "@/lib/database/types";
 import type { schema } from "@/lib/database";
+import type { Result } from "@/lib/primitives/result/results";
 
 import type {
   ExternalTmsCredential,
@@ -79,6 +80,15 @@ export type ExternalTmsSourceFileUploadResult = {
   providerPayload?: Record<string, unknown>;
 };
 
+export type ExternalTmsSourceFileUploadError =
+  | { code: "invalid_crowdin_project_id" }
+  | { code: "crowdin_branch_not_found" }
+  | { code: "phrase_source_locale_not_found" }
+  | { code: "phrase_source_file_format_required" }
+  | { code: "lokalise_source_locale_required" }
+  | { code: "lokalise_source_file_format_required" }
+  | { code: "smartling_source_file_type_required" };
+
 export type ExternalTmsSourceFileUploader = (input: {
   organizationId: string;
   projectId: string;
@@ -88,7 +98,7 @@ export type ExternalTmsSourceFileUploader = (input: {
   project: ExternalTmsProject;
   secretMaterial: string;
   file: ExternalTmsSourceFileUpload;
-}) => Promise<ExternalTmsSourceFileUploadResult>;
+}) => Promise<Result<ExternalTmsSourceFileUploadResult, ExternalTmsSourceFileUploadError>>;
 
 export type ExternalTmsJobTaskMetadata = {
   externalJobId: string;

--- a/docs/adr/2026-07-05-public-files-tms-source-upload-design.md
+++ b/docs/adr/2026-07-05-public-files-tms-source-upload-design.md
@@ -1,0 +1,85 @@
+# ADR: Extend public file upload to external TMS source uploads
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-05
+
+## Context
+
+Integrations such as the Canva app need one API for source uploads. Today
+`POST /api/v1/files` uploads source files to native Hyperlocalise projects
+only. External TMS projects expose live read APIs and translation write-back,
+but they do not expose source-file upload through the web API.
+
+The product model already treats native and external TMS projects as workspace
+projects. Keeping source upload behind one public endpoint avoids making
+integrations choose a provider-specific route.
+
+## Decision
+
+Extend `POST /api/v1/files` so it routes by `projectId`.
+
+- Native projects keep the current behavior: store the file, create a source
+  version, and enqueue ingest.
+- External TMS projects upload the source bytes to the connected provider
+  project through the TypeScript TMS adapter contract.
+- The endpoint keeps the existing multipart shape and adds optional provider
+  fields such as `sourceLocale`, `format`, and `branch`.
+- The response remains resource-keyed under `file`, with a `destination` field
+  and provider metadata for TMS uploads.
+
+## API shape
+
+`POST /api/v1/files`
+
+Required fields:
+
+- `projectId`
+- `sourcePath`
+- `file`
+
+Optional fields:
+
+- `sourceHash`
+- `commitSha`
+- `workflowRunId`
+- `sourceLocale`
+- `format`
+- `branch`
+
+## Provider behavior
+
+The web TMS adapter contract gains a source-upload capability. Each provider
+maps the normalized upload request to its own API:
+
+- Crowdin uploads or updates source files.
+- Phrase creates an upload for the source locale.
+- Lokalise queues a source-file import.
+- Smartling uploads the source file URI.
+
+Providers that cannot upload sources return `source_upload_unsupported`.
+
+## Error handling
+
+Expected failures return stable JSON errors:
+
+- `project_not_found`
+- `invalid_file_payload`
+- `unsupported_file`
+- `source_upload_unsupported`
+- `source_upload_failed`
+
+Provider errors must not expose secrets or raw file contents.
+
+## Testing
+
+Add route and adapter tests for:
+
+- native uploads still store and enqueue ingest;
+- provider-backed projects dispatch to the selected adapter;
+- unsupported providers return `source_upload_unsupported`;
+- provider adapters construct the expected upload request.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

- Extends `POST /api/v1/files` so native projects keep the existing stored-file ingest behavior and external TMS projects upload source files through provider adapters.
- Adds normalized TMS source-upload types, provider adapter methods, and provider-specific upload implementations for Crowdin, Phrase, Lokalise, and Smartling.
- Addresses review feedback by restoring native ingest enqueue warning logs, replacing expected source-upload exceptions with typed `Result` errors, and moving Crowdin file lookup before storage upload.
- Adds an ADR and focused tests for route dispatch, typed upload errors, and provider upload request construction.

## How to test

- `vp test src/api/routes/public-files/public-files.route.test.ts src/lib/providers/adapters/source-file-upload-api.test.ts`
- `vp check --fix`
- `vp test`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90cc5a71-3972-4787-89c1-5cb689a2e521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90cc5a71-3972-4787-89c1-5cb689a2e521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

