### PR TITLE
fix(web): colocate sandbox i18n.yml to stop path_escapes_root

### DIFF
--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
@@ -190,7 +190,7 @@ async function runFileTranslationInSandbox(input: {
   );
   await writeTempConfig(input.sandboxId, config, sandboxI18nConfigPath);
 
-  const prefilledPath = `prefilled-${input.targetLocale}.json`;
+  const prefilledPath = `/tmp/prefilled-${input.targetLocale}.json`;
   let prefilledFlags = "";
   if (Object.keys(input.prefilledEntries).length > 0) {
     await writeFileToSandbox(

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
@@ -172,6 +172,7 @@ async function runFileTranslationInSandbox(input: {
     getSandboxTranslationEnv,
     readTranslatedFile,
     runSandboxCommand,
+    sandboxI18nConfigPath,
     writeFileToSandbox,
     writeTempConfig,
   } = await import("@/lib/translation/sandbox");
@@ -179,7 +180,6 @@ async function runFileTranslationInSandbox(input: {
   const inputFilename = sanitizeSandboxFilename(input.sourceFilename);
   const outputFilename = getSandboxOutputFilename(input.sourceFilename, input.targetLocale);
 
-  const configPath = "/tmp/hyperlocalise-file.yml";
   const config = buildTempConfig(
     inputFilename,
     outputFilename,
@@ -188,9 +188,9 @@ async function runFileTranslationInSandbox(input: {
     null,
     input.context,
   );
-  await writeTempConfig(input.sandboxId, config, configPath);
+  await writeTempConfig(input.sandboxId, config, sandboxI18nConfigPath);
 
-  const prefilledPath = `/tmp/hyperlocalise-prefilled-${input.targetLocale}.json`;
+  const prefilledPath = `prefilled-${input.targetLocale}.json`;
   let prefilledFlags = "";
   if (Object.keys(input.prefilledEntries).length > 0) {
     await writeFileToSandbox(
@@ -206,7 +206,7 @@ async function runFileTranslationInSandbox(input: {
     "bash",
     [
       "-lc",
-      `hl run --config '${shellSingleQuote(configPath)}' --locale '${shellSingleQuote(input.targetLocale)}' --force --progress off${prefilledFlags}`,
+      `hl run --config '${shellSingleQuote(sandboxI18nConfigPath)}' --locale '${shellSingleQuote(input.targetLocale)}' --force --progress off${prefilledFlags}`,
     ],
     { env: getSandboxTranslationEnv() },
   );

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
@@ -110,8 +110,8 @@ describe("sandbox command runner", () => {
 });
 
 describe("sandbox translation temporary config", () => {
-  it("colocates i18n.yml with sandbox files under a file bucket", () => {
-    expect(sandboxI18nConfigPath).toBe("i18n.yml");
+  it("colocates reserved i18n config with sandbox files under a file bucket", () => {
+    expect(sandboxI18nConfigPath).toBe(".hl-sandbox-i18n.yml");
     expect(sandboxFileBucketName).toBe("file");
 
     const config = buildTempConfig("source.md", "source-de-DE.md", "en-US", "de-DE", null);

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
@@ -30,6 +30,8 @@ import {
   buildTempConfig,
   createTranslationSandbox,
   runSandboxCommand,
+  sandboxFileBucketName,
+  sandboxI18nConfigPath,
   userFacingFailureReason,
 } from "@/lib/translation/sandbox";
 
@@ -108,6 +110,17 @@ describe("sandbox command runner", () => {
 });
 
 describe("sandbox translation temporary config", () => {
+  it("colocates i18n.yml with sandbox files under a file bucket", () => {
+    expect(sandboxI18nConfigPath).toBe("i18n.yml");
+    expect(sandboxFileBucketName).toBe("file");
+
+    const config = buildTempConfig("source.md", "source-de-DE.md", "en-US", "de-DE", null);
+    expect(config).toContain("  file:");
+    expect(config).not.toContain("  email:");
+    expect(config).toContain('from: "source.md"');
+    expect(config).toContain('to: "source-de-DE.md"');
+  });
+
   it("augments file translation system prompt with project context, job context, and glossary", () => {
     const config = buildTempConfig(
       "source.json",
@@ -131,6 +144,7 @@ describe("sandbox translation temporary config", () => {
     );
 
     expect(config).toContain("system_prompt:");
+    expect(config).toContain("  file:");
     expect(config).toContain("Project: Marketing Site");
     expect(config).toContain("Project translation context: Use concise product-marketing copy.");
     expect(config).toContain("Job context: Homepage launch banner.");
@@ -143,6 +157,7 @@ describe("sandbox translation temporary config", () => {
     const config = buildTempConfig("source.json", "target.json", "en-US", "fr-FR", null);
 
     expect(config).toContain("system_prompt:");
+    expect(config).toContain("  file:");
     expect(config).not.toContain("Project translation context:");
     expect(config).not.toContain("Glossary terms:");
   });

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
@@ -12,6 +12,9 @@ import type { SandboxTranslationContext } from "@/lib/translation/domain";
 
 export const sandboxTimeoutMs = 10 * 60 * 1000;
 export const crowdinSandboxConfigPath = "/tmp/crowdin.yml";
+/** Colocated with sandbox source/output files so CLI pathguard root matches. */
+export const sandboxI18nConfigPath = "i18n.yml";
+export const sandboxFileBucketName = "file";
 
 export type { SandboxTranslationContext };
 
@@ -164,7 +167,7 @@ export class HyperlocaliseCliConfigBuilder {
       `    - ${yamlString(targetLocale)}`,
       "",
       "buckets:",
-      "  email:",
+      `  ${sandboxFileBucketName}:`,
       "    files:",
       `      - from: ${yamlString(inputFile)}`,
       `        to: ${yamlString(outputFile)}`,
@@ -381,7 +384,6 @@ export class HyperlocaliseCliRunner {
     targetLocale: string,
     instructions: string | null,
   ): Promise<{ exitCode: number; output: string }> {
-    const configPath = "/tmp/hyperlocalise-email.yml";
     const config = this.configBuilder.build(
       inputFile,
       outputFile,
@@ -389,14 +391,14 @@ export class HyperlocaliseCliRunner {
       targetLocale,
       instructions,
     );
-    await this.writeTempConfig(sandboxId, config, configPath);
+    await this.writeTempConfig(sandboxId, config, sandboxI18nConfigPath);
 
     return this.lifecycle.runCommand(
       sandboxId,
       "bash",
       [
         "-lc",
-        `hl run --config ${shellQuote(configPath)} --locale ${shellQuote(targetLocale)} --force --progress off`,
+        `hl run --config ${shellQuote(sandboxI18nConfigPath)} --locale ${shellQuote(targetLocale)} --force --progress off`,
       ],
       { env: getSandboxTranslationEnv() },
     );

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
@@ -12,8 +12,9 @@ import type { SandboxTranslationContext } from "@/lib/translation/domain";
 
 export const sandboxTimeoutMs = 10 * 60 * 1000;
 export const crowdinSandboxConfigPath = "/tmp/crowdin.yml";
-/** Colocated with sandbox source/output files so CLI pathguard root matches. */
-export const sandboxI18nConfigPath = "i18n.yml";
+/** Colocated with sandbox source/output files so CLI pathguard root matches.
+ *  Reserved name so a user source named i18n.yml is not overwritten. */
+export const sandboxI18nConfigPath = ".hl-sandbox-i18n.yml";
 export const sandboxFileBucketName = "file";
 
 export type { SandboxTranslationContext };

--- a/apps/hyperlocalise-web/src/workflows/email-translation.ts
+++ b/apps/hyperlocalise-web/src/workflows/email-translation.ts
@@ -132,16 +132,16 @@ async function runTranslationCommand(
 ): Promise<{ exitCode: number; output: string }> {
   "use step";
 
-  const configPath = "/tmp/hyperlocalise-email.yml";
+  const { sandboxI18nConfigPath } = await import("@/lib/translation/sandbox");
   const config = buildTempConfig(inputFile, outputFile, sourceLocale, targetLocale, instructions);
-  await writeTempConfig(sandboxId, config, configPath);
+  await writeTempConfig(sandboxId, config, sandboxI18nConfigPath);
 
   return runSandboxCommand(
     sandboxId,
     "bash",
     [
       "-lc",
-      `hl run --config ${shellQuote(configPath)} --locale ${shellQuote(targetLocale)} --force --progress off`,
+      `hl run --config ${shellQuote(sandboxI18nConfigPath)} --locale ${shellQuote(targetLocale)} --force --progress off`,
     ],
     {
       env: getSandboxTranslationEnv(),

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -256,7 +256,7 @@ async function runTranslationStep(
   );
   await writeTempConfig(sandboxId, config, sandboxI18nConfigPath);
 
-  const prefilledPath = `prefilled-${targetLocale}.json`;
+  const prefilledPath = `/tmp/prefilled-${targetLocale}.json`;
   let prefilledFlags = "";
   if (Object.keys(prefilledEntries).length > 0) {
     await writeFileToSandbox(

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -241,11 +241,11 @@ async function runTranslationStep(
     buildTempConfig,
     getSandboxTranslationEnv,
     runSandboxCommand,
+    sandboxI18nConfigPath,
     writeFileToSandbox,
     writeTempConfig,
   } = await import("@/lib/translation/sandbox");
 
-  const configPath = "/tmp/hyperlocalise-file.yml";
   const config = buildTempConfig(
     inputFile,
     outputFile,
@@ -254,9 +254,9 @@ async function runTranslationStep(
     instructions,
     context,
   );
-  await writeTempConfig(sandboxId, config, configPath);
+  await writeTempConfig(sandboxId, config, sandboxI18nConfigPath);
 
-  const prefilledPath = `/tmp/hyperlocalise-prefilled-${targetLocale}.json`;
+  const prefilledPath = `prefilled-${targetLocale}.json`;
   let prefilledFlags = "";
   if (Object.keys(prefilledEntries).length > 0) {
     await writeFileToSandbox(
@@ -272,7 +272,7 @@ async function runTranslationStep(
     "bash",
     [
       "-lc",
-      `hl run --config '${shellSingleQuote(configPath)}' --locale '${shellSingleQuote(targetLocale)}' --force --progress off${prefilledFlags}`,
+      `hl run --config '${shellSingleQuote(sandboxI18nConfigPath)}' --locale '${shellSingleQuote(targetLocale)}' --force --progress off${prefilledFlags}`,
     ],
     {
       env: getSandboxTranslationEnv(),


### PR DESCRIPTION
## What changed

Sandbox file translation wrote `hl` config under `/tmp` while source/output files lived in the sandbox cwd. The CLI treats the config directory as the project root, so relative paths failed with `path_escapes_root`.

- Write colocated `i18n.yml` next to sandbox source/output files
- Rename the shared sandbox bucket from `email` to `file`
- Keep the email workflow's own `email` bucket; only move its config path

## How to test

- [x] `vp test src/lib/translation/sandbox-translation.test.ts src/workflows/email-translation.test.ts`
- [x] `vp check --fix` on the touched files
- [ ] Retry a markdown file translation job and confirm `hl run` no longer fails with `path_escapes_root`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix` for web changes)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)