### PR TITLE
ci(web): run Hyperlocalise Web Localize on schedule only

### DIFF
--- a/.github/workflows/hyperlocalise-web-localize.yml
+++ b/.github/workflows/hyperlocalise-web-localize.yml
@@ -15,20 +15,12 @@ on:
     - cron: "0 2 * * *"
     # Download translated catalogs later so Hyperlocalise has time to finish jobs.
     - cron: "0 10 * * *"
-  push:
-    branches:
-      - main
-    paths:
-      - apps/hyperlocalise-web/src/**
-      - apps/hyperlocalise-web/i18n.yml
-      - .github/workflows/hyperlocalise-web-localize.yml
-      - .github/actions/hyperlocalise-web-sync/action.yml
 
 permissions:
   contents: read
 
 concurrency:
-  group: hyperlocalise-web-localize-${{ github.event.schedule || github.event.inputs.job || 'push' }}-${{ github.ref }}
+  group: hyperlocalise-web-localize-${{ github.event.schedule || github.event.inputs.job || 'manual' }}-${{ github.ref }}
   cancel-in-progress: false
 
 env:
@@ -49,7 +41,6 @@ jobs:
     name: Upload Web Sources
     if: >-
       ${{
-        github.event_name == 'push' ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.job == 'upload') ||
         (github.event_name == 'schedule' && github.event.schedule == '0 2 * * *')
       }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the `push` trigger from Hyperlocalise Web Localize so it no longer runs on every `main` push.

The workflow still runs:
- on schedule (`0 2 * * *` upload, `0 10 * * *` download)
- via manual `workflow_dispatch`

Also drops the upload job’s `push` condition and updates the concurrency group fallback from `push` to `manual`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73370987-16ce-4cf1-aac4-5cc29da31bab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73370987-16ce-4cf1-aac4-5cc29da31bab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

