### PR TITLE
fix(web): use project locales for native CAT files

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -1429,7 +1429,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           );
         }
 
-        if (result.translatedKeyCount === 0) {
+        if (result.loadedKeyCount === 0) {
           return translationsNotFoundResponse(c);
         }
 

--- a/apps/hyperlocalise-web/src/api/routes/public-translations/public-translations.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-translations/public-translations.route.test.ts
@@ -138,7 +138,7 @@ describe("publicTranslationRoutes", () => {
     expect(body.error).toBe("source_file_not_found");
   });
 
-  it("returns 404 when source keys exist but no translations are ready", async () => {
+  it("downloads source fallbacks when source keys exist but no translations are ready", async () => {
     const { apiKey, project } = await createPublicApiFixture();
     await db
       .update(schema.organizationApiKeys)
@@ -166,9 +166,9 @@ describe("publicTranslationRoutes", () => {
       { headers: { "x-api-key": apiKey } },
     );
 
-    expect(response.status).toBe(404);
-    const body = (await response.json()) as { error: string };
-    expect(body.error).toBe("translations_not_found");
+    expect(response.status).toBe(200);
+    const content = await response.text();
+    expect(JSON.parse(content)).toEqual({ greeting: "Hello" });
   });
 
   it("exports every source key while preserving translated values", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/public-translations/public-translations.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-translations/public-translations.route.ts
@@ -90,7 +90,7 @@ export function createPublicTranslationRoutes() {
           return sourceFileTooLargeResponse(c, result.maxKeyCount);
         }
 
-        if (result.translatedKeyCount === 0) {
+        if (result.loadedKeyCount === 0) {
           return translationsNotFoundResponse(c);
         }
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.test.tsx
@@ -268,6 +268,26 @@ describe("ProjectFileCatPageContent CAT shell", () => {
     expect(screen.getByTestId("cat-workspace")).toHaveAttribute("data-target-locales", "vi,fr-FR");
   });
 
+  it("shows a warning when a requested native locale falls back", async () => {
+    render(
+      <CatTestProviders>
+        <ProjectFileCatPageContent
+          organizationSlug="acme"
+          projectId="proj_1"
+          sourcePath="en-US.json"
+          highlightLocale="ja-JP"
+        />
+      </CatTestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("cat-workspace")).toHaveAttribute("data-target-locale", "vi");
+    });
+    expect(
+      screen.getByText("ja-JP is not a target locale for this file. Showing vi instead."),
+    ).toBeInTheDocument();
+  });
+
   it("prompts for a repository when multiple GitHub repos are enabled and none is selected", async () => {
     render(
       <CatTestProviders>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.test.tsx
@@ -22,14 +22,20 @@ const {
     ({
       repositoryFullName,
       sourcePath,
+      targetLocale,
+      targetLocales,
     }: {
       repositoryFullName?: string | null;
       sourcePath: string;
+      targetLocale: string;
+      targetLocales?: string[];
     }) => (
       <div
         data-testid="cat-workspace"
         data-repo={repositoryFullName ?? ""}
         data-source-path={sourcePath}
+        data-target-locale={targetLocale}
+        data-target-locales={(targetLocales ?? []).join(",")}
       />
     ),
   ),
@@ -78,8 +84,12 @@ vi.mock("@/lib/api-client-instance", () => ({
 }));
 
 vi.mock("@/components/cat/project-file/project-file-cat-workspace", () => ({
-  ProjectFileCatWorkspace: (props: { repositoryFullName?: string | null; sourcePath: string }) =>
-    ProjectFileCatWorkspaceMock(props),
+  ProjectFileCatWorkspace: (props: {
+    repositoryFullName?: string | null;
+    sourcePath: string;
+    targetLocale: string;
+    targetLocales?: string[];
+  }) => ProjectFileCatWorkspaceMock(props),
 }));
 
 import { ProjectFileCatPageContent } from "./project-file-cat-page-content";
@@ -124,7 +134,7 @@ function mockReadyProjectQuery() {
     isLoading: false,
     isError: false,
     isSuccess: true,
-    data: { sourceLocale: "en" },
+    data: { sourceLocale: "en", targetLocales: ["vi", "fr-FR"] },
     error: null,
   });
 }
@@ -238,6 +248,24 @@ describe("ProjectFileCatPageContent CAT shell", () => {
     await waitFor(() => {
       expect(screen.getByTestId("cat-workspace")).toHaveAttribute("data-repo", "acme/docs");
     });
+  });
+
+  it("opens native CAT with the first project target locale when the URL has no locale", async () => {
+    render(
+      <CatTestProviders>
+        <ProjectFileCatPageContent
+          organizationSlug="acme"
+          projectId="proj_1"
+          sourcePath="en-US.json"
+          highlightLocale={null}
+        />
+      </CatTestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("cat-workspace")).toHaveAttribute("data-target-locale", "vi");
+    });
+    expect(screen.getByTestId("cat-workspace")).toHaveAttribute("data-target-locales", "vi,fr-FR");
   });
 
   it("prompts for a repository when multiple GitHub repos are enabled and none is selected", async () => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
@@ -17,6 +17,8 @@ import {
   buildProjectFileCatHref,
   canOpenProjectFileCat,
   hasProjectFileCatIdentityFromUrl,
+  resolveProjectFileCatTargetLocale,
+  resolveProjectFileCatTargetLocales,
 } from "@/lib/projects/project-file-cat-routing";
 
 import { ProjectPageShell, useProjectPageQuery } from "../../_components/project-page-shell";
@@ -25,7 +27,6 @@ import {
   readCatFileRepositoryPreference,
   writeCatFileRepositoryPreference,
 } from "../../jobs/[jobId]/strings/_components/job-cat-repository-preference";
-import { selectJobCatTargetLocale } from "../../jobs/[jobId]/strings/_components/job-cat-target-locale";
 import {
   canLookupFreshCatRepositoryContext,
   selectJobCatRepository,
@@ -255,11 +256,12 @@ export function ProjectFileCatPageContent({
     );
   }
 
-  const targetLocale = file?.provider
-    ? selectJobCatTargetLocale({
-        requestedTargetLocale: highlightLocale,
-        providerTargetLocales: file.provider.targetLocales,
-      })
+  const projectTargetLocales = projectQuery.data?.targetLocales;
+  const workspaceTargetLocales = file
+    ? resolveProjectFileCatTargetLocales(file, projectTargetLocales)
+    : [];
+  const targetLocale = file
+    ? resolveProjectFileCatTargetLocale(file, highlightLocale, projectTargetLocales)
     : highlightLocale;
 
   if (!targetLocale) {
@@ -318,6 +320,7 @@ export function ProjectFileCatPageContent({
       nextFile,
       highlightLocale,
       branch,
+      projectTargetLocales,
     );
     if (href) {
       router.push(href);
@@ -397,7 +400,7 @@ export function ProjectFileCatPageContent({
           externalResourceId={resolvedExternalResourceId}
           resourceType={resolvedResourceType}
           targetLocale={targetLocale}
-          targetLocales={file?.provider?.targetLocales}
+          targetLocales={workspaceTargetLocales}
           highlightLocale={highlightLocale}
           repositoryFullName={selectedRepositoryFullName}
           canLookupFreshContext={canLookupFreshCatRepositoryContext(

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
@@ -17,7 +17,7 @@ import {
   buildProjectFileCatHref,
   canOpenProjectFileCat,
   hasProjectFileCatIdentityFromUrl,
-  resolveProjectFileCatTargetLocale,
+  resolveProjectFileCatTargetLocaleResolution,
   resolveProjectFileCatTargetLocales,
 } from "@/lib/projects/project-file-cat-routing";
 
@@ -260,9 +260,21 @@ export function ProjectFileCatPageContent({
   const workspaceTargetLocales = file
     ? resolveProjectFileCatTargetLocales(file, projectTargetLocales)
     : [];
-  const targetLocale = file
-    ? resolveProjectFileCatTargetLocale(file, highlightLocale, projectTargetLocales)
-    : highlightLocale;
+  const targetLocaleResolution = file
+    ? resolveProjectFileCatTargetLocaleResolution(file, highlightLocale, projectTargetLocales)
+    : {
+        requestedLocale: highlightLocale,
+        status: highlightLocale ? ("exact" as const) : ("none" as const),
+        targetLocale: highlightLocale,
+        targetLocales: [],
+      };
+  const targetLocale = targetLocaleResolution.targetLocale;
+  const localeFallbackMessage =
+    targetLocaleResolution.status === "fallback" &&
+    targetLocaleResolution.requestedLocale &&
+    targetLocaleResolution.requestedLocale !== targetLocale
+      ? `${targetLocaleResolution.requestedLocale} is not a target locale for this file. Showing ${targetLocale} instead.`
+      : null;
 
   if (!targetLocale) {
     return (
@@ -389,6 +401,14 @@ export function ProjectFileCatPageContent({
           )}
         </div>
       )}
+
+      {localeFallbackMessage ? (
+        <div className="shrink-0 border-b border-border px-3 py-1.5 sm:px-4 lg:px-6">
+          <TypographyP className="text-xs text-muted-foreground">
+            {localeFallbackMessage}
+          </TypographyP>
+        </div>
+      ) : null}
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 py-2 sm:px-4 lg:px-6">
         <ProjectFileCatWorkspace

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-detail-panel.tsx
@@ -350,20 +350,20 @@ export function ProjectFileDetailPanelView({
               <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} />
               Import translations
             </Button>
-            {downloadableLocales.length > 0 ? (
-              downloadableLocales.map((locale) => (
-                <Button
-                  key={locale}
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  onClick={() => downloadTranslation(locale)}
-                >
-                  <HugeiconsIcon icon={Download01Icon} strokeWidth={1.8} />
-                  Download {locale}
-                </Button>
-              ))
-            ) : null}
+            {downloadableLocales.length > 0
+              ? downloadableLocales.map((locale) => (
+                  <Button
+                    key={locale}
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => downloadTranslation(locale)}
+                  >
+                    <HugeiconsIcon icon={Download01Icon} strokeWidth={1.8} />
+                    Download {locale}
+                  </Button>
+                ))
+              : null}
           </div>
         ) : null}
       </header>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-detail-panel.tsx
@@ -21,7 +21,6 @@ import { formatBytes } from "./project-files-shared";
 import { CreateTranslationJobDialog } from "./create-translation-job-dialog";
 import { ImportTranslationsDialog } from "./import-translations-dialog";
 import {
-  countReadyLocales,
   resolveFileLocaleReadiness,
   summarizeNativeLocaleReadiness,
 } from "@/lib/projects/files/native-locale-readiness";
@@ -257,10 +256,7 @@ export function ProjectFileDetailPanelView({
     : jobsByLocale;
   const localeReadiness = resolveFileLocaleReadiness(file);
   const readinessSummary = summarizeNativeLocaleReadiness(localeReadiness, targetLocales.length);
-  const readyLocaleCount = countReadyLocales(localeReadiness);
-  const downloadableLocales = targetLocales.filter(
-    (locale) => localeReadiness[locale] === "ready" || localeReadiness[locale] === "complete",
-  );
+  const downloadableLocales = targetLocales;
 
   function downloadTranslation(locale: string) {
     if (!sourcePath) return;
@@ -367,10 +363,6 @@ export function ProjectFileDetailPanelView({
                   Download {locale}
                 </Button>
               ))
-            ) : readyLocaleCount === 0 && targetLocales.length > 0 ? (
-              <TypographyP className="self-center text-xs text-muted-foreground">
-                Translations will be downloadable after jobs complete.
-              </TypographyP>
             ) : null}
           </div>
         ) : null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.tsx
@@ -16,6 +16,7 @@ export function ProjectFileSelectionActions({
   projectId,
   file,
   highlightLocale,
+  projectTargetLocales,
   branch = null,
   layout = "default",
 }: {
@@ -23,6 +24,7 @@ export function ProjectFileSelectionActions({
   projectId: string;
   file: ProjectFileRecord;
   highlightLocale: string | null;
+  projectTargetLocales?: readonly string[] | null;
   branch?: string | null;
   layout?: "default" | "compact";
 }) {
@@ -33,6 +35,7 @@ export function ProjectFileSelectionActions({
     file,
     highlightLocale,
     branch,
+    projectTargetLocales,
   );
 
   if (layout === "compact") {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx
@@ -128,4 +128,16 @@ describe("ProjectFilesPageContent CAT entry UX", () => {
       screen.getByText(/Double-click a file or use View strings to open the CAT workspace for vi/i),
     ).toBeInTheDocument();
   });
+
+  it("shows when a requested native locale will fall back to a project locale", () => {
+    searchParamsMock.mockReturnValue("sourcePath=en-US.json&locale=ja-JP");
+
+    render(<ProjectFilesPageContent organizationSlug="acme" projectId="proj_1" />);
+
+    expect(
+      screen.getByText(
+        "ja-JP is not a target locale for this file. Double-click a file or use View strings to open the CAT workspace for vi.",
+      ),
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx
@@ -3,7 +3,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useEffect, type ReactNode } from "react";
-import { describe, expect, it, vi } from "vite-plus/test";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { createProjectFileRecord } from "./project-files.fixture";
 
@@ -13,8 +13,9 @@ const enUsFile = createProjectFileRecord({
   filename: "en-US.json",
 });
 
-const { routerPushMock } = vi.hoisted(() => ({
+const { routerPushMock, searchParamsMock } = vi.hoisted(() => ({
   routerPushMock: vi.fn(),
+  searchParamsMock: vi.fn(() => "sourcePath=en-US.json&locale=vi"),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -23,7 +24,7 @@ vi.mock("next/navigation", () => ({
     push: routerPushMock,
     replace: vi.fn(),
   }),
-  useSearchParams: () => new URLSearchParams("sourcePath=en-US.json&locale=vi"),
+  useSearchParams: () => new URLSearchParams(searchParamsMock()),
 }));
 
 vi.mock("@tanstack/react-query", async (importOriginal) => {
@@ -83,16 +84,33 @@ vi.mock("../../_components/project-page-shell", () => ({
   useProjectPageQuery: () => ({
     isLoading: false,
     isError: false,
-    data: { sourceLocale: "en" },
+    data: { sourceLocale: "en", targetLocales: ["vi", "fr-FR"] },
   }),
 }));
 
 import { ProjectFilesPageContent } from "./project-files-page-content";
 
 describe("ProjectFilesPageContent CAT entry UX", () => {
+  beforeEach(() => {
+    searchParamsMock.mockReturnValue("sourcePath=en-US.json&locale=vi");
+    routerPushMock.mockClear();
+  });
+
   it("opens CAT when a project file is double-clicked", async () => {
     const user = userEvent.setup();
-    routerPushMock.mockClear();
+
+    render(<ProjectFilesPageContent organizationSlug="acme" projectId="proj_1" />);
+
+    await user.dblClick(screen.getByRole("button", { name: "en-US.json" }));
+
+    expect(routerPushMock).toHaveBeenCalledWith(
+      "/org/acme/projects/proj_1/files/cat?sourcePath=en-US.json&locale=vi",
+    );
+  });
+
+  it("falls back to a native project target locale when no URL locale is selected", async () => {
+    const user = userEvent.setup();
+    searchParamsMock.mockReturnValue("sourcePath=en-US.json");
 
     render(<ProjectFilesPageContent organizationSlug="acme" projectId="proj_1" />);
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -26,6 +26,7 @@ import {
   ProjectPageShell,
   ProjectSectionHeader,
   ProjectSectionTitle,
+  useProjectPageQuery,
 } from "../../_components/project-page-shell";
 import { ProjectFileSelectionActions } from "./project-file-selection-actions";
 import { ProjectFilesBranchFilter } from "./project-files-branch-filter";
@@ -202,6 +203,8 @@ export function ProjectFilesPageContent({
   const resolvedFiles = useMemo(() => sortFilesByPath(loadedFiles), [loadedFiles]);
   const projectCapabilities = getProjectWorkspaceCapabilities({ projectId });
   const isProviderProject = projectCapabilities.isProviderProject;
+  const projectQuery = useProjectPageQuery(organizationSlug, projectId);
+  const projectTargetLocales = projectQuery.data?.targetLocales;
 
   const openFileInCat = useCallback(
     (sourcePath: string) => {
@@ -210,7 +213,7 @@ export function ProjectFilesPageContent({
         return;
       }
 
-      const targetLocale = resolveProjectFileCatTargetLocale(file, highlightLocale);
+      const targetLocale = resolveProjectFileCatTargetLocale(file, highlightLocale, projectTargetLocales);
       if (!canOpenProjectFileCat(file) || !targetLocale) {
         toast.error(
           targetLocale
@@ -226,12 +229,21 @@ export function ProjectFilesPageContent({
         file,
         highlightLocale,
         selectedBranch,
+        projectTargetLocales,
       );
       if (href) {
         router.push(href);
       }
     },
-    [highlightLocale, organizationSlug, projectId, resolvedFiles, router, selectedBranch],
+    [
+      highlightLocale,
+      organizationSlug,
+      projectId,
+      projectTargetLocales,
+      resolvedFiles,
+      router,
+      selectedBranch,
+    ],
   );
 
   const selectedFileForTree = useMemo(
@@ -243,6 +255,7 @@ export function ProjectFilesPageContent({
         const targetLocale = resolveProjectFileCatTargetLocale(
           selectedFileForTree,
           highlightLocale,
+          projectTargetLocales,
         );
         if (targetLocale) {
           return `Double-click a file or use View strings to open the CAT workspace for ${targetLocale}.`;
@@ -297,6 +310,7 @@ export function ProjectFilesPageContent({
                   projectId={projectId}
                   file={selectedFile}
                   highlightLocale={highlightLocale}
+                  projectTargetLocales={projectTargetLocales}
                   branch={selectedBranch}
                   layout="compact"
                 />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -213,7 +213,11 @@ export function ProjectFilesPageContent({
         return;
       }
 
-      const targetLocale = resolveProjectFileCatTargetLocale(file, highlightLocale, projectTargetLocales);
+      const targetLocale = resolveProjectFileCatTargetLocale(
+        file,
+        highlightLocale,
+        projectTargetLocales,
+      );
       if (!canOpenProjectFileCat(file) || !targetLocale) {
         toast.error(
           targetLocale

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -19,7 +19,7 @@ import { getProjectWorkspaceCapabilities } from "@/lib/projects/workspace-resour
 import {
   buildProjectFileCatHref,
   canOpenProjectFileCat,
-  resolveProjectFileCatTargetLocale,
+  resolveProjectFileCatTargetLocaleResolution,
 } from "@/lib/projects/project-file-cat-routing";
 
 import {
@@ -213,11 +213,12 @@ export function ProjectFilesPageContent({
         return;
       }
 
-      const targetLocale = resolveProjectFileCatTargetLocale(
+      const targetLocaleResolution = resolveProjectFileCatTargetLocaleResolution(
         file,
         highlightLocale,
         projectTargetLocales,
       );
+      const targetLocale = targetLocaleResolution.targetLocale;
       if (!canOpenProjectFileCat(file) || !targetLocale) {
         toast.error(
           targetLocale
@@ -225,6 +226,16 @@ export function ProjectFilesPageContent({
             : "No target locale is available for this file.",
         );
         return;
+      }
+
+      if (
+        targetLocaleResolution.status === "fallback" &&
+        targetLocaleResolution.requestedLocale &&
+        targetLocaleResolution.requestedLocale !== targetLocale
+      ) {
+        toast.warning(
+          `${targetLocaleResolution.requestedLocale} is not a target locale for this file. Opening ${targetLocale} instead.`,
+        );
       }
 
       const href = buildProjectFileCatHref(
@@ -256,12 +267,21 @@ export function ProjectFilesPageContent({
   );
   const catOpenHint = selectedFileForTree
     ? (() => {
-        const targetLocale = resolveProjectFileCatTargetLocale(
+        const targetLocaleResolution = resolveProjectFileCatTargetLocaleResolution(
           selectedFileForTree,
           highlightLocale,
           projectTargetLocales,
         );
+        const targetLocale = targetLocaleResolution.targetLocale;
         if (targetLocale) {
+          if (
+            targetLocaleResolution.status === "fallback" &&
+            targetLocaleResolution.requestedLocale &&
+            targetLocaleResolution.requestedLocale !== targetLocale
+          ) {
+            return `${targetLocaleResolution.requestedLocale} is not a target locale for this file. Double-click a file or use View strings to open the CAT workspace for ${targetLocale}.`;
+          }
+
           return `Double-click a file or use View strings to open the CAT workspace for ${targetLocale}.`;
         }
 

--- a/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from "vite-plus/test";
 
 import { createProjectFileRecord } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files.fixture";
 
-import { buildProjectFileCatHref, canOpenProjectFileCat } from "./project-file-cat-routing";
+import {
+  buildProjectFileCatHref,
+  canOpenProjectFileCat,
+  resolveProjectFileCatTargetLocale,
+  resolveProjectFileCatTargetLocales,
+} from "./project-file-cat-routing";
 
 describe("canOpenProjectFileCat", () => {
   it("allows provider files supported by the live CAT workspace", () => {
@@ -119,5 +124,79 @@ describe("buildProjectFileCatHref", () => {
     expect(buildProjectFileCatHref("acme", "project_website", file, "fr-FR", "main")).toBe(
       "/org/acme/projects/project_website/files/cat?sourcePath=marketing%2Fhome.json&locale=fr-FR&branch=main",
     );
+  });
+
+  it("falls back to the first native project target locale", () => {
+    const file = createProjectFileRecord({
+      sourcePath: "marketing/home.json",
+    });
+
+    expect(
+      buildProjectFileCatHref("acme", "project_website", file, null, null, ["vi", "fr-FR"]),
+    ).toBe("/org/acme/projects/project_website/files/cat?sourcePath=marketing%2Fhome.json&locale=vi");
+  });
+});
+
+describe("resolveProjectFileCatTargetLocale", () => {
+  it("uses the requested native locale when it belongs to the project", () => {
+    expect(resolveProjectFileCatTargetLocale(createProjectFileRecord(), "fr-FR", ["vi", "fr-FR"]))
+      .toBe("fr-FR");
+  });
+
+  it("falls back to the first configured native project target locale", () => {
+    expect(resolveProjectFileCatTargetLocale(createProjectFileRecord(), null, ["vi", "fr-FR"])).toBe(
+      "vi",
+    );
+  });
+
+  it("falls back from an unknown requested native locale to a project locale", () => {
+    expect(resolveProjectFileCatTargetLocale(createProjectFileRecord(), "ja-JP", ["vi"])).toBe(
+      "vi",
+    );
+  });
+
+  it("returns null when native project locales are known to be empty", () => {
+    expect(resolveProjectFileCatTargetLocale(createProjectFileRecord(), "vi", [])).toBe(null);
+  });
+
+  it("can infer native locales from file readiness when project data is not supplied", () => {
+    expect(
+      resolveProjectFileCatTargetLocale(
+        createProjectFileRecord({ localeReadiness: { vi: "missing" } }),
+        null,
+      ),
+    ).toBe("vi");
+  });
+});
+
+describe("resolveProjectFileCatTargetLocales", () => {
+  it("returns native project locales when supplied", () => {
+    expect(resolveProjectFileCatTargetLocales(createProjectFileRecord(), ["vi", "fr-FR"])).toEqual([
+      "vi",
+      "fr-FR",
+    ]);
+  });
+
+  it("returns provider locales for provider files", () => {
+    const file = createProjectFileRecord({
+      origin: "provider",
+      storedFileId: null,
+      provider: {
+        kind: "crowdin",
+        resourceType: "file",
+        externalProjectId: "project_website",
+        externalResourceId: "file_home_json",
+        externalUrl: null,
+        syncState: "synced",
+        sourceLocale: "en",
+        targetLocales: ["fr-FR"],
+        localeReadiness: {},
+        revision: "1",
+        format: "json",
+        lastSyncedAt: new Date().toISOString(),
+      },
+    });
+
+    expect(resolveProjectFileCatTargetLocales(file, ["vi"])).toEqual(["fr-FR"]);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.test.ts
@@ -133,20 +133,23 @@ describe("buildProjectFileCatHref", () => {
 
     expect(
       buildProjectFileCatHref("acme", "project_website", file, null, null, ["vi", "fr-FR"]),
-    ).toBe("/org/acme/projects/project_website/files/cat?sourcePath=marketing%2Fhome.json&locale=vi");
+    ).toBe(
+      "/org/acme/projects/project_website/files/cat?sourcePath=marketing%2Fhome.json&locale=vi",
+    );
   });
 });
 
 describe("resolveProjectFileCatTargetLocale", () => {
   it("uses the requested native locale when it belongs to the project", () => {
-    expect(resolveProjectFileCatTargetLocale(createProjectFileRecord(), "fr-FR", ["vi", "fr-FR"]))
-      .toBe("fr-FR");
+    expect(
+      resolveProjectFileCatTargetLocale(createProjectFileRecord(), "fr-FR", ["vi", "fr-FR"]),
+    ).toBe("fr-FR");
   });
 
   it("falls back to the first configured native project target locale", () => {
-    expect(resolveProjectFileCatTargetLocale(createProjectFileRecord(), null, ["vi", "fr-FR"])).toBe(
-      "vi",
-    );
+    expect(
+      resolveProjectFileCatTargetLocale(createProjectFileRecord(), null, ["vi", "fr-FR"]),
+    ).toBe("vi");
   });
 
   it("falls back from an unknown requested native locale to a project locale", () => {

--- a/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.test.ts
@@ -6,6 +6,7 @@ import {
   buildProjectFileCatHref,
   canOpenProjectFileCat,
   resolveProjectFileCatTargetLocale,
+  resolveProjectFileCatTargetLocaleResolution,
   resolveProjectFileCatTargetLocales,
 } from "./project-file-cat-routing";
 
@@ -152,10 +153,15 @@ describe("resolveProjectFileCatTargetLocale", () => {
     ).toBe("vi");
   });
 
-  it("falls back from an unknown requested native locale to a project locale", () => {
-    expect(resolveProjectFileCatTargetLocale(createProjectFileRecord(), "ja-JP", ["vi"])).toBe(
-      "vi",
-    );
+  it("reports fallback from an unknown requested native locale to a project locale", () => {
+    expect(
+      resolveProjectFileCatTargetLocaleResolution(createProjectFileRecord(), "ja-JP", ["vi"]),
+    ).toMatchObject({
+      requestedLocale: "ja-JP",
+      status: "fallback",
+      targetLocale: "vi",
+      targetLocales: ["vi"],
+    });
   });
 
   it("returns null when native project locales are known to be empty", () => {

--- a/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.ts
@@ -35,11 +35,57 @@ export function resolveProjectFileCatTargetLocales(
   }
 
   const configuredTargetLocales = normalizeTargetLocales(projectTargetLocales);
-  if (projectTargetLocales != null || configuredTargetLocales.length > 0) {
+  if (projectTargetLocales != null) {
     return configuredTargetLocales;
   }
 
   return normalizeTargetLocales(Object.keys(file.localeReadiness ?? {}));
+}
+
+export type ProjectFileCatTargetLocaleResolution = {
+  requestedLocale: string | null;
+  status: "exact" | "fallback" | "none";
+  targetLocale: string | null;
+  targetLocales: string[];
+};
+
+export function resolveProjectFileCatTargetLocaleResolution(
+  file: ProjectFileRecord,
+  highlightLocale: string | null,
+  projectTargetLocales?: readonly string[] | null,
+): ProjectFileCatTargetLocaleResolution {
+  const targetLocales = resolveProjectFileCatTargetLocales(file, projectTargetLocales);
+  const requestedLocale = highlightLocale?.trim() ? highlightLocale.trim() : null;
+  if (requestedLocale && targetLocales.includes(requestedLocale)) {
+    return {
+      requestedLocale,
+      status: "exact",
+      targetLocale: requestedLocale,
+      targetLocales,
+    };
+  }
+
+  if (
+    !file.provider &&
+    targetLocales.length === 0 &&
+    projectTargetLocales == null &&
+    requestedLocale
+  ) {
+    return {
+      requestedLocale,
+      status: "exact",
+      targetLocale: requestedLocale,
+      targetLocales,
+    };
+  }
+
+  const fallbackLocale = targetLocales[0] ?? null;
+  return {
+    requestedLocale,
+    status: fallbackLocale ? "fallback" : "none",
+    targetLocale: fallbackLocale,
+    targetLocales,
+  };
 }
 
 export function resolveProjectFileCatTargetLocale(
@@ -47,16 +93,8 @@ export function resolveProjectFileCatTargetLocale(
   highlightLocale: string | null,
   projectTargetLocales?: readonly string[] | null,
 ) {
-  const targetLocales = resolveProjectFileCatTargetLocales(file, projectTargetLocales);
-  if (highlightLocale && targetLocales.includes(highlightLocale)) {
-    return highlightLocale;
-  }
-
-  if (!file.provider && targetLocales.length === 0 && projectTargetLocales == null) {
-    return highlightLocale;
-  }
-
-  return targetLocales[0] ?? null;
+  return resolveProjectFileCatTargetLocaleResolution(file, highlightLocale, projectTargetLocales)
+    .targetLocale;
 }
 
 function resolveProjectFileTargetLocale(

--- a/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.ts
@@ -9,23 +9,62 @@ export function canOpenProjectFileCat(file: ProjectFileRecord) {
   return Boolean(file.storedFileId);
 }
 
+function normalizeTargetLocales(locales: readonly string[] | null | undefined) {
+  if (!locales) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const locale of locales) {
+    const trimmed = locale.trim();
+    if (trimmed && !seen.has(trimmed)) {
+      seen.add(trimmed);
+      normalized.push(trimmed);
+    }
+  }
+  return normalized;
+}
+
+export function resolveProjectFileCatTargetLocales(
+  file: ProjectFileRecord,
+  projectTargetLocales?: readonly string[] | null,
+) {
+  if (file.provider) {
+    return normalizeTargetLocales(file.provider.targetLocales);
+  }
+
+  const configuredTargetLocales = normalizeTargetLocales(projectTargetLocales);
+  if (projectTargetLocales != null || configuredTargetLocales.length > 0) {
+    return configuredTargetLocales;
+  }
+
+  return normalizeTargetLocales(Object.keys(file.localeReadiness ?? {}));
+}
+
 export function resolveProjectFileCatTargetLocale(
   file: ProjectFileRecord,
   highlightLocale: string | null,
+  projectTargetLocales?: readonly string[] | null,
 ) {
-  if (file.provider) {
-    if (highlightLocale && file.provider.targetLocales.includes(highlightLocale)) {
-      return highlightLocale;
-    }
-
-    return file.provider.targetLocales[0] ?? null;
+  const targetLocales = resolveProjectFileCatTargetLocales(file, projectTargetLocales);
+  if (highlightLocale && targetLocales.includes(highlightLocale)) {
+    return highlightLocale;
   }
 
-  return highlightLocale;
+  if (!file.provider && targetLocales.length === 0 && projectTargetLocales == null) {
+    return highlightLocale;
+  }
+
+  return targetLocales[0] ?? null;
 }
 
-function resolveProjectFileTargetLocale(file: ProjectFileRecord, highlightLocale: string | null) {
-  return resolveProjectFileCatTargetLocale(file, highlightLocale);
+function resolveProjectFileTargetLocale(
+  file: ProjectFileRecord,
+  highlightLocale: string | null,
+  projectTargetLocales?: readonly string[] | null,
+) {
+  return resolveProjectFileCatTargetLocale(file, highlightLocale, projectTargetLocales);
 }
 
 export type ProjectFileCatUrlParams = {
@@ -83,6 +122,7 @@ export function buildProjectFileCatHref(
   file: ProjectFileRecord,
   highlightLocale: string | null = null,
   branch: string | null = null,
+  projectTargetLocales?: readonly string[] | null,
 ) {
   if (!canOpenProjectFileCat(file)) {
     return null;
@@ -92,7 +132,7 @@ export function buildProjectFileCatHref(
     sourcePath: file.sourcePath,
   });
 
-  const targetLocale = resolveProjectFileTargetLocale(file, highlightLocale);
+  const targetLocale = resolveProjectFileTargetLocale(file, highlightLocale, projectTargetLocales);
   if (targetLocale) {
     params.set("locale", targetLocale);
   }

--- a/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.test.ts
@@ -208,6 +208,49 @@ describe("loadProjectTranslationsAsPrefilledEntries", () => {
     expect(result.translatedKeyCount).toBe(1);
   });
 
+  it("exports source fallback entries when no target translations exist", async () => {
+    repoLimitMock.mockResolvedValueOnce([{ id: "repo_file_1", sourcePath: "locales/en.json" }]);
+    offsetMock.mockResolvedValueOnce([
+      { id: "key_1", key: "greeting", sourceText: "Hello" },
+      { id: "key_2", key: "farewell", sourceText: "Goodbye" },
+    ]);
+
+    whereMock.mockImplementationOnce(() => ({
+      limit: repoLimitMock,
+      orderBy: orderByMock,
+    }));
+    whereMock.mockImplementationOnce(() => ({
+      limit: repoLimitMock,
+      orderBy: orderByMock,
+    }));
+    whereMock.mockImplementationOnce(
+      () =>
+        Promise.resolve([]) as unknown as {
+          limit: typeof repoLimitMock;
+          orderBy: typeof orderByMock;
+        },
+    );
+
+    const result = await loadProjectTranslationsAsPrefilledEntries({
+      organizationId: "org_1",
+      projectId: "project_1",
+      sourcePath: "locales/en.json",
+      targetLocale: "fr",
+      includeAllSourceKeys: true,
+    });
+
+    expect(result).toEqual({
+      prefilled: {
+        greeting: "Hello",
+        farewell: "Goodbye",
+      },
+      truncated: false,
+      loadedKeyCount: 2,
+      maxKeyCount: 5_000,
+      translatedKeyCount: 0,
+    });
+  });
+
   it("reports truncation when the source file exceeds the prefill key cap", async () => {
     const overLimitKeys = Array.from({ length: 5_001 }, (_, index) => ({
       id: `key_${index}`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Native project files now resolve CAT target locales from project target locales (or readiness-derived native locales) before showing the no-locale error. New native source files can open in CAT for configured project locales even before target locale files exist.

Native locale resolution now returns an explicit `exact` / `fallback` / `none` status. When a bookmarked or manually typed native locale is not configured for the project, the files page warns before opening the fallback locale and the CAT page shows an inline fallback message.

Native translation downloads now treat source keys as the export contract: when source keys exist, the authenticated and public download APIs return a generated target JSON file, using the existing source-text fallback for untranslated keys. The native file detail panel exposes download buttons for all configured project target locales so users can download locale scaffolds immediately.

[native_file_download_buttons_storybook.mp4](https://cursor.com/agents/bc-7c7eb30e-1ec0-4cfa-bdb0-f23768002598/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnative_file_download_buttons_storybook.mp4)

## How to test

- `vp test src/lib/projects/project-file-cat-routing.test.ts src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.test.tsx src/lib/projects/translations/project-translation-service.test.ts src/api/routes/public-translations/public-translations.route.test.ts`
- `vp test src/lib/projects/project-file-cat-routing.test.ts src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.test.tsx`
- `vp check --fix`
- `vp test`
- Manual Storybook walkthrough: `vp run storybook --host 0.0.0.0`, then `App/Project/Files/Detail Panel / Metadata Only` verified `Download fr-FR` and `Download de-DE` are visible.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c7eb30e-1ec0-4cfa-bdb0-f23768002598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c7eb30e-1ec0-4cfa-bdb0-f23768002598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

