### PR TITLE
feat(chat): improve dock empty state with capability chips

### DIFF
--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -1379,6 +1379,10 @@
     "defaultMessage": "Could not start this chat. Try again.",
     "description": "Error when creating a conversation from the chat dock fails"
   },
+  "C1FbXuFTUH": {
+    "defaultMessage": "Start a translation",
+    "description": "Suggested prompt chip to start a translation"
+  },
   "C7FCjLc6gc": {
     "defaultMessage": "{displayName} saved. Connect your Phrase account to continue.",
     "description": "Toast after saving Phrase OAuth app when user OAuth is still required"
@@ -1582,6 +1586,10 @@
   "ECh2wuwOCJ": {
     "defaultMessage": "Markdown content",
     "description": "Default accessible label for read-only rendered markdown content"
+  },
+  "EChSkkf+KW": {
+    "defaultMessage": "What changed recently",
+    "description": "Suggested prompt chip for recent localisation changes"
   },
   "ECw5CTvkCi": {
     "defaultMessage": "Give reviewers a clear view of locale coverage, quality flags, and unresolved items before merge.",
@@ -2295,6 +2303,10 @@
     "defaultMessage": "Installed on {workspace}",
     "description": "Slack integration description when a workspace is linked"
   },
+  "N83FNjAdU2": {
+    "defaultMessage": "What localisation strings changed recently?",
+    "description": "Prefilled prompt when choosing the recent-changes chip"
+  },
   "NBLnrSCLwC": {
     "defaultMessage": "Save provider",
     "description": "Button label to save a BYOK provider credential"
@@ -2342,6 +2354,10 @@
   "Nuj0umLVvu": {
     "defaultMessage": "Workspace name",
     "description": "Label for the workspace name input on onboarding"
+  },
+  "NuylnhUe8K": {
+    "defaultMessage": "Ask Hyperlocalise…",
+    "description": "Placeholder for a new chat dock composer"
   },
   "NxMkWJ+eS3": {
     "defaultMessage": "Choose a Hyperlocalise project for pull translations.",
@@ -2602,6 +2618,10 @@
   "Qov7AjZh9+": {
     "defaultMessage": "A pricing page refactor opens a pull request on Tuesday",
     "description": "Scenario section title for the github-release-localisation use case"
+  },
+  "QpIX9JaUhS": {
+    "defaultMessage": "Check localisation progress",
+    "description": "Suggested prompt chip for TMS localisation progress"
   },
   "Qy1pnimpzM": {
     "defaultMessage": "Block merge when locales are unresolved",
@@ -2935,10 +2955,6 @@
     "defaultMessage": "Contentful connection saved",
     "description": "Toast after successfully saving a Contentful connection"
   },
-  "V9yUZUb6UP": {
-    "defaultMessage": "Ask Hyperlocalise to translate or localise…",
-    "description": "Placeholder for a new chat dock composer"
-  },
   "VBPz2AKNYS": {
     "defaultMessage": "Security, subprocessor, privacy, and certification status information for Hyperlocalise.",
     "description": "Open Graph description for the Trust Center page"
@@ -2950,6 +2966,10 @@
   "VGayu+ZFkL": {
     "defaultMessage": "Previous segment ({shortcut})",
     "description": "Tooltip for the previous segment navigation button"
+  },
+  "VKjWHU/QDH": {
+    "defaultMessage": "What does this string mean, and where is it used?",
+    "description": "Prefilled prompt when choosing the find-context chip"
   },
   "VMLVh0fGup": {
     "defaultMessage": "Workspace",
@@ -3026,6 +3046,10 @@
   "W5kKZQXtt1": {
     "defaultMessage": "Intelligence panel failed to load",
     "description": "Error boundary title when the CAT intelligence panel crashes"
+  },
+  "W8paQ6RjZy": {
+    "defaultMessage": "How is localisation progress looking across linked TMS projects?",
+    "description": "Prefilled prompt when choosing the progress chip"
   },
   "WA49vhY6w5": {
     "defaultMessage": "Refresh the repository list and metadata from GitHub. This does not push or pull translations.",
@@ -4035,6 +4059,10 @@
     "defaultMessage": "Secret: {secret}",
     "description": "Displays the Contentful webhook signing secret"
   },
+  "homymlbTZo": {
+    "defaultMessage": "Translate the following text:",
+    "description": "Prefilled prompt when choosing the translate chip"
+  },
   "huDfeEPmkj": {
     "defaultMessage": "TMS agnostic",
     "description": "Differentiator point 1 for the github-release-localisation use case"
@@ -4330,6 +4358,10 @@
   "l0d6YXPPZ9": {
     "defaultMessage": "Google Gemini",
     "description": "Google Gemini BYOK provider name on the integrations page"
+  },
+  "l2MbFKxoMr": {
+    "defaultMessage": "Ask about strings, context, progress, or translations",
+    "description": "Empty state subtitle describing chat capabilities"
   },
   "l5r0xPEJDX": {
     "defaultMessage": "Add at least one branch pattern for push triggers.",
@@ -5187,6 +5219,10 @@
     "defaultMessage": "Built for localisation operations at scale",
     "description": "Differentiator point 5 for the localisation-operations use case"
   },
+  "vHurxfGj2i": {
+    "defaultMessage": "Find context for a string",
+    "description": "Suggested prompt chip to find localisation context"
+  },
   "vJGZC1FhAF": {
     "defaultMessage": "Source changes, CMS updates, and launch requests stop depending on someone remembering to open a ticket.",
     "description": "Proof point 1 body for the agents automation product page"
@@ -5310,6 +5346,10 @@
   "wUKFu5cEaD": {
     "defaultMessage": "default",
     "description": "Fallback label when a repository has no default branch name"
+  },
+  "wUNlUdJpD/": {
+    "defaultMessage": "Welcome to Hyperlocalise",
+    "description": "Empty state title for a new chat dock conversation"
   },
   "wYUzxhVyTO": {
     "defaultMessage": "e.g. Crowdin Production",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.stories.tsx
@@ -46,9 +46,7 @@ export const ChatConversation: Story = {
     await expect(
       canvas.getByRole("heading", { name: "Translate homepage hero copy" }),
     ).toBeInTheDocument();
-    await expect(
-      canvas.getByPlaceholderText("Paste text or describe what to translate..."),
-    ).toBeInTheDocument();
+    await expect(canvas.getByPlaceholderText("Ask Hyperlocalise…")).toBeInTheDocument();
   },
 };
 
@@ -85,9 +83,7 @@ export const EmailConversation: Story = {
     jobs: [],
   },
   play: async ({ canvas }) => {
-    await expect(
-      canvas.queryByPlaceholderText("Paste text or describe what to translate..."),
-    ).not.toBeInTheDocument();
+    await expect(canvas.queryByPlaceholderText("Ask Hyperlocalise…")).not.toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-view.stories.tsx
@@ -115,9 +115,7 @@ export const EmailConversation: Story = {
   },
   play: async ({ canvas }) => {
     await expect(canvas.getByText("Email: Q3 release notes")).toBeInTheDocument();
-    await expect(
-      canvas.queryByPlaceholderText("Paste text or describe what to translate..."),
-    ).not.toBeInTheDocument();
+    await expect(canvas.queryByPlaceholderText("Ask Hyperlocalise…")).not.toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.stories.tsx
@@ -36,9 +36,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   play: async ({ canvas }) => {
-    await expect(
-      canvas.getByPlaceholderText("Paste text or describe what to translate..."),
-    ).toBeInTheDocument();
+    await expect(canvas.getByPlaceholderText("Ask Hyperlocalise…")).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Send reply" })).toBeInTheDocument();
     await expect(canvas.getByText("GitHub repo")).toBeInTheDocument();
   },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
@@ -16,6 +16,7 @@ import {
   PromptInputTextarea,
   PromptInputTools,
   usePromptInputAttachments,
+  usePromptInputController,
 } from "@/components/ai-elements/prompt-input";
 import {
   Attachment,
@@ -56,6 +57,7 @@ type ReplyComposerViewProps = {
     files: File[],
     options?: { projectId?: string; repositoryFullName?: string },
   ) => void | Promise<void>;
+  placeholder?: string;
   repositories: InboxGithubRepository[];
   repositoriesIsError: boolean;
   repositoriesIsLoading: boolean;
@@ -68,6 +70,7 @@ export function ReplyComposerView({
   isStreaming,
   onDraftChange,
   onSend,
+  placeholder,
   repositories,
   repositoriesIsError,
   repositoriesIsLoading,
@@ -75,6 +78,15 @@ export function ReplyComposerView({
 }: ReplyComposerViewProps) {
   const [replyText, setReplyText] = useState(draft);
   const [selectedRepositoryFullName, setSelectedRepositoryFullName] = useState("");
+  const promptInputController = usePromptInputController();
+
+  useEffect(() => {
+    if (draft === replyText) {
+      return;
+    }
+    setReplyText(draft);
+    promptInputController.textInput.setInput(draft);
+  }, [draft, promptInputController, replyText]);
 
   useEffect(() => {
     if (
@@ -154,9 +166,7 @@ export function ReplyComposerView({
                   : "min-h-24 px-4 py-4 text-base leading-6 sm:px-6 sm:py-5"
               }
               placeholder={
-                isStreaming
-                  ? "Agent is responding..."
-                  : "Paste text or describe what to translate..."
+                isStreaming ? "Agent is responding..." : (placeholder ?? "Ask Hyperlocalise…")
               }
               rows={1}
             />

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-empty-state.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-empty-state.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import type { ComponentProps } from "react";
+import {
+  AnalyticsUpIcon,
+  Chat01Icon,
+  Clock01Icon,
+  FileSearchIcon,
+  TranslateIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { Button } from "@/components/ui/button";
+
+import { chatDockMessages } from "./chat-dock.messages";
+
+type Icon = ComponentProps<typeof HugeiconsIcon>["icon"];
+type MessageDescriptor = (typeof chatDockMessages)[keyof typeof chatDockMessages];
+
+type Suggestion = {
+  icon: Icon;
+  label: MessageDescriptor;
+  prompt: MessageDescriptor;
+};
+
+const suggestions: Suggestion[] = [
+  {
+    icon: FileSearchIcon,
+    label: chatDockMessages.suggestionFindContext,
+    prompt: chatDockMessages.promptFindContext,
+  },
+  {
+    icon: Clock01Icon,
+    label: chatDockMessages.suggestionRecentChanges,
+    prompt: chatDockMessages.promptRecentChanges,
+  },
+  {
+    icon: AnalyticsUpIcon,
+    label: chatDockMessages.suggestionProgress,
+    prompt: chatDockMessages.promptProgress,
+  },
+  {
+    icon: TranslateIcon,
+    label: chatDockMessages.suggestionTranslate,
+    prompt: chatDockMessages.promptTranslate,
+  },
+];
+
+export function ChatDockEmptyState({
+  onSelectSuggestion,
+}: {
+  onSelectSuggestion: (prompt: string) => void;
+}) {
+  const intl = useIntl();
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-5 overflow-y-auto px-5 py-8 text-center">
+      <div className="flex size-10 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+        <HugeiconsIcon icon={Chat01Icon} strokeWidth={1.8} className="size-5" />
+      </div>
+
+      <div className="max-w-sm space-y-1">
+        <h2 className="text-balance text-sm font-semibold text-foreground">
+          <FormattedMessage {...chatDockMessages.emptyTitle} />
+        </h2>
+        <p className="text-pretty text-sm text-muted-foreground">
+          <FormattedMessage {...chatDockMessages.emptySubtitle} />
+        </p>
+      </div>
+
+      <div className="flex max-w-sm flex-wrap justify-center gap-2">
+        {suggestions.map((suggestion) => (
+          <Button
+            key={suggestion.label.id}
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1.5 rounded-full bg-background text-xs font-medium"
+            onClick={() => onSelectSuggestion(intl.formatMessage(suggestion.prompt))}
+          >
+            <HugeiconsIcon icon={suggestion.icon} strokeWidth={1.8} className="size-3.5" />
+            <FormattedMessage {...suggestion.label} />
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
@@ -23,6 +23,7 @@ import { TypographyMuted } from "@/components/ui/typography";
 import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 
+import { ChatDockEmptyState } from "./chat-dock-empty-state";
 import { chatDockMessages } from "./chat-dock.messages";
 import { CHAT_DOCK_MAX_CONCURRENT_STREAMS } from "./chat-dock-persistence";
 import type { ChatDockStore } from "./chat-dock-store";
@@ -280,6 +281,7 @@ export const ChatDockPanel = observer(function ChatDockPanel({
     <section
       className="fixed inset-x-2 bottom-[calc(var(--app-shell-plan-footer-height)+0.5rem)] z-50 flex h-[min(44rem,calc(100svh-var(--app-shell-plan-footer-height)-1rem))] flex-col overflow-hidden rounded-xl border border-border bg-background shadow-2xl shadow-black/15 sm:inset-x-auto sm:right-3 sm:w-[30rem]"
       aria-label={tab.title}
+      data-chat-dock-panel={tab.id}
     >
       <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-3">
         <div className="min-w-0 flex-1">
@@ -329,11 +331,22 @@ export const ChatDockPanel = observer(function ChatDockPanel({
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {tab.isPending ? (
-          <div className="flex min-h-0 flex-1 items-center justify-center px-4">
-            <TypographyMuted className="text-center text-sm">
-              <FormattedMessage {...chatDockMessages.emptyComposer} />
-            </TypographyMuted>
-          </div>
+          <ChatDockEmptyState
+            onSelectSuggestion={(prompt) => {
+              store.setDraft(tab.id, prompt);
+              requestAnimationFrame(() => {
+                const textarea = document.querySelector<HTMLTextAreaElement>(
+                  `[data-chat-dock-panel="${tab.id}"] textarea`,
+                );
+                if (!textarea) {
+                  return;
+                }
+                textarea.focus();
+                const cursor = textarea.value.length;
+                textarea.setSelectionRange(cursor, cursor);
+              });
+            }}
+          />
         ) : (
           <ConversationMessageList
             conversationId={tab.id}
@@ -353,6 +366,7 @@ export const ChatDockPanel = observer(function ChatDockPanel({
           onDraftChange={(nextDraft) => store.setDraft(tab.id, nextDraft)}
           onSend={onSendMessage}
           organizationSlug={organizationSlug}
+          placeholder={intl.formatMessage(chatDockMessages.emptyComposer)}
           variant="compact"
         />
       </div>

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
@@ -72,6 +72,7 @@ export const ChatDockPanel = observer(function ChatDockPanel({
   const queryClient = useQueryClient();
   const streamManager = getChatStreamManager(organizationSlug, store);
   const autoTriggeredRef = useRef<string | null>(null);
+  const panelRef = useRef<HTMLElement>(null);
 
   const conversationId = tab && !tab.isPending ? tab.id : "";
 
@@ -279,9 +280,9 @@ export const ChatDockPanel = observer(function ChatDockPanel({
 
   return (
     <section
+      ref={panelRef}
       className="fixed inset-x-2 bottom-[calc(var(--app-shell-plan-footer-height)+0.5rem)] z-50 flex h-[min(44rem,calc(100svh-var(--app-shell-plan-footer-height)-1rem))] flex-col overflow-hidden rounded-xl border border-border bg-background shadow-2xl shadow-black/15 sm:inset-x-auto sm:right-3 sm:w-[30rem]"
       aria-label={tab.title}
-      data-chat-dock-panel={tab.id}
     >
       <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-3">
         <div className="min-w-0 flex-1">
@@ -335,9 +336,7 @@ export const ChatDockPanel = observer(function ChatDockPanel({
             onSelectSuggestion={(prompt) => {
               store.setDraft(tab.id, prompt);
               requestAnimationFrame(() => {
-                const textarea = document.querySelector<HTMLTextAreaElement>(
-                  `[data-chat-dock-panel="${tab.id}"] textarea`,
-                );
+                const textarea = panelRef.current?.querySelector("textarea");
                 if (!textarea) {
                   return;
                 }

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.messages.ts
@@ -29,9 +29,59 @@ export const chatDockMessages = defineMessages({
     description: "Link from chat dock to the full inbox page",
   },
   emptyComposer: {
-    id: "V9yUZUb6UP",
-    defaultMessage: "Ask Hyperlocalise to translate or localise…",
+    id: "NuylnhUe8K",
+    defaultMessage: "Ask Hyperlocalise…",
     description: "Placeholder for a new chat dock composer",
+  },
+  emptyTitle: {
+    id: "wUNlUdJpD/",
+    defaultMessage: "Welcome to Hyperlocalise",
+    description: "Empty state title for a new chat dock conversation",
+  },
+  emptySubtitle: {
+    id: "l2MbFKxoMr",
+    defaultMessage: "Ask about strings, context, progress, or translations",
+    description: "Empty state subtitle describing chat capabilities",
+  },
+  suggestionFindContext: {
+    id: "vHurxfGj2i",
+    defaultMessage: "Find context for a string",
+    description: "Suggested prompt chip to find localisation context",
+  },
+  suggestionRecentChanges: {
+    id: "EChSkkf+KW",
+    defaultMessage: "What changed recently",
+    description: "Suggested prompt chip for recent localisation changes",
+  },
+  suggestionProgress: {
+    id: "QpIX9JaUhS",
+    defaultMessage: "Check localisation progress",
+    description: "Suggested prompt chip for TMS localisation progress",
+  },
+  suggestionTranslate: {
+    id: "C1FbXuFTUH",
+    defaultMessage: "Start a translation",
+    description: "Suggested prompt chip to start a translation",
+  },
+  promptFindContext: {
+    id: "VKjWHU/QDH",
+    defaultMessage: "What does this string mean, and where is it used?",
+    description: "Prefilled prompt when choosing the find-context chip",
+  },
+  promptRecentChanges: {
+    id: "N83FNjAdU2",
+    defaultMessage: "What localisation strings changed recently?",
+    description: "Prefilled prompt when choosing the recent-changes chip",
+  },
+  promptProgress: {
+    id: "W8paQ6RjZy",
+    defaultMessage: "How is localisation progress looking across linked TMS projects?",
+    description: "Prefilled prompt when choosing the progress chip",
+  },
+  promptTranslate: {
+    id: "homymlbTZo",
+    defaultMessage: "Translate the following text:",
+    description: "Prefilled prompt when choosing the translate chip",
   },
   streaming: {
     id: "pXpP8bdMfG",


### PR DESCRIPTION
## What changed

The chat dock empty state previously framed Hyperlocalise as a paste-and-translate box. It now mirrors a Linear-style welcome state: a broader capability subtitle, starter prompt chips (context, recent changes, TMS progress, translation), and a shorter `Ask Hyperlocalise…` composer placeholder. Chip clicks prefill and focus the composer.

## How to test

- [ ] Open a new chat dock tab and confirm the welcome empty state + four suggestion chips
- [ ] Click each chip and confirm it prefills the composer and focuses the textarea
- [ ] Confirm the composer placeholder reads `Ask Hyperlocalise…`
- [ ] `vp test` / `vp check --fix` in `apps/hyperlocalise-web`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)