### PR TITLE
🧪 Scout: improve PHP parser robustness for invalid hex escapes

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -123,3 +123,7 @@
 ## 2026-08-12 - [Newline Parity and CRLF Literal Width]
 **Learning:** Localization validation must protect leading/trailing newlines (`\n`, `\r`) as they often affect UI layout. Naive whitespace definitions that only include space and tab skip these critical characters. Additionally, escaped special character scanners must correctly track the width of multibackslash sequences (e.g., `\r\n` is 4 bytes: `\`, `r`, `\`, `n`) to avoid index misalignment during extraction.
 **Action:** Include `\r` and `\n` in edge whitespace parity checks. Ensure special character literal width matches the source representation (e.g., `width: 4` for `\r\n`) to maintain scanner integrity.
+
+## 2025-08-15 - [PHP Hex Escape Robustness]
+**Learning:** PHP's string parser is lenient with invalid hex escape sequences (e.g., `\x` followed by a non-hex character), treating them as literal text rather than fatal errors. Mirroring this behavior in translation parsers prevents unnecessary extraction failures on valid PHP files that happen to contain these sequences.
+**Action:** When parsing escaped sequences in format-specific parsers, prefer falling back to literal text for malformed or incomplete escapes if that matches the source language's runtime behavior.

--- a/internal/i18n/translationfileparser/php_array_parser.go
+++ b/internal/i18n/translationfileparser/php_array_parser.go
@@ -333,7 +333,9 @@ func (s *phpArrayScanner) parseStringLiteral() (phpStringToken, error) {
 		case 'x':
 			v, consumed, ok := readPHPHexEscape(s.text, i)
 			if !ok {
-				return phpStringToken{}, fmt.Errorf("php locale array: invalid hex escape at line %d", lineNumberAt(s.text, i-2))
+				b.WriteByte('\\')
+				b.WriteByte('x')
+				continue
 			}
 			b.WriteByte(v)
 			i += consumed

--- a/internal/i18n/translationfileparser/php_array_parser_test.go
+++ b/internal/i18n/translationfileparser/php_array_parser_test.go
@@ -276,3 +276,21 @@ func TestStrategyParsesPHPArrayLocale(t *testing.T) {
 		t.Fatalf("unexpected value: %#v", got)
 	}
 }
+
+func TestPHPArrayParserKeepsInvalidHexEscapeLiteral(t *testing.T) {
+	content := []byte(`<?php return [
+    'invalid_hex' => "\x",
+    'not_hex' => "\xG",
+];`)
+
+	got, err := (PHPArrayParser{}).Parse(content)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got["invalid_hex"] != `\x` {
+		t.Fatalf("invalid_hex = %q, want literal \\x", got["invalid_hex"])
+	}
+	if got["not_hex"] != `\xG` {
+		t.Fatalf("not_hex = %q, want literal \\xG", got["not_hex"])
+	}
+}


### PR DESCRIPTION
- 💡 What: Modified `PHPArrayParser` to handle invalid hex escapes (e.g., `\x`, `\xG`) by falling back to literal text instead of failing with an error. Added a corresponding unit test `TestPHPArrayParserKeepsInvalidHexEscapeLiteral`.
- 🎯 Why: PHP's runtime is lenient with these sequences, and being too strict in the translation parser causes unnecessary failures on otherwise valid PHP files.
- 🧩 Scope: `internal/i18n/translationfileparser/php_array_parser.go` and `internal/i18n/translationfileparser/php_array_parser_test.go`.
- ✅ Verification: `go test -v ./internal/i18n/translationfileparser/ -run PHPArrayParser`
- 🛡️ Confidence: This alignment with PHP's actual behavior increases parser reliability for legacy or non-standard PHP localization files.

---
*PR created automatically by Jules for task [16611592334919778182](https://jules.google.com/task/16611592334919778182) started by @cungminh2710*