### PR TITLE
chore(ci): extract source catalogs before translation download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,15 @@ jobs:
           mode: download
           working-directory: apps/hyperlocalise-web
           config-path: i18n.yml
+          extract-path: src
+          extract-out-file: lang/en-US.json
+          extract-ignore: |
+            **/*.test.ts
+            **/*.test.tsx
+            **/*.stories.tsx
+            **/*.fixture.ts
+            **/*.e2e.ts
+            **/__tests__/**
           dry-run: true
           fail-on-findings: false
           upload-artifact: false

--- a/.github/workflows/hyperlocalise-web-localize.yml
+++ b/.github/workflows/hyperlocalise-web-localize.yml
@@ -94,12 +94,15 @@ jobs:
         with:
           persist-credentials: true
 
-      - name: Download and validate web translations
+      - name: Extract, download, and validate web translations
         uses: ./sync
         with:
           mode: download
           working-directory: ${{ env.WEB_WORKING_DIRECTORY }}
           config-path: ${{ env.WEB_I18N_CONFIG }}
+          extract-path: ${{ env.WEB_EXTRACT_PATH }}
+          extract-out-file: ${{ env.WEB_EXTRACT_OUT_FILE }}
+          extract-ignore: ${{ env.WEB_EXTRACT_IGNORE }}
           fail-on-findings: true
           upload-artifact: true
         env:
@@ -124,7 +127,7 @@ jobs:
           body: |
             Automated translation pull from Hyperlocalise for `apps/hyperlocalise-web`.
 
-            - Source catalog: `apps/hyperlocalise-web/lang/en-US.json`
+            - Source catalog: `apps/hyperlocalise-web/lang/en-US.json` (refreshed via `hyperlocalise extract` before pull)
             - Target catalogs: `apps/hyperlocalise-web/lang/*.json`
             - Validation: `hyperlocalise check --diff-stdin` on the pulled diff
 

--- a/sync/action.yml
+++ b/sync/action.yml
@@ -1,5 +1,5 @@
 name: Hyperlocalise Sync
-description: Upload sources with React Intl extraction or download translations with git diff validation.
+description: Extract React Intl catalogs, upload sources, or download translations with git diff validation.
 
 branding:
   icon: sync
@@ -19,7 +19,7 @@ inputs:
     description: Hyperlocalise release version to install.
     default: latest
   extract-path:
-    description: Optional path to scan for React Intl extraction before upload. Leave empty to skip extraction.
+    description: Optional path to scan for React Intl extraction before upload or download. Leave empty to skip extraction.
     default: ""
   extract-out-file:
     description: Output file for extracted FormatJS catalog. Required when extract-path is set.
@@ -95,15 +95,13 @@ runs:
           echo "Unsupported prefix-id value: ${PREFIX_ID}" >&2
           exit 1
         fi
-        if [[ "${MODE}" == "upload" || "${MODE}" == "all" ]]; then
-          if [[ -n "${EXTRACT_PATH}" && -z "${EXTRACT_OUT_FILE}" ]]; then
-            echo "extract-out-file is required when extract-path is set." >&2
-            exit 1
-          fi
-          if [[ -z "${EXTRACT_PATH}" && -n "${EXTRACT_OUT_FILE}" ]]; then
-            echo "extract-path is required when extract-out-file is set." >&2
-            exit 1
-          fi
+        if [[ -n "${EXTRACT_PATH}" && -z "${EXTRACT_OUT_FILE}" ]]; then
+          echo "extract-out-file is required when extract-path is set." >&2
+          exit 1
+        fi
+        if [[ -z "${EXTRACT_PATH}" && -n "${EXTRACT_OUT_FILE}" ]]; then
+          echo "extract-path is required when extract-out-file is set." >&2
+          exit 1
         fi
 
     - name: Prepare artifact paths
@@ -133,7 +131,7 @@ runs:
         echo "${install_dir}" >>"${GITHUB_PATH}"
 
     - name: Extract React Intl messages
-      if: ${{ (inputs.mode == 'upload' || inputs.mode == 'all') && inputs.extract-path != '' }}
+      if: ${{ inputs.extract-path != '' }}
       shell: bash
       env:
         EXTRACT_PATH: ${{ inputs.extract-path }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The scheduled and manual **download** localization workflow now refreshes the English source catalog from the codebase before pulling translated files from Hyperlocalise.

## Changes

- **`sync/action.yml`**: Run `hyperlocalise extract` whenever `extract-path` is provided, including in `download` mode (not only `upload` / `all`).
- **`hyperlocalise-web-localize.yml`**: Pass the same extract settings used by the upload job into the download job so `lang/en-US.json` is created/updated before `sync pull`.
- **`ci.yml`**: Extend the sync action self-test so download mode also exercises extraction.

## Why

Without extraction on download, translation PRs could miss newly added or changed source strings that were never written to `lang/en-US.json`. Running extract first keeps the source catalog in sync with `src/` before translated catalogs are pulled and validated.

## Testing

- CI sync action self-test covers download + extract in dry-run mode.
- Full download workflow runs on schedule / `workflow_dispatch` after merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3c6b-6fef-765f-a974-a3692d695150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3c6b-6fef-765f-a974-a3692d695150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

