### PR TITLE
feat(web): include blog markdown posts in i18n sync

### DIFF
--- a/apps/hyperlocalise-web/i18n.yml
+++ b/apps/hyperlocalise-web/i18n.yml
@@ -10,6 +10,10 @@ buckets:
     files:
       - from: lang/en-US.json
         to: lang/{{target}}.json
+  blog:
+    files:
+      - from: _posts/en/**/*.md
+        to: _posts/{{target}}/**/*.md
 
 llm:
   profiles:


### PR DESCRIPTION
## What changed

Add a `blog` bucket to `apps/hyperlocalise-web/i18n.yml` so `_posts/en/**/*.md` syncs to `_posts/{{target}}/**/*.md` for zh-CN and vi-VN.

## How to test

- [ ] Confirm `apps/hyperlocalise-web/i18n.yml` includes the `blog` bucket mapping
- [ ] Dry-run sync from `apps/hyperlocalise-web` and verify blog markdown files are planned for upload/download

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)