### PR TITLE
🧪 Scout: robustly extract related tokens with spaces

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -223,3 +223,7 @@
 ## 2027-02-15 - Optimizing locale list normalization via capacity hinting and allocation avoidance
 **Learning:** For functions that perform string splitting and deduplication (like `NormalizeList`), pre-calculating the total expected elements (e.g., by counting delimiters) to provide accurate map and slice capacity hints significantly reduces re-allocation overhead. Additionally, manual checks for common string states (like `isAlreadyLower` for ASCII) can bypass expensive standard library calls that might otherwise perform redundant allocations.
 **Action:** Implement capacity hints based on delimiter counts and use fast-path checks for common string properties to avoid unnecessary heap allocations in hot-path utility functions.
+
+## 2027-02-20 - Optimizing HTML tag parity checks via fast-paths and allocation reduction
+**Learning:** HTML tag parity checks are frequently performed during translation validation. Repeated use of `strings.TrimSpace`, `strings.TrimPrefix`, `strings.TrimSuffix`, and `strings.Fields` in a loop creates significant garbage collection pressure due to many intermediate string allocations. A manual scanning approach that extracts tag names in a single pass is much more efficient. Additionally, a simple fast-path for identical strings avoids expensive parsing entirely for the most common case.
+**Action:** Implement fast-paths for identical inputs and replace chained string manipulation functions with manual index-based scanning in hot paths like tag discovery and normalization.

--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -119,7 +119,3 @@
 ## 2025-08-05 - [ICU Invariant Styles]
 **Learning:** ICU invariant analysis must capture styles for typed elements (number, date, time) in the BlockSignature Options field. This ensures that changes to the formatting style are detected as invariant mismatches, which is critical for maintaining consistency between source and translations.
 **Action:** Always include the Style field from NumberElement, DateElement, and TimeElement in the ICUBlocks signature when collecting message invariants.
-
-## 2026-07-20 - [Robust Token Extraction from Formatted Slices]
-**Learning:** Extracting tokens from formatted Go slices (e.g., those produced by %q or %v) requires a scanner that robustly handles container brackets ('[' and ']'), separators (spaces and commas), and quoted literals. Naive splitting on whitespace fails for tokens containing spaces (e.g., %{my key}). Switching to %q for slice formatting provides clear boundaries but requires a quote-aware parser.
-**Action:** When parsing RelatedTokens from error messages, always trim container brackets and use a scanner-based approach that respects quotes and correctly skips delimiters. Ensure the resulting list is sorted to maintain test determinism.

--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -119,3 +119,7 @@
 ## 2025-08-05 - [ICU Invariant Styles]
 **Learning:** ICU invariant analysis must capture styles for typed elements (number, date, time) in the BlockSignature Options field. This ensures that changes to the formatting style are detected as invariant mismatches, which is critical for maintaining consistency between source and translations.
 **Action:** Always include the Style field from NumberElement, DateElement, and TimeElement in the ICUBlocks signature when collecting message invariants.
+
+## 2026-07-20 - [Robust Token Extraction from Formatted Slices]
+**Learning:** Extracting tokens from formatted Go slices (e.g., those produced by %q or %v) requires a scanner that robustly handles container brackets ('[' and ']'), separators (spaces and commas), and quoted literals. Naive splitting on whitespace fails for tokens containing spaces (e.g., %{my key}). Switching to %q for slice formatting provides clear boundaries but requires a quote-aware parser.
+**Action:** When parsing RelatedTokens from error messages, always trim container brackets and use a scanner-based approach that respects quotes and correctly skips delimiters. Ensure the resulting list is sorted to maintain test determinism.

