### PR TITLE
refactor(inbox): use shadcn message primitives

### DIFF
--- a/apps/hyperlocalise-web/package.json
+++ b/apps/hyperlocalise-web/package.json
@@ -40,6 +40,7 @@
     "@pierre/trees": "1.0.0-beta.5",
     "@radix-ui/react-use-controllable-state": "^1.2.2",
     "@rive-app/react-webgl2": "^4.29.4",
+    "@shadcn/react": "^0.2.1",
     "@streamdown/cjk": "^1.0.3",
     "@streamdown/code": "^1.1.1",
     "@streamdown/math": "^1.0.2",

--- a/apps/hyperlocalise-web/pnpm-lock.yaml
+++ b/apps/hyperlocalise-web/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       '@rive-app/react-webgl2':
         specifier: ^4.29.4
         version: 4.29.4(react@19.2.7)
+      '@shadcn/react':
+        specifier: ^0.2.1
+        version: 0.2.1(@types/react@19.2.17)(react@19.2.7)
       '@streamdown/cjk':
         specifier: ^1.0.3
         version: 1.0.3(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(react@19.2.7)(unified@11.0.5)
@@ -2937,6 +2940,17 @@ packages:
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@shadcn/react@0.2.1':
+    resolution: {integrity: sha512-5krgi3dRMKb5jH6a+qPzVJUy/54s0kKE4Rw4LjDfLqOdVQTWKUgxWf1kW8r912I0jX/Lzxqc+pgjkjWxUIK5BQ==}
+    peerDependencies:
+      '@types/react': '>=19'
+      react: '>=19'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
 
   '@shikijs/core@3.23.0':
     resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
@@ -11287,6 +11301,11 @@ snapshots:
       picomatch: 4.0.4
 
   '@sec-ant/readable-stream@0.4.1': {}
+
+  '@shadcn/react@0.2.1(@types/react@19.2.17)(react@19.2.7)':
+    optionalDependencies:
+      '@types/react': 19.2.17
+      react: 19.2.7
 
   '@shikijs/core@3.23.0':
     dependencies:

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
@@ -11,14 +11,9 @@ import type {
 import { DownloadIcon, FileTextIcon } from "lucide-react";
 import { memo, type ReactNode } from "react";
 
-import {
-  Conversation,
-  ConversationContent,
-  ConversationEmptyState,
-  ConversationScrollButton,
-} from "@/components/ai-elements/conversation";
+import { ConversationEmptyState } from "@/components/ai-elements/conversation";
 import { AiElementErrorBoundary } from "@/components/ai-elements/ai-element-error-boundary";
-import { Message, MessageContent, MessageResponse } from "@/components/ai-elements/message";
+import { MessageResponse } from "@/components/ai-elements/message";
 import { Reasoning, ReasoningContent, ReasoningTrigger } from "@/components/ai-elements/reasoning";
 import { Source, Sources, SourcesContent, SourcesTrigger } from "@/components/ai-elements/sources";
 import {
@@ -30,7 +25,18 @@ import {
   ToolOutput,
 } from "@/components/ai-elements/tool";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Marker, MarkerContent, MarkerIcon } from "@/components/ui/marker";
+import { Message, MessageAvatar, MessageContent, MessageFooter } from "@/components/ui/message";
+import {
+  MessageScroller,
+  MessageScrollerButton,
+  MessageScrollerContent,
+  MessageScrollerItem,
+  MessageScrollerProvider,
+  MessageScrollerViewport,
+} from "@/components/ui/message-scroller";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Spinner } from "@/components/ui/spinner";
 import { TypographyMuted, TypographyP, TypographySmall } from "@/components/ui/typography";
 
 import {
@@ -78,55 +84,76 @@ export function ConversationMessageList({
   let renderedStream = false;
 
   return (
-    <Conversation className="min-h-0 flex-1">
-      <ConversationContent className="mx-auto w-full max-w-4xl gap-4 px-4 py-5 sm:px-6">
-        {isLoading ? (
-          <MessageListSkeleton />
-        ) : messages.length === 0 && !activeStream ? (
-          <ConversationEmptyState
-            className="min-h-96"
-            title="No messages yet"
-            description="Conversation messages will appear here."
-          />
-        ) : (
-          <>
-            {messages.map((message, index) => {
-              const previousMessage = messages[index - 1];
-              const shouldRenderStream =
-                message.senderType === "agent" &&
-                activeStream?.responseToMessageId === previousMessage?.id;
+    <MessageScrollerProvider
+      autoScroll
+      defaultScrollPosition="last-anchor"
+      scrollPreviousItemPeek={64}
+    >
+      <MessageScroller className="min-h-0 flex-1">
+        <MessageScrollerViewport>
+          <MessageScrollerContent className="mx-auto w-full max-w-4xl gap-4 px-4 py-5 sm:px-6">
+            {isLoading ? (
+              <MessageScrollerItem messageId="loading">
+                <MessageListSkeleton />
+              </MessageScrollerItem>
+            ) : messages.length === 0 && !activeStream ? (
+              <MessageScrollerItem messageId="empty">
+                <ConversationEmptyState
+                  className="min-h-96"
+                  title="No messages yet"
+                  description="Conversation messages will appear here."
+                />
+              </MessageScrollerItem>
+            ) : (
+              <>
+                {messages.map((message, index) => {
+                  const previousMessage = messages[index - 1];
+                  const shouldRenderStream =
+                    message.senderType === "agent" &&
+                    activeStream?.responseToMessageId === previousMessage?.id;
 
-              if (shouldRenderStream && activeStream) {
-                renderedStream = true;
-                return (
-                  <AssistantStreamMessage
-                    key={message.id}
-                    message={activeStream.message}
-                    isStreaming={isStreaming && activeStream.status === "streaming"}
-                    createdAt={message.createdAt}
-                  />
-                );
-              }
+                  if (shouldRenderStream && activeStream) {
+                    renderedStream = true;
+                    return (
+                      <MessageScrollerItem key={message.id} messageId={message.id}>
+                        <AssistantStreamMessage
+                          message={activeStream.message}
+                          isStreaming={isStreaming && activeStream.status === "streaming"}
+                          createdAt={message.createdAt}
+                        />
+                      </MessageScrollerItem>
+                    );
+                  }
 
-              return (
-                <PersistedMessage key={message.id} currentUser={currentUser} message={message} />
-              );
-            })}
+                  return (
+                    <MessageScrollerItem
+                      key={message.id}
+                      messageId={message.id}
+                      scrollAnchor={message.senderType === "user"}
+                    >
+                      <PersistedMessage currentUser={currentUser} message={message} />
+                    </MessageScrollerItem>
+                  );
+                })}
 
-            {activeStream &&
-            !renderedStream &&
-            messages.at(-1)?.id === activeStream.responseToMessageId ? (
-              <AssistantStreamMessage
-                message={activeStream.message}
-                isStreaming={isStreaming && activeStream.status === "streaming"}
-                createdAt={null}
-              />
-            ) : null}
-          </>
-        )}
-      </ConversationContent>
-      <ConversationScrollButton />
-    </Conversation>
+                {activeStream &&
+                !renderedStream &&
+                messages.at(-1)?.id === activeStream.responseToMessageId ? (
+                  <MessageScrollerItem messageId={activeStream.message.id}>
+                    <AssistantStreamMessage
+                      message={activeStream.message}
+                      isStreaming={isStreaming && activeStream.status === "streaming"}
+                      createdAt={null}
+                    />
+                  </MessageScrollerItem>
+                ) : null}
+              </>
+            )}
+          </MessageScrollerContent>
+        </MessageScrollerViewport>
+        <MessageScrollerButton />
+      </MessageScroller>
+    </MessageScrollerProvider>
   );
 }
 
@@ -265,26 +292,24 @@ function MessageFrame({
   createdAt: string | null;
   role: "user" | "assistant";
 }) {
-  const timestamp = (
-    <TypographyMuted className="mt-1 text-xs">
-      {createdAt ? formatRelativeTime(createdAt) : "now"}
-    </TypographyMuted>
-  );
+  const timestamp = createdAt ? formatRelativeTime(createdAt) : "now";
 
   if (role === "assistant") {
     return (
-      <Message from="assistant" className="w-full max-w-full">
+      <Message className="w-full max-w-full">
         <MessageContent className="w-full max-w-full leading-6">
           {children}
-          {timestamp}
+          <MessageFooter className="px-0">
+            <TypographyMuted className="text-xs">{timestamp}</TypographyMuted>
+          </MessageFooter>
         </MessageContent>
       </Message>
     );
   }
 
   return (
-    <Message from="user" className="max-w-[85%]">
-      <div className="flex flex-row-reverse items-start gap-3">
+    <Message align="end" className="max-w-[85%]">
+      <MessageAvatar className="size-8 self-start">
         <Avatar className="size-8 shrink-0 bg-muted">
           {avatarImageUrl ? (
             <AvatarImage src={avatarImageUrl} alt={avatarAlt ?? avatarLabel} />
@@ -293,11 +318,15 @@ function MessageFrame({
             {avatarLabel}
           </AvatarFallback>
         </Avatar>
-        <MessageContent className="leading-6">
+      </MessageAvatar>
+      <MessageContent className="leading-6">
+        <div className="w-fit max-w-full rounded-lg bg-muted px-4 py-3 text-foreground">
           {children}
-          {timestamp}
-        </MessageContent>
-      </div>
+        </div>
+        <MessageFooter className="px-0">
+          <TypographyMuted className="text-xs">{timestamp}</TypographyMuted>
+        </MessageFooter>
+      </MessageContent>
     </Message>
   );
 }
@@ -384,7 +413,12 @@ function AssistantMessageParts({
           <MessageResponse isAnimating={isStreaming}>{text}</MessageResponse>
         </AiElementErrorBoundary>
       ) : isStreaming ? (
-        <TypingIndicator />
+        <Marker role="status">
+          <MarkerIcon>
+            <Spinner />
+          </MarkerIcon>
+          <MarkerContent>Hyperlocalise is working…</MarkerContent>
+        </Marker>
       ) : null}
     </>
   );
@@ -436,16 +470,6 @@ function AssistantSources({ parts }: { parts: SourcePart[] }) {
         )}
       </SourcesContent>
     </Sources>
-  );
-}
-
-function TypingIndicator() {
-  return (
-    <span className="inline-flex items-center gap-1">
-      <span className="size-1.5 animate-bounce rounded-full bg-muted-foreground [animation-delay:0ms]" />
-      <span className="size-1.5 animate-bounce rounded-full bg-muted-foreground [animation-delay:150ms]" />
-      <span className="size-1.5 animate-bounce rounded-full bg-muted-foreground [animation-delay:300ms]" />
-    </span>
   );
 }
 

--- a/apps/hyperlocalise-web/src/components/ui/marker.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/marker.tsx
@@ -1,0 +1,60 @@
+import { mergeProps } from "@base-ui/react/merge-props";
+import { useRender } from "@base-ui/react/use-render";
+import { cva, type VariantProps } from "class-variance-authority";
+import type { ComponentProps } from "react";
+
+import { cn } from "@/lib/primitives/cn";
+
+const markerVariants = cva(
+  "group/marker relative flex min-h-4 w-full items-center gap-2 text-start text-sm text-muted-foreground [&_svg:not([class*='size-'])]:size-4 [a]:underline [a]:underline-offset-3 [a]:hover:text-foreground",
+  {
+    variants: {
+      variant: {
+        default: "",
+        separator:
+          "before:me-1 before:h-px before:min-w-0 before:flex-1 before:bg-border after:ms-1 after:h-px after:min-w-0 after:flex-1 after:bg-border",
+        border: "border-b border-border pb-2",
+      },
+    },
+  },
+);
+
+export function Marker({
+  className,
+  variant = "default",
+  render,
+  ...props
+}: useRender.ComponentProps<"div"> & VariantProps<typeof markerVariants>) {
+  return useRender({
+    defaultTagName: "div",
+    props: mergeProps<"div">({ className: cn(markerVariants({ variant, className })) }, props),
+    render,
+    state: { slot: "marker", variant },
+  });
+}
+
+export function MarkerIcon({ className, ...props }: ComponentProps<"span">) {
+  return (
+    <span
+      aria-hidden="true"
+      data-slot="marker-icon"
+      className={cn("size-4 shrink-0 [&_svg:not([class*='size-'])]:size-4", className)}
+      {...props}
+    />
+  );
+}
+
+export function MarkerContent({ className, ...props }: ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="marker-content"
+      className={cn(
+        "min-w-0 wrap-break-word group-data-[variant=separator]/marker:flex-none group-data-[variant=separator]/marker:text-center *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { markerVariants };

--- a/apps/hyperlocalise-web/src/components/ui/message-scroller.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/message-scroller.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { ArrowDown02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  MessageScroller as MessageScrollerPrimitive,
+  useMessageScroller,
+  useMessageScrollerScrollable,
+  useMessageScrollerVisibility,
+} from "@shadcn/react/message-scroller";
+import type { ComponentProps } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/primitives/cn";
+
+export function MessageScrollerProvider(
+  props: ComponentProps<typeof MessageScrollerPrimitive.Provider>,
+) {
+  return <MessageScrollerPrimitive.Provider {...props} />;
+}
+
+export function MessageScroller({
+  className,
+  ...props
+}: ComponentProps<typeof MessageScrollerPrimitive.Root>) {
+  return (
+    <MessageScrollerPrimitive.Root
+      data-slot="message-scroller"
+      className={cn(
+        "group/message-scroller relative flex size-full min-h-0 flex-col overflow-hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function MessageScrollerViewport({
+  className,
+  ...props
+}: ComponentProps<typeof MessageScrollerPrimitive.Viewport>) {
+  return (
+    <MessageScrollerPrimitive.Viewport
+      data-slot="message-scroller-viewport"
+      className={cn(
+        "size-full min-h-0 min-w-0 overflow-y-auto overscroll-contain contain-content",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function MessageScrollerContent({
+  className,
+  ...props
+}: ComponentProps<typeof MessageScrollerPrimitive.Content>) {
+  return (
+    <MessageScrollerPrimitive.Content
+      data-slot="message-scroller-content"
+      className={cn("flex h-max min-h-full flex-col gap-8", className)}
+      {...props}
+    />
+  );
+}
+
+export function MessageScrollerItem({
+  className,
+  scrollAnchor = false,
+  ...props
+}: ComponentProps<typeof MessageScrollerPrimitive.Item>) {
+  return (
+    <MessageScrollerPrimitive.Item
+      data-slot="message-scroller-item"
+      scrollAnchor={scrollAnchor}
+      className={cn(
+        "min-w-0 shrink-0 [contain-intrinsic-size:auto_10rem] [content-visibility:auto]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function MessageScrollerButton({
+  children,
+  className,
+  direction = "end",
+  render,
+  size = "icon-sm",
+  variant = "secondary",
+  ...props
+}: ComponentProps<typeof MessageScrollerPrimitive.Button> &
+  Pick<ComponentProps<typeof Button>, "size" | "variant">) {
+  return (
+    <MessageScrollerPrimitive.Button
+      data-direction={direction}
+      data-size={size}
+      data-slot="message-scroller-button"
+      data-variant={variant}
+      direction={direction}
+      className={cn(
+        "absolute inset-s-1/2 -translate-x-1/2 rtl:translate-x-1/2 border-border bg-background text-foreground transition-[translate,scale,opacity] duration-200 hover:bg-muted hover:text-foreground data-[active=false]:pointer-events-none data-[active=false]:scale-95 data-[active=false]:opacity-0 data-[active=false]:duration-400 data-[active=false]:ease-[cubic-bezier(0.7,0,0.84,0)] data-[active=true]:translate-y-0 data-[active=true]:scale-100 data-[active=true]:opacity-100 data-[active=true]:ease-[cubic-bezier(0.23,1,0.32,1)] data-[direction=end]:bottom-4 data-[direction=end]:data-[active=false]:translate-y-full data-[direction=start]:top-4 data-[direction=start]:data-[active=false]:-translate-y-full data-[direction=start]:[&_svg]:rotate-180",
+        className,
+      )}
+      render={render ?? <Button size={size} variant={variant} />}
+      {...props}
+    >
+      {children ?? (
+        <>
+          <HugeiconsIcon icon={ArrowDown02Icon} strokeWidth={2} />
+          <span className="sr-only">
+            {direction === "end" ? "Scroll to end" : "Scroll to start"}
+          </span>
+        </>
+      )}
+    </MessageScrollerPrimitive.Button>
+  );
+}
+
+export { useMessageScroller, useMessageScrollerScrollable, useMessageScrollerVisibility };

--- a/apps/hyperlocalise-web/src/components/ui/message.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/message.tsx
@@ -42,7 +42,7 @@ export function MessageContent({ className, ...props }: ComponentProps<"div">) {
     <div
       data-slot="message-content"
       className={cn(
-        "flex w-full min-w-0 flex-col gap-2.5 wrap-break-word group-data-[align=end]/message:*:data-slot:self-end",
+        "flex w-full min-w-0 flex-col gap-2.5 wrap-break-word group-data-[align=end]/message:items-end",
         className,
       )}
       {...props}

--- a/apps/hyperlocalise-web/src/components/ui/message.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/message.tsx
@@ -1,0 +1,77 @@
+import type { ComponentProps } from "react";
+
+import { cn } from "@/lib/primitives/cn";
+
+export function MessageGroup({ className, ...props }: ComponentProps<"div">) {
+  return <div className={cn("flex min-w-0 flex-col gap-2", className)} {...props} />;
+}
+
+export function Message({
+  align = "start",
+  className,
+  ...props
+}: ComponentProps<"div"> & { align?: "start" | "end" }) {
+  return (
+    <div
+      data-align={align}
+      data-slot="message"
+      className={cn(
+        "group/message relative flex w-full min-w-0 gap-2 text-sm data-[align=end]:flex-row-reverse",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function MessageAvatar({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="message-avatar"
+      className={cn(
+        "flex w-fit min-w-8 shrink-0 items-center justify-center self-end overflow-hidden rounded-full bg-muted group-has-data-[slot=message-footer]/message:-translate-y-8",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function MessageContent({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="message-content"
+      className={cn(
+        "flex w-full min-w-0 flex-col gap-2.5 wrap-break-word group-data-[align=end]/message:*:data-slot:self-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function MessageHeader({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="message-header"
+      className={cn(
+        "flex max-w-full min-w-0 items-center px-3.5 text-xs font-medium text-muted-foreground group-has-data-[variant=ghost]/message:px-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function MessageFooter({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="message-footer"
+      className={cn(
+        "flex max-w-full min-w-0 items-center px-3.5 text-xs font-medium text-muted-foreground group-has-data-[variant=ghost]/message:px-0 group-data-[align=end]/message:justify-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/docs/plans/2026-07-11-inbox-message-scroller-design.md
+++ b/docs/plans/2026-07-11-inbox-message-scroller-design.md
@@ -1,0 +1,24 @@
+# Inbox message scroller design
+
+## Goal
+
+Improve the Hyperlocalise inbox transcript without changing its agent transport, persistence, or rich AI content renderers.
+
+## Scope
+
+- Replace the inbox transcript shell with shadcn `MessageScroller`.
+- Replace inbox message-row layout with shadcn `Message`.
+- Use shadcn `Marker` for the active agent status.
+- Retain the existing AI Elements markdown, reasoning, source, tool, and attachment rendering.
+
+## Interaction model
+
+- Each persisted or streamed message is a `MessageScrollerItem` with its stable message ID.
+- User messages anchor a turn; saved threads reopen at the latest user anchor.
+- The scroller follows streamed output only while the reader remains at the live edge.
+- The in-progress agent response shows a status marker. It is not persisted as a normal message and is announced as a status update.
+
+## Validation
+
+- Run the focused inbox component tests if present.
+- Run `vp check --fix` and the applicable `vp test` suite from `apps/hyperlocalise-web`.


### PR DESCRIPTION
## What changed

- Replace the inbox transcript layout with shadcn `MessageScroller`, `Message`, and `Marker` primitives.
- Anchor user turns, preserve the reader’s position during streaming, and provide a jump-to-latest control.
- Replace the typing dots with an accessible live status marker.
- Keep existing AI Elements renderers for markdown, reasoning, sources, tools, and attachments.
- Add `@shadcn/react`; leave the existing Button component unchanged.

## How to test

- `cd apps/hyperlocalise-web && vp check --fix`
- `cd apps/hyperlocalise-web && vp test run src/components/app-shell/chat-dock/chat-dock-store.test.ts src/components/app-shell/chat-dock/chat-dock-persistence.test.ts src/components/app-shell/chat-dock/chat-dock-tab-bar.test.tsx src/components/app-shell/chat-dock/chat-stream-manager.test.ts`

`vp check --fix` and the focused chat-dock tests pass. The full `vp test` suite requires local Postgres on `:5432` and an app server on `:3000`, which were unavailable.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review