### PR TITLE
feat(web): restore import and download actions on files page

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/download-translations-dialog.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/download-translations-dialog.test.tsx
@@ -1,14 +1,17 @@
 // @vitest-environment happy-dom
 
-import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vite-plus/test";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { DownloadTranslationsDialog } from "./download-translations-dialog";
 
 describe("DownloadTranslationsDialog", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
   it("downloads the selected source file for the chosen locale", async () => {
-    const user = userEvent.setup();
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ greeting: "bonjour" }), {
         status: 200,
@@ -18,7 +21,18 @@ describe("DownloadTranslationsDialog", () => {
       }),
     );
     vi.stubGlobal("fetch", fetchMock);
-    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    const createObjectUrlMock = vi.fn(() => "blob:translation");
+    const revokeObjectUrlMock = vi.fn();
+    vi.stubGlobal("URL", {
+      ...URL,
+      createObjectURL: createObjectUrlMock,
+      revokeObjectURL: revokeObjectUrlMock,
+    });
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        expect(this.isConnected).toBe(true);
+      });
 
     render(
       <DownloadTranslationsDialog
@@ -32,13 +46,32 @@ describe("DownloadTranslationsDialog", () => {
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: "Download" }));
+    const scheduledTimeouts: Array<() => void> = [];
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      handler: () => void,
+    ) => {
+      scheduledTimeouts.push(handler);
+      return 0;
+    }) as typeof setTimeout);
 
-    await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith(
-        "/api/orgs/acme/projects/proj_1/files/translations/download?sourcePath=marketing%2Fhome.json&locale=fr-FR",
-      );
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Download" }));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
     });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/orgs/acme/projects/proj_1/files/translations/download?sourcePath=marketing%2Fhome.json&locale=fr-FR",
