### PR TITLE
feat(web): add Storybook stories for Issues Sheet pages

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.stories.tsx
@@ -1,0 +1,111 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, fn } from "storybook/test";
+
+import {
+  issuesOrganizationSlug,
+  issuesSummaryFixture,
+  organizationIssuesFixture,
+} from "./issues.fixture";
+import { IssuesPageView } from "./issues-page-view";
+
+const meta = {
+  title: "App/Issues/Page",
+  component: IssuesPageView,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    organizationSlug: issuesOrganizationSlug,
+    issues: organizationIssuesFixture,
+    summary: issuesSummaryFixture,
+    view: "all_open",
+    search: "",
+    isLoading: false,
+    isError: false,
+    isFetchingMore: false,
+    hasMore: false,
+    onViewChange: fn(),
+    onSearchChange: fn(),
+    onLoadMore: fn(),
+  },
+} satisfies Meta<typeof IssuesPageView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Issues" })).toBeInTheDocument();
+    await expect(canvas.getByText("Source string needs context")).toBeInTheDocument();
+    await expect(canvas.getByText("Website localization")).toBeInTheDocument();
+    await expect(canvas.getByText("4 total")).toBeInTheDocument();
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    issues: [],
+    summary: undefined,
+    isLoading: true,
+  },
+  play: async ({ canvas, canvasElement }) => {
+    await expect(canvas.getByRole("heading", { name: "Issues" })).toBeInTheDocument();
+    await expect(canvasElement.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(
+      0,
+    );
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    issues: [],
+    summary: {
+      total: 0,
+      open: 0,
+      inProgress: 0,
+      resolved: 0,
+      wontFix: 0,
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("No issues match this view.")).toBeInTheDocument();
+  },
+};
+
+export const Error: Story = {
+  args: {
+    issues: [],
+    summary: undefined,
+    isError: true,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Issues could not be loaded.")).toBeInTheDocument();
+  },
+};
+
+export const LoadMore: Story = {
+  args: {
+    hasMore: true,
+    isFetchingMore: true,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("button", { name: "Loading..." })).toBeDisabled();
+  },
+};
+
+export const QaTriageView: Story = {
+  args: {
+    view: "qa_triage",
+    issues: organizationIssuesFixture.filter((issue) => issue.issueType === "qa_failure"),
+    summary: {
+      total: 1,
+      open: 0,
+      inProgress: 0,
+      resolved: 1,
+      wontFix: 0,
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("QA failure on hero headline")).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues.fixture.ts
@@ -1,0 +1,82 @@
+import type { OrganizationIssue } from "./issues-page-view";
+
+const fixedNow = "2026-06-07T12:00:00.000Z";
+
+function iso(offsetMs: number) {
+  return new Date(Date.parse(fixedNow) + offsetMs).toISOString();
+}
+
+export const issuesOrganizationSlug = "acme";
+
+export const issuesSummaryFixture = {
+  total: 4,
+  open: 2,
+  inProgress: 1,
+  resolved: 1,
+  wontFix: 0,
+};
+
+export function createOrganizationIssue(
+  overrides: Partial<OrganizationIssue> = {},
+): OrganizationIssue {
+  return {
+    id: "issue_001",
+    projectId: "project_website",
+    projectName: "Website localization",
+    title: "Source string needs context",
+    description: "The CTA is ambiguous for German translators.",
+    issueType: "context_request",
+    status: "open",
+    targetLocale: "de-DE",
+    sourcePath: "messages/home.json",
+    linkKind: "cat_segment",
+    linkLabel: "Open in CAT",
+    linkUrl: null,
+    reporter: "Mina Chen",
+    assignee: "Otto Klein",
+    createdAt: iso(-86_400_000),
+    updatedAt: iso(-1_800_000),
+    ...overrides,
+  };
+}
+
+export const organizationIssuesFixture: OrganizationIssue[] = [
+  createOrganizationIssue(),
+  createOrganizationIssue({
+    id: "issue_002",
+    title: "Translation mistake in checkout",
+    description: "Payment button label is too long in French.",
+    issueType: "translation_mistake",
+    status: "in_progress",
+    targetLocale: "fr-FR",
+    sourcePath: "messages/checkout.json",
+    assignee: "Mina Chen",
+    updatedAt: iso(-3_600_000),
+  }),
+  createOrganizationIssue({
+    id: "issue_003",
+    projectId: "project_mobile",
+    projectName: "Mobile app",
+    title: "Glossary violation in onboarding",
+    description: "Product name should stay untranslated.",
+    issueType: "glossary_violation",
+    status: "open",
+    targetLocale: "es-ES",
+    sourcePath: "mobile/onboarding.json",
+    reporter: "Aiko Tanaka",
+    assignee: null,
+    updatedAt: iso(-7_200_000),
+  }),
+  createOrganizationIssue({
+    id: "issue_004",
+    title: "QA failure on hero headline",
+    description: "Length check failed for German headline.",
+    issueType: "qa_failure",
+    status: "resolved",
+    targetLocale: "de-DE",
+    sourcePath: "messages/home.json",
+    reporter: "QA Bot",
+    assignee: "Otto Klein",
+    updatedAt: iso(-172_800_000),
+  }),
+];

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-msw-handlers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-msw-handlers.ts
@@ -6,48 +6,38 @@ import {
   issueSheetResponseFixture,
 } from "./issue-sheet.fixture";
 
-function issueSheetPath(organizationSlug: string, projectId: string, suffix = "") {
-  return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/issue-sheet${suffix}`;
-}
+const issueSheetBasePath = "/api/orgs/:organizationSlug/projects/:projectId/issue-sheet";
 
 export const issueSheetMswHandlers = [
   http.get("/api/orgs/:organizationSlug/projects/:projectId", () =>
     HttpResponse.json({ project: issueSheetProjectFixture }),
   ),
-  http.get(issueSheetPath(":organizationSlug", ":projectId"), () =>
-    HttpResponse.json(issueSheetResponseFixture),
-  ),
-  http.patch(
-    issueSheetPath(":organizationSlug", ":projectId", "/:issueId"),
-    async ({ params, request }) => {
-      const body = (await request.json()) as Record<string, unknown>;
-      const issue = issueSheetIssuesFixture.find((row) => row.id === params.issueId);
-      if (!issue) {
-        return HttpResponse.json({ error: "issue_not_found" }, { status: 404 });
-      }
-      return HttpResponse.json({
-        issue: {
-          ...issue,
-          ...body,
-          updatedAt: new Date().toISOString(),
-        },
-      });
-    },
-  ),
-  http.patch(
-    issueSheetPath(":organizationSlug", ":projectId", "/:issueId/values"),
-    async ({ params, request }) => {
-      const body = (await request.json()) as { columnKey: string; value: unknown };
-      const issue = issueSheetIssuesFixture.find((row) => row.id === params.issueId);
-      if (!issue) {
-        return HttpResponse.json({ error: "issue_not_found" }, { status: 404 });
-      }
-      return HttpResponse.json({
-        value: body.value,
-      });
-    },
-  ),
-  http.post(issueSheetPath(":organizationSlug", ":projectId"), async ({ request }) => {
+  http.get(issueSheetBasePath, () => HttpResponse.json(issueSheetResponseFixture)),
+  http.patch(`${issueSheetBasePath}/:issueId`, async ({ params, request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    const issue = issueSheetIssuesFixture.find((row) => row.id === params.issueId);
+    if (!issue) {
+      return HttpResponse.json({ error: "issue_not_found" }, { status: 404 });
+    }
+    return HttpResponse.json({
+      issue: {
+        ...issue,
+        ...body,
+        updatedAt: new Date().toISOString(),
+      },
+    });
+  }),
+  http.patch(`${issueSheetBasePath}/:issueId/values`, async ({ params, request }) => {
+    const body = (await request.json()) as { columnKey: string; value: unknown };
+    const issue = issueSheetIssuesFixture.find((row) => row.id === params.issueId);
+    if (!issue) {
+      return HttpResponse.json({ error: "issue_not_found" }, { status: 404 });
+    }
+    return HttpResponse.json({
+      value: body.value,
+    });
+  }),
+  http.post(issueSheetBasePath, async ({ request }) => {
     const body = (await request.json()) as Record<string, unknown>;
     const issue = issueSheetIssuesFixture[0];
     return HttpResponse.json(
@@ -62,7 +52,7 @@ export const issueSheetMswHandlers = [
       { status: 201 },
     );
   }),
-  http.post(issueSheetPath(":organizationSlug", ":projectId", "/columns"), async ({ request }) => {
+  http.post(`${issueSheetBasePath}/columns`, async ({ request }) => {
     const body = (await request.json()) as {
       key: string;
       label: string;
@@ -90,7 +80,7 @@ export const issueSheetEmptyMswHandlers = [
   http.get("/api/orgs/:organizationSlug/projects/:projectId", () =>
     HttpResponse.json({ project: issueSheetProjectFixture }),
   ),
-  http.get(issueSheetPath(":organizationSlug", ":projectId"), () =>
+  http.get(issueSheetBasePath, () =>
     HttpResponse.json({
       issues: [],
       columns: issueSheetResponseFixture.columns,
@@ -110,7 +100,7 @@ export const issueSheetLoadingMswHandlers = [
     await delay("infinite");
     return HttpResponse.json({ project: issueSheetProjectFixture });
   }),
-  http.get(issueSheetPath(":organizationSlug", ":projectId"), async () => {
+  http.get(issueSheetBasePath, async () => {
     await delay("infinite");
     return HttpResponse.json(issueSheetResponseFixture);
   }),
@@ -120,7 +110,7 @@ export const issueSheetErrorMswHandlers = [
   http.get("/api/orgs/:organizationSlug/projects/:projectId", () =>
     HttpResponse.json({ project: issueSheetProjectFixture }),
   ),
-  http.get(issueSheetPath(":organizationSlug", ":projectId"), () =>
+  http.get(issueSheetBasePath, () =>
     HttpResponse.json({ error: "issue_sheet_load_failed" }, { status: 500 }),
   ),
 ];

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-msw-handlers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-msw-handlers.ts
@@ -1,0 +1,126 @@
+import { delay, http, HttpResponse } from "msw";
+
+import {
+  issueSheetIssuesFixture,
+  issueSheetProjectFixture,
+  issueSheetResponseFixture,
+} from "./issue-sheet.fixture";
+
+function issueSheetPath(organizationSlug: string, projectId: string, suffix = "") {
+  return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/issue-sheet${suffix}`;
+}
+
+export const issueSheetMswHandlers = [
+  http.get("/api/orgs/:organizationSlug/projects/:projectId", () =>
+    HttpResponse.json({ project: issueSheetProjectFixture }),
+  ),
+  http.get(issueSheetPath(":organizationSlug", ":projectId"), () =>
+    HttpResponse.json(issueSheetResponseFixture),
+  ),
+  http.patch(
+    issueSheetPath(":organizationSlug", ":projectId", "/:issueId"),
+    async ({ params, request }) => {
+      const body = (await request.json()) as Record<string, unknown>;
+      const issue = issueSheetIssuesFixture.find((row) => row.id === params.issueId);
+      if (!issue) {
+        return HttpResponse.json({ error: "issue_not_found" }, { status: 404 });
+      }
+      return HttpResponse.json({
+        issue: {
+          ...issue,
+          ...body,
+          updatedAt: new Date().toISOString(),
+        },
+      });
+    },
+  ),
+  http.patch(
+    issueSheetPath(":organizationSlug", ":projectId", "/:issueId/values"),
+    async ({ params, request }) => {
+      const body = (await request.json()) as { columnKey: string; value: unknown };
+      const issue = issueSheetIssuesFixture.find((row) => row.id === params.issueId);
+      if (!issue) {
+        return HttpResponse.json({ error: "issue_not_found" }, { status: 404 });
+      }
+      return HttpResponse.json({
+        value: body.value,
+      });
+    },
+  ),
+  http.post(issueSheetPath(":organizationSlug", ":projectId"), async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    const issue = issueSheetIssuesFixture[0];
+    return HttpResponse.json(
+      {
+        issue: {
+          ...issue,
+          id: "issue_new",
+          title: typeof body.title === "string" ? body.title : issue.title,
+          description: typeof body.description === "string" ? body.description : issue.description,
+        },
+      },
+      { status: 201 },
+    );
+  }),
+  http.post(issueSheetPath(":organizationSlug", ":projectId", "/columns"), async ({ request }) => {
+    const body = (await request.json()) as {
+      key: string;
+      label: string;
+      type: string;
+      config?: { options?: { id: string; label: string }[] };
+    };
+    return HttpResponse.json(
+      {
+        column: {
+          id: `col_${body.key}`,
+          key: body.key,
+          label: body.label,
+          layer: "custom",
+          type: body.type,
+          config: body.config ?? {},
+          sortOrder: issueSheetResponseFixture.columns.length,
+        },
+      },
+      { status: 201 },
+    );
+  }),
+];
+
+export const issueSheetEmptyMswHandlers = [
+  http.get("/api/orgs/:organizationSlug/projects/:projectId", () =>
+    HttpResponse.json({ project: issueSheetProjectFixture }),
+  ),
+  http.get(issueSheetPath(":organizationSlug", ":projectId"), () =>
+    HttpResponse.json({
+      issues: [],
+      columns: issueSheetResponseFixture.columns,
+      summary: {
+        total: 0,
+        open: 0,
+        inProgress: 0,
+        resolved: 0,
+        wontFix: 0,
+      },
+    }),
+  ),
+];
+
+export const issueSheetLoadingMswHandlers = [
+  http.get("/api/orgs/:organizationSlug/projects/:projectId", async () => {
+    await delay("infinite");
+    return HttpResponse.json({ project: issueSheetProjectFixture });
+  }),
+  http.get(issueSheetPath(":organizationSlug", ":projectId"), async () => {
+    await delay("infinite");
+    return HttpResponse.json(issueSheetResponseFixture);
+  }),
+];
+
+export const issueSheetErrorMswHandlers = [
+  http.get("/api/orgs/:organizationSlug/projects/:projectId", () =>
+    HttpResponse.json({ project: issueSheetProjectFixture }),
+  ),
+  http.get(issueSheetPath(":organizationSlug", ":projectId"), () =>
+    HttpResponse.json({ error: "issue_sheet_load_failed" }, { status: 500 }),
+  ),
+];

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect } from "storybook/test";
+
+import {
+  issueSheetEmptyMswHandlers,
+  issueSheetErrorMswHandlers,
+  issueSheetLoadingMswHandlers,
+  issueSheetMswHandlers,
+} from "./issue-sheet-msw-handlers";
+import { issueSheetOrganizationSlug, issueSheetProjectId } from "./issue-sheet.fixture";
+import { IssueSheetPageContent } from "./issue-sheet-page-content";
+
+const meta = {
+  title: "App/Project/Issue Sheet/Page",
+  component: IssueSheetPageContent,
+  parameters: {
+    layout: "fullscreen",
+    nextjs: {
+      navigation: {
+        pathname: `/org/${issueSheetOrganizationSlug}/projects/${issueSheetProjectId}/issue-sheet`,
+      },
+    },
+  },
+  args: {
+    organizationSlug: issueSheetOrganizationSlug,
+    projectId: issueSheetProjectId,
+  },
+} satisfies Meta<typeof IssueSheetPageContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: issueSheetMswHandlers,
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Issue Sheet")).toBeInTheDocument();
+    await expect(canvas.getByText("Source string needs context")).toBeInTheDocument();
+    await expect(canvas.getByText("3 total")).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Issue" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Column" })).toBeInTheDocument();
+  },
+};
+
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: issueSheetLoadingMswHandlers,
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Issue Sheet")).toBeInTheDocument();
+    await expect(canvas.getByText("Loading issues...")).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  parameters: {
+    msw: {
+      handlers: issueSheetEmptyMswHandlers,
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("No issues in this view.")).toBeInTheDocument();
+    await expect(
+      canvas.getByText("Add an issue manually or from CAT to start tracking team context."),
+    ).toBeInTheDocument();
+  },
+};
+
+export const Error: Story = {
+  parameters: {
+    msw: {
+      handlers: issueSheetErrorMswHandlers,
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Issue Sheet")).toBeInTheDocument();
+    await expect(canvas.getByText("No issues in this view.")).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.stories.tsx
@@ -79,6 +79,7 @@ export const Error: Story = {
   },
   play: async ({ canvas }) => {
     await expect(canvas.getByText("Issue Sheet")).toBeInTheDocument();
-    await expect(canvas.getByText("No issues in this view.")).toBeInTheDocument();
+    await expect(canvas.getByText("Issues could not be loaded.")).toBeInTheDocument();
+    await expect(canvas.queryByText("No issues in this view.")).not.toBeInTheDocument();
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
@@ -322,6 +322,15 @@ export function IssueSheetPageContent({
                     Loading issues...
                   </td>
                 </tr>
+              ) : issueSheetQuery.isError ? (
+                <tr>
+                  <td
+                    colSpan={5 + editableColumns.length}
+                    className="px-4 py-10 text-center text-muted-foreground"
+                  >
+                    Issues could not be loaded.
+                  </td>
+                </tr>
               ) : data?.issues.length ? (
                 data.issues.map((issue) => (
                   <tr key={issue.id} className="align-top">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet.fixture.ts
@@ -1,0 +1,191 @@
+import type { ProjectRecord } from "@/api/routes/project/project.schema";
+
+const fixedNow = "2026-06-07T12:00:00.000Z";
+
+function iso(offsetMs: number) {
+  return new Date(Date.parse(fixedNow) + offsetMs).toISOString();
+}
+
+export const issueSheetOrganizationSlug = "acme";
+export const issueSheetProjectId = "project_website";
+
+export const issueSheetSummaryFixture = {
+  total: 3,
+  open: 1,
+  inProgress: 1,
+  resolved: 1,
+  wontFix: 0,
+};
+
+export type IssueSheetColumnFixture = {
+  id: string;
+  key: string;
+  label: string;
+  layer: string;
+  type: string;
+  config: { options?: { id: string; label: string; color?: string }[] };
+  sortOrder: number;
+};
+
+export type IssueSheetIssueFixture = {
+  id: string;
+  title: string;
+  description: string;
+  issueType: string;
+  status: string;
+  targetLocale: string | null;
+  sourcePath: string | null;
+  segmentId: string | null;
+  linkKind: string | null;
+  linkLabel: string | null;
+  linkUrl: string | null;
+  assigneeUserId: string | null;
+  reporter: string | null;
+  assignee: string | null;
+  key: string | null;
+  sourceText: string | null;
+  createdAt: string;
+  updatedAt: string;
+  resolvedAt: string | null;
+  values: Record<string, unknown>;
+};
+
+export const issueSheetColumnsFixture: IssueSheetColumnFixture[] = [
+  {
+    id: "col_priority",
+    key: "priority",
+    label: "Priority",
+    layer: "system",
+    type: "select",
+    config: {
+      options: [
+        { id: "P0", label: "P0" },
+        { id: "P1", label: "P1" },
+        { id: "P2", label: "P2" },
+      ],
+    },
+    sortOrder: 0,
+  },
+  {
+    id: "col_owner_note",
+    key: "owner_note",
+    label: "Owner note",
+    layer: "custom",
+    type: "long_text",
+    config: {},
+    sortOrder: 1,
+  },
+  {
+    id: "col_context",
+    key: "context",
+    label: "Context",
+    layer: "custom",
+    type: "enrichment",
+    config: {},
+    sortOrder: 2,
+  },
+];
+
+export function createIssueSheetIssue(
+  overrides: Partial<IssueSheetIssueFixture> = {},
+): IssueSheetIssueFixture {
+  return {
+    id: "issue_001",
+    title: "Source string needs context",
+    description: "The CTA is ambiguous.",
+    issueType: "context_request",
+    status: "open",
+    targetLocale: "de-DE",
+    sourcePath: "messages/home.json",
+    segmentId: "cta.save",
+    linkKind: "cat_segment",
+    linkLabel: "Open in CAT",
+    linkUrl: null,
+    assigneeUserId: "user_otto",
+    reporter: "Mina Chen",
+    assignee: "Otto Klein",
+    key: "home.cta.save",
+    sourceText: "Save changes",
+    createdAt: iso(-86_400_000),
+    updatedAt: iso(-1_800_000),
+    resolvedAt: null,
+    values: {
+      priority: "P1",
+      owner_note: "Waiting on product copy review.",
+      context: "",
+    },
+    ...overrides,
+  };
+}
+
+export const issueSheetIssuesFixture: IssueSheetIssueFixture[] = [
+  createIssueSheetIssue(),
+  createIssueSheetIssue({
+    id: "issue_002",
+    title: "Translation mistake in checkout",
+    description: "Payment button label is too long in French.",
+    issueType: "translation_mistake",
+    status: "in_progress",
+    targetLocale: "fr-FR",
+    sourcePath: "messages/checkout.json",
+    segmentId: "checkout.pay",
+    key: "checkout.pay",
+    sourceText: "Pay now",
+    values: {
+      priority: "P2",
+      owner_note: "Shorten to fit mobile layout.",
+      context: "",
+    },
+    updatedAt: iso(-3_600_000),
+  }),
+  createIssueSheetIssue({
+    id: "issue_003",
+    title: "QA failure on hero headline",
+    description: "Length check failed for German headline.",
+    issueType: "qa_failure",
+    status: "resolved",
+    targetLocale: "de-DE",
+    sourcePath: "messages/home.json",
+    segmentId: "hero.title",
+    key: "hero.title",
+    sourceText: "Welcome back",
+    reporter: "QA Bot",
+    assignee: "Aiko Tanaka",
+    values: {
+      priority: "P1",
+      owner_note: "Shortened German variant approved.",
+      context: "Suggested shorter headline: Willkommen zurück",
+    },
+    resolvedAt: iso(-172_800_000),
+    updatedAt: iso(-172_800_000),
+  }),
+];
+
+export const issueSheetResponseFixture = {
+  issues: issueSheetIssuesFixture,
+  columns: issueSheetColumnsFixture,
+  summary: issueSheetSummaryFixture,
+};
+
+export const issueSheetProjectFixture: ProjectRecord = {
+  id: issueSheetProjectId,
+  organizationId: "org_acme",
+  teamId: null,
+  createdByUserId: "user_mina",
+  name: "Website localization",
+  description: "Marketing site and product copy",
+  translationContext: "Friendly, concise marketing tone",
+  source: "external_tms",
+  externalProviderKind: "crowdin",
+  externalProjectId: "42",
+  sourceLocale: "en-US",
+  targetLocales: ["fr-FR", "de-DE", "es-ES"],
+  externalProjectUrl: "https://crowdin.com/project/website",
+  isActive: true,
+  lastSyncedAt: iso(-7_200_000),
+  lastSyncErrorAt: null,
+  lastSyncErrorMessage: null,
+  createdAt: iso(-2_592_000_000),
+  updatedAt: iso(-7_200_000),
+  openJobCount: 2,
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds Storybook coverage for both Issues Sheet surfaces:

- **Org-wide Issues page** (`App/Issues/Page`) — stories for `IssuesPageView` with fixture data covering default, loading, empty, error, load-more, and QA triage states.
- **Project Issue Sheet page** (`App/Project/Issue Sheet/Page`) — stories for `IssueSheetPageContent` with MSW handlers for default, loading, empty, and error states.

New files follow existing patterns from Jobs, Inbox, and Integrations stories (fixtures + `play` assertions, MSW for data-fetching pages).

## How to test

```bash
cd apps/hyperlocalise-web
vp check --fix
vp run storybook
```

In Storybook, browse:
- `App/Issues/Page`
- `App/Project/Issue Sheet/Page`

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3ba6-893d-77f6-a5b9-1b9668bea819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3ba6-893d-77f6-a5b9-1b9668bea819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

