### PR TITLE
feat(translation): batch file-job locales into one hl run

### DIFF
--- a/apps/cli/cmd/run.go
+++ b/apps/cli/cmd/run.go
@@ -88,8 +88,8 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().StringSliceVar(&o.locales, "locale", nil, "only run tasks for the given target locale(s)")
 	cmd.Flags().StringSliceVar(&o.targetLocaleAlias, "target-locale", nil, "alias for --locale")
 	cmd.Flags().StringVar(&o.outputPath, "output", "", "report output JSON path")
-	cmd.Flags().StringVar(&o.prefilledEntriesPath, "prefilled-entries", "", "JSON file containing prefilled translation entries keyed by entry id")
-	cmd.Flags().StringVar(&o.prefilledTargetPath, "prefilled-target-path", "", "target output path to apply --prefilled-entries to")
+	cmd.Flags().StringVar(&o.prefilledEntriesPath, "prefilled-entries", "", "JSON file of prefilled translations: flat {entryId:value} with --prefilled-target-path, or locale-keyed {locale:{entryId:value}}")
+	cmd.Flags().StringVar(&o.prefilledTargetPath, "prefilled-target-path", "", "target output path for flat --prefilled-entries (omit for locale-keyed maps)")
 	cmd.Flags().BoolVar(&o.experimentalContextMemory, "experimental-context-memory", o.experimentalContextMemory, "enable experimental two-stage context memory generation before translation")
 	cmd.Flags().StringVar(&o.contextMemoryScope, "context-memory-scope", runsvc.ContextMemoryScopeFile, "scope for experimental context memory: file|bucket|group")
 	cmd.Flags().IntVar(&o.contextMemoryMaxChars, "context-memory-max-chars", 1200, "maximum context memory characters injected into each translation request")
@@ -136,25 +136,74 @@ func normalizeRunFileFlags(paths []string) ([]string, error) {
 	return normalized, nil
 }
 
