### PR TITLE
fix(web): theme tree search and portal row file actions

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-tree-context-menu.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-tree-context-menu.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useLayoutEffect, useState, type CSSProperties } from "react";
+import { createPortal } from "react-dom";
 import { Download01Icon, TranslateIcon, Upload01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ListIcon } from "lucide-react";
@@ -24,6 +26,74 @@ export type ProjectFileTreeActionsConfig = {
   onDownloadFile?: (file: ProjectFileRecord) => void;
 };
 
+const MENU_MIN_WIDTH_PX = 208;
+const MENU_VIEWPORT_GAP_PX = 8;
+const MENU_OFFSET_PX = 4;
+
+function lockWindowScroll(): () => void {
+  const { body, documentElement } = document;
+  const scrollbarWidth = window.innerWidth - documentElement.clientWidth;
+  const previousOverflow = body.style.overflow;
+  const previousPaddingRight = body.style.paddingRight;
+  body.style.overflow = "hidden";
+  if (scrollbarWidth > 0) {
+    body.style.paddingRight = `${scrollbarWidth}px`;
+  }
+  return () => {
+    body.style.overflow = previousOverflow;
+    body.style.paddingRight = previousPaddingRight;
+  };
+}
+
+function useWindowScrollLock() {
+  useEffect(() => lockWindowScroll(), []);
+}
+
+function resolveMenuStyle(context: ContextMenuOpenContext): CSSProperties {
+  const elementRect = context.anchorElement?.getBoundingClientRect();
+  const rect =
+    context.anchorRect ??
+    (elementRect
+      ? {
+          top: elementRect.top,
+          right: elementRect.right,
+          bottom: elementRect.bottom,
+          left: elementRect.left,
+          width: elementRect.width,
+          height: elementRect.height,
+        }
+      : null);
+
+  if (!rect) {
+    return {
+      position: "fixed",
+      top: MENU_VIEWPORT_GAP_PX,
+      left: MENU_VIEWPORT_GAP_PX,
+      zIndex: 50,
+    };
+  }
+
+  const preferredLeft = rect.right - MENU_MIN_WIDTH_PX;
+  const maxLeft = window.innerWidth - MENU_MIN_WIDTH_PX - MENU_VIEWPORT_GAP_PX;
+  const left = Math.min(
+    Math.max(MENU_VIEWPORT_GAP_PX, preferredLeft),
+    Math.max(MENU_VIEWPORT_GAP_PX, maxLeft),
+  );
+  const preferredTop = rect.bottom + MENU_OFFSET_PX;
+  const estimatedHeight = 220;
+  const top =
+    preferredTop + estimatedHeight > window.innerHeight - MENU_VIEWPORT_GAP_PX
+      ? Math.max(MENU_VIEWPORT_GAP_PX, rect.top - estimatedHeight - MENU_OFFSET_PX)
+      : preferredTop;
+
+  return {
+    position: "fixed",
+    top,
+    left,
+    zIndex: 50,
+  };
+}
+
 export function ProjectFileTreeContextMenu({
   file,
   context,
@@ -35,76 +105,93 @@ export function ProjectFileTreeContextMenu({
   fileActions: ProjectFileTreeActionsConfig;
   capabilities: ProjectFileActionCapabilities;
 }) {
+  useWindowScrollLock();
+  const [mounted, setMounted] = useState(false);
+  const [menuStyle, setMenuStyle] = useState<CSSProperties>(() => resolveMenuStyle(context));
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useLayoutEffect(() => {
+    setMenuStyle(resolveMenuStyle(context));
+  }, [context]);
+
   const closeMenu = () => {
     context.close({ restoreFocus: false });
   };
 
-  return (
-    <>
-      <div
-        className="flex min-w-52 flex-col gap-1 rounded-md border bg-background p-2 shadow"
-        data-file-tree-context-menu-root="true"
+  const menu = (
+    <div
+      className="flex min-w-52 flex-col gap-1 rounded-md border bg-background p-2 shadow"
+      data-file-tree-context-menu-root="true"
+      style={menuStyle}
+    >
+      <Button
+        type="button"
+        size="sm"
+        className="w-full justify-start"
+        disabled={!capabilities.canOpenCat || !capabilities.catHref}
+        onClick={() => {
+          closeMenu();
+          if (capabilities.canOpenCat) {
+            fileActions.onViewStrings(file);
+          }
+        }}
       >
-        <Button
-          type="button"
-          size="sm"
-          className="w-full justify-start"
-          disabled={!capabilities.canOpenCat || !capabilities.catHref}
-          onClick={() => {
-            closeMenu();
-            if (capabilities.canOpenCat) {
-              fileActions.onViewStrings(file);
-            }
-          }}
-        >
-          <ListIcon />
-          View strings
-        </Button>
-        {capabilities.isNativeFile ? (
-          <>
-            <Button
-              type="button"
-              size="sm"
-              className="w-full justify-start"
-              disabled={!capabilities.canTranslateWithAgent}
-              title={capabilities.translateDisabledTitle}
-              onClick={() => {
-                fileActions.onTranslateFile?.(file);
-                closeMenu();
-              }}
-            >
-              <HugeiconsIcon icon={TranslateIcon} strokeWidth={1.8} />
-              Translate with agent
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              className="w-full justify-start"
-              onClick={() => {
-                fileActions.onImportFile?.(file);
-                closeMenu();
-              }}
-            >
-              <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} />
-              Import translations
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              className="w-full justify-start"
-              onClick={() => {
-                fileActions.onDownloadFile?.(file);
-                closeMenu();
-              }}
-            >
-              <HugeiconsIcon icon={Download01Icon} strokeWidth={1.8} />
-              Download
-            </Button>
-          </>
-        ) : null}
-      </div>
-    </>
+        <ListIcon />
+        View strings
+      </Button>
+      {capabilities.isNativeFile ? (
+        <>
+          <Button
+            type="button"
+            size="sm"
+            className="w-full justify-start"
+            disabled={!capabilities.canTranslateWithAgent}
+            title={capabilities.translateDisabledTitle}
+            onClick={() => {
+              fileActions.onTranslateFile?.(file);
+              closeMenu();
+            }}
+          >
+            <HugeiconsIcon icon={TranslateIcon} strokeWidth={1.8} />
+            Translate with agent
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="w-full justify-start"
+            onClick={() => {
+              fileActions.onImportFile?.(file);
+              closeMenu();
+            }}
+          >
+            <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} />
+            Import translations
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="w-full justify-start"
+            onClick={() => {
+              fileActions.onDownloadFile?.(file);
+              closeMenu();
+            }}
+          >
+            <HugeiconsIcon icon={Download01Icon} strokeWidth={1.8} />
+            Download
+          </Button>
+        </>
+      ) : null}
+    </div>
   );
+
+  if (!mounted) {
+    return null;
+  }
+
+  return createPortal(menu, document.body);
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.stories.tsx
@@ -5,7 +5,6 @@ import { expect, waitFor } from "storybook/test";
 import { TypographyP } from "@/components/ui/typography";
 
 import { ProjectSectionTitle } from "../../_components/project-page-shell";
-import { ProjectFileSelectionActions } from "./project-file-selection-actions";
 import { ProjectFilesBranchFilterView } from "./project-files-branch-filter-view";
 import { ProjectFilesPageContentView } from "./project-files-page-content";
 import { ProjectFilesTree } from "./project-files-tree";
@@ -25,14 +24,10 @@ function storyFilesTree({
   files,
   selectedSourcePath,
   onSelectSourcePath,
-  organizationSlug,
-  projectId,
-  highlightLocale,
-  projectTargetLocales = null,
-  nativeSourcePaths = null,
   showBranchFilter = false,
   selectedBranch = null,
   onSelectBranch,
+  fileActions,
 }: {
   files: typeof projectFilesFixture;
   selectedSourcePath: string | null;
@@ -45,8 +40,9 @@ function storyFilesTree({
   showBranchFilter?: boolean;
   selectedBranch?: string | null;
   onSelectBranch?: (branch: string | null) => void;
+  fileActions?: Parameters<typeof ProjectFilesTree>[0]["fileActions"];
 }) {
-  return (selectedFileRecord: ReturnType<typeof createProjectFileRecord> | null) => (
+  return () => (
     <>
       <header className="flex shrink-0 items-center justify-between gap-3 border-b border-border px-4 py-2.5">
         <div className="min-w-0">
@@ -55,29 +51,15 @@ function storyFilesTree({
             {files.length} file{files.length === 1 ? "" : "s"}
           </TypographyP>
         </div>
-        <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
-          {showBranchFilter ? (
+        {showBranchFilter ? (
+          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
             <ProjectFilesBranchFilterView
               branches={providerProjectBranchesFixture}
               selectedBranch={selectedBranch}
               onSelectedBranchChange={onSelectBranch ?? (() => undefined)}
             />
-          ) : null}
-          {selectedFileRecord ? (
-            <ProjectFileSelectionActions
-              organizationSlug={organizationSlug}
-              projectId={projectId}
-              file={selectedFileRecord}
-              highlightLocale={highlightLocale}
-              projectTargetLocales={projectTargetLocales}
-              nativeSourcePaths={
-                nativeSourcePaths ??
-                files.filter((entry) => !entry.provider).map((entry) => entry.sourcePath)
-              }
-              layout="compact"
-            />
-          ) : null}
-        </div>
+          </div>
+        ) : null}
       </header>
 
       <div className="min-h-0 flex-1 p-2">
@@ -85,6 +67,7 @@ function storyFilesTree({
           files={files}
           selectedSourcePath={selectedSourcePath}
           onSelectFile={(sourcePath) => onSelectSourcePath(sourcePath)}
+          fileActions={fileActions}
         />
       </div>
     </>
@@ -133,10 +116,10 @@ export const RepositoryFiles: Story = {
     await expect(canvas.getByRole("heading", { name: "Project files" })).toBeInTheDocument();
     await expect(canvas.getByText("3 files")).toBeInTheDocument();
     await expect(canvas.getAllByText("marketing/home.json").length).toBeGreaterThan(0);
-    await expect(canvas.getByRole("link", { name: "View strings" })).toBeInTheDocument();
-    await expect(canvas.getByRole("button", { name: "Translate with agent" })).toBeInTheDocument();
-    await expect(canvas.getByRole("button", { name: "Import translations" })).toBeInTheDocument();
-    await expect(canvas.getByRole("button", { name: "Download" })).toBeInTheDocument();
+    await expect(canvas.queryByRole("link", { name: "View strings" })).toBeNull();
+    await expect(canvas.queryByRole("button", { name: "Translate with agent" })).toBeNull();
+    await expect(canvas.queryByRole("button", { name: "Import translations" })).toBeNull();
+    await expect(canvas.queryByRole("button", { name: "Download" })).toBeNull();
     await waitFor(() => {
       void expect(canvasElement.querySelector("file-tree-container")).toBeTruthy();
     });
@@ -181,7 +164,7 @@ export const ProviderFiles: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByText("Branch")).toBeInTheDocument();
     await expect(canvas.getByRole("combobox")).toBeInTheDocument();
-    await expect(canvas.getByRole("link", { name: "View strings" })).toBeInTheDocument();
+    await expect(canvas.queryByRole("link", { name: "View strings" })).toBeNull();
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx
@@ -6,7 +6,6 @@ import { useEffect, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { createProjectFileRecord } from "./project-files.fixture";
-import { ProjectFileSelectionActions } from "./project-file-selection-actions";
 
 const enUsFile = createProjectFileRecord({
   sourcePath: "en-US.json",
@@ -66,6 +65,8 @@ vi.mock("./project-files-tree-panel", () => ({
     headerActions?: ReactNode;
     fileActions?: {
       onDownloadFile?: (file: typeof pricingFile) => void;
+      onTranslateFile?: (file: typeof pricingFile) => void;
+      onImportFile?: (file: typeof pricingFile) => void;
     };
   }) => {
     useEffect(() => {
@@ -82,13 +83,40 @@ vi.mock("./project-files-tree-panel", () => ({
         <button type="button" onClick={() => fileActions?.onDownloadFile?.(pricingFile)}>
           Download pricing from context menu
         </button>
+        <button type="button" onClick={() => fileActions?.onTranslateFile?.(pricingFile)}>
+          Translate pricing from context menu
+        </button>
+        <button type="button" onClick={() => fileActions?.onImportFile?.(pricingFile)}>
+          Import pricing from context menu
+        </button>
       </div>
     );
   },
 }));
 
 vi.mock("./create-translation-job-dialog", () => ({
-  CreateTranslationJobDialog: () => null,
+  CreateTranslationJobDialog: ({ open }: { open: boolean }) =>
+    open ? <div role="dialog" aria-label="Translate with agent" /> : null,
+}));
+
+vi.mock("./import-translations-dialog", () => ({
+  ImportTranslationsDialog: ({ open }: { open: boolean }) =>
+    open ? <div role="dialog" aria-label="Import translations" /> : null,
+}));
+
+vi.mock("./download-translations-dialog", () => ({
+  DownloadTranslationsDialog: ({
+    open,
+    initialSourcePath,
+  }: {
+    open: boolean;
+    initialSourcePath?: string;
+  }) =>
+    open ? (
+      <div role="dialog" aria-label="Download translations">
+        {initialSourcePath ? <span>{initialSourcePath}</span> : null}
+      </div>
+    ) : null,
 }));
 
 vi.mock("./project-files-branch-filter", () => ({
@@ -106,7 +134,7 @@ vi.mock("../../_components/project-page-shell", () => ({
   }),
 }));
 
-import { ProjectFilesPageContent, ProjectFilesPageContentView } from "./project-files-page-content";
+import { ProjectFilesPageContent } from "./project-files-page-content";
 
 describe("ProjectFilesPageContent CAT entry UX", () => {
   beforeEach(() => {
@@ -152,90 +180,42 @@ describe("ProjectFilesPageContent CAT entry UX", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows translate with agent and import/download actions for native project files", () => {
+  it("does not show selection-dependent header action buttons", () => {
     render(<ProjectFilesPageContent organizationSlug="acme" projectId="proj_1" />);
 
-    expect(screen.getByRole("button", { name: "Translate with agent" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Import translations" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Download" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Translate with agent" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Import translations" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Download" })).not.toBeInTheDocument();
   });
 
-  it("opens the header download dialog for the context-menu file after URL selection updates", async () => {
+  it("opens the download dialog for the context-menu file without selecting it first", async () => {
     const user = userEvent.setup();
-    const view = render(<ProjectFilesPageContent organizationSlug="acme" projectId="proj_1" />);
+
+    render(<ProjectFilesPageContent organizationSlug="acme" projectId="proj_1" />);
 
     await user.click(screen.getByRole("button", { name: "Download pricing from context menu" }));
-
-    expect(routerReplaceMock).toHaveBeenCalledWith(
-      "/org/acme/projects/proj_1/files?sourcePath=marketing%2Fpricing.json&locale=vi",
-      { scroll: false },
-    );
-
-    view.rerender(<ProjectFilesPageContent organizationSlug="acme" projectId="proj_1" />);
 
     await waitFor(() => {
       expect(screen.getByRole("dialog", { name: "Download translations" })).toBeInTheDocument();
     });
-    expect(screen.getByLabelText(pricingFile.sourcePath)).toBeChecked();
+    expect(screen.getByText(pricingFile.sourcePath)).toBeInTheDocument();
+    expect(routerReplaceMock).not.toHaveBeenCalled();
   });
 
-  it("passes project target locales to default-layout download actions", async () => {
+  it("opens translate and import dialogs from the context menu for the clicked file", async () => {
     const user = userEvent.setup();
 
-    render(
-      <ProjectFilesPageContentView
-        organizationSlug="acme"
-        projectId="proj_1"
-        files={[enUsFile]}
-        isFilesLoading={false}
-        isFilesFetching={false}
-        selectedSourcePath="en-US.json"
-        highlightLocale={null}
-        projectTargetLocales={["vi", "fr-FR"]}
-        selectedFiles={[]}
-        isUploading={false}
-        onSelectSourcePath={() => undefined}
-        onAddSelectedFiles={() => undefined}
-        onRemoveSelectedFile={() => undefined}
-        onUploadSelectedFiles={() => undefined}
-      />,
-    );
+    render(<ProjectFilesPageContent organizationSlug="acme" projectId="proj_1" />);
 
-    await user.click(screen.getByRole("button", { name: "Download" }));
+    await user.click(screen.getByRole("button", { name: "Translate pricing from context menu" }));
+    await waitFor(() => {
+      expect(screen.getByRole("dialog", { name: "Translate with agent" })).toBeInTheDocument();
+    });
 
-    expect(screen.getByText("Target locale")).toBeInTheDocument();
-    expect(screen.getByText("vi")).toBeInTheDocument();
-    expect(
-      screen.queryByText("Add target locales in project settings before downloading translations."),
-    ).not.toBeInTheDocument();
-  });
-
-  it("preserves open download dialog selections across parent re-renders", async () => {
-    const user = userEvent.setup();
-    const targetLocales = ["vi", "fr-FR"] as const;
-    const nativeSourcePaths = [enUsFile.sourcePath, pricingFile.sourcePath] as const;
-    const renderActions = (layout: "default" | "compact") => (
-      <ProjectFileSelectionActions
-        organizationSlug="acme"
-        projectId="proj_1"
-        file={enUsFile}
-        highlightLocale={null}
-        projectTargetLocales={targetLocales}
-        nativeSourcePaths={nativeSourcePaths}
-        layout={layout}
-      />
-    );
-
-    const { rerender } = render(renderActions("default"));
-
-    await user.click(screen.getByRole("button", { name: "Download" }));
-    await user.click(screen.getByLabelText(pricingFile.sourcePath));
-    await user.click(screen.getByLabelText("fr-FR"));
-
-    rerender(renderActions("compact"));
-
-    expect(screen.getByLabelText(pricingFile.sourcePath)).toBeChecked();
-    expect(screen.getByLabelText("fr-FR")).toBeChecked();
+    await user.click(screen.getByRole("button", { name: "Import pricing from context menu" }));
+    await waitFor(() => {
+      expect(screen.getByRole("dialog", { name: "Import translations" })).toBeInTheDocument();
+    });
   });
 
   it("shows when a requested native locale will fall back to a project locale", () => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -28,10 +28,7 @@ import {
   ProjectSectionTitle,
   useProjectPageQuery,
 } from "../../_components/project-page-shell";
-import {
-  ProjectFileSelectionActions,
-  type ProjectFileSelectionActionsHandle,
-} from "./project-file-selection-actions";
+import { ProjectFileActionDialogs } from "./project-file-action-dialogs";
 import type { ProjectFileTreeActionsConfig } from "./project-file-tree-context-menu";
 import { ProjectFilesBranchFilter } from "./project-files-branch-filter";
 import {
@@ -41,12 +38,82 @@ import {
 } from "./project-files-tree-panel";
 import { ProjectFilesTree } from "./project-files-tree";
 import { formatBytes } from "./project-files-shared";
+import { useProjectFileActions } from "./use-project-file-actions";
 
 const FILE_ACCEPT =
   ".json,.jsonc,.yaml,.yml,.arb,.xlf,.xlif,.xliff,.po,.html,.md,.mdx,.strings,.stringsdict,.xcstrings,.csv";
 const MAX_UPLOAD_FILES = 10;
 
 type PendingFileDialogAction = "translate" | "import" | "download";
+
+function ProjectFileDialogHost({
+  file,
+  initialAction,
+  organizationSlug,
+  projectId,
+  highlightLocale,
+  projectTargetLocales,
+  sourceLocale,
+  nativeSourcePaths,
+  branch,
+  onClose,
+}: {
+  file: ProjectFileRecord;
+  initialAction: PendingFileDialogAction;
+  organizationSlug: string;
+  projectId: string;
+  highlightLocale: string | null;
+  projectTargetLocales?: readonly string[] | null;
+  sourceLocale: string;
+  nativeSourcePaths: readonly string[];
+  branch: string | null;
+  onClose: () => void;
+}) {
+  const actions = useProjectFileActions({
+    organizationSlug,
+    projectId,
+    file,
+    highlightLocale,
+    projectTargetLocales,
+    sourceLocale,
+    nativeSourcePaths,
+    branch,
+  });
+  const [hasOpened, setHasOpened] = useState(false);
+
+  useEffect(() => {
+    if (hasOpened) {
+      return;
+    }
+    const openDialog = {
+      translate: () => actions.setTranslateDialogOpen(true),
+      import: () => actions.setImportDialogOpen(true),
+      download: () => actions.setDownloadDialogOpen(true),
+    }[initialAction];
+    openDialog();
+    setHasOpened(true);
+  }, [actions, hasOpened, initialAction]);
+
+  useEffect(() => {
+    if (!hasOpened) {
+      return;
+    }
+
+    const anyOpen =
+      actions.translateDialogOpen || actions.importDialogOpen || actions.downloadDialogOpen;
+    if (!anyOpen) {
+      onClose();
+    }
+  }, [
+    actions.downloadDialogOpen,
+    actions.importDialogOpen,
+    actions.translateDialogOpen,
+    hasOpened,
+    onClose,
+  ]);
+
+  return <ProjectFileActionDialogs file={file} actions={actions} />;
+}
 
 function apiPath(organizationSlug: string, projectId: string) {
   return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/files`;
@@ -300,48 +367,18 @@ export function ProjectFilesPageContent({
       })()
     : null;
 
-  const selectionActionsRef = useRef<ProjectFileSelectionActionsHandle>(null);
-  const [pendingFileDialogAction, setPendingFileDialogAction] =
-    useState<PendingFileDialogAction | null>(null);
-  const pendingFileDialogSourcePathRef = useRef<string | null>(null);
+  const [dialogRequest, setDialogRequest] = useState<{
+    file: ProjectFileRecord;
+    action: PendingFileDialogAction;
+  } | null>(null);
 
-  const openSelectionDialog = useCallback((action: PendingFileDialogAction) => {
-    const openDialog = {
-      translate: () => selectionActionsRef.current?.openTranslate(),
-      import: () => selectionActionsRef.current?.openImport(),
-      download: () => selectionActionsRef.current?.openDownload(),
-    }[action];
-    queueMicrotask(openDialog);
+  const closeFileDialog = useCallback(() => {
+    setDialogRequest(null);
   }, []);
 
-  const openFileDialog = useCallback(
-    (file: ProjectFileRecord, action: PendingFileDialogAction) => {
-      if (selectedSourcePath === file.sourcePath) {
-        openSelectionDialog(action);
-        return;
-      }
-
-      pendingFileDialogSourcePathRef.current = file.sourcePath;
-      setPendingFileDialogAction(action);
-      setSelectedSourcePath(file.sourcePath);
-    },
-    [openSelectionDialog, selectedSourcePath, setSelectedSourcePath],
-  );
-
-  useEffect(() => {
-    const pendingSourcePath = pendingFileDialogSourcePathRef.current;
-    if (!pendingFileDialogAction || !pendingSourcePath) {
-      return;
-    }
-
-    if (selectedSourcePath !== pendingSourcePath) {
-      return;
-    }
-
-    openSelectionDialog(pendingFileDialogAction);
-    pendingFileDialogSourcePathRef.current = null;
-    setPendingFileDialogAction(null);
-  }, [openSelectionDialog, pendingFileDialogAction, selectedSourcePath]);
+  const openFileDialog = useCallback((file: ProjectFileRecord, action: PendingFileDialogAction) => {
+    setDialogRequest({ file, action });
+  }, []);
 
   const treeFileActions = useMemo<ProjectFileTreeActionsConfig>(
     () => ({
@@ -371,66 +408,67 @@ export function ProjectFilesPageContent({
   );
 
   return (
-    <ProjectFilesPageContentView
-      organizationSlug={organizationSlug}
-      projectId={projectId}
-      files={[]}
-      resolvedFiles={resolvedFiles}
-      isFilesLoading={false}
-      isFilesFetching={false}
-      selectedSourcePath={selectedSourcePath}
-      highlightLocale={highlightLocale}
-      selectedBranch={selectedBranch}
-      projectTargetLocales={projectTargetLocales}
-      projectSourceLocale={projectSourceLocale}
-      isProviderProject={isProviderProject}
-      selectedFiles={selectedFiles}
-      isUploading={uploadFiles.isPending}
-      onSelectSourcePath={setSelectedSourcePath}
-      onSelectBranch={setSelectedBranch}
-      onAddSelectedFiles={addSelectedFiles}
-      onRemoveSelectedFile={removeSelectedFile}
-      onUploadSelectedFiles={() => uploadFiles.mutate(selectedFiles)}
-      filesTree={(selectedFile) => (
-        <ProjectFilesTreePanel
+    <>
+      {dialogRequest ? (
+        <ProjectFileDialogHost
+          key={`${dialogRequest.file.sourcePath}:${dialogRequest.action}`}
+          file={dialogRequest.file}
+          initialAction={dialogRequest.action}
           organizationSlug={organizationSlug}
           projectId={projectId}
-          selectedSourcePath={selectedSourcePath}
-          onSelectSourcePath={setSelectedSourcePath}
-          onLoadedFilesChange={setLoadedFiles}
-          onActivateFile={openFileInCat}
-          catOpenHint={catOpenHint}
-          fileActions={treeFileActions}
+          highlightLocale={highlightLocale}
+          projectTargetLocales={projectTargetLocales}
+          sourceLocale={projectSourceLocale}
+          nativeSourcePaths={nativeSourcePaths}
           branch={selectedBranch}
-          headerActions={
-            <>
-              {isProviderProject ? (
+          onClose={closeFileDialog}
+        />
+      ) : null}
+      <ProjectFilesPageContentView
+        organizationSlug={organizationSlug}
+        projectId={projectId}
+        files={[]}
+        resolvedFiles={resolvedFiles}
+        isFilesLoading={false}
+        isFilesFetching={false}
+        selectedSourcePath={selectedSourcePath}
+        highlightLocale={highlightLocale}
+        selectedBranch={selectedBranch}
+        projectTargetLocales={projectTargetLocales}
+        projectSourceLocale={projectSourceLocale}
+        isProviderProject={isProviderProject}
+        selectedFiles={selectedFiles}
+        isUploading={uploadFiles.isPending}
+        onSelectSourcePath={setSelectedSourcePath}
+        onSelectBranch={setSelectedBranch}
+        onAddSelectedFiles={addSelectedFiles}
+        onRemoveSelectedFile={removeSelectedFile}
+        onUploadSelectedFiles={() => uploadFiles.mutate(selectedFiles)}
+        filesTree={() => (
+          <ProjectFilesTreePanel
+            organizationSlug={organizationSlug}
+            projectId={projectId}
+            selectedSourcePath={selectedSourcePath}
+            onSelectSourcePath={setSelectedSourcePath}
+            onLoadedFilesChange={setLoadedFiles}
+            onActivateFile={openFileInCat}
+            catOpenHint={catOpenHint}
+            fileActions={treeFileActions}
+            branch={selectedBranch}
+            headerActions={
+              isProviderProject ? (
                 <ProjectFilesBranchFilter
                   organizationSlug={organizationSlug}
                   projectId={projectId}
                   selectedBranch={selectedBranch}
                   onSelectedBranchChange={setSelectedBranch}
                 />
-              ) : null}
-              {selectedFile ? (
-                <ProjectFileSelectionActions
-                  ref={selectionActionsRef}
-                  organizationSlug={organizationSlug}
-                  projectId={projectId}
-                  file={selectedFile}
-                  highlightLocale={highlightLocale}
-                  projectTargetLocales={projectTargetLocales}
-                  sourceLocale={projectSourceLocale}
-                  nativeSourcePaths={nativeSourcePaths}
-                  branch={selectedBranch}
-                  layout="compact"
-                />
-              ) : null}
-            </>
-          }
-        />
-      )}
-    />
+              ) : null
+            }
+          />
+        )}
+      />
+    </>
   );
 }
 
@@ -443,10 +481,10 @@ export function ProjectFilesPageContentView({
   isFilesFetching,
   filesError,
   selectedSourcePath,
-  highlightLocale,
+  highlightLocale: _highlightLocale,
   selectedBranch: _selectedBranch = null,
-  projectTargetLocales,
-  projectSourceLocale = "en",
+  projectTargetLocales: _projectTargetLocales,
+  projectSourceLocale: _projectSourceLocale = "en",
   isProviderProject: isProviderProjectProp,
   selectedFiles,
   isUploading,
@@ -488,10 +526,6 @@ export function ProjectFilesPageContentView({
   const selectedFile = useMemo(
     () => displayFiles.find((file) => file.sourcePath === selectedSourcePath) ?? null,
     [displayFiles, selectedSourcePath],
-  );
-  const nativeSourcePaths = useMemo(
-    () => displayFiles.filter((entry) => !entry.provider).map((entry) => entry.sourcePath),
-    [displayFiles],
   );
   const projectCapabilities = getProjectWorkspaceCapabilities({ projectId });
   const isProviderProject = isProviderProjectProp ?? projectCapabilities.isProviderProject;
@@ -588,18 +622,6 @@ export function ProjectFilesPageContentView({
           <div className="flex min-h-0 flex-1 flex-col">{filesTree(selectedFile)}</div>
         ) : (
           <>
-            {selectedFile ? (
-              <ProjectFileSelectionActions
-                organizationSlug={organizationSlug}
-                projectId={projectId}
-                file={selectedFile}
-                highlightLocale={highlightLocale}
-                projectTargetLocales={projectTargetLocales}
-                sourceLocale={projectSourceLocale}
-                nativeSourcePaths={nativeSourcePaths}
-                branch={_selectedBranch}
-              />
-            ) : null}
             <header className="flex shrink-0 items-center justify-between gap-3 border-b border-border px-4 py-3">
               <div>
                 <ProjectSectionTitle>Project files</ProjectSectionTitle>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.stories.tsx
@@ -58,6 +58,7 @@ export const SearchFiles: Story = {
     if (!(searchInput instanceof HTMLInputElement)) {
       throw new Error("Expected built-in file tree search input");
     }
+    await expect(searchInput.getAttribute("aria-label")).toBe("Search files");
 
     await userEvent.type(searchInput, "pricing");
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.stories.tsx
@@ -53,23 +53,23 @@ export const SearchFiles: Story = {
       void expect(canvasElement.querySelector("file-tree-container")).toBeTruthy();
     });
 
-    const searchInput = canvasElement.querySelector('input[aria-label="Search files"]');
+    const treeContainer = canvasElement.querySelector("file-tree-container");
+    const searchInput = treeContainer?.shadowRoot?.querySelector("[data-file-tree-search-input]");
     if (!(searchInput instanceof HTMLInputElement)) {
-      throw new Error("Expected search input above file tree");
+      throw new Error("Expected built-in file tree search input");
     }
 
     await userEvent.type(searchInput, "pricing");
 
     await waitFor(() => {
-      const treeContainer = canvasElement.querySelector("file-tree-container");
       const pricingRow = treeContainer?.shadowRoot?.querySelector(
         '[data-item-path="marketing/pricing.json"]',
       );
-      const homepageRow = treeContainer?.shadowRoot?.querySelector(
-        '[data-item-path="marketing/homepage.json"]',
+      const homeRow = treeContainer?.shadowRoot?.querySelector(
+        '[data-item-path="marketing/home.json"]',
       );
       void expect(pricingRow).toBeTruthy();
-      void expect(homepageRow).toBeFalsy();
+      void expect(homeRow).toBeFalsy();
     });
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
@@ -1,15 +1,12 @@
 "use client";
 
 import { useEffect, useMemo, useRef, type CSSProperties } from "react";
-import { SearchIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import type { FileTreeRowDecorationContext } from "@pierre/trees";
-import { FileTree as PierreFileTree, useFileTree, useFileTreeSearch } from "@pierre/trees/react";
+import { FileTree as PierreFileTree, useFileTree } from "@pierre/trees/react";
 import { preloadFileTree } from "@pierre/trees/ssr";
 import "@pierre/trees/web-components";
 
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
-import { Input } from "@/components/ui/input";
 
 import {
   ProjectFileTreeContextMenu,
@@ -38,6 +35,9 @@ const projectFilesTreeStyle = {
   "--trees-fg-override": "var(--foreground)",
   "--trees-fg-muted-override": "var(--muted-foreground)",
   "--trees-focus-ring-color-override": "var(--ring)",
+  "--trees-input-bg-override": "var(--background)",
+  "--trees-search-bg-override": "var(--background)",
+  "--trees-search-fg-override": "var(--foreground)",
   "--trees-selected-bg-override": "var(--muted)",
   "--trees-selected-fg-override": "var(--foreground)",
   "--trees-selected-focused-border-color-override": "var(--ring)",
@@ -193,6 +193,7 @@ function ProjectFilesTreeView({
     initialVisibleRowCount: Math.max(paths.length, 8),
     paths,
     search: true,
+    searchBlurBehavior: "retain",
     fileTreeSearchMode: "hide-non-matches",
     composition: fileActions
       ? {
@@ -230,8 +231,6 @@ function ProjectFilesTreeView({
     },
   });
 
-  const search = useFileTreeSearch(model);
-
   useEffect(() => {
     model.resetPaths(paths);
   }, [model, paths]);
@@ -250,20 +249,7 @@ function ProjectFilesTreeView({
   }
 
   return (
-    <div ref={containerRef} className="flex w-full min-w-0 flex-col gap-2">
-      <div className="relative shrink-0">
-        <HugeiconsIcon
-          icon={SearchIcon}
-          className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground"
-        />
-        <Input
-          value={search.value}
-          onChange={(event) => search.setValue(event.target.value)}
-          placeholder="Search files..."
-          aria-label="Search files"
-          className="h-9 pl-9 font-mono text-xs"
-        />
-      </div>
+    <div ref={containerRef} className="flex w-full min-w-0 flex-col">
       <PierreFileTree
         aria-label={ariaLabel}
         className="w-full min-w-0 border-0 bg-transparent"

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
@@ -244,6 +244,14 @@ function ProjectFilesTreeView({
     model.scrollToPath(selectedSourcePath, { offset: "nearest" });
   }, [fileByPath, model, selectedSourcePath]);
 
+  useEffect(() => {
+    const host = containerRef.current?.querySelector("file-tree-container");
+    const searchInput = host?.shadowRoot?.querySelector("[data-file-tree-search-input]");
+    if (searchInput instanceof HTMLInputElement) {
+      searchInput.setAttribute("aria-label", "Search files");
+    }
+  }, [model, paths.length]);
+
   if (paths.length === 0) {
     return null;
   }

--- a/docs/adr/2026-07-10-project-files-tree-actions-design.md
+++ b/docs/adr/2026-07-10-project-files-tree-actions-design.md
@@ -1,0 +1,35 @@
+# Project files tree search and row actions
+
+## Decision
+
+Use the Pierre Trees built-in search field, themed with host CSS variables so it
+matches the app. Put file actions only in each row's context menu. Portal that
+menu and lock window scroll while it is open so it stays visible and anchored.
+
+## Search
+
+Remove the external `components/ui` search input above the tree. Keep
+`search: true` and theme the built-in field with `--trees-search-*` and related
+host overrides (`--trees-bg-*`, `--trees-border-*`, `--trees-fg-*`).
+
+## Actions
+
+Remove header and selection-dependent action buttons (View strings, Translate
+with agent, Import translations, Download). Open those commands from the row
+`⋯` menu only. Compute enablement from the clicked file. Own translate, import,
+and download dialogs at page level for that file; do not select a row first to
+open a dialog.
+
+## Context menu
+
+Keep `composition.contextMenu` with a button trigger. Render menu content
+through a portal to `document.body`, position it from the trees
+`anchorRect` / `anchorElement`, mark the root with
+`data-file-tree-context-menu-root="true"`, and lock window scroll for the menu
+lifetime per the Trees docs.
+
+## Verification
+
+Update project files page and tree tests/stories for menu-only actions and the
+built-in search field. Run `vp test` and `vp check --fix` from
+`apps/hyperlocalise-web`.


### PR DESCRIPTION
## Summary
- Theme the Pierre Trees built-in search field with host CSS variables and remove the duplicate external search input.
- Move View strings / Translate / Import / Download into each row’s context menu only, opening dialogs for the clicked file without selecting first.
- Portal the context menu and lock window scroll while open so actions stay visible and anchored.

## Test plan
- [ ] Open Project files and confirm a single themed search field (no black duplicate bar).
- [ ] Confirm header no longer shows selection-dependent action buttons.
- [ ] Open a row `⋯` menu and verify View strings / Translate / Import / Download appear and stay in viewport.
- [ ] Trigger Translate / Import / Download from the menu without selecting the row first; dialogs open for that file.
- [ ] Run `vp test` and `vp check --fix` in `apps/hyperlocalise-web`.


Made with [Cursor](https://cursor.com)