### PR TITLE
fix(web): default CAT queue filter from job context

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-view-helpers.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-view-helpers.test.ts
@@ -93,11 +93,7 @@ describe("jobs-view-helpers", () => {
       "queueFilter=needs_review",
     );
     expect(
-      buildJobCatHref(
-        "acme",
-        "project-1",
-        createJob({ status: "waiting_for_review" }),
-      ),
+      buildJobCatHref("acme", "project-1", createJob({ status: "waiting_for_review" })),
     ).toContain("queueFilter=needs_review");
   });
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-view-helpers.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-view-helpers.test.ts
@@ -79,13 +79,26 @@ describe("jobs-view-helpers", () => {
 
   it("builds provider CAT hrefs with locale and source path when available", () => {
     expect(buildJobCatHref("acme", "project-1", createJob())).toBe(
-      "/org/acme/projects/project-1/jobs/ext%3Acrowdin%3Aproject-1%3Ajob-1/strings?targetLocale=fr-FR&sourcePath=locales%2Fen.json",
+      "/org/acme/projects/project-1/jobs/ext%3Acrowdin%3Aproject-1%3Ajob-1/strings?targetLocale=fr-FR&sourcePath=locales%2Fen.json&queueFilter=untranslated",
     );
     expect(buildJobCatHref("acme", null, createJob())).toBe(
-      "/org/acme/projects/ext%3Acrowdin%3Aproject-1/jobs/ext%3Acrowdin%3Aproject-1%3Ajob-1/strings?targetLocale=fr-FR&sourcePath=locales%2Fen.json",
+      "/org/acme/projects/ext%3Acrowdin%3Aproject-1/jobs/ext%3Acrowdin%3Aproject-1%3Ajob-1/strings?targetLocale=fr-FR&sourcePath=locales%2Fen.json&queueFilter=untranslated",
     );
     expect(buildJobCatHref("acme", null, createJob({ id: "job_native" }))).toBeNull();
     expect(buildJobCatHref("acme", "project-1", createJob({ kind: "sync" }))).toBeNull();
+  });
+
+  it("includes needs_review queue filter for review jobs", () => {
+    expect(buildJobCatHref("acme", "project-1", createJob({ kind: "review" }))).toContain(
+      "queueFilter=needs_review",
+    );
+    expect(
+      buildJobCatHref(
+        "acme",
+        "project-1",
+        createJob({ status: "waiting_for_review" }),
+      ),
+    ).toContain("queueFilter=needs_review");
   });
 
   it("builds native CAT hrefs with stored file id and target locale", () => {
@@ -104,7 +117,7 @@ describe("jobs-view-helpers", () => {
         }),
       ),
     ).toBe(
-      "/org/acme/projects/project-1/jobs/job_native/strings?storedFileId=file_home_json&targetLocale=fr-FR",
+      "/org/acme/projects/project-1/jobs/job_native/strings?storedFileId=file_home_json&targetLocale=fr-FR&queueFilter=untranslated",
     );
   });
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section.tsx
@@ -5,7 +5,10 @@ import { toast } from "sonner";
 
 import { apiClient } from "@/lib/api-client-instance";
 import type { JobProviderActionId } from "@/lib/providers/jobs/job-provider-actions";
-import { resolveDefaultJobCatQueueFilter } from "@/lib/projects/job-cat-routing";
+import {
+  resolveDefaultJobCatQueueFilter,
+  type JobCatQueueFilterContext,
+} from "@/lib/projects/job-cat-routing";
 import { resolveEncodedProviderJobId } from "@/lib/providers/jobs/tms-provider-resource-id";
 
 import { JobAgentRunDiffReviewSection } from "./job-agent-run-diff-review-section";
