### PR TITLE
fix(web): recover file translation when sandbox stream closes

### DIFF
--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
@@ -230,6 +230,7 @@ describe("sandbox command runner", () => {
         exitCode: 0,
         output: sandboxMocks.output,
       });
+    const getCommand = vi.fn().mockResolvedValue({ wait });
     sandboxMocks.output.mockResolvedValueOnce("recovered");
     sandboxMocks.runCommand.mockResolvedValueOnce({
       cmdId: "cmd_1",
@@ -242,7 +243,10 @@ describe("sandbox command runner", () => {
       .mockResolvedValueOnce({
         stop,
       })
-      .mockResolvedValueOnce({});
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({
+        getCommand,
+      });
 
     await expect(runSandboxCommand("sandbox_123", "echo", ["hello"])).resolves.toEqual({
       exitCode: 0,
@@ -253,6 +257,7 @@ describe("sandbox command runner", () => {
     expect(sandboxMocks.get).toHaveBeenCalledWith({ name: "sandbox_123", resume: false });
     expect(sandboxMocks.get).toHaveBeenCalledWith({ name: "sandbox_123", resume: true });
     expect(sandboxMocks.runCommand).toHaveBeenCalledTimes(1);
+    expect(getCommand).toHaveBeenCalledWith("cmd_1");
     expect(wait).toHaveBeenCalledTimes(2);
   });
 

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
@@ -41,7 +41,9 @@ import {
   buildTempConfig,
   createTranslationSandbox,
   getOutputFilenamePattern,
+  isSandboxDisconnectError,
   isSandboxStreamClosedError,
+  isSandboxTransientNetworkError,
   runSandboxCommand,
   sandboxFileBucketName,
   sandboxI18nConfigPath,
@@ -52,6 +54,7 @@ import { StreamError } from "@vercel/sandbox";
 describe("sandbox command runner", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // createConfiguredVercelSandbox calls sandbox.runCommand directly (blocking).
     sandboxMocks.runCommand.mockResolvedValue({
       exitCode: 0,
       output: sandboxMocks.output,
@@ -83,10 +86,14 @@ describe("sandbox command runner", () => {
   });
 
   it("captures combined output by default", async () => {
-    sandboxMocks.output.mockResolvedValueOnce("stdout and stderr");
-    sandboxMocks.runCommand.mockResolvedValueOnce({
+    const wait = vi.fn().mockResolvedValue({
       exitCode: 0,
       output: sandboxMocks.output,
+    });
+    sandboxMocks.output.mockResolvedValueOnce("stdout and stderr");
+    sandboxMocks.runCommand.mockResolvedValueOnce({
+      cmdId: "cmd_1",
+      wait,
     });
     sandboxMocks.get.mockResolvedValueOnce({
       runCommand: sandboxMocks.runCommand,
@@ -101,10 +108,14 @@ describe("sandbox command runner", () => {
   });
 
   it("can capture stdout only for machine-readable command output", async () => {
-    sandboxMocks.output.mockResolvedValueOnce('{"hello":"world"}');
-    sandboxMocks.runCommand.mockResolvedValueOnce({
+    const wait = vi.fn().mockResolvedValue({
       exitCode: 0,
       output: sandboxMocks.output,
+    });
+    sandboxMocks.output.mockResolvedValueOnce('{"hello":"world"}');
+    sandboxMocks.runCommand.mockResolvedValueOnce({
+      cmdId: "cmd_1",
+      wait,
     });
     sandboxMocks.get.mockResolvedValueOnce({
       runCommand: sandboxMocks.runCommand,
@@ -140,10 +151,73 @@ describe("sandbox command runner", () => {
     expect(isSandboxStreamClosedError(new Error("translation failed"))).toBe(false);
   });
 
+  it("detects undici terminated network disconnects", () => {
+    const terminated = new TypeError("terminated");
+    (terminated as Error & { cause?: Error }).cause = Object.assign(new Error("read ECONNRESET"), {
+      code: "ECONNRESET",
+    });
+
+    expect(isSandboxTransientNetworkError(terminated)).toBe(true);
+    expect(isSandboxDisconnectError(terminated)).toBe(true);
+    expect(isSandboxStreamClosedError(terminated)).toBe(false);
+  });
+
+  it("runs commands detached and waits for completion", async () => {
+    const wait = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      output: sandboxMocks.output,
+    });
+    sandboxMocks.output.mockResolvedValueOnce("stdout and stderr");
+    sandboxMocks.runCommand.mockResolvedValueOnce({
+      cmdId: "cmd_1",
+      wait,
+    });
+    sandboxMocks.get.mockResolvedValueOnce({
+      runCommand: sandboxMocks.runCommand,
+    });
+
+    await expect(runSandboxCommand("sandbox_123", "echo", ["hello"])).resolves.toEqual({
+      exitCode: 0,
+      output: "stdout and stderr",
+    });
+
+    expect(sandboxMocks.runCommand).toHaveBeenCalledWith({
+      cmd: "echo",
+      args: ["hello"],
+      env: undefined,
+      detached: true,
+    });
+    expect(wait).toHaveBeenCalledTimes(1);
+    expect(sandboxMocks.output).toHaveBeenCalledWith("both");
+  });
+
+  it("retries wait when the wait connection drops with TypeError terminated", async () => {
+    const wait = vi.fn().mockRejectedValueOnce(new TypeError("terminated")).mockResolvedValueOnce({
+      exitCode: 0,
+      output: sandboxMocks.output,
+    });
+    sandboxMocks.output.mockResolvedValueOnce("recovered");
+    sandboxMocks.runCommand.mockResolvedValueOnce({
+      cmdId: "cmd_1",
+      wait,
+    });
+    sandboxMocks.get.mockResolvedValueOnce({
+      runCommand: sandboxMocks.runCommand,
+    });
+
+    await expect(runSandboxCommand("sandbox_123", "echo", ["hello"])).resolves.toEqual({
+      exitCode: 0,
+      output: "recovered",
+    });
+
+    expect(wait).toHaveBeenCalledTimes(2);
+    expect(sandboxMocks.runCommand).toHaveBeenCalledTimes(1);
+  });
+
   it("recovers the sandbox session and retries when the command stream closes", async () => {
     const stop = vi.fn().mockResolvedValue(undefined);
-    sandboxMocks.output.mockResolvedValueOnce("recovered");
-    sandboxMocks.runCommand
+    const wait = vi
+      .fn()
       .mockRejectedValueOnce(
         new StreamError(
           "sandbox_stream_closed",
@@ -154,6 +228,16 @@ describe("sandbox command runner", () => {
       .mockResolvedValueOnce({
         exitCode: 0,
         output: sandboxMocks.output,
+      });
+    sandboxMocks.output.mockResolvedValueOnce("recovered");
+    sandboxMocks.runCommand
+      .mockResolvedValueOnce({
+        cmdId: "cmd_1",
+        wait,
+      })
+      .mockResolvedValueOnce({
+        cmdId: "cmd_2",
+        wait,
       });
     sandboxMocks.get
       .mockResolvedValueOnce({
@@ -352,6 +436,10 @@ describe("sandbox translation failure reasons", () => {
         ),
       ),
     ).toBe(
+      "the translation environment disconnected mid-run. This is usually temporary — try again.",
+    );
+
+    expect(userFacingFailureReason(new TypeError("terminated"))).toBe(
       "the translation environment disconnected mid-run. This is usually temporary — try again.",
     );
   });

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
@@ -44,6 +44,7 @@ import {
   isSandboxDisconnectError,
   isSandboxStreamClosedError,
   isSandboxTransientNetworkError,
+  readTranslatedFile,
   runSandboxCommand,
   sandboxFileBucketName,
   sandboxI18nConfigPath,
@@ -214,7 +215,7 @@ describe("sandbox command runner", () => {
     expect(sandboxMocks.runCommand).toHaveBeenCalledTimes(1);
   });
 
-  it("recovers the sandbox session and retries when the command stream closes", async () => {
+  it("recovers the sandbox session and retries wait when the command stream closes", async () => {
     const stop = vi.fn().mockResolvedValue(undefined);
     const wait = vi
       .fn()
@@ -230,15 +231,10 @@ describe("sandbox command runner", () => {
         output: sandboxMocks.output,
       });
     sandboxMocks.output.mockResolvedValueOnce("recovered");
-    sandboxMocks.runCommand
-      .mockResolvedValueOnce({
-        cmdId: "cmd_1",
-        wait,
-      })
-      .mockResolvedValueOnce({
-        cmdId: "cmd_2",
-        wait,
-      });
+    sandboxMocks.runCommand.mockResolvedValueOnce({
+      cmdId: "cmd_1",
+      wait,
+    });
     sandboxMocks.get
       .mockResolvedValueOnce({
         runCommand: sandboxMocks.runCommand,
@@ -246,10 +242,7 @@ describe("sandbox command runner", () => {
       .mockResolvedValueOnce({
         stop,
       })
-      .mockResolvedValueOnce({})
-      .mockResolvedValueOnce({
-        runCommand: sandboxMocks.runCommand,
-      });
+      .mockResolvedValueOnce({});
 
     await expect(runSandboxCommand("sandbox_123", "echo", ["hello"])).resolves.toEqual({
       exitCode: 0,
@@ -259,7 +252,29 @@ describe("sandbox command runner", () => {
     expect(stop).toHaveBeenCalledTimes(1);
     expect(sandboxMocks.get).toHaveBeenCalledWith({ name: "sandbox_123", resume: false });
     expect(sandboxMocks.get).toHaveBeenCalledWith({ name: "sandbox_123", resume: true });
-    expect(sandboxMocks.runCommand).toHaveBeenCalledTimes(2);
+    expect(sandboxMocks.runCommand).toHaveBeenCalledTimes(1);
+    expect(wait).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries read without stop/resume when the read connection drops", async () => {
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const readFileToBuffer = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("terminated"))
+      .mockResolvedValueOnce(new Uint8Array([1, 2, 3]));
+    sandboxMocks.get
+      .mockResolvedValueOnce({ readFileToBuffer })
+      .mockResolvedValueOnce({ readFileToBuffer });
+
+    await expect(readTranslatedFile("sandbox_123", "source-de-DE.md")).resolves.toEqual(
+      Buffer.from([1, 2, 3]),
+    );
+
+    expect(readFileToBuffer).toHaveBeenCalledTimes(2);
+    expect(stop).not.toHaveBeenCalled();
+    expect(sandboxMocks.get).not.toHaveBeenCalledWith(
+      expect.objectContaining({ resume: expect.anything() }),
+    );
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
@@ -22,6 +22,16 @@ vi.mock("@vercel/sandbox", () => ({
     create: sandboxMocks.create,
     get: sandboxMocks.get,
   },
+  StreamError: class StreamError extends Error {
+    code: string;
+    sessionId: string;
+    constructor(code: string, message: string, sessionId: string) {
+      super(message);
+      this.name = "StreamError";
+      this.code = code;
+      this.sessionId = sessionId;
+    }
+  },
 }));
 
 import {
@@ -31,11 +41,13 @@ import {
   buildTempConfig,
   createTranslationSandbox,
   getOutputFilenamePattern,
+  isSandboxStreamClosedError,
   runSandboxCommand,
   sandboxFileBucketName,
   sandboxI18nConfigPath,
   userFacingFailureReason,
 } from "@/lib/translation/sandbox";
+import { StreamError } from "@vercel/sandbox";
 
 describe("sandbox command runner", () => {
   beforeEach(() => {
@@ -108,6 +120,62 @@ describe("sandbox command runner", () => {
     });
 
     expect(sandboxMocks.output).toHaveBeenCalledWith("stdout");
+  });
+
+  it("detects sandbox stream closed errors", () => {
+    expect(
+      isSandboxStreamClosedError(
+        new StreamError(
+          "sandbox_stream_closed",
+          "Sandbox stream was closed and is not accepting commands.",
+          "session_1",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isSandboxStreamClosedError(
+        new Error("Sandbox stream was closed and is not accepting commands."),
+      ),
+    ).toBe(true);
+    expect(isSandboxStreamClosedError(new Error("translation failed"))).toBe(false);
+  });
+
+  it("recovers the sandbox session and retries when the command stream closes", async () => {
+    const stop = vi.fn().mockResolvedValue(undefined);
+    sandboxMocks.output.mockResolvedValueOnce("recovered");
+    sandboxMocks.runCommand
+      .mockRejectedValueOnce(
+        new StreamError(
+          "sandbox_stream_closed",
+          "Sandbox stream was closed and is not accepting commands.",
+          "session_1",
+        ),
+      )
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        output: sandboxMocks.output,
+      });
+    sandboxMocks.get
+      .mockResolvedValueOnce({
+        runCommand: sandboxMocks.runCommand,
+      })
+      .mockResolvedValueOnce({
+        stop,
+      })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({
+        runCommand: sandboxMocks.runCommand,
+      });
+
+    await expect(runSandboxCommand("sandbox_123", "echo", ["hello"])).resolves.toEqual({
+      exitCode: 0,
+      output: "recovered",
+    });
+
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(sandboxMocks.get).toHaveBeenCalledWith({ name: "sandbox_123", resume: false });
+    expect(sandboxMocks.get).toHaveBeenCalledWith({ name: "sandbox_123", resume: true });
+    expect(sandboxMocks.runCommand).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -272,5 +340,19 @@ describe("sandbox translation failure reasons", () => {
         },
       ),
     ).toBe("the markdown file couldn't be parsed for translation.");
+  });
+
+  it("maps sandbox stream closed errors to a temporary disconnect message", () => {
+    expect(
+      userFacingFailureReason(
+        new StreamError(
+          "sandbox_stream_closed",
+          "Sandbox stream was closed and is not accepting commands.",
+          "session_1",
+        ),
+      ),
+    ).toBe(
+      "the translation environment disconnected mid-run. This is usually temporary — try again.",
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
@@ -291,6 +291,10 @@ export class SandboxLifecycle {
             });
             throw error;
           }
+
+          const sandbox = await Sandbox.get({ name: sandboxId });
+          const command = await sandbox.getCommand(started.cmdId);
+          return command.wait();
         }
 
         return started.wait();

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
@@ -23,8 +23,25 @@ function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return "";
+}
+
+function errorCauseMessage(error: unknown): string {
+  if (!error || typeof error !== "object" || !("cause" in error)) {
+    return "";
+  }
+  return errorMessage((error as { cause?: unknown }).cause);
+}
+
 /**
- * True when the sandbox command stream died mid-flight.
+ * True when the sandbox command stream itself died (session no longer accepts commands).
  * The SDK's withResume only recovers HTTP 410/422 stopped states — not StreamError —
  * so callers must stop+resume (or recreate) before retrying commands.
  */
@@ -43,10 +60,46 @@ export function isSandboxStreamClosedError(error: unknown): boolean {
     return true;
   }
 
+  const message = errorMessage(error);
   return (
-    typeof err.message === "string" &&
-    err.message.includes("Sandbox stream was closed and is not accepting commands")
+    message.includes("Sandbox stream was closed and is not accepting commands") ||
+    message.includes("sandbox_stream_closed") ||
+    message.includes("stream_ended_early")
   );
+}
+
+/**
+ * Transient transport failures while talking to a still-running sandbox.
+ * Commonly undici `TypeError: terminated` when the NDJSON/wait connection drops.
+ */
+export function isSandboxTransientNetworkError(error: unknown): boolean {
+  if (isSandboxStreamClosedError(error)) {
+    return false;
+  }
+
+  const message = errorMessage(error);
+  const cause = errorCauseMessage(error);
+  const combined = `${message}\n${cause}`;
+
+  if (error instanceof TypeError && message === "terminated") {
+    return true;
+  }
+
+  return (
+    message === "terminated" ||
+    combined.includes("fetch failed") ||
+    combined.includes("ECONNRESET") ||
+    combined.includes("ECONNREFUSED") ||
+    combined.includes("ETIMEDOUT") ||
+    combined.includes("socket hang up") ||
+    combined.includes("other side closed") ||
+    combined.includes("UND_ERR_")
+  );
+}
+
+/** Any disconnect that should trigger sandbox recovery or workflow recreate. */
+export function isSandboxDisconnectError(error: unknown): boolean {
+  return isSandboxStreamClosedError(error) || isSandboxTransientNetworkError(error);
 }
 
 export class SandboxErrorMapper {
@@ -122,7 +175,7 @@ export class SandboxErrorMapper {
       return "the translation finished, but the output file couldn't be read back. This is usually temporary.";
     }
 
-    if (isSandboxStreamClosedError(error)) {
+    if (isSandboxDisconnectError(error)) {
       return "the translation environment disconnected mid-run. This is usually temporary — try again.";
     }
 
@@ -151,7 +204,7 @@ export class SandboxLifecycle {
       await sandbox.stop();
     } catch (error) {
       // Already stopped / gone — still try resume below.
-      if (!isSandboxStreamClosedError(error)) {
+      if (!isSandboxDisconnectError(error)) {
         console.warn("[sandbox] stop before resume failed", {
           sandboxId,
           error: error instanceof Error ? error.message : "unknown",
@@ -162,15 +215,20 @@ export class SandboxLifecycle {
     await Sandbox.get({ name: sandboxId, resume: true });
   }
 
-  private async withStreamRecovery<T>(sandboxId: string, fn: () => Promise<T>): Promise<T> {
+  private async withDisconnectRecovery<T>(sandboxId: string, fn: () => Promise<T>): Promise<T> {
     try {
       return await fn();
     } catch (error) {
-      if (!isSandboxStreamClosedError(error)) {
+      if (!isSandboxDisconnectError(error)) {
         throw error;
       }
 
-      console.warn("[sandbox] command stream closed; recovering session", { sandboxId });
+      console.warn("[sandbox] disconnect during sandbox IO; recovering session", {
+        sandboxId,
+        streamClosed: isSandboxStreamClosedError(error),
+        transientNetwork: isSandboxTransientNetworkError(error),
+        error: error instanceof Error ? error.message : "unknown",
+      });
       try {
         await this.recoverSession(sandboxId);
       } catch (recoverError) {
@@ -190,12 +248,37 @@ export class SandboxLifecycle {
     args: string[],
     options?: { env?: Record<string, string>; output?: "stdout" | "stderr" | "both" },
   ): Promise<{ exitCode: number; output: string }> {
-    return this.withStreamRecovery(sandboxId, async () => {
+    return this.withDisconnectRecovery(sandboxId, async () => {
       const sandbox = await Sandbox.get({ name: sandboxId });
-      const result = await sandbox.runCommand({ cmd: command, args, env: options?.env });
+      // Detached start + wait avoids the long-lived NDJSON wait:true stream that
+      // undici often aborts with TypeError: terminated on long hl runs.
+      const started = await sandbox.runCommand({
+        cmd: command,
+        args,
+        env: options?.env,
+        detached: true,
+      });
+
+      let finished;
+      try {
+        finished = await started.wait();
+      } catch (error) {
+        if (!isSandboxTransientNetworkError(error)) {
+          throw error;
+        }
+        // Wait connection dropped, but the command may still be running.
+        // Poll getCommand again without tearing down the sandbox.
+        console.warn("[sandbox] wait connection dropped; retrying command wait", {
+          sandboxId,
+          cmdId: started.cmdId,
+          error: error instanceof Error ? error.message : "unknown",
+        });
+        finished = await started.wait();
+      }
+
       return {
-        exitCode: result.exitCode,
-        output: await result.output(options?.output ?? "both"),
+        exitCode: finished.exitCode,
+        output: await finished.output(options?.output ?? "both"),
       };
     });
   }
@@ -204,7 +287,7 @@ export class SandboxLifecycle {
     sandboxId: string,
     files: Array<{ path: string; content: string | Buffer }>,
   ): Promise<void> {
-    return this.withStreamRecovery(sandboxId, async () => {
+    return this.withDisconnectRecovery(sandboxId, async () => {
       const sandbox = await Sandbox.get({ name: sandboxId });
       await sandbox.writeFiles(
         files.map((file) => ({
@@ -216,7 +299,7 @@ export class SandboxLifecycle {
   }
 
   async readFile(sandboxId: string, outputFile: string): Promise<Buffer> {
-    return this.withStreamRecovery(sandboxId, async () => {
+    return this.withDisconnectRecovery(sandboxId, async () => {
       const sandbox = await Sandbox.get({ name: sandboxId });
       const content = await sandbox.readFileToBuffer({ path: outputFile });
       if (!content) {

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
@@ -248,39 +248,86 @@ export class SandboxLifecycle {
     args: string[],
     options?: { env?: Record<string, string>; output?: "stdout" | "stderr" | "both" },
   ): Promise<{ exitCode: number; output: string }> {
-    return this.withDisconnectRecovery(sandboxId, async () => {
+    const outputMode = options?.output ?? "both";
+
+    const startDetachedCommand = async () => {
       const sandbox = await Sandbox.get({ name: sandboxId });
       // Detached start + wait avoids the long-lived NDJSON wait:true stream that
       // undici often aborts with TypeError: terminated on long hl runs.
-      const started = await sandbox.runCommand({
+      return sandbox.runCommand({
         cmd: command,
         args,
         env: options?.env,
         detached: true,
       });
+    };
 
-      let finished;
+    const waitForDetachedCommand = async (
+      started: Awaited<ReturnType<typeof startDetachedCommand>>,
+    ) => {
       try {
-        finished = await started.wait();
+        return await started.wait();
       } catch (error) {
-        if (!isSandboxTransientNetworkError(error)) {
+        if (!isSandboxDisconnectError(error)) {
           throw error;
         }
-        // Wait connection dropped, but the command may still be running.
-        // Poll getCommand again without tearing down the sandbox.
-        console.warn("[sandbox] wait connection dropped; retrying command wait", {
+
+        // The detached command may still be running — never submit a second copy.
+        console.warn("[sandbox] disconnect while waiting for detached command; retrying wait", {
           sandboxId,
           cmdId: started.cmdId,
+          streamClosed: isSandboxStreamClosedError(error),
+          transientNetwork: isSandboxTransientNetworkError(error),
           error: error instanceof Error ? error.message : "unknown",
         });
-        finished = await started.wait();
+
+        if (isSandboxStreamClosedError(error)) {
+          try {
+            await this.recoverSession(sandboxId);
+          } catch (recoverError) {
+            console.warn("[sandbox] session recovery failed", {
+              sandboxId,
+              error: recoverError instanceof Error ? recoverError.message : "unknown",
+            });
+            throw error;
+          }
+        }
+
+        return started.wait();
+      }
+    };
+
+    let started;
+    try {
+      started = await startDetachedCommand();
+    } catch (error) {
+      if (!isSandboxDisconnectError(error)) {
+        throw error;
       }
 
-      return {
-        exitCode: finished.exitCode,
-        output: await finished.output(options?.output ?? "both"),
-      };
-    });
+      console.warn("[sandbox] disconnect during sandbox IO; recovering session", {
+        sandboxId,
+        streamClosed: isSandboxStreamClosedError(error),
+        transientNetwork: isSandboxTransientNetworkError(error),
+        error: error instanceof Error ? error.message : "unknown",
+      });
+      try {
+        await this.recoverSession(sandboxId);
+      } catch (recoverError) {
+        console.warn("[sandbox] session recovery failed", {
+          sandboxId,
+          error: recoverError instanceof Error ? recoverError.message : "unknown",
+        });
+        throw error;
+      }
+      started = await startDetachedCommand();
+    }
+
+    const finished = await waitForDetachedCommand(started);
+    return {
+      exitCode: finished.exitCode,
+      output: await finished.output(outputMode),
+    };
   }
 
   async writeFiles(
@@ -299,14 +346,33 @@ export class SandboxLifecycle {
   }
 
   async readFile(sandboxId: string, outputFile: string): Promise<Buffer> {
-    return this.withDisconnectRecovery(sandboxId, async () => {
+    const readOnce = async () => {
       const sandbox = await Sandbox.get({ name: sandboxId });
       const content = await sandbox.readFileToBuffer({ path: outputFile });
       if (!content) {
         throw new Error(`failed to read translated file: ${outputFile}`);
       }
       return Buffer.from(content);
-    });
+    };
+
+    try {
+      return await readOnce();
+    } catch (error) {
+      if (!isSandboxDisconnectError(error)) {
+        throw error;
+      }
+
+      // Reconnect and retry the read only. Stop+resume rolls persistent sandboxes
+      // back to the last snapshot and can discard output files from a just-finished run.
+      console.warn("[sandbox] disconnect during sandbox read; retrying read", {
+        sandboxId,
+        outputFile,
+        streamClosed: isSandboxStreamClosedError(error),
+        transientNetwork: isSandboxTransientNetworkError(error),
+        error: error instanceof Error ? error.message : "unknown",
+      });
+      return readOnce();
+    }
   }
 }
 

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
@@ -1,4 +1,4 @@
-import { Sandbox } from "@vercel/sandbox";
+import { Sandbox, StreamError } from "@vercel/sandbox";
 
 import { env } from "@/lib/env";
 import { createConfiguredVercelSandbox } from "@/lib/vercel-sandbox-config";
@@ -21,6 +21,32 @@ export type { SandboxTranslationContext };
 
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+/**
+ * True when the sandbox command stream died mid-flight.
+ * The SDK's withResume only recovers HTTP 410/422 stopped states — not StreamError —
+ * so callers must stop+resume (or recreate) before retrying commands.
+ */
+export function isSandboxStreamClosedError(error: unknown): boolean {
+  if (error instanceof StreamError) {
+    return error.code === "sandbox_stream_closed" || error.code === "stream_ended_early";
+  }
+
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const err = error as { name?: unknown; code?: unknown; message?: unknown };
+  const code = typeof err.code === "string" ? err.code : null;
+  if (code === "sandbox_stream_closed" || code === "stream_ended_early") {
+    return true;
+  }
+
+  return (
+    typeof err.message === "string" &&
+    err.message.includes("Sandbox stream was closed and is not accepting commands")
+  );
 }
 
 export class SandboxErrorMapper {
@@ -96,6 +122,10 @@ export class SandboxErrorMapper {
       return "the translation finished, but the output file couldn't be read back. This is usually temporary.";
     }
 
+    if (isSandboxStreamClosedError(error)) {
+      return "the translation environment disconnected mid-run. This is usually temporary — try again.";
+    }
+
     return "the translation failed before it could finish. This is usually temporary.";
   }
 }
@@ -111,40 +141,89 @@ export class SandboxLifecycle {
     await sandbox.stop();
   }
 
+  /**
+   * Force a new session after the command stream dies.
+   * Persistent sandboxes restore filesystem from the last snapshot on resume.
+   */
+  async recoverSession(sandboxId: string): Promise<void> {
+    try {
+      const sandbox = await Sandbox.get({ name: sandboxId, resume: false });
+      await sandbox.stop();
+    } catch (error) {
+      // Already stopped / gone — still try resume below.
+      if (!isSandboxStreamClosedError(error)) {
+        console.warn("[sandbox] stop before resume failed", {
+          sandboxId,
+          error: error instanceof Error ? error.message : "unknown",
+        });
+      }
+    }
+
+    await Sandbox.get({ name: sandboxId, resume: true });
+  }
+
+  private async withStreamRecovery<T>(sandboxId: string, fn: () => Promise<T>): Promise<T> {
+    try {
+      return await fn();
+    } catch (error) {
+      if (!isSandboxStreamClosedError(error)) {
+        throw error;
+      }
+
+      console.warn("[sandbox] command stream closed; recovering session", { sandboxId });
+      try {
+        await this.recoverSession(sandboxId);
+      } catch (recoverError) {
+        console.warn("[sandbox] session recovery failed", {
+          sandboxId,
+          error: recoverError instanceof Error ? recoverError.message : "unknown",
+        });
+        throw error;
+      }
+      return fn();
+    }
+  }
+
   async runCommand(
     sandboxId: string,
     command: string,
     args: string[],
     options?: { env?: Record<string, string>; output?: "stdout" | "stderr" | "both" },
   ): Promise<{ exitCode: number; output: string }> {
-    const sandbox = await Sandbox.get({ name: sandboxId });
-    const result = await sandbox.runCommand({ cmd: command, args, env: options?.env });
-    return {
-      exitCode: result.exitCode,
-      output: await result.output(options?.output ?? "both"),
-    };
+    return this.withStreamRecovery(sandboxId, async () => {
+      const sandbox = await Sandbox.get({ name: sandboxId });
+      const result = await sandbox.runCommand({ cmd: command, args, env: options?.env });
+      return {
+        exitCode: result.exitCode,
+        output: await result.output(options?.output ?? "both"),
+      };
+    });
   }
 
   async writeFiles(
     sandboxId: string,
     files: Array<{ path: string; content: string | Buffer }>,
   ): Promise<void> {
-    const sandbox = await Sandbox.get({ name: sandboxId });
-    await sandbox.writeFiles(
-      files.map((file) => ({
-        path: file.path,
-        content: file.content,
-      })),
-    );
+    return this.withStreamRecovery(sandboxId, async () => {
+      const sandbox = await Sandbox.get({ name: sandboxId });
+      await sandbox.writeFiles(
+        files.map((file) => ({
+          path: file.path,
+          content: file.content,
+        })),
+      );
+    });
   }
 
   async readFile(sandboxId: string, outputFile: string): Promise<Buffer> {
-    const sandbox = await Sandbox.get({ name: sandboxId });
-    const content = await sandbox.readFileToBuffer({ path: outputFile });
-    if (!content) {
-      throw new Error(`failed to read translated file: ${outputFile}`);
-    }
-    return Buffer.from(content);
+    return this.withStreamRecovery(sandboxId, async () => {
+      const sandbox = await Sandbox.get({ name: sandboxId });
+      const content = await sandbox.readFileToBuffer({ path: outputFile });
+      if (!content) {
+        throw new Error(`failed to read translated file: ${outputFile}`);
+      }
+      return Buffer.from(content);
+    });
   }
 }
 
@@ -519,6 +598,10 @@ export async function createTranslationSandbox() {
 
 export async function stopTranslationSandbox(sandboxId: string) {
   return defaultLifecycle.stop(sandboxId);
+}
+
+export async function recoverTranslationSandboxSession(sandboxId: string) {
+  return defaultLifecycle.recoverSession(sandboxId);
 }
 
 export async function runSandboxCommand(

--- a/apps/hyperlocalise-web/src/workflows/README.md
+++ b/apps/hyperlocalise-web/src/workflows/README.md
@@ -95,7 +95,7 @@ fileTranslationJobWorkflow
         |
         +-- hl run (all target locales, nested --prefilled-entries)
         |
-        +-- on sandbox stream closed: recreate sandbox + rewrite source, then retry
+        +-- on sandbox disconnect (stream closed / undici terminated): recreate sandbox + rewrite source, then retry
         |
         +-- per locale: validate glossary
         |

--- a/apps/hyperlocalise-web/src/workflows/README.md
+++ b/apps/hyperlocalise-web/src/workflows/README.md
@@ -95,7 +95,7 @@ fileTranslationJobWorkflow
         |
         +-- hl run (all target locales, nested --prefilled-entries)
         |
-        +-- on sandbox disconnect (stream closed / undici terminated): recreate sandbox + rewrite source, then retry
+        +-- on sandbox disconnect: retry same sandbox without --force (lockfile resume), else recreate
         |
         +-- per locale: validate glossary
         |

--- a/apps/hyperlocalise-web/src/workflows/README.md
+++ b/apps/hyperlocalise-web/src/workflows/README.md
@@ -95,6 +95,8 @@ fileTranslationJobWorkflow
         |
         +-- hl run (all target locales, nested --prefilled-entries)
         |
+        +-- on sandbox stream closed: recreate sandbox + rewrite source, then retry
+        |
         +-- per locale: validate glossary
         |
         +-- retry hl run for glossary-failed locales only

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -183,6 +183,14 @@ function userFacingTranslationFailureReason(
   return "the file format may not be supported, or the content didn't match what the translator expected.";
 }
 
+function isSandboxStreamClosedMessage(message: string): boolean {
+  return (
+    message.includes("Sandbox stream was closed and is not accepting commands") ||
+    message.includes("sandbox_stream_closed") ||
+    message.includes("stream_ended_early")
+  );
+}
+
 function userFacingFailureReason(
   error: unknown,
   detection?: {
@@ -195,6 +203,10 @@ function userFacingFailureReason(
 
   if (message.startsWith("glossary validation failed")) {
     return message;
+  }
+
+  if (isSandboxStreamClosedMessage(message)) {
+    return "the translation environment disconnected mid-run. This is usually temporary — try again.";
   }
 
   if (
@@ -237,6 +249,29 @@ async function writeSourceFileStep(sandboxId: string, filename: string, content:
   return writeFileToSandbox(sandboxId, filename, content);
 }
 
+async function recreateSandboxWithSourceStep(input: {
+  previousSandboxId: string | null;
+  filename: string;
+  content: Buffer;
+}) {
+  "use step";
+  const { createTranslationSandbox, prepareSandbox, stopTranslationSandbox, writeFileToSandbox } =
+    await import("@/lib/translation/sandbox");
+
+  if (input.previousSandboxId) {
+    try {
+      await stopTranslationSandbox(input.previousSandboxId);
+    } catch {
+      // Best-effort cleanup of the dead sandbox.
+    }
+  }
+
+  const { sandboxId } = await createTranslationSandbox();
+  await prepareSandbox(sandboxId);
+  await writeFileToSandbox(sandboxId, input.filename, input.content);
+  return { sandboxId };
+}
+
 async function runTranslationStep(
   sandboxId: string,
   inputFile: string,
@@ -252,6 +287,8 @@ async function runTranslationStep(
   const {
     buildMultiLocaleTempConfig,
     getSandboxTranslationEnv,
+    isSandboxStreamClosedError,
+    recoverTranslationSandboxSession,
     runSandboxCommand,
     sandboxI18nConfigPath,
     writeFileToSandbox,
@@ -288,17 +325,33 @@ async function runTranslationStep(
   }
 
   const localeArg = localeFlags ? ` ${localeFlags}` : "";
-  return runSandboxCommand(
-    sandboxId,
-    "bash",
-    [
-      "-lc",
-      `hl run --config '${shellSingleQuote(sandboxI18nConfigPath)}'${localeArg} --force --progress off${prefilledFlags}`,
-    ],
-    {
-      env: getSandboxTranslationEnv(),
-    },
-  );
+  try {
+    return await runSandboxCommand(
+      sandboxId,
+      "bash",
+      [
+        "-lc",
+        `hl run --config '${shellSingleQuote(sandboxI18nConfigPath)}'${localeArg} --force --progress off${prefilledFlags}`,
+      ],
+      {
+        env: getSandboxTranslationEnv(),
+      },
+    );
+  } catch (error) {
+    // Surface a stable marker so the workflow can recreate the sandbox when
+    // session recovery inside runSandboxCommand is not enough.
+    if (isSandboxStreamClosedError(error)) {
+      try {
+        await recoverTranslationSandboxSession(sandboxId);
+      } catch {
+        // Ignore — workflow will recreate.
+      }
+      throw new Error(
+        `sandbox_stream_closed: Sandbox stream was closed and is not accepting commands.`,
+      );
+    }
+    throw error;
+  }
 }
 
 async function extractEntriesStep(
@@ -540,7 +593,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
     throw error;
   }
 
-  const { sandboxId } = await createSandboxStep();
+  let { sandboxId } = await createSandboxStep();
   const inputFilename = getSandboxInputFilename(sourceFile.filename);
   const instructions = parsedInput.metadata?.instructions ?? null;
   const context = await assembleFileTranslationContextStep({
@@ -694,20 +747,48 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
             }
           : context;
 
-      const translation = await runTranslationStep(
-        sandboxId,
-        inputFilename,
-        outputPattern,
-        parsedInput.sourceLocale,
-        locales,
-        retryFeedback ? [instructions, retryFeedback].filter(Boolean).join("\n\n") : instructions,
-        runContext,
-        Object.fromEntries(
-          locales
-            .filter((locale) => prefilledByLocale[locale])
-            .map((locale) => [locale, prefilledByLocale[locale]]),
-        ),
-      );
+      const runOnce = async () =>
+        runTranslationStep(
+          sandboxId,
+          inputFilename,
+          outputPattern,
+          parsedInput.sourceLocale,
+          locales,
+          retryFeedback ? [instructions, retryFeedback].filter(Boolean).join("\n\n") : instructions,
+          runContext,
+          Object.fromEntries(
+            locales
+              .filter((locale) => prefilledByLocale[locale])
+              .map((locale) => [locale, prefilledByLocale[locale]]),
+          ),
+        );
+
+      let translation: Awaited<ReturnType<typeof runTranslationStep>>;
+      try {
+        translation = await runOnce();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "";
+        if (!isSandboxStreamClosedMessage(message)) {
+          throw error;
+        }
+
+        // Stream closed mid-run: the old session cannot accept more commands.
+        // Recreate a fresh sandbox with the source file so locale retries can proceed.
+        console.warn("[file-translation-workflow] sandbox stream closed; recreating sandbox", {
+          jobId: claim.job.id,
+          projectId: claim.job.projectId,
+          previousSandboxId: sandboxId,
+          targetLocales: locales,
+          attempt,
+        });
+        const recreated = await recreateSandboxWithSourceStep({
+          previousSandboxId: sandboxId,
+          filename: inputFilename,
+          content: sourceContent,
+        });
+        sandboxId = recreated.sandboxId;
+        translation = await runOnce();
+      }
 
       if (translation.exitCode !== 0) {
         const cliFailureKind = classifyCliFailureKind(translation.output);

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -286,6 +286,7 @@ async function runTranslationStep(
   instructions: string | null,
   context: SandboxTranslationContext,
   prefilledByLocale: Record<string, Record<string, string>>,
+  options?: { force?: boolean },
 ) {
   "use step";
 
@@ -330,13 +331,16 @@ async function runTranslationStep(
   }
 
   const localeArg = localeFlags ? ` ${localeFlags}` : "";
+  // First runs use --force for a clean slate. Same-sandbox retries omit it so
+  // `.hyperlocalise.lock.json` can skip completed tasks / resume checkpoints.
+  const forceFlag = options?.force === false ? "" : " --force";
   try {
     return await runSandboxCommand(
       sandboxId,
       "bash",
       [
         "-lc",
-        `hl run --config '${shellSingleQuote(sandboxI18nConfigPath)}'${localeArg} --force --progress off${prefilledFlags}`,
+        `hl run --config '${shellSingleQuote(sandboxI18nConfigPath)}'${localeArg}${forceFlag} --progress off${prefilledFlags}`,
       ],
       {
         env: getSandboxTranslationEnv(),
@@ -740,7 +744,13 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
     const translatedByLocale = new Map<string, Buffer>();
     const runFailures: Array<{ locale: string; kind: string; exitCode: number }> = [];
 
-    const runHlForLocales = async (locales: string[], attempt: 1 | 2, retryFeedback?: string) => {
+    const runHlForLocales = async (
+      locales: string[],
+      attempt: 1 | 2,
+      options?: { retryFeedback?: string; force?: boolean },
+    ) => {
+      const force = options?.force ?? true;
+      const retryFeedback = options?.retryFeedback;
       const localeSet = new Set(locales);
       const runContext =
         context.glossaryTerms != null
@@ -752,7 +762,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
             }
           : context;
 
-      const runOnce = async () =>
+      const runOnce = async (runForce: boolean) =>
         runTranslationStep(
           sandboxId,
           inputFilename,
@@ -766,34 +776,53 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
               .filter((locale) => prefilledByLocale[locale])
               .map((locale) => [locale, prefilledByLocale[locale]]),
           ),
+          { force: runForce },
         );
 
       let translation: Awaited<ReturnType<typeof runTranslationStep>>;
       try {
-        translation = await runOnce();
+        translation = await runOnce(force);
       } catch (error) {
         const message = error instanceof Error ? error.message : "";
         if (!isSandboxDisconnectMessage(message)) {
           throw error;
         }
 
-        // Disconnect mid-run: recreate a fresh sandbox with the source file
-        // so locale retries can proceed on a healthy session.
-        console.warn("[file-translation-workflow] sandbox disconnect; recreating sandbox", {
+        // Prefer same-sandbox resume without --force so the lockfile can skip
+        // completed tasks. Only recreate when that still cannot accept commands.
+        console.warn("[file-translation-workflow] sandbox disconnect; retrying without force", {
           jobId: claim.job.id,
           projectId: claim.job.projectId,
-          previousSandboxId: sandboxId,
+          sandboxId,
           targetLocales: locales,
           attempt,
           error: message,
         });
-        const recreated = await recreateSandboxWithSourceStep({
-          previousSandboxId: sandboxId,
-          filename: inputFilename,
-          content: sourceContent,
-        });
-        sandboxId = recreated.sandboxId;
-        translation = await runOnce();
+        try {
+          translation = await runOnce(false);
+        } catch (retryError) {
+          const retryMessage = retryError instanceof Error ? retryError.message : "";
+          if (!isSandboxDisconnectMessage(retryMessage)) {
+            throw retryError;
+          }
+
+          console.warn("[file-translation-workflow] sandbox disconnect; recreating sandbox", {
+            jobId: claim.job.id,
+            projectId: claim.job.projectId,
+            previousSandboxId: sandboxId,
+            targetLocales: locales,
+            attempt,
+            error: retryMessage,
+          });
+          const recreated = await recreateSandboxWithSourceStep({
+            previousSandboxId: sandboxId,
+            filename: inputFilename,
+            content: sourceContent,
+          });
+          sandboxId = recreated.sandboxId;
+          // Fresh sandbox has no lockfile — force is irrelevant; keep caller's intent.
+          translation = await runOnce(force);
+        }
       }
 
       if (translation.exitCode !== 0) {
@@ -805,6 +834,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
           fileFormat: parsedInput.fileFormat,
           targetLocales: locales,
           attempt,
+          force,
           sandboxInputExtension: fileExtension(inputFilename),
           exitCode: translation.exitCode,
           cliOutputLength: translation.output.length,
@@ -822,6 +852,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         fileFormat: parsedInput.fileFormat,
         targetLocales: locales,
         attempt,
+        force,
         exitCode: translation.exitCode,
       });
       return { ok: true as const };
@@ -845,7 +876,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
 
     // Happy path: one batched run for all locales. On non-zero exit, salvage
     // any locale outputs the CLI already flushed, then retry only missing ones.
-    const batchResult = await runHlForLocales(parsedInput.targetLocales, 1);
+    const batchResult = await runHlForLocales(parsedInput.targetLocales, 1, { force: true });
     let localesNeedingWork = [...parsedInput.targetLocales];
 
     if (batchResult.ok) {
@@ -872,10 +903,11 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
     }
 
     // Retry missing locales individually so one bad locale cannot block the rest.
+    // Omit --force so the lockfile can skip work already completed in the batch.
     if (localesNeedingWork.length > 0) {
       const stillMissing: string[] = [];
       for (const targetLocale of localesNeedingWork) {
-        const localeResult = await runHlForLocales([targetLocale], 1);
+        const localeResult = await runHlForLocales([targetLocale], 1, { force: false });
         if (!localeResult.ok) {
           stillMissing.push(targetLocale);
           // Replace batch-level failure with the per-locale one when available.
@@ -962,7 +994,10 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
           ),
         ].join("\n");
 
-        const retryResult = await runHlForLocales([targetLocale], 2, feedback);
+        const retryResult = await runHlForLocales([targetLocale], 2, {
+          retryFeedback: feedback,
+          force: true,
+        });
         if (!retryResult.ok) {
           translatedByLocale.delete(targetLocale);
           stillFailing.push({ targetLocale, failures });

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -903,11 +903,11 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
     }
 
     // Retry missing locales individually so one bad locale cannot block the rest.
-    // Omit --force so the lockfile can skip work already completed in the batch.
+    // Use --force: a failed batch may have checkpointed a locale before flushing output.
     if (localesNeedingWork.length > 0) {
       const stillMissing: string[] = [];
       for (const targetLocale of localesNeedingWork) {
-        const localeResult = await runHlForLocales([targetLocale], 1, { force: false });
+        const localeResult = await runHlForLocales([targetLocale], 1, { force: true });
         if (!localeResult.ok) {
           stillMissing.push(targetLocale);
           // Replace batch-level failure with the per-locale one when available.

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -183,11 +183,16 @@ function userFacingTranslationFailureReason(
   return "the file format may not be supported, or the content didn't match what the translator expected.";
 }
 
-function isSandboxStreamClosedMessage(message: string): boolean {
+function isSandboxDisconnectMessage(message: string): boolean {
   return (
     message.includes("Sandbox stream was closed and is not accepting commands") ||
     message.includes("sandbox_stream_closed") ||
-    message.includes("stream_ended_early")
+    message.includes("stream_ended_early") ||
+    message.includes("sandbox_disconnect") ||
+    message === "terminated" ||
+    message.includes("fetch failed") ||
+    message.includes("ECONNRESET") ||
+    message.includes("UND_ERR_")
   );
 }
 
@@ -205,7 +210,7 @@ function userFacingFailureReason(
     return message;
   }
 
-  if (isSandboxStreamClosedMessage(message)) {
+  if (isSandboxDisconnectMessage(message)) {
     return "the translation environment disconnected mid-run. This is usually temporary — try again.";
   }
 
@@ -287,7 +292,7 @@ async function runTranslationStep(
   const {
     buildMultiLocaleTempConfig,
     getSandboxTranslationEnv,
-    isSandboxStreamClosedError,
+    isSandboxDisconnectError,
     recoverTranslationSandboxSession,
     runSandboxCommand,
     sandboxI18nConfigPath,
@@ -340,14 +345,14 @@ async function runTranslationStep(
   } catch (error) {
     // Surface a stable marker so the workflow can recreate the sandbox when
     // session recovery inside runSandboxCommand is not enough.
-    if (isSandboxStreamClosedError(error)) {
+    if (isSandboxDisconnectError(error)) {
       try {
         await recoverTranslationSandboxSession(sandboxId);
       } catch {
         // Ignore — workflow will recreate.
       }
       throw new Error(
-        `sandbox_stream_closed: Sandbox stream was closed and is not accepting commands.`,
+        `sandbox_disconnect: Sandbox stream was closed and is not accepting commands.`,
       );
     }
     throw error;
@@ -768,18 +773,19 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         translation = await runOnce();
       } catch (error) {
         const message = error instanceof Error ? error.message : "";
-        if (!isSandboxStreamClosedMessage(message)) {
+        if (!isSandboxDisconnectMessage(message)) {
           throw error;
         }
 
-        // Stream closed mid-run: the old session cannot accept more commands.
-        // Recreate a fresh sandbox with the source file so locale retries can proceed.
-        console.warn("[file-translation-workflow] sandbox stream closed; recreating sandbox", {
+        // Disconnect mid-run: recreate a fresh sandbox with the source file
+        // so locale retries can proceed on a healthy session.
+        console.warn("[file-translation-workflow] sandbox disconnect; recreating sandbox", {
           jobId: claim.job.id,
           projectId: claim.job.projectId,
           previousSandboxId: sandboxId,
           targetLocales: locales,
           attempt,
+          error: message,
         });
         const recreated = await recreateSandboxWithSourceStep({
           previousSandboxId: sandboxId,

--- a/docs/plans/2026-07-09-multi-locale-file-translation-run-design.md
+++ b/docs/plans/2026-07-09-multi-locale-file-translation-run-design.md
@@ -50,8 +50,9 @@ Glossary terms for all locales stay in the system prompt (already tagged by loca
 
 ## Errors
 
-- Non-zero batch `hl run`: salvage any locale outputs already on disk, retry missing locales individually, persist successes, then fail only for locales still missing.
-- Glossary retry runs **per failed locale** with that locale's feedback only (no cross-locale contamination).
+- Non-zero batch `hl run`: salvage any locale outputs already on disk, retry missing locales individually **without `--force`** so the lockfile can skip completed work, persist successes, then fail only for locales still missing.
+- Glossary retry runs **per failed locale** with that locale's feedback only (no cross-locale contamination) and keeps `--force` so corrected output is rewritten.
+- Sandbox disconnect: retry the same sandbox without `--force` first; recreate only if the session is still unusable.
 - Single-locale jobs use the same multi-locale path with one target.
 
 ## Testing


### PR DESCRIPTION
## What changed

File translation retries were failing with `StreamError: Sandbox stream was closed and is not accepting commands` because the workflow reused a dead sandbox session. The Vercel SDK only auto-resumes on HTTP 410/422, not stream-closed errors.

This change:
- Detects `sandbox_stream_closed` / `stream_ended_early` in the sandbox lifecycle
- Stops and resumes the session, then retries the command once
- Recreates a fresh sandbox (and rewrites the source file) in `fileTranslationJobWorkflow` when `hl run` still hits a closed stream
- Maps the error to a clearer temporary-disconnect user message

## How to test

- [x] `vp test src/lib/translation/sandbox-translation.test.ts`
- [x] `vp check --fix`
- [ ] Re-run a multi-locale file translation job that previously failed with sandbox stream closed and confirm locale retries proceed

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)