### PR TITLE
fix(cli): preserve literal <, >, and & in JSON locale writes

### DIFF
--- a/apps/cli/internal/i18n/runsvc/output_json.go
+++ b/apps/cli/internal/i18n/runsvc/output_json.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/translationfileparser"
 	jsoncparser "github.com/tidwall/jsonc"
 )
 
@@ -74,11 +75,11 @@ func marshalJSONTarget(path string, template []byte, values map[string]string, p
 
 	// Note: JSONC comments/trailing commas are not preserved on write-back.
 	// We always emit canonical JSON syntax (while allowing .jsonc extension).
-	content, err := json.MarshalIndent(payload, "", "  ")
+	content, err := translationfileparser.MarshalJSONIndent(payload)
 	if err != nil {
 		return nil, fmt.Errorf("flush outputs: marshal %q: %w", path, err)
 	}
-	return append(content, '\n'), nil
+	return content, nil
 }
 
 func (s *Service) marshalJSONTargetWithFallback(path, sourcePath string, values map[string]string, pruneKeys map[string]struct{}) ([]byte, error) {

--- a/apps/cli/internal/i18n/runsvc/output_json_test.go
+++ b/apps/cli/internal/i18n/runsvc/output_json_test.go
@@ -40,6 +40,31 @@ func TestMarshalJSONTargetFormatJSPruneAndUpdate(t *testing.T) {
 	}
 }
 
+func TestMarshalJSONTargetPreservesHTMLSensitiveCharacters(t *testing.T) {
+	template := []byte(`{
+  "rich.example": {
+    "defaultMessage": "Use <tag>main</tag> or Review & approval"
+  }
+}`)
+	content, err := marshalJSONTarget("/tmp/messages.json", template, map[string]string{
+		"rich.example": "Use <tag>main</tag> or Review & approval",
+	}, nil)
+	if err != nil {
+		t.Fatalf("marshal json formatjs: %v", err)
+	}
+
+	text := string(content)
+	if strings.Contains(text, `\u003`) || strings.Contains(text, `\u0026`) {
+		t.Fatalf("expected literal <, >, and &, got escaped output:\n%s", text)
+	}
+	if !strings.Contains(text, "<tag>main</tag>") {
+		t.Fatalf("expected rich text tags in output:\n%s", text)
+	}
+	if !strings.Contains(text, "Review & approval") {
+		t.Fatalf("expected ampersand in output:\n%s", text)
+	}
+}
+
 func TestMarshalJSONTargetNestedPruneAndUpdate(t *testing.T) {
 	template := []byte(`{"home":{"title":"Old","body":"Body"},"meta":1}`)
 	values := map[string]string{"home.title": "New", "home.subtitle": "Sub"}

--- a/internal/i18n/translationfileparser/json_marshal.go
+++ b/internal/i18n/translationfileparser/json_marshal.go
@@ -1,10 +1,25 @@
 package translationfileparser
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strconv"
 )
+
+// MarshalJSONIndent encodes v as indented JSON with a trailing newline.
+// HTML-sensitive characters (<, >, &) are not escaped so locale files with
+// ICU rich-text tags remain readable in version control.
+func MarshalJSONIndent(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
 
 // MarshalJSON rewrites a JSON translation file using the provided flattened values.
 func MarshalJSON(template []byte, values map[string]string) ([]byte, error) {
@@ -32,11 +47,11 @@ func MarshalJSON(template []byte, values map[string]string) ([]byte, error) {
 		rewriteJSONObject(payload, "", values)
 	}
 
-	body, err := json.MarshalIndent(payload, "", "  ")
+	body, err := MarshalJSONIndent(payload)
 	if err != nil {
 		return nil, fmt.Errorf("json encode: %w", err)
 	}
-	return append(body, '\n'), nil
+	return body, nil
 }
 
 func rewriteJSONObject(payload map[string]any, prefix string, values map[string]string) {

--- a/internal/i18n/translationfileparser/json_parser_test.go
+++ b/internal/i18n/translationfileparser/json_parser_test.go
@@ -1,6 +1,9 @@
 package translationfileparser
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestJSONParserParsesFormatJSDefaultMessageOnly(t *testing.T) {
 	content := []byte(`{
@@ -168,6 +171,26 @@ func TestMarshalJSONRewritesNestedObjectArrays(t *testing.T) {
 	}
 	if parsed["home.steps[1].description"] != "Segundo" {
 		t.Fatalf("unexpected rewritten home.steps[1].description: %q", parsed["home.steps[1].description"])
+	}
+}
+
+func TestMarshalJSONPreservesHTMLSensitiveCharacters(t *testing.T) {
+	template := []byte(`{
+  "rich.example": {
+    "defaultMessage": "Use <tag>main</tag> or Review & approval"
+  }
+}`)
+
+	got, err := MarshalJSON(template, map[string]string{
+		"rich.example": "Use <tag>main</tag> or Review & approval",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	text := string(got)
+	if strings.Contains(text, `\u003`) || strings.Contains(text, `\u0026`) {
+		t.Fatalf("expected literal <, >, and &, got escaped output:\n%s", text)
 	}
 }
 


### PR DESCRIPTION
## What changed

`run` and `sync pull` reconstruct JSON locale files using Go's default `json.MarshalIndent`, which escapes `<`, `>`, and `&` as `\u003c`, `\u003e`, and `\u0026`. That produced noisy diffs for ICU rich-text tags and ampersands in strings like `Review & approval`.

This PR adds `MarshalJSONIndent` with `SetEscapeHTML(false)` and uses it in the run/sync JSON write path, matching `entries`, `pack`, and `extract`.

## How to test

```bash
go test ./internal/i18n/translationfileparser/... ./apps/cli/internal/i18n/runsvc/... -run 'MarshalJSON'
```

Run `hl sync pull` on a project with formatjs JSON locale files containing `<tag>` markup and verify the output keeps literal characters instead of `\u` escapes.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)