### PR TITLE
feat(web): add app shell plan footer

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-view.tsx
@@ -56,7 +56,7 @@ export function InboxPageView({
   return (
     <main
       data-organization={organizationSlug}
-      className="-mx-4 -my-5 flex h-[calc(100svh-var(--app-shell-header-height))] min-h-0 flex-col overflow-hidden bg-background text-foreground sm:-mx-6 lg:-mx-8"
+      className="-mx-4 -my-5 flex h-[var(--app-shell-content-height)] min-h-0 flex-col overflow-hidden bg-background text-foreground sm:-mx-6 lg:-mx-8"
     >
       <div
         className={cn(

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
@@ -389,7 +389,7 @@ export function ProjectFileCatPageContent({
   };
 
   return (
-    <main className="-mx-4 -my-5 flex h-[calc(100svh-var(--app-shell-header-height))] min-h-0 flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
+    <main className="-mx-4 -my-5 flex h-[var(--app-shell-content-height)] min-h-0 flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
       <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 sm:px-4 lg:px-6">
         <Button
           variant="outline"

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -518,7 +518,7 @@ export function JobCatPageContent({
     }
 
     return (
-      <main className="-mx-4 -my-5 flex h-[calc(100svh-var(--app-shell-header-height))] min-h-0 flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
+      <main className="-mx-4 -my-5 flex h-[var(--app-shell-content-height)] min-h-0 flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
         <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 sm:px-4 lg:px-6">
           <Button
             variant="outline"
@@ -636,7 +636,7 @@ export function JobCatPageContent({
   };
 
   return (
-    <main className="-mx-4 -my-5 flex h-[calc(100svh-var(--app-shell-header-height))] min-h-0 flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
+    <main className="-mx-4 -my-5 flex h-[var(--app-shell-content-height)] min-h-0 flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
       <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 sm:px-4 lg:px-6">
         <Button
           variant="outline"

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/billing/_components/billing-settings-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/billing/_components/billing-settings-content.tsx
@@ -382,7 +382,7 @@ function ConfiguredBillingSettingsPanel({
         </CardHeader>
         <Separator className="bg-skeleton" />
         <div className="px-5 py-5">
-          <PlanUsageSummaryContent summary={planUsageSummary} variant="billing" />
+          <PlanUsageSummaryContent summary={planUsageSummary} />
         </div>
         <Separator className="bg-skeleton" />
         <CardContent className="divide-y divide-border px-5 py-0">

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
@@ -75,7 +75,12 @@ export function AppShellClient({
       <TmsUserOAuthErrorToast />
       <SidebarProvider
         defaultOpen
-        style={{ "--sidebar-width": "15rem" } as CSSProperties}
+        style={
+          {
+            "--app-shell-footer-height": "calc(2.5rem + env(safe-area-inset-bottom))",
+            "--sidebar-width": "15rem",
+          } as CSSProperties
+        }
         className="min-h-svh bg-background text-foreground"
       >
         <SidebarStoreBridge />
@@ -98,14 +103,14 @@ export function AppShellClient({
             </div>
           </SidebarHeader>
 
-          <SidebarContent className="gap-0 px-2 pt-2 pb-12">
+          <SidebarContent className="gap-0 px-2 pt-2 pb-[var(--app-shell-footer-height)]">
             <AppShellNavigation organizationSlug={organizationSlug} />
           </SidebarContent>
 
           <SidebarRail />
         </Sidebar>
 
-        <SidebarInset className="min-h-svh bg-background pb-[calc(2.5rem+env(safe-area-inset-bottom))]">
+        <SidebarInset className="min-h-svh bg-background pb-[var(--app-shell-footer-height)]">
           <div className="sticky top-0 z-20 border-b border-border bg-background/96 backdrop-blur">
             <div className="flex h-[var(--app-shell-header-height)] items-center justify-between gap-3 px-4 sm:px-6 lg:px-8">
               <div className="flex min-w-0 items-center gap-3">

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
@@ -77,6 +77,8 @@ export function AppShellClient({
         defaultOpen
         style={
           {
+            "--app-shell-content-height":
+              "calc(100svh - var(--app-shell-header-height) - var(--app-shell-footer-height))",
             "--app-shell-footer-height": "calc(2.5rem + env(safe-area-inset-bottom))",
             "--sidebar-width": "15rem",
           } as CSSProperties

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
@@ -3,7 +3,6 @@
 import type { CSSProperties, ReactNode } from "react";
 import Image from "next/image";
 
-import { PlanUsageSidebarWidget } from "@/components/billing/plan-usage-summary";
 import {
   Sidebar,
   SidebarContent,
@@ -28,6 +27,7 @@ import { useTmsUserConnectCta } from "@/app/[lang]/(authenticated)/org/[organiza
 import { NavUser } from "./nav-user";
 import { Separator } from "@/components/ui/separator";
 import { TypographyP } from "@/components/ui/typography";
+import { AppShellFooter } from "./app-shell-footer";
 
 type AppShellClientProps = {
   autumnConfigured?: boolean;
@@ -98,18 +98,14 @@ export function AppShellClient({
             </div>
           </SidebarHeader>
 
-          <SidebarContent className="gap-0 px-2 py-2">
+          <SidebarContent className="gap-0 px-2 pt-2 pb-12">
             <AppShellNavigation organizationSlug={organizationSlug} />
-
-            {showBillingLink && autumnConfigured ? (
-              <PlanUsageSidebarWidget organizationSlug={organizationSlug} />
-            ) : null}
           </SidebarContent>
 
           <SidebarRail />
         </Sidebar>
 
-        <SidebarInset className="min-h-svh bg-background">
+        <SidebarInset className="min-h-svh bg-background pb-[calc(2.5rem+env(safe-area-inset-bottom))]">
           <div className="sticky top-0 z-20 border-b border-border bg-background/96 backdrop-blur">
             <div className="flex h-[var(--app-shell-header-height)] items-center justify-between gap-3 px-4 sm:px-6 lg:px-8">
               <div className="flex min-w-0 items-center gap-3">
@@ -147,6 +143,11 @@ export function AppShellClient({
 
           <div className="flex-1 px-4 py-5 sm:px-6 lg:px-8">{children}</div>
         </SidebarInset>
+
+        <AppShellFooter
+          organizationSlug={organizationSlug}
+          showPlan={showBillingLink && autumnConfigured}
+        />
       </SidebarProvider>
     </AppShellStoreProvider>
   );

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.test.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { AppShellFooter } from "@/components/app-shell/app-shell-footer";
+import { planUsagePrimaryFeatureId } from "@/lib/billing/plan-usage";
+
+const autumnMocks = vi.hoisted(() => ({
+  useCustomer: vi.fn(),
+  useListPlans: vi.fn(),
+}));
+
+vi.mock("autumn-js/react", () => autumnMocks);
+
+afterEach(() => {
+  autumnMocks.useCustomer.mockReset();
+  autumnMocks.useListPlans.mockReset();
+});
+
+describe("AppShellFooter", () => {
+  it("opens plan usage from the fixed footer control", async () => {
+    const user = userEvent.setup();
+    autumnMocks.useCustomer.mockReturnValue({
+      data: {
+        subscriptions: [
+          {
+            planId: "growth",
+            status: "active",
+            plan: { name: "Growth" },
+          },
+        ],
+        balances: {
+          [planUsagePrimaryFeatureId]: {
+            usage: 25,
+            granted: 100,
+            remaining: 75,
+          },
+        },
+      },
+      isLoading: false,
+      error: null,
+    });
+    autumnMocks.useListPlans.mockReturnValue({
+      data: [{ id: "growth", name: "Growth" }],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<AppShellFooter organizationSlug="acme" showPlan />);
+
+    await user.click(screen.getByRole("button", { name: "Open plan usage: Growth" }));
+
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.getByText("Your workspace is on the Growth plan")).toBeTruthy();
+    expect(screen.getByText("25 / 100 AI credits used")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Open billing" }).getAttribute("href")).toBe(
+      "/org/acme/settings/billing#plan-usage",
+    );
+  });
+
+  it("keeps support available without billing access", () => {
+    render(<AppShellFooter organizationSlug="acme" showPlan={false} />);
+
+    expect(screen.queryByText("Growth")).toBeNull();
+    expect(screen.getByRole("link", { name: "Email support" }).getAttribute("href")).toBe(
+      "mailto:minh@hyperlocalise.com",
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { CustomerSupportIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { PlanUsageFooterControl } from "@/components/billing/plan-usage-summary";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+const SUPPORT_EMAIL = "minh@hyperlocalise.com";
+
+export function AppShellFooter({
+  organizationSlug,
+  showPlan,
+}: {
+  organizationSlug: string;
+  showPlan: boolean;
+}) {
+  return (
+    <footer className="fixed inset-x-0 bottom-0 z-40 flex min-h-10 items-center border-t border-border bg-background px-2 pb-[env(safe-area-inset-bottom)]">
+      {showPlan ? <PlanUsageFooterControl organizationSlug={organizationSlug} /> : null}
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              className="ms-auto"
+              render={<a href={`mailto:${SUPPORT_EMAIL}`} />}
+              aria-label="Email support"
+            >
+              <HugeiconsIcon icon={CustomerSupportIcon} strokeWidth={2} />
+            </Button>
+          }
+        />
+        <TooltipContent side="top" align="end">
+          Support
+        </TooltipContent>
+      </Tooltip>
+    </footer>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
@@ -17,26 +17,28 @@ export function AppShellFooter({
   showPlan: boolean;
 }) {
   return (
-    <footer className="fixed inset-x-0 bottom-0 z-40 flex min-h-10 items-center border-t border-border bg-background px-2 pb-[env(safe-area-inset-bottom)]">
-      {showPlan ? <PlanUsageFooterControl organizationSlug={organizationSlug} /> : null}
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <Button
-              variant="ghost"
-              size="icon-xs"
-              className="ms-auto"
-              render={<a href={`mailto:${SUPPORT_EMAIL}`} />}
-              aria-label="Email support"
-            >
-              <HugeiconsIcon icon={CustomerSupportIcon} strokeWidth={2} />
-            </Button>
-          }
-        />
-        <TooltipContent side="top" align="end">
-          Support
-        </TooltipContent>
-      </Tooltip>
+    <footer className="fixed inset-x-0 bottom-0 z-40 h-[var(--app-shell-footer-height)] border-t border-border bg-background px-2">
+      <div className="flex h-10 items-center">
+        {showPlan ? <PlanUsageFooterControl organizationSlug={organizationSlug} /> : null}
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                className="ms-auto"
+                render={<a href={`mailto:${SUPPORT_EMAIL}`} />}
+                aria-label="Email support"
+              >
+                <HugeiconsIcon icon={CustomerSupportIcon} strokeWidth={2} />
+              </Button>
+            }
+          />
+          <TooltipContent side="top" align="end">
+            Support
+          </TooltipContent>
+        </Tooltip>
+      </div>
     </footer>
   );
 }

--- a/apps/hyperlocalise-web/src/components/billing/plan-usage-summary.tsx
+++ b/apps/hyperlocalise-web/src/components/billing/plan-usage-summary.tsx
@@ -2,123 +2,69 @@
 
 import Link from "next/link";
 import { useMemo } from "react";
-import { usePathname } from "next/navigation";
-import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import { CreditCardIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useCustomer, useListPlans } from "autumn-js/react";
 
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Progress } from "@/components/ui/progress";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
 import { TypographyP } from "@/components/ui/typography";
 import {
-  availablePlansSectionId,
   buildAvailablePlansHref,
   buildPlanUsageHref,
   hasPlanUsageMeter,
-  isPlanUsageBillingPath,
-  planUsageSectionId,
   resolvePlanUsageSummary,
-  scrollToBillingSection,
   type ResolvedPlanUsageSummary,
 } from "@/lib/billing/plan-usage";
 
-function PlanUsageSummarySkeleton({ variant }: { variant: "sidebar" | "billing" }) {
-  if (variant === "sidebar") {
-    return (
-      <div className="rounded-lg border border-sidebar-border bg-sidebar-accent px-3 py-3">
-        <div className="h-3 w-16 animate-pulse rounded bg-sidebar-accent" />
-        <div className="mt-3 h-3 w-24 animate-pulse rounded bg-sidebar-accent" />
-        <div className="mt-2 h-3 w-32 animate-pulse rounded bg-sidebar-accent" />
-        <div className="mt-3 h-1.5 animate-pulse rounded-full bg-sidebar-accent" />
-        <div className="mt-3 h-3 w-28 animate-pulse rounded bg-sidebar-accent" />
-      </div>
-    );
-  }
-
+function PlanUsageSummarySkeleton() {
   return (
-    <div className="space-y-3 px-5 py-5">
-      <div className="h-4 w-28 animate-pulse rounded bg-accent" />
-      <div className="h-3 w-40 animate-pulse rounded bg-accent" />
-      <div className="h-1.5 animate-pulse rounded-full bg-accent" />
-      <div className="h-3 w-36 animate-pulse rounded bg-accent" />
+    <div className="flex flex-col gap-3 py-2" aria-label="Loading plan usage">
+      <Skeleton className="h-4 w-28" />
+      <Skeleton className="h-3 w-40" />
+      <Skeleton className="h-2 w-full" />
+      <Skeleton className="h-3 w-36" />
     </div>
   );
 }
 
-function SidebarPlanUsageShell({
-  children,
-  href,
-  onViewUsageClick,
-}: {
-  children: React.ReactNode;
-  href: string;
-  onViewUsageClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
-}) {
-  return (
-    <div className="mt-auto px-1 pb-2 group-data-[collapsible=icon]:hidden">
-      <Link
-        href={href}
-        onClick={onViewUsageClick}
-        className="block rounded-lg border border-sidebar-border bg-sidebar-accent px-3 py-3 transition-colors hover:bg-sidebar-accent/80"
-      >
-        {children}
-      </Link>
-    </div>
-  );
-}
-
-export function PlanUsageSummaryContent({
-  summary,
-  variant,
-}: {
-  summary: ResolvedPlanUsageSummary;
-  variant: "sidebar" | "billing";
-}) {
+export function PlanUsageSummaryContent({ summary }: { summary: ResolvedPlanUsageSummary }) {
   const planName = summary.activePlanName ?? "No active plan";
-  const isSidebar = variant === "sidebar";
-  const planNameClassName = isSidebar
-    ? "mt-3 text-xs text-sidebar-foreground"
-    : "text-sm font-medium text-foreground";
-  const renewalClassName = isSidebar
-    ? "mt-1 text-xs text-sidebar-muted-foreground"
-    : "mt-1 text-sm text-muted-foreground";
-  const usageClassName = isSidebar
-    ? "mt-3 text-xs text-sidebar-muted-foreground"
-    : "mt-3 text-sm text-subtle-foreground";
-  const progressTrackClassName = isSidebar
-    ? "mt-3 h-1.5 overflow-hidden rounded-full bg-sidebar-accent"
-    : "mt-4 h-2 overflow-hidden rounded-full bg-accent";
 
   return (
-    <>
-      {isSidebar ? (
-        <TypographyP className="text-xs font-medium text-sidebar-foreground">
-          Plan usage
-        </TypographyP>
-      ) : null}
-      <TypographyP className={planNameClassName}>{planName}</TypographyP>
-      {summary.renewalCopy ? (
-        <TypographyP className={renewalClassName}>{summary.renewalCopy}</TypographyP>
-      ) : null}
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-1">
+        <TypographyP className="text-sm font-medium text-foreground">{planName}</TypographyP>
+        {summary.renewalCopy ? (
+          <TypographyP className="text-sm text-muted-foreground">{summary.renewalCopy}</TypographyP>
+        ) : null}
+      </div>
       {summary.usageProgressPercent !== null ? (
-        <div className={progressTrackClassName}>
-          <div
-            className="h-full rounded-full bg-bud-500"
-            style={{ width: `${summary.usageProgressPercent}%` }}
-          />
-        </div>
+        <Progress
+          value={summary.usageProgressPercent}
+          aria-label={summary.usageSummary}
+          className="[&_[data-slot=progress-track]]:h-2"
+        />
       ) : null}
-      <TypographyP className={usageClassName}>{summary.usageSummary}</TypographyP>
-      {isSidebar ? (
-        <div className="mt-3 flex items-center gap-2 text-xs text-sidebar-muted-foreground">
-          <span>View usage</span>
-          <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={1.7} className="size-3.5" />
-        </div>
-      ) : null}
-    </>
+      <TypographyP className="text-sm text-subtle-foreground tabular-nums">
+        {summary.usageSummary}
+      </TypographyP>
+    </div>
   );
 }
 
-export function PlanUsageSidebarWidget({ organizationSlug }: { organizationSlug: string }) {
-  const pathname = usePathname();
+export function PlanUsageFooterControl({ organizationSlug }: { organizationSlug: string }) {
   const { data: customer, isLoading: customerLoading, error: customerError } = useCustomer();
   const { data: plans, isLoading: plansLoading, error: plansError } = useListPlans();
 
@@ -132,79 +78,60 @@ export function PlanUsageSidebarWidget({ organizationSlug }: { organizationSlug:
     [customer?.balances, customer?.subscriptions, plans],
   );
 
-  function handleBillingSectionClick(
-    sectionId: string,
-    event: React.MouseEvent<HTMLAnchorElement>,
-  ) {
-    if (!isPlanUsageBillingPath(pathname, organizationSlug)) {
-      return;
-    }
-
-    event.preventDefault();
-    scrollToBillingSection(sectionId);
-    window.history.replaceState(null, "", `#${sectionId}`);
-  }
-
-  function handleViewUsageClick(event: React.MouseEvent<HTMLAnchorElement>) {
-    handleBillingSectionClick(planUsageSectionId, event);
-  }
-
-  function handleViewPlansClick(event: React.MouseEvent<HTMLAnchorElement>) {
-    handleBillingSectionClick(availablePlansSectionId, event);
-  }
-
-  if (customerLoading || plansLoading) {
-    return (
-      <div className="mt-auto px-1 pb-2 group-data-[collapsible=icon]:hidden">
-        <PlanUsageSummarySkeleton variant="sidebar" />
-      </div>
-    );
-  }
-
-  if (customerError || plansError) {
-    return (
-      <SidebarPlanUsageShell href={buildPlanUsageHref(organizationSlug)}>
-        <TypographyP className="text-xs font-medium text-sidebar-foreground">
-          Plan usage
-        </TypographyP>
-        <TypographyP className="mt-3 text-xs text-sidebar-muted-foreground">
-          Couldn&apos;t load usage right now.
-        </TypographyP>
-        <div className="mt-3 flex items-center gap-2 text-xs text-sidebar-muted-foreground">
-          <span>Open billing</span>
-          <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={1.7} className="size-3.5" />
-        </div>
-      </SidebarPlanUsageShell>
-    );
-  }
-
-  if (!summary.activePlanName && !hasPlanUsageMeter(summary)) {
-    return (
-      <SidebarPlanUsageShell
-        href={buildAvailablePlansHref(organizationSlug)}
-        onViewUsageClick={handleViewPlansClick}
-      >
-        <TypographyP className="text-xs font-medium text-sidebar-foreground">
-          Plan usage
-        </TypographyP>
-        <TypographyP className="mt-3 text-xs text-sidebar-foreground">No active plan</TypographyP>
-        <TypographyP className="mt-1 text-xs text-sidebar-muted-foreground">
-          Choose a plan to start tracking usage.
-        </TypographyP>
-        <div className="mt-3 flex items-center gap-2 text-xs text-sidebar-muted-foreground">
-          <span>View plans</span>
-          <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={1.7} className="size-3.5" />
-        </div>
-      </SidebarPlanUsageShell>
-    );
-  }
+  const isLoading = customerLoading || plansLoading;
+  const hasError = Boolean(customerError || plansError);
+  const hasActivePlan = Boolean(summary.activePlanName || hasPlanUsageMeter(summary));
+  const planName = isLoading ? "Loading plan" : (summary.activePlanName ?? "Choose a plan");
 
   return (
-    <SidebarPlanUsageShell
-      href={buildPlanUsageHref(organizationSlug)}
-      onViewUsageClick={handleViewUsageClick}
-    >
-      <PlanUsageSummaryContent summary={summary} variant="sidebar" />
-    </SidebarPlanUsageShell>
+    <Dialog>
+      <DialogTrigger
+        render={
+          <Button variant="outline" size="xs" aria-label={`Open plan usage: ${planName}`}>
+            <HugeiconsIcon icon={CreditCardIcon} strokeWidth={2} data-icon="inline-start" />
+            <span className="max-w-40 truncate">{planName}</span>
+          </Button>
+        }
+      />
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <div className="flex size-9 items-center justify-center rounded-full bg-muted text-foreground">
+            <HugeiconsIcon icon={CreditCardIcon} strokeWidth={1.8} className="size-5" />
+          </div>
+          <DialogTitle>
+            {isLoading
+              ? "Loading your workspace plan"
+              : hasActivePlan
+                ? `Your workspace is on the ${summary.activePlanName ?? "current"} plan`
+                : "Choose a plan for your workspace"}
+          </DialogTitle>
+          <DialogDescription>
+            Review current usage here or open billing for complete plan details.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Separator />
+
+        {isLoading ? <PlanUsageSummarySkeleton /> : null}
+        {hasError ? (
+          <TypographyP className="text-sm text-destructive">
+            Couldn&apos;t load plan usage. Open billing to try again.
+          </TypographyP>
+        ) : null}
+        {!isLoading && !hasError ? <PlanUsageSummaryContent summary={summary} /> : null}
+
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            render={<Link href={buildAvailablePlansHref(organizationSlug)} />}
+          >
+            See all plans
+          </Button>
+          <Button render={<Link href={buildPlanUsageHref(organizationSlug)} />}>
+            Open billing
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/docs/adr/2026-07-10-app-shell-plan-footer-design.md
+++ b/docs/adr/2026-07-10-app-shell-plan-footer-design.md
@@ -1,0 +1,27 @@
+# App shell plan footer
+
+## Goal
+
+Simplify the app shell's billing summary and keep support easy to reach without taking space from the main navigation.
+
+## Design
+
+A fixed footer spans the full viewport below the sidebar and main content. The footer uses the existing app-shell surfaces and border tokens so it remains calm in light and dark themes.
+
+The left side contains a compact plan pill with a plan icon and the active plan name. Selecting it opens an accessible dialog with the current plan, renewal details, primary usage meter, and links to usage and available plans on the billing settings page. Loading, unavailable, and no-plan states stay inside the same surface.
+
+The right side contains a Support icon button. It opens the user's email client with `mailto:minh@hyperlocalise.com`.
+
+The app shell reserves space for the footer, including the device safe area, so the footer never covers navigation or page content. The footer remains independent of the sidebar's expanded or collapsed state.
+
+## Data and permissions
+
+The plan pill reuses the existing Autumn customer and plan queries. It appears only when the user can read billing and Autumn is configured. The support action remains available to every authenticated user.
+
+## Accessibility
+
+The plan pill has a visible label and uses the existing dialog primitive for keyboard focus and dismissal. The icon-only Support button has an accessible name and tooltip. Usage values use tabular numerals, and the dialog exposes a title and description.
+
+## Verification
+
+Add focused component coverage for the plan footer states and actions. Run the affected tests and `vp check --fix` from `apps/hyperlocalise-web`.

--- a/docs/adr/2026-07-10-app-shell-plan-footer-design.md
+++ b/docs/adr/2026-07-10-app-shell-plan-footer-design.md
@@ -12,7 +12,7 @@ The left side contains a compact plan pill with a plan icon and the active plan 
 
 The right side contains a Support icon button. It opens the user's email client with `mailto:minh@hyperlocalise.com`.
 
-The app shell uses one shared footer-height token for the footer, sidebar scroll padding, and main content padding. The token includes the device safe area so the footer never covers navigation or page content. The footer remains independent of the sidebar's expanded or collapsed state.
+The app shell uses one shared footer-height token for the footer, sidebar scroll padding, and main content padding. The token includes the device safe area so the footer never covers navigation or page content. A derived content-height token constrains inbox and CAT views that intentionally fill the remaining viewport. The footer remains independent of the sidebar's expanded or collapsed state.
 
 ## Data and permissions
 

--- a/docs/adr/2026-07-10-app-shell-plan-footer-design.md
+++ b/docs/adr/2026-07-10-app-shell-plan-footer-design.md
@@ -12,7 +12,7 @@ The left side contains a compact plan pill with a plan icon and the active plan 
 
 The right side contains a Support icon button. It opens the user's email client with `mailto:minh@hyperlocalise.com`.
 
-The app shell reserves space for the footer, including the device safe area, so the footer never covers navigation or page content. The footer remains independent of the sidebar's expanded or collapsed state.
+The app shell uses one shared footer-height token for the footer, sidebar scroll padding, and main content padding. The token includes the device safe area so the footer never covers navigation or page content. The footer remains independent of the sidebar's expanded or collapsed state.
 
 ## Data and permissions
 


### PR DESCRIPTION
## What changed

- Replace the sidebar plan usage card with a fixed footer spanning the app shell.
- Add a compact plan pill that opens a dialog with the active plan, renewal details, usage, and billing links.
- Add a Support button that opens an email to `minh@hyperlocalise.com`.
- Reserve space for the footer and device safe areas so it does not cover sidebar or page content.
- Add focused component coverage and document the approved design.

## How to test

- Run `vp check --fix`.
- Run `vp test src/components/app-shell/app-shell-footer.test.tsx src/lib/billing/plan-usage.test.ts`.
- Open the authenticated app and confirm the plan pill opens the usage dialog.
- Confirm the Support button opens `mailto:minh@hyperlocalise.com`.
- `vp test` was also run: 353 test files passed, but the full suite remained blocked by local PostgreSQL connection failures on port 5432.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review