### PR TITLE
feat(web): wire translated locale catalogs and cover blog sync globs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
           mode: upload
           working-directory: apps/hyperlocalise-web
           config-path: i18n.yml
+          hyperlocalise-version: 1.8.19
           extract-path: src
           extract-out-file: lang/en-US.json
           extract-ignore: |
@@ -97,6 +98,7 @@ jobs:
           mode: download
           working-directory: apps/hyperlocalise-web
           config-path: i18n.yml
+          hyperlocalise-version: 1.8.19
           extract-path: src
           extract-out-file: lang/en-US.json
           extract-ignore: |

--- a/.github/workflows/hyperlocalise-web-localize.yml
+++ b/.github/workflows/hyperlocalise-web-localize.yml
@@ -66,6 +66,7 @@ jobs:
           mode: upload
           working-directory: ${{ env.WEB_WORKING_DIRECTORY }}
           config-path: ${{ env.WEB_I18N_CONFIG }}
+          hyperlocalise-version: 1.8.19
           extract-path: ${{ env.WEB_EXTRACT_PATH }}
           extract-out-file: ${{ env.WEB_EXTRACT_OUT_FILE }}
           extract-ignore: ${{ env.WEB_EXTRACT_IGNORE }}
@@ -112,6 +113,7 @@ jobs:
           mode: download
           working-directory: ${{ env.WEB_WORKING_DIRECTORY }}
           config-path: ${{ env.WEB_I18N_CONFIG }}
+          hyperlocalise-version: 1.8.19
           extract-path: ${{ env.WEB_EXTRACT_PATH }}
           extract-out-file: ${{ env.WEB_EXTRACT_OUT_FILE }}
           extract-ignore: ${{ env.WEB_EXTRACT_IGNORE }}

--- a/apps/cli/cmd/sync_hyperlocalise_test.go
+++ b/apps/cli/cmd/sync_hyperlocalise_test.go
@@ -169,6 +169,70 @@ func TestHyperlocalisePushDryRunPlansGlobSourcePaths(t *testing.T) {
 	}
 }
 
+func TestPlanHyperlocaliseFilesExpandsBlogMarkdownGlob(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writePushSourceFile(t, "_posts/en/what-is-translation-intelligence.md", "# What is translation intelligence")
+	writePushSourceFile(t, "_posts/en/how-to-add-ai-translation.md", "# How to add AI translation")
+	writePushSourceFile(t, "_posts/zh-CN/what-is-translation-intelligence.md", "# 什么是翻译智能")
+
+	cfg := &config.I18NConfig{
+		Locales: config.LocaleConfig{
+			Source:  "en-US",
+			Targets: []string{"zh-CN", "de-DE"},
+		},
+		Buckets: map[string]config.BucketConfig{
+			"blog": {
+				Files: []config.BucketFileMapping{{
+					From: "_posts/en/**/*.md",
+					To:   "_posts/{{target}}/**/*.md",
+				}},
+			},
+		},
+	}
+
+	plans, err := planHyperlocaliseFiles(cfg, nil)
+	if err != nil {
+		t.Fatalf("planHyperlocaliseFiles: %v", err)
+	}
+	if len(plans) != 2 {
+		t.Fatalf("len(plans) = %d, want 2 expanded English markdown sources", len(plans))
+	}
+
+	bySource := make(map[string]hyperlocaliseFilePlan, len(plans))
+	for _, plan := range plans {
+		if strings.Contains(plan.SourcePath, "*") {
+			t.Fatalf("source path still contains glob tokens: %q", plan.SourcePath)
+		}
+		if plan.SourceHash == "" {
+			t.Fatalf("source hash empty for %q", plan.SourcePath)
+		}
+		if plan.FileFormat != "markdown" {
+			t.Fatalf("fileFormat = %q, want markdown for %q", plan.FileFormat, plan.SourcePath)
+		}
+		bySource[filepath.ToSlash(plan.SourcePath)] = plan
+	}
+
+	first, ok := bySource["_posts/en/how-to-add-ai-translation.md"]
+	if !ok {
+		t.Fatalf("missing plan for _posts/en/how-to-add-ai-translation.md, got %#v", bySource)
+	}
+	if got := filepath.ToSlash(first.TargetPaths["zh-CN"]); got != "_posts/zh-CN/how-to-add-ai-translation.md" {
+		t.Fatalf("zh-CN target = %q, want _posts/zh-CN/how-to-add-ai-translation.md", got)
+	}
+	if got := filepath.ToSlash(first.TargetPaths["de-DE"]); got != "_posts/de-DE/how-to-add-ai-translation.md" {
+		t.Fatalf("de-DE target = %q, want _posts/de-DE/how-to-add-ai-translation.md", got)
+	}
+
+	second, ok := bySource["_posts/en/what-is-translation-intelligence.md"]
+	if !ok {
+		t.Fatalf("missing plan for _posts/en/what-is-translation-intelligence.md, got %#v", bySource)
+	}
+	if got := filepath.ToSlash(second.TargetPaths["zh-CN"]); got != "_posts/zh-CN/what-is-translation-intelligence.md" {
+		t.Fatalf("zh-CN target = %q, want _posts/zh-CN/what-is-translation-intelligence.md", got)
+	}
+}
+
 func TestHyperlocalisePushDryRunPlansWithoutUploading(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)

--- a/apps/hyperlocalise-web/i18n.yml
+++ b/apps/hyperlocalise-web/i18n.yml
@@ -4,6 +4,8 @@ locales:
   targets:
     - zh-CN
     - vi-VN