-func loadPrefilledEntries(path string) (map[string]string, error) {
+type loadedPrefilledEntries struct {
+	Flat     map[string]string
+	ByLocale map[string]map[string]string
+}
+
+func loadPrefilledEntries(path string) (loadedPrefilledEntries, error) {
 	trimmed := strings.TrimSpace(path)
 	if trimmed == "" {
-		return nil, nil
+		return loadedPrefilledEntries{}, nil
 	}
 	raw, err := os.ReadFile(trimmed)
 	if err != nil {
-		return nil, fmt.Errorf("read --prefilled-entries %q: %w", trimmed, err)
+		return loadedPrefilledEntries{}, fmt.Errorf("read --prefilled-entries %q: %w", trimmed, err)
 	}
 	decoder := json.NewDecoder(bytes.NewReader(raw))
-	decoder.DisallowUnknownFields()
-	entries := map[string]string{}
-	if err := decoder.Decode(&entries); err != nil {
-		return nil, fmt.Errorf("parse --prefilled-entries %q: %w", trimmed, err)
+	decoder.UseNumber()
+	var top map[string]json.RawMessage
+	if err := decoder.Decode(&top); err != nil {
+		return loadedPrefilledEntries{}, fmt.Errorf("parse --prefilled-entries %q: %w", trimmed, err)
 	}
 	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
-		return nil, fmt.Errorf("parse --prefilled-entries %q: unexpected trailing data", trimmed)
+		return loadedPrefilledEntries{}, fmt.Errorf("parse --prefilled-entries %q: unexpected trailing data", trimmed)
 	}
-	return entries, nil
+	if len(top) == 0 {
+		return loadedPrefilledEntries{}, nil
+	}
+
+	flat := map[string]string{}
+	byLocale := map[string]map[string]string{}
+	sawString := false
+	sawObject := false
+	for key, rawValue := range top {
+		trimmedKey := strings.TrimSpace(key)
+		if trimmedKey == "" {
+			return loadedPrefilledEntries{}, fmt.Errorf("parse --prefilled-entries %q: empty top-level key", trimmed)
+		}
+		rawValue = bytes.TrimSpace(rawValue)
+		if len(rawValue) == 0 {
+			return loadedPrefilledEntries{}, fmt.Errorf("parse --prefilled-entries %q: empty value for %q", trimmed, trimmedKey)
+		}
+		switch rawValue[0] {
+		case '"':
+			sawString = true
+			var value string
+			if err := json.Unmarshal(rawValue, &value); err != nil {
+				return loadedPrefilledEntries{}, fmt.Errorf("parse --prefilled-entries %q: flat value for %q: %w", trimmed, trimmedKey, err)
+			}
+			flat[trimmedKey] = value
+		case '{':
+			sawObject = true
+			var entries map[string]string
+			entryDecoder := json.NewDecoder(bytes.NewReader(rawValue))
+			entryDecoder.DisallowUnknownFields()
+			if err := entryDecoder.Decode(&entries); err != nil {
+				return loadedPrefilledEntries{}, fmt.Errorf("parse --prefilled-entries %q: locale map for %q: %w", trimmed, trimmedKey, err)
+			}
+			byLocale[trimmedKey] = entries
+		default:
+			return loadedPrefilledEntries{}, fmt.Errorf("parse --prefilled-entries %q: value for %q must be a string or object", trimmed, trimmedKey)
+		}
+	}
+	if sawString && sawObject {
+		return loadedPrefilledEntries{}, fmt.Errorf("parse --prefilled-entries %q: mixed flat and locale-keyed shapes are not allowed", trimmed)
+	}
+	if sawObject {
+		return loadedPrefilledEntries{ByLocale: byLocale}, nil
+	}
+	return loadedPrefilledEntries{Flat: flat}, nil
 }
 
 func executeRun(cmd *cobra.Command, o runOptions) error {
@@ -242,12 +291,16 @@ func executeRun(cmd *cobra.Command, o runOptions) error {
 		defer renderer.Close()
 	}
 
-	prefilledEntries, err := loadPrefilledEntries(o.prefilledEntriesPath)
+	prefilled, err := loadPrefilledEntries(o.prefilledEntriesPath)
 	if err != nil {
 		return err
 	}
-	if len(prefilledEntries) > 0 && strings.TrimSpace(o.prefilledTargetPath) == "" {
-		return fmt.Errorf("--prefilled-target-path is required when --prefilled-entries is provided")
+	prefilledTargetPath := strings.TrimSpace(o.prefilledTargetPath)
+	if len(prefilled.Flat) > 0 && prefilledTargetPath == "" {
+		return fmt.Errorf("--prefilled-target-path is required when --prefilled-entries uses a flat entry map")
+	}
+	if len(prefilled.ByLocale) > 0 && prefilledTargetPath != "" {
+		return fmt.Errorf("--prefilled-target-path must not be set when --prefilled-entries uses a locale-keyed map")
 	}
 
 	input := runsvc.Input{
@@ -266,8 +319,9 @@ func executeRun(cmd *cobra.Command, o runOptions) error {
 		ContextMemoryScope:        contextMemoryScope,
 		ContextMemoryMaxChars:     o.contextMemoryMaxChars,
 		ReportJSONDetail:          jsonDetail,
-		PrefilledEntries:          prefilledEntries,
-		PrefilledTargetPath:       strings.TrimSpace(o.prefilledTargetPath),
+		PrefilledEntries:          prefilled.Flat,
+		PrefilledByLocale:         prefilled.ByLocale,
+		PrefilledTargetPath:       prefilledTargetPath,
 	}
 	if renderer != nil {
 		input.OnEvent = func(event runsvc.Event) {

--- a/apps/cli/cmd/run_test.go
+++ b/apps/cli/cmd/run_test.go
@@ -1928,3 +1928,39 @@ func TestRunWritesSummaryArtifactOmitsHeavyFields(t *testing.T) {
 		t.Fatalf("expected pruneCandidateCount=1, got %v", payload["pruneCandidateCount"])
 	}
 }
+
+func TestLoadPrefilledEntriesFlatAndLocaleKeyed(t *testing.T) {
+	dir := t.TempDir()
+
+	flatPath := filepath.Join(dir, "flat.json")
+	if err := os.WriteFile(flatPath, []byte(`{"hello":"bonjour"}`), 0o600); err != nil {
+		t.Fatalf("write flat: %v", err)
+	}
+	flat, err := loadPrefilledEntries(flatPath)
+	if err != nil {
+		t.Fatalf("load flat: %v", err)
+	}
+	if len(flat.ByLocale) != 0 || flat.Flat["hello"] != "bonjour" {
+		t.Fatalf("unexpected flat load: %+v", flat)
+	}
+
+	nestedPath := filepath.Join(dir, "nested.json")
+	if err := os.WriteFile(nestedPath, []byte(`{"fr":{"hello":"bonjour"},"de":{"hello":"hallo"}}`), 0o600); err != nil {
+		t.Fatalf("write nested: %v", err)
+	}
+	nested, err := loadPrefilledEntries(nestedPath)
+	if err != nil {
+		t.Fatalf("load nested: %v", err)
+	}
+	if len(nested.Flat) != 0 || nested.ByLocale["fr"]["hello"] != "bonjour" || nested.ByLocale["de"]["hello"] != "hallo" {
+		t.Fatalf("unexpected nested load: %+v", nested)
+	}
+
+	mixedPath := filepath.Join(dir, "mixed.json")
+	if err := os.WriteFile(mixedPath, []byte(`{"hello":"bonjour","fr":{"bye":"au revoir"}}`), 0o600); err != nil {
+		t.Fatalf("write mixed: %v", err)
+	}
+	if _, err := loadPrefilledEntries(mixedPath); err == nil || !strings.Contains(err.Error(), "mixed") {
+		t.Fatalf("expected mixed shape error, got %v", err)
+	}
+}

--- a/apps/cli/internal/i18n/runsvc/prefill_test.go
+++ b/apps/cli/internal/i18n/runsvc/prefill_test.go
@@ -1,0 +1,99 @@
+package runsvc
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestApplyPrefilledEntriesFlatRequiresTargetPath(t *testing.T) {
+	t.Parallel()
+	tasks := []Task{{TargetPath: "out-fr.json", TargetLocale: "fr", EntryKey: "hello", SourcePath: "in.json", SourceLocale: "en"}}
+	_, _, _, err := applyPrefilledEntries(tasks, map[string]stagedOutput{}, map[string]string{"hello": "bonjour"}, nil, "")
+	if err == nil || !strings.Contains(err.Error(), "prefilled-target-path is required") {
+		t.Fatalf("expected flat target path error, got %v", err)
+	}
+}
+
+func TestApplyPrefilledEntriesLocaleKeyedRejectsTargetPath(t *testing.T) {
+	t.Parallel()
+	tasks := []Task{{TargetPath: "out-fr.json", TargetLocale: "fr", EntryKey: "hello", SourcePath: "in.json", SourceLocale: "en"}}
+	_, _, _, err := applyPrefilledEntries(tasks, map[string]stagedOutput{}, nil, map[string]map[string]string{
+		"fr": {"hello": "bonjour"},
+	}, "out-fr.json")
+	if err == nil || !strings.Contains(err.Error(), "must not be set") {
+		t.Fatalf("expected locale-keyed target path error, got %v", err)
+	}
+}
+
+func TestApplyPrefilledEntriesLocaleKeyedAcrossLocales(t *testing.T) {
+	t.Parallel()
+	tasks := []Task{
+		{TargetPath: "out-fr.json", TargetLocale: "fr", EntryKey: "hello", SourcePath: "in.json", SourceLocale: "en"},
+		{TargetPath: "out-fr.json", TargetLocale: "fr", EntryKey: "bye", SourcePath: "in.json", SourceLocale: "en"},
+		{TargetPath: "out-de.json", TargetLocale: "de", EntryKey: "hello", SourcePath: "in.json", SourceLocale: "en"},
+		{TargetPath: "out-de.json", TargetLocale: "de", EntryKey: "bye", SourcePath: "in.json", SourceLocale: "en"},
+	}
+	staged := map[string]stagedOutput{}
+	filtered, reused, warnings, err := applyPrefilledEntries(tasks, staged, nil, map[string]map[string]string{
+		"fr": {"hello": "bonjour"},
+		"de": {"hello": "hallo", "bye": "tschüss"},
+		"es": {"hello": "hola"},
+	}, "")
+	if err != nil {
+		t.Fatalf("applyPrefilledEntries: %v", err)
+	}
+	if reused != 3 {
+		t.Fatalf("expected 3 reused entries, got %d", reused)
+	}
+	if len(filtered) != 1 || filtered[0].EntryKey != "bye" || filtered[0].TargetLocale != "fr" {
+		t.Fatalf("expected only fr/bye remaining, got %+v", filtered)
+	}
+	fr := staged["out-fr.json"]
+	if fr.entries["hello"] != "bonjour" {
+		t.Fatalf("expected fr hello staged, got %+v", fr.entries)
+	}
+	de := staged["out-de.json"]
+	if de.entries["hello"] != "hallo" || de.entries["bye"] != "tschüss" {
+		t.Fatalf("expected de entries staged, got %+v", de.entries)
+	}
+	joined := strings.Join(warnings, "\n")
+	if !strings.Contains(joined, "prefilled_entries_unknown_locale locale=es") {
+		t.Fatalf("expected unknown locale warning, got %v", warnings)
+	}
+	if !strings.Contains(joined, "prefilled_entries_reused_by_locale count=3") {
+		t.Fatalf("expected reuse warning, got %v", warnings)
+	}
+}
+
+func TestApplyPrefilledEntriesLocaleKeyedErrorsWhenNoLocalesMatch(t *testing.T) {
+	t.Parallel()
+	tasks := []Task{{TargetPath: "out-fr.json", TargetLocale: "fr", EntryKey: "hello", SourcePath: "in.json", SourceLocale: "en"}}
+	_, _, warnings, err := applyPrefilledEntries(tasks, map[string]stagedOutput{}, nil, map[string]map[string]string{
+		"es": {"hello": "hola"},
+	}, "")
+	if err == nil || !strings.Contains(err.Error(), "matched no planned locales") {
+		t.Fatalf("expected no-match error, got %v", err)
+	}
+	if len(warnings) == 0 || !strings.Contains(warnings[0], "unknown_locale") {
+		t.Fatalf("expected unknown locale warning, got %v", warnings)
+	}
+}
+
+func TestApplyPrefilledEntriesFlatStillWorks(t *testing.T) {
+	t.Parallel()
+	tasks := []Task{
+		{TargetPath: "out-fr.json", TargetLocale: "fr", EntryKey: "hello", SourcePath: "in.json", SourceLocale: "en"},
+		{TargetPath: "out-de.json", TargetLocale: "de", EntryKey: "hello", SourcePath: "in.json", SourceLocale: "en"},
+	}
+	staged := map[string]stagedOutput{}
+	filtered, reused, warnings, err := applyPrefilledEntries(tasks, staged, map[string]string{"hello": "bonjour"}, nil, "out-fr.json")
+	if err != nil {
+		t.Fatalf("applyPrefilledEntries: %v", err)
+	}
+	if reused != 1 || len(filtered) != 1 || filtered[0].TargetLocale != "de" {
+		t.Fatalf("unexpected flat result reused=%d filtered=%+v", reused, filtered)
+	}
+	if !strings.Contains(strings.Join(warnings, "\n"), "prefilled_entries_reused target=out-fr.json count=1") {
+		t.Fatalf("expected flat reuse warning, got %v", warnings)
+	}
+}

--- a/apps/cli/internal/i18n/runsvc/run_orchestrator.go
+++ b/apps/cli/internal/i18n/runsvc/run_orchestrator.go
@@ -83,15 +83,15 @@ func (s *Service) run(ctx context.Context, in Input) (report Report, err error) 
 		endRunSpan(lockSpan, err, "lock_filter")
 		return Report{}, err
 	}
-	executable, reusedByPrefill, prefillErr := applyPrefilledEntries(executable, checkpointStaged, in.PrefilledEntries, in.PrefilledTargetPath)
+	executable, reusedByPrefill, prefillWarnings, prefillErr := applyPrefilledEntries(executable, checkpointStaged, in.PrefilledEntries, in.PrefilledByLocale, in.PrefilledTargetPath)
 	if prefillErr != nil {
 		endRunSpan(lockSpan, prefillErr, "apply_prefilled_entries")
 		return Report{}, prefillErr
 	}
+	report.Warnings = append(report.Warnings, prefillWarnings...)
 	if reusedByPrefill > 0 {
 		report.SkippedByLock += reusedByPrefill
 		report.ExecutableTotal = len(executable)
-		report.Warnings = append(report.Warnings, fmt.Sprintf("prefilled_entries_reused target=%s count=%d", in.PrefilledTargetPath, reusedByPrefill))
 	}
 
 	report.GeneratedAt = s.now()
@@ -196,10 +196,42 @@ func (s *Service) run(ctx context.Context, in Input) (report Report, err error) 
 	return report, nil
 }
 
-func applyPrefilledEntries(tasks []Task, staged map[string]stagedOutput, entries map[string]string, targetPath string) (filtered []Task, reused int, err error) {
-	if len(entries) == 0 || strings.TrimSpace(targetPath) == "" {
-		return tasks, 0, nil
+func applyPrefilledEntries(
+	tasks []Task,
+	staged map[string]stagedOutput,
+	flatEntries map[string]string,
+	byLocale map[string]map[string]string,
+	targetPath string,
+) (filtered []Task, reused int, warnings []string, err error) {
+	hasFlat := len(flatEntries) > 0
+	hasByLocale := len(byLocale) > 0
+	if hasFlat && hasByLocale {
+		return nil, 0, nil, fmt.Errorf("prefilled entries: flat and locale-keyed maps are mutually exclusive")
 	}
+	if !hasFlat && !hasByLocale {
+		return tasks, 0, nil, nil
+	}
+	if hasFlat {
+		trimmedTargetPath := strings.TrimSpace(targetPath)
+		if trimmedTargetPath == "" {
+			return nil, 0, nil, fmt.Errorf("prefilled entries: --prefilled-target-path is required for flat entry maps")
+		}
+		filtered, reused, err = applyFlatPrefilledEntries(tasks, staged, flatEntries, trimmedTargetPath)
+		if err != nil {
+			return nil, 0, nil, err
+		}
+		if reused > 0 {
+			warnings = append(warnings, fmt.Sprintf("prefilled_entries_reused target=%s count=%d", trimmedTargetPath, reused))
+		}
+		return filtered, reused, warnings, nil
+	}
+	if strings.TrimSpace(targetPath) != "" {
+		return nil, 0, nil, fmt.Errorf("prefilled entries: --prefilled-target-path must not be set for locale-keyed entry maps")
+	}
+	return applyLocaleKeyedPrefilledEntries(tasks, staged, byLocale)
+}
+
+func applyFlatPrefilledEntries(tasks []Task, staged map[string]stagedOutput, entries map[string]string, targetPath string) (filtered []Task, reused int, err error) {
 	trimmedTargetPath := filepath.Clean(strings.TrimSpace(targetPath))
 	filtered = make([]Task, 0, len(tasks))
 	for _, task := range tasks {
@@ -218,6 +250,48 @@ func applyPrefilledEntries(tasks []Task, staged map[string]stagedOutput, entries
 		reused++
 	}
 	return filtered, reused, nil
+}
+
+func applyLocaleKeyedPrefilledEntries(tasks []Task, staged map[string]stagedOutput, byLocale map[string]map[string]string) (filtered []Task, reused int, warnings []string, err error) {
+	localeKeys := make([]string, 0, len(byLocale))
+	for locale := range byLocale {
+		localeKeys = append(localeKeys, locale)
+	}
+	sort.Strings(localeKeys)
+
+	matchedLocales := map[string]struct{}{}
+	filtered = make([]Task, 0, len(tasks))
+	for _, task := range tasks {
+		entries, ok := byLocale[task.TargetLocale]
+		if !ok || isImageTask(task) {
+			filtered = append(filtered, task)
+			continue
+		}
+		matchedLocales[task.TargetLocale] = struct{}{}
+		value, hasValue := entries[task.EntryKey]
+		if !hasValue || strings.TrimSpace(value) == "" {
+			filtered = append(filtered, task)
+			continue
+		}
+		if err := stageTaskOutput(staged, task.TargetPath, task.SourcePath, task.SourceLocale, task.TargetLocale, task.EntryKey, value, nil); err != nil {
+			return nil, 0, nil, fmt.Errorf("stage prefilled output for %s: %w", taskIdentity(task.TargetPath, task.EntryKey), err)
+		}
+		reused++
+	}
+
+	for _, locale := range localeKeys {
+		if _, ok := matchedLocales[locale]; ok {
+			continue
+		}
+		warnings = append(warnings, fmt.Sprintf("prefilled_entries_unknown_locale locale=%s", locale))
+	}
+	if len(matchedLocales) == 0 && len(byLocale) > 0 {
+		return nil, 0, warnings, fmt.Errorf("prefilled entries: locale-keyed map matched no planned locales")
+	}
+	if reused > 0 {
+		warnings = append(warnings, fmt.Sprintf("prefilled_entries_reused_by_locale count=%d locales=%d", reused, len(matchedLocales)))
+	}
+	return filtered, reused, warnings, nil
 }
 
 func warningsForLegacyPrompts(tasks []Task) []string {

--- a/apps/cli/internal/i18n/runsvc/service.go
+++ b/apps/cli/internal/i18n/runsvc/service.go
@@ -49,8 +49,12 @@ type Input struct {
 	// ReportJSONDetail controls --output JSON shape: summary (aggregate-only) or full (complete report).
 	// The CLI defaults to summary; an empty value normalizes to full for backward compatibility with
 	// library callers that omit the field. Run applies NormalizeReportJSONDetail again (idempotent).
-	ReportJSONDetail    string
-	PrefilledEntries    map[string]string
+	ReportJSONDetail string
+	// PrefilledEntries is the legacy flat map keyed by entry id. Requires PrefilledTargetPath.
+	PrefilledEntries map[string]string
+	// PrefilledByLocale is locale -> entry id -> value. Mutually exclusive with PrefilledEntries.
+	// Target paths are resolved from planned tasks; PrefilledTargetPath must be empty.
+	PrefilledByLocale   map[string]map[string]string
 	PrefilledTargetPath string
 }
 

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
@@ -27,8 +27,10 @@ vi.mock("@vercel/sandbox", () => ({
 import {
   buildCrowdinFileSandboxConfig,
   buildCrowdinTranslationPath,
+  buildMultiLocaleTempConfig,
   buildTempConfig,
   createTranslationSandbox,
+  getOutputFilenamePattern,
   runSandboxCommand,
   sandboxFileBucketName,
   sandboxI18nConfigPath,
@@ -160,6 +162,38 @@ describe("sandbox translation temporary config", () => {
     expect(config).toContain("  file:");
     expect(config).not.toContain("Project translation context:");
     expect(config).not.toContain("Glossary terms:");
+  });
+
+  it("builds multi-locale configs with {{target}} output patterns", () => {
+    expect(getOutputFilenamePattern("messages.json")).toBe("messages-{{target}}.json");
+
+    const config = buildMultiLocaleTempConfig(
+      "messages.json",
+      "messages-{{target}}.json",
+      "en-US",
+      ["fr-FR", "de-DE"],
+      null,
+      {
+        glossaryTerms: [
+          {
+            sourceTerm: "workspace",
+            targetTerm: "espace de travail",
+            targetLocale: "fr-FR",
+          },
+          {
+            sourceTerm: "workspace",
+            targetTerm: "Arbeitsbereich",
+            targetLocale: "de-DE",
+          },
+        ],
+      },
+    );
+
+    expect(config).toContain('- "fr-FR"');
+    expect(config).toContain('- "de-DE"');
+    expect(config).toContain('to: "messages-{{target}}.json"');
+    expect(config).toContain("workspace -> espace de travail (fr-FR)");
+    expect(config).toContain("workspace -> Arbeitsbereich (de-DE)");
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
@@ -157,21 +157,40 @@ export class HyperlocaliseCliConfigBuilder {
     instructions: string | null = null,
     context: SandboxTranslationContext | null = null,
   ): string {
+    return this.buildMultiLocale(
+      inputFile,
+      outputFile,
+      sourceLocale,
+      [targetLocale],
+      instructions,
+      context,
+    );
+  }
+
+  buildMultiLocale(
+    inputFile: string,
+    outputPattern: string,
+    sourceLocale: string | null,
+    targetLocales: string[],
+    instructions: string | null = null,
+    context: SandboxTranslationContext | null = null,
+  ): string {
     const yamlString = (value: string) => JSON.stringify(value);
     const systemPrompt = translationPromptPolicy.buildSandboxConfigPrompt(context, instructions);
     const userPrompt = ["Translate from {{source}} to {{target}}.", "", "{{input}}"].join("\n");
+    const targets = targetLocales.map((locale) => `    - ${yamlString(locale)}`);
 
     return [
       "locales:",
       `  source: ${yamlString(sourceLocale ?? "auto")}`,
       "  targets:",
-      `    - ${yamlString(targetLocale)}`,
+      ...targets,
       "",
       "buckets:",
       `  ${sandboxFileBucketName}:`,
       "    files:",
       `      - from: ${yamlString(inputFile)}`,
-      `        to: ${yamlString(outputFile)}`,
+      `        to: ${yamlString(outputPattern)}`,
       "",
       "llm:",
       "  profiles:",
@@ -369,6 +388,24 @@ export class HyperlocaliseCliRunner {
     );
   }
 
+  buildMultiLocaleConfig(
+    inputFile: string,
+    outputPattern: string,
+    sourceLocale: string | null,
+    targetLocales: string[],
+    instructions: string | null = null,
+    context: SandboxTranslationContext | null = null,
+  ): string {
+    return this.configBuilder.buildMultiLocale(
+      inputFile,
+      outputPattern,
+      sourceLocale,
+      targetLocales,
+      instructions,
+      context,
+    );
+  }
+
   async writeTempConfig(
     sandboxId: string,
     configContent: string,
@@ -451,6 +488,17 @@ export function getOutputFilename(inputFilename: string, targetLocale: string): 
   return `${name}-${targetLocale}${ext}`;
 }
 
+/** Output path pattern for multi-locale `hl run` configs (`{{target}}` resolved by the CLI). */
+export function getOutputFilenamePattern(inputFilename: string): string {
+  const lastDot = inputFilename.lastIndexOf(".");
+  if (lastDot === -1) {
+    return `${inputFilename}-{{target}}`;
+  }
+  const name = inputFilename.slice(0, lastDot);
+  const ext = inputFilename.slice(lastDot);
+  return `${name}-{{target}}${ext}`;
+}
+
 export function sanitizeFilename(email: string): string {
   return email.replace(/[^a-zA-Z0-9._-]/g, "_");
 }
@@ -512,6 +560,24 @@ export function buildTempConfig(
     outputFile,
     sourceLocale,
     targetLocale,
+    instructions,
+    context,
+  );
+}
+
+export function buildMultiLocaleTempConfig(
+  inputFile: string,
+  outputPattern: string,
+  sourceLocale: string | null,
+  targetLocales: string[],
+  instructions: string | null = null,
+  context: SandboxTranslationContext | null = null,
+) {
+  return defaultRunner.buildMultiLocaleConfig(
+    inputFile,
+    outputPattern,
+    sourceLocale,
+    targetLocales,
     instructions,
     context,
   );

--- a/apps/hyperlocalise-web/src/workflows/README.md
+++ b/apps/hyperlocalise-web/src/workflows/README.md
@@ -91,20 +91,15 @@ fileTranslationJobWorkflow
         |
         +-- extract source entries for TM reuse
         |
-        +-- for each target locale
-        |       |
-        |       +-- reuseFileTranslationMemoryEntriesStep
-        |       |
-        |       +-- hl run
-        |       |
-        |       +-- validate glossary terms
-        |       |       `-- retry once with validation feedback
-        |       |
-        |       +-- log translated file diagnostics
-        |       |
-        |       +-- store output file
-        |       |
-        |       `-- persist target TM entries best-effort
+        +-- assemble locale-keyed prefill (TM + project translations)
+        |
+        +-- hl run (all target locales, nested --prefilled-entries)
+        |
+        +-- per locale: validate glossary
+        |
+        +-- retry hl run for glossary-failed locales only
+        |
+        +-- per locale: log diagnostics, store output, persist TM
         |
         +-- completeFileTranslationJobStep
         |

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -668,6 +668,14 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
       sandboxId,
     });
 
+    type LocaleGlossaryFailure = {
+      targetLocale: string;
+      failures: ReturnType<typeof validateGlossaryTermsInTranslation>;
+    };
+
+    const translatedByLocale = new Map<string, Buffer>();
+    const runFailures: Array<{ locale: string; kind: string; exitCode: number }> = [];
+
     const runHlForLocales = async (locales: string[], attempt: 1 | 2, retryFeedback?: string) => {
       const translation = await runTranslationStep(
         sandboxId,
@@ -701,9 +709,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
           hasRetryFeedback: Boolean(retryFeedback),
           sandboxId,
         });
-        throw new Error(
-          `translation failed for ${locales.join(",")}: exitCode=${translation.exitCode} kind=${cliFailureKind}`,
-        );
+        return { ok: false as const, cliFailureKind, exitCode: translation.exitCode };
       }
 
       console.info("[file-translation-workflow] hl run succeeded", {
@@ -714,22 +720,99 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         attempt,
         exitCode: translation.exitCode,
       });
+      return { ok: true as const };
     };
 
-    await runHlForLocales(parsedInput.targetLocales, 1);
-
-    type LocaleGlossaryFailure = {
-      targetLocale: string;
-      failures: ReturnType<typeof validateGlossaryTermsInTranslation>;
+    const tryReadLocaleOutputs = async (locales: string[], attempt: 1 | 2) => {
+      const readable: string[] = [];
+      const missing: string[] = [];
+      for (const targetLocale of locales) {
+        const outputFilename = getSandboxOutputFilename(sourceFile.filename, targetLocale);
+        try {
+          const translatedContent = await readOutputStep(sandboxId, outputFilename, attempt);
+          translatedByLocale.set(targetLocale, translatedContent);
+          readable.push(targetLocale);
+        } catch {
+          missing.push(targetLocale);
+        }
+      }
+      return { readable, missing };
     };
 
-    const translatedByLocale = new Map<string, Buffer>();
+    // Happy path: one batched run for all locales. On non-zero exit, salvage
+    // any locale outputs the CLI already flushed, then retry only missing ones.
+    const batchResult = await runHlForLocales(parsedInput.targetLocales, 1);
+    let localesNeedingWork = [...parsedInput.targetLocales];
+
+    if (batchResult.ok) {
+      const { missing } = await tryReadLocaleOutputs(parsedInput.targetLocales, 1);
+      localesNeedingWork = missing;
+    } else {
+      const { readable, missing } = await tryReadLocaleOutputs(parsedInput.targetLocales, 1);
+      console.warn("[file-translation-workflow] batch hl run failed; salvaging readable outputs", {
+        jobId: claim.job.id,
+        projectId: claim.job.projectId,
+        readableLocales: readable,
+        missingLocales: missing,
+        cliFailureKind: batchResult.cliFailureKind,
+        exitCode: batchResult.exitCode,
+      });
+      localesNeedingWork = missing;
+      for (const locale of missing) {
+        runFailures.push({
+          locale,
+          kind: batchResult.cliFailureKind,
+          exitCode: batchResult.exitCode,
+        });
+      }
+    }
+
+    // Retry missing locales individually so one bad locale cannot block the rest.
+    if (localesNeedingWork.length > 0) {
+      const stillMissing: string[] = [];
+      for (const targetLocale of localesNeedingWork) {
+        const localeResult = await runHlForLocales([targetLocale], 1);
+        if (!localeResult.ok) {
+          stillMissing.push(targetLocale);
+          // Replace batch-level failure with the per-locale one when available.
+          const idx = runFailures.findIndex((f) => f.locale === targetLocale);
+          const failure = {
+            locale: targetLocale,
+            kind: localeResult.cliFailureKind,
+            exitCode: localeResult.exitCode,
+          };
+          if (idx >= 0) {
+            runFailures[idx] = failure;
+          } else {
+            runFailures.push(failure);
+          }
+          continue;
+        }
+        const { missing } = await tryReadLocaleOutputs([targetLocale], 1);
+        if (missing.length > 0) {
+          stillMissing.push(targetLocale);
+          runFailures.push({
+            locale: targetLocale,
+            kind: "missing_output",
+            exitCode: 0,
+          });
+        } else {
+          // Successfully recovered this locale; drop any prior batch failure record.
+          const idx = runFailures.findIndex((f) => f.locale === targetLocale);
+          if (idx >= 0) {
+            runFailures.splice(idx, 1);
+          }
+        }
+      }
+      localesNeedingWork = stillMissing;
+    }
+
     const glossaryFailuresByLocale: LocaleGlossaryFailure[] = [];
-
     for (const targetLocale of parsedInput.targetLocales) {
-      const outputFilename = getSandboxOutputFilename(sourceFile.filename, targetLocale);
-      const translatedContent = await readOutputStep(sandboxId, outputFilename, 1);
-      translatedByLocale.set(targetLocale, translatedContent);
+      const translatedContent = translatedByLocale.get(targetLocale);
+      if (!translatedContent) {
+        continue;
+      }
 
       const localeTerms = (context.glossaryTerms ?? []).filter(
         (term) => term.targetLocale === targetLocale,
@@ -751,11 +834,10 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
     }
 
     if (glossaryFailuresByLocale.length > 0) {
-      const failedLocales = glossaryFailuresByLocale.map((item) => item.targetLocale);
       console.warn("[file-translation-workflow] glossary validation failed; retrying", {
         jobId: claim.job.id,
         projectId: claim.job.projectId,
-        failedLocales,
+        failedLocales: glossaryFailuresByLocale.map((item) => item.targetLocale),
         failedTermCount: glossaryFailuresByLocale.reduce(
           (sum, item) => sum + item.failures.length,
           0,
@@ -763,24 +845,35 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         attempt: 1,
       });
 
-      const feedback = [
-        "Glossary validation failed. Fix these term constraints exactly and regenerate:",
-        ...glossaryFailuresByLocale.flatMap(({ targetLocale, failures }) => [
-          `Locale ${targetLocale}:`,
+      // Retry each failed locale individually with locale-specific feedback so
+      // one locale's glossary constraints cannot contaminate another.
+      const stillFailing: LocaleGlossaryFailure[] = [];
+      for (const { targetLocale, failures } of glossaryFailuresByLocale) {
+        const feedback = [
+          `Glossary validation failed for locale ${targetLocale}. Fix these term constraints exactly and regenerate:`,
           ...failures.map((failure) =>
             failure.forbidden
               ? `- Forbidden term violation for source "${failure.sourceTerm}": do not use "${failure.targetTerm}"`
               : `- Missing preferred term for source "${failure.sourceTerm}": must include "${failure.targetTerm}"`,
           ),
-        ]),
-      ].join("\n");
+        ].join("\n");
 
-      await runHlForLocales(failedLocales, 2, feedback);
+        const retryResult = await runHlForLocales([targetLocale], 2, feedback);
+        if (!retryResult.ok) {
+          translatedByLocale.delete(targetLocale);
+          stillFailing.push({ targetLocale, failures });
+          continue;
+        }
 
-      const stillFailing: LocaleGlossaryFailure[] = [];
-      for (const targetLocale of failedLocales) {
         const outputFilename = getSandboxOutputFilename(sourceFile.filename, targetLocale);
-        const translatedContent = await readOutputStep(sandboxId, outputFilename, 2);
+        let translatedContent: Buffer;
+        try {
+          translatedContent = await readOutputStep(sandboxId, outputFilename, 2);
+        } catch {
+          translatedByLocale.delete(targetLocale);
+          stillFailing.push({ targetLocale, failures });
+          continue;
+        }
         translatedByLocale.set(targetLocale, translatedContent);
 
         const localeTerms = (context.glossaryTerms ?? []).filter(
@@ -798,25 +891,31 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
           })),
         });
         if (glossaryFailures.length > 0) {
+          translatedByLocale.delete(targetLocale);
           stillFailing.push({ targetLocale, failures: glossaryFailures });
         }
       }
 
       if (stillFailing.length > 0) {
-        const diagnostics = stillFailing.map(({ targetLocale, failures }) => ({
-          targetLocale,
-          failedTermCount: failures.length,
-          failures,
-        }));
-        throw new Error(`glossary validation failed: ${JSON.stringify(diagnostics)}`);
+        runFailures.push(
+          ...stillFailing.map(({ targetLocale }) => ({
+            locale: targetLocale,
+            kind: "glossary_validation",
+            exitCode: 0,
+          })),
+        );
       }
     }
 
+    // Persist every locale we successfully translated. If any locale is still
+    // missing after salvage/retry, persist the good ones then fail the job.
+    const missingLocales: string[] = [];
     for (const targetLocale of parsedInput.targetLocales) {
       const outputFilename = getSandboxOutputFilename(sourceFile.filename, targetLocale);
       const translatedContent = translatedByLocale.get(targetLocale);
       if (!translatedContent) {
-        throw new Error(`missing translated content for ${targetLocale}`);
+        missingLocales.push(targetLocale);
+        continue;
       }
 
       await logDiagnosticsStep(
@@ -884,6 +983,15 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         locale: targetLocale,
         filename: outputFilename,
       });
+    }
+
+    if (missingLocales.length > 0) {
+      const failedKinds = new Map(runFailures.map((f) => [f.locale, f.kind]));
+      throw new Error(
+        `translation failed for locales: ${missingLocales
+          .map((locale) => `${locale}(${failedKinds.get(locale) ?? "missing_output"})`)
+          .join(",")}`,
+      );
     }
 
     await completeFileTranslationJobStep({

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -677,6 +677,17 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
     const runFailures: Array<{ locale: string; kind: string; exitCode: number }> = [];
 
     const runHlForLocales = async (locales: string[], attempt: 1 | 2, retryFeedback?: string) => {
+      const localeSet = new Set(locales);
+      const runContext =
+        context.glossaryTerms != null
+          ? {
+              ...context,
+              glossaryTerms: context.glossaryTerms.filter((term) =>
+                localeSet.has(term.targetLocale),
+              ),
+            }
+          : context;
+
       const translation = await runTranslationStep(
         sandboxId,
         inputFilename,
@@ -684,7 +695,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         parsedInput.sourceLocale,
         locales,
         retryFeedback ? [instructions, retryFeedback].filter(Boolean).join("\n\n") : instructions,
-        context,
+        runContext,
         Object.fromEntries(
           locales
             .filter((locale) => prefilledByLocale[locale])

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -51,6 +51,18 @@ function getSandboxOutputFilename(attachmentFilename: string, targetLocale: stri
   return `${name}-${targetLocale}${ext}`;
 }
 
+function getSandboxOutputFilenamePattern(attachmentFilename: string): string {
+  const inputFilename = sanitizeSandboxFilename(attachmentFilename);
+  const lastDot = inputFilename.lastIndexOf(".");
+  if (lastDot === -1) {
+    return `${inputFilename}-{{target}}`;
+  }
+
+  const name = inputFilename.slice(0, lastDot);
+  const ext = inputFilename.slice(lastDot);
+  return `${name}-{{target}}${ext}`;
+}
+
 function fileExtension(filename: string): string | null {
   const lastDot = filename.lastIndexOf(".");
   if (lastDot === -1 || lastDot === filename.length - 1) {
@@ -228,17 +240,17 @@ async function writeSourceFileStep(sandboxId: string, filename: string, content:
 async function runTranslationStep(
   sandboxId: string,
   inputFile: string,
-  outputFile: string,
+  outputPattern: string,
   sourceLocale: string | null,
-  targetLocale: string,
+  targetLocales: string[],
   instructions: string | null,
   context: SandboxTranslationContext,
-  prefilledEntries: Record<string, string>,
+  prefilledByLocale: Record<string, Record<string, string>>,
 ) {
   "use step";
 
   const {
-    buildTempConfig,
+    buildMultiLocaleTempConfig,
     getSandboxTranslationEnv,
     runSandboxCommand,
     sandboxI18nConfigPath,
@@ -246,33 +258,42 @@ async function runTranslationStep(
     writeTempConfig,
   } = await import("@/lib/translation/sandbox");
 
-  const config = buildTempConfig(
+  const config = buildMultiLocaleTempConfig(
     inputFile,
-    outputFile,
+    outputPattern,
     sourceLocale,
-    targetLocale,
+    targetLocales,
     instructions,
     context,
   );
   await writeTempConfig(sandboxId, config, sandboxI18nConfigPath);
 
-  const prefilledPath = `/tmp/prefilled-${targetLocale}.json`;
+  const localeFlags =
+    targetLocales.length > 0
+      ? targetLocales.map((locale) => `--locale '${shellSingleQuote(locale)}'`).join(" ")
+      : "";
+
   let prefilledFlags = "";
-  if (Object.keys(prefilledEntries).length > 0) {
-    await writeFileToSandbox(
-      sandboxId,
-      prefilledPath,
-      Buffer.from(JSON.stringify(prefilledEntries), "utf8"),
-    );
-    prefilledFlags = ` --prefilled-entries '${shellSingleQuote(prefilledPath)}' --prefilled-target-path '${shellSingleQuote(outputFile)}'`;
+  const localesWithPrefill = Object.entries(prefilledByLocale).filter(
+    ([, entries]) => Object.keys(entries).length > 0,
+  );
+  if (localesWithPrefill.length > 0) {
+    const nested: Record<string, Record<string, string>> = {};
+    for (const [locale, entries] of localesWithPrefill) {
+      nested[locale] = entries;
+    }
+    const prefilledPath = "/tmp/prefilled-by-locale.json";
+    await writeFileToSandbox(sandboxId, prefilledPath, Buffer.from(JSON.stringify(nested), "utf8"));
+    prefilledFlags = ` --prefilled-entries '${shellSingleQuote(prefilledPath)}'`;
   }
 
+  const localeArg = localeFlags ? ` ${localeFlags}` : "";
   return runSandboxCommand(
     sandboxId,
     "bash",
     [
       "-lc",
-      `hl run --config '${shellSingleQuote(sandboxI18nConfigPath)}' --locale '${shellSingleQuote(targetLocale)}' --force --progress off${prefilledFlags}`,
+      `hl run --config '${shellSingleQuote(sandboxI18nConfigPath)}'${localeArg} --force --progress off${prefilledFlags}`,
     ],
     {
       env: getSandboxTranslationEnv(),
@@ -570,9 +591,10 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
     }
 
     const sourceText = sourceContent.toString("utf8");
+    const outputPattern = getSandboxOutputFilenamePattern(sourceFile.filename);
+    const prefilledByLocale: Record<string, Record<string, string>> = {};
 
     for (const targetLocale of parsedInput.targetLocales) {
-      const outputFilename = getSandboxOutputFilename(sourceFile.filename, targetLocale);
       let tmPrefilled: Record<string, string> = {};
       if (sourceEntries) {
         tmPrefilled = await reuseFileTranslationMemoryEntriesStep({
@@ -620,80 +642,154 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         }
       }
 
-      const prefilledEntries = { ...tmPrefilled, ...existingPrefilled };
-      const localeContext = context.glossaryTerms
-        ? {
-            ...context,
-            glossaryTerms: context.glossaryTerms.filter(
-              (term) => term.targetLocale === targetLocale,
-            ),
-          }
-        : context;
+      const merged = { ...tmPrefilled, ...existingPrefilled };
+      if (Object.keys(merged).length > 0) {
+        prefilledByLocale[targetLocale] = merged;
+      }
+    }
 
-      console.info("[file-translation-workflow] starting hl run", {
-        jobId: claim.job.id,
-        projectId: claim.job.projectId,
-        storedFileId: parsedInput.sourceFileId,
-        fileFormat: parsedInput.fileFormat,
-        targetLocale,
-        sandboxInputExtension: fileExtension(inputFilename),
-        sourceEntryCount: sourceEntries ? Object.keys(sourceEntries).length : null,
-        prefilledEntryCount: Object.keys(prefilledEntries).length,
-        tmPrefilledEntryCount: Object.keys(tmPrefilled).length,
-        existingPrefilledEntryCount: Object.keys(existingPrefilled).length,
-        glossaryTermCount: localeContext.glossaryTerms?.length ?? 0,
+    const prefilledLocaleCount = Object.keys(prefilledByLocale).length;
+    const prefilledEntryCount = Object.values(prefilledByLocale).reduce(
+      (sum, entries) => sum + Object.keys(entries).length,
+      0,
+    );
+
+    console.info("[file-translation-workflow] starting hl run", {
+      jobId: claim.job.id,
+      projectId: claim.job.projectId,
+      storedFileId: parsedInput.sourceFileId,
+      fileFormat: parsedInput.fileFormat,
+      targetLocales: parsedInput.targetLocales,
+      sandboxInputExtension: fileExtension(inputFilename),
+      sourceEntryCount: sourceEntries ? Object.keys(sourceEntries).length : null,
+      prefilledLocaleCount,
+      prefilledEntryCount,
+      glossaryTermCount: context.glossaryTerms?.length ?? 0,
+      sandboxId,
+    });
+
+    const runHlForLocales = async (locales: string[], attempt: 1 | 2, retryFeedback?: string) => {
+      const translation = await runTranslationStep(
         sandboxId,
-      });
+        inputFilename,
+        outputPattern,
+        parsedInput.sourceLocale,
+        locales,
+        retryFeedback ? [instructions, retryFeedback].filter(Boolean).join("\n\n") : instructions,
+        context,
+        Object.fromEntries(
+          locales
+            .filter((locale) => prefilledByLocale[locale])
+            .map((locale) => [locale, prefilledByLocale[locale]]),
+        ),
+      );
 
-      const runTranslationWithValidation = async (attempt: 1 | 2, retryFeedback?: string) => {
-        const translation = await runTranslationStep(
-          sandboxId,
-          inputFilename,
-          outputFilename,
-          parsedInput.sourceLocale,
-          targetLocale,
-          retryFeedback ? [instructions, retryFeedback].filter(Boolean).join("\n\n") : instructions,
-          localeContext,
-          prefilledEntries,
-        );
-
-        if (translation.exitCode !== 0) {
-          const cliFailureKind = classifyCliFailureKind(translation.output);
-          console.error("[file-translation-workflow] hl run failed", {
-            jobId: claim.job.id,
-            projectId: claim.job.projectId,
-            storedFileId: parsedInput.sourceFileId,
-            fileFormat: parsedInput.fileFormat,
-            targetLocale,
-            attempt,
-            sandboxInputExtension: fileExtension(inputFilename),
-            exitCode: translation.exitCode,
-            cliOutputLength: translation.output.length,
-            cliFailureKind,
-            prefilledEntryCount: Object.keys(prefilledEntries).length,
-            hasRetryFeedback: Boolean(retryFeedback),
-            sandboxId,
-          });
-          throw new Error(
-            `translation failed for ${targetLocale}: exitCode=${translation.exitCode} kind=${cliFailureKind}`,
-          );
-        }
-
-        console.info("[file-translation-workflow] hl run succeeded", {
+      if (translation.exitCode !== 0) {
+        const cliFailureKind = classifyCliFailureKind(translation.output);
+        console.error("[file-translation-workflow] hl run failed", {
           jobId: claim.job.id,
           projectId: claim.job.projectId,
+          storedFileId: parsedInput.sourceFileId,
           fileFormat: parsedInput.fileFormat,
-          targetLocale,
+          targetLocales: locales,
           attempt,
+          sandboxInputExtension: fileExtension(inputFilename),
           exitCode: translation.exitCode,
+          cliOutputLength: translation.output.length,
+          cliFailureKind,
+          prefilledEntryCount,
+          hasRetryFeedback: Boolean(retryFeedback),
+          sandboxId,
         });
+        throw new Error(
+          `translation failed for ${locales.join(",")}: exitCode=${translation.exitCode} kind=${cliFailureKind}`,
+        );
+      }
 
-        const translatedContent = await readOutputStep(sandboxId, outputFilename, attempt);
-        const translatedText = translatedContent.toString("utf8");
+      console.info("[file-translation-workflow] hl run succeeded", {
+        jobId: claim.job.id,
+        projectId: claim.job.projectId,
+        fileFormat: parsedInput.fileFormat,
+        targetLocales: locales,
+        attempt,
+        exitCode: translation.exitCode,
+      });
+    };
+
+    await runHlForLocales(parsedInput.targetLocales, 1);
+
+    type LocaleGlossaryFailure = {
+      targetLocale: string;
+      failures: ReturnType<typeof validateGlossaryTermsInTranslation>;
+    };
+
+    const translatedByLocale = new Map<string, Buffer>();
+    const glossaryFailuresByLocale: LocaleGlossaryFailure[] = [];
+
+    for (const targetLocale of parsedInput.targetLocales) {
+      const outputFilename = getSandboxOutputFilename(sourceFile.filename, targetLocale);
+      const translatedContent = await readOutputStep(sandboxId, outputFilename, 1);
+      translatedByLocale.set(targetLocale, translatedContent);
+
+      const localeTerms = (context.glossaryTerms ?? []).filter(
+        (term) => term.targetLocale === targetLocale,
+      );
+      const glossaryFailures = validateGlossaryTermsInTranslation({
+        sourceText,
+        translatedText: translatedContent.toString("utf8"),
+        terms: localeTerms.map((term) => ({
+          sourceTerm: term.sourceTerm,
+          targetTerm: term.targetTerm,
+          targetLocale: term.targetLocale,
+          forbidden: term.forbidden,
+          caseSensitive: term.caseSensitive,
+        })),
+      });
+      if (glossaryFailures.length > 0) {
+        glossaryFailuresByLocale.push({ targetLocale, failures: glossaryFailures });
+      }
+    }
+
+    if (glossaryFailuresByLocale.length > 0) {
+      const failedLocales = glossaryFailuresByLocale.map((item) => item.targetLocale);
+      console.warn("[file-translation-workflow] glossary validation failed; retrying", {
+        jobId: claim.job.id,
+        projectId: claim.job.projectId,
+        failedLocales,
+        failedTermCount: glossaryFailuresByLocale.reduce(
+          (sum, item) => sum + item.failures.length,
+          0,
+        ),
+        attempt: 1,
+      });
+
+      const feedback = [
+        "Glossary validation failed. Fix these term constraints exactly and regenerate:",
+        ...glossaryFailuresByLocale.flatMap(({ targetLocale, failures }) => [
+          `Locale ${targetLocale}:`,
+          ...failures.map((failure) =>
+            failure.forbidden
+              ? `- Forbidden term violation for source "${failure.sourceTerm}": do not use "${failure.targetTerm}"`
+              : `- Missing preferred term for source "${failure.sourceTerm}": must include "${failure.targetTerm}"`,
+          ),
+        ]),
+      ].join("\n");
+
+      await runHlForLocales(failedLocales, 2, feedback);
+
+      const stillFailing: LocaleGlossaryFailure[] = [];
+      for (const targetLocale of failedLocales) {
+        const outputFilename = getSandboxOutputFilename(sourceFile.filename, targetLocale);
+        const translatedContent = await readOutputStep(sandboxId, outputFilename, 2);
+        translatedByLocale.set(targetLocale, translatedContent);
+
+        const localeTerms = (context.glossaryTerms ?? []).filter(
+          (term) => term.targetLocale === targetLocale,
+        );
         const glossaryFailures = validateGlossaryTermsInTranslation({
           sourceText,
-          translatedText,
-          terms: (localeContext.glossaryTerms ?? []).map((term) => ({
+          translatedText: translatedContent.toString("utf8"),
+          terms: localeTerms.map((term) => ({
             sourceTerm: term.sourceTerm,
             targetTerm: term.targetTerm,
             targetLocale: term.targetLocale,
@@ -701,39 +797,28 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
             caseSensitive: term.caseSensitive,
           })),
         });
-
-        if (glossaryFailures.length > 0 && attempt === 1) {
-          console.warn("[file-translation-workflow] glossary validation failed; retrying", {
-            jobId: claim.job.id,
-            projectId: claim.job.projectId,
-            targetLocale,
-            failedTermCount: glossaryFailures.length,
-            attempt,
-          });
-          const feedback = [
-            `Glossary validation failed for locale ${targetLocale}. Fix these term constraints exactly and regenerate:`,
-            ...glossaryFailures.map((failure) =>
-              failure.forbidden
-                ? `- Forbidden term violation for source "${failure.sourceTerm}": do not use "${failure.targetTerm}"`
-                : `- Missing preferred term for source "${failure.sourceTerm}": must include "${failure.targetTerm}"`,
-            ),
-          ].join("\n");
-          return runTranslationWithValidation(2, feedback);
-        }
-
         if (glossaryFailures.length > 0) {
-          const diagnostics = {
-            targetLocale,
-            failedTermCount: glossaryFailures.length,
-            failures: glossaryFailures,
-          };
-          throw new Error(`glossary validation failed: ${JSON.stringify(diagnostics)}`);
+          stillFailing.push({ targetLocale, failures: glossaryFailures });
         }
+      }
 
-        return translatedContent;
-      };
+      if (stillFailing.length > 0) {
+        const diagnostics = stillFailing.map(({ targetLocale, failures }) => ({
+          targetLocale,
+          failedTermCount: failures.length,
+          failures,
+        }));
+        throw new Error(`glossary validation failed: ${JSON.stringify(diagnostics)}`);
+      }
+    }
 
-      const translatedContent = await runTranslationWithValidation(1);
+    for (const targetLocale of parsedInput.targetLocales) {
+      const outputFilename = getSandboxOutputFilename(sourceFile.filename, targetLocale);
+      const translatedContent = translatedByLocale.get(targetLocale);
+      if (!translatedContent) {
+        throw new Error(`missing translated content for ${targetLocale}`);
+      }
+
       await logDiagnosticsStep(
         claim.job.id,
         sourceFile.filename,

--- a/docs/plans/2026-07-09-multi-locale-file-translation-run-design.md
+++ b/docs/plans/2026-07-09-multi-locale-file-translation-run-design.md
@@ -50,8 +50,8 @@ Glossary terms for all locales stay in the system prompt (already tagged by loca
 
 ## Errors
 
-- Non-zero `hl run` fails the whole job.
-- Glossary retry covers only locales that failed attempt 1.
+- Non-zero batch `hl run`: salvage any locale outputs already on disk, retry missing locales individually, persist successes, then fail only for locales still missing.
+- Glossary retry runs **per failed locale** with that locale's feedback only (no cross-locale contamination).
 - Single-locale jobs use the same multi-locale path with one target.
 
 ## Testing

--- a/docs/plans/2026-07-09-multi-locale-file-translation-run-design.md
+++ b/docs/plans/2026-07-09-multi-locale-file-translation-run-design.md
@@ -1,0 +1,60 @@
+# Multi-locale file translation in one `hl run`
+
+## Problem
+
+`fileTranslationJobWorkflow` runs `hl run` once per target locale. The CLI already plans and executes all `locales.targets` in one invocation. Prefill is the blocker: `--prefilled-entries` is a flat `map[string]string` scoped to a single `--prefilled-target-path`, so the same entry key cannot carry different values for FR and DE.
+
+## Decision
+
+1. Extend the CLI so `--prefilled-entries` accepts a locale-keyed nested JSON object.
+2. Change the file translation workflow to write one multi-locale config and one `hl run` for all targets.
+3. Validate glossary terms after the run; retry only failed locales.
+
+## Prefill contract
+
+Detection after parsing `--prefilled-entries`:
+
+- Every top-level value is a string → legacy flat mode (still requires `--prefilled-target-path`).
+- Every top-level value is a non-null object → locale-keyed mode (`--prefilled-target-path` must be omitted).
+- Mixed shapes → error.
+
+Locale-keyed apply (after planning + lock filter):
+
+- For each `locale → entries`, stage matching `EntryKey`s onto planned tasks with that `TargetLocale`.
+- Unknown locales in the file → warning; error if the file is non-empty and no entries apply.
+- Empty locale maps are omitted by the workflow writer.
+
+Example:
+
+```json
+{
+  "fr-FR": { "hello": "Bonjour" },
+  "de-DE": { "hello": "Hallo" }
+}
+```
+
+## Workflow
+
+```text
+extract source entries (once)
+assemble prefill per locale → nested JSON
+write config with locales.targets + to: name-{{target}}.ext
+hl run --prefilled-entries (no --locale, no --prefilled-target-path)
+per locale: read output, glossary validate, persist
+retry: hl run --locale <failed...> with feedback
+```
+
+Glossary terms for all locales stay in the system prompt (already tagged by locale).
+
+`provider-agent-file-translate.ts` stays on the per-locale path for now; flat flags remain valid.
+
+## Errors
+
+- Non-zero `hl run` fails the whole job.
+- Glossary retry covers only locales that failed attempt 1.
+- Single-locale jobs use the same multi-locale path with one target.
+
+## Testing
+
+- CLI: flat vs nested parse; reject mixed; nested applies across locales; nested + `--prefilled-target-path` errors; unknown locale warns.
+- Web: multi-target config with `{{target}}`; prefill assembly shape; retry selection for failed locales.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

`fileTranslationJobWorkflow` no longer runs `hl run` once per locale. It writes a multi-locale sandbox config (`locales.targets` + `to: …{{target}}…`) and a single locale-keyed `--prefilled-entries` file, then lets `hl` translate all locales in one invocation.

CLI `--prefilled-entries` now accepts either:

- flat `{ entryId: value }` with `--prefilled-target-path` (unchanged), or
- nested `{ locale: { entryId: value } }` without `--prefilled-target-path`

Glossary validation still runs per locale after the batch; only failed locales are retried.

**Review fixes:**
1. On batch `hl run` failure, salvage any locale outputs already flushed, retry missing locales individually, persist successes, then fail only for locales still missing.
2. Glossary retries run per failed locale with that locale’s feedback only (no cross-locale contamination).
3. Retry/`hl run` configs filter `glossaryTerms` to the locales in that run so single-locale retries don’t include other locales’ terms.

Design notes: `docs/plans/2026-07-09-multi-locale-file-translation-run-design.md`

## How to test

- `go test ./apps/cli/internal/i18n/runsvc/ -run TestApplyPrefilled`
- `go test ./apps/cli/cmd/ -run TestLoadPrefilledEntries`
- `go test ./...`
- `cd apps/hyperlocalise-web && vp test src/lib/translation/sandbox-translation.test.ts && vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `go test ./...`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a60549d-0715-43b1-bca2-9befbf5c5025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a60549d-0715-43b1-bca2-9befbf5c5025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

