### PR TITLE
feat(app-shell): persistent MobX chat dock with conversation tabs

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
@@ -48,7 +48,9 @@ function dataUrlToFile(dataUrl: string, filename: string, mediaType?: string): F
 
 type ReplyComposerViewProps = {
   disabled: boolean;
+  draft?: string;
   isStreaming: boolean;
+  onDraftChange?: (draft: string) => void;
   onSend: (
     text: string,
     files: File[],
@@ -61,13 +63,15 @@ type ReplyComposerViewProps = {
 
 export function ReplyComposerView({
   disabled,
+  draft = "",
   isStreaming,
+  onDraftChange,
   onSend,
   repositories,
   repositoriesIsError,
   repositoriesIsLoading,
 }: ReplyComposerViewProps) {
-  const [replyText, setReplyText] = useState("");
+  const [replyText, setReplyText] = useState(draft);
   const [selectedRepositoryFullName, setSelectedRepositoryFullName] = useState("");
 
   useEffect(() => {
@@ -96,6 +100,7 @@ export function ReplyComposerView({
       repositoryFullName: resolvedRepositoryFullName || undefined,
     });
     setReplyText("");
+    onDraftChange?.("");
     attachments.clear();
   };
 
@@ -126,7 +131,11 @@ export function ReplyComposerView({
             )}
             <PromptInputTextarea
               disabled={disabled}
-              onChange={(event) => setReplyText(event.currentTarget.value)}
+              onChange={(event) => {
+                const next = event.currentTarget.value;
+                setReplyText(next);
+                onDraftChange?.(next);
+              }}
               className="min-h-24 px-4 py-4 text-base leading-6 sm:px-6 sm:py-5"
               placeholder={
                 isStreaming
@@ -190,6 +199,7 @@ type ReplyComposerProps = Omit<
 export const ReplyComposer = memo(function ReplyComposer({
   organizationSlug,
   inboxApi: injectedInboxApi = inboxApi,
+  draft,
   ...viewProps
 }: ReplyComposerProps) {
   const repositoriesQuery = useQuery({
@@ -198,9 +208,10 @@ export const ReplyComposer = memo(function ReplyComposer({
   });
 
   return (
-    <PromptInputProvider>
+    <PromptInputProvider initialInput={draft ?? ""}>
       <ReplyComposerView
         {...viewProps}
+        draft={draft}
         repositories={repositoriesQuery.data ?? []}
         repositoriesIsError={repositoriesQuery.isError}
         repositoriesIsLoading={repositoriesQuery.isLoading}

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
@@ -29,7 +29,6 @@ import { NavUser } from "./nav-user";
 import { Separator } from "@/components/ui/separator";
 import { TypographyP } from "@/components/ui/typography";
 import { AppShellFooter } from "./app-shell-footer";
-import { ChatDock } from "./chat-dock/chat-dock";
 
 import { appShellClientMessages } from "./app-shell-client.messages";
 
@@ -159,21 +158,18 @@ export function AppShellClient({
           <div className="flex-1 px-4 py-5 sm:px-6 lg:px-8">{children}</div>
         </SidebarInset>
 
-        {organizationSlug ? (
-          <ChatDock
-            organizationSlug={organizationSlug}
-            currentUser={{
-              avatarUrl: user.avatarUrl ?? null,
-              email: user.email,
-              name: user.name,
-            }}
-            planFooterHeightPx={40}
-          />
-        ) : null}
-
         <AppShellFooter
           organizationSlug={organizationSlug}
           showPlan={showBillingLink && autumnConfigured}
+          currentUser={
+            organizationSlug
+              ? {
+                  avatarUrl: user.avatarUrl ?? null,
+                  email: user.email,
+                  name: user.name,
+                }
+              : undefined
+          }
         />
       </SidebarProvider>
     </AppShellStoreProvider>

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
@@ -29,6 +29,7 @@ import { NavUser } from "./nav-user";
 import { Separator } from "@/components/ui/separator";
 import { TypographyP } from "@/components/ui/typography";
 import { AppShellFooter } from "./app-shell-footer";
+import { ChatDock } from "./chat-dock/chat-dock";
 
 import { appShellClientMessages } from "./app-shell-client.messages";
 
@@ -50,6 +51,7 @@ type AppShellClientProps = {
   showMembersLink?: boolean;
   user: {
     name: string;
+    email: string;
     avatarUrl?: string;
   };
 };
@@ -83,7 +85,9 @@ export function AppShellClient({
           {
             "--app-shell-content-height":
               "calc(100svh - var(--app-shell-header-height) - var(--app-shell-footer-height))",
-            "--app-shell-footer-height": "calc(2.5rem + env(safe-area-inset-bottom))",
+            "--app-shell-plan-footer-height": "calc(2.5rem + env(safe-area-inset-bottom))",
+            "--app-shell-footer-height":
+              "calc(var(--app-shell-plan-footer-height) + var(--app-shell-dock-height, 0px))",
             "--sidebar-width": "15rem",
           } as CSSProperties
         }
@@ -154,6 +158,18 @@ export function AppShellClient({
 
           <div className="flex-1 px-4 py-5 sm:px-6 lg:px-8">{children}</div>
         </SidebarInset>
+
+        {organizationSlug ? (
+          <ChatDock
+            organizationSlug={organizationSlug}
+            currentUser={{
+              avatarUrl: user.avatarUrl ?? null,
+              email: user.email,
+              name: user.name,
+            }}
+            planFooterHeightPx={40}
+          />
+        ) : null}
 
         <AppShellFooter
           organizationSlug={organizationSlug}

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.test.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.test.tsx
@@ -108,7 +108,7 @@ describe("AppShellFooter", () => {
     );
   });
 
-  it("hosts chat tabs on the left of the footer status row", async () => {
+  it("hosts chat tabs on the right of the footer status row with support", async () => {
     const user = userEvent.setup();
     autumnMocks.useCustomer.mockReturnValue({
       data: null,
@@ -124,8 +124,12 @@ describe("AppShellFooter", () => {
     renderFooter({ showPlan: false, withChat: true });
 
     const newChat = screen.getByRole("button", { name: "New chat" });
+    const support = screen.getByRole("link", { name: "Email support" });
     expect(newChat.closest("footer")).toBeTruthy();
-    expect(screen.getByRole("link", { name: "Email support" })).toBeTruthy();
+    expect(support.closest("footer")).toBeTruthy();
+    expect(
+      newChat.compareDocumentPosition(support) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
 
     await user.click(newChat);
     const tablist = screen.getByRole("tablist", { name: "Chat conversations" });

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.test.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.test.tsx
@@ -2,9 +2,12 @@
 
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { IntlProvider } from "react-intl";
 
 import { AppShellFooter } from "@/components/app-shell/app-shell-footer";
+import { AppShellStoreProvider } from "@/components/app-shell/store/app-shell-store-context";
 import { planUsagePrimaryFeatureId } from "@/lib/billing/plan-usage";
 
 const autumnMocks = vi.hoisted(() => ({
@@ -14,10 +17,46 @@ const autumnMocks = vi.hoisted(() => ({
 
 vi.mock("autumn-js/react", () => autumnMocks);
 
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/org/acme/dashboard",
+}));
+
 afterEach(() => {
   autumnMocks.useCustomer.mockReset();
   autumnMocks.useListPlans.mockReset();
 });
+
+function renderFooter(
+  props: {
+    organizationSlug?: string;
+    showPlan?: boolean;
+    withChat?: boolean;
+  } = {},
+) {
+  const { organizationSlug = "acme", showPlan = true, withChat = false } = props;
+
+  return render(
+    <QueryClientProvider client={new QueryClient()}>
+      <IntlProvider locale="en" messages={{}}>
+        <AppShellStoreProvider defaultNavigationGroups={[]}>
+          <AppShellFooter
+            organizationSlug={organizationSlug}
+            showPlan={showPlan}
+            currentUser={
+              withChat
+                ? {
+                    avatarUrl: null,
+                    email: "user@example.com",
+                    name: "Test User",
+                  }
+                : undefined
+            }
+          />
+        </AppShellStoreProvider>
+      </IntlProvider>
+    </QueryClientProvider>,
+  );
+}
 
 describe("AppShellFooter", () => {
   it("opens plan usage from the fixed footer control", async () => {
@@ -48,7 +87,7 @@ describe("AppShellFooter", () => {
       error: null,
     });
 
-    render(<AppShellFooter organizationSlug="acme" showPlan />);
+    renderFooter({ showPlan: true });
 
     await user.click(screen.getByRole("button", { name: "Open plan usage: Growth" }));
 
@@ -61,11 +100,35 @@ describe("AppShellFooter", () => {
   });
 
   it("keeps support available without billing access", () => {
-    render(<AppShellFooter organizationSlug="acme" showPlan={false} />);
+    renderFooter({ showPlan: false });
 
     expect(screen.queryByText("Growth")).toBeNull();
     expect(screen.getByRole("link", { name: "Email support" }).getAttribute("href")).toBe(
       "mailto:minh@hyperlocalise.com",
     );
+  });
+
+  it("hosts the chat dock new-chat control in the footer status row", async () => {
+    const user = userEvent.setup();
+    autumnMocks.useCustomer.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+    });
+    autumnMocks.useListPlans.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
+
+    renderFooter({ showPlan: false, withChat: true });
+
+    const newChat = screen.getByRole("button", { name: "New chat" });
+    expect(newChat).toBeTruthy();
+    expect(newChat.closest("footer")).toBeTruthy();
+
+    await user.click(newChat);
+    expect(screen.getByRole("tablist", { name: "Chat conversations" })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: /New chat/i })).toBeTruthy();
   });
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.test.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.test.tsx
@@ -108,7 +108,7 @@ describe("AppShellFooter", () => {
     );
   });
 
-  it("hosts the chat dock new-chat control in the footer status row", async () => {
+  it("hosts chat tabs on the left of the footer status row", async () => {
     const user = userEvent.setup();
     autumnMocks.useCustomer.mockReturnValue({
       data: null,
@@ -124,11 +124,12 @@ describe("AppShellFooter", () => {
     renderFooter({ showPlan: false, withChat: true });
 
     const newChat = screen.getByRole("button", { name: "New chat" });
-    expect(newChat).toBeTruthy();
     expect(newChat.closest("footer")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Email support" })).toBeTruthy();
 
     await user.click(newChat);
-    expect(screen.getByRole("tablist", { name: "Chat conversations" })).toBeTruthy();
+    const tablist = screen.getByRole("tablist", { name: "Chat conversations" });
+    expect(tablist.closest("footer")).toBeTruthy();
     expect(screen.getByRole("tab", { name: /New chat/i })).toBeTruthy();
   });
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
@@ -35,26 +35,27 @@ export function AppShellFooter({
 
       <div className="flex h-[var(--app-shell-plan-footer-height)] shrink-0 items-stretch px-2">
         <div className="flex h-10 w-full items-center gap-2">
-          {showChatDock ? <ChatDockFooterControls organizationSlug={organizationSlug} /> : null}
           {showPlan ? <PlanUsageFooterControl organizationSlug={organizationSlug} /> : null}
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  className="ms-auto"
-                  render={<a href={`mailto:${SUPPORT_EMAIL}`} />}
-                  aria-label="Email support"
-                >
-                  <HugeiconsIcon icon={CustomerSupportIcon} strokeWidth={2} />
-                </Button>
-              }
-            />
-            <TooltipContent side="top" align="end">
-              Support
-            </TooltipContent>
-          </Tooltip>
+          <div className="ms-auto flex min-w-0 items-center gap-2">
+            {showChatDock ? <ChatDockFooterControls organizationSlug={organizationSlug} /> : null}
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    render={<a href={`mailto:${SUPPORT_EMAIL}`} />}
+                    aria-label="Email support"
+                  >
+                    <HugeiconsIcon icon={CustomerSupportIcon} strokeWidth={2} />
+                  </Button>
+                }
+              />
+              <TooltipContent side="top" align="end">
+                Support
+              </TooltipContent>
+            </Tooltip>
+          </div>
         </div>
       </div>
     </footer>

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
@@ -4,7 +4,11 @@ import { CustomerSupportIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
 import type { InboxCurrentUser } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-types";
-import { ChatDock, ChatDockNewChatButton } from "@/components/app-shell/chat-dock/chat-dock";
+import {
+  ChatDockBridge,
+  ChatDockFooterControls,
+  ChatDockPanelHost,
+} from "@/components/app-shell/chat-dock/chat-dock";
 import { PlanUsageFooterControl } from "@/components/billing/plan-usage-summary";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -24,13 +28,14 @@ export function AppShellFooter({
 
   return (
     <footer className="fixed inset-x-0 bottom-0 z-40 flex flex-col border-t border-border bg-background">
+      {showChatDock ? <ChatDockBridge organizationSlug={organizationSlug} /> : null}
       {showChatDock && currentUser ? (
-        <ChatDock organizationSlug={organizationSlug} currentUser={currentUser} />
+        <ChatDockPanelHost organizationSlug={organizationSlug} currentUser={currentUser} />
       ) : null}
 
       <div className="flex h-[var(--app-shell-plan-footer-height)] shrink-0 items-stretch px-2">
         <div className="flex h-10 w-full items-center gap-2">
-          {showChatDock ? <ChatDockNewChatButton organizationSlug={organizationSlug} /> : null}
+          {showChatDock ? <ChatDockFooterControls organizationSlug={organizationSlug} /> : null}
           {showPlan ? <PlanUsageFooterControl organizationSlug={organizationSlug} /> : null}
           <Tooltip>
             <TooltipTrigger

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
@@ -3,6 +3,8 @@
 import { CustomerSupportIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
+import type { InboxCurrentUser } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-types";
+import { ChatDock, ChatDockNewChatButton } from "@/components/app-shell/chat-dock/chat-dock";
 import { PlanUsageFooterControl } from "@/components/billing/plan-usage-summary";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -12,32 +14,43 @@ const SUPPORT_EMAIL = "minh@hyperlocalise.com";
 export function AppShellFooter({
   organizationSlug,
   showPlan,
+  currentUser,
 }: {
   organizationSlug: string;
   showPlan: boolean;
+  currentUser?: InboxCurrentUser;
 }) {
+  const showChatDock = Boolean(organizationSlug && currentUser);
+
   return (
-    <footer className="fixed inset-x-0 bottom-0 z-40 h-[var(--app-shell-plan-footer-height)] border-t border-border bg-background px-2">
-      <div className="flex h-10 items-center">
-        {showPlan ? <PlanUsageFooterControl organizationSlug={organizationSlug} /> : null}
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                className="ms-auto"
-                render={<a href={`mailto:${SUPPORT_EMAIL}`} />}
-                aria-label="Email support"
-              >
-                <HugeiconsIcon icon={CustomerSupportIcon} strokeWidth={2} />
-              </Button>
-            }
-          />
-          <TooltipContent side="top" align="end">
-            Support
-          </TooltipContent>
-        </Tooltip>
+    <footer className="fixed inset-x-0 bottom-0 z-40 flex flex-col border-t border-border bg-background">
+      {showChatDock && currentUser ? (
+        <ChatDock organizationSlug={organizationSlug} currentUser={currentUser} />
+      ) : null}
+
+      <div className="flex h-[var(--app-shell-plan-footer-height)] shrink-0 items-stretch px-2">
+        <div className="flex h-10 w-full items-center gap-2">
+          {showChatDock ? <ChatDockNewChatButton organizationSlug={organizationSlug} /> : null}
+          {showPlan ? <PlanUsageFooterControl organizationSlug={organizationSlug} /> : null}
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  className="ms-auto"
+                  render={<a href={`mailto:${SUPPORT_EMAIL}`} />}
+                  aria-label="Email support"
+                >
+                  <HugeiconsIcon icon={CustomerSupportIcon} strokeWidth={2} />
+                </Button>
+              }
+            />
+            <TooltipContent side="top" align="end">
+              Support
+            </TooltipContent>
+          </Tooltip>
+        </div>
       </div>
     </footer>
   );

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
@@ -17,7 +17,7 @@ export function AppShellFooter({
   showPlan: boolean;
 }) {
   return (
-    <footer className="fixed inset-x-0 bottom-0 z-40 h-[var(--app-shell-footer-height)] border-t border-border bg-background px-2">
+    <footer className="fixed inset-x-0 bottom-0 z-40 h-[var(--app-shell-plan-footer-height)] border-t border-border bg-background px-2">
       <div className="flex h-10 items-center">
         {showPlan ? <PlanUsageFooterControl organizationSlug={organizationSlug} /> : null}
         <Tooltip>

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
@@ -74,6 +74,7 @@ export async function AppShell({
       showMembersLink={hasCapability(auth.membership.role, "workspace:read")}
       user={{
         name: displayName,
+        email: auth.sessionUser.email,
         avatarUrl: auth.sessionUser.profilePictureUrl ?? undefined,
       }}
       navigationGroups={navigationGroups}

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
@@ -208,15 +208,15 @@ export const ChatDockPanel = observer(function ChatDockPanel({
       }
 
       if (tab.isPending) {
+        const pendingId = tab.id;
         try {
-          const pendingId = tab.id;
-          store.setDraft(pendingId, "");
           store.setLastError(pendingId, null);
           const result = await createConversationMutation.mutateAsync({
             text,
             files,
             repositoryFullName: options?.repositoryFullName,
           });
+          store.setDraft(pendingId, "");
           const title = text.trim().slice(0, 48) || result.conversation.title || "Chat";
           store.promotePendingTab(pendingId, result.conversation.id, title);
           await queryClient.invalidateQueries({
@@ -227,8 +227,9 @@ export const ChatDockPanel = observer(function ChatDockPanel({
           });
         } catch (error) {
           console.error(error);
-          store.setLastError(tab.id, intl.formatMessage(chatDockMessages.createFailed));
+          store.setLastError(pendingId, intl.formatMessage(chatDockMessages.createFailed));
           toast.error(intl.formatMessage(chatDockMessages.createFailed));
+          throw error;
         }
         return;
       }
@@ -245,6 +246,7 @@ export const ChatDockPanel = observer(function ChatDockPanel({
         console.error(error);
         store.setLastError(tab.id, intl.formatMessage(chatDockMessages.sendFailed));
         toast.error(intl.formatMessage(chatDockMessages.sendFailed));
+        throw error;
       }
     },
     [

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import Link from "next/link";
+import { observer } from "mobx-react-lite";
+import { ArrowDown01Icon, ArrowUpRight01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { FormattedMessage, useIntl } from "react-intl";
+import { toast } from "sonner";
+
+import { ConversationMessageList } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list";
+import { createInboxApi } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api";
+import type {
+  Conversation,
+  ConversationMessage,
+  InboxCurrentUser,
+  StreamedAssistantMessage,
+} from "@/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-types";
+import { ReplyComposer } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer";
+import { Button } from "@/components/ui/button";
+import { TypographyMuted } from "@/components/ui/typography";
+import { apiClient } from "@/lib/api-client-instance";
+import { readApiResponseError } from "@/lib/api-error";
+
+import { chatDockMessages } from "./chat-dock.messages";
+import {
+  CHAT_DOCK_MAX_CONCURRENT_STREAMS,
+  CHAT_DOCK_PANEL_HEIGHT_PX,
+} from "./chat-dock-persistence";
+import type { ChatDockStore } from "./chat-dock-store";
+import { getChatStreamManager } from "./chat-stream-manager";
+
+const inboxApi = createInboxApi(apiClient);
+
+function messagesQueryKey(conversationId: string) {
+  return ["conversation-messages", conversationId] as const;
+}
+
+function conversationsQueryKey(organizationSlug: string) {
+  return ["conversations", organizationSlug] as const;
+}
+
+function buildPlaceholderConversation(tab: {
+  id: string;
+  title: string;
+  isPending: boolean;
+}): Conversation {
+  const now = new Date().toISOString();
+  return {
+    id: tab.id,
+    title: tab.title,
+    source: "chat_ui",
+    status: "active",
+    projectId: null,
+    lastMessageAt: now,
+    createdAt: now,
+    participantEmail: null,
+    lastMessage: null,
+  };
+}
+
+export const ChatDockPanel = observer(function ChatDockPanel({
+  organizationSlug,
+  currentUser,
+  store,
+}: {
+  organizationSlug: string;
+  currentUser: InboxCurrentUser;
+  store: ChatDockStore;
+}) {
+  const intl = useIntl();
+  const tab = store.activeTab;
+  const queryClient = useQueryClient();
+  const streamManager = getChatStreamManager(organizationSlug, store);
+  const autoTriggeredRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    streamManager.setOnStreamFinished(async (conversationId) => {
+      await queryClient.invalidateQueries({ queryKey: messagesQueryKey(conversationId) });
+      await queryClient.invalidateQueries({ queryKey: conversationsQueryKey(organizationSlug) });
+      store.clearStreamSnapshot(conversationId);
+    });
+
+    return () => {
+      streamManager.setOnStreamFinished(null);
+    };
+  }, [organizationSlug, queryClient, store, streamManager]);
+
+  const conversationId = tab && !tab.isPending ? tab.id : "";
+
+  const conversationsQuery = useQuery({
+    queryKey: conversationsQueryKey(organizationSlug),
+    queryFn: () => inboxApi.listConversations(organizationSlug),
+  });
+
+  const messagesQuery = useQuery({
+    queryKey: messagesQueryKey(conversationId),
+    queryFn: () => inboxApi.listMessages(organizationSlug, conversationId),
+    enabled: Boolean(conversationId),
+    retry: false,
+  });
+
+  useEffect(() => {
+    if (!messagesQuery.isError || !tab || tab.isPending) {
+      return;
+    }
+
+    const message =
+      messagesQuery.error instanceof Error
+        ? messagesQuery.error.message
+        : intl.formatMessage(chatDockMessages.conversationMissing);
+
+    if (/not found|404/i.test(message)) {
+      toast.error(intl.formatMessage(chatDockMessages.conversationMissing));
+      store.closeTab(tab.id);
+    }
+  }, [intl, messagesQuery.error, messagesQuery.isError, store, tab]);
+
+  const conversation =
+    conversationsQuery.data?.find((entry) => entry.id === conversationId) ??
+    (tab ? buildPlaceholderConversation(tab) : undefined);
+
+  useEffect(() => {
+    if (conversation && tab && !tab.isPending && conversation.title !== tab.title) {
+      store.setTitle(tab.id, conversation.title);
+    }
+  }, [conversation, store, tab]);
+
+  const startStreamForMessage = useCallback(
+    async (input: { conversationId: string; responseToMessageId: string; text: string }) => {
+      const result = await streamManager.start(input);
+      if (!result.started && result.reason) {
+        toast.error(
+          intl.formatMessage(chatDockMessages.maxStreams, {
+            count: CHAT_DOCK_MAX_CONCURRENT_STREAMS,
+          }),
+        );
+      }
+    },
+    [intl, streamManager],
+  );
+
+  const messages = messagesQuery.data ?? [];
+  const lastMessage = messages.at(-1);
+
+  useEffect(() => {
+    if (
+      !conversationId ||
+      !messagesQuery.isSuccess ||
+      lastMessage?.senderType !== "user" ||
+      streamManager.isStreaming(conversationId) ||
+      autoTriggeredRef.current === lastMessage.id
+    ) {
+      return;
+    }
+
+    autoTriggeredRef.current = lastMessage.id;
+    void startStreamForMessage({
+      conversationId,
+      responseToMessageId: lastMessage.id,
+      text: lastMessage.text,
+    });
+  }, [
+    conversationId,
+    lastMessage?.id,
+    lastMessage?.senderType,
+    lastMessage?.text,
+    messagesQuery.isSuccess,
+    startStreamForMessage,
+    streamManager,
+  ]);
+
+  const createConversationMutation = useMutation({
+    mutationFn: async (input: { text: string; files: File[]; repositoryFullName?: string }) => {
+      const formData = new FormData();
+      formData.set("text", input.text.trim() || "Please translate the attached source file.");
+      if (input.repositoryFullName) {
+        formData.set("repositoryFullName", input.repositoryFullName);
+      }
+      for (const file of input.files) {
+        formData.append("files", file);
+      }
+
+      const response = await fetch(
+        `/api/orgs/${encodeURIComponent(organizationSlug)}/conversations`,
+        {
+          method: "POST",
+          body: formData,
+        },
+      );
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to create conversation");
+      }
+
+      return response.json() as Promise<{
+        conversation: { id: string; title?: string };
+        message?: { id: string; text: string };
+      }>;
+    },
+  });
+
+  const sendMessageMutation = useMutation({
+    mutationFn: (input: {
+      text: string;
+      files: File[];
+      projectId?: string;
+      repositoryFullName?: string;
+    }) => inboxApi.sendMessage(organizationSlug, conversationId, input),
+  });
+
+  const onSendMessage = useCallback(
+    async (
+      text: string,
+      files: File[],
+      options?: { projectId?: string; repositoryFullName?: string },
+    ) => {
+      if (!tab) {
+        return;
+      }
+
+      if (tab.isPending) {
+        try {
+          const pendingId = tab.id;
+          store.setDraft(pendingId, "");
+          store.setLastError(pendingId, null);
+          const result = await createConversationMutation.mutateAsync({
+            text,
+            files,
+            repositoryFullName: options?.repositoryFullName,
+          });
+          const title = text.trim().slice(0, 48) || result.conversation.title || "Chat";
+          store.promotePendingTab(pendingId, result.conversation.id, title);
+          await queryClient.invalidateQueries({
+            queryKey: conversationsQueryKey(organizationSlug),
+          });
+          await queryClient.invalidateQueries({
+            queryKey: messagesQueryKey(result.conversation.id),
+          });
+        } catch (error) {
+          console.error(error);
+          store.setLastError(tab.id, intl.formatMessage(chatDockMessages.createFailed));
+          toast.error(intl.formatMessage(chatDockMessages.createFailed));
+        }
+        return;
+      }
+
+      try {
+        store.setLastError(tab.id, null);
+        await sendMessageMutation.mutateAsync({ text, files, ...options });
+        await queryClient.invalidateQueries({ queryKey: messagesQueryKey(tab.id) });
+        await queryClient.invalidateQueries({
+          queryKey: conversationsQueryKey(organizationSlug),
+        });
+      } catch (error) {
+        console.error(error);
+        store.setLastError(tab.id, intl.formatMessage(chatDockMessages.sendFailed));
+        toast.error(intl.formatMessage(chatDockMessages.sendFailed));
+      }
+    },
+    [
+      createConversationMutation,
+      intl,
+      organizationSlug,
+      queryClient,
+      sendMessageMutation,
+      store,
+      tab,
+    ],
+  );
+
+  if (!tab) {
+    return null;
+  }
+
+  const streamedAssistant: StreamedAssistantMessage | null = tab.streamSnapshot
+    ? {
+        conversationId: tab.streamSnapshot.conversationId,
+        responseToMessageId: tab.streamSnapshot.responseToMessageId,
+        message: tab.streamSnapshot.message,
+        status: tab.streamSnapshot.status,
+      }
+    : null;
+
+  const isBusy =
+    createConversationMutation.isPending ||
+    sendMessageMutation.isPending ||
+    tab.isStreaming ||
+    streamManager.isStreaming(tab.id);
+
+  return (
+    <section
+      className="flex flex-col overflow-hidden border-t border-border bg-background shadow-[0_-8px_24px_rgba(0,0,0,0.06)]"
+      style={{ height: CHAT_DOCK_PANEL_HEIGHT_PX }}
+      aria-label={tab.title}
+    >
+      <header className="flex h-11 shrink-0 items-center gap-2 border-b border-border px-3">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-foreground">{tab.title}</p>
+        </div>
+        {!tab.isPending ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1 px-2 text-xs"
+            render={<Link href={`/org/${organizationSlug}/inbox/${tab.id}`} />}
+          >
+            <FormattedMessage {...chatDockMessages.openInInbox} />
+            <HugeiconsIcon icon={ArrowUpRight01Icon} strokeWidth={2} className="size-3.5" />
+          </Button>
+        ) : null}
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label={intl.formatMessage(chatDockMessages.collapsePanel)}
+          onClick={() => store.setPanelOpen(false)}
+        >
+          <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={2} className="size-3.5" />
+        </Button>
+      </header>
+
+      {tab.lastError ? (
+        <div className="border-b border-border bg-destructive/5 px-3 py-2">
+          <TypographyMuted className="text-xs text-destructive">{tab.lastError}</TypographyMuted>
+        </div>
+      ) : null}
+
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        {tab.isPending ? (
+          <div className="flex min-h-0 flex-1 items-center justify-center px-4">
+            <TypographyMuted className="text-center text-sm">
+              <FormattedMessage {...chatDockMessages.emptyComposer} />
+            </TypographyMuted>
+          </div>
+        ) : (
+          <ConversationMessageList
+            conversationId={tab.id}
+            currentUser={currentUser}
+            isLoading={messagesQuery.isLoading}
+            isStreaming={tab.isStreaming}
+            messages={messages as ConversationMessage[]}
+            streamedAssistant={streamedAssistant}
+          />
+        )}
+
+        <ReplyComposer
+          disabled={isBusy}
+          isStreaming={tab.isStreaming}
+          onSend={onSendMessage}
+          organizationSlug={organizationSlug}
+        />
+      </div>
+    </section>
+  );
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
@@ -75,18 +75,6 @@ export const ChatDockPanel = observer(function ChatDockPanel({
   const streamManager = getChatStreamManager(organizationSlug, store);
   const autoTriggeredRef = useRef<string | null>(null);
 
-  useEffect(() => {
-    streamManager.setOnStreamFinished(async (conversationId) => {
-      await queryClient.invalidateQueries({ queryKey: messagesQueryKey(conversationId) });
-      await queryClient.invalidateQueries({ queryKey: conversationsQueryKey(organizationSlug) });
-      store.clearStreamSnapshot(conversationId);
-    });
-
-    return () => {
-      streamManager.setOnStreamFinished(null);
-    };
-  }, [organizationSlug, queryClient, store, streamManager]);
-
   const conversationId = tab && !tab.isPending ? tab.id : "";
 
   const conversationsQuery = useQuery({
@@ -248,6 +236,7 @@ export const ChatDockPanel = observer(function ChatDockPanel({
       try {
         store.setLastError(tab.id, null);
         await sendMessageMutation.mutateAsync({ text, files, ...options });
+        store.setDraft(tab.id, "");
         await queryClient.invalidateQueries({ queryKey: messagesQueryKey(tab.id) });
         await queryClient.invalidateQueries({
           queryKey: conversationsQueryKey(organizationSlug),
@@ -345,8 +334,11 @@ export const ChatDockPanel = observer(function ChatDockPanel({
         )}
 
         <ReplyComposer
+          key={tab.id}
           disabled={isBusy}
+          draft={tab.draft}
           isStreaming={tab.isStreaming}
+          onDraftChange={(nextDraft) => store.setDraft(tab.id, nextDraft)}
           onSend={onSendMessage}
           organizationSlug={organizationSlug}
         />

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
@@ -290,7 +290,7 @@ export const ChatDockPanel = observer(function ChatDockPanel({
 
   return (
     <section
-      className="flex flex-col overflow-hidden border-t border-border bg-background shadow-[0_-8px_24px_rgba(0,0,0,0.06)]"
+      className="flex flex-col overflow-hidden bg-background"
       style={{ height: CHAT_DOCK_PANEL_HEIGHT_PX }}
       aria-label={tab.title}
     >

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-persistence.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-persistence.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  chatDockStorageKey,
+  clearChatDockState,
+  createEmptyChatDockState,
+  readChatDockState,
+  writeChatDockState,
+  type ChatDockStorage,
+  type PersistedChatDockState,
+} from "./chat-dock-persistence";
+
+function createMemoryStorage(initial: Record<string, string> = {}): ChatDockStorage {
+  const data = { ...initial };
+  return {
+    getItem(key) {
+      return data[key] ?? null;
+    },
+    setItem(key, value) {
+      data[key] = value;
+    },
+    removeItem(key) {
+      delete data[key];
+    },
+  };
+}
+
+describe("chat-dock-persistence", () => {
+  it("round-trips a valid dock state", () => {
+    const storage = createMemoryStorage();
+    const state: PersistedChatDockState = {
+      version: 1,
+      organizationSlug: "acme",
+      activeTabId: "conv_1",
+      panelOpen: true,
+      tabs: [
+        {
+          id: "conv_1",
+          title: "Translate checkout",
+          draft: "hello",
+          isPending: false,
+          isStreaming: true,
+          streamSnapshot: {
+            conversationId: "conv_1",
+            responseToMessageId: "msg_1",
+            message: { id: "stream-msg_1", role: "assistant", parts: [] },
+            status: "streaming",
+          },
+          lastError: null,
+        },
+      ],
+    };
+
+    writeChatDockState(state, storage);
+    expect(readChatDockState("acme", storage)).toEqual(state);
+    expect(storage.getItem(chatDockStorageKey("acme"))).toBeTruthy();
+  });
+
+  it("returns empty state for corrupt or version-mismatched payloads", () => {
+    const storage = createMemoryStorage({
+      [chatDockStorageKey("acme")]: "{not-json",
+    });
+    expect(readChatDockState("acme", storage)).toEqual(createEmptyChatDockState("acme"));
+
+    writeChatDockState(
+      {
+        version: 1,
+        organizationSlug: "acme",
+        activeTabId: null,
+        panelOpen: false,
+        tabs: [],
+      },
+      storage,
+    );
+    storage.setItem(
+      chatDockStorageKey("acme"),
+      JSON.stringify({ version: 99, tabs: [{ id: "x" }] }),
+    );
+    expect(readChatDockState("acme", storage)).toEqual(createEmptyChatDockState("acme"));
+  });
+
+  it("clears stored state", () => {
+    const storage = createMemoryStorage();
+    writeChatDockState(createEmptyChatDockState("acme"), storage);
+    clearChatDockState("acme", storage);
+    expect(storage.getItem(chatDockStorageKey("acme"))).toBeNull();
+  });
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-persistence.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-persistence.ts
@@ -1,0 +1,169 @@
+const CHAT_DOCK_STORAGE_VERSION = 1;
+export const CHAT_DOCK_MAX_CONCURRENT_STREAMS = 3;
+export const CHAT_DOCK_TAB_BAR_HEIGHT_PX = 40;
+export const CHAT_DOCK_PANEL_HEIGHT_PX = 420;
+
+export type ChatDockStreamStatus = "idle" | "streaming" | "complete" | "error";
+
+export type PersistedChatDockStreamSnapshot = {
+  conversationId: string;
+  responseToMessageId: string;
+  message: {
+    id: string;
+    role: "assistant";
+    parts: unknown[];
+  };
+  status: Exclude<ChatDockStreamStatus, "idle">;
+};
+
+export type PersistedChatDockTab = {
+  id: string;
+  title: string;
+  draft: string;
+  isPending: boolean;
+  isStreaming: boolean;
+  streamSnapshot: PersistedChatDockStreamSnapshot | null;
+  lastError: string | null;
+};
+
+export type PersistedChatDockState = {
+  version: typeof CHAT_DOCK_STORAGE_VERSION;
+  organizationSlug: string;
+  activeTabId: string | null;
+  panelOpen: boolean;
+  tabs: PersistedChatDockTab[];
+};
+
+export type ChatDockStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+export function chatDockStorageKey(organizationSlug: string) {
+  return `chat-dock:v${CHAT_DOCK_STORAGE_VERSION}:${organizationSlug}`;
+}
+
+function getBrowserStorage(): ChatDockStorage | undefined {
+  try {
+    return typeof window === "undefined" ? undefined : window.localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+function isPersistedStreamSnapshot(value: unknown): value is PersistedChatDockStreamSnapshot {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const snapshot = value as Partial<PersistedChatDockStreamSnapshot>;
+  return (
+    typeof snapshot.conversationId === "string" &&
+    typeof snapshot.responseToMessageId === "string" &&
+    Boolean(snapshot.message) &&
+    typeof snapshot.message === "object" &&
+    typeof snapshot.message.id === "string" &&
+    snapshot.message.role === "assistant" &&
+    Array.isArray(snapshot.message.parts) &&
+    (snapshot.status === "streaming" ||
+      snapshot.status === "complete" ||
+      snapshot.status === "error")
+  );
+}
+
+function isPersistedTab(value: unknown): value is PersistedChatDockTab {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const tab = value as Partial<PersistedChatDockTab>;
+  return (
+    typeof tab.id === "string" &&
+    tab.id.length > 0 &&
+    typeof tab.title === "string" &&
+    typeof tab.draft === "string" &&
+    typeof tab.isPending === "boolean" &&
+    typeof tab.isStreaming === "boolean" &&
+    (tab.streamSnapshot === null || isPersistedStreamSnapshot(tab.streamSnapshot)) &&
+    (tab.lastError === null || typeof tab.lastError === "string")
+  );
+}
+
+export function createEmptyChatDockState(organizationSlug: string): PersistedChatDockState {
+  return {
+    version: CHAT_DOCK_STORAGE_VERSION,
+    organizationSlug,
+    activeTabId: null,
+    panelOpen: false,
+    tabs: [],
+  };
+}
+
+export function readChatDockState(
+  organizationSlug: string,
+  storage: ChatDockStorage | undefined = getBrowserStorage(),
+): PersistedChatDockState {
+  if (!storage || !organizationSlug) {
+    return createEmptyChatDockState(organizationSlug);
+  }
+
+  try {
+    const raw = storage.getItem(chatDockStorageKey(organizationSlug));
+    if (!raw) {
+      return createEmptyChatDockState(organizationSlug);
+    }
+
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") {
+      return createEmptyChatDockState(organizationSlug);
+    }
+
+    const state = parsed as Partial<PersistedChatDockState>;
+    if (state.version !== CHAT_DOCK_STORAGE_VERSION || !Array.isArray(state.tabs)) {
+      return createEmptyChatDockState(organizationSlug);
+    }
+
+    const tabs = state.tabs.filter(isPersistedTab);
+    const activeTabId =
+      typeof state.activeTabId === "string" && tabs.some((tab) => tab.id === state.activeTabId)
+        ? state.activeTabId
+        : (tabs[0]?.id ?? null);
+
+    return {
+      version: CHAT_DOCK_STORAGE_VERSION,
+      organizationSlug,
+      activeTabId,
+      panelOpen: Boolean(state.panelOpen) && tabs.length > 0,
+      tabs,
+    };
+  } catch {
+    return createEmptyChatDockState(organizationSlug);
+  }
+}
+
+export function writeChatDockState(
+  state: PersistedChatDockState,
+  storage: ChatDockStorage | undefined = getBrowserStorage(),
+) {
+  if (!storage || !state.organizationSlug) {
+    return;
+  }
+
+  try {
+    storage.setItem(chatDockStorageKey(state.organizationSlug), JSON.stringify(state));
+  } catch {
+    // Dock persistence is best-effort; private mode / quota must not break chat.
+  }
+}
+
+export function clearChatDockState(
+  organizationSlug: string,
+  storage: ChatDockStorage | undefined = getBrowserStorage(),
+) {
+  if (!storage || !organizationSlug) {
+    return;
+  }
+
+  try {
+    storage.removeItem(chatDockStorageKey(organizationSlug));
+  } catch {
+    // Ignore storage failures on clear.
+  }
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  CHAT_DOCK_MAX_CONCURRENT_STREAMS,
+  CHAT_DOCK_PANEL_HEIGHT_PX,
+  CHAT_DOCK_TAB_BAR_HEIGHT_PX,
+} from "./chat-dock-persistence";
+import { ChatDockStore } from "./chat-dock-store";
+
+function createMemoryStorage() {
+  const data: Record<string, string> = {};
+  return {
+    getItem(key: string) {
+      return data[key] ?? null;
+    },
+    setItem(key: string, value: string) {
+      data[key] = value;
+    },
+    removeItem(key: string) {
+      delete data[key];
+    },
+  };
+}
+
+describe("ChatDockStore", () => {
+  it("opens, selects, and closes tabs", () => {
+    const store = new ChatDockStore(createMemoryStorage());
+    store.setOrganizationSlug("acme");
+
+    const pendingId = store.openNewTab();
+    expect(store.tabs).toHaveLength(1);
+    expect(store.activeTabId).toBe(pendingId);
+    expect(store.panelOpen).toBe(true);
+    expect(store.chromeHeightPx).toBe(CHAT_DOCK_TAB_BAR_HEIGHT_PX + CHAT_DOCK_PANEL_HEIGHT_PX);
+
+    store.openTab({ id: "conv_1", title: "Checkout" });
+    expect(store.tabs).toHaveLength(2);
+    expect(store.activeTabId).toBe("conv_1");
+
+    store.selectTab("conv_1");
+    expect(store.panelOpen).toBe(false);
+    expect(store.chromeHeightPx).toBe(CHAT_DOCK_TAB_BAR_HEIGHT_PX);
+
+    store.closeTab(pendingId);
+    expect(store.tabs.map((tab) => tab.id)).toEqual(["conv_1"]);
+
+    store.closeTab("conv_1");
+    expect(store.hasTabs).toBe(false);
+    expect(store.panelOpen).toBe(false);
+    expect(store.chromeHeightPx).toBe(0);
+  });
+
+  it("persists and hydrates org-scoped state", () => {
+    const storage = createMemoryStorage();
+    const store = new ChatDockStore(storage);
+    store.setOrganizationSlug("acme");
+    const pendingId = store.openNewTab();
+    store.setDraft(pendingId, "Translate this");
+    store.promotePendingTab(pendingId, "conv_99", "Translate this");
+
+    const restored = new ChatDockStore(storage);
+    restored.setOrganizationSlug("acme");
+    expect(restored.tabs).toHaveLength(1);
+    expect(restored.tabs[0]?.id).toBe("conv_99");
+    expect(restored.tabs[0]?.title).toBe("Translate this");
+    expect(restored.activeTabId).toBe("conv_99");
+    expect(restored.panelOpen).toBe(true);
+  });
+
+  it("tracks concurrent stream capacity", () => {
+    const store = new ChatDockStore(createMemoryStorage());
+    store.setOrganizationSlug("acme");
+
+    for (let index = 0; index < CHAT_DOCK_MAX_CONCURRENT_STREAMS; index += 1) {
+      store.openTab({ id: `conv_${index}`, title: `Chat ${index}` });
+      store.markStreaming(`conv_${index}`, true);
+    }
+
+    expect(store.streamingCount).toBe(CHAT_DOCK_MAX_CONCURRENT_STREAMS);
+    expect(store.canStartStream).toBe(false);
+  });
+
+  it("stores stream snapshots and clears them", () => {
+    const store = new ChatDockStore(createMemoryStorage());
+    store.setOrganizationSlug("acme");
+    store.openTab({ id: "conv_1", title: "Chat" });
+
+    store.setStreamSnapshot("conv_1", {
+      conversationId: "conv_1",
+      responseToMessageId: "msg_1",
+      message: { id: "stream-msg_1", role: "assistant", parts: [] },
+      status: "streaming",
+    });
+    expect(store.tabs[0]?.isStreaming).toBe(true);
+
+    store.clearStreamSnapshot("conv_1");
+    expect(store.tabs[0]?.streamSnapshot).toBeNull();
+    expect(store.tabs[0]?.isStreaming).toBe(false);
+  });
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   CHAT_DOCK_MAX_CONCURRENT_STREAMS,
   CHAT_DOCK_PANEL_HEIGHT_PX,
-  CHAT_DOCK_TAB_BAR_HEIGHT_PX,
 } from "./chat-dock-persistence";
 import { ChatDockStore } from "./chat-dock-store";
 
@@ -31,7 +30,7 @@ describe("ChatDockStore", () => {
     expect(store.tabs).toHaveLength(1);
     expect(store.activeTabId).toBe(pendingId);
     expect(store.panelOpen).toBe(true);
-    expect(store.chromeHeightPx).toBe(CHAT_DOCK_TAB_BAR_HEIGHT_PX + CHAT_DOCK_PANEL_HEIGHT_PX);
+    expect(store.chromeHeightPx).toBe(CHAT_DOCK_PANEL_HEIGHT_PX);
 
     store.openTab({ id: "conv_1", title: "Checkout" });
     expect(store.tabs).toHaveLength(2);
@@ -39,7 +38,7 @@ describe("ChatDockStore", () => {
 
     store.selectTab("conv_1");
     expect(store.panelOpen).toBe(false);
-    expect(store.chromeHeightPx).toBe(CHAT_DOCK_TAB_BAR_HEIGHT_PX);
+    expect(store.chromeHeightPx).toBe(0);
 
     store.closeTab(pendingId);
     expect(store.tabs.map((tab) => tab.id)).toEqual(["conv_1"]);

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.ts
@@ -1,0 +1,380 @@
+import { makeAutoObservable, observable } from "mobx";
+import type { UIMessage } from "ai";
+
+import {
+  CHAT_DOCK_MAX_CONCURRENT_STREAMS,
+  CHAT_DOCK_PANEL_HEIGHT_PX,
+  CHAT_DOCK_TAB_BAR_HEIGHT_PX,
+  createEmptyChatDockState,
+  readChatDockState,
+  writeChatDockState,
+  type ChatDockStorage,
+  type ChatDockStreamStatus,
+  type PersistedChatDockState,
+  type PersistedChatDockStreamSnapshot,
+  type PersistedChatDockTab,
+} from "./chat-dock-persistence";
+
+export type ChatDockStreamSnapshot = {
+  conversationId: string;
+  responseToMessageId: string;
+  message: UIMessage;
+  status: Exclude<ChatDockStreamStatus, "idle">;
+};
+
+export type ChatDockTab = {
+  id: string;
+  title: string;
+  draft: string;
+  isPending: boolean;
+  isStreaming: boolean;
+  streamSnapshot: ChatDockStreamSnapshot | null;
+  lastError: string | null;
+};
+
+function createPendingTabId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `pending-${crypto.randomUUID()}`;
+  }
+
+  return `pending-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function toPersistedSnapshot(
+  snapshot: ChatDockStreamSnapshot | null,
+): PersistedChatDockStreamSnapshot | null {
+  if (!snapshot) {
+    return null;
+  }
+
+  return {
+    conversationId: snapshot.conversationId,
+    responseToMessageId: snapshot.responseToMessageId,
+    message: {
+      id: snapshot.message.id,
+      role: "assistant",
+      parts: snapshot.message.parts as unknown[],
+    },
+    status: snapshot.status,
+  };
+}
+
+function fromPersistedSnapshot(
+  snapshot: PersistedChatDockStreamSnapshot | null,
+): ChatDockStreamSnapshot | null {
+  if (!snapshot) {
+    return null;
+  }
+
+  return {
+    conversationId: snapshot.conversationId,
+    responseToMessageId: snapshot.responseToMessageId,
+    message: {
+      id: snapshot.message.id,
+      role: "assistant",
+      parts: snapshot.message.parts as UIMessage["parts"],
+    },
+    status: snapshot.status,
+  };
+}
+
+function fromPersistedTab(tab: PersistedChatDockTab): ChatDockTab {
+  return {
+    id: tab.id,
+    title: tab.title,
+    draft: tab.draft,
+    isPending: tab.isPending,
+    isStreaming: tab.isStreaming,
+    streamSnapshot: fromPersistedSnapshot(tab.streamSnapshot),
+    lastError: tab.lastError,
+  };
+}
+
+export class ChatDockStore {
+  organizationSlug = "";
+  tabs: ChatDockTab[] = [];
+  activeTabId: string | null = null;
+  panelOpen = false;
+  hydrated = false;
+
+  private storage: ChatDockStorage | undefined;
+  private persistEnabled = true;
+
+  constructor(storage?: ChatDockStorage) {
+    this.storage = storage;
+    makeAutoObservable(
+      this,
+      {
+        tabs: observable.shallow,
+      },
+      { autoBind: true },
+    );
+  }
+
+  get activeTab(): ChatDockTab | null {
+    return this.tabs.find((tab) => tab.id === this.activeTabId) ?? null;
+  }
+
+  get hasTabs() {
+    return this.tabs.length > 0;
+  }
+
+  get streamingCount() {
+    return this.tabs.filter((tab) => tab.isStreaming).length;
+  }
+
+  get canStartStream() {
+    return this.streamingCount < CHAT_DOCK_MAX_CONCURRENT_STREAMS;
+  }
+
+  get tabBarVisible() {
+    return this.hasTabs;
+  }
+
+  get chromeHeightPx() {
+    if (!this.hasTabs) {
+      return 0;
+    }
+
+    const tabBar = CHAT_DOCK_TAB_BAR_HEIGHT_PX;
+    const panel = this.panelOpen ? CHAT_DOCK_PANEL_HEIGHT_PX : 0;
+    return tabBar + panel;
+  }
+
+  setOrganizationSlug(organizationSlug: string) {
+    if (this.organizationSlug === organizationSlug && this.hydrated) {
+      return;
+    }
+
+    this.organizationSlug = organizationSlug;
+    this.hydrate();
+  }
+
+  hydrate() {
+    const state = readChatDockState(this.organizationSlug, this.storage);
+    this.applyPersistedState(state);
+    this.hydrated = true;
+  }
+
+  openNewTab() {
+    const id = createPendingTabId();
+    const tab: ChatDockTab = {
+      id,
+      title: "New chat",
+      draft: "",
+      isPending: true,
+      isStreaming: false,
+      streamSnapshot: null,
+      lastError: null,
+    };
+
+    this.tabs = [...this.tabs, tab];
+    this.activeTabId = id;
+    this.panelOpen = true;
+    this.persist();
+    return id;
+  }
+
+  openTab(input: { id: string; title?: string }) {
+    const existing = this.tabs.find((tab) => tab.id === input.id);
+    if (existing) {
+      this.activeTabId = existing.id;
+      this.panelOpen = true;
+      this.persist();
+      return existing.id;
+    }
+
+    const tab: ChatDockTab = {
+      id: input.id,
+      title: input.title?.trim() || "Chat",
+      draft: "",
+      isPending: false,
+      isStreaming: false,
+      streamSnapshot: null,
+      lastError: null,
+    };
+
+    this.tabs = [...this.tabs, tab];
+    this.activeTabId = tab.id;
+    this.panelOpen = true;
+    this.persist();
+    return tab.id;
+  }
+
+  selectTab(tabId: string) {
+    if (!this.tabs.some((tab) => tab.id === tabId)) {
+      return;
+    }
+
+    if (this.activeTabId === tabId && this.panelOpen) {
+      this.panelOpen = false;
+      this.persist();
+      return;
+    }
+
+    this.activeTabId = tabId;
+    this.panelOpen = true;
+    this.persist();
+  }
+
+  closeTab(tabId: string) {
+    const index = this.tabs.findIndex((tab) => tab.id === tabId);
+    if (index < 0) {
+      return;
+    }
+
+    const wasActive = this.activeTabId === tabId;
+    this.tabs = this.tabs.filter((tab) => tab.id !== tabId);
+
+    if (this.tabs.length === 0) {
+      this.activeTabId = null;
+      this.panelOpen = false;
+      this.persist();
+      return;
+    }
+
+    if (wasActive) {
+      const next = this.tabs[Math.min(index, this.tabs.length - 1)];
+      this.activeTabId = next?.id ?? null;
+    }
+
+    this.persist();
+  }
+
+  setPanelOpen(open: boolean) {
+    if (!this.hasTabs) {
+      this.panelOpen = false;
+      this.persist();
+      return;
+    }
+
+    this.panelOpen = open;
+    this.persist();
+  }
+
+  togglePanel() {
+    this.setPanelOpen(!this.panelOpen);
+  }
+
+  setDraft(tabId: string, draft: string) {
+    this.updateTab(tabId, (tab) => {
+      tab.draft = draft;
+    });
+  }
+
+  setTitle(tabId: string, title: string) {
+    this.updateTab(tabId, (tab) => {
+      tab.title = title.trim() || tab.title;
+    });
+  }
+
+  setLastError(tabId: string, error: string | null) {
+    this.updateTab(tabId, (tab) => {
+      tab.lastError = error;
+    });
+  }
+
+  promotePendingTab(pendingId: string, conversationId: string, title?: string) {
+    const tab = this.tabs.find((entry) => entry.id === pendingId);
+    if (!tab) {
+      return;
+    }
+
+    tab.id = conversationId;
+    tab.isPending = false;
+    if (title?.trim()) {
+      tab.title = title.trim();
+    } else if (tab.title === "New chat" && tab.draft.trim()) {
+      tab.title = tab.draft.trim().slice(0, 48);
+    }
+
+    if (this.activeTabId === pendingId) {
+      this.activeTabId = conversationId;
+    }
+
+    this.tabs = [...this.tabs];
+    this.persist();
+  }
+
+  setStreamSnapshot(tabId: string, snapshot: ChatDockStreamSnapshot | null) {
+    this.updateTab(tabId, (tab) => {
+      tab.streamSnapshot = snapshot;
+      tab.isStreaming = snapshot?.status === "streaming";
+      if (snapshot?.status === "error") {
+        tab.lastError = "Sorry, I encountered an error while generating a response.";
+      } else if (snapshot?.status === "complete") {
+        tab.lastError = null;
+      }
+    });
+  }
+
+  markStreaming(tabId: string, isStreaming: boolean) {
+    this.updateTab(tabId, (tab) => {
+      tab.isStreaming = isStreaming;
+      if (!isStreaming && tab.streamSnapshot?.status === "streaming") {
+        tab.streamSnapshot = {
+          ...tab.streamSnapshot,
+          status: "complete",
+        };
+      }
+    });
+  }
+
+  clearStreamSnapshot(tabId: string) {
+    this.updateTab(tabId, (tab) => {
+      tab.streamSnapshot = null;
+      tab.isStreaming = false;
+    });
+  }
+
+  toPersistedState(): PersistedChatDockState {
+    return {
+      version: 1,
+      organizationSlug: this.organizationSlug,
+      activeTabId: this.activeTabId,
+      panelOpen: this.panelOpen,
+      tabs: this.tabs.map((tab) => ({
+        id: tab.id,
+        title: tab.title,
+        draft: tab.draft,
+        isPending: tab.isPending,
+        isStreaming: tab.isStreaming,
+        streamSnapshot: toPersistedSnapshot(tab.streamSnapshot),
+        lastError: tab.lastError,
+      })),
+    };
+  }
+
+  private applyPersistedState(state: PersistedChatDockState) {
+    this.tabs = state.tabs.map(fromPersistedTab);
+    this.activeTabId = state.activeTabId;
+    this.panelOpen = state.panelOpen;
+  }
+
+  private updateTab(tabId: string, mutate: (tab: ChatDockTab) => void) {
+    const tab = this.tabs.find((entry) => entry.id === tabId);
+    if (!tab) {
+      return;
+    }
+
+    mutate(tab);
+    this.tabs = [...this.tabs];
+    this.persist();
+  }
+
+  private persist() {
+    if (!this.persistEnabled || !this.organizationSlug) {
+      return;
+    }
+
+    writeChatDockState(this.toPersistedState(), this.storage);
+  }
+}
+
+export function createChatDockStore(storage?: ChatDockStorage) {
+  return new ChatDockStore(storage);
+}
+
+export function createEmptyChatDockStoreState(organizationSlug: string) {
+  return createEmptyChatDockState(organizationSlug);
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.ts
@@ -4,7 +4,6 @@ import type { UIMessage } from "ai";
 import {
   CHAT_DOCK_MAX_CONCURRENT_STREAMS,
   CHAT_DOCK_PANEL_HEIGHT_PX,
-  CHAT_DOCK_TAB_BAR_HEIGHT_PX,
   createEmptyChatDockState,
   readChatDockState,
   writeChatDockState,
@@ -132,13 +131,11 @@ export class ChatDockStore {
   }
 
   get chromeHeightPx() {
-    if (!this.hasTabs) {
+    if (!this.hasTabs || !this.panelOpen) {
       return 0;
     }
 
-    const tabBar = CHAT_DOCK_TAB_BAR_HEIGHT_PX;
-    const panel = this.panelOpen ? CHAT_DOCK_PANEL_HEIGHT_PX : 0;
-    return tabBar + panel;
+    return CHAT_DOCK_PANEL_HEIGHT_PX;
   }
 
   setOrganizationSlug(organizationSlug: string) {

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-tab-bar.test.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-tab-bar.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { IntlProvider } from "react-intl";
+
+import { ChatDockTabBar } from "./chat-dock-tab-bar";
+import type { ChatDockTab } from "./chat-dock-store";
+
+const tabs: ChatDockTab[] = [
+  {
+    id: "conv_1",
+    title: "Checkout copy",
+    draft: "",
+    isPending: false,
+    isStreaming: true,
+    streamSnapshot: null,
+    lastError: null,
+  },
+  {
+    id: "conv_2",
+    title: "Help docs",
+    draft: "",
+    isPending: false,
+    isStreaming: false,
+    streamSnapshot: null,
+    lastError: null,
+  },
+];
+
+describe("ChatDockTabBar", () => {
+  it("selects, closes, and creates tabs", async () => {
+    const user = userEvent.setup();
+    const onSelectTab = vi.fn();
+    const onCloseTab = vi.fn();
+    const onNewTab = vi.fn();
+
+    render(
+      <IntlProvider locale="en" messages={{}}>
+        <ChatDockTabBar
+          tabs={tabs}
+          activeTabId="conv_1"
+          onSelectTab={onSelectTab}
+          onCloseTab={onCloseTab}
+          onNewTab={onNewTab}
+        />
+      </IntlProvider>,
+    );
+
+    expect(screen.getByRole("tab", { name: /Checkout copy/i })).toBeTruthy();
+    expect(screen.getByLabelText("Generating response")).toBeTruthy();
+
+    await user.click(screen.getByRole("tab", { name: /Help docs/i }));
+    expect(onSelectTab).toHaveBeenCalledWith("conv_2");
+
+    await user.click(screen.getAllByLabelText("Close chat")[0]!);
+    expect(onCloseTab).toHaveBeenCalledWith("conv_1");
+
+    await user.click(screen.getByLabelText("New chat"));
+    expect(onNewTab).toHaveBeenCalled();
+  });
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-tab-bar.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-tab-bar.tsx
@@ -3,14 +3,13 @@
 import { observer } from "mobx-react-lite";
 import { Add01Icon, Cancel01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/primitives/cn";
 
 import { chatDockMessages } from "./chat-dock.messages";
 import type { ChatDockTab } from "./chat-dock-store";
-import { CHAT_DOCK_TAB_BAR_HEIGHT_PX } from "./chat-dock-persistence";
 
 export const ChatDockTabBar = observer(function ChatDockTabBar({
   tabs,
@@ -29,19 +28,18 @@ export const ChatDockTabBar = observer(function ChatDockTabBar({
 
   return (
     <div
-      className="flex items-center gap-1 border-b border-border bg-background px-2"
-      style={{ height: CHAT_DOCK_TAB_BAR_HEIGHT_PX }}
+      className="flex min-w-0 max-w-md items-center gap-1"
       role="tablist"
       aria-label="Chat conversations"
     >
-      <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
+      <div className="flex min-w-0 items-center gap-1 overflow-x-auto">
         {tabs.map((tab) => {
           const selected = tab.id === activeTabId;
           return (
             <div
               key={tab.id}
               className={cn(
-                "group flex max-w-48 shrink-0 items-center gap-1 rounded-md border px-2 py-1 text-xs",
+                "group flex max-w-40 shrink-0 items-center gap-1 rounded-md border px-2 py-1 text-xs",
                 selected
                   ? "border-border bg-muted text-foreground"
                   : "border-transparent text-muted-foreground hover:bg-muted/60 hover:text-foreground",
@@ -90,9 +88,6 @@ export const ChatDockTabBar = observer(function ChatDockTabBar({
       >
         <HugeiconsIcon icon={Add01Icon} strokeWidth={2} className="size-3.5" />
       </Button>
-      <span className="sr-only">
-        <FormattedMessage {...chatDockMessages.newChat} />
-      </span>
     </div>
   );
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-tab-bar.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-tab-bar.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { observer } from "mobx-react-lite";
+import { Add01Icon, Cancel01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/primitives/cn";
+
+import { chatDockMessages } from "./chat-dock.messages";
+import type { ChatDockTab } from "./chat-dock-store";
+import { CHAT_DOCK_TAB_BAR_HEIGHT_PX } from "./chat-dock-persistence";
+
+export const ChatDockTabBar = observer(function ChatDockTabBar({
+  tabs,
+  activeTabId,
+  onSelectTab,
+  onCloseTab,
+  onNewTab,
+}: {
+  tabs: ChatDockTab[];
+  activeTabId: string | null;
+  onSelectTab: (tabId: string) => void;
+  onCloseTab: (tabId: string) => void;
+  onNewTab: () => void;
+}) {
+  const intl = useIntl();
+
+  return (
+    <div
+      className="flex items-center gap-1 border-t border-border bg-background px-2"
+      style={{ height: CHAT_DOCK_TAB_BAR_HEIGHT_PX }}
+      role="tablist"
+      aria-label="Chat conversations"
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
+        {tabs.map((tab) => {
+          const selected = tab.id === activeTabId;
+          return (
+            <div
+              key={tab.id}
+              className={cn(
+                "group flex max-w-48 shrink-0 items-center gap-1 rounded-md border px-2 py-1 text-xs",
+                selected
+                  ? "border-border bg-muted text-foreground"
+                  : "border-transparent text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+              )}
+            >
+              <button
+                type="button"
+                role="tab"
+                aria-selected={selected}
+                className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+                onClick={() => onSelectTab(tab.id)}
+              >
+                {tab.isStreaming ? (
+                  <span
+                    className="size-1.5 shrink-0 animate-pulse rounded-full bg-grove-500"
+                    aria-label={intl.formatMessage(chatDockMessages.streaming)}
+                  />
+                ) : null}
+                <span className="truncate">{tab.title}</span>
+              </button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                className="size-5 opacity-70 group-hover:opacity-100"
+                aria-label={intl.formatMessage(chatDockMessages.closeTab)}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onCloseTab(tab.id);
+                }}
+              >
+                <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} className="size-3" />
+              </Button>
+            </div>
+          );
+        })}
+      </div>
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        className="shrink-0"
+        aria-label={intl.formatMessage(chatDockMessages.newChat)}
+        onClick={onNewTab}
+      >
+        <HugeiconsIcon icon={Add01Icon} strokeWidth={2} className="size-3.5" />
+      </Button>
+      <span className="sr-only">
+        <FormattedMessage {...chatDockMessages.newChat} />
+      </span>
+    </div>
+  );
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-tab-bar.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-tab-bar.tsx
@@ -29,7 +29,7 @@ export const ChatDockTabBar = observer(function ChatDockTabBar({
 
   return (
     <div
-      className="flex items-center gap-1 border-t border-border bg-background px-2"
+      className="flex items-center gap-1 border-b border-border bg-background px-2"
       style={{ height: CHAT_DOCK_TAB_BAR_HEIGHT_PX }}
       role="tablist"
       aria-label="Chat conversations"

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.messages.ts
@@ -1,0 +1,61 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const chatDockMessages = defineMessages({
+  newChat: {
+    id: "BpXeCSziJl",
+    defaultMessage: "New chat",
+    description: "Button to open a new chat dock tab",
+  },
+  closeTab: {
+    id: "1fxDZQx14T",
+    defaultMessage: "Close chat",
+    description: "Accessible label for closing a chat dock tab",
+  },
+  collapsePanel: {
+    id: "yZhpu31YiJ",
+    defaultMessage: "Collapse chat",
+    description: "Accessible label for collapsing the chat dock panel",
+  },
+  expandPanel: {
+    id: "GmObeT3Tn1",
+    defaultMessage: "Expand chat",
+    description: "Accessible label for expanding the chat dock panel",
+  },
+  openInInbox: {
+    id: "vVbXCgpKIh",
+    defaultMessage: "Open in Inbox",
+    description: "Link from chat dock to the full inbox page",
+  },
+  emptyComposer: {
+    id: "V9yUZUb6UP",
+    defaultMessage: "Ask Hyperlocalise to translate or localise…",
+    description: "Placeholder for a new chat dock composer",
+  },
+  streaming: {
+    id: "pXpP8bdMfG",
+    defaultMessage: "Generating response",
+    description: "Accessible label for a streaming chat tab indicator",
+  },
+  maxStreams: {
+    id: "/Q3+a6FMED",
+    defaultMessage: "You can run up to {count} chats at once.",
+    description: "Toast when the concurrent stream limit is reached",
+  },
+  createFailed: {
+    id: "C0+hlj1Es4",
+    defaultMessage: "Could not start this chat. Try again.",
+    description: "Error when creating a conversation from the chat dock fails",
+  },
+  sendFailed: {
+    id: "ZeUNHM/VrO",
+    defaultMessage: "Could not send your message. Try again.",
+    description: "Error when sending a chat dock reply fails",
+  },
+  conversationMissing: {
+    id: "d8Vs3k3UER",
+    defaultMessage: "This conversation is no longer available.",
+    description: "Toast when a docked conversation returns 404",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { observer } from "mobx-react-lite";
 import { Add01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useIntl } from "react-intl";
 
 import type { InboxCurrentUser } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-types";
@@ -18,6 +19,14 @@ import { chatDockMessages } from "./chat-dock.messages";
 import { ChatDockPanel } from "./chat-dock-panel";
 import { ChatDockTabBar } from "./chat-dock-tab-bar";
 
+function messagesQueryKey(conversationId: string) {
+  return ["conversation-messages", conversationId] as const;
+}
+
+function conversationsQueryKey(organizationSlug: string) {
+  return ["conversations", organizationSlug] as const;
+}
+
 /** Shell-lifetime setup: hydrate, CSS height var, stream manager. Mount once in the footer. */
 export const ChatDockBridge = observer(function ChatDockBridge({
   organizationSlug,
@@ -26,6 +35,7 @@ export const ChatDockBridge = observer(function ChatDockBridge({
 }) {
   const store = useAppShellStore();
   const { chatDock } = store;
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     if (!organizationSlug) {
@@ -38,8 +48,17 @@ export const ChatDockBridge = observer(function ChatDockBridge({
     }
 
     chatDock.setOrganizationSlug(organizationSlug);
-    getChatStreamManager(organizationSlug, chatDock);
-  }, [chatDock, organizationSlug]);
+    const streamManager = getChatStreamManager(organizationSlug, chatDock);
+    streamManager.setOnStreamFinished(async (conversationId) => {
+      await queryClient.invalidateQueries({ queryKey: messagesQueryKey(conversationId) });
+      await queryClient.invalidateQueries({ queryKey: conversationsQueryKey(organizationSlug) });
+      chatDock.clearStreamSnapshot(conversationId);
+    });
+
+    return () => {
+      streamManager.setOnStreamFinished(null);
+    };
+  }, [chatDock, organizationSlug, queryClient]);
 
   useEffect(() => {
     const root = document.documentElement;
@@ -93,7 +112,7 @@ export const ChatDockPanelHost = observer(function ChatDockPanelHost({
   );
 });
 
-/** Left-side footer controls: New chat icon, or open conversation tabs. */
+/** Right-side footer controls: New chat icon, or open conversation tabs. */
 export const ChatDockFooterControls = observer(function ChatDockFooterControls({
   organizationSlug,
 }: {

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.tsx
@@ -69,26 +69,25 @@ export const ChatDockBridge = observer(function ChatDockBridge({
   }, [chatDock.chromeHeightPx]);
 
   useEffect(() => {
-    if (!chatDock.hydrated) {
+    if (!chatDock.hydrated || !organizationSlug) {
       return;
     }
 
-    for (const tab of chatDock.tabs) {
-      if (!tab.isStreaming || tab.isPending) {
-        continue;
-      }
+    const interruptedIds = chatDock.tabs
+      .filter((tab) => tab.isStreaming && !tab.isPending)
+      .map((tab) => tab.id);
 
-      if (tab.streamSnapshot) {
-        chatDock.setStreamSnapshot(tab.id, {
-          ...tab.streamSnapshot,
-          status:
-            tab.streamSnapshot.status === "streaming" ? "complete" : tab.streamSnapshot.status,
-        });
-      } else {
-        chatDock.markStreaming(tab.id, false);
-      }
+    if (interruptedIds.length === 0) {
+      return;
     }
-  }, [chatDock, chatDock.hydrated]);
+
+    for (const conversationId of interruptedIds) {
+      chatDock.clearStreamSnapshot(conversationId);
+      void queryClient.invalidateQueries({ queryKey: messagesQueryKey(conversationId) });
+    }
+
+    void queryClient.invalidateQueries({ queryKey: conversationsQueryKey(organizationSlug) });
+  }, [chatDock, chatDock.hydrated, organizationSlug, queryClient]);
 
   return null;
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.tsx
@@ -18,16 +18,14 @@ import { chatDockMessages } from "./chat-dock.messages";
 import { ChatDockPanel } from "./chat-dock-panel";
 import { ChatDockTabBar } from "./chat-dock-tab-bar";
 
+/** Footer-embedded chat dock: panel + tabs (no fixed positioning of its own). */
 export const ChatDock = observer(function ChatDock({
   organizationSlug,
   currentUser,
-  planFooterHeightPx = 40,
 }: {
   organizationSlug: string;
   currentUser: InboxCurrentUser;
-  planFooterHeightPx?: number;
 }) {
-  const intl = useIntl();
   const store = useAppShellStore();
   const { chatDock } = store;
 
@@ -53,8 +51,7 @@ export const ChatDock = observer(function ChatDock({
     };
   }, [chatDock.chromeHeightPx]);
 
-  // Best-effort reconnect: tabs marked streaming after hydrate get a message refetch;
-  // live SSE cannot resume, so clear the streaming flag once messages are available again.
+  // Best-effort reconnect after hydrate: keep restored snapshot, clear spinning state.
   useEffect(() => {
     if (!chatDock.hydrated) {
       return;
@@ -65,7 +62,6 @@ export const ChatDock = observer(function ChatDock({
         continue;
       }
 
-      // Keep the restored snapshot visible; mark as complete so UI does not spin forever.
       if (tab.streamSnapshot) {
         chatDock.setStreamSnapshot(tab.id, {
           ...tab.streamSnapshot,
@@ -78,38 +74,12 @@ export const ChatDock = observer(function ChatDock({
     }
   }, [chatDock, chatDock.hydrated]);
 
-  if (!organizationSlug) {
+  if (!organizationSlug || !chatDock.hasTabs) {
     return null;
   }
 
-  const bottomOffset = planFooterHeightPx;
-
-  if (!chatDock.hasTabs) {
-    return (
-      <div
-        className="pointer-events-none fixed inset-x-0 z-40 flex justify-end px-3"
-        style={{ bottom: `calc(${bottomOffset}px + env(safe-area-inset-bottom))` }}
-      >
-        <Button
-          type="button"
-          size="sm"
-          variant="secondary"
-          className="pointer-events-auto mb-1 h-8 gap-1.5 shadow-sm"
-          aria-label={intl.formatMessage(chatDockMessages.newChat)}
-          onClick={() => chatDock.openNewTab()}
-        >
-          <HugeiconsIcon icon={Add01Icon} strokeWidth={2} className="size-3.5" />
-          {intl.formatMessage(chatDockMessages.newChat)}
-        </Button>
-      </div>
-    );
-  }
-
   return (
-    <div
-      className="fixed inset-x-0 z-40 flex flex-col"
-      style={{ bottom: `calc(${bottomOffset}px + env(safe-area-inset-bottom))` }}
-    >
+    <div className="flex min-h-0 flex-col">
       {chatDock.panelOpen ? (
         <ChatDockPanel
           organizationSlug={organizationSlug}
@@ -129,5 +99,42 @@ export const ChatDock = observer(function ChatDock({
         onNewTab={() => chatDock.openNewTab()}
       />
     </div>
+  );
+});
+
+/** Compact New chat control for the footer status row when no tabs are open. */
+export const ChatDockNewChatButton = observer(function ChatDockNewChatButton({
+  organizationSlug,
+}: {
+  organizationSlug: string;
+}) {
+  const intl = useIntl();
+  const store = useAppShellStore();
+  const { chatDock } = store;
+
+  useEffect(() => {
+    if (!organizationSlug) {
+      return;
+    }
+
+    chatDock.setOrganizationSlug(organizationSlug);
+  }, [chatDock, organizationSlug]);
+
+  if (!organizationSlug || chatDock.hasTabs) {
+    return null;
+  }
+
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="ghost"
+      className="h-7 gap-1.5 px-2 text-xs"
+      aria-label={intl.formatMessage(chatDockMessages.newChat)}
+      onClick={() => chatDock.openNewTab()}
+    >
+      <HugeiconsIcon icon={Add01Icon} strokeWidth={2} className="size-3.5" />
+      {intl.formatMessage(chatDockMessages.newChat)}
+    </Button>
   );
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.tsx
@@ -18,13 +18,11 @@ import { chatDockMessages } from "./chat-dock.messages";
 import { ChatDockPanel } from "./chat-dock-panel";
 import { ChatDockTabBar } from "./chat-dock-tab-bar";
 
-/** Footer-embedded chat dock: panel + tabs (no fixed positioning of its own). */
-export const ChatDock = observer(function ChatDock({
+/** Shell-lifetime setup: hydrate, CSS height var, stream manager. Mount once in the footer. */
+export const ChatDockBridge = observer(function ChatDockBridge({
   organizationSlug,
-  currentUser,
 }: {
   organizationSlug: string;
-  currentUser: InboxCurrentUser;
 }) {
   const store = useAppShellStore();
   const { chatDock } = store;
@@ -51,7 +49,6 @@ export const ChatDock = observer(function ChatDock({
     };
   }, [chatDock.chromeHeightPx]);
 
-  // Best-effort reconnect after hydrate: keep restored snapshot, clear spinning state.
   useEffect(() => {
     if (!chatDock.hydrated) {
       return;
@@ -74,67 +71,66 @@ export const ChatDock = observer(function ChatDock({
     }
   }, [chatDock, chatDock.hydrated]);
 
-  if (!organizationSlug || !chatDock.hasTabs) {
+  return null;
+});
+
+/** Expandable conversation panel above the footer status row. */
+export const ChatDockPanelHost = observer(function ChatDockPanelHost({
+  organizationSlug,
+  currentUser,
+}: {
+  organizationSlug: string;
+  currentUser: InboxCurrentUser;
+}) {
+  const { chatDock } = useAppShellStore();
+
+  if (!organizationSlug || !chatDock.hasTabs || !chatDock.panelOpen || !chatDock.activeTab) {
     return null;
   }
 
   return (
-    <div className="flex min-h-0 flex-col">
-      {chatDock.panelOpen ? (
-        <ChatDockPanel
-          organizationSlug={organizationSlug}
-          currentUser={currentUser}
-          store={chatDock}
-        />
-      ) : null}
-      <ChatDockTabBar
-        tabs={chatDock.tabs}
-        activeTabId={chatDock.activeTabId}
-        onSelectTab={(tabId) => chatDock.selectTab(tabId)}
-        onCloseTab={(tabId) => {
-          const manager = getChatStreamManager(organizationSlug, chatDock);
-          manager.stop(tabId);
-          chatDock.closeTab(tabId);
-        }}
-        onNewTab={() => chatDock.openNewTab()}
-      />
-    </div>
+    <ChatDockPanel organizationSlug={organizationSlug} currentUser={currentUser} store={chatDock} />
   );
 });
 
-/** Compact New chat control for the footer status row when no tabs are open. */
-export const ChatDockNewChatButton = observer(function ChatDockNewChatButton({
+/** Left-side footer controls: New chat icon, or open conversation tabs. */
+export const ChatDockFooterControls = observer(function ChatDockFooterControls({
   organizationSlug,
 }: {
   organizationSlug: string;
 }) {
   const intl = useIntl();
-  const store = useAppShellStore();
-  const { chatDock } = store;
+  const { chatDock } = useAppShellStore();
 
-  useEffect(() => {
-    if (!organizationSlug) {
-      return;
-    }
-
-    chatDock.setOrganizationSlug(organizationSlug);
-  }, [chatDock, organizationSlug]);
-
-  if (!organizationSlug || chatDock.hasTabs) {
+  if (!organizationSlug) {
     return null;
   }
 
+  if (!chatDock.hasTabs) {
+    return (
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        aria-label={intl.formatMessage(chatDockMessages.newChat)}
+        onClick={() => chatDock.openNewTab()}
+      >
+        <HugeiconsIcon icon={Add01Icon} strokeWidth={2} />
+      </Button>
+    );
+  }
+
   return (
-    <Button
-      type="button"
-      size="sm"
-      variant="ghost"
-      className="h-7 gap-1.5 px-2 text-xs"
-      aria-label={intl.formatMessage(chatDockMessages.newChat)}
-      onClick={() => chatDock.openNewTab()}
-    >
-      <HugeiconsIcon icon={Add01Icon} strokeWidth={2} className="size-3.5" />
-      {intl.formatMessage(chatDockMessages.newChat)}
-    </Button>
+    <ChatDockTabBar
+      tabs={chatDock.tabs}
+      activeTabId={chatDock.activeTabId}
+      onSelectTab={(tabId) => chatDock.selectTab(tabId)}
+      onCloseTab={(tabId) => {
+        const manager = getChatStreamManager(organizationSlug, chatDock);
+        manager.stop(tabId);
+        chatDock.closeTab(tabId);
+      }}
+      onNewTab={() => chatDock.openNewTab()}
+    />
   );
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.tsx
@@ -73,15 +73,15 @@ export const ChatDockBridge = observer(function ChatDockBridge({
       return;
     }
 
-    const interruptedIds = chatDock.tabs
-      .filter((tab) => tab.isStreaming && !tab.isPending)
+    const staleIds = chatDock.tabs
+      .filter((tab) => !tab.isPending && tab.streamSnapshot !== null)
       .map((tab) => tab.id);
 
-    if (interruptedIds.length === 0) {
+    if (staleIds.length === 0) {
       return;
     }
 
-    for (const conversationId of interruptedIds) {
+    for (const conversationId of staleIds) {
       chatDock.clearStreamSnapshot(conversationId);
       void queryClient.invalidateQueries({ queryKey: messagesQueryKey(conversationId) });
     }

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useEffect } from "react";
+import { observer } from "mobx-react-lite";
+import { Add01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useIntl } from "react-intl";
+
+import type { InboxCurrentUser } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-types";
+import { Button } from "@/components/ui/button";
+import { useAppShellStore } from "@/components/app-shell/store/app-shell-store-context";
+import {
+  disposeChatStreamManager,
+  getChatStreamManager,
+} from "@/components/app-shell/chat-dock/chat-stream-manager";
+
+import { chatDockMessages } from "./chat-dock.messages";
+import { ChatDockPanel } from "./chat-dock-panel";
+import { ChatDockTabBar } from "./chat-dock-tab-bar";
+
+export const ChatDock = observer(function ChatDock({
+  organizationSlug,
+  currentUser,
+  planFooterHeightPx = 40,
+}: {
+  organizationSlug: string;
+  currentUser: InboxCurrentUser;
+  planFooterHeightPx?: number;
+}) {
+  const intl = useIntl();
+  const store = useAppShellStore();
+  const { chatDock } = store;
+
+  useEffect(() => {
+    if (!organizationSlug) {
+      return;
+    }
+
+    const previousSlug = chatDock.organizationSlug;
+    if (previousSlug && previousSlug !== organizationSlug) {
+      disposeChatStreamManager(previousSlug);
+    }
+
+    chatDock.setOrganizationSlug(organizationSlug);
+    getChatStreamManager(organizationSlug, chatDock);
+  }, [chatDock, organizationSlug]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.style.setProperty("--app-shell-dock-height", `${chatDock.chromeHeightPx}px`);
+    return () => {
+      root.style.setProperty("--app-shell-dock-height", "0px");
+    };
+  }, [chatDock.chromeHeightPx]);
+
+  // Best-effort reconnect: tabs marked streaming after hydrate get a message refetch;
+  // live SSE cannot resume, so clear the streaming flag once messages are available again.
+  useEffect(() => {
+    if (!chatDock.hydrated) {
+      return;
+    }
+
+    for (const tab of chatDock.tabs) {
+      if (!tab.isStreaming || tab.isPending) {
+        continue;
+      }
+
+      // Keep the restored snapshot visible; mark as complete so UI does not spin forever.
+      if (tab.streamSnapshot) {
+        chatDock.setStreamSnapshot(tab.id, {
+          ...tab.streamSnapshot,
+          status:
+            tab.streamSnapshot.status === "streaming" ? "complete" : tab.streamSnapshot.status,
+        });
+      } else {
+        chatDock.markStreaming(tab.id, false);
+      }
+    }
+  }, [chatDock, chatDock.hydrated]);
+
+  if (!organizationSlug) {
+    return null;
+  }
+
+  const bottomOffset = planFooterHeightPx;
+
+  if (!chatDock.hasTabs) {
+    return (
+      <div
+        className="pointer-events-none fixed inset-x-0 z-40 flex justify-end px-3"
+        style={{ bottom: `calc(${bottomOffset}px + env(safe-area-inset-bottom))` }}
+      >
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          className="pointer-events-auto mb-1 h-8 gap-1.5 shadow-sm"
+          aria-label={intl.formatMessage(chatDockMessages.newChat)}
+          onClick={() => chatDock.openNewTab()}
+        >
+          <HugeiconsIcon icon={Add01Icon} strokeWidth={2} className="size-3.5" />
+          {intl.formatMessage(chatDockMessages.newChat)}
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="fixed inset-x-0 z-40 flex flex-col"
+      style={{ bottom: `calc(${bottomOffset}px + env(safe-area-inset-bottom))` }}
+    >
+      {chatDock.panelOpen ? (
+        <ChatDockPanel
+          organizationSlug={organizationSlug}
+          currentUser={currentUser}
+          store={chatDock}
+        />
+      ) : null}
+      <ChatDockTabBar
+        tabs={chatDock.tabs}
+        activeTabId={chatDock.activeTabId}
+        onSelectTab={(tabId) => chatDock.selectTab(tabId)}
+        onCloseTab={(tabId) => {
+          const manager = getChatStreamManager(organizationSlug, chatDock);
+          manager.stop(tabId);
+          chatDock.closeTab(tabId);
+        }}
+        onNewTab={() => chatDock.openNewTab()}
+      />
+    </div>
+  );
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-stream-manager.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-stream-manager.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { CHAT_DOCK_MAX_CONCURRENT_STREAMS } from "./chat-dock-persistence";
+import { ChatDockStore } from "./chat-dock-store";
+import { ChatStreamManager } from "./chat-stream-manager";
+
+describe("ChatStreamManager", () => {
+  it("refuses a fourth concurrent stream before calling the network", async () => {
+    const store = new ChatDockStore();
+    store.setOrganizationSlug("acme");
+    for (const id of ["a", "b", "c", "d"]) {
+      store.openTab({ id, title: id });
+    }
+
+    const manager = new ChatStreamManager("acme", store);
+    const activeStreams = (
+      manager as unknown as {
+        activeStreams: Map<string, { conversationId: string; controller: AbortController }>;
+      }
+    ).activeStreams;
+
+    for (const id of ["a", "b", "c"]) {
+      activeStreams.set(id, { conversationId: id, controller: new AbortController() });
+      store.markStreaming(id, true);
+    }
+
+    expect(manager.activeCount).toBe(CHAT_DOCK_MAX_CONCURRENT_STREAMS);
+
+    const result = await manager.start({
+      conversationId: "d",
+      responseToMessageId: "msg_d",
+      text: "hello",
+    });
+
+    expect(result).toEqual({
+      started: false,
+      reason: `You can run up to ${CHAT_DOCK_MAX_CONCURRENT_STREAMS} chats at once.`,
+    });
+    expect(manager.isStreaming("d")).toBe(false);
+  });
+
+  it("stops an active stream and clears streaming state", () => {
+    const store = new ChatDockStore();
+    store.setOrganizationSlug("acme");
+    store.openTab({ id: "conv_1", title: "Chat" });
+    store.markStreaming("conv_1", true);
+
+    const manager = new ChatStreamManager("acme", store);
+    const activeStreams = (
+      manager as unknown as {
+        activeStreams: Map<string, { conversationId: string; controller: AbortController }>;
+      }
+    ).activeStreams;
+    activeStreams.set("conv_1", {
+      conversationId: "conv_1",
+      controller: new AbortController(),
+    });
+
+    manager.stop("conv_1");
+    expect(manager.isStreaming("conv_1")).toBe(false);
+    expect(store.tabs[0]?.isStreaming).toBe(false);
+  });
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-stream-manager.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-stream-manager.ts
@@ -1,0 +1,183 @@
+import { DefaultChatTransport, readUIMessageStream, type UIMessage } from "ai";
+
+import { CHAT_DOCK_MAX_CONCURRENT_STREAMS } from "./chat-dock-persistence";
+import type { ChatDockStore, ChatDockStreamSnapshot } from "./chat-dock-store";
+
+const streamErrorMessage = "Sorry, I encountered an error while generating a response.";
+
+export type ChatStreamStartInput = {
+  conversationId: string;
+  responseToMessageId: string;
+  text: string;
+};
+
+type ActiveStream = {
+  conversationId: string;
+  controller: AbortController;
+};
+
+function createAssistantMessage(id: string, text = ""): UIMessage {
+  return {
+    id,
+    role: "assistant",
+    parts: text ? [{ type: "text", text, state: "done" }] : [],
+  };
+}
+
+export class ChatStreamManager {
+  private readonly organizationSlug: string;
+  private readonly store: ChatDockStore;
+  private readonly activeStreams = new Map<string, ActiveStream>();
+  private onStreamFinished: ((conversationId: string) => void | Promise<void>) | null = null;
+
+  constructor(organizationSlug: string, store: ChatDockStore) {
+    this.organizationSlug = organizationSlug;
+    this.store = store;
+  }
+
+  setOnStreamFinished(handler: ((conversationId: string) => void | Promise<void>) | null) {
+    this.onStreamFinished = handler;
+  }
+
+  get activeCount() {
+    return this.activeStreams.size;
+  }
+
+  isStreaming(conversationId: string) {
+    return this.activeStreams.has(conversationId);
+  }
+
+  stop(conversationId: string) {
+    const active = this.activeStreams.get(conversationId);
+    active?.controller.abort();
+    this.activeStreams.delete(conversationId);
+    this.store.markStreaming(conversationId, false);
+  }
+
+  stopAll() {
+    const conversationIds = Array.from(this.activeStreams.keys());
+    for (const conversationId of conversationIds) {
+      this.stop(conversationId);
+    }
+  }
+
+  async start(input: ChatStreamStartInput): Promise<{ started: boolean; reason?: string }> {
+    const { conversationId, responseToMessageId, text } = input;
+
+    if (this.activeStreams.has(conversationId)) {
+      this.stop(conversationId);
+    }
+
+    if (this.activeStreams.size >= CHAT_DOCK_MAX_CONCURRENT_STREAMS) {
+      return {
+        started: false,
+        reason: `You can run up to ${CHAT_DOCK_MAX_CONCURRENT_STREAMS} chats at once.`,
+      };
+    }
+
+    const controller = new AbortController();
+    const messageId = `stream-${responseToMessageId}`;
+    this.activeStreams.set(conversationId, { conversationId, controller });
+
+    const initialSnapshot: ChatDockStreamSnapshot = {
+      conversationId,
+      responseToMessageId,
+      message: createAssistantMessage(messageId),
+      status: "streaming",
+    };
+    this.store.setStreamSnapshot(conversationId, initialSnapshot);
+
+    let finishedSuccessfully = false;
+
+    try {
+      const transport = new DefaultChatTransport({
+        api: `/api/orgs/${this.organizationSlug}/conversations/${conversationId}/chat`,
+      });
+
+      const chunkStream = await transport.sendMessages({
+        abortSignal: controller.signal,
+        chatId: conversationId,
+        messageId: undefined,
+        messages: [
+          {
+            id: responseToMessageId,
+            role: "user",
+            parts: [{ type: "text", text }],
+          },
+        ],
+        trigger: "submit-message",
+      });
+
+      let latestMessage: UIMessage | null = null;
+      const messageStream = readUIMessageStream({
+        message: createAssistantMessage(messageId),
+        stream: chunkStream,
+        terminateOnError: true,
+      });
+
+      for await (const nextMessage of messageStream) {
+        latestMessage = nextMessage;
+        this.store.setStreamSnapshot(conversationId, {
+          conversationId,
+          responseToMessageId,
+          message: nextMessage,
+          status: "streaming",
+        });
+      }
+
+      finishedSuccessfully = true;
+      this.store.setStreamSnapshot(conversationId, {
+        conversationId,
+        responseToMessageId,
+        message: latestMessage ?? createAssistantMessage(messageId),
+        status: "complete",
+      });
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        return { started: true };
+      }
+
+      console.error("Chat dock streaming error:", error);
+      this.store.setStreamSnapshot(conversationId, {
+        conversationId,
+        responseToMessageId,
+        message: createAssistantMessage(messageId, streamErrorMessage),
+        status: "error",
+      });
+    } finally {
+      const active = this.activeStreams.get(conversationId);
+      if (active?.controller === controller) {
+        this.activeStreams.delete(conversationId);
+      }
+
+      if (finishedSuccessfully) {
+        await this.onStreamFinished?.(conversationId);
+      }
+    }
+
+    return { started: true };
+  }
+}
+
+const managers = new Map<string, ChatStreamManager>();
+
+export function getChatStreamManager(organizationSlug: string, store: ChatDockStore) {
+  const existing = managers.get(organizationSlug);
+  if (existing) {
+    return existing;
+  }
+
+  const manager = new ChatStreamManager(organizationSlug, store);
+  managers.set(organizationSlug, manager);
+  return manager;
+}
+
+export function disposeChatStreamManager(organizationSlug: string) {
+  const manager = managers.get(organizationSlug);
+  if (!manager) {
+    return;
+  }
+
+  manager.stopAll();
+  managers.delete(organizationSlug);
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store.ts
@@ -1,5 +1,6 @@
 import { makeAutoObservable } from "mobx";
 
+import { ChatDockStore } from "@/components/app-shell/chat-dock/chat-dock-store";
 import type { NavigationGroup } from "@/components/app-shell/navigation-config";
 
 import { BreadcrumbStore } from "./breadcrumb-store";
@@ -12,14 +13,22 @@ export class AppShellStore {
   navigation: NavigationStore;
   breadcrumb: BreadcrumbStore;
   headerActions: HeaderActionsStore;
+  chatDock: ChatDockStore;
 
   constructor(defaultNavigationGroups: readonly NavigationGroup[]) {
     this.sidebar = new SidebarStore();
     this.navigation = new NavigationStore(defaultNavigationGroups);
     this.breadcrumb = new BreadcrumbStore();
     this.headerActions = new HeaderActionsStore();
+    this.chatDock = new ChatDockStore();
 
-    makeAutoObservable(this, {}, { autoBind: true });
+    makeAutoObservable(
+      this,
+      {
+        chatDock: false,
+      },
+      { autoBind: true },
+    );
   }
 
   resetPageScope() {

--- a/docs/plans/2026-07-11-chat-dock-footer-design.md
+++ b/docs/plans/2026-07-11-chat-dock-footer-design.md
@@ -25,8 +25,8 @@ AppShellStore
 
 AppShellClient
   └── AppShellFooter
-        ├── ChatDockPanel + ChatDockTabBar
-        └── status row (New chat / plan / support)
+        ├── ChatDockPanel (when open)
+        └── status row (chat tabs left / plan / support right)
 ```
 
 Persistence key: `chat-dock:v1:${organizationSlug}`.
@@ -36,10 +36,9 @@ Persistence key: `chat-dock:v1:${organizationSlug}`.
 The chat dock is part of the fixed app shell footer:
 
 1. Expandable conversation panel (when open)
-2. Conversation tab bar (when tabs exist)
-3. Status row: New chat (when empty), plan usage, support
+2. Status row: chat tabs / New chat on the **left**, plan usage, support on the **right**
 
-Dynamic `--app-shell-dock-height` keeps page padding clear of the full footer chrome.
+Tabs sit in the same footer row as support. Dynamic `--app-shell-dock-height` only grows for the open panel.
 
 ## Data flow
 

--- a/docs/plans/2026-07-11-chat-dock-footer-design.md
+++ b/docs/plans/2026-07-11-chat-dock-footer-design.md
@@ -26,7 +26,7 @@ AppShellStore
 AppShellClient
   └── AppShellFooter
         ├── ChatDockPanel (when open)
-        └── status row (chat tabs left / plan / support right)
+        └── status row (plan left / chat tabs + support right)
 ```
 
 Persistence key: `chat-dock:v1:${organizationSlug}`.
@@ -36,9 +36,9 @@ Persistence key: `chat-dock:v1:${organizationSlug}`.
 The chat dock is part of the fixed app shell footer:
 
 1. Expandable conversation panel (when open)
-2. Status row: chat tabs / New chat on the **left**, plan usage, support on the **right**
+2. Status row: plan usage on the **left**; chat tabs / New chat and support on the **right**
 
-Tabs sit in the same footer row as support. Dynamic `--app-shell-dock-height` only grows for the open panel.
+Tabs sit in the same footer row as support on the right. Dynamic `--app-shell-dock-height` only grows for the open panel.
 
 ## Data flow
 

--- a/docs/plans/2026-07-11-chat-dock-footer-design.md
+++ b/docs/plans/2026-07-11-chat-dock-footer-design.md
@@ -1,0 +1,66 @@
+# Chat dock footer
+
+## Goal
+
+Keep active chats available across org pages through a docked panel and tab bar in the app shell. State lives in MobX and survives navigation and refresh.
+
+## Decisions
+
+- Docked panel on the current page (no forced navigation to inbox).
+- Persist tabs, panel open/collapsed, drafts, and best-effort stream snapshots in versioned `localStorage`.
+- Keep `/inbox` unchanged as a separate full-page experience.
+- Background tabs keep streaming (cap of 3 concurrent streams).
+
+## Architecture
+
+`ChatDockStore` hangs off `AppShellStore` and owns open tabs, the active tab, panel visibility, drafts, and stream UI snapshots. A shell-lifetime `ChatStreamManager` runs SSE streams keyed by conversation id. React Query still loads conversation metadata and message history from existing APIs.
+
+```
+AppShellStore
+  └── ChatDockStore
+        ├── tabs[]
+        ├── activeTabId
+        ├── panelOpen
+        └── persistence (localStorage)
+
+AppShellClient
+  ├── page content
+  ├── ChatDockPanel + ChatDockTabBar
+  └── AppShellFooter (plan + support)
+```
+
+Persistence key: `chat-dock:v1:${organizationSlug}`.
+
+## UI
+
+- Tab bar above the existing plan/support footer: titles, streaming pulse, close, and **+** for a new chat.
+- Expandable panel (~40–50vh) shows the active conversation with the existing message list and reply composer.
+- Collapsing the panel or changing routes does not stop background streams.
+- Dynamic `--app-shell-dock-height` keeps page padding clear of the dock chrome.
+
+## Data flow
+
+1. **+** creates a pending tab; first send calls `POST /conversations` and replaces the pending id.
+2. Replies use the existing message + chat stream endpoints.
+3. Stream deltas update the tab snapshot in MobX; on finish, React Query refetches messages.
+4. On shell mount, hydrate from storage, refetch messages, and attempt stream reconnect when a tab was marked streaming.
+
+## Error handling
+
+- Stream failure keeps a partial snapshot and offers retry.
+- Create/send failures keep the draft and show an inline or toast error.
+- Corrupt or unavailable `localStorage` falls back to in-memory state.
+- A fourth concurrent stream is refused with a toast.
+
+## Testing
+
+- Unit tests for store actions, persistence versioning, and stream concurrency.
+- Component coverage for tab select/close/new and panel open/collapse.
+- Manual checks: navigate away mid-stream, refresh, and confirm inbox still works independently.
+
+## Out of scope
+
+- Syncing dock tabs with inbox selection
+- Drag-reorder tabs
+- Pop-out / full-screen dock
+- Cross-device open-tab sync

--- a/docs/plans/2026-07-11-chat-dock-footer-design.md
+++ b/docs/plans/2026-07-11-chat-dock-footer-design.md
@@ -24,19 +24,22 @@ AppShellStore
         └── persistence (localStorage)
 
 AppShellClient
-  ├── page content
-  ├── ChatDockPanel + ChatDockTabBar
-  └── AppShellFooter (plan + support)
+  └── AppShellFooter
+        ├── ChatDockPanel + ChatDockTabBar
+        └── status row (New chat / plan / support)
 ```
 
 Persistence key: `chat-dock:v1:${organizationSlug}`.
 
 ## UI
 
-- Tab bar above the existing plan/support footer: titles, streaming pulse, close, and **+** for a new chat.
-- Expandable panel (~40–50vh) shows the active conversation with the existing message list and reply composer.
-- Collapsing the panel or changing routes does not stop background streams.
-- Dynamic `--app-shell-dock-height` keeps page padding clear of the dock chrome.
+The chat dock is part of the fixed app shell footer:
+
+1. Expandable conversation panel (when open)
+2. Conversation tab bar (when tabs exist)
+3. Status row: New chat (when empty), plan usage, support
+
+Dynamic `--app-shell-dock-height` keeps page padding clear of the full footer chrome.
 
 ## Data flow
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a shell-level chat dock so conversations stay available across org pages.

- **MobX `ChatDockStore`** on `AppShellStore` owns open tabs, active tab, panel open/collapsed, drafts, and stream snapshots
- **Chat dock lives in `AppShellFooter`**: panel above; status row with plan on the left and **chat tabs / New chat + Support on the right**
- **`localStorage` persistence** (`chat-dock:v1:${org}`) restores tabs, panel state, drafts, and stream snapshots after refresh
- **Background streaming** via `ChatStreamManager` (up to 3 concurrent); streams continue when the panel is collapsed or the route changes
- Inbox remains a separate full-page experience

Design: `docs/plans/2026-07-11-chat-dock-footer-design.md`

## Test plan

- [x] `vp test` for chat-dock + app-shell footer/store
- [x] `vp check --fix`
- [ ] Manually: confirm New chat / tabs sit on the right of the footer row next to Support
- [ ] Manually: open a chat, send a message, navigate away, confirm stream continues
- [ ] Manually: refresh and confirm tabs restore
- [ ] Manually: confirm inbox still works independently
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4f0c-a753-7738-93b4-88ad6f8288f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4f0c-a753-7738-93b4-88ad6f8288f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

