### PR TITLE
feat(web): wire content locales ahead of routing support

### DIFF
--- a/apps/hyperlocalise-web/src/lib/app-i18n/intl.test.ts
+++ b/apps/hyperlocalise-web/src/lib/app-i18n/intl.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { getIntlShape } from "./intl";
+
+describe("getIntlShape", () => {
+  it("returns empty messages for the source locale", () => {
+    expect(getIntlShape("en").messages).toEqual({});
+  });
+
+  it("loads translated catalogs for every content locale", () => {
+    for (const locale of ["zh-CN", "vi-VN", "de-DE", "fr-FR"] as const) {
+      const messages = getIntlShape(locale).messages;
+      expect(Object.keys(messages).length).toBeGreaterThan(0);
+      expect(getIntlShape(locale).locale).toBe(locale);
+    }
+  });
+
+  it("falls back to the default locale for unknown locales", () => {
+    expect(getIntlShape("ja-JP").locale).toBe("en");
+    expect(getIntlShape("ja-JP").messages).toEqual({});
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/app-i18n/intl.ts
+++ b/apps/hyperlocalise-web/src/lib/app-i18n/intl.ts
@@ -1,9 +1,16 @@
 import { createIntl, createIntlCache, type IntlShape } from "@formatjs/intl";
 
+import deDEMessages from "../../../lang/de-DE.json";
+import frFRMessages from "../../../lang/fr-FR.json";
 import viVNMessages from "../../../lang/vi-VN.json";
 import zhCNMessages from "../../../lang/zh-CN.json";
 
-import { DEFAULT_APP_LOCALE, normalizeAppLocale, type AppLocale } from "./locales";
+import {
+  DEFAULT_APP_LOCALE,
+  normalizeAppContentLocale,
+  normalizeAppLocale,
+  type AppContentLocale,
+} from "./locales";
 
 const cache = createIntlCache();
 
@@ -24,26 +31,25 @@ function toMessages(catalog: LocaleCatalog): Record<string, string> {
   return messages;
 }
 
-const translatedCatalogs = {
+const translatedCatalogs: Partial<Record<AppContentLocale, Record<string, string>>> = {
   "zh-CN": toMessages(zhCNMessages as LocaleCatalog),
   "vi-VN": toMessages(viVNMessages as LocaleCatalog),
-} as const;
+  "de-DE": toMessages(deDEMessages as LocaleCatalog),
+  "fr-FR": toMessages(frFRMessages as LocaleCatalog),
+};
 
-function getMessagesForLocale(locale: AppLocale): Record<string, string> {
+function getMessagesForLocale(locale: AppContentLocale): Record<string, string> {
   // Source locale uses defaultMessage from descriptors; no en-US catalog needed.
   if (locale === DEFAULT_APP_LOCALE) {
     return {};
   }
 
-  if (locale in translatedCatalogs) {
-    return translatedCatalogs[locale as keyof typeof translatedCatalogs];
-  }
-
-  return {};
+  return translatedCatalogs[locale] ?? {};
 }
 
 export function getIntlShape(locale: string = DEFAULT_APP_LOCALE): IntlShape {
-  const normalizedLocale = normalizeAppLocale(locale) ?? DEFAULT_APP_LOCALE;
+  const normalizedLocale =
+    normalizeAppLocale(locale) ?? normalizeAppContentLocale(locale) ?? DEFAULT_APP_LOCALE;
 
   return createIntl(
     {

--- a/apps/hyperlocalise-web/src/lib/app-i18n/locales.test.ts
+++ b/apps/hyperlocalise-web/src/lib/app-i18n/locales.test.ts
@@ -3,9 +3,12 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   APP_LOCALE_COOKIE_NAME,
+  AVAILABLE_APP_CONTENT_LOCALES,
   DEFAULT_APP_LOCALE,
   getAppLocaleFromRequest,
+  isAvailableAppContentLocale,
   isSupportedAppLocale,
+  normalizeAppContentLocale,
   normalizeAppLocale,
   SUPPORTED_APP_LOCALES,
 } from "./locales";
@@ -32,6 +35,16 @@ describe("app i18n locales", () => {
   it("normalizes supported locales case-insensitively", () => {
     expect(normalizeAppLocale("EN")).toBe("en");
     expect(normalizeAppLocale("fr")).toBeNull();
+  });
+
+  it("keeps content locales ready ahead of supported routing locales", () => {
+    expect(AVAILABLE_APP_CONTENT_LOCALES).toEqual(["en", "zh-CN", "vi-VN", "de-DE", "fr-FR"]);
+    expect(isAvailableAppContentLocale("zh-CN")).toBe(true);
+    expect(isAvailableAppContentLocale("fr-FR")).toBe(true);
+    expect(normalizeAppContentLocale("zh-cn")).toBe("zh-CN");
+    expect(normalizeAppContentLocale("de-de")).toBe("de-DE");
+    expect(normalizeAppContentLocale("ja-JP")).toBeNull();
+    expect(isSupportedAppLocale("zh-CN")).toBe(false);
   });
 
   it("prefers the locale cookie before accept-language negotiation", () => {

--- a/apps/hyperlocalise-web/src/lib/app-i18n/locales.ts
+++ b/apps/hyperlocalise-web/src/lib/app-i18n/locales.ts
@@ -4,7 +4,14 @@ import type { NextRequest } from "next/server";
 
 export const SUPPORTED_APP_LOCALES = ["en"] as const;
 
+/**
+ * Locales with message catalogs and/or blog posts ready to serve.
+ * Keep this ahead of SUPPORTED_APP_LOCALES so enabling a locale is a one-line change.
+ */
+export const AVAILABLE_APP_CONTENT_LOCALES = ["en", "zh-CN", "vi-VN", "de-DE", "fr-FR"] as const;
+
 export type AppLocale = (typeof SUPPORTED_APP_LOCALES)[number];
+export type AppContentLocale = (typeof AVAILABLE_APP_CONTENT_LOCALES)[number];
 
 export const DEFAULT_APP_LOCALE: AppLocale = "en";
 export const APP_LOCALE_COOKIE_NAME = "hl_locale";
@@ -17,9 +24,24 @@ export function isSupportedAppLocale(value: unknown): value is AppLocale {
   );
 }
 
+export function isAvailableAppContentLocale(value: unknown): value is AppContentLocale {
+  return (
+    typeof value === "string" &&
+    AVAILABLE_APP_CONTENT_LOCALES.some((locale) => locale.toLowerCase() === value.toLowerCase())
+  );
+}
+
 export function normalizeAppLocale(value: string): AppLocale | null {
   const locale = SUPPORTED_APP_LOCALES.find(
     (supportedLocale) => supportedLocale.toLowerCase() === value.toLowerCase(),
+  );
+
+  return locale ?? null;
+}
+
+export function normalizeAppContentLocale(value: string): AppContentLocale | null {
+  const locale = AVAILABLE_APP_CONTENT_LOCALES.find(
+    (contentLocale) => contentLocale.toLowerCase() === value.toLowerCase(),
   );
 
   return locale ?? null;

--- a/apps/hyperlocalise-web/src/lib/blog/blog-post.test.ts
+++ b/apps/hyperlocalise-web/src/lib/blog/blog-post.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { basename } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
@@ -137,6 +138,36 @@ describe("getAllPosts", () => {
     const result = blogPost.getAllPosts(DEFAULT_LOCALE);
 
     expect(result.map((post) => post.slug)).toEqual(["published"]);
+  });
+});
+
+describe("postsDirectory locale resolution", () => {
+  beforeEach(() => {
+    directoryEntries.length = 0;
+    for (const key of Object.keys(fileContents)) {
+      delete fileContents[key];
+    }
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves content locales that are not yet in SUPPORTED_APP_LOCALES", () => {
+    directoryEntries.push("translated-post.md");
+    fileContents["translated-post"] = serializePost({
+      slug: "translated-post",
+      title: "Translated",
+      excerpt: "Excerpt",
+      date: "2024-06-01T00:00:00.000Z",
+      category: "Blog",
+      content: "Body",
+    });
+
+    const post = blogPost.getPostBySlug("translated-post", "zh-CN");
+
+    expect(post?.title).toBe("Translated");
+    expect(vi.mocked(fs.readFileSync).mock.calls[0]?.[0]).toContain("_posts/zh-CN/");
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/blog/blog-post.ts
+++ b/apps/hyperlocalise-web/src/lib/blog/blog-post.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 
 import matter from "gray-matter";
 
-import { DEFAULT_APP_LOCALE, normalizeAppLocale } from "@/lib/app-i18n/locales";
+import { DEFAULT_APP_LOCALE, normalizeAppContentLocale } from "@/lib/app-i18n/locales";
 import { isValidBlogPostSlug, normalizeBlogPostSlug } from "@/lib/blog/blog-post-path";
 
 export interface Post {
@@ -43,7 +43,8 @@ function frontmatterDate(value: unknown, fallback = ""): string {
 }
 
 function postsDirectory(locale: string) {
-  const safeLocale = normalizeAppLocale(locale) ?? DEFAULT_APP_LOCALE;
+  // Resolve against content locales (not only SUPPORTED) so posts are ready before a locale is enabled.
+  const safeLocale = normalizeAppContentLocale(locale) ?? DEFAULT_APP_LOCALE;
   return join(process.cwd(), "_posts", safeLocale);
 }
 


### PR DESCRIPTION
## What changed

Wire all translated message catalogs (`zh-CN`, `vi-VN`, `de-DE`, `fr-FR`) into `getIntlShape`, and resolve blog posts via a new `AVAILABLE_APP_CONTENT_LOCALES` allowlist so content is ready before those locales are added to `SUPPORTED_APP_LOCALES`.

## How to test

- `cd apps/hyperlocalise-web && vp test src/lib/app-i18n/intl.test.ts src/lib/app-i18n/locales.test.ts src/lib/blog/blog-post.test.ts`
- `cd apps/hyperlocalise-web && vp check --fix src/lib/app-i18n/intl.ts src/lib/app-i18n/intl.test.ts src/lib/app-i18n/locales.ts src/lib/app-i18n/locales.test.ts src/lib/blog/blog-post.ts src/lib/blog/blog-post.test.ts`
- Confirm `SUPPORTED_APP_LOCALES` remains `["en"]` and routing is unchanged

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix` on touched files)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)