### PR TITLE
fix(web): add CAT locale picker and independent panel scrolling

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/cat-header-pickers.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/cat-header-pickers.tsx
@@ -52,6 +52,25 @@ function GitHubMark({ className }: { className?: string }) {
   );
 }
 
+function LocaleIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      className={className}
+    >
+      <circle cx="12" cy="12" r="10" />
+      <path d="M2 12h20" />
+      <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+    </svg>
+  );
+}
+
 export function CatFileTreePicker({
   files,
   selectedSourcePath,
@@ -140,6 +159,43 @@ export function CatFileTreePicker({
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+export function CatLocaleSelect({
+  targetLocales,
+  selectedTargetLocale,
+  onTargetLocaleChange,
+}: {
+  targetLocales: string[];
+  selectedTargetLocale: string;
+  onTargetLocaleChange: (targetLocale: string) => void;
+}) {
+  const handleValueChange = (targetLocale: string | null) => {
+    if (targetLocale) {
+      onTargetLocaleChange(targetLocale);
+    }
+  };
+
+  return (
+    <Select value={selectedTargetLocale} onValueChange={handleValueChange}>
+      <SelectTrigger
+        className="h-8 min-w-0 flex-1 basis-28 font-mono text-xs sm:max-w-40"
+        aria-label="Target locale"
+        disabled={targetLocales.length <= 1}
+      >
+        <LocaleIcon className="size-4 text-muted-foreground" />
+        <SelectValue placeholder="Locale" />
+      </SelectTrigger>
+      <SelectContent>
+        {targetLocales.map((locale) => (
+          <SelectItem key={locale} value={locale}>
+            <LocaleIcon className="size-4 text-muted-foreground" />
+            {locale}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   );
 }
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
@@ -38,7 +38,11 @@ import {
   projectFilesQueryKey,
   sortFilesByPath,
 } from "./project-files-tree-panel";
-import { CatFileTreePicker, CatRepositorySelect } from "../../_components/cat-header-pickers";
+import {
+  CatFileTreePicker,
+  CatLocaleSelect,
+  CatRepositorySelect,
+} from "../../_components/cat-header-pickers";
 
 type ProjectFileCatGithubRepository = {
   fullName: string;
@@ -348,8 +352,35 @@ export function ProjectFileCatPageContent({
     setRepositoryOverride(nextRepositoryFullName);
   };
 
+  const handleLocaleChange = (nextLocale: string) => {
+    if (!sourcePath || nextLocale === targetLocale) {
+      return;
+    }
+
+    const params = new URLSearchParams({
+      sourcePath,
+      locale: nextLocale,
+    });
+
+    if (resolvedExternalResourceId) {
+      params.set("externalResourceId", resolvedExternalResourceId);
+    }
+
+    if (resolvedResourceType && resolvedResourceType !== "file") {
+      params.set("resourceType", resolvedResourceType);
+    }
+
+    if (branch) {
+      params.set("branch", branch);
+    }
+
+    router.push(
+      `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/files/cat?${params.toString()}`,
+    );
+  };
+
   return (
-    <main className="-mx-4 -my-5 flex min-h-[calc(100svh-var(--app-shell-header-height))] flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
+    <main className="-mx-4 -my-5 flex h-[calc(100svh-var(--app-shell-header-height))] min-h-0 flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
       <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 sm:px-4 lg:px-6">
         <Button
           variant="outline"
@@ -377,6 +408,14 @@ export function ProjectFileCatPageContent({
             repositoryFullNames={enabledRepositoryFullNames}
             selectedRepositoryFullName={selectedRepositoryFullName}
             onRepositoryChange={handleRepositoryChange}
+          />
+        ) : null}
+
+        {workspaceTargetLocales.length > 0 ? (
+          <CatLocaleSelect
+            targetLocales={workspaceTargetLocales}
+            selectedTargetLocale={targetLocale}
+            onTargetLocaleChange={handleLocaleChange}
           />
         ) : null}
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.test.tsx
@@ -12,6 +12,7 @@ const {
   loadJobCatTargetFileMock,
   loadJobCatProviderJobFilesMock,
   loadJobCatJobSourceFilesMock,
+  loadJobCatSelectableTargetLocalesMock,
   routerReplaceMock,
   repositoriesGetMock,
   ProjectFileCatWorkspaceMock,
@@ -21,6 +22,7 @@ const {
   loadJobCatTargetFileMock: vi.fn(),
   loadJobCatProviderJobFilesMock: vi.fn(),
   loadJobCatJobSourceFilesMock: vi.fn(),
+  loadJobCatSelectableTargetLocalesMock: vi.fn(),
   routerReplaceMock: vi.fn(),
   repositoriesGetMock: vi.fn(),
   ProjectFileCatWorkspaceMock: vi.fn(
@@ -67,6 +69,8 @@ vi.mock("./load-job-cat-files", () => ({
   loadJobCatTargetFile: (...args: unknown[]) => loadJobCatTargetFileMock(...args),
   loadJobCatProviderJobFiles: (...args: unknown[]) => loadJobCatProviderJobFilesMock(...args),
   loadJobCatJobSourceFiles: (...args: unknown[]) => loadJobCatJobSourceFilesMock(...args),
+  loadJobCatSelectableTargetLocales: (...args: unknown[]) =>
+    loadJobCatSelectableTargetLocalesMock(...args),
 }));
 
 vi.mock("@/lib/api-client-instance", () => ({
@@ -256,6 +260,7 @@ describe("JobCatPageContent CAT shell", () => {
       { fullName: "acme/web", enabled: true, archived: false },
       { fullName: "acme/docs", enabled: true, archived: false },
     ]);
+    loadJobCatSelectableTargetLocalesMock.mockResolvedValue(["vi", "de-DE"]);
     ProjectFileCatWorkspaceMock.mockClear();
     vi.stubGlobal("localStorage", createLocalStorageMock());
   });
@@ -282,6 +287,7 @@ describe("JobCatPageContent CAT shell", () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText("Source file")).toBeInTheDocument();
+      expect(screen.getByLabelText("Target locale")).toBeInTheDocument();
       expect(screen.getByLabelText("GitHub repository")).toBeInTheDocument();
       expect(screen.getByTestId("cat-workspace")).toHaveAttribute(
         "data-source-path",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -605,7 +605,8 @@ export function JobCatPageContent({
 
     const nextTargetLocale = selectJobCatTargetLocale({
       requestedTargetLocale: targetLocale,
-      providerTargetLocales: jobTargetLocales,
+      providerTargetLocales:
+        jobTargetLocales.length > 0 ? jobTargetLocales : targetLocale ? [targetLocale] : [],
     });
 
     if (!nextTargetLocale) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -13,7 +13,11 @@ import { apiClient } from "@/lib/api-client-instance";
 import { useAppShellSidebar } from "@/components/app-shell/store/use-app-shell-sidebar";
 import { supportsProviderCatFile } from "@/lib/providers/capabilities/provider-cat-capabilities";
 
-import { CatFileTreePicker, CatRepositorySelect } from "../../../../_components/cat-header-pickers";
+import {
+  CatFileTreePicker,
+  CatLocaleSelect,
+  CatRepositorySelect,
+} from "../../../../_components/cat-header-pickers";
 import { ProjectPageShell, useProjectPageQuery } from "../../../../_components/project-page-shell";
 import {
   catFileRepositoryPreferenceKey,
@@ -25,6 +29,7 @@ import { resolveDefaultJobCatFileReference } from "./job-cat-default-file";
 import {
   loadJobCatJobSourceFiles,
   loadJobCatProviderJobFiles,
+  loadJobCatSelectableTargetLocales,
   loadJobCatTargetFile,
 } from "./load-job-cat-files";
 import {
@@ -70,6 +75,14 @@ function projectJobCatDefaultFileQueryKey(
     jobId,
     targetLocale,
   ] as const;
+}
+
+function projectJobCatSelectableLocalesQueryKey(
+  organizationSlug: string,
+  projectId: string,
+  jobId: string,
+) {
+  return ["project-job-cat-selectable-locales", organizationSlug, projectId, jobId] as const;
 }
 
 function projectJobCatProviderFilesQueryKey(
@@ -185,6 +198,12 @@ export function JobCatPageContent({
     queryFn: () => loadJobCatProviderJobFiles({ organizationSlug, projectId, jobId, targetLocale }),
   });
 
+  const jobLocalesQuery = useQuery({
+    queryKey: projectJobCatSelectableLocalesQueryKey(organizationSlug, projectId, jobId),
+    enabled: hasFileReference,
+    queryFn: () => loadJobCatSelectableTargetLocales({ organizationSlug, projectId, jobId }),
+  });
+
   const repositoriesQuery = useQuery({
     queryKey: githubInstallationRepositoriesQueryKey(organizationSlug),
     enabled: hasFileReference,
@@ -246,6 +265,31 @@ export function JobCatPageContent({
   }, [enabledRepositoryFullNames, repositoryPreferenceKey]);
 
   const selectedRepositoryFullName = repositoryOverride ?? autoSelectedRepositoryFullName;
+  const jobTargetLocales = jobLocalesQuery.data ?? [];
+  const activeTargetLocale = selectJobCatTargetLocale({
+    requestedTargetLocale: targetLocale,
+    providerTargetLocales:
+      jobTargetLocales.length > 0 ? jobTargetLocales : targetLocale ? [targetLocale] : [],
+  });
+
+  const handleLocaleChange = (nextLocale: string) => {
+    if (!nextLocale || nextLocale === activeTargetLocale) {
+      return;
+    }
+
+    router.push(
+      stringsPageHref({
+        organizationSlug,
+        projectId,
+        jobId,
+        sourcePath: sourcePath ?? undefined,
+        storedFileId: storedFileId ?? undefined,
+        targetLocale: nextLocale,
+        segment: initialSegmentKey,
+        queueFilter: initialQueueFilter,
+      }),
+    );
+  };
 
   useEffect(() => {
     if (
@@ -452,7 +496,7 @@ export function JobCatPageContent({
     ) : null;
 
   if (isNativeFile) {
-    if (!targetLocale) {
+    if (!activeTargetLocale) {
       return (
         <ProjectPageShell>
           <div className="rounded-lg border border-border bg-card p-5">
@@ -465,7 +509,7 @@ export function JobCatPageContent({
     }
 
     return (
-      <main className="-mx-4 -my-5 flex min-h-[calc(100svh-var(--app-shell-header-height))] flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
+      <main className="-mx-4 -my-5 flex h-[calc(100svh-var(--app-shell-header-height))] min-h-0 flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
         <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 sm:px-4 lg:px-6">
           <Button
             variant="outline"
@@ -480,6 +524,14 @@ export function JobCatPageContent({
             {selectedFile.sourcePath}
           </TypographyP>
 
+          {jobTargetLocales.length > 0 ? (
+            <CatLocaleSelect
+              targetLocales={jobTargetLocales}
+              selectedTargetLocale={activeTargetLocale}
+              onTargetLocaleChange={handleLocaleChange}
+            />
+          ) : null}
+
           {enabledRepositoryFullNames.length > 0 ? (
             <CatRepositorySelect
               repositoryFullNames={enabledRepositoryFullNames}
@@ -493,13 +545,13 @@ export function JobCatPageContent({
 
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 py-2 sm:px-4 lg:px-6">
           <ProjectFileCatWorkspace
-            key={selectedFile.sourcePath}
+            key={`${selectedFile.sourcePath}:${activeTargetLocale}`}
             organizationSlug={organizationSlug}
             projectId={projectId}
             sourceLocale={sourceLocale}
             sourcePath={selectedFile.sourcePath}
-            targetLocale={targetLocale}
-            highlightLocale={targetLocale}
+            targetLocale={activeTargetLocale}
+            highlightLocale={activeTargetLocale}
             repositoryFullName={selectedRepositoryFullName}
             canLookupFreshContext={canLookupFreshCatRepositoryContext(
               enabledRepositoryFullNames,
@@ -527,10 +579,7 @@ export function JobCatPageContent({
     );
   }
 
-  const selectedTargetLocale = selectJobCatTargetLocale({
-    requestedTargetLocale: targetLocale,
-    providerTargetLocales: selectedFile.provider.targetLocales,
-  });
+  const selectedTargetLocale = activeTargetLocale;
 
   if (!selectedTargetLocale) {
     return (
@@ -556,7 +605,7 @@ export function JobCatPageContent({
 
     const nextTargetLocale = selectJobCatTargetLocale({
       requestedTargetLocale: targetLocale,
-      providerTargetLocales: nextFile.provider.targetLocales,
+      providerTargetLocales: jobTargetLocales,
     });
 
     if (!nextTargetLocale) {
@@ -593,6 +642,14 @@ export function JobCatPageContent({
           onSelectFile={handleFileChange}
         />
 
+        {jobTargetLocales.length > 0 ? (
+          <CatLocaleSelect
+            targetLocales={jobTargetLocales}
+            selectedTargetLocale={selectedTargetLocale}
+            onTargetLocaleChange={handleLocaleChange}
+          />
+        ) : null}
+
         {enabledRepositoryFullNames.length > 0 ? (
           <CatRepositorySelect
             repositoryFullNames={enabledRepositoryFullNames}
@@ -610,7 +667,7 @@ export function JobCatPageContent({
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 py-2 sm:px-4 lg:px-6">
         <ProjectFileCatWorkspace
-          key={selectedFile.sourcePath}
+          key={`${selectedFile.sourcePath}:${selectedTargetLocale}`}
           organizationSlug={organizationSlug}
           projectId={projectId}
           sourceLocale={sourceLocale}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-target-locale.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-target-locale.test.ts
@@ -1,6 +1,40 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { selectJobCatTargetLocale } from "./job-cat-target-locale";
+import { createProviderBackedJobDetail } from "../../_components/job-detail.fixture";
+import {
+  resolveJobCatSelectableTargetLocales,
+  selectJobCatTargetLocale,
+} from "./job-cat-target-locale";
+
+describe("resolveJobCatSelectableTargetLocales", () => {
+  it("prefers external target locales for provider-backed jobs", () => {
+    expect(
+      resolveJobCatSelectableTargetLocales(
+        createProviderBackedJobDetail({ externalTargetLocales: ["fr-FR", "de-DE"] }),
+      ),
+    ).toEqual(["fr-FR", "de-DE"]);
+  });
+
+  it("uses native job payload target locales", () => {
+    expect(
+      resolveJobCatSelectableTargetLocales({
+        externalTargetLocales: null,
+        reviewTargetLocale: null,
+        inputPayload: { targetLocales: ["vi", "ja-JP"] },
+      }),
+    ).toEqual(["vi", "ja-JP"]);
+  });
+
+  it("falls back to review target locale", () => {
+    expect(
+      resolveJobCatSelectableTargetLocales({
+        externalTargetLocales: null,
+        reviewTargetLocale: "fr-FR",
+        inputPayload: {},
+      }),
+    ).toEqual(["fr-FR"]);
+  });
+});
 
 describe("selectJobCatTargetLocale", () => {
   it("honors the requested URL target locale when the provider file supports it", () => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-target-locale.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-target-locale.ts
@@ -1,3 +1,53 @@
+import type { JobDetailRecord } from "../../_components/job-detail-types";
+
+function normalizeTargetLocales(locales: readonly string[]) {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const locale of locales) {
+    const trimmed = locale.trim();
+    if (trimmed && !seen.has(trimmed)) {
+      seen.add(trimmed);
+      normalized.push(trimmed);
+    }
+  }
+
+  return normalized;
+}
+
+function getInputPayloadStringArray(job: { inputPayload: unknown }, key: string) {
+  if (typeof job.inputPayload !== "object" || !job.inputPayload || !(key in job.inputPayload)) {
+    return [];
+  }
+
+  const value = (job.inputPayload as Record<string, unknown>)[key];
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
+}
+
+export function resolveJobCatSelectableTargetLocales(
+  job: Pick<JobDetailRecord, "externalTargetLocales" | "reviewTargetLocale" | "inputPayload">,
+) {
+  if (job.externalTargetLocales && job.externalTargetLocales.length > 0) {
+    return normalizeTargetLocales(job.externalTargetLocales);
+  }
+
+  const payloadLocales = getInputPayloadStringArray(job, "targetLocales");
+  if (payloadLocales.length > 0) {
+    return normalizeTargetLocales(payloadLocales);
+  }
+
+  const reviewTargetLocale = job.reviewTargetLocale?.trim();
+  if (reviewTargetLocale) {
+    return [reviewTargetLocale];
+  }
+
+  return [];
+}
+
 export function selectJobCatTargetLocale({
   requestedTargetLocale,
   providerTargetLocales,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/load-job-cat-files.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/load-job-cat-files.ts
@@ -16,6 +16,7 @@ import {
   providerSourceFileToProjectFileRecord,
   tmsLiveFileToProjectFileRecord,
 } from "../../_components/tms/job-source-file-mappers";
+import { resolveJobCatSelectableTargetLocales } from "./job-cat-target-locale";
 
 export const PROJECT_FILES_FETCH_LIMIT = 1_000;
 
@@ -206,6 +207,42 @@ export function mapSyncedProviderSourceFiles(input: {
     );
     return record ? [record] : [];
   });
+}
+
+export async function loadJobCatSelectableTargetLocales(input: {
+  organizationSlug: string;
+  projectId: string;
+  jobId: string;
+}) {
+  const parsedJobId = parseProviderJobId(input.jobId);
+  if (parsedJobId) {
+    const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].jobs[
+      ":encodedJobId"
+    ].$get({
+      param: {
+        organizationSlug: input.organizationSlug,
+        encodedJobId: input.jobId,
+      },
+    });
+
+    if (!response.ok) {
+      return [];
+    }
+
+    const body = (await response.json()) as { job: { externalTargetLocales?: string[] } };
+    return resolveJobCatSelectableTargetLocales({
+      externalTargetLocales: body.job.externalTargetLocales ?? null,
+      reviewTargetLocale: null,
+      inputPayload: null,
+    });
+  }
+
+  const job = await fetchJobDetail(input.organizationSlug, input.jobId);
+  if (job.projectId !== input.projectId) {
+    return [];
+  }
+
+  return resolveJobCatSelectableTargetLocales(job);
 }
 
 export async function loadJobCatProviderJobFiles(input: {


### PR DESCRIPTION
## What changed

- Added a `CatLocaleSelect` header control with a globe icon, matching the file and GitHub pickers.
- Project Files CAT: locale switching updates `?locale=` in the URL; the shell uses a fixed viewport height so queue, editor, and intelligence panels scroll independently.
- Job CAT: locale options are scoped to the job (`externalTargetLocales`, native `targetLocales`, or review locale) instead of all file/project locales; single-locale jobs show one disabled option.

## How to test

- Open a project file in CAT from **Files** and confirm the locale picker appears when multiple target locales exist; changing it reloads the workspace for that locale.
- Confirm each CAT panel scrolls independently (queue, editor, intelligence) without scrolling the whole page.
- Open CAT from a job with one target locale and confirm only that locale is shown (disabled selector).
- Open CAT from a job with multiple target locales and confirm only those job locales appear in the picker.
- Run `vp test` and `vp check --fix` in `apps/hyperlocalise-web`.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)