### PR TITLE
fix(web): isolate chat dock render failures

### DIFF
--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
@@ -9,6 +9,7 @@ import {
   ChatDockFooterControls,
   ChatDockPanelHost,
 } from "@/components/app-shell/chat-dock/chat-dock";
+import { ChatDockErrorBoundary } from "@/components/app-shell/chat-dock/chat-dock-error-boundary";
 import { PlanUsageFooterControl } from "@/components/billing/plan-usage-summary";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -30,7 +31,9 @@ export function AppShellFooter({
     <footer className="fixed inset-x-0 bottom-0 z-40 flex flex-col border-t border-border bg-background">
       {showChatDock ? <ChatDockBridge organizationSlug={organizationSlug} /> : null}
       {showChatDock && currentUser ? (
-        <ChatDockPanelHost organizationSlug={organizationSlug} currentUser={currentUser} />
+        <ChatDockErrorBoundary organizationSlug={organizationSlug}>
+          <ChatDockPanelHost organizationSlug={organizationSlug} currentUser={currentUser} />
+        </ChatDockErrorBoundary>
       ) : null}
 
       <div className="flex h-[var(--app-shell-plan-footer-height)] shrink-0 items-stretch px-2">

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-error-boundary.test.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-error-boundary.test.tsx
@@ -2,11 +2,11 @@
 
 import { useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { IntlProvider } from "react-intl";
 import { observer } from "mobx-react-lite";
-import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { AppShellStoreProvider } from "@/components/app-shell/store/app-shell-store-context";
 import { useAppShellStore } from "@/components/app-shell/store/app-shell-store-context";
@@ -18,35 +18,95 @@ vi.mock("next/navigation", () => ({
   usePathname: () => "/org/acme/dashboard",
 }));
 
-function InitializeOpenChatDock() {
+function createQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function InitializeFailedChatDock() {
   const { chatDock } = useAppShellStore();
   useState(() => {
     chatDock.setOrganizationSlug("acme");
-    chatDock.openNewTab();
+    // Strict Mode remounts can hydrate a prior tab; start from a single failed tab.
+    const existingTabIds = chatDock.tabs.map((tab) => tab.id);
+    for (const tabId of existingTabIds) {
+      chatDock.closeTab(tabId);
+    }
+    const tabId = chatDock.openNewTab();
+    chatDock.setStreamSnapshot(tabId, {
+      conversationId: tabId,
+      responseToMessageId: "msg_1",
+      message: {
+        id: "assistant_1",
+        role: "assistant",
+        parts: [{ type: "text", text: "partial reply", state: "done" }],
+      },
+      status: "error",
+    });
+    chatDock.setLastError(tabId, "stale stream failure");
   });
   return null;
 }
 
-const ThrowingPanel = observer(function ThrowingPanel({ shouldThrow }: { shouldThrow: boolean }) {
+const ThrowingPanel = observer(function ThrowingPanel({
+  throwWhenLastError,
+}: {
+  throwWhenLastError: boolean;
+}) {
   const { chatDock } = useAppShellStore();
   if (!chatDock.panelOpen) {
     return null;
   }
-  if (shouldThrow) {
-    throw new Error("Broken chat panel");
+  if (throwWhenLastError && chatDock.activeTab?.lastError) {
+    throw new Error("Broken chat panel with user text: please translate this secret");
   }
   return <div>Recovered chat panel</div>;
 });
 
-function renderBoundary(shouldThrow: boolean) {
+const ChatDockProbe = observer(function ChatDockProbe() {
+  const { chatDock } = useAppShellStore();
+  // The failed tab is the one that still carries the seeded error / snapshot before recovery,
+  // or — after openNewTab — the non-active tab that originally failed.
+  const failedTab =
+    chatDock.tabs.find((tab) => tab.id !== chatDock.activeTabId) ??
+    chatDock.tabs.find((tab) => tab.lastError || tab.streamSnapshot) ??
+    chatDock.tabs[0];
+  const failedTabId = failedTab?.id ?? "";
+
+  return (
+    <div>
+      <span data-testid="active-tab-id">{chatDock.activeTabId}</span>
+      <span data-testid="failed-tab-id">{failedTabId}</span>
+      <span data-testid="failed-tab-error">{failedTab?.lastError ?? ""}</span>
+      <span data-testid="failed-tab-snapshot">
+        {failedTab?.streamSnapshot ? "present" : "cleared"}
+      </span>
+      <button type="button" onClick={() => chatDock.openNewTab()}>
+        Open second tab
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          if (failedTabId) {
+            chatDock.selectTab(failedTabId);
+          }
+        }}
+      >
+        Select first tab
+      </button>
+    </div>
+  );
+});
+
+function renderBoundary(throwWhenLastError: boolean, { withProbe = false } = {}) {
   return render(
-    <QueryClientProvider client={new QueryClient()}>
+    <QueryClientProvider client={createQueryClient()}>
       <IntlProvider locale="en" messages={{}}>
         <AppShellStoreProvider defaultNavigationGroups={[]}>
-          <InitializeOpenChatDock />
+          <InitializeFailedChatDock />
           <ChatDockErrorBoundary organizationSlug="acme">
-            <ThrowingPanel shouldThrow={shouldThrow} />
+            <ThrowingPanel throwWhenLastError={throwWhenLastError} />
           </ChatDockErrorBoundary>
+          {withProbe ? <ChatDockProbe /> : null}
           <a href="mailto:support@example.com">Email support</a>
         </AppShellStoreProvider>
       </IntlProvider>
@@ -55,6 +115,10 @@ function renderBoundary(shouldThrow: boolean) {
 }
 
 describe("ChatDockErrorBoundary", () => {
+  beforeEach(() => {
+    clearChatDockState("acme");
+  });
+
   afterEach(() => {
     clearChatDockState("acme");
     vi.restoreAllMocks();
@@ -70,18 +134,33 @@ describe("ChatDockErrorBoundary", () => {
     expect(screen.getByRole("link", { name: "Email support" })).toBeTruthy();
   });
 
+  it("logs only safe error metadata without message or stack", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    renderBoundary(true);
+
+    expect(consoleError).toHaveBeenCalled();
+    const panelLogCall = consoleError.mock.calls.find((call) => call[0] === "[chat-dock:panel]");
+    expect(panelLogCall).toBeTruthy();
+    const payload = panelLogCall?.[1] as Record<string, unknown>;
+    expect(payload).toMatchObject({ name: "Error" });
+    expect(payload).not.toHaveProperty("message");
+    expect(payload).not.toHaveProperty("stack");
+    expect(JSON.stringify(payload)).not.toContain("please translate this secret");
+  });
+
   it("retries the panel without replacing surrounding content", async () => {
     const user = userEvent.setup();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     const view = renderBoundary(true);
 
     view.rerender(
-      <QueryClientProvider client={new QueryClient()}>
+      <QueryClientProvider client={createQueryClient()}>
         <IntlProvider locale="en" messages={{}}>
           <AppShellStoreProvider defaultNavigationGroups={[]}>
-            <InitializeOpenChatDock />
+            <InitializeFailedChatDock />
             <ChatDockErrorBoundary organizationSlug="acme">
-              <ThrowingPanel shouldThrow={false} />
+              <ThrowingPanel throwWhenLastError={false} />
             </ChatDockErrorBoundary>
             <a href="mailto:support@example.com">Email support</a>
           </AppShellStoreProvider>
@@ -103,5 +182,32 @@ describe("ChatDockErrorBoundary", () => {
 
     expect(screen.queryByRole("alert")).toBeNull();
     expect(screen.getByRole("link", { name: "Email support" })).toBeTruthy();
+  });
+
+  it("cleans up the failed tab when switching away via resetKeys", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    renderBoundary(true, { withProbe: true });
+
+    const failedTabId = screen.getByTestId("active-tab-id").textContent;
+    expect(failedTabId).toBeTruthy();
+    expect(screen.getByTestId("failed-tab-error").textContent).toBe("stale stream failure");
+    expect(screen.getByTestId("failed-tab-snapshot").textContent).toBe("present");
+
+    await user.click(screen.getByRole("button", { name: "Open second tab" }));
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByTestId("active-tab-id").textContent).not.toBe(failedTabId);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("failed-tab-error").textContent).toBe("");
+      expect(screen.getByTestId("failed-tab-snapshot").textContent).toBe("cleared");
+    });
+
+    await user.click(screen.getByRole("button", { name: "Select first tab" }));
+
+    expect(screen.getByTestId("active-tab-id").textContent).toBe(failedTabId);
+    expect(screen.getByText("Recovered chat panel")).toBeTruthy();
   });
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-error-boundary.test.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-error-boundary.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment happy-dom
+
+import { useState } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IntlProvider } from "react-intl";
+import { observer } from "mobx-react-lite";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { AppShellStoreProvider } from "@/components/app-shell/store/app-shell-store-context";
+import { useAppShellStore } from "@/components/app-shell/store/app-shell-store-context";
+
+import { ChatDockErrorBoundary } from "./chat-dock-error-boundary";
+import { clearChatDockState } from "./chat-dock-persistence";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/org/acme/dashboard",
+}));
+
+function InitializeOpenChatDock() {
+  const { chatDock } = useAppShellStore();
+  useState(() => {
+    chatDock.setOrganizationSlug("acme");
+    chatDock.openNewTab();
+  });
+  return null;
+}
+
+const ThrowingPanel = observer(function ThrowingPanel({ shouldThrow }: { shouldThrow: boolean }) {
+  const { chatDock } = useAppShellStore();
+  if (!chatDock.panelOpen) {
+    return null;
+  }
+  if (shouldThrow) {
+    throw new Error("Broken chat panel");
+  }
+  return <div>Recovered chat panel</div>;
+});
+
+function renderBoundary(shouldThrow: boolean) {
+  return render(
+    <QueryClientProvider client={new QueryClient()}>
+      <IntlProvider locale="en" messages={{}}>
+        <AppShellStoreProvider defaultNavigationGroups={[]}>
+          <InitializeOpenChatDock />
+          <ChatDockErrorBoundary organizationSlug="acme">
+            <ThrowingPanel shouldThrow={shouldThrow} />
+          </ChatDockErrorBoundary>
+          <a href="mailto:support@example.com">Email support</a>
+        </AppShellStoreProvider>
+      </IntlProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ChatDockErrorBoundary", () => {
+  afterEach(() => {
+    clearChatDockState("acme");
+    vi.restoreAllMocks();
+  });
+
+  it("contains a panel render failure and keeps surrounding controls available", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    renderBoundary(true);
+
+    expect(screen.getByRole("alert")).toBeTruthy();
+    expect(screen.getByText("Chat could not be displayed")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Email support" })).toBeTruthy();
+  });
+
+  it("retries the panel without replacing surrounding content", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const view = renderBoundary(true);
+
+    view.rerender(
+      <QueryClientProvider client={new QueryClient()}>
+        <IntlProvider locale="en" messages={{}}>
+          <AppShellStoreProvider defaultNavigationGroups={[]}>
+            <InitializeOpenChatDock />
+            <ChatDockErrorBoundary organizationSlug="acme">
+              <ThrowingPanel shouldThrow={false} />
+            </ChatDockErrorBoundary>
+            <a href="mailto:support@example.com">Email support</a>
+          </AppShellStoreProvider>
+        </IntlProvider>
+      </QueryClientProvider>,
+    );
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(screen.getByText("Recovered chat panel")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Email support" })).toBeTruthy();
+  });
+
+  it("closes the failed panel without deleting the active tab", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    renderBoundary(true);
+    await user.click(screen.getByRole("button", { name: "Close chat" }));
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByRole("link", { name: "Email support" })).toBeTruthy();
+  });
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-error-boundary.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-error-boundary.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { AlertCircleIcon } from "lucide-react";
+import { type ErrorInfo, type ReactNode } from "react";
+import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
+import { useQueryClient } from "@tanstack/react-query";
+import { observer } from "mobx-react-lite";
+import { FormattedMessage } from "react-intl";
+
+import { useAppShellStore } from "@/components/app-shell/store/app-shell-store-context";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+
+import { chatDockMessages } from "./chat-dock.messages";
+import { getChatStreamManager } from "./chat-stream-manager";
+
+function logChatDockError(error: Error, info: ErrorInfo) {
+  console.error("[chat-dock:panel]", {
+    name: error.name,
+    message: error.message,
+    stack: error.stack,
+    componentStack: info.componentStack,
+  });
+}
+
+function ChatDockErrorFallback({
+  resetErrorBoundary,
+  organizationSlug,
+}: FallbackProps & { organizationSlug: string }) {
+  const { chatDock } = useAppShellStore();
+  const queryClient = useQueryClient();
+
+  function retry() {
+    const activeTab = chatDock.activeTab;
+    if (activeTab) {
+      getChatStreamManager(organizationSlug, chatDock).stop(activeTab.id);
+      chatDock.clearStreamSnapshot(activeTab.id);
+      chatDock.setLastError(activeTab.id, null);
+      void queryClient.invalidateQueries({
+        queryKey: ["conversation-messages", activeTab.id],
+      });
+    }
+    void queryClient.invalidateQueries({
+      queryKey: ["conversations", organizationSlug],
+    });
+    resetErrorBoundary();
+  }
+
+  return (
+    <div className="flex min-h-48 items-center justify-center border-b border-border p-4">
+      <Alert variant="destructive" className="max-w-md">
+        <AlertCircleIcon />
+        <AlertTitle className="text-balance">
+          <FormattedMessage {...chatDockMessages.panelErrorTitle} />
+        </AlertTitle>
+        <AlertDescription className="space-y-3">
+          <p className="text-pretty">
+            <FormattedMessage {...chatDockMessages.panelErrorDescription} />
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <Button type="button" variant="outline" size="sm" onClick={retry}>
+              <FormattedMessage {...chatDockMessages.tryAgain} />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => chatDock.setPanelOpen(false)}
+            >
+              <FormattedMessage {...chatDockMessages.closeChat} />
+            </Button>
+          </div>
+        </AlertDescription>
+      </Alert>
+    </div>
+  );
+}
+
+export const ChatDockErrorBoundary = observer(function ChatDockErrorBoundary({
+  children,
+  organizationSlug,
+}: {
+  children: ReactNode;
+  organizationSlug: string;
+}) {
+  const { chatDock } = useAppShellStore();
+
+  return (
+    <ErrorBoundary
+      fallbackRender={(fallbackProps) => (
+        <ChatDockErrorFallback {...fallbackProps} organizationSlug={organizationSlug} />
+      )}
+      onError={(error, info) => {
+        if (error instanceof Error) {
+          logChatDockError(error, info);
+        }
+      }}
+      resetKeys={[organizationSlug, chatDock.activeTabId, chatDock.panelOpen]}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-error-boundary.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-error-boundary.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { AlertCircleIcon } from "lucide-react";
-import { type ErrorInfo, type ReactNode } from "react";
+import { type ErrorInfo, type ReactNode, useRef } from "react";
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { observer } from "mobx-react-lite";
 import { FormattedMessage } from "react-intl";
 
@@ -12,39 +12,38 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 
 import { chatDockMessages } from "./chat-dock.messages";
+import { ChatDockStore } from "./chat-dock-store";
 import { getChatStreamManager } from "./chat-stream-manager";
 
 function logChatDockError(error: Error, info: ErrorInfo) {
+  // Omit message/stack — render errors can include conversation text or API bodies.
   console.error("[chat-dock:panel]", {
     name: error.name,
-    message: error.message,
-    stack: error.stack,
     componentStack: info.componentStack,
   });
 }
 
-function ChatDockErrorFallback({
-  resetErrorBoundary,
-  organizationSlug,
-}: FallbackProps & { organizationSlug: string }) {
-  const { chatDock } = useAppShellStore();
-  const queryClient = useQueryClient();
-
-  function retry() {
-    const activeTab = chatDock.activeTab;
-    if (activeTab) {
-      getChatStreamManager(organizationSlug, chatDock).stop(activeTab.id);
-      chatDock.clearStreamSnapshot(activeTab.id);
-      chatDock.setLastError(activeTab.id, null);
-      void queryClient.invalidateQueries({
-        queryKey: ["conversation-messages", activeTab.id],
-      });
-    }
+function recoverFailedTab(
+  organizationSlug: string,
+  chatDock: ChatDockStore,
+  tabId: string | null,
+  queryClient: QueryClient,
+) {
+  if (tabId) {
+    getChatStreamManager(organizationSlug, chatDock).stop(tabId);
+    chatDock.clearStreamSnapshot(tabId);
+    chatDock.setLastError(tabId, null);
     void queryClient.invalidateQueries({
-      queryKey: ["conversations", organizationSlug],
+      queryKey: ["conversation-messages", tabId],
     });
-    resetErrorBoundary();
   }
+  void queryClient.invalidateQueries({
+    queryKey: ["conversations", organizationSlug],
+  });
+}
+
+function ChatDockErrorFallback({ resetErrorBoundary }: FallbackProps) {
+  const { chatDock } = useAppShellStore();
 
   return (
     <div className="flex min-h-48 items-center justify-center border-b border-border p-4">
@@ -58,7 +57,7 @@ function ChatDockErrorFallback({
             <FormattedMessage {...chatDockMessages.panelErrorDescription} />
           </p>
           <div className="flex flex-wrap gap-2">
-            <Button type="button" variant="outline" size="sm" onClick={retry}>
+            <Button type="button" variant="outline" size="sm" onClick={resetErrorBoundary}>
               <FormattedMessage {...chatDockMessages.tryAgain} />
             </Button>
             <Button
@@ -84,16 +83,22 @@ export const ChatDockErrorBoundary = observer(function ChatDockErrorBoundary({
   organizationSlug: string;
 }) {
   const { chatDock } = useAppShellStore();
+  const queryClient = useQueryClient();
+  const failedTabIdRef = useRef<string | null>(null);
 
   return (
     <ErrorBoundary
-      fallbackRender={(fallbackProps) => (
-        <ChatDockErrorFallback {...fallbackProps} organizationSlug={organizationSlug} />
-      )}
+      fallbackRender={(fallbackProps) => <ChatDockErrorFallback {...fallbackProps} />}
       onError={(error, info) => {
+        failedTabIdRef.current = chatDock.activeTabId;
         if (error instanceof Error) {
           logChatDockError(error, info);
         }
+      }}
+      onReset={() => {
+        const failedTabId = failedTabIdRef.current;
+        failedTabIdRef.current = null;
+        recoverFailedTab(organizationSlug, chatDock, failedTabId, queryClient);
       }}
       resetKeys={[organizationSlug, chatDock.activeTabId, chatDock.panelOpen]}
     >

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.messages.ts
@@ -108,4 +108,24 @@ export const chatDockMessages = defineMessages({
     defaultMessage: "This conversation is no longer available.",
     description: "Toast when a docked conversation returns 404",
   },
+  panelErrorTitle: {
+    id: "trM5T+lG0s",
+    defaultMessage: "Chat could not be displayed",
+    description: "Title shown when the chat dock panel fails to render",
+  },
+  panelErrorDescription: {
+    id: "K99IJACIpb",
+    defaultMessage: "The rest of your workspace is still available. Try loading this chat again.",
+    description: "Description shown when the chat dock panel fails to render",
+  },
+  tryAgain: {
+    id: "hjMbjSqPe8",
+    defaultMessage: "Try again",
+    description: "Button to retry rendering the chat dock panel",
+  },
+  closeChat: {
+    id: "wANdpDUOzB",
+    defaultMessage: "Close chat",
+    description: "Button to collapse a failed chat dock panel",
+  },
 });

--- a/docs/plans/2026-07-13-chat-dock-error-isolation-design.md
+++ b/docs/plans/2026-07-13-chat-dock-error-isolation-design.md
@@ -1,0 +1,25 @@
+# Chat dock error isolation
+
+## Decision
+
+Wrap only the expandable chat dock panel in a client-side error boundary. Keep the
+chat bridge, footer controls, plan usage, support link, and application shell outside
+the boundary so they remain usable when the panel fails to render.
+
+## Recovery
+
+The fallback appears in the dock's normal panel area and offers two local actions:
+
+- **Try again** clears the active tab's transient stream error, invalidates its
+  conversation data, and rerenders the panel.
+- **Close chat** collapses the failed panel without deleting the tab or its draft.
+
+Changing organizations resets the boundary. Unexpected errors are logged with the
+chat-dock scope and React component stack, consistent with the app's existing panel
+boundaries.
+
+## Testing
+
+Render a failing child inside the boundary and verify that the local fallback appears
+while content outside the boundary remains available. Verify that retry rerenders the
+child and that closing the fallback collapses the dock without deleting its tab.

--- a/docs/plans/2026-07-13-chat-dock-error-isolation-design.md
+++ b/docs/plans/2026-07-13-chat-dock-error-isolation-design.md
@@ -10,16 +10,23 @@ the boundary so they remain usable when the panel fails to render.
 
 The fallback appears in the dock's normal panel area and offers two local actions:
 
-- **Try again** clears the active tab's transient stream error, invalidates its
+- **Try again** clears the failed tab's transient stream error, invalidates its
   conversation data, and rerenders the panel.
 - **Close chat** collapses the failed panel without deleting the tab or its draft.
 
-Changing organizations resets the boundary. Unexpected errors are logged with the
-chat-dock scope and React component stack, consistent with the app's existing panel
-boundaries.
+Changing organizations, switching tabs, or closing the panel resets the boundary
+through `resetKeys`. Reset always runs the same recovery cleanup against the tab
+that originally failed, so switching away while the fallback is visible does not
+leave that tab's stream snapshot, last error, or message cache stale.
+
+Unexpected errors are logged with the chat-dock scope, error name, and React
+component stack. Message and stack text are omitted so conversation content or
+API bodies cannot leak into logs.
 
 ## Testing
 
 Render a failing child inside the boundary and verify that the local fallback appears
 while content outside the boundary remains available. Verify that retry rerenders the
-child and that closing the fallback collapses the dock without deleting its tab.
+child, that closing the fallback collapses the dock without deleting its tab, and that
+switching tabs while the fallback is visible clears the failed tab's transient stream
+state so returning to it does not revive the same failure.


### PR DESCRIPTION
## What changed

- Isolate chat dock panel render failures from the application shell and footer controls.
- Add a localized fallback with retry and close actions.
- Reset transient stream state and refresh conversation data when retrying.
- Keep the active tab and draft when closing a failed panel.
- Add focused tests for failure containment and recovery.

## How to test

- `vp test run src/components/app-shell/chat-dock/chat-dock-error-boundary.test.tsx src/components/app-shell/app-shell-footer.test.tsx`
- `vp check --fix`
- `vp test` *(blocked by PostgreSQL not running on port 5432; 2,201 tests passed before database-backed suites failed)*

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review