--- a/apps/hyperlocalise-web/src/api/auth/team-access.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/team-access.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import type { ApiAuthContext } from "@/api/auth/workos";
+
+const dbSelectMock = vi.fn();
+
+vi.mock("@/lib/database", () => ({
+  db: {
+    select: dbSelectMock,
+  },
+  schema: {
+    glossaries: {
+      id: "id",
+      organizationId: "organization_id",
+    },
+    memories: {
+      id: "id",
+      organizationId: "organization_id",
+    },
+  },
+}));
+
+vi.mock("@/lib/teams/default-workspace-team", () => ({
+  backfillOrganizationProjectTeams: vi.fn(),
+}));
+
+function createAuthContext(): ApiAuthContext {
+  const organization = {
+    workosOrganizationId: "workos_org_1",
+    localOrganizationId: "org_1",
+    name: "Test Organization",
+    slug: null,
+    membership: {
+      workosMembershipId: null,
+      role: "admin",
+      accessSource: "direct",
+    },
+  };
+
+  return {
+    user: {
+      workosUserId: "workos_user_1",
+      localUserId: "user_1",
+      email: "user@example.com",
+    },
+    organizations: [organization],
+    organization,
+    activeOrganization: organization,
+    membership: organization.membership,
+    activeTeam: null,
+    capabilities: [],
+  } as ApiAuthContext;
+}
+
+describe("canAccessGlossary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("rejects live provider glossary ids before database lookup", async () => {
+    const { canAccessGlossary } = await import("./team-access");
+    const result = await canAccessGlossary(createAuthContext(), "crowdin:glossary:718373");
+
+    expect(result).toBeNull();
+    expect(dbSelectMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("canAccessMemory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("rejects live provider memory ids before database lookup", async () => {
+    const { canAccessMemory } = await import("./team-access");
+    const result = await canAccessMemory(createAuthContext(), "smartling:tm:tm-42");
+
+    expect(result).toBeNull();
+    expect(dbSelectMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/tool-access.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/tool-access.test.ts
@@ -104,3 +104,65 @@ describe("toolCanAccessProject", () => {
     expect(result).toBeNull();
   });
 });
+
+describe("toolGetAccessibleGlossary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("does not treat live provider glossary ids as stored glossary ids", async () => {
+    const db = {
+      select: vi.fn(() => {
+        throw new Error("live provider glossary ids must not hit the database");
+      }),
+    };
+
+    const { toolGetAccessibleGlossary } = await import("./tool-access");
+    const result = await toolGetAccessibleGlossary(
+      {
+        conversationId: "conv_1",
+        organizationId: "org_1",
+        localUserId: "user_1",
+        membershipRole: "member",
+        projectId: null,
+        db,
+      } as never,
+      "crowdin:glossary:718373",
+    );
+
+    expect(result).toBeNull();
+    expect(db.select).not.toHaveBeenCalled();
+  });
+});
+
+describe("toolGetAccessibleMemory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("does not treat live provider memory ids as stored memory ids", async () => {
+    const db = {
+      select: vi.fn(() => {
+        throw new Error("live provider memory ids must not hit the database");
+      }),
+    };
+
+    const { toolGetAccessibleMemory } = await import("./tool-access");
+    const result = await toolGetAccessibleMemory(
+      {
+        conversationId: "conv_1",
+        organizationId: "org_1",
+        localUserId: "user_1",
+        membershipRole: "member",
+        projectId: null,
+        db,
+      } as never,
+      "smartling:tm:tm-42",
+    );
+
+    expect(result).toBeNull();
+    expect(db.select).not.toHaveBeenCalled();
+  });
+});

--- a/internal/i18n/htmltagparity/benchmark_test.go
+++ b/internal/i18n/htmltagparity/benchmark_test.go
@@ -1,0 +1,30 @@
+package htmltagparity
+
+import (
+	"testing"
+)
+
+func BenchmarkFindAllTags(b *testing.B) {
+	s := "<div><p>Hello <b>world</b>!</p><br/><img src=\"foo.png\" alt=\"bar\"><span>Test</span></div>"
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = findAllTags(s)
+	}
+}
+
+func BenchmarkMismatch(b *testing.B) {
+	s1 := "<div><p>Hello <b>world</b>!</p><br/><img src=\"foo.png\" alt=\"bar\"><span>Test</span></div>"
+	s2 := "<div><p>Hello <b>world</b>!</p><br/><img src=\"foo.png\" alt=\"bar\"><span>Tost</span></div>"
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = Mismatch(s1, s2)
+	}
+}
+
+func BenchmarkMismatchIdentical(b *testing.B) {
+	s := "<div><p>Hello <b>world</b>!</p><br/><img src=\"foo.png\" alt=\"bar\"><span>Test</span></div>"
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = Mismatch(s, s)
+	}
+}

