### PR TITLE
Improve Task and Source String upload parity

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -215,3 +215,9 @@
 **Learning:** The Crowdin API v2 Language resource includes an `internalCode` field in its response, which was missing from the Go SDK's `Language` model. This field provides the internal Crowdin language code, which can differ from standard ISO codes.
 
 **Action:** Added `InternalCode` (string) to the `Language` struct in `model/languages.go`. Updated contract tests in `languages_test.go` to include the `internalCode` field in mock responses and verify correct unmarshaling across List, Get, and Add operations.
+
+## 2026-11-07 - Improve Task and Source Strings upload parity
+
+**Learning:** Crowdin API v2 allows specifying task content via `directoryIds`, and the Source Strings upload response includes an `updateOption` attribute indicating how string updates were handled. These were missing from the Go SDK models.
+
+**Action:** Added `DirectoryIDs` to the `Task` model and all relevant task creation forms (`TaskCreateForm`, `EnterpriseTaskCreateForm`, etc.) and updated validation logic. Added `UpdateOption` to the `SourceStringsUpload` attributes. Updated contract tests to verify correct unmarshaling and request validation.

--- a/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
@@ -39,6 +39,16 @@ type SourceStringsGetResponse struct {
 	Data *SourceString `json:"data"`
 }
 
+// UpdateOption defines whether to keep existing translations and
+// approvals for updated strings.
+type UpdateOption string
+
+const (
+	UpdateOptionClearTranslationsAndApprovals UpdateOption = "clear_translations_and_approvals"
+	UpdateOptionKeepTranslations              UpdateOption = "keep_translations"
+	UpdateOptionKeepTranslationsAndApprovals  UpdateOption = "keep_translations_and_approvals"
+)
+
 // SourceStringsListResponse describes the response when getting
 // a list of source strings.
 type SourceStringsListResponse struct {
@@ -245,9 +255,9 @@ type SourceStringsUpload struct {
 			ImportTranslations      bool           `json:"importTranslations"`
 			Scheme                  map[string]int `json:"scheme"`
 		} `json:"importOptions"`
-		UpdateStrings bool   `json:"updateStrings"`
-		UpdateOption  string `json:"updateOption,omitempty"`
-		CleanupMode   bool   `json:"cleanupMode"`
+		UpdateStrings bool         `json:"updateStrings"`
+		UpdateOption  UpdateOption `json:"updateOption,omitempty"`
+		CleanupMode   bool         `json:"cleanupMode"`
 	} `json:"attributes"`
 	CreatedAt  string `json:"createdAt"`
 	UpdatedAt  string `json:"updatedAt"`
@@ -299,7 +309,7 @@ type SourceStringsUploadRequest struct {
 	// Option for updating strings. Default: "clear_translations_and_approvals".
 	// Enum: "clear_translations_and_approvals" "keep_translations" "keep_translations_and_approvals"
 	// Must be used together with updateStrings = true
-	UpdateOption string `json:"updateOption,omitempty"`
+	UpdateOption UpdateOption `json:"updateOption,omitempty"`
 }
 
 // SourceStringsImportOptions defines the options for importing strings.

--- a/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
@@ -245,8 +245,9 @@ type SourceStringsUpload struct {
 			ImportTranslations      bool           `json:"importTranslations"`
 			Scheme                  map[string]int `json:"scheme"`
 		} `json:"importOptions"`
-		UpdateStrings bool `json:"updateStrings"`
-		CleanupMode   bool `json:"cleanupMode"`
+		UpdateStrings bool   `json:"updateStrings"`
+		UpdateOption  string `json:"updateOption,omitempty"`
+		CleanupMode   bool   `json:"cleanupMode"`
 	} `json:"attributes"`
 	CreatedAt  string `json:"createdAt"`
 	UpdatedAt  string `json:"updatedAt"`

