### PR TITLE
fix(sync): keep git diff validation and ignore warnings on download

### DIFF
--- a/.github/workflows/hyperlocalise-web-localize.yml
+++ b/.github/workflows/hyperlocalise-web-localize.yml
@@ -129,7 +129,7 @@ jobs:
 
             - Source catalog: `apps/hyperlocalise-web/lang/en-US.json` (refreshed via `hyperlocalise extract` before pull)
             - Target catalogs: `apps/hyperlocalise-web/lang/*.json`
-            - Validation: `hyperlocalise check` on all configured catalogs (warnings ignored)
+            - Validation: `hyperlocalise check --diff-stdin` on the pulled diff (warnings ignored)
 
             Review ICU placeholders, message ids, and locale coverage before merging.
           add-paths: |

--- a/.github/workflows/hyperlocalise-web-localize.yml
+++ b/.github/workflows/hyperlocalise-web-localize.yml
@@ -129,7 +129,7 @@ jobs:
 
             - Source catalog: `apps/hyperlocalise-web/lang/en-US.json` (refreshed via `hyperlocalise extract` before pull)
             - Target catalogs: `apps/hyperlocalise-web/lang/*.json`
-            - Validation: `hyperlocalise check --diff-stdin` on the pulled diff
+            - Validation: `hyperlocalise check` on all configured catalogs (warnings ignored)
 
             Review ICU placeholders, message ids, and locale coverage before merging.
           add-paths: |

--- a/sync/action.yml
+++ b/sync/action.yml
@@ -1,5 +1,5 @@
 name: Hyperlocalise Sync
-description: Extract React Intl catalogs, upload sources, or download translations with full-catalog validation.
+description: Extract React Intl catalogs, upload sources, or download translations with git diff validation.
 
 branding:
   icon: sync
@@ -31,10 +31,10 @@ inputs:
     description: Preview sync push and pull without uploading, downloading, or writing files.
     default: "false"
   fail-on-findings:
-    description: Fail the action when validation reports errors. Warnings are ignored.
+    description: Fail the action when git diff validation reports errors. Warnings are ignored.
     default: "true"
   prefix-id:
-    description: Pass --prefix-id to validation when source keys use extract --prefix-id prefixes.
+    description: Pass --prefix-id to git diff validation when source keys use extract --prefix-id prefixes.
     default: "false"
   upload-artifact:
     description: Upload JSON reports and validation summary artifacts.
@@ -48,13 +48,13 @@ outputs:
     description: Path to the sync pull JSON report.
     value: ${{ steps.prepare.outputs.pull-report-path }}
   validation-report-path:
-    description: Path to the validation JSON report.
+    description: Path to the git diff validation JSON report.
     value: ${{ steps.prepare.outputs.validation-report-path }}
   validation-summary-path:
-    description: Path to the validation text summary.
+    description: Path to the git diff validation text summary.
     value: ${{ steps.prepare.outputs.validation-summary-path }}
   findings-detected:
-    description: Whether validation found issues.
+    description: Whether git diff validation found issues.
     value: ${{ steps.analyze-validation.outputs.findings-detected }}
   findings-total:
     description: Total number of validation errors and warnings.
@@ -197,9 +197,9 @@ runs:
         hyperlocalise "${args[@]}" | tee "${PULL_REPORT_PATH}"
         popd >/dev/null
 
-    - name: Validate pulled translations
+    - name: Validate pulled changes
       if: ${{ inputs.mode == 'download' || inputs.mode == 'all' }}
-      id: validate
+      id: validate-diff
       shell: bash
       env:
         CONFIG_PATH: ${{ inputs.config-path }}
@@ -210,7 +210,7 @@ runs:
         set +e
         set -u
 
-        args=(check --no-fail --json-report "${VALIDATION_REPORT_PATH}")
+        args=(check --diff-stdin --no-fail --json-report "${VALIDATION_REPORT_PATH}")
         if [[ "${PREFIX_ID}" == "true" ]]; then
           args+=(--prefix-id)
         fi
@@ -219,7 +219,8 @@ runs:
         fi
 
         pushd "${WORKING_DIRECTORY}" >/dev/null
-        hyperlocalise "${args[@]}"
+        git add -A .
+        git diff --staged | hyperlocalise "${args[@]}"
         cli_exit=$?
         popd >/dev/null
 
@@ -234,7 +235,7 @@ runs:
         CONFIG_PATH: ${{ inputs.config-path }}
         VALIDATION_REPORT_PATH: ${{ steps.prepare.outputs.validation-report-path }}
         VALIDATION_SUMMARY_PATH: ${{ steps.prepare.outputs.validation-summary-path }}
-        CLI_EXIT_CODE: ${{ steps.validate.outputs.cli-exit-code }}
+        CLI_EXIT_CODE: ${{ steps.validate-diff.outputs.cli-exit-code }}
       run: |
         set -euo pipefail
         node "${GITHUB_ACTION_PATH}/../tools/github-action/hyperlocalise-ci/scripts/write-action-summary.mjs" \
@@ -266,11 +267,11 @@ runs:
           ${{ steps.prepare.outputs.validation-summary-path }}
 
     - name: Fail on CLI error
-      if: ${{ (inputs.mode == 'download' || inputs.mode == 'all') && steps.validate.outputs.cli-exit-code != '0' }}
+      if: ${{ (inputs.mode == 'download' || inputs.mode == 'all') && steps.validate-diff.outputs.cli-exit-code != '0' }}
       shell: bash
       run: |
         set -euo pipefail
-        echo "Hyperlocalise validation failed before a clean report could be produced." >&2
+        echo "Hyperlocalise git diff validation failed before a clean report could be produced." >&2
         exit 1
 
     - name: Fail on unknown validation state

