### PR TITLE
feat: use gpt-5.6-luna instead of gpt-5.4-mini

### DIFF
--- a/apps/hyperlocalise-web/i18n.yml
+++ b/apps/hyperlocalise-web/i18n.yml
@@ -21,7 +21,7 @@ llm:
   profiles:
     default:
       provider: openai
-      model: gpt-5.4-mini
+      model: gpt-5.6-luna
 
 hyperlocalise:
   project_id_env: HYPERLOCALISE_PROJECT_ID

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/model-id.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/model-id.ts
@@ -1,0 +1,2 @@
+/** Lightweight model id for config writers and workflows (no SDK / env imports). */
+export const hyperlocaliseAgentModelId = "gpt-5.6-luna";

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/model.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/model.ts
@@ -2,7 +2,9 @@ import { openai } from "@ai-sdk/openai";
 
 import { env } from "@/lib/env";
 
-export const hyperlocaliseAgentModelId = "gpt-5.6-luna";
+import { hyperlocaliseAgentModelId } from "./model-id";
+
+export { hyperlocaliseAgentModelId } from "./model-id";
 
 export function getHyperlocaliseAgentModel() {
   if (!env.OPENAI_API_KEY) {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/model.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/model.ts
@@ -2,7 +2,7 @@ import { openai } from "@ai-sdk/openai";
 
 import { env } from "@/lib/env";
 
-export const hyperlocaliseAgentModelId = "gpt-5.4-mini";
+export const hyperlocaliseAgentModelId = "gpt-5.6-luna";
 
 export function getHyperlocaliseAgentModel() {
   if (!env.OPENAI_API_KEY) {

--- a/apps/hyperlocalise-web/src/lib/agents/email/README.md
+++ b/apps/hyperlocalise-web/src/lib/agents/email/README.md
@@ -12,7 +12,7 @@ The code is split by integration boundary so the workflow stays testable.
 2. `users.ts` verifies that the sender is a registered Hyperlocalise user.
 3. `organizations.ts` resolves the addressed inbound alias to an enabled
    organization where the sender is a member.
-4. `intent.ts` asks `gpt-5.4-mini` to classify the subject and body as a
+4. `intent.ts` asks `gpt-5.6-luna` to classify the subject and body as a
    translation, check, keyword research, or unknown request.
 5. `image-attachments.ts` sends image attachments and the interpreted request
    directly to the image model, then replies with the generated image.

--- a/apps/hyperlocalise-web/src/lib/agents/slack/image-attachments.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/image-attachments.ts
@@ -8,6 +8,7 @@ import {
   localizeImageAttachment,
   type ImageLocalizationAttachment,
 } from "@/lib/agents/image-localization";
+import { hyperlocaliseAgentModelId } from "@/lib/agent-runtime/loops/model";
 import { env } from "@/lib/env";
 
 import {
@@ -55,7 +56,7 @@ function getSlackImageIntentModel() {
   if (!env.OPENAI_API_KEY) {
     throw new Error("OPENAI_API_KEY is not configured");
   }
-  return openai("gpt-5.4-mini");
+  return openai(hyperlocaliseAgentModelId);
 }
 
 function normalizeLocale(locale: string) {

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/materialize-hl-check-workspace.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/materialize-hl-check-workspace.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 
-import { hyperlocaliseAgentModelId } from "@/lib/agent-runtime/loops/model";
+import { hyperlocaliseAgentModelId } from "@/lib/agent-runtime/loops/model-id";
 import type {
   ExternalTmsTaskContent,
   ExternalTmsTranslationUnit,

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/materialize-hl-check-workspace.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/materialize-hl-check-workspace.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 
+import { hyperlocaliseAgentModelId } from "@/lib/agent-runtime/loops/model";
 import type {
   ExternalTmsTaskContent,
   ExternalTmsTranslationUnit,
@@ -85,7 +86,7 @@ function buildCheckConfigContent(
   "locales": {"source":${JSON.stringify(sourceLocale)},"targets":[${quotedLocales.join(",")}]},
   "buckets": {"provider":{"files":[{"from":${JSON.stringify(sourcePath)},"to":${JSON.stringify(targetPathTemplate)}}]}},
   "groups": {"default":{"targets":[${quotedLocales.join(",")}],"buckets":["provider"]}},
-  "llm": {"profiles":{"default":{"provider":"openai","model":"gpt-5.4-mini","prompt":"Translate {{input}}"}}}
+  "llm": {"profiles":{"default":{"provider":"openai","model":${JSON.stringify(hyperlocaliseAgentModelId)},"prompt":"Translate {{input}}"}}}
 }`;
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/shared/catalog.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/shared/catalog.ts
@@ -15,7 +15,7 @@ export const llmProviderSchema = z.enum(curatedLlmProviders);
 export const llmProviderCatalog = {
   openai: {
     label: "OpenAI",
-    models: ["gpt-5.5", "gpt-5.5-pro", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"],
+    models: ["gpt-5.5", "gpt-5.5-pro", "gpt-5.4", "gpt-5.6-luna", "gpt-5.4-nano"],
   },
   anthropic: {
     label: "Anthropic",

--- a/apps/hyperlocalise-web/src/lib/providers/shared/catalog.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/shared/catalog.ts
@@ -15,7 +15,14 @@ export const llmProviderSchema = z.enum(curatedLlmProviders);
 export const llmProviderCatalog = {
   openai: {
     label: "OpenAI",
-    models: ["gpt-5.5", "gpt-5.5-pro", "gpt-5.4", "gpt-5.6-luna", "gpt-5.4-nano"],
+    models: [
+      "gpt-5.5",
+      "gpt-5.5-pro",
+      "gpt-5.4",
+      "gpt-5.6-luna",
+      "gpt-5.4-mini",
+      "gpt-5.4-nano",
+    ],
   },
   anthropic: {
     label: "Anthropic",

--- a/apps/hyperlocalise-web/src/lib/providers/shared/catalog.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/shared/catalog.ts
@@ -16,12 +16,15 @@ export const llmProviderCatalog = {
   openai: {
     label: "OpenAI",
     models: [
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
       "gpt-5.5",
       "gpt-5.5-pro",
       "gpt-5.4",
-      "gpt-5.6-luna",
       "gpt-5.4-mini",
       "gpt-5.4-nano",
+      "gpt-5.4-pro",
     ],
   },
   anthropic: {

--- a/apps/hyperlocalise-web/src/lib/translation/generation.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/generation.ts
@@ -585,7 +585,7 @@ export const translateStringJobWithOpenAI: StringTranslationGenerator = async (i
     throw new Error("OPENAI_API_KEY is not configured");
   }
 
-  return createStringTranslationGenerator({ model: openai("gpt-5.4-mini") })(input);
+  return createStringTranslationGenerator({ model: openai(hyperlocaliseAgentModelId) })(input);
 };
 
 const defaultModelResolver = new OrganizationModelResolver();

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
@@ -1,5 +1,6 @@
 import { Sandbox, StreamError } from "@vercel/sandbox";
 
+import { hyperlocaliseAgentModelId } from "@/lib/agent-runtime/loops/model";
 import { env } from "@/lib/env";
 import { createConfiguredVercelSandbox } from "@/lib/vercel-sandbox-config";
 import {
@@ -443,7 +444,7 @@ export class HyperlocaliseCliConfigBuilder {
       "  profiles:",
       "    default:",
       "      provider: openai",
-      "      model: gpt-5.4-mini",
+      `      model: ${hyperlocaliseAgentModelId}`,
       `      system_prompt: ${yamlString(systemPrompt)}`,
       `      user_prompt: ${yamlString(userPrompt)}`,
     ].join("\n");

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
@@ -1,6 +1,6 @@
 import { Sandbox, StreamError } from "@vercel/sandbox";
 
-import { hyperlocaliseAgentModelId } from "@/lib/agent-runtime/loops/model";
+import { hyperlocaliseAgentModelId } from "@/lib/agent-runtime/loops/model-id";
 import { env } from "@/lib/env";
 import { createConfiguredVercelSandbox } from "@/lib/vercel-sandbox-config";
 import {

--- a/apps/hyperlocalise-web/src/workflows/email-translation.ts
+++ b/apps/hyperlocalise-web/src/workflows/email-translation.ts
@@ -1,6 +1,6 @@
 import { getWorkflowMetadata } from "workflow";
 
-import { hyperlocaliseAgentModelId } from "@/lib/agent-runtime/loops/model";
+import { hyperlocaliseAgentModelId } from "@/lib/agent-runtime/loops/model-id";
 import { env } from "@/lib/env";
 import type { EmailAgentTask, EmailAgentTaskAttachment } from "@/lib/workflow/types";
 import {

--- a/apps/hyperlocalise-web/src/workflows/email-translation.ts
+++ b/apps/hyperlocalise-web/src/workflows/email-translation.ts
@@ -1,5 +1,6 @@
 import { getWorkflowMetadata } from "workflow";
 
+import { hyperlocaliseAgentModelId } from "@/lib/agent-runtime/loops/model";
 import { env } from "@/lib/env";
 import type { EmailAgentTask, EmailAgentTaskAttachment } from "@/lib/workflow/types";
 import {
@@ -104,7 +105,7 @@ export function buildTempConfig(
     "  profiles:",
     "    default:",
     "      provider: openai",
-    "      model: gpt-5.4-mini",
+    `      model: ${hyperlocaliseAgentModelId}`,
     `      system_prompt: ${yamlString(systemPrompt)}`,
     `      user_prompt: ${yamlString(userPrompt)}`,
   ].join("\n");

--- a/eval_dataset/article_001.yaml
+++ b/eval_dataset/article_001.yaml
@@ -15,9 +15,9 @@ experiments:
   - id: openai-gpt-5.4-nano
     provider: openai
     model: gpt-5.4-nano
-  - id: openai-gpt-5.4-mini
+  - id: openai-gpt-5.6-luna
     provider: openai
-    model: gpt-5.4-mini
+    model: gpt-5.6-luna
 judge:
   provider: openai
   model: gpt-5.4

--- a/i18n.yml
+++ b/i18n.yml
@@ -111,7 +111,7 @@ llm:
   # When set, this provider/model pair is used only for context-memory building.
   context_memory:
     provider: openai
-    model: "gpt-5.4-mini"
+    model: "gpt-5.6-luna"
   # Profiles define provider/model and optional prompt behavior.
   # A default profile is required.
   # Supported providers: openai, azure_openai, anthropic, gemini, bedrock, lmstudio, groq, ollama.
@@ -120,7 +120,7 @@ llm:
     default:
       # Provider: openai, azure_openai, anthropic, gemini, bedrock, lmstudio, groq, or ollama.
       provider: openai
-      model: gpt-5.4-mini
+      model: gpt-5.6-luna
       # Optional explicit system message template.
       # system_prompt: You are a senior localization expert.
       # Optional explicit user message template.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates Hyperlocalise to use `gpt-5.6-luna` instead of `gpt-5.4-mini`, with review fixes for credential compatibility and lightweight imports.

### Changes
- Agent model constant → `gpt-5.6-luna` (dep-free `model-id.ts` for workflows/config writers)
- Slack image intent, managed/legacy translation, sandbox/email templates, QA fixture
- OpenAI provider catalog aligned with current pricing models: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.5-pro`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.4-pro`
- Root and web `i18n.yml` defaults + eval dataset entry
- Email agent README

### Review fixes
1. Restored `gpt-5.4-mini` in the OpenAI catalog so saved org credentials still validate
2. Workflows/QA helpers import model id from `model-id.ts` (no OpenAI SDK / env at import time)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5058-2b01-72d0-a040-5f54b6af4ed0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5058-2b01-72d0-a040-5f54b6af4ed0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

