### PR TITLE
feat(web): enable app locales and add language toggle

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar.tsx
@@ -18,6 +18,7 @@ import { env } from "@/lib/env";
 import Image from "next/image";
 import Link from "next/link";
 
+import LocaleToggle from "@/components/locale-toggle/locale-toggle";
 import ThemeToggle from "@/components/theme-toggle/theme-toggle";
 
 const navigationLinks: { href: string; label: string; active?: boolean }[] = [
@@ -161,6 +162,7 @@ export default function Navbar() {
           <Button nativeButton={false} render={<a href={env.NEXT_PUBLIC_WAITLIST_URL} />}>
             Join waitlist
           </Button>
+          <LocaleToggle />
           <ThemeToggle />
         </div>
 
@@ -173,6 +175,7 @@ export default function Navbar() {
             Join waitlist
           </Button>
           <MobileNavigation />
+          <LocaleToggle />
           <ThemeToggle />
         </div>
       </div>

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
@@ -13,6 +13,7 @@ import {
   SidebarRail,
   SidebarTrigger,
 } from "@/components/ui/sidebar";
+import LocaleToggle from "@/components/locale-toggle/locale-toggle";
 import ThemeToggle from "@/components/theme-toggle/theme-toggle";
 import { AppShellBreadcrumb } from "./app-shell-breadcrumb";
 import { AppShellNavigation } from "./app-shell-navigation";
@@ -129,6 +130,7 @@ export function AppShellClient({
                     connectMethod={resolvedTmsUserConnectCta.connectMethod}
                   />
                 ) : null}
+                <LocaleToggle />
                 <ThemeToggle />
                 <NavUser
                   organizationName={activeOrganization.name}

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -186,6 +186,11 @@ describe("stripAppLocalePrefix", () => {
     expect(stripAppLocalePrefix("/org/acme/inbox")).toBe("/org/acme/inbox");
     expect(stripAppLocalePrefix("/fr/org/acme/inbox")).toBe("/fr/org/acme/inbox");
   });
+
+  it("removes newly supported locale prefixes", () => {
+    expect(stripAppLocalePrefix("/fr-FR/org/acme/inbox")).toBe("/org/acme/inbox");
+    expect(stripAppLocalePrefix("/zh-CN/blog")).toBe("/blog");
+  });
 });
 
 describe("parseProjectRoute", () => {

--- a/apps/hyperlocalise-web/src/components/locale-toggle/locale-toggle.messages.ts
+++ b/apps/hyperlocalise-web/src/components/locale-toggle/locale-toggle.messages.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const localeToggleMessages = defineMessages({
+  changeLanguage: {
+    defaultMessage: "Change language",
+    id: "AHsrowfXdB",
+    description: "Accessible label and tooltip for the app language toggle button",
+  },
+  languageAria: {
+    defaultMessage: "Language",
+    id: "0YNeNLXRIW",
+    description: "Accessible label for the language selection radio group",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/locale-toggle/locale-toggle.tsx
+++ b/apps/hyperlocalise-web/src/components/locale-toggle/locale-toggle.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { LanguageCircleIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { usePathname, useRouter } from "next/navigation";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { SUPPORTED_APP_LOCALES, type AppLocale } from "@/lib/app-i18n/locales";
+import {
+  getAppLocaleFromPathname,
+  getNativeLocaleDisplayName,
+  rewriteAppLocalePath,
+} from "@/lib/app-i18n/rewrite-app-locale-path";
+
+import { localeToggleMessages } from "./locale-toggle.messages";
+
+export function LocaleToggle() {
+  const intl = useIntl();
+  const pathname = usePathname() ?? "/";
+  const router = useRouter();
+  const activeLocale = getAppLocaleFromPathname(pathname);
+
+  return (
+    <DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <DropdownMenuTrigger
+              render={
+                <Button variant="outline" size="icon-sm" className="rounded-full">
+                  <HugeiconsIcon icon={LanguageCircleIcon} strokeWidth={2} className="size-4" />
+                  <span className="sr-only">
+                    <FormattedMessage {...localeToggleMessages.changeLanguage} />
+                  </span>
+                </Button>
+              }
+            />
+          }
+        />
+        <TooltipContent side="bottom" align="center">
+          <FormattedMessage {...localeToggleMessages.changeLanguage} />
+        </TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align="end">
+        <DropdownMenuRadioGroup
+          aria-label={intl.formatMessage(localeToggleMessages.languageAria)}
+          value={activeLocale}
+          onValueChange={(value) => {
+            const nextLocale = value as AppLocale;
+            if (nextLocale === activeLocale) {
+              return;
+            }
+
+            const search = typeof window !== "undefined" ? window.location.search : "";
+            const hash = typeof window !== "undefined" ? window.location.hash : "";
+            router.push(rewriteAppLocalePath(`${pathname}${search}${hash}`, nextLocale));
+          }}
+        >
+          {SUPPORTED_APP_LOCALES.map((locale) => (
+            <DropdownMenuRadioItem key={locale} value={locale}>
+              <span className="truncate">{getNativeLocaleDisplayName(locale)}</span>
+              <span className="text-muted-foreground">({locale})</span>
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export default LocaleToggle;

--- a/apps/hyperlocalise-web/src/lib/app-i18n/locales.test.ts
+++ b/apps/hyperlocalise-web/src/lib/app-i18n/locales.test.ts
@@ -32,19 +32,27 @@ describe("app i18n locales", () => {
     expect(isSupportedAppLocale("en")).toBe(true);
   });
 
+  it("supports every ready content locale for routing", () => {
+    expect(SUPPORTED_APP_LOCALES).toEqual(AVAILABLE_APP_CONTENT_LOCALES);
+    expect(SUPPORTED_APP_LOCALES).toEqual(["en", "zh-CN", "vi-VN", "de-DE", "fr-FR"]);
+    expect(isSupportedAppLocale("zh-CN")).toBe(true);
+    expect(isSupportedAppLocale("fr-FR")).toBe(true);
+    expect(isSupportedAppLocale("ja-JP")).toBe(false);
+  });
+
   it("normalizes supported locales case-insensitively", () => {
     expect(normalizeAppLocale("EN")).toBe("en");
+    expect(normalizeAppLocale("zh-cn")).toBe("zh-CN");
     expect(normalizeAppLocale("fr")).toBeNull();
   });
 
-  it("keeps content locales ready ahead of supported routing locales", () => {
+  it("keeps content locale helpers aligned with supported routing locales", () => {
     expect(AVAILABLE_APP_CONTENT_LOCALES).toEqual(["en", "zh-CN", "vi-VN", "de-DE", "fr-FR"]);
     expect(isAvailableAppContentLocale("zh-CN")).toBe(true);
     expect(isAvailableAppContentLocale("fr-FR")).toBe(true);
     expect(normalizeAppContentLocale("zh-cn")).toBe("zh-CN");
     expect(normalizeAppContentLocale("de-de")).toBe("de-DE");
     expect(normalizeAppContentLocale("ja-JP")).toBeNull();
-    expect(isSupportedAppLocale("zh-CN")).toBe(false);
   });
 
   it("prefers the locale cookie before accept-language negotiation", () => {
@@ -58,7 +66,16 @@ describe("app i18n locales", () => {
     ).toBe("en");
   });
 
+  it("negotiates supported accept-language values", () => {
+    expect(getAppLocaleFromRequest(createRequest({ acceptLanguage: "fr-FR,fr;q=0.9" }))).toBe(
+      "fr-FR",
+    );
+    expect(getAppLocaleFromRequest(createRequest({ acceptLanguage: "zh-CN,zh;q=0.8" }))).toBe(
+      "zh-CN",
+    );
+  });
+
   it("falls back to English for unsupported accept-language values", () => {
-    expect(getAppLocaleFromRequest(createRequest({ acceptLanguage: "fr-FR,fr;q=0.9" }))).toBe("en");
+    expect(getAppLocaleFromRequest(createRequest({ acceptLanguage: "ja-JP,ja;q=0.9" }))).toBe("en");
   });
 });

--- a/apps/hyperlocalise-web/src/lib/app-i18n/locales.ts
+++ b/apps/hyperlocalise-web/src/lib/app-i18n/locales.ts
@@ -2,13 +2,15 @@ import { match } from "@formatjs/intl-localematcher";
 import Negotiator from "negotiator";
 import type { NextRequest } from "next/server";
 
-export const SUPPORTED_APP_LOCALES = ["en"] as const;
-
 /**
  * Locales with message catalogs and/or blog posts ready to serve.
- * Keep this ahead of SUPPORTED_APP_LOCALES so enabling a locale is a one-line change.
+ * When adding a locale, land catalogs here first, then promote into
+ * SUPPORTED_APP_LOCALES once routing should accept it.
  */
 export const AVAILABLE_APP_CONTENT_LOCALES = ["en", "zh-CN", "vi-VN", "de-DE", "fr-FR"] as const;
+
+/** Locales accepted by `/[lang]` routing, cookies, and the language toggle. */
+export const SUPPORTED_APP_LOCALES = AVAILABLE_APP_CONTENT_LOCALES;
 
 export type AppLocale = (typeof SUPPORTED_APP_LOCALES)[number];
 export type AppContentLocale = (typeof AVAILABLE_APP_CONTENT_LOCALES)[number];

--- a/apps/hyperlocalise-web/src/lib/app-i18n/rewrite-app-locale-path.test.ts
+++ b/apps/hyperlocalise-web/src/lib/app-i18n/rewrite-app-locale-path.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  getAppLocaleFromPathname,
+  getNativeLocaleDisplayName,
+  rewriteAppLocalePath,
+} from "./rewrite-app-locale-path";
+
+describe("rewriteAppLocalePath", () => {
+  it("swaps an existing locale prefix", () => {
+    expect(rewriteAppLocalePath("/en/org/acme/inbox", "fr-FR")).toBe("/fr-FR/org/acme/inbox");
+    expect(rewriteAppLocalePath("/zh-CN/blog", "vi-VN")).toBe("/vi-VN/blog");
+  });
+
+  it("prefixes paths that lack a locale segment", () => {
+    expect(rewriteAppLocalePath("/org/acme/inbox", "de-DE")).toBe("/de-DE/org/acme/inbox");
+    expect(rewriteAppLocalePath("/", "zh-CN")).toBe("/zh-CN");
+  });
+
+  it("preserves query and hash", () => {
+    expect(rewriteAppLocalePath("/en/blog?page=2#comments", "fr-FR")).toBe(
+      "/fr-FR/blog?page=2#comments",
+    );
+  });
+
+  it("normalizes locale-only paths", () => {
+    expect(rewriteAppLocalePath("/en", "de-DE")).toBe("/de-DE");
+    expect(rewriteAppLocalePath("/en/", "vi-VN")).toBe("/vi-VN");
+  });
+
+  it("returns the same path shape when the locale is unchanged", () => {
+    expect(rewriteAppLocalePath("/fr-FR/product/agents-automation", "fr-FR")).toBe(
+      "/fr-FR/product/agents-automation",
+    );
+  });
+});
+
+describe("getAppLocaleFromPathname", () => {
+  it("reads a supported locale prefix", () => {
+    expect(getAppLocaleFromPathname("/zh-CN/blog")).toBe("zh-CN");
+    expect(getAppLocaleFromPathname("/EN/org/acme")).toBe("en");
+  });
+
+  it("falls back to the default locale when missing or unsupported", () => {
+    expect(getAppLocaleFromPathname("/org/acme")).toBe("en");
+    expect(getAppLocaleFromPathname("/ja/blog")).toBe("en");
+    expect(getAppLocaleFromPathname("/")).toBe("en");
+  });
+});
+
+describe("getNativeLocaleDisplayName", () => {
+  it("returns a native language label", () => {
+    expect(getNativeLocaleDisplayName("en")).toMatch(/english/i);
+    expect(getNativeLocaleDisplayName("de-DE")).toMatch(/deutsch/i);
+    expect(getNativeLocaleDisplayName("zh-CN")).toMatch(/中文|chinese/i);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/app-i18n/rewrite-app-locale-path.ts
+++ b/apps/hyperlocalise-web/src/lib/app-i18n/rewrite-app-locale-path.ts
@@ -1,0 +1,51 @@
+import { DEFAULT_APP_LOCALE, normalizeAppLocale, type AppLocale } from "./locales";
+
+/**
+ * Rewrites a pathname (optionally with query/hash) to use `nextLocale` as the
+ * `/[lang]` prefix. Preserves query and hash. Same-locale input is returned as-is
+ * after normalizing the locale segment casing.
+ */
+export function rewriteAppLocalePath(href: string, nextLocale: AppLocale): string {
+  const hashIndex = href.indexOf("#");
+  const hash = hashIndex >= 0 ? href.slice(hashIndex) : "";
+  const withoutHash = hashIndex >= 0 ? href.slice(0, hashIndex) : href;
+
+  const queryIndex = withoutHash.indexOf("?");
+  const query = queryIndex >= 0 ? withoutHash.slice(queryIndex) : "";
+  const pathname = queryIndex >= 0 ? withoutHash.slice(0, queryIndex) : withoutHash;
+
+  const segments = pathname.split("/");
+  const firstSegment = segments[1] ?? "";
+  const currentLocale = firstSegment ? normalizeAppLocale(firstSegment) : null;
+
+  let pathnameWithoutLocale: string;
+  if (currentLocale) {
+    const rest = segments.slice(2).join("/");
+    pathnameWithoutLocale = rest ? `/${rest}` : "/";
+  } else {
+    pathnameWithoutLocale = pathname || "/";
+  }
+
+  const normalizedPath =
+    pathnameWithoutLocale === "/" ? `/${nextLocale}` : `/${nextLocale}${pathnameWithoutLocale}`;
+
+  return `${normalizedPath}${query}${hash}`;
+}
+
+export function getAppLocaleFromPathname(pathname: string): AppLocale {
+  const firstSegment = pathname.split("/").filter(Boolean)[0];
+  if (!firstSegment) {
+    return DEFAULT_APP_LOCALE;
+  }
+
+  return normalizeAppLocale(firstSegment) ?? DEFAULT_APP_LOCALE;
+}
+
+export function getNativeLocaleDisplayName(locale: AppLocale): string {
+  try {
+    const formatter = new Intl.DisplayNames([locale], { type: "language" });
+    return formatter.of(locale) ?? locale;
+  } catch {
+    return locale;
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/blog/blog-post.test.ts
+++ b/apps/hyperlocalise-web/src/lib/blog/blog-post.test.ts
@@ -153,7 +153,7 @@ describe("postsDirectory locale resolution", () => {
     vi.clearAllMocks();
   });
 
-  it("resolves content locales that are not yet in SUPPORTED_APP_LOCALES", () => {
+  it("resolves posts for supported content locales", () => {
     directoryEntries.push("translated-post.md");
     fileContents["translated-post"] = serializePost({
       slug: "translated-post",

--- a/apps/hyperlocalise-web/src/proxy.test.ts
+++ b/apps/hyperlocalise-web/src/proxy.test.ts
@@ -26,6 +26,8 @@ describe("isUnsupportedLocalePath", () => {
     expect(isUnsupportedLocalePath("/en")).toBe(false);
     expect(isUnsupportedLocalePath("/en/blog")).toBe(false);
     expect(isUnsupportedLocalePath("/EN/product/localisation")).toBe(false);
+    expect(isUnsupportedLocalePath("/zh-CN/blog")).toBe(false);
+    expect(isUnsupportedLocalePath("/fr-FR/org/acme/dashboard")).toBe(false);
   });
 
   it("allows non-locale root routes", () => {

--- a/docs/adr/2026-07-10-app-locale-support-and-selector-design.md
+++ b/docs/adr/2026-07-10-app-locale-support-and-selector-design.md
@@ -1,0 +1,50 @@
+# App locale support and selector
+
+## Decision
+
+Promote ready content locales into `SUPPORTED_APP_LOCALES` and add a
+`LocaleToggle` beside `ThemeToggle` on marketing and in the app shell.
+
+## Supported locales
+
+Set `SUPPORTED_APP_LOCALES` to match `AVAILABLE_APP_CONTENT_LOCALES`:
+
+`en`, `zh-CN`, `vi-VN`, `de-DE`, `fr-FR`
+
+Routing, cookie negotiation (`hl_locale`), sitemap, robots, and Storybook
+toolbar all derive from this list. Message catalogs for these locales already
+exist under `apps/hyperlocalise-web/lang/`.
+
+## Locale toggle
+
+Add `LocaleToggle` under `src/components/locale-toggle/`, shaped like
+`ThemeToggle` (icon button, dropdown radio list, tooltip, a11y messages).
+
+- Options: `SUPPORTED_APP_LOCALES`
+- Labels: each locale’s native display name
+- Placement: next to `ThemeToggle` in the marketing navbar and app shell header
+
+## Switch behavior
+
+On select:
+
+1. Rewrite the current path’s `/[lang]` prefix to the chosen locale (prefix if
+   missing; preserve query and hash).
+2. Navigate with the App Router.
+3. Let the existing proxy set `X-Locale` and the `hl_locale` cookie on the
+   localized response.
+
+Same-locale selection is a no-op. The switcher only offers supported locales,
+so it cannot invent invalid tags.
+
+## Out of scope
+
+- Filling remaining untranslated UI strings beyond existing catalogs
+- Changing project translation `COMMON_LOCALES` or project locale pickers
+
+## Verification
+
+- Update `locales.test.ts` for the expanded supported set and Accept-Language /
+  cookie negotiation.
+- Unit-test the path rewrite helper.
+- Run `vp test` and `vp check --fix` from `apps/hyperlocalise-web`.


### PR DESCRIPTION
## What changed

Promote ready content locales (`zh-CN`, `vi-VN`, `de-DE`, `fr-FR`) into `SUPPORTED_APP_LOCALES` so routing, cookies, sitemap, and robots cover them. Add a `LocaleToggle` beside `ThemeToggle` on the marketing navbar and in the app shell. Includes the approved ADR.

## How to test

- [ ] Open marketing or app shell and switch language via the new toggle; confirm URL prefix and UI locale update
- [ ] Confirm `/zh-CN/...`, `/vi-VN/...`, `/de-DE/...`, `/fr-FR/...` routes resolve
- [ ] Spot-check `sitemap.xml` and `robots.txt` include the new locales
- [ ] From `apps/hyperlocalise-web`: `vp test src/lib/app-i18n/` and `vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`; locale-related `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)