### PR TITLE
feat(issue-sheet): CSV import with column mapping wizard

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.test.ts
@@ -263,4 +263,86 @@ describe("Issue Sheet routes", () => {
     const listBody = (await listResponse.json()) as IssueSheetListResponse;
     expect(listBody.issues).toHaveLength(1);
   });
+
+  it("imports issues from csv with dry run and duplicate skip", async () => {
+    const { identity, project } = await projectFixture.createStoredProjectFixture();
+    const headers = await projectFixture.authHeadersFor(identity);
+    const organizationSlug = identity.organization.slug ?? "missing-slug";
+
+    const csv = `Summary,Status,External ID,Priority
+First import issue,Open,EXT-1,P1
+Second import issue,Done,EXT-2,P2`;
+
+    const mapping = [
+      { csvHeader: "Summary", target: { kind: "system", field: "title" } },
+      { csvHeader: "Status", target: { kind: "system", field: "status" } },
+      { csvHeader: "External ID", target: { kind: "system", field: "external_ref" } },
+      {
+        csvHeader: "Priority",
+        target: { kind: "create", key: "csv_priority", label: "CSV Priority", type: "select" },
+      },
+    ];
+
+    const previewResponse = await requestJson(
+      issueSheetUrl(organizationSlug, project.id, "/import"),
+      {
+        method: "POST",
+        headers,
+        body: {
+          content: csv,
+          dryRun: true,
+          mapping,
+        },
+      },
+    );
+    expect(previewResponse.status).toBe(200);
+    const previewBody = (await previewResponse.json()) as {
+      import: { created: number; skippedDuplicates: number };
+    };
+    expect(previewBody.import.created).toBe(2);
+    expect(previewBody.import.skippedDuplicates).toBe(0);
+
+    const importResponse = await requestJson(
+      issueSheetUrl(organizationSlug, project.id, "/import"),
+      {
+        method: "POST",
+        headers,
+        body: {
+          content: csv,
+          dryRun: false,
+          mapping,
+        },
+      },
+    );
+    expect(importResponse.status).toBe(201);
+    const importBody = (await importResponse.json()) as {
+      import: { created: number; skippedDuplicates: number };
+    };
+    expect(importBody.import.created).toBe(2);
+
+    const reimportResponse = await requestJson(
+      issueSheetUrl(organizationSlug, project.id, "/import"),
+      {
+        method: "POST",
+        headers,
+        body: {
+          content: csv,
+          dryRun: true,
+          mapping,
+        },
+      },
+    );
+    const reimportBody = (await reimportResponse.json()) as {
+      import: { created: number; skippedDuplicates: number };
+    };
+    expect(reimportBody.import.created).toBe(0);
+    expect(reimportBody.import.skippedDuplicates).toBe(2);
+
+    const listResponse = await requestJson(issueSheetUrl(organizationSlug, project.id), {
+      headers,
+      query: { status: "all" },
+    });
+    const listBody = (await listResponse.json()) as IssueSheetListResponse;
+    expect(listBody.issues).toHaveLength(2);
+  });
 });

