### PR TITLE
feat(web): localize marketing navbar with react-intl

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar.messages.ts
@@ -5,46 +5,57 @@ import { defineMessages } from "react-intl";
 export const navbarMessages = defineMessages({
   navAgents: {
     defaultMessage: "Agents",
+    id: "vxPX8Bfa3e",
     description: "Marketing navbar link to the agents automation product page",
   },
   navCatTool: {
     defaultMessage: "CAT Tool",
+    id: "jwTdsyTe54",
     description: "Marketing navbar link to the next-gen CAT tool product page",
   },
   navKnowledge: {
     defaultMessage: "Knowledge",
+    id: "BgfpkbN4Fe",
     description: "Marketing navbar link to the self-evolving knowledge product page",
   },
   navBlog: {
     defaultMessage: "Blog",
+    id: "Qmtq3rDIqg",
     description: "Marketing navbar link to the blog",
   },
   logoAlt: {
     defaultMessage: "Hyperlocalise logo",
+    id: "FeC29AzS2o",
     description: "Alt text for the Hyperlocalise logo image in the marketing navbar",
   },
   openNavigationMenu: {
     defaultMessage: "Open navigation menu",
+    id: "gvu/VOCeeU",
     description: "Screen-reader label for the mobile menu open button",
   },
   navigationMenuTitle: {
     defaultMessage: "Navigation menu",
+    id: "JuVYR2r3yd",
     description: "Screen-reader title for the mobile navigation sheet",
   },
   navigationHeading: {
     defaultMessage: "Navigation",
+    id: "IsIHLHu2zb",
     description: "Visible heading above links in the mobile navigation sheet",
   },
   mobileNavAriaLabel: {
     defaultMessage: "Mobile",
+    id: "nE0iR4v6Zt",
     description: "Accessible label for the mobile navigation landmark",
   },
   signIn: {
     defaultMessage: "Sign in",
+    id: "mGCNboJK+t",
     description: "Marketing navbar button to sign in",
   },
   joinWaitlist: {
     defaultMessage: "Join waitlist",
+    id: "EGk/6OwbtI",
     description: "Marketing navbar call-to-action to join the waitlist",
   },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar.messages.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const navbarMessages = defineMessages({
+  navAgents: {
+    defaultMessage: "Agents",
+    description: "Marketing navbar link to the agents automation product page",
+  },
+  navCatTool: {
+    defaultMessage: "CAT Tool",
+    description: "Marketing navbar link to the next-gen CAT tool product page",
+  },
+  navKnowledge: {
+    defaultMessage: "Knowledge",
+    description: "Marketing navbar link to the self-evolving knowledge product page",
+  },
+  navBlog: {
+    defaultMessage: "Blog",
+    description: "Marketing navbar link to the blog",
+  },
+  logoAlt: {
+    defaultMessage: "Hyperlocalise logo",
+    description: "Alt text for the Hyperlocalise logo image in the marketing navbar",
+  },
+  openNavigationMenu: {
+    defaultMessage: "Open navigation menu",
+    description: "Screen-reader label for the mobile menu open button",
+  },
+  navigationMenuTitle: {
+    defaultMessage: "Navigation menu",
+    description: "Screen-reader title for the mobile navigation sheet",
+  },
+  navigationHeading: {
+    defaultMessage: "Navigation",
+    description: "Visible heading above links in the mobile navigation sheet",
+  },
+  mobileNavAriaLabel: {
+    defaultMessage: "Mobile",
+    description: "Accessible label for the mobile navigation landmark",
+  },
+  signIn: {
+    defaultMessage: "Sign in",
+    description: "Marketing navbar button to sign in",
+  },
+  joinWaitlist: {
+    defaultMessage: "Join waitlist",
+    description: "Marketing navbar call-to-action to join the waitlist",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Button } from "@/components/ui/button";
 import {
   NavigationMenu,
@@ -17,22 +19,28 @@ import {
 import { env } from "@/lib/env";
 import Image from "next/image";
 import Link from "next/link";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import LocaleToggle from "@/components/locale-toggle/locale-toggle";
 import ThemeToggle from "@/components/theme-toggle/theme-toggle";
 
-const navigationLinks: { href: string; label: string; active?: boolean }[] = [
-  { href: "/product/agents-automation", label: "Agents" },
-  { href: "/product/next-gen-cat-tool", label: "CAT Tool" },
-  { href: "/product/self-evolving-knowledge", label: "Knowledge" },
-  { href: "/blog", label: "Blog" },
-];
+import { navbarMessages } from "./navbar.messages";
+
+const navigationLinks = [
+  { href: "/product/agents-automation", labelKey: "navAgents" },
+  { href: "/product/next-gen-cat-tool", labelKey: "navCatTool" },
+  { href: "/product/self-evolving-knowledge", labelKey: "navKnowledge" },
+  { href: "/blog", labelKey: "navBlog" },
+] as const;
+
 const signInHref = "/auth/sign-in";
 
 const mobileNavLinkClassName =
   "flex min-h-11 items-center rounded-3xl px-4 py-3 text-base font-medium text-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 data-[active=true]:bg-muted data-[active=true]:text-foreground";
 
 function Logo() {
+  const intl = useIntl();
+
   return (
     <Link href="/" className="flex items-center gap-2.5">
       <Image
@@ -40,7 +48,7 @@ function Logo() {
         className="size-8"
         width={32}
         height={32}
-        alt="Hyperlocalise logo"
+        alt={intl.formatMessage(navbarMessages.logoAlt)}
       />
       <span className="font-sans text-base font-semibold tracking-tight">Hyperlocalise</span>
     </Link>
@@ -48,6 +56,8 @@ function Logo() {
 }
 
 function MobileNavigation() {
+  const intl = useIntl();
+
   return (
     <Sheet>
       <SheetTrigger
@@ -59,7 +69,9 @@ function MobileNavigation() {
           />
         }
       >
-        <span className="sr-only">Open navigation menu</span>
+        <span className="sr-only">
+          <FormattedMessage {...navbarMessages.openNavigationMenu} />
+        </span>
         <svg
           aria-hidden="true"
           className="pointer-events-none"
@@ -83,24 +95,28 @@ function MobileNavigation() {
         className="w-[min(90vw,22rem)] border-s border-border bg-background/98 px-0"
       >
         <SheetHeader className="gap-4 border-b border-border px-5 pb-5 pt-6 text-left">
-          <SheetTitle className="sr-only">Navigation menu</SheetTitle>
+          <SheetTitle className="sr-only">
+            <FormattedMessage {...navbarMessages.navigationMenuTitle} />
+          </SheetTitle>
           <div className="text-xs font-medium tracking-[0.18em] text-muted-foreground uppercase">
-            Navigation
+            <FormattedMessage {...navbarMessages.navigationHeading} />
           </div>
           <div className="pr-10">
             <Logo />
           </div>
         </SheetHeader>
         <div className="flex flex-1 flex-col px-3 py-4">
-          <nav aria-label="Mobile" className="flex flex-col gap-1.5">
+          <nav
+            aria-label={intl.formatMessage(navbarMessages.mobileNavAriaLabel)}
+            className="flex flex-col gap-1.5"
+          >
             {navigationLinks.map((link) => (
               <SheetClose
-                key={link.label}
+                key={link.href}
                 render={<a href={link.href} />}
                 className={mobileNavLinkClassName}
-                data-active={link.active}
               >
-                {link.label}
+                <FormattedMessage {...navbarMessages[link.labelKey]} />
               </SheetClose>
             ))}
           </nav>
@@ -114,12 +130,12 @@ function MobileNavigation() {
               nativeButton={false}
               render={<span />}
             >
-              Sign in
+              <FormattedMessage {...navbarMessages.signIn} />
             </Button>
           </SheetClose>
           <SheetClose render={<a href={env.NEXT_PUBLIC_WAITLIST_URL} />} className="w-full">
             <Button size="lg" className="w-full" nativeButton={false} render={<span />}>
-              Join waitlist
+              <FormattedMessage {...navbarMessages.joinWaitlist} />
             </Button>
           </SheetClose>
         </SheetFooter>
@@ -137,13 +153,12 @@ export default function Navbar() {
           <NavigationMenu className="mx-auto hidden max-w-none md:flex">
             <NavigationMenuList className="gap-1">
               {navigationLinks.map((link) => (
-                <NavigationMenuItem key={link.label}>
+                <NavigationMenuItem key={link.href}>
                   <NavigationMenuLink
-                    active={link.active}
                     href={link.href}
                     className="px-3 py-2 font-medium text-muted-foreground hover:text-foreground"
                   >
-                    {link.label}
+                    <FormattedMessage {...navbarMessages[link.labelKey]} />
                   </NavigationMenuLink>
                 </NavigationMenuItem>
               ))}
@@ -157,10 +172,10 @@ export default function Navbar() {
             nativeButton={false}
             render={<Link href={signInHref} prefetch={false} />}
           >
-            Sign in
+            <FormattedMessage {...navbarMessages.signIn} />
           </Button>
           <Button nativeButton={false} render={<a href={env.NEXT_PUBLIC_WAITLIST_URL} />}>
-            Join waitlist
+            <FormattedMessage {...navbarMessages.joinWaitlist} />
           </Button>
           <LocaleToggle />
           <ThemeToggle />
@@ -172,7 +187,7 @@ export default function Navbar() {
             nativeButton={false}
             render={<a href={env.NEXT_PUBLIC_WAITLIST_URL} />}
           >
-            Join waitlist
+            <FormattedMessage {...navbarMessages.joinWaitlist} />
           </Button>
           <MobileNavigation />
           <LocaleToggle />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Localize the marketing navbar with react-intl (ICU):

- Add colocated `navbar.messages.ts` with `defineMessages` for nav labels, CTAs, logo alt, and mobile sheet a11y copy
- Convert `navbar.tsx` to a client component using `<FormattedMessage>` / `useIntl`
- Leave the Hyperlocalise brand wordmark as a proper noun (not translated)

## How to test

- [x] `vp check --fix` in `apps/hyperlocalise-web`
- [x] `vp test` in `apps/hyperlocalise-web` (2747 passed)
- [ ] Spot-check marketing pages: desktop nav, mobile sheet, Sign in / Join waitlist

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e3ded4f-12da-4cab-8b6f-e9bdbd67eea4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e3ded4f-12da-4cab-8b6f-e9bdbd67eea4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

