### PR TITLE
feat(lokalise): add CAT workspace and live TMS APIs

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_hooks/use-provider-job-locale-readiness.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_hooks/use-provider-job-locale-readiness.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { apiClient } from "@/lib/api-client-instance";
+
+import {
+  extractCrowdinLocaleReadinessEntry,
+  resolveProviderTaskLanguageId,
+} from "../jobs/_components/provider-tms-job-display";
+
+export const providerJobLocaleReadinessQueryKey = (
+  organizationSlug: string,
+  providerKind: string,
+  externalProjectId: string,
+  languageId: string,
+) =>
+  [
+    "provider-job-locale-readiness",
+    organizationSlug,
+    providerKind,
+    externalProjectId,
+    languageId,
+  ] as const;
+
+export async function fetchProviderJobLocaleReadiness(
+  organizationSlug: string,
+  externalProjectId: string,
+  languageId: string,
+) {
+  const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].projects[
+    ":externalProjectId"
+  ]["locale-readiness"].$get({
+    param: { organizationSlug, externalProjectId },
+    query: { languageId },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load translation progress (${response.status})`);
+  }
+
+  const body = (await response.json()) as { localeReadiness: Record<string, unknown> | null };
+  return extractCrowdinLocaleReadinessEntry(body.localeReadiness, languageId);
+}
+
+export function useProviderJobLocaleReadiness(input: {
+  organizationSlug: string;
+  externalProjectId: string | null | undefined;
+  providerKind: string | null | undefined;
+  providerPayload: Record<string, unknown> | null | undefined;
+  enabled?: boolean;
+}) {
+  const supportsLazyReadiness =
+    input.providerKind === "crowdin" || input.providerKind === "lokalise";
+  const languageId = resolveProviderTaskLanguageId(
+    input.providerKind,
+    input.providerPayload ?? null,
+  );
+  const externalProjectId = input.externalProjectId?.trim() ?? "";
+  const enabled =
+    (input.enabled ?? true) &&
+    supportsLazyReadiness &&
+    externalProjectId.length > 0 &&
+    Boolean(languageId);
+
+  return useQuery({
+    queryKey: providerJobLocaleReadinessQueryKey(
+      input.organizationSlug,
+      input.providerKind ?? "unknown",
+      externalProjectId,
+      languageId ?? "",
+    ),
+    enabled,
+    queryFn: () =>
+      fetchProviderJobLocaleReadiness(input.organizationSlug, externalProjectId, languageId!),
+    staleTime: 60_000,
+  });
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/provider-tms-job-display.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/provider-tms-job-display.ts
@@ -1,0 +1,221 @@
+import {
+  extractCrowdinLocaleReadinessEntry,
+  formatLocaleLabel,
+  formatLocaleList,
+  formatReadinessProgress,
+  formatWordsToDo,
+  getCrowdinLanguageLabel,
+  getCrowdinTargetLocales,
+  getCrowdinTaskLanguageId,
+  getCrowdinTaskTypeLabel,
+  getProviderPayloadString,
+  getProviderPayloadStringArray,
+  getReadinessNumber,
+  getReadinessWords,
+  resolveCrowdinLocaleReadiness,
+} from "./provider-crowdin-job-display";
+
+export {
+  extractCrowdinLocaleReadinessEntry,
+  formatLocaleLabel,
+  formatLocaleList,
+  formatReadinessProgress,
+  formatWordsToDo,
+  getProviderPayloadString,
+  getReadinessNumber,
+  getReadinessWords,
+};
+
+type ProviderPayload = Record<string, unknown> | null;
+
+function readLanguageObjects(payload: ProviderPayload) {
+  const languages = payload?.languages;
+  if (!Array.isArray(languages)) {
+    return [];
+  }
+
+  return languages.filter(
+    (language): language is Record<string, unknown> =>
+      Boolean(language) && typeof language === "object" && !Array.isArray(language),
+  );
+}
+
+export function getLokaliseTaskTypeLabel(payload: ProviderPayload) {
+  const taskType = getProviderPayloadString(payload, "taskType");
+  if (!taskType) {
+    return null;
+  }
+
+  switch (taskType) {
+    case "translation":
+      return "Translation";
+    case "review":
+      return "Review";
+    default:
+      return taskType.replaceAll("_", " ");
+  }
+}
+
+export function getLokaliseTaskLanguageId(payload: ProviderPayload) {
+  const languages = readLanguageObjects(payload);
+  const firstLanguage = languages[0];
+  const languageIso = firstLanguage?.languageIso;
+  if (typeof languageIso === "string" && languageIso.trim()) {
+    return languageIso.trim();
+  }
+
+  return getProviderPayloadStringArray(payload, "targetLanguageIds")[0] ?? null;
+}
+
+export function getLokaliseLanguageLabel(payload: ProviderPayload) {
+  const languageId = getLokaliseTaskLanguageId(payload);
+  if (languageId) {
+    return formatLocaleLabel(languageId);
+  }
+
+  const languages = readLanguageObjects(payload);
+  const languageName = languages[0]?.languageName;
+  if (typeof languageName === "string" && languageName.trim()) {
+    return languageName.trim();
+  }
+
+  return null;
+}
+
+export function getLokaliseTargetLocales(payload: ProviderPayload, fallback: string[]) {
+  const languages = readLanguageObjects(payload)
+    .map((language) => language.languageIso)
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0);
+
+  if (languages.length > 0) {
+    return languages;
+  }
+
+  if (fallback.length > 0) {
+    return fallback;
+  }
+
+  const languageId = getLokaliseTaskLanguageId(payload);
+  return languageId ? [languageId] : [];
+}
+
+export function resolveLokaliseLocaleReadiness(
+  payload: ProviderPayload,
+  lazyReadinessByLanguage?: Record<string, unknown> | null,
+): Record<string, unknown> | null {
+  const languageId = getLokaliseTaskLanguageId(payload);
+  const fromLazy = extractCrowdinLocaleReadinessEntry(lazyReadinessByLanguage ?? null, languageId);
+  if (fromLazy) {
+    return fromLazy;
+  }
+
+  const languages = readLanguageObjects(payload);
+  const matched = languageId
+    ? languages.find(
+        (language) =>
+          typeof language.languageIso === "string" &&
+          language.languageIso.trim() === languageId.trim(),
+      )
+    : languages[0];
+
+  const progress =
+    typeof matched?.progress === "number" && Number.isFinite(matched.progress)
+      ? Math.round(matched.progress)
+      : null;
+  if (progress == null) {
+    return null;
+  }
+
+  return {
+    translationProgress: progress,
+    approvalProgress: progress,
+    words: {
+      total: 100,
+      translated: progress,
+      approved: progress,
+    },
+    phrases: {
+      total: 100,
+      translated: progress,
+      approved: progress,
+    },
+  };
+}
+
+export function resolveProviderTaskLanguageLabel(
+  providerKind: string | null | undefined,
+  payload: ProviderPayload,
+) {
+  if (providerKind === "crowdin") {
+    return getCrowdinLanguageLabel(payload);
+  }
+
+  if (providerKind === "lokalise") {
+    return getLokaliseLanguageLabel(payload);
+  }
+
+  return null;
+}
+
+export function resolveProviderTargetLocales(
+  providerKind: string | null | undefined,
+  payload: ProviderPayload,
+  fallback: string[],
+) {
+  if (providerKind === "crowdin") {
+    return getCrowdinTargetLocales(payload, fallback);
+  }
+
+  if (providerKind === "lokalise") {
+    return getLokaliseTargetLocales(payload, fallback);
+  }
+
+  return fallback;
+}
+
+export function resolveProviderTaskTypeLabel(
+  providerKind: string | null | undefined,
+  payload: ProviderPayload,
+  fallback: string,
+) {
+  if (providerKind === "crowdin") {
+    return getCrowdinTaskTypeLabel(payload) ?? fallback;
+  }
+
+  if (providerKind === "lokalise") {
+    return getLokaliseTaskTypeLabel(payload) ?? fallback;
+  }
+
+  return fallback;
+}
+
+export function resolveProviderTaskLanguageId(
+  providerKind: string | null | undefined,
+  payload: ProviderPayload,
+) {
+  if (providerKind === "crowdin") {
+    return getCrowdinTaskLanguageId(payload);
+  }
+
+  if (providerKind === "lokalise") {
+    return getLokaliseTaskLanguageId(payload);
+  }
+
+  return null;
+}
+
+export function resolveProviderLocaleReadiness(
+  providerKind: string | null | undefined,
+  payload: ProviderPayload,
+  lazyReadinessByLanguage?: Record<string, unknown> | null,
+) {
+  if (providerKind === "crowdin") {
+    return resolveCrowdinLocaleReadiness(payload, lazyReadinessByLanguage);
+  }
+
+  if (providerKind === "lokalise") {
+    return resolveLokaliseLocaleReadiness(payload, lazyReadinessByLanguage);
+  }
+
+  return null;
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/provider-tms-job-display.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/provider-tms-job-display.ts
@@ -129,16 +129,6 @@ export function resolveLokaliseLocaleReadiness(
   return {
     translationProgress: progress,
     approvalProgress: progress,
-    words: {
-      total: 100,
-      translated: progress,
-      approved: progress,
-    },
-    phrases: {
-      total: 100,
-      translated: progress,
-      approved: progress,
-    },
   };
 }
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-layout-helpers.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-layout-helpers.tsx
@@ -18,12 +18,12 @@ import {
   formatLocaleList,
   formatReadinessProgress,
   formatWordsToDo,
-  getCrowdinLanguageLabel,
-  getCrowdinTargetLocales,
-  getCrowdinTaskTypeLabel,
   getReadinessNumber,
-  resolveCrowdinLocaleReadiness,
-} from "../../../../../jobs/_components/provider-crowdin-job-display";
+  resolveProviderLocaleReadiness,
+  resolveProviderTargetLocales,
+  resolveProviderTaskLanguageLabel,
+  resolveProviderTaskTypeLabel,
+} from "../../../../../jobs/_components/provider-tms-job-display";
 
 import { formatJobDetailDate, isProviderBackedJob, type JobDetailRecord } from "./job-detail-types";
 import type { JobDetailViewMetric, JobDetailViewProperty } from "./job-detail-view";
@@ -76,7 +76,7 @@ function resolveTaskLocaleReadiness(input: JobDetailTaskLayoutInput) {
     return input.localeReadinessOverride;
   }
 
-  return resolveCrowdinLocaleReadiness(input.externalProviderPayload);
+  return resolveProviderLocaleReadiness(input.externalProviderKind, input.externalProviderPayload);
 }
 
 function getProgressValue(readiness: Record<string, unknown> | null) {
@@ -115,8 +115,10 @@ export function jobDetailTaskMetrics(input: JobDetailTaskLayoutInput): JobDetail
     {
       icon: LanguageSquareIcon,
       label:
-        getCrowdinLanguageLabel(payload) ??
-        formatLocaleList(getCrowdinTargetLocales(payload, input.externalTargetLocales ?? [])) ??
+        resolveProviderTaskLanguageLabel(providerKind, payload) ??
+        formatLocaleList(
+          resolveProviderTargetLocales(providerKind, payload, input.externalTargetLocales ?? []),
+        ) ??
         "—",
     },
     {
@@ -148,9 +150,15 @@ export function jobDetailTaskProperties(input: JobDetailTaskLayoutInput): {
       : null;
   const providerName = formatProviderKind(input.externalProviderKind);
   const targetLocales = formatLocaleList(
-    getCrowdinTargetLocales(payload, input.externalTargetLocales ?? []),
+    resolveProviderTargetLocales(
+      input.externalProviderKind,
+      payload,
+      input.externalTargetLocales ?? [],
+    ),
   );
-  const taskType = getCrowdinTaskTypeLabel(payload) ?? formatJobKind(input.kind);
+  const taskType =
+    resolveProviderTaskTypeLabel(input.externalProviderKind, payload, formatJobKind(input.kind)) ??
+    formatJobKind(input.kind);
   const wordsToDo = formatWordsToDo(readiness);
 
   const properties: JobDetailViewProperty[] = [
@@ -194,7 +202,7 @@ export function jobDetailTaskProperties(input: JobDetailTaskLayoutInput): {
     { label: "Project", value: input.projectName ?? input.projectId ?? "—" },
     {
       label: "Language",
-      value: getCrowdinLanguageLabel(payload) ?? "—",
+      value: resolveProviderTaskLanguageLabel(input.externalProviderKind, payload) ?? "—",
     },
     { label: "External job ID", value: input.externalJobId },
     { label: "External task ID", value: input.externalTaskId },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
@@ -8,7 +8,7 @@ import type { TmsProviderLiveJobDetail } from "@/lib/providers/tms-provider-live
 import { parseProviderJobId } from "@/lib/providers/tms-provider-resource-id";
 
 import { ProviderJobDescriptionField } from "../../../../../jobs/_components/provider-job-description-field";
-import { useCrowdinJobLocaleReadiness } from "../../../../../_hooks/use-crowdin-job-locale-readiness";
+import { useProviderJobLocaleReadiness } from "../../../../../_hooks/use-provider-job-locale-readiness";
 import { ProviderLiveJobDetailView } from "./provider-live-job-detail-view";
 import { TmsLiveJobFilesSection } from "./tms/tms-live-job-files-section";
 
@@ -25,7 +25,9 @@ export function ProviderLiveJobDetailContent({
 }) {
   const queryClient = useQueryClient();
   const jobQueryKey = ["tms-provider-job", organizationSlug, jobId] as const;
-  const showComments = parseProviderJobId(jobId)?.providerKind === "crowdin";
+  const showComments =
+    parseProviderJobId(jobId)?.providerKind === "crowdin" ||
+    parseProviderJobId(jobId)?.providerKind === "lokalise";
 
   const jobQuery = useQuery({
     queryKey: jobQueryKey,
@@ -46,7 +48,7 @@ export function ProviderLiveJobDetailContent({
   });
 
   const parsedJobId = parseProviderJobId(jobId);
-  const localeReadinessQuery = useCrowdinJobLocaleReadiness({
+  const localeReadinessQuery = useProviderJobLocaleReadiness({
     organizationSlug,
     externalProjectId: parsedJobId?.externalProjectId,
     providerKind: jobQuery.data?.externalProviderKind,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
@@ -25,9 +25,9 @@ export function ProviderLiveJobDetailContent({
 }) {
   const queryClient = useQueryClient();
   const jobQueryKey = ["tms-provider-job", organizationSlug, jobId] as const;
+  const parsedJobId = parseProviderJobId(jobId);
   const showComments =
-    parseProviderJobId(jobId)?.providerKind === "crowdin" ||
-    parseProviderJobId(jobId)?.providerKind === "lokalise";
+    parsedJobId?.providerKind === "crowdin" || parsedJobId?.providerKind === "lokalise";
 
   const jobQuery = useQuery({
     queryKey: jobQueryKey,
@@ -47,7 +47,6 @@ export function ProviderLiveJobDetailContent({
     },
   });
 
-  const parsedJobId = parseProviderJobId(jobId);
   const localeReadinessQuery = useProviderJobLocaleReadiness({
     organizationSlug,
     externalProjectId: parsedJobId?.externalProjectId,

--- a/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-filter.ts
+++ b/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-filter.ts
@@ -31,7 +31,7 @@ export function isQueueFilterSupportedForProvider(
   }
 
   if (
-    providerKind === "phrase" &&
+    (providerKind === "phrase" || providerKind === "lokalise") &&
     (filter === "untranslated" || filter === "needs_review" || filter === "reviewed")
   ) {
     return false;

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/load-lokalise-project-credential.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/load-lokalise-project-credential.ts
@@ -1,0 +1,94 @@
+import { and, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import { getActiveOrganizationExternalTmsProviderCredentialRow } from "@/lib/providers/organization-external-tms-provider-credentials";
+import { parseProviderProjectId } from "@/lib/providers/tms-provider-resource-id";
+import {
+  decryptProviderCredential,
+  unwrapProviderCredentialCrypto,
+} from "@/lib/security/provider-credential-crypto";
+
+export type LokaliseProjectCredential = {
+  externalProjectId: string;
+  credential: typeof schema.organizationExternalTmsProviderCredentials.$inferSelect;
+};
+
+export async function loadLokaliseProjectCredential(input: {
+  organizationId: string;
+  projectId: string;
+}): Promise<LokaliseProjectCredential | null> {
+  const [project] = await db
+    .select({
+      externalProjectId: schema.projects.externalProjectId,
+      externalProviderCredentialId: schema.projects.externalProviderCredentialId,
+      externalProviderKind: schema.projects.externalProviderKind,
+    })
+    .from(schema.projects)
+    .where(
+      and(
+        eq(schema.projects.id, input.projectId),
+        eq(schema.projects.organizationId, input.organizationId),
+        eq(schema.projects.externalProviderKind, "lokalise"),
+        eq(schema.projects.source, "external_tms"),
+      ),
+    )
+    .limit(1);
+
+  if (project?.externalProjectId && project.externalProviderCredentialId) {
+    const [credential] = await db
+      .select()
+      .from(schema.organizationExternalTmsProviderCredentials)
+      .where(
+        and(
+          eq(
+            schema.organizationExternalTmsProviderCredentials.organizationId,
+            input.organizationId,
+          ),
+          eq(schema.organizationExternalTmsProviderCredentials.providerKind, "lokalise"),
+          eq(
+            schema.organizationExternalTmsProviderCredentials.id,
+            project.externalProviderCredentialId,
+          ),
+        ),
+      )
+      .limit(1);
+
+    if (credential) {
+      return {
+        externalProjectId: project.externalProjectId,
+        credential,
+      };
+    }
+  }
+
+  const encodedProject = parseProviderProjectId(input.projectId);
+  if (encodedProject?.providerKind !== "lokalise") {
+    return null;
+  }
+
+  const credential = await getActiveOrganizationExternalTmsProviderCredentialRow(
+    input.organizationId,
+  );
+  if (!credential || credential.providerKind !== "lokalise") {
+    return null;
+  }
+
+  return {
+    externalProjectId: encodedProject.externalProjectId,
+    credential,
+  };
+}
+
+export function decryptLokaliseCredentialToken(
+  credential: LokaliseProjectCredential["credential"],
+): string {
+  return unwrapProviderCredentialCrypto(
+    decryptProviderCredential({
+      algorithm: credential.encryptionAlgorithm,
+      keyVersion: credential.keyVersion,
+      ciphertext: credential.ciphertext,
+      iv: credential.iv,
+      authTag: credential.authTag,
+    }),
+  );
+}

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-api.ts
@@ -417,6 +417,48 @@ export class LokaliseApiClient {
     return maxKeys != null ? keys.slice(0, maxKeys) : keys;
   }
 
+  async listKeysCursorPage(
+    projectId: string,
+    options?: {
+      includeTranslations?: boolean;
+      filterKeyIds?: number[];
+      filterTranslationLangIds?: number[];
+      cursor?: string;
+      limit?: number;
+    },
+  ): Promise<{ keys: LokaliseKey[]; nextCursor: string | null }> {
+    const pageLimit = options?.limit ?? 500;
+    const includeTranslations = options?.includeTranslations ?? true;
+    const filterKeyIds = options?.filterKeyIds?.length ? options.filterKeyIds.join(",") : null;
+    const filterTranslationLangIds = options?.filterTranslationLangIds?.length
+      ? options.filterTranslationLangIds.join(",")
+      : null;
+
+    const params = new URLSearchParams({
+      pagination: "cursor",
+      limit: String(pageLimit),
+      include_translations: includeTranslations ? "1" : "0",
+    });
+    if (options?.cursor) {
+      params.set("cursor", options.cursor);
+    }
+    if (filterKeyIds) {
+      params.set("filter_key_ids", filterKeyIds);
+    }
+    if (filterTranslationLangIds) {
+      params.set("filter_translation_lang_ids", filterTranslationLangIds);
+    }
+
+    const { body, nextCursor } = await this.getWithPagination<LokaliseKeysListResponse>(
+      `/projects/${encodeURIComponent(projectId)}/keys?${params.toString()}`,
+    );
+
+    return {
+      keys: (body.keys ?? []).map(normalizeLokaliseKey),
+      nextCursor: nextCursor?.trim() ? nextCursor.trim() : null,
+    };
+  }
+
   async listTasks(projectId: string, options?: LokaliseListTasksOptions): Promise<LokaliseTask[]> {
     const tasks: LokaliseTask[] = [];
     let page = 1;

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-cat-concordance.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-cat-concordance.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { LokaliseApiClient } from "./lokalise-api";
+import { searchLokaliseCatConcordance } from "./lokalise-cat-concordance";
+
+describe("searchLokaliseCatConcordance", () => {
+  it("maps Lokalise glossary and project-key TM matches without attached resource filtering", async () => {
+    const listGlossaryTerms = vi.fn().mockResolvedValue([
+      {
+        id: 11,
+        term: "workspace",
+        description: "Product term",
+        caseSensitive: false,
+        translatable: true,
+        forbidden: false,
+        translations: [
+          {
+            languageId: 640,
+            languageIso: "fr",
+            translation: "espace de travail",
+          },
+        ],
+        tags: [],
+      },
+    ]);
+    const listProjectLanguages = vi
+      .fn()
+      .mockResolvedValue([{ langId: 640, langIso: "fr", langName: "French" }]);
+    const listKeys = vi.fn().mockResolvedValue([
+      {
+        keyId: 99,
+        keyName: { web: "sign_in" },
+        translations: [
+          { languageIso: "en", translation: "Sign in to your workspace" },
+          {
+            languageIso: "fr",
+            translation: "Connectez-vous a votre espace de travail",
+          },
+        ],
+      },
+    ]);
+
+    const client = {
+      listGlossaryTerms,
+      listProjectLanguages,
+      listKeys,
+    } as unknown as LokaliseApiClient;
+
+    const result = await searchLokaliseCatConcordance({
+      client,
+      externalProjectId: "proj.123",
+      sourceLocale: "en",
+      targetLocale: "fr",
+      sourceText: "Sign in to your workspace",
+    });
+
+    expect(listGlossaryTerms).toHaveBeenCalledWith("proj.123");
+    expect(listKeys).toHaveBeenCalledWith("proj.123", { includeTranslations: true });
+    expect(result.glossaryTerms).toHaveLength(1);
+    expect(result.glossaryTerms[0]).toMatchObject({
+      sourceTerm: "workspace",
+      targetTerm: "espace de travail",
+      glossaryName: "Lokalise glossary (proj.123)",
+      matchSource: "live_provider",
+    });
+    expect(result.translationMemoryMatches).toHaveLength(1);
+    expect(result.translationMemoryMatches[0]).toMatchObject({
+      sourceText: "Sign in to your workspace",
+      targetText: "Connectez-vous a votre espace de travail",
+      memoryName: "Lokalise translation memory (proj.123)",
+      externalResourceId: "proj.123:translation-memory",
+    });
+  });
+
+  it("maps forbidden Lokalise glossary terms into normalized term flags", async () => {
+    const client = {
+      listGlossaryTerms: vi.fn().mockResolvedValue([
+        {
+          id: 11,
+          term: "workspace",
+          description: null,
+          caseSensitive: false,
+          translatable: true,
+          forbidden: true,
+          translations: [
+            {
+              languageId: 640,
+              languageIso: "fr",
+              translation: "espace",
+            },
+          ],
+          tags: [],
+        },
+      ]),
+      listProjectLanguages: vi
+        .fn()
+        .mockResolvedValue([{ langId: 640, langIso: "fr", langName: "French" }]),
+      listKeys: vi.fn().mockResolvedValue([]),
+    } as unknown as LokaliseApiClient;
+
+    const result = await searchLokaliseCatConcordance({
+      client,
+      externalProjectId: "proj.123",
+      sourceLocale: "en",
+      targetLocale: "fr",
+      sourceText: "workspace",
+    });
+
+    expect(result.glossaryTerms[0]?.termStatus).toEqual({
+      forbidden: true,
+      preferred: false,
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-cat-concordance.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-cat-concordance.ts
@@ -1,0 +1,152 @@
+import type { NormalizedGlossaryMatch } from "@/lib/providers/contracts/glossary-match";
+import { normalizeProviderGlossaryMatch } from "@/lib/providers/contracts/glossary-match";
+import type { NormalizedTranslationMemoryMatch } from "@/lib/providers/contracts/translation-memory-match";
+import { normalizeProviderTranslationMemoryMatch } from "@/lib/providers/contracts/translation-memory-match";
+import { TmsProviderLiveError } from "@/lib/providers/tms-provider-live";
+
+import { LokaliseApiClient, LokaliseApiError, LOKALISE_TM_SYNC_MAX_KEYS } from "./lokalise-api";
+import {
+  buildLokaliseProjectGlossaryExternalId,
+  buildLokaliseProjectTranslationMemoryExternalId,
+  buildLokaliseTranslationMemorySegmentCandidates,
+  matchesLokaliseGlossaryTerm,
+  pickLokaliseGlossaryTranslation,
+} from "./normalize-lokalise-context-matches";
+
+function rethrowLokaliseConcordanceApiError(error: unknown): never {
+  if (error instanceof LokaliseApiError) {
+    if (error.status === 401 || error.status === 403) {
+      throw new TmsProviderLiveError(
+        "lokalise_auth_invalid",
+        "Lokalise credentials are invalid or lack permission for this project.",
+      );
+    }
+    if (error.status === 404) {
+      throw new TmsProviderLiveError(
+        "invalid_lokalise_project_id",
+        "The Lokalise project could not be found.",
+      );
+    }
+    throw new TmsProviderLiveError(
+      "provider_fetch_failed",
+      "Failed to fetch glossary and translation memory from Lokalise.",
+    );
+  }
+
+  if (error instanceof Error && error.message === "lokalise_auth_invalid") {
+    throw new TmsProviderLiveError("lokalise_auth_invalid", "Lokalise credentials are invalid.");
+  }
+
+  throw error;
+}
+
+export async function searchLokaliseCatConcordance(input: {
+  client: LokaliseApiClient;
+  externalProjectId: string;
+  sourceLocale: string;
+  targetLocale: string;
+  sourceText: string;
+  glossaryLimit?: number;
+  translationMemoryLimit?: number;
+}): Promise<{
+  glossaryTerms: NormalizedGlossaryMatch[];
+  translationMemoryMatches: NormalizedTranslationMemoryMatch[];
+}> {
+  const projectId = input.externalProjectId.trim();
+  if (!projectId) {
+    return { glossaryTerms: [], translationMemoryMatches: [] };
+  }
+
+  const glossaryLimit = input.glossaryLimit ?? 20;
+  const translationMemoryLimit = input.translationMemoryLimit ?? 10;
+  const externalGlossaryId = buildLokaliseProjectGlossaryExternalId(projectId);
+  const externalMemoryId = buildLokaliseProjectTranslationMemoryExternalId(projectId);
+  const glossaryName = `Lokalise glossary (${projectId})`;
+  const memoryName = `Lokalise translation memory (${projectId})`;
+
+  let terms: Awaited<ReturnType<LokaliseApiClient["listGlossaryTerms"]>>;
+  let languages: Awaited<ReturnType<LokaliseApiClient["listProjectLanguages"]>>;
+  let keys: Awaited<ReturnType<LokaliseApiClient["listKeys"]>>;
+
+  try {
+    [terms, languages, keys] = await Promise.all([
+      input.client.listGlossaryTerms(projectId),
+      input.client.listProjectLanguages(projectId),
+      input.client.listKeys(projectId, { includeTranslations: true }),
+    ]);
+  } catch (error) {
+    rethrowLokaliseConcordanceApiError(error);
+  }
+
+  const languageIsoById = new Map(
+    languages
+      .filter((language) => language.langId > 0 && language.langIso.trim())
+      .map((language) => [language.langId, language.langIso.trim()] as const),
+  );
+
+  const glossaryTerms: NormalizedGlossaryMatch[] = [];
+  for (const [index, term] of terms.entries()) {
+    if (!matchesLokaliseGlossaryTerm(input.sourceText, term)) {
+      continue;
+    }
+
+    const sourceTerm = term.term.trim();
+    const targetTerm = pickLokaliseGlossaryTranslation(term, input.targetLocale, languageIsoById);
+    if (!sourceTerm || !targetTerm) {
+      continue;
+    }
+
+    glossaryTerms.push(
+      normalizeProviderGlossaryMatch({
+        sourceTerm,
+        targetTerm,
+        sourceLocale: input.sourceLocale,
+        targetLocale: input.targetLocale,
+        description: term.description,
+        caseSensitive: term.caseSensitive,
+        providerKind: "lokalise",
+        resourceId: externalGlossaryId,
+        externalResourceId: externalGlossaryId,
+        externalTermId: String(term.id),
+        glossaryName,
+        rank: 1 - index * 0.01,
+        status: {
+          forbidden: term.forbidden,
+        },
+      }),
+    );
+  }
+
+  const tmCandidates = buildLokaliseTranslationMemorySegmentCandidates(
+    keys.slice(0, LOKALISE_TM_SYNC_MAX_KEYS),
+    {
+      sourceLocale: input.sourceLocale,
+      targetLocale: input.targetLocale,
+      sourceText: input.sourceText,
+      limit: translationMemoryLimit,
+    },
+  );
+
+  const translationMemoryMatches = tmCandidates.map((candidate, index) =>
+    normalizeProviderTranslationMemoryMatch({
+      sourceText: candidate.sourceText,
+      targetText: candidate.targetText,
+      sourceLocale: input.sourceLocale,
+      targetLocale: input.targetLocale,
+      matchScore: candidate.matchScore,
+      providerKind: "lokalise",
+      resourceId: externalMemoryId,
+      externalResourceId: externalMemoryId,
+      externalSegmentId: String(candidate.keyId),
+      memoryName,
+      rank: 1 - index * 0.01,
+    }),
+  );
+
+  return {
+    glossaryTerms: glossaryTerms
+      .toSorted((left, right) => right.rank - left.rank)
+      .slice(0, glossaryLimit),
+    translationMemoryMatches,
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-job-comments.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-job-comments.ts
@@ -36,7 +36,7 @@ export async function listLokaliseTaskComments(input: {
   try {
     task = await client.getTask(projectId, parsedJobId.taskId);
   } catch (error) {
-    if (error instanceof LokaliseApiError && error.status === 401) {
+    if (error instanceof LokaliseApiError && (error.status === 401 || error.status === 403)) {
       throw new Error("lokalise_auth_invalid");
     }
     if (error instanceof LokaliseApiError && error.status === 404) {
@@ -61,7 +61,7 @@ export async function listLokaliseTaskComments(input: {
       }
     }
   } catch (error) {
-    if (error instanceof LokaliseApiError && error.status === 401) {
+    if (error instanceof LokaliseApiError && (error.status === 401 || error.status === 403)) {
       throw new Error("lokalise_auth_invalid");
     }
     throw error;

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-job-comments.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-job-comments.ts
@@ -1,0 +1,80 @@
+import type { TmsProviderLiveJobComment } from "@/lib/providers/tms-provider-live";
+
+import {
+  collectLokaliseTaskKeyIds,
+  LokaliseApiClient,
+  LokaliseApiError,
+  parseLokaliseExternalJobId,
+} from "./lokalise-api";
+
+function chunkArray<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
+export async function listLokaliseTaskComments(input: {
+  secretMaterial: string;
+  baseUrl?: string | null;
+  externalProjectId: string;
+  externalJobId: string;
+}): Promise<TmsProviderLiveJobComment[] | null> {
+  const projectId = input.externalProjectId.trim();
+  const parsedJobId = parseLokaliseExternalJobId(input.externalJobId);
+  if (!projectId || !parsedJobId) {
+    return null;
+  }
+
+  const client = new LokaliseApiClient({
+    token: input.secretMaterial,
+    baseUrl: input.baseUrl,
+  });
+
+  let task: Awaited<ReturnType<typeof client.getTask>>;
+  try {
+    task = await client.getTask(projectId, parsedJobId.taskId);
+  } catch (error) {
+    if (error instanceof LokaliseApiError && error.status === 401) {
+      throw new Error("lokalise_auth_invalid");
+    }
+    if (error instanceof LokaliseApiError && error.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+
+  const keyIds = collectLokaliseTaskKeyIds(task);
+  if (keyIds.length === 0) {
+    return [];
+  }
+
+  const comments: Awaited<ReturnType<typeof client.listKeyComments>> = [];
+  try {
+    for (const chunk of chunkArray(keyIds, 25)) {
+      const chunkResults = await Promise.all(
+        chunk.map((keyId) => client.listKeyComments(projectId, keyId)),
+      );
+      for (const keyComments of chunkResults) {
+        comments.push(...keyComments);
+      }
+    }
+  } catch (error) {
+    if (error instanceof LokaliseApiError && error.status === 401) {
+      throw new Error("lokalise_auth_invalid");
+    }
+    throw error;
+  }
+
+  return comments.map((comment) => ({
+    id: `lokalise:key-comment:${comment.commentId}`,
+    externalCommentId: String(comment.commentId),
+    userId: String(comment.addedBy ?? comment.addedByEmail ?? "unknown"),
+    taskId: String(parsedJobId.taskId),
+    text: comment.comment,
+    timeSpentSeconds: null,
+    createdAt: comment.addedAt ?? "",
+    updatedAt: comment.addedAt ?? "",
+  }));
+}

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-live-cat.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-live-cat.test.ts
@@ -155,6 +155,110 @@ describe("buildLokaliseLiveCatFile", () => {
       }),
     ).rejects.toBeInstanceOf(LokaliseLiveCatError);
   });
+
+  it("paginates unscoped file queues beyond the first 100 keys", async () => {
+    const firstPageKeys = Array.from({ length: 100 }, (_, index) => ({
+      key_id: index + 1,
+      key_name: { web: `key.${index + 1}`, ios: "", android: "", other: "" },
+      filenames: { web: "", ios: "", android: "", other: "" },
+      description: null,
+      tags: [],
+      translations: [
+        {
+          translation_id: index + 1,
+          key_id: index + 1,
+          language_iso: "en",
+          translation: `Source ${index + 1}`,
+          is_reviewed: true,
+          is_unverified: false,
+        },
+      ],
+    }));
+    const secondPageKeys = [
+      {
+        key_id: 101,
+        key_name: { web: "key.101", ios: "", android: "", other: "" },
+        filenames: { web: "", ios: "", android: "", other: "" },
+        description: null,
+        tags: [],
+        translations: [
+          {
+            translation_id: 101,
+            key_id: 101,
+            language_iso: "en",
+            translation: "Source 101",
+            is_reviewed: true,
+            is_unverified: false,
+          },
+        ],
+      },
+    ];
+
+    const fetchMock = vi.fn(async (url: string) => {
+      const path = String(url);
+
+      if (path.includes("/languages")) {
+        return new Response(
+          JSON.stringify({
+            languages: [
+              { lang_id: 640, lang_iso: "en", lang_name: "English", is_rtl: false },
+              { lang_id: 641, lang_iso: "fr", lang_name: "French", is_rtl: false },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/keys")) {
+        const cursor = new URL(path, "https://api.lokalise.test").searchParams.get("cursor");
+        return new Response(JSON.stringify({ keys: cursor ? secondPageKeys : firstPageKeys }), {
+          status: 200,
+          headers: cursor ? {} : { "X-Pagination-Next-Cursor": "page-2" },
+        });
+      }
+
+      return new Response("not found", { status: 404 });
+    });
+
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const catFile = await buildLokaliseLiveCatFile({
+      secretMaterial: "token",
+      baseUrl: "https://api.lokalise.test/api2",
+      externalProjectId: "proj.123",
+      file: createLokaliseKeyFile({
+        sourcePath: "files/app.json",
+        filename: "app.json",
+        metadata: { tags: [] },
+        provider: {
+          kind: "lokalise",
+          resourceType: "file",
+          externalProjectId: "proj.123",
+          externalResourceId: "file:app.json",
+          externalUrl: null,
+          syncState: "synced",
+          sourceLocale: "en",
+          targetLocales: ["fr"],
+          localeReadiness: {},
+          revision: null,
+          format: "json",
+          lastSyncedAt: null,
+        },
+      }),
+      targetLocale: "fr",
+      canEditTranslations: true,
+      pagination: { offset: 100, limit: 1, queueFilter: "all", paginated: true },
+    });
+
+    expect(catFile.segments).toEqual([
+      expect.objectContaining({
+        externalStringId: "101",
+        key: "key.101",
+        sourceText: "Source 101",
+      }),
+    ]);
+    expect(fetchMock.mock.calls.filter(([url]) => String(url).includes("/keys"))).toHaveLength(2);
+  });
 });
 
 describe("getLokaliseLiveCatSegmentTarget", () => {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-live-cat.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-live-cat.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import type { TmsProviderLiveFile } from "@/lib/providers/tms-provider-live";
+
+import {
+  buildLokaliseLiveCatFile,
+  getLokaliseLiveCatSegmentTarget,
+  LokaliseLiveCatError,
+  saveLokaliseLiveCatTranslation,
+} from "./lokalise-live-cat";
+
+function createLokaliseKeyFile(overrides: Partial<TmsProviderLiveFile> = {}): TmsProviderLiveFile {
+  return {
+    origin: "provider",
+    sourcePath: "keys/home.hero.title",
+    sourceHash: null,
+    commitSha: null,
+    workflowRunId: null,
+    uploadedAt: "2026-06-08T00:00:00Z",
+    storedFileId: null,
+    metadata: {
+      id: 101,
+      key: "home.hero.title",
+      tags: ["app"],
+    },
+    filename: "home.hero.title",
+    byteSize: null,
+    provider: {
+      kind: "lokalise",
+      resourceType: "key",
+      externalProjectId: "proj.123",
+      externalResourceId: "101",
+      externalUrl: null,
+      syncState: "synced",
+      sourceLocale: "en",
+      targetLocales: ["fr"],
+      localeReadiness: {},
+      revision: null,
+      format: "json",
+      lastSyncedAt: null,
+    },
+    latestJob: null,
+    ...overrides,
+  };
+}
+
+describe("buildLokaliseLiveCatFile", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  it("loads a single key file without embedding targets in the queue", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      const path = String(url);
+
+      if (path.includes("/languages")) {
+        return new Response(
+          JSON.stringify({
+            project_id: "proj.123",
+            languages: [
+              { lang_id: 640, lang_iso: "en", lang_name: "English", is_rtl: false },
+              { lang_id: 641, lang_iso: "fr", lang_name: "French", is_rtl: false },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/keys") && path.includes("filter_key_ids=101")) {
+        return new Response(
+          JSON.stringify({
+            project_id: "proj.123",
+            keys: [
+              {
+                key_id: 101,
+                key_name: { web: "home.hero.title", ios: "", android: "", other: "" },
+                filenames: { web: "", ios: "", android: "", other: "" },
+                description: "Hero title",
+                tags: ["app"],
+                translations: [
+                  {
+                    translation_id: 1,
+                    key_id: 101,
+                    language_iso: "en",
+                    translation: "Welcome",
+                    is_reviewed: true,
+                    is_unverified: false,
+                  },
+                ],
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("not found", { status: 404 });
+    });
+
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const catFile = await buildLokaliseLiveCatFile({
+      secretMaterial: "token",
+      baseUrl: "https://api.lokalise.test/api2",
+      externalProjectId: "proj.123",
+      file: createLokaliseKeyFile(),
+      targetLocale: "fr",
+      canEditTranslations: true,
+      pagination: { offset: 0, limit: 50, queueFilter: "all", paginated: true },
+    });
+
+    expect(catFile.segments).toEqual([
+      {
+        externalStringId: "101",
+        key: "home.hero.title",
+        sourceText: "Welcome",
+        context: "Hero title",
+        type: null,
+      },
+    ]);
+    expect(catFile.segments[0]).not.toHaveProperty("target");
+  });
+
+  it("rejects unsupported queue filters", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (String(url).includes("/languages")) {
+        return new Response(
+          JSON.stringify({
+            languages: [{ lang_id: 641, lang_iso: "fr", lang_name: "French", is_rtl: false }],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("not found", { status: 404 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(
+      buildLokaliseLiveCatFile({
+        secretMaterial: "token",
+        baseUrl: "https://api.lokalise.test/api2",
+        externalProjectId: "proj.123",
+        file: createLokaliseKeyFile(),
+        targetLocale: "fr",
+        canEditTranslations: true,
+        pagination: { offset: 0, limit: 50, queueFilter: "has_issues", paginated: true },
+      }),
+    ).rejects.toBeInstanceOf(LokaliseLiveCatError);
+  });
+});
+
+describe("getLokaliseLiveCatSegmentTarget", () => {
+  it("maps reviewed translations to approved targets", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      const path = String(url);
+
+      if (path.includes("/languages")) {
+        return new Response(
+          JSON.stringify({
+            languages: [{ lang_id: 641, lang_iso: "fr", lang_name: "French", is_rtl: false }],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/keys")) {
+        return new Response(
+          JSON.stringify({
+            keys: [
+              {
+                key_id: 101,
+                key_name: { web: "home.hero.title", ios: "", android: "", other: "" },
+                filenames: { web: "", ios: "", android: "", other: "" },
+                translations: [
+                  {
+                    translation_id: 2,
+                    key_id: 101,
+                    language_iso: "fr",
+                    translation: "Bienvenue",
+                    is_reviewed: true,
+                    is_unverified: false,
+                  },
+                ],
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("not found", { status: 404 });
+    });
+
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const target = await getLokaliseLiveCatSegmentTarget({
+      secretMaterial: "token",
+      baseUrl: "https://api.lokalise.test/api2",
+      externalProjectId: "proj.123",
+      file: createLokaliseKeyFile(),
+      targetLocale: "fr",
+      externalStringId: "101",
+    });
+
+    expect(target).toEqual({
+      text: "Bienvenue",
+      externalTranslationId: "2",
+      isApproved: true,
+    });
+  });
+});
+
+describe("saveLokaliseLiveCatTranslation", () => {
+  it("writes reviewed translations back to Lokalise", async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const path = String(url);
+
+      if (path.includes("/languages")) {
+        return new Response(
+          JSON.stringify({
+            languages: [{ lang_id: 641, lang_iso: "fr", lang_name: "French", is_rtl: false }],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (init?.method === "PUT" && path.includes("/keys")) {
+        return new Response(JSON.stringify({ keys: [], errors: [] }), { status: 200 });
+      }
+
+      if (path.includes("/keys")) {
+        return new Response(
+          JSON.stringify({
+            keys: [
+              {
+                key_id: 101,
+                key_name: { web: "home.hero.title", ios: "", android: "", other: "" },
+                filenames: { web: "", ios: "", android: "", other: "" },
+                translations: [
+                  {
+                    translation_id: 2,
+                    key_id: 101,
+                    language_iso: "fr",
+                    translation: "Bonjour",
+                    is_reviewed: true,
+                    is_unverified: false,
+                  },
+                ],
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("not found", { status: 404 });
+    });
+
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const saved = await saveLokaliseLiveCatTranslation({
+      secretMaterial: "token",
+      baseUrl: "https://api.lokalise.test/api2",
+      externalProjectId: "proj.123",
+      file: createLokaliseKeyFile(),
+      targetLocale: "fr",
+      externalStringId: "101",
+      text: "Bonjour",
+    });
+
+    expect(saved).toEqual({
+      text: "Bonjour",
+      externalTranslationId: "2",
+      isApproved: true,
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-live-cat.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-live-cat.ts
@@ -239,11 +239,16 @@ async function advanceLokaliseKeysCursor(input: {
 }): Promise<{ cursor: string; scanComplete: boolean }> {
   let cursor = "";
   for (let page = 1; page < input.targetScanPage; page++) {
-    const result = await input.client.listKeysCursorPage(input.projectId, {
-      includeTranslations: false,
-      cursor: cursor || undefined,
-      limit: input.pageSize,
-    });
+    let result: Awaited<ReturnType<LokaliseApiClient["listKeysCursorPage"]>>;
+    try {
+      result = await input.client.listKeysCursorPage(input.projectId, {
+        includeTranslations: false,
+        cursor: cursor || undefined,
+        limit: input.pageSize,
+      });
+    } catch (error) {
+      mapLokaliseApiError(error);
+    }
     if (!result.nextCursor) {
       return { cursor: "", scanComplete: true };
     }

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-live-cat.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-live-cat.ts
@@ -338,11 +338,16 @@ async function loadLokaliseQueuePage(input: {
     let hasMore = false;
 
     while (collected.length < limit) {
-      const page = await input.client.listKeysCursorPage(input.scope.projectId, {
-        includeTranslations: false,
-        cursor: cursor || undefined,
-        limit: LOKALISE_QUEUE_SCAN_PAGE_SIZE,
-      });
+      let page: Awaited<ReturnType<LokaliseApiClient["listKeysCursorPage"]>>;
+      try {
+        page = await input.client.listKeysCursorPage(input.scope.projectId, {
+          includeTranslations: false,
+          cursor: cursor || undefined,
+          limit: LOKALISE_QUEUE_SCAN_PAGE_SIZE,
+        });
+      } catch (error) {
+        mapLokaliseApiError(error);
+      }
 
       let stoppedEarly = false;
       for (const key of page.keys) {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-live-cat.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-live-cat.ts
@@ -51,8 +51,11 @@ type LokaliseQueueSegmentDraft = {
 };
 
 function mapLokaliseApiError(error: unknown): never {
-  if (error instanceof LokaliseApiError && error.status === 401) {
-    throw new LokaliseLiveCatError("lokalise_auth_invalid", "Lokalise credentials are invalid.");
+  if (error instanceof LokaliseApiError && (error.status === 401 || error.status === 403)) {
+    throw new LokaliseLiveCatError(
+      "lokalise_auth_invalid",
+      "Lokalise credentials are invalid or lack permission for this project.",
+    );
   }
   throw error;
 }

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-live-cat.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-live-cat.ts
@@ -228,6 +228,28 @@ async function fetchLokaliseKeysByIds(input: {
   return keys;
 }
 
+async function advanceLokaliseKeysCursor(input: {
+  client: LokaliseApiClient;
+  projectId: string;
+  targetScanPage: number;
+  pageSize: number;
+}): Promise<{ cursor: string; scanComplete: boolean }> {
+  let cursor = "";
+  for (let page = 1; page < input.targetScanPage; page++) {
+    const result = await input.client.listKeysCursorPage(input.projectId, {
+      includeTranslations: false,
+      cursor: cursor || undefined,
+      limit: input.pageSize,
+    });
+    if (!result.nextCursor) {
+      return { cursor: "", scanComplete: true };
+    }
+    cursor = result.nextCursor;
+  }
+
+  return { cursor, scanComplete: false };
+}
+
 async function loadLokaliseQueuePage(input: {
   client: LokaliseApiClient;
   scope: LokaliseLiveCatContext;
@@ -306,6 +328,53 @@ async function loadLokaliseQueuePage(input: {
     };
   }
 
+  if (!needsClientSideFilter && scopedKeyIds.length === 0) {
+    const collected: LokaliseKey[] = [];
+    let cursor = "";
+    let skipped = 0;
+    let hasMore = false;
+
+    while (collected.length < limit) {
+      const page = await input.client.listKeysCursorPage(input.scope.projectId, {
+        includeTranslations: false,
+        cursor: cursor || undefined,
+        limit: LOKALISE_QUEUE_SCAN_PAGE_SIZE,
+      });
+
+      let stoppedEarly = false;
+      for (const key of page.keys) {
+        if (skipped < offset) {
+          skipped += 1;
+          continue;
+        }
+
+        collected.push(key);
+        if (collected.length >= limit) {
+          stoppedEarly = true;
+          break;
+        }
+      }
+
+      if (collected.length >= limit) {
+        hasMore = Boolean(page.nextCursor) || stoppedEarly;
+        break;
+      }
+
+      if (!page.nextCursor) {
+        break;
+      }
+
+      cursor = page.nextCursor;
+    }
+
+    return {
+      segments: collected
+        .map((key) => buildQueueSegmentFromKey(key, sourceLocale))
+        .map(draftToQueueSegment),
+      hasMore,
+    };
+  }
+
   const collected: ProjectFileCatQueueSegment[] = [];
   const resumingScan = input.paginationInput.phraseScanPage != null;
   let scanPage = resumingScan ? input.paginationInput.phraseScanPage! : 1;
@@ -313,6 +382,20 @@ async function loadLokaliseQueuePage(input: {
   let scanComplete = false;
   let nextPhraseScanPage: number | undefined;
   let nextPhraseScanSkip: number | undefined;
+  let listKeysCursor = "";
+  if (resumingScan && scopedKeyIds.length === 0) {
+    const advanced = await advanceLokaliseKeysCursor({
+      client: input.client,
+      projectId: input.scope.projectId,
+      targetScanPage: scanPage,
+      pageSize: LOKALISE_QUEUE_SCAN_PAGE_SIZE,
+    });
+    if (advanced.scanComplete) {
+      scanComplete = true;
+    } else {
+      listKeysCursor = advanced.cursor;
+    }
+  }
   const scanPageBudget = resumingScan
     ? scanPage + LOKALISE_MAX_SCAN_PAGES - 1
     : Math.max(
@@ -320,7 +403,7 @@ async function loadLokaliseQueuePage(input: {
         Math.ceil((offset + limit) / LOKALISE_QUEUE_SCAN_PAGE_SIZE) + LOKALISE_MAX_SCAN_PAGES,
       );
 
-  while (collected.length < limit && scanPage <= scanPageBudget) {
+  while (!scanComplete && collected.length < limit && scanPage <= scanPageBudget) {
     const chunkStart = (scanPage - 1) * LOKALISE_QUEUE_SCAN_PAGE_SIZE;
     const chunkKeyIds =
       scopedKeyIds.length > 0
@@ -340,14 +423,19 @@ async function loadLokaliseQueuePage(input: {
       });
     } else {
       try {
-        keys = await input.client.listKeys(input.scope.projectId, {
+        const page = await input.client.listKeysCursorPage(input.scope.projectId, {
           includeTranslations: false,
-          maxKeys: LOKALISE_QUEUE_SCAN_PAGE_SIZE,
+          cursor: listKeysCursor || undefined,
+          limit: LOKALISE_QUEUE_SCAN_PAGE_SIZE,
         });
+        keys = page.keys;
+        listKeysCursor = page.nextCursor ?? "";
+        if (!page.nextCursor) {
+          scanComplete = true;
+        }
       } catch (error) {
         mapLokaliseApiError(error);
       }
-      scanComplete = true;
     }
 
     const filteredKeys = filterKeysByFileTags(keys, metadata.tags);
@@ -382,8 +470,7 @@ async function loadLokaliseQueuePage(input: {
         scanComplete = true;
         break;
       }
-    } else {
-      scanComplete = true;
+    } else if (scanComplete) {
       break;
     }
 

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-live-cat.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-live-cat.ts
@@ -1,0 +1,676 @@
+import type {
+  ProjectFileCatComment,
+  ProjectFileCatQueueFile,
+  ProjectFileCatQueueSegment,
+  ProjectFileCatTranslation,
+} from "@/api/routes/project/project.schema";
+import { legacyProviderCatSegmentLimit } from "@/api/routes/project/project.schema";
+import {
+  buildCatFilePagination,
+  type ProjectFileCatPaginationInput,
+} from "@/lib/projects/cat/project-file-cat-pagination";
+import type { TmsProviderLiveFile } from "@/lib/providers/tms-provider-live";
+
+import {
+  extractLokaliseKeyName,
+  LokaliseApiClient,
+  LokaliseApiError,
+  type LokaliseKey,
+  type LokaliseLanguage,
+  type LokaliseTranslation,
+} from "./lokalise-api";
+import { mapLokaliseTranslationReadiness } from "./lokalise-locale-readiness";
+import { pickLokaliseKeyTranslation } from "./normalize-lokalise-context-matches";
+
+const LOKALISE_KEY_FETCH_CHUNK_SIZE = 50;
+const LOKALISE_QUEUE_SCAN_PAGE_SIZE = 100;
+const LOKALISE_MAX_SCAN_PAGES = 50;
+
+export class LokaliseLiveCatError extends Error {
+  constructor(
+    readonly code: string,
+    message?: string,
+  ) {
+    super(message ?? code);
+    this.name = "LokaliseLiveCatError";
+  }
+}
+
+type LokaliseLiveCatContext = {
+  token: string;
+  baseUrl?: string | null;
+  projectId: string;
+};
+
+type LokaliseQueueSegmentDraft = {
+  externalStringId: string;
+  key: string;
+  sourceText: string;
+  context: string | null;
+  type: string | null;
+};
+
+function mapLokaliseApiError(error: unknown): never {
+  if (error instanceof LokaliseApiError && error.status === 401) {
+    throw new LokaliseLiveCatError("lokalise_auth_invalid", "Lokalise credentials are invalid.");
+  }
+  throw error;
+}
+
+function readFileMetadata(file: TmsProviderLiveFile) {
+  const payload = file.metadata ?? {};
+  const tags = Array.isArray(payload.tags)
+    ? payload.tags.filter((tag): tag is string => typeof tag === "string" && tag.trim().length > 0)
+    : [];
+  const keyIds = Array.isArray(payload.keyIds)
+    ? payload.keyIds
+        .map((value) => Number(value))
+        .filter((value) => Number.isFinite(value) && value > 0)
+    : [];
+
+  return { tags, keyIds };
+}
+
+function resolveLokaliseLiveCatContext(input: {
+  file: TmsProviderLiveFile;
+  externalProjectId: string;
+  secretMaterial: string;
+  baseUrl?: string | null;
+}): LokaliseLiveCatContext {
+  const projectId = input.externalProjectId.trim();
+  if (!projectId) {
+    throw new LokaliseLiveCatError(
+      "invalid_lokalise_project_id",
+      "Lokalise project identifier is invalid.",
+    );
+  }
+
+  return {
+    token: input.secretMaterial,
+    baseUrl: input.baseUrl,
+    projectId,
+  };
+}
+
+function buildQueueSegmentFromKey(
+  key: LokaliseKey,
+  sourceLocale: string | null,
+): LokaliseQueueSegmentDraft {
+  const keyName = extractLokaliseKeyName(key.keyName);
+  const sourceTranslation = sourceLocale ? pickLokaliseKeyTranslation(key, sourceLocale) : null;
+  const sourceText = sourceTranslation?.translation.trim() || keyName;
+
+  return {
+    externalStringId: String(key.keyId),
+    key: keyName,
+    sourceText,
+    context: key.context ?? key.description,
+    type: key.isPlural ? "plural" : null,
+  };
+}
+
+function draftToQueueSegment(draft: LokaliseQueueSegmentDraft): ProjectFileCatQueueSegment {
+  return {
+    externalStringId: draft.externalStringId,
+    key: draft.key,
+    sourceText: draft.sourceText,
+    context: draft.context,
+    type: draft.type,
+  };
+}
+
+function segmentMatchesSearch(segment: LokaliseQueueSegmentDraft, search: string | undefined) {
+  const query = search?.trim().toLowerCase();
+  if (!query) {
+    return true;
+  }
+
+  return (
+    segment.key.toLowerCase().includes(query) ||
+    segment.sourceText.toLowerCase().includes(query) ||
+    (segment.context?.toLowerCase().includes(query) ?? false)
+  );
+}
+
+function filterKeysByFileTags(keys: LokaliseKey[], tags: string[]) {
+  if (tags.length === 0) {
+    return keys;
+  }
+
+  return keys.filter((key) => key.tags.some((tag) => tags.includes(tag)));
+}
+
+function lokaliseTranslationIsApproved(translation: LokaliseTranslation | null | undefined) {
+  if (!translation) {
+    return false;
+  }
+
+  return (
+    mapLokaliseTranslationReadiness({
+      content: translation.translation,
+      isUnverified: translation.isUnverified,
+      isReviewed: translation.isReviewed,
+    }) === "ready"
+  );
+}
+
+function mapLokaliseTargetTranslation(
+  translation: LokaliseTranslation | null | undefined,
+): ProjectFileCatTranslation | null {
+  if (!translation?.translation?.trim()) {
+    return null;
+  }
+
+  return {
+    text: translation.translation,
+    externalTranslationId: String(translation.translationId),
+    isApproved: lokaliseTranslationIsApproved(translation),
+  };
+}
+
+function resolveLokaliseTargetLocale(
+  targetLocale: string,
+  languages: LokaliseLanguage[],
+): LokaliseLanguage {
+  const normalized = targetLocale.trim().toLowerCase();
+  const matched =
+    languages.find((language) => language.langIso.trim().toLowerCase() === normalized) ?? null;
+  if (!matched) {
+    throw new LokaliseLiveCatError(
+      "lokalise_target_locale_not_found",
+      `Target locale "${targetLocale}" was not found in the Lokalise project.`,
+    );
+  }
+
+  return matched;
+}
+
+function mapLokaliseKeyComment(comment: {
+  commentId: number;
+  comment: string;
+  addedAt: string | null;
+  addedByEmail: string | null;
+}): ProjectFileCatComment {
+  return {
+    externalCommentId: String(comment.commentId),
+    type: "comment",
+    status: null,
+    text: comment.comment,
+    createdAt: comment.addedAt,
+    locale: null,
+    author: comment.addedByEmail,
+  };
+}
+
+async function fetchLokaliseKeysByIds(input: {
+  client: LokaliseApiClient;
+  projectId: string;
+  keyIds: number[];
+}): Promise<LokaliseKey[]> {
+  if (input.keyIds.length === 0) {
+    return [];
+  }
+
+  const keys: LokaliseKey[] = [];
+  for (let index = 0; index < input.keyIds.length; index += LOKALISE_KEY_FETCH_CHUNK_SIZE) {
+    const chunk = input.keyIds.slice(index, index + LOKALISE_KEY_FETCH_CHUNK_SIZE);
+    try {
+      const pageKeys = await input.client.listKeys(input.projectId, {
+        includeTranslations: true,
+        filterKeyIds: chunk,
+      });
+      keys.push(...pageKeys);
+    } catch (error) {
+      mapLokaliseApiError(error);
+    }
+  }
+
+  return keys;
+}
+
+async function loadLokaliseQueuePage(input: {
+  client: LokaliseApiClient;
+  scope: LokaliseLiveCatContext;
+  file: TmsProviderLiveFile;
+  paginationInput: ProjectFileCatPaginationInput;
+}): Promise<{
+  segments: ProjectFileCatQueueSegment[];
+  hasMore: boolean;
+  nextPhraseScanPage?: number;
+  nextPhraseScanSkip?: number;
+}> {
+  const metadata = readFileMetadata(input.file);
+  const resourceType = input.file.provider?.resourceType;
+  const sourceLocale = input.file.provider?.sourceLocale ?? null;
+  const { offset, limit, search, queueFilter } = input.paginationInput;
+
+  if (queueFilter === "has_issues") {
+    throw new LokaliseLiveCatError(
+      "lokalise_cat_queue_filter_unsupported",
+      "Lokalise does not support filtering the CAT queue by issues.",
+    );
+  }
+
+  if (resourceType === "key") {
+    const keyId = Number(input.file.provider?.externalResourceId);
+    if (!Number.isFinite(keyId) || keyId <= 0) {
+      return { segments: [], hasMore: false };
+    }
+
+    let keys: LokaliseKey[];
+    try {
+      keys = await fetchLokaliseKeysByIds({
+        client: input.client,
+        projectId: input.scope.projectId,
+        keyIds: [keyId],
+      });
+    } catch (error) {
+      if (error instanceof LokaliseApiError && error.status === 404) {
+        return { segments: [], hasMore: false };
+      }
+      mapLokaliseApiError(error);
+    }
+
+    const segments = keys
+      .map((key) => buildQueueSegmentFromKey(key, sourceLocale))
+      .filter((segment) => segmentMatchesSearch(segment, search))
+      .slice(offset, offset + limit)
+      .map(draftToQueueSegment);
+
+    return {
+      segments,
+      hasMore: false,
+    };
+  }
+
+  const scopedKeyIds = metadata.keyIds;
+  const needsClientSideFilter = Boolean(search?.trim()) || metadata.tags.length > 0;
+
+  if (!needsClientSideFilter && scopedKeyIds.length > 0) {
+    const pageKeyIds = scopedKeyIds.slice(offset, offset + limit);
+    const keys = await fetchLokaliseKeysByIds({
+      client: input.client,
+      projectId: input.scope.projectId,
+      keyIds: pageKeyIds,
+    });
+    const keysById = new Map(keys.map((key) => [key.keyId, key]));
+    const segments = pageKeyIds
+      .map((keyId) => keysById.get(keyId))
+      .filter((key): key is LokaliseKey => key != null)
+      .map((key) => buildQueueSegmentFromKey(key, sourceLocale))
+      .map(draftToQueueSegment);
+
+    return {
+      segments,
+      hasMore: offset + limit < scopedKeyIds.length,
+    };
+  }
+
+  const collected: ProjectFileCatQueueSegment[] = [];
+  const resumingScan = input.paginationInput.phraseScanPage != null;
+  let scanPage = resumingScan ? input.paginationInput.phraseScanPage! : 1;
+  let skipMatches = resumingScan ? (input.paginationInput.phraseScanSkip ?? 0) : offset;
+  let scanComplete = false;
+  let nextPhraseScanPage: number | undefined;
+  let nextPhraseScanSkip: number | undefined;
+  const scanPageBudget = resumingScan
+    ? scanPage + LOKALISE_MAX_SCAN_PAGES - 1
+    : Math.max(
+        LOKALISE_MAX_SCAN_PAGES,
+        Math.ceil((offset + limit) / LOKALISE_QUEUE_SCAN_PAGE_SIZE) + LOKALISE_MAX_SCAN_PAGES,
+      );
+
+  while (collected.length < limit && scanPage <= scanPageBudget) {
+    const chunkStart = (scanPage - 1) * LOKALISE_QUEUE_SCAN_PAGE_SIZE;
+    const chunkKeyIds =
+      scopedKeyIds.length > 0
+        ? scopedKeyIds.slice(chunkStart, chunkStart + LOKALISE_QUEUE_SCAN_PAGE_SIZE)
+        : null;
+
+    let keys: LokaliseKey[];
+    if (chunkKeyIds != null) {
+      if (chunkKeyIds.length === 0) {
+        scanComplete = true;
+        break;
+      }
+      keys = await fetchLokaliseKeysByIds({
+        client: input.client,
+        projectId: input.scope.projectId,
+        keyIds: chunkKeyIds,
+      });
+    } else {
+      try {
+        keys = await input.client.listKeys(input.scope.projectId, {
+          includeTranslations: false,
+          maxKeys: LOKALISE_QUEUE_SCAN_PAGE_SIZE,
+        });
+      } catch (error) {
+        mapLokaliseApiError(error);
+      }
+      scanComplete = true;
+    }
+
+    const filteredKeys = filterKeysByFileTags(keys, metadata.tags);
+    const drafts = filteredKeys.map((key) => buildQueueSegmentFromKey(key, sourceLocale));
+
+    let matchesSeenOnPage = 0;
+    for (const draft of drafts) {
+      if (!segmentMatchesSearch(draft, search)) {
+        continue;
+      }
+
+      matchesSeenOnPage += 1;
+      if (skipMatches > 0) {
+        skipMatches -= 1;
+        continue;
+      }
+
+      collected.push(draftToQueueSegment(draft));
+      if (collected.length >= limit) {
+        nextPhraseScanPage = scanPage;
+        nextPhraseScanSkip = matchesSeenOnPage;
+        break;
+      }
+    }
+
+    if (collected.length >= limit) {
+      break;
+    }
+
+    if (chunkKeyIds != null) {
+      if (chunkStart + LOKALISE_QUEUE_SCAN_PAGE_SIZE >= scopedKeyIds.length) {
+        scanComplete = true;
+        break;
+      }
+    } else {
+      scanComplete = true;
+      break;
+    }
+
+    scanPage += 1;
+    skipMatches = 0;
+  }
+
+  return {
+    segments: collected,
+    hasMore: collected.length >= limit && !scanComplete,
+    nextPhraseScanPage,
+    nextPhraseScanSkip,
+  };
+}
+
+export async function buildLokaliseLiveCatFile(input: {
+  secretMaterial: string;
+  baseUrl?: string | null;
+  externalProjectId: string;
+  file: TmsProviderLiveFile;
+  targetLocale: string;
+  canEditTranslations: boolean;
+  pagination?: ProjectFileCatPaginationInput;
+}): Promise<ProjectFileCatQueueFile> {
+  const scope = resolveLokaliseLiveCatContext({
+    file: input.file,
+    externalProjectId: input.externalProjectId,
+    secretMaterial: input.secretMaterial,
+    baseUrl: input.baseUrl,
+  });
+  const client = new LokaliseApiClient({
+    token: scope.token,
+    baseUrl: scope.baseUrl,
+  });
+
+  let languages: LokaliseLanguage[];
+  try {
+    languages = await client.listProjectLanguages(scope.projectId);
+  } catch (error) {
+    mapLokaliseApiError(error);
+  }
+
+  resolveLokaliseTargetLocale(input.targetLocale, languages);
+
+  const paginationInput = input.pagination ?? {
+    offset: 0,
+    limit: legacyProviderCatSegmentLimit,
+    search: undefined,
+    queueFilter: "all",
+    paginated: true,
+  };
+
+  const { segments, hasMore, nextPhraseScanPage, nextPhraseScanSkip } = await loadLokaliseQueuePage(
+    {
+      client,
+      scope,
+      file: input.file,
+      paginationInput,
+    },
+  );
+
+  const pagination = buildCatFilePagination({
+    offset: paginationInput.offset,
+    limit: paginationInput.limit,
+    returnedCount: segments.length,
+    totalCount: hasMore
+      ? paginationInput.offset + segments.length + 1
+      : paginationInput.offset + segments.length,
+    hasMore,
+    nextPhraseScanPage,
+    nextPhraseScanSkip,
+  });
+
+  return {
+    sourcePath: input.file.sourcePath,
+    filename: input.file.filename,
+    provider: input.file.provider,
+    targetLocale: input.targetLocale,
+    canEditTranslations: input.canEditTranslations,
+    truncated: pagination.hasMore,
+    pagination,
+    segments,
+  };
+}
+
+export async function getLokaliseLiveCatSegmentTarget(input: {
+  secretMaterial: string;
+  baseUrl?: string | null;
+  externalProjectId: string;
+  file: TmsProviderLiveFile;
+  targetLocale: string;
+  externalStringId: string;
+}): Promise<ProjectFileCatTranslation | null | "not_found"> {
+  const scope = resolveLokaliseLiveCatContext({
+    file: input.file,
+    externalProjectId: input.externalProjectId,
+    secretMaterial: input.secretMaterial,
+    baseUrl: input.baseUrl,
+  });
+  const client = new LokaliseApiClient({
+    token: scope.token,
+    baseUrl: scope.baseUrl,
+  });
+
+  let languages: LokaliseLanguage[];
+  try {
+    languages = await client.listProjectLanguages(scope.projectId);
+  } catch (error) {
+    mapLokaliseApiError(error);
+  }
+
+  const targetLocale = resolveLokaliseTargetLocale(input.targetLocale, languages);
+  const keyId = Number(input.externalStringId);
+  if (!Number.isFinite(keyId) || keyId <= 0) {
+    return "not_found";
+  }
+
+  let keys: LokaliseKey[];
+  try {
+    keys = await fetchLokaliseKeysByIds({
+      client,
+      projectId: scope.projectId,
+      keyIds: [keyId],
+    });
+  } catch (error) {
+    if (error instanceof LokaliseApiError && error.status === 404) {
+      return "not_found";
+    }
+    mapLokaliseApiError(error);
+  }
+
+  const key = keys[0];
+  if (!key) {
+    return "not_found";
+  }
+
+  const translation = pickLokaliseKeyTranslation(key, targetLocale.langIso);
+  return mapLokaliseTargetTranslation(translation);
+}
+
+export async function getLokaliseLiveCatSegmentComments(input: {
+  secretMaterial: string;
+  baseUrl?: string | null;
+  externalProjectId: string;
+  file: TmsProviderLiveFile;
+  targetLocale: string;
+  externalStringId: string;
+}): Promise<ProjectFileCatComment[]> {
+  const scope = resolveLokaliseLiveCatContext({
+    file: input.file,
+    externalProjectId: input.externalProjectId,
+    secretMaterial: input.secretMaterial,
+    baseUrl: input.baseUrl,
+  });
+  const client = new LokaliseApiClient({
+    token: scope.token,
+    baseUrl: scope.baseUrl,
+  });
+
+  const keyId = Number(input.externalStringId);
+  if (!Number.isFinite(keyId) || keyId <= 0) {
+    return [];
+  }
+
+  try {
+    const comments = await client.listKeyComments(scope.projectId, keyId);
+    return comments.map((comment) => mapLokaliseKeyComment(comment));
+  } catch (error) {
+    if (error instanceof LokaliseApiError && error.status === 404) {
+      return [];
+    }
+    mapLokaliseApiError(error);
+  }
+}
+
+export async function saveLokaliseLiveCatTranslation(input: {
+  secretMaterial: string;
+  baseUrl?: string | null;
+  externalProjectId: string;
+  file: TmsProviderLiveFile;
+  targetLocale: string;
+  externalStringId: string;
+  text: string;
+}): Promise<ProjectFileCatTranslation> {
+  const scope = resolveLokaliseLiveCatContext({
+    file: input.file,
+    externalProjectId: input.externalProjectId,
+    secretMaterial: input.secretMaterial,
+    baseUrl: input.baseUrl,
+  });
+  const client = new LokaliseApiClient({
+    token: scope.token,
+    baseUrl: scope.baseUrl,
+  });
+
+  let languages: LokaliseLanguage[];
+  try {
+    languages = await client.listProjectLanguages(scope.projectId);
+  } catch (error) {
+    mapLokaliseApiError(error);
+  }
+
+  const targetLocale = resolveLokaliseTargetLocale(input.targetLocale, languages);
+  const keyId = Number(input.externalStringId);
+  if (!Number.isFinite(keyId) || keyId <= 0) {
+    throw new LokaliseLiveCatError(
+      "invalid_lokalise_key_id",
+      "Lokalise key identifier is invalid.",
+    );
+  }
+
+  try {
+    await client.bulkUpdateKeys(scope.projectId, [
+      {
+        keyId,
+        translations: [
+          {
+            languageIso: targetLocale.langIso,
+            translation: input.text,
+            isUnverified: false,
+            isReviewed: true,
+          },
+        ],
+      },
+    ]);
+  } catch (error) {
+    mapLokaliseApiError(error);
+  }
+
+  const keys = await fetchLokaliseKeysByIds({
+    client,
+    projectId: scope.projectId,
+    keyIds: [keyId],
+  });
+  const savedTranslation = pickLokaliseKeyTranslation(keys[0], targetLocale.langIso);
+
+  return {
+    text: savedTranslation?.translation.trim() || input.text,
+    externalTranslationId: savedTranslation
+      ? String(savedTranslation.translationId)
+      : `${keyId}:${targetLocale.langIso}`,
+    isApproved: lokaliseTranslationIsApproved(savedTranslation),
+  };
+}
+
+export async function saveLokaliseLiveCatComment(input: {
+  secretMaterial: string;
+  baseUrl?: string | null;
+  externalProjectId: string;
+  file: TmsProviderLiveFile;
+  targetLocale: string;
+  externalStringId: string;
+  text: string;
+}): Promise<ProjectFileCatComment> {
+  const scope = resolveLokaliseLiveCatContext({
+    file: input.file,
+    externalProjectId: input.externalProjectId,
+    secretMaterial: input.secretMaterial,
+    baseUrl: input.baseUrl,
+  });
+  const client = new LokaliseApiClient({
+    token: scope.token,
+    baseUrl: scope.baseUrl,
+  });
+
+  const keyId = Number(input.externalStringId);
+  if (!Number.isFinite(keyId) || keyId <= 0) {
+    throw new LokaliseLiveCatError(
+      "invalid_lokalise_key_id",
+      "Lokalise key identifier is invalid.",
+    );
+  }
+
+  let created: Awaited<ReturnType<typeof client.createKeyComments>>;
+  try {
+    created = await client.createKeyComments(scope.projectId, keyId, [{ comment: input.text }]);
+  } catch (error) {
+    mapLokaliseApiError(error);
+  }
+
+  const comment = created[0];
+  if (!comment) {
+    throw new LokaliseLiveCatError(
+      "lokalise_provider_comment_create_failed",
+      "Lokalise did not return the created comment.",
+    );
+  }
+
+  return mapLokaliseKeyComment(comment);
+}

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-locale-progress.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-locale-progress.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  loadLokaliseProjectLocaleReadiness,
+  mapLokaliseLocaleProgressToReadiness,
+} from "./lokalise-locale-progress";
+
+describe("mapLokaliseLocaleProgressToReadiness", () => {
+  it("maps phrase counts to crowdin-compatible readiness fields", () => {
+    expect(
+      mapLokaliseLocaleProgressToReadiness({
+        locale: "fr",
+        counts: { total: 4, translated: 3, approved: 2 },
+      }),
+    ).toEqual({
+      translationProgress: 75,
+      approvalProgress: 50,
+      words: { total: 4, translated: 3, approved: 2 },
+      phrases: { total: 4, translated: 3, approved: 2 },
+    });
+  });
+});
+
+describe("loadLokaliseProjectLocaleReadiness", () => {
+  it("aggregates key translation states per locale", async () => {
+    const client = {
+      listKeys: vi.fn(async () => [
+        {
+          keyId: 1,
+          keyName: { web: "a", ios: "", android: "", other: "" },
+          filenames: { web: "", ios: "", android: "", other: "" },
+          description: null,
+          context: null,
+          platforms: ["web"],
+          tags: [],
+          isPlural: false,
+          isHidden: false,
+          isArchived: false,
+          createdAt: null,
+          modifiedAt: null,
+          translationsModifiedAt: null,
+          translations: [
+            {
+              translationId: 1,
+              keyId: 1,
+              languageIso: "fr",
+              translation: "A",
+              modifiedAt: null,
+              modifiedAtTimestamp: null,
+              isReviewed: true,
+              isUnverified: false,
+            },
+          ],
+        },
+        {
+          keyId: 2,
+          keyName: { web: "b", ios: "", android: "", other: "" },
+          filenames: { web: "", ios: "", android: "", other: "" },
+          description: null,
+          context: null,
+          platforms: ["web"],
+          tags: [],
+          isPlural: false,
+          isHidden: false,
+          isArchived: false,
+          createdAt: null,
+          modifiedAt: null,
+          translationsModifiedAt: null,
+          translations: [],
+        },
+      ]),
+      listProjectLanguages: vi.fn(async () => [
+        { langId: 641, langIso: "fr", langName: "French", isRtl: false },
+      ]),
+    };
+
+    const readiness = await loadLokaliseProjectLocaleReadiness({
+      client: client as never,
+      projectId: "proj.123",
+      languageId: "fr",
+    });
+
+    expect(readiness).toEqual({
+      translationProgress: 50,
+      approvalProgress: 50,
+      words: { total: 2, translated: 1, approved: 1 },
+      phrases: { total: 2, translated: 1, approved: 1 },
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-locale-progress.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-locale-progress.ts
@@ -84,7 +84,7 @@ export async function loadLokaliseProjectLocaleReadiness(input: {
       input.client.listProjectLanguages(input.projectId),
     ]);
   } catch (error) {
-    if (error instanceof LokaliseApiError && error.status === 401) {
+    if (error instanceof LokaliseApiError && (error.status === 401 || error.status === 403)) {
       throw new Error("lokalise_auth_invalid");
     }
     throw error;

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-locale-progress.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-locale-progress.ts
@@ -1,0 +1,132 @@
+import { LokaliseApiClient, LokaliseApiError, type LokaliseKey } from "./lokalise-api";
+import { mapLokaliseTranslationReadiness } from "./lokalise-locale-readiness";
+import { pickLokaliseKeyTranslation } from "./normalize-lokalise-context-matches";
+
+type LocaleProgressCounts = {
+  total: number;
+  translated: number;
+  approved: number;
+};
+
+function isCountableKey(key: LokaliseKey) {
+  return !key.isArchived && !key.isHidden;
+}
+
+function countTranslationState(keys: LokaliseKey[], locale: string): LocaleProgressCounts {
+  let total = 0;
+  let translated = 0;
+  let approved = 0;
+
+  for (const key of keys) {
+    if (!isCountableKey(key)) {
+      continue;
+    }
+
+    total += 1;
+    const translation = pickLokaliseKeyTranslation(key, locale);
+    const readiness = mapLokaliseTranslationReadiness({
+      content: translation?.translation,
+      isUnverified: translation?.isUnverified,
+      isReviewed: translation?.isReviewed,
+      isArchived: key.isArchived,
+      isHidden: key.isHidden,
+    });
+
+    if (readiness === "missing" || readiness === "excluded") {
+      continue;
+    }
+
+    translated += 1;
+    if (readiness === "ready") {
+      approved += 1;
+    }
+  }
+
+  return { total, translated, approved };
+}
+
+function toProgressPercent(completed: number, total: number) {
+  if (total <= 0) {
+    return 0;
+  }
+
+  return Math.round((completed / total) * 100);
+}
+
+export function mapLokaliseLocaleProgressToReadiness(input: {
+  locale: string;
+  counts: LocaleProgressCounts;
+}): Record<string, unknown> {
+  const phrases = {
+    total: input.counts.total,
+    translated: input.counts.translated,
+    approved: input.counts.approved,
+  };
+
+  return {
+    translationProgress: toProgressPercent(input.counts.translated, input.counts.total),
+    approvalProgress: toProgressPercent(input.counts.approved, input.counts.total),
+    words: phrases,
+    phrases,
+  };
+}
+
+export async function loadLokaliseProjectLocaleReadiness(input: {
+  client: LokaliseApiClient;
+  projectId: string;
+  languageId?: string;
+}): Promise<Record<string, unknown>> {
+  let keys: LokaliseKey[];
+  let languages: Awaited<ReturnType<LokaliseApiClient["listProjectLanguages"]>>;
+  try {
+    [keys, languages] = await Promise.all([
+      input.client.listKeys(input.projectId, { includeTranslations: true }),
+      input.client.listProjectLanguages(input.projectId),
+    ]);
+  } catch (error) {
+    if (error instanceof LokaliseApiError && error.status === 401) {
+      throw new Error("lokalise_auth_invalid");
+    }
+    throw error;
+  }
+
+  const targetLocales = languages
+    .map((language) => language.langIso.trim())
+    .filter((locale) => locale.length > 0);
+  const locales = input.languageId?.trim()
+    ? targetLocales.filter((locale) => locale === input.languageId?.trim())
+    : targetLocales;
+
+  const localeReadiness: Record<string, unknown> = {};
+  for (const locale of locales) {
+    const counts = countTranslationState(keys, locale);
+    localeReadiness[locale] = mapLokaliseLocaleProgressToReadiness({ locale, counts });
+  }
+
+  if (input.languageId?.trim() && localeReadiness[input.languageId.trim()]) {
+    return localeReadiness[input.languageId.trim()] as Record<string, unknown>;
+  }
+
+  return localeReadiness;
+}
+
+export function mapLokaliseTaskLanguageProgressToReadiness(input: {
+  languageIso: string;
+  progress: number;
+}): Record<string, unknown> {
+  const rounded = Math.max(0, Math.min(100, Math.round(input.progress)));
+  return {
+    translationProgress: rounded,
+    approvalProgress: rounded,
+    words: {
+      total: 100,
+      translated: rounded,
+      approved: rounded,
+    },
+    phrases: {
+      total: 100,
+      translated: rounded,
+      approved: rounded,
+    },
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-locale-progress.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-locale-progress.ts
@@ -118,15 +118,5 @@ export function mapLokaliseTaskLanguageProgressToReadiness(input: {
   return {
     translationProgress: rounded,
     approvalProgress: rounded,
-    words: {
-      total: 100,
-      translated: rounded,
-      approved: rounded,
-    },
-    phrases: {
-      total: 100,
-      translated: rounded,
-      approved: rounded,
-    },
   };
 }

--- a/apps/hyperlocalise-web/src/lib/providers/download-provider-source-file.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/download-provider-source-file.ts
@@ -3,6 +3,11 @@ import { and, eq } from "drizzle-orm";
 import { db, schema } from "@/lib/database";
 import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
 import { CrowdinApiClient, CrowdinApiError } from "@/lib/providers/adapters/crowdin/crowdin-api";
+import {
+  LokaliseApiClient,
+  LokaliseApiError,
+  LOKALISE_DEFAULT_BUNDLE_STRUCTURE,
+} from "@/lib/providers/adapters/lokalise/lokalise-api";
 import type {
   ExternalTmsCredential,
   ExternalTmsProviderKind,
@@ -212,6 +217,158 @@ async function downloadCrowdinSourceFile(input: {
   }
 }
 
+function resolveLokaliseSourceFileMetadata(input: { externalFileId: string; sourcePath: string }):
+  | {
+      ok: true;
+      filename: string;
+      fileFormat: NonNullable<ReturnType<typeof inferSupportedFileTranslationFileFormat>>;
+      filterFilename: string;
+    }
+  | {
+      ok: false;
+      code: string;
+      message: string;
+    } {
+  const fileFormat = inferSupportedFileTranslationFileFormat(input.sourcePath);
+  if (!fileFormat) {
+    return {
+      ok: false,
+      code: "unsupported_file_format",
+      message: `Source path ${input.sourcePath} is not a supported translation file format`,
+    };
+  }
+
+  const [, filename] = input.externalFileId.split("::");
+  const resolvedFilename = filename?.trim() || input.sourcePath.split("/").pop() || "";
+  if (!resolvedFilename) {
+    return {
+      ok: false,
+      code: "invalid_provider_file_id",
+      message: "Provider file identifiers are invalid",
+    };
+  }
+
+  return {
+    ok: true,
+    filename: resolvedFilename,
+    fileFormat,
+    filterFilename: resolvedFilename,
+  };
+}
+
+async function resolveLokaliseSourceFileDownload(input: {
+  credential: ExternalTmsCredential;
+  secretMaterial: string;
+  externalProjectId: string;
+  externalFileId: string;
+  sourcePath: string;
+  sourceLocale?: string | null;
+}): Promise<ResolveProviderSourceFileDownloadResult> {
+  const metadata = resolveLokaliseSourceFileMetadata({
+    externalFileId: input.externalFileId,
+    sourcePath: input.sourcePath,
+  });
+  if (!metadata.ok) {
+    return metadata;
+  }
+
+  if (!input.externalProjectId.trim()) {
+    return {
+      ok: false,
+      code: "invalid_provider_file_id",
+      message: "Provider file identifiers are invalid",
+    };
+  }
+
+  const client = new LokaliseApiClient({
+    token: input.secretMaterial,
+    baseUrl: input.credential.baseUrl ?? undefined,
+  });
+
+  const sourceLocale = input.sourceLocale?.trim();
+  if (!sourceLocale) {
+    return {
+      ok: false,
+      code: "provider_source_locale_missing",
+      message: "Source locale is required to download Lokalise source files",
+    };
+  }
+
+  try {
+    const download = await client.requestFileDownload(input.externalProjectId, {
+      format: metadata.fileFormat,
+      originalFilenames: true,
+      bundleStructure: LOKALISE_DEFAULT_BUNDLE_STRUCTURE,
+      filterLangs: [sourceLocale],
+      filterFilenames: [metadata.filterFilename],
+    });
+    const downloadUrl = normalizeProviderDownloadUrl(download.bundleUrl);
+    if (!downloadUrl) {
+      return {
+        ok: false,
+        code: "provider_file_download_url_invalid",
+        message: "Provider file download URL is invalid or unsafe",
+      };
+    }
+
+    return {
+      ok: true,
+      downloadUrl,
+      filename: metadata.filename,
+      fileFormat: metadata.fileFormat,
+    };
+  } catch (error) {
+    if (error instanceof LokaliseApiError && error.status === 401) {
+      return {
+        ok: false,
+        code: "provider_auth_invalid",
+        message: "Provider credentials are invalid",
+      };
+    }
+
+    return {
+      ok: false,
+      code: "provider_file_download_failed",
+      message: error instanceof Error ? error.message : "Provider file download failed",
+    };
+  }
+}
+
+async function downloadLokaliseSourceFile(input: {
+  credential: ExternalTmsCredential;
+  secretMaterial: string;
+  externalProjectId: string;
+  externalFileId: string;
+  sourcePath: string;
+  sourceLocale?: string | null;
+}): Promise<DownloadProviderSourceFileResult> {
+  const resolved = await resolveLokaliseSourceFileDownload(input);
+  if (!resolved.ok) {
+    return resolved;
+  }
+
+  const client = new LokaliseApiClient({
+    token: input.secretMaterial,
+    baseUrl: input.credential.baseUrl ?? undefined,
+  });
+
+  try {
+    const bytes = await client.downloadUrl(resolved.downloadUrl);
+    return {
+      ok: true,
+      content: Buffer.from(bytes),
+      filename: resolved.filename,
+      fileFormat: resolved.fileFormat,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      code: "provider_file_download_failed",
+      message: error instanceof Error ? error.message : "Provider file download failed",
+    };
+  }
+}
+
 export async function loadProviderCrowdinDownloadContext(input: {
   organizationId: string;
   projectId: string;
@@ -304,6 +461,18 @@ export async function resolveProviderSourceFileDownload(input: {
     });
   }
 
+  if (input.providerKind === "lokalise") {
+    const sourceLocaleMatch = input.sourcePath.match(/^locales\/([^/]+)\//);
+    return resolveLokaliseSourceFileDownload({
+      credential: context.credential,
+      secretMaterial,
+      externalProjectId: context.externalProjectId,
+      externalFileId: input.externalFileId,
+      sourcePath: input.sourcePath,
+      sourceLocale: sourceLocaleMatch?.[1] ?? null,
+    });
+  }
+
   return {
     ok: false,
     code: "provider_file_download_unsupported",
@@ -346,6 +515,18 @@ export async function downloadProviderSourceFile(input: {
       externalProjectId: context.externalProjectId,
       externalFileId: input.externalFileId,
       sourcePath: input.sourcePath,
+    });
+  }
+
+  if (input.providerKind === "lokalise") {
+    const sourceLocaleMatch = input.sourcePath.match(/^locales\/([^/]+)\//);
+    return downloadLokaliseSourceFile({
+      credential: context.credential,
+      secretMaterial,
+      externalProjectId: context.externalProjectId,
+      externalFileId: input.externalFileId,
+      sourcePath: input.sourcePath,
+      sourceLocale: sourceLocaleMatch?.[1] ?? null,
     });
   }
 

--- a/apps/hyperlocalise-web/src/lib/providers/provider-cat-capabilities.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-cat-capabilities.test.ts
@@ -34,12 +34,20 @@ describe("supportsProviderCatFile", () => {
     ).toBe(true);
   });
 
-  it("returns false for providers without live CAT yet", () => {
+  it("supports Lokalise file and key resources", () => {
     expect(
       supportsProviderCatFile({
         provider: { kind: "lokalise", resourceType: "file" },
       }),
-    ).toBe(false);
+    ).toBe(true);
+    expect(
+      supportsProviderCatFile({
+        provider: { kind: "lokalise", resourceType: "key" },
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for providers without live CAT yet", () => {
     expect(
       supportsProviderCatFile({
         provider: { kind: "smartling", resourceType: "file" },

--- a/apps/hyperlocalise-web/src/lib/providers/provider-cat-capabilities.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-cat-capabilities.ts
@@ -25,7 +25,7 @@ export function supportsProviderCatFile(file: ProviderCatFile): boolean {
     return provider.resourceType === "file";
   }
 
-  if (provider.kind === "phrase") {
+  if (provider.kind === "phrase" || provider.kind === "lokalise") {
     return provider.resourceType === "file" || provider.resourceType === "key";
   }
 

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -53,6 +53,17 @@ import {
   getLokaliseUserConnection,
   resolveLokaliseUserConnectionSecretMaterial,
 } from "@/lib/providers/adapters/lokalise/lokalise-user-connections";
+import { listLokaliseTaskComments } from "@/lib/providers/adapters/lokalise/lokalise-job-comments";
+import {
+  buildLokaliseLiveCatFile,
+  getLokaliseLiveCatSegmentComments,
+  getLokaliseLiveCatSegmentTarget,
+  LokaliseLiveCatError,
+  saveLokaliseLiveCatComment,
+  saveLokaliseLiveCatTranslation,
+} from "@/lib/providers/adapters/lokalise/lokalise-live-cat";
+import { loadLokaliseProjectLocaleReadiness } from "@/lib/providers/adapters/lokalise/lokalise-locale-progress";
+import { LokaliseApiClient } from "@/lib/providers/adapters/lokalise/lokalise-api";
 import { sourceContentType } from "@/lib/file-storage/source-file-metadata";
 import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-with-concurrency";
 import { normalizeProviderAssigneeCandidates } from "@/lib/providers/tms-provider-assignee-match";
@@ -768,6 +779,14 @@ function mapPhraseLiveCatError(error: unknown): never {
   throw error;
 }
 
+function mapLokaliseLiveCatError(error: unknown): never {
+  if (error instanceof LokaliseLiveCatError) {
+    throw new TmsProviderLiveError(error.code, error.message);
+  }
+
+  throw error;
+}
+
 function supportsLiveProviderCat(
   providerKind: ExternalTmsProviderKind,
   file: TmsProviderLiveFile,
@@ -780,7 +799,7 @@ function supportsLiveProviderCat(
     return file.provider.resourceType === "file";
   }
 
-  if (providerKind === "phrase") {
+  if (providerKind === "phrase" || providerKind === "lokalise") {
     return file.provider.resourceType === "file" || file.provider.resourceType === "key";
   }
 
@@ -798,7 +817,9 @@ function resolveLiveCatFileFromExternalResourceId(input: {
     providerKind: input.providerKind,
     externalProjectId: input.externalProjectId,
     file: {
-      resourceType: input.resourceType ?? (input.providerKind === "phrase" ? "key" : "file"),
+      resourceType:
+        input.resourceType ??
+        (input.providerKind === "phrase" || input.providerKind === "lokalise" ? "key" : "file"),
       externalResourceId: input.externalResourceId,
       sourcePath: input.sourcePath,
     },
@@ -855,6 +876,16 @@ async function resolveLiveCatFile(input: {
       externalResourceId: input.externalResourceId,
       sourcePath: input.sourcePath,
       resourceType: "file",
+    });
+  }
+
+  if (input.context.providerKind === "lokalise" || input.context.providerKind === "phrase") {
+    return resolveLiveCatFileFromExternalResourceId({
+      providerKind: input.context.providerKind,
+      externalProjectId: input.externalProjectId,
+      externalResourceId: input.externalResourceId,
+      sourcePath: input.sourcePath,
+      resourceType: input.resourceType ?? "key",
     });
   }
 
@@ -1995,6 +2026,22 @@ export async function getTmsProviderLiveCatFile(
     }
   }
 
+  if (context.providerKind === "lokalise") {
+    try {
+      return await buildLokaliseLiveCatFile({
+        secretMaterial: context.secretMaterial,
+        baseUrl: context.credential.baseUrl,
+        externalProjectId,
+        file,
+        targetLocale,
+        canEditTranslations: options?.canEditTranslations ?? false,
+        pagination: options?.pagination,
+      });
+    } catch (error) {
+      mapLokaliseLiveCatError(error);
+    }
+  }
+
   return buildCrowdinLiveCatFile({
     context,
     file,
@@ -2051,6 +2098,21 @@ export async function getTmsProviderLiveCatSegmentTarget(
       });
     } catch (error) {
       mapPhraseLiveCatError(error);
+    }
+  }
+
+  if (context.providerKind === "lokalise") {
+    try {
+      return await getLokaliseLiveCatSegmentTarget({
+        secretMaterial: context.secretMaterial,
+        baseUrl: context.credential.baseUrl,
+        externalProjectId,
+        file,
+        targetLocale,
+        externalStringId,
+      });
+    } catch (error) {
+      mapLokaliseLiveCatError(error);
     }
   }
 
@@ -2112,6 +2174,21 @@ export async function getTmsProviderLiveCatSegmentComments(
     }
   }
 
+  if (context.providerKind === "lokalise") {
+    try {
+      return await getLokaliseLiveCatSegmentComments({
+        secretMaterial: context.secretMaterial,
+        baseUrl: context.credential.baseUrl,
+        externalProjectId,
+        file,
+        targetLocale,
+        externalStringId,
+      });
+    } catch (error) {
+      mapLokaliseLiveCatError(error);
+    }
+  }
+
   return buildCrowdinLiveCatSegmentComments({
     context,
     file,
@@ -2170,6 +2247,22 @@ export async function saveTmsProviderLiveCatTranslation(
     }
   }
 
+  if (context.providerKind === "lokalise") {
+    try {
+      return await saveLokaliseLiveCatTranslation({
+        secretMaterial: context.secretMaterial,
+        baseUrl: context.credential.baseUrl,
+        externalProjectId,
+        file,
+        targetLocale: input.targetLocale,
+        externalStringId: input.externalStringId,
+        text: input.text,
+      });
+    } catch (error) {
+      mapLokaliseLiveCatError(error);
+    }
+  }
+
   return saveCrowdinLiveCatTranslation({
     context,
     file,
@@ -2214,14 +2307,16 @@ export async function saveTmsProviderLiveCatComment(
     );
   }
 
-  if (context.providerKind === "phrase") {
+  if (context.providerKind === "phrase" || context.providerKind === "lokalise") {
     if (input.type === "issue") {
       throw new TmsProviderLiveError(
         "provider_cat_unsupported",
-        "Issue comments are not available for Phrase files.",
+        `Issue comments are not available for ${context.providerKind} files.`,
       );
     }
+  }
 
+  if (context.providerKind === "phrase") {
     try {
       return await savePhraseLiveCatComment({
         secretMaterial: context.secretMaterial,
@@ -2235,6 +2330,22 @@ export async function saveTmsProviderLiveCatComment(
       });
     } catch (error) {
       mapPhraseLiveCatError(error);
+    }
+  }
+
+  if (context.providerKind === "lokalise") {
+    try {
+      return await saveLokaliseLiveCatComment({
+        secretMaterial: context.secretMaterial,
+        baseUrl: context.credential.baseUrl,
+        externalProjectId,
+        file,
+        targetLocale: input.targetLocale,
+        externalStringId: input.externalStringId,
+        text: input.text,
+      });
+    } catch (error) {
+      mapLokaliseLiveCatError(error);
     }
   }
 
@@ -2370,6 +2481,34 @@ export async function getTmsProviderLiveProjectLocaleReadiness(
   const context = await loadActiveTmsProviderContext(organizationId, {
     actorUserId: options?.actorUserId,
   });
+
+  if (context.providerKind === "lokalise") {
+    if (!externalProjectId.trim()) {
+      return null;
+    }
+
+    const client = new LokaliseApiClient({
+      token: context.secretMaterial,
+      baseUrl: context.credential.baseUrl ?? undefined,
+    });
+
+    try {
+      return await loadLokaliseProjectLocaleReadiness({
+        client,
+        projectId: externalProjectId,
+        languageId: options?.languageId,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.message === "lokalise_auth_invalid") {
+        throw new TmsProviderLiveError(
+          "lokalise_auth_invalid",
+          "Lokalise credentials are invalid.",
+        );
+      }
+      throw error;
+    }
+  }
+
   if (context.providerKind !== "crowdin") {
     return null;
   }
@@ -2571,6 +2710,25 @@ export async function listTmsProviderLiveJobComments(
   });
   if (context.providerKind !== parsed.providerKind) {
     return null;
+  }
+
+  if (context.providerKind === "lokalise") {
+    try {
+      return await listLokaliseTaskComments({
+        secretMaterial: context.secretMaterial,
+        baseUrl: context.credential.baseUrl ?? undefined,
+        externalProjectId: parsed.externalProjectId,
+        externalJobId: parsed.externalJobId,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.message === "lokalise_auth_invalid") {
+        throw new TmsProviderLiveError(
+          "lokalise_auth_invalid",
+          "Lokalise credentials are invalid.",
+        );
+      }
+      throw error;
+    }
   }
 
   if (context.providerKind !== "crowdin") {

--- a/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-concordance.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-concordance.test.ts
@@ -236,4 +236,48 @@ describe("loadCatSegmentConcordance", () => {
 
     expect(searchLokaliseCatConcordanceMock).not.toHaveBeenCalled();
   });
+
+  it.each(["lokalise_oauth_refresh_failed", "lokalise_oauth_token_invalid"] as const)(
+    "throws a reconnect error when Lokalise OAuth token is invalid (%s)",
+    async (errorCode) => {
+      resolveExternalTmsSecretMaterialForActorMock.mockRejectedValue(new Error(errorCode));
+
+      await expect(
+        loadCatSegmentConcordance({
+          organizationId: "org_1",
+          projectId: "ext:lokalise:proj.123",
+          providerKind: "lokalise",
+          actorUserId: "user_1",
+          sourceLocale: "en",
+          targetLocale: "fr",
+          sourceText: "Hello",
+        }),
+      ).rejects.toMatchObject({
+        code: "lokalise_user_auth_invalid",
+        message: "Your Lokalise connection is invalid. Reconnect Lokalise and try again.",
+      } satisfies Partial<TmsProviderLiveError>);
+
+      expect(searchLokaliseCatConcordanceMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not remap unknown Lokalise errors as auth failures", async () => {
+    resolveExternalTmsSecretMaterialForActorMock.mockRejectedValue(
+      new Error("lokalise_rate_limit_exceeded"),
+    );
+
+    await expect(
+      loadCatSegmentConcordance({
+        organizationId: "org_1",
+        projectId: "ext:lokalise:proj.123",
+        providerKind: "lokalise",
+        actorUserId: "user_1",
+        sourceLocale: "en",
+        targetLocale: "fr",
+        sourceText: "Hello",
+      }),
+    ).rejects.toThrow("lokalise_rate_limit_exceeded");
+
+    expect(searchLokaliseCatConcordanceMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-concordance.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-concordance.test.ts
@@ -2,18 +2,28 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const {
   crowdinClientOptions,
+  lokaliseClientOptions,
   loadCrowdinProjectCredentialMock,
+  loadLokaliseProjectCredentialMock,
   resolveExternalTmsSecretMaterialForActorMock,
   searchCrowdinCatConcordanceMock,
+  searchLokaliseCatConcordanceMock,
 } = vi.hoisted(() => ({
   crowdinClientOptions: [] as unknown[],
+  lokaliseClientOptions: [] as unknown[],
   loadCrowdinProjectCredentialMock: vi.fn(),
+  loadLokaliseProjectCredentialMock: vi.fn(),
   resolveExternalTmsSecretMaterialForActorMock: vi.fn(),
   searchCrowdinCatConcordanceMock: vi.fn(),
+  searchLokaliseCatConcordanceMock: vi.fn(),
 }));
 
 vi.mock("@/lib/providers/adapters/crowdin/load-crowdin-project-credential", () => ({
   loadCrowdinProjectCredential: (...args: unknown[]) => loadCrowdinProjectCredentialMock(...args),
+}));
+
+vi.mock("@/lib/providers/adapters/lokalise/load-lokalise-project-credential", () => ({
+  loadLokaliseProjectCredential: (...args: unknown[]) => loadLokaliseProjectCredentialMock(...args),
 }));
 
 vi.mock("@/lib/providers/tms-provider-content", () => ({
@@ -29,8 +39,20 @@ vi.mock("@/lib/providers/adapters/crowdin/crowdin-api", () => ({
   },
 }));
 
+vi.mock("@/lib/providers/adapters/lokalise/lokalise-api", () => ({
+  LokaliseApiClient: class MockLokaliseApiClient {
+    constructor(options: unknown) {
+      lokaliseClientOptions.push(options);
+    }
+  },
+}));
+
 vi.mock("@/lib/providers/adapters/crowdin/crowdin-cat-concordance", () => ({
   searchCrowdinCatConcordance: (...args: unknown[]) => searchCrowdinCatConcordanceMock(...args),
+}));
+
+vi.mock("@/lib/providers/adapters/lokalise/lokalise-cat-concordance", () => ({
+  searchLokaliseCatConcordance: (...args: unknown[]) => searchLokaliseCatConcordanceMock(...args),
 }));
 
 import { TmsProviderLiveError } from "@/lib/providers/tms-provider-live";
@@ -49,16 +71,31 @@ const baseCredential = {
   baseUrl: "https://acme.crowdin.com/api/v2",
 };
 
+const lokaliseCredential = {
+  ...baseCredential,
+  providerKind: "lokalise" as const,
+  baseUrl: "https://api.lokalise.com/api2",
+};
+
 describe("loadCatSegmentConcordance", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     crowdinClientOptions.length = 0;
+    lokaliseClientOptions.length = 0;
     loadCrowdinProjectCredentialMock.mockResolvedValue({
       externalProjectId: "42",
       credential: baseCredential,
     });
+    loadLokaliseProjectCredentialMock.mockResolvedValue({
+      externalProjectId: "proj.123",
+      credential: lokaliseCredential,
+    });
     resolveExternalTmsSecretMaterialForActorMock.mockResolvedValue("user-token");
     searchCrowdinCatConcordanceMock.mockResolvedValue({
+      glossaryTerms: [],
+      translationMemoryMatches: [],
+    });
+    searchLokaliseCatConcordanceMock.mockResolvedValue({
       glossaryTerms: [],
       translationMemoryMatches: [],
     });
@@ -143,4 +180,60 @@ describe("loadCatSegmentConcordance", () => {
       expect(searchCrowdinCatConcordanceMock).not.toHaveBeenCalled();
     },
   );
+
+  it("resolves per-user Lokalise credentials for live concordance", async () => {
+    await loadCatSegmentConcordance({
+      organizationId: "org_1",
+      projectId: "ext:lokalise:proj.123",
+      providerKind: "lokalise",
+      actorUserId: "user_1",
+      sourceLocale: "en",
+      targetLocale: "fr",
+      sourceText: "Hello",
+    });
+
+    expect(resolveExternalTmsSecretMaterialForActorMock).toHaveBeenCalledWith({
+      credential: lokaliseCredential,
+      organizationId: "org_1",
+      actorUserId: "user_1",
+    });
+    expect(lokaliseClientOptions).toEqual([
+      {
+        token: "user-token",
+        baseUrl: "https://api.lokalise.com/api2",
+      },
+    ]);
+    expect(searchLokaliseCatConcordanceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        externalProjectId: "proj.123",
+        sourceLocale: "en",
+        targetLocale: "fr",
+        sourceText: "Hello",
+      }),
+    );
+  });
+
+  it("throws a user-facing error when Lokalise per-user auth is missing", async () => {
+    resolveExternalTmsSecretMaterialForActorMock.mockRejectedValue(
+      new Error("lokalise_user_connection_required"),
+    );
+
+    await expect(
+      loadCatSegmentConcordance({
+        organizationId: "org_1",
+        projectId: "ext:lokalise:proj.123",
+        providerKind: "lokalise",
+        actorUserId: "user_1",
+        sourceLocale: "en",
+        targetLocale: "fr",
+        sourceText: "Hello",
+      }),
+    ).rejects.toMatchObject({
+      code: "lokalise_user_connection_required",
+      message:
+        "Connect your Lokalise account before loading glossary and translation memory matches.",
+    } satisfies Partial<TmsProviderLiveError>);
+
+    expect(searchLokaliseCatConcordanceMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-concordance.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-concordance.ts
@@ -85,6 +85,12 @@ const LOKALISE_USER_CONNECTION_ERROR_MESSAGES: Record<string, string> = {
     "Connect your Lokalise account before loading glossary and translation memory matches.",
 };
 
+const LOKALISE_OAUTH_ERROR_CODES = new Set([
+  "lokalise_oauth_refresh_failed",
+  "lokalise_oauth_token_invalid",
+  "lokalise_oauth_token_response_invalid",
+]);
+
 const LOKALISE_USER_AUTH_INVALID_MESSAGE =
   "Your Lokalise connection is invalid. Reconnect Lokalise and try again.";
 
@@ -172,7 +178,7 @@ async function resolveLokaliseConcordanceToken(input: {
         throw new TmsProviderLiveError(error.message, message);
       }
 
-      if (error.message.startsWith("lokalise_")) {
+      if (LOKALISE_OAUTH_ERROR_CODES.has(error.message)) {
         throw new TmsProviderLiveError(
           "lokalise_user_auth_invalid",
           LOKALISE_USER_AUTH_INVALID_MESSAGE,

--- a/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-concordance.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-concordance.ts
@@ -6,6 +6,12 @@ import {
   loadCrowdinProjectCredential,
   type CrowdinProjectCredential,
 } from "@/lib/providers/adapters/crowdin/load-crowdin-project-credential";
+import { searchLokaliseCatConcordance } from "@/lib/providers/adapters/lokalise/lokalise-cat-concordance";
+import { LokaliseApiClient } from "@/lib/providers/adapters/lokalise/lokalise-api";
+import {
+  loadLokaliseProjectCredential,
+  type LokaliseProjectCredential,
+} from "@/lib/providers/adapters/lokalise/load-lokalise-project-credential";
 import { TmsProviderLiveError } from "@/lib/providers/tms-provider-live";
 import { resolveExternalTmsSecretMaterialForActor } from "@/lib/providers/tms-provider-content";
 import type { ExternalTmsProviderKind } from "@/lib/providers/contracts/external-tms-provider-kind";
@@ -57,6 +63,8 @@ type CrowdinLiveConcordance = {
   translationMemoryMatches: NormalizedTranslationMemoryMatch[];
 };
 
+type LokaliseLiveConcordance = CrowdinLiveConcordance;
+
 const CROWDIN_USER_CONNECTION_ERROR_MESSAGES: Record<string, string> = {
   crowdin_user_connection_required:
     "Connect your Crowdin account before loading glossary and translation memory matches.",
@@ -71,6 +79,14 @@ const CROWDIN_OAUTH_ERROR_CODES = new Set([
 
 const CROWDIN_USER_AUTH_INVALID_MESSAGE =
   "Your Crowdin connection is invalid. Reconnect Crowdin and try again.";
+
+const LOKALISE_USER_CONNECTION_ERROR_MESSAGES: Record<string, string> = {
+  lokalise_user_connection_required:
+    "Connect your Lokalise account before loading glossary and translation memory matches.",
+};
+
+const LOKALISE_USER_AUTH_INVALID_MESSAGE =
+  "Your Lokalise connection is invalid. Reconnect Lokalise and try again.";
 
 async function resolveCrowdinConcordanceToken(input: {
   organizationId: string;
@@ -138,6 +154,72 @@ async function loadCrowdinLiveConcordance(input: {
   });
 }
 
+async function resolveLokaliseConcordanceToken(input: {
+  organizationId: string;
+  credential: LokaliseProjectCredential["credential"];
+  actorUserId?: string | null;
+}): Promise<string> {
+  try {
+    return await resolveExternalTmsSecretMaterialForActor({
+      credential: input.credential,
+      organizationId: input.organizationId,
+      actorUserId: input.actorUserId,
+    });
+  } catch (error) {
+    if (error instanceof Error) {
+      const message = LOKALISE_USER_CONNECTION_ERROR_MESSAGES[error.message];
+      if (message) {
+        throw new TmsProviderLiveError(error.message, message);
+      }
+
+      if (error.message.startsWith("lokalise_")) {
+        throw new TmsProviderLiveError(
+          "lokalise_user_auth_invalid",
+          LOKALISE_USER_AUTH_INVALID_MESSAGE,
+        );
+      }
+    }
+
+    throw error;
+  }
+}
+
+async function loadLokaliseLiveConcordance(input: {
+  organizationId: string;
+  projectId: string;
+  actorUserId?: string | null;
+  sourceLocale: string;
+  targetLocale: string;
+  sourceText: string;
+}): Promise<LokaliseLiveConcordance | null> {
+  const projectCredential = await loadLokaliseProjectCredential({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+  });
+  if (!projectCredential) {
+    return null;
+  }
+
+  const { credential, externalProjectId } = projectCredential;
+  const token = await resolveLokaliseConcordanceToken({
+    organizationId: input.organizationId,
+    credential,
+    actorUserId: input.actorUserId,
+  });
+  const client = new LokaliseApiClient({
+    token,
+    baseUrl: credential.baseUrl,
+  });
+
+  return searchLokaliseCatConcordance({
+    client,
+    externalProjectId,
+    sourceLocale: input.sourceLocale,
+    targetLocale: input.targetLocale,
+    sourceText: input.sourceText,
+  });
+}
+
 export async function loadCatSegmentConcordance(input: {
   organizationId: string;
   projectId: string;
@@ -149,6 +231,26 @@ export async function loadCatSegmentConcordance(input: {
 }): Promise<CatSegmentConcordance> {
   if (input.providerKind === "crowdin") {
     const liveMatches = await loadCrowdinLiveConcordance({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      actorUserId: input.actorUserId,
+      sourceLocale: input.sourceLocale,
+      targetLocale: input.targetLocale,
+      sourceText: input.sourceText,
+    });
+
+    if (liveMatches) {
+      return {
+        glossaryTerms: liveMatches.glossaryTerms.map(toCatGlossaryTerm),
+        translationMemoryMatches: liveMatches.translationMemoryMatches.map((match) =>
+          toCatTranslationMemoryMatch(match, input.sourceText),
+        ),
+      };
+    }
+  }
+
+  if (input.providerKind === "lokalise") {
+    const liveMatches = await loadLokaliseLiveConcordance({
       organizationId: input.organizationId,
       projectId: input.projectId,
       actorUserId: input.actorUserId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Closes parity gaps **1** and **2** from the Lokalise vs Crowdin roadmap:

### 1. CAT workspace
- Added `lokalise-live-cat.ts` with key-based queue, segment target/comments, translation save, and comment save
- Wired Lokalise into `tms-provider-live.ts` CAT dispatch (alongside Phrase/Crowdin)
- Enabled Lokalise in `provider-cat-capabilities.ts` for `file` and `key` resources
- Applied Phrase-style server-side filter restrictions in `cat-queue-filter.ts`

### 2. Live TMS APIs
- **Locale readiness:** `lokalise-locale-progress.ts` aggregates key translation states into Crowdin-compatible readiness shape
- **Job comments:** `lokalise-job-comments.ts` fetches task key comments via Lokalise API
- **Source file download:** Lokalise branch in `download-provider-source-file.ts` using `requestFileDownload`

### Live CAT concordance
- Added `lokalise-cat-concordance.ts` — live glossary term matching + project-key TM search (no attached resource requirement)
- Added `load-lokalise-project-credential.ts` for credential resolution
- Wired Lokalise into `load-cat-segment-concordance.ts` with per-user OAuth support (mirrors Crowdin path)

### Job UI hooks
- Added `provider-tms-job-display.ts` with provider-agnostic helpers for task type, language, locales, and readiness
- Added `use-provider-job-locale-readiness.ts` hook for Crowdin + Lokalise
- Updated job detail layout and live job detail content to use the new helpers

## How to test

```bash
cd apps/hyperlocalise-web
vp test src/lib/providers/adapters/lokalise/lokalise-live-cat.test.ts \
  src/lib/providers/adapters/lokalise/lokalise-locale-progress.test.ts \
  src/lib/providers/adapters/lokalise/lokalise-cat-concordance.test.ts \
  src/lib/translation/load-cat-segment-concordance.test.ts \
  src/lib/providers/provider-cat-capabilities.test.ts
vp check --fix
```

Manual (requires Lokalise credentials):
1. Open a Lokalise-backed project CAT workspace and verify key queue, translation save, comments, and concordance panel
2. Open a Lokalise job detail and confirm locale readiness, task metadata, and comments load

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f329f-6575-767c-8072-c76dfaa34bb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f329f-6575-767c-8072-c76dfaa34bb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

