### PR TITLE
🧪 Scout: Improve Java Properties line number tracking for \r line endings

### DIFF
--- a/internal/i18n/translationfileparser/properties_parser.go
+++ b/internal/i18n/translationfileparser/properties_parser.go
@@ -95,7 +95,7 @@ func parseJavaPropertiesDocument(content []byte) (propertiesDocument, error) {
 		first := firstPropertiesNonWhitespace(rawLine)
 		if first >= len(rawLine) {
 			pendingComments = nil
-			currentLine += strings.Count(text[pos:next], "\n")
+			currentLine += countPropertiesLines(text[pos:next])
 			pos = next
 			continue
 		}
@@ -107,7 +107,7 @@ func parseJavaPropertiesDocument(content []byte) (propertiesDocument, error) {
 				comment = comment[1:]
 			}
 			pendingComments = append(pendingComments, comment)
-			currentLine += strings.Count(text[pos:next], "\n")
+			currentLine += countPropertiesLines(text[pos:next])
 			pos = next
 			continue
 		}
@@ -127,7 +127,7 @@ func parseJavaPropertiesDocument(content []byte) (propertiesDocument, error) {
 		}
 		seen[entry.key] = entry.line
 		doc.entries = append(doc.entries, entry)
-		currentLine += strings.Count(text[pos:nextPos], "\n")
+		currentLine += countPropertiesLines(text[pos:nextPos])
 		pos = nextPos
 	}
 
@@ -313,7 +313,7 @@ func readPropertiesLogicalLine(text string, start int, lineNumber int) (properti
 
 		if pNext >= len(text) {
 			// Accurately report the line where the dangling continuation was found.
-			errLine := lineNumber + strings.Count(text[start:pEnd], "\n")
+			errLine := lineNumber + countPropertiesLines(text[start:pEnd])
 			return propertiesLogicalLine{}, pNext, fmt.Errorf("line %d: continuation escape at end of file", errLine)
 		}
 
@@ -385,6 +385,12 @@ func skipPropertiesPhysicalWhitespace(s string, start, end int) int {
 
 func isPropertiesWhitespace(ch byte) bool {
 	return ch == ' ' || ch == '\t' || ch == '\f'
+}
+
+func countPropertiesLines(s string) int {
+	// Java properties lines can be terminated by \n, \r, or \r\n.
+	// We count all \n and all \r, then subtract \r\n to avoid double-counting.
+	return strings.Count(s, "\n") + strings.Count(s, "\r") - strings.Count(s, "\r\n")
 }
 
 func decodeJavaPropertiesEscapes(raw string) (string, error) {

--- a/internal/i18n/translationfileparser/properties_parser_test.go
+++ b/internal/i18n/translationfileparser/properties_parser_test.go
@@ -163,3 +163,20 @@ key = value
 		t.Fatalf("unexpected context for key:\ngot:  %q\nwant: %q", got, want)
 	}
 }
+
+func TestJavaPropertiesParserLineNumbersWithCarriageReturn(t *testing.T) {
+	// \r is a valid line terminator in Java properties.
+	content := []byte("key1=val1\rkey1=val2")
+
+	_, err := (JavaPropertiesParser{}).Parse(content)
+	if err == nil {
+		t.Fatal("expected duplicate key error")
+	}
+
+	// If \r is not counted as a newline, both keys will be thought to be on line 1.
+	// But they are on line 1 and line 2.
+	const want = "line 2: duplicate properties key \"key1\" first defined on line 1"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("unexpected error message: %v\nwant: %s", err, want)
+	}
+}


### PR DESCRIPTION
💡 What: Improved the line counting logic in `JavaPropertiesParser` to correctly handle all valid Java properties line terminators (`\n`, `\r`, `\r\n`).

🎯 Why: Java `.properties` files support `\r` as a line terminator. The current implementation relied on `strings.Count(..., "\n")`, which caused incorrect line numbers in error messages (like duplicate key detections) when `\r` was used.

🧩 Scope: `internal/i18n/translationfileparser/properties_parser.go` and `internal/i18n/translationfileparser/properties_parser_test.go`.

✅ Verification: Ran `go test -v ./internal/i18n/translationfileparser` and the full repo test suite (`make fmt`, `make lint`, `go test ./...`).

🛡️ Confidence: High. The fix uses the same logic as the physical line scanner already present in the parser, ensuring consistency.

---
*PR created automatically by Jules for task [7489082581801814414](https://jules.google.com/task/7489082581801814414) started by @cungminh2710*