### PR TITLE
feat(web): localize app shell UI with react-intl

### DIFF
--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-breadcrumb.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-breadcrumb.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { observer } from "mobx-react-lite";
+import { useIntl } from "react-intl";
 
 import {
   Breadcrumb,
@@ -28,6 +29,7 @@ type AppShellBreadcrumbProps = {
 export const AppShellBreadcrumb = observer(function AppShellBreadcrumb({
   organizationSlug,
 }: AppShellBreadcrumbProps) {
+  const intl = useIntl();
   const store = useAppShellStore();
   const pathname = usePathname();
   const projectRoute = parseProjectRoute(pathname);
@@ -52,7 +54,7 @@ export const AppShellBreadcrumb = observer(function AppShellBreadcrumb({
   });
 
   const breadcrumbs = store.breadcrumb.applyOverrides(
-    getAppShellBreadcrumbs(pathname, {
+    getAppShellBreadcrumbs(pathname, intl, {
       projectName: projectQuery.data?.name,
     }),
   );

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.messages.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const appShellClientMessages = defineMessages({
+  logoAlt: {
+    defaultMessage: "Hyperlocalise logo",
+    id: "YEpKGG3Nzw",
+    description: "Alt text for the Hyperlocalise logo in the app shell sidebar",
+  },
+  brandName: {
+    defaultMessage: "Hyperlocalise",
+    id: "bAOcwldO3V",
+    description: "Product name shown next to the logo in the app shell sidebar",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
@@ -2,6 +2,7 @@
 
 import type { CSSProperties, ReactNode } from "react";
 import Image from "next/image";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { PlanUsageSidebarWidget } from "@/components/billing/plan-usage-summary";
 import {
@@ -28,6 +29,8 @@ import { useTmsUserConnectCta } from "@/app/[lang]/(authenticated)/org/[organiza
 import { NavUser } from "./nav-user";
 import { Separator } from "@/components/ui/separator";
 import { TypographyP } from "@/components/ui/typography";
+
+import { appShellClientMessages } from "./app-shell-client.messages";
 
 type AppShellClientProps = {
   autumnConfigured?: boolean;
@@ -63,6 +66,7 @@ export function AppShellClient({
   showMembersLink = false,
   user,
 }: AppShellClientProps) {
+  const intl = useIntl();
   const organizationSlug = activeOrganization.slug ?? "";
   const tmsUserConnectQuery = useTmsUserConnectCta(organizationSlug, {
     enabled: Boolean(organizationSlug),
@@ -87,12 +91,12 @@ export function AppShellClient({
                 width={28}
                 height={28}
                 sizes="28px"
-                alt="Hyperlocalise logo"
+                alt={intl.formatMessage(appShellClientMessages.logoAlt)}
                 className="size-7 shrink-0 rounded-lg"
               />
               <div className="min-w-0 group-data-[collapsible=icon]:hidden">
                 <TypographyP className="truncate text-sm font-medium text-sidebar-foreground">
-                  Hyperlocalise
+                  <FormattedMessage {...appShellClientMessages.brandName} />
                 </TypographyP>
               </div>
             </div>
@@ -111,7 +115,7 @@ export function AppShellClient({
 
         <SidebarInset className="min-h-svh bg-background">
           <div className="sticky top-0 z-20 border-b border-border bg-background/96 backdrop-blur">
-            <div className="flex h-[var(--app-shell-header-height)] items-center justify-between gap-3 px-4 sm:px-6 lg:px-8">
+            <div className="flex h-(--app-shell-header-height) items-center justify-between gap-3 px-4 sm:px-6 lg:px-8">
               <div className="flex min-w-0 items-center gap-3">
                 <SidebarTrigger className="-ms-1" />
                 <Separator

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.messages.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const appShellNavigationMessages = defineMessages({
+  allProjects: {
+    defaultMessage: "All projects",
+    id: "SUXI1fXBfn",
+    description: "Sidebar link to return from a project to the projects list",
+  },
+  projectSection: {
+    defaultMessage: "Project",
+    id: "73pQzYGwei",
+    description: "Sidebar section label above the current project name and project nav items",
+  },
+  projectFallbackName: {
+    defaultMessage: "Project",
+    id: "E2040akAix",
+    description: "Fallback project name in the sidebar while the project is loading",
+  },
+  badgeSeparator: {
+    defaultMessage: "{label} · {badge}",
+    id: "90L8I4Y/Gl",
+    description: "Sidebar tooltip combining a navigation item label and its badge",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
@@ -6,6 +6,7 @@ import { ArrowDown01Icon, ArrowLeft01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useQuery } from "@tanstack/react-query";
 import { observer } from "mobx-react-lite";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import {
@@ -20,6 +21,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { apiClient } from "@/lib/api-client-instance";
 import { cn } from "@/lib/primitives/cn";
 
+import { appShellNavigationMessages } from "./app-shell-navigation.messages";
 import {
   buildOrganizationPath,
   buildProjectNavigationItems,
@@ -145,6 +147,7 @@ function ProjectNavigation({
   projectName?: string;
   items?: readonly NavigationItem[];
 }) {
+  const intl = useIntl();
   const projectQuery = useQuery({
     queryKey: ["translation-project", organizationSlug, projectId],
     enabled: !projectName && !items,
@@ -160,9 +163,13 @@ function ProjectNavigation({
     },
   });
 
-  const resolvedItems = items ?? buildProjectNavigationItems(organizationSlug, projectId);
-  const resolvedProjectName = projectName ?? projectQuery.data?.name ?? "Project";
+  const resolvedItems = items ?? buildProjectNavigationItems(organizationSlug, projectId, intl);
+  const resolvedProjectName =
+    projectName ??
+    projectQuery.data?.name ??
+    intl.formatMessage(appShellNavigationMessages.projectFallbackName);
   const projectsHref = buildOrganizationPath(organizationSlug, "projects");
+  const allProjectsLabel = intl.formatMessage(appShellNavigationMessages.allProjects);
 
   return (
     <div className="flex flex-col gap-3">
@@ -172,11 +179,13 @@ function ProjectNavigation({
             <SidebarMenuItem>
               <SidebarMenuButton
                 render={<Link href={projectsHref} />}
-                tooltip="All projects"
+                tooltip={allProjectsLabel}
                 className="h-8 rounded-md px-2.5 text-sm font-medium text-muted-foreground hover:text-sidebar-foreground group-data-[collapsible=icon]:size-8!"
               >
                 <HugeiconsIcon icon={ArrowLeft01Icon} strokeWidth={2} className="size-4" />
-                <span>All projects</span>
+                <span>
+                  <FormattedMessage {...appShellNavigationMessages.allProjects} />
+                </span>
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>
@@ -185,7 +194,7 @@ function ProjectNavigation({
 
       <SidebarGroup className="gap-1 p-0">
         <SidebarGroupLabel className="h-auto px-3 py-1 text-xs font-medium tracking-wide text-muted-foreground uppercase group-data-[collapsible=icon]:hidden">
-          Project
+          <FormattedMessage {...appShellNavigationMessages.projectSection} />
         </SidebarGroupLabel>
         <div className="px-3 pb-1 group-data-[collapsible=icon]:hidden">
           {!projectName && projectQuery.isLoading ? (
@@ -218,6 +227,8 @@ function NavigationGroupItems({
   organizationSlug: string;
   projectId?: string;
 }) {
+  const intl = useIntl();
+
   return (
     <SidebarGroupContent>
       <SidebarMenu className="gap-1">
@@ -226,13 +237,19 @@ function NavigationGroupItems({
             projectId,
             organizationSlug,
           });
+          const tooltip = item.badge
+            ? intl.formatMessage(appShellNavigationMessages.badgeSeparator, {
+                label: item.label,
+                badge: item.badge,
+              })
+            : item.label;
 
           return (
             <SidebarMenuItem key={item.href}>
               <SidebarMenuButton
                 render={<Link href={item.href} />}
                 isActive={isActive}
-                tooltip={item.badge ? `${item.label} · ${item.badge}` : item.label}
+                tooltip={tooltip}
                 className={navigationButtonClass(isActive)}
               >
                 <HugeiconsIcon icon={item.icon} strokeWidth={2} className="size-4" />

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
@@ -17,6 +17,7 @@ describe("getAppShellTitle", () => {
     ["/org/acme/projects/proj_1", "proj_1"],
     ["/org/acme/projects/proj_1/files", "Files"],
     ["/org/acme/projects/proj_1/jobs", "Jobs"],
+    ["/org/acme/projects/proj_1/issue-sheet", "Issue Sheet"],
     ["/org/acme/projects/proj_1/agent-runs", "Agent Runs"],
     ["/org/acme/projects/proj_1/activity", "Activity"],
     ["/org/acme/projects/proj_1/context", "Context"],
@@ -102,6 +103,18 @@ describe("getAppShellBreadcrumbs", () => {
       { label: "Projects", href: "/org/acme/projects" },
       { label: "proj_1", href: "/org/acme/projects/proj_1" },
       { label: "Jobs" },
+    ]);
+  });
+
+  it("returns issue sheet breadcrumbs for the project issue-sheet section", () => {
+    expect(
+      getAppShellBreadcrumbs("/org/acme/projects/proj_1/issue-sheet", intl, {
+        projectName: "Checkout",
+      }),
+    ).toEqual([
+      { label: "Projects", href: "/org/acme/projects" },
+      { label: "Checkout", href: "/org/acme/projects/proj_1" },
+      { label: "Issue Sheet" },
     ]);
   });
 

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vite-plus/test";
+import type { IntlShape } from "react-intl";
+
+import { getIntlShape } from "@/lib/app-i18n/intl";
 
 import { getAppShellBreadcrumbs, getAppShellTitle } from "./app-shell-title";
+
+const intl = getIntlShape("en") as IntlShape;
 
 describe("getAppShellTitle", () => {
   it.each([
@@ -33,58 +38,58 @@ describe("getAppShellTitle", () => {
     ["/org/acme/settings/account", "Account"],
     ["/org/acme/settings/billing", "Billing"],
   ])("returns the route title for %s", (pathname, title) => {
-    expect(getAppShellTitle(pathname)).toBe(title);
+    expect(getAppShellTitle(pathname, intl)).toBe(title);
   });
 
   it("falls back to overview for unknown or empty paths", () => {
-    expect(getAppShellTitle(null)).toBe("Overview");
-    expect(getAppShellTitle("")).toBe("Overview");
-    expect(getAppShellTitle("/org/acme/unknown")).toBe("Overview");
+    expect(getAppShellTitle(null, intl)).toBe("Overview");
+    expect(getAppShellTitle("", intl)).toBe("Overview");
+    expect(getAppShellTitle("/org/acme/unknown", intl)).toBe("Overview");
   });
 
   it("falls back to overview when the org slug is missing", () => {
-    expect(getAppShellTitle("/org")).toBe("Overview");
-    expect(getAppShellTitle("/org/")).toBe("Overview");
-    expect(getAppShellTitle("/dashboard")).toBe("Overview");
+    expect(getAppShellTitle("/org", intl)).toBe("Overview");
+    expect(getAppShellTitle("/org/", intl)).toBe("Overview");
+    expect(getAppShellTitle("/dashboard", intl)).toBe("Overview");
   });
 
   it("resolves the title from locale-prefixed paths", () => {
-    expect(getAppShellTitle("/en/org/acme/inbox")).toBe("Inbox");
-    expect(getAppShellTitle("/en/org/acme/settings/billing")).toBe("Billing");
+    expect(getAppShellTitle("/en/org/acme/inbox", intl)).toBe("Inbox");
+    expect(getAppShellTitle("/en/org/acme/settings/billing", intl)).toBe("Billing");
   });
 
   it("uses the project id as the title for unknown project sections", () => {
-    expect(getAppShellTitle("/org/acme/projects/proj_1/unknown-section")).toBe("proj_1");
+    expect(getAppShellTitle("/org/acme/projects/proj_1/unknown-section", intl)).toBe("proj_1");
   });
 });
 
 describe("getAppShellBreadcrumbs", () => {
   it("returns a single crumb for top-level routes", () => {
-    expect(getAppShellBreadcrumbs("/org/acme/inbox")).toEqual([{ label: "Inbox" }]);
+    expect(getAppShellBreadcrumbs("/org/acme/inbox", intl)).toEqual([{ label: "Inbox" }]);
   });
 
   it("returns settings breadcrumbs for settings subpages", () => {
-    expect(getAppShellBreadcrumbs("/org/acme/settings/account")).toEqual([
+    expect(getAppShellBreadcrumbs("/org/acme/settings/account", intl)).toEqual([
       { label: "Settings", href: "/org/acme/settings" },
       { label: "Account" },
     ]);
   });
 
   it("returns teams breadcrumbs for team detail pages", () => {
-    expect(getAppShellBreadcrumbs("/org/acme/teams")).toEqual([{ label: "Teams" }]);
-    expect(getAppShellBreadcrumbs("/org/acme/teams/team_1")).toEqual([
+    expect(getAppShellBreadcrumbs("/org/acme/teams", intl)).toEqual([{ label: "Teams" }]);
+    expect(getAppShellBreadcrumbs("/org/acme/teams/team_1", intl)).toEqual([
       { label: "Teams", href: "/org/acme/teams" },
       { label: "team_1" },
     ]);
   });
 
   it("returns members breadcrumbs", () => {
-    expect(getAppShellBreadcrumbs("/org/acme/members")).toEqual([{ label: "Members" }]);
+    expect(getAppShellBreadcrumbs("/org/acme/members", intl)).toEqual([{ label: "Members" }]);
   });
 
   it("returns project breadcrumbs with the project name", () => {
     expect(
-      getAppShellBreadcrumbs("/org/acme/projects/proj_1/files", { projectName: "Checkout" }),
+      getAppShellBreadcrumbs("/org/acme/projects/proj_1/files", intl, { projectName: "Checkout" }),
     ).toEqual([
       { label: "Projects", href: "/org/acme/projects" },
       { label: "Checkout", href: "/org/acme/projects/proj_1" },
@@ -93,7 +98,7 @@ describe("getAppShellBreadcrumbs", () => {
   });
 
   it("falls back to the project id when the project name is unavailable", () => {
-    expect(getAppShellBreadcrumbs("/org/acme/projects/proj_1/jobs")).toEqual([
+    expect(getAppShellBreadcrumbs("/org/acme/projects/proj_1/jobs", intl)).toEqual([
       { label: "Projects", href: "/org/acme/projects" },
       { label: "proj_1", href: "/org/acme/projects/proj_1" },
       { label: "Jobs" },
@@ -102,60 +107,62 @@ describe("getAppShellBreadcrumbs", () => {
 
   it("returns project overview breadcrumbs without a section crumb", () => {
     expect(
-      getAppShellBreadcrumbs("/org/acme/projects/proj_1", { projectName: "Checkout" }),
+      getAppShellBreadcrumbs("/org/acme/projects/proj_1", intl, { projectName: "Checkout" }),
     ).toEqual([{ label: "Projects", href: "/org/acme/projects" }, { label: "Checkout" }]);
-    expect(getAppShellBreadcrumbs("/org/acme/projects/proj_1")).toEqual([
+    expect(getAppShellBreadcrumbs("/org/acme/projects/proj_1", intl)).toEqual([
       { label: "Projects", href: "/org/acme/projects" },
       { label: "proj_1" },
     ]);
   });
 
   it("falls back to the dashboard crumb when there is no org route", () => {
-    expect(getAppShellBreadcrumbs(null)).toEqual([{ label: "Overview" }]);
-    expect(getAppShellBreadcrumbs("")).toEqual([{ label: "Overview" }]);
-    expect(getAppShellBreadcrumbs("/org")).toEqual([{ label: "Overview" }]);
-    expect(getAppShellBreadcrumbs("/dashboard")).toEqual([{ label: "Overview" }]);
+    expect(getAppShellBreadcrumbs(null, intl)).toEqual([{ label: "Overview" }]);
+    expect(getAppShellBreadcrumbs("", intl)).toEqual([{ label: "Overview" }]);
+    expect(getAppShellBreadcrumbs("/org", intl)).toEqual([{ label: "Overview" }]);
+    expect(getAppShellBreadcrumbs("/dashboard", intl)).toEqual([{ label: "Overview" }]);
   });
 
   it("resolves breadcrumbs from locale-prefixed paths", () => {
-    expect(getAppShellBreadcrumbs("/en/org/acme/settings/account")).toEqual([
+    expect(getAppShellBreadcrumbs("/en/org/acme/settings/account", intl)).toEqual([
       { label: "Settings", href: "/org/acme/settings" },
       { label: "Account" },
     ]);
   });
 
   it("returns the settings section verbatim for unknown subsections", () => {
-    expect(getAppShellBreadcrumbs("/org/acme/settings/unknown")).toEqual([
+    expect(getAppShellBreadcrumbs("/org/acme/settings/unknown", intl)).toEqual([
       { label: "Settings", href: "/org/acme/settings" },
       { label: "unknown" },
     ]);
   });
 
   it("decodes encoded team detail segments", () => {
-    expect(getAppShellBreadcrumbs("/org/acme/teams/team%20alpha")).toEqual([
+    expect(getAppShellBreadcrumbs("/org/acme/teams/team%20alpha", intl)).toEqual([
       { label: "Teams", href: "/org/acme/teams" },
       { label: "team alpha" },
     ]);
   });
 
   it("keeps a malformed team segment untouched when it cannot be decoded", () => {
-    expect(getAppShellBreadcrumbs("/org/acme/teams/%E0%A4%A")).toEqual([
+    expect(getAppShellBreadcrumbs("/org/acme/teams/%E0%A4%A", intl)).toEqual([
       { label: "Teams", href: "/org/acme/teams" },
       { label: "%E0%A4%A" },
     ]);
   });
 
   it("decodes encoded external project ids while keeping hrefs encoded", () => {
-    expect(getAppShellBreadcrumbs("/org/acme/projects/ext%3Acrowdin%3A902807/files")).toEqual([
-      { label: "Projects", href: "/org/acme/projects" },
-      { label: "ext:crowdin:902807", href: "/org/acme/projects/ext%3Acrowdin%3A902807" },
-      { label: "Files" },
-    ]);
+    expect(getAppShellBreadcrumbs("/org/acme/projects/ext%3Acrowdin%3A902807/files", intl)).toEqual(
+      [
+        { label: "Projects", href: "/org/acme/projects" },
+        { label: "ext:crowdin:902807", href: "/org/acme/projects/ext%3Acrowdin%3A902807" },
+        { label: "Files" },
+      ],
+    );
   });
 
   it("ignores unknown project sections and keeps the project crumb", () => {
     expect(
-      getAppShellBreadcrumbs("/org/acme/projects/proj_1/unknown-section", {
+      getAppShellBreadcrumbs("/org/acme/projects/proj_1/unknown-section", intl, {
         projectName: "Checkout",
       }),
     ).toEqual([{ label: "Projects", href: "/org/acme/projects" }, { label: "Checkout" }]);
@@ -163,7 +170,7 @@ describe("getAppShellBreadcrumbs", () => {
 
   it("falls back to the project id when the project name is only whitespace", () => {
     expect(
-      getAppShellBreadcrumbs("/org/acme/projects/proj_1/files", { projectName: "   " }),
+      getAppShellBreadcrumbs("/org/acme/projects/proj_1/files", intl, { projectName: "   " }),
     ).toEqual([
       { label: "Projects", href: "/org/acme/projects" },
       { label: "proj_1", href: "/org/acme/projects/proj_1" },

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
@@ -1,56 +1,94 @@
-const ROUTE_TITLES = {
-  account: "Account",
-  activity: "Activity",
-  "agent-runs": "Agent Runs",
-  "api-keys": "API Keys",
-  billing: "Billing",
-  chat: "New Request",
-  dashboard: "Overview",
-  files: "Files",
-  glossaries: "Glossaries",
-  inbox: "Inbox",
-  integrations: "Integrations",
-  issues: "Issues",
-  "issue-sheet": "Issue Sheet",
-  jobs: "Jobs",
-  knowledge: "Knowledge",
-  locales: "Locales",
-  members: "Members",
-  "my-jobs": "My Jobs",
-  "my-work": "My Jobs",
-  "new-request": "New Request",
-  projects: "Projects",
-  qa: "QA",
-  reviews: "Reviews",
-  settings: "Settings",
-  teams: "Teams",
-  "translation-memories": "Translation Memories",
-} as const;
+import type { IntlShape } from "react-intl";
 
 export type AppShellBreadcrumb = {
   label: string;
   href?: string;
 };
 
-const PROJECT_SECTION_TITLES = {
-  activity: "Activity",
-  "agent-runs": "Agent Runs",
-  context: "Context",
-  files: "Files",
-  "issue-sheet": "Issue Sheet",
-  jobs: "Jobs",
-  locales: "Locales",
-  qa: "QA",
-  reviews: "Reviews",
-  settings: "Settings",
-} as const;
+type RouteTitleKey =
+  | "account"
+  | "activity"
+  | "agent-runs"
+  | "api-keys"
+  | "billing"
+  | "chat"
+  | "dashboard"
+  | "files"
+  | "glossaries"
+  | "inbox"
+  | "integrations"
+  | "issues"
+  | "issue-sheet"
+  | "jobs"
+  | "knowledge"
+  | "locales"
+  | "members"
+  | "my-jobs"
+  | "my-work"
+  | "new-request"
+  | "projects"
+  | "qa"
+  | "reviews"
+  | "settings"
+  | "teams"
+  | "translation-memories";
 
-function isRouteTitleKey(value: string): value is keyof typeof ROUTE_TITLES {
-  return value in ROUTE_TITLES;
+type ProjectSectionKey =
+  | "activity"
+  | "agent-runs"
+  | "context"
+  | "files"
+  | "issue-sheet"
+  | "jobs"
+  | "locales"
+  | "qa"
+  | "reviews"
+  | "settings";
+
+function isRouteTitleKey(value: string): value is RouteTitleKey {
+  return (
+    value === "account" ||
+    value === "activity" ||
+    value === "agent-runs" ||
+    value === "api-keys" ||
+    value === "billing" ||
+    value === "chat" ||
+    value === "dashboard" ||
+    value === "files" ||
+    value === "glossaries" ||
+    value === "inbox" ||
+    value === "integrations" ||
+    value === "issues" ||
+    value === "issue-sheet" ||
+    value === "jobs" ||
+    value === "knowledge" ||
+    value === "locales" ||
+    value === "members" ||
+    value === "my-jobs" ||
+    value === "my-work" ||
+    value === "new-request" ||
+    value === "projects" ||
+    value === "qa" ||
+    value === "reviews" ||
+    value === "settings" ||
+    value === "teams" ||
+    value === "translation-memories"
+  );
 }
 
-function isProjectSectionKey(value: string): value is keyof typeof PROJECT_SECTION_TITLES {
-  return value in PROJECT_SECTION_TITLES;
+function isProjectSectionKey(value: string): value is ProjectSectionKey {
+  return (
+    value === "activity" ||
+    value === "agent-runs" ||
+    value === "context" ||
+    value === "files" ||
+    value === "issue-sheet" ||
+    value === "jobs" ||
+    value === "locales" ||
+    value === "qa" ||
+    value === "reviews" ||
+    value === "settings"
+  );
 }
 
 function parseOrgRoute(pathname: string | null) {
@@ -87,17 +125,181 @@ function decodePathSegment(value: string) {
   }
 }
 
-function routeTitle(segment: string) {
-  return isRouteTitleKey(segment) ? ROUTE_TITLES[segment] : segment;
+function routeTitle(intl: IntlShape, segment: string) {
+  return isRouteTitleKey(segment) ? formatRouteTitle(intl, segment) : segment;
+}
+
+function formatRouteTitle(intl: IntlShape, key: RouteTitleKey): string {
+  switch (key) {
+    case "account":
+      return intl.formatMessage({
+        defaultMessage: "Account",
+        id: "tMPM8tkhJg",
+        description: "App shell breadcrumb title for the account settings page",
+      });
+    case "activity":
+      return intl.formatMessage({
+        defaultMessage: "Activity",
+        id: "rW0O4vxb9w",
+        description: "App shell breadcrumb title for the activity page",
+      });
+    case "agent-runs":
+      return intl.formatMessage({
+        defaultMessage: "Agent Runs",
+        id: "2he28Pg1K2",
+        description: "App shell breadcrumb title for the agent runs page",
+      });
+    case "api-keys":
+      return intl.formatMessage({
+        defaultMessage: "API Keys",
+        id: "BuW96vtm0m",
+        description: "App shell breadcrumb title for the API keys settings page",
+      });
+    case "billing":
+      return intl.formatMessage({
+        defaultMessage: "Billing",
+        id: "Rn6kkInOe/",
+        description: "App shell breadcrumb title for the billing settings page",
+      });
+    case "chat":
+    case "new-request":
+      return intl.formatMessage({
+        defaultMessage: "New Request",
+        id: "iC/MBnVVSN",
+        description: "App shell breadcrumb title for the new request page",
+      });
+    case "dashboard":
+      return intl.formatMessage({
+        defaultMessage: "Overview",
+        id: "cQIBb8VVUr",
+        description: "App shell breadcrumb title for the workspace overview page",
+      });
+    case "files":
+      return intl.formatMessage({
+        defaultMessage: "Files",
+        id: "CGit9CSACq",
+        description: "App shell breadcrumb title for the files page",
+      });
+    case "glossaries":
+      return intl.formatMessage({
+        defaultMessage: "Glossaries",
+        id: "Qbn+bjzsz0",
+        description: "App shell breadcrumb title for the glossaries page",
+      });
+    case "inbox":
+      return intl.formatMessage({
+        defaultMessage: "Inbox",
+        id: "2f2Oa8dJQI",
+        description: "App shell breadcrumb title for the inbox page",
+      });
+    case "integrations":
+      return intl.formatMessage({
+        defaultMessage: "Integrations",
+        id: "XOLvGAW68Q",
+        description: "App shell breadcrumb title for the integrations page",
+      });
+    case "issues":
+      return intl.formatMessage({
+        defaultMessage: "Issues",
+        id: "RtEbYHhw1P",
+        description: "App shell breadcrumb title for the issues page",
+      });
+    case "issue-sheet":
+      return intl.formatMessage({
+        defaultMessage: "Issue Sheet",
+        id: "FRn2vWc0wk",
+        description: "App shell breadcrumb title for the issue sheet page",
+      });
+    case "jobs":
+      return intl.formatMessage({
+        defaultMessage: "Jobs",
+        id: "WzPTL0QId6",
+        description: "App shell breadcrumb title for the jobs page",
+      });
+    case "knowledge":
+      return intl.formatMessage({
+        defaultMessage: "Knowledge",
+        id: "T+wQxH/IG1",
+        description: "App shell breadcrumb title for the knowledge page",
+      });
+    case "locales":
+      return intl.formatMessage({
+        defaultMessage: "Locales",
+        id: "s+WyHO3V5f",
+        description: "App shell breadcrumb title for the locales page",
+      });
+    case "members":
+      return intl.formatMessage({
+        defaultMessage: "Members",
+        id: "p97Cor56nd",
+        description: "App shell breadcrumb title for the members page",
+      });
+    case "my-jobs":
+    case "my-work":
+      return intl.formatMessage({
+        defaultMessage: "My Jobs",
+        id: "YM1jd5PwaY",
+        description: "App shell breadcrumb title for the my jobs page",
+      });
+    case "projects":
+      return intl.formatMessage({
+        defaultMessage: "Projects",
+        id: "A0qlCRVH2r",
+        description: "App shell breadcrumb title for the projects page",
+      });
+    case "qa":
+      return intl.formatMessage({
+        defaultMessage: "QA",
+        id: "A4tXh3Cw8D",
+        description: "App shell breadcrumb title for the QA page",
+      });
+    case "reviews":
+      return intl.formatMessage({
+        defaultMessage: "Reviews",
+        id: "2uwHtwT4Tc",
+        description: "App shell breadcrumb title for the reviews page",
+      });
+    case "settings":
+      return intl.formatMessage({
+        defaultMessage: "Settings",
+        id: "5Xs2gSCUMi",
+        description: "App shell breadcrumb title for the settings page",
+      });
+    case "teams":
+      return intl.formatMessage({
+        defaultMessage: "Teams",
+        id: "LD3YSKplTh",
+        description: "App shell breadcrumb title for the teams page",
+      });
+    case "translation-memories":
+      return intl.formatMessage({
+        defaultMessage: "Translation Memories",
+        id: "vbaH3BSX3d",
+        description: "App shell breadcrumb title for the translation memories page",
+      });
+  }
+}
+
+function formatProjectSectionTitle(intl: IntlShape, key: ProjectSectionKey): string {
+  if (key === "context") {
+    return intl.formatMessage({
+      defaultMessage: "Context",
+      id: "FkLEYWNws0",
+      description: "App shell breadcrumb title for a project context section",
+    });
+  }
+
+  return formatRouteTitle(intl, key);
 }
 
 export function getAppShellBreadcrumbs(
   pathname: string | null,
+  intl: IntlShape,
   options?: { projectName?: string },
 ): AppShellBreadcrumb[] {
   const orgRoute = parseOrgRoute(pathname);
   if (!orgRoute) {
-    return [{ label: ROUTE_TITLES.dashboard }];
+    return [{ label: formatRouteTitle(intl, "dashboard") }];
   }
 
   const { organizationSlug, routeSegments } = orgRoute;
@@ -105,28 +307,31 @@ export function getAppShellBreadcrumbs(
 
   if (section === "settings") {
     if (!subsection) {
-      return [{ label: ROUTE_TITLES.settings }];
+      return [{ label: formatRouteTitle(intl, "settings") }];
     }
 
     return [
-      { label: ROUTE_TITLES.settings, href: buildOrgPath(organizationSlug, "settings") },
-      { label: routeTitle(subsection) },
+      {
+        label: formatRouteTitle(intl, "settings"),
+        href: buildOrgPath(organizationSlug, "settings"),
+      },
+      { label: routeTitle(intl, subsection) },
     ];
   }
 
   if (section === "teams") {
     if (!subsection) {
-      return [{ label: ROUTE_TITLES.teams }];
+      return [{ label: formatRouteTitle(intl, "teams") }];
     }
 
     return [
-      { label: ROUTE_TITLES.teams, href: buildOrgPath(organizationSlug, "teams") },
+      { label: formatRouteTitle(intl, "teams"), href: buildOrgPath(organizationSlug, "teams") },
       { label: decodePathSegment(subsection) },
     ];
   }
 
   if (section === "members") {
-    return [{ label: ROUTE_TITLES.members }];
+    return [{ label: formatRouteTitle(intl, "members") }];
   }
 
   if (section === "projects" && subsection) {
@@ -136,30 +341,36 @@ export function getAppShellBreadcrumbs(
 
     if (projectSection && isProjectSectionKey(projectSection)) {
       return [
-        { label: ROUTE_TITLES.projects, href: buildOrgPath(organizationSlug, "projects") },
+        {
+          label: formatRouteTitle(intl, "projects"),
+          href: buildOrgPath(organizationSlug, "projects"),
+        },
         { label: projectLabel, href: projectHref },
-        { label: PROJECT_SECTION_TITLES[projectSection] },
+        { label: formatProjectSectionTitle(intl, projectSection) },
       ];
     }
 
     return [
-      { label: ROUTE_TITLES.projects, href: buildOrgPath(organizationSlug, "projects") },
+      {
+        label: formatRouteTitle(intl, "projects"),
+        href: buildOrgPath(organizationSlug, "projects"),
+      },
       { label: projectLabel },
     ];
   }
 
   if (section === "projects") {
-    return [{ label: ROUTE_TITLES.projects }];
+    return [{ label: formatRouteTitle(intl, "projects") }];
   }
 
   if (section && isRouteTitleKey(section)) {
-    return [{ label: ROUTE_TITLES[section] }];
+    return [{ label: formatRouteTitle(intl, section) }];
   }
 
-  return [{ label: ROUTE_TITLES.dashboard }];
+  return [{ label: formatRouteTitle(intl, "dashboard") }];
 }
 
-export function getAppShellTitle(pathname: string | null): string {
-  const breadcrumbs = getAppShellBreadcrumbs(pathname);
-  return breadcrumbs[breadcrumbs.length - 1]?.label ?? ROUTE_TITLES.dashboard;
+export function getAppShellTitle(pathname: string | null, intl: IntlShape): string {
+  const breadcrumbs = getAppShellBreadcrumbs(pathname, intl);
+  return breadcrumbs[breadcrumbs.length - 1]?.label ?? formatRouteTitle(intl, "dashboard");
 }

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
@@ -33,17 +33,20 @@ type RouteTitleKey =
   | "teams"
   | "translation-memories";
 
-type ProjectSectionKey =
-  | "activity"
-  | "agent-runs"
-  | "context"
-  | "files"
-  | "issue-sheet"
-  | "jobs"
-  | "locales"
-  | "qa"
-  | "reviews"
-  | "settings";
+const PROJECT_SECTION_KEYS = {
+  activity: true,
+  "agent-runs": true,
+  context: true,
+  files: true,
+  "issue-sheet": true,
+  jobs: true,
+  locales: true,
+  qa: true,
+  reviews: true,
+  settings: true,
+} as const;
+
+type ProjectSectionKey = keyof typeof PROJECT_SECTION_KEYS;
 
 function isRouteTitleKey(value: string): value is RouteTitleKey {
   return (
@@ -77,18 +80,7 @@ function isRouteTitleKey(value: string): value is RouteTitleKey {
 }
 
 function isProjectSectionKey(value: string): value is ProjectSectionKey {
-  return (
-    value === "activity" ||
-    value === "agent-runs" ||
-    value === "context" ||
-    value === "files" ||
-    value === "issue-sheet" ||
-    value === "jobs" ||
-    value === "locales" ||
-    value === "qa" ||
-    value === "reviews" ||
-    value === "settings"
-  );
+  return value in PROJECT_SECTION_KEYS;
 }
 
 function parseOrgRoute(pathname: string | null) {

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
@@ -3,6 +3,8 @@ import type { ReactNode } from "react";
 import { hasCapability } from "@/api/auth/policy";
 import { AppShellClient } from "@/components/app-shell/app-shell-client";
 import { buildGlobalNavigationGroups } from "@/components/app-shell/navigation-config";
+import { getIntlShape } from "@/lib/app-i18n/intl";
+import { getAppLocale } from "@/lib/app-i18n/server-locale";
 import {
   evaluateWorkspaceFeatureFlags,
   filterNavigationByWorkspaceFlags,
@@ -13,6 +15,7 @@ import {
   type TmsUserConnectCta,
 } from "@/lib/providers/credentials/tms-user-connection";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
+import type { IntlShape } from "react-intl";
 
 import { OrgTmsQueryProvider } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/_components/org-tms-query-provider";
 import type { ActiveTmsProviderConnection } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/_hooks/use-active-tms-provider";
@@ -30,13 +33,14 @@ export async function AppShell({
 }: AppShellProps) {
   const auth = await requireAppAuthContext({ organizationSlug });
   const activeOrganizationSlug = auth.activeOrganization.slug ?? organizationSlug;
+  const intl = getIntlShape(await getAppLocale()) as IntlShape;
 
   const displayName =
     [auth.sessionUser.firstName, auth.sessionUser.lastName].filter(Boolean).join(" ") ||
     auth.sessionUser.email;
   const workspaceFeatureFlags = await evaluateWorkspaceFeatureFlags(auth);
   const navigationGroups = filterNavigationByWorkspaceFlags(
-    buildGlobalNavigationGroups(activeOrganizationSlug),
+    buildGlobalNavigationGroups(activeOrganizationSlug, intl),
     workspaceFeatureFlags,
   );
   const tmsUserConnectCta: TmsUserConnectCta = hasCapability(auth.membership.role, "jobs:read")

--- a/apps/hyperlocalise-web/src/components/app-shell/crowdin-user-pat-connect-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/crowdin-user-pat-connect-dialog.messages.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const crowdinUserPatConnectDialogMessages = defineMessages({
+  title: {
+    defaultMessage: "Connect {provider}",
+    id: "1fG/7mjDdt",
+    description: "Dialog title when connecting a Crowdin account with a personal access token",
+  },
+  description: {
+    defaultMessage:
+      "Paste your personal access token from Crowdin. Your admin already configured the API base URL for this workspace—you only need your token.",
+    id: "6xVOEtsDdv",
+    description:
+      "Dialog description explaining how to connect Crowdin with a personal access token",
+  },
+  tokenLabel: {
+    defaultMessage: "Personal access token",
+    id: "XHTRGbNDAl",
+    description: "Label for the Crowdin personal access token input field",
+  },
+  tokenHelp: {
+    defaultMessage:
+      "Create a token in Crowdin under Account Settings → API, or in Crowdin Enterprise under your account or Organization Settings → User Access Tokens.",
+    id: "J0zJVMmJUF",
+    description: "Help text describing where to create a Crowdin personal access token",
+  },
+  tokenPlaceholder: {
+    defaultMessage: "Paste your Crowdin token",
+    id: "TiPe1DO4xa",
+    description: "Placeholder for the Crowdin personal access token input",
+  },
+  hideToken: {
+    defaultMessage: "Hide token",
+    id: "jeSX+Yj7ku",
+    description: "Accessible label to hide the personal access token value",
+  },
+  showToken: {
+    defaultMessage: "Show token",
+    id: "toaWaws2L2",
+    description: "Accessible label to reveal the personal access token value",
+  },
+  cancel: {
+    defaultMessage: "Cancel",
+    id: "jbZZYRafrx",
+    description: "Cancel button that closes the Crowdin PAT connect dialog",
+  },
+  connect: {
+    defaultMessage: "Connect",
+    id: "qySc0NPK9C",
+    description: "Primary button to submit the Crowdin personal access token",
+  },
+  connecting: {
+    defaultMessage: "Connecting...",
+    id: "jCBwr9gFgn",
+    description: "Pending label while Crowdin personal access token connection is in progress",
+  },
+  connectFailed: {
+    defaultMessage: "Failed to connect Crowdin",
+    id: "6eyR0nBKXG",
+    description: "Toast error when Crowdin personal access token connection fails",
+  },
+  connected: {
+    defaultMessage: "{provider} connected",
+    id: "df83PL1R8p",
+    description: "Toast success after connecting a Crowdin account with a personal access token",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/crowdin-user-pat-connect-dialog.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/crowdin-user-pat-connect-dialog.tsx
@@ -5,6 +5,7 @@ import { Key01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { EyeIcon, EyeOffIcon } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
+import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
 
 import { tmsUserConnectCtaQueryKey } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/_hooks/use-tms-user-connect-cta";
@@ -21,6 +22,8 @@ import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { apiClient } from "@/lib/api-client-instance";
 
+import { crowdinUserPatConnectDialogMessages } from "./crowdin-user-pat-connect-dialog.messages";
+
 type CrowdinUserPatConnectDialogProps = {
   organizationSlug: string;
   providerDisplayName?: string;
@@ -34,6 +37,7 @@ export function CrowdinUserPatConnectDialog({
   open,
   onOpenChange,
 }: CrowdinUserPatConnectDialogProps) {
+  const intl = useIntl();
   const tokenFieldId = useId();
   const [personalAccessToken, setPersonalAccessToken] = useState("");
   const [showToken, setShowToken] = useState(false);
@@ -60,7 +64,11 @@ export function CrowdinUserPatConnectDialog({
           error?: string;
           message?: string;
         } | null;
-        throw new Error(body?.message ?? body?.error ?? "Failed to connect Crowdin");
+        throw new Error(
+          body?.message ??
+            body?.error ??
+            intl.formatMessage(crowdinUserPatConnectDialogMessages.connectFailed),
+        );
       }
 
       await Promise.all([
@@ -78,9 +86,17 @@ export function CrowdinUserPatConnectDialog({
       setPersonalAccessToken("");
       setShowToken(false);
       onOpenChange(false);
-      toast.success(`${providerDisplayName} connected`);
+      toast.success(
+        intl.formatMessage(crowdinUserPatConnectDialogMessages.connected, {
+          provider: providerDisplayName,
+        }),
+      );
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to connect Crowdin");
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : intl.formatMessage(crowdinUserPatConnectDialogMessages.connectFailed),
+      );
     } finally {
       setIsPending(false);
     }
@@ -101,18 +117,23 @@ export function CrowdinUserPatConnectDialog({
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Connect {providerDisplayName}</DialogTitle>
+          <DialogTitle>
+            <FormattedMessage
+              {...crowdinUserPatConnectDialogMessages.title}
+              values={{ provider: providerDisplayName }}
+            />
+          </DialogTitle>
           <DialogDescription>
-            Paste your personal access token from Crowdin. Your admin already configured the API
-            base URL for this workspace—you only need your token.
+            <FormattedMessage {...crowdinUserPatConnectDialogMessages.description} />
           </DialogDescription>
         </DialogHeader>
 
         <Field className="gap-2">
-          <FieldLabel htmlFor={tokenFieldId}>Personal access token</FieldLabel>
+          <FieldLabel htmlFor={tokenFieldId}>
+            <FormattedMessage {...crowdinUserPatConnectDialogMessages.tokenLabel} />
+          </FieldLabel>
           <FieldDescription>
-            Create a token in Crowdin under Account Settings → API, or in Crowdin Enterprise under
-            your account or Organization Settings → User Access Tokens.
+            <FormattedMessage {...crowdinUserPatConnectDialogMessages.tokenHelp} />
           </FieldDescription>
           <div className="relative">
             <HugeiconsIcon
@@ -126,14 +147,18 @@ export function CrowdinUserPatConnectDialog({
               autoComplete="off"
               value={personalAccessToken}
               onChange={(event) => setPersonalAccessToken(event.target.value)}
-              placeholder="Paste your Crowdin token"
+              placeholder={intl.formatMessage(crowdinUserPatConnectDialogMessages.tokenPlaceholder)}
               className="ps-9 pe-9"
             />
             <button
               type="button"
               onClick={() => setShowToken((current) => !current)}
               className="absolute top-1/2 right-3 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
-              aria-label={showToken ? "Hide token" : "Show token"}
+              aria-label={intl.formatMessage(
+                showToken
+                  ? crowdinUserPatConnectDialogMessages.hideToken
+                  : crowdinUserPatConnectDialogMessages.showToken,
+              )}
             >
               {showToken ? <EyeOffIcon size={16} /> : <EyeIcon size={16} />}
             </button>
@@ -147,7 +172,7 @@ export function CrowdinUserPatConnectDialog({
             onClick={() => onOpenChange(false)}
             disabled={isPending}
           >
-            Cancel
+            <FormattedMessage {...crowdinUserPatConnectDialogMessages.cancel} />
           </Button>
           <Button
             type="button"
@@ -156,7 +181,11 @@ export function CrowdinUserPatConnectDialog({
             }}
             disabled={!personalAccessToken.trim() || isPending}
           >
-            {isPending ? "Connecting..." : "Connect"}
+            {isPending ? (
+              <FormattedMessage {...crowdinUserPatConnectDialogMessages.connecting} />
+            ) : (
+              <FormattedMessage {...crowdinUserPatConnectDialogMessages.connect} />
+            )}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/hyperlocalise-web/src/components/app-shell/nav-user.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/nav-user.messages.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const navUserMessages = defineMessages({
+  openAccountMenu: {
+    defaultMessage: "Open account menu for {name}",
+    id: "zMY6O3OGwK",
+    description: "Screen-reader label for the account menu trigger button",
+  },
+  accountTooltip: {
+    defaultMessage: "Account",
+    id: "MIC7tMfqgJ",
+    description: "Tooltip for the account menu button in the app shell header",
+  },
+  account: {
+    defaultMessage: "Account",
+    id: "8qa1pUW6eX",
+    description: "Account settings link in the user menu",
+  },
+  members: {
+    defaultMessage: "Members",
+    id: "tUtjQfuwWO",
+    description: "Workspace members link in the user menu",
+  },
+  apiKeys: {
+    defaultMessage: "API Keys",
+    id: "wsCg6j7Kx+",
+    description: "API keys settings link in the user menu",
+  },
+  billing: {
+    defaultMessage: "Billing",
+    id: "36gU2d3aFl",
+    description: "Billing settings link in the user menu",
+  },
+  switchWorkspace: {
+    defaultMessage: "Switch workspace",
+    id: "TG1FpMpW2X",
+    description: "Submenu trigger to switch between workspaces",
+  },
+  workspaces: {
+    defaultMessage: "Workspaces",
+    id: "JpSMiCgbq5",
+    description: "Label above the list of workspaces in the switch submenu",
+  },
+  viewAllWorkspaces: {
+    defaultMessage: "View all workspaces",
+    id: "do0p3JfCkF",
+    description: "Link to the organization selection page from the user menu",
+  },
+  logOut: {
+    defaultMessage: "Log out",
+    id: "TbfAHmBI7l",
+    description: "Sign-out action in the user account menu",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/nav-user.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/nav-user.tsx
@@ -12,6 +12,7 @@ import {
   UserGroupIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage } from "react-intl";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -30,6 +31,8 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { buildOrganizationSwitchHref } from "@/components/team-switcher";
 import { buildPlanUsageHref } from "@/lib/billing/plan-usage";
+
+import { navUserMessages } from "./nav-user.messages";
 
 type OrganizationOption = {
   name: string;
@@ -85,14 +88,19 @@ export function NavUser({
                     <AvatarImage src={user.avatar} alt={user.name} />
                     <AvatarFallback className="rounded-full text-xs">{initials}</AvatarFallback>
                   </Avatar>
-                  <span className="sr-only">Open account menu for {user.name}</span>
+                  <span className="sr-only">
+                    <FormattedMessage
+                      {...navUserMessages.openAccountMenu}
+                      values={{ name: user.name }}
+                    />
+                  </span>
                 </Button>
               }
             />
           }
         />
         <TooltipContent side="bottom" align="center">
-          Account
+          <FormattedMessage {...navUserMessages.accountTooltip} />
         </TooltipContent>
       </Tooltip>
       <DropdownMenuContent className="min-w-56 rounded-lg" side="bottom" align="end" sideOffset={4}>
@@ -114,24 +122,24 @@ export function NavUser({
         <DropdownMenuGroup>
           <DropdownMenuItem render={<Link href={`/org/${organizationSlug}/settings/account`} />}>
             <HugeiconsIcon icon={AiUserIcon} strokeWidth={2} className="size-4" />
-            Account
+            <FormattedMessage {...navUserMessages.account} />
           </DropdownMenuItem>
           {showMembersLink ? (
             <DropdownMenuItem render={<Link href={`/org/${organizationSlug}/members`} />}>
               <HugeiconsIcon icon={UserGroupIcon} strokeWidth={2} className="size-4" />
-              Members
+              <FormattedMessage {...navUserMessages.members} />
             </DropdownMenuItem>
           ) : null}
           {showApiKeysLink ? (
             <DropdownMenuItem render={<Link href={`/org/${organizationSlug}/settings/api-keys`} />}>
               <HugeiconsIcon icon={Key01Icon} strokeWidth={2} className="size-4" />
-              API Keys
+              <FormattedMessage {...navUserMessages.apiKeys} />
             </DropdownMenuItem>
           ) : null}
           {showBillingLink ? (
             <DropdownMenuItem render={<Link href={buildPlanUsageHref(organizationSlug)} />}>
               <HugeiconsIcon icon={CreditCardIcon} strokeWidth={2} className="size-4" />
-              Billing
+              <FormattedMessage {...navUserMessages.billing} />
             </DropdownMenuItem>
           ) : null}
         </DropdownMenuGroup>
@@ -141,11 +149,11 @@ export function NavUser({
             <DropdownMenuSub>
               <DropdownMenuSubTrigger>
                 <HugeiconsIcon icon={Building02Icon} strokeWidth={2} className="size-4" />
-                Switch workspace
+                <FormattedMessage {...navUserMessages.switchWorkspace} />
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent className="min-w-56">
                 <DropdownMenuLabel className="text-xs text-muted-foreground">
-                  Workspaces
+                  <FormattedMessage {...navUserMessages.workspaces} />
                 </DropdownMenuLabel>
                 {switchableOrganizations.map((organization) => {
                   const isActive = organization.slug === organizationSlug;
@@ -177,7 +185,7 @@ export function NavUser({
                 })}
                 <DropdownMenuSeparator />
                 <DropdownMenuItem render={<Link href="/auth/select-organization" />}>
-                  View all workspaces
+                  <FormattedMessage {...navUserMessages.viewAllWorkspaces} />
                 </DropdownMenuItem>
               </DropdownMenuSubContent>
             </DropdownMenuSub>
@@ -186,7 +194,7 @@ export function NavUser({
         ) : null}
         <DropdownMenuItem render={<Link href="/auth/sign-out?returnTo=/" prefetch={false} />}>
           <HugeiconsIcon icon={Logout01Icon} strokeWidth={2} className="size-4" />
-          Log out
+          <FormattedMessage {...navUserMessages.logOut} />
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
+import type { IntlShape } from "react-intl";
+
+import { getIntlShape } from "@/lib/app-i18n/intl";
 
 import {
   WORKSPACE_AUTOMATIONS_FLAG,
@@ -14,6 +17,8 @@ import {
   parseProjectRoute,
   stripAppLocalePrefix,
 } from "./navigation-config";
+
+const intl = getIntlShape("en") as IntlShape;
 
 describe("navigation-config", () => {
   it("encodes external project ids as one path segment and parses them back", () => {
@@ -145,7 +150,7 @@ describe("path builders", () => {
   });
 
   it("builds global navigation groups scoped to the organization", () => {
-    const groups = buildGlobalNavigationGroups("acme");
+    const groups = buildGlobalNavigationGroups("acme", intl);
     const items = groups.flatMap((group) => group.items);
     const byLabel = new Map(items.map((item) => [item.label, item]));
 
@@ -156,7 +161,7 @@ describe("path builders", () => {
   });
 
   it("builds project navigation items scoped to the project", () => {
-    const items = buildProjectNavigationItems("acme", "proj_1");
+    const items = buildProjectNavigationItems("acme", "proj_1", intl);
 
     expect(items.map((item) => [item.label, item.href])).toEqual([
       ["Overview", "/org/acme/projects/proj_1"],

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -1,4 +1,5 @@
 import type { ComponentProps } from "react";
+import type { IntlShape } from "react-intl";
 
 import { normalizeAppLocale } from "@/lib/app-i18n/locales";
 import {
@@ -48,86 +49,165 @@ export function buildProjectPath(organizationSlug: string, projectId: string, se
   return section ? `${base}/${section}` : base;
 }
 
-export function buildGlobalNavigationGroups(organizationSlug: string): readonly NavigationGroup[] {
+export function buildGlobalNavigationGroups(
+  organizationSlug: string,
+  intl: IntlShape,
+): readonly NavigationGroup[] {
   const org = (section: string) => buildOrganizationPath(organizationSlug, section);
 
   return [
     {
       items: [
         {
-          label: "New Request",
+          label: intl.formatMessage({
+            defaultMessage: "New Request",
+            id: "VtO24sqmBM",
+            description: "Sidebar navigation item to start a new localisation request",
+          }),
           href: org("chat"),
           icon: Chat01Icon,
-          description: "Ask the localisation agent to prepare work",
+          description: intl.formatMessage({
+            defaultMessage: "Ask the localisation agent to prepare work",
+            id: "z45OPLD254",
+            description: "Sidebar description for the New Request navigation item",
+          }),
         },
         {
-          label: "Inbox",
+          label: intl.formatMessage({
+            defaultMessage: "Inbox",
+            id: "qYH/VTnW7r",
+            description: "Sidebar navigation item for the workspace inbox",
+          }),
           href: org("inbox"),
           icon: InboxIcon,
         },
         {
-          label: "My Jobs",
+          label: intl.formatMessage({
+            defaultMessage: "My Jobs",
+            id: "7VRqQJwWUI",
+            description: "Sidebar navigation item for the current user’s jobs",
+          }),
           href: org("my-work"),
           icon: WorkHistoryIcon,
         },
         {
-          label: "Issues",
+          label: intl.formatMessage({
+            defaultMessage: "Issues",
+            id: "olmZvevw/Q",
+            description: "Sidebar navigation item for workspace issues",
+          }),
           href: org("issues"),
           icon: ClipboardListIcon,
         },
         {
-          label: "Overview",
+          label: intl.formatMessage({
+            defaultMessage: "Overview",
+            id: "M1acCMedpF",
+            description: "Sidebar navigation item for the workspace dashboard overview",
+          }),
           href: org("dashboard"),
           icon: DashboardSquare01Icon,
         },
         {
-          label: "Automations",
+          label: intl.formatMessage({
+            defaultMessage: "Automations",
+            id: "87mk4HgY5S",
+            description: "Sidebar navigation item for workspace automations",
+          }),
           href: org("automations"),
           icon: Task01Icon,
-          description: "Scheduled and GitHub-triggered deterministic workflows",
-          badge: "Beta",
+          description: intl.formatMessage({
+            defaultMessage: "Scheduled and GitHub-triggered deterministic workflows",
+            id: "TBagRGINiT",
+            description: "Sidebar description for the Automations navigation item",
+          }),
+          badge: intl.formatMessage({
+            defaultMessage: "Beta",
+            id: "+WwLLR9+vz",
+            description: "Badge shown next to the Automations navigation item",
+          }),
           featureFlagKey: WORKSPACE_AUTOMATIONS_FLAG,
         },
       ],
     },
     {
-      label: "Workspace",
+      label: intl.formatMessage({
+        defaultMessage: "Workspace",
+        id: "VMLVh0fGup",
+        description: "Sidebar group label for workspace-level navigation items",
+      }),
       items: [
         {
-          label: "Projects",
+          label: intl.formatMessage({
+            defaultMessage: "Projects",
+            id: "WXz3UNteSC",
+            description: "Sidebar navigation item for the projects list",
+          }),
           href: org("projects"),
           icon: FolderKanbanIcon,
         },
         {
-          label: "Knowledge",
+          label: intl.formatMessage({
+            defaultMessage: "Knowledge",
+            id: "HrKmOaq57x",
+            description: "Sidebar navigation item for workspace knowledge",
+          }),
           href: org("knowledge"),
           icon: AiBrain01Icon,
-          description: "Workspace memory for agents and teams",
+          description: intl.formatMessage({
+            defaultMessage: "Workspace memory for agents and teams",
+            id: "ZFNYMG0eSQ",
+            description: "Sidebar description for the Knowledge navigation item",
+          }),
           featureFlagKey: WORKSPACE_KNOWLEDGE_FLAG,
         },
         {
-          label: "Glossaries",
+          label: intl.formatMessage({
+            defaultMessage: "Glossaries",
+            id: "p2ZEW4INMa",
+            description: "Sidebar navigation item for glossaries",
+          }),
           href: org("glossaries"),
           icon: BookOpenTextIcon,
         },
         {
-          label: "Translation Memories",
+          label: intl.formatMessage({
+            defaultMessage: "Translation Memories",
+            id: "x6PqOisw0g",
+            description: "Sidebar navigation item for translation memories",
+          }),
           href: org("translation-memories"),
           icon: DatabaseSyncIcon,
         },
         {
-          label: "Integrations",
+          label: intl.formatMessage({
+            defaultMessage: "Integrations",
+            id: "lq1y6qqiDK",
+            description: "Sidebar navigation item for integrations",
+          }),
           href: org("integrations"),
           icon: LinkSquare02Icon,
         },
         {
-          label: "Members",
+          label: intl.formatMessage({
+            defaultMessage: "Members",
+            id: "1/YUf106Rt",
+            description: "Sidebar navigation item for workspace members",
+          }),
           href: org("members"),
           icon: UserMultiple02Icon,
-          description: "Invite people and manage workspace roles",
+          description: intl.formatMessage({
+            defaultMessage: "Invite people and manage workspace roles",
+            id: "blLcFpSkB4",
+            description: "Sidebar description for the Members navigation item",
+          }),
         },
         {
-          label: "Settings",
+          label: intl.formatMessage({
+            defaultMessage: "Settings",
+            id: "3cDDnXngWu",
+            description: "Sidebar navigation item for workspace settings",
+          }),
           href: org("settings"),
           icon: Settings01Icon,
         },
@@ -139,32 +219,53 @@ export function buildGlobalNavigationGroups(organizationSlug: string): readonly 
 export function buildProjectNavigationItems(
   organizationSlug: string,
   projectId: string,
+  intl: IntlShape,
 ): readonly NavigationItem[] {
   const project = (section: string) => buildProjectPath(organizationSlug, projectId, section);
 
   return [
     {
-      label: "Overview",
+      label: intl.formatMessage({
+        defaultMessage: "Overview",
+        id: "w6stmLL+C3",
+        description: "Project sidebar navigation item for the project overview",
+      }),
       href: buildProjectPath(organizationSlug, projectId),
       icon: FolderKanbanIcon,
     },
     {
-      label: "Files",
+      label: intl.formatMessage({
+        defaultMessage: "Files",
+        id: "IMr6sfD/7/",
+        description: "Project sidebar navigation item for project files",
+      }),
       href: project("files"),
       icon: File01Icon,
     },
     {
-      label: "Jobs",
+      label: intl.formatMessage({
+        defaultMessage: "Jobs",
+        id: "8HNfmSDv7C",
+        description: "Project sidebar navigation item for project jobs",
+      }),
       href: project("jobs"),
       icon: Task01Icon,
     },
     {
-      label: "Issue Sheet",
+      label: intl.formatMessage({
+        defaultMessage: "Issue Sheet",
+        id: "rDacSGpJfq",
+        description: "Project sidebar navigation item for the project issue sheet",
+      }),
       href: project("issue-sheet"),
       icon: ClipboardListIcon,
     },
     {
-      label: "Settings",
+      label: intl.formatMessage({
+        defaultMessage: "Settings",
+        id: "Ly3jSjXVvC",
+        description: "Project sidebar navigation item for project settings",
+      }),
       href: project("settings"),
       icon: Settings01Icon,
     },

--- a/apps/hyperlocalise-web/src/components/app-shell/tms-user-connect-button.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/tms-user-connect-button.messages.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const tmsUserConnectButtonMessages = defineMessages({
+  connect: {
+    defaultMessage: "Connect {provider}",
+    id: "Aa0lbVkG8M",
+    description: "Button label to start connecting a TMS user account",
+  },
+  connecting: {
+    defaultMessage: "Connecting...",
+    id: "P+9nP38ODj",
+    description: "Pending label while a TMS OAuth connection is starting",
+  },
+  startFailed: {
+    defaultMessage: "Failed to start {provider} connection",
+    id: "RWrEpStLhj",
+    description: "Toast error when starting a TMS OAuth connection fails",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/tms-user-connect-button.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/tms-user-connect-button.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Key01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
 
 import { CrowdinUserPatConnectDialog } from "@/components/app-shell/crowdin-user-pat-connect-dialog";
@@ -13,6 +14,8 @@ import {
   formatTmsUserConnectProviderLabel,
   type TmsUserConnectProviderKind,
 } from "@/lib/providers/credentials/tms-user-connection-shared";
+
+import { tmsUserConnectButtonMessages } from "./tms-user-connect-button.messages";
 
 export function TmsUserConnectButton({
   organizationSlug,
@@ -27,6 +30,7 @@ export function TmsUserConnectButton({
   connectMethod?: "oauth" | "pat";
   className?: string;
 }) {
+  const intl = useIntl();
   const label = providerDisplayName ?? formatTmsUserConnectProviderLabel(providerKind);
   const [isPending, setIsPending] = useState(false);
   const [patDialogOpen, setPatDialogOpen] = useState(false);
@@ -56,14 +60,22 @@ export function TmsUserConnectButton({
           error?: string;
           message?: string;
         } | null;
-        throw new Error(body?.message ?? body?.error ?? `Failed to start ${label} connection`);
+        throw new Error(
+          body?.message ??
+            body?.error ??
+            intl.formatMessage(tmsUserConnectButtonMessages.startFailed, { provider: label }),
+        );
       }
 
       const body = (await response.json()) as { authorizationUrl: string };
       window.location.assign(body.authorizationUrl);
     } catch (error) {
       setIsPending(false);
-      toast.error(error instanceof Error ? error.message : `Failed to start ${label} connection`);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : intl.formatMessage(tmsUserConnectButtonMessages.startFailed, { provider: label }),
+      );
     }
   }
 
@@ -87,7 +99,14 @@ export function TmsUserConnectButton({
         onClick={handleClick}
       >
         <HugeiconsIcon icon={Key01Icon} strokeWidth={2} className="size-4" />
-        {isPending ? "Connecting..." : `Connect ${label}`}
+        {isPending ? (
+          <FormattedMessage {...tmsUserConnectButtonMessages.connecting} />
+        ) : (
+          <FormattedMessage
+            {...tmsUserConnectButtonMessages.connect}
+            values={{ provider: label }}
+          />
+        )}
       </Button>
 
       {providerKind === "crowdin" && connectMethod === "pat" ? (

--- a/apps/hyperlocalise-web/src/components/app-shell/tms-user-connection-prompt.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/tms-user-connection-prompt.messages.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const tmsUserConnectionPromptMessages = defineMessages({
+  connectionRequired: {
+    defaultMessage: "Connect {provider} to view provider {resource}.",
+    id: "Bfwle3X1Yy",
+    description:
+      "Error heading when TMS provider data cannot load because the user has not connected their account",
+  },
+  loadFailed: {
+    defaultMessage: "Failed to load provider data.",
+    id: "LURuzj5+No",
+    description: "Generic error heading when TMS provider data fails to load",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/tms-user-connection-prompt.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/tms-user-connection-prompt.tsx
@@ -1,8 +1,12 @@
 "use client";
 
+import { useIntl } from "react-intl";
+
 import { useTmsUserConnectCta } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/_hooks/use-tms-user-connect-cta";
 import { TmsUserConnectButton } from "@/components/app-shell/tms-user-connect-button";
-import { tmsUserConnectionRequiredMessage } from "@/lib/providers/credentials/tms-user-connection-shared";
+import { formatTmsUserConnectProviderLabel } from "@/lib/providers/credentials/tms-user-connection-shared";
+
+import { tmsUserConnectionPromptMessages } from "./tms-user-connection-prompt.messages";
 
 export function TmsUserConnectionErrorPanel({
   organizationSlug,
@@ -15,13 +19,19 @@ export function TmsUserConnectionErrorPanel({
   error: unknown;
   className?: string;
 }) {
+  const intl = useIntl();
   const query = useTmsUserConnectCta(organizationSlug);
   const resolved = query.data;
 
   const heading =
     resolved?.showConnectCta === true
-      ? tmsUserConnectionRequiredMessage(resolved.providerKind, resource)
-      : "Failed to load provider data.";
+      ? intl.formatMessage(tmsUserConnectionPromptMessages.connectionRequired, {
+          provider:
+            resolved.providerDisplayName ??
+            formatTmsUserConnectProviderLabel(resolved.providerKind),
+          resource,
+        })
+      : intl.formatMessage(tmsUserConnectionPromptMessages.loadFailed);
 
   return (
     <div className={className}>

--- a/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { ReadonlyRequestCookies } from "flags";
+import type { IntlShape } from "react-intl";
 
 import { buildGlobalNavigationGroups } from "@/components/app-shell/navigation-config";
 import {
@@ -7,6 +8,7 @@ import {
   WORKSPACE_KNOWLEDGE_FLAG,
 } from "@/lib/flags/workos-flag-entities";
 import { filterNavigationByWorkspaceFlags } from "@/lib/flags/workspace-flags";
+import { getIntlShape } from "@/lib/app-i18n/intl";
 
 const isEnabled = vi.fn();
 const waitUntilReady = vi.fn().mockResolvedValue(undefined);
@@ -134,9 +136,11 @@ describe("workosAdapter", () => {
   });
 });
 
+const intl = getIntlShape("en") as IntlShape;
+
 describe("filterNavigationByWorkspaceFlags", () => {
   it("removes Automations and Knowledge when workspace flags are disabled", () => {
-    const groups = buildGlobalNavigationGroups("acme");
+    const groups = buildGlobalNavigationGroups("acme", intl);
     const filtered = filterNavigationByWorkspaceFlags(groups, {
       automations: false,
       knowledge: false,
@@ -151,7 +155,7 @@ describe("filterNavigationByWorkspaceFlags", () => {
   });
 
   it("keeps Automations and Knowledge when workspace flags are enabled", () => {
-    const groups = buildGlobalNavigationGroups("acme");
+    const groups = buildGlobalNavigationGroups("acme", intl);
     const filtered = filterNavigationByWorkspaceFlags(groups, {
       automations: true,
       knowledge: true,


### PR DESCRIPTION
## What changed

Localize hardcoded user-facing strings in `apps/hyperlocalise-web/src/components/app-shell` with react-intl (ICU):

- Account menu, sidebar brand, Crowdin PAT dialog, and TMS connect CTAs use colocated `*.messages.ts` modules
- Global/project navigation labels and breadcrumb titles format through `intl.formatMessage`
- Server `AppShell` builds navigation with `getIntlShape(await getAppLocale())`

Unrelated `vite.config.ts` change (enabling `formatjs/no-literal-string-in-jsx` repo-wide) was left out of this PR.

## How to test

- [ ] `cd apps/hyperlocalise-web && vp lint src/components/app-shell`
- [ ] `cd apps/hyperlocalise-web && vp test src/components/app-shell src/lib/flags/workos-adapter.test.ts`
- [ ] Open an org route and confirm sidebar, breadcrumbs, and account menu still render English defaults
- [ ] Switch locale via the language toggle and confirm app-shell labels update where catalogs exist

## Checklist

- [x] I ran relevant checks locally (`vp lint` / `vp test` for app-shell)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)