### PR TITLE
fix(crowdin): improve Workflows ListSteps parity and pagination

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -231,3 +231,7 @@
 ## 2026-11-21 - Optimize JoinSlice for task-related enums
 **Learning:** The `model.JoinSlice` utility used for encoding query parameters was using reflection-based `fmt.Fprintf` for any slice type other than `[]int` and `[]string`. This included task-related enums like `TaskStatus` and `TaskType`, which are frequently joined into comma-separated strings for filtering. Specialized type switch cases using `strings.Builder` and direct string/integer conversion are significantly more efficient.
 **Action:** Added specialized type switch cases for `[]TaskStatus` and `[]TaskType` to `JoinSlice` and updated the test suite to use concrete typed slices to ensure these optimized paths are exercised and verified.
+
+## 2026-11-28 - Improve Workflows ListSteps parity and pagination
+**Learning:** The `Workflows.ListSteps` endpoint in the Crowdin API v2 uses an integer for the project ID and supports pagination via `limit` and `offset`. The Go SDK was incorrectly using a string for the project ID and was missing pagination support for both the request and response models.
+**Action:** Updated `WorkflowsService.ListSteps` to accept `projectID` as an `int` and added `WorkflowStepsListOptions` for pagination. Added the `Pagination` field to `WorkflowStepsResponse`. Note that `WorkflowStep.Languages` at the project level uses string identifiers (e.g., "de"), which differs from the numeric IDs used at the workflow template level. Verified with updated contract tests in `workflows_test.go`.

--- a/third_party/crowdin-api-client-go/crowdin/model/workflows.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/workflows.go
@@ -23,7 +23,24 @@ type WorkflowStepResponse struct {
 // WorkflowStepsResponse defines the structure of the response when
 // getting a list of workflow steps.
 type WorkflowStepsResponse struct {
-	Data []*WorkflowStepResponse `json:"data"`
+	Data       []*WorkflowStepResponse `json:"data"`
+	Pagination *Pagination             `json:"pagination"`
+}
+
+// WorkflowStepsListOptions specifies the optional parameters to the
+// WorkflowsService.ListSteps method.
+type WorkflowStepsListOptions struct {
+	ListOptions
+}
+
+// Values returns the url.Values representation of the options.
+// It implements the crowdin.ListOptionsProvider interface.
+func (o *WorkflowStepsListOptions) Values() (url.Values, bool) {
+	if o == nil {
+		return nil, false
+	}
+
+	return o.ListOptions.Values()
 }
 
 type (

--- a/third_party/crowdin-api-client-go/crowdin/workflows.go
+++ b/third_party/crowdin-api-client-go/crowdin/workflows.go
@@ -22,9 +22,11 @@ type WorkflowsService struct {
 // ListSteps returns a list of workflow steps available in the project.
 //
 // https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.workflow-steps.getMany
-func (s *WorkflowsService) ListSteps(ctx context.Context, projectID string) ([]*model.WorkflowStep, *Response, error) {
+func (s *WorkflowsService) ListSteps(ctx context.Context, projectID int, opts *model.WorkflowStepsListOptions) (
+	[]*model.WorkflowStep, *Response, error,
+) {
 	res := new(model.WorkflowStepsResponse)
-	resp, err := s.client.Get(ctx, fmt.Sprintf("/api/v2/projects/%s/workflow-steps", projectID), nil, res)
+	resp, err := s.client.Get(ctx, fmt.Sprintf("/api/v2/projects/%d/workflow-steps", projectID), opts, res)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/third_party/crowdin-api-client-go/crowdin/workflows_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/workflows_test.go
@@ -237,55 +237,81 @@ func TestWorkflowsService_GetStep(t *testing.T) {
 }
 
 func TestWorkflowsService_ListSteps(t *testing.T) {
-	client, mux, teardown := setupClient()
-	defer teardown()
-
-	const path = "/api/v2/projects/1/workflow-steps"
-	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, http.MethodGet)
-		testURL(t, r, path)
-
-		fmt.Fprint(w, `{
-			"data": [
-				{
-					"data": {
-						"id": 311,
-						"title": "Translate",
-						"type": "Translate",
-						"languages": ["de","it"],
-						"config": {
-							"minRelevant": "perfect",
-							"autoSubstitution": 2
-						}
-					}
-				}
-			],
-			"pagination": {
-				"offset": 10,
-				"limit": 25
-			}
-		}`)
-	})
-
-	steps, resp, err := client.Workflows.ListSteps(context.Background(), "1")
-	require.NoError(t, err)
-
-	expected := []*model.WorkflowStep{
+	tests := []struct {
+		name          string
+		opts          *model.WorkflowStepsListOptions
+		expectedQuery string
+	}{
 		{
-			ID:        311,
-			Title:     "Translate",
-			Type:      "Translate",
-			Languages: []string{"de", "it"},
-			Config: map[string]any{
-				"minRelevant":      "perfect",
-				"autoSubstitution": float64(2),
+			name: "nil options",
+			opts: nil,
+		},
+		{
+			name: "empty options",
+			opts: &model.WorkflowStepsListOptions{},
+		},
+		{
+			name: "all options",
+			opts: &model.WorkflowStepsListOptions{
+				ListOptions: model.ListOptions{Offset: 10, Limit: 25},
 			},
+			expectedQuery: "?limit=25&offset=10",
 		},
 	}
-	assert.Equal(t, expected, steps)
 
-	assert.Equal(t, 10, resp.Pagination.Offset)
-	assert.Equal(t, 25, resp.Pagination.Limit)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, mux, teardown := setupClient()
+			defer teardown()
+
+			const path = "/api/v2/projects/1/workflow-steps"
+			mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+				testMethod(t, r, http.MethodGet)
+				testURL(t, r, path+tt.expectedQuery)
+
+				fmt.Fprint(w, `{
+					"data": [
+						{
+							"data": {
+								"id": 311,
+								"title": "Translate",
+								"type": "Translate",
+								"languages": ["de","it"],
+								"config": {
+									"minRelevant": "perfect",
+									"autoSubstitution": 2
+								}
+							}
+						}
+					],
+					"pagination": {
+						"offset": 10,
+						"limit": 25
+					}
+				}`)
+			})
+
+			steps, resp, err := client.Workflows.ListSteps(context.Background(), 1, tt.opts)
+			require.NoError(t, err)
+
+			expected := []*model.WorkflowStep{
+				{
+					ID:        311,
+					Title:     "Translate",
+					Type:      "Translate",
+					Languages: []string{"de", "it"},
+					Config: map[string]any{
+						"minRelevant":      "perfect",
+						"autoSubstitution": float64(2),
+					},
+				},
+			}
+			assert.Equal(t, expected, steps)
+
+			assert.Equal(t, 10, resp.Pagination.Offset)
+			assert.Equal(t, 25, resp.Pagination.Limit)
+		})
+	}
 }
 
 func TestWorkflowsService_ListSteps_invalidJSON(t *testing.T) {
@@ -296,7 +322,7 @@ func TestWorkflowsService_ListSteps_invalidJSON(t *testing.T) {
 		fmt.Fprint(w, `invalid json`)
 	})
 
