### PR TITLE
feat(web): add create and import actions to workspace issues

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-actions.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-actions.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState } from "react";
+import { PlusSignIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useQuery } from "@tanstack/react-query";
+
+import { Button } from "@/components/ui/button";
+import { readApiResponseError } from "@/lib/api-error";
+
+import { IssueSheetCreateIssueDialog } from "../../projects/[projectId]/issue-sheet/_components/issue-sheet-create-issue-dialog";
+import { IssuesProjectImportDialog } from "./issues-project-import-dialog";
+
+type ProjectOption = {
+  id: string;
+  name: string;
+};
+
+function organizationProjectsPath(organizationSlug: string) {
+  return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects`;
+}
+
+export function IssuesActions({
+  organizationSlug,
+  onIssuesChanged,
+}: {
+  organizationSlug: string;
+  onIssuesChanged: () => Promise<void>;
+}) {
+  const [createOpen, setCreateOpen] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
+
+  const projectsQuery = useQuery({
+    queryKey: ["projects", organizationSlug],
+    queryFn: async () => {
+      const response = await fetch(organizationProjectsPath(organizationSlug));
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to load projects");
+      }
+      const body = (await response.json()) as { projects: ProjectOption[] };
+      return body.projects;
+    },
+  });
+
+  const projects = projectsQuery.data ?? [];
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => setImportOpen(true)}
+          disabled={projectsQuery.isLoading}
+        >
+          Import CSV
+        </Button>
+        <Button
+          type="button"
+          onClick={() => setCreateOpen(true)}
+          disabled={projectsQuery.isLoading}
+        >
+          <HugeiconsIcon icon={PlusSignIcon} strokeWidth={2} data-icon="inline-start" />
+          Issue
+        </Button>
+      </div>
+
+      <IssueSheetCreateIssueDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        organizationSlug={organizationSlug}
+        projects={projects}
+        onCreated={onIssuesChanged}
+      />
+      <IssuesProjectImportDialog
+        open={importOpen}
+        onOpenChange={setImportOpen}
+        organizationSlug={organizationSlug}
+        projects={projects}
+        onImported={onIssuesChanged}
+      />
+    </>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-content.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 
 import { readApiResponseError } from "@/lib/api-error";
 
+import { IssuesActions } from "./issues-actions";
 import { ISSUES_PAGE_SIZE, IssuesPageView, type OrganizationIssue } from "./issues-page-view";
 
 const issuesQueryKey = (organizationSlug: string, view: string, search: string) =>
@@ -27,6 +28,7 @@ type OrganizationIssuesResponse = {
 };
 
 export function IssuesPageContent({ organizationSlug }: { organizationSlug: string }) {
+  const queryClient = useQueryClient();
   const [view, setView] = useState<"all_open" | "my_work" | "qa_triage" | "source_context">(
     "all_open",
   );
@@ -70,6 +72,12 @@ export function IssuesPageContent({ organizationSlug }: { organizationSlug: stri
   const total = issuesQuery.data?.pages[0]?.total ?? 0;
   const hasMore = issues.length < total;
 
+  const refreshIssues = async () => {
+    await queryClient.invalidateQueries({
+      queryKey: ["organization-issues", organizationSlug],
+    });
+  };
+
   return (
     <IssuesPageView
       organizationSlug={organizationSlug}
@@ -81,6 +89,9 @@ export function IssuesPageContent({ organizationSlug }: { organizationSlug: stri
       isError={issuesQuery.isError}
       isFetchingMore={issuesQuery.isFetchingNextPage}
       hasMore={hasMore}
+      actions={
+        <IssuesActions organizationSlug={organizationSlug} onIssuesChanged={refreshIssues} />
+      }
       onViewChange={setView}
       onSearchChange={setSearch}
       onLoadMore={() => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { expect, fn } from "storybook/test";
 
+import { IssuesActions } from "./issues-actions";
 import {
   issuesOrganizationSlug,
   issuesSummaryFixture,
@@ -90,6 +91,18 @@ export const LoadMore: Story = {
   },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("button", { name: "Loading..." })).toBeDisabled();
+  },
+};
+
+export const WithActions: Story = {
+  args: {
+    actions: (
+      <IssuesActions organizationSlug={issuesOrganizationSlug} onIssuesChanged={async () => {}} />
+    ),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("button", { name: "Import CSV" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Issue" })).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import Link from "next/link";
 import { ClipboardListIcon } from "@hugeicons/core-free-icons";
 
@@ -98,6 +99,7 @@ export function IssuesPageView({
   isError,
   isFetchingMore,
   hasMore,
+  actions,
   onViewChange,
   onSearchChange,
   onLoadMore,
@@ -117,6 +119,7 @@ export function IssuesPageView({
   isError: boolean;
   isFetchingMore: boolean;
   hasMore: boolean;
+  actions?: ReactNode;
   onViewChange: (view: IssueView) => void;
   onSearchChange: (search: string) => void;
   onLoadMore: () => void;
@@ -128,6 +131,7 @@ export function IssuesPageView({
         label="Workspace"
         title="Issues"
         description="Open issues across all projects in this workspace."
+        actions={actions}
       />
 
       <div className="grid gap-3 rounded-2xl border bg-card p-4 md:grid-cols-[220px_1fr]">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-project-import-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-project-import-dialog.tsx
@@ -75,7 +75,7 @@ export function IssuesProjectImportDialog({
 
   const issueSheetQuery = useQuery({
     queryKey: ["issue-sheet", organizationSlug, selectedProjectId, "import-columns"],
-    enabled: importOpen && Boolean(selectedProjectId),
+    enabled: Boolean(selectedProjectId),
     queryFn: async () => {
       const response = await fetch(issueSheetPath(organizationSlug, selectedProjectId));
       return readJsonOrThrow<IssueSheetResponse>(response);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-project-import-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-project-import-dialog.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { readApiResponseError } from "@/lib/api-error";
+
+import { IssueSheetImportDialog } from "../../projects/[projectId]/issue-sheet/_components/issue-sheet-import-dialog";
+
+type IssueSheetColumn = {
+  id: string;
+  key: string;
+  label: string;
+  type: string;
+};
+
+type IssueSheetResponse = {
+  columns: IssueSheetColumn[];
+};
+
+function issueSheetPath(organizationSlug: string, projectId: string) {
+  return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/issue-sheet`;
+}
+
+async function readJsonOrThrow<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const error = await readApiResponseError(response, "Request failed");
+    throw new Error(error.message || "Request failed");
+  }
+  return (await response.json()) as T;
+}
+
+export function IssuesProjectImportDialog({
+  open,
+  onOpenChange,
+  organizationSlug,
+  projects,
+  onImported,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationSlug: string;
+  projects: { id: string; name: string }[];
+  onImported: () => Promise<void>;
+}) {
+  const [selectedProjectId, setSelectedProjectId] = useState("");
+  const [importOpen, setImportOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setSelectedProjectId("");
+      setImportOpen(false);
+      return;
+    }
+    if (projects.length === 1) {
+      setSelectedProjectId(projects[0].id);
+    }
+  }, [open, projects]);
+
+  const issueSheetQuery = useQuery({
+    queryKey: ["issue-sheet", organizationSlug, selectedProjectId, "import-columns"],
+    enabled: importOpen && Boolean(selectedProjectId),
+    queryFn: async () => {
+      const response = await fetch(issueSheetPath(organizationSlug, selectedProjectId));
+      return readJsonOrThrow<IssueSheetResponse>(response);
+    },
+  });
+
+  function closePicker() {
+    onOpenChange(false);
+    setSelectedProjectId("");
+    setImportOpen(false);
+  }
+
+  function startImport() {
+    if (!selectedProjectId) {
+      return;
+    }
+    setImportOpen(true);
+  }
+
+  const projectItems = projects.map((project) => ({ value: project.id, label: project.name }));
+
+  return (
+    <>
+      <Dialog open={open && !importOpen} onOpenChange={(next) => !next && closePicker()}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Import issues</DialogTitle>
+            <DialogDescription>
+              Choose which project should receive the imported Issue Sheet rows.
+            </DialogDescription>
+          </DialogHeader>
+          {projects.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              Create a project first, then import issues into its Issue Sheet.
+            </p>
+          ) : (
+            <Select
+              value={selectedProjectId || undefined}
+              items={projectItems}
+              onValueChange={(value) => setSelectedProjectId(value ?? "")}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Project" />
+              </SelectTrigger>
+              <SelectContent>
+                {projects.map((project) => (
+                  <SelectItem key={project.id} value={project.id} label={project.name}>
+                    {project.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={closePicker}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={startImport} disabled={!selectedProjectId}>
+              Continue
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {selectedProjectId ? (
+        <IssueSheetImportDialog
+          open={importOpen}
+          onOpenChange={(next) => {
+            if (!next) {
+              closePicker();
+              return;
+            }
+            setImportOpen(true);
+          }}
+          organizationSlug={organizationSlug}
+          projectId={selectedProjectId}
+          columns={issueSheetQuery.data?.columns ?? []}
+          onImported={onImported}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-constants.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-constants.ts
@@ -1,0 +1,8 @@
+export const issueTypes = [
+  { value: "general_question", label: "General question" },
+  { value: "translation_mistake", label: "Translation mistake" },
+  { value: "context_request", label: "Context request" },
+  { value: "source_mistake", label: "Source mistake" },
+  { value: "glossary_violation", label: "Glossary violation" },
+  { value: "qa_failure", label: "QA failure" },
+] as const;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-create-issue-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-create-issue-dialog.tsx
@@ -24,14 +24,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { readApiResponseError } from "@/lib/api-error";
 
-const issueTypes = [
-  { value: "general_question", label: "General question" },
-  { value: "translation_mistake", label: "Translation mistake" },
-  { value: "context_request", label: "Context request" },
-  { value: "source_mistake", label: "Source mistake" },
-  { value: "glossary_violation", label: "Glossary violation" },
-  { value: "qa_failure", label: "QA failure" },
-] as const;
+import { issueTypes } from "./issue-sheet-constants";
 
 const priorities = [
   { value: "P0", label: "P0" },
@@ -75,6 +68,7 @@ export function IssueSheetCreateIssueDialog({
 
   useEffect(() => {
     if (!open) {
+      setSelectedProjectId("");
       return;
     }
     if (projectId) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-create-issue-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-create-issue-dialog.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { readApiResponseError } from "@/lib/api-error";
+
+const issueTypes = [
+  { value: "general_question", label: "General question" },
+  { value: "translation_mistake", label: "Translation mistake" },
+  { value: "context_request", label: "Context request" },
+  { value: "source_mistake", label: "Source mistake" },
+  { value: "glossary_violation", label: "Glossary violation" },
+  { value: "qa_failure", label: "QA failure" },
+] as const;
+
+const priorities = [
+  { value: "P0", label: "P0" },
+  { value: "P1", label: "P1" },
+  { value: "P2", label: "P2" },
+] as const;
+
+function issueSheetPath(organizationSlug: string, projectId: string) {
+  return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/issue-sheet`;
+}
+
+function formString(formData: FormData, key: string, fallback = "") {
+  const value = formData.get(key);
+  return typeof value === "string" ? value : fallback;
+}
+
+async function readJsonOrThrow<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const error = await readApiResponseError(response, "Request failed");
+    throw new Error(error.message || "Request failed");
+  }
+  return (await response.json()) as T;
+}
+
+export function IssueSheetCreateIssueDialog({
+  open,
+  onOpenChange,
+  organizationSlug,
+  projectId,
+  projects,
+  onCreated,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationSlug: string;
+  projectId?: string;
+  projects?: { id: string; name: string }[];
+  onCreated: () => Promise<void>;
+}) {
+  const [selectedProjectId, setSelectedProjectId] = useState(projectId ?? "");
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    if (projectId) {
+      setSelectedProjectId(projectId);
+      return;
+    }
+    if (projects?.length === 1) {
+      setSelectedProjectId(projects[0].id);
+    }
+  }, [open, projectId, projects]);
+
+  const resolvedProjectId = projectId ?? selectedProjectId;
+
+  const createIssue = useMutation({
+    mutationFn: async (formData: FormData) => {
+      if (!resolvedProjectId) {
+        throw new Error("Select a project");
+      }
+      const response = await fetch(issueSheetPath(organizationSlug, resolvedProjectId), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: formString(formData, "title"),
+          description: formString(formData, "description"),
+          issueType: formString(formData, "issueType", "general_question"),
+          targetLocale: formString(formData, "targetLocale") || undefined,
+          sourcePath: formString(formData, "sourcePath") || undefined,
+          linkKind: formString(formData, "linkUrl") ? "url" : "manual",
+          linkLabel: formString(formData, "linkLabel") || undefined,
+          linkUrl: formString(formData, "linkUrl") || undefined,
+          priority: formString(formData, "priority", "P2"),
+        }),
+      });
+      return readJsonOrThrow<{ issue: { id: string } }>(response);
+    },
+    onSuccess: async () => {
+      toast.success("Issue added");
+      onOpenChange(false);
+      await onCreated();
+    },
+    onError: (error) => toast.error(error instanceof Error ? error.message : "Issue create failed"),
+  });
+
+  function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    createIssue.mutate(new FormData(event.currentTarget));
+  }
+
+  const projectItems =
+    projects?.map((project) => ({ value: project.id, label: project.name })) ?? [];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <form onSubmit={submit} className="space-y-4">
+          <DialogHeader>
+            <DialogTitle>Add issue</DialogTitle>
+            <DialogDescription>
+              Create a generic Issue Sheet row. Link it to CAT or another issue tracker when useful.
+            </DialogDescription>
+          </DialogHeader>
+          {projects && projects.length > 0 ? (
+            <Select
+              value={selectedProjectId || undefined}
+              items={projectItems}
+              onValueChange={(value) => setSelectedProjectId(value ?? "")}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Project" />
+              </SelectTrigger>
+              <SelectContent>
+                {projects.map((project) => (
+                  <SelectItem key={project.id} value={project.id} label={project.name}>
+                    {project.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : null}
+          <Input name="title" placeholder="Short issue title" required />
+          <Textarea name="description" placeholder="What needs context, review, or a fix?" />
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Select name="issueType" defaultValue="general_question" items={issueTypes}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Issue type" />
+              </SelectTrigger>
+              <SelectContent>
+                {issueTypes.map((type) => (
+                  <SelectItem key={type.value} value={type.value} label={type.label}>
+                    {type.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select name="priority" defaultValue="P2" items={priorities}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Priority" />
+              </SelectTrigger>
+              <SelectContent>
+                {priorities.map((priority) => (
+                  <SelectItem key={priority.value} value={priority.value} label={priority.label}>
+                    {priority.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Input name="targetLocale" placeholder="Locale, e.g. de-DE" />
+            <Input name="sourcePath" placeholder="Source path" />
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Input name="linkLabel" placeholder="Link label" />
+            <Input name="linkUrl" placeholder="https://..." />
+          </div>
+          <DialogFooter>
+            <Button type="submit" disabled={createIssue.isPending || !resolvedProjectId}>
+              Add issue
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
@@ -30,6 +30,7 @@ import { readApiResponseError } from "@/lib/api-error";
 
 import { ProjectPageShell, ProjectSectionHeader } from "../../_components/project-page-shell";
 import { useProjectPageQuery } from "../../_components/project-page-shell";
+import { IssueSheetCreateIssueDialog } from "./issue-sheet-create-issue-dialog";
 import { IssueSheetImportDialog } from "./issue-sheet-import-dialog";
 
 type IssueSheetColumn = {
@@ -105,12 +106,6 @@ const columnTypes = [
   { value: "long_text", label: "Long text" },
   { value: "select", label: "Select" },
   { value: "user", label: "User ID" },
-] as const;
-
-const priorities = [
-  { value: "P0", label: "P0" },
-  { value: "P1", label: "P1" },
-  { value: "P2", label: "P2" },
 ] as const;
 
 function issueSheetPath(organizationSlug: string, projectId: string) {
@@ -449,7 +444,7 @@ export function IssueSheetPageContent({
         </div>
       </div>
 
-      <CreateIssueDialog
+      <IssueSheetCreateIssueDialog
         open={createDialogOpen}
         onOpenChange={setCreateDialogOpen}
         organizationSlug={organizationSlug}
@@ -564,108 +559,6 @@ function CustomCell({
       placeholder="—"
       className="w-44"
     />
-  );
-}
-
-function CreateIssueDialog({
-  open,
-  onOpenChange,
-  organizationSlug,
-  projectId,
-  onCreated,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  organizationSlug: string;
-  projectId: string;
-  onCreated: () => Promise<void>;
-}) {
-  const createIssue = useMutation({
-    mutationFn: async (formData: FormData) => {
-      const response = await fetch(issueSheetPath(organizationSlug, projectId), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          title: formString(formData, "title"),
-          description: formString(formData, "description"),
-          issueType: formString(formData, "issueType", "general_question"),
-          targetLocale: formString(formData, "targetLocale") || undefined,
-          sourcePath: formString(formData, "sourcePath") || undefined,
-          linkKind: formString(formData, "linkUrl") ? "url" : "manual",
-          linkLabel: formString(formData, "linkLabel") || undefined,
-          linkUrl: formString(formData, "linkUrl") || undefined,
-          priority: formString(formData, "priority", "P2"),
-        }),
-      });
-      return readJsonOrThrow<{ issue: IssueSheetIssue }>(response);
-    },
-    onSuccess: async () => {
-      toast.success("Issue added");
-      onOpenChange(false);
-      await onCreated();
-    },
-    onError: (error) => toast.error(error instanceof Error ? error.message : "Issue create failed"),
-  });
-
-  function submit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    createIssue.mutate(new FormData(event.currentTarget));
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <form onSubmit={submit} className="space-y-4">
-          <DialogHeader>
-            <DialogTitle>Add issue</DialogTitle>
-            <DialogDescription>
-              Create a generic Issue Sheet row. Link it to CAT or another issue tracker when useful.
-            </DialogDescription>
-          </DialogHeader>
-          <Input name="title" placeholder="Short issue title" required />
-          <Textarea name="description" placeholder="What needs context, review, or a fix?" />
-          <div className="grid gap-3 sm:grid-cols-2">
-            <Select name="issueType" defaultValue="general_question" items={issueTypes}>
-              <SelectTrigger className="w-full">
-                <SelectValue placeholder="Issue type" />
-              </SelectTrigger>
-              <SelectContent>
-                {issueTypes.map((type) => (
-                  <SelectItem key={type.value} value={type.value} label={type.label}>
-                    {type.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Select name="priority" defaultValue="P2" items={priorities}>
-              <SelectTrigger className="w-full">
-                <SelectValue placeholder="Priority" />
-              </SelectTrigger>
-              <SelectContent>
-                {priorities.map((priority) => (
-                  <SelectItem key={priority.value} value={priority.value} label={priority.label}>
-                    {priority.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="grid gap-3 sm:grid-cols-2">
-            <Input name="targetLocale" placeholder="Locale, e.g. de-DE" />
-            <Input name="sourcePath" placeholder="Source path" />
-          </div>
-          <div className="grid gap-3 sm:grid-cols-2">
-            <Input name="linkLabel" placeholder="Link label" />
-            <Input name="linkUrl" placeholder="https://..." />
-          </div>
-          <DialogFooter>
-            <Button type="submit" disabled={createIssue.isPending}>
-              Add issue
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
   );
 }
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
@@ -28,6 +28,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { TypographyP } from "@/components/ui/typography";
 import { readApiResponseError } from "@/lib/api-error";
 
+import { issueTypes } from "./issue-sheet-constants";
+
 import { ProjectPageShell, ProjectSectionHeader } from "../../_components/project-page-shell";
 import { useProjectPageQuery } from "../../_components/project-page-shell";
 import { IssueSheetCreateIssueDialog } from "./issue-sheet-create-issue-dialog";
@@ -83,15 +85,6 @@ const views = [
   { value: "my_work", label: "My work" },
   { value: "qa_triage", label: "QA triage" },
   { value: "source_context", label: "Source & context" },
-] as const;
-
-const issueTypes = [
-  { value: "general_question", label: "General question" },
-  { value: "translation_mistake", label: "Translation mistake" },
-  { value: "context_request", label: "Context request" },
-  { value: "source_mistake", label: "Source mistake" },
-  { value: "glossary_violation", label: "Glossary violation" },
-  { value: "qa_failure", label: "QA failure" },
 ] as const;
 
 const statuses = [


### PR DESCRIPTION
## What changed

The org-wide Workspace Issues page (`/org/[slug]/issues`) was read-only. This adds **Issue** and **Import CSV** header actions so users can create issues and import CSV rows without navigating into a project Issue Sheet first.

- **Create issue** — shared `IssueSheetCreateIssueDialog` with a project picker on the workspace page
- **Import CSV** — project picker followed by the existing Issue Sheet CSV import wizard
- **List refresh** — the issues list invalidates after create/import
- **Refactor** — extracted the create dialog from the project Issue Sheet page for reuse

## How to test

1. Open `/org/[slug]/issues`
2. Click **Issue**, select a project, fill in the form, and submit — confirm the new issue appears in the list
3. Click **Import CSV**, select a project, upload a CSV, map columns, and import — confirm imported issues appear
4. Run `cd apps/hyperlocalise-web && vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)