### PR TITLE
feat(agent): add git history tool for repository context

### DIFF
--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/find-context.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/find-context.md
@@ -20,6 +20,11 @@ In multi-turn conversations, treat the latest user message as the active lookup 
 ## Search procedure
 
 - Follow the `repo-tools` search procedure first.
+- If the request asks for context for source strings changed recently or in bulk, use `gitHistory` first:
+  - call `gitHistory` with `mode: "changedFiles"` and the requested `since`/`until` window; when no paths are provided it discovers source files from `i18n.yml`, `i18n.jsonc`, `crowdin.yml`, `crowdin.yaml`, `.phrase.yml`, `phrase.yml`, or `phrase.yaml`
+  - use `mode: "fileDiff"` for changed source files to inspect the relevant source-entry changes
+  - use `mode: "entryLog"` or `mode: "blame"` only when a specific changed key/source string needs more provenance
+  - summarize only translation-relevant changed strings; do not include a raw git log or broad implementation review
 - If `sourceText` is present, search with the exact text first.
 - If `stringKey` is present, search with the exact key first. This is enough to proceed when source text is missing or too generic.
 - If exact key search has no useful matches, search nearby key variants, namespace fragments, locale/resource files, and code references that consume the key.

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/repo-tools.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/repo-tools.md
@@ -1,7 +1,7 @@
 ---
 id: repo-tools
 requiresSandbox: true
-tools: grep,fuzzySearch,read,glob,detectRepoConfig,todoWrite
+tools: grep,fuzzySearch,read,glob,detectRepoConfig,gitHistory,todoWrite
 ---
 
 ## Repository tools
@@ -16,5 +16,6 @@ Use these tools for read-only inspection of the connected GitHub repository.
 - Use `glob` to discover locale, resource, route, component, or i18n config paths when needed.
 - Use `read` to inspect surrounding lines before drawing conclusions from a match.
 - Use `detectRepoConfig` when asked about i18n.yml or project locale setup.
+- Use `gitHistory` when the request asks what changed recently, asks for history/provenance, or asks for context for strings changed in a time window such as "last week".
 - Prefer concrete `path:line` evidence over guesses from filenames.
 - Stop once you have enough evidence for the active skill; do not continue into broad codebase exploration.

