### PR TITLE
feat(web): add file tree search and context menu actions

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-action-dialogs.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-action-dialogs.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+
+import { CreateTranslationJobDialog } from "./create-translation-job-dialog";
+import { DownloadTranslationsDialog } from "./download-translations-dialog";
+import { ImportTranslationsDialog } from "./import-translations-dialog";
+import type { useProjectFileActions } from "./use-project-file-actions";
+
+export function ProjectFileActionDialogs({
+  file,
+  actions,
+}: {
+  file: ProjectFileRecord;
+  actions: ReturnType<typeof useProjectFileActions>;
+}) {
+  if (!actions.isNativeFile) {
+    return null;
+  }
+
+  return (
+    <>
+      <CreateTranslationJobDialog
+        open={actions.translateDialogOpen}
+        onOpenChange={actions.setTranslateDialogOpen}
+        organizationSlug={actions.organizationSlug}
+        projectId={actions.projectId}
+        file={file}
+        sourceLocale={actions.sourceLocale}
+        targetLocales={actions.stableTargetLocales}
+      />
+      <ImportTranslationsDialog
+        open={actions.importDialogOpen}
+        onOpenChange={actions.setImportDialogOpen}
+        organizationSlug={actions.organizationSlug}
+        projectId={actions.projectId}
+        sourcePath={file.sourcePath}
+        targetLocales={actions.targetLocales}
+      />
+      <DownloadTranslationsDialog
+        open={actions.downloadDialogOpen}
+        onOpenChange={actions.setDownloadDialogOpen}
+        organizationSlug={actions.organizationSlug}
+        projectId={actions.projectId}
+        sourcePaths={actions.nativeSourcePaths}
+        initialSourcePath={file.sourcePath}
+        targetLocales={actions.targetLocales}
+      />
+    </>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
 import { Download01Icon, TranslateIcon, Upload01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ListIcon } from "lucide-react";
@@ -9,15 +8,9 @@ import { ListIcon } from "lucide-react";
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
 import { Button } from "@/components/ui/button";
 import { TypographyP } from "@/components/ui/typography";
-import {
-  buildProjectFileCatHref,
-  canOpenProjectFileCat,
-} from "@/lib/projects/project-file-cat-routing";
-import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
 
-import { CreateTranslationJobDialog } from "./create-translation-job-dialog";
-import { DownloadTranslationsDialog } from "./download-translations-dialog";
-import { ImportTranslationsDialog } from "./import-translations-dialog";
+import { ProjectFileActionDialogs } from "./project-file-action-dialogs";
+import { useProjectFileActions } from "./use-project-file-actions";
 
 const EMPTY_STRING_ARRAY: readonly string[] = [];
 
@@ -42,57 +35,16 @@ export function ProjectFileSelectionActions({
   branch?: string | null;
   layout?: "default" | "compact";
 }) {
-  const [importDialogOpen, setImportDialogOpen] = useState(false);
-  const [downloadDialogOpen, setDownloadDialogOpen] = useState(false);
-  const [translateDialogOpen, setTranslateDialogOpen] = useState(false);
-  const canOpenCat = canOpenProjectFileCat(file);
-  const isNativeFile = !file.provider;
-  const targetLocales = projectTargetLocales ?? EMPTY_STRING_ARRAY;
-  const stableTargetLocales = useMemo(() => [...targetLocales], [targetLocales]);
-  const canTranslateWithAgent =
-    isNativeFile &&
-    Boolean(file.storedFileId) &&
-    Boolean(inferSupportedFileTranslationFileFormat(file.sourcePath)) &&
-    targetLocales.length > 0;
-  const catHref = buildProjectFileCatHref(
+  const actions = useProjectFileActions({
     organizationSlug,
     projectId,
     file,
     highlightLocale,
-    branch,
     projectTargetLocales,
-  );
-
-  const nativeDialogs = isNativeFile ? (
-    <>
-      <CreateTranslationJobDialog
-        open={translateDialogOpen}
-        onOpenChange={setTranslateDialogOpen}
-        organizationSlug={organizationSlug}
-        projectId={projectId}
-        file={file}
-        sourceLocale={sourceLocale}
-        targetLocales={stableTargetLocales}
-      />
-      <ImportTranslationsDialog
-        open={importDialogOpen}
-        onOpenChange={setImportDialogOpen}
-        organizationSlug={organizationSlug}
-        projectId={projectId}
-        sourcePath={file.sourcePath}
-        targetLocales={targetLocales}
-      />
-      <DownloadTranslationsDialog
-        open={downloadDialogOpen}
-        onOpenChange={setDownloadDialogOpen}
-        organizationSlug={organizationSlug}
-        projectId={projectId}
-        sourcePaths={nativeSourcePaths}
-        initialSourcePath={file.sourcePath}
-        targetLocales={targetLocales}
-      />
-    </>
-  ) : null;
+    sourceLocale,
+    nativeSourcePaths,
+    branch,
+  });
 
   const actionButtons = (
     <>
@@ -100,25 +52,21 @@ export function ProjectFileSelectionActions({
         type="button"
         size="sm"
         className={layout === "default" ? "w-full shrink-0 sm:w-fit" : "shrink-0"}
-        disabled={!canOpenCat || !catHref}
-        render={canOpenCat && catHref ? <Link href={catHref} /> : undefined}
+        disabled={!actions.canOpenCat || !actions.catHref}
+        render={actions.canOpenCat && actions.catHref ? <Link href={actions.catHref} /> : undefined}
       >
         <ListIcon />
         View strings
       </Button>
-      {isNativeFile ? (
+      {actions.isNativeFile ? (
         <>
           <Button
             type="button"
             size="sm"
             className={layout === "default" ? "w-full shrink-0 sm:w-fit" : "shrink-0"}
-            disabled={!canTranslateWithAgent}
-            title={
-              canTranslateWithAgent
-                ? undefined
-                : "Upload a supported file and add target locales in project settings to translate with agent."
-            }
-            onClick={() => setTranslateDialogOpen(true)}
+            disabled={!actions.canTranslateWithAgent}
+            title={actions.translateDisabledTitle}
+            onClick={() => actions.setTranslateDialogOpen(true)}
           >
             <HugeiconsIcon icon={TranslateIcon} strokeWidth={1.8} />
             Translate with agent
@@ -128,7 +76,7 @@ export function ProjectFileSelectionActions({
             size="sm"
             variant="outline"
             className={layout === "default" ? "w-full shrink-0 sm:w-fit" : "shrink-0"}
-            onClick={() => setImportDialogOpen(true)}
+            onClick={() => actions.setImportDialogOpen(true)}
           >
             <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} />
             Import translations
@@ -138,7 +86,7 @@ export function ProjectFileSelectionActions({
             size="sm"
             variant="outline"
             className={layout === "default" ? "w-full shrink-0 sm:w-fit" : "shrink-0"}
-            onClick={() => setDownloadDialogOpen(true)}
+            onClick={() => actions.setDownloadDialogOpen(true)}
           >
             <HugeiconsIcon icon={Download01Icon} strokeWidth={1.8} />
             Download
@@ -151,7 +99,7 @@ export function ProjectFileSelectionActions({
   if (layout === "compact") {
     return (
       <>
-        {nativeDialogs}
+        <ProjectFileActionDialogs file={file} actions={actions} />
         <div className="flex flex-wrap items-center justify-end gap-2">{actionButtons}</div>
       </>
     );
@@ -159,14 +107,14 @@ export function ProjectFileSelectionActions({
 
   return (
     <>
-      {nativeDialogs}
+      <ProjectFileActionDialogs file={file} actions={actions} />
       <div className="flex shrink-0 flex-col gap-3 border-b border-border px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="min-w-0">
           <TypographyP className="truncate font-mono text-sm text-foreground">
             {file.sourcePath}
           </TypographyP>
           <TypographyP className="text-xs text-muted-foreground">
-            {canOpenCat
+            {actions.canOpenCat
               ? "Open this file in the CAT workspace to review and edit translations."
               : "The CAT workspace is not available for this file yet."}
           </TypographyP>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-tree-context-menu.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-tree-context-menu.tsx
@@ -8,8 +8,7 @@ import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
 import type { ContextMenuOpenContext } from "@pierre/trees";
 import { Button } from "@/components/ui/button";
 
-import { ProjectFileActionDialogs } from "./project-file-action-dialogs";
-import { useProjectFileActions } from "./use-project-file-actions";
+import type { useProjectFileActions } from "./use-project-file-actions";
 
 export type ProjectFileTreeActionsConfig = {
   organizationSlug: string;
@@ -26,29 +25,19 @@ export function ProjectFileTreeContextMenu({
   file,
   context,
   fileActions,
+  actions,
 }: {
   file: ProjectFileRecord;
   context: ContextMenuOpenContext;
   fileActions: ProjectFileTreeActionsConfig;
+  actions: ReturnType<typeof useProjectFileActions>;
 }) {
-  const actions = useProjectFileActions({
-    organizationSlug: fileActions.organizationSlug,
-    projectId: fileActions.projectId,
-    file,
-    highlightLocale: fileActions.highlightLocale,
-    projectTargetLocales: fileActions.projectTargetLocales,
-    sourceLocale: fileActions.sourceLocale,
-    nativeSourcePaths: fileActions.nativeSourcePaths,
-    branch: fileActions.branch,
-  });
-
   const closeMenu = () => {
     context.close({ restoreFocus: false });
   };
 
   return (
     <>
-      <ProjectFileActionDialogs file={file} actions={actions} />
       <div
         className="flex min-w-52 flex-col gap-1 rounded-md border bg-background p-2 shadow"
         data-file-tree-context-menu-root="true"
@@ -77,8 +66,8 @@ export function ProjectFileTreeContextMenu({
               disabled={!actions.canTranslateWithAgent}
               title={actions.translateDisabledTitle}
               onClick={() => {
-                closeMenu();
                 actions.setTranslateDialogOpen(true);
+                closeMenu();
               }}
             >
               <HugeiconsIcon icon={TranslateIcon} strokeWidth={1.8} />
@@ -90,8 +79,8 @@ export function ProjectFileTreeContextMenu({
               variant="outline"
               className="w-full justify-start"
               onClick={() => {
-                closeMenu();
                 actions.setImportDialogOpen(true);
+                closeMenu();
               }}
             >
               <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} />
@@ -103,8 +92,8 @@ export function ProjectFileTreeContextMenu({
               variant="outline"
               className="w-full justify-start"
               onClick={() => {
-                closeMenu();
                 actions.setDownloadDialogOpen(true);
+                closeMenu();
               }}
             >
               <HugeiconsIcon icon={Download01Icon} strokeWidth={1.8} />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-tree-context-menu.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-tree-context-menu.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { Download01Icon, TranslateIcon, Upload01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ListIcon } from "lucide-react";
+
+import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+import type { ContextMenuOpenContext } from "@pierre/trees";
+import { Button } from "@/components/ui/button";
+
+import { ProjectFileActionDialogs } from "./project-file-action-dialogs";
+import { useProjectFileActions } from "./use-project-file-actions";
+
+export type ProjectFileTreeActionsConfig = {
+  organizationSlug: string;
+  projectId: string;
+  highlightLocale: string | null;
+  projectTargetLocales?: readonly string[] | null;
+  sourceLocale?: string;
+  nativeSourcePaths?: readonly string[];
+  branch?: string | null;
+  onViewStrings: (file: ProjectFileRecord) => void;
+};
+
+export function ProjectFileTreeContextMenu({
+  file,
+  context,
+  fileActions,
+}: {
+  file: ProjectFileRecord;
+  context: ContextMenuOpenContext;
+  fileActions: ProjectFileTreeActionsConfig;
+}) {
+  const actions = useProjectFileActions({
+    organizationSlug: fileActions.organizationSlug,
+    projectId: fileActions.projectId,
+    file,
+    highlightLocale: fileActions.highlightLocale,
+    projectTargetLocales: fileActions.projectTargetLocales,
+    sourceLocale: fileActions.sourceLocale,
+    nativeSourcePaths: fileActions.nativeSourcePaths,
+    branch: fileActions.branch,
+  });
+
+  const closeMenu = () => {
+    context.close({ restoreFocus: false });
+  };
+
+  return (
+    <>
+      <ProjectFileActionDialogs file={file} actions={actions} />
+      <div
+        className="flex min-w-52 flex-col gap-1 rounded-md border bg-background p-2 shadow"
+        data-file-tree-context-menu-root="true"
+      >
+        <Button
+          type="button"
+          size="sm"
+          className="w-full justify-start"
+          disabled={!actions.canOpenCat || !actions.catHref}
+          onClick={() => {
+            closeMenu();
+            if (actions.canOpenCat) {
+              fileActions.onViewStrings(file);
+            }
+          }}
+        >
+          <ListIcon />
+          View strings
+        </Button>
+        {actions.isNativeFile ? (
+          <>
+            <Button
+              type="button"
+              size="sm"
+              className="w-full justify-start"
+              disabled={!actions.canTranslateWithAgent}
+              title={actions.translateDisabledTitle}
+              onClick={() => {
+                closeMenu();
+                actions.setTranslateDialogOpen(true);
+              }}
+            >
+              <HugeiconsIcon icon={TranslateIcon} strokeWidth={1.8} />
+              Translate with agent
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="w-full justify-start"
+              onClick={() => {
+                closeMenu();
+                actions.setImportDialogOpen(true);
+              }}
+            >
+              <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} />
+              Import translations
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="w-full justify-start"
+              onClick={() => {
+                closeMenu();
+                actions.setDownloadDialogOpen(true);
+              }}
+            >
+              <HugeiconsIcon icon={Download01Icon} strokeWidth={1.8} />
+              Download
+            </Button>
+          </>
+        ) : null}
+      </div>
+    </>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -29,6 +29,7 @@ import {
   useProjectPageQuery,
 } from "../../_components/project-page-shell";
 import { ProjectFileSelectionActions } from "./project-file-selection-actions";
+import type { ProjectFileTreeActionsConfig } from "./project-file-tree-context-menu";
 import { ProjectFilesBranchFilter } from "./project-files-branch-filter";
 import {
   ProjectFilesTreePanel,
@@ -294,6 +295,29 @@ export function ProjectFilesPageContent({
       })()
     : null;
 
+  const treeFileActions = useMemo<ProjectFileTreeActionsConfig>(
+    () => ({
+      organizationSlug,
+      projectId,
+      highlightLocale,
+      projectTargetLocales,
+      sourceLocale: projectSourceLocale,
+      nativeSourcePaths,
+      branch: selectedBranch,
+      onViewStrings: (file) => openFileInCat(file.sourcePath),
+    }),
+    [
+      highlightLocale,
+      nativeSourcePaths,
+      openFileInCat,
+      organizationSlug,
+      projectId,
+      projectSourceLocale,
+      projectTargetLocales,
+      selectedBranch,
+    ],
+  );
+
   return (
     <ProjectFilesPageContentView
       organizationSlug={organizationSlug}
@@ -324,6 +348,7 @@ export function ProjectFilesPageContent({
           onLoadedFilesChange={setLoadedFiles}
           onActivateFile={openFileInCat}
           catOpenHint={catOpenHint}
+          fileActions={treeFileActions}
           branch={selectedBranch}
           headerActions={
             <>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.tsx
@@ -15,6 +15,7 @@ import { getProjectWorkspaceCapabilities } from "@/lib/projects/workspace-resour
 import { ProjectSectionTitle } from "../../_components/project-page-shell";
 import { ProjectFilesErrorBoundary } from "./project-files-error-boundary";
 import { ProjectFilesTree } from "./project-files-tree";
+import type { ProjectFileTreeActionsConfig } from "./project-file-tree-context-menu";
 import { dedupeProjectFilesBySourcePath } from "./project-files-shared";
 
 export const PROJECT_FILES_PAGE_SIZE = 500;
@@ -108,6 +109,7 @@ function ProjectFilesTreeBody({
   onSelectSourcePath,
   onActivateFile,
   catOpenHint,
+  fileActions,
 }: {
   projectId: string;
   files: ProjectFileRecord[];
@@ -115,6 +117,7 @@ function ProjectFilesTreeBody({
   onSelectSourcePath: (sourcePath: string | null) => void;
   onActivateFile?: (sourcePath: string) => void;
   catOpenHint?: string | null;
+  fileActions?: ProjectFileTreeActionsConfig;
 }) {
   const projectCapabilities = getProjectWorkspaceCapabilities({ projectId });
   const isProviderProject = projectCapabilities.isProviderProject;
@@ -148,6 +151,7 @@ function ProjectFilesTreeBody({
           selectedSourcePath={selectedSourcePath}
           onSelectFile={onSelectSourcePath}
           onActivateFile={onActivateFile}
+          fileActions={fileActions}
         />
       </div>
     </div>
@@ -162,6 +166,7 @@ function ProjectFilesTreeQueryResult({
   onSelectSourcePath,
   onActivateFile,
   catOpenHint,
+  fileActions,
 }: {
   error: unknown;
   projectId: string;
@@ -170,6 +175,7 @@ function ProjectFilesTreeQueryResult({
   onSelectSourcePath: (sourcePath: string | null) => void;
   onActivateFile?: (sourcePath: string) => void;
   catOpenHint?: string | null;
+  fileActions?: ProjectFileTreeActionsConfig;
 }) {
   if (error) {
     throw error;
@@ -183,6 +189,7 @@ function ProjectFilesTreeQueryResult({
       onSelectSourcePath={onSelectSourcePath}
       onActivateFile={onActivateFile}
       catOpenHint={catOpenHint}
+      fileActions={fileActions}
     />
   );
 }
@@ -196,6 +203,7 @@ export function ProjectFilesTreePanel({
   onActivateFile,
   catOpenHint = null,
   headerActions,
+  fileActions,
   branch = null,
 }: {
   organizationSlug: string;
@@ -206,6 +214,7 @@ export function ProjectFilesTreePanel({
   onActivateFile?: (sourcePath: string) => void;
   catOpenHint?: string | null;
   headerActions?: ReactNode;
+  fileActions?: ProjectFileTreeActionsConfig;
   branch?: string | null;
 }) {
   const queryClient = useQueryClient();
@@ -316,6 +325,7 @@ export function ProjectFilesTreePanel({
             onSelectSourcePath={onSelectSourcePath}
             onActivateFile={onActivateFile}
             catOpenHint={catOpenHint}
+            fileActions={fileActions}
           />
           {hasMoreFiles ? (
             <div className="shrink-0 border-t border-border p-2">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.stories.tsx
@@ -46,3 +46,30 @@ export const SelectFile: Story = {
     await expect(args.onSelectFile).toHaveBeenCalledWith("marketing/pricing.json");
   },
 };
+
+export const SearchFiles: Story = {
+  play: async ({ canvasElement }) => {
+    await waitFor(() => {
+      void expect(canvasElement.querySelector("file-tree-container")).toBeTruthy();
+    });
+
+    const searchInput = canvasElement.querySelector('input[aria-label="Search files"]');
+    if (!(searchInput instanceof HTMLInputElement)) {
+      throw new Error("Expected search input above file tree");
+    }
+
+    await userEvent.type(searchInput, "pricing");
+
+    await waitFor(() => {
+      const treeContainer = canvasElement.querySelector("file-tree-container");
+      const pricingRow = treeContainer?.shadowRoot?.querySelector(
+        '[data-item-path="marketing/pricing.json"]',
+      );
+      const homepageRow = treeContainer?.shadowRoot?.querySelector(
+        '[data-item-path="marketing/homepage.json"]',
+      );
+      void expect(pricingRow).toBeTruthy();
+      void expect(homepageRow).toBeFalsy();
+    });
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, type CSSProperties } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import { SearchIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { FileTreeRowDecorationContext } from "@pierre/trees";
@@ -11,11 +11,14 @@ import "@pierre/trees/web-components";
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
 import { Input } from "@/components/ui/input";
 
+import { ProjectFileActionDialogs } from "./project-file-action-dialogs";
 import {
   ProjectFileTreeContextMenu,
   type ProjectFileTreeActionsConfig,
 } from "./project-file-tree-context-menu";
 import { dedupeProjectFilesBySourcePath, formatBytes } from "./project-files-shared";
+import { createProjectFileRecord } from "./project-files.fixture";
+import { useProjectFileActions } from "./use-project-file-actions";
 
 export const TREE_HEIGHT_PX = 480;
 
@@ -79,6 +82,97 @@ export function ProjectFilesTree({
   fileActions?: ProjectFileTreeActionsConfig;
   ariaLabel?: string;
 }) {
+  if (fileActions) {
+    return (
+      <ProjectFilesTreeWithRowActions
+        files={files}
+        selectedSourcePath={selectedSourcePath}
+        onSelectFile={onSelectFile}
+        onActivateFile={onActivateFile}
+        fileActions={fileActions}
+        ariaLabel={ariaLabel}
+      />
+    );
+  }
+
+  return (
+    <ProjectFilesTreeView
+      files={files}
+      selectedSourcePath={selectedSourcePath}
+      onSelectFile={onSelectFile}
+      onActivateFile={onActivateFile}
+      ariaLabel={ariaLabel}
+    />
+  );
+}
+
+function ProjectFilesTreeWithRowActions({
+  files,
+  selectedSourcePath,
+  onSelectFile,
+  onActivateFile,
+  fileActions,
+  ariaLabel,
+}: {
+  files: ProjectFileRecord[];
+  selectedSourcePath: string | null;
+  onSelectFile: (sourcePath: string) => void;
+  onActivateFile?: (sourcePath: string) => void;
+  fileActions: ProjectFileTreeActionsConfig;
+  ariaLabel: string;
+}) {
+  const [contextMenuFile, setContextMenuFile] = useState<ProjectFileRecord | null>(null);
+  const displayFiles = useMemo(() => dedupeProjectFilesBySourcePath(files), [files]);
+  const actionFile = contextMenuFile ?? displayFiles[0] ?? createProjectFileRecord();
+  const contextMenuActions = useProjectFileActions({
+    organizationSlug: fileActions.organizationSlug,
+    projectId: fileActions.projectId,
+    file: actionFile,
+    highlightLocale: fileActions.highlightLocale,
+    projectTargetLocales: fileActions.projectTargetLocales,
+    sourceLocale: fileActions.sourceLocale,
+    nativeSourcePaths: fileActions.nativeSourcePaths,
+    branch: fileActions.branch,
+  });
+
+  return (
+    <>
+      {contextMenuFile ? (
+        <ProjectFileActionDialogs file={contextMenuFile} actions={contextMenuActions} />
+      ) : null}
+      <ProjectFilesTreeView
+        files={files}
+        selectedSourcePath={selectedSourcePath}
+        onSelectFile={onSelectFile}
+        onActivateFile={onActivateFile}
+        fileActions={fileActions}
+        contextMenuActions={contextMenuActions}
+        onContextMenuFileChange={setContextMenuFile}
+        ariaLabel={ariaLabel}
+      />
+    </>
+  );
+}
+
+function ProjectFilesTreeView({
+  files,
+  selectedSourcePath,
+  onSelectFile,
+  onActivateFile,
+  fileActions,
+  contextMenuActions,
+  onContextMenuFileChange,
+  ariaLabel = "Project files",
+}: {
+  files: ProjectFileRecord[];
+  selectedSourcePath: string | null;
+  onSelectFile: (sourcePath: string) => void;
+  onActivateFile?: (sourcePath: string) => void;
+  fileActions?: ProjectFileTreeActionsConfig;
+  contextMenuActions?: ReturnType<typeof useProjectFileActions>;
+  onContextMenuFileChange?: (file: ProjectFileRecord | null) => void;
+  ariaLabel?: string;
+}) {
   const containerRef = useRef<HTMLDivElement>(null);
   const displayFiles = useMemo(() => dedupeProjectFilesBySourcePath(files), [files]);
   const paths = useMemo(() => displayFiles.map((file) => file.sourcePath), [displayFiles]);
@@ -88,7 +182,14 @@ export function ProjectFilesTree({
   );
   const selectedPaths =
     selectedSourcePath && fileByPath.has(selectedSourcePath) ? [selectedSourcePath] : [];
-  const latestStateRef = useRef({ fileActions, fileByPath, onSelectFile, onActivateFile });
+  const latestStateRef = useRef({
+    contextMenuActions,
+    fileActions,
+    fileByPath,
+    onContextMenuFileChange,
+    onSelectFile,
+    onActivateFile,
+  });
   const preloadedData = useMemo(
     () =>
       paths.length > 0
@@ -103,8 +204,22 @@ export function ProjectFilesTree({
   );
 
   useEffect(() => {
-    latestStateRef.current = { fileActions, fileByPath, onActivateFile, onSelectFile };
-  }, [fileActions, fileByPath, onActivateFile, onSelectFile]);
+    latestStateRef.current = {
+      contextMenuActions,
+      fileActions,
+      fileByPath,
+      onContextMenuFileChange,
+      onActivateFile,
+      onSelectFile,
+    };
+  }, [
+    contextMenuActions,
+    fileActions,
+    fileByPath,
+    onContextMenuFileChange,
+    onActivateFile,
+    onSelectFile,
+  ]);
 
   useEffect(() => {
     if (!onActivateFile) {
@@ -148,8 +263,18 @@ export function ProjectFilesTree({
       ? {
           contextMenu: {
             enabled: true,
-            triggerMode: "both",
+            triggerMode: "button",
             buttonVisibility: "when-needed",
+            onOpen: (item) => {
+              if (item.kind !== "file") {
+                return;
+              }
+
+              const file = latestStateRef.current.fileByPath.get(item.path);
+              if (file) {
+                latestStateRef.current.onContextMenuFileChange?.(file);
+              }
+            },
           },
         }
       : undefined,
@@ -229,12 +354,18 @@ export function ProjectFilesTree({
 
                 const file = latestStateRef.current.fileByPath.get(item.path);
                 const actions = latestStateRef.current.fileActions;
-                if (!file || !actions) {
+                const contextMenuActions = latestStateRef.current.contextMenuActions;
+                if (!file || !actions || !contextMenuActions) {
                   return null;
                 }
 
                 return (
-                  <ProjectFileTreeContextMenu file={file} context={context} fileActions={actions} />
+                  <ProjectFileTreeContextMenu
+                    file={file}
+                    context={context}
+                    fileActions={actions}
+                    actions={contextMenuActions}
+                  />
                 );
               }
             : undefined

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
@@ -1,12 +1,20 @@
 "use client";
 
 import { useEffect, useMemo, useRef, type CSSProperties } from "react";
+import { SearchIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import type { FileTreeRowDecorationContext } from "@pierre/trees";
-import { FileTree as PierreFileTree, useFileTree } from "@pierre/trees/react";
+import { FileTree as PierreFileTree, useFileTree, useFileTreeSearch } from "@pierre/trees/react";
 import { preloadFileTree } from "@pierre/trees/ssr";
 import "@pierre/trees/web-components";
 
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+import { Input } from "@/components/ui/input";
+
+import {
+  ProjectFileTreeContextMenu,
+  type ProjectFileTreeActionsConfig,
+} from "./project-file-tree-context-menu";
 import { dedupeProjectFilesBySourcePath, formatBytes } from "./project-files-shared";
 
 export const TREE_HEIGHT_PX = 480;
@@ -61,12 +69,14 @@ export function ProjectFilesTree({
   selectedSourcePath,
   onSelectFile,
   onActivateFile,
+  fileActions,
   ariaLabel = "Project files",
 }: {
   files: ProjectFileRecord[];
   selectedSourcePath: string | null;
   onSelectFile: (sourcePath: string) => void;
   onActivateFile?: (sourcePath: string) => void;
+  fileActions?: ProjectFileTreeActionsConfig;
   ariaLabel?: string;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -78,7 +88,7 @@ export function ProjectFilesTree({
   );
   const selectedPaths =
     selectedSourcePath && fileByPath.has(selectedSourcePath) ? [selectedSourcePath] : [];
-  const latestStateRef = useRef({ fileByPath, onSelectFile, onActivateFile });
+  const latestStateRef = useRef({ fileActions, fileByPath, onSelectFile, onActivateFile });
   const preloadedData = useMemo(
     () =>
       paths.length > 0
@@ -93,8 +103,8 @@ export function ProjectFilesTree({
   );
 
   useEffect(() => {
-    latestStateRef.current = { fileByPath, onSelectFile, onActivateFile };
-  }, [fileByPath, onActivateFile, onSelectFile]);
+    latestStateRef.current = { fileActions, fileByPath, onActivateFile, onSelectFile };
+  }, [fileActions, fileByPath, onActivateFile, onSelectFile]);
 
   useEffect(() => {
     if (!onActivateFile) {
@@ -132,6 +142,17 @@ export function ProjectFilesTree({
     initialSelectedPaths: selectedPaths,
     initialVisibleRowCount: Math.max(paths.length, 8),
     paths,
+    search: true,
+    fileTreeSearchMode: "hide-non-matches",
+    composition: fileActions
+      ? {
+          contextMenu: {
+            enabled: true,
+            triggerMode: "both",
+            buttonVisibility: "when-needed",
+          },
+        }
+      : undefined,
     renderRowDecoration: (context: FileTreeRowDecorationContext) => {
       if (context.item.kind !== "file") {
         return null;
@@ -159,6 +180,8 @@ export function ProjectFilesTree({
     },
   });
 
+  const search = useFileTreeSearch(model);
+
   useEffect(() => {
     model.resetPaths(paths);
   }, [model, paths]);
@@ -177,13 +200,45 @@ export function ProjectFilesTree({
   }
 
   return (
-    <div ref={containerRef} className="w-full min-w-0">
+    <div ref={containerRef} className="flex w-full min-w-0 flex-col gap-2">
+      <div className="relative shrink-0">
+        <HugeiconsIcon
+          icon={SearchIcon}
+          className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground"
+        />
+        <Input
+          value={search.value}
+          onChange={(event) => search.setValue(event.target.value)}
+          placeholder="Search files..."
+          aria-label="Search files"
+          className="h-9 pl-9 font-mono text-xs"
+        />
+      </div>
       <PierreFileTree
         aria-label={ariaLabel}
         className="w-full min-w-0 border-0 bg-transparent"
         id="project-files-tree"
         model={model}
         preloadedData={preloadedData ?? undefined}
+        renderContextMenu={
+          fileActions
+            ? (item, context) => {
+                if (item.kind !== "file") {
+                  return null;
+                }
+
+                const file = latestStateRef.current.fileByPath.get(item.path);
+                const actions = latestStateRef.current.fileActions;
+                if (!file || !actions) {
+                  return null;
+                }
+
+                return (
+                  <ProjectFileTreeContextMenu file={file} context={context} fileActions={actions} />
+                );
+              }
+            : undefined
+        }
         style={projectFilesTreeStyle}
       />
     </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/use-project-file-actions.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/use-project-file-actions.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+import {
+  buildProjectFileCatHref,
+  canOpenProjectFileCat,
+} from "@/lib/projects/project-file-cat-routing";
+import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
+
+const EMPTY_STRING_ARRAY: readonly string[] = [];
+
+export function useProjectFileActions({
+  organizationSlug,
+  projectId,
+  file,
+  highlightLocale,
+  projectTargetLocales,
+  sourceLocale = "en",
+  nativeSourcePaths = EMPTY_STRING_ARRAY,
+  branch = null,
+}: {
+  organizationSlug: string;
+  projectId: string;
+  file: ProjectFileRecord;
+  highlightLocale: string | null;
+  projectTargetLocales?: readonly string[] | null;
+  sourceLocale?: string;
+  nativeSourcePaths?: readonly string[];
+  branch?: string | null;
+}) {
+  const [importDialogOpen, setImportDialogOpen] = useState(false);
+  const [downloadDialogOpen, setDownloadDialogOpen] = useState(false);
+  const [translateDialogOpen, setTranslateDialogOpen] = useState(false);
+
+  const canOpenCat = canOpenProjectFileCat(file);
+  const isNativeFile = !file.provider;
+  const targetLocales = projectTargetLocales ?? EMPTY_STRING_ARRAY;
+  const stableTargetLocales = useMemo(() => [...targetLocales], [targetLocales]);
+  const canTranslateWithAgent =
+    isNativeFile &&
+    Boolean(file.storedFileId) &&
+    Boolean(inferSupportedFileTranslationFileFormat(file.sourcePath)) &&
+    targetLocales.length > 0;
+  const catHref = buildProjectFileCatHref(
+    organizationSlug,
+    projectId,
+    file,
+    highlightLocale,
+    branch,
+    projectTargetLocales,
+  );
+  const translateDisabledTitle = canTranslateWithAgent
+    ? undefined
+    : "Upload a supported file and add target locales in project settings to translate with agent.";
+
+  return {
+    branch,
+    canOpenCat,
+    canTranslateWithAgent,
+    catHref,
+    downloadDialogOpen,
+    highlightLocale,
+    importDialogOpen,
+    isNativeFile,
+    nativeSourcePaths,
+    organizationSlug,
+    projectId,
+    setDownloadDialogOpen,
+    setImportDialogOpen,
+    setTranslateDialogOpen,
+    sourceLocale,
+    stableTargetLocales,
+    targetLocales,
+    translateDialogOpen,
+    translateDisabledTitle,
+  };
+}


### PR DESCRIPTION
## What changed

- Added a search input above `ProjectFilesTree` wired to Pierre's `useFileTreeSearch`, with `hide-non-matches` filtering.
- Added a per-file context menu (right-click and overflow button) with View strings, Translate with agent, Import translations, and Download.
- Extracted shared file action state/dialogs so the header toolbar and tree context menu stay in sync.

## How to test

- Open a project's Files page and confirm the search box filters the tree as you type.
- Right-click a file (or use the row menu button) and verify each context menu action matches the header toolbar behavior.
- Run `cd apps/hyperlocalise-web && vp test src/app/[lang]/\(authenticated\)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.test.tsx src/app/[lang]/\(authenticated\)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx src/app/[lang]/\(authenticated\)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.test.ts`
- Run `cd apps/hyperlocalise-web && vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)