### PR TITLE
fix(web): refine floating chat dock

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
@@ -164,7 +164,7 @@ export function ReplyComposerView({
           <PromptInputFooter
             className={
               variant === "compact"
-                ? "min-h-10 flex-nowrap gap-2 border-0 bg-transparent px-2 pb-2"
+                ? "min-h-10 flex-wrap gap-2 border-0 bg-transparent px-2 pb-2 sm:flex-nowrap"
                 : "flex-wrap gap-3 border-t border-border bg-muted px-4 py-3 sm:px-5"
             }
           >

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
@@ -59,6 +59,7 @@ type ReplyComposerViewProps = {
   repositories: InboxGithubRepository[];
   repositoriesIsError: boolean;
   repositoriesIsLoading: boolean;
+  variant?: "default" | "compact";
 };
 
 export function ReplyComposerView({
@@ -70,6 +71,7 @@ export function ReplyComposerView({
   repositories,
   repositoriesIsError,
   repositoriesIsLoading,
+  variant = "default",
 }: ReplyComposerViewProps) {
   const [replyText, setReplyText] = useState(draft);
   const [selectedRepositoryFullName, setSelectedRepositoryFullName] = useState("");
@@ -105,11 +107,21 @@ export function ReplyComposerView({
   };
 
   return (
-    <section className="sticky bottom-0 z-20 shrink-0 border-t border-border bg-background/95 px-4 py-4 backdrop-blur sm:px-6">
+    <section
+      className={
+        variant === "compact"
+          ? "sticky bottom-0 z-20 shrink-0 border-t border-border bg-background p-3"
+          : "sticky bottom-0 z-20 shrink-0 border-t border-border bg-background/95 px-4 py-4 backdrop-blur sm:px-6"
+      }
+    >
       <div className="mx-auto w-full max-w-4xl">
         <PromptInput
           onSubmit={({ text, files }) => sendReply(text, files)}
-          className="overflow-hidden rounded-[1.35rem] border border-border bg-background text-foreground shadow-2xl shadow-black/10 [&_[data-slot=input-group]]:h-auto [&_[data-slot=input-group]]:rounded-[1.35rem] [&_[data-slot=input-group]]:border-0 [&_[data-slot=input-group]]:bg-transparent"
+          className={
+            variant === "compact"
+              ? "overflow-hidden rounded-xl border border-border bg-muted/30 text-foreground shadow-sm [&_[data-slot=input-group]]:h-auto [&_[data-slot=input-group]]:rounded-xl [&_[data-slot=input-group]]:border-0 [&_[data-slot=input-group]]:bg-transparent"
+              : "overflow-hidden rounded-[1.35rem] border border-border bg-background text-foreground shadow-2xl shadow-black/10 [&_[data-slot=input-group]]:h-auto [&_[data-slot=input-group]]:rounded-[1.35rem] [&_[data-slot=input-group]]:border-0 [&_[data-slot=input-group]]:bg-transparent"
+          }
         >
           <PromptInputBody>
             {attachments.files.length > 0 && (
@@ -136,7 +148,11 @@ export function ReplyComposerView({
                 setReplyText(next);
                 onDraftChange?.(next);
               }}
-              className="min-h-24 px-4 py-4 text-base leading-6 sm:px-6 sm:py-5"
+              className={
+                variant === "compact"
+                  ? "min-h-12 max-h-28 px-3 py-3 text-sm leading-5"
+                  : "min-h-24 px-4 py-4 text-base leading-6 sm:px-6 sm:py-5"
+              }
               placeholder={
                 isStreaming
                   ? "Agent is responding..."
@@ -145,7 +161,13 @@ export function ReplyComposerView({
               rows={1}
             />
           </PromptInputBody>
-          <PromptInputFooter className="flex-wrap gap-3 border-t border-border bg-muted px-4 py-3 sm:px-5">
+          <PromptInputFooter
+            className={
+              variant === "compact"
+                ? "min-h-10 flex-nowrap gap-2 border-0 bg-transparent px-2 pb-2"
+                : "flex-wrap gap-3 border-t border-border bg-muted px-4 py-3 sm:px-5"
+            }
+          >
             <PromptInputTools className="flex-wrap gap-2 text-sm text-muted-foreground">
               <PromptInputButton
                 className="inline-flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent/20 hover:text-foreground"

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.test.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.test.tsx
@@ -123,7 +123,7 @@ describe("AppShellFooter", () => {
 
     renderFooter({ showPlan: false, withChat: true });
 
-    const newChat = screen.getByRole("button", { name: "New chat" });
+    const newChat = screen.getByRole("button", { name: "New request" });
     const support = screen.getByRole("link", { name: "Email support" });
     expect(newChat.closest("footer")).toBeTruthy();
     expect(support.closest("footer")).toBeTruthy();

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import Link from "next/link";
 import { observer } from "mobx-react-lite";
-import { ArrowDown01Icon, ArrowUpRight01Icon } from "@hugeicons/core-free-icons";
+import { ArrowUpRight01Icon, Cancel01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -24,10 +24,7 @@ import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 
 import { chatDockMessages } from "./chat-dock.messages";
-import {
-  CHAT_DOCK_MAX_CONCURRENT_STREAMS,
-  CHAT_DOCK_PANEL_HEIGHT_PX,
-} from "./chat-dock-persistence";
+import { CHAT_DOCK_MAX_CONCURRENT_STREAMS } from "./chat-dock-persistence";
 import type { ChatDockStore } from "./chat-dock-store";
 import { getChatStreamManager } from "./chat-stream-manager";
 
@@ -281,11 +278,10 @@ export const ChatDockPanel = observer(function ChatDockPanel({
 
   return (
     <section
-      className="flex flex-col overflow-hidden bg-background"
-      style={{ height: CHAT_DOCK_PANEL_HEIGHT_PX }}
+      className="fixed inset-x-2 bottom-[calc(var(--app-shell-plan-footer-height)+0.5rem)] z-50 flex h-[min(44rem,calc(100svh-var(--app-shell-plan-footer-height)-1rem))] flex-col overflow-hidden rounded-xl border border-border bg-background shadow-2xl shadow-black/15 sm:inset-x-auto sm:right-3 sm:w-[30rem]"
       aria-label={tab.title}
     >
-      <header className="flex h-11 shrink-0 items-center gap-2 border-b border-border px-3">
+      <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-3">
         <div className="min-w-0 flex-1">
           <p className="truncate text-sm font-medium text-foreground">{tab.title}</p>
         </div>
@@ -307,7 +303,21 @@ export const ChatDockPanel = observer(function ChatDockPanel({
           aria-label={intl.formatMessage(chatDockMessages.collapsePanel)}
           onClick={() => store.setPanelOpen(false)}
         >
-          <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={2} className="size-3.5" />
+          <span aria-hidden className="text-base leading-none">
+            −
+          </span>
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label={intl.formatMessage(chatDockMessages.closeTab)}
+          onClick={() => {
+            streamManager.stop(tab.id);
+            store.closeTab(tab.id);
+          }}
+        >
+          <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} className="size-3.5" />
         </Button>
       </header>
 
@@ -343,6 +353,7 @@ export const ChatDockPanel = observer(function ChatDockPanel({
           onDraftChange={(nextDraft) => store.setDraft(tab.id, nextDraft)}
           onSend={onSendMessage}
           organizationSlug={organizationSlug}
+          variant="compact"
         />
       </div>
     </section>

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-persistence.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-persistence.ts
@@ -1,7 +1,5 @@
 const CHAT_DOCK_STORAGE_VERSION = 1;
 export const CHAT_DOCK_MAX_CONCURRENT_STREAMS = 3;
-export const CHAT_DOCK_TAB_BAR_HEIGHT_PX = 40;
-export const CHAT_DOCK_PANEL_HEIGHT_PX = 420;
 
 export type ChatDockStreamStatus = "idle" | "streaming" | "complete" | "error";
 

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import {
-  CHAT_DOCK_MAX_CONCURRENT_STREAMS,
-  CHAT_DOCK_PANEL_HEIGHT_PX,
-} from "./chat-dock-persistence";
+import { CHAT_DOCK_MAX_CONCURRENT_STREAMS } from "./chat-dock-persistence";
 import { ChatDockStore } from "./chat-dock-store";
 
 function createMemoryStorage() {
@@ -30,7 +27,6 @@ describe("ChatDockStore", () => {
     expect(store.tabs).toHaveLength(1);
     expect(store.activeTabId).toBe(pendingId);
     expect(store.panelOpen).toBe(true);
-    expect(store.chromeHeightPx).toBe(CHAT_DOCK_PANEL_HEIGHT_PX);
 
     store.openTab({ id: "conv_1", title: "Checkout" });
     expect(store.tabs).toHaveLength(2);
@@ -38,7 +34,6 @@ describe("ChatDockStore", () => {
 
     store.selectTab("conv_1");
     expect(store.panelOpen).toBe(false);
-    expect(store.chromeHeightPx).toBe(0);
 
     store.closeTab(pendingId);
     expect(store.tabs.map((tab) => tab.id)).toEqual(["conv_1"]);
@@ -46,7 +41,6 @@ describe("ChatDockStore", () => {
     store.closeTab("conv_1");
     expect(store.hasTabs).toBe(false);
     expect(store.panelOpen).toBe(false);
-    expect(store.chromeHeightPx).toBe(0);
   });
 
   it("persists and hydrates org-scoped state", () => {

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.ts
@@ -3,7 +3,6 @@ import type { UIMessage } from "ai";
 
 import {
   CHAT_DOCK_MAX_CONCURRENT_STREAMS,
-  CHAT_DOCK_PANEL_HEIGHT_PX,
   createEmptyChatDockState,
   readChatDockState,
   writeChatDockState,
@@ -128,14 +127,6 @@ export class ChatDockStore {
 
   get tabBarVisible() {
     return this.hasTabs;
-  }
-
-  get chromeHeightPx() {
-    if (!this.hasTabs || !this.panelOpen) {
-      return 0;
-    }
-
-    return CHAT_DOCK_PANEL_HEIGHT_PX;
   }
 
   setOrganizationSlug(organizationSlug: string) {

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-tab-bar.test.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-tab-bar.test.tsx
@@ -58,7 +58,7 @@ describe("ChatDockTabBar", () => {
     await user.click(screen.getAllByLabelText("Close chat")[0]!);
     expect(onCloseTab).toHaveBeenCalledWith("conv_1");
 
-    await user.click(screen.getByLabelText("New chat"));
+    await user.click(screen.getByRole("button", { name: "New request" }));
     expect(onNewTab).toHaveBeenCalled();
   });
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-tab-bar.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-tab-bar.tsx
@@ -3,7 +3,7 @@
 import { observer } from "mobx-react-lite";
 import { Add01Icon, Cancel01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/primitives/cn";
@@ -81,12 +81,13 @@ export const ChatDockTabBar = observer(function ChatDockTabBar({
       <Button
         type="button"
         variant="ghost"
-        size="icon-xs"
-        className="shrink-0"
+        size="xs"
+        className="shrink-0 gap-1.5 px-2"
         aria-label={intl.formatMessage(chatDockMessages.newChat)}
         onClick={onNewTab}
       >
         <HugeiconsIcon icon={Add01Icon} strokeWidth={2} className="size-3.5" />
+        <FormattedMessage {...chatDockMessages.newChat} />
       </Button>
     </div>
   );

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.messages.ts
@@ -4,8 +4,8 @@ import { defineMessages } from "react-intl";
 
 export const chatDockMessages = defineMessages({
   newChat: {
-    id: "BpXeCSziJl",
-    defaultMessage: "New chat",
+    id: "mV0v+ofKFK",
+    defaultMessage: "New request",
     description: "Button to open a new chat dock tab",
   },
   closeTab: {

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.tsx
@@ -5,7 +5,7 @@ import { observer } from "mobx-react-lite";
 import { Add01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import type { InboxCurrentUser } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-types";
 import { Button } from "@/components/ui/button";
@@ -27,7 +27,7 @@ function conversationsQueryKey(organizationSlug: string) {
   return ["conversations", organizationSlug] as const;
 }
 
-/** Shell-lifetime setup: hydrate, CSS height var, stream manager. Mount once in the footer. */
+/** Shell-lifetime setup: hydrate and stream manager. Mount once in the footer. */
 export const ChatDockBridge = observer(function ChatDockBridge({
   organizationSlug,
 }: {
@@ -59,14 +59,6 @@ export const ChatDockBridge = observer(function ChatDockBridge({
       streamManager.setOnStreamFinished(null);
     };
   }, [chatDock, organizationSlug, queryClient]);
-
-  useEffect(() => {
-    const root = document.documentElement;
-    root.style.setProperty("--app-shell-dock-height", `${chatDock.chromeHeightPx}px`);
-    return () => {
-      root.style.setProperty("--app-shell-dock-height", "0px");
-    };
-  }, [chatDock.chromeHeightPx]);
 
   useEffect(() => {
     if (!chatDock.hydrated || !organizationSlug) {
@@ -129,11 +121,13 @@ export const ChatDockFooterControls = observer(function ChatDockFooterControls({
       <Button
         type="button"
         variant="ghost"
-        size="icon-xs"
+        size="xs"
+        className="gap-1.5 px-2"
         aria-label={intl.formatMessage(chatDockMessages.newChat)}
         onClick={() => chatDock.openNewTab()}
       >
-        <HugeiconsIcon icon={Add01Icon} strokeWidth={2} />
+        <HugeiconsIcon icon={Add01Icon} strokeWidth={2} className="size-3.5" />
+        <FormattedMessage {...chatDockMessages.newChat} />
       </Button>
     );
   }

--- a/docs/adr/2026-07-11-floating-chat-dock-design.md
+++ b/docs/adr/2026-07-11-floating-chat-dock-design.md
@@ -1,0 +1,19 @@
+# Floating chat dock design
+
+## Goal
+
+Make chat available without compressing the application workspace. The dock should feel like a focused utility window rather than a full-width page section.
+
+## Design
+
+The expanded chat is a fixed bottom-right panel on desktop and uses narrow viewport gutters on mobile. It has a compact header for the conversation title, Inbox link, minimize action, and close action. Messages own the flexible middle region, while the composer remains pinned to the bottom of the panel.
+
+The composer uses a short, growing textarea and a single compact control row. Existing conversation, streaming, attachment, repository selection, and persistence behavior remains unchanged.
+
+The global footer continues to expose chat tabs and a labeled new-request action, but opening the panel no longer changes application content height.
+
+## Validation
+
+- Existing chat dock store and component tests continue to pass.
+- The web app type and style checks pass.
+- The panel remains usable in both themes and at mobile viewport widths.


### PR DESCRIPTION
## What changed

- Replace the full-width chat dock with a responsive floating panel anchored above the app footer.
- Add compact header controls to minimize, close, or open the conversation in Inbox.
- Add a compact composer variant with a shorter, auto-growing input and condensed controls.
- Label the chat creation action as “New request.”
- Stop the expanded dock from changing the app shell’s content height.
- Document the floating dock design and update affected tests.

## How to test

- Run `vp test run src/components/app-shell/app-shell-footer.test.tsx src/components/app-shell/chat-dock/chat-dock-store.test.ts src/components/app-shell/chat-dock/chat-dock-tab-bar.test.tsx`.
- Run `vp check --fix`.
- Open a new request and confirm the chat appears as a floating bottom-right panel.
- Confirm the composer remains compact, messages scroll, and minimize and close actions work.
- Confirm the panel adapts to narrow viewports.
- Full `vp test` was attempted but remains blocked by the local PostgreSQL service being unavailable on port 5432.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review