### PR TITLE
fix(web): show display names on target locale chips

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-locale-picker.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-locale-picker.tsx
@@ -25,6 +25,15 @@ function sortLocaleCodes(locales: string[]) {
   return [...locales].toSorted((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
 }
 
+function sortLocalesByDisplayName(
+  locales: string[],
+  intl: Parameters<typeof formatLocaleDisplayName>[0],
+) {
+  return [...locales].toSorted((a, b) =>
+    formatLocaleDisplayName(intl, a).localeCompare(formatLocaleDisplayName(intl, b)),
+  );
+}
+
 export function ProjectSourceLocalePicker({
   value,
   onChange,
@@ -115,12 +124,20 @@ export function ProjectTargetLocalesPicker({
     [],
   );
   const commonLocales = useMemo(
-    () => sortLocaleCodes(COMMON_LOCALES.filter((locale) => locale.toLowerCase() !== sourceKey)),
-    [sourceKey],
+    () =>
+      sortLocalesByDisplayName(
+        COMMON_LOCALES.filter((locale) => locale.toLowerCase() !== sourceKey),
+        intl,
+      ),
+    [intl, sourceKey],
   );
   const extraSelectedLocales = useMemo(
-    () => sortLocaleCodes(value.filter((locale) => !commonLocaleKeys.has(locale.toLowerCase()))),
-    [commonLocaleKeys, value],
+    () =>
+      sortLocalesByDisplayName(
+        value.filter((locale) => !commonLocaleKeys.has(locale.toLowerCase())),
+        intl,
+      ),
+    [commonLocaleKeys, intl, value],
   );
 
   useEffect(() => {
@@ -183,8 +200,9 @@ export function ProjectTargetLocalesPicker({
               onClick={() => toggleLocale(locale)}
               className="h-7 px-2.5 text-xs"
               title={formatLocaleOptionLabel(intl, locale)}
+              aria-label={formatLocaleOptionLabel(intl, locale)}
             >
-              {locale}
+              {formatLocaleDisplayName(intl, locale)}
             </Button>
           );
         })}
@@ -200,8 +218,9 @@ export function ProjectTargetLocalesPicker({
               onClick={() => toggleLocale(locale)}
               className="h-7 px-2.5 text-xs"
               title={formatLocaleOptionLabel(intl, locale)}
+              aria-label={formatLocaleOptionLabel(intl, locale)}
             >
-              {locale}
+              {formatLocaleDisplayName(intl, locale)}
             </Button>
           ))}
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Target locale chips in the project locale picker still showed raw BCP-47 codes (`de-DE`) even after source selects switched to localised display names.

This updates the chip labels to use `formatLocaleDisplayName` (e.g. "German (Germany)"), keeps the code in the tooltip/`aria-label` via `formatLocaleOptionLabel`, and sorts chips by display name.

## Test plan

- [ ] Open project settings / create project dialog Locales section
- [ ] Confirm source select still shows display names
- [ ] Confirm target chips show display names instead of codes
- [ ] Hover a chip and confirm tooltip includes the locale code
- [ ] Toggle chips and save; selected values still persist as locale codes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d40f3880-8319-4d55-8142-500fc9e1daa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d40f3880-8319-4d55-8142-500fc9e1daa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