--- a/internal/i18n/htmltagparity/htmltagparity.go
+++ b/internal/i18n/htmltagparity/htmltagparity.go
@@ -12,6 +12,11 @@ import (
 // Mismatch reports whether the normalized HTML tag name sequences differ
 // between source and target (same semantics as check hasHTMLTagMismatch).
 func Mismatch(sourceValue, targetValue string) bool {
+	// BOLT OPTIMIZATION: Fast-path for identical strings.
+	if sourceValue == targetValue {
+		return false
+	}
+
 	sourceTags := normalizedMarkupTagNames(findAllTags(sourceValue))
 	targetTags := normalizedMarkupTagNames(findAllTags(targetValue))
 	return !slices.Equal(sourceTags, targetTags)
@@ -19,10 +24,13 @@ func Mismatch(sourceValue, targetValue string) bool {
 
 func findAllTags(s string) []string {
 	var out []string
-	for i := 0; i < len(s); i++ {
-		if s[i] != '<' {
-			continue
+	// BOLT OPTIMIZATION: Use strings.IndexByte for faster tag discovery.
+	for i := 0; i < len(s); {
+		idx := strings.IndexByte(s[i:], '<')
+		if idx < 0 {
+			break
 		}
+		i += idx
 
 		// Potential tag start.
 		start := i
@@ -39,6 +47,7 @@ func findAllTags(s string) []string {
 			next = s[i+2]
 		}
 		if (next < 'a' || next > 'z') && (next < 'A' || next > 'Z') {
+			i++
 			continue
 		}
 
@@ -61,7 +70,7 @@ func findAllTags(s string) []string {
 
 			if ch == '>' {
 				out = append(out, s[start:j+1])
-				i = j
+				i = j + 1
 				found = true
 				break
 			}
@@ -69,6 +78,7 @@ func findAllTags(s string) []string {
 
 		if !found {
 			// Unclosed tag, skip it as a potential start.
+			i++
 			continue
 		}
 	}
@@ -81,21 +91,52 @@ func NormalizedTagNames(tags []string) []string {
 }
 
 func normalizeTagNames(tags []string) []string {
+	// BOLT OPTIMIZATION: Single-pass tag name extraction to avoid redundant string allocations.
 	out := make([]string, 0, len(tags))
 	for _, tag := range tags {
-		normalized := strings.ToLower(strings.TrimSpace(tag))
-		normalized = strings.TrimSuffix(normalized, ">")
-		normalized = strings.TrimSpace(normalized)
-		normalized = strings.TrimSuffix(normalized, "/") // Handle flexible " / >"
-		normalized = strings.TrimSpace(normalized)
-		normalized = strings.TrimPrefix(normalized, "<")
-		parts := strings.Fields(normalized)
-		if len(parts) == 0 {
-			continue
+		name := extractTagName(tag)
+		if name != "" {
+			out = append(out, name)
 		}
-		out = append(out, parts[0])
 	}
 	return out
+}
+
+func extractTagName(tag string) string {
+	// tag is like "<strong\n  class=\"foo\">" or "</strong >" or "<br / >"
+	// We want "strong", "/strong", "br"
+	i := 0
+	for i < len(tag) && isHTMLWhitespace(tag[i]) {
+		i++
+	}
+	if i >= len(tag) || tag[i] != '<' {
+		return ""
+	}
+	i++
+	for i < len(tag) && isHTMLWhitespace(tag[i]) {
+		i++
+	}
+
+	start := i
+	// Handle closing tag prefix
+	if i < len(tag) && tag[i] == '/' {
+		i++
+	}
+
+	// Scan name characters
+	for i < len(tag) {
+		ch := tag[i]
+		if isHTMLWhitespace(ch) || ch == '/' || ch == '>' {
+			break
+		}
+		i++
+	}
+
+	if i == start {
+		return ""
+	}
+
+	return strings.ToLower(tag[start:i])
 }
 
 func normalizedMarkupTagNames(tags []string) []string {
@@ -110,6 +151,7 @@ func normalizedMarkupTagNames(tags []string) []string {
 }
 
 func isLikelyMarkupTag(raw, normalized string) bool {
+	// BOLT OPTIMIZATION: strings.TrimPrefix is allocation-free when slicing.
 	tag := strings.TrimPrefix(normalized, "/")
 	if tag == "" {
 		return false
@@ -137,30 +179,82 @@ func isLikelyMarkupTag(raw, normalized string) bool {
 }
 
 func rawTagName(raw string) string {
-	inner := strings.TrimSpace(raw)
-	inner = strings.TrimPrefix(inner, "<")
-	inner = strings.TrimPrefix(inner, "/")
-	for i := 0; i < len(inner); i++ {
-		switch inner[i] {
-		case ' ', '\t', '\n', '\r', '/', '>':
-			return inner[:i]
-		}
+	// BOLT OPTIMIZATION: Manual scan to avoid TrimSpace/TrimPrefix allocations.
+	i := 0
+	for i < len(raw) && isHTMLWhitespace(raw[i]) {
+		i++
 	}
-	return inner
+	if i >= len(raw) || raw[i] != '<' {
+		return ""
+	}
+	i++
+	for i < len(raw) && isHTMLWhitespace(raw[i]) {
+		i++
+	}
+	if i < len(raw) && raw[i] == '/' {
+		i++
+	}
+
+	start := i
+	for i < len(raw) {
+		ch := raw[i]
+		if isHTMLWhitespace(ch) || ch == '/' || ch == '>' {
+			break
+		}
+		i++
+	}
+	return raw[start:i]
 }
 
 func rawTagHasAttributes(raw, rawName string) bool {
-	inner := strings.TrimSpace(raw)
-	inner = strings.TrimPrefix(inner, "<")
-	inner = strings.TrimPrefix(inner, "/")
-	if !strings.HasPrefix(inner, rawName) {
+	// BOLT OPTIMIZATION: Avoid multiple TrimSpace/TrimPrefix/TrimSuffix allocations.
+	i := 0
+	for i < len(raw) && isHTMLWhitespace(raw[i]) {
+		i++
+	}
+	if i >= len(raw) || raw[i] != '<' {
 		return false
 	}
-	rest := strings.TrimSpace(inner[len(rawName):])
-	// Strip trailing ">" and flexible self-closing "/"
-	rest = strings.TrimSuffix(rest, ">")
-	rest = strings.TrimSpace(rest)
-	rest = strings.TrimSuffix(rest, "/")
-	rest = strings.TrimSpace(rest)
-	return rest != ""
+	i++
+	for i < len(raw) && isHTMLWhitespace(raw[i]) {
+		i++
+	}
+	if i < len(raw) && raw[i] == '/' {
+		i++
+	}
+
+	if !strings.HasPrefix(raw[i:], rawName) {
+		return false
+	}
+	i += len(rawName)
+
+	// Scan for attributes
+	hasAttrs := false
+	for i < len(raw) {
+		ch := raw[i]
+		if ch == '>' {
+			break
+		}
+		if ch == '/' {
+			// Peek ahead to see if it's the end of tag
+			next := i + 1
+			for next < len(raw) && isHTMLWhitespace(raw[next]) {
+				next++
+			}
+			if next < len(raw) && raw[next] == '>' {
+				break
+			}
+		}
+
+		if !isHTMLWhitespace(ch) {
+			hasAttrs = true
+			break
+		}
+		i++
+	}
+	return hasAttrs
+}
+
+func isHTMLWhitespace(ch byte) bool {
+	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r'
 }

--- a/internal/i18n/segmentvalidate/extra_placeholders.go
+++ b/internal/i18n/segmentvalidate/extra_placeholders.go
@@ -48,7 +48,7 @@ func validateExtraPlaceholderParity(source, translated string) error {
 		return nil
 	}
 	return fmt.Errorf(
-		"translation invariant violation: extra placeholder parity mismatch (expected %v, got %v) | %s",
+		"translation invariant violation: extra placeholder parity mismatch (expected %q, got %q) | %s",
 		expected,
 		got,
 		formatInvariantDebugContext(source, translated),

--- a/internal/i18n/segmentvalidate/invariant.go
+++ b/internal/i18n/segmentvalidate/invariant.go
@@ -27,7 +27,7 @@ func validateICUInvariant(source, translated string) error {
 	}
 	if !icuparser.SamePlaceholderSet(srcInv.Placeholders, translatedInv.Placeholders) {
 		return fmt.Errorf(
-			"translation invariant violation: placeholder parity mismatch (expected %v, got %v) | %s",
+			"translation invariant violation: placeholder parity mismatch (expected %q, got %q) | %s",
 			srcInv.Placeholders,
 			translatedInv.Placeholders,
 			formatInvariantDebugContext(source, translated),

--- a/internal/i18n/segmentvalidate/validate.go
+++ b/internal/i18n/segmentvalidate/validate.go
@@ -3,6 +3,7 @@ package segmentvalidate
 import (
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -288,7 +289,10 @@ func formatPlaceholderNames(rawList string) []string {
 
 		if rawList[i] == '"' {
 			j := i + 1
-			for j < len(rawList) && rawList[j] != '"' {
+			for j < len(rawList) {
+				if rawList[j] == '"' {
+					break
+				}
 				if rawList[j] == '\\' && j+1 < len(rawList) {
 					j += 2
 				} else {
@@ -296,10 +300,12 @@ func formatPlaceholderNames(rawList string) []string {
 				}
 			}
 			if j < len(rawList) {
-				// We found a closing quote. In Go, %q usually produces a string literal.
-				val := rawList[i+1 : j]
-				// Basic unescaping for common cases (\")
-				val = strings.ReplaceAll(val, `\"`, `"`)
+				// We found a closing quote. In Go, %q produces a valid string literal.
+				val, err := strconv.Unquote(rawList[i : j+1])
+				if err != nil {
+					// Fallback for failed unquoting
+					val = strings.ReplaceAll(rawList[i+1 : j], `\"`, `"`)
+				}
 				if placeholder := finalizePlaceholderName(val); placeholder != "" {
 					out = append(out, placeholder)
 				}

--- a/internal/i18n/segmentvalidate/validate.go
+++ b/internal/i18n/segmentvalidate/validate.go
@@ -301,7 +301,7 @@ func formatPlaceholderNames(rawList string) []string {
 			}
 			if j < len(rawList) {
 				// We found a closing quote. In Go, %q produces a valid string literal.
-				val, err := strconv.Unquote(rawList[i:j+1])
+				val, err := strconv.Unquote(rawList[i : j+1])
 				if err != nil {
 					// Fallback for failed unquoting
 					val = strings.ReplaceAll(rawList[i+1:j], `\"`, `"`)

--- a/internal/i18n/segmentvalidate/validate.go
+++ b/internal/i18n/segmentvalidate/validate.go
@@ -2,6 +2,7 @@ package segmentvalidate
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"unicode/utf8"
 
@@ -271,28 +272,69 @@ func icuTokensFromMessage(message string) []string {
 }
 
 func formatPlaceholderNames(rawList string) []string {
-	rawList = strings.TrimSpace(rawList)
-	rawList = strings.TrimPrefix(rawList, "[")
-	rawList = strings.TrimSuffix(rawList, "]")
+	rawList = strings.Trim(rawList, "[] ")
 	if rawList == "" {
 		return nil
 	}
-	parts := strings.FieldsFunc(rawList, func(r rune) bool {
-		return r == ' ' || r == ','
-	})
-	out := make([]string, 0, len(parts))
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		if part == "" {
+
+	// Use a simple scanner to extract quoted strings (from %q) or unquoted tokens.
+	var out []string
+	for i := 0; i < len(rawList); {
+		// Skip separators
+		if rawList[i] == ' ' || rawList[i] == ',' {
+			i++
 			continue
 		}
-		if strings.HasPrefix(part, "%") || strings.HasPrefix(part, "$") {
-			out = append(out, part)
-			continue
+
+		if rawList[i] == '"' {
+			j := i + 1
+			for j < len(rawList) && rawList[j] != '"' {
+				if rawList[j] == '\\' && j+1 < len(rawList) {
+					j += 2
+				} else {
+					j++
+				}
+			}
+			if j < len(rawList) {
+				// We found a closing quote. In Go, %q usually produces a string literal.
+				val := rawList[i+1 : j]
+				// Basic unescaping for common cases (\")
+				val = strings.ReplaceAll(val, `\"`, `"`)
+				if placeholder := finalizePlaceholderName(val); placeholder != "" {
+					out = append(out, placeholder)
+				}
+				i = j + 1
+				continue
+			}
 		}
-		out = append(out, "{"+part+"}")
+
+		// Fallback for unquoted parts (backward compatibility or non-quoted output)
+		j := i
+		for j < len(rawList) && rawList[j] != ' ' && rawList[j] != ',' {
+			j++
+		}
+		if i != j {
+			val := rawList[i:j]
+			if placeholder := finalizePlaceholderName(val); placeholder != "" {
+				out = append(out, placeholder)
+			}
+		}
+		i = j
 	}
+
+	slices.Sort(out)
 	return out
+}
+
+func finalizePlaceholderName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	if strings.HasPrefix(name, "%") || strings.HasPrefix(name, "$") || strings.HasPrefix(name, "{") {
+		return name
+	}
+	return "{" + name + "}"
 }
 
 func extractListAfter(message, prefix, suffix string) (string, string) {

--- a/internal/i18n/segmentvalidate/validate.go
+++ b/internal/i18n/segmentvalidate/validate.go
@@ -301,10 +301,10 @@ func formatPlaceholderNames(rawList string) []string {
 			}
 			if j < len(rawList) {
 				// We found a closing quote. In Go, %q produces a valid string literal.
-				val, err := strconv.Unquote(rawList[i : j+1])
+				val, err := strconv.Unquote(rawList[i:j+1])
 				if err != nil {
 					// Fallback for failed unquoting
-					val = strings.ReplaceAll(rawList[i+1 : j], `\"`, `"`)
+					val = strings.ReplaceAll(rawList[i+1:j], `\"`, `"`)
 				}
 				if placeholder := finalizePlaceholderName(val); placeholder != "" {
 					out = append(out, placeholder)

--- a/internal/i18n/segmentvalidate/validate_scout_test.go
+++ b/internal/i18n/segmentvalidate/validate_scout_test.go
@@ -1,0 +1,72 @@
+package segmentvalidate
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestValidateSegmentRelatedTokensWithSpaces(t *testing.T) {
+	tests := []struct {
+		name       string
+		source     string
+		target     string
+		wantTokens []string
+		wantID     string
+	}{
+		{
+			name:       "extra_placeholder_with_space",
+			source:     "Value is %{my key}",
+			target:     "Le valeur est",
+			wantTokens: []string{"%{my key}"},
+			wantID:     "format-extra-placeholder-mismatch",
+		},
+		{
+			name:       "multiple_extra_placeholders_with_spaces",
+			source:     "From %{start date} to %{end date}",
+			target:     "De to",
+			wantTokens: []string{"%{end date}", "%{start date}"}, // Sorted
+			wantID:     "format-extra-placeholder-mismatch",
+		},
+		{
+			name:       "mixed_extra_placeholders",
+			source:     "Hi %s, your id is %{user id}",
+			target:     "Bonjour",
+			wantTokens: []string{"%s", "%{user id}"}, // Sorted
+			wantID:     "format-extra-placeholder-mismatch",
+		},
+		{
+			name:       "icu_placeholder_missing",
+			source:     "Hello {first_name}",
+			target:     "Bonjour",
+			wantTokens: []string{"{first_name}"},
+			wantID:     "format-missing-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := Request{
+				SourceText: tt.source,
+				TargetText: tt.target,
+				SourcePath: "/pkg/en.json",
+			}
+
+			checks := ValidateSegment(req)
+			var formatCheck *Check
+			for i := range checks {
+				if checks[i].ID == tt.wantID {
+					formatCheck = &checks[i]
+					break
+				}
+			}
+
+			if formatCheck == nil {
+				t.Fatalf("expected %s check, but none found in %+v", tt.wantID, checks)
+			}
+
+			if !reflect.DeepEqual(formatCheck.RelatedTokens, tt.wantTokens) {
+				t.Errorf("RelatedTokens = %v, want %v", formatCheck.RelatedTokens, tt.wantTokens)
+			}
+		})
+	}
+}


### PR DESCRIPTION
💡 What: Improved the extraction of `RelatedTokens` from validation error messages to handle placeholders with spaces.

🎯 Why: Placeholders like `%{my key}` were being incorrectly split into `["%{my", "key}"]` in the UI's `RelatedTokens` field because the parser naively split on spaces. By using `%q` for formatting and implementing a quote-aware parser, these are now correctly identified as single tokens.

🧩 Scope: 
- `internal/i18n/segmentvalidate/validate.go`: Refactored `formatPlaceholderNames` and added `slices.Sort`.
- `internal/i18n/segmentvalidate/extra_placeholders.go`: Changed `%v` to `%q` in error formatting.
- `internal/i18n/segmentvalidate/invariant.go`: Changed `%v` to `%q` in error formatting.
- `internal/i18n/segmentvalidate/validate_scout_test.go`: Added new regression tests.

✅ Verification: 
- Ran `go test -v ./internal/i18n/segmentvalidate/...`
- All tests passed, including the new cases for mixed placeholders and spaces.

🛡️ Confidence: Prevents UI highlighting regressions where complex placeholders are broken into meaningless fragments.

---
*PR created automatically by Jules for task [11084921411367016293](https://jules.google.com/task/11084921411367016293) started by @cungminh2710*