### PR TITLE
feat(i18n): localised BCP-47 locale display names in selects

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-locale-picker.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-locale-picker.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useId, useMemo, useState } from "react";
 import { Add01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -15,15 +16,10 @@ import {
 } from "@/components/ui/select";
 import { Field, FieldError, FieldLabel } from "@/components/ui/field";
 import {
-  canonicalizeLocale,
-  COMMON_LOCALES,
-  getLocaleLabel,
-  isValidLocaleInput,
-} from "@/lib/i18n/locales";
-
-function sortLocales(locales: string[]) {
-  return [...locales].toSorted((a, b) => getLocaleLabel(a).localeCompare(getLocaleLabel(b)));
-}
+  formatLocaleDisplayName,
+  formatLocaleOptionLabel,
+} from "@/lib/i18n/locale-display-names.messages";
+import { canonicalizeLocale, COMMON_LOCALES, isValidLocaleInput } from "@/lib/i18n/locales";
 
 function sortLocaleCodes(locales: string[]) {
   return [...locales].toSorted((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
@@ -41,14 +37,17 @@ export function ProjectSourceLocalePicker({
   error?: string;
 }) {
   const fieldId = useId();
+  const intl = useIntl();
 
   const options = useMemo(() => {
     const merged = new Set<string>(COMMON_LOCALES);
     if (value) {
       merged.add(value);
     }
-    return sortLocales([...merged]);
-  }, [value]);
+    return [...merged].toSorted((a, b) =>
+      formatLocaleDisplayName(intl, a).localeCompare(formatLocaleDisplayName(intl, b)),
+    );
+  }, [intl, value]);
 
   return (
     <Field className="gap-1">
@@ -71,8 +70,8 @@ export function ProjectSourceLocalePicker({
           className="w-max min-w-[17rem] max-w-[min(22rem,calc(100vw-2rem))]"
         >
           {options.map((locale) => (
-            <SelectItem key={locale} value={locale}>
-              <span className="truncate">{getLocaleLabel(locale)}</span>
+            <SelectItem key={locale} value={locale} label={formatLocaleOptionLabel(intl, locale)}>
+              <span className="truncate">{formatLocaleDisplayName(intl, locale)}</span>
               <span className="text-muted-foreground">({locale})</span>
             </SelectItem>
           ))}
@@ -98,6 +97,7 @@ export function ProjectTargetLocalesPicker({
 }) {
   const fieldId = useId();
   const customId = useId();
+  const intl = useIntl();
   const [showCustomInput, setShowCustomInput] = useState(false);
   const [customLocale, setCustomLocale] = useState("");
   const [customError, setCustomError] = useState<string | undefined>();
@@ -182,6 +182,7 @@ export function ProjectTargetLocalesPicker({
               disabled={disabled}
               onClick={() => toggleLocale(locale)}
               className="h-7 px-2.5 text-xs"
+              title={formatLocaleOptionLabel(intl, locale)}
             >
               {locale}
             </Button>
@@ -198,6 +199,7 @@ export function ProjectTargetLocalesPicker({
               disabled={disabled}
               onClick={() => toggleLocale(locale)}
               className="h-7 px-2.5 text-xs"
+              title={formatLocaleOptionLabel(intl, locale)}
             >
               {locale}
             </Button>

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
@@ -20,6 +20,10 @@ import {
 import { TypographyP } from "@/components/ui/typography";
 import { readApiError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
+import {
+  formatLocaleDisplayName,
+  formatLocaleOptionLabel,
+} from "@/lib/i18n/locale-display-names.messages";
 import { mapCatConcordanceForAiRecommendation } from "@/lib/translation/cat-recommendation-mapper";
 import { cn } from "@/lib/primitives/cn";
 
@@ -529,13 +533,18 @@ export function ProjectFileCatWorkspace({
               });
             }}
           >
-            <SelectTrigger className="h-9 w-full font-mono text-xs">
+            <SelectTrigger className="h-9 w-full text-xs">
               <SelectValue placeholder="Select locale" />
             </SelectTrigger>
-            <SelectContent>
+            <SelectContent
+              align="start"
+              alignItemWithTrigger={false}
+              className="w-max min-w-[17rem] max-w-[min(22rem,calc(100vw-2rem))]"
+            >
               {(targetLocales ?? []).map((locale) => (
-                <SelectItem key={locale} value={locale}>
-                  {locale}
+                <SelectItem key={locale} value={locale} label={formatLocaleOptionLabel(intl, locale)}>
+                  <span className="truncate">{formatLocaleDisplayName(intl, locale)}</span>
+                  <span className="font-mono text-muted-foreground">({locale})</span>
                 </SelectItem>
               ))}
             </SelectContent>

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
@@ -542,7 +542,11 @@ export function ProjectFileCatWorkspace({
               className="w-max min-w-[17rem] max-w-[min(22rem,calc(100vw-2rem))]"
             >
               {(targetLocales ?? []).map((locale) => (
-                <SelectItem key={locale} value={locale} label={formatLocaleOptionLabel(intl, locale)}>
+                <SelectItem
+                  key={locale}
+                  value={locale}
+                  label={formatLocaleOptionLabel(intl, locale)}
+                >
                   <span className="truncate">{formatLocaleDisplayName(intl, locale)}</span>
                   <span className="font-mono text-muted-foreground">({locale})</span>
                 </SelectItem>

--- a/apps/hyperlocalise-web/src/lib/i18n/locale-display-names.messages.test.ts
+++ b/apps/hyperlocalise-web/src/lib/i18n/locale-display-names.messages.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vite-plus/test";
+import { createIntl } from "@formatjs/intl";
+
+import {
+  commonLocaleDisplayNameMessages,
+  formatLocaleDisplayName,
+  formatLocaleOptionLabel,
+  getCommonLocaleDisplayNameMessage,
+} from "./locale-display-names.messages";
+import { COMMON_LOCALES } from "./locales";
+
+describe("locale-display-names.messages", () => {
+  const intl = createIntl({ locale: "en", messages: {} });
+
+  it("defines a message for every common locale", () => {
+    for (const locale of COMMON_LOCALES) {
+      expect(getCommonLocaleDisplayNameMessage(locale)).toBeDefined();
+    }
+    expect(Object.keys(commonLocaleDisplayNameMessages)).toHaveLength(COMMON_LOCALES.length);
+  });
+
+  it("formats known locales via defineMessages and appends the code", () => {
+    expect(formatLocaleDisplayName(intl, "fr-FR")).toBe("French (France)");
+    expect(formatLocaleOptionLabel(intl, "fr-FR")).toBe("French (France) (fr-FR)");
+    expect(formatLocaleOptionLabel(intl, "en")).toBe("English (en)");
+  });
+
+  it("falls back to Intl.DisplayNames for unknown BCP-47 tags", () => {
+    expect(formatLocaleDisplayName(intl, "sw-KE")).toContain("Swahili");
+    expect(formatLocaleOptionLabel(intl, "sw-KE")).toMatch(/\(sw-KE\)$/);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/i18n/locale-display-names.messages.ts
+++ b/apps/hyperlocalise-web/src/lib/i18n/locale-display-names.messages.ts
@@ -1,0 +1,251 @@
+"use client";
+
+import { defineMessages, type MessageDescriptor } from "react-intl";
+
+import { COMMON_LOCALES, canonicalizeLocale, getLocaleLabel, type CommonLocale } from "./locales";
+
+function localeMessageKey(locale: CommonLocale): string {
+  return locale.replaceAll("-", "_");
+}
+
+export const commonLocaleDisplayNameMessages = defineMessages({
+  en: {
+    defaultMessage: "English",
+    id: "8qtlRUPEdv",
+    description: "Display name for BCP-47 locale en",
+  },
+  en_US: {
+    defaultMessage: "English (United States)",
+    id: "9yja2gkowg",
+    description: "Display name for BCP-47 locale en-US",
+  },
+  en_GB: {
+    defaultMessage: "English (United Kingdom)",
+    id: "tVauVnOkcX",
+    description: "Display name for BCP-47 locale en-GB",
+  },
+  en_AU: {
+    defaultMessage: "English (Australia)",
+    id: "NqAGQvs7qB",
+    description: "Display name for BCP-47 locale en-AU",
+  },
+  en_IN: {
+    defaultMessage: "English (India)",
+    id: "XQOIgvLSGN",
+    description: "Display name for BCP-47 locale en-IN",
+  },
+  es_ES: {
+    defaultMessage: "Spanish (Spain)",
+    id: "BUUxfUaq94",
+    description: "Display name for BCP-47 locale es-ES",
+  },
+  es_MX: {
+    defaultMessage: "Spanish (Mexico)",
+    id: "cdYuP66GRZ",
+    description: "Display name for BCP-47 locale es-MX",
+  },
+  fr_FR: {
+    defaultMessage: "French (France)",
+    id: "DJGr6J4yAS",
+    description: "Display name for BCP-47 locale fr-FR",
+  },
+  fr_CA: {
+    defaultMessage: "French (Canada)",
+    id: "ZxL7hC2wPP",
+    description: "Display name for BCP-47 locale fr-CA",
+  },
+  de_DE: {
+    defaultMessage: "German (Germany)",
+    id: "9WGORyVfVo",
+    description: "Display name for BCP-47 locale de-DE",
+  },
+  it_IT: {
+    defaultMessage: "Italian (Italy)",
+    id: "yIwRFz93s7",
+    description: "Display name for BCP-47 locale it-IT",
+  },
+  pt_BR: {
+    defaultMessage: "Portuguese (Brazil)",
+    id: "0MjCwM2JVC",
+    description: "Display name for BCP-47 locale pt-BR",
+  },
+  pt_PT: {
+    defaultMessage: "Portuguese (Portugal)",
+    id: "oCbdMbr62i",
+    description: "Display name for BCP-47 locale pt-PT",
+  },
+  nl_NL: {
+    defaultMessage: "Dutch (Netherlands)",
+    id: "0KX3L72Boe",
+    description: "Display name for BCP-47 locale nl-NL",
+  },
+  sv_SE: {
+    defaultMessage: "Swedish (Sweden)",
+    id: "dCGRsZA2Gq",
+    description: "Display name for BCP-47 locale sv-SE",
+  },
+  da_DK: {
+    defaultMessage: "Danish (Denmark)",
+    id: "IRhB9WkxFD",
+    description: "Display name for BCP-47 locale da-DK",
+  },
+  nb_NO: {
+    defaultMessage: "Norwegian Bokmål (Norway)",
+    id: "2Gq43ufxii",
+    description: "Display name for BCP-47 locale nb-NO",
+  },
+  fi_FI: {
+    defaultMessage: "Finnish (Finland)",
+    id: "FRwUYE4HKC",
+    description: "Display name for BCP-47 locale fi-FI",
+  },
+  pl_PL: {
+    defaultMessage: "Polish (Poland)",
+    id: "qtTx0ZhgLU",
+    description: "Display name for BCP-47 locale pl-PL",
+  },
+  cs_CZ: {
+    defaultMessage: "Czech (Czechia)",
+    id: "qyAeUOVpZe",
+    description: "Display name for BCP-47 locale cs-CZ",
+  },
+  hu_HU: {
+    defaultMessage: "Hungarian (Hungary)",
+    id: "ngHznLyUeM",
+    description: "Display name for BCP-47 locale hu-HU",
+  },
+  ro_RO: {
+    defaultMessage: "Romanian (Romania)",
+    id: "NrJMjFZDfb",
+    description: "Display name for BCP-47 locale ro-RO",
+  },
+  tr_TR: {
+    defaultMessage: "Turkish (Türkiye)",
+    id: "PSqr8lzpHo",
+    description: "Display name for BCP-47 locale tr-TR",
+  },
+  el_GR: {
+    defaultMessage: "Greek (Greece)",
+    id: "tuvZlDHxtM",
+    description: "Display name for BCP-47 locale el-GR",
+  },
+  ru_RU: {
+    defaultMessage: "Russian (Russia)",
+    id: "r6Ldwc5qHk",
+    description: "Display name for BCP-47 locale ru-RU",
+  },
+  uk_UA: {
+    defaultMessage: "Ukrainian (Ukraine)",
+    id: "ddPY0So4Vu",
+    description: "Display name for BCP-47 locale uk-UA",
+  },
+  ar_SA: {
+    defaultMessage: "Arabic (Saudi Arabia)",
+    id: "5cCuwKVimM",
+    description: "Display name for BCP-47 locale ar-SA",
+  },
+  he_IL: {
+    defaultMessage: "Hebrew (Israel)",
+    id: "iUgXrXTD7Q",
+    description: "Display name for BCP-47 locale he-IL",
+  },
+  fa_IR: {
+    defaultMessage: "Persian (Iran)",
+    id: "HmztzT6qT0",
+    description: "Display name for BCP-47 locale fa-IR",
+  },
+  hi_IN: {
+    defaultMessage: "Hindi (India)",
+    id: "8QnsMQk5Mf",
+    description: "Display name for BCP-47 locale hi-IN",
+  },
+  bn_BD: {
+    defaultMessage: "Bangla (Bangladesh)",
+    id: "qABPUMMqNa",
+    description: "Display name for BCP-47 locale bn-BD",
+  },
+  id_ID: {
+    defaultMessage: "Indonesian (Indonesia)",
+    id: "OMX8Bbcvwm",
+    description: "Display name for BCP-47 locale id-ID",
+  },
+  ms_MY: {
+    defaultMessage: "Malay (Malaysia)",
+    id: "a5JQ0J1lXL",
+    description: "Display name for BCP-47 locale ms-MY",
+  },
+  vi_VN: {
+    defaultMessage: "Vietnamese (Vietnam)",
+    id: "WPbNdWbmRX",
+    description: "Display name for BCP-47 locale vi-VN",
+  },
+  th_TH: {
+    defaultMessage: "Thai (Thailand)",
+    id: "o0UaTUXfqZ",
+    description: "Display name for BCP-47 locale th-TH",
+  },
+  fil_PH: {
+    defaultMessage: "Filipino (Philippines)",
+    id: "1iajv5nbml",
+    description: "Display name for BCP-47 locale fil-PH",
+  },
+  ja_JP: {
+    defaultMessage: "Japanese (Japan)",
+    id: "GZgOkkX0hj",
+    description: "Display name for BCP-47 locale ja-JP",
+  },
+  ko_KR: {
+    defaultMessage: "Korean (South Korea)",
+    id: "9YNv5fx63k",
+    description: "Display name for BCP-47 locale ko-KR",
+  },
+  zh_CN: {
+    defaultMessage: "Chinese (China)",
+    id: "wvaLTvlaJ6",
+    description: "Display name for BCP-47 locale zh-CN",
+  },
+  zh_TW: {
+    defaultMessage: "Chinese (Taiwan)",
+    id: "8n5eYbhjGv",
+    description: "Display name for BCP-47 locale zh-TW",
+  },
+  zh_HK: {
+    defaultMessage: "Chinese (Hong Kong SAR China)",
+    id: "x9TtAEs9eF",
+    description: "Display name for BCP-47 locale zh-HK",
+  },
+});
+
+const commonLocaleMessageByCode = Object.fromEntries(
+  COMMON_LOCALES.map((locale) => [
+    locale,
+    commonLocaleDisplayNameMessages[
+      localeMessageKey(locale) as keyof typeof commonLocaleDisplayNameMessages
+    ],
+  ]),
+) as Record<CommonLocale, MessageDescriptor>;
+
+export function getCommonLocaleDisplayNameMessage(locale: string): MessageDescriptor | undefined {
+  const canonical = canonicalizeLocale(locale) ?? locale;
+  return commonLocaleMessageByCode[canonical as CommonLocale];
+}
+
+/** Localised display name for a BCP-47 tag; falls back to Intl.DisplayNames for unknown tags. */
+export function formatLocaleDisplayName(
+  intl: { formatMessage: (descriptor: MessageDescriptor) => string },
+  locale: string,
+): string {
+  const message = getCommonLocaleDisplayNameMessage(locale);
+  if (message) {
+    return intl.formatMessage(message);
+  }
+  return getLocaleLabel(locale);
+}
+
+/** Display name with locale code, e.g. "French (France) (fr-FR)". */
+export function formatLocaleOptionLabel(
+  intl: { formatMessage: (descriptor: MessageDescriptor) => string },
+  locale: string,
+): string {
+  return `${formatLocaleDisplayName(intl, locale)} (${canonicalizeLocale(locale) ?? locale})`;
+}

--- a/apps/hyperlocalise-web/src/lib/i18n/locale-display-names.messages.ts
+++ b/apps/hyperlocalise-web/src/lib/i18n/locale-display-names.messages.ts
@@ -21,7 +21,7 @@ export const commonLocaleDisplayNameMessages = defineMessages({
   },
   en_GB: {
     defaultMessage: "English (United Kingdom)",
-    id: "tVauVnOkcX",
+    id: "tVauVn/Okc",
     description: "Display name for BCP-47 locale en-GB",
   },
   en_AU: {
@@ -71,7 +71,7 @@ export const commonLocaleDisplayNameMessages = defineMessages({
   },
   pt_PT: {
     defaultMessage: "Portuguese (Portugal)",
-    id: "oCbdMbr62i",
+    id: "o+CbdMbr62",
     description: "Display name for BCP-47 locale pt-PT",
   },
   nl_NL: {
@@ -81,7 +81,7 @@ export const commonLocaleDisplayNameMessages = defineMessages({
   },
   sv_SE: {
     defaultMessage: "Swedish (Sweden)",
-    id: "dCGRsZA2Gq",
+    id: "dCGRsZA2+G",
     description: "Display name for BCP-47 locale sv-SE",
   },
   da_DK: {
@@ -111,12 +111,12 @@ export const commonLocaleDisplayNameMessages = defineMessages({
   },
   hu_HU: {
     defaultMessage: "Hungarian (Hungary)",
-    id: "ngHznLyUeM",
+    id: "+ngHznLyUe",
     description: "Display name for BCP-47 locale hu-HU",
   },
   ro_RO: {
     defaultMessage: "Romanian (Romania)",
-    id: "NrJMjFZDfb",
+    id: "NrJMjFZ+Df",
     description: "Display name for BCP-47 locale ro-RO",
   },
   tr_TR: {
@@ -151,7 +151,7 @@ export const commonLocaleDisplayNameMessages = defineMessages({
   },
   fa_IR: {
     defaultMessage: "Persian (Iran)",
-    id: "HmztzT6qT0",
+    id: "Hmzt+zT6qT",
     description: "Display name for BCP-47 locale fa-IR",
   },
   hi_IN: {
@@ -166,12 +166,12 @@ export const commonLocaleDisplayNameMessages = defineMessages({
   },
   id_ID: {
     defaultMessage: "Indonesian (Indonesia)",
-    id: "OMX8Bbcvwm",
+    id: "OMX/+8Bbcv",
     description: "Display name for BCP-47 locale id-ID",
   },
   ms_MY: {
     defaultMessage: "Malay (Malaysia)",
-    id: "a5JQ0J1lXL",
+    id: "a5J/Q0J1lX",
     description: "Display name for BCP-47 locale ms-MY",
   },
   vi_VN: {
@@ -186,7 +186,7 @@ export const commonLocaleDisplayNameMessages = defineMessages({
   },
   fil_PH: {
     defaultMessage: "Filipino (Philippines)",
-    id: "1iajv5nbml",
+    id: "+1iajv5nbm",
     description: "Display name for BCP-47 locale fil-PH",
   },
   ja_JP: {
@@ -211,7 +211,7 @@ export const commonLocaleDisplayNameMessages = defineMessages({
   },
   zh_HK: {
     defaultMessage: "Chinese (Hong Kong SAR China)",
-    id: "x9TtAEs9eF",
+    id: "x/9TtAEs9e",
     description: "Display name for BCP-47 locale zh-HK",
   },
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds a `react-intl` `defineMessages` mapping from common BCP-47 locale codes to localised display names, and shows display name + locale code in:

- Project source locale select
- CAT tool target locale select

New module: `apps/hyperlocalise-web/src/lib/i18n/locale-display-names.messages.ts` covering all `COMMON_LOCALES`, with helpers that fall back to `Intl.DisplayNames` for unknown tags.

## How to test

- `vp test src/lib/i18n/locale-display-names.messages.test.ts src/lib/i18n/locales.test.ts`
- `vp check --fix`
- Manually verify project create/settings source locale select shows e.g. `French (France) (fr-FR)`
- Manually verify CAT workspace target locale select shows name + code

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, focused `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7604223-647c-4043-a55e-83c421df89f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7604223-647c-4043-a55e-83c421df89f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