@@ -43,7 +46,7 @@ export function JobProviderDetailSection({
   showAgentActions = true,
   showProviderMetadata = true,
 }: {
-  job: ProviderBackedJobFields;
+  job: ProviderBackedJobFields & JobCatQueueFilterContext;
   jobId: string;
   organizationSlug: string;
   projectId: string | null;
@@ -132,7 +135,7 @@ export function JobProviderDetailSection({
           externalJobId: providerJob.externalJobId,
           externalTaskId: providerJob.externalTaskId,
         });
-        const queueFilter = resolveDefaultJobCatQueueFilter(providerJob);
+        const queueFilter = resolveDefaultJobCatQueueFilter(job);
 
         if (encodedJobId) {
           return (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 
 import { apiClient } from "@/lib/api-client-instance";
 import type { JobProviderActionId } from "@/lib/providers/jobs/job-provider-actions";
+import { resolveDefaultJobCatQueueFilter } from "@/lib/projects/job-cat-routing";
 import { resolveEncodedProviderJobId } from "@/lib/providers/jobs/tms-provider-resource-id";
 
 import { JobAgentRunDiffReviewSection } from "./job-agent-run-diff-review-section";
@@ -131,6 +132,7 @@ export function JobProviderDetailSection({
           externalJobId: providerJob.externalJobId,
           externalTaskId: providerJob.externalTaskId,
         });
+        const queueFilter = resolveDefaultJobCatQueueFilter(providerJob);
 
         if (encodedJobId) {
           return (
@@ -139,6 +141,7 @@ export function JobProviderDetailSection({
               projectId={projId}
               encodedJobId={encodedJobId}
               highlightLocale={providerJob.externalTargetLocales?.[0] ?? null}
+              queueFilter={queueFilter}
             />
           );
         }
@@ -151,6 +154,7 @@ export function JobProviderDetailSection({
             providerKind={providerJob.externalProviderKind}
             sourceFiles={providerJob.providerSourceFiles ?? []}
             highlightLocale={providerJob.externalTargetLocales?.[0] ?? null}
+            queueFilter={queueFilter}
           />
         );
       }}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-helpers.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-helpers.tsx
@@ -8,6 +8,7 @@ import { jobDetailTaskLayoutFromRecord } from "./job-detail-layout-helpers";
 import { isProviderBackedJob, type JobDetailRecord } from "./job-detail-types";
 import { JobSourceFilesPanel } from "./tms/job-source-files-panel";
 import { nativeJobToProjectFileRecord } from "./tms/job-source-file-mappers";
+import { resolveDefaultJobCatQueueFilter } from "@/lib/projects/job-cat-routing";
 
 function getInputPayloadString(job: JobDetailRecord, key: string) {
   if (typeof job.inputPayload !== "object" || !job.inputPayload || !(key in job.inputPayload)) {
@@ -77,6 +78,7 @@ export function NativeJobSourceFilesSection({
   const file = useMemo(() => buildNativeJobFileRecord(job), [job]);
   const targetLocales = getInputPayloadStringArray(job, "targetLocales");
   const highlightLocale = targetLocales[0] ?? null;
+  const queueFilter = resolveDefaultJobCatQueueFilter(job);
 
   if (!file) {
     return null;
@@ -89,6 +91,7 @@ export function NativeJobSourceFilesSection({
       encodedJobId={job.id}
       files={[file]}
       highlightLocale={highlightLocale}
+      queueFilter={queueFilter}
       emptyMessage="No source file linked to this job."
     />
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
@@ -6,6 +6,7 @@ import { useAppShellBreadcrumbAppend } from "@/components/app-shell/store/use-ap
 import { apiClient } from "@/lib/api-client-instance";
 import type { TmsProviderLiveJobDetail } from "@/lib/providers/jobs/tms-provider-live";
 import { parseProviderJobId } from "@/lib/providers/jobs/tms-provider-resource-id";
+import { resolveDefaultJobCatQueueFilter } from "@/lib/projects/job-cat-routing";
 
 import { ProviderJobDescriptionField } from "../../../../../jobs/_components/provider-job-description-field";
 import { useProviderJobLocaleReadiness } from "../../../../../_hooks/use-provider-job-locale-readiness";
@@ -99,6 +100,7 @@ export function ProviderLiveJobDetailContent({
               ? job.externalProviderPayload.languageId
               : (job.externalTargetLocales?.[0] ?? null)
           }
+          queueFilter={resolveDefaultJobCatQueueFilter(job)}
         />
       )}
     />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.tsx
@@ -10,6 +10,8 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TypographyH4, TypographyP } from "@/components/ui/typography";
 import { supportsProviderCatFile } from "@/lib/providers/capabilities/provider-cat-capabilities";
+import { jobCatQueueFilterParam } from "@/lib/projects/job-cat-routing";
+import type { CatQueueFilter } from "@/components/cat/queue/cat-queue-filter";
 import { toast } from "sonner";
 
 import { ProjectFilesTree } from "../../../../files/_components/project-files-tree";
@@ -27,6 +29,7 @@ function stringsHref(input: {
   targetLocale: string;
   sourcePath?: string;
   storedFileId?: string;
+  queueFilter?: CatQueueFilter;
 }) {
   const params = new URLSearchParams({
     targetLocale: input.targetLocale,
@@ -38,6 +41,10 @@ function stringsHref(input: {
 
   if (input.storedFileId) {
     params.set("storedFileId", input.storedFileId);
+  }
+
+  if (input.queueFilter && input.queueFilter !== "all") {
+    params.set(jobCatQueueFilterParam, input.queueFilter);
   }
 
   return `/org/${input.organizationSlug}/projects/${encodeURIComponent(input.projectId)}/jobs/${encodeURIComponent(input.encodedJobId)}/strings?${params.toString()}`;
@@ -93,6 +100,7 @@ export function JobSourceFilesPanel({
   errorMessage,
   emptyMessage = "No source files linked to this job.",
   highlightLocale = null,
+  queueFilter,
 }: {
   organizationSlug: string;
   projectId: string;
@@ -103,6 +111,7 @@ export function JobSourceFilesPanel({
   errorMessage?: string;
   emptyMessage?: string;
   highlightLocale?: string | null;
+  queueFilter?: CatQueueFilter;
 }) {
   const router = useRouter();
   const sortedFiles = useMemo(() => sortFilesByPath(files), [files]);
@@ -134,13 +143,14 @@ export function JobSourceFilesPanel({
           projectId,
           encodedJobId,
           targetLocale: targetLocale as string,
+          queueFilter,
           ...(supportsProviderCatFile(file)
             ? { sourcePath }
             : { storedFileId: file.storedFileId as string }),
         }),
       );
     },
-    [encodedJobId, highlightLocale, organizationSlug, projectId, router, sortedFiles],
+    [encodedJobId, highlightLocale, organizationSlug, projectId, queueFilter, router, sortedFiles],
   );
 
   const handleSelectFile = useCallback((sourcePath: string) => {
@@ -162,6 +172,7 @@ export function JobSourceFilesPanel({
           projectId,
           encodedJobId,
           targetLocale: selectedTargetLocale,
+          queueFilter,
           ...(supportsProviderCatFile(selectedFile)
             ? { sourcePath: activeSourcePath }
             : { storedFileId: selectedFile.storedFileId as string }),

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/synced-job-source-files-section.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/synced-job-source-files-section.tsx
@@ -7,6 +7,7 @@ import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resour
 import type { ProviderSourceFile } from "../job-provider-detail-section";
 import { providerSourceFileToProjectFileRecord } from "./job-source-file-mappers";
 import { JobSourceFilesPanel } from "./job-source-files-panel";
+import type { CatQueueFilter } from "@/components/cat/queue/cat-queue-filter";
 
 export function SyncedJobSourceFilesSection({
   organizationSlug,
@@ -15,6 +16,7 @@ export function SyncedJobSourceFilesSection({
   providerKind,
   sourceFiles,
   highlightLocale,
+  queueFilter,
 }: {
   organizationSlug: string;
   projectId: string;
@@ -22,6 +24,7 @@ export function SyncedJobSourceFilesSection({
   providerKind: string;
   sourceFiles: ProviderSourceFile[];
   highlightLocale?: string | null;
+  queueFilter?: CatQueueFilter;
 }) {
   const encodedProjectId = parseProviderProjectId(projectId);
   const externalProjectId = encodedProjectId?.externalProjectId ?? projectId;
@@ -43,6 +46,7 @@ export function SyncedJobSourceFilesSection({
       files={files}
       emptyMessage="No synced source files linked to this job."
       highlightLocale={highlightLocale ?? null}
+      queueFilter={queueFilter}
     />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/tms-live-job-files-section.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/tms-live-job-files-section.tsx
@@ -7,6 +7,7 @@ import type { TmsProviderLiveFile } from "@/lib/providers/jobs/tms-provider-live
 
 import { tmsLiveFileToProjectFileRecord } from "./job-source-file-mappers";
 import { JobSourceFilesPanel } from "./job-source-files-panel";
+import type { CatQueueFilter } from "@/components/cat/queue/cat-queue-filter";
 
 function tmsLiveJobFilesQueryKey(organizationSlug: string, encodedJobId: string) {
   return ["tms-provider-job-files", organizationSlug, encodedJobId] as const;
@@ -17,11 +18,13 @@ export function TmsLiveJobFilesSection({
   projectId,
   encodedJobId,
   highlightLocale,
+  queueFilter,
 }: {
   organizationSlug: string;
   projectId: string;
   encodedJobId: string;
   highlightLocale?: string | null;
+  queueFilter?: CatQueueFilter;
 }) {
   const filesQuery = useQuery({
     queryKey: tmsLiveJobFilesQueryKey(organizationSlug, encodedJobId),
@@ -56,6 +59,7 @@ export function TmsLiveJobFilesSection({
       }
       emptyMessage="No files are linked to this task."
       highlightLocale={highlightLocale ?? null}
+      queueFilter={queueFilter}
     />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.test.tsx
@@ -181,7 +181,7 @@ describe("JobCatPageContent guard ordering", () => {
 
     await waitFor(() => {
       expect(routerReplaceMock).toHaveBeenCalledWith(
-        "/org/acme/projects/proj_1/jobs/job_1/strings?targetLocale=vi&sourcePath=crowdin%2Fhome.json",
+        "/org/acme/projects/proj_1/jobs/job_1/strings?targetLocale=vi&sourcePath=crowdin%2Fhome.json&queueFilter=untranslated",
       );
     });
     expect(

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.test.tsx
@@ -294,6 +294,31 @@ describe("JobCatPageContent CAT shell", () => {
     });
   });
 
+  it("opens with needs_review queue filter when provided", async () => {
+    loadJobCatTargetFileMock.mockResolvedValue({ status: "found", file: providerFile });
+    loadJobCatProviderJobFilesMock.mockResolvedValue([providerFile]);
+
+    render(
+      <CatTestProviders>
+        <JobCatPageContent
+          organizationSlug="acme"
+          projectId="proj_1"
+          jobId="job_1"
+          sourcePath="crowdin/home.json"
+          targetLocale="vi"
+          initialQueueFilter="needs_review"
+        />
+      </CatTestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("cat-workspace")).toHaveAttribute(
+        "data-initial-queue-filter",
+        "needs_review",
+      );
+    });
+  });
+
   it("passes a saved repository preference into provider task CAT", async () => {
     localStorage.setItem("job-cat-repository:acme:proj_1:crowdin/home.json", "acme/docs");
     loadJobCatTargetFileMock.mockResolvedValue({ status: "found", file: providerFile });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -33,8 +33,8 @@ import {
   sortJobCatProviderFiles,
 } from "./select-job-cat-repository";
 import { ProjectFileCatWorkspace } from "@/components/cat/project-file/project-file-cat-workspace";
-
-const JOB_CAT_DEFAULT_QUEUE_FILTER = "untranslated" as const;
+import type { CatQueueFilter } from "@/components/cat/queue/cat-queue-filter";
+import { jobCatQueueFilterParam } from "@/lib/projects/job-cat-routing";
 
 type JobCatGithubRepository = {
   fullName: string;
@@ -92,6 +92,7 @@ function stringsPageHref(input: {
   storedFileId?: string;
   targetLocale: string;
   segment?: string | null;
+  queueFilter?: CatQueueFilter;
 }) {
   const params = new URLSearchParams({
     targetLocale: input.targetLocale,
@@ -109,6 +110,10 @@ function stringsPageHref(input: {
     params.set("segment", input.segment);
   }
 
+  if (input.queueFilter && input.queueFilter !== "all") {
+    params.set(jobCatQueueFilterParam, input.queueFilter);
+  }
+
   return `/org/${input.organizationSlug}/projects/${encodeURIComponent(input.projectId)}/jobs/${encodeURIComponent(input.jobId)}/strings?${params.toString()}`;
 }
 
@@ -120,6 +125,7 @@ export function JobCatPageContent({
   storedFileId = null,
   targetLocale,
   initialSegmentKey = null,
+  initialQueueFilter = "untranslated",
 }: {
   organizationSlug: string;
   projectId: string;
@@ -128,6 +134,7 @@ export function JobCatPageContent({
   storedFileId?: string | null;
   targetLocale: string | null;
   initialSegmentKey?: string | null;
+  initialQueueFilter?: CatQueueFilter;
 }) {
   const router = useRouter();
   const taskHref = `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(jobId)}`;
@@ -259,12 +266,14 @@ export function JobCatPageContent({
         storedFileId: defaultFileQuery.data.reference.storedFileId ?? undefined,
         targetLocale: defaultFileQuery.data.reference.targetLocale,
         segment: initialSegmentKey,
+        queueFilter: initialQueueFilter,
       }),
     );
   }, [
     defaultFileQuery.data,
     hasFileReference,
     initialSegmentKey,
+    initialQueueFilter,
     jobId,
     organizationSlug,
     projectId,
@@ -497,7 +506,7 @@ export function JobCatPageContent({
               selectedRepositoryFullName,
             )}
             initialSegmentKey={initialSegmentKey}
-            initialQueueFilter={JOB_CAT_DEFAULT_QUEUE_FILTER}
+            initialQueueFilter={initialQueueFilter}
             layout="fullscreen"
             className="min-h-0 flex-1"
           />
@@ -561,6 +570,7 @@ export function JobCatPageContent({
         jobId,
         sourcePath: nextSourcePath,
         targetLocale: nextTargetLocale,
+        queueFilter: initialQueueFilter,
       }),
     );
   };
@@ -614,7 +624,7 @@ export function JobCatPageContent({
             selectedRepositoryFullName,
           )}
           initialSegmentKey={initialSegmentKey}
-          initialQueueFilter={JOB_CAT_DEFAULT_QUEUE_FILTER}
+          initialQueueFilter={initialQueueFilter}
           layout="fullscreen"
           className="min-h-0 flex-1"
         />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
@@ -1,4 +1,8 @@
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
+import {
+  parseJobCatQueueFilterParam,
+  resolveDefaultJobCatQueueFilter,
+} from "@/lib/projects/job-cat-routing";
 
 import { JobCatPageContent } from "./_components/job-cat-page-content";
 
@@ -12,11 +16,15 @@ export default async function ProjectJobStringsPage({
     storedFileId?: string;
     targetLocale?: string;
     segment?: string;
+    queueFilter?: string;
   }>;
 }) {
   const { organizationSlug, projectId, jobId } = await params;
-  const { sourcePath, storedFileId, targetLocale, segment } = await searchParams;
+  const { sourcePath, storedFileId, targetLocale, segment, queueFilter } = await searchParams;
   await requireAppAuthContext({ organizationSlug });
+
+  const initialQueueFilter =
+    parseJobCatQueueFilterParam(queueFilter) ?? resolveDefaultJobCatQueueFilter({ kind: "translation" });
 
   return (
     <JobCatPageContent
@@ -27,6 +35,7 @@ export default async function ProjectJobStringsPage({
       storedFileId={storedFileId ?? null}
       targetLocale={targetLocale ?? null}
       initialSegmentKey={segment ?? null}
+      initialQueueFilter={initialQueueFilter}
     />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
@@ -24,7 +24,8 @@ export default async function ProjectJobStringsPage({
   await requireAppAuthContext({ organizationSlug });
 
   const initialQueueFilter =
-    parseJobCatQueueFilterParam(queueFilter) ?? resolveDefaultJobCatQueueFilter({ kind: "translation" });
+    parseJobCatQueueFilterParam(queueFilter) ??
+    resolveDefaultJobCatQueueFilter({ kind: "translation" });
 
   return (
     <JobCatPageContent

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
@@ -1,8 +1,5 @@
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
-import {
-  parseJobCatQueueFilterParam,
-  resolveDefaultJobCatQueueFilter,
-} from "@/lib/projects/job-cat-routing";
+import { resolveJobCatInitialQueueFilter } from "@/lib/projects/resolve-job-cat-initial-queue-filter";
 
 import { JobCatPageContent } from "./_components/job-cat-page-content";
 
@@ -21,11 +18,13 @@ export default async function ProjectJobStringsPage({
 }) {
   const { organizationSlug, projectId, jobId } = await params;
   const { sourcePath, storedFileId, targetLocale, segment, queueFilter } = await searchParams;
-  await requireAppAuthContext({ organizationSlug });
+  const auth = await requireAppAuthContext({ organizationSlug });
 
-  const initialQueueFilter =
-    parseJobCatQueueFilterParam(queueFilter) ??
-    resolveDefaultJobCatQueueFilter({ kind: "translation" });
+  const initialQueueFilter = await resolveJobCatInitialQueueFilter({
+    auth,
+    jobId,
+    queueFilterParam: queueFilter,
+  });
 
   return (
     <JobCatPageContent

--- a/apps/hyperlocalise-web/src/lib/projects/job-cat-routing.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/job-cat-routing.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { buildJobCatHref, canOpenJobCat } from "./job-cat-routing";
+import {
+  buildJobCatHref,
+  canOpenJobCat,
+  parseJobCatQueueFilterParam,
+  resolveDefaultJobCatQueueFilter,
+} from "./job-cat-routing";
 
 function createJob(
   overrides: Partial<Parameters<typeof canOpenJobCat>[0]> = {},
@@ -58,16 +63,56 @@ describe("canOpenJobCat", () => {
   });
 });
 
+describe("resolveDefaultJobCatQueueFilter", () => {
+  it("defaults review jobs and waiting-for-review tasks to needs_review", () => {
+    expect(resolveDefaultJobCatQueueFilter({ kind: "review" })).toBe("needs_review");
+    expect(
+      resolveDefaultJobCatQueueFilter({ kind: "translation", status: "waiting_for_review" }),
+    ).toBe("needs_review");
+  });
+
+  it("defaults translation jobs to untranslated", () => {
+    expect(resolveDefaultJobCatQueueFilter({ kind: "translation", status: "running" })).toBe(
+      "untranslated",
+    );
+  });
+
+  it("falls back to all for other job kinds", () => {
+    expect(resolveDefaultJobCatQueueFilter({ kind: "sync" })).toBe("all");
+  });
+});
+
+describe("parseJobCatQueueFilterParam", () => {
+  it("accepts supported queue filters and rejects unknown values", () => {
+    expect(parseJobCatQueueFilterParam("needs_review")).toBe("needs_review");
+    expect(parseJobCatQueueFilterParam("invalid")).toBeUndefined();
+    expect(parseJobCatQueueFilterParam(undefined)).toBeUndefined();
+  });
+});
+
 describe("buildJobCatHref", () => {
   it("builds provider CAT hrefs with locale and source path when available", () => {
     expect(buildJobCatHref("acme", "project-1", createJob())).toBe(
-      "/org/acme/projects/project-1/jobs/ext%3Acrowdin%3Aproject-1%3Ajob-1/strings?targetLocale=fr-FR&sourcePath=locales%2Fen.json",
+      "/org/acme/projects/project-1/jobs/ext%3Acrowdin%3Aproject-1%3Ajob-1/strings?targetLocale=fr-FR&sourcePath=locales%2Fen.json&queueFilter=untranslated",
     );
     expect(buildJobCatHref("acme", null, createJob())).toBe(
-      "/org/acme/projects/ext%3Acrowdin%3Aproject-1/jobs/ext%3Acrowdin%3Aproject-1%3Ajob-1/strings?targetLocale=fr-FR&sourcePath=locales%2Fen.json",
+      "/org/acme/projects/ext%3Acrowdin%3Aproject-1/jobs/ext%3Acrowdin%3Aproject-1%3Ajob-1/strings?targetLocale=fr-FR&sourcePath=locales%2Fen.json&queueFilter=untranslated",
     );
     expect(buildJobCatHref("acme", null, createJob({ id: "job_native" }))).toBeNull();
     expect(buildJobCatHref("acme", "project-1", createJob({ kind: "sync" }))).toBeNull();
+  });
+
+  it("includes needs_review queue filter for review jobs", () => {
+    expect(buildJobCatHref("acme", "project-1", createJob({ kind: "review" }))).toContain(
+      "queueFilter=needs_review",
+    );
+    expect(
+      buildJobCatHref(
+        "acme",
+        "project-1",
+        createJob({ status: "waiting_for_review" }),
+      ),
+    ).toContain("queueFilter=needs_review");
   });
 
   it("builds native CAT hrefs with stored file id and target locale", () => {
@@ -86,7 +131,7 @@ describe("buildJobCatHref", () => {
         }),
       ),
     ).toBe(
-      "/org/acme/projects/project-1/jobs/job_native/strings?storedFileId=file_home_json&targetLocale=fr-FR",
+      "/org/acme/projects/project-1/jobs/job_native/strings?storedFileId=file_home_json&targetLocale=fr-FR&queueFilter=untranslated",
     );
   });
 });

--- a/apps/hyperlocalise-web/src/lib/projects/job-cat-routing.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/job-cat-routing.test.ts
@@ -107,11 +107,7 @@ describe("buildJobCatHref", () => {
       "queueFilter=needs_review",
     );
     expect(
-      buildJobCatHref(
-        "acme",
-        "project-1",
-        createJob({ status: "waiting_for_review" }),
-      ),
+      buildJobCatHref("acme", "project-1", createJob({ status: "waiting_for_review" })),
     ).toContain("queueFilter=needs_review");
   });
 

--- a/apps/hyperlocalise-web/src/lib/projects/job-cat-routing.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/job-cat-routing.ts
@@ -19,7 +19,10 @@ export type JobCatTarget = {
   inputPayload: unknown;
 };
 
-export type JobCatQueueFilterContext = Pick<JobCatTarget, "kind" | "status">;
+export type JobCatQueueFilterContext = {
+  kind?: JobCatTarget["kind"];
+  status?: JobCatTarget["status"];
+};
 
 export function resolveDefaultJobCatQueueFilter(
   job: JobCatQueueFilterContext,
@@ -28,7 +31,7 @@ export function resolveDefaultJobCatQueueFilter(
     return "needs_review";
   }
 
-  if (job.kind === "translation") {
+  if (job.kind === "translation" || job.kind === undefined) {
     return "untranslated";
   }
 

--- a/apps/hyperlocalise-web/src/lib/projects/job-cat-routing.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/job-cat-routing.ts
@@ -1,18 +1,50 @@
+import type { ProjectFileCatQueueFilter } from "@/api/routes/project/project.schema";
+import { projectFileCatQueueFilterSchema } from "@/api/routes/project/project.schema";
 import {
   canOpenNativeJobCat,
   canOpenProviderJobCat,
 } from "@/lib/projects/workspace-resource-capabilities";
 import { resolveJobProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 
+export const jobCatQueueFilterParam = "queueFilter";
+
 export type JobCatTarget = {
   id: string;
   kind: "translation" | "research" | "review" | "sync" | "asset_management";
   type: "string" | "file" | null;
+  status?: "queued" | "running" | "succeeded" | "failed" | "waiting_for_review" | "cancelled";
   externalProviderKind: string | null;
   externalTargetLocales: string[] | null;
   reviewTargetLocale: string | null;
   inputPayload: unknown;
 };
+
+export type JobCatQueueFilterContext = Pick<JobCatTarget, "kind" | "status">;
+
+export function resolveDefaultJobCatQueueFilter(
+  job: JobCatQueueFilterContext,
+): ProjectFileCatQueueFilter {
+  if (job.kind === "review" || job.status === "waiting_for_review") {
+    return "needs_review";
+  }
+
+  if (job.kind === "translation") {
+    return "untranslated";
+  }
+
+  return "all";
+}
+
+export function parseJobCatQueueFilterParam(
+  value: string | undefined,
+): ProjectFileCatQueueFilter | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const result = projectFileCatQueueFilterSchema.safeParse(value);
+  return result.success ? result.data : undefined;
+}
 
 function getInputPayloadString(job: JobCatTarget, key: string) {
   if (typeof job.inputPayload !== "object" || !job.inputPayload || !(key in job.inputPayload)) {
@@ -73,6 +105,11 @@ export function buildJobCatHref(
     if (targetLocale) {
       params.set("targetLocale", targetLocale);
     }
+  }
+
+  const queueFilter = resolveDefaultJobCatQueueFilter(job);
+  if (queueFilter !== "all") {
+    params.set(jobCatQueueFilterParam, queueFilter);
   }
 
   const base = `/org/${organizationSlug}/projects/${encodeURIComponent(resolvedProjectId)}/jobs/${encodeURIComponent(job.id)}/strings`;

--- a/apps/hyperlocalise-web/src/lib/projects/resolve-job-cat-initial-queue-filter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/resolve-job-cat-initial-queue-filter.test.ts
@@ -76,4 +76,15 @@ describe("resolveJobCatInitialQueueFilter", () => {
       }),
     ).resolves.toBe("untranslated");
   });
+
+  it("falls back to untranslated when provider job lookup throws", async () => {
+    getTmsProviderLiveJobDetailMock.mockRejectedValue(new Error("provider_fetcher_unavailable"));
+
+    await expect(
+      resolveJobCatInitialQueueFilter({
+        auth,
+        jobId: "ext:crowdin:project-1:job-1",
+      }),
+    ).resolves.toBe("untranslated");
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/projects/resolve-job-cat-initial-queue-filter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/resolve-job-cat-initial-queue-filter.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import type { ApiAuthContext } from "@/api/auth/workos";
+
+import { resolveJobCatInitialQueueFilter } from "./resolve-job-cat-initial-queue-filter";
+
+const getOrganizationJobByIdMock = vi.fn();
+const getTmsProviderLiveJobDetailMock = vi.fn();
+
+vi.mock("@/lib/projects/jobs/organization-job-query-service", () => ({
+  getOrganizationJobById: (...args: unknown[]) => getOrganizationJobByIdMock(...args),
+}));
+
+vi.mock("@/lib/providers/jobs/tms-provider-live", () => ({
+  getTmsProviderLiveJobDetail: (...args: unknown[]) => getTmsProviderLiveJobDetailMock(...args),
+}));
+
+const auth = {
+  user: { localUserId: "user_1" },
+  organization: { localOrganizationId: "org_1" },
+} as ApiAuthContext;
+
+describe("resolveJobCatInitialQueueFilter", () => {
+  beforeEach(() => {
+    getOrganizationJobByIdMock.mockReset();
+    getTmsProviderLiveJobDetailMock.mockReset();
+  });
+
+  it("returns the URL queue filter when present", async () => {
+    await expect(
+      resolveJobCatInitialQueueFilter({
+        auth,
+        jobId: "job_1",
+        queueFilterParam: "needs_review",
+      }),
+    ).resolves.toBe("needs_review");
+    expect(getOrganizationJobByIdMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves the default from native job data when the URL param is missing", async () => {
+    getOrganizationJobByIdMock.mockResolvedValue({
+      kind: "translation",
+      status: "waiting_for_review",
+    });
+
+    await expect(
+      resolveJobCatInitialQueueFilter({
+        auth,
+        jobId: "job_1",
+      }),
+    ).resolves.toBe("needs_review");
+  });
+
+  it("resolves the default from provider live job data", async () => {
+    getTmsProviderLiveJobDetailMock.mockResolvedValue({
+      kind: "review",
+      status: "running",
+    });
+
+    await expect(
+      resolveJobCatInitialQueueFilter({
+        auth,
+        jobId: "ext:crowdin:project-1:job-1",
+      }),
+    ).resolves.toBe("needs_review");
+    expect(getOrganizationJobByIdMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to untranslated when job data is unavailable", async () => {
+    getOrganizationJobByIdMock.mockResolvedValue(null);
+
+    await expect(
+      resolveJobCatInitialQueueFilter({
+        auth,
+        jobId: "job_missing",
+      }),
+    ).resolves.toBe("untranslated");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/projects/resolve-job-cat-initial-queue-filter.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/resolve-job-cat-initial-queue-filter.ts
@@ -15,16 +15,20 @@ async function loadJobCatQueueFilterContext(
   auth: ApiAuthContext,
   jobId: string,
 ): Promise<JobCatQueueFilterContext | null> {
-  if (parseProviderJobId(jobId)) {
-    const job = await getTmsProviderLiveJobDetail(auth.organization.localOrganizationId, jobId, {
-      actorUserId: auth.user.localUserId,
-    });
+  try {
+    if (parseProviderJobId(jobId)) {
+      const job = await getTmsProviderLiveJobDetail(auth.organization.localOrganizationId, jobId, {
+        actorUserId: auth.user.localUserId,
+      });
 
+      return job ? { kind: job.kind, status: job.status } : null;
+    }
+
+    const job = await getOrganizationJobById(auth, jobId);
     return job ? { kind: job.kind, status: job.status } : null;
+  } catch {
+    return null;
   }
-
-  const job = await getOrganizationJobById(auth, jobId);
-  return job ? { kind: job.kind, status: job.status } : null;
 }
 
 export async function resolveJobCatInitialQueueFilter(input: {

--- a/apps/hyperlocalise-web/src/lib/projects/resolve-job-cat-initial-queue-filter.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/resolve-job-cat-initial-queue-filter.ts
@@ -1,0 +1,46 @@
+import type { ApiAuthContext } from "@/api/auth/workos";
+import type { ProjectFileCatQueueFilter } from "@/api/routes/project/project.schema";
+import { getOrganizationJobById } from "@/lib/projects/jobs/organization-job-query-service";
+import {
+  parseJobCatQueueFilterParam,
+  resolveDefaultJobCatQueueFilter,
+  type JobCatQueueFilterContext,
+} from "@/lib/projects/job-cat-routing";
+import { getTmsProviderLiveJobDetail } from "@/lib/providers/jobs/tms-provider-live";
+import { parseProviderJobId } from "@/lib/providers/jobs/tms-provider-resource-id";
+
+const JOB_CAT_QUEUE_FILTER_FALLBACK: ProjectFileCatQueueFilter = "untranslated";
+
+async function loadJobCatQueueFilterContext(
+  auth: ApiAuthContext,
+  jobId: string,
+): Promise<JobCatQueueFilterContext | null> {
+  if (parseProviderJobId(jobId)) {
+    const job = await getTmsProviderLiveJobDetail(auth.organization.localOrganizationId, jobId, {
+      actorUserId: auth.user.localUserId,
+    });
+
+    return job ? { kind: job.kind, status: job.status } : null;
+  }
+
+  const job = await getOrganizationJobById(auth, jobId);
+  return job ? { kind: job.kind, status: job.status } : null;
+}
+
+export async function resolveJobCatInitialQueueFilter(input: {
+  auth: ApiAuthContext;
+  jobId: string;
+  queueFilterParam?: string;
+}): Promise<ProjectFileCatQueueFilter> {
+  const fromParam = parseJobCatQueueFilterParam(input.queueFilterParam);
+  if (fromParam) {
+    return fromParam;
+  }
+
+  const context = await loadJobCatQueueFilterContext(input.auth, input.jobId);
+  if (!context) {
+    return JOB_CAT_QUEUE_FILTER_FALLBACK;
+  }
+
+  return resolveDefaultJobCatQueueFilter(context);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The job CAT workspace always opened with the **Untranslated** queue filter, even when entering from review jobs or tasks waiting for review. This change picks a context-appropriate default filter and carries it through navigation.

## Behavior

| Job context | Default queue filter |
|-------------|---------------------|
| Review job (`kind: review`) | Needs review |
| Waiting for review (`status: waiting_for_review`) | Needs review |
| Translation job | Untranslated |
| Other | All |

## Changes

- Add `resolveDefaultJobCatQueueFilter()` in `job-cat-routing.ts` to centralize default selection.
- Add `resolveJobCatInitialQueueFilter()` to fetch job kind/status server-side when the URL omits `queueFilter`.
- Include `queueFilter` in `buildJobCatHref()` URLs so jobs board, kanban, and detail "View strings" links open the right filter.
- Parse `queueFilter` from the job strings page search params and pass it into `JobCatPageContent`.
- Preserve `queueFilter` when switching files inside the CAT workspace or opening from the job source files panel.

## Testing

- `vp test` on routing, jobs view helpers, job CAT page content, and new server resolver tests
- `vp check --fix`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3bb0-2254-7743-94c0-0a8b4abf230c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3bb0-2254-7743-94c0-0a8b4abf230c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

