### PR TITLE
feat(web): add Storybook stories for glossaries and translation memories pages

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-content.tsx
@@ -26,9 +26,11 @@ import {
   type GlossaryListRow,
 } from "./glossary-list";
 import type { TmsProviderLiveGlossary } from "@/lib/providers/tms-provider-live";
-import { GlossariesPageView, type GlossaryCreateForm } from "./glossaries-page-view";
-
-const GLOSSARIES_PAGE_SIZE = 100;
+import {
+  GlossariesPageView,
+  GLOSSARIES_PAGE_SIZE,
+  type GlossaryCreateForm,
+} from "./glossaries-page-view";
 
 type GlossaryListFilters = {
   searchQuery: string;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-content.tsx
@@ -3,38 +3,13 @@
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useSearchParams } from "next/navigation";
-import { Add01Icon, BookOpenTextIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
-import { Field, FieldError, FieldLabel } from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Button } from "@/components/ui/button";
-import { Spinner } from "@/components/ui/spinner";
-import { Textarea } from "@/components/ui/textarea";
-import { TypographyP } from "@/components/ui/typography";
 import { readApiError, readApiResponseError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
 
 import { useActiveTmsProvider } from "../../_hooks/use-active-tms-provider";
-
-import { TmsLiveProjectPicker } from "../../_components/tms-live-project-picker";
 
 import {
   GLOSSARY_SYNC_FILTERS,
@@ -42,11 +17,6 @@ import {
   readWorkspaceFilterParam,
   TMS_PROVIDER_KINDS,
 } from "../../_components/workspace-filter-params";
-import {
-  PageHeader,
-  WorkspaceFilterField,
-  workspaceFilterTriggerClassName,
-} from "../../_components/workspace-resource-shared";
 import {
   buildProjectIdByExternalKey,
   mapGlossaryToListRow,
@@ -56,33 +26,9 @@ import {
   type GlossaryListRow,
 } from "./glossary-list";
 import type { TmsProviderLiveGlossary } from "@/lib/providers/tms-provider-live";
-import { GlossariesEmptyAction, GlossariesTable } from "./glossaries-table";
-import {
-  ProjectSourceLocalePicker,
-  ProjectTargetLocalesPicker,
-} from "../../projects/_components/project-locale-picker";
+import { GlossariesPageView, type GlossaryCreateForm } from "./glossaries-page-view";
 
 const GLOSSARIES_PAGE_SIZE = 100;
-
-const sourceFilterLabels = {
-  all: "All sources",
-  native: "Workspace",
-  external_tms: "Provider",
-} as const;
-
-const resourceTypeFilterLabels = {
-  all: "All resource types",
-  glossary: "Glossary",
-  term_base: "Term base",
-} as const;
-
-const syncFilterLabels = {
-  all: "All sync states",
-  synced: "Synced",
-  stale: "Stale",
-  syncing: "Syncing",
-  error: "Sync error",
-} as const;
 
 type GlossaryListFilters = {
   searchQuery: string;
@@ -147,13 +93,6 @@ const credentialsQueryKey = (organizationSlug: string) => [
   organizationSlug,
 ];
 
-type GlossaryCreateForm = {
-  name: string;
-  description: string;
-  sourceLocale: string;
-  targetLocales: string[];
-};
-
 function createEmptyGlossaryForm(): GlossaryCreateForm {
   return {
     name: "",
@@ -199,6 +138,14 @@ function useGlossaryFilters(searchParams: URLSearchParams) {
 
   const hasActiveFilters = activeFilterCount > 0;
 
+  function clearFilters() {
+    setSearchQuery("");
+    setSourceFilter("all");
+    setProviderFilter("all");
+    setResourceTypeFilter("all");
+    setSyncFilter("all");
+  }
+
   return {
     filters,
     searchQuery,
@@ -213,6 +160,7 @@ function useGlossaryFilters(searchParams: URLSearchParams) {
     setSyncFilter,
     activeFilterCount,
     hasActiveFilters,
+    clearFilters,
   };
 }
 
@@ -245,6 +193,7 @@ export function GlossariesPageContent({
     setSyncFilter,
     activeFilterCount,
     hasActiveFilters,
+    clearFilters,
   } = useGlossaryFilters(searchParams);
   const { data: activeTmsProvider } = useActiveTmsProvider(organizationSlug);
   const useLiveProviderGlossaries = Boolean(activeTmsProvider);
@@ -442,18 +391,6 @@ export function GlossariesPageContent({
     ? Boolean(activeTmsProvider)
     : credentialsQuery.isSuccess && connectedCredentials.length > 0;
 
-  const liveProjectSelectionRequired = useLiveProviderGlossaries && !selectedExternalProjectId;
-
-  const emptyTitle = hasConnectedProvider ? "No glossaries yet" : "Connect a TMS provider";
-  const emptyDescription = hasConnectedProvider
-    ? "Provider glossaries and term bases appear here after sync. Connect or resync a TMS provider from Integrations if you expected to see one."
-    : "Connect Crowdin, Phrase, Smartling, or Lokalise from Integrations to sync glossaries into this workspace.";
-
-  const glossaryCountLabel =
-    glossariesQuery.isSuccess && glossaryTotal > 0
-      ? `${glossaryTotal} ${glossaryTotal === 1 ? "glossary" : "glossaries"}`
-      : undefined;
-
   function submitCreateGlossary() {
     const errors: { name?: string; targetLocales?: string } = {};
     if (!createForm.name.trim()) {
@@ -470,335 +407,47 @@ export function GlossariesPageContent({
   }
 
   return (
-    <main className="mx-auto flex w-full max-w-6xl flex-col gap-6">
-      <PageHeader
-        icon={BookOpenTextIcon}
-        label="Workspace"
-        title="Glossaries"
-        description="Create first-party workspace glossaries or sync provider term bases. Provider glossaries stay read-only."
-        statusLabel={glossaryCountLabel}
-        actions={
-          allowCreateGlossaries ? (
-            <Button
-              type="button"
-              onClick={() => setCreateDialogOpen(true)}
-              className="w-full sm:w-fit"
-            >
-              <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
-              Create glossary
-            </Button>
-          ) : null
-        }
-      />
-
-      {useLiveProviderGlossaries ? (
-        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:gap-2">
-          <TmsLiveProjectPicker
-            organizationSlug={organizationSlug}
-            value={selectedExternalProjectId}
-            onValueChange={setSelectedExternalProjectId}
-          />
-        </div>
-      ) : null}
-
-      {glossariesQuery.isSuccess && (glossaryTotal > 0 || hasActiveFilters) ? (
-        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:gap-2">
-          <WorkspaceFilterField label="Search" className="w-full sm:max-w-xs">
-            <Input
-              placeholder="Name, project, or external ID..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full"
-            />
-          </WorkspaceFilterField>
-          <WorkspaceFilterField label="Source" className="w-full sm:w-40">
-            <Select
-              value={sourceFilter}
-              onValueChange={(value) => {
-                setSourceFilter(value ?? "all");
-                if (value === "native") {
-                  setProviderFilter("all");
-                  setResourceTypeFilter("all");
-                  setSyncFilter("all");
-                }
-              }}
-            >
-              <SelectTrigger className={workspaceFilterTriggerClassName}>
-                <SelectValue>
-                  {sourceFilterLabels[sourceFilter as keyof typeof sourceFilterLabels] ??
-                    sourceFilter}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all" label={sourceFilterLabels.all}>
-                  {sourceFilterLabels.all}
-                </SelectItem>
-                <SelectItem value="native" label={sourceFilterLabels.native}>
-                  {sourceFilterLabels.native}
-                </SelectItem>
-                <SelectItem value="external_tms" label={sourceFilterLabels.external_tms}>
-                  {sourceFilterLabels.external_tms}
-                </SelectItem>
-              </SelectContent>
-            </Select>
-          </WorkspaceFilterField>
-
-          {hasExternalGlossaries && sourceFilter !== "native" ? (
-            <WorkspaceFilterField label="Provider" className="w-full sm:w-40">
-              <Select
-                value={providerFilter}
-                onValueChange={(value) => setProviderFilter(value ?? "all")}
-              >
-                <SelectTrigger className={workspaceFilterTriggerClassName}>
-                  <SelectValue>
-                    {providerFilter === "all"
-                      ? "All providers"
-                      : providerLabel(providerFilter as (typeof TMS_PROVIDER_KINDS)[number])}
-                  </SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all" label="All providers">
-                    All providers
-                  </SelectItem>
-                  {providerKinds.map((kind) => (
-                    <SelectItem key={kind} value={kind} label={providerLabel(kind)}>
-                      {providerLabel(kind)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </WorkspaceFilterField>
-          ) : null}
-
-          {hasResourceTypes && sourceFilter !== "native" ? (
-            <WorkspaceFilterField label="Resource" className="w-full sm:w-44">
-              <Select
-                value={resourceTypeFilter}
-                onValueChange={(value) => setResourceTypeFilter(value ?? "all")}
-              >
-                <SelectTrigger className={workspaceFilterTriggerClassName}>
-                  <SelectValue>
-                    {resourceTypeFilterLabels[
-                      resourceTypeFilter as keyof typeof resourceTypeFilterLabels
-                    ] ?? resourceTypeFilter}
-                  </SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all" label={resourceTypeFilterLabels.all}>
-                    {resourceTypeFilterLabels.all}
-                  </SelectItem>
-                  <SelectItem value="glossary" label={resourceTypeFilterLabels.glossary}>
-                    {resourceTypeFilterLabels.glossary}
-                  </SelectItem>
-                  <SelectItem value="term_base" label={resourceTypeFilterLabels.term_base}>
-                    {resourceTypeFilterLabels.term_base}
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-            </WorkspaceFilterField>
-          ) : null}
-
-          {hasExternalGlossaries && sourceFilter !== "native" ? (
-            <WorkspaceFilterField label="Sync" className="w-full sm:w-40">
-              <Select value={syncFilter} onValueChange={(value) => setSyncFilter(value ?? "all")}>
-                <SelectTrigger className={workspaceFilterTriggerClassName}>
-                  <SelectValue>
-                    {syncFilterLabels[syncFilter as keyof typeof syncFilterLabels] ?? syncFilter}
-                  </SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all" label={syncFilterLabels.all}>
-                    {syncFilterLabels.all}
-                  </SelectItem>
-                  <SelectItem value="synced" label={syncFilterLabels.synced}>
-                    {syncFilterLabels.synced}
-                  </SelectItem>
-                  <SelectItem value="stale" label={syncFilterLabels.stale}>
-                    {syncFilterLabels.stale}
-                  </SelectItem>
-                  <SelectItem value="syncing" label={syncFilterLabels.syncing}>
-                    {syncFilterLabels.syncing}
-                  </SelectItem>
-                  <SelectItem value="error" label={syncFilterLabels.error}>
-                    {syncFilterLabels.error}
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-            </WorkspaceFilterField>
-          ) : null}
-
-          {activeFilterCount > 0 ? (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                setSearchQuery("");
-                setSourceFilter("all");
-                setProviderFilter("all");
-                setResourceTypeFilter("all");
-                setSyncFilter("all");
-              }}
-            >
-              Clear filters
-            </Button>
-          ) : null}
-        </div>
-      ) : null}
-
-      {glossariesQuery.isSuccess && hasActiveFilters && glossaryTotal === 0 ? (
-        <div className="text-sm text-muted-foreground">
-          No glossaries match your filters.{" "}
-          <button
-            type="button"
-            onClick={() => {
-              setSearchQuery("");
-              setSourceFilter("all");
-              setProviderFilter("all");
-              setResourceTypeFilter("all");
-              setSyncFilter("all");
-            }}
-            className="text-subtle-foreground underline hover:text-foreground"
-          >
-            Clear filters
-          </button>
-        </div>
-      ) : null}
-
-      {liveProjectSelectionRequired ? (
-        <div className="space-y-3 py-10">
-          <TypographyP className="text-sm font-medium text-foreground">
-            Choose a TMS project
-          </TypographyP>
-          <TypographyP className="max-w-xl text-sm leading-6 text-muted-foreground">
-            Select a project above to load live glossaries and term bases from your connected
-            provider.
-          </TypographyP>
-        </div>
-      ) : (
-        <GlossariesTable
-          glossaries={glossaries}
-          glossariesQuery={glossariesQuery}
-          organizationSlug={organizationSlug}
-          emptyTitle={allowCreateGlossaries ? "No glossaries yet" : emptyTitle}
-          emptyDescription={
-            allowCreateGlossaries
-              ? "Create a workspace glossary, import terms, then assign it to the projects that should use it."
-              : emptyDescription
-          }
-          emptyAction={
-            allowCreateGlossaries ? (
-              <Button type="button" size="sm" onClick={() => setCreateDialogOpen(true)}>
-                Create glossary
-              </Button>
-            ) : (
-              <GlossariesEmptyAction organizationSlug={organizationSlug} />
-            )
-          }
-        />
-      )}
-
-      {!liveProjectSelectionRequired &&
-      glossariesQuery.isSuccess &&
-      glossaryTotal > GLOSSARIES_PAGE_SIZE ? (
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <p className="text-sm text-muted-foreground">
-            Showing {pageStart}–{pageEnd} of {glossaryTotal} glossaries
-          </p>
-          <div className="flex flex-wrap items-center gap-2">
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              disabled={page <= 1}
-              onClick={() => setPage((current) => Math.max(1, current - 1))}
-            >
-              Previous
-            </Button>
-            <p className="text-sm text-muted-foreground">
-              Page {page} of {totalPages}
-            </p>
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              disabled={page >= totalPages}
-              onClick={() => setPage((current) => current + 1)}
-            >
-              Next
-            </Button>
-          </div>
-        </div>
-      ) : null}
-      <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
-        <DialogContent className="max-h-[min(85dvh,42rem)] overflow-y-auto sm:max-w-lg">
-          <DialogHeader>
-            <DialogTitle>Create glossary</DialogTitle>
-            <DialogDescription>
-              Add a first-party terminology library. You can import and edit terms after creation.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="grid gap-4">
-            <Field className="gap-1.5">
-              <FieldLabel>Name</FieldLabel>
-              <Input
-                value={createForm.name}
-                onChange={(event) =>
-                  setCreateForm((current) => ({ ...current, name: event.target.value }))
-                }
-                disabled={createGlossary.isPending}
-                placeholder="Product terminology"
-              />
-              <FieldError
-                errors={createErrors.name ? [{ message: createErrors.name }] : undefined}
-              />
-            </Field>
-            <ProjectSourceLocalePicker
-              value={createForm.sourceLocale}
-              onChange={(sourceLocale) =>
-                setCreateForm((current) => ({ ...current, sourceLocale }))
-              }
-              disabled={createGlossary.isPending}
-            />
-            <ProjectTargetLocalesPicker
-              value={createForm.targetLocales}
-              sourceLocale={createForm.sourceLocale}
-              onChange={(targetLocales) =>
-                setCreateForm((current) => ({
-                  ...current,
-                  targetLocales: targetLocales.slice(0, 1),
-                }))
-              }
-              disabled={createGlossary.isPending}
-              error={createErrors.targetLocales}
-            />
-            <Field className="gap-1.5">
-              <FieldLabel>Description</FieldLabel>
-              <Textarea
-                value={createForm.description}
-                onChange={(event) =>
-                  setCreateForm((current) => ({ ...current, description: event.target.value }))
-                }
-                disabled={createGlossary.isPending}
-                placeholder="Where this glossary should be used"
-              />
-            </Field>
-          </div>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setCreateDialogOpen(false)}
-              disabled={createGlossary.isPending}
-            >
-              Cancel
-            </Button>
-            <Button onClick={submitCreateGlossary} disabled={createGlossary.isPending}>
-              {createGlossary.isPending ? <Spinner /> : null}
-              Create glossary
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </main>
+    <GlossariesPageView
+      organizationSlug={organizationSlug}
+      glossaries={glossaries}
+      glossaryTotal={glossaryTotal}
+      isLoading={glossariesQuery.isLoading}
+      isError={glossariesQuery.isError}
+      isSuccess={glossariesQuery.isSuccess}
+      error={glossariesQuery.error}
+      allowCreateGlossaries={allowCreateGlossaries}
+      hasConnectedProvider={hasConnectedProvider}
+      useLiveProviderGlossaries={useLiveProviderGlossaries}
+      selectedExternalProjectId={selectedExternalProjectId}
+      onSelectedExternalProjectIdChange={setSelectedExternalProjectId}
+      searchQuery={searchQuery}
+      onSearchQueryChange={setSearchQuery}
+      sourceFilter={sourceFilter}
+      onSourceFilterChange={setSourceFilter}
+      providerFilter={providerFilter}
+      onProviderFilterChange={setProviderFilter}
+      resourceTypeFilter={resourceTypeFilter}
+      onResourceTypeFilterChange={setResourceTypeFilter}
+      syncFilter={syncFilter}
+      onSyncFilterChange={setSyncFilter}
+      providerKinds={providerKinds}
+      hasExternalGlossaries={hasExternalGlossaries}
+      hasResourceTypes={hasResourceTypes}
+      hasActiveFilters={hasActiveFilters}
+      activeFilterCount={activeFilterCount}
+      onClearFilters={clearFilters}
+      page={page}
+      totalPages={totalPages}
+      pageStart={pageStart}
+      pageEnd={pageEnd}
+      onPageChange={setPage}
+      createDialogOpen={createDialogOpen}
+      onCreateDialogOpenChange={setCreateDialogOpen}
+      createForm={createForm}
+      onCreateFormChange={setCreateForm}
+      createErrors={createErrors}
+      isCreating={createGlossary.isPending}
+      onSubmitCreateGlossary={submitCreateGlossary}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-view.stories.tsx
@@ -173,3 +173,21 @@ export const LiveProjectSelectionRequired: Story = {
     await expect(canvas.getByText("Choose a TMS project")).toBeInTheDocument();
   },
 };
+
+export const NoFilterMatches: Story = {
+  args: {
+    glossaries: [],
+    glossaryTotal: 0,
+    hasActiveFilters: true,
+    activeFilterCount: 1,
+    sourceFilter: "native",
+    pageStart: 0,
+    pageEnd: 0,
+    providerKinds: [],
+    hasExternalGlossaries: false,
+    hasResourceTypes: false,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("No glossaries match your filters.")).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-view.stories.tsx
@@ -1,0 +1,175 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, fn } from "storybook/test";
+
+import { createEmptyGlossaryFormFixture, glossariesFixture } from "./glossaries.fixture";
+import { GlossariesPageView } from "./glossaries-page-view";
+
+const meta = {
+  title: "App/Glossaries/Page",
+  component: GlossariesPageView,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    organizationSlug: "acme",
+    glossaries: glossariesFixture,
+    glossaryTotal: glossariesFixture.length,
+    isLoading: false,
+    isError: false,
+    isSuccess: true,
+    error: null,
+    allowCreateGlossaries: true,
+    hasConnectedProvider: true,
+    useLiveProviderGlossaries: false,
+    selectedExternalProjectId: "",
+    onSelectedExternalProjectIdChange: fn(),
+    searchQuery: "",
+    onSearchQueryChange: fn(),
+    sourceFilter: "all",
+    onSourceFilterChange: fn(),
+    providerFilter: "all",
+    onProviderFilterChange: fn(),
+    resourceTypeFilter: "all",
+    onResourceTypeFilterChange: fn(),
+    syncFilter: "all",
+    onSyncFilterChange: fn(),
+    providerKinds: ["phrase", "crowdin"],
+    hasExternalGlossaries: true,
+    hasResourceTypes: true,
+    hasActiveFilters: false,
+    activeFilterCount: 0,
+    onClearFilters: fn(),
+    page: 1,
+    totalPages: 1,
+    pageStart: 1,
+    pageEnd: glossariesFixture.length,
+    onPageChange: fn(),
+    createDialogOpen: false,
+    onCreateDialogOpenChange: fn(),
+    createForm: createEmptyGlossaryFormFixture(),
+    onCreateFormChange: fn(),
+    createErrors: {},
+    isCreating: false,
+    onSubmitCreateGlossary: fn(),
+  },
+} satisfies Meta<typeof GlossariesPageView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Glossaries" })).toBeInTheDocument();
+    await expect(canvas.getByText("Product UI")).toBeInTheDocument();
+    await expect(canvas.getByText("Phrase Term Base")).toBeInTheDocument();
+    await expect(canvas.getByText("Crowdin Glossary")).toBeInTheDocument();
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    glossaries: [],
+    glossaryTotal: 0,
+    isLoading: true,
+    isSuccess: false,
+    pageStart: 0,
+    pageEnd: 0,
+    providerKinds: [],
+    hasExternalGlossaries: false,
+    hasResourceTypes: false,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Loading glossaries...")).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    glossaries: [],
+    glossaryTotal: 0,
+    pageStart: 0,
+    pageEnd: 0,
+    providerKinds: [],
+    hasExternalGlossaries: false,
+    hasResourceTypes: false,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("No glossaries yet")).toBeInTheDocument();
+    await expect(
+      canvas.getByText(
+        "Create a workspace glossary, import terms, then assign it to the projects that should use it.",
+      ),
+    ).toBeInTheDocument();
+  },
+};
+
+export const NoProviderConnected: Story = {
+  args: {
+    glossaries: [],
+    glossaryTotal: 0,
+    allowCreateGlossaries: false,
+    hasConnectedProvider: false,
+    pageStart: 0,
+    pageEnd: 0,
+    providerKinds: [],
+    hasExternalGlossaries: false,
+    hasResourceTypes: false,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Connect a TMS provider")).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Connect a provider" })).toBeInTheDocument();
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    allowCreateGlossaries: false,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.queryByRole("button", { name: "Create glossary" })).not.toBeInTheDocument();
+  },
+};
+
+export const CreateDialogOpen: Story = {
+  args: {
+    createDialogOpen: true,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("dialog", { name: "Create glossary" })).toBeInTheDocument();
+  },
+};
+
+export const LoadError: Story = {
+  args: {
+    glossaries: [],
+    glossaryTotal: 0,
+    isError: true,
+    isSuccess: false,
+    error: new Error("The glossaries API returned a 500."),
+    pageStart: 0,
+    pageEnd: 0,
+    providerKinds: [],
+    hasExternalGlossaries: false,
+    hasResourceTypes: false,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Glossaries failed to load.")).toBeInTheDocument();
+  },
+};
+
+export const LiveProjectSelectionRequired: Story = {
+  args: {
+    glossaries: [],
+    glossaryTotal: 0,
+    useLiveProviderGlossaries: true,
+    allowCreateGlossaries: false,
+    pageStart: 0,
+    pageEnd: 0,
+    providerKinds: [],
+    hasExternalGlossaries: false,
+    hasResourceTypes: false,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Choose a TMS project")).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-view.tsx
@@ -1,0 +1,481 @@
+"use client";
+
+import { BookOpenTextIcon, Add01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { Textarea } from "@/components/ui/textarea";
+import { TypographyP } from "@/components/ui/typography";
+
+import { TmsLiveProjectPicker } from "../../_components/tms-live-project-picker";
+import {
+  PageHeader,
+  WorkspaceFilterField,
+  workspaceFilterTriggerClassName,
+} from "../../_components/workspace-resource-shared";
+import type { GlossaryListRow } from "./glossary-list";
+import { providerLabel } from "./glossary-list";
+import { GlossariesEmptyAction, GlossariesTable } from "./glossaries-table";
+import {
+  ProjectSourceLocalePicker,
+  ProjectTargetLocalesPicker,
+} from "../../projects/_components/project-locale-picker";
+
+const GLOSSARIES_PAGE_SIZE = 100;
+
+const sourceFilterLabels = {
+  all: "All sources",
+  native: "Workspace",
+  external_tms: "Provider",
+} as const;
+
+const resourceTypeFilterLabels = {
+  all: "All resource types",
+  glossary: "Glossary",
+  term_base: "Term base",
+} as const;
+
+const syncFilterLabels = {
+  all: "All sync states",
+  synced: "Synced",
+  stale: "Stale",
+  syncing: "Syncing",
+  error: "Sync error",
+} as const;
+
+export type GlossaryCreateForm = {
+  name: string;
+  description: string;
+  sourceLocale: string;
+  targetLocales: string[];
+};
+
+export function GlossariesPageView({
+  organizationSlug,
+  glossaries,
+  glossaryTotal,
+  isLoading,
+  isError,
+  isSuccess,
+  error,
+  allowCreateGlossaries,
+  hasConnectedProvider,
+  useLiveProviderGlossaries,
+  selectedExternalProjectId,
+  onSelectedExternalProjectIdChange,
+  searchQuery,
+  onSearchQueryChange,
+  sourceFilter,
+  onSourceFilterChange,
+  providerFilter,
+  onProviderFilterChange,
+  resourceTypeFilter,
+  onResourceTypeFilterChange,
+  syncFilter,
+  onSyncFilterChange,
+  providerKinds,
+  hasExternalGlossaries,
+  hasResourceTypes,
+  hasActiveFilters,
+  activeFilterCount,
+  onClearFilters,
+  page,
+  totalPages,
+  pageStart,
+  pageEnd,
+  onPageChange,
+  createDialogOpen,
+  onCreateDialogOpenChange,
+  createForm,
+  onCreateFormChange,
+  createErrors,
+  isCreating,
+  onSubmitCreateGlossary,
+}: {
+  organizationSlug: string;
+  glossaries: GlossaryListRow[];
+  glossaryTotal: number;
+  isLoading: boolean;
+  isError: boolean;
+  isSuccess: boolean;
+  error: Error | null;
+  allowCreateGlossaries: boolean;
+  hasConnectedProvider: boolean;
+  useLiveProviderGlossaries: boolean;
+  selectedExternalProjectId: string;
+  onSelectedExternalProjectIdChange: (value: string) => void;
+  searchQuery: string;
+  onSearchQueryChange: (value: string) => void;
+  sourceFilter: string;
+  onSourceFilterChange: (value: string) => void;
+  providerFilter: string;
+  onProviderFilterChange: (value: string) => void;
+  resourceTypeFilter: string;
+  onResourceTypeFilterChange: (value: string) => void;
+  syncFilter: string;
+  onSyncFilterChange: (value: string) => void;
+  providerKinds: string[];
+  hasExternalGlossaries: boolean;
+  hasResourceTypes: boolean;
+  hasActiveFilters: boolean;
+  activeFilterCount: number;
+  onClearFilters: () => void;
+  page: number;
+  totalPages: number;
+  pageStart: number;
+  pageEnd: number;
+  onPageChange: (page: number) => void;
+  createDialogOpen: boolean;
+  onCreateDialogOpenChange: (open: boolean) => void;
+  createForm: GlossaryCreateForm;
+  onCreateFormChange: (form: GlossaryCreateForm) => void;
+  createErrors: { name?: string; targetLocales?: string };
+  isCreating: boolean;
+  onSubmitCreateGlossary: () => void;
+}) {
+  const liveProjectSelectionRequired = useLiveProviderGlossaries && !selectedExternalProjectId;
+
+  const emptyTitle = hasConnectedProvider ? "No glossaries yet" : "Connect a TMS provider";
+  const emptyDescription = hasConnectedProvider
+    ? "Provider glossaries and term bases appear here after sync. Connect or resync a TMS provider from Integrations if you expected to see one."
+    : "Connect Crowdin, Phrase, Smartling, or Lokalise from Integrations to sync glossaries into this workspace.";
+
+  const glossaryCountLabel =
+    isSuccess && glossaryTotal > 0
+      ? `${glossaryTotal} ${glossaryTotal === 1 ? "glossary" : "glossaries"}`
+      : undefined;
+
+  const glossariesQuery = { isLoading, isError, isSuccess, error };
+
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-col gap-6">
+      <PageHeader
+        icon={BookOpenTextIcon}
+        label="Workspace"
+        title="Glossaries"
+        description="Create first-party workspace glossaries or sync provider term bases. Provider glossaries stay read-only."
+        statusLabel={glossaryCountLabel}
+        actions={
+          allowCreateGlossaries ? (
+            <Button
+              type="button"
+              onClick={() => onCreateDialogOpenChange(true)}
+              className="w-full sm:w-fit"
+            >
+              <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
+              Create glossary
+            </Button>
+          ) : null
+        }
+      />
+
+      {useLiveProviderGlossaries ? (
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:gap-2">
+          <TmsLiveProjectPicker
+            organizationSlug={organizationSlug}
+            value={selectedExternalProjectId}
+            onValueChange={onSelectedExternalProjectIdChange}
+          />
+        </div>
+      ) : null}
+
+      {isSuccess && (glossaryTotal > 0 || hasActiveFilters) ? (
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:gap-2">
+          <WorkspaceFilterField label="Search" className="w-full sm:max-w-xs">
+            <Input
+              placeholder="Name, project, or external ID..."
+              value={searchQuery}
+              onChange={(e) => onSearchQueryChange(e.target.value)}
+              className="w-full"
+            />
+          </WorkspaceFilterField>
+          <WorkspaceFilterField label="Source" className="w-full sm:w-40">
+            <Select
+              value={sourceFilter}
+              onValueChange={(value) => {
+                onSourceFilterChange(value ?? "all");
+                if (value === "native") {
+                  onProviderFilterChange("all");
+                  onResourceTypeFilterChange("all");
+                  onSyncFilterChange("all");
+                }
+              }}
+            >
+              <SelectTrigger className={workspaceFilterTriggerClassName}>
+                <SelectValue>
+                  {sourceFilterLabels[sourceFilter as keyof typeof sourceFilterLabels] ??
+                    sourceFilter}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all" label={sourceFilterLabels.all}>
+                  {sourceFilterLabels.all}
+                </SelectItem>
+                <SelectItem value="native" label={sourceFilterLabels.native}>
+                  {sourceFilterLabels.native}
+                </SelectItem>
+                <SelectItem value="external_tms" label={sourceFilterLabels.external_tms}>
+                  {sourceFilterLabels.external_tms}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </WorkspaceFilterField>
+
+          {hasExternalGlossaries && sourceFilter !== "native" ? (
+            <WorkspaceFilterField label="Provider" className="w-full sm:w-40">
+              <Select
+                value={providerFilter}
+                onValueChange={(value) => onProviderFilterChange(value ?? "all")}
+              >
+                <SelectTrigger className={workspaceFilterTriggerClassName}>
+                  <SelectValue>
+                    {providerFilter === "all" ? "All providers" : providerLabel(providerFilter)}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all" label="All providers">
+                    All providers
+                  </SelectItem>
+                  {providerKinds.map((kind) => (
+                    <SelectItem key={kind} value={kind} label={providerLabel(kind)}>
+                      {providerLabel(kind)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </WorkspaceFilterField>
+          ) : null}
+
+          {hasResourceTypes && sourceFilter !== "native" ? (
+            <WorkspaceFilterField label="Resource" className="w-full sm:w-44">
+              <Select
+                value={resourceTypeFilter}
+                onValueChange={(value) => onResourceTypeFilterChange(value ?? "all")}
+              >
+                <SelectTrigger className={workspaceFilterTriggerClassName}>
+                  <SelectValue>
+                    {resourceTypeFilterLabels[
+                      resourceTypeFilter as keyof typeof resourceTypeFilterLabels
+                    ] ?? resourceTypeFilter}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all" label={resourceTypeFilterLabels.all}>
+                    {resourceTypeFilterLabels.all}
+                  </SelectItem>
+                  <SelectItem value="glossary" label={resourceTypeFilterLabels.glossary}>
+                    {resourceTypeFilterLabels.glossary}
+                  </SelectItem>
+                  <SelectItem value="term_base" label={resourceTypeFilterLabels.term_base}>
+                    {resourceTypeFilterLabels.term_base}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </WorkspaceFilterField>
+          ) : null}
+
+          {hasExternalGlossaries && sourceFilter !== "native" ? (
+            <WorkspaceFilterField label="Sync" className="w-full sm:w-40">
+              <Select
+                value={syncFilter}
+                onValueChange={(value) => onSyncFilterChange(value ?? "all")}
+              >
+                <SelectTrigger className={workspaceFilterTriggerClassName}>
+                  <SelectValue>
+                    {syncFilterLabels[syncFilter as keyof typeof syncFilterLabels] ?? syncFilter}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all" label={syncFilterLabels.all}>
+                    {syncFilterLabels.all}
+                  </SelectItem>
+                  <SelectItem value="synced" label={syncFilterLabels.synced}>
+                    {syncFilterLabels.synced}
+                  </SelectItem>
+                  <SelectItem value="stale" label={syncFilterLabels.stale}>
+                    {syncFilterLabels.stale}
+                  </SelectItem>
+                  <SelectItem value="syncing" label={syncFilterLabels.syncing}>
+                    {syncFilterLabels.syncing}
+                  </SelectItem>
+                  <SelectItem value="error" label={syncFilterLabels.error}>
+                    {syncFilterLabels.error}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </WorkspaceFilterField>
+          ) : null}
+
+          {activeFilterCount > 0 ? (
+            <Button type="button" variant="ghost" size="sm" onClick={onClearFilters}>
+              Clear filters
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
+
+      {isSuccess && hasActiveFilters && glossaryTotal === 0 ? (
+        <div className="text-sm text-muted-foreground">
+          No glossaries match your filters.{" "}
+          <button
+            type="button"
+            onClick={onClearFilters}
+            className="text-subtle-foreground underline hover:text-foreground"
+          >
+            Clear filters
+          </button>
+        </div>
+      ) : null}
+
+      {liveProjectSelectionRequired ? (
+        <div className="space-y-3 py-10">
+          <TypographyP className="text-sm font-medium text-foreground">
+            Choose a TMS project
+          </TypographyP>
+          <TypographyP className="max-w-xl text-sm leading-6 text-muted-foreground">
+            Select a project above to load live glossaries and term bases from your connected
+            provider.
+          </TypographyP>
+        </div>
+      ) : (
+        <GlossariesTable
+          glossaries={glossaries}
+          glossariesQuery={glossariesQuery}
+          organizationSlug={organizationSlug}
+          emptyTitle={allowCreateGlossaries ? "No glossaries yet" : emptyTitle}
+          emptyDescription={
+            allowCreateGlossaries
+              ? "Create a workspace glossary, import terms, then assign it to the projects that should use it."
+              : emptyDescription
+          }
+          emptyAction={
+            allowCreateGlossaries ? (
+              <Button type="button" size="sm" onClick={() => onCreateDialogOpenChange(true)}>
+                Create glossary
+              </Button>
+            ) : (
+              <GlossariesEmptyAction organizationSlug={organizationSlug} />
+            )
+          }
+        />
+      )}
+
+      {!liveProjectSelectionRequired && isSuccess && glossaryTotal > GLOSSARIES_PAGE_SIZE ? (
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <p className="text-sm text-muted-foreground">
+            Showing {pageStart}–{pageEnd} of {glossaryTotal} glossaries
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={page <= 1}
+              onClick={() => onPageChange(Math.max(1, page - 1))}
+            >
+              Previous
+            </Button>
+            <p className="text-sm text-muted-foreground">
+              Page {page} of {totalPages}
+            </p>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={page >= totalPages}
+              onClick={() => onPageChange(page + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      <Dialog open={createDialogOpen} onOpenChange={onCreateDialogOpenChange}>
+        <DialogContent className="max-h-[min(85dvh,42rem)] overflow-y-auto sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Create glossary</DialogTitle>
+            <DialogDescription>
+              Add a first-party terminology library. You can import and edit terms after creation.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4">
+            <Field className="gap-1.5">
+              <FieldLabel>Name</FieldLabel>
+              <Input
+                value={createForm.name}
+                onChange={(event) =>
+                  onCreateFormChange({ ...createForm, name: event.target.value })
+                }
+                disabled={isCreating}
+                placeholder="Product terminology"
+              />
+              <FieldError
+                errors={createErrors.name ? [{ message: createErrors.name }] : undefined}
+              />
+            </Field>
+            <ProjectSourceLocalePicker
+              value={createForm.sourceLocale}
+              onChange={(sourceLocale) => onCreateFormChange({ ...createForm, sourceLocale })}
+              disabled={isCreating}
+            />
+            <ProjectTargetLocalesPicker
+              value={createForm.targetLocales}
+              sourceLocale={createForm.sourceLocale}
+              onChange={(targetLocales) =>
+                onCreateFormChange({
+                  ...createForm,
+                  targetLocales: targetLocales.slice(0, 1),
+                })
+              }
+              disabled={isCreating}
+              error={createErrors.targetLocales}
+            />
+            <Field className="gap-1.5">
+              <FieldLabel>Description</FieldLabel>
+              <Textarea
+                value={createForm.description}
+                onChange={(event) =>
+                  onCreateFormChange({ ...createForm, description: event.target.value })
+                }
+                disabled={isCreating}
+                placeholder="Where this glossary should be used"
+              />
+            </Field>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => onCreateDialogOpenChange(false)}
+              disabled={isCreating}
+            >
+              Cancel
+            </Button>
+            <Button onClick={onSubmitCreateGlossary} disabled={isCreating}>
+              {isCreating ? <Spinner /> : null}
+              Create glossary
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </main>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-view.tsx
@@ -39,7 +39,7 @@ import {
   ProjectTargetLocalesPicker,
 } from "../../projects/_components/project-locale-picker";
 
-const GLOSSARIES_PAGE_SIZE = 100;
+export const GLOSSARIES_PAGE_SIZE = 100;
 
 const sourceFilterLabels = {
   all: "All sources",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries.fixture.ts
@@ -1,0 +1,102 @@
+import type { GlossaryRecord } from "@/api/routes/glossary/glossary.schema";
+
+import {
+  buildProjectIdByExternalKey,
+  mapGlossaryToListRow,
+  type GlossaryListRow,
+} from "./glossary-list";
+
+const fixedNow = "2026-06-07T12:00:00.000Z";
+
+const projectMap = buildProjectIdByExternalKey([
+  {
+    id: "project-1",
+    externalProviderKind: "phrase",
+    externalProjectId: "phrase-project-9",
+  },
+]);
+
+function createApiGlossary(overrides: Partial<GlossaryRecord> = {}): GlossaryRecord {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    organizationId: "org-1",
+    createdByUserId: null,
+    name: "Product UI",
+    description: "Core product terminology",
+    sourceLocale: "en-US",
+    targetLocale: "fr-FR",
+    status: "active",
+    source: "native",
+    externalProviderKind: null,
+    externalProjectId: null,
+    externalResourceType: null,
+    externalGlossaryId: null,
+    localeCoverage: ["en-US", "fr-FR"],
+    termCount: 120,
+    syncState: null,
+    termCapabilities: { preferredTerms: true, forbiddenTerms: true },
+    externalUrl: null,
+    lastSyncedAt: null,
+    lastSyncErrorAt: null,
+    lastSyncErrorMessage: null,
+    createdAt: fixedNow,
+    updatedAt: fixedNow,
+    ...overrides,
+  };
+}
+
+export function createGlossaryListRow(overrides: Partial<GlossaryListRow> = {}): GlossaryListRow {
+  return {
+    ...mapGlossaryToListRow(createApiGlossary(), projectMap),
+    ...overrides,
+  };
+}
+
+export const glossariesFixture: GlossaryListRow[] = [
+  createGlossaryListRow(),
+  mapGlossaryToListRow(
+    createApiGlossary({
+      id: "22222222-2222-4222-8222-222222222222",
+      name: "Phrase Term Base",
+      description: "Marketing terminology",
+      source: "external_tms",
+      externalProviderKind: "phrase",
+      externalProjectId: "phrase-project-9",
+      externalResourceType: "term_base",
+      externalGlossaryId: "tb-42",
+      localeCoverage: ["en-US", "fr-FR", "de-DE", "es-ES"],
+      termCount: 4_200,
+      syncState: "synced",
+      externalUrl: "https://phrase.com/tb/42",
+      lastSyncedAt: "2026-05-20T12:00:00.000Z",
+    }),
+    projectMap,
+  ),
+  mapGlossaryToListRow(
+    createApiGlossary({
+      id: "33333333-3333-4333-8333-333333333333",
+      name: "Crowdin Glossary",
+      description: "",
+      source: "external_tms",
+      externalProviderKind: "crowdin",
+      externalProjectId: "crowdin-project-1",
+      externalResourceType: "glossary",
+      externalGlossaryId: "gl-99",
+      localeCoverage: ["en-US", "de-DE"],
+      termCount: 85,
+      syncState: "error",
+      lastSyncErrorAt: "2026-05-19T08:00:00.000Z",
+      lastSyncErrorMessage: "Provider API rate limit exceeded",
+    }),
+    projectMap,
+  ),
+];
+
+export function createEmptyGlossaryFormFixture() {
+  return {
+    name: "",
+    description: "",
+    sourceLocale: "en-US",
+    targetLocales: ["fr-FR"],
+  };
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-content.tsx
@@ -2,38 +2,13 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Add01Icon, DatabaseSyncIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Field, FieldError, FieldLabel } from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Button } from "@/components/ui/button";
-import { Spinner } from "@/components/ui/spinner";
-import { Textarea } from "@/components/ui/textarea";
-import { TypographyP } from "@/components/ui/typography";
 import { readApiError, readApiResponseError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
 
 import { useActiveTmsProvider } from "../../_hooks/use-active-tms-provider";
-
-import { TmsLiveProjectPicker } from "../../_components/tms-live-project-picker";
 
 import {
   GLOSSARY_SYNC_FILTERS,
@@ -41,11 +16,6 @@ import {
   readWorkspaceFilterParam,
   TMS_PROVIDER_KINDS,
 } from "../../_components/workspace-filter-params";
-import {
-  PageHeader,
-  WorkspaceFilterField,
-  workspaceFilterTriggerClassName,
-} from "../../_components/workspace-resource-shared";
 import {
   buildProjectIdByExternalKey,
   mapLiveTmsProviderMemoryToListRow,
@@ -56,25 +26,11 @@ import {
 } from "./memory-list";
 import type { TmsProviderLiveTranslationMemory } from "@/lib/providers/tms-provider-live";
 import {
-  TranslationMemoriesEmptyAction,
-  TranslationMemoriesTable,
-} from "./translation-memories-table";
+  TranslationMemoriesPageView,
+  type MemoryCreateForm,
+} from "./translation-memories-page-view";
 
 const MEMORIES_PAGE_SIZE = 100;
-
-const sourceFilterLabels = {
-  all: "All sources",
-  native: "Workspace",
-  external_tms: "Provider",
-} as const;
-
-const syncFilterLabels = {
-  all: "All sync states",
-  synced: "Synced",
-  stale: "Stale",
-  syncing: "Syncing",
-  error: "Sync error",
-} as const;
 
 const memoriesQueryKey = (organizationSlug: string, page: number) => [
   "translation-memories",
@@ -89,11 +45,6 @@ const credentialsQueryKey = (organizationSlug: string) => [
   "translation-memory-credentials",
   organizationSlug,
 ];
-
-type MemoryCreateForm = {
-  name: string;
-  description: string;
-};
 
 function createEmptyMemoryForm(): MemoryCreateForm {
   return { name: "", description: "" };
@@ -143,6 +94,13 @@ function useMemoryFilters(memories: MemoryListRow[], searchParams: URLSearchPara
     (f) => f !== "all",
   ).length;
 
+  function clearFilters() {
+    setSearchQuery("");
+    setSourceFilter("all");
+    setProviderFilter("all");
+    setSyncFilter("all");
+  }
+
   return {
     searchQuery,
     setSearchQuery,
@@ -154,6 +112,7 @@ function useMemoryFilters(memories: MemoryListRow[], searchParams: URLSearchPara
     setSyncFilter,
     filteredMemories,
     activeFilterCount,
+    clearFilters,
   };
 }
 
@@ -175,6 +134,7 @@ export function TranslationMemoriesPageContent({
   const { data: activeTmsProvider } = useActiveTmsProvider(organizationSlug);
   const useLiveProviderMemories = Boolean(activeTmsProvider);
   const allowCreateMemories = canCreateMemories && !useLiveProviderMemories;
+
   const projectsQuery = useQuery({
     queryKey: projectsQueryKey(organizationSlug),
     enabled: !useLiveProviderMemories,
@@ -266,6 +226,7 @@ export function TranslationMemoriesPageContent({
       };
     },
   });
+
   const createMemory = useMutation({
     mutationFn: async (values: MemoryCreateForm) => {
       const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"].$post({
@@ -340,6 +301,7 @@ export function TranslationMemoriesPageContent({
     setSyncFilter,
     filteredMemories,
     activeFilterCount,
+    clearFilters,
   } = useMemoryFilters(memories, searchParams);
 
   useEffect(() => {
@@ -371,20 +333,6 @@ export function TranslationMemoriesPageContent({
     ? Boolean(activeTmsProvider)
     : credentialsQuery.isSuccess && connectedCredentials.length > 0;
 
-  const liveProjectSelectionRequired = useLiveProviderMemories && !selectedExternalProjectId;
-
-  const emptyTitle = hasConnectedProvider
-    ? "No translation memories yet"
-    : "Connect a TMS provider";
-  const emptyDescription = hasConnectedProvider
-    ? "Provider translation memories appear here after sync. Connect or resync a TMS provider from Integrations if you expected to see one."
-    : "Connect Crowdin, Phrase, Smartling, or Lokalise from Integrations to sync translation memories into this workspace.";
-
-  const memoryCountLabel =
-    memoriesQuery.isSuccess && memoryTotal > 0
-      ? `${memoryTotal} ${memoryTotal === 1 ? "memory" : "memories"}`
-      : undefined;
-
   function submitCreateMemory() {
     const errors: { name?: string } = {};
     if (!createForm.name.trim()) {
@@ -398,284 +346,47 @@ export function TranslationMemoriesPageContent({
   }
 
   return (
-    <main className="mx-auto flex w-full max-w-6xl flex-col gap-6">
-      <PageHeader
-        icon={DatabaseSyncIcon}
-        label="Workspace"
-        title="Translation Memories"
-        description="Create first-party workspace memories or sync provider translation memories. Provider memories stay read-only."
-        statusLabel={memoryCountLabel}
-        actions={
-          allowCreateMemories ? (
-            <Button
-              type="button"
-              onClick={() => setCreateDialogOpen(true)}
-              className="w-full sm:w-fit"
-            >
-              <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
-              Create memory
-            </Button>
-          ) : null
-        }
-      />
-
-      {useLiveProviderMemories ? (
-        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:gap-2">
-          <TmsLiveProjectPicker
-            organizationSlug={organizationSlug}
-            value={selectedExternalProjectId}
-            onValueChange={setSelectedExternalProjectId}
-          />
-        </div>
-      ) : null}
-
-      {memoriesQuery.isSuccess && memories.length > 0 ? (
-        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:gap-2">
-          <WorkspaceFilterField label="Search" className="w-full sm:max-w-xs">
-            <Input
-              placeholder="Name, project, or external ID..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full"
-            />
-          </WorkspaceFilterField>
-          <WorkspaceFilterField label="Source" className="w-full sm:w-40">
-            <Select
-              value={sourceFilter}
-              onValueChange={(value) => {
-                setSourceFilter(value ?? "all");
-                if (value === "native") {
-                  setProviderFilter("all");
-                  setSyncFilter("all");
-                }
-              }}
-            >
-              <SelectTrigger className={workspaceFilterTriggerClassName}>
-                <SelectValue>
-                  {sourceFilterLabels[sourceFilter as keyof typeof sourceFilterLabels] ??
-                    sourceFilter}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all" label={sourceFilterLabels.all}>
-                  {sourceFilterLabels.all}
-                </SelectItem>
-                <SelectItem value="native" label={sourceFilterLabels.native}>
-                  {sourceFilterLabels.native}
-                </SelectItem>
-                <SelectItem value="external_tms" label={sourceFilterLabels.external_tms}>
-                  {sourceFilterLabels.external_tms}
-                </SelectItem>
-              </SelectContent>
-            </Select>
-          </WorkspaceFilterField>
-
-          {hasExternalMemories && sourceFilter !== "native" ? (
-            <WorkspaceFilterField label="Provider" className="w-full sm:w-40">
-              <Select
-                value={providerFilter}
-                onValueChange={(value) => setProviderFilter(value ?? "all")}
-              >
-                <SelectTrigger className={workspaceFilterTriggerClassName}>
-                  <SelectValue>
-                    {providerFilter === "all"
-                      ? "All providers"
-                      : providerLabel(providerFilter as (typeof TMS_PROVIDER_KINDS)[number])}
-                  </SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all" label="All providers">
-                    All providers
-                  </SelectItem>
-                  {providerKinds.map((kind) => (
-                    <SelectItem key={kind} value={kind} label={providerLabel(kind)}>
-                      {providerLabel(kind)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </WorkspaceFilterField>
-          ) : null}
-
-          {hasExternalMemories && sourceFilter !== "native" ? (
-            <WorkspaceFilterField label="Sync" className="w-full sm:w-40">
-              <Select value={syncFilter} onValueChange={(value) => setSyncFilter(value ?? "all")}>
-                <SelectTrigger className={workspaceFilterTriggerClassName}>
-                  <SelectValue>
-                    {syncFilterLabels[syncFilter as keyof typeof syncFilterLabels] ?? syncFilter}
-                  </SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all" label={syncFilterLabels.all}>
-                    {syncFilterLabels.all}
-                  </SelectItem>
-                  <SelectItem value="synced" label={syncFilterLabels.synced}>
-                    {syncFilterLabels.synced}
-                  </SelectItem>
-                  <SelectItem value="stale" label={syncFilterLabels.stale}>
-                    {syncFilterLabels.stale}
-                  </SelectItem>
-                  <SelectItem value="syncing" label={syncFilterLabels.syncing}>
-                    {syncFilterLabels.syncing}
-                  </SelectItem>
-                  <SelectItem value="error" label={syncFilterLabels.error}>
-                    {syncFilterLabels.error}
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-            </WorkspaceFilterField>
-          ) : null}
-
-          {activeFilterCount > 0 ? (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                setSearchQuery("");
-                setSourceFilter("all");
-                setProviderFilter("all");
-                setSyncFilter("all");
-              }}
-            >
-              Clear filters
-            </Button>
-          ) : null}
-        </div>
-      ) : null}
-
-      {memoriesQuery.isSuccess && memories.length > 0 && filteredMemories.length === 0 ? (
-        <div className="text-sm text-muted-foreground">
-          No translation memories match your filters.{" "}
-          <button
-            type="button"
-            onClick={() => {
-              setSearchQuery("");
-              setSourceFilter("all");
-              setProviderFilter("all");
-              setSyncFilter("all");
-            }}
-            className="text-subtle-foreground underline hover:text-foreground"
-          >
-            Clear filters
-          </button>
-        </div>
-      ) : null}
-
-      {liveProjectSelectionRequired ? (
-        <div className="space-y-3 py-10">
-          <TypographyP className="text-sm font-medium text-foreground">
-            Choose a TMS project
-          </TypographyP>
-          <TypographyP className="max-w-xl text-sm leading-6 text-muted-foreground">
-            Select a project above to load live translation memories from your connected provider.
-          </TypographyP>
-        </div>
-      ) : (
-        <TranslationMemoriesTable
-          memories={filteredMemories}
-          memoriesQuery={memoriesQuery}
-          organizationSlug={organizationSlug}
-          emptyTitle={allowCreateMemories ? "No translation memories yet" : emptyTitle}
-          emptyDescription={
-            allowCreateMemories
-              ? "Create a workspace memory, import entries, then assign it to the projects that should use it."
-              : emptyDescription
-          }
-          emptyAction={
-            allowCreateMemories ? (
-              <Button type="button" size="sm" onClick={() => setCreateDialogOpen(true)}>
-                Create memory
-              </Button>
-            ) : (
-              <TranslationMemoriesEmptyAction organizationSlug={organizationSlug} />
-            )
-          }
-        />
-      )}
-
-      {!liveProjectSelectionRequired &&
-      memoriesQuery.isSuccess &&
-      memoryTotal > MEMORIES_PAGE_SIZE ? (
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <p className="text-sm text-muted-foreground">
-            Showing {pageStart}–{pageEnd} of {memoryTotal} translation memories
-          </p>
-          <div className="flex flex-wrap items-center gap-2">
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              disabled={page <= 1}
-              onClick={() => setPage((current) => Math.max(1, current - 1))}
-            >
-              Previous
-            </Button>
-            <p className="text-sm text-muted-foreground">
-              Page {page} of {totalPages}
-            </p>
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              disabled={page >= totalPages}
-              onClick={() => setPage((current) => current + 1)}
-            >
-              Next
-            </Button>
-          </div>
-        </div>
-      ) : null}
-      <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
-        <DialogContent className="sm:max-w-lg">
-          <DialogHeader>
-            <DialogTitle>Create translation memory</DialogTitle>
-            <DialogDescription>
-              Add a first-party memory library. You can import and edit entries after creation.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="grid gap-4">
-            <Field className="gap-1.5">
-              <FieldLabel>Name</FieldLabel>
-              <Input
-                value={createForm.name}
-                onChange={(event) =>
-                  setCreateForm((current) => ({ ...current, name: event.target.value }))
-                }
-                disabled={createMemory.isPending}
-                placeholder="Marketing launch memory"
-              />
-              <FieldError
-                errors={createErrors.name ? [{ message: createErrors.name }] : undefined}
-              />
-            </Field>
-            <Field className="gap-1.5">
-              <FieldLabel>Description</FieldLabel>
-              <Textarea
-                value={createForm.description}
-                onChange={(event) =>
-                  setCreateForm((current) => ({ ...current, description: event.target.value }))
-                }
-                disabled={createMemory.isPending}
-                placeholder="When this memory should be used"
-              />
-            </Field>
-          </div>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setCreateDialogOpen(false)}
-              disabled={createMemory.isPending}
-            >
-              Cancel
-            </Button>
-            <Button onClick={submitCreateMemory} disabled={createMemory.isPending}>
-              {createMemory.isPending ? <Spinner /> : null}
-              Create memory
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </main>
+    <TranslationMemoriesPageView
+      organizationSlug={organizationSlug}
+      memories={filteredMemories}
+      memoryTotal={memoryTotal}
+      isLoading={memoriesQuery.isLoading}
+      isError={memoriesQuery.isError}
+      isSuccess={memoriesQuery.isSuccess}
+      error={memoriesQuery.error}
+      allowCreateMemories={allowCreateMemories}
+      hasConnectedProvider={hasConnectedProvider}
+      useLiveProviderMemories={useLiveProviderMemories}
+      selectedExternalProjectId={selectedExternalProjectId}
+      onSelectedExternalProjectIdChange={setSelectedExternalProjectId}
+      searchQuery={searchQuery}
+      onSearchQueryChange={setSearchQuery}
+      sourceFilter={sourceFilter}
+      onSourceFilterChange={setSourceFilter}
+      providerFilter={providerFilter}
+      onProviderFilterChange={setProviderFilter}
+      syncFilter={syncFilter}
+      onSyncFilterChange={setSyncFilter}
+      providerKinds={providerKinds}
+      hasExternalMemories={hasExternalMemories}
+      hasMemories={memories.length > 0}
+      activeFilterCount={activeFilterCount}
+      showNoFilterMatches={
+        memoriesQuery.isSuccess && memories.length > 0 && filteredMemories.length === 0
+      }
+      onClearFilters={clearFilters}
+      page={page}
+      totalPages={totalPages}
+      pageStart={pageStart}
+      pageEnd={pageEnd}
+      onPageChange={setPage}
+      createDialogOpen={createDialogOpen}
+      onCreateDialogOpenChange={setCreateDialogOpen}
+      createForm={createForm}
+      onCreateFormChange={setCreateForm}
+      createErrors={createErrors}
+      isCreating={createMemory.isPending}
+      onSubmitCreateMemory={submitCreateMemory}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-content.tsx
@@ -27,10 +27,9 @@ import {
 import type { TmsProviderLiveTranslationMemory } from "@/lib/providers/tms-provider-live";
 import {
   TranslationMemoriesPageView,
+  MEMORIES_PAGE_SIZE,
   type MemoryCreateForm,
 } from "./translation-memories-page-view";
-
-const MEMORIES_PAGE_SIZE = 100;
 
 const memoriesQueryKey = (organizationSlug: string, page: number) => [
   "translation-memories",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-view.stories.tsx
@@ -1,0 +1,193 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, fn } from "storybook/test";
+
+import {
+  createEmptyMemoryFormFixture,
+  translationMemoriesFixture,
+} from "./translation-memories.fixture";
+import { TranslationMemoriesPageView } from "./translation-memories-page-view";
+
+const meta = {
+  title: "App/TranslationMemories/Page",
+  component: TranslationMemoriesPageView,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    organizationSlug: "acme",
+    memories: translationMemoriesFixture,
+    memoryTotal: translationMemoriesFixture.length,
+    isLoading: false,
+    isError: false,
+    isSuccess: true,
+    error: null,
+    allowCreateMemories: true,
+    hasConnectedProvider: true,
+    useLiveProviderMemories: false,
+    selectedExternalProjectId: "",
+    onSelectedExternalProjectIdChange: fn(),
+    searchQuery: "",
+    onSearchQueryChange: fn(),
+    sourceFilter: "all",
+    onSourceFilterChange: fn(),
+    providerFilter: "all",
+    onProviderFilterChange: fn(),
+    syncFilter: "all",
+    onSyncFilterChange: fn(),
+    providerKinds: ["phrase", "crowdin"],
+    hasExternalMemories: true,
+    hasMemories: true,
+    activeFilterCount: 0,
+    showNoFilterMatches: false,
+    onClearFilters: fn(),
+    page: 1,
+    totalPages: 1,
+    pageStart: 1,
+    pageEnd: translationMemoriesFixture.length,
+    onPageChange: fn(),
+    createDialogOpen: false,
+    onCreateDialogOpenChange: fn(),
+    createForm: createEmptyMemoryFormFixture(),
+    onCreateFormChange: fn(),
+    createErrors: {},
+    isCreating: false,
+    onSubmitCreateMemory: fn(),
+  },
+} satisfies Meta<typeof TranslationMemoriesPageView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Translation Memories" })).toBeInTheDocument();
+    await expect(canvas.getByText("Product UI")).toBeInTheDocument();
+    await expect(canvas.getByText("Phrase TM")).toBeInTheDocument();
+    await expect(canvas.getByText("Crowdin Memory")).toBeInTheDocument();
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    memories: [],
+    memoryTotal: 0,
+    isLoading: true,
+    isSuccess: false,
+    pageStart: 0,
+    pageEnd: 0,
+    providerKinds: [],
+    hasExternalMemories: false,
+    hasMemories: false,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Loading translation memories...")).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    memories: [],
+    memoryTotal: 0,
+    pageStart: 0,
+    pageEnd: 0,
+    providerKinds: [],
+    hasExternalMemories: false,
+    hasMemories: false,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("No translation memories yet")).toBeInTheDocument();
+    await expect(
+      canvas.getByText(
+        "Create a workspace memory, import entries, then assign it to the projects that should use it.",
+      ),
+    ).toBeInTheDocument();
+  },
+};
+
+export const NoProviderConnected: Story = {
+  args: {
+    memories: [],
+    memoryTotal: 0,
+    allowCreateMemories: false,
+    hasConnectedProvider: false,
+    pageStart: 0,
+    pageEnd: 0,
+    providerKinds: [],
+    hasExternalMemories: false,
+    hasMemories: false,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Connect a TMS provider")).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Connect a provider" })).toBeInTheDocument();
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    allowCreateMemories: false,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.queryByRole("button", { name: "Create memory" })).not.toBeInTheDocument();
+  },
+};
+
+export const CreateDialogOpen: Story = {
+  args: {
+    createDialogOpen: true,
+  },
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByRole("dialog", { name: "Create translation memory" }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const LoadError: Story = {
+  args: {
+    memories: [],
+    memoryTotal: 0,
+    isError: true,
+    isSuccess: false,
+    error: new Error("The translation memories API returned a 500."),
+    pageStart: 0,
+    pageEnd: 0,
+    providerKinds: [],
+    hasExternalMemories: false,
+    hasMemories: false,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Translation memories failed to load.")).toBeInTheDocument();
+  },
+};
+
+export const LiveProjectSelectionRequired: Story = {
+  args: {
+    memories: [],
+    memoryTotal: 0,
+    useLiveProviderMemories: true,
+    allowCreateMemories: false,
+    pageStart: 0,
+    pageEnd: 0,
+    providerKinds: [],
+    hasExternalMemories: false,
+    hasMemories: false,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Choose a TMS project")).toBeInTheDocument();
+  },
+};
+
+export const NoFilterMatches: Story = {
+  args: {
+    memories: [],
+    showNoFilterMatches: true,
+    hasMemories: true,
+    activeFilterCount: 1,
+    sourceFilter: "native",
+  },
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByText("No translation memories match your filters."),
+    ).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-view.tsx
@@ -38,7 +38,7 @@ import {
   TranslationMemoriesTable,
 } from "./translation-memories-table";
 
-const MEMORIES_PAGE_SIZE = 100;
+export const MEMORIES_PAGE_SIZE = 100;
 
 const sourceFilterLabels = {
   all: "All sources",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-view.tsx
@@ -1,0 +1,423 @@
+"use client";
+
+import { Add01Icon, DatabaseSyncIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { Textarea } from "@/components/ui/textarea";
+import { TypographyP } from "@/components/ui/typography";
+
+import { TmsLiveProjectPicker } from "../../_components/tms-live-project-picker";
+import {
+  PageHeader,
+  WorkspaceFilterField,
+  workspaceFilterTriggerClassName,
+} from "../../_components/workspace-resource-shared";
+import type { MemoryListRow } from "./memory-list";
+import { providerLabel } from "./memory-list";
+import {
+  TranslationMemoriesEmptyAction,
+  TranslationMemoriesTable,
+} from "./translation-memories-table";
+
+const MEMORIES_PAGE_SIZE = 100;
+
+const sourceFilterLabels = {
+  all: "All sources",
+  native: "Workspace",
+  external_tms: "Provider",
+} as const;
+
+const syncFilterLabels = {
+  all: "All sync states",
+  synced: "Synced",
+  stale: "Stale",
+  syncing: "Syncing",
+  error: "Sync error",
+} as const;
+
+export type MemoryCreateForm = {
+  name: string;
+  description: string;
+};
+
+export function TranslationMemoriesPageView({
+  organizationSlug,
+  memories,
+  memoryTotal,
+  isLoading,
+  isError,
+  isSuccess,
+  error,
+  allowCreateMemories,
+  hasConnectedProvider,
+  useLiveProviderMemories,
+  selectedExternalProjectId,
+  onSelectedExternalProjectIdChange,
+  searchQuery,
+  onSearchQueryChange,
+  sourceFilter,
+  onSourceFilterChange,
+  providerFilter,
+  onProviderFilterChange,
+  syncFilter,
+  onSyncFilterChange,
+  providerKinds,
+  hasExternalMemories,
+  hasMemories,
+  activeFilterCount,
+  showNoFilterMatches,
+  onClearFilters,
+  page,
+  totalPages,
+  pageStart,
+  pageEnd,
+  onPageChange,
+  createDialogOpen,
+  onCreateDialogOpenChange,
+  createForm,
+  onCreateFormChange,
+  createErrors,
+  isCreating,
+  onSubmitCreateMemory,
+}: {
+  organizationSlug: string;
+  memories: MemoryListRow[];
+  memoryTotal: number;
+  isLoading: boolean;
+  isError: boolean;
+  isSuccess: boolean;
+  error: Error | null;
+  allowCreateMemories: boolean;
+  hasConnectedProvider: boolean;
+  useLiveProviderMemories: boolean;
+  selectedExternalProjectId: string;
+  onSelectedExternalProjectIdChange: (value: string) => void;
+  searchQuery: string;
+  onSearchQueryChange: (value: string) => void;
+  sourceFilter: string;
+  onSourceFilterChange: (value: string) => void;
+  providerFilter: string;
+  onProviderFilterChange: (value: string) => void;
+  syncFilter: string;
+  onSyncFilterChange: (value: string) => void;
+  providerKinds: string[];
+  hasExternalMemories: boolean;
+  hasMemories: boolean;
+  activeFilterCount: number;
+  showNoFilterMatches: boolean;
+  onClearFilters: () => void;
+  page: number;
+  totalPages: number;
+  pageStart: number;
+  pageEnd: number;
+  onPageChange: (page: number) => void;
+  createDialogOpen: boolean;
+  onCreateDialogOpenChange: (open: boolean) => void;
+  createForm: MemoryCreateForm;
+  onCreateFormChange: (form: MemoryCreateForm) => void;
+  createErrors: { name?: string };
+  isCreating: boolean;
+  onSubmitCreateMemory: () => void;
+}) {
+  const liveProjectSelectionRequired = useLiveProviderMemories && !selectedExternalProjectId;
+
+  const emptyTitle = hasConnectedProvider
+    ? "No translation memories yet"
+    : "Connect a TMS provider";
+  const emptyDescription = hasConnectedProvider
+    ? "Provider translation memories appear here after sync. Connect or resync a TMS provider from Integrations if you expected to see one."
+    : "Connect Crowdin, Phrase, Smartling, or Lokalise from Integrations to sync translation memories into this workspace.";
+
+  const memoryCountLabel =
+    isSuccess && memoryTotal > 0
+      ? `${memoryTotal} ${memoryTotal === 1 ? "memory" : "memories"}`
+      : undefined;
+
+  const memoriesQuery = { isLoading, isError, isSuccess, error };
+
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-col gap-6">
+      <PageHeader
+        icon={DatabaseSyncIcon}
+        label="Workspace"
+        title="Translation Memories"
+        description="Create first-party workspace memories or sync provider translation memories. Provider memories stay read-only."
+        statusLabel={memoryCountLabel}
+        actions={
+          allowCreateMemories ? (
+            <Button
+              type="button"
+              onClick={() => onCreateDialogOpenChange(true)}
+              className="w-full sm:w-fit"
+            >
+              <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
+              Create memory
+            </Button>
+          ) : null
+        }
+      />
+
+      {useLiveProviderMemories ? (
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:gap-2">
+          <TmsLiveProjectPicker
+            organizationSlug={organizationSlug}
+            value={selectedExternalProjectId}
+            onValueChange={onSelectedExternalProjectIdChange}
+          />
+        </div>
+      ) : null}
+
+      {isSuccess && hasMemories ? (
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:gap-2">
+          <WorkspaceFilterField label="Search" className="w-full sm:max-w-xs">
+            <Input
+              placeholder="Name, project, or external ID..."
+              value={searchQuery}
+              onChange={(e) => onSearchQueryChange(e.target.value)}
+              className="w-full"
+            />
+          </WorkspaceFilterField>
+          <WorkspaceFilterField label="Source" className="w-full sm:w-40">
+            <Select
+              value={sourceFilter}
+              onValueChange={(value) => {
+                onSourceFilterChange(value ?? "all");
+                if (value === "native") {
+                  onProviderFilterChange("all");
+                  onSyncFilterChange("all");
+                }
+              }}
+            >
+              <SelectTrigger className={workspaceFilterTriggerClassName}>
+                <SelectValue>
+                  {sourceFilterLabels[sourceFilter as keyof typeof sourceFilterLabels] ??
+                    sourceFilter}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all" label={sourceFilterLabels.all}>
+                  {sourceFilterLabels.all}
+                </SelectItem>
+                <SelectItem value="native" label={sourceFilterLabels.native}>
+                  {sourceFilterLabels.native}
+                </SelectItem>
+                <SelectItem value="external_tms" label={sourceFilterLabels.external_tms}>
+                  {sourceFilterLabels.external_tms}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </WorkspaceFilterField>
+
+          {hasExternalMemories && sourceFilter !== "native" ? (
+            <WorkspaceFilterField label="Provider" className="w-full sm:w-40">
+              <Select
+                value={providerFilter}
+                onValueChange={(value) => onProviderFilterChange(value ?? "all")}
+              >
+                <SelectTrigger className={workspaceFilterTriggerClassName}>
+                  <SelectValue>
+                    {providerFilter === "all" ? "All providers" : providerLabel(providerFilter)}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all" label="All providers">
+                    All providers
+                  </SelectItem>
+                  {providerKinds.map((kind) => (
+                    <SelectItem key={kind} value={kind} label={providerLabel(kind)}>
+                      {providerLabel(kind)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </WorkspaceFilterField>
+          ) : null}
+
+          {hasExternalMemories && sourceFilter !== "native" ? (
+            <WorkspaceFilterField label="Sync" className="w-full sm:w-40">
+              <Select
+                value={syncFilter}
+                onValueChange={(value) => onSyncFilterChange(value ?? "all")}
+              >
+                <SelectTrigger className={workspaceFilterTriggerClassName}>
+                  <SelectValue>
+                    {syncFilterLabels[syncFilter as keyof typeof syncFilterLabels] ?? syncFilter}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all" label={syncFilterLabels.all}>
+                    {syncFilterLabels.all}
+                  </SelectItem>
+                  <SelectItem value="synced" label={syncFilterLabels.synced}>
+                    {syncFilterLabels.synced}
+                  </SelectItem>
+                  <SelectItem value="stale" label={syncFilterLabels.stale}>
+                    {syncFilterLabels.stale}
+                  </SelectItem>
+                  <SelectItem value="syncing" label={syncFilterLabels.syncing}>
+                    {syncFilterLabels.syncing}
+                  </SelectItem>
+                  <SelectItem value="error" label={syncFilterLabels.error}>
+                    {syncFilterLabels.error}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </WorkspaceFilterField>
+          ) : null}
+
+          {activeFilterCount > 0 ? (
+            <Button type="button" variant="ghost" size="sm" onClick={onClearFilters}>
+              Clear filters
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
+
+      {showNoFilterMatches ? (
+        <div className="text-sm text-muted-foreground">
+          No translation memories match your filters.{" "}
+          <button
+            type="button"
+            onClick={onClearFilters}
+            className="text-subtle-foreground underline hover:text-foreground"
+          >
+            Clear filters
+          </button>
+        </div>
+      ) : null}
+
+      {liveProjectSelectionRequired ? (
+        <div className="space-y-3 py-10">
+          <TypographyP className="text-sm font-medium text-foreground">
+            Choose a TMS project
+          </TypographyP>
+          <TypographyP className="max-w-xl text-sm leading-6 text-muted-foreground">
+            Select a project above to load live translation memories from your connected provider.
+          </TypographyP>
+        </div>
+      ) : (
+        <TranslationMemoriesTable
+          memories={memories}
+          memoriesQuery={memoriesQuery}
+          organizationSlug={organizationSlug}
+          emptyTitle={allowCreateMemories ? "No translation memories yet" : emptyTitle}
+          emptyDescription={
+            allowCreateMemories
+              ? "Create a workspace memory, import entries, then assign it to the projects that should use it."
+              : emptyDescription
+          }
+          emptyAction={
+            allowCreateMemories ? (
+              <Button type="button" size="sm" onClick={() => onCreateDialogOpenChange(true)}>
+                Create memory
+              </Button>
+            ) : (
+              <TranslationMemoriesEmptyAction organizationSlug={organizationSlug} />
+            )
+          }
+        />
+      )}
+
+      {!liveProjectSelectionRequired && isSuccess && memoryTotal > MEMORIES_PAGE_SIZE ? (
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <p className="text-sm text-muted-foreground">
+            Showing {pageStart}–{pageEnd} of {memoryTotal} translation memories
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={page <= 1}
+              onClick={() => onPageChange(Math.max(1, page - 1))}
+            >
+              Previous
+            </Button>
+            <p className="text-sm text-muted-foreground">
+              Page {page} of {totalPages}
+            </p>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={page >= totalPages}
+              onClick={() => onPageChange(page + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      <Dialog open={createDialogOpen} onOpenChange={onCreateDialogOpenChange}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Create translation memory</DialogTitle>
+            <DialogDescription>
+              Add a first-party memory library. You can import and edit entries after creation.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4">
+            <Field className="gap-1.5">
+              <FieldLabel>Name</FieldLabel>
+              <Input
+                value={createForm.name}
+                onChange={(event) =>
+                  onCreateFormChange({ ...createForm, name: event.target.value })
+                }
+                disabled={isCreating}
+                placeholder="Marketing launch memory"
+              />
+              <FieldError
+                errors={createErrors.name ? [{ message: createErrors.name }] : undefined}
+              />
+            </Field>
+            <Field className="gap-1.5">
+              <FieldLabel>Description</FieldLabel>
+              <Textarea
+                value={createForm.description}
+                onChange={(event) =>
+                  onCreateFormChange({ ...createForm, description: event.target.value })
+                }
+                disabled={isCreating}
+                placeholder="When this memory should be used"
+              />
+            </Field>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => onCreateDialogOpenChange(false)}
+              disabled={isCreating}
+            >
+              Cancel
+            </Button>
+            <Button onClick={onSubmitCreateMemory} disabled={isCreating}>
+              {isCreating ? <Spinner /> : null}
+              Create memory
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </main>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories.fixture.ts
@@ -1,0 +1,95 @@
+import type { MemoryRecord } from "@/api/routes/memory/memory.schema";
+
+import { buildProjectIdByExternalKey, mapMemoryToListRow, type MemoryListRow } from "./memory-list";
+
+const fixedNow = "2026-06-07T12:00:00.000Z";
+
+const projectMap = buildProjectIdByExternalKey([
+  {
+    id: "project-1",
+    externalProviderKind: "phrase",
+    externalProjectId: "phrase-project-9",
+  },
+]);
+
+function createApiMemory(overrides: Partial<MemoryRecord> = {}): MemoryRecord {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    organizationId: "org-1",
+    createdByUserId: null,
+    name: "Product UI",
+    description: "Core product translations",
+    status: "active",
+    source: "native",
+    externalProviderKind: null,
+    externalProjectId: null,
+    externalMemoryId: null,
+    localeCoverage: ["en-US", "fr-FR"],
+    segmentCount: 1200,
+    syncState: null,
+    capabilityMode: null,
+    segmentCapabilities: {},
+    externalUrl: null,
+    lastSyncedAt: null,
+    lastSyncErrorAt: null,
+    lastSyncErrorMessage: null,
+    createdAt: fixedNow,
+    updatedAt: fixedNow,
+    ...overrides,
+  };
+}
+
+export function createMemoryListRow(overrides: Partial<MemoryListRow> = {}): MemoryListRow {
+  return {
+    ...mapMemoryToListRow(createApiMemory(), projectMap),
+    ...overrides,
+  };
+}
+
+export const translationMemoriesFixture: MemoryListRow[] = [
+  createMemoryListRow(),
+  mapMemoryToListRow(
+    createApiMemory({
+      id: "22222222-2222-4222-8222-222222222222",
+      name: "Phrase TM",
+      description: "Marketing translations",
+      source: "external_tms",
+      externalProviderKind: "phrase",
+      externalProjectId: "phrase-project-9",
+      externalMemoryId: "tm-42",
+      localeCoverage: ["en-US", "fr-FR", "de-DE", "es-ES"],
+      segmentCount: 50_000,
+      syncState: "synced",
+      capabilityMode: "live_search",
+      segmentCapabilities: { search: true },
+      externalUrl: "https://phrase.com/tm/42",
+      lastSyncedAt: "2026-05-20T12:00:00.000Z",
+    }),
+    projectMap,
+  ),
+  mapMemoryToListRow(
+    createApiMemory({
+      id: "33333333-3333-4333-8333-333333333333",
+      name: "Crowdin Memory",
+      description: "",
+      source: "external_tms",
+      externalProviderKind: "crowdin",
+      externalProjectId: "crowdin-project-1",
+      externalMemoryId: "tm-99",
+      localeCoverage: ["en-US", "de-DE"],
+      segmentCount: 8_500,
+      syncState: "error",
+      capabilityMode: "synced_import",
+      lastSyncErrorAt: "2026-05-19T08:00:00.000Z",
+      lastSyncErrorMessage: "Provider API rate limit exceeded",
+    }),
+    projectMap,
+  ),
+];
+
+export function createEmptyMemoryFormFixture() {
+  return {
+    name: "",
+    description: "",
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds Storybook coverage for the Glossaries and Translation Memories list pages, following the same PageView + fixture + stories pattern used by Teams, Jobs, and Automations.

- Extracted `GlossariesPageView` and `TranslationMemoriesPageView` presentational components from their data-fetching page content containers
- Added `glossaries.fixture.ts` and `translation-memories.fixture.ts` with native and provider-synced sample rows
- Added stories under `App/Glossaries/Page` and `App/TranslationMemories/Page` covering:
  - Default (populated list)
  - Loading
  - Empty
  - No provider connected
  - Read-only (no create button)
  - Create dialog open
  - Load error
  - Live TMS project selection required
  - No filter matches (translation memories)

## How to test

```bash
cd apps/hyperlocalise-web
vp check --fix
vp run build-storybook
vp run storybook
```

In Storybook, open **App/Glossaries/Page** and **App/TranslationMemories/Page** and walk through the story variants.

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp run build-storybook`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f348c-c65b-7e54-b4f3-723abf443da2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f348c-c65b-7e54-b4f3-723abf443da2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

