### PR TITLE
fix(web): log hl CLI diagnostics for file translation failures

### DIFF
--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
@@ -179,4 +179,22 @@ describe("sandbox translation failure reasons", () => {
 
     expect(userFacingFailureReason(new Error(message))).toBe(message);
   });
+
+  it("includes the detected file format in translation failure messages", () => {
+    expect(
+      userFacingFailureReason(new Error("translation failed for fr-FR: boom"), {
+        fileFormat: "markdown",
+      }),
+    ).toBe(
+      "the detected file format (markdown) may not be supported, or the content didn't match what the translator expected.",
+    );
+
+    expect(
+      userFacingFailureReason(new Error("translation failed for fr-FR: boom"), {
+        sourceExtension: ".md",
+      }),
+    ).toBe(
+      "the detected file format (md) may not be supported, or the content didn't match what the translator expected.",
+    );
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
@@ -15,7 +15,13 @@ function shellQuote(value: string): string {
 }
 
 export class SandboxErrorMapper {
-  userFacingFailureReason(error: unknown): string {
+  userFacingFailureReason(
+    error: unknown,
+    detection?: {
+      fileFormat?: string | null;
+      sourceExtension?: string | null;
+    },
+  ): string {
     const message = error instanceof Error ? error.message : "Unknown translation failure";
 
     if (message.startsWith("glossary validation failed")) {
@@ -38,6 +44,13 @@ export class SandboxErrorMapper {
     }
 
     if (message.includes("translation failed")) {
+      const detected =
+        detection?.fileFormat?.trim() ||
+        detection?.sourceExtension?.trim()?.replace(/^\./, "") ||
+        null;
+      if (detected) {
+        return `the detected file format (${detected}) may not be supported, or the content didn't match what the translator expected.`;
+      }
       return "the file format may not be supported, or the content didn't match what the translator expected.";
     }
 
@@ -544,6 +557,12 @@ export async function downloadCrowdinTranslationsInSandbox(
   return defaultRunner.crowdin.downloadTranslations(input);
 }
 
-export function userFacingFailureReason(error: unknown) {
-  return defaultRunner.errors.userFacingFailureReason(error);
+export function userFacingFailureReason(
+  error: unknown,
+  detection?: {
+    fileFormat?: string | null;
+    sourceExtension?: string | null;
+  },
+) {
+  return defaultRunner.errors.userFacingFailureReason(error, detection);
 }

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -25,6 +25,8 @@ import {
   storeOutputFileStep,
 } from "./steps/translation-job";
 
+const CLI_OUTPUT_LOG_LIMIT = 4_000;
+
 function shellSingleQuote(value: string) {
   return value.replaceAll("'", "'\\''");
 }
@@ -47,6 +49,28 @@ function getSandboxOutputFilename(attachmentFilename: string, targetLocale: stri
   const name = inputFilename.slice(0, lastDot);
   const ext = inputFilename.slice(lastDot);
   return `${name}-${targetLocale}${ext}`;
+}
+
+function fileExtension(filename: string): string | null {
+  const lastDot = filename.lastIndexOf(".");
+  if (lastDot === -1 || lastDot === filename.length - 1) {
+    return null;
+  }
+  return filename.slice(lastDot).toLowerCase();
+}
+
+function truncateForLog(value: string, limit = CLI_OUTPUT_LOG_LIMIT): string {
+  if (value.length <= limit) {
+    return value;
+  }
+  return `${value.slice(0, limit)}…[truncated ${value.length - limit} chars]`;
+}
+
+function errorMessageForLog(error: unknown): string {
+  if (error instanceof Error) {
+    return truncateForLog(error.message);
+  }
+  return truncateForLog(String(error));
 }
 
 function userFacingFailureReason(error: unknown): string {
@@ -398,17 +422,43 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
     await prepareSandboxStep(sandboxId);
     await writeSourceFileStep(sandboxId, inputFilename, sourceContent);
 
+    console.info("[file-translation-workflow] source file written to sandbox", {
+      jobId: claim.job.id,
+      projectId: claim.job.projectId,
+      storedFileId: parsedInput.sourceFileId,
+      fileFormat: parsedInput.fileFormat,
+      sourceExtension: fileExtension(sourceFile.filename),
+      sandboxInputFilename: inputFilename,
+      sandboxInputExtension: fileExtension(inputFilename),
+      byteLength: sourceContent.byteLength,
+      hasRepositorySourcePath: Boolean(repositorySourcePath),
+      targetLocaleCount: parsedInput.targetLocales.length,
+      sandboxId,
+    });
+
     const outputFiles: Array<{ fileId: string; locale: string; filename: string }> = [];
     let sourceEntries: Record<string, string> | null = null;
 
     try {
       sourceEntries = await extractEntriesStep(sandboxId, inputFilename);
+      console.info("[file-translation-workflow] source entries extracted", {
+        jobId: claim.job.id,
+        projectId: claim.job.projectId,
+        storedFileId: parsedInput.sourceFileId,
+        fileFormat: parsedInput.fileFormat,
+        sandboxInputFilename: inputFilename,
+        sourceEntryCount: Object.keys(sourceEntries).length,
+      });
     } catch (error) {
       console.warn("[file-translation-workflow] source TM extraction failed", {
         jobId: claim.job.id,
         projectId: claim.job.projectId,
-        sourcePath: repositorySourcePath ?? sourceFile.filename,
-        error: userFacingFailureReason(error),
+        storedFileId: parsedInput.sourceFileId,
+        fileFormat: parsedInput.fileFormat,
+        sandboxInputFilename: inputFilename,
+        hasRepositorySourcePath: Boolean(repositorySourcePath),
+        error: errorMessageForLog(error),
+        userFacingError: userFacingFailureReason(error),
       });
     }
 
@@ -475,6 +525,22 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
           }
         : context;
 
+      console.info("[file-translation-workflow] starting hl run", {
+        jobId: claim.job.id,
+        projectId: claim.job.projectId,
+        storedFileId: parsedInput.sourceFileId,
+        fileFormat: parsedInput.fileFormat,
+        targetLocale,
+        sandboxInputFilename: inputFilename,
+        sandboxOutputFilename: outputFilename,
+        sourceEntryCount: sourceEntries ? Object.keys(sourceEntries).length : null,
+        prefilledEntryCount: Object.keys(prefilledEntries).length,
+        tmPrefilledEntryCount: Object.keys(tmPrefilled).length,
+        existingPrefilledEntryCount: Object.keys(existingPrefilled).length,
+        glossaryTermCount: localeContext.glossaryTerms?.length ?? 0,
+        sandboxId,
+      });
+
       const runTranslationWithValidation = async (attempt: 1 | 2, retryFeedback?: string) => {
         const translation = await runTranslationStep(
           sandboxId,
@@ -488,8 +554,35 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         );
 
         if (translation.exitCode !== 0) {
+          console.error("[file-translation-workflow] hl run failed", {
+            jobId: claim.job.id,
+            projectId: claim.job.projectId,
+            storedFileId: parsedInput.sourceFileId,
+            fileFormat: parsedInput.fileFormat,
+            targetLocale,
+            attempt,
+            sandboxInputFilename: inputFilename,
+            sandboxOutputFilename: outputFilename,
+            sandboxInputExtension: fileExtension(inputFilename),
+            exitCode: translation.exitCode,
+            cliOutputLength: translation.output.length,
+            cliOutput: truncateForLog(translation.output),
+            prefilledEntryCount: Object.keys(prefilledEntries).length,
+            hasRetryFeedback: Boolean(retryFeedback),
+            sandboxId,
+          });
           throw new Error(`translation failed for ${targetLocale}: ${translation.output}`);
         }
+
+        console.info("[file-translation-workflow] hl run succeeded", {
+          jobId: claim.job.id,
+          projectId: claim.job.projectId,
+          fileFormat: parsedInput.fileFormat,
+          targetLocale,
+          attempt,
+          sandboxOutputFilename: outputFilename,
+          exitCode: translation.exitCode,
+        });
 
         const translatedContent = await readOutputStep(sandboxId, outputFilename, attempt);
         const translatedText = translatedContent.toString("utf8");
@@ -506,6 +599,13 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         });
 
         if (glossaryFailures.length > 0 && attempt === 1) {
+          console.warn("[file-translation-workflow] glossary validation failed; retrying", {
+            jobId: claim.job.id,
+            projectId: claim.job.projectId,
+            targetLocale,
+            failedTermCount: glossaryFailures.length,
+            attempt,
+          });
           const feedback = [
             `Glossary validation failed for locale ${targetLocale}. Fix these term constraints exactly and regenerate:`,
             ...glossaryFailures.map((failure) =>
@@ -575,9 +675,9 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
             jobId: claim.job.id,
             projectId: claim.job.projectId,
             targetLocale,
-            sourcePath: repositorySourcePath,
             outputPath: outputFilename,
-            error: userFacingFailureReason(error),
+            error: errorMessageForLog(error),
+            userFacingError: userFacingFailureReason(error),
           });
         }
       } else if (sourceEntries && !repositorySourcePath) {
@@ -609,7 +709,17 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
     console.error("[file-translation-workflow] file translation failed", {
       jobId: claim.job.id,
       projectId: claim.job.projectId,
+      storedFileId: parsedInput.sourceFileId,
+      fileFormat: parsedInput.fileFormat,
+      sourceExtension: fileExtension(sourceFile.filename),
+      sandboxInputFilename: inputFilename,
+      sandboxInputExtension: fileExtension(inputFilename),
+      byteLength: sourceContent.byteLength,
+      hasRepositorySourcePath: Boolean(repositorySourcePath),
+      targetLocales: parsedInput.targetLocales,
+      sandboxId,
       error: reason,
+      underlyingError: errorMessageForLog(error),
     });
     await failTranslationJobStep({
       jobId: claim.job.id,

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -25,8 +25,6 @@ import {
   storeOutputFileStep,
 } from "./steps/translation-job";
 
-const CLI_OUTPUT_LOG_LIMIT = 4_000;
-
 function shellSingleQuote(value: string) {
   return value.replaceAll("'", "'\\''");
 }
@@ -59,18 +57,33 @@ function fileExtension(filename: string): string | null {
   return filename.slice(lastDot).toLowerCase();
 }
 
-function truncateForLog(value: string, limit = CLI_OUTPUT_LOG_LIMIT): string {
-  if (value.length <= limit) {
-    return value;
+/** Classify CLI failures using only known safe substrings — never log raw CLI output. */
+function classifyCliFailureKind(output: string): string {
+  if (output.includes("markdown AST parity mismatch")) {
+    return "markdown_ast_parity_mismatch";
   }
-  return `${value.slice(0, limit)}…[truncated ${value.length - limit} chars]`;
-}
-
-function errorMessageForLog(error: unknown): string {
-  if (error instanceof Error) {
-    return truncateForLog(error.message);
+  if (output.includes("markdown parity retry exhausted")) {
+    return "markdown_parity_retry_exhausted";
   }
-  return truncateForLog(String(error));
+  if (output.includes("placeholder parity")) {
+    return "placeholder_parity_mismatch";
+  }
+  if (output.includes("escapes root")) {
+    return "path_escapes_root";
+  }
+  if (output.includes("OPENAI_API_KEY")) {
+    return "missing_openai_api_key";
+  }
+  if (output.includes("planning tasks")) {
+    return "planning_failed";
+  }
+  if (output.includes("no extension")) {
+    return "missing_file_extension";
+  }
+  if (output.includes("translation file parser")) {
+    return "parser_failed";
+  }
+  return "unknown";
 }
 
 function formatDetectionLabel(input: {
@@ -212,7 +225,9 @@ async function extractEntriesStep(sandboxId: string, path: string) {
     { env: getSandboxTranslationEnv(), output: "stdout" },
   );
   if (result.exitCode !== 0) {
-    throw new Error(`failed to extract entries for ${path}: ${result.output}`);
+    throw new Error(
+      `failed to extract entries: exitCode=${result.exitCode} kind=${classifyCliFailureKind(result.output)}`,
+    );
   }
   return JSON.parse(result.output) as Record<string, string>;
 }
@@ -455,7 +470,6 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
       storedFileId: parsedInput.sourceFileId,
       fileFormat: parsedInput.fileFormat,
       sourceExtension: fileExtension(sourceFile.filename),
-      sandboxInputFilename: inputFilename,
       sandboxInputExtension: fileExtension(inputFilename),
       byteLength: sourceContent.byteLength,
       hasRepositorySourcePath: Boolean(repositorySourcePath),
@@ -473,7 +487,6 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         projectId: claim.job.projectId,
         storedFileId: parsedInput.sourceFileId,
         fileFormat: parsedInput.fileFormat,
-        sandboxInputFilename: inputFilename,
         sourceEntryCount: Object.keys(sourceEntries).length,
       });
     } catch (error) {
@@ -482,9 +495,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         projectId: claim.job.projectId,
         storedFileId: parsedInput.sourceFileId,
         fileFormat: parsedInput.fileFormat,
-        sandboxInputFilename: inputFilename,
         hasRepositorySourcePath: Boolean(repositorySourcePath),
-        error: errorMessageForLog(error),
         userFacingError: userFacingFailureReason(error, {
           fileFormat: parsedInput.fileFormat,
           sourceExtension: fileExtension(sourceFile.filename),
@@ -530,7 +541,6 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
             jobId: claim.job.id,
             projectId: claim.job.projectId,
             targetLocale,
-            sourcePath: repositorySourcePath,
             loadedKeyCount: projectPrefill.loadedKeyCount,
             maxKeyCount: projectPrefill.maxKeyCount,
           });
@@ -541,7 +551,6 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
             projectId: claim.job.projectId,
             targetLocale,
             prefilledEntryCount: Object.keys(existingPrefilled).length,
-            sourcePath: repositorySourcePath,
           });
         }
       }
@@ -562,8 +571,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         storedFileId: parsedInput.sourceFileId,
         fileFormat: parsedInput.fileFormat,
         targetLocale,
-        sandboxInputFilename: inputFilename,
-        sandboxOutputFilename: outputFilename,
+        sandboxInputExtension: fileExtension(inputFilename),
         sourceEntryCount: sourceEntries ? Object.keys(sourceEntries).length : null,
         prefilledEntryCount: Object.keys(prefilledEntries).length,
         tmPrefilledEntryCount: Object.keys(tmPrefilled).length,
@@ -585,6 +593,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         );
 
         if (translation.exitCode !== 0) {
+          const cliFailureKind = classifyCliFailureKind(translation.output);
           console.error("[file-translation-workflow] hl run failed", {
             jobId: claim.job.id,
             projectId: claim.job.projectId,
@@ -592,17 +601,17 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
             fileFormat: parsedInput.fileFormat,
             targetLocale,
             attempt,
-            sandboxInputFilename: inputFilename,
-            sandboxOutputFilename: outputFilename,
             sandboxInputExtension: fileExtension(inputFilename),
             exitCode: translation.exitCode,
             cliOutputLength: translation.output.length,
-            cliOutput: truncateForLog(translation.output),
+            cliFailureKind,
             prefilledEntryCount: Object.keys(prefilledEntries).length,
             hasRetryFeedback: Boolean(retryFeedback),
             sandboxId,
           });
-          throw new Error(`translation failed for ${targetLocale}: ${translation.output}`);
+          throw new Error(
+            `translation failed for ${targetLocale}: exitCode=${translation.exitCode} kind=${cliFailureKind}`,
+          );
         }
 
         console.info("[file-translation-workflow] hl run succeeded", {
@@ -611,7 +620,6 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
           fileFormat: parsedInput.fileFormat,
           targetLocale,
           attempt,
-          sandboxOutputFilename: outputFilename,
           exitCode: translation.exitCode,
         });
 
@@ -706,8 +714,6 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
             jobId: claim.job.id,
             projectId: claim.job.projectId,
             targetLocale,
-            outputPath: outputFilename,
-            error: errorMessageForLog(error),
             userFacingError: userFacingFailureReason(error, {
               fileFormat: parsedInput.fileFormat,
               sourceExtension: fileExtension(sourceFile.filename),
@@ -720,7 +726,6 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
           jobId: claim.job.id,
           projectId: claim.job.projectId,
           storedFileId: parsedInput.sourceFileId,
-          filename: sourceFile.filename,
         });
       }
 
@@ -751,14 +756,12 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
       storedFileId: parsedInput.sourceFileId,
       fileFormat: parsedInput.fileFormat,
       sourceExtension: fileExtension(sourceFile.filename),
-      sandboxInputFilename: inputFilename,
       sandboxInputExtension: fileExtension(inputFilename),
       byteLength: sourceContent.byteLength,
       hasRepositorySourcePath: Boolean(repositorySourcePath),
       targetLocales: parsedInput.targetLocales,
       sandboxId,
       error: reason,
-      underlyingError: errorMessageForLog(error),
     });
     await failTranslationJobStep({
       jobId: claim.job.id,

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -73,7 +73,30 @@ function errorMessageForLog(error: unknown): string {
   return truncateForLog(String(error));
 }
 
-function userFacingFailureReason(error: unknown): string {
+function formatDetectionLabel(input: {
+  fileFormat?: string | null;
+  sourceExtension?: string | null;
+  sandboxInputExtension?: string | null;
+}): string | null {
+  const fileFormat = input.fileFormat?.trim();
+  if (fileFormat) {
+    return fileFormat;
+  }
+  const extension = input.sandboxInputExtension?.trim() || input.sourceExtension?.trim();
+  if (extension) {
+    return extension.startsWith(".") ? extension.slice(1) : extension;
+  }
+  return null;
+}
+
+function userFacingFailureReason(
+  error: unknown,
+  detection?: {
+    fileFormat?: string | null;
+    sourceExtension?: string | null;
+    sandboxInputExtension?: string | null;
+  },
+): string {
   const message = error instanceof Error ? error.message : "Unknown translation failure";
 
   if (message.startsWith("glossary validation failed")) {
@@ -92,6 +115,10 @@ function userFacingFailureReason(error: unknown): string {
   }
 
   if (message.includes("translation failed")) {
+    const detected = detection ? formatDetectionLabel(detection) : null;
+    if (detected) {
+      return `the detected file format (${detected}) may not be supported, or the content didn't match what the translator expected.`;
+    }
     return "the file format may not be supported, or the content didn't match what the translator expected.";
   }
 
@@ -458,7 +485,11 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         sandboxInputFilename: inputFilename,
         hasRepositorySourcePath: Boolean(repositorySourcePath),
         error: errorMessageForLog(error),
-        userFacingError: userFacingFailureReason(error),
+        userFacingError: userFacingFailureReason(error, {
+          fileFormat: parsedInput.fileFormat,
+          sourceExtension: fileExtension(sourceFile.filename),
+          sandboxInputExtension: fileExtension(inputFilename),
+        }),
       });
     }
 
@@ -677,7 +708,11 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
             targetLocale,
             outputPath: outputFilename,
             error: errorMessageForLog(error),
-            userFacingError: userFacingFailureReason(error),
+            userFacingError: userFacingFailureReason(error, {
+              fileFormat: parsedInput.fileFormat,
+              sourceExtension: fileExtension(sourceFile.filename),
+              sandboxInputExtension: fileExtension(inputFilename),
+            }),
           });
         }
       } else if (sourceEntries && !repositorySourcePath) {
@@ -705,7 +740,11 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
 
     return outputFiles;
   } catch (error) {
-    const reason = userFacingFailureReason(error);
+    const reason = userFacingFailureReason(error, {
+      fileFormat: parsedInput.fileFormat,
+      sourceExtension: fileExtension(sourceFile.filename),
+      sandboxInputExtension: fileExtension(inputFilename),
+    });
     console.error("[file-translation-workflow] file translation failed", {
       jobId: claim.job.id,
       projectId: claim.job.projectId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Native file translation failures currently map any `hl run` error to a generic “file format may not be supported” message, which hides the real CLI reason (especially for markdown, which is a supported format).

This adds safer diagnostics:

- Logs `exitCode`, `cliOutputLength`, and a classified `cliFailureKind` (e.g. `markdown_ast_parity_mismatch`) — **not** raw CLI stdout/stderr
- Includes the **detected file format** in the user-facing failure message, e.g. `the detected file format (markdown) may not be supported…`
- Logs only opaque IDs, format/extension, counts, and statuses — no customer filenames, repo paths, or unsanitized exception messages

## How to test

- `vp check --fix` in `apps/hyperlocalise-web`
- `vp test src/lib/translation/sandbox-translation.test.ts`
- Re-run a failing markdown file translation job and confirm the job error names `markdown`, and logs include `cliFailureKind` / `exitCode` without raw CLI text or filenames

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, targeted `vp test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ddeac3dc-5fa8-4beb-9430-53d96825615a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddeac3dc-5fa8-4beb-9430-53d96825615a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

