### PR TITLE
fix(web): improve project file browser capacity

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx
@@ -41,7 +41,7 @@ vi.mock("@tanstack/react-query", async (importOriginal) => {
 });
 
 vi.mock("./project-files-tree-panel", () => ({
-  PROJECT_FILES_PAGE_SIZE: 50,
+  PROJECT_FILES_PAGE_SIZE: 500,
   PROJECT_FILES_MAX_LIMIT: 1000,
   projectFilesQueryKey: () => ["project-files"],
   sortFilesByPath: (files: unknown[]) => files,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { fetchProjectFiles, PROJECT_FILES_PAGE_SIZE } from "./project-files-tree-panel";
+import { TREE_HEIGHT_PX } from "./project-files-tree";
+
+describe("project files browser capacity", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("requests 500 files by default", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ files: [] }), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchProjectFiles("acme", "proj_1");
+
+    expect(PROJECT_FILES_PAGE_SIZE).toBe(500);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/orgs/acme/projects/proj_1/files?limit=500",
+      { method: "GET" },
+    );
+  });
+
+  it("uses a 480 pixel tree viewport", () => {
+    expect(TREE_HEIGHT_PX).toBe(480);
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.test.ts
@@ -22,10 +22,9 @@ describe("project files browser capacity", () => {
     await fetchProjectFiles("acme", "proj_1");
 
     expect(PROJECT_FILES_PAGE_SIZE).toBe(500);
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/orgs/acme/projects/proj_1/files?limit=500",
-      { method: "GET" },
-    );
+    expect(fetchMock).toHaveBeenCalledWith("/api/orgs/acme/projects/proj_1/files?limit=500", {
+      method: "GET",
+    });
   });
 
   it("uses a 480 pixel tree viewport", () => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.tsx
@@ -16,7 +16,7 @@ import { ProjectSectionTitle } from "../../_components/project-page-shell";
 import { ProjectFilesErrorBoundary } from "./project-files-error-boundary";
 import { ProjectFilesTree } from "./project-files-tree";
 
-export const PROJECT_FILES_PAGE_SIZE = 50;
+export const PROJECT_FILES_PAGE_SIZE = 500;
 export const PROJECT_FILES_MAX_LIMIT = 1_000;
 
 export function projectFilesQueryKey(

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
@@ -9,7 +9,7 @@ import "@pierre/trees/web-components";
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
 import { formatBytes } from "./project-files-shared";
 
-const TREE_MIN_HEIGHT_PX = 320;
+export const TREE_HEIGHT_PX = 480;
 
 const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
   dateStyle: "medium",
@@ -19,7 +19,7 @@ const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
 const projectFilesTreeStyle = {
   width: "100%",
   minWidth: "100%",
-  height: `${TREE_MIN_HEIGHT_PX}px`,
+  height: `${TREE_HEIGHT_PX}px`,
   backgroundColor: "transparent",
   color: "var(--foreground)",
   borderColor: "var(--border)",

--- a/docs/adr/2026-07-06-project-file-browser-capacity-design.md
+++ b/docs/adr/2026-07-06-project-file-browser-capacity-design.md
@@ -1,0 +1,18 @@
+# Project file browser capacity
+
+## Decision
+
+Show 500 project files in the first browser batch and retain the existing
+1,000-file cap with a second load-more batch. Increase the file tree viewport
+from 320 to 480 pixels so users can scan more paths without scrolling the page.
+
+## Provider behavior
+
+The project files API already accepts limits up to 1,000. External TMS adapters
+paginate their provider APIs and return the requested slice, so a 500-file
+browser batch works for native and provider-backed projects.
+
+## Verification
+
+Update focused component tests for the new batch size and tree height. Run
+`vp test` and `vp check --fix` from `apps/hyperlocalise-web`.


### PR DESCRIPTION
## What changed

- Increased the project file browser batch size from 50 to 500 files.
- Kept the existing 1,000-file max cap and “load more” behavior.
- Made the file tree viewport taller, from 320px to 480px, so larger project file lists are easier to scan.
- Added regression coverage for the 500-file request size and 480px tree viewport.
- Documented the capacity decision and external TMS support behavior in an ADR.

External TMS support: the app-side project files API already supports up to 1,000 files, and provider-backed projects can return 500 files through the existing live TMS file listing path.

## How to test

- `vp test run 'src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.test.ts' 'src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx'`
- `vp check --fix`

Also attempted full `vp test`; it is blocked locally by PostgreSQL being unavailable on `localhost:5432`.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review