### PR TITLE
feat(web): add Storybook stories for integrations page

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-msw-handlers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-msw-handlers.ts
@@ -1,0 +1,135 @@
+import { delay, http, HttpResponse } from "msw";
+
+import {
+  integrationsContentfulConnectionsFixture,
+  integrationsCrowdinCredentialFixture,
+  integrationsEmailAgentFixture,
+  integrationsExternalTmsCredentialsFixture,
+  integrationsGitHubInstallationFixture,
+  integrationsGitHubRepositoriesFixture,
+  integrationsProviderCredentialFixture,
+  integrationsSlackAgentFixture,
+} from "./integrations.fixture";
+
+type IntegrationsSlackAgentFixture = {
+  enabled: boolean;
+  teamId: string | null;
+  teamName: string | null;
+};
+
+type IntegrationsEmailAgentFixture = {
+  enabled: boolean;
+  inboundEmailAddress: string | null;
+};
+
+function createIntegrationsGetHandlers({
+  providerCredential = integrationsProviderCredentialFixture,
+  externalTmsCredentials = integrationsExternalTmsCredentialsFixture,
+  activeExternalTmsProviderCredential = integrationsCrowdinCredentialFixture,
+  githubInstallation = integrationsGitHubInstallationFixture,
+  githubRepositories = integrationsGitHubRepositoriesFixture,
+  slackAgent = integrationsSlackAgentFixture,
+  emailAgent = integrationsEmailAgentFixture,
+  contentfulConnections = integrationsContentfulConnectionsFixture,
+}: {
+  providerCredential?: typeof integrationsProviderCredentialFixture | null;
+  externalTmsCredentials?: typeof integrationsExternalTmsCredentialsFixture;
+  activeExternalTmsProviderCredential?: typeof integrationsCrowdinCredentialFixture | null;
+  githubInstallation?: typeof integrationsGitHubInstallationFixture | null;
+  githubRepositories?: typeof integrationsGitHubRepositoriesFixture;
+  slackAgent?: IntegrationsSlackAgentFixture;
+  emailAgent?: IntegrationsEmailAgentFixture;
+  contentfulConnections?: typeof integrationsContentfulConnectionsFixture;
+} = {}) {
+  return [
+    http.get("/api/orgs/:organizationSlug/provider-credential", () =>
+      HttpResponse.json({ providerCredential }),
+    ),
+    http.get("/api/orgs/:organizationSlug/external-tms-provider-credential", () =>
+      HttpResponse.json({
+        externalTmsProviderCredentials: externalTmsCredentials,
+        activeExternalTmsProviderCredential,
+      }),
+    ),
+    http.get("/api/orgs/:organizationSlug/github-installation", () =>
+      HttpResponse.json({ installation: githubInstallation }),
+    ),
+    http.get("/api/orgs/:organizationSlug/github-installation/repositories", () =>
+      HttpResponse.json({ repositories: githubRepositories }),
+    ),
+    http.get("/api/orgs/:organizationSlug/agent-slack", () => HttpResponse.json({ slackAgent })),
+    http.get("/api/orgs/:organizationSlug/agent-email", () => HttpResponse.json({ emailAgent })),
+    http.get("/api/orgs/:organizationSlug/contentful-connections", () =>
+      HttpResponse.json({ contentfulConnections }),
+    ),
+  ];
+}
+
+export const integrationsConnectedMswHandlers = createIntegrationsGetHandlers();
+
+export const integrationsDisconnectedMswHandlers = createIntegrationsGetHandlers({
+  providerCredential: null,
+  externalTmsCredentials: [],
+  activeExternalTmsProviderCredential: null,
+  githubInstallation: null,
+  githubRepositories: [],
+  slackAgent: {
+    enabled: false,
+    teamId: null,
+    teamName: null,
+  },
+  emailAgent: {
+    enabled: false,
+    inboundEmailAddress: null,
+  },
+  contentfulConnections: [],
+});
+
+export const integrationsManagedProviderMswHandlers = createIntegrationsGetHandlers({
+  providerCredential: null,
+});
+
+export const integrationsLoadingMswHandlers = [
+  http.get("/api/orgs/:organizationSlug/provider-credential", async () => {
+    await delay("infinite");
+    return HttpResponse.json({ providerCredential: null });
+  }),
+  http.get("/api/orgs/:organizationSlug/external-tms-provider-credential", async () => {
+    await delay("infinite");
+    return HttpResponse.json({
+      externalTmsProviderCredentials: [],
+      activeExternalTmsProviderCredential: null,
+    });
+  }),
+  http.get("/api/orgs/:organizationSlug/github-installation", async () => {
+    await delay("infinite");
+    return HttpResponse.json({ installation: null });
+  }),
+  http.get("/api/orgs/:organizationSlug/github-installation/repositories", async () => {
+    await delay("infinite");
+    return HttpResponse.json({ repositories: [] });
+  }),
+  http.get("/api/orgs/:organizationSlug/agent-slack", async () => {
+    await delay("infinite");
+    return HttpResponse.json({
+      slackAgent: {
+        enabled: false,
+        teamId: null,
+        teamName: null,
+      },
+    });
+  }),
+  http.get("/api/orgs/:organizationSlug/agent-email", async () => {
+    await delay("infinite");
+    return HttpResponse.json({
+      emailAgent: {
+        enabled: false,
+        inboundEmailAddress: null,
+      },
+    });
+  }),
+  http.get("/api/orgs/:organizationSlug/contentful-connections", async () => {
+    await delay("infinite");
+    return HttpResponse.json({ contentfulConnections: [] });
+  }),
+];

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-msw-handlers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-msw-handlers.ts
@@ -11,16 +11,9 @@ import {
   integrationsSlackAgentFixture,
 } from "./integrations.fixture";
 