--- a/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.test.ts
@@ -345,4 +345,27 @@ Second import issue,Done,EXT-2,P2`;
     const listBody = (await listResponse.json()) as IssueSheetListResponse;
     expect(listBody.issues).toHaveLength(2);
   });
+
+  it("rejects duplicate system field mappings", async () => {
+    const { identity, project } = await projectFixture.createStoredProjectFixture();
+    const headers = await projectFixture.authHeadersFor(identity);
+    const organizationSlug = identity.organization.slug ?? "missing-slug";
+
+    const response = await requestJson(issueSheetUrl(organizationSlug, project.id, "/import"), {
+      method: "POST",
+      headers,
+      body: {
+        content: "Title,Summary\nIssue one,Issue two",
+        dryRun: true,
+        mapping: [
+          { csvHeader: "Title", target: { kind: "system", field: "title" } },
+          { csvHeader: "Summary", target: { kind: "system", field: "title" } },
+        ],
+      },
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("invalid_issue_sheet_import_payload");
+  });
 });

--- a/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.ts
@@ -13,6 +13,7 @@ import {
   issueSheetColumnParamsSchema,
   issueSheetCreateColumnBodySchema,
   issueSheetCreateIssueBodySchema,
+  issueSheetImportBodySchema,
   issueSheetIssueParamsSchema,
   issueSheetParamsSchema,
   issueSheetQuerySchema,
@@ -62,6 +63,11 @@ const validateSetValueBody = createZodValidator(
   "json",
   issueSheetSetValueBodySchema,
   "invalid_issue_sheet_value_payload",
+);
+const validateImportBody = createZodValidator(
+  "json",
+  issueSheetImportBodySchema,
+  "invalid_issue_sheet_import_payload",
 );
 
 async function requireProject(c: { var: { auth: AuthVariables["auth"] } }, projectId: string) {
@@ -113,6 +119,53 @@ export function createIssueSheetRoutes() {
         }
         if (error instanceof Error && error.message.includes("duplicate")) {
           return conflictResponse(c, "issue_sheet_issue_exists", "Issue already exists");
+        }
+        throw error;
+      }
+    })
+    .post("/import", validateIssueSheetParams, validateImportBody, async (c) => {
+      if (!isWriteBackTranslationAllowed(c.var.auth.membership.role)) {
+        return forbiddenResponse(c);
+      }
+      const params = c.req.valid("param");
+      const project = await requireProject(c, params.projectId);
+      if (!project) {
+        return projectNotFoundResponse(c);
+      }
+
+      try {
+        const result = await service.importFromCsv({
+          organizationId: c.var.auth.organization.localOrganizationId,
+          projectId: project.id,
+          actorUserId: c.var.auth.user.localUserId,
+          body: c.req.valid("json"),
+        });
+        return c.json({ import: result }, result.dryRun ? 200 : 201);
+      } catch (error) {
+        if (error instanceof Error) {
+          if (error.message === "issue_sheet_import_missing_title_mapping") {
+            return badRequestResponse(
+              c,
+              "missing_required_mapping",
+              "Map at least one column to Title",
+            );
+          }
+          if (error.message === "issue_sheet_import_empty_csv") {
+            return badRequestResponse(c, "invalid_csv", "CSV file is empty");
+          }
+          if (error.message === "issue_sheet_import_file_too_large") {
+            return badRequestResponse(c, "invalid_csv", "CSV file is too large");
+          }
+          if (error.message === "issue_sheet_import_too_many_rows") {
+            return badRequestResponse(c, "invalid_csv", "CSV has too many rows");
+          }
+          if (error.message === "issue_sheet_import_too_many_new_columns") {
+            return badRequestResponse(
+              c,
+              "invalid_issue_sheet_import_payload",
+              "Too many new columns requested",
+            );
+          }
         }
         throw error;
       }

--- a/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.schema.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { issueSheetImportContentExceedsByteLimit } from "@/lib/projects/issue-sheet/issue-sheet-csv-import";
+
 import { projectIdParamsSchema } from "./project.schema";
 
 export const issueSheetIssueStatusSchema = z.enum(["open", "in_progress", "resolved", "wont_fix"]);
@@ -157,7 +159,17 @@ export const issueSheetImportColumnMappingSchema = z.discriminatedUnion("kind", 
 ]);
 
 export const issueSheetImportBodySchema = z.object({
-  content: z.string().min(1).max(2_097_152),
+  content: z
+    .string()
+    .min(1)
+    .superRefine((value, ctx) => {
+      if (issueSheetImportContentExceedsByteLimit(value)) {
+        ctx.addIssue({
+          code: "custom",
+          message: "CSV file is too large",
+        });
+      }
+    }),
   dryRun: z.boolean(),
   mapping: z
     .array(

--- a/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.schema.ts
@@ -118,8 +118,66 @@ export const issueSheetSetValueBodySchema = z.object({
   value: z.unknown(),
 });
 
+export const issueSheetSystemFieldSchema = z.enum([
+  "title",
+  "description",
+  "status",
+  "issue_type",
+  "target_locale",
+  "source_path",
+  "segment_id",
+  "external_ref",
+  "link_url",
+  "assignee",
+]);
+
+export const issueSheetImportColumnMappingSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("system"),
+    field: issueSheetSystemFieldSchema,
+  }),
+  z.object({
+    kind: z.literal("column"),
+    columnId: z.string().uuid(),
+  }),
+  z.object({
+    kind: z.literal("create"),
+    key: z
+      .string()
+      .trim()
+      .min(1)
+      .max(64)
+      .regex(/^[a-z][a-z0-9_]*$/, "Use lowercase letters, numbers, and underscores"),
+    label: z.string().trim().min(1).max(120),
+    type: issueSheetColumnTypeSchema.exclude(["enrichment", "user"]),
+  }),
+  z.object({
+    kind: z.literal("skip"),
+  }),
+]);
+
+export const issueSheetImportBodySchema = z.object({
+  content: z.string().min(1).max(2_097_152),
+  dryRun: z.boolean(),
+  mapping: z
+    .array(
+      z.object({
+        csvHeader: z.string().trim().min(1).max(256),
+        target: issueSheetImportColumnMappingSchema,
+      }),
+    )
+    .min(1)
+    .max(200),
+  options: z
+    .object({
+      skipInvalidRows: z.boolean().optional(),
+    })
+    .optional(),
+});
+
 export type IssueSheetQuery = z.infer<typeof issueSheetQuerySchema>;
 export type IssueSheetCreateIssueBody = z.infer<typeof issueSheetCreateIssueBodySchema>;
 export type IssueSheetUpdateIssueBody = z.infer<typeof issueSheetUpdateIssueBodySchema>;
 export type IssueSheetCreateColumnBody = z.infer<typeof issueSheetCreateColumnBodySchema>;
 export type IssueSheetSetValueBody = z.infer<typeof issueSheetSetValueBodySchema>;
+export type IssueSheetImportBody = z.infer<typeof issueSheetImportBodySchema>;

--- a/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.schema.ts
@@ -179,7 +179,24 @@ export const issueSheetImportBodySchema = z.object({
       }),
     )
     .min(1)
-    .max(200),
+    .max(200)
+    .superRefine((mapping, ctx) => {
+      const seenSystemFields = new Set<string>();
+      for (const [index, entry] of mapping.entries()) {
+        if (entry.target.kind !== "system") {
+          continue;
+        }
+        if (seenSystemFields.has(entry.target.field)) {
+          ctx.addIssue({
+            code: "custom",
+            message: `System field "${entry.target.field}" is mapped more than once`,
+            path: [index, "target", "field"],
+          });
+          continue;
+        }
+        seenSystemFields.add(entry.target.field);
+      }
+    }),
   options: z
     .object({
       skipInvalidRows: z.boolean().optional(),

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-import-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-import-dialog.tsx
@@ -1,0 +1,485 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import { Upload01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { TypographyP } from "@/components/ui/typography";
+import { readApiResponseError } from "@/lib/api-error";
+import {
+  issueSheetSystemFieldLabel,
+  issueSheetSystemFields,
+  parseIssueSheetImportCsv,
+  suggestIssueSheetImportMappings,
+  type IssueSheetImportColumnMapping,
+  type IssueSheetImportColumnType,
+  type IssueSheetSuggestedMapping,
+} from "@/lib/projects/issue-sheet/issue-sheet-csv-import";
+
+type IssueSheetColumn = {
+  id: string;
+  key: string;
+  label: string;
+  type: string;
+};
+
+type ImportResponse = {
+  import: {
+    dryRun: boolean;
+    totalRows: number;
+    created: number;
+    skippedDuplicates: number;
+    skippedInvalid: number;
+    warnings: { row: number; message: string }[];
+    errors: { row: number; message: string }[];
+    columnsCreated: { key: string; label: string }[];
+  };
+};
+
+type ImportStep = "upload" | "map" | "preview" | "done";
+
+const createTypes: { value: IssueSheetImportColumnType; label: string }[] = [
+  { value: "text", label: "Text" },
+  { value: "long_text", label: "Long text" },
+  { value: "select", label: "Select" },
+];
+
+function issueSheetImportPath(organizationSlug: string, projectId: string) {
+  return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/issue-sheet/import`;
+}
+
+async function readJsonOrThrow<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const error = await readApiResponseError(response, "Import failed");
+    throw new Error(error.message || "Import failed");
+  }
+  return (await response.json()) as T;
+}
+
+function buildMappingOptions(columns: IssueSheetColumn[]) {
+  const options: { value: string; label: string; target: IssueSheetImportColumnMapping }[] = [
+    { value: "skip", label: "Skip", target: { kind: "skip" } },
+  ];
+
+  for (const field of issueSheetSystemFields()) {
+    options.push({
+      value: `system:${field}`,
+      label: issueSheetSystemFieldLabel(field),
+      target: { kind: "system", field },
+    });
+  }
+
+  for (const column of columns) {
+    if (column.type === "enrichment") {
+      continue;
+    }
+    options.push({
+      value: `column:${column.id}`,
+      label: column.label,
+      target: { kind: "column", columnId: column.id },
+    });
+  }
+
+  return options;
+}
+
+function mappingToSelectValue(target: IssueSheetImportColumnMapping) {
+  if (target.kind === "skip") {
+    return "skip";
+  }
+  if (target.kind === "system") {
+    return `system:${target.field}`;
+  }
+  if (target.kind === "column") {
+    return `column:${target.columnId}`;
+  }
+  return `create:${target.key}`;
+}
+
+export function IssueSheetImportDialog({
+  open,
+  onOpenChange,
+  organizationSlug,
+  projectId,
+  columns,
+  onImported,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationSlug: string;
+  projectId: string;
+  columns: IssueSheetColumn[];
+  onImported: () => Promise<void>;
+}) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [step, setStep] = useState<ImportStep>("upload");
+  const [csvContent, setCsvContent] = useState("");
+  const [headers, setHeaders] = useState<string[]>([]);
+  const [previewRows, setPreviewRows] = useState<string[][]>([]);
+  const [mappings, setMappings] = useState<IssueSheetSuggestedMapping[]>([]);
+  const [previewResult, setPreviewResult] = useState<ImportResponse["import"] | null>(null);
+
+  const mappingOptions = useMemo(() => buildMappingOptions(columns), [columns]);
+
+  const reset = () => {
+    setStep("upload");
+    setCsvContent("");
+    setHeaders([]);
+    setPreviewRows([]);
+    setMappings([]);
+    setPreviewResult(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const close = () => {
+    onOpenChange(false);
+    reset();
+  };
+
+  const importMutation = useMutation({
+    mutationFn: async (dryRun: boolean) => {
+      const response = await fetch(issueSheetImportPath(organizationSlug, projectId), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          content: csvContent,
+          dryRun,
+          mapping: mappings.map((entry) => ({
+            csvHeader: entry.csvHeader,
+            target: entry.target,
+          })),
+          options: { skipInvalidRows: true },
+        }),
+      });
+      return readJsonOrThrow<ImportResponse>(response);
+    },
+    onError: (error) => toast.error(error instanceof Error ? error.message : "Import failed"),
+  });
+
+  const handleFile = async (file: File) => {
+    if (!file.name.toLowerCase().endsWith(".csv")) {
+      toast.error("Upload a UTF-8 CSV file");
+      return;
+    }
+
+    const content = await file.text();
+    try {
+      const parsed = parseIssueSheetImportCsv(content);
+      const suggestions = suggestIssueSheetImportMappings({
+        headers: parsed.headers,
+        rows: parsed.rows,
+        columns: columns.map((column) => ({
+          id: column.id,
+          key: column.key,
+          label: column.label,
+        })),
+      });
+      setCsvContent(content);
+      setHeaders(parsed.headers);
+      setPreviewRows(parsed.rows.slice(0, 5));
+      setMappings(suggestions);
+      setPreviewResult(null);
+      setStep("map");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not parse CSV");
+    }
+  };
+
+  const updateMapping = (csvHeader: string, optionValue: string) => {
+    setMappings((current) =>
+      current.map((entry) => {
+        if (entry.csvHeader !== csvHeader) {
+          return entry;
+        }
+        const option = mappingOptions.find((item) => item.value === optionValue);
+        if (option) {
+          return { csvHeader, target: option.target };
+        }
+        if (entry.target.kind === "create") {
+          return entry;
+        }
+        return entry;
+      }),
+    );
+  };
+
+  const updateCreateType = (csvHeader: string, type: IssueSheetImportColumnType) => {
+    setMappings((current) =>
+      current.map((entry) => {
+        if (entry.csvHeader !== csvHeader || entry.target.kind !== "create") {
+          return entry;
+        }
+        return {
+          csvHeader,
+          target: { ...entry.target, type },
+        };
+      }),
+    );
+  };
+
+  const runPreview = async () => {
+    const result = await importMutation.mutateAsync(true);
+    setPreviewResult(result.import);
+    setStep("preview");
+  };
+
+  const runImport = async () => {
+    const result = await importMutation.mutateAsync(false);
+    setPreviewResult(result.import);
+    await onImported();
+    toast.success(`Imported ${result.import.created} issues`);
+    setStep("done");
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          close();
+          return;
+        }
+        onOpenChange(true);
+      }}
+    >
+      <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Import issues from CSV</DialogTitle>
+          <DialogDescription>
+            Upload a spreadsheet export, map columns to Issue Sheet fields, preview the result, then
+            import.
+          </DialogDescription>
+        </DialogHeader>
+
+        {step === "upload" ? (
+          <div className="space-y-4">
+            <button
+              type="button"
+              className="flex w-full flex-col items-center justify-center gap-3 rounded-2xl border border-dashed bg-muted/20 px-6 py-10 text-center"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <HugeiconsIcon icon={Upload01Icon} className="size-8 text-muted-foreground" />
+              <div>
+                <TypographyP className="font-medium">Choose a CSV file</TypographyP>
+                <TypographyP className="text-sm text-muted-foreground">
+                  UTF-8 CSV up to 2 MB and 2,000 rows
+                </TypographyP>
+              </div>
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".csv,text/csv"
+              className="hidden"
+              onChange={(event) => {
+                const file = event.currentTarget.files?.[0];
+                if (file) {
+                  void handleFile(file);
+                }
+              }}
+            />
+          </div>
+        ) : null}
+
+        {step === "map" ? (
+          <div className="space-y-4">
+            <div className="flex flex-wrap gap-2">
+              <Badge variant="secondary">{headers.length} columns</Badge>
+              <Badge variant="secondary">{previewRows.length} preview rows</Badge>
+            </div>
+            <div className="overflow-x-auto rounded-xl border">
+              <table className="min-w-full text-sm">
+                <thead className="bg-muted/40 text-left text-xs text-muted-foreground">
+                  <tr>
+                    <th className="px-3 py-2 font-medium">CSV column</th>
+                    <th className="px-3 py-2 font-medium">Maps to</th>
+                    <th className="px-3 py-2 font-medium">Sample</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y">
+                  {mappings.map((entry) => {
+                    const columnIndex = headers.indexOf(entry.csvHeader);
+                    const sample =
+                      previewRows
+                        .map((row) => row[columnIndex] ?? "")
+                        .find((value) => value.trim()) ?? "—";
+                    return (
+                      <tr key={entry.csvHeader}>
+                        <td className="px-3 py-3 font-medium">{entry.csvHeader}</td>
+                        <td className="px-3 py-3">
+                          <div className="flex flex-col gap-2">
+                            <Select
+                              value={mappingToSelectValue(entry.target)}
+                              onValueChange={(value) =>
+                                updateMapping(entry.csvHeader, value ?? "skip")
+                              }
+                            >
+                              <SelectTrigger className="w-full min-w-48">
+                                <SelectValue placeholder="Choose mapping" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {mappingOptions.map((option) => (
+                                  <SelectItem
+                                    key={option.value}
+                                    value={option.value}
+                                    label={option.label}
+                                  >
+                                    {option.label}
+                                  </SelectItem>
+                                ))}
+                                {entry.target.kind === "create" ? (
+                                  <SelectItem
+                                    value={`create:${entry.target.key}`}
+                                    label={`Create: ${entry.target.label}`}
+                                  >
+                                    Create: {entry.target.label}
+                                  </SelectItem>
+                                ) : null}
+                              </SelectContent>
+                            </Select>
+                            {entry.target.kind === "create" ? (
+                              <Select
+                                value={entry.target.type}
+                                onValueChange={(value) =>
+                                  updateCreateType(
+                                    entry.csvHeader,
+                                    (value ?? "text") as IssueSheetImportColumnType,
+                                  )
+                                }
+                              >
+                                <SelectTrigger className="w-full min-w-48">
+                                  <SelectValue placeholder="Column type" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {createTypes.map((type) => (
+                                    <SelectItem
+                                      key={type.value}
+                                      value={type.value}
+                                      label={type.label}
+                                    >
+                                      {type.label}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            ) : null}
+                          </div>
+                        </td>
+                        <td className="max-w-56 truncate px-3 py-3 text-muted-foreground">
+                          {sample}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        ) : null}
+
+        {step === "preview" && previewResult ? (
+          <div className="space-y-4">
+            <div className="flex flex-wrap gap-2">
+              <Badge variant="secondary">{previewResult.totalRows} rows</Badge>
+              <Badge variant="success">{previewResult.created} to import</Badge>
+              <Badge variant="outline">{previewResult.skippedDuplicates} duplicates skipped</Badge>
+              <Badge variant="warning">{previewResult.skippedInvalid} invalid skipped</Badge>
+            </div>
+            {previewResult.columnsCreated.length > 0 ? (
+              <TypographyP className="text-sm text-muted-foreground">
+                New columns: {previewResult.columnsCreated.map((column) => column.label).join(", ")}
+              </TypographyP>
+            ) : null}
+            {previewResult.warnings.length > 0 ? (
+              <div className="rounded-xl border bg-muted/20 p-3 text-sm">
+                <p className="font-medium">Warnings</p>
+                <ul className="mt-2 space-y-1 text-muted-foreground">
+                  {previewResult.warnings.slice(0, 8).map((warning, index) => (
+                    <li key={`${warning.row}-${index}`}>
+                      {warning.row > 0 ? `Row ${warning.row}: ` : ""}
+                      {warning.message}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+            {previewResult.errors.length > 0 ? (
+              <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-3 text-sm">
+                <p className="font-medium text-destructive">Errors</p>
+                <ul className="mt-2 space-y-1 text-muted-foreground">
+                  {previewResult.errors.slice(0, 8).map((error, index) => (
+                    <li key={`${error.row}-${index}`}>
+                      Row {error.row}: {error.message}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+
+        {step === "done" && previewResult ? (
+          <div className="space-y-3">
+            <TypographyP className="text-sm">
+              Imported {previewResult.created} issues. Skipped {previewResult.skippedDuplicates}{" "}
+              duplicates and {previewResult.skippedInvalid} invalid rows.
+            </TypographyP>
+          </div>
+        ) : null}
+
+        <DialogFooter className="gap-2 sm:justify-between">
+          <Button variant="ghost" onClick={close}>
+            Close
+          </Button>
+          <div className="flex flex-wrap gap-2">
+            {step === "map" ? (
+              <>
+                <Button variant="outline" onClick={() => setStep("upload")}>
+                  Back
+                </Button>
+                <Button onClick={() => void runPreview()} disabled={importMutation.isPending}>
+                  Preview import
+                </Button>
+              </>
+            ) : null}
+            {step === "preview" ? (
+              <>
+                <Button variant="outline" onClick={() => setStep("map")}>
+                  Back
+                </Button>
+                <Button
+                  onClick={() => void runImport()}
+                  disabled={importMutation.isPending || previewResult?.created === 0}
+                >
+                  Import {previewResult?.created ?? 0} issues
+                </Button>
+              </>
+            ) : null}
+            {step === "done" ? <Button onClick={close}>Done</Button> : null}
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-import-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-import-dialog.tsx
@@ -216,9 +216,6 @@ export function IssueSheetImportDialog({
         if (option) {
           return { csvHeader, target: option.target };
         }
-        if (entry.target.kind === "create") {
-          return entry;
-        }
         return entry;
       }),
     );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
@@ -30,6 +30,7 @@ import { readApiResponseError } from "@/lib/api-error";
 
 import { ProjectPageShell, ProjectSectionHeader } from "../../_components/project-page-shell";
 import { useProjectPageQuery } from "../../_components/project-page-shell";
+import { IssueSheetImportDialog } from "./issue-sheet-import-dialog";
 
 type IssueSheetColumn = {
   id: string;
@@ -182,6 +183,7 @@ export function IssueSheetPageContent({
   const [search, setSearch] = useState("");
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [columnDialogOpen, setColumnDialogOpen] = useState(false);
+  const [importDialogOpen, setImportDialogOpen] = useState(false);
 
   const queryKey = ["issue-sheet", organizationSlug, projectId, view, search];
   const issueSheetQuery = useQuery({
@@ -252,6 +254,9 @@ export function IssueSheetPageContent({
           description="Track localization issues in Hyperlocalise, then link rows to CAT segments, native issues, provider threads, or external context."
           actions={
             <div className="flex flex-wrap gap-2">
+              <Button variant="outline" onClick={() => setImportDialogOpen(true)}>
+                Import CSV
+              </Button>
               <Button variant="outline" onClick={() => setColumnDialogOpen(true)}>
                 <HugeiconsIcon icon={PlusSignIcon} strokeWidth={2} data-icon="inline-start" />
                 Column
@@ -432,6 +437,14 @@ export function IssueSheetPageContent({
         organizationSlug={organizationSlug}
         projectId={projectId}
         onCreated={refresh}
+      />
+      <IssueSheetImportDialog
+        open={importDialogOpen}
+        onOpenChange={setImportDialogOpen}
+        organizationSlug={organizationSlug}
+        projectId={projectId}
+        columns={data?.columns ?? []}
+        onImported={refresh}
       />
     </ProjectPageShell>
   );

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-csv-import-runner.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-csv-import-runner.ts
@@ -265,6 +265,9 @@ export async function runIssueSheetCsvImport(
     if (!title) {
       result.skippedInvalid += 1;
       result.errors.push({ row: row.rowNumber, message: "Title is required" });
+      if (!skipInvalidRows) {
+        return result;
+      }
       continue;
     }
 
@@ -292,9 +295,7 @@ export async function runIssueSheetCsvImport(
     let assigneeUserId: string | null = null;
     const assigneeRaw = row.system.assignee?.trim();
     if (assigneeRaw) {
-      const email = assigneeRaw.includes("@")
-        ? assigneeRaw.toLowerCase()
-        : assigneeRaw.toLowerCase();
+      const email = assigneeRaw.toLowerCase();
       assigneeUserId = memberByEmail.get(email) ?? null;
       if (!assigneeUserId) {
         result.warnings.push({
@@ -352,6 +353,9 @@ export async function runIssueSheetCsvImport(
 
     if (rowInvalid) {
       result.skippedInvalid += 1;
+      if (!skipInvalidRows) {
+        return result;
+      }
       continue;
     }
 

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-csv-import-runner.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-csv-import-runner.ts
@@ -1,0 +1,440 @@
+import { and, eq } from "drizzle-orm";
+
+import type { IssueSheetImportBody } from "@/api/routes/project/issue-sheet.schema";
+import { db, schema } from "@/lib/database";
+
+import {
+  countIssueSheetImportCreateMappings,
+  ISSUE_SHEET_IMPORT_MAX_NEW_COLUMNS,
+  issueSheetImportHasTitleMapping,
+  normalizeIssueSheetImportIssueType,
+  normalizeIssueSheetImportStatus,
+  parseIssueSheetImportCsv,
+  type IssueSheetImportColumnMapping,
+  type IssueSheetSystemField,
+} from "./issue-sheet-csv-import";
+import type { IssueSheetColumn, IssueSheetService } from "./issue-sheet-service";
+
+export type IssueSheetImportResult = {
+  dryRun: boolean;
+  totalRows: number;
+  created: number;
+  skippedDuplicates: number;
+  skippedInvalid: number;
+  warnings: { row: number; message: string }[];
+  errors: { row: number; message: string }[];
+  columnsCreated: { key: string; label: string }[];
+};
+
+type ParsedRow = {
+  rowNumber: number;
+  system: Partial<Record<IssueSheetSystemField, string>>;
+  custom: { mapping: IssueSheetImportColumnMapping; value: string }[];
+};
+
+type ColumnLookup = Map<string, IssueSheetColumn>;
+
+function buildHeaderMappings(headers: string[], mapping: IssueSheetImportBody["mapping"]) {
+  const indexByHeader = new Map(headers.map((header, index) => [header, index]));
+  return mapping.map((entry) => ({
+    csvHeader: entry.csvHeader,
+    target: entry.target,
+    columnIndex: indexByHeader.get(entry.csvHeader) ?? -1,
+  }));
+}
+
+function resolveSelectValue(
+  column: IssueSheetColumn,
+  raw: string,
+): { value: string | null; warning?: string } {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return { value: null };
+  }
+
+  const options = Array.isArray(column.config.options) ? column.config.options : [];
+  const byId = options.find((option) => option.id.toLowerCase() === trimmed.toLowerCase());
+  if (byId) {
+    return { value: byId.id };
+  }
+  const byLabel = options.find((option) => option.label.toLowerCase() === trimmed.toLowerCase());
+  if (byLabel) {
+    return { value: byLabel.id };
+  }
+
+  return {
+    value: null,
+    warning: `Value "${trimmed}" is not a valid option for ${column.label}`,
+  };
+}
+
+export async function runIssueSheetCsvImport(
+  service: IssueSheetService,
+  input: {
+    organizationId: string;
+    projectId: string;
+    actorUserId: string;
+    body: IssueSheetImportBody;
+  },
+): Promise<IssueSheetImportResult> {
+  const skipInvalidRows = input.body.options?.skipInvalidRows ?? true;
+  const result: IssueSheetImportResult = {
+    dryRun: input.body.dryRun,
+    totalRows: 0,
+    created: 0,
+    skippedDuplicates: 0,
+    skippedInvalid: 0,
+    warnings: [],
+    errors: [],
+    columnsCreated: [],
+  };
+
+  if (!issueSheetImportHasTitleMapping(input.body.mapping.map((entry) => entry.target))) {
+    throw new Error("issue_sheet_import_missing_title_mapping");
+  }
+
+  if (
+    countIssueSheetImportCreateMappings(input.body.mapping.map((entry) => entry.target)) >
+    ISSUE_SHEET_IMPORT_MAX_NEW_COLUMNS
+  ) {
+    throw new Error("issue_sheet_import_too_many_new_columns");
+  }
+
+  const parsed = parseIssueSheetImportCsv(input.body.content);
+  result.totalRows = parsed.rows.length;
+
+  if (parsed.rows.length === 0) {
+    return result;
+  }
+
+  await service.ensureStarterColumns({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    actorUserId: input.actorUserId,
+  });
+
+  let columns = await service.listColumns({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    actorUserId: input.actorUserId,
+  });
+
+  const mappingWithHeaders = input.body.mapping;
+
+  if (!input.body.dryRun) {
+    for (const entry of mappingWithHeaders) {
+      if (entry.target.kind !== "create") {
+        continue;
+      }
+      const createTarget = entry.target;
+      const exists = columns.some((column) => column.key === createTarget.key);
+      if (exists) {
+        continue;
+      }
+
+      const config =
+        createTarget.type === "select"
+          ? {
+              options: [
+                ...new Set(
+                  parsed.rows
+                    .map((row) => {
+                      const columnIndex = parsed.headers.indexOf(entry.csvHeader);
+                      return columnIndex >= 0 ? (row[columnIndex] ?? "").trim() : "";
+                    })
+                    .filter(Boolean),
+                ),
+              ]
+                .slice(0, 25)
+                .map((value) => ({ id: value, label: value })),
+            }
+          : undefined;
+
+      const column = await service.createColumn({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        actorUserId: input.actorUserId,
+        body: {
+          key: createTarget.key,
+          label: createTarget.label,
+          type: createTarget.type,
+          config,
+        },
+      });
+      columns = [...columns, column];
+      result.columnsCreated.push({ key: column.key, label: column.label });
+    }
+  } else {
+    for (const entry of mappingWithHeaders) {
+      if (entry.target.kind === "create") {
+        result.columnsCreated.push({ key: entry.target.key, label: entry.target.label });
+      }
+    }
+  }
+
+  const columnById: ColumnLookup = new Map(columns.map((column) => [column.id, column]));
+  const columnByKey = new Map(columns.map((column) => [column.key, column]));
+
+  const existingExternalRefs = new Set(
+    (
+      await db
+        .select({ externalRef: schema.issueSheetIssues.externalRef })
+        .from(schema.issueSheetIssues)
+        .where(
+          and(
+            eq(schema.issueSheetIssues.organizationId, input.organizationId),
+            eq(schema.issueSheetIssues.projectId, input.projectId),
+          ),
+        )
+    )
+      .map((row) => row.externalRef)
+      .filter((ref): ref is string => ref != null),
+  );
+
+  const memberRows = await db
+    .select({
+      userId: schema.users.id,
+      email: schema.users.email,
+    })
+    .from(schema.organizationMemberships)
+    .innerJoin(schema.users, eq(schema.organizationMemberships.userId, schema.users.id))
+    .where(eq(schema.organizationMemberships.organizationId, input.organizationId));
+
+  const memberByEmail = new Map(
+    memberRows.map((row) => [row.email.toLowerCase(), row.userId] as const),
+  );
+
+  const headerMappings = buildHeaderMappings(parsed.headers, input.body.mapping);
+
+  const hasExternalRefMapping = headerMappings.some(
+    (entry) => entry.target.kind === "system" && entry.target.field === "external_ref",
+  );
+  if (!hasExternalRefMapping) {
+    result.warnings.push({
+      row: 0,
+      message: "No External ID column mapped — re-importing the same file may create duplicates",
+    });
+  }
+
+  const parsedRows: ParsedRow[] = [];
+
+  for (const [rowIndex, row] of parsed.rows.entries()) {
+    const rowNumber = rowIndex + 2;
+    const system: Partial<Record<IssueSheetSystemField, string>> = {};
+    const custom: ParsedRow["custom"] = [];
+
+    for (const entry of headerMappings) {
+      if (entry.columnIndex < 0) {
+        continue;
+      }
+      const raw = (row[entry.columnIndex] ?? "").trim();
+      if (!raw && entry.target.kind !== "system") {
+        continue;
+      }
+
+      if (entry.target.kind === "skip") {
+        continue;
+      }
+      if (entry.target.kind === "system") {
+        system[entry.target.field] = raw;
+        continue;
+      }
+      custom.push({ mapping: entry.target, value: raw });
+    }
+
+    parsedRows.push({ rowNumber, system, custom });
+  }
+
+  const rowsToCreate: {
+    rowNumber: number;
+    title: string;
+    description: string;
+    issueType: string;
+    status: string;
+    targetLocale: string | null;
+    sourcePath: string | null;
+    segmentId: string | null;
+    externalRef: string | null;
+    linkUrl: string | null;
+    assigneeUserId: string | null;
+    customValues: { columnKey: string; value: unknown }[];
+  }[] = [];
+
+  for (const row of parsedRows) {
+    const title = row.system.title?.trim() ?? "";
+    if (!title) {
+      result.skippedInvalid += 1;
+      result.errors.push({ row: row.rowNumber, message: "Title is required" });
+      continue;
+    }
+
+    const externalRef = row.system.external_ref?.trim() || null;
+    if (externalRef && existingExternalRefs.has(externalRef)) {
+      result.skippedDuplicates += 1;
+      continue;
+    }
+
+    const statusResult = normalizeIssueSheetImportStatus(row.system.status ?? "");
+    if (statusResult.error) {
+      result.skippedInvalid += 1;
+      result.errors.push({ row: row.rowNumber, message: statusResult.error });
+      if (!skipInvalidRows) {
+        return result;
+      }
+      continue;
+    }
+
+    const typeResult = normalizeIssueSheetImportIssueType(row.system.issue_type ?? "");
+    if (typeResult.warning) {
+      result.warnings.push({ row: row.rowNumber, message: typeResult.warning });
+    }
+
+    let assigneeUserId: string | null = null;
+    const assigneeRaw = row.system.assignee?.trim();
+    if (assigneeRaw) {
+      const email = assigneeRaw.includes("@")
+        ? assigneeRaw.toLowerCase()
+        : assigneeRaw.toLowerCase();
+      assigneeUserId = memberByEmail.get(email) ?? null;
+      if (!assigneeUserId) {
+        result.warnings.push({
+          row: row.rowNumber,
+          message: `Assignee "${assigneeRaw}" was not found in the organization`,
+        });
+      }
+    }
+
+    const customValues: { columnKey: string; value: unknown }[] = [];
+    let rowInvalid = false;
+
+    for (const entry of row.custom) {
+      if (entry.mapping.kind === "column") {
+        const column = columnById.get(entry.mapping.columnId);
+        if (!column) {
+          result.errors.push({ row: row.rowNumber, message: "Mapped column no longer exists" });
+          rowInvalid = true;
+          break;
+        }
+        if (column.type === "select") {
+          const resolved = resolveSelectValue(column, entry.value);
+          if (resolved.warning) {
+            result.warnings.push({ row: row.rowNumber, message: resolved.warning });
+          }
+          if (resolved.value) {
+            customValues.push({ columnKey: column.key, value: resolved.value });
+          }
+        } else if (column.type === "enrichment") {
+          continue;
+        } else {
+          customValues.push({ columnKey: column.key, value: entry.value });
+        }
+      } else if (entry.mapping.kind === "create") {
+        const column = columnByKey.get(entry.mapping.key);
+        if (!column) {
+          if (input.body.dryRun) {
+            customValues.push({ columnKey: entry.mapping.key, value: entry.value });
+          }
+          continue;
+        }
+        if (column.type === "select") {
+          const resolved = resolveSelectValue(column, entry.value);
+          if (resolved.warning) {
+            result.warnings.push({ row: row.rowNumber, message: resolved.warning });
+          }
+          if (resolved.value) {
+            customValues.push({ columnKey: column.key, value: resolved.value });
+          }
+        } else {
+          customValues.push({ columnKey: column.key, value: entry.value });
+        }
+      }
+    }
+
+    if (rowInvalid) {
+      result.skippedInvalid += 1;
+      continue;
+    }
+
+    const linkUrl = row.system.link_url?.trim() || null;
+    rowsToCreate.push({
+      rowNumber: row.rowNumber,
+      title,
+      description: row.system.description?.trim() ?? "",
+      issueType: typeResult.issueType,
+      status: statusResult.status ?? "open",
+      targetLocale: row.system.target_locale?.trim() || null,
+      sourcePath: row.system.source_path?.trim() || null,
+      segmentId: row.system.segment_id?.trim() || null,
+      externalRef,
+      linkUrl,
+      assigneeUserId,
+      customValues,
+    });
+
+    if (externalRef) {
+      existingExternalRefs.add(externalRef);
+    }
+  }
+
+  result.created = rowsToCreate.length;
+
+  if (input.body.dryRun || rowsToCreate.length === 0) {
+    return result;
+  }
+
+  await db.transaction(async (tx) => {
+    for (const row of rowsToCreate) {
+      const [issue] = await tx
+        .insert(schema.issueSheetIssues)
+        .values({
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+          title: row.title,
+          description: row.description,
+          issueType: row.issueType,
+          status: row.status,
+          targetLocale: row.targetLocale,
+          sourcePath: row.sourcePath,
+          segmentId: row.segmentId,
+          linkKind: row.linkUrl ? "url" : null,
+          linkLabel: row.linkUrl ? "Open link" : null,
+          linkUrl: row.linkUrl,
+          externalRef: row.externalRef,
+          reporterUserId: input.actorUserId,
+          assigneeUserId: row.assigneeUserId,
+          resolvedAt: row.status === "resolved" || row.status === "wont_fix" ? new Date() : null,
+        })
+        .returning({ id: schema.issueSheetIssues.id });
+
+      if (!issue) {
+        throw new Error("issue_sheet_import_insert_failed");
+      }
+
+      for (const value of row.customValues) {
+        const column = columnByKey.get(value.columnKey);
+        if (!column) {
+          continue;
+        }
+        await tx
+          .insert(schema.issueSheetRowValues)
+          .values({
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            issueId: issue.id,
+            columnId: column.id,
+            value: value.value,
+            computedAt: null,
+          })
+          .onConflictDoUpdate({
+            target: [schema.issueSheetRowValues.issueId, schema.issueSheetRowValues.columnId],
+            set: {
+              value: value.value,
+              updatedAt: new Date(),
+            },
+          });
+      }
+    }
+  });
+
+  return result;
+}

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-csv-import.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-csv-import.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  getIssueSheetImportContentByteLength,
   inferIssueSheetImportColumnType,
+  issueSheetImportContentExceedsByteLimit,
   issueSheetImportHasTitleMapping,
   normalizeIssueSheetImportIssueType,
   normalizeIssueSheetImportStatus,
   parseIssueSheetImportCsv,
   slugifyIssueSheetColumnKey,
   suggestIssueSheetImportMappings,
+  uniqueIssueSheetColumnKey,
 } from "./issue-sheet-csv-import";
 
 describe("issue-sheet-csv-import", () => {
@@ -66,5 +69,21 @@ Update glossary term,Done,P2,S24,2`;
   it("slugifies column labels into valid keys", () => {
     expect(slugifyIssueSheetColumnKey("Reviewer Notes")).toBe("reviewer_notes");
     expect(slugifyIssueSheetColumnKey("123-start")).toBe("col_123_start");
+  });
+
+  it("enforces import size by utf-8 byte length", () => {
+    const cjk = "你".repeat(700_000);
+    expect(getIssueSheetImportContentByteLength(cjk)).toBeGreaterThan(2 * 1024 * 1024);
+    expect(issueSheetImportContentExceedsByteLimit(cjk)).toBe(true);
+    expect(() => parseIssueSheetImportCsv(`Title\n${cjk}`)).toThrow(
+      "issue_sheet_import_file_too_large",
+    );
+  });
+
+  it("keeps generated column keys within the schema limit", () => {
+    const used = new Set<string>(["x".repeat(64)]);
+    const key = uniqueIssueSheetColumnKey("x".repeat(80), used, ["priority"]);
+    expect(key.length).toBeLessThanOrEqual(64);
+    expect(used.has(key)).toBe(false);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-csv-import.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-csv-import.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  inferIssueSheetImportColumnType,
+  issueSheetImportHasTitleMapping,
+  normalizeIssueSheetImportIssueType,
+  normalizeIssueSheetImportStatus,
+  parseIssueSheetImportCsv,
+  slugifyIssueSheetColumnKey,
+  suggestIssueSheetImportMappings,
+} from "./issue-sheet-csv-import";
+
+describe("issue-sheet-csv-import", () => {
+  it("suggests system fields and creates custom columns with smart defaults", () => {
+    const csv = `Summary,Status,Priority,Sprint,Row #
+Fix CTA copy,Open,P1,S24,1
+Update glossary term,Done,P2,S24,2`;
+    const { headers, rows } = parseIssueSheetImportCsv(csv);
+    const suggestions = suggestIssueSheetImportMappings({
+      headers,
+      rows,
+      columns: [{ id: "priority-id", key: "priority", label: "Priority" }],
+    });
+
+    expect(suggestions).toEqual([
+      { csvHeader: "Summary", target: { kind: "system", field: "title" } },
+      { csvHeader: "Status", target: { kind: "system", field: "status" } },
+      {
+        csvHeader: "Priority",
+        target: { kind: "column", columnId: "priority-id" },
+      },
+      {
+        csvHeader: "Sprint",
+        target: { kind: "create", key: "sprint", label: "Sprint", type: "select" },
+      },
+      { csvHeader: "Row #", target: { kind: "skip" } },
+    ]);
+  });
+
+  it("normalizes status and issue type values", () => {
+    expect(normalizeIssueSheetImportStatus("In Progress")).toEqual({ status: "in_progress" });
+    expect(normalizeIssueSheetImportStatus("weird")).toEqual({
+      error: "Unknown status: weird",
+    });
+    expect(normalizeIssueSheetImportIssueType("QA")).toEqual({
+      issueType: "qa_failure",
+    });
+    expect(normalizeIssueSheetImportIssueType("misc")).toEqual({
+      issueType: "general_question",
+      warning: 'Unknown issue type "misc", defaulted to general question',
+    });
+  });
+
+  it("infers long text columns from large values", () => {
+    const longValue = "x".repeat(250);
+    expect(inferIssueSheetImportColumnType(["short", longValue])).toBe("long_text");
+  });
+
+  it("requires a title mapping before import", () => {
+    expect(
+      issueSheetImportHasTitleMapping([{ kind: "system", field: "description" }, { kind: "skip" }]),
+    ).toBe(false);
+    expect(issueSheetImportHasTitleMapping([{ kind: "system", field: "title" }])).toBe(true);
+  });
+
+  it("slugifies column labels into valid keys", () => {
+    expect(slugifyIssueSheetColumnKey("Reviewer Notes")).toBe("reviewer_notes");
+    expect(slugifyIssueSheetColumnKey("123-start")).toBe("col_123_start");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-csv-import.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-csv-import.ts
@@ -2,7 +2,18 @@ import { parseCsvRows } from "@/lib/csv/parse-csv-rows";
 
 export const ISSUE_SHEET_IMPORT_MAX_ROWS = 2_000;
 export const ISSUE_SHEET_IMPORT_MAX_CONTENT_BYTES = 2 * 1024 * 1024;
+export const ISSUE_SHEET_IMPORT_MAX_COLUMN_KEY_LENGTH = 64;
 export const ISSUE_SHEET_IMPORT_MAX_NEW_COLUMNS = 20;
+
+const textEncoder = new TextEncoder();
+
+export function getIssueSheetImportContentByteLength(content: string) {
+  return textEncoder.encode(content).byteLength;
+}
+
+export function issueSheetImportContentExceedsByteLimit(content: string) {
+  return getIssueSheetImportContentByteLength(content) > ISSUE_SHEET_IMPORT_MAX_CONTENT_BYTES;
+}
 
 export type IssueSheetSystemField =
   | "title"
@@ -231,6 +242,29 @@ export function inferIssueSheetImportColumnType(values: string[]): IssueSheetImp
   return "text";
 }
 
+export function uniqueIssueSheetColumnKey(
+  label: string,
+  usedKeys: Set<string>,
+  existingKeys: Iterable<string>,
+) {
+  const existing = new Set(existingKeys);
+  const base = slugifyIssueSheetColumnKey(label).slice(0, ISSUE_SHEET_IMPORT_MAX_COLUMN_KEY_LENGTH);
+  if (!usedKeys.has(base) && !existing.has(base)) {
+    return base;
+  }
+
+  for (let suffix = 2; suffix < 1_000; suffix += 1) {
+    const suffixText = `_${suffix}`;
+    const trimmedBase = base.slice(0, ISSUE_SHEET_IMPORT_MAX_COLUMN_KEY_LENGTH - suffixText.length);
+    const candidate = `${trimmedBase}${suffixText}`;
+    if (!usedKeys.has(candidate) && !existing.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error("issue_sheet_import_column_key_collision");
+}
+
 export function suggestIssueSheetImportMappings(input: {
   headers: string[];
   rows: string[][];
@@ -259,10 +293,11 @@ export function suggestIssueSheetImportMappings(input: {
 
     const columnValues = input.rows.map((row) => row[columnIndex] ?? "");
     const inferredType = inferIssueSheetImportColumnType(columnValues);
-    let key = slugifyIssueSheetColumnKey(csvHeader);
-    while (usedCreateKeys.has(key) || input.columns.some((column) => column.key === key)) {
-      key = `${key}_import`;
-    }
+    const key = uniqueIssueSheetColumnKey(
+      csvHeader,
+      usedCreateKeys,
+      input.columns.map((column) => column.key),
+    );
     usedCreateKeys.add(key);
 
     return {
@@ -278,7 +313,7 @@ export function suggestIssueSheetImportMappings(input: {
 }
 
 export function parseIssueSheetImportCsv(content: string) {
-  if (content.length > ISSUE_SHEET_IMPORT_MAX_CONTENT_BYTES) {
+  if (issueSheetImportContentExceedsByteLimit(content)) {
     throw new Error("issue_sheet_import_file_too_large");
   }
 

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-csv-import.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-csv-import.ts
@@ -1,0 +1,343 @@
+import { parseCsvRows } from "@/lib/csv/parse-csv-rows";
+
+export const ISSUE_SHEET_IMPORT_MAX_ROWS = 2_000;
+export const ISSUE_SHEET_IMPORT_MAX_CONTENT_BYTES = 2 * 1024 * 1024;
+export const ISSUE_SHEET_IMPORT_MAX_NEW_COLUMNS = 20;
+
+export type IssueSheetSystemField =
+  | "title"
+  | "description"
+  | "status"
+  | "issue_type"
+  | "target_locale"
+  | "source_path"
+  | "segment_id"
+  | "external_ref"
+  | "link_url"
+  | "assignee";
+
+export type IssueSheetImportColumnType = "text" | "long_text" | "select";
+
+export type IssueSheetImportColumnMapping =
+  | { kind: "system"; field: IssueSheetSystemField }
+  | { kind: "column"; columnId: string }
+  | {
+      kind: "create";
+      key: string;
+      label: string;
+      type: IssueSheetImportColumnType;
+    }
+  | { kind: "skip" };
+
+export type IssueSheetImportMappingColumn = {
+  id: string;
+  key: string;
+  label: string;
+};
+
+export type IssueSheetSuggestedMapping = {
+  csvHeader: string;
+  target: IssueSheetImportColumnMapping;
+};
+
+export type IssueSheetImportStatus = "open" | "in_progress" | "resolved" | "wont_fix";
+
+export type IssueSheetImportIssueType =
+  | "general_question"
+  | "translation_mistake"
+  | "context_request"
+  | "source_mistake"
+  | "glossary_violation"
+  | "qa_failure";
+
+const SYSTEM_FIELD_LABELS: Record<IssueSheetSystemField, string> = {
+  title: "Title",
+  description: "Description",
+  status: "Status",
+  issue_type: "Type",
+  target_locale: "Locale",
+  source_path: "Source path",
+  segment_id: "Segment ID",
+  external_ref: "External ID",
+  link_url: "Link URL",
+  assignee: "Assignee",
+};
+
+const SYSTEM_FIELD_ALIASES: Record<string, IssueSheetSystemField> = {
+  title: "title",
+  summary: "title",
+  "issue title": "title",
+  issue: "title",
+  name: "title",
+  subject: "title",
+  description: "description",
+  details: "description",
+  body: "description",
+  notes: "description",
+  comment: "description",
+  status: "status",
+  state: "status",
+  workflow: "status",
+  "issue type": "issue_type",
+  type: "issue_type",
+  category: "issue_type",
+  kind: "issue_type",
+  locale: "target_locale",
+  language: "target_locale",
+  "target locale": "target_locale",
+  "target language": "target_locale",
+  "source path": "source_path",
+  file: "source_path",
+  filepath: "source_path",
+  path: "source_path",
+  "segment id": "segment_id",
+  segment: "segment_id",
+  key: "segment_id",
+  "string key": "segment_id",
+  "external id": "external_ref",
+  "external ref": "external_ref",
+  id: "external_ref",
+  "ticket id": "external_ref",
+  "ticket #": "external_ref",
+  ticket: "external_ref",
+  "issue id": "external_ref",
+  "link url": "link_url",
+  url: "link_url",
+  link: "link_url",
+  assignee: "assignee",
+  owner: "assignee",
+  "assigned to": "assignee",
+};
+
+const JUNK_HEADERS = new Set(["", "#", "row", "row id", "row #", "row number", "index"]);
+
+const STATUS_ALIASES: Record<string, IssueSheetImportStatus> = {
+  open: "open",
+  new: "open",
+  todo: "open",
+  backlog: "open",
+  "in progress": "in_progress",
+  "in-progress": "in_progress",
+  doing: "in_progress",
+  active: "in_progress",
+  resolved: "resolved",
+  done: "resolved",
+  closed: "resolved",
+  fixed: "resolved",
+  complete: "resolved",
+  completed: "resolved",
+  "won't fix": "wont_fix",
+  wontfix: "wont_fix",
+  "wont fix": "wont_fix",
+  invalid: "wont_fix",
+  rejected: "wont_fix",
+};
+
+const ISSUE_TYPE_ALIASES: Record<string, IssueSheetImportIssueType> = {
+  general_question: "general_question",
+  question: "general_question",
+  general: "general_question",
+  translation_mistake: "translation_mistake",
+  translation: "translation_mistake",
+  mistake: "translation_mistake",
+  context_request: "context_request",
+  context: "context_request",
+  source_mistake: "source_mistake",
+  source: "source_mistake",
+  glossary_violation: "glossary_violation",
+  glossary: "glossary_violation",
+  qa_failure: "qa_failure",
+  qa: "qa_failure",
+  lqa: "qa_failure",
+};
+
+export function issueSheetSystemFieldLabel(field: IssueSheetSystemField) {
+  return SYSTEM_FIELD_LABELS[field];
+}
+
+export function issueSheetSystemFields(): IssueSheetSystemField[] {
+  return Object.keys(SYSTEM_FIELD_LABELS) as IssueSheetSystemField[];
+}
+
+function normalizeHeader(header: string) {
+  return header.trim().toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ");
+}
+
+export function slugifyIssueSheetColumnKey(label: string) {
+  const slug = label
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .replace(/_+/g, "_");
+  if (!slug) {
+    return "imported_column";
+  }
+  return /^[a-z]/.test(slug) ? slug : `col_${slug}`;
+}
+
+function isJunkHeader(header: string) {
+  return JUNK_HEADERS.has(normalizeHeader(header));
+}
+
+function columnHasData(rows: string[][], columnIndex: number) {
+  return rows.some((row) => (row[columnIndex] ?? "").trim().length > 0);
+}
+
+function matchSystemField(header: string): IssueSheetSystemField | null {
+  const normalized = normalizeHeader(header);
+  if (SYSTEM_FIELD_ALIASES[normalized]) {
+    return SYSTEM_FIELD_ALIASES[normalized];
+  }
+  for (const [alias, field] of Object.entries(SYSTEM_FIELD_ALIASES)) {
+    if (normalized.includes(alias) && alias.length >= 4) {
+      return field;
+    }
+  }
+  return null;
+}
+
+function matchExistingColumn(
+  header: string,
+  columns: IssueSheetImportMappingColumn[],
+): IssueSheetImportMappingColumn | null {
+  const normalized = normalizeHeader(header);
+  return (
+    columns.find(
+      (column) =>
+        normalizeHeader(column.label) === normalized || normalizeHeader(column.key) === normalized,
+    ) ?? null
+  );
+}
+
+export function inferIssueSheetImportColumnType(values: string[]): IssueSheetImportColumnType {
+  const nonEmpty = values.map((value) => value.trim()).filter(Boolean);
+  if (nonEmpty.length === 0) {
+    return "text";
+  }
+
+  if (nonEmpty.some((value) => value.length > 200)) {
+    return "long_text";
+  }
+
+  const unique = new Set(nonEmpty.map((value) => value.toLowerCase()));
+  if (unique.size <= 12) {
+    const ratio = unique.size / nonEmpty.length;
+    if (ratio <= 0.5 || unique.size <= 8) {
+      return "select";
+    }
+  }
+
+  return "text";
+}
+
+export function suggestIssueSheetImportMappings(input: {
+  headers: string[];
+  rows: string[][];
+  columns: IssueSheetImportMappingColumn[];
+}): IssueSheetSuggestedMapping[] {
+  const usedSystemFields = new Set<IssueSheetSystemField>();
+  const usedColumnIds = new Set<string>();
+  const usedCreateKeys = new Set<string>();
+
+  return input.headers.map((csvHeader, columnIndex) => {
+    if (isJunkHeader(csvHeader) || !columnHasData(input.rows, columnIndex)) {
+      return { csvHeader, target: { kind: "skip" } };
+    }
+
+    const systemField = matchSystemField(csvHeader);
+    if (systemField && !usedSystemFields.has(systemField)) {
+      usedSystemFields.add(systemField);
+      return { csvHeader, target: { kind: "system", field: systemField } };
+    }
+
+    const existing = matchExistingColumn(csvHeader, input.columns);
+    if (existing && !usedColumnIds.has(existing.id)) {
+      usedColumnIds.add(existing.id);
+      return { csvHeader, target: { kind: "column", columnId: existing.id } };
+    }
+
+    const columnValues = input.rows.map((row) => row[columnIndex] ?? "");
+    const inferredType = inferIssueSheetImportColumnType(columnValues);
+    let key = slugifyIssueSheetColumnKey(csvHeader);
+    while (usedCreateKeys.has(key) || input.columns.some((column) => column.key === key)) {
+      key = `${key}_import`;
+    }
+    usedCreateKeys.add(key);
+
+    return {
+      csvHeader,
+      target: {
+        kind: "create",
+        key,
+        label: csvHeader.trim() || key,
+        type: inferredType,
+      },
+    };
+  });
+}
+
+export function parseIssueSheetImportCsv(content: string) {
+  if (content.length > ISSUE_SHEET_IMPORT_MAX_CONTENT_BYTES) {
+    throw new Error("issue_sheet_import_file_too_large");
+  }
+
+  const rows = parseCsvRows(content);
+  if (rows.length === 0) {
+    throw new Error("issue_sheet_import_empty_csv");
+  }
+
+  const [headerRow, ...dataRows] = rows;
+  const headers = headerRow.map((cell, index) => cell.trim() || `Column ${index + 1}`);
+  const bodyRows = dataRows.filter((row) => row.some((cell) => cell.trim().length > 0));
+
+  if (bodyRows.length > ISSUE_SHEET_IMPORT_MAX_ROWS) {
+    throw new Error("issue_sheet_import_too_many_rows");
+  }
+
+  return { headers, rows: bodyRows };
+}
+
+export function normalizeIssueSheetImportStatus(raw: string): {
+  status?: IssueSheetImportStatus;
+  error?: string;
+} {
+  const normalized = raw.trim().toLowerCase().replace(/[_-]+/g, " ");
+  if (!normalized) {
+    return { status: "open" };
+  }
+  const status = STATUS_ALIASES[normalized];
+  if (status) {
+    return { status };
+  }
+  return { error: `Unknown status: ${raw.trim()}` };
+}
+
+export function normalizeIssueSheetImportIssueType(raw: string): {
+  issueType: IssueSheetImportIssueType;
+  warning?: string;
+} {
+  const normalized = raw
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+  if (!normalized) {
+    return { issueType: "general_question" };
+  }
+  const issueType = ISSUE_TYPE_ALIASES[normalized];
+  if (issueType) {
+    return { issueType };
+  }
+  return {
+    issueType: "general_question",
+    warning: `Unknown issue type "${raw.trim()}", defaulted to general question`,
+  };
+}
+
+export function issueSheetImportHasTitleMapping(mapping: IssueSheetImportColumnMapping[]) {
+  return mapping.some((entry) => entry.kind === "system" && entry.field === "title");
+}
+
+export function countIssueSheetImportCreateMappings(mapping: IssueSheetImportColumnMapping[]) {
+  return mapping.filter((entry) => entry.kind === "create").length;
+}

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
@@ -8,7 +8,13 @@ import {
   type IssueSheetSetValueBody,
   type IssueSheetUpdateIssueBody,
 } from "@/api/routes/project/issue-sheet.schema";
+import type { IssueSheetImportBody } from "@/api/routes/project/issue-sheet.schema";
 import { db, schema } from "@/lib/database";
+
+import {
+  runIssueSheetCsvImport,
+  type IssueSheetImportResult,
+} from "./issue-sheet-csv-import-runner";
 
 export type IssueSheetColumn = {
   id: string;
@@ -424,6 +430,15 @@ export class IssueSheetService {
     }
 
     return this.getIssueById(input);
+  }
+
+  async importFromCsv(input: {
+    organizationId: string;
+    projectId: string;
+    actorUserId: string;
+    body: IssueSheetImportBody;
+  }): Promise<IssueSheetImportResult> {
+    return runIssueSheetCsvImport(this, input);
   }
 
   async setValue(input: {

--- a/docs/plans/2026-07-07-issue-sheet-csv-import-design.md
+++ b/docs/plans/2026-07-07-issue-sheet-csv-import-design.md
@@ -1,0 +1,47 @@
+# Issue Sheet CSV Import — Design
+
+**Status:** Approved  
+**Date:** 2026-07-07
+
+## Summary
+
+Project-scoped CSV import for Issue Sheet with per-column mapping, smart header defaults, dry-run preview, and skip-on-duplicate via `external_ref`.
+
+## Decisions
+
+| Topic | Choice |
+|-------|--------|
+| Source | Generic CSV (UTF-8) |
+| Unmapped columns | Per-column mapping with smart defaults |
+| Duplicates | Skip when `external_ref` already exists in project |
+| Architecture | Client parse for mapping UI; server dry-run + execute |
+| Scope | Project Issue Sheet only |
+
+## Flow
+
+1. Upload CSV on Issue Sheet page
+2. Map columns (system field, existing custom, create new, skip)
+3. Preview via `dryRun: true`
+4. Import via `dryRun: false`
+
+## API
+
+`POST /api/orgs/:slug/projects/:projectId/issue-sheet/import`
+
+Body: `{ content, dryRun, mapping, options? }`  
+Response: `{ import: { dryRun, totalRows, created, skippedDuplicates, skippedInvalid, warnings, errors, columnsCreated? } }`
+
+## Limits
+
+- 2 MB file size
+- 2,000 rows
+- 20 new custom columns per import
+- Title mapping required
+
+## Out of scope (v1)
+
+- Excel (`.xlsx`)
+- Update existing issues on re-import
+- Segment/key auto-linking
+- Org-wide import
+- CLI import


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds project-scoped CSV import to Issue Sheet so teams can migrate generic spreadsheet exports without rebuilding issues manually.

- **Import wizard** on the Issue Sheet page: upload → map columns → preview → import
- **Smart defaults** for header matching (system fields, existing custom columns, or create new)
- **Dry-run preview** via `POST .../issue-sheet/import` with `dryRun: true`
- **Duplicate handling**: rows with an existing `external_ref` are skipped (no updates in v1)
- **Value normalization** for status, issue type, assignee email, and select column options

## API

`POST /api/orgs/:slug/projects/:projectId/issue-sheet/import`

```json
{
  "content": "<csv>",
  "dryRun": true,
  "mapping": [{ "csvHeader": "Summary", "target": { "kind": "system", "field": "title" } }],
  "options": { "skipInvalidRows": true }
}
```

## Limits

- UTF-8 CSV, 2 MB, 2,000 rows, 20 new custom columns per import
- Title mapping required

## Design doc

`docs/plans/2026-07-07-issue-sheet-csv-import-design.md`

## Testing

- `vp check --fix` passes
- Unit tests: `issue-sheet-csv-import.test.ts`
- Route test: import dry-run, execute, duplicate skip
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3bac-9ad1-77ff-a753-458fa2474aba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3bac-9ad1-77ff-a753-458fa2474aba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