-	steps, _, err := client.Workflows.ListSteps(context.Background(), "1")
+	steps, _, err := client.Workflows.ListSteps(context.Background(), 1, nil)
 	require.Error(t, err)
 	assert.Nil(t, steps)
 }


### PR DESCRIPTION
### 💡 What
Updated the `Workflows.ListSteps` method to use an integer for the project ID and added support for pagination in both requests and responses.

### 🎯 Why
The Crowdin API v2 defines `{projectId}` as an integer and supports standard pagination for listing workflow steps. The previous implementation was inconsistent with other services and lacked the ability to handle multi-page results.

### 📚 Docs
[Crowdin Enterprise API v2 - List Workflow Steps](https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.workflow-steps.getMany)

### 🧩 Scope
- `third_party/crowdin-api-client-go/crowdin/workflows.go`: Updated method signature and URL formatting.
- `third_party/crowdin-api-client-go/crowdin/model/workflows.go`: Added `WorkflowStepsListOptions` and updated `WorkflowStepsResponse`.
- `third_party/crowdin-api-client-go/crowdin/workflows_test.go`: Refactored tests to use table-driven approach and verify pagination.

### ✅ Verification
Ran `go test -v ./third_party/crowdin-api-client-go/crowdin/...` and all tests passed, including the updated workflow step tests.

### 🛡️ Confidence
High. The changes strictly follow the documented API contract and use existing SDK patterns for pagination and ID types.

---
*PR created automatically by Jules for task [2031455204294808300](https://jules.google.com/task/2031455204294808300) started by @cungminh2710*