### PR TITLE
fix(web): show skeleton while side-by-side translations load

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-lazy-segment-sync.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-lazy-segment-sync.tsx
@@ -184,17 +184,12 @@ function useCatLoadedQueueTargetsSync(input: {
       return;
     }
 
-    const loadingIds = segmentIds.filter((segmentId, index) => {
+    // Track fetch-in-flight only. Draft text is filtered in `loadingSegmentIds`
+    // so typing during a fetch clears the skeleton without needing this effect
+    // to re-run on draft changes.
+    const loadingIds = segmentIds.filter((_segmentId, index) => {
       const query = targetQueries[index];
-      if (!query) {
-        return false;
-      }
-
-      return (
-        query.isFetching &&
-        query.data === undefined &&
-        !store.drafts.get(segmentId)?.targetText.trim()
-      );
+      return Boolean(query?.isFetching && query.data === undefined);
     });
 
     store.setQueueTargetLoadingSegmentIds(loadingIds);

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-lazy-segment-sync.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-lazy-segment-sync.tsx
@@ -154,6 +154,8 @@ function useCatLoadedQueueTargetsSync(input: {
       catFile: input.catFile,
     });
 
+  const targetsEnabled = input.enabled && Boolean(input.catFile) && segmentIds.length > 0;
+
   const targetQueries = useCatSegmentTargets({
     organizationSlug: input.organizationSlug,
     projectId: input.projectId,
@@ -162,7 +164,7 @@ function useCatLoadedQueueTargetsSync(input: {
     resourceType: resolvedResourceType,
     targetLocale: input.targetLocale,
     externalStringIds: segmentIds,
-    enabled: input.enabled && Boolean(input.catFile) && segmentIds.length > 0,
+    enabled: targetsEnabled,
   });
 
   useEffect(() => {
@@ -175,6 +177,28 @@ function useCatLoadedQueueTargetsSync(input: {
       store.applySegmentTarget(segmentId, query.data);
     });
   }, [segmentIds, store, targetQueries]);
+
+  useEffect(() => {
+    if (!targetsEnabled) {
+      store.setQueueTargetLoadingSegmentIds([]);
+      return;
+    }
+
+    const loadingIds = segmentIds.filter((segmentId, index) => {
+      const query = targetQueries[index];
+      if (!query) {
+        return false;
+      }
+
+      return (
+        query.isFetching &&
+        query.data === undefined &&
+        !store.drafts.get(segmentId)?.targetText.trim()
+      );
+    });
+
+    store.setQueueTargetLoadingSegmentIds(loadingIds);
+  }, [segmentIds, store, targetQueries, targetsEnabled]);
 }
 
 export const CatWorkspaceLazySegmentSync = observer(function CatWorkspaceLazySegmentSync({

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.test.ts
@@ -700,4 +700,20 @@ describe("CatWorkspaceOrchestrator ui state", () => {
 
     expect([...store.loadingSegmentIds]).toEqual(["seg-01", "seg-02"]);
   });
+
+  it("includes queue target loading segment ids in side-by-side loading state", () => {
+    const store = createCatWorkspace(createCatWorkspaceState({ selectedSegmentId: "seg-01" }));
+
+    store.setQueueTargetLoadingSegmentIds(["seg-02", "seg-03"]);
+
+    expect([...store.loadingSegmentIds].toSorted()).toEqual(["seg-02", "seg-03"]);
+
+    store.setSegmentTargetLoading(true);
+
+    expect([...store.loadingSegmentIds].toSorted()).toEqual(["seg-01", "seg-02", "seg-03"]);
+
+    store.setQueueTargetLoadingSegmentIds([]);
+
+    expect([...store.loadingSegmentIds]).toEqual(["seg-01"]);
+  });
 });

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.test.ts
@@ -702,7 +702,17 @@ describe("CatWorkspaceOrchestrator ui state", () => {
   });
 
   it("includes queue target loading segment ids in side-by-side loading state", () => {
-    const store = createCatWorkspace(createCatWorkspaceState({ selectedSegmentId: "seg-01" }));
+    const store = createCatWorkspace(
+      createCatWorkspaceState({
+        selectedSegmentId: "seg-01",
+        queueSegments: [
+          { id: "seg-01", index: 1, key: "first", sourceText: "First" },
+          { id: "seg-02", index: 2, key: "second", sourceText: "Second" },
+          { id: "seg-03", index: 3, key: "third", sourceText: "Third" },
+        ],
+        segments: [],
+      }),
+    );
 
     store.setQueueTargetLoadingSegmentIds(["seg-02", "seg-03"]);
 
@@ -715,5 +725,24 @@ describe("CatWorkspaceOrchestrator ui state", () => {
     store.setQueueTargetLoadingSegmentIds([]);
 
     expect([...store.loadingSegmentIds]).toEqual(["seg-01"]);
+  });
+
+  it("drops queue loading ids once draft target text is present", () => {
+    const store = createCatWorkspace(
+      createCatWorkspaceState({
+        selectedSegmentId: "seg-01",
+        queueSegments: [
+          { id: "seg-01", index: 1, key: "first", sourceText: "First" },
+          { id: "seg-02", index: 2, key: "second", sourceText: "Second" },
+          { id: "seg-03", index: 3, key: "third", sourceText: "Third" },
+        ],
+        segments: [],
+      }),
+    );
+
+    store.setQueueTargetLoadingSegmentIds(["seg-02", "seg-03"]);
+    store.setTargetText("seg-02", "Typed while fetching");
+
+    expect([...store.loadingSegmentIds]).toEqual(["seg-03"]);
   });
 });

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
@@ -534,12 +534,13 @@ export class CatWorkspaceOrchestrator {
   get loadingSegmentIds(): ReadonlySet<string> {
     const hasSelectedLoading = this.isSegmentTargetLoading && this.selectedSegmentId;
     const hasPreviewLoading = this.ui.previewTargetLoading && this.ui.previewLoadingSegmentId;
+    const queueLoadingIds = this.segments.queueTargetLoadingSegmentIds;
 
-    if (!hasSelectedLoading && !hasPreviewLoading) {
+    if (!hasSelectedLoading && !hasPreviewLoading && queueLoadingIds.size === 0) {
       return EMPTY_LOADING_SEGMENT_IDS;
     }
 
-    const ids = new Set<string>();
+    const ids = new Set<string>(queueLoadingIds);
     if (hasSelectedLoading) {
       ids.add(this.selectedSegmentId);
     }
@@ -702,6 +703,10 @@ export class CatWorkspaceOrchestrator {
 
   setSegmentTargetLoading(loading: boolean) {
     this.isSegmentTargetLoading = loading;
+  }
+
+  setQueueTargetLoadingSegmentIds(segmentIds: readonly string[]) {
+    this.segments.setQueueTargetLoadingSegmentIds(segmentIds);
   }
 
   setCommentsLoading(loading: boolean) {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
@@ -540,7 +540,13 @@ export class CatWorkspaceOrchestrator {
       return EMPTY_LOADING_SEGMENT_IDS;
     }
 
-    const ids = new Set<string>(queueLoadingIds);
+    const ids = new Set<string>();
+    for (const segmentId of queueLoadingIds) {
+      // Read drafts here so MobX recomputes when the user types during a fetch.
+      if (!this.drafts.get(segmentId)?.targetText.trim()) {
+        ids.add(segmentId);
+      }
+    }
     if (hasSelectedLoading) {
       ids.add(this.selectedSegmentId);
     }

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-segment-store.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-segment-store.ts
@@ -14,9 +14,21 @@ export class CatSegmentStore {
   isResolvingComment = false;
   resolvingCommentId: string | null = null;
   commentPostError: string | undefined;
+  queueTargetLoadingSegmentIds = new Set<string>();
 
   constructor() {
     makeAutoObservable(this, {}, { autoBind: true });
+  }
+
+  setQueueTargetLoadingSegmentIds(segmentIds: readonly string[]) {
+    if (
+      this.queueTargetLoadingSegmentIds.size === segmentIds.length &&
+      segmentIds.every((segmentId) => this.queueTargetLoadingSegmentIds.has(segmentId))
+    ) {
+      return;
+    }
+
+    this.queueTargetLoadingSegmentIds = new Set(segmentIds);
   }
 
   get dirtySegmentIds(): ReadonlySet<string> {
@@ -32,6 +44,7 @@ export class CatSegmentStore {
   clear() {
     this.comments.clear();
     this.drafts.clear();
+    this.queueTargetLoadingSegmentIds.clear();
   }
 
   removeIfClean(segmentId: string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

In side-by-side CAT view, queue rows showed "Click to translate" while their translations were still being fetched. That made empty cells look actionable when they were just loading.

This tracks per-segment queue target fetch loading and includes those IDs in `loadingSegmentIds`, so the existing row skeleton renders until the target resolves. Truly empty translations still show "Click to translate" after loading finishes.

Follow-up: draft text is filtered in the MobX `loadingSegmentIds` computed (not only in the sync effect), so typing during an in-flight fetch clears the skeleton immediately.

## How to test

- Open a project file in side-by-side view
- Confirm empty translation cells show skeletons while targets load
- Confirm loaded translations appear once fetches complete
- Confirm truly empty segments still show "Click to translate" after loading
- Confirm typing into a focused empty row during load clears the skeleton
- `vp test src/components/cat/workspace/cat-workspace-orchestrator.test.ts`
- `vp check --fix` in `apps/hyperlocalise-web`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba5619e5-82a6-4c32-be47-c0cfb2cfc400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba5619e5-82a6-4c32-be47-c0cfb2cfc400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

