### PR TITLE
feat(ci): pack react-intl catalogs after web sync download

### DIFF
--- a/.github/actions/hyperlocalise-web-sync/action.yml
+++ b/.github/actions/hyperlocalise-web-sync/action.yml
@@ -1,5 +1,5 @@
 name: Hyperlocalise Web Sync
-description: Extract React Intl catalogs, upload sources, or download translations for apps/hyperlocalise-web.
+description: Extract React Intl catalogs, upload sources, or download and pack translations for apps/hyperlocalise-web.
 
 inputs:
   mode:
@@ -182,6 +182,23 @@ runs:
 
         pushd "${WORKING_DIRECTORY}" >/dev/null
         hyperlocalise "${args[@]}" | tee "${PULL_REPORT_PATH}"
+        popd >/dev/null
+
+    - name: Pack React Intl catalogs
+      if: ${{ (inputs.mode == 'download' || inputs.mode == 'all') && inputs.dry-run != 'true' }}
+      shell: bash
+      env:
+        CONFIG_PATH: ${{ inputs.config-path }}
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+        args=(pack)
+        if [[ -n "${CONFIG_PATH}" ]]; then
+          args+=(--config "${CONFIG_PATH}")
+        fi
+
+        pushd "${WORKING_DIRECTORY}" >/dev/null
+        hyperlocalise "${args[@]}"
         popd >/dev/null
 
     - name: Validate pulled changes

--- a/.github/workflows/hyperlocalise-web-localize.yml
+++ b/.github/workflows/hyperlocalise-web-localize.yml
@@ -151,7 +151,7 @@ jobs:
             Automated translation pull from Hyperlocalise for `apps/hyperlocalise-web`.
 
             - Source catalog: `apps/hyperlocalise-web/lang/en-US.json` (refreshed via `hyperlocalise extract` before pull)
-            - Target catalogs: `apps/hyperlocalise-web/lang/*.json`
+            - Target catalogs: `apps/hyperlocalise-web/lang/*.json` (packed with `hyperlocalise pack` after pull)
             - Validation: `hyperlocalise check --diff-stdin` on the pulled diff (warnings ignored)
 
             Review ICU placeholders, message ids, and locale coverage before merging.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After `hyperlocalise sync pull` in the web sync composite action, run `hyperlocalise pack` so FormatJS locale JSON is prepared before validation and PR creation.

- Adds a **Pack React Intl catalogs** step after download (skipped on dry-run)
- Uses config discovery (`pack --config …`) so only react-intl JSON targets are packed; blog markdown is left alone
- Updates the localize workflow PR body to mention packing

## Test plan

- [ ] Confirm CI dry-run download job still skips pack (`dry-run: true`)
- [ ] On next scheduled/manual download, verify packed `lang/*.json` catalogs land in the translation PR without `description` fields on FormatJS entries
- [ ] Confirm validation still runs on the packed diff
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d776897-5d70-4c10-9073-a8b5f27894f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d776897-5d70-4c10-9073-a8b5f27894f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

