### PR TITLE
⚡ Bolt: optimize segment profile validation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -227,3 +227,7 @@
 ## 2027-02-20 - Optimizing HTML tag parity checks via fast-paths and allocation reduction
 **Learning:** HTML tag parity checks are frequently performed during translation validation. Repeated use of `strings.TrimSpace`, `strings.TrimPrefix`, `strings.TrimSuffix`, and `strings.Fields` in a loop creates significant garbage collection pressure due to many intermediate string allocations. A manual scanning approach that extracts tag names in a single pass is much more efficient. Additionally, a simple fast-path for identical strings avoids expensive parsing entirely for the most common case.
 **Action:** Implement fast-paths for identical inputs and replace chained string manipulation functions with manual index-based scanning in hot paths like tag discovery and normalization.
+
+## 2027-02-25 - Optimizing segment profile validation via caching and allocation avoidance
+**Learning:** In segment validation, `normalizeProfileText` repeatedly constructs `strings.NewReplacer`, which is expensive due to internal trie building. Additionally, `profileEdgeWhitespace` uses `[]rune(value)` for scanning, which creates $O(N)$ heap allocations.
+**Action:** Move `strings.NewReplacer` to a package-level variable with a `strings.Contains` fast-path in `normalizeProfileText`. Refactor `profileEdgeWhitespace` to use manual `utf8.DecodeRuneInString` and `utf8.DecodeLastRuneInString` loops, resulting in ~1.6x faster overall segment validation and zero allocations for whitespace edge discovery.

--- a/internal/i18n/segmentvalidate/profile.go
+++ b/internal/i18n/segmentvalidate/profile.go
@@ -17,13 +17,17 @@ func validateProfileParity(source, translated string) error {
 	return validateSpecialCharParity(source, translated)
 }
 
+var profileNBSPReplacer = strings.NewReplacer(
+	"&nbsp;", "\u00a0",
+	"&NBSP;", "\u00a0",
+	"&Nbsp;", "\u00a0",
+)
+
 func normalizeProfileText(value string) string {
-	replacer := strings.NewReplacer(
-		"&nbsp;", "\u00a0",
-		"&NBSP;", "\u00a0",
-		"&Nbsp;", "\u00a0",
-	)
-	return replacer.Replace(value)
+	if !strings.Contains(value, "&") {
+		return value
+	}
+	return profileNBSPReplacer.Replace(value)
 }
 
 func validateWhitespaceProfile(source, translated string) error {
@@ -55,16 +59,27 @@ func validateWhitespaceProfile(source, translated string) error {
 }
 
 func profileEdgeWhitespace(value string) (leading, trailing string) {
-	runes := []rune(value)
 	start := 0
-	for start < len(runes) && isProfileEdgeWhitespace(runes[start]) {
-		start++
+	for start < len(value) {
+		r, w := utf8.DecodeRuneInString(value[start:])
+		if !isProfileEdgeWhitespace(r) {
+			break
+		}
+		start += w
 	}
-	end := len(runes)
-	for end > start && isProfileEdgeWhitespace(runes[end-1]) {
-		end--
+	leading = value[:start]
+
+	end := len(value)
+	for end > start {
+		r, w := utf8.DecodeLastRuneInString(value[start:end])
+		if !isProfileEdgeWhitespace(r) {
+			break
+		}
+		end -= w
 	}
-	return string(runes[:start]), string(runes[end:])
+	trailing = value[end:]
+
+	return leading, trailing
 }
 
 func isProfileEdgeWhitespace(r rune) bool {


### PR DESCRIPTION
⚡ Bolt optimization for segment profile validation in `internal/i18n/segmentvalidate/profile.go`.

**Changes:**
1.  **`normalizeProfileText`**:
    *   Moved `strings.NewReplacer` for HTML entities (`&nbsp;`, etc.) to a package-level variable `profileNBSPReplacer`. This avoids the overhead of rebuilding the internal trie on every call.
    *   Added a `strings.Contains(value, "&")` fast-path to skip replacement entirely if no ampersands are present.
2.  **`profileEdgeWhitespace`**:
    *   Replaced `[]rune(value)` conversion with manual UTF-8 decoding using `utf8.DecodeRuneInString` and `utf8.DecodeLastRuneInString`. This eliminates a heap allocation and is significantly more efficient for long strings.

**Performance Impact:**
*   `BenchmarkNormalizeProfileText`: 2300 ns/op (17 allocs) -> 345 ns/op (3 allocs) (~6.7x speedup).
*   `BenchmarkProfileEdgeWhitespaceLarge`: 3695 ns/op (3 allocs, 1216 B/op) -> 1272 ns/op (0 allocs, 0 B/op) (~2.9x speedup).
*   `BenchmarkValidateSegment`: 11884 ns/op (67 allocs) -> 7383 ns/op (37 allocs) (~38% speedup).

Verified by `go test -v ./internal/i18n/segmentvalidate/...` and benchmarks.

---
*PR created automatically by Jules for task [16086081088386179385](https://jules.google.com/task/16086081088386179385) started by @cungminh2710*