### PR TITLE
fix(web): restore repository selector dropdown

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/repository-selector.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/repository-selector.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import type { GithubRepository } from "./github-repository";
+import { RepositorySelector } from "./repository-selector";
+
+function createRepository(overrides: Partial<GithubRepository> = {}): GithubRepository {
+  const name = overrides.name ?? "web";
+  const owner = overrides.owner ?? "acme";
+
+  return {
+    archived: false,
+    defaultBranch: "main",
+    enabled: true,
+    fullName: `${owner}/${name}`,
+    githubRepositoryId: `repo_${owner}_${name}`,
+    id: `installation_repo_${owner}_${name}`,
+    name,
+    owner,
+    ...overrides,
+  };
+}
+
+describe("RepositorySelector", () => {
+  it("opens the repository menu and selects a repository", async () => {
+    const user = userEvent.setup();
+    const onSelectRepository = vi.fn();
+
+    render(
+      <RepositorySelector
+        repositories={[
+          createRepository({ name: "web", fullName: "acme/web" }),
+          createRepository({ name: "docs", fullName: "acme/docs" }),
+        ]}
+        repositoriesIsError={false}
+        repositoriesIsLoading={false}
+        selectedRepositoryFullName=""
+        onSelectRepository={onSelectRepository}
+        triggerStyle="button"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /github repo/i }));
+    await user.click(await screen.findByText("acme/docs"));
+
+    expect(onSelectRepository).toHaveBeenCalledWith("acme/docs");
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/repository-selector.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/repository-selector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { siGithub } from "simple-icons";
@@ -21,27 +21,40 @@ import type { GithubRepository } from "./github-repository";
 
 type RepositorySelectorTriggerStyle = "button" | "prompt-input";
 
+type RepositorySelectorTriggerProps = Omit<
+  ComponentPropsWithoutRef<"button">,
+  "children" | "className" | "disabled" | "style"
+> & {
+  children: ReactNode;
+  className?: string;
+  disabled?: boolean;
+  triggerStyle: RepositorySelectorTriggerStyle;
+};
+
 function RepositorySelectorTrigger({
   children,
   className,
   disabled,
-  style,
-}: {
-  children: ReactNode;
-  className?: string;
-  disabled?: boolean;
-  style: RepositorySelectorTriggerStyle;
-}) {
-  if (style === "prompt-input") {
+  triggerStyle,
+  ...props
+}: RepositorySelectorTriggerProps) {
+  if (triggerStyle === "prompt-input") {
     return (
-      <PromptInputButton className={className} size="sm" disabled={disabled}>
+      <PromptInputButton className={className} size="sm" disabled={disabled} {...props}>
         {children}
       </PromptInputButton>
     );
   }
 
   return (
-    <Button type="button" variant="ghost" size="sm" className={className} disabled={disabled}>
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      className={className}
+      disabled={disabled}
+      {...props}
+    >
       {children}
     </Button>
   );
@@ -77,7 +90,11 @@ export function RepositorySelector({
 
   if (repositoriesIsLoading) {
     return (
-      <RepositorySelectorTrigger style={triggerStyle} className={disabledTriggerClassName} disabled>
+      <RepositorySelectorTrigger
+        triggerStyle={triggerStyle}
+        className={disabledTriggerClassName}
+        disabled
+      >
         <SimpleBrandIcon icon={siGithub} colored className="size-4" />
         <Skeleton className="h-3.5 w-24 rounded-full bg-muted" />
       </RepositorySelectorTrigger>
@@ -86,7 +103,11 @@ export function RepositorySelector({
 
   if (repositoriesIsError) {
     return (
-      <RepositorySelectorTrigger style={triggerStyle} className={disabledTriggerClassName} disabled>
+      <RepositorySelectorTrigger
+        triggerStyle={triggerStyle}
+        className={disabledTriggerClassName}
+        disabled
+      >
         <SimpleBrandIcon icon={siGithub} colored className="size-4" />
         Repos unavailable
       </RepositorySelectorTrigger>
@@ -95,7 +116,11 @@ export function RepositorySelector({
 
   if (repositories.length === 0) {
     return (
-      <RepositorySelectorTrigger style={triggerStyle} className={disabledTriggerClassName} disabled>
+      <RepositorySelectorTrigger
+        triggerStyle={triggerStyle}
+        className={disabledTriggerClassName}
+        disabled
+      >
         <SimpleBrandIcon icon={siGithub} colored className="size-4" />
         No GitHub repos
       </RepositorySelectorTrigger>
@@ -105,7 +130,7 @@ export function RepositorySelector({
   if (repositories.length === 1) {
     return (
       <RepositorySelectorTrigger
-        style={triggerStyle}
+        triggerStyle={triggerStyle}
         className={singleRepositoryTriggerClassName}
         disabled
       >
@@ -119,7 +144,10 @@ export function RepositorySelector({
     <DropdownMenu>
       <DropdownMenuTrigger
         render={
-          <RepositorySelectorTrigger style={triggerStyle} className={interactiveTriggerClassName}>
+          <RepositorySelectorTrigger
+            triggerStyle={triggerStyle}
+            className={interactiveTriggerClassName}
+          >
             <SimpleBrandIcon icon={siGithub} colored className="size-4 shrink-0" />
             <span className="max-w-44 truncate">{selectedRepositoryFullName || "GitHub repo"}</span>
             <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={1.8} className="size-3.5 shrink-0" />


### PR DESCRIPTION
## What changed

Fixed the shared repository selector so its custom trigger forwards Base UI dropdown trigger props to the underlying button. This restores the GitHub repo menu on the new request page when multiple repositories are enabled.

## How to test

- `vp check --fix`
- `vp test "src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/repository-selector.test.tsx"`
- `vp test` was run, but existing unrelated API/auth tests failed with `403` responses across public API and MCP route suites.

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, focused selector test)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)