### PR TITLE
fix(web): avoid PKCE cookie writes on expired WorkOS sessions

### DIFF
--- a/apps/hyperlocalise-web/src/lib/workos/request-url-header.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/request-url-header.ts
@@ -1,0 +1,2 @@
+/** Forwarded by `proxy.ts` so Server Components can recover the original URL. */
+export const REQUEST_URL_HEADER = "x-url";

--- a/apps/hyperlocalise-web/src/lib/workos/server-auth.test.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/server-auth.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { workosWithAuthMock, resolveFixtureAuthSessionMock, headersMock, redirectMock } = vi.hoisted(
+  () => ({
+    workosWithAuthMock: vi.fn(),
+    resolveFixtureAuthSessionMock: vi.fn(),
+    headersMock: vi.fn(),
+    redirectMock: vi.fn((url: string) => {
+      throw new Error(`redirect:${url}`);
+    }),
+  }),
+);
+
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  withAuth: workosWithAuthMock,
+}));
+
+vi.mock("@/lib/e2e/fixture-auth", () => ({
+  resolveFixtureAuthSession: resolveFixtureAuthSessionMock,
+}));
+
+vi.mock("next/headers", () => ({
+  headers: headersMock,
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: redirectMock,
+}));
+
+describe("withAuth", () => {
+  beforeEach(() => {
+    workosWithAuthMock.mockReset();
+    resolveFixtureAuthSessionMock.mockReset();
+    headersMock.mockReset();
+    redirectMock.mockClear();
+    resolveFixtureAuthSessionMock.mockResolvedValue(null);
+    headersMock.mockResolvedValue(
+      new Headers({
+        "x-url": "http://localhost:3000/en-US/org/acme/projects/proj_1",
+      }),
+    );
+  });
+
+  it("does not pass ensureSignedIn to WorkOS withAuth", async () => {
+    workosWithAuthMock.mockResolvedValue({
+      user: { id: "user_1", email: "a@example.com" },
+    });
+
+    const { withAuth } = await import("./server-auth");
+    await withAuth({ ensureSignedIn: true });
+
+    expect(workosWithAuthMock).toHaveBeenCalledWith();
+  });
+
+  it("redirects expired sessions through /auth/sign-in instead of setting PKCE cookies", async () => {
+    workosWithAuthMock.mockResolvedValue({ user: null });
+
+    const { withAuth } = await import("./server-auth");
+
+    await expect(withAuth({ ensureSignedIn: true })).rejects.toThrow(
+      "redirect:/auth/sign-in?returnTo=%2Fen-US%2Forg%2Facme%2Fprojects%2Fproj_1",
+    );
+    expect(workosWithAuthMock).toHaveBeenCalledWith();
+    expect(redirectMock).toHaveBeenCalledWith(
+      "/auth/sign-in?returnTo=%2Fen-US%2Forg%2Facme%2Fprojects%2Fproj_1",
+    );
+  });
+
+  it("returns null user without redirecting when ensureSignedIn is false", async () => {
+    workosWithAuthMock.mockResolvedValue({ user: null });
+
+    const { withAuth } = await import("./server-auth");
+    await expect(withAuth()).resolves.toEqual({ user: null });
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/workos/server-auth.test.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/server-auth.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
+import { REQUEST_URL_HEADER } from "@/lib/workos/request-url-header";
+
 const { workosWithAuthMock, resolveFixtureAuthSessionMock, headersMock, redirectMock } = vi.hoisted(
   () => ({
     workosWithAuthMock: vi.fn(),
@@ -36,7 +38,7 @@ describe("withAuth", () => {
     resolveFixtureAuthSessionMock.mockResolvedValue(null);
     headersMock.mockResolvedValue(
       new Headers({
-        "x-url": "http://localhost:3000/en-US/org/acme/projects/proj_1",
+        [REQUEST_URL_HEADER]: "http://localhost:3000/en-US/org/acme/projects/proj_1",
       }),
     );
   });
@@ -63,6 +65,17 @@ describe("withAuth", () => {
     expect(workosWithAuthMock).toHaveBeenCalledWith();
     expect(redirectMock).toHaveBeenCalledWith(
       "/auth/sign-in?returnTo=%2Fen-US%2Forg%2Facme%2Fprojects%2Fproj_1",
+    );
+  });
+
+  it("falls back to /dashboard when the request URL header is missing", async () => {
+    workosWithAuthMock.mockResolvedValue({ user: null });
+    headersMock.mockResolvedValue(new Headers());
+
+    const { withAuth } = await import("./server-auth");
+
+    await expect(withAuth({ ensureSignedIn: true })).rejects.toThrow(
+      "redirect:/auth/sign-in?returnTo=%2Fdashboard",
     );
   });
 

--- a/apps/hyperlocalise-web/src/lib/workos/server-auth.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/server-auth.ts
@@ -7,6 +7,7 @@ import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
 import { resolveFixtureAuthSession } from "@/lib/e2e/fixture-auth";
+import { REQUEST_URL_HEADER } from "@/lib/workos/request-url-header";
 import { sanitizeReturnTo } from "@/lib/workos/return-to";
 
 type WithAuthOptions = Parameters<typeof workosWithAuth>[0];
@@ -21,10 +22,13 @@ type WithAuthOptions = Parameters<typeof workosWithAuth>[0];
  *
  * WorkOS guidance: set PKCE cookies only from a Server Action or Route Handler
  * (see workos/skills authkit-nextjs hardening for Server Component cookie violations).
+ *
+ * `REQUEST_URL_HEADER` (`x-url`) is set by `proxy.ts` on every continued request
+ * so returnTo can recover the protected org/project URL after sign-in.
  */
 async function redirectToAppSignIn(): Promise<never> {
   const headersList = await headers();
-  const requestUrl = headersList.get("x-url");
+  const requestUrl = headersList.get(REQUEST_URL_HEADER);
   const returnPathname = requestUrl
     ? (() => {
         try {

--- a/apps/hyperlocalise-web/src/lib/workos/server-auth.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/server-auth.ts
@@ -3,22 +3,60 @@ import {
   type NoUserInfo,
   type UserInfo,
 } from "@workos-inc/authkit-nextjs";
+import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
 import { resolveFixtureAuthSession } from "@/lib/e2e/fixture-auth";
+import { sanitizeReturnTo } from "@/lib/workos/return-to";
 
 type WithAuthOptions = Parameters<typeof workosWithAuth>[0];
+
+/**
+ * Redirect unauthenticated users through `/auth/sign-in` (a Route Handler).
+ *
+ * Do not call WorkOS `withAuth({ ensureSignedIn: true })` from Server Components.
+ * That path runs `redirectToSignIn()` → `setPKCECookie()` via `cookies().set()`,
+ * which throws in Next.js 15+/16:
+ * "Cookies can only be modified in a Server Action or Route Handler".
+ *
+ * WorkOS guidance: set PKCE cookies only from a Server Action or Route Handler
+ * (see workos/skills authkit-nextjs hardening for Server Component cookie violations).
+ */
+async function redirectToAppSignIn(): Promise<never> {
+  const headersList = await headers();
+  const requestUrl = headersList.get("x-url");
+  const returnPathname = requestUrl
+    ? (() => {
+        try {
+          const url = new URL(requestUrl);
+          return `${url.pathname}${url.search}`;
+        } catch {
+          return "/dashboard";
+        }
+      })()
+    : "/dashboard";
+  const returnTo = sanitizeReturnTo(returnPathname, "/dashboard");
+
+  redirect(`/auth/sign-in?returnTo=${encodeURIComponent(returnTo)}`);
+}
 
 export async function withAuth(options?: WithAuthOptions): Promise<UserInfo | NoUserInfo> {
   const fixtureSession = await resolveFixtureAuthSession();
 
   if (fixtureSession) {
     if (options?.ensureSignedIn && !fixtureSession.user) {
-      redirect("/auth/sign-in");
+      await redirectToAppSignIn();
     }
 
     return fixtureSession;
   }
 
-  return workosWithAuth(options);
+  // Never forward ensureSignedIn to WorkOS — handle it via the sign-in route instead.
+  const session = await workosWithAuth();
+
+  if (options?.ensureSignedIn && !session.user) {
+    await redirectToAppSignIn();
+  }
+
+  return session;
 }

--- a/apps/hyperlocalise-web/src/proxy.test.ts
+++ b/apps/hyperlocalise-web/src/proxy.test.ts
@@ -1,7 +1,8 @@
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { describe, expect, it, vi } from "vite-plus/test";
 
-import proxy, { isUnsupportedLocalePath } from "./proxy";
+import { REQUEST_URL_HEADER } from "@/lib/workos/request-url-header";
+import proxy, { ensureRequestUrlHeader, isUnsupportedLocalePath } from "./proxy";
 
 const { authkitProxyMock } = vi.hoisted(() => ({
   authkitProxyMock: vi.fn(),
@@ -52,6 +53,32 @@ describe("isUnsupportedLocalePath", () => {
   });
 });
 
+describe("ensureRequestUrlHeader", () => {
+  it("adds x-url request overrides when AuthKit did not set them", () => {
+    const request = createRequest("/en-US/org/acme/projects/proj_1");
+    const response = ensureRequestUrlHeader(request, NextResponse.next());
+
+    expect(response.headers.get(`x-middleware-request-${REQUEST_URL_HEADER}`)).toBe(request.url);
+    expect(response.headers.get("x-middleware-override-headers")?.split(",")).toContain(
+      REQUEST_URL_HEADER,
+    );
+  });
+
+  it("preserves existing AuthKit overrides and still sets x-url", () => {
+    const request = createRequest("/en-US/org/acme/projects/proj_1");
+    const response = NextResponse.next();
+    response.headers.set("x-middleware-override-headers", "x-workos-middleware,x-workos-session");
+    response.headers.set("x-middleware-request-x-workos-middleware", "true");
+    response.headers.set("x-middleware-request-x-workos-session", "sealed");
+
+    const next = ensureRequestUrlHeader(request, response);
+
+    expect(next.headers.get(`x-middleware-request-${REQUEST_URL_HEADER}`)).toBe(request.url);
+    expect(next.headers.get("x-middleware-override-headers")).toContain(REQUEST_URL_HEADER);
+    expect(next.headers.get("x-middleware-request-x-workos-session")).toBe("sealed");
+  });
+});
+
 describe("proxy", () => {
   it("returns 404 for unsupported locale paths before AuthKit runs", async () => {
     authkitProxyMock.mockReset();
@@ -61,14 +88,16 @@ describe("proxy", () => {
     expect(authkitProxyMock).not.toHaveBeenCalled();
   });
 
-  it("still delegates supported locale paths to AuthKit", async () => {
+  it("still delegates supported locale paths to AuthKit and forwards x-url", async () => {
     authkitProxyMock.mockReset();
-    authkitProxyMock.mockResolvedValueOnce(new Response(null, { status: 200 }));
+    authkitProxyMock.mockResolvedValueOnce(NextResponse.next());
 
-    const response = await proxy(createRequest("/en/blog"), {} as never);
+    const request = createRequest("/en/org/acme/projects/proj_1");
+    const response = await proxy(request, {} as never);
 
     expect(authkitProxyMock).toHaveBeenCalledOnce();
     expect(response?.status).toBe(200);
+    expect(response?.headers.get(`x-middleware-request-${REQUEST_URL_HEADER}`)).toBe(request.url);
   });
 
   it("redirects localized marketing paths without a locale prefix", async () => {
@@ -95,7 +124,7 @@ describe("proxy", () => {
 
   it("delegates /api paths to AuthKit instead of returning 404", async () => {
     authkitProxyMock.mockReset();
-    authkitProxyMock.mockResolvedValueOnce(new Response(null, { status: 200 }));
+    authkitProxyMock.mockResolvedValueOnce(NextResponse.next());
 
     const response = await proxy(createRequest("/api/auth/callback"), {} as never);
 

--- a/apps/hyperlocalise-web/src/proxy.ts
+++ b/apps/hyperlocalise-web/src/proxy.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/app-i18n/locales";
 import { isFixtureAuthEnabled } from "@/lib/e2e/config";
 import { hasFixtureSessionCookie } from "@/lib/e2e/fixture-auth";
+import { REQUEST_URL_HEADER } from "@/lib/workos/request-url-header";
 
 const workosProxy = authkitProxy();
 type WorkosProxyResult = Awaited<ReturnType<typeof workosProxy>>;
@@ -25,12 +26,68 @@ function shouldBypassWorkosProxy(request: NextRequest) {
   return hasFixtureSessionCookie(request.headers.get("cookie") ?? undefined);
 }
 
-async function maybeWorkosProxy(request: NextRequest, event: NextFetchEvent) {
-  if (shouldBypassWorkosProxy(request)) {
-    return NextResponse.next();
+function nextWithRequestUrl(request: NextRequest): NextResponse {
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set(REQUEST_URL_HEADER, request.url);
+  return NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+}
+
+/**
+ * Guarantee `x-url` is forwarded as a request header so Server Components can
+ * recover the original path for post-login returnTo. AuthKit usually sets this;
+ * fixture-auth bypass and other bare `NextResponse.next()` paths do not.
+ */
+export function ensureRequestUrlHeader(request: NextRequest, response: NextResponse): NextResponse {
+  if (response.headers.has("location")) {
+    return response;
   }
 
-  return workosProxy(request, event);
+  const requestHeaderName = `x-middleware-request-${REQUEST_URL_HEADER}`;
+  response.headers.set(requestHeaderName, request.url);
+
+  const override = response.headers.get("x-middleware-override-headers");
+  if (override == null || override === "") {
+    const next = nextWithRequestUrl(request);
+    response.headers.forEach((value, key) => {
+      const lower = key.toLowerCase();
+      if (lower.startsWith("x-middleware-")) {
+        return;
+      }
+      if (lower === "set-cookie") {
+        next.headers.append(key, value);
+        return;
+      }
+      next.headers.set(key, value);
+    });
+    return next;
+  }
+
+  const names = override
+    .split(",")
+    .map((name) => name.trim())
+    .filter(Boolean);
+  if (!names.includes(REQUEST_URL_HEADER)) {
+    response.headers.set("x-middleware-override-headers", [...names, REQUEST_URL_HEADER].join(","));
+  }
+
+  return response;
+}
+
+async function maybeWorkosProxy(request: NextRequest, event: NextFetchEvent) {
+  if (shouldBypassWorkosProxy(request)) {
+    return nextWithRequestUrl(request);
+  }
+
+  const response = await workosProxy(request, event);
+  if (!(response instanceof NextResponse)) {
+    return response;
+  }
+
+  return ensureRequestUrlHeader(request, response);
 }
 
 const PUBLIC_LOCALIZED_PREFIXES = ["/product", "/use-cases", "/blog"];


### PR DESCRIPTION
## What changed

When a WorkOS session cookie expires and a user revisits an org/project URL, `withAuth({ ensureSignedIn: true })` was calling WorkOS `redirectToSignIn()` → `setPKCECookie()` during Server Component render. Next.js throws `Cookies can only be modified in a Server Action or Route Handler`.

Our `withAuth` wrapper now never forwards `ensureSignedIn` to WorkOS. Unauthenticated users are redirected to `/auth/sign-in?returnTo=…`, where the Route Handler can safely set the PKCE cookie (per WorkOS AuthKit guidance).

## How to test

- [ ] Clear or expire the WorkOS session cookie, then open an org project URL such as `/en-US/org/<slug>/projects/<id>`
- [ ] Confirm redirect to sign-in instead of a cookies error page
- [ ] After signing in, confirm return to the original project URL
- [ ] `vp test src/lib/workos/server-auth.test.ts`
- [ ] `vp check --fix` in `apps/hyperlocalise-web`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)