--- a/apps/hyperlocalise-web/src/lib/agent-contracts/repository-workspace-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-contracts/repository-workspace-tools.ts
@@ -5,6 +5,7 @@ export const repositoryWorkspaceToolNames = [
   "read",
   "glob",
   "detectRepoConfig",
+  "gitHistory",
   "todoWrite",
 ] as const;
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
@@ -55,7 +55,7 @@ describe("conversation skill registry", () => {
     const repoToolsSkill = skills.find((skill) => skill.id === "repo-tools");
     expect(repoToolsSkill).toMatchObject({
       requiresSandbox: true,
-      tools: ["grep", "fuzzySearch", "read", "glob", "detectRepoConfig", "todoWrite"],
+      tools: ["grep", "fuzzySearch", "read", "glob", "detectRepoConfig", "gitHistory", "todoWrite"],
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/find-context-instructions.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/find-context-instructions.test.ts
@@ -24,4 +24,13 @@ describe("buildFindContextSkillInstructions", () => {
     expect(instructions).toContain("Source file path in the TMS project: locales/en.json");
     expect(instructions).toContain("Source text: Save");
   });
+
+  it("instructs bulk recent-change lookups to use git history and config discovery", () => {
+    const instructions = buildFindContextSkillInstructions({});
+
+    expect(instructions).toContain("gitHistory");
+    expect(instructions).toContain('mode: "changedFiles"');
+    expect(instructions).toContain("crowdin.yml");
+    expect(instructions).toContain(".phrase.yml");
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/manifest.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/manifest.ts
@@ -66,6 +66,12 @@ export const toolManifests = [
     requiredWorkspaceCapability: "repo_read",
   },
   {
+    name: "gitHistory",
+    domain: "repo",
+    sideEffect: "none",
+    requiredWorkspaceCapability: "repo_read",
+  },
+  {
     name: "repoGitState",
     domain: "repo",
     sideEffect: "none",

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/registry.test.ts
@@ -34,6 +34,7 @@ describe("agent-runtime tool registry", () => {
     expect(tools.read).toBeDefined();
     expect(tools.glob).toBeDefined();
     expect(tools.detectRepoConfig).toBeDefined();
+    expect(tools.gitHistory).toBeDefined();
     expect(tools.bash).toBeDefined();
     expect(tools.todoWrite).toBeDefined();
     expect(tools.applyHyperlocaliseFixes).toBeUndefined();

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/registry.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/registry.ts
@@ -6,6 +6,7 @@ import { ensureAgentSession, type ToolContext } from "@/lib/agent-contracts/tool
 
 import {
   createDetectRepoConfigTool,
+  createGitHistoryTool,
   createRepoGitStateTool,
   createRunHyperlocaliseCliTool,
 } from "./repo-read-tools";
@@ -44,6 +45,9 @@ function createWorkspaceTools(ctx: ToolContext, repoBash: RepoToolContext): Tool
   }
   if (policy.isToolAllowed("detectRepoConfig")) {
     tools.detectRepoConfig = createDetectRepoConfigTool(repoBash);
+  }
+  if (policy.isToolAllowed("gitHistory")) {
+    tools.gitHistory = createGitHistoryTool(repoBash);
   }
   if (policy.isToolAllowed("bash")) {
     tools.bash = createBashTool(repoBash);

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
@@ -898,6 +898,20 @@ describe("createGitHistoryTool", () => {
     expect((result as { diff: string }).diff.length).toBeLessThan(200_000);
   });
 
+  it("rejects option-like git revision ranges", async () => {
+    const ctx = createTestContext();
+    const t = createGitHistoryTool(ctx);
+    const result = await t.execute!(
+      { mode: "fileDiff", paths: ["lang/en.json"], range: "--no-index" },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: 'Range "--no-index" must be a revision range, not a git option.',
+    });
+  });
+
   it("uses pickaxe entry log for a source string or key", async () => {
     const ctx = createTestContext();
     ctx.bash.registerCommand(
@@ -921,6 +935,34 @@ describe("createGitHistoryTool", () => {
 
     expect(result).toMatchObject({ success: true, mode: "entryLog", query: "Save" });
     expect((result as { log: string }).log).toContain("Add Save");
+  });
+
+  it("rejects option-like revision ranges before git log", async () => {
+    const ctx = createTestContext();
+    const t = createGitHistoryTool(ctx);
+    const result = await t.execute!(
+      { mode: "entryLog", paths: ["lang/en.json"], query: "Save", range: "--all" },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: 'Range "--all" must be a revision range, not a git option.',
+    });
+  });
+
+  it("rejects blame requests with multiple paths", async () => {
+    const ctx = createTestContext();
+    const t = createGitHistoryTool(ctx);
+    const result = await t.execute!(
+      { mode: "blame", paths: ["lang/en.json", "lang/fr.json"], query: "Save" },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "blame accepts exactly one path.",
+    });
   });
 
   it("returns blame metadata for a current query line", async () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
@@ -9,6 +9,7 @@ import { createFuzzySearchTool, createGrepTool, createReadTool, parseGrepLine } 
 import {
   buildHlArgs,
   createDetectRepoConfigTool,
+  createGitHistoryTool,
   createRepoGitStateTool,
   createRunHyperlocaliseCliTool,
   redact,
@@ -752,6 +753,211 @@ describe("createRepoGitStateTool", () => {
       isDirty: true,
     });
     expect((result as { changedFiles: string[] }).changedFiles).toContain("dirty.txt");
+  });
+});
+
+describe("createGitHistoryTool", () => {
+  it("discovers Hyperlocalise source files before Crowdin fallback", async () => {
+    const ctx = createTestContext({
+      "/home/user/project/i18n.yml": "locales:\n  source: en-US\n",
+      "/home/user/project/crowdin.yml": "files:\n  - source: /ignored.json\n",
+    });
+    const yqCalls: string[][] = [];
+    const gitCalls: string[][] = [];
+    ctx.bash.registerCommand(
+      defineCommand("yq", async (args) => {
+        yqCalls.push(args);
+        return {
+          stdout: JSON.stringify({
+            locales: { source: "en-US" },
+            buckets: { web: { files: [{ from: "lang/{{source}}.json", to: "lang/fr.json" }] } },
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      }),
+    );
+    ctx.bash.registerCommand(
+      defineCommand("git", async (args) => {
+        gitCalls.push(args);
+        if (args[0] === "ls-files") {
+          return { stdout: "lang/en-US.json\n", stderr: "", exitCode: 0 };
+        }
+        if (args[0] === "log") {
+          return {
+            stdout: "abc\t2026-07-01T00:00:00Z\tMina\tUpdate strings\nlang/en-US.json\n",
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        return { stdout: "", stderr: "", exitCode: 1 };
+      }),
+    );
+
+    const t = createGitHistoryTool(ctx);
+    const result = await t.execute!(
+      { mode: "changedFiles", since: "1 week ago", maxResults: 10 },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      mode: "changedFiles",
+      files: ["lang/en-US.json"],
+      discovery: { configKind: "hyperlocalise", configPath: "i18n.yml" },
+    });
+    expect(yqCalls[0]).toEqual(["-o", "json", ".", "i18n.yml"]);
+    expect(gitCalls).toContainEqual(["ls-files", "--", "lang/en-US.json"]);
+    expect(gitCalls.find((args) => args[0] === "log")).toEqual(
+      expect.arrayContaining(["--since=1 week ago", "--", "lang/en-US.json"]),
+    );
+  });
+
+  it("falls back to Crowdin files[].source", async () => {
+    const ctx = createTestContext({
+      "/home/user/project/crowdin.yml": "files:\n  - source: /src/messages.json\n",
+    });
+    ctx.bash.registerCommand(
+      defineCommand("yq", async () => ({
+        stdout: JSON.stringify({ files: [{ source: "/src/messages.json" }] }),
+        stderr: "",
+        exitCode: 0,
+      })),
+    );
+    ctx.bash.registerCommand(
+      defineCommand("git", async (args) => {
+        if (args[0] === "ls-files") {
+          return { stdout: "src/messages.json\n", stderr: "", exitCode: 0 };
+        }
+        if (args[0] === "log") {
+          return { stdout: "src/messages.json\n", stderr: "", exitCode: 0 };
+        }
+        return { stdout: "", stderr: "", exitCode: 1 };
+      }),
+    );
+
+    const t = createGitHistoryTool(ctx);
+    const result = await t.execute!({ mode: "changedFiles" }, toolCallInfo);
+
+    expect(result).toMatchObject({
+      success: true,
+      files: ["src/messages.json"],
+      discovery: { configKind: "crowdin", configPath: "crowdin.yml" },
+    });
+  });
+
+  it("reports unresolved Phrase placeholders as skipped diagnostics", async () => {
+    const ctx = createTestContext({
+      "/home/user/project/.phrase.yml": "phrase:\n  push:\n    sources: []\n",
+    });
+    ctx.bash.registerCommand(
+      defineCommand("yq", async () => ({
+        stdout: JSON.stringify({
+          phrase: { push: { sources: [{ file: "./locales/<locale_name>.json" }] } },
+        }),
+        stderr: "",
+        exitCode: 0,
+      })),
+    );
+
+    const t = createGitHistoryTool(ctx);
+    const result = await t.execute!({ mode: "changedFiles" }, toolCallInfo);
+
+    expect(result).toMatchObject({
+      success: true,
+      files: [],
+      discovery: {
+        configKind: "phrase",
+        configPath: ".phrase.yml",
+        skippedPatterns: [
+          {
+            pattern: "./locales/<locale_name>.json",
+            reason: "Pattern contains unresolved Phrase placeholder.",
+          },
+        ],
+      },
+    });
+  });
+
+  it("returns bounded file diffs", async () => {
+    const ctx = createTestContext();
+    ctx.bash.registerCommand(
+      defineCommand("git", async (args) => {
+        expect(args).toEqual(["diff", "main..HEAD", "--", "lang/en.json"]);
+        return { stdout: "A".repeat(200_000), stderr: "", exitCode: 0 };
+      }),
+    );
+
+    const t = createGitHistoryTool(ctx);
+    const result = await t.execute!(
+      { mode: "fileDiff", paths: ["lang/en.json"], range: "main..HEAD" },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({ success: true, mode: "fileDiff", truncated: true });
+    expect((result as { diff: string }).diff.length).toBeLessThan(200_000);
+  });
+
+  it("uses pickaxe entry log for a source string or key", async () => {
+    const ctx = createTestContext();
+    ctx.bash.registerCommand(
+      defineCommand("git", async (args) => {
+        expect(args).toEqual(
+          expect.arrayContaining(["--patch", "--unified=3", "-SSave", "--", "lang/en.json"]),
+        );
+        return {
+          stdout: 'abc\t2026-07-01T00:00:00Z\tMina\tAdd Save\n+  "save": "Save"\n',
+          stderr: "",
+          exitCode: 0,
+        };
+      }),
+    );
+
+    const t = createGitHistoryTool(ctx);
+    const result = await t.execute!(
+      { mode: "entryLog", paths: ["lang/en.json"], query: "Save" },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({ success: true, mode: "entryLog", query: "Save" });
+    expect((result as { log: string }).log).toContain("Add Save");
+  });
+
+  it("returns blame metadata for a current query line", async () => {
+    const ctx = createTestContext({
+      "/home/user/project/lang/en.json": '{\n  "save": "Save"\n}\n',
+    });
+    ctx.bash.registerCommand(
+      defineCommand("git", async (args) => {
+        expect(args).toEqual(["blame", "--line-porcelain", "-L2,2", "--", "lang/en.json"]);
+        return {
+          stdout:
+            'abc1234 2 2 1\nauthor Mina\nauthor-time 1782864000\nsummary Add Save\n\t  "save": "Save"\n',
+          stderr: "",
+          exitCode: 0,
+        };
+      }),
+    );
+
+    const t = createGitHistoryTool(ctx);
+    const result = await t.execute!(
+      { mode: "blame", paths: ["lang/en.json"], query: "Save" },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      mode: "blame",
+      entries: [
+        {
+          commit: "abc1234",
+          author: "Mina",
+          authorTime: "1782864000",
+          summary: "Add Save",
+          line: '  "save": "Save"',
+        },
+      ],
+    });
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
@@ -846,6 +846,45 @@ describe("createGitHistoryTool", () => {
     });
   });
 
+  it("reports truncation when changedFiles reaches the commit limit before the file limit", async () => {
+    const ctx = createTestContext();
+    const gitCalls: string[][] = [];
+    ctx.bash.registerCommand(
+      defineCommand("git", async (args) => {
+        gitCalls.push(args);
+        if (args[0] === "log") {
+          return {
+            stdout: [
+              "1111111111111111111111111111111111111111\t2026-07-01T00:00:00Z\tMina\tOne",
+              "src/messages.json",
+              "2222222222222222222222222222222222222222\t2026-07-02T00:00:00Z\tMina\tTwo",
+              "src/messages.json",
+              "3333333333333333333333333333333333333333\t2026-07-03T00:00:00Z\tMina\tThree",
+              "src/other.json",
+            ].join("\n"),
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        return { stdout: "", stderr: "", exitCode: 1 };
+      }),
+    );
+
+    const t = createGitHistoryTool(ctx);
+    const result = await t.execute!(
+      { mode: "changedFiles", paths: ["src/messages.json", "src/other.json"], maxResults: 2 },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      mode: "changedFiles",
+      files: ["src/messages.json"],
+      truncated: true,
+    });
+    expect(gitCalls[0]).toContain("--max-count=3");
+  });
+
   it("reports unresolved Phrase placeholders as skipped diagnostics", async () => {
     const ctx = createTestContext({
       "/home/user/project/.phrase.yml": "phrase:\n  push:\n    sources: []\n",

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.ts
@@ -219,6 +219,15 @@ export function createGitHistoryTool(ctx: RepoToolContext) {
 
 async function executeGitHistory(ctx: RepoToolContext, input: GitHistoryInput) {
   const maxResults = clampMaxResults(input.maxResults);
+  const rangeResult = normalizeGitRevisionRange(input.range);
+  if (isErr(rangeResult)) {
+    return {
+      success: false as const,
+      error: rangeResult.error,
+    };
+  }
+
+  const normalizedInput = { ...input, range: rangeResult.value };
   const normalizedPathsResult = normalizeGitHistoryPaths(input.paths);
   if (isErr(normalizedPathsResult)) {
     return {
@@ -228,15 +237,20 @@ async function executeGitHistory(ctx: RepoToolContext, input: GitHistoryInput) {
   }
 
   try {
-    switch (input.mode) {
+    switch (normalizedInput.mode) {
       case "changedFiles":
-        return await changedFilesHistory(ctx, input, normalizedPathsResult.value, maxResults);
+        return await changedFilesHistory(
+          ctx,
+          normalizedInput,
+          normalizedPathsResult.value,
+          maxResults,
+        );
       case "fileDiff":
-        return await fileDiffHistory(ctx, input, normalizedPathsResult.value, maxResults);
+        return await fileDiffHistory(ctx, normalizedInput, normalizedPathsResult.value, maxResults);
       case "entryLog":
-        return await entryLogHistory(ctx, input, normalizedPathsResult.value, maxResults);
+        return await entryLogHistory(ctx, normalizedInput, normalizedPathsResult.value, maxResults);
       case "blame":
-        return await blameHistory(ctx, input, normalizedPathsResult.value, maxResults);
+        return await blameHistory(ctx, normalizedInput, normalizedPathsResult.value, maxResults);
     }
   } catch (error) {
     return {
@@ -264,6 +278,16 @@ function normalizeGitHistoryPaths(
     normalized.push(value);
   }
   return ok(Array.from(new Set(normalized)));
+}
+
+function normalizeGitRevisionRange(range: string | undefined): Result<string | undefined, string> {
+  if (!range) return ok(undefined);
+  const normalized = range.trim();
+  if (!normalized) return ok(undefined);
+  if (normalized.startsWith("-")) {
+    return err(`Range "${range}" must be a revision range, not a git option.`);
+  }
+  return ok(normalized);
 }
 
 async function changedFilesHistory(
@@ -397,6 +421,10 @@ async function blameHistory(
   paths: string[] | undefined,
   maxResults: number,
 ) {
+  if (paths && paths.length > 1) {
+    return { success: false as const, error: "blame accepts exactly one path." };
+  }
+
   const path = paths?.[0];
   if (!path) {
     return { success: false as const, error: "blame requires a path." };
@@ -427,14 +455,15 @@ async function blameHistory(
     return { success: false as const, error: redact(result.stderr || "Failed to read git blame.") };
   }
 
-  const entries = parseBlamePorcelain(result.stdout).slice(0, maxResults);
+  const allEntries = parseBlamePorcelain(result.stdout);
+  const entries = allEntries.slice(0, maxResults);
   return {
     success: true as const,
     mode: "blame" as const,
     path,
     query,
     entries,
-    truncated: entries.length < parseBlamePorcelain(result.stdout).length,
+    truncated: entries.length < allEntries.length,
   };
 }
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.ts
@@ -319,7 +319,7 @@ async function changedFilesHistory(
 
   const args = buildGitLogArgs(input, {
     nameOnly: true,
-    maxCount: maxResults,
+    maxCount: maxResults + 1,
     paths,
   });
   const result = await ctx.bash.exec("git", { args });
@@ -332,7 +332,13 @@ async function changedFilesHistory(
   }
 
   const pathSet = new Set(paths);
-  const changedFiles = uniqueLines(result.stdout)
+  const parsedCommits = parseGitNameOnlyCommits(result.stdout);
+  const commitLimited = parsedCommits.length > maxResults;
+  const changedFileLines =
+    parsedCommits.length > 0
+      ? parsedCommits.slice(0, maxResults).flatMap((commit) => commit.files)
+      : uniqueLines(result.stdout);
+  const changedFiles = uniqueLines(changedFileLines.join("\n"))
     .map((line) => normalizeSourcePath(line))
     .filter((line): line is string => Boolean(line))
     .filter((line) => pathSet.has(line));
@@ -343,7 +349,7 @@ async function changedFilesHistory(
     mode: "changedFiles" as const,
     files,
     discovery,
-    truncated: files.length < changedFiles.length,
+    truncated: commitLimited || files.length < changedFiles.length,
   };
 }
 
@@ -705,6 +711,24 @@ function uniqueLines(output: string): string[] {
         .filter(Boolean),
     ),
   );
+}
+
+function parseGitNameOnlyCommits(output: string): Array<{ files: string[] }> {
+  const commits: Array<{ files: string[] }> = [];
+  let current: { files: string[] } | null = null;
+
+  for (const rawLine of output.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (/^[0-9a-f]{40}\t/i.test(line)) {
+      current = { files: [] };
+      commits.push(current);
+      continue;
+    }
+    current?.files.push(line);
+  }
+
+  return commits;
 }
 
 function readString(value: unknown): string | null {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.ts
@@ -3,6 +3,7 @@ import type { Bash } from "just-bash";
 import { z } from "zod";
 
 import { DEFAULT_MAX_OUTPUT_BYTES, redact, truncate, type RepoToolContext } from "./workspace";
+import { normalizeWorkspacePath } from "./workspace/path";
 import { normalizeJsonc } from "@/lib/i18n/parse-jsonc-config";
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 
@@ -160,6 +161,582 @@ export function createRepoGitStateTool(ctx: RepoToolContext) {
       };
     },
   });
+}
+
+const GIT_HISTORY_MODES = ["changedFiles", "fileDiff", "entryLog", "blame"] as const;
+const DEFAULT_GIT_HISTORY_MAX_RESULTS = 20;
+const MAX_GIT_HISTORY_RESULTS = 100;
+const CONFIG_CANDIDATES = [
+  { kind: "hyperlocalise", path: "i18n.yml", parser: "yaml" },
+  { kind: "hyperlocalise", path: "i18n.jsonc", parser: "jsonc" },
+  { kind: "crowdin", path: "crowdin.yml", parser: "yaml" },
+  { kind: "crowdin", path: "crowdin.yaml", parser: "yaml" },
+  { kind: "phrase", path: ".phrase.yml", parser: "yaml" },
+  { kind: "phrase", path: "phrase.yml", parser: "yaml" },
+  { kind: "phrase", path: "phrase.yaml", parser: "yaml" },
+] as const;
+
+type GitHistoryMode = (typeof GIT_HISTORY_MODES)[number];
+type ConfigCandidate = (typeof CONFIG_CANDIDATES)[number];
+type SourceFileDiscovery = {
+  configKind: ConfigCandidate["kind"];
+  configPath: string;
+  files: string[];
+  skippedPatterns: Array<{ pattern: string; reason: string }>;
+};
+
+type GitHistoryInput = {
+  mode: GitHistoryMode;
+  paths?: string[];
+  since?: string;
+  until?: string;
+  range?: string;
+  query?: string;
+  maxResults?: number;
+};
+
+export function createGitHistoryTool(ctx: RepoToolContext) {
+  return tool({
+    description:
+      "Inspect read-only git history for repository localization context. Use changedFiles for time-window discovery, fileDiff for bounded patches, entryLog for commits touching a key/source string, and blame only for current-line provenance.",
+    inputSchema: z.object({
+      mode: z.enum(GIT_HISTORY_MODES).describe("Git history lookup mode."),
+      paths: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Workspace-relative paths. If omitted for changedFiles, source files are discovered from localization config.",
+        ),
+      since: z.string().optional().describe('Git --since value, for example "1 week ago".'),
+      until: z.string().optional().describe("Git --until value."),
+      range: z.string().optional().describe("Explicit git revision range, for example main..HEAD."),
+      query: z.string().optional().describe("Source string or key for entryLog/blame."),
+      maxResults: z.number().int().positive().max(MAX_GIT_HISTORY_RESULTS).optional(),
+    }),
+    execute: async (input) => executeGitHistory(ctx, input),
+  });
+}
+
+async function executeGitHistory(ctx: RepoToolContext, input: GitHistoryInput) {
+  const maxResults = clampMaxResults(input.maxResults);
+  const normalizedPathsResult = normalizeGitHistoryPaths(input.paths);
+  if (isErr(normalizedPathsResult)) {
+    return {
+      success: false as const,
+      error: normalizedPathsResult.error,
+    };
+  }
+
+  try {
+    switch (input.mode) {
+      case "changedFiles":
+        return await changedFilesHistory(ctx, input, normalizedPathsResult.value, maxResults);
+      case "fileDiff":
+        return await fileDiffHistory(ctx, input, normalizedPathsResult.value, maxResults);
+      case "entryLog":
+        return await entryLogHistory(ctx, input, normalizedPathsResult.value, maxResults);
+      case "blame":
+        return await blameHistory(ctx, input, normalizedPathsResult.value, maxResults);
+    }
+  } catch (error) {
+    return {
+      success: false as const,
+      error: redact(error instanceof Error ? error.message : String(error)),
+    };
+  }
+}
+
+function clampMaxResults(value: number | undefined): number {
+  if (!value) return DEFAULT_GIT_HISTORY_MAX_RESULTS;
+  return Math.min(Math.max(value, 1), MAX_GIT_HISTORY_RESULTS);
+}
+
+function normalizeGitHistoryPaths(
+  paths: string[] | undefined,
+): Result<string[] | undefined, string> {
+  if (!paths) return ok(undefined);
+  const normalized: string[] = [];
+  for (const path of paths) {
+    const value = normalizeSourcePath(path);
+    if (!value) {
+      return err(`Path "${path}" must stay within the workspace.`);
+    }
+    normalized.push(value);
+  }
+  return ok(Array.from(new Set(normalized)));
+}
+
+async function changedFilesHistory(
+  ctx: RepoToolContext,
+  input: GitHistoryInput,
+  providedPaths: string[] | undefined,
+  maxResults: number,
+) {
+  const discovery = providedPaths ? null : await discoverSourceFiles(ctx);
+  if (!providedPaths && !discovery) {
+    return {
+      success: false as const,
+      error:
+        "No localization config found. Looked for i18n.yml, i18n.jsonc, crowdin.yml, crowdin.yaml, .phrase.yml, phrase.yml, and phrase.yaml.",
+    };
+  }
+
+  const paths = providedPaths ?? discovery?.files ?? [];
+  if (paths.length === 0) {
+    return {
+      success: true as const,
+      mode: "changedFiles" as const,
+      files: [],
+      discovery,
+      truncated: false,
+      diagnostics: ["No source files were resolved from localization config."],
+    };
+  }
+
+  const args = buildGitLogArgs(input, {
+    nameOnly: true,
+    maxCount: maxResults,
+    paths,
+  });
+  const result = await ctx.bash.exec("git", { args });
+  if (result.exitCode !== 0) {
+    return {
+      success: false as const,
+      error: redact(result.stderr || "Failed to read git changed files."),
+      discovery,
+    };
+  }
+
+  const pathSet = new Set(paths);
+  const changedFiles = uniqueLines(result.stdout)
+    .map((line) => normalizeSourcePath(line))
+    .filter((line): line is string => Boolean(line))
+    .filter((line) => pathSet.has(line));
+  const files = changedFiles.slice(0, maxResults);
+
+  return {
+    success: true as const,
+    mode: "changedFiles" as const,
+    files,
+    discovery,
+    truncated: files.length < changedFiles.length,
+  };
+}
+
+async function fileDiffHistory(
+  ctx: RepoToolContext,
+  input: GitHistoryInput,
+  paths: string[] | undefined,
+  maxResults: number,
+) {
+  if (!paths || paths.length === 0) {
+    return { success: false as const, error: "fileDiff requires at least one path." };
+  }
+
+  const args = input.range
+    ? ["diff", input.range, "--", ...paths]
+    : buildGitLogArgs(input, {
+        patch: true,
+        maxCount: maxResults,
+        paths,
+      });
+  const result = await ctx.bash.exec("git", { args });
+  if (result.exitCode !== 0) {
+    return { success: false as const, error: redact(result.stderr || "Failed to read git diff.") };
+  }
+
+  const output = truncate(redact(result.stdout), DEFAULT_MAX_OUTPUT_BYTES);
+  return {
+    success: true as const,
+    mode: "fileDiff" as const,
+    paths,
+    diff: output.text,
+    truncated: output.truncated,
+  };
+}
+
+async function entryLogHistory(
+  ctx: RepoToolContext,
+  input: GitHistoryInput,
+  paths: string[] | undefined,
+  maxResults: number,
+) {
+  const query = input.query?.trim();
+  if (!query) {
+    return { success: false as const, error: "entryLog requires query." };
+  }
+
+  const args = buildGitLogArgs(input, {
+    patch: true,
+    maxCount: maxResults,
+    pickaxe: query,
+    paths,
+  });
+  const result = await ctx.bash.exec("git", { args });
+  if (result.exitCode !== 0) {
+    return {
+      success: false as const,
+      error: redact(result.stderr || "Failed to read git entry log."),
+    };
+  }
+
+  const output = truncate(redact(result.stdout), DEFAULT_MAX_OUTPUT_BYTES);
+  return {
+    success: true as const,
+    mode: "entryLog" as const,
+    query,
+    paths: paths ?? [],
+    log: output.text,
+    truncated: output.truncated,
+  };
+}
+
+async function blameHistory(
+  ctx: RepoToolContext,
+  input: GitHistoryInput,
+  paths: string[] | undefined,
+  maxResults: number,
+) {
+  const path = paths?.[0];
+  if (!path) {
+    return { success: false as const, error: "blame requires a path." };
+  }
+
+  const query = input.query?.trim();
+  const lineRange = query ? await findLineRangeForQuery(ctx, path, query) : null;
+  if (query && !lineRange) {
+    return {
+      success: true as const,
+      mode: "blame" as const,
+      path,
+      query,
+      entries: [],
+      truncated: false,
+      diagnostics: ["Query was not found in the current file, so blame cannot resolve it."],
+    };
+  }
+
+  const args = ["blame", "--line-porcelain"];
+  if (lineRange) {
+    args.push(`-L${lineRange.start},${lineRange.end}`);
+  }
+  args.push("--", path);
+
+  const result = await ctx.bash.exec("git", { args });
+  if (result.exitCode !== 0) {
+    return { success: false as const, error: redact(result.stderr || "Failed to read git blame.") };
+  }
+
+  const entries = parseBlamePorcelain(result.stdout).slice(0, maxResults);
+  return {
+    success: true as const,
+    mode: "blame" as const,
+    path,
+    query,
+    entries,
+    truncated: entries.length < parseBlamePorcelain(result.stdout).length,
+  };
+}
+
+function buildGitLogArgs(
+  input: Pick<GitHistoryInput, "since" | "until" | "range">,
+  options: {
+    paths?: string[];
+    maxCount?: number;
+    nameOnly?: boolean;
+    patch?: boolean;
+    pickaxe?: string;
+  },
+): string[] {
+  const args = ["log", "--date=iso-strict", "--format=%H%x09%ad%x09%an%x09%s"];
+  if (options.maxCount) {
+    args.push(`--max-count=${options.maxCount}`);
+  }
+  if (input.since) {
+    args.push(`--since=${input.since}`);
+  }
+  if (input.until) {
+    args.push(`--until=${input.until}`);
+  }
+  if (options.nameOnly) {
+    args.push("--name-only");
+  }
+  if (options.patch) {
+    args.push("--patch", "--unified=3");
+  }
+  if (options.pickaxe) {
+    args.push(`-S${options.pickaxe}`);
+  }
+  if (input.range) {
+    args.push(input.range);
+  }
+  if (options.paths && options.paths.length > 0) {
+    args.push("--", ...options.paths);
+  }
+  return args;
+}
+
+async function discoverSourceFiles(ctx: RepoToolContext): Promise<SourceFileDiscovery | null> {
+  for (const candidate of CONFIG_CANDIDATES) {
+    const exists = await ctx.bash.exec("test", { args: ["-f", candidate.path] });
+    if (exists.exitCode !== 0) {
+      continue;
+    }
+
+    const json = await readConfigAsJson(ctx, candidate);
+    if (!json) {
+      return {
+        configKind: candidate.kind,
+        configPath: candidate.path,
+        files: [],
+        skippedPatterns: [{ pattern: candidate.path, reason: "Config could not be parsed." }],
+      };
+    }
+
+    const patterns = extractSourcePatterns(candidate.kind, json);
+    const skippedPatterns: Array<{ pattern: string; reason: string }> = [];
+    const files: string[] = [];
+    for (const pattern of patterns) {
+      const expanded = await expandSourcePattern(ctx, pattern);
+      files.push(...expanded.files);
+      skippedPatterns.push(...expanded.skippedPatterns);
+    }
+
+    return {
+      configKind: candidate.kind,
+      configPath: candidate.path,
+      files: Array.from(new Set(files)).sort(),
+      skippedPatterns,
+    };
+  }
+
+  return null;
+}
+
+async function readConfigAsJson(
+  ctx: RepoToolContext,
+  candidate: ConfigCandidate,
+): Promise<Record<string, unknown> | null> {
+  try {
+    let jsonText: string;
+    if (candidate.parser === "jsonc") {
+      jsonText = normalizeJsonc(await ctx.bash.readFile(candidate.path));
+    } else {
+      const result = await ctx.bash.exec("yq", { args: ["-o", "json", ".", candidate.path] });
+      if (result.exitCode !== 0) return null;
+      jsonText = result.stdout;
+    }
+    const parsed = JSON.parse(jsonText);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function extractSourcePatterns(
+  kind: ConfigCandidate["kind"],
+  json: Record<string, unknown>,
+): string[] {
+  switch (kind) {
+    case "hyperlocalise":
+      return extractHyperlocaliseSourcePatterns(json);
+    case "crowdin":
+      return extractCrowdinSourcePatterns(json);
+    case "phrase":
+      return extractPhraseSourcePatterns(json);
+  }
+}
+
+function extractHyperlocaliseSourcePatterns(json: Record<string, unknown>): string[] {
+  const sourceLocale = readNestedString(json, ["locales", "source"]);
+  const buckets = json.buckets;
+  if (!buckets || typeof buckets !== "object" || Array.isArray(buckets)) return [];
+
+  const patterns: string[] = [];
+  for (const bucket of Object.values(buckets)) {
+    if (!bucket || typeof bucket !== "object" || Array.isArray(bucket)) continue;
+    const files = (bucket as { files?: unknown }).files;
+    if (!Array.isArray(files)) continue;
+    for (const file of files) {
+      if (!file || typeof file !== "object" || Array.isArray(file)) continue;
+      const from = (file as { from?: unknown }).from;
+      if (typeof from === "string") {
+        patterns.push(expandHyperlocaliseSourcePattern(from, sourceLocale));
+      }
+    }
+  }
+  return patterns;
+}
+
+function expandHyperlocaliseSourcePattern(pattern: string, sourceLocale: string | null): string {
+  if (!sourceLocale) return pattern;
+  return pattern
+    .replaceAll("{{source}}", sourceLocale)
+    .replaceAll("{{locale}}", sourceLocale)
+    .replaceAll("[locale]", sourceLocale);
+}
+
+function extractCrowdinSourcePatterns(json: Record<string, unknown>): string[] {
+  const basePath = readString(json.base_path);
+  const files = json.files;
+  if (!Array.isArray(files)) return [];
+  return files
+    .map((file) =>
+      file && typeof file === "object" && !Array.isArray(file)
+        ? readString((file as { source?: unknown }).source)
+        : null,
+    )
+    .filter((source): source is string => Boolean(source))
+    .map((source) => joinConfigPath(basePath, source.replace(/^\/+/, "")));
+}
+
+function extractPhraseSourcePatterns(json: Record<string, unknown>): string[] {
+  const phrase = json.phrase;
+  if (!phrase || typeof phrase !== "object" || Array.isArray(phrase)) return [];
+  const sources = ((phrase as { push?: { sources?: unknown } }).push?.sources ?? []) as unknown;
+  if (!Array.isArray(sources)) return [];
+  return sources
+    .map((source) =>
+      source && typeof source === "object" && !Array.isArray(source)
+        ? readString((source as { file?: unknown }).file)
+        : null,
+    )
+    .filter((file): file is string => Boolean(file));
+}
+
+async function expandSourcePattern(
+  ctx: RepoToolContext,
+  pattern: string,
+): Promise<{
+  files: string[];
+  skippedPatterns: Array<{ pattern: string; reason: string }>;
+}> {
+  if (/<[^>]+>/.test(pattern)) {
+    return {
+      files: [],
+      skippedPatterns: [{ pattern, reason: "Pattern contains unresolved Phrase placeholder." }],
+    };
+  }
+
+  const normalizedPattern = normalizeSourcePath(pattern);
+  if (!normalizedPattern) {
+    return {
+      files: [],
+      skippedPatterns: [{ pattern, reason: "Pattern escapes the workspace." }],
+    };
+  }
+
+  const result = await ctx.bash.exec("git", { args: ["ls-files", "--", normalizedPattern] });
+  if (result.exitCode !== 0) {
+    return {
+      files: [],
+      skippedPatterns: [{ pattern, reason: redact(result.stderr || "git ls-files failed.") }],
+    };
+  }
+
+  const files = uniqueLines(result.stdout)
+    .map((line) => normalizeSourcePath(line))
+    .filter((line): line is string => Boolean(line));
+  if (files.length > 0) {
+    return { files, skippedPatterns: [] };
+  }
+
+  if (hasGlobCharacters(normalizedPattern)) {
+    return {
+      files: [],
+      skippedPatterns: [{ pattern, reason: "Glob did not match any git-tracked source files." }],
+    };
+  }
+
+  return { files: [normalizedPattern], skippedPatterns: [] };
+}
+
+function normalizeSourcePath(path: string): string | null {
+  const normalized = path.trim().replace(/\\/g, "/").replace(/^\.\//, "").replace(/^\/+/, "");
+  return normalizeWorkspacePath(normalized);
+}
+
+function joinConfigPath(basePath: string | null, path: string): string {
+  if (!basePath) return path;
+  return `${basePath.replace(/^\/+|\/+$/g, "")}/${path}`;
+}
+
+function hasGlobCharacters(pattern: string): boolean {
+  return /[*?[\]{}]/.test(pattern);
+}
+
+function uniqueLines(output: string): string[] {
+  return Array.from(
+    new Set(
+      output
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function readNestedString(json: Record<string, unknown>, path: string[]): string | null {
+  let current: unknown = json;
+  for (const key of path) {
+    if (!current || typeof current !== "object" || Array.isArray(current)) return null;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return readString(current);
+}
+
+async function findLineRangeForQuery(
+  ctx: RepoToolContext,
+  path: string,
+  query: string,
+): Promise<{ start: number; end: number } | null> {
+  const content = await ctx.bash.readFile(path);
+  const lines = content.split("\n");
+  const index = lines.findIndex((line) => line.includes(query));
+  if (index < 0) return null;
+  const line = index + 1;
+  return { start: line, end: line };
+}
+
+type BlameEntry = {
+  commit: string;
+  author?: string;
+  authorTime?: string;
+  summary?: string;
+  line?: string;
+};
+
+function parseBlamePorcelain(output: string): BlameEntry[] {
+  const entries: BlameEntry[] = [];
+  let current: BlameEntry | null = null;
+
+  for (const line of output.split("\n")) {
+    const header = line.match(/^([0-9a-f]{7,40})\s+\d+\s+\d+/i);
+    if (header) {
+      if (current) entries.push(current);
+      current = { commit: header[1] };
+      continue;
+    }
+    if (!current) continue;
+    if (line.startsWith("author ")) {
+      current.author = line.slice("author ".length);
+    } else if (line.startsWith("author-time ")) {
+      current.authorTime = line.slice("author-time ".length);
+    } else if (line.startsWith("summary ")) {
+      current.summary = line.slice("summary ".length);
+    } else if (line.startsWith("\t")) {
+      current.line = redact(line.slice(1));
+    }
+  }
+
+  if (current) entries.push(current);
+  return entries;
 }
 
 export type RunHyperlocaliseCliOutput = {


### PR DESCRIPTION
## What changed

- Added a read-only `gitHistory` repository tool for Hyperlocalise agents with `changedFiles`, `fileDiff`, `entryLog`, and `blame` modes.
- Exposed `gitHistory` through the repository workspace tool manifest/registry and repo-tools skill so repository subagents can inspect source-file history without broad shell access.
- Updated find-context guidance to use git history for bulk recent-change prompts, including config-discovered source files from `i18n.yml`, `crowdin.yml`, and Phrase config fallbacks.
- Added focused coverage for config fallback discovery, git history modes, tool registry exposure, and find-context instructions.

## How to test

- `vp test src/lib/agent-runtime/tools/repo-read-tools.test.ts src/lib/agent-runtime/tools/registry.test.ts src/lib/agent-runtime/skills/find-context-instructions.test.ts src/lib/agent-runtime/skills/conversation-skill-registry.test.ts`
- `vp check --fix`
- `git diff --check`
- `vp test` completed, but existing unrelated auth/public API suites failed with 401/403 status mismatches and one MCP authorization-code replay assertion.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review