### PR TITLE
feat(web): add route error recovery

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/error.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/error.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect } from "react";
+import { useParams } from "next/navigation";
+
+import { LocalizedErrorRecovery } from "@/components/error-recovery/localized-error-recovery";
+
+type OrganizationErrorProps = {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+};
+
+export default function OrganizationError({ error, unstable_retry }: OrganizationErrorProps) {
+  const { lang, organizationSlug } = useParams<{
+    lang: string;
+    organizationSlug: string;
+  }>();
+
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <LocalizedErrorRecovery
+      dashboardHref={`/${lang}/org/${organizationSlug}/dashboard`}
+      retry={unstable_retry}
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/error.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect } from "react";
+import { useParams } from "next/navigation";
+
+import { LocalizedErrorRecovery } from "@/components/error-recovery/localized-error-recovery";
+
+type LocaleErrorProps = {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+};
+
+export default function LocaleError({ error, unstable_retry }: LocaleErrorProps) {
+  const { lang } = useParams<{ lang: string }>();
+
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <LocalizedErrorRecovery dashboardHref={`/${lang}/dashboard`} retry={unstable_retry} fullPage />
+  );
+}

--- a/apps/hyperlocalise-web/src/app/global-error.tsx
+++ b/apps/hyperlocalise-web/src/app/global-error.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { ErrorRecovery } from "@/components/error-recovery/error-recovery";
+
+import "./globals.css";
+
+type GlobalErrorProps = {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+};
+
+export default function GlobalError({ error, unstable_retry }: GlobalErrorProps) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body>
+        <title>Page unavailable | Hyperlocalise</title>
+        <ErrorRecovery
+          title="We couldn't load this page"
+          description="The problem may be temporary. Try loading the page again, or return to your dashboard."
+          tryAgainLabel="Try again"
+          dashboardLabel="Go to dashboard"
+          supportLabel="Contact support"
+          dashboardHref="/dashboard"
+          retry={unstable_retry}
+          fullPage
+        />
+      </body>
+    </html>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
@@ -12,8 +12,7 @@ import {
 import { PlanUsageFooterControl } from "@/components/billing/plan-usage-summary";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-
-const SUPPORT_EMAIL = "minh@hyperlocalise.com";
+import { SUPPORT_EMAIL } from "@/lib/support-contact";
 
 export function AppShellFooter({
   organizationSlug,

--- a/apps/hyperlocalise-web/src/components/error-recovery/error-recovery.messages.ts
+++ b/apps/hyperlocalise-web/src/components/error-recovery/error-recovery.messages.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const errorRecoveryMessages = defineMessages({
+  title: {
+    defaultMessage: "We couldn't load this page",
+    id: "tLThxyOpTE",
+    description: "Heading shown when an application route fails unexpectedly",
+  },
+  description: {
+    defaultMessage:
+      "The problem may be temporary. Try loading the page again, or return to your dashboard.",
+    id: "RUWijemH62",
+    description: "Guidance shown when an application route fails unexpectedly",
+  },
+  tryAgain: {
+    defaultMessage: "Try again",
+    id: "mdDGkHBHvr",
+    description: "Button that retries rendering a failed application route",
+  },
+  goToDashboard: {
+    defaultMessage: "Go to dashboard",
+    id: "xSPEc7l3cj",
+    description: "Link from a route error to the workspace dashboard",
+  },
+  contactSupport: {
+    defaultMessage: "Contact support",
+    id: "GfQL0NJI1y",
+    description: "Link from a route error to email customer support",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/error-recovery/error-recovery.test.tsx
+++ b/apps/hyperlocalise-web/src/components/error-recovery/error-recovery.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment happy-dom
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { ErrorRecovery } from "@/components/error-recovery/error-recovery";
+import { SUPPORT_EMAIL } from "@/lib/support-contact";
+
+describe("ErrorRecovery", () => {
+  it("offers retry, dashboard, and support actions", () => {
+    const retry = vi.fn();
+
+    render(
+      <ErrorRecovery
+        title="We couldn't load this page"
+        description="Try loading the page again."
+        tryAgainLabel="Try again"
+        dashboardLabel="Go to dashboard"
+        supportLabel="Contact support"
+        dashboardHref="/fr-FR/org/acme/dashboard"
+        retry={retry}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(retry).toHaveBeenCalledOnce();
+    expect(screen.getByRole("button", { name: "Go to dashboard" })).toHaveAttribute(
+      "href",
+      "/fr-FR/org/acme/dashboard",
+    );
+    expect(screen.getByRole("button", { name: "Contact support" })).toHaveAttribute(
+      "href",
+      `mailto:${SUPPORT_EMAIL}`,
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/components/error-recovery/error-recovery.tsx
+++ b/apps/hyperlocalise-web/src/components/error-recovery/error-recovery.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import {
+  CustomerSupportIcon,
+  DashboardSquare01Icon,
+  RefreshIcon,
+  SecurityCheckIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { cn } from "@/lib/primitives/cn";
+import { SUPPORT_EMAIL } from "@/lib/support-contact";
+
+type ErrorRecoveryProps = {
+  title: string;
+  description: string;
+  tryAgainLabel: string;
+  dashboardLabel: string;
+  supportLabel: string;
+  dashboardHref: string;
+  retry: () => void;
+  fullPage?: boolean;
+};
+
+export function ErrorRecovery({
+  title,
+  description,
+  tryAgainLabel,
+  dashboardLabel,
+  supportLabel,
+  dashboardHref,
+  retry,
+  fullPage = false,
+}: ErrorRecoveryProps) {
+  return (
+    <main
+      className={cn(
+        "flex w-full items-center justify-center bg-background px-4 py-12 text-foreground",
+        fullPage ? "min-h-dvh" : "min-h-[60vh]",
+      )}
+    >
+      <Empty className="max-w-xl border border-border bg-card px-6 py-12 shadow-sm sm:px-12">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <HugeiconsIcon icon={SecurityCheckIcon} strokeWidth={1.75} />
+          </EmptyMedia>
+          <EmptyTitle className="font-heading text-2xl font-semibold text-balance">
+            {title}
+          </EmptyTitle>
+          <EmptyDescription className="max-w-md text-pretty">{description}</EmptyDescription>
+        </EmptyHeader>
+
+        <EmptyContent className="max-w-md gap-3 sm:flex-row sm:justify-center">
+          <Button className="w-full sm:w-auto" onClick={retry}>
+            <HugeiconsIcon data-icon="inline-start" icon={RefreshIcon} strokeWidth={2} />
+            {tryAgainLabel}
+          </Button>
+          <Button
+            className="w-full sm:w-auto"
+            variant="outline"
+            nativeButton={false}
+            render={<Link href={dashboardHref} />}
+          >
+            <HugeiconsIcon data-icon="inline-start" icon={DashboardSquare01Icon} strokeWidth={2} />
+            {dashboardLabel}
+          </Button>
+          <Button
+            className="w-full sm:w-auto"
+            variant="ghost"
+            nativeButton={false}
+            render={<a href={`mailto:${SUPPORT_EMAIL}`} />}
+          >
+            <HugeiconsIcon data-icon="inline-start" icon={CustomerSupportIcon} strokeWidth={2} />
+            {supportLabel}
+          </Button>
+        </EmptyContent>
+      </Empty>
+    </main>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/error-recovery/localized-error-recovery.tsx
+++ b/apps/hyperlocalise-web/src/components/error-recovery/localized-error-recovery.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useIntl } from "react-intl";
+
+import { ErrorRecovery } from "@/components/error-recovery/error-recovery";
+import { errorRecoveryMessages } from "@/components/error-recovery/error-recovery.messages";
+
+type LocalizedErrorRecoveryProps = {
+  dashboardHref: string;
+  retry: () => void;
+  fullPage?: boolean;
+};
+
+export function LocalizedErrorRecovery({
+  dashboardHref,
+  retry,
+  fullPage,
+}: LocalizedErrorRecoveryProps) {
+  const intl = useIntl();
+
+  return (
+    <ErrorRecovery
+      title={intl.formatMessage(errorRecoveryMessages.title)}
+      description={intl.formatMessage(errorRecoveryMessages.description)}
+      tryAgainLabel={intl.formatMessage(errorRecoveryMessages.tryAgain)}
+      dashboardLabel={intl.formatMessage(errorRecoveryMessages.goToDashboard)}
+      supportLabel={intl.formatMessage(errorRecoveryMessages.contactSupport)}
+      dashboardHref={dashboardHref}
+      retry={retry}
+      fullPage={fullPage}
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/lib/support-contact.ts
+++ b/apps/hyperlocalise-web/src/lib/support-contact.ts
@@ -1,0 +1,1 @@
+export const SUPPORT_EMAIL = "minh@hyperlocalise.com";

--- a/docs/adr/2026-07-13-route-error-recovery-design.md
+++ b/docs/adr/2026-07-13-route-error-recovery-design.md
@@ -1,0 +1,19 @@
+# Route error recovery
+
+## Context
+
+Unexpected App Router failures currently fall through to Next.js defaults. Users lose product context, navigation, and a clear recovery path.
+
+## Design
+
+Add three boundaries with progressively broader coverage:
+
+- The organization boundary handles failures below the organization layout and keeps the application shell available.
+- The locale boundary handles failures in localized marketing and authenticated routes, including failures that prevent the organization shell from rendering.
+- The global boundary handles failures in the root layout and remains self-contained because application providers may be unavailable.
+
+The locale and organization boundaries use the active message catalog. Each boundary offers a retry, a dashboard route, and the existing support email address. A shared presentation component keeps the recovery experience consistent without coupling it to route state or localization providers.
+
+## Verification
+
+Cover the shared recovery actions and boundary-specific routes with focused component tests. Run the web app's formatting, lint, and type checks.

--- a/docs/adr/2026-07-13-route-error-recovery-design.md
+++ b/docs/adr/2026-07-13-route-error-recovery-design.md
@@ -14,6 +14,20 @@ Add three boundaries with progressively broader coverage:
 
 The locale and organization boundaries use the active message catalog. Each boundary offers a retry, a dashboard route, and the existing support email address. A shared presentation component keeps the recovery experience consistent without coupling it to route state or localization providers.
 
+### Retry
+
+Next.js 16.2+ supplies both `reset` and `unstable_retry` to `error.js` / `global-error.js`. Boundaries call `unstable_retry`, which re-fetches and re-renders the failed segment. Prefer it over `reset`, which only clears client error state and does not recover Server Component failures.
+
+### Dashboard fallbacks
+
+Dashboard destinations differ by how much route context remains available:
+
+- Organization boundary: `/${lang}/org/${organizationSlug}/dashboard`
+- Locale boundary: `/${lang}/dashboard`, which resolves the active organization through the authenticated dashboard route
+- Global boundary: `/dashboard`, which the locale proxy rewrites to `/${locale}/dashboard`, then the same authenticated dashboard route
+
+These resolver paths are intentional. Locale and global boundaries do not have a reliable organization slug, so they must not hard-code an org-scoped URL.
+
 ## Verification
 
 Cover the shared recovery actions and boundary-specific routes with focused component tests. Run the web app's formatting, lint, and type checks.


### PR DESCRIPTION
## What changed

- Add global, locale, and organization-level App Router error boundaries.
- Add a shared localized recovery experience with retry, dashboard, and support actions.
- Preserve the application shell when failures occur below the organization layout.
- Share the support email between the recovery UI and application footer.
- Document the route error recovery design.

## How to test

- `vp exec vitest run src/components/error-recovery/error-recovery.test.tsx src/components/app-shell/app-shell-footer.test.tsx`
- `vp check --fix`
- `git diff --check`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review