### PR TITLE
fix(ci): use client-id for localize GitHub App token

### DIFF
--- a/.github/workflows/hyperlocalise-web-localize.yml
+++ b/.github/workflows/hyperlocalise-web-localize.yml
@@ -94,8 +94,9 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           # Client ID from the GitHub App settings page (not the numeric App ID).
-          client-id: ${{ vars.GITHUB_APP_CLIENT_ID }}
-          private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
+          # Secret names must not start with GITHUB_.
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/hyperlocalise-web-localize.yml
+++ b/.github/workflows/hyperlocalise-web-localize.yml
@@ -93,7 +93,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.GITHUB_APP_ID }}
+          # Client ID from the GitHub App settings page (not the numeric App ID).
+          client-id: ${{ vars.GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The `hyperlocalise-web-localize` download job now passes `client-id` to `actions/create-github-app-token` instead of the deprecated `app-id`, and reads both values from secrets whose names do not start with `GITHUB_` (GitHub rejects that prefix for custom secrets).

```yaml
client-id: ${{ secrets.APP_CLIENT_ID }}
private-key: ${{ secrets.APP_PRIVATE_KEY }}
```

## Why

`create-github-app-token@v3` deprecates `app-id` and requires a non-empty `client-id`. The download job was failing with an empty ID, and `GITHUB_*` secret names are not allowed.

## Setup required

In the `hyperlocalise-web-localize` GitHub Actions environment, set:

1. **Secret** `APP_CLIENT_ID` — Client ID from the GitHub App settings page (e.g. `Iv1.…`), not the numeric App ID
2. **Secret** `APP_PRIVATE_KEY` — matching PEM private key

## How to test

1. Confirm the environment secrets above are set
2. Dispatch **Hyperlocalise Web Localize** with `job: download`
3. Confirm the Create GitHub App token step succeeds and a translation PR is opened
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cc83ff3-afaa-4df2-85c2-2305e1866765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cc83ff3-afaa-4df2-85c2-2305e1866765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

