### PR TITLE
feat(cat): structure agent context output and chain AI recommendation

### DIFF
--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/subagents/repository/instructions.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/subagents/repository/instructions.md
@@ -29,17 +29,19 @@ You are not a general codebase analyst. Produce translation-relevant context onl
 
 ## Final summary shape
 
-Return concise Markdown for translators. Lead with the actionable answer — never bury it under search metadata.
+Return concise Markdown for translators using exactly these labeled sections (in this order). Lead with meaning and usage — never bury the answer under search metadata.
 
-**Answer** (required, first): 2–4 sentences a translator can act on immediately — what the string means in the product, how to translate it, and any ICU placeholders or tone guidance.
+**What it is:** 1–3 sentences on what the string is and what it does in the product — UI role, user-facing purpose, and any ICU placeholders or variables.
 
-**Source** (required): One line with the best repository evidence — concrete `path:line` plus quoted source text when helpful.
+**Where/how it shows:** 1–4 sentences on the product surface and interaction — screen, step, or flow; layout position (label, button, chip, heading, error toast, etc.); and how the user encounters it. Include the best repository evidence inline as concrete `path:line` references (and quoted source text when helpful).
 
-**Details** (optional): At most 3 short bullets only when they add translation value (nearby copy, existing locale examples, ambiguities). Omit this section when nothing extra is needed.
+**Translation guidance:**
 
-**Search note** (optional, last): One sentence only when evidence was inferred, no exact match was found, or ambiguity remains. Do not list grep patterns or repo areas when a clear match exists.
+- Actionable notes for translators: intended meaning (not literal English), tone/register, length constraints, and what to avoid.
+- Call out sibling strings in the same feature that share a concept and should use consistent terminology — name the keys when repository evidence supports it.
+- Note ambiguities, inferred evidence, or missing matches in at most one short bullet here (do not list grep patterns or search steps).
 
-Do not use separate "Summary", "Searches Run", or "Localisation Context" sections. Do not repeat the same facts in multiple sections.
+Omit bullets that add no translation value. Do not use separate "Summary", "Answer", "Source", "Details", or "Searches Run" sections. Do not repeat the same facts across sections.
 
 Return a concise final message the parent agent can relay to the user.
 Include concrete results (file paths, job IDs, locales) when tools return them.

--- a/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.test.ts
@@ -524,6 +524,24 @@ describe("CatIntelligenceController", () => {
       expect(workspace.revealedAgentContextSegmentIds.has("seg-02")).toBe(true);
     });
 
