### PR TITLE
feat(agent): add visual mock workspace tools

### DIFF
--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/slack.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/slack.ts
@@ -24,6 +24,7 @@ import {
 } from "@/lib/agent-runtime/runs/agent-run-events";
 import { db } from "@/lib/database";
 import { env } from "@/lib/env";
+import { resolveWorkspaceVisualMockFlag } from "@/lib/flags/workspace-flags";
 import { createChatLogger, createLogger, serializeErrorForLog } from "@/lib/log";
 import {
   addInteractionMessage,
@@ -398,7 +399,13 @@ async function processSlackMessage(
       }
     }
 
-    const hasTmsIntegration = await resolveOrganizationHasTmsIntegration(organizationId);
+    const [hasTmsIntegration, hasVisualMockSkill] = await Promise.all([
+      resolveOrganizationHasTmsIntegration(organizationId),
+      resolveWorkspaceVisualMockFlag({
+        organizationId,
+        localUserId: membership.localUserId,
+      }),
+    ]);
 
     const agent = createConversationToolLoopAgent({
       surface: "slack",
@@ -413,7 +420,7 @@ async function processSlackMessage(
           ? {
               sandboxId,
               githubContext: resolvedRepositoryContext,
-              workMode: "read_only" as const,
+              workMode: hasVisualMockSkill ? ("write" as const) : ("read_only" as const),
               repositorySource: "slack" as const,
               actor: {
                 sourceUserId: message.author.userId,
@@ -425,6 +432,7 @@ async function processSlackMessage(
       },
       hasFileAttachments: hasTranslationAttachments,
       hasTmsIntegration,
+      hasVisualMockSkill,
       additionalInstructions: [buildFileTranslationInstructions(), repositoryContextInstructions]
         .filter((instruction): instruction is string => instruction !== null)
         .join("\n\n"),

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/conversation.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/conversation.md
@@ -15,7 +15,7 @@ Use the capability skills and tools available for this turn. Match the user's re
 - **find-context** — find localization context for source text or keys using repo-tools
 - **translation-tools** — translate files, images, or inline strings and create translation jobs
 - **web-tools** — fetch public web pages and documentation as markdown
-- **visual-mock** — inspect repository UI code and create or plan mock UI screenshots for visual context
+- **visual-mock** — inspect repository UI code and create or plan mock UI screenshots for visual context when enabled
 
 When multiple capability skills are active, gather repository context before creating translation jobs when both apply.
 

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/conversation.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/conversation.md
@@ -15,6 +15,7 @@ Use the capability skills and tools available for this turn. Match the user's re
 - **find-context** — find localization context for source text or keys using repo-tools
 - **translation-tools** — translate files, images, or inline strings and create translation jobs
 - **web-tools** — fetch public web pages and documentation as markdown
+- **visual-mock** — inspect repository UI code and create or plan mock UI screenshots for visual context
 
 When multiple capability skills are active, gather repository context before creating translation jobs when both apply.
 

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/visual-mock.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/visual-mock.md
@@ -1,6 +1,7 @@
 ---
 id: visual-mock
 requiresSandbox: true
+requiresVisualMockSkill: true
 tools: grep,fuzzySearch,read,glob,todoWrite,write,applyPatch,fetch
 ---
 
@@ -16,6 +17,7 @@ This is an agent workflow skill, not a screenshot product tool. Compose lower-le
 - Inspect the repository for the relevant route, component, design system, fixtures, stories, test data, and styling before inventing UI.
 - Prefer existing UI code, Storybook stories, route fixtures, or small temporary preview files over freehand descriptions.
 - When coding write primitives such as `write` or `apply_patch` are available, use them only for temporary preview scaffolding or narrowly scoped mock fixtures unless the user also asks for a production code change.
+- Do not commit changes, push branches, open pull requests, or publish repository changes. Visual mocks may mutate only the sandbox workspace.
 - When a browser or screenshot primitive is available, render the preview and capture an image. Record the viewport, route or preview file, and any assumptions.
 - When durable file attachment primitives are available, attach the screenshot as an agent artifact with metadata identifying it as `visual-mock`.
 - If write, render, screenshot, or attachment primitives are unavailable, do not claim a screenshot was created. Return a concise mock plan with the target component, data state, viewport, and exact next primitive needed.

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/visual-mock.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/visual-mock.md
@@ -2,7 +2,7 @@
 id: visual-mock
 requiresSandbox: true
 requiresVisualMockSkill: true
-tools: grep,fuzzySearch,read,glob,todoWrite,write,applyPatch,fetch
+tools: grep,fuzzySearch,read,glob,todoWrite,write,applyPatch,captureScreenshot,fetch
 ---
 
 ## Visual mock
@@ -19,6 +19,7 @@ This is an agent workflow skill, not a screenshot product tool. Compose lower-le
 - When coding write primitives such as `write` or `apply_patch` are available, use them only for temporary preview scaffolding or narrowly scoped mock fixtures unless the user also asks for a production code change.
 - Do not commit changes, push branches, open pull requests, or publish repository changes. Visual mocks may mutate only the sandbox workspace.
 - When a browser or screenshot primitive is available, render the preview and capture an image. Record the viewport, route or preview file, and any assumptions.
+- Use `captureScreenshot` for Storybook stories. Provide the Storybook story id and viewport; do not ask for package-manager-specific commands.
 - When durable file attachment primitives are available, attach the screenshot as an agent artifact with metadata identifying it as `visual-mock`.
 - If write, render, screenshot, or attachment primitives are unavailable, do not claim a screenshot was created. Return a concise mock plan with the target component, data state, viewport, and exact next primitive needed.
 

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/visual-mock.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/visual-mock.md
@@ -1,0 +1,39 @@
+---
+id: visual-mock
+requiresSandbox: true
+tools: grep,fuzzySearch,read,glob,todoWrite,write,applyPatch,fetch
+---
+
+## Visual mock
+
+Use this skill when the user asks the Hyperlocalise agent to create or reason from a mock UI screenshot, mocked visual context, generated UI state, wireframe, or screenshot-like preview for a connected repository.
+
+This is an agent workflow skill, not a screenshot product tool. Compose lower-level repository, coding, browser, and storage primitives when they are available.
+
+## Workflow
+
+- Clarify the target screen, state, viewport, and purpose only when they cannot be inferred from the request or repository context.
+- Inspect the repository for the relevant route, component, design system, fixtures, stories, test data, and styling before inventing UI.
+- Prefer existing UI code, Storybook stories, route fixtures, or small temporary preview files over freehand descriptions.
+- When coding write primitives such as `write` or `apply_patch` are available, use them only for temporary preview scaffolding or narrowly scoped mock fixtures unless the user also asks for a production code change.
+- When a browser or screenshot primitive is available, render the preview and capture an image. Record the viewport, route or preview file, and any assumptions.
+- When durable file attachment primitives are available, attach the screenshot as an agent artifact with metadata identifying it as `visual-mock`.
+- If write, render, screenshot, or attachment primitives are unavailable, do not claim a screenshot was created. Return a concise mock plan with the target component, data state, viewport, and exact next primitive needed.
+
+## Mocking rules
+
+- Preserve the product's visible information architecture, component library, color tokens, typography, spacing, and interaction states.
+- Make mock data realistic but clearly non-customer-specific. Do not include secrets, real customer names, emails, tokens, repository names, or raw private content unless already provided by the user for this task.
+- Mark uncertainty in the final answer when layout or data is inferred from partial repository evidence.
+- Keep generated preview scaffolding disposable and easy to remove. Do not leave unrelated refactors behind.
+
+## Output
+
+When a screenshot is created, respond with:
+
+- the screenshot artifact or attachment
+- source state used for the mock
+- viewport
+- assumptions or missing fidelity
+
+When a screenshot cannot be created, respond with the mock plan and the missing capability.

--- a/apps/hyperlocalise-web/src/lib/agent-contracts/repository-workspace-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-contracts/repository-workspace-tools.ts
@@ -7,6 +7,8 @@ export const repositoryWorkspaceToolNames = [
   "detectRepoConfig",
   "gitHistory",
   "todoWrite",
+  "write",
+  "applyPatch",
 ] as const;
 
 /** Extended toolkit for long-running repository workflows. */

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/context.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/context.ts
@@ -10,6 +10,7 @@ export type HyperlocaliseAgentRuntimeContext = {
   toolContext: ToolContext;
   hasFileAttachments: boolean;
   hasTmsIntegration: boolean;
+  hasVisualMockSkill?: boolean;
   additionalInstructions?: string;
 };
 
@@ -45,6 +46,7 @@ export function resolveAgentRuntimeContext(
     toolContext: context.toolContext,
     hasFileAttachments: context.hasFileAttachments ?? false,
     hasTmsIntegration: context.hasTmsIntegration ?? false,
+    hasVisualMockSkill: context.hasVisualMockSkill ?? false,
     additionalInstructions: context.additionalInstructions,
   });
 }

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
@@ -7,6 +7,7 @@ const {
   resolveConversationRepositoryGitHubContextMock,
   createRepositorySandboxMock,
   resolveOrganizationHasTmsIntegrationMock,
+  resolveWorkspaceVisualMockFlagMock,
   getOrganizationRepositoryConnectorConfigMock,
 } = vi.hoisted(() => ({
   classifyConversationMock: vi.fn(),
@@ -15,6 +16,7 @@ const {
   resolveConversationRepositoryGitHubContextMock: vi.fn(),
   createRepositorySandboxMock: vi.fn(),
   resolveOrganizationHasTmsIntegrationMock: vi.fn(),
+  resolveWorkspaceVisualMockFlagMock: vi.fn(),
   getOrganizationRepositoryConnectorConfigMock: vi.fn(
     async (): Promise<Record<string, unknown> | null> => null,
   ),
@@ -69,6 +71,10 @@ vi.mock("../skills/conversation-tms-integration", () => ({
   resolveOrganizationHasTmsIntegration: resolveOrganizationHasTmsIntegrationMock,
 }));
 
+vi.mock("@/lib/flags/workspace-flags", () => ({
+  resolveWorkspaceVisualMockFlag: resolveWorkspaceVisualMockFlagMock,
+}));
+
 vi.mock("@/lib/log", () => ({
   createLogger: vi.fn(() => ({
     child: vi.fn(() => ({
@@ -103,6 +109,7 @@ describe("conversation turn preparation", () => {
       { role: "user", content: "what's the progress of HL test project?" },
     ]);
     resolveOrganizationHasTmsIntegrationMock.mockResolvedValue(true);
+    resolveWorkspaceVisualMockFlagMock.mockResolvedValue(false);
     resolveConversationRepositoryGitHubContextMock.mockResolvedValue({
       status: "not_applicable",
     });
@@ -283,6 +290,52 @@ describe("conversation turn preparation", () => {
     );
     expect(result.updatedRepositorySession?.repositorySandboxSession?.sandboxId).toBe(
       "sandbox_123",
+    );
+  });
+
+  it("passes a chat UI actor when visual-mock enables repository writes", async () => {
+    const githubContext = {
+      resolved: true as const,
+      installationId: 42,
+      repositoryFullName: "acme/web",
+    };
+    classifyConversationMock.mockResolvedValue({
+      ...baseClassification,
+      needsRepositoryTools: true,
+    });
+    resolveConversationRepositoryGitHubContextMock.mockResolvedValue({
+      status: "resolved",
+      source: "single_installed_repository",
+      context: githubContext,
+    });
+    createRepositorySandboxMock.mockResolvedValue("sandbox_123");
+    resolveWorkspaceVisualMockFlagMock.mockResolvedValue(true);
+
+    await prepareConversationAgentTurn({
+      surface: "web",
+      conversationId: "conv_123",
+      organizationId: "org_123",
+      localUserId: "user_123",
+      membershipRole: "admin",
+      projectId: null,
+      messageText: "mock the checkout screen",
+      hasTranslationAttachments: false,
+      db: {} as never,
+    });
+
+    expect(createConversationToolLoopAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolContext: expect.objectContaining({
+          sandboxId: "sandbox_123",
+          repositorySource: "chat_ui",
+          workMode: "write",
+          actor: {
+            sourceUserId: "user_123",
+            userId: "user_123",
+            role: "admin",
+          },
+        }),
+      }),
     );
   });
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
@@ -283,6 +283,16 @@ export type PrepareConversationAgentTurnResult = {
   repositorySandboxId: string | null;
 };
 
+function resolveConversationActor(input: PrepareConversationAgentTurnInput): ToolContext["actor"] {
+  return (
+    input.actor ?? {
+      sourceUserId: input.localUserId,
+      userId: input.localUserId,
+      role: input.membershipRole,
+    }
+  );
+}
+
 export async function prepareConversationAgentTurn(
   input: PrepareConversationAgentTurnInput,
 ): Promise<PrepareConversationAgentTurnResult> {
@@ -366,7 +376,7 @@ export async function prepareConversationAgentTurn(
             githubContext: activeRepositoryContext,
             workMode: hasVisualMockSkill ? ("write" as const) : ("read_only" as const),
             repositorySource: input.repositorySource ?? "chat_ui",
-            actor: input.actor,
+            actor: resolveConversationActor(input),
           }
         : {}),
     },

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
@@ -32,6 +32,7 @@ import {
   getRepositoryContextKey,
   type ConversationRepositorySession,
 } from "./conversation-repository-session";
+import { resolveWorkspaceVisualMockFlag } from "@/lib/flags/workspace-flags";
 
 const logger = createLogger("conversation-turn");
 
@@ -339,7 +340,14 @@ export async function prepareConversationAgentTurn(
     }
   }
 
-  const hasTmsIntegration = await resolveOrganizationHasTmsIntegration(input.organizationId);
+  const [hasTmsIntegration, hasVisualMockSkill] = await Promise.all([
+    resolveOrganizationHasTmsIntegration(input.organizationId),
+    resolveWorkspaceVisualMockFlag({
+      organizationId: input.organizationId,
+      localUserId: input.localUserId,
+      dbClient: input.db,
+    }),
+  ]);
 
   const preparedMessages = replaceLastUserMessage(chatMessages, input.messageText);
 
@@ -356,7 +364,7 @@ export async function prepareConversationAgentTurn(
         ? {
             sandboxId,
             githubContext: activeRepositoryContext,
-            workMode: "read_only" as const,
+            workMode: hasVisualMockSkill ? ("write" as const) : ("read_only" as const),
             repositorySource: input.repositorySource ?? "chat_ui",
             actor: input.actor,
           }
@@ -364,6 +372,7 @@ export async function prepareConversationAgentTurn(
     },
     hasFileAttachments: input.hasTranslationAttachments,
     hasTmsIntegration,
+    hasVisualMockSkill,
     additionalInstructions: [buildFileTranslationInstructions(), repositoryInstructions]
       .filter((instruction): instruction is string => instruction !== null)
       .join("\n\n"),

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/hyperlocalise-agent.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/hyperlocalise-agent.ts
@@ -154,15 +154,18 @@ export function createConversationToolLoopAgent({
   onFinish,
   hasFileAttachments = false,
   hasTmsIntegration = false,
+  hasVisualMockSkill = false,
 }: CreateConversationAgentInput & {
   hasFileAttachments?: boolean;
   hasTmsIntegration?: boolean;
+  hasVisualMockSkill?: boolean;
 }) {
   const runtime: HyperlocaliseAgentRuntimeContext = {
     surface,
     toolContext,
     hasFileAttachments,
     hasTmsIntegration,
+    hasVisualMockSkill,
     additionalInstructions: additionalInstructions?.trim() || undefined,
   };
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
@@ -314,16 +314,64 @@ describe("conversation skill registry", () => {
           conversationId: "conv_1",
           organizationId: "org_1",
           localUserId: "user_1",
-          membershipRole: "member",
+          membershipRole: "admin",
           projectId: null,
           db: {} as never,
           sandboxId: "sbx_1",
           workMode: "write",
+          repositorySource: "chat_ui",
+          actor: { sourceUserId: "user_1", role: "admin" },
         },
       },
     );
 
     expect(toolNames).toEqual(["grep", "write", "applyPatch", "captureScreenshot"]);
+  });
+
+  it("hides repository write tools when the write gate rejects the actor", () => {
+    const toolNames = filterAvailableConversationToolNames(
+      ["grep", "write", "applyPatch", "captureScreenshot"],
+      {
+        hasFileAttachments: false,
+        toolContext: {
+          conversationId: "conv_1",
+          organizationId: "org_1",
+          localUserId: "user_1",
+          membershipRole: "member",
+          projectId: null,
+          db: {} as never,
+          sandboxId: "sbx_1",
+          workMode: "write",
+          repositorySource: "slack",
+          actor: { sourceUserId: "U1", role: "member" },
+        },
+      },
+    );
+
+    expect(toolNames).toEqual(["grep"]);
+  });
+
+  it("hides repository write tools for chat members without job write access", () => {
+    const toolNames = filterAvailableConversationToolNames(
+      ["grep", "write", "applyPatch", "captureScreenshot"],
+      {
+        hasFileAttachments: false,
+        toolContext: {
+          conversationId: "conv_1",
+          organizationId: "org_1",
+          localUserId: "user_1",
+          membershipRole: "member",
+          projectId: null,
+          db: {} as never,
+          sandboxId: "sbx_1",
+          workMode: "write",
+          repositorySource: "chat_ui",
+          actor: { sourceUserId: "user_1", role: "member" },
+        },
+      },
+    );
+
+    expect(toolNames).toEqual(["grep"]);
   });
 
   it("parses comma-separated frontmatter values", () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
@@ -63,7 +63,17 @@ describe("conversation skill registry", () => {
     expect(visualMockSkill).toMatchObject({
       requiresSandbox: true,
       requiresVisualMockSkill: true,
-      tools: ["grep", "fuzzySearch", "read", "glob", "todoWrite", "write", "applyPatch", "fetch"],
+      tools: [
+        "grep",
+        "fuzzySearch",
+        "read",
+        "glob",
+        "todoWrite",
+        "write",
+        "applyPatch",
+        "captureScreenshot",
+        "fetch",
+      ],
     });
   });
 
@@ -275,39 +285,45 @@ describe("conversation skill registry", () => {
   });
 
   it("gates repository write tools from read-only conversation runtimes", () => {
-    const toolNames = filterAvailableConversationToolNames(["grep", "write", "applyPatch"], {
-      hasFileAttachments: false,
-      toolContext: {
-        conversationId: "conv_1",
-        organizationId: "org_1",
-        localUserId: "user_1",
-        membershipRole: "member",
-        projectId: null,
-        db: {} as never,
-        sandboxId: "sbx_1",
-        workMode: "read_only",
+    const toolNames = filterAvailableConversationToolNames(
+      ["grep", "write", "applyPatch", "captureScreenshot"],
+      {
+        hasFileAttachments: false,
+        toolContext: {
+          conversationId: "conv_1",
+          organizationId: "org_1",
+          localUserId: "user_1",
+          membershipRole: "member",
+          projectId: null,
+          db: {} as never,
+          sandboxId: "sbx_1",
+          workMode: "read_only",
+        },
       },
-    });
+    );
 
     expect(toolNames).toEqual(["grep"]);
   });
 
   it("allows repository write tools for write-enabled conversation runtimes", () => {
-    const toolNames = filterAvailableConversationToolNames(["grep", "write", "applyPatch"], {
-      hasFileAttachments: false,
-      toolContext: {
-        conversationId: "conv_1",
-        organizationId: "org_1",
-        localUserId: "user_1",
-        membershipRole: "member",
-        projectId: null,
-        db: {} as never,
-        sandboxId: "sbx_1",
-        workMode: "write",
+    const toolNames = filterAvailableConversationToolNames(
+      ["grep", "write", "applyPatch", "captureScreenshot"],
+      {
+        hasFileAttachments: false,
+        toolContext: {
+          conversationId: "conv_1",
+          organizationId: "org_1",
+          localUserId: "user_1",
+          membershipRole: "member",
+          projectId: null,
+          db: {} as never,
+          sandboxId: "sbx_1",
+          workMode: "write",
+        },
       },
-    });
+    );
 
-    expect(toolNames).toEqual(["grep", "write", "applyPatch"]);
+    expect(toolNames).toEqual(["grep", "write", "applyPatch", "captureScreenshot"]);
   });
 
   it("parses comma-separated frontmatter values", () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
@@ -24,6 +24,7 @@ describe("conversation skill registry", () => {
         "repo-tools",
         "tms-tools",
         "translation-tools",
+        "visual-mock",
       ]),
     );
 
@@ -56,6 +57,12 @@ describe("conversation skill registry", () => {
     expect(repoToolsSkill).toMatchObject({
       requiresSandbox: true,
       tools: ["grep", "fuzzySearch", "read", "glob", "detectRepoConfig", "gitHistory", "todoWrite"],
+    });
+
+    const visualMockSkill = skills.find((skill) => skill.id === "visual-mock");
+    expect(visualMockSkill).toMatchObject({
+      requiresSandbox: true,
+      tools: ["grep", "fuzzySearch", "read", "glob", "todoWrite", "write", "applyPatch", "fetch"],
     });
   });
 
@@ -131,6 +138,30 @@ describe("conversation skill registry", () => {
     expect(
       isConversationSkillActivated(
         repoToolsSkill!,
+        toConversationSkillActivationContext({
+          hasFileAttachments: false,
+          hasTmsIntegration: false,
+          toolContext: {
+            conversationId: "conv_1",
+            organizationId: "org_1",
+            localUserId: "user_1",
+            membershipRole: "member",
+            projectId: null,
+            db: {} as never,
+            sandboxId: "sbx_1",
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("activates visual-mock when a sandbox is available", () => {
+    const visualMockSkill = listConversationSkills().find((skill) => skill.id === "visual-mock");
+    expect(visualMockSkill).toBeDefined();
+
+    expect(
+      isConversationSkillActivated(
+        visualMockSkill!,
         toConversationSkillActivationContext({
           hasFileAttachments: false,
           hasTmsIntegration: false,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
@@ -62,6 +62,7 @@ describe("conversation skill registry", () => {
     const visualMockSkill = skills.find((skill) => skill.id === "visual-mock");
     expect(visualMockSkill).toMatchObject({
       requiresSandbox: true,
+      requiresVisualMockSkill: true,
       tools: ["grep", "fuzzySearch", "read", "glob", "todoWrite", "write", "applyPatch", "fetch"],
     });
   });
@@ -155,7 +156,7 @@ describe("conversation skill registry", () => {
     ).toBe(true);
   });
 
-  it("activates visual-mock when a sandbox is available", () => {
+  it("activates visual-mock when a sandbox is available and the flag is enabled", () => {
     const visualMockSkill = listConversationSkills().find((skill) => skill.id === "visual-mock");
     expect(visualMockSkill).toBeDefined();
 
@@ -165,6 +166,7 @@ describe("conversation skill registry", () => {
         toConversationSkillActivationContext({
           hasFileAttachments: false,
           hasTmsIntegration: false,
+          hasVisualMockSkill: true,
           toolContext: {
             conversationId: "conv_1",
             organizationId: "org_1",
@@ -173,10 +175,37 @@ describe("conversation skill registry", () => {
             projectId: null,
             db: {} as never,
             sandboxId: "sbx_1",
+            workMode: "read_only",
           },
         }),
       ),
     ).toBe(true);
+  });
+
+  it("does not activate visual-mock when the flag is disabled", () => {
+    const visualMockSkill = listConversationSkills().find((skill) => skill.id === "visual-mock");
+    expect(visualMockSkill).toBeDefined();
+
+    expect(
+      isConversationSkillActivated(
+        visualMockSkill!,
+        toConversationSkillActivationContext({
+          hasFileAttachments: false,
+          hasTmsIntegration: false,
+          hasVisualMockSkill: false,
+          toolContext: {
+            conversationId: "conv_1",
+            organizationId: "org_1",
+            localUserId: "user_1",
+            membershipRole: "member",
+            projectId: null,
+            db: {} as never,
+            sandboxId: "sbx_1",
+            workMode: "read_only",
+          },
+        }),
+      ),
+    ).toBe(false);
   });
 
   it("always activates translation-tools", () => {
@@ -245,6 +274,42 @@ describe("conversation skill registry", () => {
     expect(toolNames).toEqual(["translate_string", "list_projects"]);
   });
 
+  it("gates repository write tools from read-only conversation runtimes", () => {
+    const toolNames = filterAvailableConversationToolNames(["grep", "write", "applyPatch"], {
+      hasFileAttachments: false,
+      toolContext: {
+        conversationId: "conv_1",
+        organizationId: "org_1",
+        localUserId: "user_1",
+        membershipRole: "member",
+        projectId: null,
+        db: {} as never,
+        sandboxId: "sbx_1",
+        workMode: "read_only",
+      },
+    });
+
+    expect(toolNames).toEqual(["grep"]);
+  });
+
+  it("allows repository write tools for write-enabled conversation runtimes", () => {
+    const toolNames = filterAvailableConversationToolNames(["grep", "write", "applyPatch"], {
+      hasFileAttachments: false,
+      toolContext: {
+        conversationId: "conv_1",
+        organizationId: "org_1",
+        localUserId: "user_1",
+        membershipRole: "member",
+        projectId: null,
+        db: {} as never,
+        sandboxId: "sbx_1",
+        workMode: "write",
+      },
+    });
+
+    expect(toolNames).toEqual(["grep", "write", "applyPatch"]);
+  });
+
   it("parses comma-separated frontmatter values", () => {
     expect(
       parseConversationSkillMetadata({
@@ -253,6 +318,7 @@ describe("conversation skill registry", () => {
           tools: "list_projects, check_crowdin_progress",
           sharedSkills: "crowdin",
           requiresTmsIntegration: "true",
+          requiresVisualMockSkill: "true",
         },
         body: "",
       }),
@@ -260,6 +326,7 @@ describe("conversation skill registry", () => {
       tools: ["list_projects", "check_crowdin_progress"],
       sharedSkills: ["crowdin"],
       requiresTmsIntegration: true,
+      requiresVisualMockSkill: true,
     });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.ts
@@ -7,6 +7,7 @@ import { createTranslateStringTool } from "@/agents/_runtime/shared-tools/transl
 import type { HyperlocaliseAgentRuntimeContext } from "@/lib/agent-runtime/context";
 import { repositoryWorkspaceToolNames } from "@/lib/agent-contracts/repository-workspace-tools";
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
+import { assertRepositoryWriteAllowed } from "@/lib/agent-runtime/tools/policy";
 import { createSandboxRepoBash } from "@/lib/agent-runtime/workspaces/sandbox-repo-bash";
 import { buildTools, buildWorkspaceTools } from "@/lib/agent-runtime/tools/registry";
 import {
@@ -190,8 +191,11 @@ export function filterAvailableConversationToolNames(
   runtime: Pick<HyperlocaliseAgentRuntimeContext, "hasFileAttachments" | "toolContext">,
 ): string[] {
   return toolNames.filter((toolName) => {
-    if (REPO_WRITE_TOOL_NAMES.has(toolName) && runtime.toolContext.workMode !== "write") {
-      return false;
+    if (REPO_WRITE_TOOL_NAMES.has(toolName)) {
+      const gate = assertRepositoryWriteAllowed(runtime.toolContext, "apply_fixes");
+      if (!gate.allowed) {
+        return false;
+      }
     }
 
     if (

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.ts
@@ -17,10 +17,10 @@ import {
 
 const CONVERSATION_AGENT_ID = "hyperlocalise";
 
-const REPO_TOOL_NAMES = new Set<string>(repositoryWorkspaceToolNames);
+const REPO_TOOL_NAMES = new Set<string>([...repositoryWorkspaceToolNames, "captureScreenshot"]);
 const WEB_TOOL_NAMES = new Set(["fetch"]);
 const FILE_JOB_GATED_TOOL_NAMES = new Set(["createTranslationJob"]);
-const REPO_WRITE_TOOL_NAMES = new Set(["write", "applyPatch"]);
+const REPO_WRITE_TOOL_NAMES = new Set(["write", "applyPatch", "captureScreenshot"]);
 
 export type ConversationSkillMetadata = {
   id: string;

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.ts
@@ -20,6 +20,7 @@ const CONVERSATION_AGENT_ID = "hyperlocalise";
 const REPO_TOOL_NAMES = new Set<string>(repositoryWorkspaceToolNames);
 const WEB_TOOL_NAMES = new Set(["fetch"]);
 const FILE_JOB_GATED_TOOL_NAMES = new Set(["createTranslationJob"]);
+const REPO_WRITE_TOOL_NAMES = new Set(["write", "applyPatch"]);
 
 export type ConversationSkillMetadata = {
   id: string;
@@ -29,6 +30,7 @@ export type ConversationSkillMetadata = {
   requiresTmsIntegration: boolean;
   requiresFileAttachments?: boolean;
   requiresProjectOrAttachments: boolean;
+  requiresVisualMockSkill: boolean;
   tools: string[];
   sharedSkills: string[];
 };
@@ -44,6 +46,7 @@ export type ConversationSkillActivationContext = {
   hasProjectId: boolean;
   hasSandbox: boolean;
   hasTmsIntegration: boolean;
+  hasVisualMockSkill: boolean;
 };
 
 type ConversationSkillToolFactory = (toolContext: ToolContext) => ToolSet[string];
@@ -91,6 +94,7 @@ export function parseConversationSkillMetadata(
     requiresTmsIntegration: frontmatter.requiresTmsIntegration === "true",
     requiresFileAttachments: parseBooleanFlag(frontmatter.requiresFileAttachments),
     requiresProjectOrAttachments: frontmatter.requiresProjectOrAttachments === "true",
+    requiresVisualMockSkill: frontmatter.requiresVisualMockSkill === "true",
     tools: parseCommaSeparated(frontmatter.tools),
     sharedSkills: parseCommaSeparated(frontmatter.sharedSkills),
   };
@@ -104,7 +108,7 @@ export function listConversationSkills(): ConversationSkillMetadata[] {
 export function toConversationSkillActivationContext(
   runtime: Pick<
     HyperlocaliseAgentRuntimeContext,
-    "hasFileAttachments" | "hasTmsIntegration" | "toolContext"
+    "hasFileAttachments" | "hasTmsIntegration" | "hasVisualMockSkill" | "toolContext"
   >,
 ): ConversationSkillActivationContext {
   return {
@@ -112,6 +116,7 @@ export function toConversationSkillActivationContext(
     hasProjectId: Boolean(runtime.toolContext.projectId),
     hasSandbox: Boolean(runtime.toolContext.sandboxId),
     hasTmsIntegration: runtime.hasTmsIntegration,
+    hasVisualMockSkill: runtime.hasVisualMockSkill ?? false,
   };
 }
 
@@ -147,12 +152,17 @@ export function isConversationSkillActivated(
     return false;
   }
 
+  if (skill.requiresVisualMockSkill && !context.hasVisualMockSkill) {
+    return false;
+  }
+
   const hasActivationRule =
     skill.requiresSandbox ||
     skill.requiresTmsIntegration ||
     skill.requiresProjectId ||
     skill.requiresFileAttachments !== undefined ||
-    skill.requiresProjectOrAttachments;
+    skill.requiresProjectOrAttachments ||
+    skill.requiresVisualMockSkill;
 
   return hasActivationRule;
 }
@@ -160,7 +170,7 @@ export function isConversationSkillActivated(
 export function buildConversationSkillPlan(
   runtime: Pick<
     HyperlocaliseAgentRuntimeContext,
-    "hasFileAttachments" | "hasTmsIntegration" | "toolContext"
+    "hasFileAttachments" | "hasTmsIntegration" | "hasVisualMockSkill" | "toolContext"
   >,
 ): ConversationSkillPlan {
   const context = toConversationSkillActivationContext(runtime);
@@ -180,6 +190,10 @@ export function filterAvailableConversationToolNames(
   runtime: Pick<HyperlocaliseAgentRuntimeContext, "hasFileAttachments" | "toolContext">,
 ): string[] {
   return toolNames.filter((toolName) => {
+    if (REPO_WRITE_TOOL_NAMES.has(toolName) && runtime.toolContext.workMode !== "write") {
+      return false;
+    }
+
     if (
       FILE_JOB_GATED_TOOL_NAMES.has(toolName) &&
       !runtime.toolContext.projectId &&

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/manifest.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/manifest.ts
@@ -60,6 +60,18 @@ export const toolManifests = [
     requiredWorkspaceCapability: "repo_read",
   },
   {
+    name: "write",
+    domain: "repo",
+    sideEffect: "workspace_write",
+    requiredWorkspaceCapability: "repo_write",
+  },
+  {
+    name: "applyPatch",
+    domain: "repo",
+    sideEffect: "workspace_write",
+    requiredWorkspaceCapability: "repo_write",
+  },
+  {
     name: "detectRepoConfig",
     domain: "repo",
     sideEffect: "none",

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/manifest.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/manifest.ts
@@ -72,6 +72,12 @@ export const toolManifests = [
     requiredWorkspaceCapability: "repo_write",
   },
   {
+    name: "captureScreenshot",
+    domain: "repo",
+    sideEffect: "workspace_write",
+    requiredWorkspaceCapability: "repo_write",
+  },
+  {
     name: "detectRepoConfig",
     domain: "repo",
     sideEffect: "none",

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/registry.test.ts
@@ -36,6 +36,7 @@ describe("agent-runtime tool registry", () => {
     expect(tools.detectRepoConfig).toBeDefined();
     expect(tools.gitHistory).toBeDefined();
     expect(tools.bash).toBeDefined();
+    expect(tools.captureScreenshot).toBeDefined();
     expect(tools.todoWrite).toBeDefined();
     expect(tools.applyHyperlocaliseFixes).toBeUndefined();
   });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/registry.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/registry.ts
@@ -16,6 +16,7 @@ import { wrapToolSetWithLogging } from "./tool-logging";
 import {
   createBashTool,
   createApplyPatchTool,
+  createCaptureScreenshotTool,
   createFetchTool,
   createFuzzySearchTool,
   createGlobTool,
@@ -59,6 +60,9 @@ function createWorkspaceTools(ctx: ToolContext, repoBash: RepoToolContext): Tool
   }
   if (policy.isToolAllowed("applyPatch")) {
     tools.applyPatch = createApplyPatchTool(ctx, repoBash);
+  }
+  if (policy.isToolAllowed("captureScreenshot")) {
+    tools.captureScreenshot = createCaptureScreenshotTool(ctx, repoBash);
   }
   if (policy.isToolAllowed("fetch")) {
     tools.fetch = createFetchTool();

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/registry.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/registry.ts
@@ -15,12 +15,14 @@ import { resolveToolPolicy } from "./policy";
 import { wrapToolSetWithLogging } from "./tool-logging";
 import {
   createBashTool,
+  createApplyPatchTool,
   createFetchTool,
   createFuzzySearchTool,
   createGlobTool,
   createGrepTool,
   createReadTool,
   createTodoWriteTool,
+  createWriteTool,
   type RepoToolContext,
 } from "./workspace";
 
@@ -51,6 +53,12 @@ function createWorkspaceTools(ctx: ToolContext, repoBash: RepoToolContext): Tool
   }
   if (policy.isToolAllowed("bash")) {
     tools.bash = createBashTool(repoBash);
+  }
+  if (policy.isToolAllowed("write")) {
+    tools.write = createWriteTool(ctx, repoBash);
+  }
+  if (policy.isToolAllowed("applyPatch")) {
+    tools.applyPatch = createApplyPatchTool(ctx, repoBash);
   }
   if (policy.isToolAllowed("fetch")) {
     tools.fetch = createFetchTool();
@@ -86,7 +94,7 @@ export function buildTools(ctx: ToolContext): ToolSet {
   }
 
   if (ctx.sandboxId) {
-    const repoBash = createSandboxRepoBash(ctx.sandboxId) as Bash;
+    const repoBash = createSandboxRepoBash(ctx.sandboxId) as Bash & RepoToolContext["bash"];
     Object.assign(tools, createWorkspaceTools(ctx, { bash: repoBash }));
   } else if (policy.isToolAllowed("fetch")) {
     tools.fetch = createFetchTool();

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/apply-patch.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/apply-patch.ts
@@ -1,0 +1,135 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+import type { ToolContext } from "@/lib/agent-contracts/tool-context";
+import { assertRepositoryWriteAllowed } from "@/lib/agent-runtime/tools/policy";
+
+import { normalizeWorkspacePath } from "./path";
+import { DEFAULT_MAX_OUTPUT_BYTES, redact, truncate } from "./redact";
+import type { RepoToolContext } from "./types";
+
+const applyPatchInputSchema = z.object({
+  patch: z.string().describe("Unified diff patch to apply with git apply."),
+});
+
+function stripDiffPathPrefix(path: string) {
+  return path.replace(/^(?:a|b)\//, "");
+}
+
+function parsePatchPath(value: string) {
+  const path = value.trim().split(/\s+/)[0];
+  if (!path || path === "/dev/null") {
+    return null;
+  }
+  return normalizeWorkspacePath(stripDiffPathPrefix(path));
+}
+
+function extractPatchPaths(patch: string): { paths: string[]; error?: string } {
+  const paths = new Set<string>();
+
+  for (const line of patch.split("\n")) {
+    if (!line.startsWith("--- ") && !line.startsWith("+++ ")) {
+      continue;
+    }
+
+    const path = parsePatchPath(line.slice(4));
+    if (!path) {
+      if (!line.includes("/dev/null")) {
+        return { paths: [], error: "Patch contains a path outside the workspace." };
+      }
+      continue;
+    }
+    paths.add(path);
+  }
+
+  return { paths: [...paths] };
+}
+
+export function createApplyPatchTool(ctx: ToolContext, repo: RepoToolContext) {
+  return tool({
+    description: `Apply a unified diff patch to files in the connected repository workspace.
+
+WHEN TO USE:
+- Small or multi-file edits where a unified diff is clearer than rewriting whole files
+- Temporary mock UI scaffolding that should be easy to review and revert
+
+WHEN NOT TO USE:
+- Creating a full new generated file from scratch (use write)
+- Patches that touch paths outside the repository workspace
+
+IMPORTANT:
+- The patch is validated with git apply --check before it is applied
+- This is a repository write action and may be denied by workspace policy`,
+    inputSchema: applyPatchInputSchema,
+    execute: async ({ patch }) => {
+      const gate = assertRepositoryWriteAllowed(ctx, "apply_fixes");
+      if (!gate.allowed) {
+        return { success: false as const, error: gate.reason };
+      }
+      if (!repo.bash.writeWorkspaceFile) {
+        return {
+          success: false as const,
+          error: "Workspace write support is not available for this tool.",
+        };
+      }
+
+      if (!patch.trim()) {
+        return { success: false as const, error: "Patch is empty." };
+      }
+
+      const { paths, error } = extractPatchPaths(patch);
+      if (error) {
+        return { success: false as const, error };
+      }
+      if (paths.length === 0) {
+        return { success: false as const, error: "Patch does not contain any file paths." };
+      }
+
+      const patchPath = `.hyperlocalise-agent/patches/${crypto.randomUUID()}.diff`;
+
+      try {
+        await repo.bash.writeWorkspaceFile(patchPath, patch);
+
+        const checkResult = await repo.bash.exec("git", {
+          args: ["apply", "--check", patchPath],
+        });
+        if (checkResult.exitCode !== 0) {
+          const output = truncate(
+            redact([checkResult.stdout, checkResult.stderr].filter(Boolean).join("\n")),
+            DEFAULT_MAX_OUTPUT_BYTES,
+          );
+          return {
+            success: false as const,
+            error: output.text || "Patch failed validation.",
+            changedPaths: paths,
+            truncated: output.truncated,
+          };
+        }
+
+        const applyResult = await repo.bash.exec("git", {
+          args: ["apply", patchPath],
+        });
+        const output = truncate(
+          redact([applyResult.stdout, applyResult.stderr].filter(Boolean).join("\n")),
+          DEFAULT_MAX_OUTPUT_BYTES,
+        );
+
+        return {
+          success: applyResult.exitCode === 0,
+          changedPaths: paths,
+          output: output.text,
+          truncated: output.truncated,
+          ...(applyResult.exitCode === 0 ? {} : { error: output.text || "Patch failed." }),
+        };
+      } catch (caught) {
+        return {
+          success: false as const,
+          changedPaths: paths,
+          error: redact(caught instanceof Error ? caught.message : String(caught)),
+        };
+      } finally {
+        await repo.bash.exec("rm", { args: ["-f", patchPath] }).catch(() => undefined);
+      }
+    },
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import type { ToolContext } from "@/lib/agent-contracts/tool-context";
+import { createStoredFile } from "@/lib/file-storage/records";
+
+import {
+  classifyScreenshotCaptureFailure,
+  createCaptureScreenshotTool,
+  detectPackageManager,
+  detectStorybookScreenshotCommand,
+} from "./capture-screenshot";
+import type { RepoToolContext } from "./types";
+
+vi.mock("@/lib/file-storage/records", () => ({
+  createStoredFile: vi.fn(),
+}));
+
+const toolCallInfo = { toolCallId: "test-tool-call", messages: [] };
+
+function createToolContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    conversationId: "conv_1",
+    organizationId: "org_1",
+    localUserId: "user_1",
+    membershipRole: "admin",
+    projectId: "project_1",
+    db: {} as never,
+    workMode: "write",
+    repositorySource: "chat_ui",
+    actor: { sourceUserId: "user_1", role: "admin" },
+    sandboxId: "sbx_1",
+    ...overrides,
+  };
+}
+
+function createRepoContext(input: {
+  packageJson: Record<string, unknown>;
+  lockfiles?: readonly string[];
+  execResult?: { exitCode: number; stdout: string; stderr: string };
+}) {
+  const lockfiles = new Set(input.lockfiles ?? []);
+  const writtenFiles = new Map<string, string | Buffer>();
+  const exec = vi.fn(async () => ({
+    exitCode: input.execResult?.exitCode ?? 0,
+    stdout: input.execResult?.stdout ?? Buffer.from("png-bytes").toString("base64"),
+    stderr: input.execResult?.stderr ?? "",
+    env: {},
+  }));
+  const readFile = vi.fn(async (path: string) => {
+    if (path === "package.json") {
+      return JSON.stringify(input.packageJson);
+    }
+    if (lockfiles.has(path)) {
+      return "";
+    }
+    throw new Error(`Failed to read ${path}`);
+  });
+  const writeWorkspaceFile = vi.fn(async (path: string, content: string | Buffer) => {
+    writtenFiles.set(path, content);
+  });
+  const repo: RepoToolContext = {
+    bash: {
+      exec,
+      readFile,
+      writeWorkspaceFile,
+    },
+  };
+
+  return { exec, readFile, repo, writeWorkspaceFile, writtenFiles };
+}
+
+describe("detectPackageManager", () => {
+  it("prefers the packageManager field", () => {
+    expect(
+      detectPackageManager({
+        packageJson: { packageManager: "pnpm@11.9.0" },
+        lockfiles: ["package-lock.json"],
+      }),
+    ).toBe("pnpm");
+  });
+
+  it("falls back to lockfiles", () => {
+    expect(detectPackageManager({ packageJson: {}, lockfiles: ["yarn.lock"] })).toBe("yarn");
+  });
+});
+
+describe("detectStorybookScreenshotCommand", () => {
+  it("builds a generic Storybook command from package metadata", () => {
+    expect(
+      detectStorybookScreenshotCommand({
+        packageJson: {
+          packageManager: "pnpm@11.9.0",
+          scripts: { storybook: "storybook dev" },
+        },
+        port: 6123,
+      }),
+    ).toMatchObject({
+      packageManager: "pnpm",
+      scriptName: "storybook",
+      command: "pnpm",
+      args: ["run", "storybook", "--", "--port", "6123", "--host", "127.0.0.1", "--ci"],
+    });
+  });
+
+  it("reports when no supported Storybook script exists", () => {
+    expect(detectStorybookScreenshotCommand({ packageJson: { scripts: { dev: "vite" } } })).toEqual(
+      { errorCode: "storybook_script_not_found" },
+    );
+  });
+});
+
+describe("classifyScreenshotCaptureFailure", () => {
+  it("maps managed browser runtime sentinels to structured error codes", () => {
+    expect(
+      classifyScreenshotCaptureFailure(
+        "npm failed\nHYPERLOCALISE_SCREENSHOT_ERROR_CODE=browser_runtime_install_failed",
+      ),
+    ).toBe("browser_runtime_install_failed");
+    expect(
+      classifyScreenshotCaptureFailure(
+        "chromium failed\nHYPERLOCALISE_SCREENSHOT_ERROR_CODE=browser_binary_unavailable",
+      ),
+    ).toBe("browser_binary_unavailable");
+    expect(classifyScreenshotCaptureFailure("storybook failed")).toBe("screenshot_capture_failed");
+  });
+});
+
+describe("createCaptureScreenshotTool", () => {
+  it("captures a Storybook screenshot using a managed browser runtime", async () => {
+    vi.mocked(createStoredFile).mockResolvedValueOnce({
+      id: "file_1",
+      organizationId: "org_1",
+      projectId: "project_1",
+      createdByUserId: "user_1",
+      role: "reference",
+      sourceKind: "repository_file",
+      sourceInteractionId: "conv_1",
+      sourceJobId: null,
+      storageProvider: "vercel_blob",
+      storageKey: "organizations/org_1/files/file_1/storybook.png",
+      storageUrl: "https://blob.example/storybook.png",
+      downloadUrl: "https://download.example/storybook.png",
+      filename: "storybook-components-button--primary.png",
+      contentType: "image/png",
+      byteSize: 9,
+      sha256: "hash",
+      etag: null,
+      metadata: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const { exec, repo, writeWorkspaceFile } = createRepoContext({
+      packageJson: {
+        packageManager: "pnpm@11.9.0",
+        scripts: { storybook: "storybook dev" },
+      },
+      lockfiles: ["pnpm-lock.yaml"],
+    });
+    const captureScreenshot = createCaptureScreenshotTool(createToolContext(), repo);
+
+    const result = await captureScreenshot.execute!(
+      {
+        target: { type: "storybook", storyId: "components-button--primary" },
+        viewport: { width: 1280, height: 720 },
+      },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      fileId: "file_1",
+      url: "https://download.example/storybook.png",
+      target: { type: "storybook", storyId: "components-button--primary" },
+      viewport: { width: 1280, height: 720 },
+    });
+    expect(writeWorkspaceFile).toHaveBeenCalledWith(
+      expect.stringMatching(/^\.hyperlocalise-agent\/screenshots\/.+\/capture\.cjs$/),
+      expect.stringContaining(
+        'require("/tmp/hyperlocalise-browser-runtime/node_modules/playwright")',
+      ),
+    );
+    expect(exec).toHaveBeenCalledWith("bash", {
+      args: [
+        "-lc",
+        expect.stringContaining("npm --prefix '/tmp/hyperlocalise-browser-runtime' install"),
+      ],
+    });
+    expect(exec).toHaveBeenCalledWith("bash", {
+      args: ["-lc", expect.stringContaining("'pnpm' 'run' 'storybook'")],
+    });
+    expect(createStoredFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: "org_1",
+        projectId: "project_1",
+        createdByUserId: "user_1",
+        role: "reference",
+        sourceKind: "repository_file",
+        sourceInteractionId: "conv_1",
+        filename: "storybook-components-button--primary.png",
+        contentType: "image/png",
+        content: Buffer.from("png-bytes"),
+        metadata: expect.objectContaining({
+          kind: "visual-mock",
+          targetType: "storybook",
+          storyId: "components-button--primary",
+        }),
+      }),
+    );
+  });
+
+  it("returns a structured failure when managed Chromium install fails", async () => {
+    const { repo } = createRepoContext({
+      packageJson: {
+        scripts: { storybook: "storybook dev" },
+      },
+      execResult: {
+        exitCode: 88,
+        stdout: "",
+        stderr: "HYPERLOCALISE_SCREENSHOT_ERROR_CODE=browser_binary_unavailable",
+      },
+    });
+    const captureScreenshot = createCaptureScreenshotTool(createToolContext(), repo);
+
+    const result = await captureScreenshot.execute!(
+      { target: { type: "storybook", storyId: "components-button--primary" } },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      errorCode: "browser_binary_unavailable",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
@@ -231,4 +231,35 @@ describe("createCaptureScreenshotTool", () => {
       errorCode: "browser_binary_unavailable",
     });
   });
+
+  it("denies capture when the repository write gate rejects the actor", async () => {
+    vi.mocked(createStoredFile).mockClear();
+    const { exec, repo, writeWorkspaceFile } = createRepoContext({
+      packageJson: {
+        scripts: { storybook: "storybook dev" },
+      },
+    });
+    const captureScreenshot = createCaptureScreenshotTool(
+      createToolContext({
+        repositorySource: "slack",
+        actor: { sourceUserId: "U1", role: "member" },
+      }),
+      repo,
+    );
+
+    const result = await captureScreenshot.execute!(
+      { target: { type: "storybook", storyId: "components-button--primary" } },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      errorCode: "write_not_allowed",
+      error:
+        "Slack-triggered write actions require admin privileges. Regular members run in read-only mode.",
+    });
+    expect(writeWorkspaceFile).not.toHaveBeenCalled();
+    expect(exec).not.toHaveBeenCalled();
+    expect(createStoredFile).not.toHaveBeenCalled();
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -2,6 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
+import { assertRepositoryWriteAllowed } from "@/lib/agent-runtime/tools/policy";
 import { createStoredFile } from "@/lib/file-storage/records";
 
 import { normalizeWorkspacePath } from "./path";
@@ -266,6 +267,14 @@ The tool detects the repository package manager and Storybook script, uses a Hyp
 It does not commit, push, open pull requests, or publish repository changes.`,
     inputSchema: captureScreenshotInputSchema,
     execute: async ({ target, viewport = DEFAULT_VIEWPORT, waitForMs = DEFAULT_WAIT_FOR_MS }) => {
+      const gate = assertRepositoryWriteAllowed(ctx, "apply_fixes");
+      if (!gate.allowed) {
+        return {
+          success: false as const,
+          errorCode: "write_not_allowed" as const,
+          error: gate.reason,
+        };
+      }
       if (!repo.bash.writeWorkspaceFile) {
         return {
           success: false as const,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -1,0 +1,394 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+import type { ToolContext } from "@/lib/agent-contracts/tool-context";
+import { createStoredFile } from "@/lib/file-storage/records";
+
+import { normalizeWorkspacePath } from "./path";
+import { DEFAULT_MAX_OUTPUT_BYTES, redact, truncate } from "./redact";
+import type { RepoToolContext } from "./types";
+
+const DEFAULT_VIEWPORT = { width: 1440, height: 900 };
+const MIN_VIEWPORT_SIZE = 320;
+const MAX_VIEWPORT_SIZE = 3840;
+const DEFAULT_WAIT_FOR_MS = 500;
+const MAX_WAIT_FOR_MS = 5000;
+const STORYBOOK_PORT = 6006;
+const MANAGED_PLAYWRIGHT_VERSION = "1.61.1";
+const MANAGED_BROWSER_RUNTIME_DIR = "/tmp/hyperlocalise-browser-runtime";
+const MANAGED_PLAYWRIGHT_MODULE = `${MANAGED_BROWSER_RUNTIME_DIR}/node_modules/playwright`;
+const ERROR_CODE_PREFIX = "HYPERLOCALISE_SCREENSHOT_ERROR_CODE=";
+
+const viewportSchema = z.object({
+  width: z.number().int().min(MIN_VIEWPORT_SIZE).max(MAX_VIEWPORT_SIZE),
+  height: z.number().int().min(MIN_VIEWPORT_SIZE).max(MAX_VIEWPORT_SIZE),
+});
+
+const captureScreenshotInputSchema = z.object({
+  target: z.object({
+    type: z.literal("storybook"),
+    storyId: z.string().min(1).describe("Storybook story id, e.g. components-button--primary."),
+  }),
+  viewport: viewportSchema.optional(),
+  waitForMs: z.number().int().min(0).max(MAX_WAIT_FOR_MS).optional(),
+});
+
+type PackageJson = {
+  packageManager?: unknown;
+  scripts?: unknown;
+  dependencies?: unknown;
+  devDependencies?: unknown;
+};
+
+type PackageManager = "pnpm" | "yarn" | "bun" | "npm";
+
+export type StorybookScreenshotCommand = {
+  packageManager: PackageManager;
+  scriptName: string;
+  command: string;
+  args: string[];
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function packageManagerFromPackageJson(packageJson: PackageJson): PackageManager | null {
+  if (typeof packageJson.packageManager !== "string") {
+    return null;
+  }
+
+  if (packageJson.packageManager.startsWith("pnpm@")) {
+    return "pnpm";
+  }
+  if (packageJson.packageManager.startsWith("yarn@")) {
+    return "yarn";
+  }
+  if (packageJson.packageManager.startsWith("bun@")) {
+    return "bun";
+  }
+  if (packageJson.packageManager.startsWith("npm@")) {
+    return "npm";
+  }
+
+  return null;
+}
+
+export function detectPackageManager(input: {
+  packageJson: PackageJson;
+  lockfiles?: readonly string[];
+}): PackageManager {
+  const declared = packageManagerFromPackageJson(input.packageJson);
+  if (declared) {
+    return declared;
+  }
+
+  const lockfiles = new Set(input.lockfiles ?? []);
+  if (lockfiles.has("pnpm-lock.yaml")) {
+    return "pnpm";
+  }
+  if (lockfiles.has("yarn.lock")) {
+    return "yarn";
+  }
+  if (lockfiles.has("bun.lockb") || lockfiles.has("bun.lock")) {
+    return "bun";
+  }
+
+  return "npm";
+}
+
+function storybookArgs(port: number) {
+  return ["--port", String(port), "--host", "127.0.0.1", "--ci"];
+}
+
+function buildRunArgs(packageManager: PackageManager, scriptName: string, port: number) {
+  const args = storybookArgs(port);
+
+  switch (packageManager) {
+    case "pnpm":
+    case "npm":
+    case "bun":
+      return ["run", scriptName, "--", ...args];
+    case "yarn":
+      return [scriptName, ...args];
+  }
+}
+
+export function detectStorybookScreenshotCommand(input: {
+  packageJson: PackageJson;
+  lockfiles?: readonly string[];
+  port?: number;
+}): StorybookScreenshotCommand | { errorCode: "storybook_script_not_found" } {
+  const scripts = asRecord(input.packageJson.scripts);
+  const scriptName = Object.keys(scripts).find(
+    (name) => name === "storybook" || name === "dev:storybook" || name === "storybook:dev",
+  );
+
+  if (!scriptName) {
+    return { errorCode: "storybook_script_not_found" };
+  }
+
+  const packageManager = detectPackageManager(input);
+  return {
+    packageManager,
+    scriptName,
+    command: packageManager,
+    args: buildRunArgs(packageManager, scriptName, input.port ?? STORYBOOK_PORT),
+  };
+}
+
+async function readPackageJson(repo: RepoToolContext) {
+  const raw = await repo.bash.readFile("package.json");
+  return JSON.parse(raw) as PackageJson;
+}
+
+async function detectLockfiles(repo: RepoToolContext) {
+  const lockfiles = ["pnpm-lock.yaml", "yarn.lock", "bun.lockb", "bun.lock", "package-lock.json"];
+  const existing: string[] = [];
+
+  for (const lockfile of lockfiles) {
+    try {
+      await repo.bash.readFile(lockfile);
+      existing.push(lockfile);
+    } catch {
+      // Missing lockfiles are expected in generic repositories.
+    }
+  }
+
+  return existing;
+}
+
+function shellQuote(value: string) {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function buildPlaywrightScript(input: {
+  playwrightModulePath: string;
+  url: string;
+  outputPath: string;
+  viewport: { width: number; height: number };
+  waitForMs: number;
+}) {
+  return `
+const { chromium } = require(${JSON.stringify(input.playwrightModulePath)});
+
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({
+    viewport: ${JSON.stringify(input.viewport)}
+  });
+  await page.goto(${JSON.stringify(input.url)}, { waitUntil: "networkidle", timeout: 60000 });
+  await page.waitForTimeout(${input.waitForMs});
+  await page.screenshot({ path: ${JSON.stringify(input.outputPath)}, fullPage: true });
+  await browser.close();
+})().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exit(1);
+});
+`.trimStart();
+}
+
+export function classifyScreenshotCaptureFailure(output: string) {
+  const match = output.match(
+    /HYPERLOCALISE_SCREENSHOT_ERROR_CODE=(package_manager_unavailable|browser_runtime_install_failed|browser_binary_unavailable)\b/,
+  );
+  return match?.[1] ?? "screenshot_capture_failed";
+}
+
+function managedBrowserRuntimeCommand() {
+  const runtimeDir = shellQuote(MANAGED_BROWSER_RUNTIME_DIR);
+  const playwrightVersion = shellQuote(`playwright@${MANAGED_PLAYWRIGHT_VERSION}`);
+  const browsersPath = shellQuote(`${MANAGED_BROWSER_RUNTIME_DIR}/ms-playwright`);
+  const playwrightBin = shellQuote(`${MANAGED_BROWSER_RUNTIME_DIR}/node_modules/.bin/playwright`);
+
+  return [
+    "if ! command -v npm >/dev/null 2>&1; then",
+    `  echo "${ERROR_CODE_PREFIX}package_manager_unavailable" >&2`,
+    "  exit 86",
+    "fi",
+    `mkdir -p ${runtimeDir}`,
+    `if [ ! -d ${shellQuote(MANAGED_PLAYWRIGHT_MODULE)} ]; then`,
+    `  npm --prefix ${runtimeDir} init -y >/dev/null 2>&1 || true`,
+    `  if ! npm --prefix ${runtimeDir} install --no-audit --no-fund ${playwrightVersion} >/tmp/hyperlocalise-playwright-install.log 2>&1; then`,
+    `    cat /tmp/hyperlocalise-playwright-install.log >&2 || true`,
+    `    echo "${ERROR_CODE_PREFIX}browser_runtime_install_failed" >&2`,
+    "    exit 87",
+    "  fi",
+    "fi",
+    `if ! PLAYWRIGHT_BROWSERS_PATH=${browsersPath} ${playwrightBin} install chromium >/tmp/hyperlocalise-chromium-install.log 2>&1; then`,
+    `  cat /tmp/hyperlocalise-chromium-install.log >&2 || true`,
+    `  echo "${ERROR_CODE_PREFIX}browser_binary_unavailable" >&2`,
+    "  exit 88",
+    "fi",
+  ].join("\n");
+}
+
+function buildCaptureCommand(input: {
+  storybookCommand: StorybookScreenshotCommand;
+  baseDir: string;
+  scriptPath: string;
+  screenshotPath: string;
+  port: number;
+}) {
+  const storybookCommand = [input.storybookCommand.command, ...input.storybookCommand.args]
+    .map(shellQuote)
+    .join(" ");
+
+  return [
+    "set -euo pipefail",
+    managedBrowserRuntimeCommand(),
+    `${storybookCommand} >/tmp/hyperlocalise-storybook.log 2>&1 &`,
+    "SERVER_PID=$!",
+    'cleanup() { kill "$SERVER_PID" >/dev/null 2>&1 || true; }',
+    "trap cleanup EXIT",
+    `for i in $(seq 1 60); do if curl -fsS ${shellQuote(
+      `http://127.0.0.1:${input.port}/iframe.html`,
+    )} >/dev/null 2>&1; then break; fi; sleep 1; done`,
+    `curl -fsS ${shellQuote(`http://127.0.0.1:${input.port}/iframe.html`)} >/dev/null`,
+    `node ${shellQuote(input.scriptPath)}`,
+    `SCREENSHOT_B64=$(base64 -w 0 ${shellQuote(input.screenshotPath)})`,
+    `rm -rf ${shellQuote(input.baseDir)}`,
+    'printf "%s" "$SCREENSHOT_B64"',
+  ].join("\n");
+}
+
+export function createCaptureScreenshotTool(ctx: ToolContext, repo: RepoToolContext) {
+  return tool({
+    description: `Capture a screenshot from the connected repository workspace.
+
+Currently supported target:
+- Storybook stories by story id
+
+The tool detects the repository package manager and Storybook script, uses a Hyperlocalise-managed Playwright/Chromium runtime in the sandbox, captures a PNG, and stores it as a Hyperlocalise file artifact.
+
+It does not commit, push, open pull requests, or publish repository changes.`,
+    inputSchema: captureScreenshotInputSchema,
+    execute: async ({ target, viewport = DEFAULT_VIEWPORT, waitForMs = DEFAULT_WAIT_FOR_MS }) => {
+      if (!repo.bash.writeWorkspaceFile) {
+        return {
+          success: false as const,
+          errorCode: "workspace_write_unavailable" as const,
+          error: "Workspace write support is required to create screenshot scripts.",
+        };
+      }
+
+      let packageJson: PackageJson;
+      try {
+        packageJson = await readPackageJson(repo);
+      } catch (error) {
+        return {
+          success: false as const,
+          errorCode: "package_json_unavailable" as const,
+          error: redact(error instanceof Error ? error.message : String(error)),
+        };
+      }
+
+      const lockfiles = await detectLockfiles(repo);
+      const storybookCommand = detectStorybookScreenshotCommand({
+        packageJson,
+        lockfiles,
+        port: STORYBOOK_PORT,
+      });
+
+      if ("errorCode" in storybookCommand) {
+        return {
+          success: false as const,
+          errorCode: storybookCommand.errorCode,
+          error: "No supported Storybook script was found in package.json.",
+          checkedFiles: ["package.json", ...lockfiles],
+        };
+      }
+
+      const captureId = crypto.randomUUID();
+      const baseDir = normalizeWorkspacePath(`.hyperlocalise-agent/screenshots/${captureId}`);
+      if (!baseDir) {
+        return {
+          success: false as const,
+          errorCode: "invalid_workspace_path" as const,
+          error: "Failed to allocate a workspace path for screenshot capture.",
+        };
+      }
+
+      const storyUrl = `http://127.0.0.1:${STORYBOOK_PORT}/iframe.html?id=${encodeURIComponent(
+        target.storyId,
+      )}`;
+      const scriptPath = `${baseDir}/capture.cjs`;
+      const screenshotPath = `${baseDir}/screenshot.png`;
+
+      await repo.bash.writeWorkspaceFile(
+        scriptPath,
+        buildPlaywrightScript({
+          playwrightModulePath: MANAGED_PLAYWRIGHT_MODULE,
+          url: storyUrl,
+          outputPath: screenshotPath,
+          viewport,
+          waitForMs,
+        }),
+      );
+
+      const captureResult = await repo.bash.exec("bash", {
+        args: [
+          "-lc",
+          buildCaptureCommand({
+            storybookCommand,
+            baseDir,
+            scriptPath,
+            screenshotPath,
+            port: STORYBOOK_PORT,
+          }),
+        ],
+      });
+
+      if (captureResult.exitCode !== 0) {
+        const output = truncate(
+          redact([captureResult.stdout, captureResult.stderr].join("\n")),
+          DEFAULT_MAX_OUTPUT_BYTES,
+        );
+        const errorCode = classifyScreenshotCaptureFailure(output.text);
+        return {
+          success: false as const,
+          errorCode,
+          error: output.text || "Screenshot capture failed.",
+          truncated: output.truncated,
+        };
+      }
+
+      const content = Buffer.from(captureResult.stdout.trim(), "base64");
+      const storedFile = await createStoredFile({
+        organizationId: ctx.organizationId,
+        projectId: ctx.projectId,
+        createdByUserId: ctx.localUserId,
+        role: "reference",
+        sourceKind: "repository_file",
+        sourceInteractionId: ctx.conversationId,
+        filename: `storybook-${target.storyId}.png`,
+        contentType: "image/png",
+        content,
+        metadata: {
+          kind: "visual-mock",
+          targetType: target.type,
+          storyId: target.storyId,
+          viewport,
+          waitForMs,
+          packageManager: storybookCommand.packageManager,
+          scriptName: storybookCommand.scriptName,
+        },
+        db: ctx.db,
+      });
+
+      return {
+        success: true as const,
+        fileId: storedFile.id,
+        url: storedFile.downloadUrl ?? storedFile.storageUrl,
+        filename: storedFile.filename,
+        contentType: storedFile.contentType,
+        byteSize: storedFile.byteSize,
+        target,
+        viewport,
+        storybookUrl: storyUrl,
+      };
+    },
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/index.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/index.ts
@@ -9,6 +9,7 @@ export { createGlobTool } from "./glob";
 export { createBashTool, isAllowedBashCommand } from "./bash";
 export { createWriteTool } from "./write";
 export { createApplyPatchTool } from "./apply-patch";
+export { createCaptureScreenshotTool } from "./capture-screenshot";
 export {
   convertHTMLToMarkdown,
   createFetchTool,
@@ -25,6 +26,7 @@ export const workspacePrimitiveToolNames = [
   "bash",
   "write",
   "applyPatch",
+  "captureScreenshot",
   "fetch",
 ] as const;
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/index.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/index.ts
@@ -7,6 +7,8 @@ export { createGrepTool } from "./grep";
 export { createFuzzySearchTool } from "./fuzzy-search";
 export { createGlobTool } from "./glob";
 export { createBashTool, isAllowedBashCommand } from "./bash";
+export { createWriteTool } from "./write";
+export { createApplyPatchTool } from "./apply-patch";
 export {
   convertHTMLToMarkdown,
   createFetchTool,
@@ -21,6 +23,8 @@ export const workspacePrimitiveToolNames = [
   "fuzzySearch",
   "glob",
   "bash",
+  "write",
+  "applyPatch",
   "fetch",
 ] as const;
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/types.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/types.ts
@@ -2,5 +2,7 @@ import type { Bash } from "just-bash";
 
 /** Sandbox-scoped bash adapter for workspace primitive tools. */
 export type RepoToolContext = {
-  bash: Pick<Bash, "exec" | "readFile">;
+  bash: Pick<Bash, "exec" | "readFile"> & {
+    writeWorkspaceFile?: (path: string, content: string | Buffer) => Promise<void>;
+  };
 };

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/write.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/write.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import type { ToolContext } from "@/lib/agent-contracts/tool-context";
+
+import { createApplyPatchTool } from "./apply-patch";
+import { createWriteTool } from "./write";
+import type { RepoToolContext } from "./types";
+
+const toolCallInfo = { toolCallId: "test-tool-call", messages: [] };
+
+function createWriteContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    conversationId: "conv_1",
+    organizationId: "org_1",
+    localUserId: "user_1",
+    membershipRole: "admin",
+    projectId: null,
+    db: {} as never,
+    workMode: "write",
+    repositorySource: "github",
+    actor: { sourceUserId: "user_1", role: "admin" },
+    sandboxId: "sbx_1",
+    ...overrides,
+  };
+}
+
+function createRepoContext(overrides: Partial<RepoToolContext["bash"]> = {}) {
+  const exec = vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "", env: {} }));
+  const readFile = vi.fn(async () => "");
+  const writeWorkspaceFile = vi.fn(async () => undefined);
+  const repo: RepoToolContext = {
+    bash: {
+      exec,
+      readFile,
+      writeWorkspaceFile,
+      ...overrides,
+    },
+  };
+  return { exec, readFile, repo, writeWorkspaceFile };
+}
+
+describe("createWriteTool", () => {
+  it("writes complete file contents to a normalized workspace path", async () => {
+    const { repo, writeWorkspaceFile } = createRepoContext();
+    const write = createWriteTool(createWriteContext(), repo);
+
+    const result = await write.execute!(
+      { filePath: "./src/mock.tsx", content: "export const value = 1;\n" },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      path: "src/mock.tsx",
+      byteSize: 24,
+    });
+    expect(writeWorkspaceFile).toHaveBeenCalledWith("src/mock.tsx", "export const value = 1;\n");
+  });
+
+  it("denies writes when repository write context is unavailable", async () => {
+    const { repo, writeWorkspaceFile } = createRepoContext();
+    const write = createWriteTool(
+      createWriteContext({ workMode: undefined, repositorySource: undefined, actor: undefined }),
+      repo,
+    );
+
+    const result = await write.execute!(
+      { filePath: "src/mock.tsx", content: "export const value = 1;\n" },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "Write context is not available for this tool.",
+    });
+    expect(writeWorkspaceFile).not.toHaveBeenCalled();
+  });
+});
+
+describe("createApplyPatchTool", () => {
+  it("checks and applies a unified diff patch", async () => {
+    const { exec, repo, writeWorkspaceFile } = createRepoContext();
+    const applyPatch = createApplyPatchTool(createWriteContext(), repo);
+    const patch = [
+      "diff --git a/src/mock.tsx b/src/mock.tsx",
+      "index 1111111..2222222 100644",
+      "--- a/src/mock.tsx",
+      "+++ b/src/mock.tsx",
+      "@@ -1 +1 @@",
+      "-old",
+      "+new",
+      "",
+    ].join("\n");
+
+    const result = await applyPatch.execute!({ patch }, toolCallInfo);
+
+    expect(result).toMatchObject({
+      success: true,
+      changedPaths: ["src/mock.tsx"],
+    });
+    expect(writeWorkspaceFile).toHaveBeenCalledWith(
+      expect.stringMatching(/^\.hyperlocalise-agent\/patches\/.+\.diff$/),
+      patch,
+    );
+    expect(exec).toHaveBeenNthCalledWith(1, "git", {
+      args: [
+        "apply",
+        "--check",
+        expect.stringMatching(/^\.hyperlocalise-agent\/patches\/.+\.diff$/),
+      ],
+    });
+    expect(exec).toHaveBeenNthCalledWith(2, "git", {
+      args: ["apply", expect.stringMatching(/^\.hyperlocalise-agent\/patches\/.+\.diff$/)],
+    });
+    expect(exec).toHaveBeenNthCalledWith(3, "rm", {
+      args: ["-f", expect.stringMatching(/^\.hyperlocalise-agent\/patches\/.+\.diff$/)],
+    });
+  });
+
+  it("rejects patches that escape the workspace", async () => {
+    const { repo, writeWorkspaceFile } = createRepoContext();
+    const applyPatch = createApplyPatchTool(createWriteContext(), repo);
+
+    const result = await applyPatch.execute!(
+      {
+        patch: [
+          "diff --git a/../secret b/../secret",
+          "--- a/../secret",
+          "+++ b/../secret",
+          "@@ -1 +1 @@",
+          "-old",
+          "+new",
+          "",
+        ].join("\n"),
+      },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "Patch contains a path outside the workspace.",
+    });
+    expect(writeWorkspaceFile).not.toHaveBeenCalled();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/write.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/write.ts
@@ -1,0 +1,71 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+import type { ToolContext } from "@/lib/agent-contracts/tool-context";
+import { assertRepositoryWriteAllowed } from "@/lib/agent-runtime/tools/policy";
+
+import { normalizeWorkspacePath, toShellRelativePath } from "./path";
+import { DEFAULT_MAX_OUTPUT_BYTES, redact, truncate } from "./redact";
+import type { RepoToolContext } from "./types";
+
+const writeInputSchema = z.object({
+  filePath: z
+    .string()
+    .describe("Workspace-relative path to create or overwrite, e.g. src/app/mock/page.tsx."),
+  content: z.string().describe("Complete file contents to write."),
+});
+
+export function createWriteTool(ctx: ToolContext, repo: RepoToolContext) {
+  return tool({
+    description: `Create or overwrite a file in the connected repository workspace.
+
+WHEN TO USE:
+- Creating temporary preview files, fixtures, or small mock UI scaffolding
+- Replacing a whole generated file where a patch would be noisier
+
+WHEN NOT TO USE:
+- Small edits to an existing file (use applyPatch)
+- Reading files (use read)
+- Writing outside the repository workspace
+
+IMPORTANT:
+- This writes the complete file contents
+- Read existing files first before overwriting them
+- This is a repository write action and may be denied by workspace policy`,
+    inputSchema: writeInputSchema,
+    execute: async ({ filePath, content }) => {
+      const gate = assertRepositoryWriteAllowed(ctx, "apply_fixes");
+      if (!gate.allowed) {
+        return { success: false as const, error: gate.reason };
+      }
+      if (!repo.bash.writeWorkspaceFile) {
+        return {
+          success: false as const,
+          error: "Workspace write support is not available for this tool.",
+        };
+      }
+
+      const path = normalizeWorkspacePath(filePath);
+      if (!path) {
+        return { success: false as const, error: "Path must stay within the workspace." };
+      }
+
+      try {
+        await repo.bash.writeWorkspaceFile(toShellRelativePath(path), content);
+        const preview = truncate(redact(content), DEFAULT_MAX_OUTPUT_BYTES);
+        return {
+          success: true as const,
+          path,
+          byteSize: Buffer.byteLength(content, "utf8"),
+          preview: preview.text,
+          truncated: preview.truncated,
+        };
+      } catch (error) {
+        return {
+          success: false as const,
+          error: redact(error instanceof Error ? error.message : String(error)),
+        };
+      }
+    },
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/sandbox-repo-bash.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/sandbox-repo-bash.ts
@@ -1,11 +1,10 @@
-import type { Bash } from "just-bash";
-
 import { getVercelSandboxWorkspace } from "@/lib/agent-runtime/workspaces/vercel-sandbox-runtime";
+import type { RepoToolContext } from "@/lib/agent-runtime/tools/workspace/types";
 
 /**
  * Minimal Bash adapter backed by a Vercel sandbox for repo read/search tools.
  */
-export function createSandboxRepoBash(sandboxId: string): Pick<Bash, "exec" | "readFile"> {
+export function createSandboxRepoBash(sandboxId: string): RepoToolContext["bash"] {
   const workspace = getVercelSandboxWorkspace(sandboxId);
 
   return {
@@ -21,6 +20,9 @@ export function createSandboxRepoBash(sandboxId: string): Pick<Bash, "exec" | "r
     },
     async readFile(path) {
       return workspace.readFile(path);
+    },
+    async writeWorkspaceFile(path, content) {
+      await workspace.writeFile(path, content);
     },
   };
 }

--- a/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
@@ -140,6 +140,7 @@ describe("filterNavigationByWorkspaceFlags", () => {
     const filtered = filterNavigationByWorkspaceFlags(groups, {
       automations: false,
       knowledge: false,
+      visualMock: false,
     });
 
     const itemLabels = filtered.flatMap((group) => group.items.map((item) => item.label));
@@ -154,6 +155,7 @@ describe("filterNavigationByWorkspaceFlags", () => {
     const filtered = filterNavigationByWorkspaceFlags(groups, {
       automations: true,
       knowledge: true,
+      visualMock: true,
     });
 
     const itemLabels = filtered.flatMap((group) => group.items.map((item) => item.label));

--- a/apps/hyperlocalise-web/src/lib/flags/workos-flag-entities.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-flag-entities.ts
@@ -1,5 +1,6 @@
 export const WORKSPACE_AUTOMATIONS_FLAG = "workspace-automations";
 export const WORKSPACE_KNOWLEDGE_FLAG = "workspace-knowledge";
+export const WORKSPACE_VISUAL_MOCK_FLAG = "workspace-visual-mock";
 export const WORKSPACE_FEATURE_UNAVAILABLE_REASON = "feature-unavailable";
 
 export type WorkosFlagEntities = {
@@ -10,4 +11,5 @@ export type WorkosFlagEntities = {
 export type WorkspaceFeatureFlagState = {
   automations: boolean;
   knowledge: boolean;
+  visualMock: boolean;
 };

--- a/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
@@ -1,7 +1,9 @@
 import { redirect } from "next/navigation";
 import { flag, type Flag } from "flags/next";
+import { and, eq } from "drizzle-orm";
 
 import type { NavigationGroup } from "@/components/app-shell/navigation-config";
+import { db, schema } from "@/lib/database";
 import type { AppAuthContext } from "@/lib/workos/app-auth";
 
 import { createWorkosIdentify } from "./identify-workos-context";
@@ -10,6 +12,7 @@ import {
   WORKSPACE_AUTOMATIONS_FLAG,
   WORKSPACE_FEATURE_UNAVAILABLE_REASON,
   WORKSPACE_KNOWLEDGE_FLAG,
+  WORKSPACE_VISUAL_MOCK_FLAG,
   type WorkosFlagEntities,
   type WorkspaceFeatureFlagState,
 } from "./workos-flag-entities";
@@ -28,17 +31,70 @@ export const workspaceKnowledgeFlag = flag<boolean, WorkosFlagEntities>({
   adapter: workosAdapter(),
 });
 
+export const workspaceVisualMockFlag = flag<boolean, WorkosFlagEntities>({
+  key: WORKSPACE_VISUAL_MOCK_FLAG,
+  defaultValue: false,
+  description: "Visual mock skill for repository-backed Hyperlocalise agent previews.",
+  adapter: workosAdapter(),
+});
+
 export async function evaluateWorkspaceFeatureFlags(
   auth: Pick<AppAuthContext, "activeOrganization" | "user">,
 ): Promise<WorkspaceFeatureFlagState> {
   const identify = () => createWorkosIdentify(auth);
 
-  const [automations, knowledge] = await Promise.all([
+  const [automations, knowledge, visualMock] = await Promise.all([
     workspaceAutomationsFlag.run({ identify }),
     workspaceKnowledgeFlag.run({ identify }),
+    workspaceVisualMockFlag.run({ identify }),
   ]);
 
-  return { automations, knowledge };
+  return { automations, knowledge, visualMock };
+}
+
+export async function resolveWorkspaceVisualMockFlag(input: {
+  organizationId: string;
+  localUserId: string;
+  dbClient?: Pick<typeof db, "select">;
+}) {
+  const dbClient = input.dbClient ?? db;
+  if (typeof dbClient.select !== "function") {
+    return false;
+  }
+
+  try {
+    const [identity] = await dbClient
+      .select({
+        workosOrganizationId: schema.organizations.workosOrganizationId,
+        workosUserId: schema.users.workosUserId,
+      })
+      .from(schema.organizationMemberships)
+      .innerJoin(
+        schema.organizations,
+        eq(schema.organizations.id, schema.organizationMemberships.organizationId),
+      )
+      .innerJoin(schema.users, eq(schema.users.id, schema.organizationMemberships.userId))
+      .where(
+        and(
+          eq(schema.organizationMemberships.organizationId, input.organizationId),
+          eq(schema.organizationMemberships.userId, input.localUserId),
+        ),
+      )
+      .limit(1);
+
+    if (!identity) {
+      return false;
+    }
+
+    return workspaceVisualMockFlag.run({
+      identify: () => ({
+        organization: { id: identity.workosOrganizationId },
+        user: { id: identity.workosUserId },
+      }),
+    });
+  } catch {
+    return false;
+  }
 }
 
 export async function requireWorkspaceFeatureFlag(
@@ -66,6 +122,7 @@ export function filterNavigationByWorkspaceFlags(
   const enabledByKey: Record<string, boolean> = {
     [WORKSPACE_AUTOMATIONS_FLAG]: flags.automations,
     [WORKSPACE_KNOWLEDGE_FLAG]: flags.knowledge,
+    [WORKSPACE_VISUAL_MOCK_FLAG]: flags.visualMock,
   };
 
   return groups


### PR DESCRIPTION
## What changed

- Added a `visual-mock` Hyperlocalise agent skill for creating or planning mock UI screenshots from repository context.
- Added workspace `write` and `applyPatch` primitives so sandbox-backed agent skills can create preview files or apply unified diffs.
- Registered the new tools in the workspace tool registry, manifest, and repository workspace tool contract.
- Added focused coverage for visual-mock skill activation and the new workspace write primitives.

## How to test

- `vp test run src/lib/agent-runtime/tools/workspace/write.test.ts src/lib/agent-runtime/skills/conversation-skill-registry.test.ts`
- `vp check --fix`
- `vp test` was attempted but blocked by local Postgres not accepting connections on `localhost:5432` (`ECONNREFUSED`).

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review