### PR TITLE
fix(issue-sheet): distinct icon and select label display

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
@@ -351,7 +351,11 @@ export function IssueSheetPageContent({
                         </SelectTrigger>
                         <SelectContent>
                           {statuses.map((status) => (
-                            <SelectItem key={status.value} value={status.value} label={status.label}>
+                            <SelectItem
+                              key={status.value}
+                              value={status.value}
+                              label={status.label}
+                            >
                               {status.label}
                             </SelectItem>
                           ))}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState, type FormEvent } from "react";
-import { PlusSignIcon, Task01Icon } from "@hugeicons/core-free-icons";
+import { ClipboardListIcon, PlusSignIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -247,7 +247,7 @@ export function IssueSheetPageContent({
     <ProjectPageShell>
       <div className="space-y-6">
         <ProjectSectionHeader
-          icon={Task01Icon}
+          icon={ClipboardListIcon}
           section="Issue Sheet"
           description="Track localization issues in Hyperlocalise, then link rows to CAT segments, native issues, provider threads, or external context."
           actions={
@@ -274,7 +274,7 @@ export function IssueSheetPageContent({
             </SelectTrigger>
             <SelectContent>
               {views.map((item) => (
-                <SelectItem key={item.value} value={item.value}>
+                <SelectItem key={item.value} value={item.value} label={item.label}>
                   {item.label}
                 </SelectItem>
               ))}
@@ -351,7 +351,7 @@ export function IssueSheetPageContent({
                         </SelectTrigger>
                         <SelectContent>
                           {statuses.map((status) => (
-                            <SelectItem key={status.value} value={status.value}>
+                            <SelectItem key={status.value} value={status.value} label={status.label}>
                               {status.label}
                             </SelectItem>
                           ))}
@@ -370,7 +370,7 @@ export function IssueSheetPageContent({
                         </SelectTrigger>
                         <SelectContent>
                           {issueTypes.map((type) => (
-                            <SelectItem key={type.value} value={type.value}>
+                            <SelectItem key={type.value} value={type.value} label={type.label}>
                               {type.label}
                             </SelectItem>
                           ))}
@@ -491,7 +491,7 @@ function CustomCell({
         </SelectTrigger>
         <SelectContent>
           {options.map((option) => (
-            <SelectItem key={option.id} value={option.id}>
+            <SelectItem key={option.id} value={option.id} label={option.label}>
               {option.label}
             </SelectItem>
           ))}
@@ -587,7 +587,7 @@ function CreateIssueDialog({
               </SelectTrigger>
               <SelectContent>
                 {issueTypes.map((type) => (
-                  <SelectItem key={type.value} value={type.value}>
+                  <SelectItem key={type.value} value={type.value} label={type.label}>
                     {type.label}
                   </SelectItem>
                 ))}
@@ -598,9 +598,15 @@ function CreateIssueDialog({
                 <SelectValue placeholder="Priority" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="P0">P0</SelectItem>
-                <SelectItem value="P1">P1</SelectItem>
-                <SelectItem value="P2">P2</SelectItem>
+                <SelectItem value="P0" label="P0">
+                  P0
+                </SelectItem>
+                <SelectItem value="P1" label="P1">
+                  P1
+                </SelectItem>
+                <SelectItem value="P2" label="P2">
+                  P2
+                </SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -688,10 +694,18 @@ function CreateColumnDialog({
               <SelectValue placeholder="Column type" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="text">Text</SelectItem>
-              <SelectItem value="long_text">Long text</SelectItem>
-              <SelectItem value="select">Select</SelectItem>
-              <SelectItem value="user">User ID</SelectItem>
+              <SelectItem value="text" label="Text">
+                Text
+              </SelectItem>
+              <SelectItem value="long_text" label="Long text">
+                Long text
+              </SelectItem>
+              <SelectItem value="select" label="Select">
+                Select
+              </SelectItem>
+              <SelectItem value="user" label="User ID">
+                User ID
+              </SelectItem>
             </SelectContent>
           </Select>
           <Input name="options" placeholder="For select: Backlog, Sprint 24, Blocked" />

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -9,6 +9,7 @@ import {
   AiBrain01Icon,
   BookOpenTextIcon,
   Chat01Icon,
+  ClipboardListIcon,
   DashboardSquare01Icon,
   DatabaseSyncIcon,
   File01Icon,
@@ -155,7 +156,7 @@ export function buildProjectNavigationItems(
     {
       label: "Issue Sheet",
       href: project("issue-sheet"),
-      icon: Task01Icon,
+      icon: ClipboardListIcon,
     },
     {
       label: "Settings",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Issue Sheet was using the same `Task01Icon` as Jobs in both the project sidebar navigation and the page header. It now uses `ClipboardListIcon` so the two sections are visually distinct.

Select components on the Issue Sheet page were showing raw values (e.g. `general_question`, `all_open`) in the trigger because `SelectItem` was missing the `label` prop required by Base UI. Added `label` to every select on the page: view filter, status, issue type, custom column cells, and the create issue/column dialogs.

## How to test

1. Open a project and confirm **Jobs** still shows the task icon and **Issue Sheet** shows the clipboard-list icon in the sidebar.
2. Open the Issue Sheet page and confirm the page header uses the clipboard-list icon.
3. Verify selects show readable labels:
   - View filter: "All open", "My work", etc.
   - Issue type column: "General question", "Translation mistake", etc.
   - Custom select columns show option labels, not IDs.
   - Create issue / create column dialogs show labels in selects.

`vp check --fix` and `vp test src/components/app-shell/navigation-config.test.ts` pass.

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, targeted tests)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3b27-458e-7687-b5ec-b865df12b9af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3b27-458e-7687-b5ec-b865df12b9af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