--- a/third_party/crowdin-api-client-go/crowdin/model/tasks.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/tasks.go
@@ -52,6 +52,7 @@ type (
 		PrecedingTaskID   int                 `json:"precedingTaskId"`
 		FilesCount        int                 `json:"filesCount"`
 		FileIDs           []int               `json:"fileIds,omitempty"`
+		DirectoryIDs      []int               `json:"directoryIds,omitempty"`
 		SplitFiles        *bool               `json:"splitFiles,omitempty"`
 		Vendor            string              `json:"vendor,omitempty"`
 		BranchIDs         []int               `json:"branchIds,omitempty"`
@@ -228,13 +229,16 @@ type (
 		// Task type. Enum: 0 - translate, 1 - proofread.
 		Type *TaskType `json:"type"`
 		// Branch identifiers.
-		// One of branchIds, stringIds or fileIds is required.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
 		BranchIDs []int `json:"branchIds,omitempty"`
+		// Directory identifiers.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
+		DirectoryIDs []int `json:"directoryIds,omitempty"`
 		// Task string identifiers.
-		// One of branchIds, stringIds or fileIds is required.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
 		StringIDs []int `json:"stringIds,omitempty"`
 		// Task file identifiers.
-		// One of branchIds, stringIds or fileIds is required.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
 		FileIDs []int `json:"fileIds,omitempty"`
 		// Label identifiers.
 		LabelIDs []int `json:"labelIds,omitempty"`
@@ -280,13 +284,16 @@ type (
 		// Task vendor. Enum: "crowdin_language_service".
 		Vendor TaskVendor `json:"vendor"`
 		// Branch identifiers.
-		// One of branchIds, stringIds or fileIds is required.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
 		BranchIDs []int `json:"branchIds,omitempty"`
+		// Directory identifiers.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
+		DirectoryIDs []int `json:"directoryIds,omitempty"`
 		// String identifiers.
-		// One of branchIds, stringIds or fileIds is required.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
 		StringIDs []int `json:"stringIds,omitempty"`
 		// File identifiers.
-		// One of branchIds, stringIds or fileIds is required.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
 		FileIDs []int `json:"fileIds,omitempty"`
 		// Label identifiers.
 		LabelIDs []int `json:"labelIds,omitempty"`
@@ -320,13 +327,16 @@ type (
 		// Task vendor. Enum: "oht" - OneHourTranslation.
 		Vendor TaskVendor `json:"vendor"`
 		// Branch identifiers.
-		// One of branchIds, stringIds or fileIds is required.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
 		BranchIDs []int `json:"branchIds,omitempty"`
+		// Directory identifiers.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
+		DirectoryIDs []int `json:"directoryIds,omitempty"`
 		// String identifiers.
-		// One of branchIds, stringIds or fileIds is required.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
 		StringIDs []int `json:"stringIds,omitempty"`
 		// File identifiers.
-		// One of branchIds, stringIds or fileIds is required.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
 		FileIDs []int `json:"fileIds,omitempty"`
 		// Label identifiers.
 		LabelIDs []int `json:"labelIds,omitempty"`
@@ -369,13 +379,16 @@ type (
 		// Task vendor. Enum: "gengo" - Gengo.
 		Vendor TaskVendor `json:"vendor"`
 		// Branch identifiers.
-		// One of branchIds, stringIds or fileIds is required.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
 		BranchIDs []int `json:"branchIds,omitempty"`
+		// Directory identifiers.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
+		DirectoryIDs []int `json:"directoryIds,omitempty"`
 		// String identifiers.
-		// One of branchIds, stringIds or fileIds is required.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
 		StringIDs []int `json:"stringIds,omitempty"`
 		// File identifiers.
-		// One of branchIds, stringIds or fileIds is required.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
 		FileIDs []int `json:"fileIds,omitempty"`
 		// Label identifiers.
 		LabelIDs []int `json:"labelIds,omitempty"`
@@ -419,13 +432,16 @@ type (
 		// gte_localize, kettu_solutions, languageline_solutions.
 		Vendor TaskVendor `json:"vendor"`
 		// Branch identifiers.
-		// One of branchIds, stringIds or fileIds is required.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
 		BranchIDs []int `json:"branchIds,omitempty"`
+		// Directory identifiers.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
+		DirectoryIDs []int `json:"directoryIds,omitempty"`
 		// String identifiers.
-		// One of branchIds, stringIds or fileIds is required.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
 		StringIDs []int `json:"stringIds,omitempty"`
 		// File identifiers.
-		// One of branchIds, stringIds or fileIds is required.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
 		FileIDs []int `json:"fileIds,omitempty"`
 		// Label identifiers.
 		LabelIDs []int `json:"labelIds,omitempty"`
@@ -516,17 +532,20 @@ type (
 		// Note: Can't be used with `type` in same request.
 		WorkflowStepID int `json:"workflowStepId,omitempty"`
 		// Branch identifiers.
-		// One of branchIds, stringIds or fileIds is required.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
 		BranchIDs []int `json:"branchIds,omitempty"`
+		// Directory identifiers.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
+		DirectoryIDs []int `json:"directoryIds,omitempty"`
 		// Task title
 		Title string `json:"title"`
 		// Task language identifier.
 		LanguageID string `json:"languageId"`
 		// Task string identifiers.
-		// One of stringIds or fileIds is required.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
 		StringIDs []int `json:"stringIds,omitempty"`
 		// Task file identifiers.
-		// One of stringIds or fileIds is required.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
 		FileIDs []int `json:"fileIds,omitempty"`
 		// Label identifiers.
 		LabelIDs []int `json:"labelIds,omitempty"`
@@ -570,17 +589,20 @@ type (
 		// Task workflow step id with type `Translate by Vendor` or `Proofread by Vendor`.
 		WorkflowStepID int `json:"workflowStepId"`
 		// Branch identifiers.
-		// One of branchIds, stringIds or fileIds is required.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
 		BranchIDs []int `json:"branchIds,omitempty"`
+		// Directory identifiers.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
+		DirectoryIDs []int `json:"directoryIds,omitempty"`
 		// Task title.
 		Title string `json:"title"`
 		// Language identifier.
 		LanguageID string `json:"languageId"`
 		// String identifiers.
-		// One of stringIds or fileIds is required.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
 		StringIDs []int `json:"stringIds,omitempty"`
 		// File identifiers.
-		// One of stringIds or fileIds is required.
+		// One of branchIds, directoryIds, stringIds or fileIds is required.
 		FileIDs []int `json:"fileIds,omitempty"`
 		// Label identifiers.
 		LabelIDs []int `json:"labelIds,omitempty"`
@@ -648,8 +670,8 @@ func (r *TaskCreateForm) ValidateRequest() error {
 	if r.Type == nil || (*r.Type != TaskTypeTranslate && *r.Type != TaskTypeProofread) {
 		return fmt.Errorf("type is required and must be one of %d, %d", TaskTypeTranslate, TaskTypeProofread)
 	}
-	if len(r.StringIDs) == 0 && len(r.FileIDs) == 0 && len(r.BranchIDs) == 0 {
-		return errors.New("one of stringIds, fileIds or branchIds is required")
+	if len(r.StringIDs) == 0 && len(r.FileIDs) == 0 && len(r.BranchIDs) == 0 && len(r.DirectoryIDs) == 0 {
+		return errors.New("one of stringIds, fileIds, branchIds or directoryIds is required")
 	}
 
 	return nil
@@ -679,8 +701,8 @@ func (r *LanguageServiceTaskCreateForm) ValidateRequest() error {
 	if r.Vendor != TaskVendorCrowdinLanguageService {
 		return fmt.Errorf("vendor is required and must be %q", TaskVendorCrowdinLanguageService)
 	}
-	if len(r.StringIDs) == 0 && len(r.FileIDs) == 0 && len(r.BranchIDs) == 0 {
-		return errors.New("one of stringIds, fileIds or branchIds is required")
+	if len(r.StringIDs) == 0 && len(r.FileIDs) == 0 && len(r.BranchIDs) == 0 && len(r.DirectoryIDs) == 0 {
+		return errors.New("one of stringIds, fileIds, branchIds or directoryIds is required")
 	}
 
 	return nil
@@ -710,8 +732,8 @@ func (r *VendorOhtTaskCreateForm) ValidateRequest() error {
 	if r.Vendor != TaskVendorOht {
 		return fmt.Errorf("vendor is required and must be %q", TaskVendorOht)
 	}
-	if len(r.StringIDs) == 0 && len(r.FileIDs) == 0 && len(r.BranchIDs) == 0 {
-		return errors.New("one of stringIds, fileIds or branchIds is required")
+	if len(r.StringIDs) == 0 && len(r.FileIDs) == 0 && len(r.BranchIDs) == 0 && len(r.DirectoryIDs) == 0 {
+		return errors.New("one of stringIds, fileIds, branchIds or directoryIds is required")
 	}
 
 	return nil
@@ -740,8 +762,8 @@ func (r *VendorGengoTaskCreateForm) ValidateRequest() error {
 	if r.Vendor != TaskVendorGengo {
 		return fmt.Errorf("vendor is required and must be %q", TaskVendorGengo)
 	}
-	if len(r.StringIDs) == 0 && len(r.FileIDs) == 0 && len(r.BranchIDs) == 0 {
-		return errors.New("one of stringIds, fileIds or branchIds is required")
+	if len(r.StringIDs) == 0 && len(r.FileIDs) == 0 && len(r.BranchIDs) == 0 && len(r.DirectoryIDs) == 0 {
+		return errors.New("one of stringIds, fileIds, branchIds or directoryIds is required")
 	}
 
 	return nil
@@ -771,8 +793,8 @@ func (r *VendorManualTaskCreateForm) ValidateRequest() error {
 	if r.Vendor == "" {
 		return errors.New("vendor is required")
 	}
-	if len(r.StringIDs) == 0 && len(r.FileIDs) == 0 && len(r.BranchIDs) == 0 {
-		return errors.New("one of stringIds, fileIds or branchIds is required")
+	if len(r.StringIDs) == 0 && len(r.FileIDs) == 0 && len(r.BranchIDs) == 0 && len(r.DirectoryIDs) == 0 {
+		return errors.New("one of stringIds, fileIds, branchIds or directoryIds is required")
 	}
 
 	return nil
@@ -879,8 +901,8 @@ func (r *EnterpriseTaskCreateForm) ValidateRequest() error {
 	if r.LanguageID == "" {
 		return errors.New("languageId is required")
 	}
-	if len(r.StringIDs) == 0 && len(r.FileIDs) == 0 && len(r.BranchIDs) == 0 {
-		return errors.New("one of stringIds, fileIds or branchIds is required")
+	if len(r.StringIDs) == 0 && len(r.FileIDs) == 0 && len(r.BranchIDs) == 0 && len(r.DirectoryIDs) == 0 {
+		return errors.New("one of stringIds, fileIds, branchIds or directoryIds is required")
 	}
 
 	return nil
@@ -906,8 +928,8 @@ func (r *EnterpriseVendorTaskCreateForm) ValidateRequest() error {
 	if r.LanguageID == "" {
 		return errors.New("languageId is required")
 	}
-	if len(r.StringIDs) == 0 && len(r.FileIDs) == 0 && len(r.BranchIDs) == 0 {
-		return errors.New("one of stringIds, fileIds or branchIds is required")
+	if len(r.StringIDs) == 0 && len(r.FileIDs) == 0 && len(r.BranchIDs) == 0 && len(r.DirectoryIDs) == 0 {
+		return errors.New("one of stringIds, fileIds, branchIds or directoryIds is required")
 	}
 
 	return nil

--- a/third_party/crowdin-api-client-go/crowdin/model/tasks_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/tasks_test.go
@@ -172,15 +172,23 @@ func TestTaskCreateFormValidate(t *testing.T) {
 			err:  "type is required and must be one of 0, 1",
 		},
 		{
-			name: "missing one of stringIds, fileIds, branchIds",
+			name: "missing one of stringIds, fileIds, branchIds, directoryIds",
 			req:  &TaskCreateForm{Title: "Test task", LanguageID: "uk", Type: toPtr(TaskTypeProofread)},
-			err:  "one of stringIds, fileIds or branchIds is required",
+			err:  "one of stringIds, fileIds, branchIds or directoryIds is required",
 		},
 		{
 			name: "valid request",
 			req: &TaskCreateForm{
 				Title: "Test task", LanguageID: "uk", Type: toPtr(TaskTypeProofread),
 				FileIDs: []int{1, 2},
+			},
+			valid: true,
+		},
+		{
+			name: "valid request with directoryIds",
+			req: &TaskCreateForm{
+				Title: "Test task", LanguageID: "uk", Type: toPtr(TaskTypeProofread),
+				DirectoryIDs: []int{4, 5},
 			},
 			valid: true,
 		},
@@ -243,12 +251,12 @@ func TestLanguageServiceTaskCreateFormValidate(t *testing.T) {
 			err: "vendor is required and must be \"crowdin_language_service\"",
 		},
 		{
-			name: "required fileIds/branchIds/stringIds",
+			name: "required fileIds/branchIds/stringIds/directoryIds",
 			req: &LanguageServiceTaskCreateForm{
 				Title: "French", LanguageID: "en", Type: TaskTypeTranslateByVendor,
 				Vendor: TaskVendorCrowdinLanguageService,
 			},
-			err: "one of stringIds, fileIds or branchIds is required",
+			err: "one of stringIds, fileIds, branchIds or directoryIds is required",
 		},
 		{
 			name: "valid validation",
@@ -314,9 +322,9 @@ func TestVendorOhtTaskCreateFormValidate(t *testing.T) {
 			err:  "vendor is required and must be \"oht\"",
 		},
 		{
-			name: "required fileIds/branchIds/stringIds",
+			name: "required fileIds/branchIds/stringIds/directoryIds",
 			req:  &VendorOhtTaskCreateForm{Title: "French", LanguageID: "en", Type: TaskTypeTranslateByVendor, Vendor: TaskVendorOht},
-			err:  "one of stringIds, fileIds or branchIds is required",
+			err:  "one of stringIds, fileIds, branchIds or directoryIds is required",
 		},
 		{
 			name: "valid validation",
@@ -382,9 +390,9 @@ func TestVendorGengoTaskCreateFormValidate(t *testing.T) {
 			err:  "vendor is required and must be \"gengo\"",
 		},
 		{
-			name: "required fileIds/branchIds/stringIds",
+			name: "required fileIds/branchIds/stringIds/directoryIds",
 			req:  &VendorGengoTaskCreateForm{Title: "French", LanguageID: "en", Type: TaskTypeTranslateByVendor, Vendor: TaskVendorGengo},
-			err:  "one of stringIds, fileIds or branchIds is required",
+			err:  "one of stringIds, fileIds, branchIds or directoryIds is required",
 		},
 		{
 			name: "valid validation",
@@ -445,9 +453,9 @@ func TestVendorManualTaskCreateFormValidate(t *testing.T) {
 			err:  "vendor is required",
 		},
 		{
-			name: "required fileIds/branchIds/stringIds",
+			name: "required fileIds/branchIds/stringIds/directoryIds",
 			req:  &VendorManualTaskCreateForm{Title: "French", LanguageID: "en", Type: TaskTypeTranslateByVendor, Vendor: TaskVendorAlconost},
-			err:  "one of stringIds, fileIds or branchIds is required",
+			err:  "one of stringIds, fileIds, branchIds or directoryIds is required",
 		},
 
 		{
@@ -655,9 +663,9 @@ func TestEnterpriseTaskCreateFormValidate(t *testing.T) {
 			err:  "languageId is required",
 		},
 		{
-			name: "stringIds, fileIds or branchIds is required",
+			name: "stringIds, fileIds, branchIds or directoryIds is required",
 			req:  &EnterpriseTaskCreateForm{WorkflowStepID: 1, Title: "French", LanguageID: "en"},
-			err:  "one of stringIds, fileIds or branchIds is required",
+			err:  "one of stringIds, fileIds, branchIds or directoryIds is required",
 		},
 		{
 			name: "valid data validation with branchIds",
@@ -666,6 +674,16 @@ func TestEnterpriseTaskCreateFormValidate(t *testing.T) {
 				Title:          "French",
 				LanguageID:     "en",
 				BranchIDs:      []int{1, 2},
+			},
+			valid: true,
+		},
+		{
+			name: "valid data validation with directoryIds",
+			req: &EnterpriseTaskCreateForm{
+				WorkflowStepID: 1,
+				Title:          "French",
+				LanguageID:     "en",
+				DirectoryIDs:   []int{1, 2},
 			},
 			valid: true,
 		},
@@ -726,9 +744,9 @@ func TestEnterpriseVendorTaskCreateFormValidate(t *testing.T) {
 			err:  "languageId is required",
 		},
 		{
-			name: "stringIds, fileIds or branchIds is required",
+			name: "stringIds, fileIds, branchIds or directoryIds is required",
 			req:  &EnterpriseVendorTaskCreateForm{WorkflowStepID: 1, Title: "French", LanguageID: "en"},
-			err:  "one of stringIds, fileIds or branchIds is required",
+			err:  "one of stringIds, fileIds, branchIds or directoryIds is required",
 		},
 		{
 			name: "valid data validation with branchIds",
@@ -737,6 +755,16 @@ func TestEnterpriseVendorTaskCreateFormValidate(t *testing.T) {
 				Title:          "French",
 				LanguageID:     "en",
 				BranchIDs:      []int{1, 2},
+			},
+			valid: true,
+		},
+		{
+			name: "valid data validation with directoryIds",
+			req: &EnterpriseVendorTaskCreateForm{
+				WorkflowStepID: 1,
+				Title:          "French",
+				LanguageID:     "en",
+				DirectoryIDs:   []int{1, 2},
 			},
 			valid: true,
 		},

--- a/third_party/crowdin-api-client-go/crowdin/source_strings_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/source_strings_test.go
@@ -798,20 +798,20 @@ func TestSourceStringsService_GetUploadStatus(t *testing.T) {
 		Status:     "finished",
 		Progress:   100,
 		Attributes: struct {
-				BranchID      int                `json:"branchId"`
-				DirectoryID   int                `json:"directoryId"`
-				StorageID     int                `json:"storageId"`
-				FileType      string             `json:"fileType"`
-				ParserVersion int                `json:"parserVersion"`
-				LabelIDs      []int              `json:"labelIds"`
+			BranchID      int    `json:"branchId"`
+			DirectoryID   int    `json:"directoryId"`
+			StorageID     int    `json:"storageId"`
+			FileType      string `json:"fileType"`
+			ParserVersion int    `json:"parserVersion"`
+			LabelIDs      []int  `json:"labelIds"`
 			ImportOptions struct {
 				FirstLineContainsHeader bool           `json:"firstLineContainsHeader"`
 				ImportTranslations      bool           `json:"importTranslations"`
 				Scheme                  map[string]int `json:"scheme"`
 			} `json:"importOptions"`
-				UpdateStrings bool               `json:"updateStrings"`
-				UpdateOption  model.UpdateOption `json:"updateOption,omitempty"`
-				CleanupMode   bool               `json:"cleanupMode"`
+			UpdateStrings bool               `json:"updateStrings"`
+			UpdateOption  model.UpdateOption `json:"updateOption,omitempty"`
+			CleanupMode   bool               `json:"cleanupMode"`
 		}{
 			BranchID:      38,
 			StorageID:     38,
@@ -833,7 +833,7 @@ func TestSourceStringsService_GetUploadStatus(t *testing.T) {
 				},
 			},
 			UpdateStrings: true,
-				UpdateOption:  model.UpdateOptionKeepTranslations,
+			UpdateOption:  model.UpdateOptionKeepTranslations,
 			CleanupMode:   false,
 		},
 		CreatedAt:  "2023-09-23T11:26:54+00:00",
@@ -926,20 +926,20 @@ func TestSourceStringsService_Upload(t *testing.T) {
 		Status:     "finished",
 		Progress:   100,
 		Attributes: struct {
-				BranchID      int                `json:"branchId"`
-				DirectoryID   int                `json:"directoryId"`
-				StorageID     int                `json:"storageId"`
-				FileType      string             `json:"fileType"`
-				ParserVersion int                `json:"parserVersion"`
-				LabelIDs      []int              `json:"labelIds"`
+			BranchID      int    `json:"branchId"`
+			DirectoryID   int    `json:"directoryId"`
+			StorageID     int    `json:"storageId"`
+			FileType      string `json:"fileType"`
+			ParserVersion int    `json:"parserVersion"`
+			LabelIDs      []int  `json:"labelIds"`
 			ImportOptions struct {
 				FirstLineContainsHeader bool           `json:"firstLineContainsHeader"`
 				ImportTranslations      bool           `json:"importTranslations"`
 				Scheme                  map[string]int `json:"scheme"`
 			} `json:"importOptions"`
-				UpdateStrings bool               `json:"updateStrings"`
-				UpdateOption  model.UpdateOption `json:"updateOption,omitempty"`
-				CleanupMode   bool               `json:"cleanupMode"`
+			UpdateStrings bool               `json:"updateStrings"`
+			UpdateOption  model.UpdateOption `json:"updateOption,omitempty"`
+			CleanupMode   bool               `json:"cleanupMode"`
 		}{
 			BranchID:      38,
 			StorageID:     38,
@@ -961,7 +961,7 @@ func TestSourceStringsService_Upload(t *testing.T) {
 				},
 			},
 			UpdateStrings: true,
-				UpdateOption:  model.UpdateOptionKeepTranslations,
+			UpdateOption:  model.UpdateOptionKeepTranslations,
 			CleanupMode:   false,
 		},
 		CreatedAt:  "2023-09-23T11:26:54+00:00",

--- a/third_party/crowdin-api-client-go/crowdin/source_strings_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/source_strings_test.go
@@ -798,20 +798,20 @@ func TestSourceStringsService_GetUploadStatus(t *testing.T) {
 		Status:     "finished",
 		Progress:   100,
 		Attributes: struct {
-			BranchID      int    `json:"branchId"`
-			DirectoryID   int    `json:"directoryId"`
-			StorageID     int    `json:"storageId"`
-			FileType      string `json:"fileType"`
-			ParserVersion int    `json:"parserVersion"`
-			LabelIDs      []int  `json:"labelIds"`
+				BranchID      int                `json:"branchId"`
+				DirectoryID   int                `json:"directoryId"`
+				StorageID     int                `json:"storageId"`
+				FileType      string             `json:"fileType"`
+				ParserVersion int                `json:"parserVersion"`
+				LabelIDs      []int              `json:"labelIds"`
 			ImportOptions struct {
 				FirstLineContainsHeader bool           `json:"firstLineContainsHeader"`
 				ImportTranslations      bool           `json:"importTranslations"`
 				Scheme                  map[string]int `json:"scheme"`
 			} `json:"importOptions"`
-			UpdateStrings bool   `json:"updateStrings"`
-			UpdateOption  string `json:"updateOption,omitempty"`
-			CleanupMode   bool   `json:"cleanupMode"`
+				UpdateStrings bool               `json:"updateStrings"`
+				UpdateOption  model.UpdateOption `json:"updateOption,omitempty"`
+				CleanupMode   bool               `json:"cleanupMode"`
 		}{
 			BranchID:      38,
 			StorageID:     38,
@@ -833,7 +833,7 @@ func TestSourceStringsService_GetUploadStatus(t *testing.T) {
 				},
 			},
 			UpdateStrings: true,
-			UpdateOption:  "keep_translations",
+				UpdateOption:  model.UpdateOptionKeepTranslations,
 			CleanupMode:   false,
 		},
 		CreatedAt:  "2023-09-23T11:26:54+00:00",
@@ -897,7 +897,7 @@ func TestSourceStringsService_Upload(t *testing.T) {
 		ParserVersion: 1,
 		LabelIDs:      []int{1, 2},
 		UpdateStrings: ToPtr(true),
-		UpdateOption:  "keep_translations",
+		UpdateOption:  model.UpdateOptionKeepTranslations,
 		CleanupMode:   ToPtr(true),
 		ImportOptions: &model.SourceStringsImportOptions{
 			FirstLineContainsHeader: ToPtr(true),
@@ -926,20 +926,20 @@ func TestSourceStringsService_Upload(t *testing.T) {
 		Status:     "finished",
 		Progress:   100,
 		Attributes: struct {
-			BranchID      int    `json:"branchId"`
-			DirectoryID   int    `json:"directoryId"`
-			StorageID     int    `json:"storageId"`
-			FileType      string `json:"fileType"`
-			ParserVersion int    `json:"parserVersion"`
-			LabelIDs      []int  `json:"labelIds"`
+				BranchID      int                `json:"branchId"`
+				DirectoryID   int                `json:"directoryId"`
+				StorageID     int                `json:"storageId"`
+				FileType      string             `json:"fileType"`
+				ParserVersion int                `json:"parserVersion"`
+				LabelIDs      []int              `json:"labelIds"`
 			ImportOptions struct {
 				FirstLineContainsHeader bool           `json:"firstLineContainsHeader"`
 				ImportTranslations      bool           `json:"importTranslations"`
 				Scheme                  map[string]int `json:"scheme"`
 			} `json:"importOptions"`
-			UpdateStrings bool   `json:"updateStrings"`
-			UpdateOption  string `json:"updateOption,omitempty"`
-			CleanupMode   bool   `json:"cleanupMode"`
+				UpdateStrings bool               `json:"updateStrings"`
+				UpdateOption  model.UpdateOption `json:"updateOption,omitempty"`
+				CleanupMode   bool               `json:"cleanupMode"`
 		}{
 			BranchID:      38,
 			StorageID:     38,
@@ -961,7 +961,7 @@ func TestSourceStringsService_Upload(t *testing.T) {
 				},
 			},
 			UpdateStrings: true,
-			UpdateOption:  "keep_translations",
+				UpdateOption:  model.UpdateOptionKeepTranslations,
 			CleanupMode:   false,
 		},
 		CreatedAt:  "2023-09-23T11:26:54+00:00",
@@ -1006,8 +1006,8 @@ func TestSourceStringsService_UploadWithValidationError(t *testing.T) {
 		{"empty storageId", &model.SourceStringsUploadRequest{BranchID: 34}, "storageId is required"},
 		{"empty branchId and directoryId", &model.SourceStringsUploadRequest{StorageID: 61}, "branchId or directoryId is required"},
 		{"both branchId and directoryId", &model.SourceStringsUploadRequest{StorageID: 61, BranchID: 34, DirectoryID: 12}, "only one of branchId or directoryId may be set"},
-		{"misconfigured updateStrings for non-empty updateOption", &model.SourceStringsUploadRequest{BranchID: 34, StorageID: 61, UpdateStrings: ToPtr(false), UpdateOption: "clear_translations_and_approvals"}, "updateStrings must be set to true to use updateOption"},
-		{"nil updateStrings for non-empty updateOption", &model.SourceStringsUploadRequest{BranchID: 34, StorageID: 61, UpdateStrings: nil, UpdateOption: "clear_translations_and_approvals"}, "updateStrings must be set to true to use updateOption"},
+		{"misconfigured updateStrings for non-empty updateOption", &model.SourceStringsUploadRequest{BranchID: 34, StorageID: 61, UpdateStrings: ToPtr(false), UpdateOption: model.UpdateOptionClearTranslationsAndApprovals}, "updateStrings must be set to true to use updateOption"},
+		{"nil updateStrings for non-empty updateOption", &model.SourceStringsUploadRequest{BranchID: 34, StorageID: 61, UpdateStrings: nil, UpdateOption: model.UpdateOptionClearTranslationsAndApprovals}, "updateStrings must be set to true to use updateOption"},
 	}
 
 	for _, tt := range cases {

--- a/third_party/crowdin-api-client-go/crowdin/source_strings_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/source_strings_test.go
@@ -776,7 +776,8 @@ func TestSourceStringsService_GetUploadStatus(t *testing.T) {
 							"de": 3
 						}
 					},
-					"updateStrings": false,
+					"updateStrings": true,
+					"updateOption": "keep_translations",
 					"cleanupMode": false
 				},
 				"createdAt": "2023-09-23T11:26:54+00:00",
@@ -808,8 +809,9 @@ func TestSourceStringsService_GetUploadStatus(t *testing.T) {
 				ImportTranslations      bool           `json:"importTranslations"`
 				Scheme                  map[string]int `json:"scheme"`
 			} `json:"importOptions"`
-			UpdateStrings bool `json:"updateStrings"`
-			CleanupMode   bool `json:"cleanupMode"`
+			UpdateStrings bool   `json:"updateStrings"`
+			UpdateOption  string `json:"updateOption,omitempty"`
+			CleanupMode   bool   `json:"cleanupMode"`
 		}{
 			BranchID:      38,
 			StorageID:     38,
@@ -830,7 +832,8 @@ func TestSourceStringsService_GetUploadStatus(t *testing.T) {
 					"de":           3,
 				},
 			},
-			UpdateStrings: false,
+			UpdateStrings: true,
+			UpdateOption:  "keep_translations",
 			CleanupMode:   false,
 		},
 		CreatedAt:  "2023-09-23T11:26:54+00:00",
@@ -852,7 +855,7 @@ func TestSourceStringsService_Upload(t *testing.T) {
 	mux.HandleFunc(fmt.Sprintf("/api/v2/projects/%d/strings/uploads", projectID), func(w http.ResponseWriter, r *http.Request) {
 		testURL(t, r, fmt.Sprintf("/api/v2/projects/%d/strings/uploads", projectID))
 		testMethod(t, r, http.MethodPost)
-		testBody(t, r, `{"storageId":61,"branchId":34,"type":"xliff","parserVersion":1,"labelIds":[1,2],"updateStrings":false,"cleanupMode":true,"importOptions":{"firstLineContainsHeader":true,"importTranslations":false,"scheme":{"context":5,"de":9,"en":8,"identifier":1,"labels":7,"maxLength":6,"none":0,"sourceOrTranslation":3,"sourcePhrase":2,"translation":4}}}`+"\n")
+		testBody(t, r, `{"storageId":61,"branchId":34,"type":"xliff","parserVersion":1,"labelIds":[1,2],"updateStrings":true,"cleanupMode":true,"importOptions":{"firstLineContainsHeader":true,"importTranslations":false,"scheme":{"context":5,"de":9,"en":8,"identifier":1,"labels":7,"maxLength":6,"none":0,"sourceOrTranslation":3,"sourcePhrase":2,"translation":4}},"updateOption":"keep_translations"}`+"\n")
 
 		fmt.Fprint(w, `{
 			"data": {
@@ -875,7 +878,8 @@ func TestSourceStringsService_Upload(t *testing.T) {
 							"de": 3
 						}
 					},
-					"updateStrings": false,
+					"updateStrings": true,
+					"updateOption": "keep_translations",
 					"cleanupMode": false
 				},
 				"createdAt": "2023-09-23T11:26:54+00:00",
@@ -892,7 +896,8 @@ func TestSourceStringsService_Upload(t *testing.T) {
 		Type:          "xliff",
 		ParserVersion: 1,
 		LabelIDs:      []int{1, 2},
-		UpdateStrings: ToPtr(false),
+		UpdateStrings: ToPtr(true),
+		UpdateOption:  "keep_translations",
 		CleanupMode:   ToPtr(true),
 		ImportOptions: &model.SourceStringsImportOptions{
 			FirstLineContainsHeader: ToPtr(true),
@@ -932,8 +937,9 @@ func TestSourceStringsService_Upload(t *testing.T) {
 				ImportTranslations      bool           `json:"importTranslations"`
 				Scheme                  map[string]int `json:"scheme"`
 			} `json:"importOptions"`
-			UpdateStrings bool `json:"updateStrings"`
-			CleanupMode   bool `json:"cleanupMode"`
+			UpdateStrings bool   `json:"updateStrings"`
+			UpdateOption  string `json:"updateOption,omitempty"`
+			CleanupMode   bool   `json:"cleanupMode"`
 		}{
 			BranchID:      38,
 			StorageID:     38,
@@ -954,7 +960,8 @@ func TestSourceStringsService_Upload(t *testing.T) {
 					"de":           3,
 				},
 			},
-			UpdateStrings: false,
+			UpdateStrings: true,
+			UpdateOption:  "keep_translations",
 			CleanupMode:   false,
 		},
 		CreatedAt:  "2023-09-23T11:26:54+00:00",

--- a/third_party/crowdin-api-client-go/crowdin/tasks_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/tasks_test.go
@@ -109,6 +109,7 @@ func TestTasksService_Get(t *testing.T) {
 				"vendor": "gengo",
 				"filesCount": 3,
 				"fileIds": [24,25,38],
+				"directoryIds": [4, 5, 6],
 				"splitFiles": true,
 				"branchIds": [24,25,38],
 				"fields": {
@@ -213,6 +214,7 @@ func TestTasksService_Get(t *testing.T) {
 		Vendor:          "gengo",
 		FilesCount:      3,
 		FileIDs:         []int{24, 25, 38},
+		DirectoryIDs:    []int{4, 5, 6},
 		SplitFiles:      ToPtr(true),
 		BranchIDs:       []int{24, 25, 38},
 		Fields: map[string]any{
@@ -366,6 +368,7 @@ func TestTasksService_Add_TaskCreateForm(t *testing.T) {
 			"languageId":"en",
 			"type":1,
 			"fileIds":[1,2,3],
+		"directoryIds":[4,5,6],
 			"labelIds":[1,2,3],
 			"excludeLabelIds":[4,5,6],
 			"status":"todo",
@@ -487,6 +490,7 @@ func TestTasksService_Add_TaskCreateForm(t *testing.T) {
 		LanguageID:                      "en",
 		Type:                            ToPtr(model.TaskTypeProofread),
 		FileIDs:                         []int{1, 2, 3},
+		DirectoryIDs:                    []int{4, 5, 6},
 		LabelIDs:                        []int{1, 2, 3},
 		ExcludeLabelIDs:                 []int{4, 5, 6},
 		Status:                          model.TaskStatusTodo,

--- a/third_party/crowdin-api-client-go/crowdin/tasks_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/tasks_test.go
@@ -368,7 +368,7 @@ func TestTasksService_Add_TaskCreateForm(t *testing.T) {
 			"languageId":"en",
 			"type":1,
 			"fileIds":[1,2,3],
-		"directoryIds":[4,5,6],
+			"directoryIds":[4,5,6],
 			"labelIds":[1,2,3],
 			"excludeLabelIds":[4,5,6],
 			"status":"todo",


### PR DESCRIPTION
Improved parity with Crowdin API v2 for Tasks and Source String uploads.

Key changes:
- Added `DirectoryIDs` to `Task` and all task creation form structs in `model/tasks.go`.
- Updated task form validation to accept `DirectoryIDs`.
- Added `UpdateOption` to `SourceStringsUpload` attributes in `model/source_strings.go`.
- Updated test suites in `tasks_test.go`, `source_strings_test.go`, and `model/tasks_test.go` to cover the new fields and validation logic.

Docs:
- Tasks: https://developer.crowdin.com/api/v2/#tag/Tasks
- Upload Strings: https://developer.crowdin.com/api/v2/#operation/api.projects.strings.uploads.post

---
*PR created automatically by Jules for task [15498360429283820972](https://jules.google.com/task/15498360429283820972) started by @cungminh2710*