### PR TITLE
refactor(ci): move web sync to internal GitHub action

### DIFF
--- a/.github/actions/hyperlocalise-web-sync/action.yml
+++ b/.github/actions/hyperlocalise-web-sync/action.yml
@@ -1,9 +1,5 @@
-name: Hyperlocalise Sync
-description: Extract React Intl catalogs, upload sources, or download translations with git diff validation.
-
-branding:
-  icon: sync
-  color: gray-dark
+name: Hyperlocalise Web Sync
+description: Extract React Intl catalogs, upload sources, or download translations for apps/hyperlocalise-web.
 
 inputs:
   mode:
@@ -14,19 +10,22 @@ inputs:
     default: i18n.yml
   working-directory:
     description: Working directory for sync commands.
-    default: .
-  hyperlocalise-version:
-    description: Hyperlocalise release version to install.
-    default: latest
+    default: apps/hyperlocalise-web
   extract-path:
     description: Optional path to scan for React Intl extraction before upload or download. Leave empty to skip extraction.
-    default: ""
+    default: src
   extract-out-file:
     description: Output file for extracted FormatJS catalog. Required when extract-path is set.
-    default: ""
+    default: lang/en-US.json
   extract-ignore:
     description: Optional newline-separated glob patterns passed to extract --ignore.
