### PR TITLE
fix(cli): align markdown hl entries to source keys

### DIFF
--- a/apps/cli/cmd/entries.go
+++ b/apps/cli/cmd/entries.go
@@ -66,6 +66,10 @@ func readEntriesCommandOutput(path string, content []byte, sourcePath, locale st
 	if sourcePath != "" {
 		ext := strings.ToLower(filepath.Ext(path))
 		if ext == ".md" || ext == ".mdx" {
+			sourceExt := strings.ToLower(filepath.Ext(sourcePath))
+			if sourceExt != ext {
+				return nil, fmt.Errorf("entries source extension %q does not match target extension %q", sourceExt, ext)
+			}
 			sourceContent, err := os.ReadFile(sourcePath)
 			if err != nil {
 				return nil, fmt.Errorf("read entries source %q: %w", sourcePath, err)

--- a/apps/cli/cmd/entries.go
+++ b/apps/cli/cmd/entries.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/translationfileparser"
@@ -13,6 +14,7 @@ import (
 
 func newEntriesCmd() *cobra.Command {
 	var locale string
+	var sourcePath string
 
 	cmd := &cobra.Command{
 		Use:          "entries <translation-file>",
@@ -28,16 +30,12 @@ func newEntriesCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("read entries input %q: %w", path, err)
 			}
-			strategy := translationfileparser.NewDefaultStrategy()
-			var entries map[string]string
-			if strings.TrimSpace(locale) != "" {
-				entries, err = strategy.ParseWithLocale(path, content, locale)
-			} else {
-				entries, err = strategy.Parse(path, content)
-			}
+
+			entries, err := readEntriesCommandOutput(path, content, strings.TrimSpace(sourcePath), strings.TrimSpace(locale))
 			if err != nil {
 				return err
 			}
+
 			var buf bytes.Buffer
 			enc := json.NewEncoder(&buf)
 			enc.SetIndent("", "  ")
@@ -55,5 +53,30 @@ func newEntriesCmd() *cobra.Command {
 		"",
 		"target locale for multi-locale files such as .xcstrings",
 	)
+	cmd.Flags().StringVar(
+		&sourcePath,
+		"source",
+		"",
+		"source file used to align content-hashed keys for markdown/MDX targets",
+	)
 	return cmd
+}
+
+func readEntriesCommandOutput(path string, content []byte, sourcePath, locale string) (map[string]string, error) {
+	if sourcePath != "" {
+		ext := strings.ToLower(filepath.Ext(path))
+		if ext == ".md" || ext == ".mdx" {
+			sourceContent, err := os.ReadFile(sourcePath)
+			if err != nil {
+				return nil, fmt.Errorf("read entries source %q: %w", sourcePath, err)
+			}
+			return translationfileparser.AlignMarkdownTargetToSource(sourceContent, content, ext == ".mdx"), nil
+		}
+	}
+
+	strategy := translationfileparser.NewDefaultStrategy()
+	if locale != "" {
+		return strategy.ParseWithLocale(path, content, locale)
+	}
+	return strategy.Parse(path, content)
 }

--- a/apps/cli/cmd/entries_test.go
+++ b/apps/cli/cmd/entries_test.go
@@ -152,6 +152,31 @@ func TestEntriesCommandAlignsMarkdownTargetToSourceKeys(t *testing.T) {
 	}
 }
 
+func TestEntriesCommandRejectsMismatchedMarkdownSourceExtension(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "guide.md")
+	targetPath := filepath.Join(dir, "guide-fr.mdx")
+	if err := os.WriteFile(sourcePath, []byte("# Guide\n\nExisting intro.\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(targetPath, []byte("# Guide\n\nIntro existant.\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	root := newRootCmd("test")
+	out := bytes.NewBuffer(nil)
+	root.SetOut(out)
+	root.SetErr(out)
+	root.SetArgs([]string{"entries", targetPath, "--source", sourcePath})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected mismatched markdown/MDX source extension to fail")
+	}
+	if !strings.Contains(err.Error(), `source extension ".md" does not match target extension ".mdx"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestEntriesCommandWithoutSourceRehashesMarkdownTarget(t *testing.T) {
 	dir := t.TempDir()
 	sourcePath := filepath.Join(dir, "guide.md")

--- a/apps/cli/cmd/entries_test.go
+++ b/apps/cli/cmd/entries_test.go
@@ -5,7 +5,10 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/translationfileparser"
 )
 
 func TestEntriesCommandOutputsParsedEntries(t *testing.T) {
@@ -103,4 +106,100 @@ func TestEntriesCommandUsesLocaleForCSV(t *testing.T) {
 	if payload["hello"] != "Bonjour" {
 		t.Fatalf("expected French CSV column value, got %+v", payload)
 	}
+}
+
+func TestEntriesCommandAlignsMarkdownTargetToSourceKeys(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "guide.md")
+	targetPath := filepath.Join(dir, "guide-fr.md")
+	source := []byte("# Guide\n\nExisting intro.\n\nExisting outro.\n")
+	target := []byte("# Guide\n\nIntro existant.\n\nConclusion existante.\n")
+	if err := os.WriteFile(sourcePath, source, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(targetPath, target, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	sourceEntries, err := (translationfileparser.MarkdownParser{}).Parse(source)
+	if err != nil {
+		t.Fatalf("parse source: %v", err)
+	}
+	introKey := findEntriesTestKeyByValue(sourceEntries, "Existing intro.")
+	outroKey := findEntriesTestKeyByValue(sourceEntries, "Existing outro.")
+	if introKey == "" || outroKey == "" {
+		t.Fatalf("expected source keys for intro/outro, got %#v", sourceEntries)
+	}
+
+	root := newRootCmd("test")
+	out := bytes.NewBuffer(nil)
+	root.SetOut(out)
+	root.SetErr(out)
+	root.SetArgs([]string{"entries", targetPath, "--source", sourcePath})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute entries: %v", err)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if got := strings.TrimSpace(payload[introKey]); got != "Intro existant." {
+		t.Fatalf("expected intro mapped to source key %q, got %q (payload=%+v)", introKey, got, payload)
+	}
+	if got := strings.TrimSpace(payload[outroKey]); got != "Conclusion existante." {
+		t.Fatalf("expected outro mapped to source key %q, got %q (payload=%+v)", outroKey, got, payload)
+	}
+}
+
+func TestEntriesCommandWithoutSourceRehashesMarkdownTarget(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "guide.md")
+	targetPath := filepath.Join(dir, "guide-fr.md")
+	source := []byte("# Guide\n\nExisting intro.\n")
+	target := []byte("# Guide\n\nIntro existant.\n")
+	if err := os.WriteFile(sourcePath, source, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(targetPath, target, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	sourceEntries, err := (translationfileparser.MarkdownParser{}).Parse(source)
+	if err != nil {
+		t.Fatalf("parse source: %v", err)
+	}
+	introKey := findEntriesTestKeyByValue(sourceEntries, "Existing intro.")
+	if introKey == "" {
+		t.Fatalf("expected source key for intro")
+	}
+
+	root := newRootCmd("test")
+	out := bytes.NewBuffer(nil)
+	root.SetOut(out)
+	root.SetErr(out)
+	root.SetArgs([]string{"entries", targetPath})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute entries: %v", err)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if _, ok := payload[introKey]; ok {
+		t.Fatalf("expected bare entries on translated markdown not to keep source key %q, got %+v", introKey, payload)
+	}
+	if findEntriesTestKeyByValue(payload, "Intro existant.") == "" {
+		t.Fatalf("expected translated segment under a rehashed key, got %+v", payload)
+	}
+}
+
+func findEntriesTestKeyByValue(entries map[string]string, want string) string {
+	for key, value := range entries {
+		if strings.TrimSpace(value) == want {
+			return key
+		}
+	}
+	return ""
 }

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
@@ -449,14 +449,16 @@ export class HyperlocaliseCliRunner {
   async extractEntries(
     sandboxId: string,
     path: string,
-    options?: { locale?: string },
+    options?: { locale?: string; sourcePath?: string },
   ): Promise<Record<string, string> | null> {
     const locale = options?.locale?.trim();
     const localeFlag = locale ? ` --locale ${shellQuote(locale)}` : "";
+    const sourcePath = options?.sourcePath?.trim();
+    const sourceFlag = sourcePath ? ` --source ${shellQuote(sourcePath)}` : "";
     const result = await this.lifecycle.runCommand(
       sandboxId,
       "bash",
-      ["-lc", `hl entries ${shellQuote(path)}${localeFlag}`],
+      ["-lc", `hl entries ${shellQuote(path)}${localeFlag}${sourceFlag}`],
       { env: getSandboxTranslationEnv(), output: "stdout" },
     );
     if (result.exitCode !== 0) {
@@ -643,7 +645,7 @@ export async function writeCrowdinFileSandboxConfig(input: {
 export async function extractSandboxEntries(
   sandboxId: string,
   path: string,
-  options?: { locale?: string },
+  options?: { locale?: string; sourcePath?: string },
 ) {
   return defaultRunner.extractEntries(sandboxId, path, options);
 }

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -301,13 +301,19 @@ async function runTranslationStep(
   );
 }
 
-async function extractEntriesStep(sandboxId: string, path: string) {
+async function extractEntriesStep(
+  sandboxId: string,
+  path: string,
+  options?: { sourcePath?: string },
+) {
   "use step";
   const { getSandboxTranslationEnv, runSandboxCommand } = await import("@/lib/translation/sandbox");
+  const sourcePath = options?.sourcePath?.trim();
+  const sourceFlag = sourcePath ? ` --source '${shellSingleQuote(sourcePath)}'` : "";
   const result = await runSandboxCommand(
     sandboxId,
     "bash",
-    ["-lc", `hl entries '${shellSingleQuote(path)}'`],
+    ["-lc", `hl entries '${shellSingleQuote(path)}'${sourceFlag}`],
     { env: getSandboxTranslationEnv(), output: "stdout" },
   );
   if (result.exitCode !== 0) {
@@ -948,7 +954,9 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
 
       if (sourceEntries && repositorySourcePath) {
         try {
-          const targetEntries = await extractEntriesStep(sandboxId, outputFilename);
+          const targetEntries = await extractEntriesStep(sandboxId, outputFilename, {
+            sourcePath: inputFilename,
+          });
           await persistFileTranslationMemoryEntriesStep({
             projectId: claim.job.projectId,
             jobId: claim.job.id,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Markdown translation keys are content-hashed (`md.<sha256>`). After `hl run`, extracting entries from the translated file re-hashed the German text into new keys, so `file-translation-job` persistence matched almost nothing and the CAT UI stayed empty ("Click to translate"). Unchanged segments (e.g. ISO dates) kept the same hash and appeared translated.

- Add `hl entries --source <path>` for `.md`/`.mdx` targets; uses existing `AlignMarkdownTargetToSource` (same as `hl status` / `hl check`).
- Wire `file-translation-job` to call `hl entries --source <source> <target>` when persisting target translations.
- Plumb optional `sourcePath` through `extractSandboxEntries` for other callers.
- Add CLI regression tests for aligned vs bare markdown entries.

## How to test

- [x] `go test ./apps/cli/cmd/ -run TestEntriesCommand`
- [x] `go test ./...`
- [x] `make fmt && make lint`
- [x] `vp check --fix` in `apps/hyperlocalise-web`
- [ ] Re-run a markdown file-translation-job and confirm CAT cells populate under source `md.*` keys

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `go test ./...`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d7d962b-201a-4109-be01-3957b33939ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d7d962b-201a-4109-be01-3957b33939ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

