### PR TITLE
feat(cli): add --max-translations session limit for paginated runs

### DIFF
--- a/apps/cli/cmd/run.go
+++ b/apps/cli/cmd/run.go
@@ -33,6 +33,7 @@ type runOptions struct {
 	prune                     bool
 	pruneLimit                int
 	pruneForce                bool
+	maxTranslations           int
 	workers                   int
 	progress                  string
 	bucket                    string
@@ -80,6 +81,7 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&o.prune, "prune", o.prune, "remove target keys that no longer exist in source files")
 	cmd.Flags().IntVar(&o.pruneLimit, "prune-max-deletions", 100, "maximum stale keys that can be deleted in one run before requiring an explicit override")
 	cmd.Flags().BoolVar(&o.pruneForce, "prune-force", o.pruneForce, "bypass prune deletion safety limit")
+	cmd.Flags().IntVar(&o.maxTranslations, "max-translations", 0, "maximum executable translations to run in this session (0 = unlimited); deferred work remains for a later run")
 	cmd.Flags().IntVar(&o.workers, "workers", o.workers, "number of parallel translation workers (default: number of CPU cores)")
 	cmd.Flags().StringVar(&o.progress, "progress", string(progressui.ModeAuto), "progress rendering mode: auto|on|off")
 	cmd.Flags().StringVar(&o.bucket, "bucket", "", "only run tasks for the given bucket")
@@ -223,6 +225,10 @@ func executeRun(cmd *cobra.Command, o runOptions) error {
 		span.SetStatus(codes.Error, "invalid_workers")
 		return fmt.Errorf("invalid --workers value %d: must be >= 1", workers)
 	}