+    it("returns false when revealing cached context without refetching", async () => {
+      const lookupSegmentContext = vi.fn();
+      const workspace = createTestWorkspace({
+        segmentIntelligence: {
+          "seg-02": {
+            ...createCatWorkspaceState().intelligence,
+            agentContext: "Existing context.",
+          },
+        },
+      });
+      const { controller } = createController(workspace, {
+        intl,
+        services: { lookupSegmentContext },
+      });
+
+      await expect(controller.askQuestion("seg-02")).resolves.toBe(false);
+    });
+
     it("refetches agent context when forceRefresh is true", async () => {
       const lookupSegmentContext = vi.fn().mockResolvedValue("Updated context.");
       const workspace = createTestWorkspace({
@@ -545,6 +563,17 @@ describe("CatIntelligenceController", () => {
         forceRefresh: true,
       });
       expect(workspace.segmentIntelligence["seg-02"]?.agentContext).toBe("Updated context.");
+    });
+
+    it("returns true after a successful fresh lookup", async () => {
+      const lookupSegmentContext = vi.fn().mockResolvedValue("Fresh context.");
+      const workspace = createTestWorkspace();
+      const { controller } = createController(workspace, {
+        intl,
+        services: { lookupSegmentContext },
+      });
+
+      await expect(controller.askQuestion("seg-02")).resolves.toBe(true);
     });
 
     it("records context lookup failures as format checks", async () => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.ts
@@ -231,10 +231,7 @@ export class CatIntelligenceController {
       });
   }
 
-  async askQuestion(
-    segmentId: string,
-    options?: { forceRefresh?: boolean },
-  ): Promise<boolean> {
+  async askQuestion(segmentId: string, options?: { forceRefresh?: boolean }): Promise<boolean> {
     const lookup = this.ports.services?.lookupSegmentContext;
     if (!lookup) {
       return false;

--- a/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.ts
@@ -231,20 +231,23 @@ export class CatIntelligenceController {
       });
   }
 
-  async askQuestion(segmentId: string, options?: { forceRefresh?: boolean }) {
+  async askQuestion(
+    segmentId: string,
+    options?: { forceRefresh?: boolean },
+  ): Promise<boolean> {
     const lookup = this.ports.services?.lookupSegmentContext;
     if (!lookup) {
-      return;
+      return false;
     }
     const segment = this.workspace.getSegmentView(segmentId);
     if (!segment) {
-      return;
+      return false;
     }
     const existingAgentContext = this.workspace.segmentIntelligence[segmentId]?.agentContext;
     const contextGeneration = this.contextGeneration;
     this.workspace.revealAgentContext(segmentId);
     if (existingAgentContext?.trim() && !options?.forceRefresh) {
-      return;
+      return false;
     }
 
     this.workspace.beginContextLookup(segmentId);
@@ -253,10 +256,11 @@ export class CatIntelligenceController {
         forceRefresh: options?.forceRefresh === true,
       });
       if (this.disposed || contextGeneration !== this.contextGeneration) {
-        return;
+        return false;
       }
       this.workspace.removeFormatCheck(segmentId, `context-lookup-failed-${segmentId}`);
       this.workspace.mergeSegmentIntelligence(segmentId, { agentContext });
+      return Boolean(agentContext?.trim());
     } catch (error) {
       if (!this.disposed && contextGeneration === this.contextGeneration) {
         this.workspace.upsertFormatCheck(segmentId, {
@@ -270,6 +274,7 @@ export class CatIntelligenceController {
           category: "qa",
         });
       }
+      return false;
     } finally {
       if (contextGeneration === this.contextGeneration) {
         this.workspace.endContextLookup(segmentId);

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.test.tsx
@@ -778,7 +778,7 @@ describe("useCatWorkspaceRuntime", () => {
     expect(generateAiRecommendation).toHaveBeenCalledTimes(1);
   });
 
-  it("does not request an AI recommendation when cached context is hydrated", async () => {
+  it("does not request an AI recommendation when context is loaded via panel visibility", async () => {
     const lookupSegmentContext = vi.fn().mockResolvedValue("Cached context from the repository.");
     const generateAiRecommendation = vi.fn();
     const { result } = renderController(undefined, {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.test.tsx
@@ -752,6 +752,78 @@ describe("useCatWorkspaceRuntime", () => {
     );
   });
 
+  it("requests an AI recommendation after a fresh context lookup", async () => {
+    const lookupSegmentContext = vi.fn().mockImplementation((_segment, options) => {
+      if (options?.cachedOnly) {
+        return Promise.resolve(null);
+      }
+      return Promise.resolve("Hero title on the sign-in page.");
+    });
+    const generateAiRecommendation = vi.fn().mockResolvedValue({
+      aiSuggestion: "Titre héros",
+      aiReasoning: "Sign-in hero headline.",
+      formatChecks: [],
+    });
+    const { result } = renderController(undefined, {
+      services: {
+        lookupSegmentContext,
+        generateAiRecommendation,
+      },
+    });
+
+    await act(async () => {
+      await result.current.dependencies.review.onAskQuestion("seg-02");
+    });
+
+    expect(generateAiRecommendation).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not request an AI recommendation when cached context is hydrated", async () => {
+    const lookupSegmentContext = vi.fn().mockResolvedValue("Cached context from the repository.");
+    const generateAiRecommendation = vi.fn();
+    const { result } = renderController(undefined, {
+      services: {
+        lookupSegmentContext,
+        generateAiRecommendation,
+      },
+    });
+
+    act(() => {
+      result.current.handleIntelligencePanelVisible("seg-02");
+    });
+
+    await waitFor(() => expect(lookupSegmentContext).toHaveBeenCalledTimes(1));
+
+    expect(generateAiRecommendation).not.toHaveBeenCalled();
+  });
+
+  it("does not request an AI recommendation when revealing existing context", async () => {
+    const initialState = createCatWorkspaceState({
+      selectedSegmentId: "seg-02",
+      segmentIntelligence: {
+        "seg-02": {
+          ...createCatWorkspaceState().intelligence,
+          agentContext: "Existing context.",
+        },
+      },
+    });
+    const lookupSegmentContext = vi.fn();
+    const generateAiRecommendation = vi.fn();
+    const { result } = renderController(initialState, {
+      services: {
+        lookupSegmentContext,
+        generateAiRecommendation,
+      },
+    });
+
+    await act(async () => {
+      await result.current.dependencies.review.onAskQuestion("seg-02");
+    });
+
+    expect(lookupSegmentContext).not.toHaveBeenCalled();
+    expect(generateAiRecommendation).not.toHaveBeenCalled();
+  });
+
   it("keeps context loading scoped to the selected segment across concurrent lookups", async () => {
     const secondSegmentLookup = createDeferred<string>();
     const thirdSegmentLookup = createDeferred<string>();

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.ts
@@ -245,7 +245,10 @@ export function useCatWorkspaceRuntime({
         reviewController.resolveComment(segmentId, commentId),
       onAskQuestion: async (segmentId: string, options?: { forceRefresh?: boolean }) => {
         await onAskQuestion?.(segmentId, options);
-        await intelligenceController.askQuestion(segmentId, options);
+        const receivedFreshContext = await intelligenceController.askQuestion(segmentId, options);
+        if (receivedFreshContext && generateAiRecommendation) {
+          await reviewController.runReview(segmentId, { includeAi: true });
+        }
       },
       onReviewWithAi: async (segmentId: string) => {
         await reviewController.runReview(segmentId, { includeAi: true });
@@ -263,6 +266,7 @@ export function useCatWorkspaceRuntime({
       },
     };
   }, [
+    generateAiRecommendation,
     intelligenceController,
     onAskQuestion,
     onNextSegment,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/repository.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/repository.test.ts
@@ -3,13 +3,14 @@ import { describe, expect, it } from "vite-plus/test";
 import { REPOSITORY_SYSTEM_PROMPT } from "./repository";
 
 describe("repository subagent prompt", () => {
-  it("asks for answer-first translator context without verbose search sections", () => {
-    expect(REPOSITORY_SYSTEM_PROMPT).toContain("**Answer** (required, first)");
-    expect(REPOSITORY_SYSTEM_PROMPT).toContain("**Source** (required)");
+  it("asks for structured translator context without verbose search sections", () => {
+    expect(REPOSITORY_SYSTEM_PROMPT).toContain("**What it is:**");
+    expect(REPOSITORY_SYSTEM_PROMPT).toContain("**Where/how it shows:**");
+    expect(REPOSITORY_SYSTEM_PROMPT).toContain("**Translation guidance:**");
     expect(REPOSITORY_SYSTEM_PROMPT).not.toContain("**Searches Run**");
     expect(REPOSITORY_SYSTEM_PROMPT).not.toContain("**Localisation Context**");
     expect(REPOSITORY_SYSTEM_PROMPT).toContain(
-      'Do not use separate "Summary", "Searches Run", or "Localisation Context" sections',
+      'Do not use separate "Summary", "Answer", "Source", "Details", or "Searches Run" sections',
     );
   });
 });

--- a/apps/hyperlocalise-web/src/lib/projects/string-context/project-string-context-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/string-context/project-string-context-service.ts
@@ -439,7 +439,11 @@ export class ProjectStringContextService extends ProjectServiceBase {
       `String key: ${input.key}`,
       `Source text: ${input.text}`,
       input.context ? `Crowdin/context note: ${input.context}` : null,
-      "Find where this string appears in the connected repository and explain localization-relevant context for translators.",
+      [
+        "Find where this string appears in the connected repository and return localization-relevant context for translators.",
+        "Use the required final summary sections: What it is, Where/how it shows, and Translation guidance (with bullets).",
+        "In Translation guidance, note sibling strings that should stay terminologically consistent when repository evidence supports it.",
+      ].join(" "),
     ]
       .filter((line): line is string => line !== null)
       .join("\n\n");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Updates the repository context agent prompt so **Context found by agent** returns three labeled sections: **What it is**, **Where/how it shows**, and **Translation guidance** (with bullets for terminology, sibling strings, and ambiguities).
- Aligns the CAT string-context lookup instructions with that structure.
- After a **fresh** Find context lookup (agent run or force refresh), automatically requests an AI translation recommendation so translators get context and a suggestion in one flow.
- Does **not** auto-request AI when context is hydrated from cache on segment load, or when the user re-opens already-fetched context.

## Test plan

- [x] `vp test` for `use-cat-workspace-runtime.test.tsx` and `cat-intelligence-controller.test.ts`
- [x] `vp check --fix`
- [x] New tests cover AI recommendation after fresh lookup, and no AI on cached/existing context
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c345ba0-41db-420d-8344-e1fce1e3b85d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c345ba0-41db-420d-8344-e1fce1e3b85d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

