### PR TITLE
feat(web): add Translate with agent for native project files

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/create-translation-job-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/create-translation-job-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
@@ -42,6 +42,12 @@ export function CreateTranslationJobDialog({
 }: CreateTranslationJobDialogProps) {
   const queryClient = useQueryClient();
   const [selectedLocales, setSelectedLocales] = useState<string[]>(targetLocales);
+
+  useEffect(() => {
+    if (open) {
+      setSelectedLocales(targetLocales);
+    }
+  }, [open, targetLocales]);
 
   const createJob = useMutation({
     mutationFn: async () => {
@@ -150,7 +156,12 @@ export function CreateTranslationJobDialog({
           </Button>
           <Button
             type="button"
-            disabled={createJob.isPending || targetLocales.length === 0 || !file?.storedFileId}
+            disabled={
+              createJob.isPending ||
+              targetLocales.length === 0 ||
+              selectedLocales.length === 0 ||
+              !file?.storedFileId
+            }
             onClick={() => createJob.mutate()}
           >
             {createJob.isPending ? <Spinner className="size-4" /> : null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/create-translation-job-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/create-translation-job-dialog.tsx
@@ -88,7 +88,7 @@ export function CreateTranslationJobDialog({
         }),
         queryClient.invalidateQueries({ queryKey: ["jobs", organizationSlug] }),
       ]);
-      toast.success("Translation job created");
+      toast.success("Translation agent is running");
       onCreated?.(jobId);
       onOpenChange(false);
     },
@@ -109,9 +109,9 @@ export function CreateTranslationJobDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Create translation job</DialogTitle>
+          <DialogTitle>Translate with agent</DialogTitle>
           <DialogDescription>
-            Queue AI translation for{" "}
+            Queue an AI translation agent for{" "}
             <span className="font-mono text-foreground">{file?.sourcePath ?? "this file"}</span>.
           </DialogDescription>
         </DialogHeader>
@@ -154,7 +154,7 @@ export function CreateTranslationJobDialog({
             onClick={() => createJob.mutate()}
           >
             {createJob.isPending ? <Spinner className="size-4" /> : null}
-            Translate
+            Translate with agent
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-detail-panel.tsx
@@ -339,7 +339,7 @@ export function ProjectFileDetailPanelView({
           <div className="flex flex-wrap gap-2 pt-1">
             <Button type="button" size="sm" onClick={() => setTranslateDialogOpen(true)}>
               <HugeiconsIcon icon={TranslateIcon} strokeWidth={1.8} />
-              Translate
+              Translate with agent
             </Button>
             <Button
               type="button"

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { Download01Icon, Upload01Icon } from "@hugeicons/core-free-icons";
+import { Download01Icon, TranslateIcon, Upload01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ListIcon } from "lucide-react";
 
@@ -13,7 +13,9 @@ import {
   buildProjectFileCatHref,
   canOpenProjectFileCat,
 } from "@/lib/projects/project-file-cat-routing";
+import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
 
+import { CreateTranslationJobDialog } from "./create-translation-job-dialog";
 import { DownloadTranslationsDialog } from "./download-translations-dialog";
 import { ImportTranslationsDialog } from "./import-translations-dialog";
 
@@ -25,6 +27,7 @@ export function ProjectFileSelectionActions({
   file,
   highlightLocale,
   projectTargetLocales,
+  sourceLocale = "en",
   nativeSourcePaths = EMPTY_STRING_ARRAY,
   branch = null,
   layout = "default",
@@ -34,15 +37,22 @@ export function ProjectFileSelectionActions({
   file: ProjectFileRecord;
   highlightLocale: string | null;
   projectTargetLocales?: readonly string[] | null;
+  sourceLocale?: string;
   nativeSourcePaths?: readonly string[];
   branch?: string | null;
   layout?: "default" | "compact";
 }) {
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const [downloadDialogOpen, setDownloadDialogOpen] = useState(false);
+  const [translateDialogOpen, setTranslateDialogOpen] = useState(false);
   const canOpenCat = canOpenProjectFileCat(file);
   const isNativeFile = !file.provider;
   const targetLocales = projectTargetLocales ?? EMPTY_STRING_ARRAY;
+  const canTranslateWithAgent =
+    isNativeFile &&
+    Boolean(file.storedFileId) &&
+    Boolean(inferSupportedFileTranslationFileFormat(file.sourcePath)) &&
+    targetLocales.length > 0;
   const catHref = buildProjectFileCatHref(
     organizationSlug,
     projectId,
@@ -54,6 +64,15 @@ export function ProjectFileSelectionActions({
 
   const nativeDialogs = isNativeFile ? (
     <>
+      <CreateTranslationJobDialog
+        open={translateDialogOpen}
+        onOpenChange={setTranslateDialogOpen}
+        organizationSlug={organizationSlug}
+        projectId={projectId}
+        file={file}
+        sourceLocale={sourceLocale}
+        targetLocales={[...targetLocales]}
+      />
       <ImportTranslationsDialog
         open={importDialogOpen}
         onOpenChange={setImportDialogOpen}
@@ -88,6 +107,21 @@ export function ProjectFileSelectionActions({
       </Button>
       {isNativeFile ? (
         <>
+          <Button
+            type="button"
+            size="sm"
+            className={layout === "default" ? "w-full shrink-0 sm:w-fit" : "shrink-0"}
+            disabled={!canTranslateWithAgent}
+            title={
+              canTranslateWithAgent
+                ? undefined
+                : "Upload a supported file and add target locales in project settings to translate with agent."
+            }
+            onClick={() => setTranslateDialogOpen(true)}
+          >
+            <HugeiconsIcon icon={TranslateIcon} strokeWidth={1.8} />
+            Translate with agent
+          </Button>
           <Button
             type="button"
             size="sm"

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Download01Icon, TranslateIcon, Upload01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ListIcon } from "lucide-react";
@@ -48,6 +48,7 @@ export function ProjectFileSelectionActions({
   const canOpenCat = canOpenProjectFileCat(file);
   const isNativeFile = !file.provider;
   const targetLocales = projectTargetLocales ?? EMPTY_STRING_ARRAY;
+  const stableTargetLocales = useMemo(() => [...targetLocales], [targetLocales]);
   const canTranslateWithAgent =
     isNativeFile &&
     Boolean(file.storedFileId) &&
@@ -71,7 +72,7 @@ export function ProjectFileSelectionActions({
         projectId={projectId}
         file={file}
         sourceLocale={sourceLocale}
-        targetLocales={[...targetLocales]}
+        targetLocales={stableTargetLocales}
       />
       <ImportTranslationsDialog
         open={importDialogOpen}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.stories.tsx
@@ -134,6 +134,7 @@ export const RepositoryFiles: Story = {
     await expect(canvas.getByText("3 files")).toBeInTheDocument();
     await expect(canvas.getAllByText("marketing/home.json").length).toBeGreaterThan(0);
     await expect(canvas.getByRole("link", { name: "View strings" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Translate with agent" })).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Import translations" })).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Download" })).toBeInTheDocument();
     await waitFor(() => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx
@@ -79,6 +79,10 @@ vi.mock("./project-files-tree-panel", () => ({
   },
 }));
 
+vi.mock("./create-translation-job-dialog", () => ({
+  CreateTranslationJobDialog: () => null,
+}));
+
 vi.mock("./project-files-branch-filter", () => ({
   ProjectFilesBranchFilter: () => null,
 }));
@@ -135,9 +139,10 @@ describe("ProjectFilesPageContent CAT entry UX", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows import and download actions for native project files", () => {
+  it("shows translate with agent and import/download actions for native project files", () => {
     render(<ProjectFilesPageContent organizationSlug="acme" projectId="proj_1" />);
 
+    expect(screen.getByRole("button", { name: "Translate with agent" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Import translations" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Download" })).toBeInTheDocument();
   });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -205,6 +205,7 @@ export function ProjectFilesPageContent({
   const isProviderProject = projectCapabilities.isProviderProject;
   const projectQuery = useProjectPageQuery(organizationSlug, projectId);
   const projectTargetLocales = projectQuery.data?.targetLocales;
+  const projectSourceLocale = projectQuery.data?.sourceLocale ?? "en";
 
   const openFileInCat = useCallback(
     (sourcePath: string) => {
@@ -305,6 +306,7 @@ export function ProjectFilesPageContent({
       highlightLocale={highlightLocale}
       selectedBranch={selectedBranch}
       projectTargetLocales={projectTargetLocales}
+      projectSourceLocale={projectSourceLocale}
       isProviderProject={isProviderProject}
       selectedFiles={selectedFiles}
       isUploading={uploadFiles.isPending}
@@ -340,6 +342,7 @@ export function ProjectFilesPageContent({
                   file={selectedFile}
                   highlightLocale={highlightLocale}
                   projectTargetLocales={projectTargetLocales}
+                  sourceLocale={projectSourceLocale}
                   nativeSourcePaths={nativeSourcePaths}
                   branch={selectedBranch}
                   layout="compact"
@@ -365,6 +368,7 @@ export function ProjectFilesPageContentView({
   highlightLocale,
   selectedBranch: _selectedBranch = null,
   projectTargetLocales,
+  projectSourceLocale = "en",
   isProviderProject: isProviderProjectProp,
   selectedFiles,
   isUploading,
@@ -388,6 +392,7 @@ export function ProjectFilesPageContentView({
   highlightLocale: string | null;
   selectedBranch?: string | null;
   projectTargetLocales?: readonly string[] | null;
+  projectSourceLocale?: string;
   isProviderProject?: boolean;
   selectedFiles: File[];
   isUploading: boolean;
@@ -512,6 +517,7 @@ export function ProjectFilesPageContentView({
                 file={selectedFile}
                 highlightLocale={highlightLocale}
                 projectTargetLocales={projectTargetLocales}
+                sourceLocale={projectSourceLocale}
                 nativeSourcePaths={nativeSourcePaths}
                 branch={_selectedBranch}
               />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enables **Translate with agent** for native Hyperlocalise projects when a file is selected on the project files page.

- Adds a **Translate with agent** button to the file selection action bar (compact header and default layout)
- Reuses the existing native file translation flow (`CreateTranslationJobDialog` → file translation job workflow)
- Aligns copy across the selection bar, file detail panel, and dialog
- Button is enabled when the file is uploaded, format is supported, and the project has target locales

## What changed

| Area | Change |
|------|--------|
| `project-file-selection-actions.tsx` | New primary action + dialog wiring for native files |
| `project-files-page-content.tsx` | Passes `sourceLocale` from project settings into selection actions |
| `project-file-detail-panel.tsx` | Renamed "Translate" → "Translate with agent" |
| `create-translation-job-dialog.tsx` | Updated title, description, button label, and success toast |

## How it works

1. User selects a file in the project files tree
2. Clicks **Translate with agent**
3. Chooses target locales in the dialog
4. Creates a native `file` translation job that runs the AI translation workflow
5. Progress and output appear on the job detail page (same as before)

## Testing

- `vp check --fix` passes
- `project-files-page-content.test.tsx` — 7/7 tests pass
- Full `vp test` has pre-existing DB/env failures unrelated to this change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4182-f374-7dd3-a41f-9c75c7d97083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4182-f374-7dd3-a41f-9c75c7d97083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