-type IntegrationsSlackAgentFixture = {
-  enabled: boolean;
-  teamId: string | null;
-  teamName: string | null;
-};
+type IntegrationsSlackAgentFixture = typeof integrationsSlackAgentFixture;
 
-type IntegrationsEmailAgentFixture = {
-  enabled: boolean;
-  inboundEmailAddress: string | null;
-};
+type IntegrationsEmailAgentFixture = typeof integrationsEmailAgentFixture;
 
 function createIntegrationsGetHandlers({
   providerCredential = integrationsProviderCredentialFixture,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.stories.tsx
@@ -1,0 +1,146 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect } from "storybook/test";
+
+import {
+  integrationsConnectedMswHandlers,
+  integrationsDisconnectedMswHandlers,
+  integrationsLoadingMswHandlers,
+  integrationsManagedProviderMswHandlers,
+} from "./integrations-msw-handlers";
+import { integrationsOrganizationSlug } from "./integrations.fixture";
+import { IntegrationsPageContent } from "./integrations-page-content";
+
+const meta = {
+  title: "App/Integrations/Page",
+  component: IntegrationsPageContent,
+  parameters: {
+    layout: "fullscreen",
+    nextjs: {
+      navigation: {
+        pathname: `/org/${integrationsOrganizationSlug}/integrations`,
+      },
+    },
+  },
+  args: {
+    organizationSlug: integrationsOrganizationSlug,
+    membershipRole: "admin",
+    canManageProviderIntegrations: true,
+    errorCode: null,
+  },
+} satisfies Meta<typeof IntegrationsPageContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: integrationsConnectedMswHandlers,
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Integrations" })).toBeInTheDocument();
+    await expect(canvas.getByText("Workspace level")).toBeInTheDocument();
+    await expect(canvas.getByText("Source control")).toBeInTheDocument();
+    await expect(canvas.getByText("Translation Management System")).toBeInTheDocument();
+    await expect(canvas.getByText("Content Management System")).toBeInTheDocument();
+    await expect(canvas.getByText("Collaboration")).toBeInTheDocument();
+    await expect(canvas.getByText("Model provider")).toBeInTheDocument();
+    await expect(canvas.getByText("GitHub")).toBeInTheDocument();
+    await expect(canvas.getByText("Crowdin")).toBeInTheDocument();
+    await expect(canvas.getByText("Contentful")).toBeInTheDocument();
+    await expect(canvas.getByText("Slack")).toBeInTheDocument();
+    await expect(canvas.getByText("Email")).toBeInTheDocument();
+    await expect(canvas.getByText("Open AI")).toBeInTheDocument();
+  },
+};
+
+export const Disconnected: Story = {
+  parameters: {
+    msw: {
+      handlers: integrationsDisconnectedMswHandlers,
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Integrations" })).toBeInTheDocument();
+    await expect(canvas.getByText("Hyperlocalise GO")).toBeInTheDocument();
+    await expect(canvas.getAllByRole("button", { name: "Connect" }).length).toBeGreaterThan(0);
+  },
+};
+
+export const ManagedProviderOnly: Story = {
+  parameters: {
+    msw: {
+      handlers: integrationsManagedProviderMswHandlers,
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Hyperlocalise GO")).toBeInTheDocument();
+    await expect(canvas.getByText("Managed by Hyperlocalise")).toBeInTheDocument();
+    await expect(canvas.getByText("Configure")).toBeInTheDocument();
+  },
+};
+
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: integrationsLoadingMswHandlers,
+    },
+  },
+  play: async ({ canvas, canvasElement }) => {
+    await expect(canvas.getByRole("heading", { name: "Integrations" })).toBeInTheDocument();
+    await expect(canvasElement.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(
+      0,
+    );
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    membershipRole: "developer",
+  },
+  parameters: {
+    msw: {
+      handlers: integrationsConnectedMswHandlers,
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Integrations" })).toBeInTheDocument();
+    await expect(canvas.queryByRole("button", { name: "Manage" })).not.toBeInTheDocument();
+    await expect(canvas.getAllByText("View only").length).toBeGreaterThan(0);
+  },
+};
+
+export const WithoutProviderIntegrations: Story = {
+  args: {
+    canManageProviderIntegrations: false,
+    membershipRole: "developer",
+  },
+  parameters: {
+    msw: {
+      handlers: integrationsConnectedMswHandlers,
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Integrations" })).toBeInTheDocument();
+    await expect(canvas.getByText("Source control")).toBeInTheDocument();
+    await expect(canvas.getByText("Collaboration")).toBeInTheDocument();
+    await expect(canvas.queryByText("Translation Management System")).not.toBeInTheDocument();
+    await expect(canvas.queryByText("Model provider")).not.toBeInTheDocument();
+  },
+};
+
+export const OAuthError: Story = {
+  args: {
+    errorCode: "crowdin_user_oauth_invalid",
+  },
+  parameters: {
+    msw: {
+      handlers: integrationsConnectedMswHandlers,
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("alert")).toBeInTheDocument();
+    await expect(canvas.getByText("Crowdin account link failed")).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations.fixture.ts
@@ -52,16 +52,9 @@ export const integrationsCrowdinCredentialFixture = createTmsCredentialFixture({
   baseUrl: "https://api.crowdin.com/api/v2",
 });
 
-export const integrationsPhraseCredentialFixture = createTmsCredentialFixture({
-  providerKind: "phrase",
-  displayName: "Phrase TMS",
-});
-
 export const integrationsExternalTmsCredentialsFixture: ExternalTmsProviderCredentialListItem[] = [
   integrationsCrowdinCredentialFixture,
 ];
-
-export const integrationsActiveExternalTmsCredentialFixture = integrationsCrowdinCredentialFixture;
 
 export const integrationsGitHubInstallationFixture = {
   githubInstallationId: "12345678",
@@ -92,13 +85,13 @@ export const integrationsGitHubRepositoriesFixture = [
 
 export const integrationsSlackAgentFixture = {
   enabled: true,
-  teamId: "T01234567",
-  teamName: "Acme",
+  teamId: "T01234567" as string | null,
+  teamName: "Acme" as string | null,
 };
 
 export const integrationsEmailAgentFixture = {
   enabled: true,
-  inboundEmailAddress: "automation@inbound.hyperlocalise.test",
+  inboundEmailAddress: "automation@inbound.hyperlocalise.test" as string | null,
 };
 
 export const integrationsContentfulConnectionsFixture: ContentfulConnectionSummary[] = [

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations.fixture.ts
@@ -1,0 +1,127 @@
+import type { LlmProvider } from "@/lib/database/types";
+import type { ExternalTmsProviderCredentialListItem } from "@/lib/providers/contracts/external-tms-provider-credential";
+import { OAUTH_AUTH_MODE } from "@/lib/providers/contracts/external-tms-provider-credential";
+import type { TmsProviderCapabilityAction } from "@/lib/providers/tms-capabilities";
+
+import type { ContentfulConnectionSummary } from "./contentful-connection-panel";
+
+const integrationTimestamp = "2026-06-01T12:00:00.000Z";
+
+function createTmsCredentialFixture(
+  input: Pick<ExternalTmsProviderCredentialListItem, "providerKind" | "displayName"> &
+    Partial<ExternalTmsProviderCredentialListItem>,
+): ExternalTmsProviderCredentialListItem {
+  const { providerKind, displayName, ...rest } = input;
+
+  return {
+    id: `tms_${providerKind}`,
+    providerKind,
+    displayName,
+    authMode: OAUTH_AUTH_MODE,
+    region: null,
+    baseUrl: null,
+    oauthExpiresAt: "2026-12-01T12:00:00.000Z",
+    validationStatus: "valid",
+    validationMessage: null,
+    lastValidatedAt: integrationTimestamp,
+    maskedSecretSuffix: "••••abcd",
+    createdAt: integrationTimestamp,
+    updatedAt: integrationTimestamp,
+    lastSuccessfulSyncAt: integrationTimestamp,
+    projectCount: 3,
+    capabilities: {} as Record<
+      TmsProviderCapabilityAction,
+      ExternalTmsProviderCredentialListItem["capabilities"][TmsProviderCapabilityAction]
+    >,
+    ...rest,
+  };
+}
+
+export const integrationsOrganizationSlug = "acme";
+
+export const integrationsProviderCredentialFixture = {
+  provider: "openai" as LlmProvider,
+  defaultModel: "gpt-5.5",
+  maskedApiKeySuffix: "••••-key",
+  lastValidatedAt: integrationTimestamp,
+};
+
+export const integrationsCrowdinCredentialFixture = createTmsCredentialFixture({
+  providerKind: "crowdin",
+  displayName: "Crowdin Production",
+  baseUrl: "https://api.crowdin.com/api/v2",
+});
+
+export const integrationsPhraseCredentialFixture = createTmsCredentialFixture({
+  providerKind: "phrase",
+  displayName: "Phrase TMS",
+});
+
+export const integrationsExternalTmsCredentialsFixture: ExternalTmsProviderCredentialListItem[] = [
+  integrationsCrowdinCredentialFixture,
+];
+
+export const integrationsActiveExternalTmsCredentialFixture = integrationsCrowdinCredentialFixture;
+
+export const integrationsGitHubInstallationFixture = {
+  githubInstallationId: "12345678",
+  accountLogin: "acme",
+  accountType: "Organization",
+  repositoryCount: 2,
+  enabledRepositoryCount: 2,
+};
+
+export const integrationsGitHubRepositoriesFixture = [
+  {
+    githubRepositoryId: "101",
+    fullName: "acme/website",
+    private: false,
+    archived: false,
+    defaultBranch: "main",
+    enabled: true,
+  },
+  {
+    githubRepositoryId: "102",
+    fullName: "acme/mobile",
+    private: true,
+    archived: false,
+    defaultBranch: "develop",
+    enabled: true,
+  },
+];
+
+export const integrationsSlackAgentFixture = {
+  enabled: true,
+  teamId: "T01234567",
+  teamName: "Acme",
+};
+
+export const integrationsEmailAgentFixture = {
+  enabled: true,
+  inboundEmailAddress: "automation@inbound.hyperlocalise.test",
+};
+
+export const integrationsContentfulConnectionsFixture: ContentfulConnectionSummary[] = [
+  {
+    id: "contentful_conn_001",
+    displayName: "Help center",
+    projectId: null,
+    spaceId: "space_help_center",
+    environmentId: "master",
+    sourceLocale: null,
+    targetLocales: [],
+    contentTypeIds: ["article", "landingPage"],
+    validationStatus: "valid",
+    validationMessage: null,
+    maskedTokenSuffix: "••••wxyz",
+    webhook: {
+      id: "webhook_001",
+      status: "active",
+      providerWebhookId: "cf_webhook_001",
+      url: "https://app.hyperlocalise.test/api/webhooks/contentful/contentful_conn_001",
+      lastDeliveryId: "delivery_001",
+      lastDeliveredAt: integrationTimestamp,
+      lastError: null,
+    },
+  },
+];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds Storybook coverage for the workspace integrations page (`IntegrationsPageContent`), following the same fixture + MSW handler pattern used by the automations editor stories.

New files:
- `integrations.fixture.ts` — shared mock data for TMS, GitHub, Slack, email, Contentful, and LLM provider credentials
- `integrations-msw-handlers.ts` — MSW handlers for connected, disconnected, managed-provider, and loading states
- `integrations-page-content.stories.tsx` — page stories under **App/Integrations/Page**

Stories included:
- **Default** — fully connected workspace
- **Disconnected** — no integrations connected
- **ManagedProviderOnly** — Hyperlocalise GO without BYOK
- **Loading** — skeleton state while API requests are pending
- **ReadOnly** — developer role without manage permissions
- **WithoutProviderIntegrations** — source control + collaboration only
- **OAuthError** — TMS user OAuth error banner

## How to test

```bash
cd apps/hyperlocalise-web
vp check --fix
vp run build-storybook
vp run storybook
```

Open **App → Integrations → Page** in Storybook and verify each story renders.

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test`, `vp run build-storybook`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f34c0-065f-7854-bd09-23c752606e02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f34c0-065f-7854-bd09-23c752606e02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