-    default: ""
+    default: |
+      **/*.test.ts
+      **/*.test.tsx
+      **/*.stories.tsx
+      **/*.fixture.ts
+      **/*.e2e.ts
+      **/__tests__/**
   dry-run:
     description: Preview sync push and pull without uploading, downloading, or writing files.
     default: "false"
@@ -109,26 +108,14 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        artifact_dir="${RUNNER_TEMP}/hyperlocalise-sync/${GITHUB_RUN_ID}/${GITHUB_ACTION}"
+        artifact_dir="${RUNNER_TEMP}/hyperlocalise-web-sync/${GITHUB_RUN_ID}/${GITHUB_ACTION}"
         mkdir -p "${artifact_dir}"
         echo "artifact-dir=${artifact_dir}" >>"${GITHUB_OUTPUT}"
-        echo "artifact-name=hyperlocalise-sync-${GITHUB_JOB}-${GITHUB_RUN_ATTEMPT}-$(date +%s)-${RANDOM}" >>"${GITHUB_OUTPUT}"
+        echo "artifact-name=hyperlocalise-web-sync-${GITHUB_JOB}-${GITHUB_RUN_ATTEMPT}-$(date +%s)-${RANDOM}" >>"${GITHUB_OUTPUT}"
         echo "push-report-path=${artifact_dir}/push-report.json" >>"${GITHUB_OUTPUT}"
         echo "pull-report-path=${artifact_dir}/pull-report.json" >>"${GITHUB_OUTPUT}"
         echo "validation-report-path=${artifact_dir}/validation-report.json" >>"${GITHUB_OUTPUT}"
         echo "validation-summary-path=${artifact_dir}/validation-summary.txt" >>"${GITHUB_OUTPUT}"
-
-    - name: Install Hyperlocalise
-      shell: bash
-      env:
-        VERSION: ${{ inputs.hyperlocalise-version }}
-        GITHUB_TOKEN: ${{ github.token }}
-      run: |
-        set -euo pipefail
-        install_dir="${RUNNER_TEMP}/hyperlocalise-bin"
-        mkdir -p "${install_dir}"
-        bash "${GITHUB_ACTION_PATH}/../tools/github-action/hyperlocalise-ci/scripts/install-hyperlocalise.sh" "${VERSION}" "${install_dir}"
-        echo "${install_dir}" >>"${GITHUB_PATH}"
 
     - name: Extract React Intl messages
       if: ${{ inputs.extract-path != '' }}
@@ -248,7 +235,7 @@ runs:
         CLI_EXIT_CODE: ${{ steps.validate-diff.outputs.cli-exit-code }}
       run: |
         set -euo pipefail
-        node "${GITHUB_ACTION_PATH}/../tools/github-action/hyperlocalise-ci/scripts/write-action-summary.mjs" \
+        node "${GITHUB_ACTION_PATH}/../../../tools/github-action/hyperlocalise-ci/scripts/write-action-summary.mjs" \
           "check" \
           "${CONFIG_PATH}" \
           "${VALIDATION_REPORT_PATH}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,8 @@ jobs:
           [[ "${ERROR_COUNT}" =~ ^[0-9]+$ ]]
           [[ "${WARNING_COUNT}" =~ ^[0-9]+$ ]]
 
-  sync-action-self-test:
-    name: Sync Action Self Test
+  web-sync-action-self-test:
+    name: Web Sync Action Self Test
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       HYPERLOCALISE_API_KEY: hl_sync_self_test
@@ -70,14 +70,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
+      - name: Install Hyperlocalise
+        uses: ./install
+        with:
+          version: 1.8.19
+
       - name: Run Hyperlocalise upload sync action
         id: hyperlocalise-sync-upload
-        uses: ./sync
+        uses: ./.github/actions/hyperlocalise-web-sync
         with:
           mode: upload
           working-directory: apps/hyperlocalise-web
           config-path: i18n.yml
-          hyperlocalise-version: 1.8.19
           extract-path: src
           extract-out-file: lang/en-US.json
           extract-ignore: |
@@ -93,12 +97,11 @@ jobs:
 
       - name: Run Hyperlocalise download sync action
         id: hyperlocalise-sync-download
-        uses: ./sync
+        uses: ./.github/actions/hyperlocalise-web-sync
         with:
           mode: download
           working-directory: apps/hyperlocalise-web
           config-path: i18n.yml
-          hyperlocalise-version: 1.8.19
           extract-path: src
           extract-out-file: lang/en-US.json
           extract-ignore: |

--- a/.github/workflows/hyperlocalise-web-localize.yml
+++ b/.github/workflows/hyperlocalise-web-localize.yml
@@ -22,7 +22,7 @@ on:
       - apps/hyperlocalise-web/src/**
       - apps/hyperlocalise-web/i18n.yml
       - .github/workflows/hyperlocalise-web-localize.yml
-      - sync/action.yml
+      - .github/actions/hyperlocalise-web-sync/action.yml
 
 permissions:
   contents: read
@@ -60,13 +60,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
+      - name: Install Hyperlocalise
+        uses: ./install
+        with:
+          version: 1.8.19
+
       - name: Extract and upload web sources
-        uses: ./sync
+        uses: ./.github/actions/hyperlocalise-web-sync
         with:
           mode: upload
           working-directory: ${{ env.WEB_WORKING_DIRECTORY }}
           config-path: ${{ env.WEB_I18N_CONFIG }}
-          hyperlocalise-version: 1.8.19
           extract-path: ${{ env.WEB_EXTRACT_PATH }}
           extract-out-file: ${{ env.WEB_EXTRACT_OUT_FILE }}
           extract-ignore: ${{ env.WEB_EXTRACT_IGNORE }}
@@ -104,16 +108,20 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           # Avoid duplicate Authorization headers with create-pull-request on checkout v6+.
-          # ./sync only needs local git add/diff; the PR action supplies its own token.
+          # Sync only needs local git add/diff; the PR action supplies its own token.
           persist-credentials: false
 
+      - name: Install Hyperlocalise
+        uses: ./install
+        with:
+          version: 1.8.19
+
       - name: Extract, download, and validate web translations
-        uses: ./sync
+        uses: ./.github/actions/hyperlocalise-web-sync
         with:
           mode: download
           working-directory: ${{ env.WEB_WORKING_DIRECTORY }}
           config-path: ${{ env.WEB_I18N_CONFIG }}
-          hyperlocalise-version: 1.8.19
           extract-path: ${{ env.WEB_EXTRACT_PATH }}
           extract-out-file: ${{ env.WEB_EXTRACT_OUT_FILE }}
           extract-ignore: ${{ env.WEB_EXTRACT_IGNORE }}

--- a/action.yml
+++ b/action.yml
@@ -134,9 +134,16 @@ runs:
         echo "github-diff-path=${artifact_dir}/github-pr.diff" >>"${GITHUB_OUTPUT}"
 
     - name: Install Hyperlocalise
-      uses: ./install
-      with:
-        version: ${{ inputs.hyperlocalise-version }}
+      shell: bash
+      env:
+        VERSION: ${{ inputs.hyperlocalise-version }}
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        install_dir="${RUNNER_TEMP}/hyperlocalise-bin"
+        mkdir -p "${install_dir}"
+        bash "${GITHUB_ACTION_PATH}/tools/github-action/hyperlocalise-ci/scripts/install-hyperlocalise.sh" "${VERSION}" "${install_dir}"
+        echo "${install_dir}" >>"${GITHUB_PATH}"
 
     - name: Fetch GitHub pull request diff
       if: ${{ inputs.github-diff == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -134,16 +134,9 @@ runs:
         echo "github-diff-path=${artifact_dir}/github-pr.diff" >>"${GITHUB_OUTPUT}"
 
     - name: Install Hyperlocalise
-      shell: bash
-      env:
-        VERSION: ${{ inputs.hyperlocalise-version }}
-        GITHUB_TOKEN: ${{ github.token }}
-      run: |
-        set -euo pipefail
-        install_dir="${RUNNER_TEMP}/hyperlocalise-bin"
-        mkdir -p "${install_dir}"
-        bash "${GITHUB_ACTION_PATH}/tools/github-action/hyperlocalise-ci/scripts/install-hyperlocalise.sh" "${VERSION}" "${install_dir}"
-        echo "${install_dir}" >>"${GITHUB_PATH}"
+      uses: ./install
+      with:
+        version: ${{ inputs.hyperlocalise-version }}
 
     - name: Fetch GitHub pull request diff
       if: ${{ inputs.github-diff == 'true' }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The public `sync/` composite action mixed too many concerns: CLI installation (already covered by `install/action.yml`), React Intl extraction paths, and web-specific sync orchestration. Not every Hyperlocalise user runs the same stack, so that logic should not ship as a published action.

This PR:

- **Removes** the public `sync/action.yml`
- **Adds** an internal composite action at `.github/actions/hyperlocalise-web-sync` for `apps/hyperlocalise-web` localization jobs
- **Updates** `hyperlocalise-web-localize.yml` and the CI self-test to compose `install` + the internal sync action
- **Keeps** the root `action.yml` install step inline via `GITHUB_ACTION_PATH` so external `hyperlocalise/hyperlocalise@v1` callers resolve scripts from the checked-out action repo

Public consumers should continue using `hyperlocalise/hyperlocalise/install@v1` plus direct `hyperlocalise sync` commands, as documented in [CI automation](https://hyperlocalise.dev/workflows/ci-automation).

## How to test

- CI `web-sync-action-self-test` job exercises upload/download dry-runs via the internal action
- `hyperlocalise-web-localize` workflow uses the same composition for scheduled upload/download jobs
- CI `action-self-test` job exercises the root action install path used by external consumers

## Checklist

- [x] This PR is scoped and ready for review
- [ ] CI passes on the branch
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f460b-f789-7288-8c83-75180d4be630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f460b-f789-7288-8c83-75180d4be630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

