### PR TITLE
fix(markdown): preserve link delimiters during translation

### DIFF
--- a/internal/i18n/translationfileparser/markdown_md_parser.go
+++ b/internal/i18n/translationfileparser/markdown_md_parser.go
@@ -383,6 +383,10 @@ func protectStandardMarkdownInlineSyntax(segment string) (string, map[string]str
 		}
 
 		switch {
+		case segment[idx] == '!' && idx+1 < len(segment) && startsMarkdownLinkLabel(segment, idx+1):
+			// The image marker and opening bracket form one structural opener.
+			appendPlaceholder(segment[idx : idx+2])
+			idx += 2
 		case segment[idx] == '[' && startsMarkdownLinkLabel(segment, idx):
 			// Link delimiters are structural syntax, not translatable content.
 			appendPlaceholder(segment[idx : idx+1])

--- a/internal/i18n/translationfileparser/markdown_md_parser.go
+++ b/internal/i18n/translationfileparser/markdown_md_parser.go
@@ -383,6 +383,10 @@ func protectStandardMarkdownInlineSyntax(segment string) (string, map[string]str
 		}
 
 		switch {
+		case segment[idx] == '[' && startsMarkdownLinkLabel(segment, idx):
+			// Link delimiters are structural syntax, not translatable content.
+			appendPlaceholder(segment[idx : idx+1])
+			idx++
 		case segment[idx] == '`':
 			run := 0
 			for idx+run < len(segment) && segment[idx+run] == '`' {

--- a/internal/i18n/translationfileparser/markdown_parser.go
+++ b/internal/i18n/translationfileparser/markdown_parser.go
@@ -775,7 +775,7 @@ func renderMarkdownPartWithDiagnostics(part markdownPart, translated string, dia
 		// into malformed Markdown without leaving a sentinel behind.
 		placeholderErr := ValidateMarkdownInternalPlaceholders(part.source, rendered)
 		canRecoverSingle := len(part.placeholders) == 1 && len(MarkdownInternalPlaceholderTokens(rendered)) == 1
-		linkOrderValid := markdownLinkPlaceholderOrderValid(rendered, part.placeholders)
+		linkOrderValid := markdownLinkPlaceholderOrderValid(part.source, rendered, part.placeholders)
 		if (placeholderErr != nil || !linkOrderValid) && !canRecoverSingle {
 			if diags != nil && part.key != "" {
 				diags.SourceFallbackKeys = append(diags.SourceFallbackKeys, part.key)
@@ -798,8 +798,31 @@ func renderMarkdownPartWithDiagnostics(part markdownPart, translated string, dia
 	return rendered
 }
 
-func markdownLinkPlaceholderOrderValid(rendered string, placeholders map[string]string) bool {
-	depth := 0
+func markdownLinkPlaceholderOrderValid(source, rendered string, placeholders map[string]string) bool {
+	expectedCloserByOpener := make(map[string]string)
+	var sourceOpeners []string
+	for _, token := range markdownPlaceholderPattern.FindAllString(source, -1) {
+		original, ok := placeholders[token]
+		if !ok {
+			continue
+		}
+		switch {
+		case original == "[":
+			sourceOpeners = append(sourceOpeners, token)
+		case strings.HasPrefix(original, "](") || strings.HasPrefix(original, "]["):
+			if len(sourceOpeners) == 0 {
+				return false
+			}
+			opener := sourceOpeners[len(sourceOpeners)-1]
+			sourceOpeners = sourceOpeners[:len(sourceOpeners)-1]
+			expectedCloserByOpener[opener] = token
+		}
+	}
+	if len(sourceOpeners) != 0 {
+		return false
+	}
+
+	var expectedClosers []string
 	for _, token := range markdownPlaceholderPattern.FindAllString(rendered, -1) {
 		original, ok := placeholders[token]
 		if !ok {
@@ -807,15 +830,19 @@ func markdownLinkPlaceholderOrderValid(rendered string, placeholders map[string]
 		}
 		switch {
 		case original == "[":
-			depth++
-		case strings.HasPrefix(original, "](") || strings.HasPrefix(original, "]["):
-			if depth == 0 {
+			expectedCloser, ok := expectedCloserByOpener[token]
+			if !ok {
 				return false
 			}
-			depth--
+			expectedClosers = append(expectedClosers, expectedCloser)
+		case strings.HasPrefix(original, "](") || strings.HasPrefix(original, "]["):
+			if len(expectedClosers) == 0 || expectedClosers[len(expectedClosers)-1] != token {
+				return false
+			}
+			expectedClosers = expectedClosers[:len(expectedClosers)-1]
 		}
 	}
-	return depth == 0
+	return len(expectedClosers) == 0
 }
 
 func yamlPlainScalarNeedsQuotes(value string) bool {

--- a/internal/i18n/translationfileparser/markdown_parser.go
+++ b/internal/i18n/translationfileparser/markdown_parser.go
@@ -370,6 +370,12 @@ func protectMarkdownInlineSyntax(segment string) (string, map[string]string, str
 		}
 
 		switch {
+		case segment[idx] == '!' && idx+1 < len(segment) && startsMarkdownLinkLabel(segment, idx+1):
+			// The image marker and opening bracket form one structural opener.
+			// Keeping the marker out of translated text prevents an image from
+			// silently degrading into a normal link.
+			appendPlaceholder(segment[idx : idx+2])
+			idx += 2
 		case segment[idx] == '[' && startsMarkdownLinkLabel(segment, idx):
 			// Keep the opening delimiter marshal-owned just like the closing
 			// delimiter and destination below. Otherwise a translator can omit
@@ -807,7 +813,7 @@ func markdownLinkPlaceholderOrderValid(source, rendered string, placeholders map
 			continue
 		}
 		switch {
-		case original == "[":
+		case original == "[" || original == "![":
 			sourceOpeners = append(sourceOpeners, token)
 		case strings.HasPrefix(original, "](") || strings.HasPrefix(original, "]["):
 			if len(sourceOpeners) == 0 {
@@ -829,7 +835,7 @@ func markdownLinkPlaceholderOrderValid(source, rendered string, placeholders map
 			continue
 		}
 		switch {
-		case original == "[":
+		case original == "[" || original == "![":
 			expectedCloser, ok := expectedCloserByOpener[token]
 			if !ok {
 				return false

--- a/internal/i18n/translationfileparser/markdown_parser.go
+++ b/internal/i18n/translationfileparser/markdown_parser.go
@@ -370,6 +370,13 @@ func protectMarkdownInlineSyntax(segment string) (string, map[string]string, str
 		}
 
 		switch {
+		case segment[idx] == '[' && startsMarkdownLinkLabel(segment, idx):
+			// Keep the opening delimiter marshal-owned just like the closing
+			// delimiter and destination below. Otherwise a translator can omit
+			// this byte while preserving the closing placeholder, producing
+			// syntactically invalid Markdown during expansion.
+			appendPlaceholder(segment[idx : idx+1])
+			idx++
 		case segment[idx] == '`':
 			run := 0
 			for idx+run < len(segment) && segment[idx+run] == '`' {
@@ -439,6 +446,36 @@ func protectMarkdownInlineSyntax(segment string) (string, map[string]string, str
 		return segment, nil, segment, false
 	}
 	return rendered.String(), placeholders, plain.String(), false
+}
+
+func startsMarkdownLinkLabel(segment string, start int) bool {
+	if start < 0 || start >= len(segment) || segment[start] != '[' {
+		return false
+	}
+	backslashes := 0
+	for idx := start - 1; idx >= 0 && segment[idx] == '\\'; idx-- {
+		backslashes++
+	}
+	if backslashes%2 != 0 {
+		return false
+	}
+
+	depth := 1
+	for idx := start + 1; idx < len(segment); idx++ {
+		switch segment[idx] {
+		case '\\':
+			idx++
+		case '[':
+			depth++
+		case ']':
+			depth--
+			if depth != 0 {
+				continue
+			}
+			return idx+1 < len(segment) && (segment[idx+1] == '(' || segment[idx+1] == '[')
+		}
+	}
+	return false
 }
 
 func findMarkdownReferenceDefinitionDestination(segment string) (int, int, bool) {
@@ -730,6 +767,22 @@ func renderMarkdownPartWithDiagnostics(part markdownPart, translated string, dia
 	if len(part.placeholders) == 0 {
 		return rendered
 	}
+	if !trustedFallback {
+		// Detect omitted sentinels before expansion makes their absence
+		// indistinguishable from ordinary translated text. A single placeholder
+		// may still use the existing recognizable-token recovery below; multiple
+		// placeholders must match exactly so duplicates or swaps cannot expand
+		// into malformed Markdown without leaving a sentinel behind.
+		placeholderErr := ValidateMarkdownInternalPlaceholders(part.source, rendered)
+		canRecoverSingle := len(part.placeholders) == 1 && len(MarkdownInternalPlaceholderTokens(rendered)) == 1
+		linkOrderValid := markdownLinkPlaceholderOrderValid(rendered, part.placeholders)
+		if (placeholderErr != nil || !linkOrderValid) && !canRecoverSingle {
+			if diags != nil && part.key != "" {
+				diags.SourceFallbackKeys = append(diags.SourceFallbackKeys, part.key)
+			}
+			return expandMarkdownPlaceholders(part.source, part.placeholders)
+		}
+	}
 	rendered = expandMarkdownPlaceholders(rendered, part.placeholders)
 	rendered = normalizeMarkdownPlaceholders(rendered, part.placeholders)
 	rendered = normalizeUnexpectedMarkdownLinkClosers(part, rendered)
@@ -743,6 +796,26 @@ func renderMarkdownPartWithDiagnostics(part markdownPart, translated string, dia
 		return expandMarkdownPlaceholders(part.source, part.placeholders)
 	}
 	return rendered
+}
+
+func markdownLinkPlaceholderOrderValid(rendered string, placeholders map[string]string) bool {
+	depth := 0
+	for _, token := range markdownPlaceholderPattern.FindAllString(rendered, -1) {
+		original, ok := placeholders[token]
+		if !ok {
+			continue
+		}
+		switch {
+		case original == "[":
+			depth++
+		case strings.HasPrefix(original, "](") || strings.HasPrefix(original, "]["):
+			if depth == 0 {
+				return false
+			}
+			depth--
+		}
+	}
+	return depth == 0
 }
 
 func yamlPlainScalarNeedsQuotes(value string) bool {

--- a/internal/i18n/translationfileparser/markdown_parser_test.go
+++ b/internal/i18n/translationfileparser/markdown_parser_test.go
@@ -184,6 +184,148 @@ func TestMarshalMarkdownPreservesLinkDestinationsWithParentheses(t *testing.T) {
 	}
 }
 
+func TestMarshalMarkdownOwnsLinkDelimiters(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		want     string
+	}{
+		{
+			name:     "inline link",
+			template: "Read [the docs](/docs) now.\n",
+			want:     "Lire [la documentation](/docs) maintenant.\n",
+		},
+		{
+			name:     "reference link",
+			template: "Read [the docs][docs] now.\n\n[docs]: /docs\n",
+			want:     "Lire [la documentation][docs] maintenant.\n\n[docs]: /docs\n",
+		},
+		{
+			name:     "image",
+			template: "View ![the diagram](/diagram.png) now.\n",
+			want:     "Voir ![le diagramme](/diagram.png) maintenant.\n",
+		},
+		{
+			name:     "nested label brackets",
+			template: "Read [the [draft] docs](/docs) now.\n",
+			want:     "Lire [la documentation [brouillon]](/docs) maintenant.\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entries, err := (MarkdownParser{}).Parse([]byte(tt.template))
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+
+			updates := make(map[string]string, len(entries))
+			for key, value := range entries {
+				if strings.Contains(value, "Read") {
+					value = strings.Replace(value, "Read ", "Lire ", 1)
+					value = strings.Replace(value, "the [draft] docs", "la documentation [brouillon]", 1)
+					value = strings.Replace(value, "the docs", "la documentation", 1)
+					value = strings.Replace(value, " now", " maintenant", 1)
+				}
+				if strings.Contains(value, "View") {
+					value = strings.Replace(value, "View ", "Voir ", 1)
+					value = strings.Replace(value, "the diagram", "le diagramme", 1)
+					value = strings.Replace(value, " now", " maintenant", 1)
+				}
+				updates[key] = value
+			}
+
+			output := string(MarshalMarkdown([]byte(tt.template), updates, false))
+			if output != tt.want {
+				t.Fatalf("output = %q, want %q", output, tt.want)
+			}
+		})
+	}
+}
+
+func TestMarkdownParserDoesNotProtectEscapedLinkLikeBracket(t *testing.T) {
+	template := []byte("Keep \\[literal](/not-a-link) unchanged.\n")
+	entries, err := (MarkdownParser{}).Parse(template)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	for _, value := range entries {
+		if len(markdownPlaceholderPattern.FindAllString(value, -1)) != 1 {
+			t.Fatalf("expected only destination-like closer protected, got %q", value)
+		}
+	}
+	if output := string(MarshalMarkdown(template, entries, false)); output != string(template) {
+		t.Fatalf("output = %q, want %q", output, template)
+	}
+}
+
+func TestMarshalMarkdownFallsBackWhenOpeningLinkDelimiterPlaceholderIsDropped(t *testing.T) {
+	template := []byte("Read [the docs](/docs) now.\n")
+	entries, err := (MarkdownParser{}).Parse(template)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	updates := make(map[string]string, len(entries))
+	for key, value := range entries {
+		placeholders := markdownPlaceholderPattern.FindAllString(value, -1)
+		if len(placeholders) != 2 {
+			t.Fatalf("expected opening link delimiter placeholder in %q", value)
+		}
+		updates[key] = strings.Replace(value, placeholders[0], "", 1)
+	}
+
+	output, diags := MarshalMarkdownWithDiagnostics(template, updates, false)
+	if string(output) != string(template) {
+		t.Fatalf("expected valid source fallback, got %q", output)
+	}
+	if len(diags.SourceFallbackKeys) != 1 {
+		t.Fatalf("expected placeholder fallback diagnostic, got %+v", diags)
+	}
+}
+
+func TestMarshalMarkdownFallsBackWhenLinkPlaceholdersAreInvalid(t *testing.T) {
+	template := []byte("Read [the docs](/docs) now.\n")
+	entries, err := (MarkdownParser{}).Parse(template)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	for name, corrupt := range map[string]func([]string, string) string{
+		"dropped closer": func(tokens []string, value string) string {
+			return strings.Replace(value, tokens[1], "", 1)
+		},
+		"duplicated opener": func(tokens []string, value string) string {
+			return strings.Replace(value, tokens[1], tokens[0], 1)
+		},
+		"swapped tokens": func(tokens []string, value string) string {
+			value = strings.Replace(value, tokens[0], "SWAP_TOKEN", 1)
+			value = strings.Replace(value, tokens[1], tokens[0], 1)
+			return strings.Replace(value, "SWAP_TOKEN", tokens[1], 1)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			updates := make(map[string]string, len(entries))
+			for key, value := range entries {
+				tokens := markdownPlaceholderPattern.FindAllString(value, -1)
+				if len(tokens) != 2 {
+					t.Fatalf("expected two link placeholders in %q", value)
+				}
+				updates[key] = corrupt(tokens, value)
+			}
+
+			output, diags := MarshalMarkdownWithDiagnostics(template, updates, false)
+			if string(output) != string(template) {
+				t.Fatalf("expected valid source fallback, got %q", output)
+			}
+			if len(diags.SourceFallbackKeys) != 1 {
+				t.Fatalf("expected placeholder fallback diagnostic, got %+v", diags)
+			}
+		})
+	}
+}
+
 func TestMarshalMarkdownPreservesLinkTitleWithParenthesis(t *testing.T) {
 	template := []byte("[link](/url \"title with ) paren\")\n")
 

--- a/internal/i18n/translationfileparser/markdown_parser_test.go
+++ b/internal/i18n/translationfileparser/markdown_parser_test.go
@@ -1,6 +1,7 @@
 package translationfileparser
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -282,6 +283,35 @@ func TestMarshalMarkdownFallsBackWhenOpeningLinkDelimiterPlaceholderIsDropped(t 
 	}
 	if len(diags.SourceFallbackKeys) != 1 {
 		t.Fatalf("expected placeholder fallback diagnostic, got %+v", diags)
+	}
+}
+
+func TestMarshalMarkdownFallsBackWhenImageOpenerPlaceholderIsDropped(t *testing.T) {
+	for _, mdx := range []bool{false, true} {
+		t.Run(fmt.Sprintf("mdx=%t", mdx), func(t *testing.T) {
+			template := []byte("View ![the diagram](/diagram.png) now.\n")
+			entries, err := (MarkdownParser{MDX: mdx}).Parse(template)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+
+			updates := make(map[string]string, len(entries))
+			for key, value := range entries {
+				placeholders := markdownPlaceholderPattern.FindAllString(value, -1)
+				if len(placeholders) != 2 {
+					t.Fatalf("expected image opener and closer placeholders in %q", value)
+				}
+				updates[key] = strings.Replace(value, placeholders[0], "", 1)
+			}
+
+			output, diags := MarshalMarkdownWithDiagnostics(template, updates, mdx)
+			if string(output) != string(template) {
+				t.Fatalf("expected valid source fallback, got %q", output)
+			}
+			if len(diags.SourceFallbackKeys) != 1 {
+				t.Fatalf("expected placeholder fallback diagnostic, got %+v", diags)
+			}
+		})
 	}
 }
 

--- a/internal/i18n/translationfileparser/markdown_parser_test.go
+++ b/internal/i18n/translationfileparser/markdown_parser_test.go
@@ -326,6 +326,45 @@ func TestMarshalMarkdownFallsBackWhenLinkPlaceholdersAreInvalid(t *testing.T) {
 	}
 }
 
+func TestMarshalMarkdownKeepsLinkPlaceholderPairsTogether(t *testing.T) {
+	template := []byte("First [A](/url-1), then [B](/url-2).\n")
+	entries, err := (MarkdownParser{}).Parse(template)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	var key, value string
+	for entryKey, entryValue := range entries {
+		key, value = entryKey, entryValue
+	}
+	tokens := markdownPlaceholderPattern.FindAllString(value, -1)
+	if len(tokens) != 4 {
+		t.Fatalf("expected four link placeholders in %q", value)
+	}
+
+	t.Run("crossed destinations fall back", func(t *testing.T) {
+		crossed := "First " + tokens[0] + "A" + tokens[3] + ", then " + tokens[2] + "B" + tokens[1] + "."
+		output, diags := MarshalMarkdownWithDiagnostics(template, map[string]string{key: crossed}, false)
+		if string(output) != string(template) {
+			t.Fatalf("expected source fallback, got %q", output)
+		}
+		if len(diags.SourceFallbackKeys) != 1 {
+			t.Fatalf("expected placeholder fallback diagnostic, got %+v", diags)
+		}
+	})
+
+	t.Run("complete links may reorder", func(t *testing.T) {
+		reordered := "First " + tokens[2] + "B" + tokens[3] + ", then " + tokens[0] + "A" + tokens[1] + "."
+		output, diags := MarshalMarkdownWithDiagnostics(template, map[string]string{key: reordered}, false)
+		if got, want := string(output), "First [B](/url-2), then [A](/url-1).\n"; got != want {
+			t.Fatalf("output = %q, want %q", got, want)
+		}
+		if len(diags.SourceFallbackKeys) != 0 {
+			t.Fatalf("unexpected fallback diagnostic: %+v", diags)
+		}
+	})
+}
+
 func TestMarshalMarkdownPreservesLinkTitleWithParenthesis(t *testing.T) {
 	template := []byte("[link](/url \"title with ) paren\")\n")
 


### PR DESCRIPTION
## What changed

- Keep opening Markdown link delimiters under marshal ownership for inline links, reference links, and images.
- Fall back to valid source Markdown when link placeholders are missing, duplicated, corrupted, or structurally reordered.
- Preserve safe placeholder reordering while enforcing balanced link delimiter order.
- Add regression coverage for nested labels, escaped brackets, dropped delimiters, and duplicated or swapped placeholders.

## How to test

- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review