+	if o.maxTranslations < 0 {
+		span.SetStatus(codes.Error, "invalid_max_translations")
+		return fmt.Errorf("invalid --max-translations value %d: must be >= 0", o.maxTranslations)
+	}
 	var targetLocales []string
 	if o.interactive {
 		targetLocales = o.targetLocales
@@ -272,6 +278,7 @@ func executeRun(cmd *cobra.Command, o runOptions) error {
 		attribute.Bool("cli.force", o.force),
 		attribute.Bool("cli.interactive", o.interactive),
 		attribute.Bool("cli.prune", o.prune),
+		attribute.Int("cli.max_translations", o.maxTranslations),
 		attribute.Int("cli.workers", workers),
 		attribute.Bool("cli.experimental_context_memory", o.experimentalContextMemory),
 	)
@@ -310,6 +317,7 @@ func executeRun(cmd *cobra.Command, o runOptions) error {
 		Prune:                     o.prune,
 		PruneLimit:                o.pruneLimit,
 		PruneForce:                o.pruneForce,
+		MaxTranslations:           o.maxTranslations,
 		Workers:                   workers,
 		Bucket:                    o.bucket,
 		Group:                     o.group,
@@ -340,6 +348,7 @@ func executeRun(cmd *cobra.Command, o runOptions) error {
 		span.SetAttributes(
 			attribute.Int("run.planned_total", report.PlannedTotal),
 			attribute.Int("run.executable_total", report.ExecutableTotal),
+			attribute.Int("run.deferred_by_limit", report.DeferredByLimit),
 			attribute.Int("run.succeeded", report.Succeeded),
 			attribute.Int("run.failed", report.Failed),
 			attribute.Int("run.prune_applied", report.PruneApplied),
@@ -416,10 +425,11 @@ func writeRunReportArtifact(path string, report runsvc.Report, jsonDetail string
 func writeRunReport(w io.Writer, report runsvc.Report, dryRun bool) error {
 	if _, err := fmt.Fprintf(
 		w,
-		"planned_total=%d skipped_by_lock=%d executable_total=%d\n",
+		"planned_total=%d skipped_by_lock=%d executable_total=%d deferred_by_limit=%d\n",
 		report.PlannedTotal,
 		report.SkippedByLock,
 		report.ExecutableTotal,
+		report.DeferredByLimit,
 	); err != nil {
 		return err
 	}

--- a/apps/cli/cmd/run_test.go
+++ b/apps/cli/cmd/run_test.go
@@ -1567,6 +1567,49 @@ func TestRunForceFlagPlumbedToServiceInput(t *testing.T) {
 	}
 }
 
+func TestRunMaxTranslationsFlagPlumbedToServiceInput(t *testing.T) {
+	originalRunFunc := runFunc
+	t.Cleanup(func() { runFunc = originalRunFunc })
+
+	var gotInput runsvc.Input
+	runFunc = func(_ context.Context, input runsvc.Input) (runsvc.Report, error) {
+		gotInput = input
+		return runsvc.Report{DeferredByLimit: 3}, nil
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"run", "--max-translations", "1000"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("run with max-translations: %v", err)
+	}
+	if gotInput.MaxTranslations != 1000 {
+		t.Fatalf("expected MaxTranslations=1000, got %d", gotInput.MaxTranslations)
+	}
+	if !strings.Contains(out.String(), "deferred_by_limit=3") {
+		t.Fatalf("expected deferred_by_limit in report output, got %q", out.String())
+	}
+}
+
+func TestRunRejectsNegativeMaxTranslationsFlag(t *testing.T) {
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"run", "--max-translations", "-1"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected invalid max-translations error")
+	}
+	if !strings.Contains(err.Error(), "invalid --max-translations value") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestRunExperimentalContextMemoryFlagsPlumbedToServiceInput(t *testing.T) {
 	originalRunFunc := runFunc
 	t.Cleanup(func() { runFunc = originalRunFunc })

--- a/apps/cli/internal/i18n/runsvc/report_json.go
+++ b/apps/cli/internal/i18n/runsvc/report_json.go
@@ -36,6 +36,7 @@ type SummaryJSONReport struct {
 	PlannedTotal    int       `json:"plannedTotal"`
 	SkippedByLock   int       `json:"skippedByLock"`
 	ExecutableTotal int       `json:"executableTotal"`
+	DeferredByLimit int       `json:"deferredByLimit"`
 	Succeeded       int       `json:"succeeded"`
 	Failed          int       `json:"failed"`
 	PersistedToLock int       `json:"persistedToLock"`
@@ -93,6 +94,7 @@ func SummaryJSONReportFrom(r Report) SummaryJSONReport {
 		PlannedTotal:                r.PlannedTotal,
 		SkippedByLock:               r.SkippedByLock,
 		ExecutableTotal:             r.ExecutableTotal,
+		DeferredByLimit:             r.DeferredByLimit,
 		Succeeded:                   r.Succeeded,
 		Failed:                      r.Failed,
 		PersistedToLock:             r.PersistedToLock,

--- a/apps/cli/internal/i18n/runsvc/run_orchestrator.go
+++ b/apps/cli/internal/i18n/runsvc/run_orchestrator.go
@@ -94,6 +94,16 @@ func (s *Service) run(ctx context.Context, in Input) (report Report, err error) 
 		report.ExecutableTotal = len(executable)
 	}
 
+	if in.MaxTranslations < 0 {
+		err := fmt.Errorf("invalid max translations %d: must be >= 0", in.MaxTranslations)
+		endRunSpan(lockSpan, err, "max_translations")
+		return Report{}, err
+	}
+	executable, deferredByLimit := applyMaxTranslationsLimit(executable, in.MaxTranslations)
+	report.DeferredByLimit = deferredByLimit
+	report.ExecutableTotal = len(executable)
+	report.Executable = append([]Task(nil), executable...)
+
 	report.GeneratedAt = s.now()
 	report.ConfigPath = in.ConfigPath
 	report.Warnings = append(report.Warnings, planWarnings...)
@@ -102,11 +112,18 @@ func (s *Service) run(ctx context.Context, in Input) (report Report, err error) 
 		report.ContextMemoryEnabled = true
 		report.ContextMemoryScope = in.ContextMemoryScope
 	}
-	emitter.emit(Event{Kind: EventPlanned, PlannedTotal: report.PlannedTotal, SkippedByLock: report.SkippedByLock, ExecutableTotal: report.ExecutableTotal})
+	emitter.emit(Event{
+		Kind:            EventPlanned,
+		PlannedTotal:    report.PlannedTotal,
+		SkippedByLock:   report.SkippedByLock,
+		ExecutableTotal: report.ExecutableTotal,
+		DeferredByLimit: report.DeferredByLimit,
+	})
 	lockSpan.SetAttributes(
 		attribute.Int("run.planned_total", report.PlannedTotal),
 		attribute.Int("run.skipped_by_lock", report.SkippedByLock),
 		attribute.Int("run.executable_total", report.ExecutableTotal),
+		attribute.Int("run.deferred_by_limit", report.DeferredByLimit),
 	)
 	endRunSpan(lockSpan, nil, "")
 
@@ -520,6 +537,15 @@ func remainingPruneTargets(pruneTargets map[string]map[string]struct{}, pruneMet
 	return remaining, remainingMetadata
 }
 
+// applyMaxTranslationsLimit keeps the first max tasks in plan order and reports
+// how many executable tasks were deferred for a later session. max <= 0 means unlimited.
+func applyMaxTranslationsLimit(executable []Task, max int) (limited []Task, deferred int) {
+	if max <= 0 || len(executable) <= max {
+		return executable, 0
+	}
+	return executable[:max], len(executable) - max
+}
+
 func completedEvent(report Report) Event {
 	usage := NormalizeTokenUsage(report.TokenUsage)
 	return eventWithTokenUsage(Event{
@@ -527,6 +553,7 @@ func completedEvent(report Report) Event {
 		PlannedTotal:    report.PlannedTotal,
 		SkippedByLock:   report.SkippedByLock,
 		ExecutableTotal: report.ExecutableTotal,
+		DeferredByLimit: report.DeferredByLimit,
 		Succeeded:       report.Succeeded,
 		Failed:          report.Failed,
 		PersistedToLock: report.PersistedToLock,

--- a/apps/cli/internal/i18n/runsvc/service.go
+++ b/apps/cli/internal/i18n/runsvc/service.go
@@ -28,16 +28,20 @@ const (
 )
 
 type Input struct {
-	ConfigPath                string
-	Bucket                    string
-	Group                     string
-	TargetLocales             []string
-	SourcePaths               []string
-	DryRun                    bool
-	Force                     bool
-	Prune                     bool
-	PruneLimit                int
-	PruneForce                bool
+	ConfigPath    string
+	Bucket        string
+	Group         string
+	TargetLocales []string
+	SourcePaths   []string
+	DryRun        bool
+	Force         bool
+	Prune         bool
+	PruneLimit    int
+	PruneForce    bool
+	// MaxTranslations caps how many executable tasks run in this session after lock
+	// filtering and prefill. 0 means unlimited. Deferred tasks remain unlocked so a
+	// later run without --force can continue.
+	MaxTranslations           int
 	LockPath                  string
 	Workers                   int
 	ExperimentalContextMemory bool
@@ -130,6 +134,7 @@ type Event struct {
 	PlannedTotal             int       `json:"plannedTotal,omitempty"`
 	SkippedByLock            int       `json:"skippedByLock,omitempty"`
 	ExecutableTotal          int       `json:"executableTotal,omitempty"`
+	DeferredByLimit          int       `json:"deferredByLimit,omitempty"`
 	Succeeded                int       `json:"succeeded,omitempty"`
 	Failed                   int       `json:"failed,omitempty"`
 	PersistedToLock          int       `json:"persistedToLock,omitempty"`
@@ -269,9 +274,12 @@ type Report struct {
 	PlannedTotal    int       `json:"plannedTotal"`
 	SkippedByLock   int       `json:"skippedByLock"`
 	ExecutableTotal int       `json:"executableTotal"`
-	Succeeded       int       `json:"succeeded"`
-	Failed          int       `json:"failed"`
-	PersistedToLock int       `json:"persistedToLock"`
+	// DeferredByLimit is the number of executable tasks left for a later session
+	// because MaxTranslations capped this run.
+	DeferredByLimit int `json:"deferredByLimit"`
+	Succeeded       int `json:"succeeded"`
+	Failed          int `json:"failed"`
+	PersistedToLock int `json:"persistedToLock"`
 	TokenUsage
 	LocaleUsage                 map[string]TokenUsage `json:"localeUsage,omitempty"`
 	Batches                     []BatchUsage          `json:"batches,omitempty"`

--- a/apps/cli/internal/i18n/runsvc/service_test.go
+++ b/apps/cli/internal/i18n/runsvc/service_test.go
@@ -482,6 +482,175 @@ func TestRunAppliesLockFilterByTargetAndEntry(t *testing.T) {
 	}
 }
 
+func TestApplyMaxTranslationsLimit(t *testing.T) {
+	tasks := []Task{
+		{EntryKey: "a"},
+		{EntryKey: "b"},
+		{EntryKey: "c"},
+	}
+	limited, deferred := applyMaxTranslationsLimit(tasks, 2)
+	if deferred != 1 || len(limited) != 2 || limited[0].EntryKey != "a" || limited[1].EntryKey != "b" {
+		t.Fatalf("unexpected limit result: limited=%+v deferred=%d", limited, deferred)
+	}
+	unlimited, deferred := applyMaxTranslationsLimit(tasks, 0)
+	if deferred != 0 || len(unlimited) != 3 {
+		t.Fatalf("expected unlimited when max=0, got limited=%d deferred=%d", len(unlimited), deferred)
+	}
+}
+
+func TestRunMaxTranslationsDefersRemainingAndContinuesWithoutForce(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.json"
+	targetPath := "/tmp/out.json"
+	files := map[string][]byte{
+		sourcePath: []byte(`{"a":"A","b":"B","c":"C"}`),
+		targetPath: []byte(`{}`),
+	}
+	var lockState lockfile.File
+	svc.loadConfig = func(_ string) (*config.I18NConfig, error) {
+		cfg := testConfig(sourcePath, targetPath)
+		return &cfg, nil
+	}
+	svc.readFile = func(path string) ([]byte, error) {
+		content, ok := files[path]
+		if !ok {
+			return nil, os.ErrNotExist
+		}
+		return content, nil
+	}
+	svc.writeFile = func(path string, content []byte) error {
+		files[path] = append([]byte(nil), content...)
+		return nil
+	}
+	svc.loadLock = func(_ string) (*lockfile.File, error) {
+		cloned := lockState
+		if cloned.RunCompleted == nil {
+			cloned.RunCompleted = map[string]lockfile.RunCompletion{}
+		}
+		if cloned.RunCheckpoint == nil {
+			cloned.RunCheckpoint = map[string]lockfile.RunCheckpoint{}
+		}
+		return &cloned, nil
+	}
+	svc.saveLock = func(_ string, f lockfile.File) error {
+		lockState = f
+		return nil
+	}
+	svc.translate = func(_ context.Context, req translator.Request) (string, error) {
+		return strings.ToUpper(req.Source), nil
+	}
+
+	first, err := svc.Run(context.Background(), Input{MaxTranslations: 2})
+	if err != nil {
+		t.Fatalf("first page: %v", err)
+	}
+	if first.ExecutableTotal != 2 || first.DeferredByLimit != 1 || first.Succeeded != 2 {
+		t.Fatalf("unexpected first page report: %+v", first)
+	}
+	if len(first.Executable) != 2 {
+		t.Fatalf("expected 2 executable tasks on first page, got %d", len(first.Executable))
+	}
+
+	second, err := svc.Run(context.Background(), Input{MaxTranslations: 2})
+	if err != nil {
+		t.Fatalf("second page: %v", err)
+	}
+	if second.SkippedByLock != 2 || second.ExecutableTotal != 1 || second.DeferredByLimit != 0 || second.Succeeded != 1 {
+		t.Fatalf("unexpected second page report: %+v", second)
+	}
+	if len(second.Executable) != 1 || second.Executable[0].EntryKey != "c" {
+		t.Fatalf("unexpected second page executable: %+v", second.Executable)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(files[targetPath], &payload); err != nil {
+		t.Fatalf("decode target: %v", err)
+	}
+	if payload["a"] != "A" || payload["b"] != "B" || payload["c"] != "C" {
+		t.Fatalf("unexpected merged target after pagination: %+v", payload)
+	}
+}
+
+func TestRunMaxTranslationsWithForceRedoesHeadOfQueue(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.json"
+	targetPath := "/tmp/out.json"
+	files := map[string][]byte{
+		sourcePath: []byte(`{"a":"A","b":"B","c":"C"}`),
+		targetPath: []byte(`{}`),
+	}
+	var lockState lockfile.File
+	svc.loadConfig = func(_ string) (*config.I18NConfig, error) {
+		cfg := testConfig(sourcePath, targetPath)
+		return &cfg, nil
+	}
+	svc.readFile = func(path string) ([]byte, error) {
+		content, ok := files[path]
+		if !ok {
+			return nil, os.ErrNotExist
+		}
+		return content, nil
+	}
+	svc.writeFile = func(path string, content []byte) error {
+		files[path] = append([]byte(nil), content...)
+		return nil
+	}
+	svc.loadLock = func(_ string) (*lockfile.File, error) {
+		cloned := lockState
+		if cloned.RunCompleted == nil {
+			cloned.RunCompleted = map[string]lockfile.RunCompletion{}
+		}
+		if cloned.RunCheckpoint == nil {
+			cloned.RunCheckpoint = map[string]lockfile.RunCheckpoint{}
+		}
+		return &cloned, nil
+	}
+	svc.saveLock = func(_ string, f lockfile.File) error {
+		lockState = f
+		return nil
+	}
+	translated := map[string]int{}
+	svc.translate = func(_ context.Context, req translator.Request) (string, error) {
+		translated[req.Source]++
+		return strings.ToUpper(req.Source), nil
+	}
+
+	if _, err := svc.Run(context.Background(), Input{MaxTranslations: 2}); err != nil {
+		t.Fatalf("first page: %v", err)
+	}
+	second, err := svc.Run(context.Background(), Input{Force: true, MaxTranslations: 2})
+	if err != nil {
+		t.Fatalf("forced second page: %v", err)
+	}
+	if second.ExecutableTotal != 2 || second.DeferredByLimit != 1 {
+		t.Fatalf("unexpected forced page report: %+v", second)
+	}
+	if translated["A"] != 2 || translated["B"] != 2 || translated["C"] != 0 {
+		t.Fatalf("expected force+limit to redo head keys only, got %+v", translated)
+	}
+}
+
+func TestRunRejectsNegativeMaxTranslations(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.json"
+	targetPath := "/tmp/out.json"
+	svc.loadConfig = func(_ string) (*config.I18NConfig, error) {
+		cfg := testConfig(sourcePath, targetPath)
+		return &cfg, nil
+	}
+	svc.readFile = func(path string) ([]byte, error) {
+		if path == sourcePath {
+			return []byte(`{"a":"A"}`), nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	_, err := svc.Run(context.Background(), Input{MaxTranslations: -1})
+	if err == nil || !strings.Contains(err.Error(), "invalid max translations") {
+		t.Fatalf("expected invalid max translations error, got %v", err)
+	}
+}
+
 func TestRunDoesNotSkipWhenSourceTextChanges(t *testing.T) {
 	svc := newTestService()
 	sourcePath := "/tmp/source.json"

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job-pagination.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job-pagination.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { parseDeferredByLimit } from "./file-translation-pagination";
+
+describe("parseDeferredByLimit", () => {
+  it("reads deferred_by_limit from hl run stdout", () => {
+    expect(
+      parseDeferredByLimit(
+        "planned_total=3000 skipped_by_lock=0 executable_total=1000 deferred_by_limit=2000\nsucceeded=1000 failed=0\n",
+      ),
+    ).toBe(2000);
+  });
+
+  it("returns 0 when the marker is absent", () => {
+    expect(parseDeferredByLimit("planned_total=1 executable_total=1\n")).toBe(0);
+  });
+
+  it("returns 0 for deferred_by_limit=0", () => {
+    expect(parseDeferredByLimit("deferred_by_limit=0\n")).toBe(0);
+  });
+});

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -1116,6 +1116,8 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
 
       // Retry each failed locale individually with locale-specific feedback so
       // one locale's glossary constraints cannot contaminate another.
+      // Page through --max-translations so a successful retry cannot leave
+      // deferred keys untranslated.
       const stillFailing: LocaleGlossaryFailure[] = [];
       for (const { targetLocale, failures } of glossaryFailuresByLocale) {
         const feedback = [
@@ -1127,27 +1129,50 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
           ),
         ].join("\n");
 
-        const retryResult = await runHlForLocales([targetLocale], 2, {
-          retryFeedback: feedback,
-          force: true,
-          maxTranslations: FILE_TRANSLATION_MAX_TRANSLATIONS_PER_SESSION,
-        });
-        if (!retryResult.ok) {
-          translatedByLocale.delete(targetLocale);
-          stillFailing.push({ targetLocale, failures });
+        let retryFailed = false;
+        for (let retryPage = 0; retryPage < FILE_TRANSLATION_MAX_PAGES; retryPage += 1) {
+          const retryResult = await runHlForLocales([targetLocale], 2, {
+            retryFeedback: feedback,
+            // Page 0 forces a clean rewrite; later pages omit --force so the
+            // lockfile advances through deferred work.
+            force: retryPage === 0,
+            maxTranslations: FILE_TRANSLATION_MAX_TRANSLATIONS_PER_SESSION,
+          });
+          if (!retryResult.ok) {
+            translatedByLocale.delete(targetLocale);
+            stillFailing.push({ targetLocale, failures });
+            retryFailed = true;
+            break;
+          }
+
+          const { readable, missing } = await tryReadLocaleOutputs([targetLocale], 2);
+          if (missing.length > 0) {
+            translatedByLocale.delete(targetLocale);
+            stillFailing.push({ targetLocale, failures });
+            retryFailed = true;
+            break;
+          }
+          if (readable.length > 0) {
+            await persistReadableLocales(readable, 2);
+          }
+          if (retryResult.deferredByLimit <= 0) {
+            break;
+          }
+          if (retryPage === FILE_TRANSLATION_MAX_PAGES - 1) {
+            translatedByLocale.delete(targetLocale);
+            stillFailing.push({ targetLocale, failures });
+            retryFailed = true;
+          }
+        }
+        if (retryFailed) {
           continue;
         }
 
-        const outputFilename = getSandboxOutputFilename(sourceFile.filename, targetLocale);
-        let translatedContent: Buffer;
-        try {
-          translatedContent = await readOutputStep(sandboxId, outputFilename, 2);
-        } catch {
-          translatedByLocale.delete(targetLocale);
+        const translatedContent = translatedByLocale.get(targetLocale);
+        if (!translatedContent) {
           stillFailing.push({ targetLocale, failures });
           continue;
         }
-        translatedByLocale.set(targetLocale, translatedContent);
 
         const localeTerms = (context.glossaryTerms ?? []).filter(
           (term) => term.targetLocale === targetLocale,

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -26,6 +26,11 @@ import {
   reuseFileTranslationMemoryEntriesStep,
   storeOutputFileStep,
 } from "./steps/translation-job";
+import {
+  FILE_TRANSLATION_MAX_PAGES,
+  FILE_TRANSLATION_MAX_TRANSLATIONS_PER_SESSION,
+  parseDeferredByLimit,
+} from "./file-translation-pagination";
 
 function shellSingleQuote(value: string) {
   return value.replaceAll("'", "'\\''");
@@ -286,7 +291,7 @@ async function runTranslationStep(
   instructions: string | null,
   context: SandboxTranslationContext,
   prefilledByLocale: Record<string, Record<string, string>>,
-  options?: { force?: boolean },
+  options?: { force?: boolean; maxTranslations?: number },
 ) {
   "use step";
 
@@ -334,13 +339,18 @@ async function runTranslationStep(
   // First runs use --force for a clean slate. Same-sandbox retries omit it so
   // `.hyperlocalise.lock.json` can skip completed tasks / resume checkpoints.
   const forceFlag = options?.force === false ? "" : " --force";
+  const maxTranslations = options?.maxTranslations;
+  const maxTranslationsFlag =
+    typeof maxTranslations === "number" && maxTranslations > 0
+      ? ` --max-translations ${maxTranslations}`
+      : "";
   try {
     return await runSandboxCommand(
       sandboxId,
       "bash",
       [
         "-lc",
-        `hl run --config '${shellSingleQuote(sandboxI18nConfigPath)}'${localeArg}${forceFlag} --progress off${prefilledFlags}`,
+        `hl run --config '${shellSingleQuote(sandboxI18nConfigPath)}'${localeArg}${forceFlag}${maxTranslationsFlag} --progress off${prefilledFlags}`,
       ],
       {
         env: getSandboxTranslationEnv(),
@@ -744,13 +754,61 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
     const translatedByLocale = new Map<string, Buffer>();
     const runFailures: Array<{ locale: string; kind: string; exitCode: number }> = [];
 
+    const persistReadableLocales = async (locales: string[], attempt: 1 | 2) => {
+      if (!sourceEntries || !repositorySourcePath) {
+        return;
+      }
+      for (const targetLocale of locales) {
+        const outputFilename = getSandboxOutputFilename(sourceFile.filename, targetLocale);
+        try {
+          const targetEntries = await extractEntriesStep(sandboxId, outputFilename, {
+            sourcePath: inputFilename,
+          });
+          await persistFileTranslationMemoryEntriesStep({
+            projectId: claim.job.projectId,
+            jobId: claim.job.id,
+            sourceLocale: parsedInput.sourceLocale,
+            targetLocale,
+            sourcePath: repositorySourcePath,
+            sourceFileHash: sourceFile.sha256,
+            sourceEntries,
+            targetEntries,
+          });
+          await persistFileProjectTranslationsStep({
+            organizationId,
+            projectId: claim.job.projectId,
+            jobId: claim.job.id,
+            sourcePath: repositorySourcePath,
+            sourceLocale: parsedInput.sourceLocale,
+            targetLocale,
+            sourceEntries,
+            targetEntries,
+          });
+        } catch (error) {
+          console.warn("[file-translation-workflow] incremental translation persistence failed", {
+            jobId: claim.job.id,
+            projectId: claim.job.projectId,
+            targetLocale,
+            attempt,
+            userFacingError: userFacingFailureReason(error, {
+              fileFormat: parsedInput.fileFormat,
+              sourceExtension: fileExtension(sourceFile.filename),
+              sandboxInputExtension: fileExtension(inputFilename),
+            }),
+          });
+        }
+      }
+    };
+
     const runHlForLocales = async (
       locales: string[],
       attempt: 1 | 2,
-      options?: { retryFeedback?: string; force?: boolean },
+      options?: { retryFeedback?: string; force?: boolean; maxTranslations?: number },
     ) => {
       const force = options?.force ?? true;
       const retryFeedback = options?.retryFeedback;
+      const maxTranslations =
+        options?.maxTranslations ?? FILE_TRANSLATION_MAX_TRANSLATIONS_PER_SESSION;
       const localeSet = new Set(locales);
       const runContext =
         context.glossaryTerms != null
@@ -776,7 +834,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
               .filter((locale) => prefilledByLocale[locale])
               .map((locale) => [locale, prefilledByLocale[locale]]),
           ),
-          { force: runForce },
+          { force: runForce, maxTranslations },
         );
 
       let translation: Awaited<ReturnType<typeof runTranslationStep>>;
@@ -825,6 +883,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         }
       }
 
+      const deferredByLimit = parseDeferredByLimit(translation.output);
       if (translation.exitCode !== 0) {
         const cliFailureKind = classifyCliFailureKind(translation.output);
         console.error("[file-translation-workflow] hl run failed", {
@@ -835,6 +894,8 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
           targetLocales: locales,
           attempt,
           force,
+          maxTranslations,
+          deferredByLimit,
           sandboxInputExtension: fileExtension(inputFilename),
           exitCode: translation.exitCode,
           cliOutputLength: translation.output.length,
@@ -843,7 +904,12 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
           hasRetryFeedback: Boolean(retryFeedback),
           sandboxId,
         });
-        return { ok: false as const, cliFailureKind, exitCode: translation.exitCode };
+        return {
+          ok: false as const,
+          cliFailureKind,
+          exitCode: translation.exitCode,
+          deferredByLimit,
+        };
       }
 
       console.info("[file-translation-workflow] hl run succeeded", {
@@ -853,9 +919,11 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         targetLocales: locales,
         attempt,
         force,
+        maxTranslations,
+        deferredByLimit,
         exitCode: translation.exitCode,
       });
-      return { ok: true as const };
+      return { ok: true as const, deferredByLimit };
     };
 
     const tryReadLocaleOutputs = async (locales: string[], attempt: 1 | 2) => {
@@ -874,24 +942,57 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
       return { readable, missing };
     };
 
-    // Happy path: one batched run for all locales. On non-zero exit, salvage
-    // any locale outputs the CLI already flushed, then retry only missing ones.
-    const batchResult = await runHlForLocales(parsedInput.targetLocales, 1, { force: true });
+    // Paginate hl run so large files stay under sandbox/workflow timeouts and
+    // project translations populate after each page.
+    let deferredByLimit = 0;
+    let page = 0;
     let localesNeedingWork = [...parsedInput.targetLocales];
+    let batchFailed = false;
 
-    if (batchResult.ok) {
-      const { missing } = await tryReadLocaleOutputs(parsedInput.targetLocales, 1);
-      localesNeedingWork = missing;
-    } else {
+    while (page < FILE_TRANSLATION_MAX_PAGES) {
+      // Page 0 may use --force for a clean slate. Later pages omit it so the
+      // lockfile skips completed tasks and advances through deferred work.
+      const batchResult = await runHlForLocales(parsedInput.targetLocales, 1, {
+        force: page === 0,
+        maxTranslations: FILE_TRANSLATION_MAX_TRANSLATIONS_PER_SESSION,
+      });
+      deferredByLimit = batchResult.deferredByLimit;
+
+      if (batchResult.ok) {
+        const { readable, missing } = await tryReadLocaleOutputs(parsedInput.targetLocales, 1);
+        localesNeedingWork = missing;
+        if (readable.length > 0) {
+          await persistReadableLocales(readable, 1);
+        }
+        console.info("[file-translation-workflow] hl run page completed", {
+          jobId: claim.job.id,
+          projectId: claim.job.projectId,
+          page,
+          deferredByLimit,
+          readableLocaleCount: readable.length,
+          missingLocaleCount: missing.length,
+        });
+        if (deferredByLimit <= 0) {
+          break;
+        }
+        page += 1;
+        continue;
+      }
+
       const { readable, missing } = await tryReadLocaleOutputs(parsedInput.targetLocales, 1);
       console.warn("[file-translation-workflow] batch hl run failed; salvaging readable outputs", {
         jobId: claim.job.id,
         projectId: claim.job.projectId,
+        page,
         readableLocales: readable,
         missingLocales: missing,
         cliFailureKind: batchResult.cliFailureKind,
         exitCode: batchResult.exitCode,
+        deferredByLimit,
       });
+      if (readable.length > 0) {
+        await persistReadableLocales(readable, 1);
+      }
       localesNeedingWork = missing;
       for (const locale of missing) {
         runFailures.push({
@@ -900,40 +1001,72 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
           exitCode: batchResult.exitCode,
         });
       }
+      batchFailed = true;
+      break;
+    }
+
+    if (!batchFailed && deferredByLimit > 0) {
+      throw new Error(
+        `translation pagination exceeded ${FILE_TRANSLATION_MAX_PAGES} pages with deferred_by_limit=${deferredByLimit}`,
+      );
     }
 
     // Retry missing locales individually so one bad locale cannot block the rest.
-    // Use --force: a failed batch may have checkpointed a locale before flushing output.
+    // Page 0 uses --force; later pages omit it so deferred work advances.
     if (localesNeedingWork.length > 0) {
       const stillMissing: string[] = [];
       for (const targetLocale of localesNeedingWork) {
-        const localeResult = await runHlForLocales([targetLocale], 1, { force: true });
-        if (!localeResult.ok) {
-          stillMissing.push(targetLocale);
-          // Replace batch-level failure with the per-locale one when available.
-          const idx = runFailures.findIndex((f) => f.locale === targetLocale);
-          const failure = {
-            locale: targetLocale,
-            kind: localeResult.cliFailureKind,
-            exitCode: localeResult.exitCode,
-          };
-          if (idx >= 0) {
-            runFailures[idx] = failure;
-          } else {
-            runFailures.push(failure);
-          }
-          continue;
-        }
-        const { missing } = await tryReadLocaleOutputs([targetLocale], 1);
-        if (missing.length > 0) {
-          stillMissing.push(targetLocale);
-          runFailures.push({
-            locale: targetLocale,
-            kind: "missing_output",
-            exitCode: 0,
+        let localeFailed = false;
+        for (let localePage = 0; localePage < FILE_TRANSLATION_MAX_PAGES; localePage += 1) {
+          const localeResult = await runHlForLocales([targetLocale], 1, {
+            force: localePage === 0,
+            maxTranslations: FILE_TRANSLATION_MAX_TRANSLATIONS_PER_SESSION,
           });
-        } else {
-          // Successfully recovered this locale; drop any prior batch failure record.
+          if (!localeResult.ok) {
+            stillMissing.push(targetLocale);
+            const idx = runFailures.findIndex((f) => f.locale === targetLocale);
+            const failure = {
+              locale: targetLocale,
+              kind: localeResult.cliFailureKind,
+              exitCode: localeResult.exitCode,
+            };
+            if (idx >= 0) {
+              runFailures[idx] = failure;
+            } else {
+              runFailures.push(failure);
+            }
+            localeFailed = true;
+            break;
+          }
+
+          const { readable, missing } = await tryReadLocaleOutputs([targetLocale], 1);
+          if (missing.length > 0) {
+            stillMissing.push(targetLocale);
+            runFailures.push({
+              locale: targetLocale,
+              kind: "missing_output",
+              exitCode: 0,
+            });
+            localeFailed = true;
+            break;
+          }
+          if (readable.length > 0) {
+            await persistReadableLocales(readable, 1);
+          }
+          if (localeResult.deferredByLimit <= 0) {
+            break;
+          }
+          if (localePage === FILE_TRANSLATION_MAX_PAGES - 1) {
+            stillMissing.push(targetLocale);
+            runFailures.push({
+              locale: targetLocale,
+              kind: "pagination_exhausted",
+              exitCode: 0,
+            });
+            localeFailed = true;
+          }
+        }
+        if (!localeFailed) {
           const idx = runFailures.findIndex((f) => f.locale === targetLocale);
           if (idx >= 0) {
             runFailures.splice(idx, 1);
@@ -997,6 +1130,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         const retryResult = await runHlForLocales([targetLocale], 2, {
           retryFeedback: feedback,
           force: true,
+          maxTranslations: FILE_TRANSLATION_MAX_TRANSLATIONS_PER_SESSION,
         });
         if (!retryResult.ok) {
           translatedByLocale.delete(targetLocale);

--- a/apps/hyperlocalise-web/src/workflows/file-translation-pagination.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-pagination.ts
@@ -1,0 +1,11 @@
+export const FILE_TRANSLATION_MAX_TRANSLATIONS_PER_SESSION = 1000;
+export const FILE_TRANSLATION_MAX_PAGES = 500;
+
+/** Parse `deferred_by_limit=N` from `hl run` stdout. Missing marker means 0. */
+export function parseDeferredByLimit(output: string): number {
+  const match = /\bdeferred_by_limit=(\d+)\b/.exec(output);
+  if (!match) {
+    return 0;
+  }
+  return Number.parseInt(match[1] ?? "0", 10) || 0;
+}

--- a/docs/plans/2026-07-09-multi-locale-file-translation-run-design.md
+++ b/docs/plans/2026-07-09-multi-locale-file-translation-run-design.md
@@ -55,6 +55,11 @@ Glossary terms for all locales stay in the system prompt (already tagged by loca
 - Sandbox disconnect: retry the same sandbox without `--force` first; recreate only if the session is still unusable.
 - Single-locale jobs use the same multi-locale path with one target.
 
+## Session pagination
+
+Large files paginate with `hl run --max-translations 1000`. See
+[`2026-07-10-run-max-translations-session-limit-design.md`](./2026-07-10-run-max-translations-session-limit-design.md).
+
 ## Testing
 
 - CLI: flat vs nested parse; reject mixed; nested applies across locales; nested + `--prefilled-target-path` errors; unknown locale warns.

--- a/docs/plans/2026-07-10-run-max-translations-session-limit-design.md
+++ b/docs/plans/2026-07-10-run-max-translations-session-limit-design.md
@@ -51,7 +51,7 @@ Notes:
 - Same-sandbox pagination relies on the lockfile only — no prefill mutation between pages.
 - If the sandbox is recreated mid-job, the lockfile is lost; that path may redo earlier keys (existing recreate limitation).
 - Incremental persist is best-effort (same as today's end-of-job persist). Failures log and continue.
-- Glossary retry keeps `--force` for the failed locale and can keep the same session cap.
+- Glossary retry keeps `--force` on page 0 for the failed locale, then pages without `--force` until `deferredByLimit` is 0 (same session cap).
 
 ## Errors
 

--- a/docs/plans/2026-07-10-run-max-translations-session-limit-design.md
+++ b/docs/plans/2026-07-10-run-max-translations-session-limit-design.md
@@ -1,0 +1,65 @@
+# Session limit for `hl run` translations
+
+## Problem
+
+Large file translation jobs can plan thousands of keys across locales. A single `hl run` in `fileTranslationJobWorkflow` can exceed sandbox/workflow timeouts. Users also wait until the whole run finishes before project translations appear.
+
+## Decision
+
+1. Add `hl run --max-translations N` to cap how many executable translation tasks run in one invocation (`0` = unlimited).
+2. After planning, lock filtering, and prefill, truncate the executable queue to `N` in plan order. Deferred tasks stay unlocked so a later run without `--force` continues.
+3. Report `deferredByLimit` (stdout + JSON summary) so callers know whether another page is needed.
+4. Update `fileTranslationJobWorkflow` to loop `hl run --max-translations 1000`, persist translations after each successful page, and stop when `deferredByLimit` is `0`.
+
+## CLI contract
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--max-translations` | `0` | Max executable tasks this session. `0` disables the cap. Negative values error. |
+
+Behavior:
+
+- Cap applies to **executable** tasks only (after lock skip + prefill reuse), not planned total.
+- Truncation keeps the first `N` tasks in deterministic plan order (sorted groups/buckets/keys/locales).
+- Partial target files still flush: existing flush already merges staged entries into the current target.
+- Exit `0` when the page succeeds even if work remains (`deferredByLimit > 0`).
+- `--force` still ignores lock skips for the planned set, then the cap applies. Pagination must omit `--force` on later pages or the same first `N` keys repeat.
+
+Report additions:
+
+- `deferredByLimit` — executable tasks not run because of the cap
+- stdout line: `deferred_by_limit=%d` (always printed; `0` when uncapped or fully drained)
+
+## Workflow
+
+```text
+page = 0
+loop:
+  hl run --max-translations 1000 [--force only on page 0]
+  if exit != 0 → existing salvage / per-locale retry (also capped)
+  for each locale with readable output:
+    extract entries → persist TM + project translations (incremental)
+  if deferredByLimit == 0 → break
+  page++
+glossary validate / retry (unchanged, per failed locale)
+complete job
+```
+
+Notes:
+
+- Fresh sandbox has an empty lock; page 0 may use `--force` for a clean slate. Later pages omit `--force` so completed lock entries are skipped.
+- Same-sandbox pagination relies on the lockfile only — no prefill mutation between pages.
+- If the sandbox is recreated mid-job, the lockfile is lost; that path may redo earlier keys (existing recreate limitation).
+- Incremental persist is best-effort (same as today's end-of-job persist). Failures log and continue.
+- Glossary retry keeps `--force` for the failed locale and can keep the same session cap.
+
+## Errors
+
+- `--max-translations < 0` → CLI validation error
+- Page failure → existing salvage/retry; do not advance the pagination cursor past failed work
+- Sandbox disconnect → existing same-sandbox resume without `--force`, then recreate
+
+## Testing
+
+- CLI: flag plumbing; truncate executable; deferred count; next run without force continues; force + limit redoes the head of the queue
+- Web: pagination loop stops when deferred is 0; page 0 uses force, later pages do not; persist called between pages


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Large file translation jobs can plan thousands of keys and time out a single `hl run` inside `fileTranslationJobWorkflow`. This adds a session cap so the workflow can page through work and persist translations as each page finishes.

## Changes

- **CLI:** `hl run --max-translations N` caps executable tasks after lock filtering and prefill (`0` = unlimited). Deferred tasks stay unlocked; report includes `deferred_by_limit`.
- **Workflow:** `fileTranslationJobWorkflow` loops `hl run --max-translations 1000`, persists TM/project translations after each successful page, and continues until `deferred_by_limit=0`.
- Page 0 may use `--force`; later pages omit it so the lockfile skips completed work (no prefill mutation between pages).
- Glossary retries also page until deferred work is drained (same force/no-force pattern).

## Testing

- `go test` for max-translations CLI/runsvc cases
- `vp test` for `parseDeferredByLimit`
- `make fmt` / `make lint`
- `vp check --fix` in `apps/hyperlocalise-web`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-758ce74a-7a56-4766-a60d-7193f761e558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-758ce74a-7a56-4766-a60d-7193f761e558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

