### PR TITLE
fix(web): improve CAT loading and file menu actions

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-tree-context-menu.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-tree-context-menu.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ContextMenuOpenContext } from "@pierre/trees";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { createProjectFileRecord } from "./project-files.fixture";
+import { ProjectFileTreeContextMenu } from "./project-file-tree-context-menu";
+
+describe("ProjectFileTreeContextMenu", () => {
+  it("closes the tree menu before opening the translation dialog", async () => {
+    const events: string[] = [];
+    const close = vi.fn(() => events.push("close"));
+    const onTranslateFile = vi.fn(() => events.push("translate"));
+    const file = createProjectFileRecord({
+      sourcePath: "marketing/pricing.json",
+      storedFileId: "file_pricing",
+    });
+
+    render(
+      <ProjectFileTreeContextMenu
+        file={file}
+        context={{ close } as unknown as ContextMenuOpenContext}
+        fileActions={{
+          organizationSlug: "acme",
+          projectId: "proj_1",
+          highlightLocale: null,
+          projectTargetLocales: ["fr"],
+          onViewStrings: vi.fn(),
+          onTranslateFile,
+        }}
+        capabilities={{
+          canOpenCat: true,
+          canTranslateWithAgent: true,
+          catHref: "/cat",
+          isNativeFile: true,
+          translateDisabledTitle: undefined,
+        }}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Translate with agent" }));
+
+    expect(close).toHaveBeenCalledWith({ restoreFocus: false });
+    expect(onTranslateFile).toHaveBeenCalledWith(file);
+    expect(events).toEqual(["close", "translate"]);
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-tree-context-menu.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-tree-context-menu.tsx
@@ -151,8 +151,8 @@ export function ProjectFileTreeContextMenu({
             disabled={!capabilities.canTranslateWithAgent}
             title={capabilities.translateDisabledTitle}
             onClick={() => {
-              fileActions.onTranslateFile?.(file);
               closeMenu();
+              fileActions.onTranslateFile?.(file);
             }}
           >
             <HugeiconsIcon icon={TranslateIcon} strokeWidth={1.8} />
@@ -164,8 +164,8 @@ export function ProjectFileTreeContextMenu({
             variant="outline"
             className="w-full justify-start"
             onClick={() => {
-              fileActions.onImportFile?.(file);
               closeMenu();
+              fileActions.onImportFile?.(file);
             }}
           >
             <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} />
@@ -177,8 +177,8 @@ export function ProjectFileTreeContextMenu({
             variant="outline"
             className="w-full justify-start"
             onClick={() => {
-              fileActions.onDownloadFile?.(file);
               closeMenu();
+              fileActions.onDownloadFile?.(file);
             }}
           >
             <HugeiconsIcon icon={Download01Icon} strokeWidth={1.8} />

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-panel.tsx
@@ -3,7 +3,7 @@
 import { FilterIcon, SearchIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { observer } from "mobx-react-lite";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
@@ -146,6 +146,10 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
   const store = useCatWorkspace();
   const hoveredSegmentId = store.ui.hoveredSegmentId;
   const intelligenceSegmentId = store.intelligenceSegmentId;
+  const handleVisibleSegmentIdsChange = useCallback(
+    (segmentIds: string[]) => store.ui.setVisibleSideBySideSegmentIds(segmentIds),
+    [store],
+  );
 
   const loadedCount = segments.length;
   const hasActiveFilter = queueFilter !== "all";
@@ -273,6 +277,7 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
               onFocusSegment={onFocusSegment}
               onHoverSegment={(segmentId) => store.ui.setHoveredSegment(segmentId)}
               onLeaveSegment={() => store.ui.clearHoveredSegment()}
+              onVisibleSegmentIdsChange={handleVisibleSegmentIdsChange}
               onTargetChange={onTargetChange}
               hasMore={hasMoreQueue}
               isLoadingMore={isFetchingPage}

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-virtual-list.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-virtual-list.tsx
@@ -21,6 +21,7 @@ export function CatSideBySideVirtualList({
   onFocusSegment,
   onHoverSegment,
   onLeaveSegment,
+  onVisibleSegmentIdsChange,
   onTargetChange,
   hasMore = false,
   isLoadingMore = false,
@@ -36,6 +37,7 @@ export function CatSideBySideVirtualList({
   onFocusSegment: (segmentId: string) => void;
   onHoverSegment: (segmentId: string) => void;
   onLeaveSegment: () => void;
+  onVisibleSegmentIdsChange: (segmentIds: string[]) => void;
   onTargetChange: (segmentId: string, value: string) => void;
   hasMore?: boolean;
   isLoadingMore?: boolean;
@@ -66,13 +68,27 @@ export function CatSideBySideVirtualList({
     [hasMore, isLoadingMore, onNearEnd, segments.length],
   );
 
+  const publishVisibleSegmentIds = useCallback(
+    (items: Array<{ index: number }>) => {
+      onVisibleSegmentIdsChange(
+        items.flatMap((item) => {
+          const segment = segments[item.index];
+          return segment ? [segment.id] : [];
+        }),
+      );
+    },
+    [onVisibleSegmentIdsChange, segments],
+  );
+
   const virtualizer = useVirtualizer({
     count: segments.length,
     getScrollElement: () => parentRef.current,
     estimateSize: () => ESTIMATED_ROW_HEIGHT,
     overscan: 6,
     onChange: (instance) => {
-      checkForNearEnd(instance.getVirtualItems());
+      const virtualItems = instance.getVirtualItems();
+      checkForNearEnd(virtualItems);
+      publishVisibleSegmentIds(virtualItems);
     },
   });
 
@@ -83,8 +99,17 @@ export function CatSideBySideVirtualList({
   }, [isLoadingMore]);
 
   useEffect(() => {
-    checkForNearEnd(virtualizer.getVirtualItems());
-  }, [checkForNearEnd, virtualizer]);
+    const virtualItems = virtualizer.getVirtualItems();
+    checkForNearEnd(virtualItems);
+    publishVisibleSegmentIds(virtualItems);
+  }, [checkForNearEnd, publishVisibleSegmentIds, virtualizer]);
+
+  useEffect(
+    () => () => {
+      onVisibleSegmentIdsChange([]);
+    },
+    [onVisibleSegmentIdsChange],
+  );
 
   return (
     <div ref={parentRef} className={cn("min-h-0 flex-1 overflow-auto", className)}>

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
@@ -125,12 +125,7 @@ const CatWorkspaceContainerObserver = observer(function CatWorkspaceContainerObs
         snapshot={queueSnapshot ?? null}
         initialSegmentKeyOrId={initialSegmentKeyOrId}
       />
-      {lazySegment ? (
-        <CatWorkspaceLazySegmentSync
-          {...lazySegment}
-          queueSegmentIds={controller.queueSegments.map((segment) => segment.id)}
-        />
-      ) : null}
+      {lazySegment ? <CatWorkspaceLazySegmentSync {...lazySegment} /> : null}
 
       <CatPanelErrorBoundary
         scope="workspace"

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-lazy-segment-sync.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-lazy-segment-sync.tsx
@@ -205,7 +205,6 @@ export const CatWorkspaceLazySegmentSync = observer(function CatWorkspaceLazySeg
   resourceType,
   catFile,
   enabled,
-  queueSegmentIds = [],
 }: {
   organizationSlug: string;
   projectId: string;
@@ -215,7 +214,6 @@ export const CatWorkspaceLazySegmentSync = observer(function CatWorkspaceLazySeg
   resourceType?: "file" | "key";
   catFile: ProjectFileCatQueueFile | null | undefined;
   enabled: boolean;
-  queueSegmentIds?: string[];
 }) {
   const store = useCatWorkspace();
   const selectedSegmentId = store.selectedSegmentId;
@@ -224,6 +222,7 @@ export const CatWorkspaceLazySegmentSync = observer(function CatWorkspaceLazySeg
       ? store.ui.hoveredSegmentId
       : null;
   const isSideBySideView = store.ui.isSideBySideView;
+  const visibleSideBySideSegmentIds = store.ui.visibleSideBySideSegmentIds;
 
   useCatLoadedQueueTargetsSync({
     organizationSlug,
@@ -234,7 +233,7 @@ export const CatWorkspaceLazySegmentSync = observer(function CatWorkspaceLazySeg
     resourceType,
     catFile,
     enabled: enabled && isSideBySideView,
-    segmentIds: queueSegmentIds,
+    segmentIds: visibleSideBySideSegmentIds,
   });
 
   const _selectedSync = useCatSegmentLazySync({

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-domain-stores.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-domain-stores.test.ts
@@ -256,4 +256,16 @@ describe("CatWorkspaceUiStore", () => {
     expect(ui.hoveredSegmentId).toBeNull();
     expect(ui.previewTargetLoading).toBe(true);
   });
+
+  it("tracks the virtualized side-by-side segment range", () => {
+    const ui = new CatWorkspaceUiStore();
+
+    ui.setVisibleSideBySideSegmentIds(["seg-01", "seg-02"]);
+
+    expect(ui.visibleSideBySideSegmentIds).toEqual(["seg-01", "seg-02"]);
+
+    ui.setVisibleSideBySideSegmentIds([]);
+
+    expect(ui.visibleSideBySideSegmentIds).toEqual([]);
+  });
 });

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-workspace-ui-store.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-workspace-ui-store.ts
@@ -13,6 +13,7 @@ export class CatWorkspaceUiStore {
   previewLoadingSegmentId: string | null = null;
   previewTargetLoading = false;
   previewCommentsLoading = false;
+  visibleSideBySideSegmentIds: string[] = [];
 
   constructor() {
     makeAutoObservable(this, {}, { autoBind: true });
@@ -37,6 +38,17 @@ export class CatWorkspaceUiStore {
 
   clearHoveredSegment() {
     this.hoveredSegmentId = null;
+  }
+
+  setVisibleSideBySideSegmentIds(segmentIds: string[]) {
+    if (
+      this.visibleSideBySideSegmentIds.length === segmentIds.length &&
+      this.visibleSideBySideSegmentIds.every((segmentId, index) => segmentId === segmentIds[index])
+    ) {
+      return;
+    }
+
+    this.visibleSideBySideSegmentIds = segmentIds;
   }
 
   setPreviewLoadingState(


### PR DESCRIPTION
## What changed

- Load side-by-side CAT translations only for virtualized visible rows and overscan instead of every segment on the page.
- Track and clear the visible segment range as users scroll or leave side-by-side view.
- Close the project file context menu before opening Translate, Import, or Download dialogs so the menu remains usable afterward.
- Add regression coverage for virtualized segment tracking and file-menu action ordering.

## How to test

- Run `vp test run src/components/cat/workspace/store/cat-domain-stores.test.ts src/components/cat/side-by-side/cat-side-by-side-intelligence-panel.test.tsx src/components/cat/workspace/cat-workspace-container.navigation.test.tsx`.
- Run `vp test run 'src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-tree-context-menu.test.tsx' 'src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.test.tsx'`.
- Run `vp check --fix`.
- Manually verify that side-by-side rows load translations as they enter the viewport.
- Open “Translate with agent” from the file-tree menu, close the dialog, and confirm the menu can be opened again.
- The full `vp test` suite requires PostgreSQL on port 5432 and the test server on port 3000; 365 test files passed before the environment-dependent failures.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review