### PR TITLE
fix(ci): use GitHub App token for localize translation PRs

### DIFF
--- a/.github/workflows/hyperlocalise-web-localize.yml
+++ b/.github/workflows/hyperlocalise-web-localize.yml
@@ -100,7 +100,8 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
+          # Persist the app token for local git commands in ./sync (add/diff only; no push/fetch).
+          persist-credentials: true
 
       - name: Extract, download, and validate web translations
         uses: ./sync

--- a/.github/workflows/hyperlocalise-web-localize.yml
+++ b/.github/workflows/hyperlocalise-web-localize.yml
@@ -89,10 +89,18 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.GITHUB_APP_ID }}
+          private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Extract, download, and validate web translations
         uses: ./sync
@@ -120,6 +128,7 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
+          token: ${{ steps.app-token.outputs.token }}
           branch: ${{ steps.branch.outputs.name }}
           delete-branch: true
           commit-message: "chore(web): sync Hyperlocalise translations"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The `hyperlocalise-web-localize` download job now authenticates branch pushes and pull request creation with a GitHub App installation token instead of the default `GITHUB_TOKEN`.

- Generate a token via `actions/create-github-app-token` using `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` from the `hyperlocalise-web-localize` environment
- Pass that token to `actions/checkout` and `peter-evans/create-pull-request`
- Persist checkout credentials so the app token is available to later git steps (not `GITHUB_TOKEN`)

## Why

The scheduled translation sync was failing when creating pull requests because the workflow token does not have the permissions or bypass rules needed to open PRs against protected branches.

## How to test

1. Confirm the `hyperlocalise-web-localize` environment has `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` configured for the Hyperlocalise GitHub App installation on this repository.
2. Run the **Download Web Translations** job via workflow dispatch (`job: download`).
3. Verify the job creates a branch and opens a PR authored by the GitHub App bot.

## Checklist

- [x] This PR is scoped and ready for review
- [x] No Go or web app code changes; workflow-only update
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f41a6-c883-7636-9873-59c1b32fb8bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f41a6-c883-7636-9873-59c1b32fb8bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