--- a/sync/action.yml
+++ b/sync/action.yml
@@ -1,5 +1,5 @@
 name: Hyperlocalise Sync
-description: Extract React Intl catalogs, upload sources, or download translations with git diff validation.
+description: Extract React Intl catalogs, upload sources, or download translations with full-catalog validation.
 
 branding:
   icon: sync
@@ -31,10 +31,10 @@ inputs:
     description: Preview sync push and pull without uploading, downloading, or writing files.
     default: "false"
   fail-on-findings:
-    description: Fail the action when git diff validation reports findings.
+    description: Fail the action when validation reports errors. Warnings are ignored.
     default: "true"
   prefix-id:
-    description: Pass --prefix-id to git diff validation when source keys use extract --prefix-id prefixes.
+    description: Pass --prefix-id to validation when source keys use extract --prefix-id prefixes.
     default: "false"
   upload-artifact:
     description: Upload JSON reports and validation summary artifacts.
@@ -48,13 +48,13 @@ outputs:
     description: Path to the sync pull JSON report.
     value: ${{ steps.prepare.outputs.pull-report-path }}
   validation-report-path:
-    description: Path to the git diff validation JSON report.
+    description: Path to the validation JSON report.
     value: ${{ steps.prepare.outputs.validation-report-path }}
   validation-summary-path:
-    description: Path to the git diff validation text summary.
+    description: Path to the validation text summary.
     value: ${{ steps.prepare.outputs.validation-summary-path }}
   findings-detected:
-    description: Whether git diff validation found issues.
+    description: Whether validation found issues.
     value: ${{ steps.analyze-validation.outputs.findings-detected }}
   findings-total:
     description: Total number of validation errors and warnings.
@@ -197,9 +197,9 @@ runs:
         hyperlocalise "${args[@]}" | tee "${PULL_REPORT_PATH}"
         popd >/dev/null
 
-    - name: Validate pulled changes
+    - name: Validate pulled translations
       if: ${{ inputs.mode == 'download' || inputs.mode == 'all' }}
-      id: validate-diff
+      id: validate
       shell: bash
       env:
         CONFIG_PATH: ${{ inputs.config-path }}
@@ -219,8 +219,7 @@ runs:
         fi
 
         pushd "${WORKING_DIRECTORY}" >/dev/null
-        git add -A .
-        git diff --staged | hyperlocalise "${args[@]}"
+        hyperlocalise "${args[@]}"
         cli_exit=$?
         popd >/dev/null
 
@@ -235,7 +234,7 @@ runs:
         CONFIG_PATH: ${{ inputs.config-path }}
         VALIDATION_REPORT_PATH: ${{ steps.prepare.outputs.validation-report-path }}
         VALIDATION_SUMMARY_PATH: ${{ steps.prepare.outputs.validation-summary-path }}
-        CLI_EXIT_CODE: ${{ steps.validate-diff.outputs.cli-exit-code }}
+        CLI_EXIT_CODE: ${{ steps.validate.outputs.cli-exit-code }}
       run: |
         set -euo pipefail
         node "${GITHUB_ACTION_PATH}/../tools/github-action/hyperlocalise-ci/scripts/write-action-summary.mjs" \
@@ -267,11 +266,11 @@ runs:
           ${{ steps.prepare.outputs.validation-summary-path }}
 
     - name: Fail on CLI error
-      if: ${{ (inputs.mode == 'download' || inputs.mode == 'all') && steps.validate-diff.outputs.cli-exit-code != '0' }}
+      if: ${{ (inputs.mode == 'download' || inputs.mode == 'all') && steps.validate.outputs.cli-exit-code != '0' }}
       shell: bash
       run: |
         set -euo pipefail
-        echo "Hyperlocalise git diff validation failed before a clean report could be produced." >&2
+        echo "Hyperlocalise validation failed before a clean report could be produced." >&2
         exit 1
 
     - name: Fail on unknown validation state
@@ -283,12 +282,12 @@ runs:
         exit 1
 
     - name: Fail on findings
-      if: ${{ (inputs.mode == 'download' || inputs.mode == 'all') && inputs.fail-on-findings == 'true' && steps.analyze-validation.outputs.findings-detected == 'true' }}
+      if: ${{ (inputs.mode == 'download' || inputs.mode == 'all') && inputs.fail-on-findings == 'true' && steps.analyze-validation.outputs.error-count != '0' }}
       shell: bash
       env:
         ERROR_COUNT: ${{ steps.analyze-validation.outputs.error-count }}
         WARNING_COUNT: ${{ steps.analyze-validation.outputs.warning-count }}
       run: |
         set -euo pipefail
-        echo "Localization validation findings detected after sync pull (${ERROR_COUNT} errors, ${WARNING_COUNT} warnings). Review the uploaded report artifacts for details." >&2
+        echo "Localization validation errors detected after sync pull (${ERROR_COUNT} errors, ${WARNING_COUNT} warnings ignored). Review the uploaded report artifacts for details." >&2
         exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The download sync action keeps git diff scoped validation after `sync pull`:

```bash
git add -A .
git diff --staged | hyperlocalise check --diff-stdin --no-fail --json-report ...
```

The action now fails only on error-level findings. Warnings are still reported in artifacts and summaries but do not fail the job.

Also adds the missing `--diff-stdin` flag so the piped diff is actually used for validation.

## How to test

- Trigger the `Hyperlocalise Web Localize` workflow with `download` mode.
- Confirm validation runs on the pulled diff via `--diff-stdin`.
- Confirm warning-only results do not fail the workflow.
- Confirm error-level findings still fail when `fail-on-findings: true`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3c84-0272-752d-b2bb-0a3d35d5f0b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3c84-0272-752d-b2bb-0a3d35d5f0b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

