### PR TITLE
fix(web): show select labels and simplify inbox chat

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/chat/_components/chat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/chat/_components/chat-page-content.tsx
@@ -2,48 +2,20 @@
 
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import {
-  BubbleChatTranslateIcon,
-  Cancel01Icon,
-  SentIcon,
-  CheckmarkCircle02Icon,
-  FileAttachmentIcon,
-  MailReceive01Icon,
-  SparklesIcon,
-} from "@hugeicons/core-free-icons";
+import { Cancel01Icon, FileAttachmentIcon, SentIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 
 import { Button } from "@/components/ui/button";
 import { Kbd } from "@/components/ui/kbd";
-import { Separator } from "@/components/ui/separator";
 import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { TypographyH2, TypographyMuted } from "@/components/ui/typography";
+import { TypographyH2 } from "@/components/ui/typography";
 import { readApiResponseError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
 
 import type { GithubRepository } from "../../_components/github-repository";
 import { RepositorySelector } from "../../_components/repository-selector";
-
-const suggestedRequests = [
-  {
-    icon: BubbleChatTranslateIcon,
-    text: "Translate these release notes into ja-JP and vi-VN using the selected project's tone and glossary.",
-  },
-  {
-    icon: FileAttachmentIcon,
-    text: "Translate the attached resource file while preserving keys, placeholders, and file structure.",
-  },
-  {
-    icon: CheckmarkCircle02Icon,
-    text: "Review these strings for tone, terminology, placeholders, and length risks before release.",
-  },
-  {
-    icon: MailReceive01Icon,
-    text: "Suggest glossary updates from this copy, including product terms and forbidden translations.",
-  },
-] as const;
 
 const translationSourceFileAccept = [
   ".json",
@@ -273,31 +245,6 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
             </div>
           </div>
         </form>
-
-        <TypographyMuted className="mt-5 flex items-center justify-center gap-2 text-xs">
-          <HugeiconsIcon icon={SparklesIcon} strokeWidth={1.7} className="size-3.5" />
-          Agent can turn inbox requests into translation jobs, glossary updates, or reviewer tasks.
-        </TypographyMuted>
-
-        <div className="mt-10 bg-muted/5">
-          {suggestedRequests.map((request, index) => (
-            <div key={request.text}>
-              <button
-                type="button"
-                onClick={() => setText(request.text)}
-                className="flex w-full items-start gap-3 px-4 py-3 text-left text-muted-foreground transition-colors outline-none hover:bg-muted/80 hover:text-foreground focus-visible:relative focus-visible:z-10 focus-visible:bg-muted/80 focus-visible:ring-[3px] focus-visible:ring-inset focus-visible:ring-ring/50"
-              >
-                <HugeiconsIcon
-                  icon={request.icon}
-                  strokeWidth={1.7}
-                  className="mt-0.5 size-4 shrink-0"
-                />
-                <span className="min-w-0 text-sm leading-5">{request.text}</span>
-              </button>
-              {index < suggestedRequests.length - 1 ? <Separator className="bg-border/20" /> : null}
-            </div>
-          ))}
-        </div>
       </section>
     </main>
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.tsx
@@ -133,6 +133,7 @@ export function IssuesPageView({
       <div className="grid gap-3 rounded-2xl border bg-card p-4 md:grid-cols-[220px_1fr]">
         <Select
           value={view}
+          items={views}
           onValueChange={(value) => onViewChange((value ?? "all_open") as IssueView)}
         >
           <SelectTrigger className="w-full">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
@@ -100,6 +100,19 @@ const statuses = [
   { value: "wont_fix", label: "Won't fix" },
 ] as const;
 
+const columnTypes = [
+  { value: "text", label: "Text" },
+  { value: "long_text", label: "Long text" },
+  { value: "select", label: "Select" },
+  { value: "user", label: "User ID" },
+] as const;
+
+const priorities = [
+  { value: "P0", label: "P0" },
+  { value: "P1", label: "P1" },
+  { value: "P2", label: "P2" },
+] as const;
+
 function issueSheetPath(organizationSlug: string, projectId: string) {
   return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/issue-sheet`;
 }
@@ -272,6 +285,7 @@ export function IssueSheetPageContent({
         <div className="grid gap-3 rounded-2xl border bg-card p-4 md:grid-cols-[220px_1fr]">
           <Select
             value={view}
+            items={views}
             onValueChange={(value) => setView((value ?? "all_open") as typeof view)}
           >
             <SelectTrigger className="w-full">
@@ -354,6 +368,7 @@ export function IssueSheetPageContent({
                     <td className="px-4 py-3">
                       <Select
                         value={issue.status}
+                        items={statuses}
                         onValueChange={(value) =>
                           updateIssue.mutate({ issueId: issue.id, body: { status: value } })
                         }
@@ -379,6 +394,7 @@ export function IssueSheetPageContent({
                     <td className="px-4 py-3">
                       <Select
                         value={issue.issueType}
+                        items={issueTypes}
                         onValueChange={(value) =>
                           updateIssue.mutate({ issueId: issue.id, body: { issueType: value } })
                         }
@@ -503,9 +519,11 @@ function CustomCell({
 
   if (column.type === "select") {
     const options = column.config.options ?? [];
+    const selectItems = options.map((option) => ({ value: option.id, label: option.label }));
     return (
       <Select
         value={draft || undefined}
+        items={selectItems}
         onValueChange={(next) => {
           const value = next ?? "";
           setDraft(value);
@@ -607,7 +625,7 @@ function CreateIssueDialog({
           <Input name="title" placeholder="Short issue title" required />
           <Textarea name="description" placeholder="What needs context, review, or a fix?" />
           <div className="grid gap-3 sm:grid-cols-2">
-            <Select name="issueType" defaultValue="general_question">
+            <Select name="issueType" defaultValue="general_question" items={issueTypes}>
               <SelectTrigger className="w-full">
                 <SelectValue placeholder="Issue type" />
               </SelectTrigger>
@@ -619,20 +637,16 @@ function CreateIssueDialog({
                 ))}
               </SelectContent>
             </Select>
-            <Select name="priority" defaultValue="P2">
+            <Select name="priority" defaultValue="P2" items={priorities}>
               <SelectTrigger className="w-full">
                 <SelectValue placeholder="Priority" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="P0" label="P0">
-                  P0
-                </SelectItem>
-                <SelectItem value="P1" label="P1">
-                  P1
-                </SelectItem>
-                <SelectItem value="P2" label="P2">
-                  P2
-                </SelectItem>
+                {priorities.map((priority) => (
+                  <SelectItem key={priority.value} value={priority.value} label={priority.label}>
+                    {priority.label}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
           </div>
@@ -715,23 +729,16 @@ function CreateColumnDialog({
           </DialogHeader>
           <Input name="label" placeholder="Column label, e.g. Sprint" required />
           <Input name="key" placeholder="column_key" required />
-          <Select name="type" defaultValue="text">
+          <Select name="type" defaultValue="text" items={columnTypes}>
             <SelectTrigger className="w-full">
               <SelectValue placeholder="Column type" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="text" label="Text">
-                Text
-              </SelectItem>
-              <SelectItem value="long_text" label="Long text">
-                Long text
-              </SelectItem>
-              <SelectItem value="select" label="Select">
-                Select
-              </SelectItem>
-              <SelectItem value="user" label="User ID">
-                User ID
-              </SelectItem>
+              {columnTypes.map((type) => (
+                <SelectItem key={type.value} value={type.value} label={type.label}>
+                  {type.label}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
           <Input name="options" placeholder="For select: Backlog, Sprint 24, Blocked" />


### PR DESCRIPTION
## What changed

- Pass `items` to Issue Sheet and workspace Issues selects so closed dropdowns show human-readable labels (for example, "All open" instead of `all_open`).
- Remove the temporary suggested-request helper section from the inbox chat page.

## How to test

- Open the inbox chat page and confirm only the request form remains (no suggested prompts or agent helper text).
- Open a project Issue Sheet and verify view, issue type, priority, and column type selects show labels in the trigger.
- Open the workspace Issues page and verify the view filter shows "All open" instead of `all_open`.
- Run `vp check --fix` in `apps/hyperlocalise-web`.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)