### PR TITLE
fix(projects): unify native and external project cards

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { UseQueryResult } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { DeleteProjectDialog } from "./delete-project-dialog";
+import type { ProjectListRow } from "./project-list";
+import { ProjectsTable } from "./projects-table";
+
+function createProject(overrides: Partial<ProjectListRow> = {}): ProjectListRow {
+  return {
+    id: "project_native",
+    name: "Hyperlocalise Web",
+    key: "HW",
+    description: "No description",
+    descriptionValue: "",
+    translationContext: "No translation context",
+    translationContextValue: "",
+    created: "Apr 29, 2026",
+    updated: "Apr 30, 2026",
+    source: "native",
+    externalProviderKind: null,
+    externalProjectId: null,
+    sourceLocale: "en",
+    targetLocales: ["vi"],
+    externalProjectUrl: null,
+    isActive: true,
+    logoUrl: null,
+    lastActivityAt: null,
+    lastSyncedAt: null,
+    lastSyncErrorAt: null,
+    lastSyncErrorMessage: null,
+    openJobCount: 0,
+    ...overrides,
+  };
+}
+
+function successQuery(): UseQueryResult<ProjectListRow[], Error> {
+  return {
+    isError: false,
+    isLoading: false,
+    isSuccess: true,
+  } as UseQueryResult<ProjectListRow[], Error>;
+}
+
+describe("ProjectsTable", () => {
+  it("shows source-to-target locales for native and external project cards", () => {
+    render(
+      <>
+        <ProjectsTable
+          projects={[createProject()]}
+          projectsQuery={successQuery()}
+          isSavingProject={false}
+          isDeletingProject={false}
+          organizationSlug="acme"
+          variant="native"
+          onEditProject={vi.fn()}
+          onDeleteProject={vi.fn()}
+        />
+        <ProjectsTable
+          projects={[
+            createProject({
+              id: "project_crowdin",
+              name: "Crowdin Site",
+              key: "CS",
+              source: "external_tms",
+              externalProviderKind: "crowdin",
+              externalProjectUrl: "https://crowdin.example/project",
+              lastActivityAt: "2026-04-30T03:20:00.000Z",
+            }),
+          ]}
+          projectsQuery={successQuery()}
+          isSavingProject={false}
+          isDeletingProject={false}
+          organizationSlug="acme"
+          variant="tms"
+        />
+      </>,
+    );
+
+    expect(screen.getByText("Hyperlocalise")).toBeInTheDocument();
+    expect(screen.getByText("Crowdin")).toBeInTheDocument();
+    expect(screen.getAllByText("en → vi")).toHaveLength(2);
+  });
+
+  it("opens native delete from the actions menu instead of a standalone icon button", async () => {
+    const user = userEvent.setup();
+    const onDeleteProject = vi.fn();
+    const project = createProject();
+
+    render(
+      <ProjectsTable
+        projects={[project]}
+        projectsQuery={successQuery()}
+        isSavingProject={false}
+        isDeletingProject={false}
+        organizationSlug="acme"
+        variant="native"
+        onEditProject={vi.fn()}
+        onDeleteProject={onDeleteProject}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: `Delete ${project.name}` }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: `Actions for ${project.name}` }));
+    await user.click(await screen.findByText("Delete project..."));
+
+    expect(onDeleteProject).toHaveBeenCalledWith(project);
+  });
+});
+
+describe("DeleteProjectDialog", () => {
+  it("requires confirming before deleting the selected native project", async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+    const project = createProject();
+
+    render(
+      <DeleteProjectDialog
+        project={project}
+        isDeleting={false}
+        onOpenChange={vi.fn()}
+        onDelete={onDelete}
+      />,
+    );
+
+    expect(screen.getByRole("alertdialog", { name: "Delete project?" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(onDelete).toHaveBeenCalledWith(project.id);
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
@@ -4,6 +4,7 @@ import {
   ArrowUpRight01Icon,
   Delete02Icon,
   Edit02Icon,
+  MoreHorizontalCircle01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { UseQueryResult } from "@tanstack/react-query";
@@ -11,6 +12,14 @@ import type { UseQueryResult } from "@tanstack/react-query";
 import { TmsUserConnectionErrorPanel } from "@/components/app-shell/tms-user-connection-prompt";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { TypographyH3, TypographyP } from "@/components/ui/typography";
@@ -24,7 +33,7 @@ import { formatProjectLocaleRoute, type ProjectListRow } from "./project-list";
 
 export const PROJECTS_PAGE_SIZE = 12;
 
-function TmsProjectCardSkeleton() {
+function ProjectCardSkeleton() {
   return (
     <article className="rounded-lg border border-border bg-muted p-4">
       <div className="flex items-start gap-3">
@@ -35,22 +44,8 @@ function TmsProjectCardSkeleton() {
           <Skeleton className="h-3 w-32" />
         </div>
       </div>
-    </article>
-  );
-}
-
-function NativeProjectCardSkeleton() {
-  return (
-    <article className="rounded-lg border border-border bg-muted p-4">
-      <div className="flex items-start gap-3">
-        <Skeleton className="size-10 shrink-0 rounded-lg" />
-        <div className="min-w-0 flex-1 space-y-2">
-          <Skeleton className="h-4 w-40 max-w-full" />
-          <Skeleton className="h-3 w-full" />
-          <Skeleton className="h-3 w-4/5" />
-        </div>
-      </div>
-      <dl className="mt-4 grid grid-cols-2 gap-3">
+      <dl className="mt-4 grid gap-3 sm:grid-cols-3">
+        <Skeleton className="h-8 w-full" />
         <Skeleton className="h-8 w-full" />
         <Skeleton className="h-8 w-full" />
       </dl>
@@ -98,53 +93,61 @@ function NativeEmptyState({
   );
 }
 
-function TmsProjectRow({
+function ProjectCard({
   project,
   organizationSlug,
+  isSavingProject,
+  isDeletingProject,
+  onEditProject,
+  onDeleteProject,
   onOpenProject,
 }: {
   project: ProjectListRow;
   organizationSlug: string;
+  isSavingProject: boolean;
+  isDeletingProject: boolean;
+  onEditProject?: (project: ProjectListRow) => void;
+  onDeleteProject?: (project: ProjectListRow) => void;
   onOpenProject?: (projectId: string) => void;
 }) {
-  const providerName = getTmsProviderBranding(project.externalProviderKind).name;
+  const providerName =
+    project.source === "external_tms"
+      ? getTmsProviderBranding(project.externalProviderKind).name
+      : "Hyperlocalise";
   const localeRoute = formatProjectLocaleRoute(project.sourceLocale, project.targetLocales);
   const activityLabel = project.lastActivityAt
     ? formatRelativeTimestamp(project.lastActivityAt)
-    : null;
-  const metaParts = [
-    providerName,
-    localeRoute,
-    activityLabel ? `Active ${activityLabel}` : null,
-  ].filter(Boolean);
+    : project.updated;
+  const isNativeProject = project.source === "native";
+  const projectHref = `/org/${organizationSlug}/projects/${project.id}`;
 
   return (
-    <article className="group min-w-0">
-      <div className="flex items-center gap-3 rounded-lg border border-border bg-muted px-3 py-3 transition-colors hover:border-beam-500/30 hover:bg-beam-500/5">
-        <ProjectAvatar project={project} compact />
+    <article className="group min-w-0 rounded-lg border border-border bg-muted p-4 transition-colors hover:border-beam-500/30 hover:bg-beam-500/5">
+      <div className="flex items-start justify-between gap-4">
         <Link
-          href={`/org/${organizationSlug}/projects/${project.id}`}
+          href={projectHref}
           onClick={() => onOpenProject?.(project.id)}
-          className="min-w-0 flex-1"
+          className="min-w-0 flex flex-1 items-start gap-3"
         >
-          <div className="flex min-w-0 items-center gap-2">
-            <TypographyH3 className="min-w-0 truncate text-sm font-medium text-foreground">
-              {project.name}
-            </TypographyH3>
-            {!project.isActive ? (
-              <Badge variant="outline" className="text-[10px]">
-                Inactive
-              </Badge>
-            ) : null}
-          </div>
-          <TypographyP className="mt-1 truncate text-xs text-muted-foreground">
-            {metaParts.join(" · ")}
-          </TypographyP>
-          {project.descriptionValue ? (
-            <TypographyP className="mt-1 line-clamp-1 text-xs text-muted-foreground">
-              {project.descriptionValue}
+          <ProjectAvatar project={project} />
+          <div className="min-w-0 flex-1">
+            <div className="flex min-w-0 items-center gap-2">
+              <TypographyH3 className="min-w-0 truncate text-base font-medium text-foreground">
+                {project.name}
+              </TypographyH3>
+              {!project.isActive ? (
+                <Badge variant="outline" className="text-[10px]">
+                  Inactive
+                </Badge>
+              ) : null}
+            </div>
+            <TypographyP className="mt-1 truncate text-xs text-muted-foreground">
+              {providerName}
             </TypographyP>
-          ) : null}
+            <TypographyP className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+              {project.descriptionValue || "No description yet"}
+            </TypographyP>
+          </div>
         </Link>
 
         <div className="flex shrink-0 items-center gap-1">
@@ -175,6 +178,49 @@ function TmsProjectRow({
               </TooltipContent>
             </Tooltip>
           ) : null}
+          {isNativeProject && onEditProject && onDeleteProject ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                render={
+                  <Button
+                    type="button"
+                    size="icon-sm"
+                    variant="ghost"
+                    aria-label={`Actions for ${project.name}`}
+                    disabled={isDeletingProject}
+                    className="text-muted-foreground hover:text-foreground"
+                  />
+                }
+              >
+                <HugeiconsIcon icon={MoreHorizontalCircle01Icon} strokeWidth={1.8} />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-48">
+                <DropdownMenuGroup>
+                  <DropdownMenuItem render={<Link href={projectHref} />}>
+                    Open project
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => onEditProject(project)}
+                    disabled={isSavingProject}
+                  >
+                    <HugeiconsIcon icon={Edit02Icon} strokeWidth={1.8} />
+                    Edit project...
+                  </DropdownMenuItem>
+                </DropdownMenuGroup>
+                <DropdownMenuSeparator />
+                <DropdownMenuGroup>
+                  <DropdownMenuItem
+                    variant="destructive"
+                    onClick={() => onDeleteProject(project)}
+                    disabled={isDeletingProject || isSavingProject}
+                  >
+                    <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
+                    Delete project...
+                  </DropdownMenuItem>
+                </DropdownMenuGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : null}
           <HugeiconsIcon
             icon={ArrowRight01Icon}
             strokeWidth={1.8}
@@ -182,95 +228,14 @@ function TmsProjectRow({
           />
         </div>
       </div>
-    </article>
-  );
-}
 
-function NativeProjectCard({
-  project,
-  organizationSlug,
-  isSavingProject,
-  isDeletingProject,
-  onEditProject,
-  onDeleteProject,
-  onOpenProject,
-}: {
-  project: ProjectListRow;
-  organizationSlug: string;
-  isSavingProject: boolean;
-  isDeletingProject: boolean;
-  onEditProject: (project: ProjectListRow) => void;
-  onDeleteProject: (project: ProjectListRow) => void;
-  onOpenProject?: (projectId: string) => void;
-}) {
-  return (
-    <article className="group min-w-0 rounded-lg border border-border bg-muted p-4 transition-colors hover:border-beam-500/30 hover:bg-beam-500/5">
-      <div className="flex items-start justify-between gap-4">
-        <Link
-          href={`/org/${organizationSlug}/projects/${project.id}`}
-          onClick={() => onOpenProject?.(project.id)}
-          className="min-w-0 flex flex-1 items-start gap-3"
-        >
-          <ProjectAvatar project={project} />
-          <div className="min-w-0 flex-1">
-            <TypographyH3 className="min-w-0 truncate text-base font-medium text-foreground">
-              {project.name}
-            </TypographyH3>
-            <TypographyP className="mt-1 line-clamp-2 text-xs text-muted-foreground">
-              {project.descriptionValue || "No description yet"}
-            </TypographyP>
-          </div>
-        </Link>
-
-        <div className="flex shrink-0 items-center gap-1">
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  type="button"
-                  size="icon-sm"
-                  variant="ghost"
-                  onClick={() => onEditProject(project)}
-                  disabled={isSavingProject}
-                  className="text-muted-foreground hover:text-foreground"
-                >
-                  <HugeiconsIcon icon={Edit02Icon} strokeWidth={1.8} />
-                  <span className="sr-only">Edit {project.name}</span>
-                </Button>
-              }
-            />
-            <TooltipContent side="bottom" align="center">
-              Edit project
-            </TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  type="button"
-                  size="icon-sm"
-                  variant="ghost"
-                  onClick={() => onDeleteProject(project)}
-                  disabled={isDeletingProject || isSavingProject}
-                  className="text-muted-foreground hover:text-foreground"
-                >
-                  <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
-                  <span className="sr-only">Delete {project.name}</span>
-                </Button>
-              }
-            />
-            <TooltipContent side="bottom" align="center">
-              Delete project
-            </TooltipContent>
-          </Tooltip>
-        </div>
-      </div>
-
-      <dl className="mt-5 grid gap-3 border-t border-border pt-4 sm:grid-cols-2">
+      <dl className="mt-5 grid gap-3 border-t border-border pt-4 sm:grid-cols-3">
         <div className="min-w-0">
-          <dt className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">
-            Open jobs
-          </dt>
+          <dt className="text-xs font-medium text-muted-foreground uppercase">Locales</dt>
+          <dd className="mt-1 truncate text-sm text-muted-foreground">{localeRoute}</dd>
+        </div>
+        <div className="min-w-0">
+          <dt className="text-xs font-medium text-muted-foreground uppercase">Open jobs</dt>
           <dd className="mt-1 truncate text-sm text-muted-foreground">
             {project.openJobCount > 0 ? (
               <Link
@@ -285,14 +250,8 @@ function NativeProjectCard({
           </dd>
         </div>
         <div className="min-w-0">
-          <dt className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">
-            Updated
-          </dt>
-          <dd className="mt-1 truncate text-sm text-muted-foreground">
-            {project.lastActivityAt
-              ? formatRelativeTimestamp(project.lastActivityAt)
-              : project.updated}
-          </dd>
+          <dt className="text-xs font-medium text-muted-foreground uppercase">Updated</dt>
+          <dd className="mt-1 truncate text-sm text-muted-foreground">{activityLabel}</dd>
         </div>
       </dl>
     </article>
@@ -336,17 +295,13 @@ export function ProjectsTable({
     <section>
       {projectsQuery.isLoading ? (
         <div
-          className={cn(variant === "tms" ? "grid gap-2 py-4" : "grid gap-3 py-8 lg:grid-cols-2")}
+          className="grid gap-3 py-4 lg:grid-cols-2"
           aria-busy="true"
           aria-label="Loading projects"
         >
-          {Array.from({ length: 4 }).map((_, index) =>
-            variant === "tms" ? (
-              <TmsProjectCardSkeleton key={index} />
-            ) : (
-              <NativeProjectCardSkeleton key={index} />
-            ),
-          )}
+          {Array.from({ length: 4 }).map((_, index) => (
+            <ProjectCardSkeleton key={index} />
+          ))}
         </div>
       ) : null}
       {projectsQuery.isError ? (
@@ -386,12 +341,15 @@ export function ProjectsTable({
         )
       ) : null}
       {projectsQuery.isSuccess && projects.length > 0 && variant === "tms" ? (
-        <div className="grid gap-2">
+        <div className="grid gap-3 lg:grid-cols-2">
           {projects.map((project) => (
-            <TmsProjectRow
+            <ProjectCard
               key={project.id}
               project={project}
               organizationSlug={organizationSlug}
+              isSavingProject={isSavingProject}
+              isDeletingProject={isDeletingProject}
+              onDeleteProject={onDeleteProject}
               onOpenProject={onOpenProject}
             />
           ))}
@@ -404,7 +362,7 @@ export function ProjectsTable({
       onDeleteProject ? (
         <div className="grid gap-3 lg:grid-cols-2">
           {projects.map((project) => (
-            <NativeProjectCard
+            <ProjectCard
               key={project.id}
               project={project}
               organizationSlug={organizationSlug}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
@@ -187,7 +187,7 @@ function ProjectCard({
                     size="icon-sm"
                     variant="ghost"
                     aria-label={`Actions for ${project.name}`}
-                    disabled={isDeletingProject}
+                    disabled={isDeletingProject || isSavingProject}
                     className="text-muted-foreground hover:text-foreground"
                   />
                 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

- Unified native and external project rendering through one shared project card layout.
- Added consistent source-to-target locale display on both native and TMS project cards.
- Moved native edit/delete actions behind an accessible actions dropdown, with delete still requiring confirmation.
- Added component coverage for locale rendering, native delete menu access, and delete confirmation.

## How to test

- `vp check --fix`
- `vp test "src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.test.tsx"`
- `vp test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d883ac65-2dcf-410d-af81-2318be8638b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d883ac65-2dcf-410d-af81-2318be8638b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

