### PR TITLE
feat(web): workspace issues page, dashboard skeletons, and project load more

### DIFF
--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -26,6 +26,7 @@ import { createContentfulWebhookRoutes } from "./routes/contentful-webhook/conte
 import { createGlossaryRoutes } from "./routes/glossary/glossary.route";
 import { createKnowledgeMemoryRoutes } from "./routes/knowledge-memory/knowledge-memory.route";
 import { createMemoryRoutes } from "./routes/memory/memory.route";
+import { createOrganizationIssuesRoutes } from "./routes/issues/issues.route";
 import { createGithubInstallationRoutes } from "./routes/github-installation/github-installation.route";
 import { createGithubWebhookRoutes } from "./routes/github-webhook/github-webhook.route";
 import { healthRoutes } from "./routes/health";
@@ -140,6 +141,7 @@ function createOrgScopedAppRoutes(
   },
 ) {
   return new Hono()
+    .route("/issues", createOrganizationIssuesRoutes())
     .route("/glossaries", createGlossaryRoutes())
     .route("/knowledge-memory", createKnowledgeMemoryRoutes())
     .route("/translation-memories", createMemoryRoutes())

--- a/apps/hyperlocalise-web/src/api/routes/issues/issues.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/issues/issues.route.test.ts
@@ -1,0 +1,100 @@
+import "dotenv/config";
+
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+
+import { app } from "@/api/app";
+import { db } from "@/lib/database";
+
+import { createProjectTestFixture } from "../project/project.fixture";
+
+const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
+  resolveApiAuthContextFromSessionMock: vi.fn(
+    (options) =>
+      globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
+      globalThis.__testApiAuthContext ??
+      null,
+  ),
+}));
+
+vi.mock("@/api/auth/workos-session", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/auth/workos-session")>();
+  return {
+    ...actual,
+    resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
+  };
+});
+
+const projectFixture = createProjectTestFixture();
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+});
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  await projectFixture.cleanup();
+});
+
+function organizationIssuesUrl(organizationSlug: string) {
+  return `/api/orgs/${encodeURIComponent(organizationSlug)}/issues`;
+}
+
+async function requestJson(
+  url: string,
+  input: {
+    method?: string;
+    headers: HeadersInit;
+    body?: unknown;
+    query?: Record<string, string>;
+  },
+) {
+  const query = input.query ? `?${new URLSearchParams(input.query).toString()}` : "";
+  return app.request(`${url}${query}`, {
+    method: input.method ?? "GET",
+    headers: {
+      ...(input.body ? { "Content-Type": "application/json" } : {}),
+      ...Object.fromEntries(new Headers(input.headers).entries()),
+    },
+    body: input.body ? JSON.stringify(input.body) : undefined,
+  });
+}
+
+describe("Organization issues routes", () => {
+  it("lists issues across accessible projects", async () => {
+    const { identity, project } = await projectFixture.createStoredProjectFixture();
+    const headers = await projectFixture.authHeadersFor(identity);
+    const organizationSlug = identity.organization.slug ?? "missing-slug";
+
+    const createResponse = await requestJson(
+      `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(project.id)}/issue-sheet`,
+      {
+        method: "POST",
+        headers,
+        body: {
+          title: "Workspace-wide issue",
+          issueType: "general_question",
+        },
+      },
+    );
+    expect(createResponse.status).toBe(201);
+
+    const listResponse = await requestJson(organizationIssuesUrl(organizationSlug), {
+      headers,
+      query: { view: "all_open" },
+    });
+
+    expect(listResponse.status).toBe(200);
+    const listBody = (await listResponse.json()) as {
+      issues: Array<{ title: string; projectId: string; projectName: string }>;
+      total: number;
+      summary: { open: number };
+    };
+    expect(listBody.total).toBe(1);
+    expect(listBody.summary.open).toBe(1);
+    expect(listBody.issues[0]).toMatchObject({
+      title: "Workspace-wide issue",
+      projectId: project.id,
+      projectName: project.name,
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/issues/issues.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/issues/issues.route.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 
 import { hasCapability } from "@/api/auth/policy";
 import { createZodValidator } from "@/api/errors";
+import { forbiddenResponse } from "@/api/response.schema";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
 import { organizationIssueService } from "@/lib/projects/issue-sheet/organization-issue-service";
 
@@ -18,7 +19,7 @@ export function createOrganizationIssuesRoutes() {
     .use("*", workosAuthMiddleware)
     .get("/", validateOrganizationIssuesQuery, async (c) => {
       if (!hasCapability(c.var.auth.membership.role, "projects:read")) {
-        return c.json({ error: "forbidden" }, 403);
+        return forbiddenResponse(c, "forbidden");
       }
 
       const query = c.req.valid("query");

--- a/apps/hyperlocalise-web/src/api/routes/issues/issues.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/issues/issues.route.ts
@@ -1,0 +1,28 @@
+import { Hono } from "hono";
+
+import { hasCapability } from "@/api/auth/policy";
+import { createZodValidator } from "@/api/errors";
+import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
+import { organizationIssueService } from "@/lib/projects/issue-sheet/organization-issue-service";
+
+import { organizationIssuesQuerySchema } from "./issues.schema";
+
+const validateOrganizationIssuesQuery = createZodValidator(
+  "query",
+  organizationIssuesQuerySchema,
+  "invalid_organization_issues_query",
+);
+
+export function createOrganizationIssuesRoutes() {
+  return new Hono<{ Variables: AuthVariables }>()
+    .use("*", workosAuthMiddleware)
+    .get("/", validateOrganizationIssuesQuery, async (c) => {
+      if (!hasCapability(c.var.auth.membership.role, "projects:read")) {
+        return c.json({ error: "forbidden" }, 403);
+      }
+
+      const query = c.req.valid("query");
+      const result = await organizationIssueService.list(c.var.auth, query);
+      return c.json(result, 200);
+    });
+}

--- a/apps/hyperlocalise-web/src/api/routes/issues/issues.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/issues/issues.schema.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+import {
+  issueSheetIssueStatusSchema,
+  issueSheetIssueTypeSchema,
+} from "@/api/routes/project/issue-sheet.schema";
+
+export const organizationIssuesQuerySchema = z.object({
+  view: z.enum(["my_work", "qa_triage", "source_context", "all_open"]).optional(),
+  status: issueSheetIssueStatusSchema.or(z.literal("all")).optional(),
+  issueType: issueSheetIssueTypeSchema.or(z.literal("all")).optional(),
+  locale: z.string().trim().min(1).max(32).optional(),
+  assignee: z.string().uuid().or(z.literal("me")).or(z.literal("unassigned")).optional(),
+  search: z.string().trim().max(200).optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+export type OrganizationIssuesQuery = z.infer<typeof organizationIssuesQuerySchema>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.tsx
@@ -131,7 +131,7 @@ function DashboardPanel({
             aria-label={`Loading ${title.toLowerCase()}`}
           >
             {Array.from({ length: 3 }).map((_, index) => (
-              <Skeleton key={index} className="h-16 rounded-lg bg-muted" />
+              <DashboardPanelCardSkeleton key={index} />
             ))}
           </div>
         ) : isError ? (
@@ -246,28 +246,46 @@ function DashboardSetupHero({
 
 function DashboardHeroSkeleton() {
   return (
-    <Card
-      className="rounded-2xl border border-border bg-card py-0 ring-0 lg:col-span-2"
-      aria-busy="true"
-      aria-label="Loading workspace overview"
-    >
-      <CardContent className="grid min-h-52 gap-6 px-6 py-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,14rem)] lg:items-end">
-        <div className="flex flex-col gap-3">
-          <Skeleton className="h-4 w-40" />
-          <Skeleton className="h-8 w-72 max-w-full" />
-          <Skeleton className="h-4 w-full max-w-xl" />
-          <Skeleton className="h-4 w-4/5 max-w-lg" />
-          <div className="mt-2 flex gap-2">
-            <Skeleton className="h-9 w-32 rounded-full" />
-            <Skeleton className="h-9 w-32 rounded-full" />
+    <>
+      <Card
+        className="rounded-2xl border border-border bg-card py-0 ring-0"
+        aria-busy="true"
+        aria-label="Loading workspace overview"
+      >
+        <CardContent className="flex h-full min-h-52 flex-col justify-between gap-6 px-6 py-6">
+          <div className="flex flex-col gap-3">
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="h-8 w-72 max-w-full" />
+            <Skeleton className="h-4 w-full max-w-xl" />
+            <Skeleton className="h-4 w-4/5 max-w-lg" />
+            <Skeleton className="mt-2 h-9 w-32 rounded-full" />
           </div>
-        </div>
-        <div className="flex flex-col gap-2">
-          <Skeleton className="h-3 w-full" />
-          <Skeleton className="h-2 w-full rounded-full" />
-        </div>
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
+      <Card className="rounded-2xl border border-border bg-muted py-0 ring-0" aria-hidden>
+        <CardContent className="flex h-full min-h-52 flex-col justify-between gap-4 px-6 py-6">
+          <div className="flex flex-col gap-3">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-7 w-56 max-w-full" />
+            <Skeleton className="h-4 w-full max-w-sm" />
+            <Skeleton className="h-4 w-4/5 max-w-xs" />
+          </div>
+          <Skeleton className="h-9 w-32 rounded-full" />
+        </CardContent>
+      </Card>
+    </>
+  );
+}
+
+function DashboardPanelCardSkeleton() {
+  return (
+    <div className="rounded-lg border border-border px-3 py-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <Skeleton className="h-4 w-40" />
+        <Skeleton className="h-5 w-16 rounded-full" />
+      </div>
+      <Skeleton className="mt-2 h-3 w-full max-w-xs" />
+    </div>
   );
 }
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-content.tsx
@@ -5,7 +5,7 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 
 import { readApiResponseError } from "@/lib/api-error";
 
-import { ISSUES_PAGE_SIZE, IssuesPageView } from "./issues-page-view";
+import { ISSUES_PAGE_SIZE, IssuesPageView, type OrganizationIssue } from "./issues-page-view";
 
 const issuesQueryKey = (organizationSlug: string, view: string, search: string) =>
   ["organization-issues", organizationSlug, view, search] as const;
@@ -13,25 +13,6 @@ const issuesQueryKey = (organizationSlug: string, view: string, search: string) 
 function organizationIssuesPath(organizationSlug: string) {
   return `/api/orgs/${encodeURIComponent(organizationSlug)}/issues`;
 }
-
-type OrganizationIssue = {
-  id: string;
-  projectId: string;
-  projectName: string;
-  title: string;
-  description: string;
-  issueType: string;
-  status: string;
-  targetLocale: string | null;
-  sourcePath: string | null;
-  linkKind: string | null;
-  linkLabel: string | null;
-  linkUrl: string | null;
-  reporter: string | null;
-  assignee: string | null;
-  createdAt: string;
-  updatedAt: string;
-};
 
 type OrganizationIssuesResponse = {
   issues: OrganizationIssue[];

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-content.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+import { readApiResponseError } from "@/lib/api-error";
+
+import { ISSUES_PAGE_SIZE, IssuesPageView } from "./issues-page-view";
+
+const issuesQueryKey = (organizationSlug: string, view: string, search: string) =>
+  ["organization-issues", organizationSlug, view, search] as const;
+
+function organizationIssuesPath(organizationSlug: string) {
+  return `/api/orgs/${encodeURIComponent(organizationSlug)}/issues`;
+}
+
+type OrganizationIssue = {
+  id: string;
+  projectId: string;
+  projectName: string;
+  title: string;
+  description: string;
+  issueType: string;
+  status: string;
+  targetLocale: string | null;
+  sourcePath: string | null;
+  linkKind: string | null;
+  linkLabel: string | null;
+  linkUrl: string | null;
+  reporter: string | null;
+  assignee: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type OrganizationIssuesResponse = {
+  issues: OrganizationIssue[];
+  total: number;
+  summary: {
+    total: number;
+    open: number;
+    inProgress: number;
+    resolved: number;
+    wontFix: number;
+  };
+};
+
+export function IssuesPageContent({ organizationSlug }: { organizationSlug: string }) {
+  const [view, setView] = useState<"all_open" | "my_work" | "qa_triage" | "source_context">(
+    "all_open",
+  );
+  const [search, setSearch] = useState("");
+
+  const issuesQuery = useInfiniteQuery({
+    queryKey: issuesQueryKey(organizationSlug, view, search),
+    initialPageParam: 0,
+    queryFn: async ({ pageParam }) => {
+      const params = new URLSearchParams({
+        view,
+        limit: String(ISSUES_PAGE_SIZE),
+        offset: String(pageParam),
+      });
+      const trimmedSearch = search.trim();
+      if (trimmedSearch) {
+        params.set("search", trimmedSearch);
+      }
+
+      const response = await fetch(
+        `${organizationIssuesPath(organizationSlug)}?${params.toString()}`,
+      );
+
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to load issues");
+      }
+
+      return (await response.json()) as OrganizationIssuesResponse;
+    },
+    getNextPageParam: (lastPage, pages) => {
+      const loaded = pages.reduce((sum, page) => sum + page.issues.length, 0);
+      return loaded < lastPage.total ? loaded : undefined;
+    },
+  });
+
+  const issues = useMemo(
+    () => issuesQuery.data?.pages.flatMap((page) => page.issues) ?? [],
+    [issuesQuery.data?.pages],
+  );
+  const summary = issuesQuery.data?.pages[0]?.summary;
+  const total = issuesQuery.data?.pages[0]?.total ?? 0;
+  const hasMore = issues.length < total;
+
+  return (
+    <IssuesPageView
+      organizationSlug={organizationSlug}
+      issues={issues}
+      summary={summary}
+      view={view}
+      search={search}
+      isLoading={issuesQuery.isLoading}
+      isError={issuesQuery.isError}
+      isFetchingMore={issuesQuery.isFetchingNextPage}
+      hasMore={hasMore}
+      onViewChange={setView}
+      onSearchChange={setSearch}
+      onLoadMore={() => {
+        void issuesQuery.fetchNextPage();
+      }}
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import Link from "next/link";
+import { ClipboardListIcon } from "@hugeicons/core-free-icons";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+
+import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
+import { formatRelativeTimestamp } from "../../_components/workspace-files-shared";
+
+export const ISSUES_PAGE_SIZE = 50;
+
+const views = [
+  { value: "all_open", label: "All open" },
+  { value: "my_work", label: "My work" },
+  { value: "qa_triage", label: "QA triage" },
+  { value: "source_context", label: "Source & context" },
+] as const;
+
+type IssueView = (typeof views)[number]["value"];
+
+type OrganizationIssue = {
+  id: string;
+  projectId: string;
+  projectName: string;
+  title: string;
+  description: string;
+  issueType: string;
+  status: string;
+  targetLocale: string | null;
+  sourcePath: string | null;
+  linkKind: string | null;
+  linkLabel: string | null;
+  linkUrl: string | null;
+  reporter: string | null;
+  assignee: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+function formatLabel(value: string) {
+  return value
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function statusVariant(status: string) {
+  if (status === "resolved") return "success" as const;
+  if (status === "wont_fix") return "outline" as const;
+  if (status === "in_progress") return "warning" as const;
+  return "secondary" as const;
+}
+
+function IssueRowSkeleton() {
+  return (
+    <tr>
+      <td className="px-4 py-3">
+        <Skeleton className="h-4 w-48" />
+        <Skeleton className="mt-2 h-3 w-full max-w-xs" />
+      </td>
+      <td className="px-4 py-3">
+        <Skeleton className="h-6 w-28 rounded-full" />
+      </td>
+      <td className="px-4 py-3">
+        <Skeleton className="h-4 w-24" />
+      </td>
+      <td className="px-4 py-3">
+        <Skeleton className="h-4 w-16" />
+      </td>
+      <td className="px-4 py-3">
+        <Skeleton className="h-4 w-32" />
+      </td>
+      <td className="px-4 py-3">
+        <Skeleton className="h-4 w-20" />
+      </td>
+    </tr>
+  );
+}
+
+export function IssuesPageView({
+  organizationSlug,
+  issues,
+  summary,
+  view,
+  search,
+  isLoading,
+  isError,
+  isFetchingMore,
+  hasMore,
+  onViewChange,
+  onSearchChange,
+  onLoadMore,
+}: {
+  organizationSlug: string;
+  issues: OrganizationIssue[];
+  summary?: {
+    total: number;
+    open: number;
+    inProgress: number;
+    resolved: number;
+    wontFix: number;
+  };
+  view: IssueView;
+  search: string;
+  isLoading: boolean;
+  isError: boolean;
+  isFetchingMore: boolean;
+  hasMore: boolean;
+  onViewChange: (view: IssueView) => void;
+  onSearchChange: (search: string) => void;
+  onLoadMore: () => void;
+}) {
+  return (
+    <WorkspacePageShell>
+      <PageHeader
+        icon={ClipboardListIcon}
+        label="Workspace"
+        title="Issues"
+        description="Open issues across all projects in this workspace."
+      />
+
+      <div className="grid gap-3 rounded-2xl border bg-card p-4 md:grid-cols-[220px_1fr]">
+        <Select
+          value={view}
+          onValueChange={(value) => onViewChange((value ?? "all_open") as IssueView)}
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="View" />
+          </SelectTrigger>
+          <SelectContent>
+            {views.map((item) => (
+              <SelectItem key={item.value} value={item.value} label={item.label}>
+                {item.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Input
+          value={search}
+          onChange={(event) => onSearchChange(event.currentTarget.value)}
+          placeholder="Search title, description, project, or source path"
+        />
+      </div>
+
+      {summary ? (
+        <div className="flex flex-wrap gap-2">
+          <Badge variant="secondary">{summary.total} total</Badge>
+          <Badge variant="secondary">{summary.open} open</Badge>
+          <Badge variant="warning">{summary.inProgress} in progress</Badge>
+          <Badge variant="success">{summary.resolved} resolved</Badge>
+        </div>
+      ) : isLoading ? (
+        <div className="flex flex-wrap gap-2" aria-busy="true" aria-label="Loading issue summary">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <Skeleton key={index} className="h-6 w-20 rounded-full" />
+          ))}
+        </div>
+      ) : null}
+
+      <div className="overflow-x-auto rounded-2xl border bg-card">
+        <table className="min-w-full text-sm">
+          <thead className="bg-muted/50 text-left text-xs text-muted-foreground">
+            <tr>
+              <th className="w-56 px-4 py-3 font-medium">Issue</th>
+              <th className="px-4 py-3 font-medium">Status</th>
+              <th className="px-4 py-3 font-medium">Type</th>
+              <th className="px-4 py-3 font-medium">Project</th>
+              <th className="px-4 py-3 font-medium">Locale</th>
+              <th className="px-4 py-3 font-medium">Updated</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            {isLoading ? (
+              Array.from({ length: 5 }).map((_, index) => <IssueRowSkeleton key={index} />)
+            ) : isError ? (
+              <tr>
+                <td colSpan={6} className="px-4 py-10 text-center text-muted-foreground">
+                  Issues could not be loaded.
+                </td>
+              </tr>
+            ) : issues.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="px-4 py-10 text-center text-muted-foreground">
+                  No issues match this view.
+                </td>
+              </tr>
+            ) : (
+              issues.map((issue) => (
+                <tr key={`${issue.projectId}:${issue.id}`} className="align-top">
+                  <td className="max-w-80 px-4 py-3">
+                    <Link
+                      href={`/org/${organizationSlug}/projects/${encodeURIComponent(issue.projectId)}/issue-sheet`}
+                      className="font-medium text-foreground hover:underline"
+                    >
+                      {issue.title}
+                    </Link>
+                    <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+                      {issue.description || issue.sourcePath || "No details yet"}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <Badge
+                      variant={statusVariant(issue.status)}
+                      className="rounded-full capitalize"
+                    >
+                      {formatLabel(issue.status)}
+                    </Badge>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {formatLabel(issue.issueType)}
+                  </td>
+                  <td className="px-4 py-3">
+                    <Link
+                      href={`/org/${organizationSlug}/projects/${encodeURIComponent(issue.projectId)}`}
+                      className="text-foreground hover:underline"
+                    >
+                      {issue.projectName}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">{issue.targetLocale ?? "—"}</td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {formatRelativeTimestamp(issue.updatedAt)}
+                  </td>
+                </tr>
+              ))
+            )}
+            {isFetchingMore
+              ? Array.from({ length: 3 }).map((_, index) => (
+                  <IssueRowSkeleton key={`more-${index}`} />
+                ))
+              : null}
+          </tbody>
+        </table>
+      </div>
+
+      {hasMore && !isLoading ? (
+        <div className="flex justify-center">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onLoadMore}
+            disabled={isFetchingMore}
+            className="rounded-full"
+          >
+            {isFetchingMore ? "Loading..." : "Load more"}
+          </Button>
+        </div>
+      ) : null}
+    </WorkspacePageShell>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.tsx
@@ -29,7 +29,7 @@ const views = [
 
 type IssueView = (typeof views)[number]["value"];
 
-type OrganizationIssue = {
+export type OrganizationIssue = {
   id: string;
   projectId: string;
   projectName: string;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/page.tsx
@@ -1,0 +1,14 @@
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
+
+import { IssuesPageContent } from "./_components/issues-page-content";
+
+export default async function IssuesPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  const { organizationSlug } = await params;
+  await requireAppAuthContext({ organizationSlug });
+
+  return <IssuesPageContent organizationSlug={organizationSlug} />;
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
@@ -31,7 +31,7 @@ import {
 } from "./project-form";
 import { ProjectDialog } from "./project-dialog";
 import { mapProjectToListRow, type ProjectListRow } from "./project-list";
-import { ProjectsTable } from "./projects-table";
+import { PROJECTS_PAGE_SIZE, ProjectsTable } from "./projects-table";
 import { recordRecentProjectVisit, resolveRecentProjects } from "./recent-projects";
 
 const nativeProjectsQueryKey = (organizationSlug: string) =>
@@ -117,6 +117,8 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
   const [deleteProject, setDeleteProject] = useState<ProjectListRow | null>(null);
   const [sourceFilter, setSourceFilter] = useState<ProjectSourceFilter>("all");
   const [recentProjects, setRecentProjects] = useState<Array<{ id: string; name: string }>>([]);
+  const [nativeVisibleCount, setNativeVisibleCount] = useState(PROJECTS_PAGE_SIZE);
+  const [tmsVisibleCount, setTmsVisibleCount] = useState(PROJECTS_PAGE_SIZE);
 
   const nativeProjectsQuery = useQuery({
     queryKey: nativeProjectsQueryKey(organizationSlug),
@@ -233,6 +235,24 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
     });
   }, [searchQuery, tmsProjects]);
 
+  useEffect(() => {
+    setNativeVisibleCount(PROJECTS_PAGE_SIZE);
+    setTmsVisibleCount(PROJECTS_PAGE_SIZE);
+  }, [searchQuery, sourceFilter]);
+
+  const visibleNativeProjects = filteredNativeProjects.slice(0, nativeVisibleCount);
+  const visibleTmsProjects = filteredTmsProjects.slice(0, tmsVisibleCount);
+  const hasMoreNativeProjects = visibleNativeProjects.length < filteredNativeProjects.length;
+  const hasMoreTmsProjects = visibleTmsProjects.length < filteredTmsProjects.length;
+
+  const loadMoreNativeProjects = useCallback(() => {
+    setNativeVisibleCount((current) => current + PROJECTS_PAGE_SIZE);
+  }, []);
+
+  const loadMoreTmsProjects = useCallback(() => {
+    setTmsVisibleCount((current) => current + PROJECTS_PAGE_SIZE);
+  }, []);
+
   const handleOpenProject = useCallback(
     (projectId: string) => {
       recordRecentProjectVisit(organizationSlug, projectId);
@@ -266,8 +286,8 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
     (sourceFilter === "all" || sourceFilter === "tms");
   const showNativeSection = sourceFilter === "all" || sourceFilter === "native";
   const hasFilteredResults =
-    (showNativeSection && filteredNativeProjects.length > 0) ||
-    (showTmsSection && filteredTmsProjects.length > 0);
+    (showNativeSection && visibleNativeProjects.length > 0) ||
+    (showTmsSection && visibleTmsProjects.length > 0);
   const tmsProviderName = activeTmsProviderQuery.data
     ? getTmsProviderBranding(activeTmsProviderQuery.data.providerKind).name
     : "TMS";
@@ -337,12 +357,14 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
         description="Live projects fetched from your connected TMS provider, ordered by recent activity."
       />
       <ProjectsTable
-        projects={filteredTmsProjects}
+        projects={visibleTmsProjects}
         projectsQuery={tmsProjectsQuery}
         isSavingProject={isSavingProject}
         isDeletingProject={deleteProjectMutation.isPending}
         organizationSlug={organizationSlug}
         variant="tms"
+        hasMore={hasMoreTmsProjects}
+        onLoadMore={loadMoreTmsProjects}
         onOpenProject={handleOpenProject}
       />
     </section>
@@ -355,13 +377,15 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
         description="Projects created and managed in this workspace."
       />
       <ProjectsTable
-        projects={filteredNativeProjects}
+        projects={visibleNativeProjects}
         projectsQuery={nativeProjectsQuery}
         isSavingProject={isSavingProject}
         isDeletingProject={deleteProjectMutation.isPending}
         organizationSlug={organizationSlug}
         variant="native"
         compactEmptyNative={compactNativeEmpty}
+        hasMore={hasMoreNativeProjects}
+        onLoadMore={loadMoreNativeProjects}
         onEditProject={openEditProjectDialog}
         onDeleteProject={setDeleteProject}
         onCreateProject={openCreateProjectDialog}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
@@ -340,7 +340,7 @@ export function ProjectsTable({
           aria-busy="true"
           aria-label="Loading projects"
         >
-          {Array.from({ length: variant === "tms" ? 4 : 4 }).map((_, index) =>
+          {Array.from({ length: 4 }).map((_, index) =>
             variant === "tms" ? (
               <TmsProjectCardSkeleton key={index} />
             ) : (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
@@ -11,6 +11,7 @@ import type { UseQueryResult } from "@tanstack/react-query";
 import { TmsUserConnectionErrorPanel } from "@/components/app-shell/tms-user-connection-prompt";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { TypographyH3, TypographyP } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
@@ -20,6 +21,42 @@ import { isTmsUserConnectionRequiredError } from "@/lib/providers/credentials/tm
 import { formatRelativeTimestamp } from "../../_components/workspace-files-shared";
 import { ProjectAvatar } from "./project-avatar";
 import { formatProjectLocaleRoute, type ProjectListRow } from "./project-list";
+
+export const PROJECTS_PAGE_SIZE = 12;
+
+function TmsProjectCardSkeleton() {
+  return (
+    <article className="rounded-lg border border-border bg-muted p-4">
+      <div className="flex items-start gap-3">
+        <Skeleton className="size-10 shrink-0 rounded-lg" />
+        <div className="min-w-0 flex-1 space-y-2">
+          <Skeleton className="h-4 w-48 max-w-full" />
+          <Skeleton className="h-3 w-full max-w-sm" />
+          <Skeleton className="h-3 w-32" />
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function NativeProjectCardSkeleton() {
+  return (
+    <article className="rounded-lg border border-border bg-muted p-4">
+      <div className="flex items-start gap-3">
+        <Skeleton className="size-10 shrink-0 rounded-lg" />
+        <div className="min-w-0 flex-1 space-y-2">
+          <Skeleton className="h-4 w-40 max-w-full" />
+          <Skeleton className="h-3 w-full" />
+          <Skeleton className="h-3 w-4/5" />
+        </div>
+      </div>
+      <dl className="mt-4 grid grid-cols-2 gap-3">
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-8 w-full" />
+      </dl>
+    </article>
+  );
+}
 
 function NativeEmptyState({
   compact,
@@ -270,6 +307,8 @@ export function ProjectsTable({
   organizationSlug,
   variant,
   compactEmptyNative = false,
+  hasMore = false,
+  onLoadMore,
   onEditProject,
   onDeleteProject,
   onCreateProject,
@@ -282,6 +321,8 @@ export function ProjectsTable({
   organizationSlug: string;
   variant: "native" | "tms";
   compactEmptyNative?: boolean;
+  hasMore?: boolean;
+  onLoadMore?: () => void;
   onEditProject?: (project: ProjectListRow) => void;
   onDeleteProject?: (project: ProjectListRow) => void;
   onCreateProject?: () => void;
@@ -294,8 +335,18 @@ export function ProjectsTable({
   return (
     <section>
       {projectsQuery.isLoading ? (
-        <div className={cn("text-sm text-muted-foreground", variant === "tms" ? "py-4" : "py-8")}>
-          Loading projects...
+        <div
+          className={cn(variant === "tms" ? "grid gap-2 py-4" : "grid gap-3 py-8 lg:grid-cols-2")}
+          aria-busy="true"
+          aria-label="Loading projects"
+        >
+          {Array.from({ length: variant === "tms" ? 4 : 4 }).map((_, index) =>
+            variant === "tms" ? (
+              <TmsProjectCardSkeleton key={index} />
+            ) : (
+              <NativeProjectCardSkeleton key={index} />
+            ),
+          )}
         </div>
       ) : null}
       {projectsQuery.isError ? (
@@ -364,6 +415,13 @@ export function ProjectsTable({
               onOpenProject={onOpenProject}
             />
           ))}
+        </div>
+      ) : null}
+      {hasMore && projectsQuery.isSuccess && projects.length > 0 && onLoadMore ? (
+        <div className={cn("flex justify-center", variant === "tms" ? "pt-4" : "pt-6")}>
+          <Button type="button" variant="outline" onClick={onLoadMore} className="rounded-full">
+            Load more
+          </Button>
         </div>
       ) : null}
     </section>

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
@@ -10,6 +10,7 @@ const ROUTE_TITLES = {
   glossaries: "Glossaries",
   inbox: "Inbox",
   integrations: "Integrations",
+  issues: "Issues",
   "issue-sheet": "Issue Sheet",
   jobs: "Jobs",
   knowledge: "Knowledge",

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -71,6 +71,11 @@ export function buildGlobalNavigationGroups(organizationSlug: string): readonly 
           icon: WorkHistoryIcon,
         },
         {
+          label: "Issues",
+          href: org("issues"),
+          icon: ClipboardListIcon,
+        },
+        {
           label: "Overview",
           href: org("dashboard"),
           icon: DashboardSquare01Icon,

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/organization-issue-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/organization-issue-service.ts
@@ -1,0 +1,255 @@
+import { and, count, desc, eq, ilike, inArray, isNull, or, sql, type SQL } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
+
+import type { OrganizationIssuesQuery } from "@/api/routes/issues/issues.schema";
+import { buildAccessibleProjectsWhere } from "@/api/auth/team-access";
+import type { ApiAuthContext } from "@/api/auth/workos";
+import { db, schema } from "@/lib/database";
+
+const assigneeUsers = alias(schema.users, "org_issue_assignee_users");
+
+export type OrganizationIssueListItem = {
+  id: string;
+  projectId: string;
+  projectName: string;
+  title: string;
+  description: string;
+  issueType: string;
+  status: string;
+  targetLocale: string | null;
+  sourcePath: string | null;
+  segmentId: string | null;
+  linkKind: string | null;
+  linkLabel: string | null;
+  linkUrl: string | null;
+  reporter: string | null;
+  assignee: string | null;
+  assigneeUserId: string | null;
+  key: string | null;
+  sourceText: string | null;
+  createdAt: string;
+  updatedAt: string;
+  resolvedAt: string | null;
+};
+
+export type OrganizationIssueListResult = {
+  issues: OrganizationIssueListItem[];
+  total: number;
+  summary: {
+    total: number;
+    open: number;
+    inProgress: number;
+    resolved: number;
+    wontFix: number;
+  };
+};
+
+function formatUser(row: {
+  firstName: string | null;
+  lastName: string | null;
+  email: string | null;
+}) {
+  if (!row.email) {
+    return null;
+  }
+  const name = [row.firstName, row.lastName].filter(Boolean).join(" ");
+  return name || row.email;
+}
+
+function buildOrganizationIssueConditions(input: {
+  organizationId: string;
+  actorUserId: string;
+  query: OrganizationIssuesQuery;
+  accessibleProjectsWhere: SQL;
+}) {
+  const conditions: SQL[] = [
+    eq(schema.issueSheetIssues.organizationId, input.organizationId),
+    input.accessibleProjectsWhere,
+  ];
+
+  const view = input.query.view;
+  if (view === "my_work") {
+    conditions.push(eq(schema.issueSheetIssues.assigneeUserId, input.actorUserId));
+    conditions.push(inArray(schema.issueSheetIssues.status, ["open", "in_progress"]));
+  } else if (view === "qa_triage") {
+    conditions.push(eq(schema.issueSheetIssues.issueType, "qa_failure"));
+    conditions.push(isNull(schema.issueSheetIssues.assigneeUserId));
+    conditions.push(inArray(schema.issueSheetIssues.status, ["open", "in_progress"]));
+  } else if (view === "source_context") {
+    conditions.push(
+      inArray(schema.issueSheetIssues.issueType, [
+        "source_mistake",
+        "context_request",
+        "general_question",
+      ]),
+    );
+    conditions.push(inArray(schema.issueSheetIssues.status, ["open", "in_progress"]));
+  } else if (view === "all_open") {
+    conditions.push(inArray(schema.issueSheetIssues.status, ["open", "in_progress"]));
+  }
+
+  if (!view && input.query.status && input.query.status !== "all") {
+    conditions.push(eq(schema.issueSheetIssues.status, input.query.status));
+  }
+  if (input.query.issueType && input.query.issueType !== "all") {
+    conditions.push(eq(schema.issueSheetIssues.issueType, input.query.issueType));
+  }
+  if (input.query.locale) {
+    conditions.push(eq(schema.issueSheetIssues.targetLocale, input.query.locale));
+  }
+  if (input.query.assignee === "me") {
+    conditions.push(eq(schema.issueSheetIssues.assigneeUserId, input.actorUserId));
+  } else if (input.query.assignee === "unassigned") {
+    conditions.push(isNull(schema.issueSheetIssues.assigneeUserId));
+  } else if (input.query.assignee) {
+    conditions.push(eq(schema.issueSheetIssues.assigneeUserId, input.query.assignee));
+  }
+  if (input.query.search) {
+    const search = `%${input.query.search}%`;
+    conditions.push(
+      or(
+        ilike(schema.issueSheetIssues.title, search),
+        ilike(schema.issueSheetIssues.description, search),
+        ilike(schema.issueSheetIssues.sourcePath, search),
+        ilike(schema.projects.name, search),
+      )!,
+    );
+  }
+
+  return conditions;
+}
+
+export class OrganizationIssueService {
+  constructor(private readonly database = db) {}
+
+  async list(
+    auth: ApiAuthContext,
+    query: OrganizationIssuesQuery,
+  ): Promise<OrganizationIssueListResult> {
+    const organizationId = auth.organization.localOrganizationId;
+    const accessibleProjectsWhere = await buildAccessibleProjectsWhere(auth);
+    const issueProjectJoin = eq(schema.issueSheetIssues.projectId, schema.projects.id);
+    const conditions = buildOrganizationIssueConditions({
+      organizationId,
+      actorUserId: auth.user.localUserId,
+      query,
+      accessibleProjectsWhere,
+    });
+    const where = and(...conditions, issueProjectJoin);
+
+    const [rows, totalRow, summary] = await Promise.all([
+      this.database
+        .select({
+          id: schema.issueSheetIssues.id,
+          projectId: schema.issueSheetIssues.projectId,
+          projectName: schema.projects.name,
+          title: schema.issueSheetIssues.title,
+          description: schema.issueSheetIssues.description,
+          issueType: schema.issueSheetIssues.issueType,
+          status: schema.issueSheetIssues.status,
+          targetLocale: schema.issueSheetIssues.targetLocale,
+          sourcePath: schema.issueSheetIssues.sourcePath,
+          segmentId: schema.issueSheetIssues.segmentId,
+          linkKind: schema.issueSheetIssues.linkKind,
+          linkLabel: schema.issueSheetIssues.linkLabel,
+          linkUrl: schema.issueSheetIssues.linkUrl,
+          assigneeUserId: schema.issueSheetIssues.assigneeUserId,
+          reporterFirstName: schema.users.firstName,
+          reporterLastName: schema.users.lastName,
+          reporterEmail: schema.users.email,
+          assigneeFirstName: assigneeUsers.firstName,
+          assigneeLastName: assigneeUsers.lastName,
+          assigneeEmail: assigneeUsers.email,
+          key: schema.projectTranslationKeys.key,
+          sourceText: schema.projectTranslationKeys.sourceText,
+          createdAt: schema.issueSheetIssues.createdAt,
+          updatedAt: schema.issueSheetIssues.updatedAt,
+          resolvedAt: schema.issueSheetIssues.resolvedAt,
+        })
+        .from(schema.issueSheetIssues)
+        .innerJoin(schema.projects, issueProjectJoin)
+        .leftJoin(schema.users, eq(schema.issueSheetIssues.reporterUserId, schema.users.id))
+        .leftJoin(assigneeUsers, eq(schema.issueSheetIssues.assigneeUserId, assigneeUsers.id))
+        .leftJoin(
+          schema.projectTranslationKeys,
+          eq(schema.issueSheetIssues.translationKeyId, schema.projectTranslationKeys.id),
+        )
+        .where(where)
+        .orderBy(desc(schema.issueSheetIssues.updatedAt))
+        .limit(query.limit)
+        .offset(query.offset),
+      this.database
+        .select({ value: count() })
+        .from(schema.issueSheetIssues)
+        .innerJoin(schema.projects, issueProjectJoin)
+        .where(where),
+      this.loadSummary(organizationId, accessibleProjectsWhere),
+    ]);
+
+    return {
+      issues: rows.map((row) => ({
+        id: row.id,
+        projectId: row.projectId,
+        projectName: row.projectName,
+        title: row.title,
+        description: row.description,
+        issueType: row.issueType,
+        status: row.status,
+        targetLocale: row.targetLocale,
+        sourcePath: row.sourcePath,
+        segmentId: row.segmentId,
+        linkKind: row.linkKind,
+        linkLabel: row.linkLabel,
+        linkUrl: row.linkUrl,
+        assigneeUserId: row.assigneeUserId,
+        reporter: formatUser({
+          firstName: row.reporterFirstName,
+          lastName: row.reporterLastName,
+          email: row.reporterEmail,
+        }),
+        assignee: formatUser({
+          firstName: row.assigneeFirstName,
+          lastName: row.assigneeLastName,
+          email: row.assigneeEmail,
+        }),
+        key: row.key,
+        sourceText: row.sourceText,
+        createdAt: row.createdAt.toISOString(),
+        updatedAt: row.updatedAt.toISOString(),
+        resolvedAt: row.resolvedAt?.toISOString() ?? null,
+      })),
+      total: totalRow[0]?.value ?? 0,
+      summary,
+    };
+  }
+
+  private async loadSummary(organizationId: string, accessibleProjectsWhere: SQL) {
+    const issueProjectJoin = eq(schema.issueSheetIssues.projectId, schema.projects.id);
+    const rows = await this.database
+      .select({
+        status: schema.issueSheetIssues.status,
+        count: sql<number>`count(*)`.mapWith(Number),
+      })
+      .from(schema.issueSheetIssues)
+      .innerJoin(schema.projects, issueProjectJoin)
+      .where(
+        and(
+          eq(schema.issueSheetIssues.organizationId, organizationId),
+          accessibleProjectsWhere,
+          issueProjectJoin,
+        ),
+      )
+      .groupBy(schema.issueSheetIssues.status);
+
+    const counts = new Map(rows.map((row) => [row.status, row.count]));
+    return {
+      total: rows.reduce((sum, row) => sum + row.count, 0),
+      open: counts.get("open") ?? 0,
+      inProgress: counts.get("in_progress") ?? 0,
+      resolved: counts.get("resolved") ?? 0,
+      wontFix: counts.get("wont_fix") ?? 0,
+    };
+  }
+}
+
+export const organizationIssueService = new OrganizationIssueService();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds **Issues** to the main sidebar, linking to a new workspace-wide issues page that aggregates issue sheet rows across all accessible projects
- Improves **dashboard** loading states with per-card skeletons in the hero section and job/project panels
- Adds **Load more** pagination to both Hyperlocalise (native) and TMS project lists on the Projects page

## Changes

### Workspace Issues
- New API: `GET /api/orgs/:organizationSlug/issues` with view filters, search, and pagination
- New page at `/org/:slug/issues` with summary badges, filterable table, and links to project issue sheets
- Sidebar nav item placed after "My Jobs"

### Dashboard
- Hero loading now shows two card-shaped skeletons (matching the loaded two-card layout)
- Panel loading uses structured card skeletons instead of plain blocks

### Projects
- Initial page size of 12 projects per section (native and TMS)
- "Load more" button reveals the next batch client-side
- Skeleton card placeholders while projects are loading

## Test plan

- [x] `vp check --fix` passes
- [x] `vp test src/api/routes/issues/issues.route.test.ts` passes
- [x] Full `vp test` suite: 2481/2482 passed (1 unrelated Autumn tracking flake)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3b7d-1c20-7b13-843d-2659eec69c4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3b7d-1c20-7b13-843d-2659eec69c4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

