### PR TITLE
fix(crowdin): optimize JoinSlice for task-related enums

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -227,3 +227,7 @@
 **Learning:** The Crowdin Label response model was missing the `isSystem` field, which indicates if a label was created by the system (e.g., for tasks). Additionally, several resource models like `Distribution` and `ReportArchive` used raw `string` types for fields where specific enum-like types (`ExportMode`, `ReportScopeType`) were already defined and used in request models.
 
 **Action:** Added `IsSystem` (bool) to the `Label` struct in `model/labels.go`. Updated `Distribution.ExportMode` and `ReportArchive.ScopeType` to use their respective typed definitions. Updated contract tests in `labels_test.go`, `distributions_test.go`, and `reports_test.go` to verify correct unmarshaling and ensure end-to-end type safety.
+
+## 2026-11-21 - Optimize JoinSlice for task-related enums
+**Learning:** The `model.JoinSlice` utility used for encoding query parameters was using reflection-based `fmt.Fprintf` for any slice type other than `[]int` and `[]string`. This included task-related enums like `TaskStatus` and `TaskType`, which are frequently joined into comma-separated strings for filtering. Specialized type switch cases using `strings.Builder` and direct string/integer conversion are significantly more efficient.
+**Action:** Added specialized type switch cases for `[]TaskStatus` and `[]TaskType` to `JoinSlice` and updated the test suite to use concrete typed slices to ensure these optimized paths are exercised and verified.

--- a/third_party/crowdin-api-client-go/crowdin/model/utils.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/utils.go
@@ -28,6 +28,26 @@ func JoinSlice[T any](s []T) string {
 
 	case []string:
 		return strings.Join(val, ",")
+
+	case []TaskStatus:
+		var b strings.Builder
+		for i, v := range val {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			b.WriteString(string(v))
+		}
+		return b.String()
+
+	case []TaskType:
+		var b strings.Builder
+		for i, v := range val {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			b.WriteString(strconv.Itoa(int(v)))
+		}
+		return b.String()
 	}
 
 	var b strings.Builder

--- a/third_party/crowdin-api-client-go/crowdin/model/utils_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/utils_test.go
@@ -16,34 +16,62 @@ func TestJoinSlice(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		slice []any
+		slice any
 		want  string
 	}{
 		{
 			name:  "int slice",
-			slice: []any{1, 2, 3},
+			slice: []int{1, 2, 3},
 			want:  "1,2,3",
 		},
 		{
 			name:  "string slice",
-			slice: []any{"a", "b", "c"},
+			slice: []string{"a", "b", "c"},
 			want:  "a,b,c",
 		},
 		{
 			name:  "custom type slice",
-			slice: []any{customTypeX, customTypeY, customTypeZ},
+			slice: []customType{customTypeX, customTypeY, customTypeZ},
 			want:  "x,y,z",
 		},
 		{
 			name:  "bool slice",
-			slice: []any{true, false, true},
+			slice: []bool{true, false, true},
 			want:  "true,false,true",
+		},
+		{
+			name:  "TaskStatus slice",
+			slice: []TaskStatus{TaskStatusTodo, TaskStatusInProgress, TaskStatusDone},
+			want:  "todo,in_progress,done",
+		},
+		{
+			name:  "TaskType slice",
+			slice: []TaskType{TaskTypeTranslate, TaskTypeProofread},
+			want:  "0,1",
+		},
+		{
+			name:  "empty slice",
+			slice: []int{},
+			want:  "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, JoinSlice(tt.slice))
+			switch s := tt.slice.(type) {
+			case []int:
+				assert.Equal(t, tt.want, JoinSlice(s))
+			case []string:
+				assert.Equal(t, tt.want, JoinSlice(s))
+			case []customType:
+				assert.Equal(t, tt.want, JoinSlice(s))
+			case []bool:
+				assert.Equal(t, tt.want, JoinSlice(s))
+			case []TaskStatus:
+				assert.Equal(t, tt.want, JoinSlice(s))
+			case []TaskType:
+				assert.Equal(t, tt.want, JoinSlice(s))
+			}
 		})
 	}
 }


### PR DESCRIPTION
- What: Optimized the `JoinSlice` utility in the Crowdin SDK fork.
- Why: Task-related enums were previously handled via a slow reflection-based fallback path during query parameter serialization.
- Docs: Performance improvement for query parameter encoding.
- Scope: `third_party/crowdin-api-client-go/crowdin/model/utils.go` and its tests.
- Tests: Ran full SDK test suite; all 100+ tests passed.
- Confidence: High. The specialized paths produce identical results to the fallback but with better performance, and tests now explicitly cover these types.

---
*PR created automatically by Jules for task [13394995995374277633](https://jules.google.com/task/13394995995374277633) started by @cungminh2710*