### PR TITLE
fix(web): stop blaming format support for markdown translation failures

### DIFF
--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
@@ -204,4 +204,24 @@ describe("sandbox translation failure reasons", () => {
       }),
     ).toBe("translating the markdown file failed. This is usually temporary — try again.");
   });
+
+  it("maps extract-entry parser failures to parse errors", () => {
+    expect(
+      userFacingFailureReason(
+        new Error("failed to extract entries: exitCode=1 kind=parser_failed"),
+        {
+          fileFormat: "markdown",
+        },
+      ),
+    ).toBe("the markdown file couldn't be parsed for translation.");
+
+    expect(
+      userFacingFailureReason(
+        new Error("failed to extract entries: exitCode=1 kind=missing_file_extension"),
+        {
+          sourceExtension: ".md",
+        },
+      ),
+    ).toBe("the markdown file couldn't be parsed for translation.");
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
@@ -180,21 +180,28 @@ describe("sandbox translation failure reasons", () => {
     expect(userFacingFailureReason(new Error(message))).toBe(message);
   });
 
-  it("includes the detected file format in translation failure messages", () => {
+  it("does not claim supported formats are unsupported", () => {
     expect(
-      userFacingFailureReason(new Error("translation failed for fr-FR: boom"), {
+      userFacingFailureReason(new Error("translation failed for fr-FR: exitCode=1 kind=unknown"), {
         fileFormat: "markdown",
       }),
+    ).toBe("translating the markdown file failed. This is usually temporary — try again.");
+
+    expect(
+      userFacingFailureReason(
+        new Error("translation failed for fr-FR: exitCode=1 kind=markdown_ast_parity_mismatch"),
+        {
+          fileFormat: "markdown",
+        },
+      ),
     ).toBe(
-      "the detected file format (markdown) may not be supported, or the content didn't match what the translator expected.",
+      "markdown translation finished but the output structure no longer matched the source. Try again, or simplify complex markdown in the source file.",
     );
 
     expect(
       userFacingFailureReason(new Error("translation failed for fr-FR: boom"), {
         sourceExtension: ".md",
       }),
-    ).toBe(
-      "the detected file format (md) may not be supported, or the content didn't match what the translator expected.",
-    );
+    ).toBe("translating the markdown file failed. This is usually temporary — try again.");
   });
 });

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
@@ -48,7 +48,7 @@ export class SandboxErrorMapper {
       return "the source file couldn't be downloaded from Crowdin. This is usually temporary.";
     }
 
-    if (message.includes("translation failed")) {
+    if (message.includes("translation failed") || message.includes("failed to extract entries")) {
       const fileFormat = detection?.fileFormat?.trim() || null;
       const extension = detection?.sourceExtension?.trim() || null;
       const inferredFromExtension = extension
@@ -70,6 +70,14 @@ export class SandboxErrorMapper {
       }
       if (kind === "placeholder_parity_mismatch") {
         return "the translation changed placeholders or markup that must stay identical to the source.";
+      }
+      if (kind === "parser_failed" || kind === "missing_file_extension") {
+        if (detected && !supportedFormat) {
+          return `the detected file format (${detected}) is not supported for file translation.`;
+        }
+        return detected
+          ? `the ${detected} file couldn't be parsed for translation.`
+          : "the file couldn't be parsed for translation.";
       }
       if (supportedFormat && detected) {
         return `translating the ${detected} file failed. This is usually temporary — try again.`;

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
@@ -2,6 +2,11 @@ import { Sandbox } from "@vercel/sandbox";
 
 import { env } from "@/lib/env";
 import { createConfiguredVercelSandbox } from "@/lib/vercel-sandbox-config";
+import {
+  inferSupportedFileTranslationFileFormat,
+  isSupportedFileTranslationFileFormat,
+  type SupportedTranslationFileFormat,
+} from "@/lib/translation/file-formats";
 import { translationPromptPolicy } from "@/lib/translation/generation";
 import type { SandboxTranslationContext } from "@/lib/translation/domain";
 
@@ -44,10 +49,31 @@ export class SandboxErrorMapper {
     }
 
     if (message.includes("translation failed")) {
-      const detected =
-        detection?.fileFormat?.trim() ||
-        detection?.sourceExtension?.trim()?.replace(/^\./, "") ||
-        null;
+      const fileFormat = detection?.fileFormat?.trim() || null;
+      const extension = detection?.sourceExtension?.trim() || null;
+      const inferredFromExtension = extension
+        ? inferSupportedFileTranslationFileFormat(
+            `file${extension.startsWith(".") ? extension : `.${extension}`}`,
+          )
+        : null;
+      const supportedFormat =
+        (fileFormat &&
+        isSupportedFileTranslationFileFormat(fileFormat as SupportedTranslationFileFormat)
+          ? (fileFormat as SupportedTranslationFileFormat)
+          : null) || inferredFromExtension;
+      const detected = fileFormat || supportedFormat || extension?.replace(/^\./, "") || null;
+      const kindMatch = /kind=([a-z0-9_]+)/i.exec(message);
+      const kind = kindMatch?.[1] ?? null;
+
+      if (kind === "markdown_ast_parity_mismatch" || kind === "markdown_parity_retry_exhausted") {
+        return "markdown translation finished but the output structure no longer matched the source. Try again, or simplify complex markdown in the source file.";
+      }
+      if (kind === "placeholder_parity_mismatch") {
+        return "the translation changed placeholders or markup that must stay identical to the source.";
+      }
+      if (supportedFormat && detected) {
+        return `translating the ${detected} file failed. This is usually temporary — try again.`;
+      }
       if (detected) {
         return `the detected file format (${detected}) may not be supported, or the content didn't match what the translator expected.`;
       }

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -196,7 +196,7 @@ function userFacingFailureReason(
     return "the attachment couldn't be retrieved. It may have been too large or the link expired.";
   }
 
-  if (message.includes("translation failed")) {
+  if (message.includes("translation failed") || message.includes("failed to extract entries")) {
     return userFacingTranslationFailureReason(message, detection);
   }
 

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -5,7 +5,9 @@ import {
   validateGlossaryTermsInTranslation,
 } from "@/lib/glossary/validate-glossary-terms-in-translation";
 import {
+  inferSupportedFileTranslationFileFormat,
   isImageTranslationFileFormat,
+  isSupportedFileTranslationFileFormat,
   type SupportedTranslationFileFormat,
 } from "@/lib/translation/file-formats";
 import type { SandboxTranslationContext } from "@/lib/translation/domain";
@@ -102,6 +104,73 @@ function formatDetectionLabel(input: {
   return null;
 }
 
+function cliFailureKindFromMessage(message: string): string | null {
+  const match = /kind=([a-z0-9_]+)/i.exec(message);
+  return match?.[1] ?? null;
+}
+
+function resolveSupportedFormat(detection?: {
+  fileFormat?: string | null;
+  sourceExtension?: string | null;
+  sandboxInputExtension?: string | null;
+}): SupportedTranslationFileFormat | null {
+  const fileFormat = detection?.fileFormat?.trim();
+  if (
+    fileFormat &&
+    isSupportedFileTranslationFileFormat(fileFormat as SupportedTranslationFileFormat)
+  ) {
+    return fileFormat as SupportedTranslationFileFormat;
+  }
+
+  const extension = detection?.sandboxInputExtension?.trim() || detection?.sourceExtension?.trim();
+  if (!extension) {
+    return null;
+  }
+  return inferSupportedFileTranslationFileFormat(
+    `file${extension.startsWith(".") ? extension : `.${extension}`}`,
+  );
+}
+
+function userFacingTranslationFailureReason(
+  message: string,
+  detection?: {
+    fileFormat?: string | null;
+    sourceExtension?: string | null;
+    sandboxInputExtension?: string | null;
+  },
+): string {
+  const kind = cliFailureKindFromMessage(message);
+  const supportedFormat = resolveSupportedFormat(detection);
+  const detected = detection ? formatDetectionLabel(detection) : null;
+  const label = detected || supportedFormat;
+
+  if (kind === "markdown_ast_parity_mismatch" || kind === "markdown_parity_retry_exhausted") {
+    return "markdown translation finished but the output structure no longer matched the source. Try again, or simplify complex markdown in the source file.";
+  }
+  if (kind === "placeholder_parity_mismatch") {
+    return "the translation changed placeholders or markup that must stay identical to the source.";
+  }
+  if (kind === "missing_openai_api_key") {
+    return "something went wrong while setting up the translation environment on our end.";
+  }
+  if (kind === "parser_failed" || kind === "missing_file_extension") {
+    if (label && !supportedFormat) {
+      return `the detected file format (${label}) is not supported for file translation.`;
+    }
+    return label
+      ? `the ${label} file couldn't be parsed for translation.`
+      : "the file couldn't be parsed for translation.";
+  }
+
+  if (supportedFormat && label) {
+    return `translating the ${label} file failed. This is usually temporary — try again.`;
+  }
+  if (label) {
+    return `the detected file format (${label}) may not be supported, or the content didn't match what the translator expected.`;
+  }
+  return "the file format may not be supported, or the content didn't match what the translator expected.";
+}
+
 function userFacingFailureReason(
   error: unknown,
   detection?: {
@@ -128,11 +197,7 @@ function userFacingFailureReason(
   }
 
   if (message.includes("translation failed")) {
-    const detected = detection ? formatDetectionLabel(detection) : null;
-    if (detected) {
-      return `the detected file format (${detected}) may not be supported, or the content didn't match what the translator expected.`;
-    }
-    return "the file format may not be supported, or the content didn't match what the translator expected.";
+    return userFacingTranslationFailureReason(message, detection);
   }
 
   if (message.includes("failed to read translated file")) {


### PR DESCRIPTION
## What changed

File translation failures for supported formats (including markdown) were mapped to a misleading “format may not be supported” message whenever `hl run` exited non-zero. Failure copy now uses the classified CLI failure kind and only claims unsupported format when the format is actually unsupported.

## How to test

- `vp test src/lib/translation/sandbox-translation.test.ts src/lib/translation/file-formats.test.ts`
- `vp check --fix` on the changed files
- Re-run a markdown file translation job and confirm a failed job no longer says markdown is unsupported when `fileFormat` is `markdown`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix` on changed files)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)