### PR TITLE
fix(inbox): strip markdown from conversation list previews

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.tsx
@@ -119,7 +119,7 @@ const ConversationListItem = memo(function ConversationListItem({
         </div>
         <TypographyMuted className="mt-1 truncate">
           {conversation.lastMessage
-            ? stripMarkdown(conversation.lastMessage.text)
+            ? stripMarkdown(conversation.lastMessage.text) || "No messages yet"
             : "No messages yet"}
         </TypographyMuted>
         <div className="mt-2 flex min-w-0 items-center gap-2 text-xs text-muted-foreground">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.tsx
@@ -5,6 +5,7 @@ import { memo } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TypographyMuted, TypographySmall } from "@/components/ui/typography";
+import { stripMarkdown } from "@/lib/markdown/strip-markdown";
 import { cn } from "@/lib/primitives/cn";
 
 import {
@@ -117,7 +118,9 @@ const ConversationListItem = memo(function ConversationListItem({
           <TypographySmall className="truncate">{conversation.title}</TypographySmall>
         </div>
         <TypographyMuted className="mt-1 truncate">
-          {conversation.lastMessage?.text ?? "No messages yet"}
+          {conversation.lastMessage
+            ? stripMarkdown(conversation.lastMessage.text)
+            : "No messages yet"}
         </TypographyMuted>
         <div className="mt-2 flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
           <span className="truncate">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.tsx
@@ -119,7 +119,7 @@ const ConversationListItem = memo(function ConversationListItem({
         </div>
         <TypographyMuted className="mt-1 truncate">
           {conversation.lastMessage
-            ? stripMarkdown(conversation.lastMessage.text) || "No messages yet"
+            ? stripMarkdown(conversation.lastMessage.text) || conversation.lastMessage.text
             : "No messages yet"}
         </TypographyMuted>
         <div className="mt-2 flex min-w-0 items-center gap-2 text-xs text-muted-foreground">

--- a/apps/hyperlocalise-web/src/lib/markdown/strip-markdown.test.ts
+++ b/apps/hyperlocalise-web/src/lib/markdown/strip-markdown.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { stripMarkdown } from "./strip-markdown";
+
+describe("stripMarkdown", () => {
+  it("strips bold, inline code, and list markers for inbox-style previews", () => {
+    expect(stripMarkdown("**HL-Test** progress:\n- **Vietnamese (`vi`)**: **Answer**")).toBe(
+      "HL-Test progress: Vietnamese (vi): Answer",
+    );
+  });
+
+  it("keeps link labels and image alt text", () => {
+    expect(stripMarkdown("See [docs](https://example.com) and ![logo](logo.png)")).toBe(
+      "See docs and logo",
+    );
+  });
+
+  it("collapses whitespace into a single line", () => {
+    expect(stripMarkdown("## Title\n\n> quoted\n\n1. first")).toBe("Title quoted first");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/markdown/strip-markdown.test.ts
+++ b/apps/hyperlocalise-web/src/lib/markdown/strip-markdown.test.ts
@@ -15,7 +15,21 @@ describe("stripMarkdown", () => {
     );
   });
 
+  it("handles nested parentheses and empty link labels", () => {
+    expect(
+      stripMarkdown(
+        "Read [Markdown](https://en.wikipedia.org/wiki/Markdown_(language)) or [](https://example.com)",
+      ),
+    ).toBe("Read Markdown or https://example.com");
+  });
+
   it("collapses whitespace into a single line", () => {
     expect(stripMarkdown("## Title\n\n> quoted\n\n1. first")).toBe("Title quoted first");
+  });
+
+  it("preserves snake_case identifiers", () => {
+    expect(stripMarkdown("Changed src/file_name_test.ts on branch feature_fix")).toBe(
+      "Changed src/file_name_test.ts on branch feature_fix",
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/lib/markdown/strip-markdown.ts
+++ b/apps/hyperlocalise-web/src/lib/markdown/strip-markdown.ts
@@ -1,0 +1,32 @@
+/**
+ * Converts markdown to a single-line plain-text preview.
+ * Strips common syntax (emphasis, code, links, headings, lists) without a full parser.
+ */
+export function stripMarkdown(markdown: string): string {
+  return (
+    markdown
+      // Fenced code blocks → keep inner text
+      .replace(/```[\w-]*\n?([\s\S]*?)```/g, "$1")
+      // Images → alt text
+      .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+      // Links → label
+      .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+      // Inline code
+      .replace(/`([^`]+)`/g, "$1")
+      // Bold / italic
+      .replace(/(\*\*|__)(.*?)\1/g, "$2")
+      .replace(/(\*|_)(.*?)\1/g, "$2")
+      // Headings
+      .replace(/^#{1,6}\s+/gm, "")
+      // Blockquotes
+      .replace(/^>\s?/gm, "")
+      // Unordered / ordered list markers
+      .replace(/^[\s]*[-*+]\s+/gm, "")
+      .replace(/^[\s]*\d+\.\s+/gm, "")
+      // Horizontal rules
+      .replace(/^(-{3,}|\*{3,}|_{3,})$/gm, "")
+      // Collapse whitespace for one-line previews
+      .replace(/\s+/g, " ")
+      .trim()
+  );
+}

--- a/apps/hyperlocalise-web/src/lib/markdown/strip-markdown.ts
+++ b/apps/hyperlocalise-web/src/lib/markdown/strip-markdown.ts
@@ -7,15 +7,18 @@ export function stripMarkdown(markdown: string): string {
     markdown
       // Fenced code blocks → keep inner text
       .replace(/```[\w-]*\n?([\s\S]*?)```/g, "$1")
-      // Images → alt text
-      .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
-      // Links → label
-      .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+      // Images → alt text (allow nested () in destination)
+      .replace(/!\[([^\]]*)\]\(((?:[^()]|\([^()]*\))*)\)/g, "$1")
+      // Links → label, or URL when the label is empty
+      .replace(
+        /\[([^\]]*)\]\(((?:[^()]|\([^()]*\))*)\)/g,
+        (_match, label: string, url: string) => label || url,
+      )
       // Inline code
       .replace(/`([^`]+)`/g, "$1")
-      // Bold / italic
+      // Bold / italic (* and ** / __ only — skip single _ so snake_case stays intact)
       .replace(/(\*\*|__)(.*?)\1/g, "$2")
-      .replace(/(\*|_)(.*?)\1/g, "$2")
+      .replace(/\*([^*]+)\*/g, "$1")
       // Headings
       .replace(/^#{1,6}\s+/gm, "")
       // Blockquotes


### PR DESCRIPTION
## What changed

Inbox conversation list previews were showing raw markdown (`**bold**`, backticks, list markers). Added a `stripMarkdown` helper and use it when rendering last-message snippets so the list stays readable.

## How to test

- [ ] Open the org inbox with conversations that have markdown in the latest message
- [ ] Confirm list previews show plain text (no `**`, backticks, or list markers)
- [ ] `vp test src/lib/markdown/strip-markdown.test.ts` (from `apps/hyperlocalise-web`)
- [ ] `vp check --fix` on the touched files

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)