### PR TITLE
🧪 Scout: reset PO parser state on comments

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -127,3 +127,7 @@
 ## 2025-08-15 - [PHP Hex Escape Robustness]
 **Learning:** PHP's string parser is lenient with invalid hex escape sequences (e.g., `\x` followed by a non-hex character), treating them as literal text rather than fatal errors. Mirroring this behavior in translation parsers prevents unnecessary extraction failures on valid PHP files that happen to contain these sequences.
 **Action:** When parsing escaped sequences in format-specific parsers, prefer falling back to literal text for malformed or incomplete escapes if that matches the source language's runtime behavior.
+
+## 2025-05-23 - [PO Parser Comment State Reset]
+**Learning:** Comments in PO files must reset the `activeField` state, just like ignored fields. If a comment is followed by a continuation line (a quoted string), the continuation would otherwise be incorrectly appended to the last active field (e.g. `msgid` or `msgstr`), leading to data corruption.
+**Action:** Ensure comment line handlers explicitly reset `activeField` to prevent trailing continuations from leaking into preceding entries.

--- a/internal/i18n/translationfileparser/po_parser.go
+++ b/internal/i18n/translationfileparser/po_parser.go
@@ -117,6 +117,7 @@ func consumePOLine(
 		return nil
 	}
 	if strings.HasPrefix(line, "#") {
+		*activeField = ""
 		return nil
 	}
 

--- a/internal/i18n/translationfileparser/po_parser_scout_test.go
+++ b/internal/i18n/translationfileparser/po_parser_scout_test.go
@@ -1,0 +1,33 @@
+package translationfileparser
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPOParserCommentDoesNotLeakContinuation(t *testing.T) {
+	// Continuation lines (quoted strings) following a comment
+	// MUST NOT be appended to the previous valid active field (like msgstr).
+	// This was a bug where comments didn't reset the activeField.
+	content := `msgid "key"
+msgstr "value"
+# This is a comment
+" leaked"
+
+msgid "next"
+msgstr "val"
+`
+	got, err := (POFileParser{}).Parse([]byte(content))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	expected := map[string]string{
+		"key":  "value",
+		"next": "val",
+	}
+
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("got %v, want %v", got, expected)
+	}
+}


### PR DESCRIPTION
💡 What: Fixed a bug in the PO file parser where comments failed to reset the internal state (`activeField`), and added a regression test.

🎯 Why: In the PO format, comments should act as boundaries. If a comment is followed by a quoted string on a new line (a continuation), the parser would incorrectly append that continuation to the previous entry's `msgid` or `msgstr` because it still thought that field was "active".

🧩 Scope: `internal/i18n/translationfileparser/po_parser.go` (fix) and `internal/i18n/translationfileparser/po_parser_scout_test.go` (test).

✅ Verification: 
- Ran `go test -v internal/i18n/translationfileparser/po_parser_scout_test.go` (failed before fix, passed after).
- Ran all tests in `internal/i18n/translationfileparser/` to ensure no regressions.
- Verified with a reproduction script.

🛡️ Confidence: Prevents data corruption in localized PO files when comments are interleaved with multi-line entries.

---
*PR created automatically by Jules for task [3080797856914460260](https://jules.google.com/task/3080797856914460260) started by @cungminh2710*