### PR TITLE
fix(web): polish locale toggle labels and reload on change

### DIFF
--- a/apps/hyperlocalise-web/src/components/locale-toggle/locale-toggle.tsx
+++ b/apps/hyperlocalise-web/src/components/locale-toggle/locale-toggle.tsx
@@ -2,7 +2,7 @@
 
 import { LanguageCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
@@ -16,6 +16,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { SUPPORTED_APP_LOCALES, type AppLocale } from "@/lib/app-i18n/locales";
 import {
+  getAppLocaleFlagEmoji,
   getAppLocaleFromPathname,
   getNativeLocaleDisplayName,
   rewriteAppLocalePath,
@@ -26,7 +27,6 @@ import { localeToggleMessages } from "./locale-toggle.messages";
 export function LocaleToggle() {
   const intl = useIntl();
   const pathname = usePathname() ?? "/";
-  const router = useRouter();
   const activeLocale = getAppLocaleFromPathname(pathname);
 
   return (
@@ -60,15 +60,17 @@ export function LocaleToggle() {
               return;
             }
 
-            const search = typeof window !== "undefined" ? window.location.search : "";
-            const hash = typeof window !== "undefined" ? window.location.hash : "";
-            router.push(rewriteAppLocalePath(`${pathname}${search}${hash}`, nextLocale));
+            const search = window.location.search;
+            const hash = window.location.hash;
+            window.location.assign(rewriteAppLocalePath(`${pathname}${search}${hash}`, nextLocale));
           }}
         >
           {SUPPORTED_APP_LOCALES.map((locale) => (
             <DropdownMenuRadioItem key={locale} value={locale}>
-              <span className="truncate">{getNativeLocaleDisplayName(locale)}</span>
-              <span className="text-muted-foreground">({locale})</span>
+              <span className="flex items-center gap-2">
+                <span aria-hidden="true">{getAppLocaleFlagEmoji(locale)}</span>
+                <span>{getNativeLocaleDisplayName(locale)}</span>
+              </span>
             </DropdownMenuRadioItem>
           ))}
         </DropdownMenuRadioGroup>

--- a/apps/hyperlocalise-web/src/components/locale-toggle/locale-toggle.tsx
+++ b/apps/hyperlocalise-web/src/components/locale-toggle/locale-toggle.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { LanguageCircleIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { usePathname } from "next/navigation";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -36,8 +34,8 @@ export function LocaleToggle() {
           render={
             <DropdownMenuTrigger
               render={
-                <Button variant="outline" size="icon-sm" className="rounded-full">
-                  <HugeiconsIcon icon={LanguageCircleIcon} strokeWidth={2} className="size-4" />
+                <Button variant="outline" size="icon-sm" className="rounded-full text-base leading-none">
+                  <span aria-hidden="true">{getAppLocaleFlagEmoji(activeLocale)}</span>
                   <span className="sr-only">
                     <FormattedMessage {...localeToggleMessages.changeLanguage} />
                   </span>

--- a/apps/hyperlocalise-web/src/lib/app-i18n/rewrite-app-locale-path.test.ts
+++ b/apps/hyperlocalise-web/src/lib/app-i18n/rewrite-app-locale-path.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  getAppLocaleFlagEmoji,
   getAppLocaleFromPathname,
   getNativeLocaleDisplayName,
   rewriteAppLocalePath,
@@ -53,5 +54,15 @@ describe("getNativeLocaleDisplayName", () => {
     expect(getNativeLocaleDisplayName("en")).toMatch(/english/i);
     expect(getNativeLocaleDisplayName("de-DE")).toMatch(/deutsch/i);
     expect(getNativeLocaleDisplayName("zh-CN")).toMatch(/中文|chinese/i);
+  });
+});
+
+describe("getAppLocaleFlagEmoji", () => {
+  it("returns a country flag for each supported locale", () => {
+    expect(getAppLocaleFlagEmoji("en")).toBe("🇺🇸");
+    expect(getAppLocaleFlagEmoji("zh-CN")).toBe("🇨🇳");
+    expect(getAppLocaleFlagEmoji("vi-VN")).toBe("🇻🇳");
+    expect(getAppLocaleFlagEmoji("de-DE")).toBe("🇩🇪");
+    expect(getAppLocaleFlagEmoji("fr-FR")).toBe("🇫🇷");
   });
 });

--- a/apps/hyperlocalise-web/src/lib/app-i18n/rewrite-app-locale-path.ts
+++ b/apps/hyperlocalise-web/src/lib/app-i18n/rewrite-app-locale-path.ts
@@ -49,3 +49,15 @@ export function getNativeLocaleDisplayName(locale: AppLocale): string {
     return locale;
   }
 }
+
+const APP_LOCALE_FLAG_EMOJI = {
+  en: "🇺🇸",
+  "zh-CN": "🇨🇳",
+  "vi-VN": "🇻🇳",
+  "de-DE": "🇩🇪",
+  "fr-FR": "🇫🇷",
+} as const satisfies Record<AppLocale, string>;
+
+export function getAppLocaleFlagEmoji(locale: AppLocale): string {
+  return APP_LOCALE_FLAG_EMOJI[locale];
+}


### PR DESCRIPTION
## What changed

- Locale selector shows only the native display name with a country flag emoji (no locale codes).
- Switching language uses a full page reload so locale catalogs apply cleanly.

## How to test

- [ ] Open the language toggle in the marketing navbar or app shell.
- [ ] Confirm each option shows a flag + native name (no `(en)` / `(zh-CN)` codes).
- [ ] Switch locale and confirm the page hard-reloads onto the new `/[lang]` path.
- [ ] `vp test src/lib/app-i18n/rewrite-app-locale-path.test.ts` (from `apps/hyperlocalise-web`)

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)