### PR TITLE
feat(web): localize dashboard overview with react-intl

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-content.messages.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const dashboardPageContentMessages = defineMessages({
+  featureUnavailable: {
+    defaultMessage: "This feature is not available for your workspace yet.",
+    id: "0GW7ilY3Dj",
+    description: "Toast when a user is redirected because a workspace feature is unavailable",
+  },
+  liveTmsJobsWarning: {
+    defaultMessage: "Live TMS jobs could not be loaded.",
+    id: "UOrQi3aNyW",
+    description: "Warning when live TMS assigned jobs fail but native jobs loaded",
+  },
+  nativeJobsWarning: {
+    defaultMessage: "Native workspace jobs could not be loaded.",
+    id: "+KUpBJ/DPe",
+    description: "Warning when native assigned jobs fail but live TMS jobs loaded",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-content.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
+import { useIntl } from "react-intl";
 import { toast } from "sonner";
 
 import { readApiResponseError } from "@/lib/api-error";
@@ -46,6 +47,8 @@ import {
   type DashboardJobItem,
   type DashboardProjectItem,
 } from "./dashboard-page-view-model";
+import { dashboardPageContentMessages } from "./dashboard-page-content.messages";
+import { dashboardPageViewModelMessages } from "./dashboard-page-view-model.messages";
 import { DashboardPageView } from "./dashboard-page-view";
 
 const api = createApiClient();
@@ -184,6 +187,7 @@ function mapDashboardProjects(
   organizationSlug: string,
   projects: readonly ProjectListRow[],
   recentProjectVisits: readonly RecentProjectVisit[],
+  nativeSourceLabel: string,
 ): DashboardProjectItem[] {
   return sortDashboardProjects(projects, recentProjectVisits)
     .slice(0, 5)
@@ -193,7 +197,7 @@ function mapDashboardProjects(
       sourceLabel:
         project.source === "external_tms" && project.externalProviderKind
           ? providerLabel(project.externalProviderKind)
-          : "Native",
+          : nativeSourceLabel,
       localeRoute: formatDashboardLocaleRoute(project.sourceLocale, project.targetLocales),
       pendingActionCount: project.openJobCount,
       updatedAt: project.lastSyncedAt ?? project.updated,
@@ -208,6 +212,7 @@ export function DashboardPageContent({
   organizationSlug: string;
   automationsEnabled?: boolean;
 }) {
+  const intl = useIntl();
   const searchParams = useSearchParams();
   const handledFeatureUnavailableRef = useRef(false);
   const [recentProjectVisits, setRecentProjectVisits] = useState<RecentProjectVisit[] | null>(null);
@@ -226,8 +231,8 @@ export function DashboardPageContent({
     url.searchParams.delete("reason");
     window.history.replaceState(null, "", url.toString());
 
-    toast.error("This feature is not available for your workspace yet.");
-  }, [searchParams]);
+    toast.error(intl.formatMessage(dashboardPageContentMessages.featureUnavailable));
+  }, [intl, searchParams]);
 
   useEffect(() => {
     setRecentProjectVisits(readRecentProjectVisits(organizationSlug));
@@ -332,7 +337,7 @@ export function DashboardPageContent({
   const tmsBranding = getTmsProviderBranding(activeTmsProvider?.providerKind);
   const integrations = useMemo(
     () =>
-      resolveDashboardIntegrations({
+      resolveDashboardIntegrations(intl, {
         tmsConnected: hasTmsConnection,
         tmsProviderKind: activeTmsProvider?.providerKind,
         tmsProviderName: hasTmsConnection ? tmsBranding.name : undefined,
@@ -343,6 +348,7 @@ export function DashboardPageContent({
       activeTmsProvider?.providerKind,
       githubQuery.data,
       hasTmsConnection,
+      intl,
       slackQuery.data,
       tmsBranding.name,
     ],
@@ -359,7 +365,7 @@ export function DashboardPageContent({
 
   const hero = useMemo(
     () =>
-      resolveDashboardHero({
+      resolveDashboardHero(intl, {
         integrations,
         projectCount: allProjects.length,
         pendingCount,
@@ -367,7 +373,15 @@ export function DashboardPageContent({
         myJobsHref,
         newRequestHref,
       }),
-    [allProjects.length, integrations, integrationsHref, myJobsHref, newRequestHref, pendingCount],
+    [
+      allProjects.length,
+      integrations,
+      integrationsHref,
+      intl,
+      myJobsHref,
+      newRequestHref,
+      pendingCount,
+    ],
   );
 
   const automationStats = useMemo(
@@ -377,13 +391,13 @@ export function DashboardPageContent({
 
   const automationRuns = useMemo(
     () =>
-      mapDashboardAutomationRuns({
+      mapDashboardAutomationRuns(intl, {
         organizationSlug,
         automations: automationsQuery.data ?? [],
         runs: automationRunsQuery.data ?? [],
         limit: 5,
       }),
-    [automationRunsQuery.data, automationsQuery.data, organizationSlug],
+    [automationRunsQuery.data, automationsQuery.data, intl, organizationSlug],
   );
 
   const mappedJobs = useMemo(
@@ -401,6 +415,8 @@ export function DashboardPageContent({
     [latestTmsJobsQuery.data, organizationSlug],
   );
 
+  const nativeSourceLabel = intl.formatMessage(dashboardPageViewModelMessages.nativeSourceLabel);
+
   const mappedProjects = useMemo(
     () =>
       recentProjectVisits
@@ -408,17 +424,23 @@ export function DashboardPageContent({
             organizationSlug,
             nativeProjectsQuery.data ?? [],
             recentProjectVisits,
+            nativeSourceLabel,
           )
         : [],
-    [nativeProjectsQuery.data, organizationSlug, recentProjectVisits],
+    [nativeProjectsQuery.data, nativeSourceLabel, organizationSlug, recentProjectVisits],
   );
 
   const mappedTmsProjects = useMemo(
     () =>
       recentProjectVisits
-        ? mapDashboardProjects(organizationSlug, tmsProjectsQuery.data ?? [], recentProjectVisits)
+        ? mapDashboardProjects(
+            organizationSlug,
+            tmsProjectsQuery.data ?? [],
+            recentProjectVisits,
+            nativeSourceLabel,
+          )
         : [],
-    [organizationSlug, recentProjectVisits, tmsProjectsQuery.data],
+    [nativeSourceLabel, organizationSlug, recentProjectVisits, tmsProjectsQuery.data],
   );
 
   const isSetupLoading =
@@ -452,9 +474,9 @@ export function DashboardPageContent({
       isJobsError={assignedJobsQuery.isError && (!hasTmsConnection || assignedTmsJobsQuery.isError)}
       jobsWarning={
         assignedTmsJobsQuery.isError && !assignedJobsQuery.isError
-          ? "Live TMS jobs could not be loaded."
+          ? intl.formatMessage(dashboardPageContentMessages.liveTmsJobsWarning)
           : assignedJobsQuery.isError && assignedTmsJobsQuery.isSuccess
-            ? "Native workspace jobs could not be loaded."
+            ? intl.formatMessage(dashboardPageContentMessages.nativeJobsWarning)
             : undefined
       }
       isLatestJobsLoading={latestJobsQuery.isLoading}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view-model.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view-model.messages.ts
@@ -1,0 +1,99 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const dashboardPageViewModelMessages = defineMessages({
+  tmsFallbackLabel: {
+    defaultMessage: "Translation management",
+    id: "Mi2Q/CduVa",
+    description: "Default TMS integration label when no provider is connected",
+  },
+  tmsConnectedDescription: {
+    defaultMessage: "{providerName} projects and translation work are available.",
+    id: "KPIIspKW7R",
+    description: "Dashboard integration description when a TMS provider is connected",
+  },
+  tmsDisconnectedDescription: {
+    defaultMessage: "Connect Crowdin, Lokalise, Phrase, or Smartling.",
+    id: "Eakafmv8Gv",
+    description: "Dashboard integration description when no TMS provider is connected",
+  },
+  githubLabel: {
+    defaultMessage: "GitHub",
+    id: "nQSI1fGvRy",
+    description: "GitHub integration label on the dashboard",
+  },
+  githubDescription: {
+    defaultMessage: "Sync localized strings and run validation on push.",
+    id: "f+cpbxZH+C",
+    description: "GitHub integration description on the dashboard",
+  },
+  slackLabel: {
+    defaultMessage: "Slack",
+    id: "2JWP4PXKxL",
+    description: "Slack integration label on the dashboard",
+  },
+  slackDescription: {
+    defaultMessage: "Get review notifications and agent handoffs in Slack.",
+    id: "+xuw6xgQgo",
+    description: "Slack integration description on the dashboard",
+  },
+  setupHeroTitle: {
+    defaultMessage: "Get your workspace ready",
+    id: "ree/WWv9H5",
+    description: "Dashboard setup hero title before workspace is fully configured",
+  },
+  setupHeroDescription: {
+    defaultMessage:
+      "Connect your tools and create a project so Hyperlocalise can route translation work to you.",
+    id: "gPLqwOpbOB",
+    description: "Dashboard setup hero description before workspace is fully configured",
+  },
+  setupHeroCta: {
+    defaultMessage: "Finish setup",
+    id: "6rnWouvhAd",
+    description: "Dashboard setup hero call-to-action label",
+  },
+  caughtUpHeroTitle: {
+    defaultMessage: "You’re all caught up",
+    id: "2eU5akyXs2",
+    description: "Dashboard hero title when there are no pending actions",
+  },
+  caughtUpHeroDescription: {
+    defaultMessage:
+      "No pending actions right now. Start a new request or browse projects when you’re ready to continue.",
+    id: "2mcGAlQ7te",
+    description: "Dashboard hero description when there are no pending actions",
+  },
+  newRequestCta: {
+    defaultMessage: "New request",
+    id: "yKtWAeejtx",
+    description: "Dashboard call-to-action to start a new localization request",
+  },
+  attentionHeroTitle: {
+    defaultMessage: "A few things need your attention",
+    id: "xOFZqYtkn0",
+    description: "Dashboard hero title when pending actions need review",
+  },
+  attentionHeroDescription: {
+    defaultMessage:
+      "{count, plural, one {# pending action across your workspace.} other {# pending actions across your workspace.}}",
+    id: "Ll8TcrApq9",
+    description: "Dashboard hero description with pending action count",
+  },
+  viewMyJobsCta: {
+    defaultMessage: "View my jobs",
+    id: "OUgvJN+For",
+    description: "Dashboard call-to-action to open assigned jobs",
+  },
+  nativeSourceLabel: {
+    defaultMessage: "Native",
+    id: "WSbyg2v11q",
+    description: "Source label for Hyperlocalise-native projects on the dashboard",
+  },
+  automationFallbackName: {
+    defaultMessage: "Automation",
+    id: "ebI/JnzL7S",
+    description: "Fallback name when an automation run’s automation is missing",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view-model.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
+import type { IntlShape } from "react-intl";
+
+import { getIntlShape } from "@/lib/app-i18n/intl";
 
 import type { ApiJob } from "../../jobs/_components/jobs-page-view";
 import type { ProjectListRow } from "../../projects/_components/project-list";
@@ -14,6 +17,7 @@ import {
   sortDashboardProjects,
 } from "./dashboard-page-view-model";
 
+const intl = getIntlShape("en") as IntlShape;
 describe("dashboard-page-view-model", () => {
   it("merges native and live TMS jobs without duplicate resource IDs", () => {
     const jobs = mergeDashboardJobSources(
@@ -84,7 +88,7 @@ describe("dashboard-page-view-model", () => {
   });
 
   it("treats setup as complete only when integrations and projects exist", () => {
-    const integrations = resolveDashboardIntegrations({
+    const integrations = resolveDashboardIntegrations(intl, {
       tmsConnected: true,
       tmsProviderKind: "crowdin",
       tmsProviderName: "Crowdin",
@@ -102,13 +106,13 @@ describe("dashboard-page-view-model", () => {
   });
 
   it("builds setup hero before workspace is ready", () => {
-    const integrations = resolveDashboardIntegrations({
+    const integrations = resolveDashboardIntegrations(intl, {
       tmsConnected: false,
       githubConnected: false,
       slackConnected: false,
     });
 
-    const hero = resolveDashboardHero({
+    const hero = resolveDashboardHero(intl, {
       integrations,
       projectCount: 0,
       pendingCount: 0,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view-model.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view-model.ts
@@ -1,3 +1,5 @@
+import type { IntlShape } from "react-intl";
+
 import type {
   WorkspaceAutomationRecord,
   WorkspaceAutomationRunRecord,
@@ -6,6 +8,8 @@ import type {
 import type { ApiJob } from "../../jobs/_components/jobs-page-view";
 import type { ProjectListRow } from "../../projects/_components/project-list";
 import type { RecentProjectVisit } from "../../projects/_components/recent-projects";
+
+import { dashboardPageViewModelMessages } from "./dashboard-page-view-model.messages";
 
 export type DashboardIntegrationId = "tms" | "github" | "slack";
 
@@ -114,33 +118,40 @@ export function formatDashboardLocaleRoute(
   return `${source} → ${preview}${suffix}`;
 }
 
-export function resolveDashboardIntegrations(input: {
-  tmsConnected: boolean;
-  tmsProviderKind?: ProjectListRow["externalProviderKind"];
-  tmsProviderName?: string;
-  githubConnected: boolean;
-  slackConnected: boolean;
-}): DashboardIntegrationItem[] {
+export function resolveDashboardIntegrations(
+  intl: IntlShape,
+  input: {
+    tmsConnected: boolean;
+    tmsProviderKind?: ProjectListRow["externalProviderKind"];
+    tmsProviderName?: string;
+    githubConnected: boolean;
+    slackConnected: boolean;
+  },
+): DashboardIntegrationItem[] {
   return [
     {
       id: "tms",
-      label: input.tmsProviderName ?? "Translation management",
+      label:
+        input.tmsProviderName ??
+        intl.formatMessage(dashboardPageViewModelMessages.tmsFallbackLabel),
       description: input.tmsProviderName
-        ? `${input.tmsProviderName} projects and translation work are available.`
-        : "Connect Crowdin, Lokalise, Phrase, or Smartling.",
+        ? intl.formatMessage(dashboardPageViewModelMessages.tmsConnectedDescription, {
+            providerName: input.tmsProviderName,
+          })
+        : intl.formatMessage(dashboardPageViewModelMessages.tmsDisconnectedDescription),
       connected: input.tmsConnected,
       providerKind: input.tmsProviderKind,
     },
     {
       id: "github",
-      label: "GitHub",
-      description: "Sync localized strings and run validation on push.",
+      label: intl.formatMessage(dashboardPageViewModelMessages.githubLabel),
+      description: intl.formatMessage(dashboardPageViewModelMessages.githubDescription),
       connected: input.githubConnected,
     },
     {
       id: "slack",
-      label: "Slack",
-      description: "Get review notifications and agent handoffs in Slack.",
+      label: intl.formatMessage(dashboardPageViewModelMessages.slackLabel),
+      description: intl.formatMessage(dashboardPageViewModelMessages.slackDescription),
       connected: input.slackConnected,
     },
   ];
@@ -168,14 +179,17 @@ export function resolveWorkspacePendingActionCount(input: {
   return openJobsFromProjects + actionableAssignedJobs;
 }
 
-export function resolveDashboardHero(input: {
-  integrations: readonly DashboardIntegrationItem[];
-  projectCount: number;
-  pendingCount: number;
-  integrationsHref: string;
-  myJobsHref: string;
-  newRequestHref: string;
-}): DashboardHeroState {
+export function resolveDashboardHero(
+  intl: IntlShape,
+  input: {
+    integrations: readonly DashboardIntegrationItem[];
+    projectCount: number;
+    pendingCount: number;
+    integrationsHref: string;
+    myJobsHref: string;
+    newRequestHref: string;
+  },
+): DashboardHeroState {
   const connectedCount = input.integrations.filter((item) => item.connected).length;
   const completedCount = connectedCount + (input.projectCount > 0 ? 1 : 0);
   const setupComplete = isDashboardSetupComplete(input.integrations, input.projectCount);
@@ -183,12 +197,11 @@ export function resolveDashboardHero(input: {
   if (!setupComplete) {
     return {
       mode: "setup",
-      title: "Get your workspace ready",
-      description:
-        "Connect your tools and create a project so Hyperlocalise can route translation work to you.",
+      title: intl.formatMessage(dashboardPageViewModelMessages.setupHeroTitle),
+      description: intl.formatMessage(dashboardPageViewModelMessages.setupHeroDescription),
       completedCount,
       totalCount: input.integrations.length + 1,
-      ctaLabel: "Finish setup",
+      ctaLabel: intl.formatMessage(dashboardPageViewModelMessages.setupHeroCta),
       ctaHref: input.integrationsHref,
     };
   }
@@ -197,10 +210,9 @@ export function resolveDashboardHero(input: {
     return {
       mode: "caught-up",
       pendingCount: 0,
-      title: "You're all caught up",
-      description:
-        "No pending actions right now. Start a new request or browse projects when you're ready to continue.",
-      ctaLabel: "New request",
+      title: intl.formatMessage(dashboardPageViewModelMessages.caughtUpHeroTitle),
+      description: intl.formatMessage(dashboardPageViewModelMessages.caughtUpHeroDescription),
+      ctaLabel: intl.formatMessage(dashboardPageViewModelMessages.newRequestCta),
       ctaHref: input.newRequestHref,
     };
   }
@@ -208,9 +220,11 @@ export function resolveDashboardHero(input: {
   return {
     mode: "attention",
     pendingCount: input.pendingCount,
-    title: "A few things need your attention",
-    description: `${input.pendingCount} pending ${input.pendingCount === 1 ? "action" : "actions"} across your workspace.`,
-    ctaLabel: "View my jobs",
+    title: intl.formatMessage(dashboardPageViewModelMessages.attentionHeroTitle),
+    description: intl.formatMessage(dashboardPageViewModelMessages.attentionHeroDescription, {
+      count: input.pendingCount,
+    }),
+    ctaLabel: intl.formatMessage(dashboardPageViewModelMessages.viewMyJobsCta),
     ctaHref: input.myJobsHref,
   };
 }
@@ -267,12 +281,15 @@ export function sortDashboardProjects(
   });
 }
 
-export function mapDashboardAutomationRuns(input: {
-  organizationSlug: string;
-  automations: readonly WorkspaceAutomationRecord[];
-  runs: readonly WorkspaceAutomationRunRecord[];
-  limit?: number;
-}): DashboardAutomationRunItem[] {
+export function mapDashboardAutomationRuns(
+  intl: IntlShape,
+  input: {
+    organizationSlug: string;
+    automations: readonly WorkspaceAutomationRecord[];
+    runs: readonly WorkspaceAutomationRunRecord[];
+    limit?: number;
+  },
+): DashboardAutomationRunItem[] {
   const automationNameById = new Map(
     input.automations.map((automation) => [automation.id, automation.name]),
   );
@@ -285,7 +302,9 @@ export function mapDashboardAutomationRuns(input: {
     .map((run) => ({
       id: run.id,
       automationId: run.automationId,
-      automationName: automationNameById.get(run.automationId) ?? "Automation",
+      automationName:
+        automationNameById.get(run.automationId) ??
+        intl.formatMessage(dashboardPageViewModelMessages.automationFallbackName),
       status: run.status,
       triggerSource: run.triggerSource,
       completedAt: run.completedAt,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.messages.ts
@@ -1,0 +1,313 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const dashboardPageViewMessages = defineMessages({
+  pageLabel: {
+    defaultMessage: "Workspace",
+    id: "mRWwmBY6N9",
+    description: "Dashboard page header eyebrow label",
+  },
+  pageTitle: {
+    defaultMessage: "Overview",
+    id: "6xnpnIBioo",
+    description: "Dashboard page heading",
+  },
+  pageDescription: {
+    defaultMessage:
+      "Your workspace at a glance — assigned work, latest activity, and recent projects.",
+    id: "0fORPZlrsy",
+    description: "Dashboard page description under the heading",
+  },
+  setupProgressLabel: {
+    defaultMessage: "Workspace setup · {completedCount} of {totalCount} complete",
+    id: "yX53I7eVol",
+    description: "Dashboard setup hero progress summary",
+  },
+  setupProgressMeter: {
+    defaultMessage: "Setup progress",
+    id: "szGONLZ/cQ",
+    description: "Label above the workspace setup progress bar",
+  },
+  setupProgressPercent: {
+    defaultMessage: "{value}%",
+    id: "tT+/GoDfXt",
+    description: "Workspace setup progress percentage value",
+  },
+  newRequest: {
+    defaultMessage: "New request",
+    id: "vKq2ly7dxU",
+    description: "Button to start a new localization request from the dashboard",
+  },
+  loadingWorkspaceOverview: {
+    defaultMessage: "Loading workspace overview",
+    id: "28e0S0f2HW",
+    description: "Accessible label while the dashboard hero is loading",
+  },
+  loadingPanel: {
+    defaultMessage: "Loading {title}",
+    id: "GpQTuQOUij",
+    description: "Accessible label while a dashboard panel is loading",
+  },
+  panelLoadError: {
+    defaultMessage: "{title} could not be loaded.",
+    id: "IvJJwlEgW1",
+    description: "Generic error when a dashboard panel fails to load",
+  },
+  quickStartLabel: {
+    defaultMessage: "Quick start",
+    id: "xg+IeoG5GL",
+    description: "Label above the dashboard quick-start card",
+  },
+  quickStartTitle: {
+    defaultMessage: "Ask the localization agent",
+    id: "YM9k2kDsM2",
+    description: "Dashboard quick-start card title",
+  },
+  quickStartDescription: {
+    defaultMessage:
+      "Describe what you need translated, researched, or reviewed and Hyperlocalise will prepare the work.",
+    id: "mrsptKTM1v",
+    description: "Dashboard quick-start card description",
+  },
+  myJobsTitle: {
+    defaultMessage: "My jobs",
+    id: "PZP/M3m1NM",
+    description: "Dashboard panel title for jobs assigned to the current user",
+  },
+  myJobsDescription: {
+    defaultMessage: "The latest work assigned to you, prioritized by what needs action.",
+    id: "YlRGuiYchN",
+    description: "Dashboard panel description for assigned jobs",
+  },
+  myJobsEmpty: {
+    defaultMessage: "No jobs assigned to you yet.",
+    id: "Q38XCcr+cJ",
+    description: "Empty state when the user has no assigned jobs",
+  },
+  latestJobsTitle: {
+    defaultMessage: "Latest jobs",
+    id: "ENDjImu9Gr",
+    description: "Dashboard panel title for recently updated workspace jobs",
+  },
+  latestJobsDescription: {
+    defaultMessage: "The most recently updated work across this workspace.",
+    id: "u7mPxFIRkS",
+    description: "Dashboard panel description for latest jobs",
+  },
+  latestJobsEmpty: {
+    defaultMessage: "No workspace jobs yet.",
+    id: "8MmPpIGj4f",
+    description: "Empty state when the workspace has no jobs",
+  },
+  recentProjectsTitle: {
+    defaultMessage: "Recent projects",
+    id: "YUeo87Wdbn",
+    description: "Dashboard panel title for recently opened projects",
+  },
+  recentProjectsDescription: {
+    defaultMessage: "Projects you opened recently, followed by active workspace projects.",
+    id: "IQiUadYsfM",
+    description: "Dashboard panel description for recent projects",
+  },
+  recentProjectsEmpty: {
+    defaultMessage: "No native projects yet. Create a project to get started.",
+    id: "1Do2u8ufv7",
+    description: "Empty state when there are no native projects",
+  },
+  tmsJobsTitle: {
+    defaultMessage: "{providerName} jobs",
+    id: "mhdxPi6b4a",
+    description: "Dashboard panel title for live TMS jobs",
+  },
+  tmsJobsDescription: {
+    defaultMessage: "Live jobs fetched from {providerName}.",
+    id: "nqMa1yML6t",
+    description: "Dashboard panel description for live TMS jobs",
+  },
+  tmsJobsEmpty: {
+    defaultMessage: "No jobs found in {providerName}.",
+    id: "IgBvohPlHZ",
+    description: "Empty state when a TMS provider has no jobs",
+  },
+  tmsProjectsTitle: {
+    defaultMessage: "{providerName} projects",
+    id: "CfAFoekPz1",
+    description: "Dashboard panel title for live TMS projects",
+  },
+  tmsProjectsDescription: {
+    defaultMessage: "Live projects fetched from {providerName}.",
+    id: "s8Aqn1fSU6",
+    description: "Dashboard panel description for live TMS projects",
+  },
+  tmsProjectsEmpty: {
+    defaultMessage: "No projects found in {providerName}.",
+    id: "EURqQwIzfO",
+    description: "Empty state when a TMS provider has no projects",
+  },
+  viewAllJobs: {
+    defaultMessage: "View all jobs",
+    id: "Z4DRhv/lJb",
+    description: "Footer link to open the full jobs list from a dashboard panel",
+  },
+  viewAllProjects: {
+    defaultMessage: "View all projects",
+    id: "GlOm2GgrZG",
+    description: "Footer link to open the full projects list from a dashboard panel",
+  },
+  workspaceFallbackProject: {
+    defaultMessage: "Workspace",
+    id: "0bdrX6gjre",
+    description: "Fallback project name when a job has no project",
+  },
+  jobMeta: {
+    defaultMessage: "{projectName} · {kindLabel} · updated {updatedAt}",
+    id: "EO0pk2ty3D",
+    description: "Secondary metadata line for a job row on the dashboard",
+  },
+  projectOpenBadge: {
+    defaultMessage: "{count} open",
+    id: "IQHhkgmw8g",
+    description: "Badge showing how many open actions a project has",
+  },
+  projectUpToDate: {
+    defaultMessage: "Up to date",
+    id: "JIuT2aW94P",
+    description: "Badge when a project has no open actions",
+  },
+  projectMetaWithUpdate: {
+    defaultMessage: "{sourceLabel} · {localeRoute} · updated {updatedAt}",
+    id: "aFSdZ6B2XX",
+    description: "Secondary metadata line for a project row with a last-updated time",
+  },
+  projectMeta: {
+    defaultMessage: "{sourceLabel} · {localeRoute}",
+    id: "w1P9m9KNH8",
+    description: "Secondary metadata line for a project row without a last-updated time",
+  },
+  integrationsTitle: {
+    defaultMessage: "Integrations",
+    id: "JYTpmBUkk7",
+    description: "Dashboard section heading for workspace integrations",
+  },
+  loadingIntegrations: {
+    defaultMessage: "Loading integrations",
+    id: "7YQmBHx9HV",
+    description: "Accessible label while dashboard integrations are loading",
+  },
+  connected: {
+    defaultMessage: "Connected",
+    id: "ykK86HWH4K",
+    description: "Badge when an integration is connected",
+  },
+  notConnected: {
+    defaultMessage: "Not connected",
+    id: "Mo3KUqU9mk",
+    description: "Badge when an integration is not connected",
+  },
+  manage: {
+    defaultMessage: "Manage",
+    id: "0ZnjVna/1A",
+    description: "Link label to manage a connected integration",
+  },
+  connect: {
+    defaultMessage: "Connect",
+    id: "kRgGKX2G/s",
+    description: "Link label to connect an integration",
+  },
+  automationRunsTitle: {
+    defaultMessage: "Automation runs",
+    id: "xCfBoLh9Rp",
+    description: "Dashboard section heading for recent automation runs",
+  },
+  viewAutomations: {
+    defaultMessage: "View automations",
+    id: "vynGfdRurY",
+    description: "Button to open the automations page from the dashboard",
+  },
+  loadingAutomationRuns: {
+    defaultMessage: "Loading automation runs",
+    id: "M1OWEzMawd",
+    description: "Accessible label while automation runs are loading",
+  },
+  automationRunsLoadError: {
+    defaultMessage: "Automation runs could not be loaded.",
+    id: "RHVJ0v0DYf",
+    description: "Error when dashboard automation runs fail to load",
+  },
+  automationStats: {
+    defaultMessage: "{total} automations · {active} active · {paused} paused",
+    id: "qPUZCfT/yV",
+    description: "Summary counts for workspace automations on the dashboard",
+  },
+  noAutomationRuns: {
+    defaultMessage: "No automation runs yet.",
+    id: "yF+d/IbGFc",
+    description: "Empty state when there are no automation runs",
+  },
+  runCompleted: {
+    defaultMessage: "{triggerSource} · completed {completedAt}",
+    id: "6QjQu7ZEVO",
+    description: "Automation run metadata when the run has completed",
+  },
+  runInProgress: {
+    defaultMessage: "{triggerSource} · in progress",
+    id: "FNTVTGlcTd",
+    description: "Automation run metadata while the run is still in progress",
+  },
+  runStatusQueued: {
+    defaultMessage: "Queued",
+    id: "Khk1oUs6TP",
+    description: "Automation run status badge for queued runs",
+  },
+  runStatusRunning: {
+    defaultMessage: "Running",
+    id: "D7NvZBBM/6",
+    description: "Automation run status badge for running runs",
+  },
+  runStatusSucceeded: {
+    defaultMessage: "Succeeded",
+    id: "B+9mu1WlLc",
+    description: "Automation run status badge for succeeded runs",
+  },
+  runStatusFailed: {
+    defaultMessage: "Failed",
+    id: "jgrmHo9SE2",
+    description: "Automation run status badge for failed runs",
+  },
+  runStatusCancelled: {
+    defaultMessage: "Cancelled",
+    id: "oKp30YYGZb",
+    description: "Automation run status badge for cancelled runs",
+  },
+  runStatusSkipped: {
+    defaultMessage: "Skipped",
+    id: "Qklvn9azHF",
+    description: "Automation run status badge for skipped runs",
+  },
+  triggerManual: {
+    defaultMessage: "Manual",
+    id: "MpshM2ubvT",
+    description: "Automation run trigger source label for manual runs",
+  },
+  triggerScheduled: {
+    defaultMessage: "Scheduled",
+    id: "t+TLW1HZ59",
+    description: "Automation run trigger source label for scheduled runs",
+  },
+  triggerGithub: {
+    defaultMessage: "GitHub",
+    id: "SYEyQ9llcS",
+    description: "Automation run trigger source label for GitHub-triggered runs",
+  },
+  triggerContentful: {
+    defaultMessage: "Contentful",
+    id: "GdufIv1RQV",
+    description: "Automation run trigger source label for Contentful-triggered runs",
+  },
+  triggerSourceUpload: {
+    defaultMessage: "Source upload",
+    id: "h3/Sx/1Xgp",
+    description: "Automation run trigger source label for source-upload-triggered runs",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.stories.tsx
@@ -1,5 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { expect } from "storybook/test";
+import type { IntlShape } from "react-intl";
+
+import { getIntlShape } from "@/lib/app-i18n/intl";
 
 import { automationsFixture } from "../../automations/_components/automations.fixture";
 import {
@@ -17,8 +20,9 @@ import {
 } from "./dashboard-page-view-model";
 
 const organizationSlug = "acme";
+const intl = getIntlShape("en") as IntlShape;
 
-const activeHero = resolveDashboardHero({
+const activeHero = resolveDashboardHero(intl, {
   integrations: dashboardIntegrationsCompleteFixture,
   projectCount: dashboardProjectsItemsFixture.length,
   pendingCount: resolveWorkspacePendingActionCount({
@@ -32,7 +36,7 @@ const activeHero = resolveDashboardHero({
   newRequestHref: `/org/${organizationSlug}/chat`,
 });
 
-const setupHero = resolveDashboardHero({
+const setupHero = resolveDashboardHero(intl, {
   integrations: dashboardIntegrationsIncompleteFixture,
   projectCount: 0,
   pendingCount: 0,
@@ -41,7 +45,7 @@ const setupHero = resolveDashboardHero({
   newRequestHref: `/org/${organizationSlug}/chat`,
 });
 
-const caughtUpHero = resolveDashboardHero({
+const caughtUpHero = resolveDashboardHero(intl, {
   integrations: dashboardIntegrationsCompleteFixture,
   projectCount: dashboardProjectsItemsFixture.length,
   pendingCount: 0,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-view.tsx
@@ -15,6 +15,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { ComponentProps, ReactNode } from "react";
+import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
 import { siGithub } from "simple-icons";
 
 import { Badge } from "@/components/ui/badge";
@@ -46,9 +47,11 @@ import type {
   DashboardJobItem,
   DashboardProjectItem,
 } from "./dashboard-page-view-model";
+import { dashboardPageViewMessages } from "./dashboard-page-view.messages";
 
 type AutomationRunStatus = DashboardAutomationRunItem["status"];
 type AutomationRunBadgeVariant = NonNullable<ComponentProps<typeof Badge>["variant"]>;
+type AutomationRunTriggerSource = DashboardAutomationRunItem["triggerSource"];
 
 const AUTOMATION_RUN_BADGE_VARIANTS: Record<AutomationRunStatus, AutomationRunBadgeVariant> = {
   queued: "warning",
@@ -58,6 +61,23 @@ const AUTOMATION_RUN_BADGE_VARIANTS: Record<AutomationRunStatus, AutomationRunBa
   cancelled: "warning",
   skipped: "warning",
 };
+
+const AUTOMATION_RUN_STATUS_MESSAGES = {
+  queued: dashboardPageViewMessages.runStatusQueued,
+  running: dashboardPageViewMessages.runStatusRunning,
+  succeeded: dashboardPageViewMessages.runStatusSucceeded,
+  failed: dashboardPageViewMessages.runStatusFailed,
+  cancelled: dashboardPageViewMessages.runStatusCancelled,
+  skipped: dashboardPageViewMessages.runStatusSkipped,
+} as const;
+
+const AUTOMATION_TRIGGER_SOURCE_MESSAGES = {
+  manual: dashboardPageViewMessages.triggerManual,
+  scheduled: dashboardPageViewMessages.triggerScheduled,
+  github: dashboardPageViewMessages.triggerGithub,
+  contentful: dashboardPageViewMessages.triggerContentful,
+  source_upload: dashboardPageViewMessages.triggerSourceUpload,
+} as const;
 
 export type DashboardLinkRenderer = (props: {
   href: string;
@@ -77,6 +97,14 @@ function defaultRenderLink({
       {children}
     </Link>
   );
+}
+
+function formatAutomationRunStatus(status: AutomationRunStatus, intl: IntlShape) {
+  return intl.formatMessage(AUTOMATION_RUN_STATUS_MESSAGES[status]);
+}
+
+function formatAutomationTriggerSource(triggerSource: AutomationRunTriggerSource, intl: IntlShape) {
+  return intl.formatMessage(AUTOMATION_TRIGGER_SOURCE_MESSAGES[triggerSource]);
 }
 
 function DashboardPanel({
@@ -108,6 +136,8 @@ function DashboardPanel({
   children: ReactNode;
   renderLink?: DashboardLinkRenderer;
 }) {
+  const intl = useIntl();
+
   return (
     <Card className="rounded-lg border border-border bg-card py-0 text-foreground ring-0">
       <CardHeader className="border-b border-border px-5 pt-5 pb-4">
@@ -128,7 +158,9 @@ function DashboardPanel({
           <div
             className="flex flex-col divide-y divide-border"
             aria-busy="true"
-            aria-label={`Loading ${title.toLowerCase()}`}
+            aria-label={intl.formatMessage(dashboardPageViewMessages.loadingPanel, {
+              title: title.toLowerCase(),
+            })}
           >
             {Array.from({ length: 3 }).map((_, index) => (
               <DashboardPanelCardSkeleton key={index} />
@@ -143,7 +175,8 @@ function DashboardPanel({
                 className="mt-0.5 size-5 text-flame-100"
               />
               <TypographyP className="text-sm text-muted-foreground">
-                {errorMessage ?? `${title} could not be loaded.`}
+                {errorMessage ??
+                  intl.formatMessage(dashboardPageViewMessages.panelLoadError, { title })}
               </TypographyP>
             </div>
           </div>
@@ -206,7 +239,13 @@ function DashboardSetupHero({
         <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,14rem)] lg:items-end">
           <div>
             <TypographyP className="text-sm font-medium text-subtle-foreground">
-              Workspace setup · {hero.completedCount} of {hero.totalCount} complete
+              <FormattedMessage
+                {...dashboardPageViewMessages.setupProgressLabel}
+                values={{
+                  completedCount: hero.completedCount,
+                  totalCount: hero.totalCount,
+                }}
+              />
             </TypographyP>
             <TypographyP className="mt-2 font-heading text-2xl font-medium text-foreground">
               {hero.title}
@@ -229,7 +268,7 @@ function DashboardSetupHero({
                 children: (
                   <Button variant="outline" className="rounded-full">
                     <HugeiconsIcon icon={Chat01Icon} strokeWidth={1.8} />
-                    New request
+                    <FormattedMessage {...dashboardPageViewMessages.newRequest} />
                   </Button>
                 ),
               })}
@@ -237,8 +276,15 @@ function DashboardSetupHero({
           </div>
           <div className="grid gap-2">
             <div className="flex items-center justify-between text-xs text-muted-foreground">
-              <span>Setup progress</span>
-              <span>{progressValue}%</span>
+              <span>
+                <FormattedMessage {...dashboardPageViewMessages.setupProgressMeter} />
+              </span>
+              <span>
+                <FormattedMessage
+                  {...dashboardPageViewMessages.setupProgressPercent}
+                  values={{ value: progressValue }}
+                />
+              </span>
             </div>
             <Progress value={progressValue} className="h-2" />
           </div>
@@ -249,12 +295,14 @@ function DashboardSetupHero({
 }
 
 function DashboardHeroSkeleton() {
+  const intl = useIntl();
+
   return (
     <>
       <Card
         className="rounded-2xl border border-border bg-card py-0 ring-0"
         aria-busy="true"
-        aria-label="Loading workspace overview"
+        aria-label={intl.formatMessage(dashboardPageViewMessages.loadingWorkspaceOverview)}
       >
         <CardContent className="flex h-full min-h-52 flex-col justify-between gap-6 px-6 py-6">
           <div className="flex flex-col gap-3">
@@ -327,18 +375,22 @@ function DashboardIntegrationsSection({
   isLoading?: boolean;
   renderLink?: DashboardLinkRenderer;
 }) {
+  const intl = useIntl();
   const connectedCount = integrations.filter((item) => item.connected).length;
 
   return (
     <section className="flex flex-col gap-4">
-      <OverviewSectionHeader title="Integrations" count={integrations.length - connectedCount} />
+      <OverviewSectionHeader
+        title={intl.formatMessage(dashboardPageViewMessages.integrationsTitle)}
+        count={integrations.length - connectedCount}
+      />
       <Card className="overflow-hidden rounded-lg border border-border bg-card py-0 ring-0">
         <CardContent className="p-0">
           {isLoading ? (
             <div
               className="flex flex-col divide-y divide-border"
               aria-busy="true"
-              aria-label="Loading integrations"
+              aria-label={intl.formatMessage(dashboardPageViewMessages.loadingIntegrations)}
             >
               {Array.from({ length: 3 }).map((_, index) => (
                 <div key={index} className="flex items-center gap-4 px-5 py-4">
@@ -381,10 +433,18 @@ function DashboardIntegrationsSection({
                                 data-icon="inline-start"
                               />
                             ) : null}
-                            {item.connected ? "Connected" : "Not connected"}
+                            {item.connected ? (
+                              <FormattedMessage {...dashboardPageViewMessages.connected} />
+                            ) : (
+                              <FormattedMessage {...dashboardPageViewMessages.notConnected} />
+                            )}
                           </Badge>
                           <span className="inline-flex items-center gap-1 text-sm font-medium text-foreground">
-                            {item.connected ? "Manage" : "Connect"}
+                            {item.connected ? (
+                              <FormattedMessage {...dashboardPageViewMessages.manage} />
+                            ) : (
+                              <FormattedMessage {...dashboardPageViewMessages.connect} />
+                            )}
                             <HugeiconsIcon
                               icon={ArrowRight01Icon}
                               strokeWidth={1.8}
@@ -420,17 +480,20 @@ function DashboardAutomationsSection({
   isError?: boolean;
   renderLink?: DashboardLinkRenderer;
 }) {
+  const intl = useIntl();
   const automationsHref = `/org/${organizationSlug}/automations`;
 
   return (
     <section className="flex flex-col gap-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <OverviewSectionHeader title="Automation runs" />
+        <OverviewSectionHeader
+          title={intl.formatMessage(dashboardPageViewMessages.automationRunsTitle)}
+        />
         {renderLink({
           href: automationsHref,
           children: (
             <Button variant="outline" size="sm" className="rounded-full">
-              View automations
+              <FormattedMessage {...dashboardPageViewMessages.viewAutomations} />
               <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={1.7} className="size-4" />
             </Button>
           ),
@@ -443,7 +506,7 @@ function DashboardAutomationsSection({
             <div
               className="flex flex-col divide-y divide-border"
               aria-busy="true"
-              aria-label="Loading automation runs"
+              aria-label={intl.formatMessage(dashboardPageViewMessages.loadingAutomationRuns)}
             >
               <div className="px-5 py-4">
                 <Skeleton className="h-4 w-48" />
@@ -461,50 +524,65 @@ function DashboardAutomationsSection({
                   className="mt-0.5 size-5 text-flame-100"
                 />
                 <TypographyP className="text-sm text-muted-foreground">
-                  Automation runs could not be loaded.
+                  <FormattedMessage {...dashboardPageViewMessages.automationRunsLoadError} />
                 </TypographyP>
               </div>
             </div>
           ) : (
             <div className="flex flex-col divide-y divide-border">
               <TypographyP className="px-5 py-4 text-sm text-muted-foreground">
-                {stats.total} automations · {stats.active} active · {stats.paused} paused
+                <FormattedMessage
+                  {...dashboardPageViewMessages.automationStats}
+                  values={{
+                    total: stats.total,
+                    active: stats.active,
+                    paused: stats.paused,
+                  }}
+                />
               </TypographyP>
               {runs.length === 0 ? (
                 <TypographyP className="px-5 py-4 text-sm text-muted-foreground">
-                  No automation runs yet.
+                  <FormattedMessage {...dashboardPageViewMessages.noAutomationRuns} />
                 </TypographyP>
               ) : (
-                runs.map((run) => (
-                  <div key={run.id}>
-                    {renderLink({
-                      href: run.href,
-                      className:
-                        "block px-5 py-4 transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
-                      children: (
-                        <>
-                          <div className="flex flex-wrap items-center gap-2">
-                            <TypographyP className="min-w-0 truncate text-sm font-medium text-foreground">
-                              {run.automationName}
+                runs.map((run) => {
+                  const triggerSourceLabel = formatAutomationTriggerSource(run.triggerSource, intl);
+
+                  return (
+                    <div key={run.id}>
+                      {renderLink({
+                        href: run.href,
+                        className:
+                          "block px-5 py-4 transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
+                        children: (
+                          <>
+                            <div className="flex flex-wrap items-center gap-2">
+                              <TypographyP className="min-w-0 truncate text-sm font-medium text-foreground">
+                                {run.automationName}
+                              </TypographyP>
+                              <Badge
+                                variant={AUTOMATION_RUN_BADGE_VARIANTS[run.status]}
+                                className="rounded-full"
+                              >
+                                {formatAutomationRunStatus(run.status, intl)}
+                              </Badge>
+                            </div>
+                            <TypographyP className="mt-1 text-xs text-muted-foreground">
+                              {run.completedAt
+                                ? intl.formatMessage(dashboardPageViewMessages.runCompleted, {
+                                    triggerSource: triggerSourceLabel,
+                                    completedAt: formatRelativeTimestamp(run.completedAt),
+                                  })
+                                : intl.formatMessage(dashboardPageViewMessages.runInProgress, {
+                                    triggerSource: triggerSourceLabel,
+                                  })}
                             </TypographyP>
-                            <Badge
-                              variant={AUTOMATION_RUN_BADGE_VARIANTS[run.status]}
-                              className="rounded-full capitalize"
-                            >
-                              {run.status}
-                            </Badge>
-                          </div>
-                          <TypographyP className="mt-1 text-xs text-muted-foreground">
-                            {run.triggerSource}
-                            {run.completedAt
-                              ? ` · completed ${formatRelativeTimestamp(run.completedAt)}`
-                              : " · in progress"}
-                          </TypographyP>
-                        </>
-                      ),
-                    })}
-                  </div>
-                ))
+                          </>
+                        ),
+                      })}
+                    </div>
+                  );
+                })
               )}
             </div>
           )}
@@ -535,13 +613,15 @@ function DashboardJobsPanel({
   emptyMessage: string;
   renderLink: DashboardLinkRenderer;
 }) {
+  const intl = useIntl();
+
   return (
     <DashboardPanel
       title={title}
       description={description}
       icon={TaskDone01Icon}
       footerHref={footerHref}
-      footerLabel="View all jobs"
+      footerLabel={intl.formatMessage(dashboardPageViewMessages.viewAllJobs)}
       isLoading={isLoading}
       isError={isError}
       warningMessage={warningMessage}
@@ -550,6 +630,8 @@ function DashboardJobsPanel({
       renderLink={renderLink}
     >
       {jobs.map((job) => {
+        const projectName =
+          job.projectName ?? intl.formatMessage(dashboardPageViewMessages.workspaceFallbackProject);
         const content = (
           <>
             <div className="flex flex-wrap items-center gap-2">
@@ -564,8 +646,11 @@ function DashboardJobsPanel({
               </Badge>
             </div>
             <TypographyP className="mt-1 text-xs text-muted-foreground">
-              {job.projectName ?? "Workspace"} · {job.kindLabel} · updated{" "}
-              {formatRelativeTimestamp(job.updatedAt)}
+              {intl.formatMessage(dashboardPageViewMessages.jobMeta, {
+                projectName,
+                kindLabel: job.kindLabel,
+                updatedAt: formatRelativeTimestamp(job.updatedAt),
+              })}
             </TypographyP>
           </>
         );
@@ -614,13 +699,15 @@ function DashboardProjectsPanel({
   emptyMessage: string;
   renderLink: DashboardLinkRenderer;
 }) {
+  const intl = useIntl();
+
   return (
     <DashboardPanel
       title={title}
       description={description}
       icon={FolderKanbanIcon}
       footerHref={footerHref}
-      footerLabel="View all projects"
+      footerLabel={intl.formatMessage(dashboardPageViewMessages.viewAllProjects)}
       isLoading={isLoading}
       isError={isError}
       isEmpty={projects.length === 0}
@@ -647,7 +734,9 @@ function DashboardProjectsPanel({
                       variant="outline"
                       className="rounded-full border-beam-500/30 bg-beam-500/15 text-beam-100"
                     >
-                      {formatPendingActionCount(project.pendingActionCount)} open
+                      {intl.formatMessage(dashboardPageViewMessages.projectOpenBadge, {
+                        count: formatPendingActionCount(project.pendingActionCount),
+                      })}
                     </Badge>
                   ) : (
                     <Badge variant="outline" className="rounded-full text-muted-foreground">
@@ -656,15 +745,21 @@ function DashboardProjectsPanel({
                         strokeWidth={1.7}
                         className="mr-1 size-3.5"
                       />
-                      Up to date
+                      <FormattedMessage {...dashboardPageViewMessages.projectUpToDate} />
                     </Badge>
                   )}
                 </div>
                 <TypographyP className="mt-1 text-xs text-muted-foreground">
-                  {project.sourceLabel} · {project.localeRoute}
                   {project.updatedAt
-                    ? ` · updated ${formatRelativeTimestamp(project.updatedAt)}`
-                    : ""}
+                    ? intl.formatMessage(dashboardPageViewMessages.projectMetaWithUpdate, {
+                        sourceLabel: project.sourceLabel,
+                        localeRoute: project.localeRoute,
+                        updatedAt: formatRelativeTimestamp(project.updatedAt),
+                      })
+                    : intl.formatMessage(dashboardPageViewMessages.projectMeta, {
+                        sourceLabel: project.sourceLabel,
+                        localeRoute: project.localeRoute,
+                      })}
                 </TypographyP>
               </>
             ),
@@ -736,6 +831,7 @@ export function DashboardPageView({
   isAutomationsError?: boolean;
   renderLink?: DashboardLinkRenderer;
 }) {
+  const intl = useIntl();
   const integrationsHref = `/org/${organizationSlug}/integrations`;
   const myJobsHref = `/org/${organizationSlug}/my-jobs`;
   const jobsHref = `/org/${organizationSlug}/jobs`;
@@ -746,9 +842,9 @@ export function DashboardPageView({
     <WorkspacePageShell>
       <PageHeader
         icon={DashboardSquare01Icon}
-        label="Workspace"
-        title="Overview"
-        description="Your workspace at a glance — assigned work, latest activity, and recent projects."
+        label={intl.formatMessage(dashboardPageViewMessages.pageLabel)}
+        title={intl.formatMessage(dashboardPageViewMessages.pageTitle)}
+        description={intl.formatMessage(dashboardPageViewMessages.pageDescription)}
       />
 
       <section className="grid gap-4 lg:grid-cols-2">
@@ -769,14 +865,13 @@ export function DashboardPageView({
               <CardContent className="flex h-full flex-col justify-between gap-4 px-6 py-6">
                 <div>
                   <TypographyP className="text-sm font-medium text-subtle-foreground">
-                    Quick start
+                    <FormattedMessage {...dashboardPageViewMessages.quickStartLabel} />
                   </TypographyP>
                   <TypographyP className="mt-2 font-heading text-xl font-medium text-foreground">
-                    Ask the localization agent
+                    <FormattedMessage {...dashboardPageViewMessages.quickStartTitle} />
                   </TypographyP>
                   <TypographyP className="mt-2 text-sm leading-6 text-muted-foreground">
-                    Describe what you need translated, researched, or reviewed and Hyperlocalise
-                    will prepare the work.
+                    <FormattedMessage {...dashboardPageViewMessages.quickStartDescription} />
                   </TypographyP>
                 </div>
                 {renderLink({
@@ -784,7 +879,7 @@ export function DashboardPageView({
                   children: (
                     <Button className="w-fit rounded-full">
                       <HugeiconsIcon icon={Chat01Icon} strokeWidth={1.8} />
-                      New request
+                      <FormattedMessage {...dashboardPageViewMessages.newRequest} />
                     </Button>
                   ),
                 })}
@@ -796,61 +891,73 @@ export function DashboardPageView({
 
       <section className="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
         <DashboardJobsPanel
-          title="My jobs"
-          description="The latest work assigned to you, prioritized by what needs action."
+          title={intl.formatMessage(dashboardPageViewMessages.myJobsTitle)}
+          description={intl.formatMessage(dashboardPageViewMessages.myJobsDescription)}
           jobs={jobs}
           footerHref={myJobsHref}
           isLoading={isJobsLoading}
           isError={isJobsError}
           warningMessage={jobsWarning}
-          emptyMessage="No jobs assigned to you yet."
+          emptyMessage={intl.formatMessage(dashboardPageViewMessages.myJobsEmpty)}
           renderLink={renderLink}
         />
 
         <DashboardJobsPanel
-          title="Latest jobs"
-          description="The most recently updated work across this workspace."
+          title={intl.formatMessage(dashboardPageViewMessages.latestJobsTitle)}
+          description={intl.formatMessage(dashboardPageViewMessages.latestJobsDescription)}
           jobs={latestJobs}
           footerHref={jobsHref}
           isLoading={isLatestJobsLoading}
           isError={isLatestJobsError}
-          emptyMessage="No workspace jobs yet."
+          emptyMessage={intl.formatMessage(dashboardPageViewMessages.latestJobsEmpty)}
           renderLink={renderLink}
         />
 
         <DashboardProjectsPanel
           organizationSlug={organizationSlug}
-          title="Recent projects"
-          description="Projects you opened recently, followed by active workspace projects."
+          title={intl.formatMessage(dashboardPageViewMessages.recentProjectsTitle)}
+          description={intl.formatMessage(dashboardPageViewMessages.recentProjectsDescription)}
           projects={projects}
           footerHref={projectsHref}
           isLoading={isProjectsLoading}
           isError={isProjectsError}
-          emptyMessage="No native projects yet. Create a project to get started."
+          emptyMessage={intl.formatMessage(dashboardPageViewMessages.recentProjectsEmpty)}
           renderLink={renderLink}
         />
 
         {showTmsSections ? (
           <>
             <DashboardJobsPanel
-              title={`${tmsProviderName} jobs`}
-              description={`Live jobs fetched from ${tmsProviderName}.`}
+              title={intl.formatMessage(dashboardPageViewMessages.tmsJobsTitle, {
+                providerName: tmsProviderName,
+              })}
+              description={intl.formatMessage(dashboardPageViewMessages.tmsJobsDescription, {
+                providerName: tmsProviderName,
+              })}
               jobs={tmsJobs}
               footerHref={jobsHref}
               isLoading={isTmsJobsLoading}
               isError={isTmsJobsError}
-              emptyMessage={`No jobs found in ${tmsProviderName}.`}
+              emptyMessage={intl.formatMessage(dashboardPageViewMessages.tmsJobsEmpty, {
+                providerName: tmsProviderName,
+              })}
               renderLink={renderLink}
             />
             <DashboardProjectsPanel
               organizationSlug={organizationSlug}
-              title={`${tmsProviderName} projects`}
-              description={`Live projects fetched from ${tmsProviderName}.`}
+              title={intl.formatMessage(dashboardPageViewMessages.tmsProjectsTitle, {
+                providerName: tmsProviderName,
+              })}
+              description={intl.formatMessage(dashboardPageViewMessages.tmsProjectsDescription, {
+                providerName: tmsProviderName,
+              })}
               projects={tmsProjects}
               footerHref={projectsHref}
               isLoading={isTmsProjectsLoading}
               isError={isTmsProjectsError}
-              emptyMessage={`No projects found in ${tmsProviderName}.`}
+              emptyMessage={intl.formatMessage(dashboardPageViewMessages.tmsProjectsEmpty, {
+                providerName: tmsProviderName,
+              })}
               renderLink={renderLink}
             />
           </>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard.fixture.ts
@@ -1,4 +1,7 @@
+import type { IntlShape } from "react-intl";
+
 import type { WorkspaceAutomationRunRecord } from "@/lib/agents/workspace-automations";
+import { getIntlShape } from "@/lib/app-i18n/intl";
 
 import { automationsFixture } from "../../automations/_components/automations.fixture";
 import type { ApiJob } from "../../jobs/_components/jobs-page-view";
@@ -22,16 +25,17 @@ import {
 } from "./dashboard-page-view-model";
 
 const organizationSlug = "acme";
+const intl = getIntlShape("en") as IntlShape;
 
 export const dashboardIntegrationsCompleteFixture: DashboardIntegrationItem[] =
-  resolveDashboardIntegrations({
+  resolveDashboardIntegrations(intl, {
     tmsConnected: true,
     githubConnected: true,
     slackConnected: true,
   });
 
 export const dashboardIntegrationsIncompleteFixture: DashboardIntegrationItem[] =
-  resolveDashboardIntegrations({
+  resolveDashboardIntegrations(intl, {
     tmsConnected: false,
     githubConnected: false,
     slackConnected: true,
@@ -226,7 +230,7 @@ const automationRunsFixture: WorkspaceAutomationRunRecord[] = [
 ];
 
 export const dashboardAutomationRunsFixture: DashboardAutomationRunItem[] =
-  mapDashboardAutomationRuns({
+  mapDashboardAutomationRuns(intl, {
     organizationSlug,
     automations: automationsFixture,
     runs: automationRunsFixture,

--- a/apps/hyperlocalise-web/src/components/locale-toggle/locale-toggle.tsx
+++ b/apps/hyperlocalise-web/src/components/locale-toggle/locale-toggle.tsx
@@ -34,7 +34,11 @@ export function LocaleToggle() {
           render={
             <DropdownMenuTrigger
               render={
-                <Button variant="outline" size="icon-sm" className="rounded-full text-base leading-none">
+                <Button
+                  variant="outline"
+                  size="icon-sm"
+                  className="rounded-full text-base leading-none"
+                >
                   <span aria-hidden="true">{getAppLocaleFlagEmoji(activeLocale)}</span>
                   <span className="sr-only">
                     <FormattedMessage {...localeToggleMessages.changeLanguage} />


### PR DESCRIPTION
## What changed

Localize the workspace dashboard overview with react-intl (ICU), including page chrome, panels, integrations, automations, hero copy from the view-model, and user-facing toasts/warnings. Colocated `*.messages.ts` modules hold client descriptors; view-model helpers now take `IntlShape`.

## How to test

- [ ] Open `/org/{slug}/dashboard` and confirm Overview, panels, integrations, and automations still render expected English copy
- [ ] Trigger the feature-unavailable redirect toast and confirm the message still appears
- [ ] `vp lint --fix "src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard"`
- [ ] `vp test "src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard"`

## Checklist

- [x] I ran relevant checks locally (`vp lint --fix` and `vp test` on the dashboard path)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)