+    );
     expect(clickSpy).toHaveBeenCalled();
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 0);
+    expect(revokeObjectUrlMock).not.toHaveBeenCalled();
+
+    for (const scheduledTimeout of scheduledTimeouts) {
+      scheduledTimeout();
+    }
+
+    expect(revokeObjectUrlMock).toHaveBeenCalledWith("blob:translation");
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/download-translations-dialog.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/download-translations-dialog.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment happy-dom
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { DownloadTranslationsDialog } from "./download-translations-dialog";
+
+describe("DownloadTranslationsDialog", () => {
+  it("downloads the selected source file for the chosen locale", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ greeting: "bonjour" }), {
+        status: 200,
+        headers: {
+          "Content-Disposition": "attachment; filename*=UTF-8''marketing-home-fr-FR.json",
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    render(
+      <DownloadTranslationsDialog
+        open
+        onOpenChange={() => undefined}
+        organizationSlug="acme"
+        projectId="proj_1"
+        sourcePaths={["marketing/home.json", "marketing/pricing.json"]}
+        initialSourcePath="marketing/home.json"
+        targetLocales={["fr-FR", "de-DE"]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Download" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/orgs/acme/projects/proj_1/files/translations/download?sourcePath=marketing%2Fhome.json&locale=fr-FR",
+      );
+    });
+    expect(clickSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/download-translations-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/download-translations-dialog.tsx
@@ -21,9 +21,9 @@ type DownloadTranslationsDialogProps = {
   onOpenChange: (open: boolean) => void;
   organizationSlug: string;
   projectId: string;
-  sourcePaths: string[];
+  sourcePaths: readonly string[];
   initialSourcePath: string;
-  targetLocales: string[];
+  targetLocales: readonly string[];
 };
 
 function buildDownloadHref(

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/download-translations-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/download-translations-dialog.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import { readApiResponseError } from "@/lib/api-error";
+import { cn } from "@/lib/primitives/cn";
+
+type DownloadTranslationsDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationSlug: string;
+  projectId: string;
+  sourcePaths: string[];
+  initialSourcePath: string;
+  targetLocales: string[];
+};
+
+function buildDownloadHref(
+  organizationSlug: string,
+  projectId: string,
+  sourcePath: string,
+  locale: string,
+) {
+  const params = new URLSearchParams({ sourcePath, locale });
+  return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/files/translations/download?${params.toString()}`;
+}
+
+function parseDownloadFilename(contentDisposition: string | null, fallback: string) {
+  if (!contentDisposition) {
+    return fallback;
+  }
+
+  const utf8Match = contentDisposition.match(/filename\*=UTF-8''([^;]+)/i);
+  if (utf8Match?.[1]) {
+    try {
+      return decodeURIComponent(utf8Match[1]);
+    } catch {
+      return fallback;
+    }
+  }
+
+  const quotedMatch = contentDisposition.match(/filename="([^"]+)"/i);
+  if (quotedMatch?.[1]) {
+    return quotedMatch[1];
+  }
+
+  return fallback;
+}
+
+async function downloadTranslationFile(
+  organizationSlug: string,
+  projectId: string,
+  sourcePath: string,
+  locale: string,
+) {
+  const href = buildDownloadHref(organizationSlug, projectId, sourcePath, locale);
+  const response = await fetch(href);
+
+  if (!response.ok) {
+    throw await readApiResponseError(response, `Failed to download ${sourcePath}`);
+  }
+
+  const blob = await response.blob();
+  const filename = parseDownloadFilename(
+    response.headers.get("Content-Disposition"),
+    `${sourcePath}-${locale}`,
+  );
+  const objectUrl = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = objectUrl;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(objectUrl);
+}
+
+export function DownloadTranslationsDialog({
+  open,
+  onOpenChange,
+  organizationSlug,
+  projectId,
+  sourcePaths,
+  initialSourcePath,
+  targetLocales,
+}: DownloadTranslationsDialogProps) {
+  const [locale, setLocale] = useState<string>(targetLocales[0] ?? "");
+  const [selectedSourcePaths, setSelectedSourcePaths] = useState<string[]>([]);
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    setLocale(targetLocales[0] ?? "");
+    setSelectedSourcePaths(
+      sourcePaths.includes(initialSourcePath) ? [initialSourcePath] : sourcePaths.slice(0, 1),
+    );
+  }, [initialSourcePath, open, sourcePaths, targetLocales]);
+
+  const toggleSourcePath = (sourcePath: string) => {
+    setSelectedSourcePaths((current) =>
+      current.includes(sourcePath)
+        ? current.filter((path) => path !== sourcePath)
+        : [...current, sourcePath],
+    );
+  };
+
+  const handleDownload = async () => {
+    if (!locale) {
+      toast.error("Select a target locale.");
+      return;
+    }
+
+    if (selectedSourcePaths.length === 0) {
+      toast.error("Select at least one source file.");
+      return;
+    }
+
+    setIsDownloading(true);
+
+    try {
+      for (const sourcePath of selectedSourcePaths) {
+        await downloadTranslationFile(organizationSlug, projectId, sourcePath, locale);
+      }
+
+      toast.success(
+        selectedSourcePaths.length === 1
+          ? "Translation file downloaded."
+          : `${selectedSourcePaths.length} translation files downloaded.`,
+      );
+      onOpenChange(false);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to download translations");
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  const hasSourcePaths = sourcePaths.length > 0;
+  const canDownload = hasSourcePaths && targetLocales.length > 0 && selectedSourcePaths.length > 0;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Download translations</DialogTitle>
+          <DialogDescription>
+            Choose source files and a target locale to export translated content.
+          </DialogDescription>
+        </DialogHeader>
+
+        {!hasSourcePaths ? (
+          <p className="text-sm text-muted-foreground">
+            No source files are available to download.
+          </p>
+        ) : targetLocales.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Add target locales in project settings before downloading translations.
+          </p>
+        ) : (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground">Source files</p>
+              <div className="max-h-48 space-y-2 overflow-y-auto pr-1">
+                {sourcePaths.map((sourcePath) => {
+                  const checked = selectedSourcePaths.includes(sourcePath);
+                  return (
+                    <label
+                      key={sourcePath}
+                      className={cn(
+                        "flex cursor-pointer items-start gap-2 rounded-md border border-border px-3 py-2 text-sm",
+                        checked && "border-primary bg-muted/40",
+                      )}
+                    >
+                      <input
+                        type="checkbox"
+                        className="mt-0.5 size-4 shrink-0 border border-input accent-primary"
+                        checked={checked}
+                        onChange={() => toggleSourcePath(sourcePath)}
+                      />
+                      <span className="min-w-0 font-mono text-xs break-all">{sourcePath}</span>
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground">Target locale</p>
+              <div className="space-y-2">
+                {targetLocales.map((targetLocale) => (
+                  <label
+                    key={targetLocale}
+                    className="flex cursor-pointer items-center gap-2 rounded-md border border-border px-3 py-2 text-sm"
+                  >
+                    <input
+                      type="radio"
+                      name="download-target-locale"
+                      className="size-4 border border-input accent-primary"
+                      checked={locale === targetLocale}
+                      onChange={() => setLocale(targetLocale)}
+                    />
+                    <span>{targetLocale}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="button" disabled={!canDownload || isDownloading} onClick={handleDownload}>
+            {isDownloading ? <Spinner className="size-4" /> : null}
+            Download
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/download-translations-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/download-translations-dialog.tsx
@@ -80,8 +80,13 @@ async function downloadTranslationFile(
   const anchor = document.createElement("a");
   anchor.href = objectUrl;
   anchor.download = filename;
-  anchor.click();
-  URL.revokeObjectURL(objectUrl);
+  try {
+    document.body.appendChild(anchor);
+    anchor.click();
+  } finally {
+    anchor.remove();
+    setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+  }
 }
 
 export function DownloadTranslationsDialog({

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/import-translations-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/import-translations-dialog.tsx
@@ -26,7 +26,7 @@ type ImportTranslationsDialogProps = {
   organizationSlug: string;
   projectId: string;
   sourcePath: string;
-  targetLocales: string[];
+  targetLocales: readonly string[];
 };
 
 function importApiPath(organizationSlug: string, projectId: string) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
+import { Download01Icon, Upload01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { ListIcon } from "lucide-react";
 
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
@@ -10,6 +13,19 @@ import {
   buildProjectFileCatHref,
   canOpenProjectFileCat,
 } from "@/lib/projects/project-file-cat-routing";
+
+import { ImportTranslationsDialog } from "./import-translations-dialog";
+
+function downloadTranslation(
+  organizationSlug: string,
+  projectId: string,
+  sourcePath: string,
+  locale: string,
+) {
+  const params = new URLSearchParams({ sourcePath, locale });
+  const href = `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/files/translations/download?${params.toString()}`;
+  window.open(href, "_blank", "noopener,noreferrer");
+}
 
 export function ProjectFileSelectionActions({
   organizationSlug,
@@ -28,7 +44,10 @@ export function ProjectFileSelectionActions({
   branch?: string | null;
   layout?: "default" | "compact";
 }) {
+  const [importDialogOpen, setImportDialogOpen] = useState(false);
   const canOpenCat = canOpenProjectFileCat(file);
+  const isNativeFile = !file.provider;
+  const targetLocales = projectTargetLocales ?? [];
   const catHref = buildProjectFileCatHref(
     organizationSlug,
     projectId,
@@ -38,43 +57,93 @@ export function ProjectFileSelectionActions({
     projectTargetLocales,
   );
 
-  if (layout === "compact") {
-    return (
+  const actionButtons = (
+    <>
       <Button
         type="button"
         size="sm"
-        className="shrink-0"
+        className={layout === "default" ? "w-full shrink-0 sm:w-fit" : "shrink-0"}
         disabled={!canOpenCat || !catHref}
         render={canOpenCat && catHref ? <Link href={catHref} /> : undefined}
       >
         <ListIcon />
         View strings
       </Button>
+      {isNativeFile ? (
+        <>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className={layout === "default" ? "w-full shrink-0 sm:w-fit" : "shrink-0"}
+            onClick={() => setImportDialogOpen(true)}
+          >
+            <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} />
+            Import translations
+          </Button>
+          {targetLocales.map((locale) => (
+            <Button
+              key={locale}
+              type="button"
+              size="sm"
+              variant="outline"
+              className={layout === "default" ? "w-full shrink-0 sm:w-fit" : "shrink-0"}
+              onClick={() =>
+                downloadTranslation(organizationSlug, projectId, file.sourcePath, locale)
+              }
+            >
+              <HugeiconsIcon icon={Download01Icon} strokeWidth={1.8} />
+              Download {locale}
+            </Button>
+          ))}
+        </>
+      ) : null}
+    </>
+  );
+
+  if (layout === "compact") {
+    return (
+      <>
+        {isNativeFile ? (
+          <ImportTranslationsDialog
+            open={importDialogOpen}
+            onOpenChange={setImportDialogOpen}
+            organizationSlug={organizationSlug}
+            projectId={projectId}
+            sourcePath={file.sourcePath}
+            targetLocales={[...targetLocales]}
+          />
+        ) : null}
+        <div className="flex flex-wrap items-center justify-end gap-2">{actionButtons}</div>
+      </>
     );
   }
 
   return (
-    <div className="flex shrink-0 flex-col gap-3 border-b border-border px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-      <div className="min-w-0">
-        <TypographyP className="truncate font-mono text-sm text-foreground">
-          {file.sourcePath}
-        </TypographyP>
-        <TypographyP className="text-xs text-muted-foreground">
-          {canOpenCat
-            ? "Open this file in the CAT workspace to review and edit translations."
-            : "The CAT workspace is not available for this file yet."}
-        </TypographyP>
+    <>
+      {isNativeFile ? (
+        <ImportTranslationsDialog
+          open={importDialogOpen}
+          onOpenChange={setImportDialogOpen}
+          organizationSlug={organizationSlug}
+          projectId={projectId}
+          sourcePath={file.sourcePath}
+          targetLocales={[...targetLocales]}
+        />
+      ) : null}
+      <div className="flex shrink-0 flex-col gap-3 border-b border-border px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <TypographyP className="truncate font-mono text-sm text-foreground">
+            {file.sourcePath}
+          </TypographyP>
+          <TypographyP className="text-xs text-muted-foreground">
+            {canOpenCat
+              ? "Open this file in the CAT workspace to review and edit translations."
+              : "The CAT workspace is not available for this file yet."}
+          </TypographyP>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 sm:justify-end">{actionButtons}</div>
       </div>
-      <Button
-        type="button"
-        size="sm"
-        className="w-full shrink-0 sm:w-fit"
-        disabled={!canOpenCat || !catHref}
-        render={canOpenCat && catHref ? <Link href={catHref} /> : undefined}
-      >
-        <ListIcon />
-        View strings
-      </Button>
-    </div>
+    </>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.tsx
@@ -14,18 +14,8 @@ import {
   canOpenProjectFileCat,
 } from "@/lib/projects/project-file-cat-routing";
 
+import { DownloadTranslationsDialog } from "./download-translations-dialog";
 import { ImportTranslationsDialog } from "./import-translations-dialog";
-
-function downloadTranslation(
-  organizationSlug: string,
-  projectId: string,
-  sourcePath: string,
-  locale: string,
-) {
-  const params = new URLSearchParams({ sourcePath, locale });
-  const href = `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/files/translations/download?${params.toString()}`;
-  window.open(href, "_blank", "noopener,noreferrer");
-}
 
 export function ProjectFileSelectionActions({
   organizationSlug,
@@ -33,6 +23,7 @@ export function ProjectFileSelectionActions({
   file,
   highlightLocale,
   projectTargetLocales,
+  nativeSourcePaths = [],
   branch = null,
   layout = "default",
 }: {
@@ -41,10 +32,12 @@ export function ProjectFileSelectionActions({
   file: ProjectFileRecord;
   highlightLocale: string | null;
   projectTargetLocales?: readonly string[] | null;
+  nativeSourcePaths?: readonly string[];
   branch?: string | null;
   layout?: "default" | "compact";
 }) {
   const [importDialogOpen, setImportDialogOpen] = useState(false);
+  const [downloadDialogOpen, setDownloadDialogOpen] = useState(false);
   const canOpenCat = canOpenProjectFileCat(file);
   const isNativeFile = !file.provider;
   const targetLocales = projectTargetLocales ?? [];
@@ -56,6 +49,28 @@ export function ProjectFileSelectionActions({
     branch,
     projectTargetLocales,
   );
+
+  const nativeDialogs = isNativeFile ? (
+    <>
+      <ImportTranslationsDialog
+        open={importDialogOpen}
+        onOpenChange={setImportDialogOpen}
+        organizationSlug={organizationSlug}
+        projectId={projectId}
+        sourcePath={file.sourcePath}
+        targetLocales={[...targetLocales]}
+      />
+      <DownloadTranslationsDialog
+        open={downloadDialogOpen}
+        onOpenChange={setDownloadDialogOpen}
+        organizationSlug={organizationSlug}
+        projectId={projectId}
+        sourcePaths={[...nativeSourcePaths]}
+        initialSourcePath={file.sourcePath}
+        targetLocales={[...targetLocales]}
+      />
+    </>
+  ) : null;
 
   const actionButtons = (
     <>
@@ -81,21 +96,16 @@ export function ProjectFileSelectionActions({
             <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} />
             Import translations
           </Button>
-          {targetLocales.map((locale) => (
-            <Button
-              key={locale}
-              type="button"
-              size="sm"
-              variant="outline"
-              className={layout === "default" ? "w-full shrink-0 sm:w-fit" : "shrink-0"}
-              onClick={() =>
-                downloadTranslation(organizationSlug, projectId, file.sourcePath, locale)
-              }
-            >
-              <HugeiconsIcon icon={Download01Icon} strokeWidth={1.8} />
-              Download {locale}
-            </Button>
-          ))}
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className={layout === "default" ? "w-full shrink-0 sm:w-fit" : "shrink-0"}
+            onClick={() => setDownloadDialogOpen(true)}
+          >
+            <HugeiconsIcon icon={Download01Icon} strokeWidth={1.8} />
+            Download
+          </Button>
         </>
       ) : null}
     </>
@@ -104,16 +114,7 @@ export function ProjectFileSelectionActions({
   if (layout === "compact") {
     return (
       <>
-        {isNativeFile ? (
-          <ImportTranslationsDialog
-            open={importDialogOpen}
-            onOpenChange={setImportDialogOpen}
-            organizationSlug={organizationSlug}
-            projectId={projectId}
-            sourcePath={file.sourcePath}
-            targetLocales={[...targetLocales]}
-          />
-        ) : null}
+        {nativeDialogs}
         <div className="flex flex-wrap items-center justify-end gap-2">{actionButtons}</div>
       </>
     );
@@ -121,16 +122,7 @@ export function ProjectFileSelectionActions({
 
   return (
     <>
-      {isNativeFile ? (
-        <ImportTranslationsDialog
-          open={importDialogOpen}
-          onOpenChange={setImportDialogOpen}
-          organizationSlug={organizationSlug}
-          projectId={projectId}
-          sourcePath={file.sourcePath}
-          targetLocales={[...targetLocales]}
-        />
-      ) : null}
+      {nativeDialogs}
       <div className="flex shrink-0 flex-col gap-3 border-b border-border px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="min-w-0">
           <TypographyP className="truncate font-mono text-sm text-foreground">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.tsx
@@ -17,13 +17,15 @@ import {
 import { DownloadTranslationsDialog } from "./download-translations-dialog";
 import { ImportTranslationsDialog } from "./import-translations-dialog";
 
+const EMPTY_STRING_ARRAY: readonly string[] = [];
+
 export function ProjectFileSelectionActions({
   organizationSlug,
   projectId,
   file,
   highlightLocale,
   projectTargetLocales,
-  nativeSourcePaths = [],
+  nativeSourcePaths = EMPTY_STRING_ARRAY,
   branch = null,
   layout = "default",
 }: {
@@ -40,7 +42,7 @@ export function ProjectFileSelectionActions({
   const [downloadDialogOpen, setDownloadDialogOpen] = useState(false);
   const canOpenCat = canOpenProjectFileCat(file);
   const isNativeFile = !file.provider;
-  const targetLocales = projectTargetLocales ?? [];
+  const targetLocales = projectTargetLocales ?? EMPTY_STRING_ARRAY;
   const catHref = buildProjectFileCatHref(
     organizationSlug,
     projectId,
@@ -58,16 +60,16 @@ export function ProjectFileSelectionActions({
         organizationSlug={organizationSlug}
         projectId={projectId}
         sourcePath={file.sourcePath}
-        targetLocales={[...targetLocales]}
+        targetLocales={targetLocales}
       />
       <DownloadTranslationsDialog
         open={downloadDialogOpen}
         onOpenChange={setDownloadDialogOpen}
         organizationSlug={organizationSlug}
         projectId={projectId}
-        sourcePaths={[...nativeSourcePaths]}
+        sourcePaths={nativeSourcePaths}
         initialSourcePath={file.sourcePath}
-        targetLocales={[...targetLocales]}
+        targetLocales={targetLocales}
       />
     </>
   ) : null;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.stories.tsx
@@ -28,6 +28,7 @@ function storyFilesTree({
   organizationSlug,
   projectId,
   highlightLocale,
+  projectTargetLocales = null,
   showBranchFilter = false,
   selectedBranch = null,
   onSelectBranch,
@@ -38,6 +39,7 @@ function storyFilesTree({
   organizationSlug: string;
   projectId: string;
   highlightLocale: string | null;
+  projectTargetLocales?: readonly string[] | null;
   showBranchFilter?: boolean;
   selectedBranch?: string | null;
   onSelectBranch?: (branch: string | null) => void;
@@ -65,6 +67,7 @@ function storyFilesTree({
               projectId={projectId}
               file={selectedFileRecord}
               highlightLocale={highlightLocale}
+              projectTargetLocales={projectTargetLocales}
               layout="compact"
             />
           ) : null}
@@ -110,6 +113,7 @@ const meta = {
       organizationSlug: "acme",
       projectId: "project_website",
       highlightLocale: "fr-FR",
+      projectTargetLocales: ["fr-FR", "de-DE"],
     }),
   },
 } satisfies Meta<typeof ProjectFilesPageContentView>;
@@ -124,6 +128,9 @@ export const RepositoryFiles: Story = {
     await expect(canvas.getByText("3 files")).toBeInTheDocument();
     await expect(canvas.getAllByText("marketing/home.json").length).toBeGreaterThan(0);
     await expect(canvas.getByRole("link", { name: "View strings" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Import translations" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Download fr-FR" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Download de-DE" })).toBeInTheDocument();
     await waitFor(() => {
       void expect(canvasElement.querySelector("file-tree-container")).toBeTruthy();
     });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.stories.tsx
@@ -29,6 +29,7 @@ function storyFilesTree({
   projectId,
   highlightLocale,
   projectTargetLocales = null,
+  nativeSourcePaths = null,
   showBranchFilter = false,
   selectedBranch = null,
   onSelectBranch,
@@ -40,6 +41,7 @@ function storyFilesTree({
   projectId: string;
   highlightLocale: string | null;
   projectTargetLocales?: readonly string[] | null;
+  nativeSourcePaths?: readonly string[] | null;
   showBranchFilter?: boolean;
   selectedBranch?: string | null;
   onSelectBranch?: (branch: string | null) => void;
@@ -68,6 +70,10 @@ function storyFilesTree({
               file={selectedFileRecord}
               highlightLocale={highlightLocale}
               projectTargetLocales={projectTargetLocales}
+              nativeSourcePaths={
+                nativeSourcePaths ??
+                files.filter((entry) => !entry.provider).map((entry) => entry.sourcePath)
+              }
               layout="compact"
             />
           ) : null}
@@ -129,8 +135,7 @@ export const RepositoryFiles: Story = {
     await expect(canvas.getAllByText("marketing/home.json").length).toBeGreaterThan(0);
     await expect(canvas.getByRole("link", { name: "View strings" })).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Import translations" })).toBeInTheDocument();
-    await expect(canvas.getByRole("button", { name: "Download fr-FR" })).toBeInTheDocument();
-    await expect(canvas.getByRole("button", { name: "Download de-DE" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Download" })).toBeInTheDocument();
     await waitFor(() => {
       void expect(canvasElement.querySelector("file-tree-container")).toBeTruthy();
     });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx
@@ -129,6 +129,14 @@ describe("ProjectFilesPageContent CAT entry UX", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows import and download actions for native project files", () => {
+    render(<ProjectFilesPageContent organizationSlug="acme" projectId="proj_1" />);
+
+    expect(screen.getByRole("button", { name: "Import translations" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Download vi" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Download fr-FR" })).toBeInTheDocument();
+  });
+
   it("shows when a requested native locale will fall back to a project locale", () => {
     searchParamsMock.mockReturnValue("sourcePath=en-US.json&locale=ja-JP");
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx
@@ -88,7 +88,7 @@ vi.mock("../../_components/project-page-shell", () => ({
   }),
 }));
 
-import { ProjectFilesPageContent } from "./project-files-page-content";
+import { ProjectFilesPageContent, ProjectFilesPageContentView } from "./project-files-page-content";
 
 describe("ProjectFilesPageContent CAT entry UX", () => {
   beforeEach(() => {
@@ -134,6 +134,37 @@ describe("ProjectFilesPageContent CAT entry UX", () => {
 
     expect(screen.getByRole("button", { name: "Import translations" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Download" })).toBeInTheDocument();
+  });
+
+  it("passes project target locales to default-layout download actions", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ProjectFilesPageContentView
+        organizationSlug="acme"
+        projectId="proj_1"
+        files={[enUsFile]}
+        isFilesLoading={false}
+        isFilesFetching={false}
+        selectedSourcePath="en-US.json"
+        highlightLocale={null}
+        projectTargetLocales={["vi", "fr-FR"]}
+        selectedFiles={[]}
+        isUploading={false}
+        onSelectSourcePath={() => undefined}
+        onAddSelectedFiles={() => undefined}
+        onRemoveSelectedFile={() => undefined}
+        onUploadSelectedFiles={() => undefined}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Download" }));
+
+    expect(screen.getByText("Target locale")).toBeInTheDocument();
+    expect(screen.getByText("vi")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Add target locales in project settings before downloading translations."),
+    ).not.toBeInTheDocument();
   });
 
   it("shows when a requested native locale will fall back to a project locale", () => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx
@@ -133,8 +133,7 @@ describe("ProjectFilesPageContent CAT entry UX", () => {
     render(<ProjectFilesPageContent organizationSlug="acme" projectId="proj_1" />);
 
     expect(screen.getByRole("button", { name: "Import translations" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Download vi" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Download fr-FR" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Download" })).toBeInTheDocument();
   });
 
   it("shows when a requested native locale will fall back to a project locale", () => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx
@@ -6,11 +6,17 @@ import { useEffect, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { createProjectFileRecord } from "./project-files.fixture";
+import { ProjectFileSelectionActions } from "./project-file-selection-actions";
 
 const enUsFile = createProjectFileRecord({
   sourcePath: "en-US.json",
   storedFileId: "file_en_us",
   filename: "en-US.json",
+});
+const pricingFile = createProjectFileRecord({
+  sourcePath: "marketing/pricing.json",
+  storedFileId: "file_pricing",
+  filename: "pricing.json",
 });
 
 const { routerPushMock, searchParamsMock } = vi.hoisted(() => ({
@@ -165,6 +171,34 @@ describe("ProjectFilesPageContent CAT entry UX", () => {
     expect(
       screen.queryByText("Add target locales in project settings before downloading translations."),
     ).not.toBeInTheDocument();
+  });
+
+  it("preserves open download dialog selections across parent re-renders", async () => {
+    const user = userEvent.setup();
+    const targetLocales = ["vi", "fr-FR"] as const;
+    const nativeSourcePaths = [enUsFile.sourcePath, pricingFile.sourcePath] as const;
+    const renderActions = (layout: "default" | "compact") => (
+      <ProjectFileSelectionActions
+        organizationSlug="acme"
+        projectId="proj_1"
+        file={enUsFile}
+        highlightLocale={null}
+        projectTargetLocales={targetLocales}
+        nativeSourcePaths={nativeSourcePaths}
+        layout={layout}
+      />
+    );
+
+    const { rerender } = render(renderActions("default"));
+
+    await user.click(screen.getByRole("button", { name: "Download" }));
+    await user.click(screen.getByLabelText(pricingFile.sourcePath));
+    await user.click(screen.getByLabelText("fr-FR"));
+
+    rerender(renderActions("compact"));
+
+    expect(screen.getByLabelText(pricingFile.sourcePath)).toBeChecked();
+    expect(screen.getByLabelText("fr-FR")).toBeChecked();
   });
 
   it("shows when a requested native locale will fall back to a project locale", () => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -304,6 +304,7 @@ export function ProjectFilesPageContent({
       selectedSourcePath={selectedSourcePath}
       highlightLocale={highlightLocale}
       selectedBranch={selectedBranch}
+      projectTargetLocales={projectTargetLocales}
       isProviderProject={isProviderProject}
       selectedFiles={selectedFiles}
       isUploading={uploadFiles.isPending}
@@ -363,6 +364,7 @@ export function ProjectFilesPageContentView({
   selectedSourcePath,
   highlightLocale,
   selectedBranch: _selectedBranch = null,
+  projectTargetLocales,
   isProviderProject: isProviderProjectProp,
   selectedFiles,
   isUploading,
@@ -385,6 +387,7 @@ export function ProjectFilesPageContentView({
   selectedSourcePath: string | null;
   highlightLocale: string | null;
   selectedBranch?: string | null;
+  projectTargetLocales?: readonly string[] | null;
   isProviderProject?: boolean;
   selectedFiles: File[];
   isUploading: boolean;
@@ -508,6 +511,7 @@ export function ProjectFilesPageContentView({
                 projectId={projectId}
                 file={selectedFile}
                 highlightLocale={highlightLocale}
+                projectTargetLocales={projectTargetLocales}
                 nativeSourcePaths={nativeSourcePaths}
                 branch={_selectedBranch}
               />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -265,6 +265,10 @@ export function ProjectFilesPageContent({
     () => resolvedFiles.find((file) => file.sourcePath === selectedSourcePath) ?? null,
     [resolvedFiles, selectedSourcePath],
   );
+  const nativeSourcePaths = useMemo(
+    () => resolvedFiles.filter((entry) => !entry.provider).map((entry) => entry.sourcePath),
+    [resolvedFiles],
+  );
   const catOpenHint = selectedFileForTree
     ? (() => {
         const targetLocaleResolution = resolveProjectFileCatTargetLocaleResolution(
@@ -335,6 +339,7 @@ export function ProjectFilesPageContent({
                   file={selectedFile}
                   highlightLocale={highlightLocale}
                   projectTargetLocales={projectTargetLocales}
+                  nativeSourcePaths={nativeSourcePaths}
                   branch={selectedBranch}
                   layout="compact"
                 />
@@ -397,6 +402,10 @@ export function ProjectFilesPageContentView({
   const selectedFile = useMemo(
     () => displayFiles.find((file) => file.sourcePath === selectedSourcePath) ?? null,
     [displayFiles, selectedSourcePath],
+  );
+  const nativeSourcePaths = useMemo(
+    () => displayFiles.filter((entry) => !entry.provider).map((entry) => entry.sourcePath),
+    [displayFiles],
   );
   const projectCapabilities = getProjectWorkspaceCapabilities({ projectId });
   const isProviderProject = isProviderProjectProp ?? projectCapabilities.isProviderProject;
@@ -499,6 +508,7 @@ export function ProjectFilesPageContentView({
                 projectId={projectId}
                 file={selectedFile}
                 highlightLocale={highlightLocale}
+                nativeSourcePaths={nativeSourcePaths}
                 branch={_selectedBranch}
               />
             ) : null}


### PR DESCRIPTION
## What changed

Restores **Import translations** and per-locale **Download** actions on the project Files page by wiring them into `ProjectFileSelectionActions` next to **View strings**.

These actions only appear for native workspace files (not TMS-linked provider files), matching the existing import API constraints. The import dialog and download endpoint were already implemented but had been disconnected when the files page moved to the compact selection bar.

## How to test

1. Open a native workspace project with target locales configured.
2. Go to **Files** and select a source file.
3. Confirm **Import translations**, **Download {locale}**, and **View strings** appear in the file header actions.
4. Click **Import translations** and verify the upload dialog opens.
5. Click a **Download** button and verify a translated file downloads.
6. Open a TMS-linked provider project and confirm import/download actions are hidden.

```bash
cd apps/hyperlocalise-web
vp test src/app/\[lang\]/\(authenticated\)/org/\[organizationSlug\]/projects/\[projectId\]/files/_components/project-files-page-content.test.tsx
vp check --fix
```

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)