### PR TITLE
fix(cat): move side-by-side intelligence panel right

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-segment-target.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-segment-target.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import type { ProjectFileCatTranslation } from "@/api/routes/project/project.schema";
 import { readApiError } from "@/lib/api-error";
@@ -60,6 +60,28 @@ export async function fetchProjectFileCatSegmentTarget(input: {
   return body.target;
 }
 
+function catSegmentTargetQueryOptions(input: {
+  organizationSlug: string;
+  projectId: string;
+  sourcePath: string;
+  externalResourceId?: string | null;
+  resourceType?: "file" | "key";
+  targetLocale: string;
+  externalStringId: string;
+  enabled?: boolean;
+}) {
+  return {
+    queryKey: projectFileCatSegmentTargetQueryKey(input),
+    enabled:
+      input.enabled !== false &&
+      Boolean(input.externalStringId) &&
+      Boolean(input.targetLocale) &&
+      Boolean(input.sourcePath),
+    staleTime: 30_000,
+    queryFn: () => fetchProjectFileCatSegmentTarget(input),
+  };
+}
+
 export function useCatSegmentTarget(input: {
   organizationSlug: string;
   projectId: string;
@@ -72,8 +94,8 @@ export function useCatSegmentTarget(input: {
 }) {
   const externalStringId = input.externalStringId ?? "";
 
-  return useQuery({
-    queryKey: projectFileCatSegmentTargetQueryKey({
+  return useQuery(
+    catSegmentTargetQueryOptions({
       organizationSlug: input.organizationSlug,
       projectId: input.projectId,
       sourcePath: input.sourcePath,
@@ -81,15 +103,28 @@ export function useCatSegmentTarget(input: {
       resourceType: input.resourceType,
       targetLocale: input.targetLocale,
       externalStringId,
+      enabled: input.enabled,
     }),
-    enabled:
-      input.enabled !== false &&
-      Boolean(input.externalStringId) &&
-      Boolean(input.targetLocale) &&
-      Boolean(input.sourcePath),
-    staleTime: 30_000,
-    queryFn: () =>
-      fetchProjectFileCatSegmentTarget({
+  );
+}
+
+export function useCatSegmentTargets(input: {
+  organizationSlug: string;
+  projectId: string;
+  sourcePath: string;
+  externalResourceId?: string | null;
+  resourceType?: "file" | "key";
+  targetLocale: string;
+  externalStringIds: string[];
+  enabled?: boolean;
+}) {
+  const externalStringIds = Array.from(
+    new Set(input.externalStringIds.filter((id) => id.trim().length > 0)),
+  );
+
+  return useQueries({
+    queries: externalStringIds.map((externalStringId) =>
+      catSegmentTargetQueryOptions({
         organizationSlug: input.organizationSlug,
         projectId: input.projectId,
         sourcePath: input.sourcePath,
@@ -97,7 +132,9 @@ export function useCatSegmentTarget(input: {
         resourceType: input.resourceType,
         targetLocale: input.targetLocale,
         externalStringId,
+        enabled: input.enabled,
       }),
+    ),
   });
 }
 

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-intelligence-panel.tsx
@@ -38,6 +38,7 @@ export function CatSideBySideIntelligencePanel({
   onUseGlossaryTerm,
   onAddComment,
   onResolveComment,
+  placement = "bottom",
   className,
 }: {
   segment: CatSegment | null;
@@ -61,13 +62,15 @@ export function CatSideBySideIntelligencePanel({
   onUseGlossaryTerm?: (term: CatGlossaryTerm) => void;
   onAddComment?: (input: CatSegmentCommentInput) => void | Promise<void>;
   onResolveComment?: (commentId: string) => void | Promise<void>;
+  placement?: "bottom" | "right";
   className?: string;
 }) {
   if (!segment || !intelligence) {
     return (
       <div
         className={cn(
-          "flex h-full min-h-32 items-center justify-center border-t border-border bg-muted/30 px-4",
+          "flex h-full min-h-32 items-center justify-center border-border bg-muted/30 px-4",
+          placement === "right" ? "border-l" : "border-t",
           className,
         )}
       >
@@ -78,9 +81,44 @@ export function CatSideBySideIntelligencePanel({
     );
   }
 
+  const intelligencePanel = (
+    <CatIntelligencePanel
+      intelligence={intelligence}
+      targetText={segment.targetText}
+      isLookingUpContext={isLookingUpContext}
+      isConcordanceLoading={isConcordanceLoading}
+      isVisualContextLoading={isVisualContextLoading}
+      showAgentContext={showAgentContext}
+      showVisualContext={showVisualContext}
+      canEditTranslations={canEditTranslations}
+      canLookupFreshContext={canLookupFreshContext}
+      onRefreshContext={onRefreshContext}
+      onUseTmMatch={onUseTmMatch}
+      onUseGlossaryTerm={onUseGlossaryTerm}
+    />
+  );
+  const commentsPanel = (
+    <CatEditorCommentsSection
+      segment={segment}
+      isLoading={isCommentsLoading}
+      isPostingComment={isPostingComment}
+      isResolvingComment={isResolvingComment}
+      resolvingCommentId={resolvingCommentId}
+      commentPostError={commentPostError}
+      canAddComment={canAddComment}
+      supportsIssueComments={supportsIssueComments}
+      onAddComment={onAddComment}
+      onResolveComment={onResolveComment}
+    />
+  );
+
   return (
     <div
-      className={cn("flex h-full min-h-0 flex-col border-t border-border bg-background", className)}
+      className={cn(
+        "flex h-full min-h-0 flex-col border-border bg-background",
+        placement === "right" ? "border-l" : "border-t",
+        className,
+      )}
     >
       <div className="shrink-0 border-b border-border px-4 py-2.5">
         <div className="flex min-w-0 items-center gap-2">
@@ -91,41 +129,22 @@ export function CatSideBySideIntelligencePanel({
         </div>
       </div>
 
-      <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,22rem)]">
-        <ScrollArea className="min-h-0">
-          <div className="p-4">
-            <CatIntelligencePanel
-              intelligence={intelligence}
-              targetText={segment.targetText}
-              isLookingUpContext={isLookingUpContext}
-              isConcordanceLoading={isConcordanceLoading}
-              isVisualContextLoading={isVisualContextLoading}
-              showAgentContext={showAgentContext}
-              showVisualContext={showVisualContext}
-              canEditTranslations={canEditTranslations}
-              canLookupFreshContext={canLookupFreshContext}
-              onRefreshContext={onRefreshContext}
-              onUseTmMatch={onUseTmMatch}
-              onUseGlossaryTerm={onUseGlossaryTerm}
-            />
-          </div>
-        </ScrollArea>
-
-        <div className="min-h-0 border-t border-border lg:border-t-0 lg:border-l">
-          <CatEditorCommentsSection
-            segment={segment}
-            isLoading={isCommentsLoading}
-            isPostingComment={isPostingComment}
-            isResolvingComment={isResolvingComment}
-            resolvingCommentId={resolvingCommentId}
-            commentPostError={commentPostError}
-            canAddComment={canAddComment}
-            supportsIssueComments={supportsIssueComments}
-            onAddComment={onAddComment}
-            onResolveComment={onResolveComment}
-          />
+      {placement === "right" ? (
+        <div className="flex min-h-0 flex-1 flex-col">
+          <div className="min-h-0 flex-1">{intelligencePanel}</div>
+          <div className="max-h-[45%] min-h-0 overflow-y-auto">{commentsPanel}</div>
         </div>
-      </div>
+      ) : (
+        <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,22rem)]">
+          <ScrollArea className="min-h-0">
+            <div className="p-4">{intelligencePanel}</div>
+          </ScrollArea>
+
+          <div className="min-h-0 border-t border-border lg:border-t-0 lg:border-l">
+            {commentsPanel}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-panel.tsx
@@ -157,150 +157,157 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
   const totalSegments = hasMoreQueue ? null : (pagination?.totalCount ?? segments.length);
 
   return (
-    <div className={cn("flex h-full min-h-0 flex-col overflow-hidden bg-background", className)}>
-      <div className="shrink-0 space-y-3 border-b border-border px-4 py-3">
-        <div className="flex items-center justify-between gap-3">
-          {onSearchChange ? (
-            <div className="relative min-w-0 flex-1">
-              <HugeiconsIcon
-                icon={SearchIcon}
-                className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground"
-              />
-              <Input
-                value={search}
-                onChange={(event) => onSearchChange(event.target.value)}
-                placeholder={intl.formatMessage(catQueuePanelMessages.searchPlaceholder)}
-                aria-label={intl.formatMessage(catQueuePanelMessages.searchAria)}
-                className="h-9 pl-9"
-              />
-              {isSearching ? (
-                <Spinner className="absolute top-1/2 right-2.5 size-4 -translate-y-1/2" />
+    <div
+      className={cn(
+        "grid h-full min-h-0 min-w-0 grid-cols-[minmax(0,1fr)_minmax(0,22rem)] overflow-hidden bg-background",
+        className,
+      )}
+    >
+      <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
+        <div className="shrink-0 space-y-3 border-b border-border px-4 py-3">
+          <div className="flex items-center justify-between gap-3">
+            {onSearchChange ? (
+              <div className="relative min-w-0 flex-1">
+                <HugeiconsIcon
+                  icon={SearchIcon}
+                  className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground"
+                />
+                <Input
+                  value={search}
+                  onChange={(event) => onSearchChange(event.target.value)}
+                  placeholder={intl.formatMessage(catQueuePanelMessages.searchPlaceholder)}
+                  aria-label={intl.formatMessage(catQueuePanelMessages.searchAria)}
+                  className="h-9 pl-9"
+                />
+                {isSearching ? (
+                  <Spinner className="absolute top-1/2 right-2.5 size-4 -translate-y-1/2" />
+                ) : null}
+              </div>
+            ) : (
+              <div className="flex-1" />
+            )}
+
+            <div className="flex shrink-0 items-center gap-2">
+              {onQueueFilterChange ? (
+                <DropdownMenu>
+                  <DropdownMenuTrigger
+                    render={
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-9 gap-1.5 px-2.5"
+                        aria-label={intl.formatMessage(catQueuePanelMessages.filterQueueAria)}
+                      />
+                    }
+                  >
+                    <HugeiconsIcon icon={FilterIcon} className="size-4" />
+                    <span className="hidden text-xs sm:inline">
+                      <FormattedMessage {...queueFilterMessageByValue[queueFilter]} />
+                    </span>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="min-w-44">
+                    <DropdownMenuRadioGroup
+                      value={queueFilter}
+                      onValueChange={(value) => {
+                        if (
+                          value === "all" ||
+                          value === "untranslated" ||
+                          value === "needs_review" ||
+                          value === "reviewed" ||
+                          value === "has_issues" ||
+                          value === "skipped"
+                        ) {
+                          onQueueFilterChange(value);
+                        }
+                      }}
+                    >
+                      {availableQueueFilters.map((filter) => (
+                        <DropdownMenuRadioItem key={filter} value={filter}>
+                          <FormattedMessage {...queueFilterMessageByValue[filter]} />
+                        </DropdownMenuRadioItem>
+                      ))}
+                    </DropdownMenuRadioGroup>
+                  </DropdownMenuContent>
+                </DropdownMenu>
               ) : null}
+
+              <CatWorkspaceViewSwitcherConnected />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-0 text-xs font-medium tracking-wide text-muted-foreground uppercase">
+            <p className="border-r border-border pr-4">
+              <FormattedMessage {...catSideBySidePanelMessages.sourceColumn} />
+            </p>
+            <p className="pl-4">
+              <FormattedMessage {...catSideBySidePanelMessages.translationColumn} />
+            </p>
+          </div>
+        </div>
+
+        <div className="flex min-h-0 flex-1 flex-col">
+          {isQueueLoading && segments.length === 0 ? (
+            <CatQueueSkeletonList className="px-4 py-3" />
+          ) : segments.length === 0 ? (
+            <div className="flex flex-1 items-center justify-center px-4 py-8 text-sm text-muted-foreground">
+              <FormattedMessage {...emptyMessage} />
             </div>
           ) : (
-            <div className="flex-1" />
+            <CatSideBySideVirtualList
+              segments={segments}
+              focusedSegmentId={focusedSegmentId}
+              hoveredSegmentId={hoveredSegmentId}
+              dirtySegmentIds={dirtySegmentIds}
+              canEdit={canEditTranslations}
+              loadingSegmentIds={loadingSegmentIds}
+              onFocusSegment={onFocusSegment}
+              onHoverSegment={(segmentId) => store.ui.setHoveredSegment(segmentId)}
+              onLeaveSegment={() => store.ui.clearHoveredSegment()}
+              onTargetChange={onTargetChange}
+              hasMore={hasMoreQueue}
+              isLoadingMore={isFetchingPage}
+              onNearEnd={onLoadMoreQueue}
+            />
           )}
 
-          <div className="flex shrink-0 items-center gap-2">
-            {onQueueFilterChange ? (
-              <DropdownMenu>
-                <DropdownMenuTrigger
-                  render={
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-9 gap-1.5 px-2.5"
-                      aria-label={intl.formatMessage(catQueuePanelMessages.filterQueueAria)}
-                    />
-                  }
-                >
-                  <HugeiconsIcon icon={FilterIcon} className="size-4" />
-                  <span className="hidden text-xs sm:inline">
-                    <FormattedMessage {...queueFilterMessageByValue[queueFilter]} />
-                  </span>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="min-w-44">
-                  <DropdownMenuRadioGroup
-                    value={queueFilter}
-                    onValueChange={(value) => {
-                      if (
-                        value === "all" ||
-                        value === "untranslated" ||
-                        value === "needs_review" ||
-                        value === "reviewed" ||
-                        value === "has_issues" ||
-                        value === "skipped"
-                      ) {
-                        onQueueFilterChange(value);
-                      }
-                    }}
-                  >
-                    {availableQueueFilters.map((filter) => (
-                      <DropdownMenuRadioItem key={filter} value={filter}>
-                        <FormattedMessage {...queueFilterMessageByValue[filter]} />
-                      </DropdownMenuRadioItem>
-                    ))}
-                  </DropdownMenuRadioGroup>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            ) : null}
-
-            <CatWorkspaceViewSwitcherConnected />
+          <div className="flex shrink-0 items-center justify-between border-t border-border px-4 py-2 text-xs text-muted-foreground">
+            <p>
+              <FormattedMessage
+                {...catQueuePanelMessages.paginationSummary}
+                values={{
+                  count: loadedCount,
+                  more: hasMoreQueue ? "+" : "",
+                }}
+              />
+            </p>
+            <p className="font-mono tabular-nums">
+              <FormattedMessage
+                {...catSideBySidePanelMessages.segmentPosition}
+                values={{
+                  position: segmentPosition,
+                  total: totalSegments ?? `${loadedCount}+`,
+                }}
+              />
+            </p>
+            {hasMoreQueue && onLoadMoreQueue ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-xs"
+                onClick={onLoadMoreQueue}
+                disabled={isFetchingPage}
+              >
+                {isFetchingPage ? <Spinner className="size-3.5" /> : null}
+                <FormattedMessage {...catQueuePanelMessages.loadMore} />
+              </Button>
+            ) : (
+              <span />
+            )}
           </div>
-        </div>
-
-        <div className="grid grid-cols-2 gap-0 text-xs font-medium tracking-wide text-muted-foreground uppercase">
-          <p className="border-r border-border pr-4">
-            <FormattedMessage {...catSideBySidePanelMessages.sourceColumn} />
-          </p>
-          <p className="pl-4">
-            <FormattedMessage {...catSideBySidePanelMessages.translationColumn} />
-          </p>
         </div>
       </div>
 
-      <div className="flex min-h-0 flex-1 flex-col">
-        {isQueueLoading && segments.length === 0 ? (
-          <CatQueueSkeletonList className="px-4 py-3" />
-        ) : segments.length === 0 ? (
-          <div className="flex flex-1 items-center justify-center px-4 py-8 text-sm text-muted-foreground">
-            <FormattedMessage {...emptyMessage} />
-          </div>
-        ) : (
-          <CatSideBySideVirtualList
-            segments={segments}
-            focusedSegmentId={focusedSegmentId}
-            hoveredSegmentId={hoveredSegmentId}
-            dirtySegmentIds={dirtySegmentIds}
-            canEdit={canEditTranslations}
-            loadingSegmentIds={loadingSegmentIds}
-            onFocusSegment={onFocusSegment}
-            onHoverSegment={(segmentId) => store.ui.setHoveredSegment(segmentId)}
-            onLeaveSegment={() => store.ui.clearHoveredSegment()}
-            onTargetChange={onTargetChange}
-            hasMore={hasMoreQueue}
-            isLoadingMore={isFetchingPage}
-            onNearEnd={onLoadMoreQueue}
-          />
-        )}
-
-        <div className="flex shrink-0 items-center justify-between border-t border-border px-4 py-2 text-xs text-muted-foreground">
-          <p>
-            <FormattedMessage
-              {...catQueuePanelMessages.paginationSummary}
-              values={{
-                count: loadedCount,
-                more: hasMoreQueue ? "+" : "",
-              }}
-            />
-          </p>
-          <p className="font-mono tabular-nums">
-            <FormattedMessage
-              {...catSideBySidePanelMessages.segmentPosition}
-              values={{
-                position: segmentPosition,
-                total: totalSegments ?? `${loadedCount}+`,
-              }}
-            />
-          </p>
-          {hasMoreQueue && onLoadMoreQueue ? (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 px-2 text-xs"
-              onClick={onLoadMoreQueue}
-              disabled={isFetchingPage}
-            >
-              {isFetchingPage ? <Spinner className="size-3.5" /> : null}
-              <FormattedMessage {...catQueuePanelMessages.loadMore} />
-            </Button>
-          ) : (
-            <span />
-          )}
-        </div>
-      </div>
-
-      <div className="h-[min(40vh,22rem)] shrink-0">
+      <div className="h-full min-h-0 min-w-0">
         <CatSideBySideIntelligencePanel
           segment={intelligenceSegment}
           intelligence={intelligence}
@@ -339,6 +346,7 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
               ? (commentId) => onResolveComment(intelligenceSegmentId, commentId)
               : undefined
           }
+          placement="right"
           className="h-full"
         />
       </div>

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
@@ -120,7 +120,12 @@ const CatWorkspaceContainerObserver = observer(function CatWorkspaceContainerObs
         snapshot={queueSnapshot ?? null}
         initialSegmentKeyOrId={initialSegmentKeyOrId}
       />
-      {lazySegment ? <CatWorkspaceLazySegmentSync {...lazySegment} /> : null}
+      {lazySegment ? (
+        <CatWorkspaceLazySegmentSync
+          {...lazySegment}
+          queueSegmentIds={controller.queueSegments.map((segment) => segment.id)}
+        />
+      ) : null}
 
       <CatPanelErrorBoundary
         scope="workspace"

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-lazy-segment-sync.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-lazy-segment-sync.tsx
@@ -1,13 +1,16 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { observer } from "mobx-react-lite";
 
 import type { ProjectFileCatQueueFile } from "@/api/routes/project/project.schema";
 
 import { resolveCatFileIdentity } from "@/components/cat/project-file/project-file-cat-mapper";
 import { useCatSegmentComments } from "@/components/cat/project-file/use-cat-segment-comments";
-import { useCatSegmentTarget } from "@/components/cat/project-file/use-cat-segment-target";
+import {
+  useCatSegmentTarget,
+  useCatSegmentTargets,
+} from "@/components/cat/project-file/use-cat-segment-target";
 
 import { useCatWorkspace } from "./cat-workspace-context";
 
@@ -120,6 +123,60 @@ function useCatSegmentLazySync(input: {
   };
 }
 
+function useCatLoadedQueueTargetsSync(input: {
+  organizationSlug: string;
+  projectId: string;
+  sourcePath: string;
+  targetLocale: string;
+  externalResourceId?: string | null;
+  resourceType?: "file" | "key";
+  catFile: ProjectFileCatQueueFile | null | undefined;
+  enabled: boolean;
+  segmentIds: string[];
+}) {
+  const store = useCatWorkspace();
+  const segmentIds = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          input.segmentIds
+            .map((segmentId) => store.findSegmentIdByKeyOrId(segmentId) ?? segmentId)
+            .filter((segmentId) => segmentId.trim().length > 0),
+        ),
+      ),
+    [input.segmentIds, store],
+  );
+
+  const { externalResourceId: resolvedExternalResourceId, resourceType: resolvedResourceType } =
+    resolveCatFileIdentity({
+      externalResourceId: input.externalResourceId,
+      resourceType: input.resourceType,
+      catFile: input.catFile,
+    });
+
+  const targetQueries = useCatSegmentTargets({
+    organizationSlug: input.organizationSlug,
+    projectId: input.projectId,
+    sourcePath: input.sourcePath,
+    externalResourceId: resolvedExternalResourceId,
+    resourceType: resolvedResourceType,
+    targetLocale: input.targetLocale,
+    externalStringIds: segmentIds,
+    enabled: input.enabled && Boolean(input.catFile) && segmentIds.length > 0,
+  });
+
+  useEffect(() => {
+    targetQueries.forEach((query, index) => {
+      const segmentId = segmentIds[index];
+      if (!segmentId || query.data === undefined) {
+        return;
+      }
+
+      store.applySegmentTarget(segmentId, query.data);
+    });
+  }, [segmentIds, store, targetQueries]);
+}
+
 export const CatWorkspaceLazySegmentSync = observer(function CatWorkspaceLazySegmentSync({
   organizationSlug,
   projectId,
@@ -129,6 +186,7 @@ export const CatWorkspaceLazySegmentSync = observer(function CatWorkspaceLazySeg
   resourceType,
   catFile,
   enabled,
+  queueSegmentIds = [],
 }: {
   organizationSlug: string;
   projectId: string;
@@ -138,6 +196,7 @@ export const CatWorkspaceLazySegmentSync = observer(function CatWorkspaceLazySeg
   resourceType?: "file" | "key";
   catFile: ProjectFileCatQueueFile | null | undefined;
   enabled: boolean;
+  queueSegmentIds?: string[];
 }) {
   const store = useCatWorkspace();
   const selectedSegmentId = store.selectedSegmentId;
@@ -145,6 +204,19 @@ export const CatWorkspaceLazySegmentSync = observer(function CatWorkspaceLazySeg
     store.ui.hoveredSegmentId && store.ui.hoveredSegmentId !== selectedSegmentId
       ? store.ui.hoveredSegmentId
       : null;
+  const isSideBySideView = store.ui.isSideBySideView;
+
+  useCatLoadedQueueTargetsSync({
+    organizationSlug,
+    projectId,
+    sourcePath,
+    targetLocale,
+    externalResourceId,
+    resourceType,
+    catFile,
+    enabled: enabled && isSideBySideView,
+    segmentIds: queueSegmentIds,
+  });
 
   const _selectedSync = useCatSegmentLazySync({
     organizationSlug,


### PR DESCRIPTION
## What changed

- Moves the side-by-side CAT Translation intelligence panel into a fixed right column, matching comfortable view placement.
- Keeps the side-by-side comments section paired with the active intelligence segment in the right pane.

## How to test

- `vp check --fix`
- `vp test src/components/cat`
- `vp test` was attempted; it failed in unrelated API auth route suites with 28 tests returning 401/403.

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test src/components/cat`)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)