### PR TITLE
fix(agent): scope find-context repo lookups

### DIFF
--- a/apps/hyperlocalise-web/src/agents/README.md
+++ b/apps/hyperlocalise-web/src/agents/README.md
@@ -43,6 +43,7 @@ The Hyperlocalise conversational agent resolves capability skills from `hyperloc
 | `conversation`      | always (includes project resolution tools)         |
 | `tms-tools`         | external TMS integrated                            |
 | `repo-tools`        | GitHub sandbox is connected                        |
+| `find-context`      | GitHub sandbox is connected                        |
 | `translation-tools` | always (`createTranslationJob` when files/project) |
 
 Skill frontmatter declares `tools`, `sharedSkills`, and context requirements (`requiresSandbox`, `requiresTmsIntegration`, `requiresProjectOrAttachments`). The agent uses whichever skills and tools are available for the turn.

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/slack.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/slack.ts
@@ -331,12 +331,7 @@ async function processSlackMessage(
       });
     }
 
-    const chatMessages = replaceLastUserMessage(
-      loadedMessages,
-      resolvedRepositoryContext
-        ? getRecentUserConversationText(loadedMessages, persistedUserText)
-        : persistedUserText,
-    );
+    const chatMessages = replaceLastUserMessage(loadedMessages, persistedUserText);
 
     if (imageAttachments.length > 0) {
       await removeEyesReaction(thread, message);

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/conversation.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/conversation.md
@@ -11,7 +11,8 @@ You are Hyperlocalise's conversational localization agent.
 Use the capability skills and tools available for this turn. Match the user's request to the right skill:
 
 - **tms-tools** — read-only linked TMS progress, locale completion, and project status (when a TMS is integrated)
-- **repo-tools** — find localization context in the connected GitHub repository (read-only)
+- **repo-tools** — read-only search and inspection tools for the connected GitHub repository
+- **find-context** — find localization context for source text or keys using repo-tools
 - **translation-tools** — translate files, images, or inline strings and create translation jobs
 
 When multiple capability skills are active, gather repository context before creating translation jobs when both apply.

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/find-context.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/find-context.md
@@ -1,0 +1,44 @@
+---
+id: find-context
+requiresSandbox: true
+---
+
+## Find context in repository
+
+This skill applies when the user or product asks for translation context for a source string, message, localization key, UI label, or uploaded-file segment. The request may provide either source text or a string key; use both when available.
+
+Use the `repo-tools` skill to search and inspect the repository. This skill adds the localization-specific search priorities and final answer contract.
+
+In multi-turn conversations, treat the latest user message as the active lookup target. Previous source strings, keys, and labels are history only; do not include them in the answer unless the latest user message explicitly asks to compare, include both, revisit a previous string, or explain a relationship between strings.
+
+## Inputs
+
+- `sourceText` is the literal source copy to find when available.
+- `stringKey` is the localization key or message identifier to find when available.
+- `sourcePath`, surrounding TMS notes, locale hints, or repository hints narrow the search when provided.
+
+## Search procedure
+
+- Follow the `repo-tools` search procedure first.
+- If `sourceText` is present, search with the exact text first.
+- If `stringKey` is present, search with the exact key first. This is enough to proceed when source text is missing or too generic.
+- If exact key search has no useful matches, search nearby key variants, namespace fragments, locale/resource files, and code references that consume the key.
+- For short visible UI labels, menu items, sidebar items, or page headings, search component, route, app shell, sidebar, navigation, and config files before accepting no-match results.
+- Try lowercase route/key variants and nearby navigation labels for single-word or short-title UI copy.
+- Mention search attempts only when evidence is inferred, no exact match was found, or ambiguity remains. Keep that to one short note in the final guidance, not a search log.
+
+## Output contract
+
+Return concise Markdown for translators using exactly these labeled sections in this order. Lead with meaning and usage; do not bury the answer under search metadata.
+
+**What it is:** 1-3 sentences on what the string or key is and what it does in the product, including UI role, user-facing purpose, and any ICU placeholders or variables.
+
+**Where/how it shows:** 1-4 sentences on the product surface and interaction: screen, step, flow, layout position, and how the user encounters it. Include the best repository evidence inline as concrete `path:line` references and quoted source text when helpful.
+
+**Translation guidance:**
+
+- Actionable notes for translators: intended meaning, tone/register, length constraints, and what to avoid.
+- Call out sibling strings in the same feature that share a concept and should use consistent terminology. Name keys when repository evidence supports it.
+- Note ambiguities, inferred evidence, or missing matches in at most one short bullet.
+
+Omit bullets that add no translation value. Do not use separate "Summary", "Answer", "Source", "Details", or "Searches Run" sections. Do not suggest code changes, review implementation, run checks, or summarize unrelated architecture.

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/repo-tools.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/repo-tools.md
@@ -6,13 +6,15 @@ tools: grep,fuzzySearch,read,glob,detectRepoConfig,todoWrite
 
 ## Repository tools
 
-Use these tools for read-only localization context in the connected GitHub repository.
+Use these tools for read-only inspection of the connected GitHub repository.
 
-- Search with the user's exact quoted string first, preserving capitalization and punctuation.
-- Follow with a case-insensitive search when the exact search has no matches.
+- Treat the repository as read-only. Do not modify files, run write commands, create tickets, review PR implementation, run checks, or summarize unrelated architecture unless another skill explicitly asks for it.
+- Start with the most specific evidence the user provided: exact source text, exact string key, file path, route, component name, or repository hint.
+- Use `grep` for exact text and key searches. Preserve capitalization and punctuation for the first search.
+- Follow exact text searches with a case-insensitive search when the exact search has no useful matches.
 - Use `fuzzySearch` for short UI labels when exact and case-insensitive searches are not enough.
-- For short visible UI labels, search component, route, app shell, sidebar, navigation, and config files before accepting no-match results.
-- Try lowercase route/key variants and nearby navigation labels for single-word or short-title UI copy.
-- Lead with an **Answer** translators can use immediately, then **Source** with `path:line` evidence.
-- Return product meaning, tone/register, placeholder semantics, nearby copy, and ambiguities when they help translation.
-- Do not use repository context for broad architecture summaries, PR fixes, code review, checks, or source edits.
+- Use `glob` to discover locale, resource, route, component, or i18n config paths when needed.
+- Use `read` to inspect surrounding lines before drawing conclusions from a match.
+- Use `detectRepoConfig` when asked about i18n.yml or project locale setup.
+- Prefer concrete `path:line` evidence over guesses from filenames.
+- Stop once you have enough evidence for the active skill; do not continue into broad codebase exploration.

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.test.ts
@@ -127,5 +127,12 @@ describe("conversation skill agent", () => {
         activeTools: expect.arrayContaining(["grep", "createTranslationJob", "translate_string"]),
       }),
     );
+
+    const settings = toolLoopAgentMock.mock.calls.at(-1)?.[0] as {
+      instructions: string;
+    };
+    expect(settings.instructions).toContain("Repository tools");
+    expect(settings.instructions).toContain("Find context in repository");
+    expect(settings.instructions).toContain("source text or a string key");
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
@@ -286,6 +286,48 @@ describe("conversation turn preparation", () => {
     );
   });
 
+  it("keeps the latest lookup target as the active agent-facing message", async () => {
+    const githubContext = {
+      resolved: true as const,
+      installationId: 42,
+      repositoryFullName: "acme/web",
+    };
+    loadInteractionModelMessagesMock.mockResolvedValue([
+      { role: "user", content: 'What is the context of "Knowledge"?' },
+      { role: "assistant", content: "Knowledge is a sidebar item." },
+      { role: "user", content: 'What is the context of "Dashboard"?' },
+    ]);
+    classifyConversationMock.mockResolvedValue({
+      ...baseClassification,
+      needsRepositoryTools: true,
+      continuesRepositoryThread: true,
+    });
+    resolveConversationRepositoryGitHubContextMock.mockResolvedValue({
+      status: "resolved",
+      source: "single_installed_repository",
+      context: githubContext,
+    });
+    createRepositorySandboxMock.mockResolvedValue("sandbox_123");
+
+    const result = await prepareConversationAgentTurn({
+      surface: "web",
+      conversationId: "conv_123",
+      organizationId: "org_123",
+      localUserId: "user_123",
+      membershipRole: "admin",
+      projectId: null,
+      messageText: 'What is the context of "Dashboard"?',
+      hasTranslationAttachments: false,
+      db: {} as never,
+    });
+
+    expect(result.chatMessages.at(-1)).toEqual({
+      role: "user",
+      content: 'What is the context of "Dashboard"?',
+    });
+    expect(result.chatMessages.at(-1)?.content).not.toContain("Knowledge");
+  });
+
   it("skips creating a sandbox when only a committed sandbox may be reused", async () => {
     const storedContext = {
       resolved: true as const,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
@@ -341,12 +341,7 @@ export async function prepareConversationAgentTurn(
 
   const hasTmsIntegration = await resolveOrganizationHasTmsIntegration(input.organizationId);
 
-  const preparedMessages = replaceLastUserMessage(
-    chatMessages,
-    activeRepositoryContext
-      ? getRecentUserConversationText(chatMessages, input.messageText)
-      : input.messageText,
-  );
+  const preparedMessages = replaceLastUserMessage(chatMessages, input.messageText);
 
   const agent = createConversationToolLoopAgent({
     surface: input.surface,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
@@ -18,7 +18,13 @@ describe("conversation skill registry", () => {
   it("loads the capability skills from frontmatter", () => {
     const skills = listConversationSkills();
     expect(skills.map((skill) => skill.id).sort()).toEqual(
-      expect.arrayContaining(["conversation", "repo-tools", "tms-tools", "translation-tools"]),
+      expect.arrayContaining([
+        "conversation",
+        "find-context",
+        "repo-tools",
+        "tms-tools",
+        "translation-tools",
+      ]),
     );
 
     const conversationSkill = skills.find((skill) => skill.id === "conversation");
@@ -38,6 +44,18 @@ describe("conversation skill registry", () => {
     expect(translationSkill).toMatchObject({
       always: true,
       tools: ["createTranslationJob", "translate_string"],
+    });
+
+    const findContextSkill = skills.find((skill) => skill.id === "find-context");
+    expect(findContextSkill).toMatchObject({
+      requiresSandbox: true,
+      tools: [],
+    });
+
+    const repoToolsSkill = skills.find((skill) => skill.id === "repo-tools");
+    expect(repoToolsSkill).toMatchObject({
+      requiresSandbox: true,
+      tools: ["grep", "fuzzySearch", "read", "glob", "detectRepoConfig", "todoWrite"],
     });
   });
 
@@ -82,13 +100,37 @@ describe("conversation skill registry", () => {
     ).toBe(true);
   });
 
-  it("activates repo-tools when a sandbox is available", () => {
-    const repoSkill = listConversationSkills().find((skill) => skill.id === "repo-tools");
-    expect(repoSkill).toBeDefined();
+  it("activates find-context when a sandbox is available", () => {
+    const findContextSkill = listConversationSkills().find((skill) => skill.id === "find-context");
+    expect(findContextSkill).toBeDefined();
 
     expect(
       isConversationSkillActivated(
-        repoSkill!,
+        findContextSkill!,
+        toConversationSkillActivationContext({
+          hasFileAttachments: false,
+          hasTmsIntegration: false,
+          toolContext: {
+            conversationId: "conv_1",
+            organizationId: "org_1",
+            localUserId: "user_1",
+            membershipRole: "member",
+            projectId: null,
+            db: {} as never,
+            sandboxId: "sbx_1",
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("activates repo-tools when a sandbox is available", () => {
+    const repoToolsSkill = listConversationSkills().find((skill) => skill.id === "repo-tools");
+    expect(repoToolsSkill).toBeDefined();
+
+    expect(
+      isConversationSkillActivated(
+        repoToolsSkill!,
         toConversationSkillActivationContext({
           hasFileAttachments: false,
           hasTmsIntegration: false,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/find-context-instructions.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/find-context-instructions.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildFindContextSkillInstructions } from "./find-context-instructions";
+
+describe("buildFindContextSkillInstructions", () => {
+  it("omits the find context request header when no request fields are present", () => {
+    const instructions = buildFindContextSkillInstructions({
+      contextNote: "  ",
+      sourcePath: null,
+      sourceText: undefined,
+      stringKey: "",
+    });
+
+    expect(instructions).not.toContain("Find context request:");
+  });
+
+  it("includes the find context request header when request fields are present", () => {
+    const instructions = buildFindContextSkillInstructions({
+      sourcePath: "locales/en.json",
+      sourceText: "Save",
+    });
+
+    expect(instructions).toContain("Find context request:\n");
+    expect(instructions).toContain("Source file path in the TMS project: locales/en.json");
+    expect(instructions).toContain("Source text: Save");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/find-context-instructions.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/find-context-instructions.ts
@@ -1,0 +1,31 @@
+import { loadAgentSkill } from "@/agents/_runtime/loader";
+
+type BuildFindContextSkillInstructionsInput = {
+  sourceText?: string | null;
+  stringKey?: string | null;
+  sourcePath?: string | null;
+  contextNote?: string | null;
+};
+
+function formatInstructionField(label: string, value: string | null | undefined) {
+  const trimmed = value?.trim();
+  return trimmed ? `${label}: ${trimmed}` : null;
+}
+
+export function buildFindContextSkillInstructions(input: BuildFindContextSkillInstructionsInput) {
+  const repoToolsSkill = loadAgentSkill({ agentId: "hyperlocalise", skillId: "repo-tools" });
+  const findContextSkill = loadAgentSkill({ agentId: "hyperlocalise", skillId: "find-context" });
+  const request = [
+    "Find context request:",
+    formatInstructionField("Source file path in the TMS project", input.sourcePath),
+    formatInstructionField("String key", input.stringKey),
+    formatInstructionField("Source text", input.sourceText),
+    formatInstructionField("TMS/context note", input.contextNote),
+  ]
+    .filter((line): line is string => line !== null)
+    .join("\n");
+
+  return [repoToolsSkill, findContextSkill, request]
+    .filter((section) => section.trim().length > 0)
+    .join("\n\n");
+}

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/find-context-instructions.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/find-context-instructions.ts
@@ -15,17 +15,17 @@ function formatInstructionField(label: string, value: string | null | undefined)
 export function buildFindContextSkillInstructions(input: BuildFindContextSkillInstructionsInput) {
   const repoToolsSkill = loadAgentSkill({ agentId: "hyperlocalise", skillId: "repo-tools" });
   const findContextSkill = loadAgentSkill({ agentId: "hyperlocalise", skillId: "find-context" });
-  const request = [
-    "Find context request:",
+  const requestFields = [
     formatInstructionField("Source file path in the TMS project", input.sourcePath),
     formatInstructionField("String key", input.stringKey),
     formatInstructionField("Source text", input.sourceText),
     formatInstructionField("TMS/context note", input.contextNote),
-  ]
-    .filter((line): line is string => line !== null)
-    .join("\n");
+  ].filter((line): line is string => line !== null);
+
+  const request =
+    requestFields.length > 0 ? ["Find context request:", ...requestFields].join("\n") : null;
 
   return [repoToolsSkill, findContextSkill, request]
-    .filter((section) => section.trim().length > 0)
+    .filter((section): section is string => section !== null && section.trim().length > 0)
     .join("\n\n");
 }

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
@@ -968,6 +968,14 @@ describe("handleNewConversation", () => {
       messages: expect.arrayContaining([
         expect.objectContaining({
           role: "user",
+          content: expect.stringContaining("org/new-repo"),
+        }),
+      ]),
+    });
+    expect(agentGenerateMock).toHaveBeenCalledWith({
+      messages: expect.not.arrayContaining([
+        expect.objectContaining({
+          role: "user",
           content: expect.stringContaining("org/old-repo"),
         }),
       ]),

--- a/apps/hyperlocalise-web/src/lib/projects/string-context/project-string-context-service.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/string-context/project-string-context-service.test.ts
@@ -184,11 +184,30 @@ describe("lookupProjectFileStringRepositoryContext", () => {
     expect(runSubagentMock).toHaveBeenCalledWith(
       "repository",
       expect.objectContaining({
+        instructions: expect.stringContaining("Find context in repository"),
         toolContext: expect.objectContaining({
           githubContext: expect.objectContaining({
             repositoryFullName: "hyperlocalise/explicit",
           }),
         }),
+      }),
+    );
+    expect(runSubagentMock).toHaveBeenCalledWith(
+      "repository",
+      expect.objectContaining({
+        instructions: expect.stringContaining("Repository tools"),
+      }),
+    );
+    expect(runSubagentMock).toHaveBeenCalledWith(
+      "repository",
+      expect.objectContaining({
+        instructions: expect.stringContaining("String key: home.hero.title"),
+      }),
+    );
+    expect(runSubagentMock).toHaveBeenCalledWith(
+      "repository",
+      expect.objectContaining({
+        instructions: expect.stringContaining("Source text: Ship localized product experiences"),
       }),
     );
     expect(stopRepositorySandboxMock).toHaveBeenCalledWith("sandbox-test");

--- a/apps/hyperlocalise-web/src/lib/projects/string-context/project-string-context-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/string-context/project-string-context-service.ts
@@ -17,6 +17,7 @@ import {
 } from "@/lib/agent-runtime/workspaces/repository-sandbox";
 import { ensureAgentSession } from "@/lib/tools/types";
 import type { ToolContext } from "@/lib/tools/types";
+import { buildFindContextSkillInstructions } from "@/lib/agent-runtime/skills/find-context-instructions";
 import { db, schema } from "@/lib/database";
 import type { OrganizationMembershipRole } from "@/lib/database/types";
 import { serializeErrorForLog } from "@/lib/log";
@@ -435,18 +436,13 @@ export class ProjectStringContextService extends ProjectServiceBase {
 
     const instructions = [
       buildRepositoryGitHubContextInstructions(githubContext),
-      `Source file path in the TMS project: ${input.sourcePath}`,
-      `String key: ${input.key}`,
-      `Source text: ${input.text}`,
-      input.context ? `Crowdin/context note: ${input.context}` : null,
-      [
-        "Find where this string appears in the connected repository and return localization-relevant context for translators.",
-        "Use the required final summary sections: What it is, Where/how it shows, and Translation guidance (with bullets).",
-        "In Translation guidance, note sibling strings that should stay terminologically consistent when repository evidence supports it.",
-      ].join(" "),
-    ]
-      .filter((line): line is string => line !== null)
-      .join("\n\n");
+      buildFindContextSkillInstructions({
+        sourcePath: input.sourcePath,
+        stringKey: input.key,
+        sourceText: input.text,
+        contextNote: input.context,
+      }),
+    ].join("\n\n");
 
     try {
       await reserveAgentRuntimeUsage({


### PR DESCRIPTION
## What changed

- Added a dedicated `find-context` skill layered on top of `repo-tools` for source text or key based repository context lookups.
- Reused the layered skill instructions from CAT repository context lookup so CAT and chat use the same prompt contract.
- Kept the latest user message as the active lookup target in web and Slack repo-enabled turns, so follow-up string lookups do not combine previous strings unless requested.

## How to test

- `vp test src/lib/agent-runtime/loops/conversation-turn.test.ts src/lib/agents/slack/bot.test.ts src/lib/agent-runtime/skills/conversation-skill-registry.test.ts src/lib/agent-runtime/loops/conversation-skill-agent.test.ts src/lib/projects/string-context/project-string-context-service.test.ts`
- `vp check --fix`
- `vp test` currently fails in unrelated public auth/API-key route tests with broad `403` mismatches.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)