+    - de-DE
+    - fr-FR
 
 buckets:
   web:

--- a/apps/hyperlocalise-web/src/lib/app-i18n/intl.ts
+++ b/apps/hyperlocalise-web/src/lib/app-i18n/intl.ts
@@ -1,11 +1,44 @@
 import { createIntl, createIntlCache, type IntlShape } from "@formatjs/intl";
 
+import viVNMessages from "../../../lang/vi-VN.json";
+import zhCNMessages from "../../../lang/zh-CN.json";
+
 import { DEFAULT_APP_LOCALE, normalizeAppLocale, type AppLocale } from "./locales";
 
 const cache = createIntlCache();
 
-function getMessagesForLocale(_locale: AppLocale): Record<string, string> {
-  // Load compiled locale catalogs here when the translation pipeline is wired up.
+type SourceCatalogEntry = {
+  defaultMessage: string;
+  description?: string;
+};
+
+type LocaleCatalog = Record<string, string | SourceCatalogEntry>;
+
+function toMessages(catalog: LocaleCatalog): Record<string, string> {
+  const messages: Record<string, string> = {};
+
+  for (const [id, value] of Object.entries(catalog)) {
+    messages[id] = typeof value === "string" ? value : value.defaultMessage;
+  }
+
+  return messages;
+}
+
+const translatedCatalogs = {
+  "zh-CN": toMessages(zhCNMessages as LocaleCatalog),
+  "vi-VN": toMessages(viVNMessages as LocaleCatalog),
+} as const;
+
+function getMessagesForLocale(locale: AppLocale): Record<string, string> {
+  // Source locale uses defaultMessage from descriptors; no en-US catalog needed.
+  if (locale === DEFAULT_APP_LOCALE) {
+    return {};
+  }
+
+  if (locale in translatedCatalogs) {
+    return translatedCatalogs[locale as keyof typeof translatedCatalogs];
+  }
+
   return {};
 }
 

--- a/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
+++ b/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
@@ -4,7 +4,7 @@ import { Sandbox } from "@vercel/sandbox";
 export const sandboxRipgrepReleaseVersion = "14.1.1";
 
 /** Pinned hyperlocalise CLI release installed into every sandbox. */
-export const sandboxHyperlocaliseReleaseVersion = "1.8.18";
+export const sandboxHyperlocaliseReleaseVersion = "1.8.19";
 
 type VercelSandboxCreateOptions = Parameters<typeof Sandbox.create>[0];
 

--- a/sync/action.yml
+++ b/sync/action.yml
@@ -225,19 +225,7 @@ runs:
         if [[ ! -s "${diff_file}" ]]; then
           # sync pull can leave a clean tree (no staged changes). Treat that as
           # a successful empty validation instead of failing --diff-stdin.
-          cat >"${VALIDATION_REPORT_PATH}" <<'EOF'
-{
-  "checks": [],
-  "findings": [],
-  "summary": {
-    "total": 0,
-    "byCheck": {},
-    "bySeverity": {},
-    "byBucket": {},
-    "byLocale": {}
-  }
-}
-EOF
+          printf '%s\n' '{"checks":[],"findings":[],"summary":{"total":0,"byCheck":{},"bySeverity":{},"byBucket":{},"byLocale":{}}}' >"${VALIDATION_REPORT_PATH}"
           cli_exit=0
         else
           hyperlocalise "${args[@]}" <"${diff_file}"

--- a/sync/action.yml
+++ b/sync/action.yml
@@ -220,8 +220,30 @@ runs:
 
         pushd "${WORKING_DIRECTORY}" >/dev/null
         git add -A .
-        git diff --staged | hyperlocalise "${args[@]}"
-        cli_exit=$?
+        diff_file="$(mktemp)"
+        git diff --staged >"${diff_file}"
+        if [[ ! -s "${diff_file}" ]]; then
+          # sync pull can leave a clean tree (no staged changes). Treat that as
+          # a successful empty validation instead of failing --diff-stdin.
+          cat >"${VALIDATION_REPORT_PATH}" <<'EOF'
+{
+  "checks": [],
+  "findings": [],
+  "summary": {
+    "total": 0,
+    "byCheck": {},
+    "bySeverity": {},
+    "byBucket": {},
+    "byLocale": {}
+  }
+}
+EOF
+          cli_exit=0
+        else
+          hyperlocalise "${args[@]}" <"${diff_file}"
+          cli_exit=$?
+        fi
+        rm -f "${diff_file}"
         popd >/dev/null
 
         echo "cli-exit-code=${cli_exit}" >>"${GITHUB_OUTPUT}"


### PR DESCRIPTION
## What changed

- Wire `getMessagesForLocale` to load translated catalogs (`zh-CN`, `vi-VN`); source `en` keeps using `defaultMessage`.
- Add `de-DE` and `fr-FR` as sync targets in `apps/hyperlocalise-web/i18n.yml`.
- Add a CLI regression test that sync push expands `_posts/en/**/*.md` into concrete files (covers the 1.8.18 glob hashing bug fixed in #1289).

## How to test

- `cd apps/hyperlocalise-web && vp check --fix && vp test src/lib/app-i18n`
- `go test ./apps/cli/cmd -run TestPlanHyperlocaliseFilesExpandsBlogMarkdownGlob`
- `make fmt && make lint && make test` (Go changes)

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)