### PR TITLE
fix(inbox): prevent stream crash from undefined tool code blocks

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
@@ -337,7 +337,14 @@ function AssistantMessageParts({
   return (
     <>
       {sourceParts.length > 0 ? (
-        <AiElementErrorBoundary scope="sources" resetKeys={[sourceParts.length]}>
+        <AiElementErrorBoundary
+          scope="sources"
+          resetKeys={sourceParts.map((part) =>
+            part.type === "source-url"
+              ? `${part.sourceId}:${part.url}:${part.title ?? ""}`
+              : `${part.sourceId}:${part.title ?? ""}:${part.filename ?? ""}:${part.mediaType ?? ""}`,
+          )}
+        >
           <AssistantSources parts={sourceParts} />
         </AiElementErrorBoundary>
       ) : null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
@@ -17,6 +17,7 @@ import {
   ConversationEmptyState,
   ConversationScrollButton,
 } from "@/components/ai-elements/conversation";
+import { AiElementErrorBoundary } from "@/components/ai-elements/ai-element-error-boundary";
 import { Message, MessageContent, MessageResponse } from "@/components/ai-elements/message";
 import { Reasoning, ReasoningContent, ReasoningTrigger } from "@/components/ai-elements/reasoning";
 import { Source, Sources, SourcesContent, SourcesTrigger } from "@/components/ai-elements/sources";
@@ -169,7 +170,9 @@ const PersistedMessage = memo(function PersistedMessage({
         ) : message.parts && message.parts.length > 0 ? (
           <AssistantMessageParts isStreaming={false} message={toAssistantUIMessage(message)} />
         ) : (
-          <MessageResponse>{message.text}</MessageResponse>
+          <AiElementErrorBoundary scope="message" resetKeys={[message.id, message.text]}>
+            <MessageResponse>{message.text}</MessageResponse>
+          </AiElementErrorBoundary>
         )}
         <MessageAttachments attachments={message.attachments} />
       </div>
@@ -328,28 +331,46 @@ function AssistantMessageParts({
   const toolParts = message.parts.filter(isToolPart);
   const text = message.parts
     .filter((part) => part.type === "text")
-    .map((part) => part.text)
+    .map((part) => part.text ?? "")
     .join("");
 
   return (
     <>
-      {sourceParts.length > 0 ? <AssistantSources parts={sourceParts} /> : null}
+      {sourceParts.length > 0 ? (
+        <AiElementErrorBoundary scope="sources" resetKeys={[sourceParts.length]}>
+          <AssistantSources parts={sourceParts} />
+        </AiElementErrorBoundary>
+      ) : null}
       {reasoningParts.map((part, index) =>
-        part.text.trim() ? (
-          <Reasoning
+        part.text?.trim() ? (
+          <AiElementErrorBoundary
             key={`${part.type}-${index}`}
-            isStreaming={isStreaming || part.state === "streaming"}
-            className="mb-3"
+            scope="reasoning"
+            resetKeys={[part.text, part.state]}
           >
-            <ReasoningTrigger />
-            <ReasoningContent>{part.text}</ReasoningContent>
-          </Reasoning>
+            <Reasoning isStreaming={isStreaming || part.state === "streaming"} className="mb-3">
+              <ReasoningTrigger />
+              <ReasoningContent>{part.text}</ReasoningContent>
+            </Reasoning>
+          </AiElementErrorBoundary>
         ) : null,
       )}
       {toolParts.map((part, index) => (
-        <AssistantToolPart key={`${part.type}-${index}`} part={part} />
+        <AiElementErrorBoundary
+          key={`${part.type}-${index}`}
+          scope="tool"
+          resetKeys={[part.type, part.state, part.toolCallId]}
+        >
+          <AssistantToolPart part={part} />
+        </AiElementErrorBoundary>
       ))}
-      {text ? <MessageResponse>{text}</MessageResponse> : isStreaming ? <TypingIndicator /> : null}
+      {text ? (
+        <AiElementErrorBoundary scope="message" resetKeys={[text, isStreaming]}>
+          <MessageResponse isAnimating={isStreaming}>{text}</MessageResponse>
+        </AiElementErrorBoundary>
+      ) : isStreaming ? (
+        <TypingIndicator />
+      ) : null}
     </>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
@@ -22,6 +22,7 @@ import { Message, MessageContent, MessageResponse } from "@/components/ai-elemen
 import { Reasoning, ReasoningContent, ReasoningTrigger } from "@/components/ai-elements/reasoning";
 import { Source, Sources, SourcesContent, SourcesTrigger } from "@/components/ai-elements/sources";
 import {
+  serializeToolJson,
   Tool,
   ToolContent,
   ToolHeader,
@@ -366,7 +367,14 @@ function AssistantMessageParts({
         <AiElementErrorBoundary
           key={`${part.type}-${index}`}
           scope="tool"
-          resetKeys={[part.type, part.state, part.toolCallId]}
+          resetKeys={[
+            part.type,
+            part.state,
+            part.toolCallId,
+            serializeToolJson(part.input),
+            serializeToolJson(part.output),
+            part.errorText ?? "",
+          ]}
         >
           <AssistantToolPart part={part} />
         </AiElementErrorBoundary>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.tsx
@@ -8,6 +8,7 @@ import { TypographyH4, TypographyMuted } from "@/components/ui/typography";
 
 import { ConversationDetails } from "./conversation-details";
 import { ConversationMessageList } from "./conversation-message-list";
+import { InboxPanelErrorBoundary } from "./inbox-panel-error-boundary";
 import {
   formatRelativeTime,
   sourceLabel,
@@ -67,30 +68,46 @@ export function ConversationPanel({
       <ConversationHeader conversation={conversation} jobs={jobs} jobsIsLoading={jobsIsLoading} />
 
       <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
-        <ConversationDetails
-          conversation={conversation}
-          jobs={jobs}
-          jobsIsLoading={jobsIsLoading}
-          organizationSlug={organizationSlug}
-        />
+        <InboxPanelErrorBoundary
+          scope="details"
+          resetKeys={[conversation.id, jobs.length, jobsIsLoading]}
+        >
+          <ConversationDetails
+            conversation={conversation}
+            jobs={jobs}
+            jobsIsLoading={jobsIsLoading}
+            organizationSlug={organizationSlug}
+          />
+        </InboxPanelErrorBoundary>
 
         <div className="flex min-h-0 flex-1 flex-col xl:pr-80">
-          <ConversationMessageList
-            conversationId={conversation.id}
-            currentUser={currentUser}
-            isLoading={messagesIsLoading}
-            isStreaming={isStreaming}
-            messages={messages}
-            streamedAssistant={streamedAssistant}
-          />
+          <InboxPanelErrorBoundary
+            scope="messages"
+            className="min-h-0 flex-1"
+            resetKeys={[conversation.id, messages.length, streamedAssistant?.status]}
+          >
+            <ConversationMessageList
+              conversationId={conversation.id}
+              currentUser={currentUser}
+              isLoading={messagesIsLoading}
+              isStreaming={isStreaming}
+              messages={messages}
+              streamedAssistant={streamedAssistant}
+            />
+          </InboxPanelErrorBoundary>
 
           {isChatUi ? (
-            <ReplyComposer
-              disabled={composerDisabled}
-              isStreaming={isStreaming}
-              onSend={onSendMessage}
-              organizationSlug={organizationSlug}
-            />
+            <InboxPanelErrorBoundary
+              scope="composer"
+              resetKeys={[conversation.id, composerDisabled]}
+            >
+              <ReplyComposer
+                disabled={composerDisabled}
+                isStreaming={isStreaming}
+                onSend={onSendMessage}
+                organizationSlug={organizationSlug}
+              />
+            </InboxPanelErrorBoundary>
           ) : null}
         </div>
       </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.tsx
@@ -84,7 +84,7 @@ export function ConversationPanel({
           <InboxPanelErrorBoundary
             scope="messages"
             className="min-h-0 flex-1"
-            resetKeys={[conversation.id, messages.length, streamedAssistant?.status]}
+            resetKeys={[conversation.id, messages, streamedAssistant?.message]}
           >
             <ConversationMessageList
               conversationId={conversation.id}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-view.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/primitives/cn";
 
 import { ConversationPanel } from "./conversation-panel";
 import { InboxList } from "./inbox-list";
+import { InboxPanelErrorBoundary } from "./inbox-panel-error-boundary";
 import type {
   Conversation,
   ConversationMessage,
@@ -66,14 +67,20 @@ export function InboxPageView({
             : "lg:grid-cols-[minmax(20rem,24rem)_minmax(0,1fr)] xl:grid-cols-[minmax(22rem,26rem)_minmax(0,1fr)]",
         )}
       >
-        <InboxList
-          conversations={conversations}
-          currentUser={currentUser}
-          isError={conversationsIsError}
-          isLoading={conversationsIsLoading}
-          onSelectConversation={onSelectConversation}
-          selectedConversationId={selectedConversationId}
-        />
+        <InboxPanelErrorBoundary
+          scope="list"
+          className="max-h-[40svh] min-h-0 shrink-0 lg:h-full lg:max-h-none lg:shrink"
+          resetKeys={[selectedConversationId, conversations.length, conversationsIsLoading]}
+        >
+          <InboxList
+            conversations={conversations}
+            currentUser={currentUser}
+            isError={conversationsIsError}
+            isLoading={conversationsIsLoading}
+            onSelectConversation={onSelectConversation}
+            selectedConversationId={selectedConversationId}
+          />
+        </InboxPanelErrorBoundary>
 
         <ConversationPanel
           conversation={selectedConversation}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-panel-error-boundary.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-panel-error-boundary.messages.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const inboxPanelErrorBoundaryMessages = defineMessages({
+  listTitle: {
+    defaultMessage: "Conversation list failed to load",
+    id: "1ggu9Tm0ub",
+    description: "Error boundary title when the inbox list panel crashes",
+  },
+  messagesTitle: {
+    defaultMessage: "Messages failed to load",
+    id: "hMQhlW9yb7",
+    description: "Error boundary title when the inbox messages panel crashes",
+  },
+  detailsTitle: {
+    defaultMessage: "Conversation details failed to load",
+    id: "yYnhoQZl4b",
+    description: "Error boundary title when the inbox details panel crashes",
+  },
+  composerTitle: {
+    defaultMessage: "Reply composer failed to load",
+    id: "OROpfMaGFB",
+    description: "Error boundary title when the inbox reply composer crashes",
+  },
+  description: {
+    defaultMessage:
+      "Something went wrong in this panel. You can retry or keep working in the other panels.",
+    id: "TIsb5WlP88",
+    description: "Error boundary description when an inbox panel crashes",
+  },
+  retry: {
+    defaultMessage: "Try again",
+    id: "cbNqGo9VKV",
+    description: "Button label to retry rendering a crashed inbox panel",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-panel-error-boundary.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-panel-error-boundary.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { AlertCircleIcon } from "lucide-react";
+import { type ErrorInfo, type ReactNode } from "react";
+import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
+import { FormattedMessage } from "react-intl";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/primitives/cn";
+
+import { inboxPanelErrorBoundaryMessages } from "./inbox-panel-error-boundary.messages";
+
+export type InboxPanelErrorBoundaryScope = "list" | "messages" | "details" | "composer";
+
+type InboxPanelErrorBoundaryProps = {
+  children: ReactNode;
+  scope: InboxPanelErrorBoundaryScope;
+  className?: string;
+  resetKeys?: unknown[];
+};
+
+const panelTitleMessageByScope = {
+  list: inboxPanelErrorBoundaryMessages.listTitle,
+  messages: inboxPanelErrorBoundaryMessages.messagesTitle,
+  details: inboxPanelErrorBoundaryMessages.detailsTitle,
+  composer: inboxPanelErrorBoundaryMessages.composerTitle,
+} as const;
+
+function logInboxPanelError(scope: InboxPanelErrorBoundaryScope, error: Error, info: ErrorInfo) {
+  console.error(`[inbox:${scope}]`, {
+    name: error.name,
+    message: error.message,
+    stack: error.stack,
+    componentStack: info.componentStack,
+  });
+}
+
+function InboxPanelErrorFallback({
+  error,
+  resetErrorBoundary,
+  scope,
+  className,
+}: FallbackProps & { scope: InboxPanelErrorBoundaryScope; className?: string }) {
+  const errorMessage = error instanceof Error ? error.message : null;
+
+  return (
+    <div
+      className={cn(
+        "flex h-full min-h-0 min-w-0 flex-col items-center justify-center p-4",
+        className,
+      )}
+      role="alert"
+      data-inbox-panel-error={scope}
+    >
+      <Alert variant="destructive" className="max-w-md">
+        <AlertCircleIcon />
+        <AlertTitle>
+          <FormattedMessage {...panelTitleMessageByScope[scope]} />
+        </AlertTitle>
+        <AlertDescription className="space-y-3">
+          <p>
+            <FormattedMessage {...inboxPanelErrorBoundaryMessages.description} />
+          </p>
+          {process.env.NODE_ENV !== "production" && errorMessage ? (
+            <p className="font-mono text-xs break-words">{errorMessage}</p>
+          ) : null}
+          <Button type="button" variant="outline" size="sm" onClick={resetErrorBoundary}>
+            <FormattedMessage {...inboxPanelErrorBoundaryMessages.retry} />
+          </Button>
+        </AlertDescription>
+      </Alert>
+    </div>
+  );
+}
+
+export function InboxPanelErrorBoundary({
+  children,
+  scope,
+  className,
+  resetKeys,
+}: InboxPanelErrorBoundaryProps) {
+  return (
+    <ErrorBoundary
+      fallbackRender={(fallbackProps) => (
+        <InboxPanelErrorFallback {...fallbackProps} scope={scope} className={className} />
+      )}
+      onError={(error, info) => {
+        if (error instanceof Error) {
+          logInboxPanelError(scope, error, info);
+        }
+      }}
+      resetKeys={resetKeys}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/ai-elements/ai-element-error-boundary.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/ai-element-error-boundary.messages.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const aiElementErrorBoundaryMessages = defineMessages({
+  messageTitle: {
+    defaultMessage: "Message failed to render",
+    id: "jztUpXyotb",
+    description: "Error boundary title when a chat message response crashes",
+  },
+  toolTitle: {
+    defaultMessage: "Tool call failed to render",
+    id: "Ifd/sQBUjN",
+    description: "Error boundary title when a tool call UI crashes",
+  },
+  reasoningTitle: {
+    defaultMessage: "Reasoning failed to render",
+    id: "D6N0QoCpN1",
+    description: "Error boundary title when reasoning UI crashes",
+  },
+  sourcesTitle: {
+    defaultMessage: "Sources failed to render",
+    id: "0nNAqN4Vgj",
+    description: "Error boundary title when sources UI crashes",
+  },
+  codeBlockTitle: {
+    defaultMessage: "Code block failed to render",
+    id: "AkuhSH8rwy",
+    description: "Error boundary title when a code block crashes",
+  },
+  description: {
+    defaultMessage:
+      "This part of the reply hit an error. Retry it, or continue with the rest of the conversation.",
+    id: "qh1KvSzeYI",
+    description: "Error boundary description when an AI element crashes",
+  },
+  retry: {
+    defaultMessage: "Try again",
+    id: "ZSpIiSP+sp",
+    description: "Button label to retry rendering a crashed AI element",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/ai-element-error-boundary.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/ai-element-error-boundary.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { AlertCircleIcon } from "lucide-react";
+import { type ErrorInfo, type ReactNode } from "react";
+import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
+import { FormattedMessage } from "react-intl";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/primitives/cn";
+
+import { aiElementErrorBoundaryMessages } from "./ai-element-error-boundary.messages";
+
+export type AiElementErrorBoundaryScope =
+  | "message"
+  | "tool"
+  | "reasoning"
+  | "sources"
+  | "code-block";
+
+type AiElementErrorBoundaryProps = {
+  children: ReactNode;
+  scope: AiElementErrorBoundaryScope;
+  className?: string;
+  resetKeys?: unknown[];
+};
+
+const panelTitleMessageByScope = {
+  message: aiElementErrorBoundaryMessages.messageTitle,
+  tool: aiElementErrorBoundaryMessages.toolTitle,
+  reasoning: aiElementErrorBoundaryMessages.reasoningTitle,
+  sources: aiElementErrorBoundaryMessages.sourcesTitle,
+  "code-block": aiElementErrorBoundaryMessages.codeBlockTitle,
+} as const;
+
+function logAiElementError(scope: AiElementErrorBoundaryScope, error: Error, info: ErrorInfo) {
+  console.error(`[ai-elements:${scope}]`, {
+    name: error.name,
+    message: error.message,
+    stack: error.stack,
+    componentStack: info.componentStack,
+  });
+}
+
+function AiElementErrorFallback({
+  error,
+  resetErrorBoundary,
+  scope,
+  className,
+}: FallbackProps & { scope: AiElementErrorBoundaryScope; className?: string }) {
+  const errorMessage = error instanceof Error ? error.message : null;
+
+  return (
+    <div
+      className={cn("my-2 w-full min-w-0", className)}
+      role="alert"
+      data-ai-element-error={scope}
+    >
+      <Alert variant="destructive" className="max-w-full">
+        <AlertCircleIcon />
+        <AlertTitle>
+          <FormattedMessage {...panelTitleMessageByScope[scope]} />
+        </AlertTitle>
+        <AlertDescription className="space-y-3">
+          <p>
+            <FormattedMessage {...aiElementErrorBoundaryMessages.description} />
+          </p>
+          {process.env.NODE_ENV !== "production" && errorMessage ? (
+            <p className="font-mono text-xs break-words">{errorMessage}</p>
+          ) : null}
+          <Button type="button" variant="outline" size="sm" onClick={resetErrorBoundary}>
+            <FormattedMessage {...aiElementErrorBoundaryMessages.retry} />
+          </Button>
+        </AlertDescription>
+      </Alert>
+    </div>
+  );
+}
+
+export function AiElementErrorBoundary({
+  children,
+  scope,
+  className,
+  resetKeys,
+}: AiElementErrorBoundaryProps) {
+  return (
+    <ErrorBoundary
+      fallbackRender={(fallbackProps) => (
+        <AiElementErrorFallback {...fallbackProps} scope={scope} className={className} />
+      )}
+      onError={(error, info) => {
+        if (error instanceof Error) {
+          logAiElementError(scope, error, info);
+        }
+      }}
+      resetKeys={resetKeys}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/ai-elements/code-block.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/code-block.tsx
@@ -106,7 +106,8 @@ const LineSpan = ({
 
 // Types
 type CodeBlockProps = HTMLAttributes<HTMLDivElement> & {
-  code: string;
+  /** Missing during tool input streaming when `JSON.stringify(undefined)` yields `undefined`. */
+  code: string | null | undefined;
   language: BundledLanguage;
   showLineNumbers?: boolean;
 };
@@ -159,20 +160,25 @@ const getHighlighter = (
   return highlighterPromise;
 };
 
+/** Coerce missing code (e.g. JSON.stringify(undefined) during tool streaming) before split. */
+export const normalizeCodeBlockSource = (code: string | null | undefined): string => code ?? "";
+
 // Create raw tokens for immediate display while highlighting loads
 const createRawTokens = (code: string): TokenizedCode => ({
   bg: "transparent",
   fg: "inherit",
-  tokens: code.split("\n").map((line) =>
-    line === ""
-      ? []
-      : [
-          {
-            color: "inherit",
-            content: line,
-          } as ThemedToken,
-        ],
-  ),
+  tokens: normalizeCodeBlockSource(code)
+    .split("\n")
+    .map((line) =>
+      line === ""
+        ? []
+        : [
+            {
+              color: "inherit",
+              content: line,
+            } as ThemedToken,
+          ],
+    ),
 });
 
 // Synchronous highlight with callback for async results
@@ -361,33 +367,35 @@ export const CodeBlockContent = ({
   language,
   showLineNumbers = false,
 }: {
-  code: string;
+  code: string | null | undefined;
   language: BundledLanguage;
   showLineNumbers?: boolean;
 }) => {
+  const safeCode = normalizeCodeBlockSource(code);
+
   // Memoized raw tokens for immediate display
-  const rawTokens = useMemo(() => createRawTokens(code), [code]);
+  const rawTokens = useMemo(() => createRawTokens(safeCode), [safeCode]);
 
   // Synchronous cache lookup — avoids setState in effect for cached results
   const syncTokens = useMemo(
-    () => highlightCode(code, language) ?? rawTokens,
-    [code, language, rawTokens],
+    () => highlightCode(safeCode, language) ?? rawTokens,
+    [safeCode, language, rawTokens],
   );
 
   // Async highlighting result (populated after shiki loads)
   const [asyncTokens, setAsyncTokens] = useState<TokenizedCode | null>(null);
-  const asyncKeyRef = useRef({ code, language });
+  const asyncKeyRef = useRef({ code: safeCode, language });
 
   // Invalidate stale async tokens synchronously during render
-  if (asyncKeyRef.current.code !== code || asyncKeyRef.current.language !== language) {
-    asyncKeyRef.current = { code, language };
+  if (asyncKeyRef.current.code !== safeCode || asyncKeyRef.current.language !== language) {
+    asyncKeyRef.current = { code: safeCode, language };
     setAsyncTokens(null);
   }
 
   useEffect(() => {
     let cancelled = false;
 
-    highlightCode(code, language, (result) => {
+    highlightCode(safeCode, language, (result) => {
       if (!cancelled) {
         setAsyncTokens(result);
       }
@@ -396,7 +404,7 @@ export const CodeBlockContent = ({
     return () => {
       cancelled = true;
     };
-  }, [code, language]);
+  }, [safeCode, language]);
 
   const tokenized = asyncTokens ?? syncTokens;
 
@@ -415,13 +423,14 @@ export const CodeBlock = ({
   children,
   ...props
 }: CodeBlockProps) => {
-  const contextValue = useMemo(() => ({ code }), [code]);
+  const safeCode = normalizeCodeBlockSource(code);
+  const contextValue = useMemo(() => ({ code: safeCode }), [safeCode]);
 
   return (
     <CodeBlockContext.Provider value={contextValue}>
       <CodeBlockContainer className={className} language={language} {...props}>
         {children}
-        <CodeBlockContent code={code} language={language} showLineNumbers={showLineNumbers} />
+        <CodeBlockContent code={safeCode} language={language} showLineNumbers={showLineNumbers} />
       </CodeBlockContainer>
     </CodeBlockContext.Provider>
   );

--- a/apps/hyperlocalise-web/src/components/ai-elements/stack-trace.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/stack-trace.tsx
@@ -112,14 +112,15 @@ const parseStackFrame = (line: string): StackFrame => {
 };
 
 const parseStackTrace = (trace: string): ParsedStackTrace => {
-  const lines = trace.split("\n").filter((line) => line.trim());
+  const safeTrace = trace ?? "";
+  const lines = safeTrace.split("\n").filter((line) => line.trim());
 
   if (lines.length === 0) {
     return {
-      errorMessage: trace,
+      errorMessage: safeTrace,
       errorType: null,
       frames: [],
-      raw: trace,
+      raw: safeTrace,
     };
   }
 
@@ -145,7 +146,7 @@ const parseStackTrace = (trace: string): ParsedStackTrace => {
     errorMessage,
     errorType,
     frames,
-    raw: trace,
+    raw: safeTrace,
   };
 };
 

--- a/apps/hyperlocalise-web/src/components/ai-elements/tool-stream-safety.test.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/tool-stream-safety.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { normalizeCodeBlockSource } from "./code-block";
+import { serializeToolJson } from "./tool";
+
+describe("serializeToolJson", () => {
+  it("returns {} when input is undefined (streaming tool args)", () => {
+    // JSON.stringify(undefined) is undefined — that previously crashed CodeBlock.split
+    expect(JSON.stringify(undefined, null, 2)).toBeUndefined();
+    expect(serializeToolJson(undefined)).toBe("{}");
+  });
+
+  it("stringifies objects and null", () => {
+    expect(serializeToolJson({ path: "src/a.ts" })).toBe('{\n  "path": "src/a.ts"\n}');
+    expect(serializeToolJson(null)).toBe("null");
+  });
+});
+
+describe("normalizeCodeBlockSource", () => {
+  it("coerces nullish code to an empty string", () => {
+    expect(normalizeCodeBlockSource(undefined)).toBe("");
+    expect(normalizeCodeBlockSource(null)).toBe("");
+    expect(normalizeCodeBlockSource("line")).toBe("line");
+  });
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/tool.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/tool.tsx
@@ -17,6 +17,7 @@ import { isValidElement } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { CodeBlock } from "./code-block";
+import { AiElementErrorBoundary } from "./ai-element-error-boundary";
 import { toolMessages } from "./tool.messages";
 import { TypographyH4 } from "@/components/ui/typography";
 
@@ -85,7 +86,12 @@ export const ToolHeader = ({
   toolName,
   ...props
 }: ToolHeaderProps) => {
-  const derivedName = type === "dynamic-tool" ? toolName : type.split("-").slice(1).join("-");
+  const derivedName =
+    type === "dynamic-tool"
+      ? toolName
+      : typeof type === "string"
+        ? type.split("-").slice(1).join("-")
+        : "tool";
 
   return (
     <CollapsibleTrigger
@@ -118,16 +124,36 @@ export type ToolInputProps = ComponentProps<"div"> & {
   input: ToolPart["input"];
 };
 
-export const ToolInput = ({ className, input, ...props }: ToolInputProps) => (
-  <div className={cn("space-y-2 overflow-hidden", className)} {...props}>
-    <TypographyH4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
-      <FormattedMessage {...toolMessages.parameters} />
-    </TypographyH4>
-    <div className="rounded-md bg-muted/50">
-      <CodeBlock code={JSON.stringify(input, null, 2)} language="json" />
+/** `JSON.stringify(undefined)` returns `undefined`, which crashes CodeBlock's `.split`. */
+export function serializeToolJson(value: unknown): string {
+  if (value === undefined) {
+    return "{}";
+  }
+
+  try {
+    const serialized = JSON.stringify(value, null, 2);
+    return typeof serialized === "string" ? serialized : "{}";
+  } catch {
+    return "{}";
+  }
+}
+
+export const ToolInput = ({ className, input, ...props }: ToolInputProps) => {
+  const serializedInput = serializeToolJson(input);
+
+  return (
+    <div className={cn("space-y-2 overflow-hidden", className)} {...props}>
+      <TypographyH4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+        <FormattedMessage {...toolMessages.parameters} />
+      </TypographyH4>
+      <div className="rounded-md bg-muted/50">
+        <AiElementErrorBoundary scope="code-block" resetKeys={[serializedInput]}>
+          <CodeBlock code={serializedInput} language="json" />
+        </AiElementErrorBoundary>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export type ToolOutputProps = ComponentProps<"div"> & {
   output: ToolPart["output"];
@@ -142,9 +168,18 @@ export const ToolOutput = ({ className, output, errorText, ...props }: ToolOutpu
   let Output = <div>{output as ReactNode}</div>;
 
   if (typeof output === "object" && !isValidElement(output)) {
-    Output = <CodeBlock code={JSON.stringify(output, null, 2)} language="json" />;
+    const serializedOutput = serializeToolJson(output);
+    Output = (
+      <AiElementErrorBoundary scope="code-block" resetKeys={[serializedOutput]}>
+        <CodeBlock code={serializedOutput} language="json" />
+      </AiElementErrorBoundary>
+    );
   } else if (typeof output === "string") {
-    Output = <CodeBlock code={output} language="json" />;
+    Output = (
+      <AiElementErrorBoundary scope="code-block" resetKeys={[output]}>
+        <CodeBlock code={output} language="json" />
+      </AiElementErrorBoundary>
+    );
   }
 
   return (


### PR DESCRIPTION
## What changed

Streaming tool calls could crash the entire inbox page: `JSON.stringify(undefined)` returns `undefined`, and `CodeBlock` called `.split` on it inside `useMemo`. Refresh looked fine because persisted tool parts already had real input.

This change:
- Guards `CodeBlock` / tool JSON serialization against nullish code during input streaming
- Adds `react-error-boundary` around inbox panels (`list`, `messages`, `details`, `composer`)
- Adds AI-element error boundaries (`message`, `tool`, `reasoning`, `sources`, `code-block`) so the next failure is scoped and logged instead of blanking the page

## How to test

- [ ] Open an inbox chat conversation and send a message that triggers tool calls
- [ ] Confirm the page no longer white-screens while tool input is streaming
- [ ] Confirm refresh still renders the completed conversation
- [ ] `cd apps/hyperlocalise-web && vp test src/components/ai-elements/tool-stream-safety.test.ts`
- [ ] `cd apps/hyperlocalise-web && vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)