### PR TITLE
fix(web): prevent duplicate TMS file paths from breaking project files browser

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-shared.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-shared.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+
+import { dedupeProjectFilesBySourcePath } from "./project-files-shared";
+
+function projectFile(sourcePath: string, externalResourceId: string): ProjectFileRecord {
+  return {
+    origin: "provider",
+    sourcePath,
+    sourceHash: null,
+    commitSha: null,
+    workflowRunId: null,
+    uploadedAt: "2026-01-01T00:00:00.000Z",
+    storedFileId: null,
+    metadata: {},
+    filename: sourcePath.split("/").at(-1) ?? sourcePath,
+    byteSize: null,
+    provider: {
+      kind: "phrase",
+      resourceType: "file",
+      externalProjectId: "proj-1",
+      externalResourceId,
+      externalUrl: null,
+      syncState: "synced",
+      sourceLocale: "en-US",
+      targetLocales: ["fr-FR"],
+      localeReadiness: {},
+      revision: null,
+      format: "json",
+      lastSyncedAt: null,
+    },
+    latestJob: null,
+  };
+}
+
+describe("dedupeProjectFilesBySourcePath", () => {
+  it("removes duplicate source paths before rendering the file tree", () => {
+    const path = "service/specialty/en/long-term-care-clinician.md";
+    const files = dedupeProjectFilesBySourcePath([
+      projectFile(path, "upload-1"),
+      projectFile(path, "upload-2"),
+    ]);
+
+    expect(files).toHaveLength(1);
+    expect(files[0]?.sourcePath).toBe(path);
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-shared.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-shared.ts
@@ -1,3 +1,6 @@
+import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+import { dedupeLiveFilesBySourcePath } from "@/lib/providers/jobs/tms-provider-live-file-dedupe";
+
 export function formatBytes(bytes: number | null) {
   if (bytes === null) return "Unknown size";
   if (bytes === 0) return "0 B";
@@ -5,4 +8,8 @@ export function formatBytes(bytes: number | null) {
   const units = ["B", "KB", "MB", "GB"];
   const unitIndex = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
   return `${Number((bytes / 1024 ** unitIndex).toFixed(1))} ${units[unitIndex]}`;
+}
+
+export function dedupeProjectFilesBySourcePath(files: ProjectFileRecord[]): ProjectFileRecord[] {
+  return dedupeLiveFilesBySourcePath(files);
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.tsx
@@ -15,6 +15,7 @@ import { getProjectWorkspaceCapabilities } from "@/lib/projects/workspace-resour
 import { ProjectSectionTitle } from "../../_components/project-page-shell";
 import { ProjectFilesErrorBoundary } from "./project-files-error-boundary";
 import { ProjectFilesTree } from "./project-files-tree";
+import { dedupeProjectFilesBySourcePath } from "./project-files-shared";
 
 export const PROJECT_FILES_PAGE_SIZE = 500;
 export const PROJECT_FILES_MAX_LIMIT = 1_000;
@@ -95,7 +96,7 @@ function apiPath(organizationSlug: string, projectId: string) {
 }
 
 export function sortFilesByPath(files: ProjectFileRecord[]) {
-  return [...files].toSorted((a, b) =>
+  return dedupeProjectFilesBySourcePath(files).toSorted((a, b) =>
     a.sourcePath.localeCompare(b.sourcePath, undefined, { sensitivity: "base" }),
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
@@ -7,7 +7,7 @@ import { preloadFileTree } from "@pierre/trees/ssr";
 import "@pierre/trees/web-components";
 
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
-import { formatBytes } from "./project-files-shared";
+import { dedupeProjectFilesBySourcePath, formatBytes } from "./project-files-shared";
 
 export const TREE_HEIGHT_PX = 480;
 
@@ -70,8 +70,12 @@ export function ProjectFilesTree({
   ariaLabel?: string;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const paths = useMemo(() => files.map((file) => file.sourcePath), [files]);
-  const fileByPath = useMemo(() => new Map(files.map((file) => [file.sourcePath, file])), [files]);
+  const displayFiles = useMemo(() => dedupeProjectFilesBySourcePath(files), [files]);
+  const paths = useMemo(() => displayFiles.map((file) => file.sourcePath), [displayFiles]);
+  const fileByPath = useMemo(
+    () => new Map(displayFiles.map((file) => [file.sourcePath, file])),
+    [displayFiles],
+  );
   const selectedPaths =
     selectedSourcePath && fileByPath.has(selectedSourcePath) ? [selectedSourcePath] : [];
   const latestStateRef = useRef({ fileByPath, onSelectFile, onActivateFile });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
@@ -2818,13 +2818,22 @@ export class CrowdinTmsProvider extends TmsProvider {
     return parts.length > 0 ? `${parts.join("/")}/` : "";
   }
 
+  private resolveCrowdinBranchPathSegment(branchId: number, branchMap: Map<number, string>) {
+    const branchName = branchMap.get(branchId);
+    if (branchName) {
+      return branchName;
+    }
+
+    return `__hl-branch-id-${branchId}__`;
+  }
+
   private sourcePathOf(
     file: { branchId: number | null; directoryId: number | null; name: string },
     branchMap: Map<number, string>,
     directoryPathById: Map<number, string>,
   ): string {
     const branchName = file.branchId
-      ? (branchMap.get(file.branchId) ?? `branch-${file.branchId}`)
+      ? this.resolveCrowdinBranchPathSegment(file.branchId, branchMap)
       : "";
     const directoryPath = file.directoryId ? (directoryPathById.get(file.directoryId) ?? "") : "";
     return branchName

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
@@ -2823,7 +2823,9 @@ export class CrowdinTmsProvider extends TmsProvider {
     branchMap: Map<number, string>,
     directoryPathById: Map<number, string>,
   ): string {
-    const branchName = file.branchId ? (branchMap.get(file.branchId) ?? "") : "";
+    const branchName = file.branchId
+      ? (branchMap.get(file.branchId) ?? `branch-${file.branchId}`)
+      : "";
     const directoryPath = file.directoryId ? (directoryPathById.get(file.directoryId) ?? "") : "";
     return branchName
       ? `${branchName}/${directoryPath}${file.name}`

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-provider-files.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-provider-files.test.ts
@@ -234,7 +234,7 @@ describe("phraseTmsProvider.fetchFileKeys", () => {
       (item) => item.resourceType === "key" && item.externalResourceId === "feature::key-feature",
     );
     expect(branchKey).toMatchObject({
-      sourcePath: "feature/keys/feature.title",
+      sourcePath: "branches/feature/keys/feature.title",
       providerPayload: expect.objectContaining({
         branch: "feature",
         tags: ["app"],
@@ -246,7 +246,7 @@ describe("phraseTmsProvider.fetchFileKeys", () => {
         item.resourceType === "file" && item.externalResourceId === "feature::upload-feature",
     );
     expect(branchFile).toMatchObject({
-      sourcePath: "feature/locales/en-US/home.json",
+      sourcePath: "branches/feature/locales/en-US/home.json",
     });
 
     const defaultFile = result.find(
@@ -347,14 +347,20 @@ describe("phrase locale readiness", () => {
     });
     expect(buildPhraseKeySourcePath("home.hero.title", null)).toBe("keys/home.hero.title");
     expect(buildPhraseKeySourcePath("home.hero.title", "feature")).toBe(
-      "feature/keys/home.hero.title",
+      "branches/feature/keys/home.hero.title",
     );
     expect(buildPhraseUploadSourcePath("en-US", "home.json", null)).toBe("locales/en-US/home.json");
     expect(buildPhraseUploadSourcePath("en-US", "home.json", "feature")).toBe(
-      "feature/locales/en-US/home.json",
+      "branches/feature/locales/en-US/home.json",
     );
     expect(buildPhraseUploadSourcePath(null, "home.json", "feature")).toBe(
-      "feature/uploads/home.json",
+      "branches/feature/uploads/home.json",
+    );
+    expect(buildPhraseUploadSourcePath("en-US", "home.json", "team/feature")).toBe(
+      "branches/team%2Ffeature/locales/en-US/home.json",
+    );
+    expect(buildPhraseUploadSourcePath("en-US", "feature/locales/en/home.json", null)).toBe(
+      "locales/en-US/feature/locales/en/home.json",
     );
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-provider-files.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-provider-files.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import {
   buildPhraseKeyExternalResourceId,
   buildPhraseKeySourcePath,
+  buildPhraseUploadSourcePath,
   mapPhraseTranslationReadiness,
   parsePhraseExternalResourceId,
   phraseTmsProvider,
@@ -240,6 +241,14 @@ describe("phraseTmsProvider.fetchFileKeys", () => {
       }),
     });
 
+    const branchFile = result.find(
+      (item) =>
+        item.resourceType === "file" && item.externalResourceId === "feature::upload-feature",
+    );
+    expect(branchFile).toMatchObject({
+      sourcePath: "feature/locales/en-US/home.json",
+    });
+
     const defaultFile = result.find(
       (item) => item.resourceType === "file" && item.externalResourceId === "upload-1",
     );
@@ -339,6 +348,13 @@ describe("phrase locale readiness", () => {
     expect(buildPhraseKeySourcePath("home.hero.title", null)).toBe("keys/home.hero.title");
     expect(buildPhraseKeySourcePath("home.hero.title", "feature")).toBe(
       "feature/keys/home.hero.title",
+    );
+    expect(buildPhraseUploadSourcePath("en-US", "home.json", null)).toBe("locales/en-US/home.json");
+    expect(buildPhraseUploadSourcePath("en-US", "home.json", "feature")).toBe(
+      "feature/locales/en-US/home.json",
+    );
+    expect(buildPhraseUploadSourcePath(null, "home.json", "feature")).toBe(
+      "feature/uploads/home.json",
     );
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-provider.ts
@@ -349,7 +349,7 @@ export class PhraseTmsProvider extends TmsProvider {
       });
 
       for (const upload of uploads) {
-        const sourcePath = buildPhraseUploadSourcePath(sourceLocale, upload.filename);
+        const sourcePath = buildPhraseUploadSourcePath(sourceLocale, upload.filename, branch);
         const uploadTags = this.mergeTags(upload.tags, upload.tag);
         const localeReadiness = this.buildUploadLocaleReadiness({
           keys,
@@ -2024,14 +2024,23 @@ export function buildPhraseKeySourcePath(keyName: string, branch: string | null)
 }
 
 /** Canonical Hyperlocalise source path for a Phrase upload (file) resource. */
-export function buildPhraseUploadSourcePath(sourceLocale: string | null, filename: string) {
+export function buildPhraseUploadSourcePath(
+  sourceLocale: string | null,
+  filename: string,
+  branch: string | null = null,
+) {
   const trimmedFilename = filename.trim();
   const trimmedLocale = sourceLocale?.trim();
-  if (!trimmedLocale) {
-    return `uploads/${trimmedFilename}`;
+  const trimmedBranch = branch?.trim();
+  const basePath = trimmedLocale
+    ? `locales/${trimmedLocale}/${trimmedFilename}`
+    : `uploads/${trimmedFilename}`;
+
+  if (!trimmedBranch) {
+    return basePath;
   }
 
-  return `locales/${trimmedLocale}/${trimmedFilename}`;
+  return `${trimmedBranch}/${basePath}`;
 }
 
 /** Normalizes Phrase TMS match scores to 0–100 integer percentages. */

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-provider.ts
@@ -2012,15 +2012,24 @@ export function buildPhraseKeyExternalResourceId(keyId: string, branch: string |
   return `${trimmedBranch}::${trimmedId}`;
 }
 
+/** Encodes a Phrase branch name for use as a single source-path segment. */
+export function encodePhraseBranchPathSegment(branch: string) {
+  return encodeURIComponent(branch.trim());
+}
+
+function buildPhraseBranchScopedPath(branch: string | null, relativePath: string) {
+  const trimmedBranch = branch?.trim();
+  if (!trimmedBranch) {
+    return relativePath;
+  }
+
+  return `branches/${encodePhraseBranchPathSegment(trimmedBranch)}/${relativePath}`;
+}
+
 /** Canonical Hyperlocalise source path for a Phrase key resource. */
 export function buildPhraseKeySourcePath(keyName: string, branch: string | null) {
   const trimmedName = keyName.trim();
-  const trimmedBranch = branch?.trim();
-  if (!trimmedBranch) {
-    return `keys/${trimmedName}`;
-  }
-
-  return `${trimmedBranch}/keys/${trimmedName}`;
+  return buildPhraseBranchScopedPath(branch, `keys/${trimmedName}`);
 }
 
 /** Canonical Hyperlocalise source path for a Phrase upload (file) resource. */
@@ -2031,16 +2040,11 @@ export function buildPhraseUploadSourcePath(
 ) {
   const trimmedFilename = filename.trim();
   const trimmedLocale = sourceLocale?.trim();
-  const trimmedBranch = branch?.trim();
   const basePath = trimmedLocale
     ? `locales/${trimmedLocale}/${trimmedFilename}`
     : `uploads/${trimmedFilename}`;
 
-  if (!trimmedBranch) {
-    return basePath;
-  }
-
-  return `${trimmedBranch}/${basePath}`;
+  return buildPhraseBranchScopedPath(branch, basePath);
 }
 
 /** Normalizes Phrase TMS match scores to 0–100 integer percentages. */

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-file-dedupe.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-file-dedupe.ts
@@ -1,0 +1,41 @@
+export type LiveFileSourcePathRecord = {
+  sourcePath: string;
+  provider?: {
+    resourceType?: "file" | "key";
+    revision?: string | null;
+    externalResourceId?: string;
+  } | null;
+};
+
+function preferLiveFileBySourcePath<T extends LiveFileSourcePathRecord>(
+  current: T,
+  candidate: T,
+): T {
+  const currentIsFile = current.provider?.resourceType === "file";
+  const candidateIsFile = candidate.provider?.resourceType === "file";
+  if (currentIsFile !== candidateIsFile) {
+    return candidateIsFile ? candidate : current;
+  }
+
+  const currentRevision = current.provider?.revision ?? "";
+  const candidateRevision = candidate.provider?.revision ?? "";
+  if (candidateRevision > currentRevision) {
+    return candidate;
+  }
+  if (candidateRevision < currentRevision) {
+    return current;
+  }
+
+  const currentId = current.provider?.externalResourceId ?? "";
+  const candidateId = candidate.provider?.externalResourceId ?? "";
+  return candidateId.localeCompare(currentId) > 0 ? candidate : current;
+}
+
+export function dedupeLiveFilesBySourcePath<T extends LiveFileSourcePathRecord>(files: T[]): T[] {
+  const bySourcePath = new Map<string, T>();
+  for (const file of files) {
+    const existing = bySourcePath.get(file.sourcePath);
+    bySourcePath.set(file.sourcePath, existing ? preferLiveFileBySourcePath(existing, file) : file);
+  }
+  return [...bySourcePath.values()];
+}

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-files-dedupe.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-files-dedupe.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  dedupeLiveFilesBySourcePath,
+  type LiveFileSourcePathRecord,
+} from "./tms-provider-live-file-dedupe";
+
+function liveFile(input: {
+  sourcePath: string;
+  resourceType: "file" | "key";
+  externalResourceId: string;
+  revision?: string | null;
+}): LiveFileSourcePathRecord {
+  return {
+    sourcePath: input.sourcePath,
+    provider: {
+      resourceType: input.resourceType,
+      externalResourceId: input.externalResourceId,
+      revision: input.revision ?? null,
+    },
+  };
+}
+
+describe("dedupeLiveFilesBySourcePath", () => {
+  it("keeps one file per source path", () => {
+    const files = dedupeLiveFilesBySourcePath([
+      liveFile({
+        sourcePath: "service/specialty/en/long-term-care-clinician.md",
+        resourceType: "file",
+        externalResourceId: "upload-1",
+      }),
+      liveFile({
+        sourcePath: "service/specialty/en/long-term-care-clinician.md",
+        resourceType: "file",
+        externalResourceId: "upload-2",
+        revision: "2026-05-02T00:00:00Z",
+      }),
+    ]);
+
+    expect(files).toHaveLength(1);
+    expect(files[0]?.provider?.externalResourceId).toBe("upload-2");
+  });
+
+  it("prefers file resources over key resources for the same path", () => {
+    const files = dedupeLiveFilesBySourcePath([
+      liveFile({
+        sourcePath: "locales/en-US/home.json",
+        resourceType: "key",
+        externalResourceId: "key-1",
+      }),
+      liveFile({
+        sourcePath: "locales/en-US/home.json",
+        resourceType: "file",
+        externalResourceId: "upload-1",
+      }),
+    ]);
+
+    expect(files).toHaveLength(1);
+    expect(files[0]?.provider?.resourceType).toBe("file");
+    expect(files[0]?.provider?.externalResourceId).toBe("upload-1");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -1974,7 +1974,7 @@ export async function listTmsProviderLiveFilesForProject(
     rethrowProviderFetcherError(error);
   }
 
-  return files.slice(0, options?.limit ?? 500).map((file) =>
+  const mapped = files.map((file) =>
     mapLiveFile({
       providerKind: context.providerKind,
       externalProjectId,
@@ -1982,7 +1982,10 @@ export async function listTmsProviderLiveFilesForProject(
       project: projectMetadata,
     }),
   );
+
+  return dedupeLiveFilesBySourcePath(mapped).slice(0, options?.limit ?? 500);
 }
+import { dedupeLiveFilesBySourcePath } from "@/lib/providers/jobs/tms-provider-live-file-dedupe";
 
 async function buildTmsProviderLiveFileDetail(
   context: ActiveTmsProviderContext,

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -1983,9 +1983,8 @@ export async function listTmsProviderLiveFilesForProject(
     }),
   );
 
-  return dedupeLiveFilesBySourcePath(mapped).slice(0, options?.limit ?? 500);
+  return mapped.slice(0, options?.limit ?? 500);
 }
-import { dedupeLiveFilesBySourcePath } from "@/lib/providers/jobs/tms-provider-live-file-dedupe";
 
 async function buildTmsProviderLiveFileDetail(
   context: ActiveTmsProviderContext,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the "Files failed to load" error caused by duplicate `sourcePath` values when browsing TMS provider files (e.g. `Duplicate path: "service/specialty/en/long-term-care-clinician.md"`).

The Pierre file tree requires unique paths; when the provider returned multiple resources mapped to the same path, the tree threw and the whole Files panel failed.

## Changes

- **Deduplicate only in the Files UI** (tree panel + tree component), preserving full provider resource lists for job-file lookup and CAT/deep-link resolution by `externalResourceId`
- **Encode Phrase branch names** under a `branches/{encodedName}/` prefix so slashes in branch names cannot collide with nested upload filenames
- **Use reserved Crowdin fallback** `__hl-branch-id-{id}__` when branch metadata is missing, avoiding collisions with real branches named `branch-{id}`
- **Include Phrase branch names in upload source paths** (matching how key paths already work), preventing cross-branch collisions when listing all branches

## Testing

- `vp check --fix` passes
- Added unit tests for dedupe logic and Phrase upload path helpers
- Targeted vitest suites for changed files pass

## Notes

Existing deep links that relied on old Phrase upload paths without branch prefixes may need `externalResourceId` in the URL (already supported for CAT navigation).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28f8236b-ad97-480c-843e-8097fa6f9654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28f8236b-ad97-480c-843e-8097fa6f9654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

