### PR TITLE
fix(web): show TMS project name in glossary and TM pickers

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/tms-live-project-picker.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/tms-live-project-picker.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { TmsLiveProjectPicker } from "./tms-live-project-picker";
+
+const useTmsLiveProjectsMock = vi.fn();
+
+vi.mock("../_hooks/use-tms-live-projects", () => ({
+  useTmsLiveProjects: (...args: unknown[]) => useTmsLiveProjectsMock(...args),
+}));
+
+describe("TmsLiveProjectPicker", () => {
+  beforeEach(() => {
+    useTmsLiveProjectsMock.mockReset();
+  });
+
+  it("shows the project name in the trigger instead of the raw external id", () => {
+    useTmsLiveProjectsMock.mockReturnValue({
+      data: [
+        {
+          id: "provider:crowdin:902807",
+          name: "Marketing website",
+          externalProjectId: "902807",
+          isActive: true,
+        },
+      ],
+      isLoading: false,
+    });
+
+    render(
+      <TmsLiveProjectPicker
+        organizationSlug="acme"
+        value="902807"
+        onValueChange={() => undefined}
+      />,
+    );
+
+    expect(screen.getByText("Marketing website")).toBeInTheDocument();
+    expect(screen.queryByText("902807")).not.toBeInTheDocument();
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/tms-live-project-picker.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/tms-live-project-picker.tsx
@@ -26,11 +26,16 @@ export function TmsLiveProjectPicker({
   const projects = (tmsProjectsQuery.data ?? []).filter(
     (project) => project.isActive !== false && project.externalProjectId,
   );
+  const projectItems = projects.map((project) => ({
+    value: project.externalProjectId!,
+    label: project.name,
+  }));
 
   return (
     <WorkspaceFilterField label="TMS project" className="w-full sm:max-w-sm">
       <Select
         value={value || null}
+        items={projectItems}
         onValueChange={(nextValue) => onValueChange(nextValue ?? "")}
         disabled={disabled || tmsProjectsQuery.isLoading}
       >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On Glossaries and Translation Memories, the TMS project select showed the raw external project id (e.g. `902807`) instead of the project name.

Base UI's `<Select.Value>` only resolves labels from the root `items` prop. `SelectItem`'s `label` alone is not enough for the closed trigger.

## Fix

Pass `items={[{ value, label }]}` into `TmsLiveProjectPicker`, matching the pattern already used by Issue Sheet selects.

## Test plan

- [x] Unit test asserts the trigger shows the project name, not the raw id
- [ ] Manually verify Glossaries and Translation Memories TMS project select shows names after selecting a project

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1567040f-f4a7-4847-a606-a8aa33c23a7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1567040f-f4a7-4847-a606-a8aa33c23a7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

