### PR TITLE
feat(cat): add approve and save draft to side-by-side view

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
@@ -872,4 +872,9 @@ export const catSideBySidePanelMessages = defineMessages({
     id: "gLK1qAKU2c",
     description: "Current segment position in side-by-side CAT view footer",
   },
+  clickToLocalizeImage: {
+    defaultMessage: "Click to localize image",
+    id: "Ga0sjgCRoD",
+    description: "Placeholder when a side-by-side image row has no localized image yet",
+  },
 });

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-panel.tsx
@@ -280,6 +280,10 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
               loadingSegmentIds={loadingSegmentIds}
               isApproving={isApproving}
               isSavingDraft={isSavingDraft}
+              isPostingComment={isPostingComment}
+              isLookingUpContext={isLookingUpContext}
+              isAiSuggestionLoading={isAiSuggestionLoading}
+              isFormatChecksLoading={isFormatChecksLoading}
               onFocusSegment={onFocusSegment}
               onHoverSegment={(segmentId) => store.ui.setHoveredSegment(segmentId)}
               onLeaveSegment={() => store.ui.clearHoveredSegment()}

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-panel.tsx
@@ -71,6 +71,7 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
   isSavingDraft = false,
   isAiSuggestionLoading = false,
   isFormatChecksLoading = false,
+  isImageBusy = false,
   isConcordanceLoading,
   isVisualContextLoading,
   showAgentContext,
@@ -91,6 +92,9 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
   onTargetChange,
   onApprove,
   onSaveDraft,
+  onTreatAsImage,
+  onRegenerateImage,
+  onUploadImage,
   onAskQuestion,
   onRefreshContext,
   onUseTmMatch,
@@ -118,6 +122,7 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
   isSavingDraft?: boolean;
   isAiSuggestionLoading?: boolean;
   isFormatChecksLoading?: boolean;
+  isImageBusy?: boolean;
   isConcordanceLoading: boolean;
   isVisualContextLoading: boolean;
   showAgentContext: boolean;
@@ -138,6 +143,9 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
   onTargetChange: (segmentId: string, value: string) => void;
   onApprove?: (segmentId: string) => void;
   onSaveDraft?: (segmentId: string) => void;
+  onTreatAsImage?: (segmentId: string, treatAsImage: boolean) => void;
+  onRegenerateImage?: (segmentId: string) => void;
+  onUploadImage?: (segmentId: string, file: File) => void;
   onAskQuestion?: () => void;
   onRefreshContext?: () => void;
   onUseTmMatch?: (segmentId: string, match: CatTranslationMemoryMatch) => void;
@@ -284,6 +292,7 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
               isLookingUpContext={isLookingUpContext}
               isAiSuggestionLoading={isAiSuggestionLoading}
               isFormatChecksLoading={isFormatChecksLoading}
+              isImageBusy={isImageBusy}
               onFocusSegment={onFocusSegment}
               onHoverSegment={(segmentId) => store.ui.setHoveredSegment(segmentId)}
               onLeaveSegment={() => store.ui.clearHoveredSegment()}
@@ -291,6 +300,9 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
               onTargetChange={onTargetChange}
               onApprove={onApprove}
               onSaveDraft={onSaveDraft}
+              onTreatAsImage={onTreatAsImage}
+              onRegenerateImage={onRegenerateImage}
+              onUploadImage={onUploadImage}
               hasMore={hasMoreQueue}
               isLoadingMore={isFetchingPage}
               onNearEnd={onLoadMoreQueue}

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-panel.tsx
@@ -89,6 +89,8 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
   onLoadMoreQueue,
   onFocusSegment,
   onTargetChange,
+  onApprove,
+  onSaveDraft,
   onAskQuestion,
   onRefreshContext,
   onUseTmMatch,
@@ -134,6 +136,8 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
   onLoadMoreQueue?: () => void;
   onFocusSegment: (segmentId: string) => void;
   onTargetChange: (segmentId: string, value: string) => void;
+  onApprove?: (segmentId: string) => void;
+  onSaveDraft?: (segmentId: string) => void;
   onAskQuestion?: () => void;
   onRefreshContext?: () => void;
   onUseTmMatch?: (segmentId: string, match: CatTranslationMemoryMatch) => void;
@@ -274,11 +278,15 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
               dirtySegmentIds={dirtySegmentIds}
               canEdit={canEditTranslations}
               loadingSegmentIds={loadingSegmentIds}
+              isApproving={isApproving}
+              isSavingDraft={isSavingDraft}
               onFocusSegment={onFocusSegment}
               onHoverSegment={(segmentId) => store.ui.setHoveredSegment(segmentId)}
               onLeaveSegment={() => store.ui.clearHoveredSegment()}
               onVisibleSegmentIdsChange={handleVisibleSegmentIdsChange}
               onTargetChange={onTargetChange}
+              onApprove={onApprove}
+              onSaveDraft={onSaveDraft}
               hasMore={hasMoreQueue}
               isLoadingMore={isFetchingPage}
               onNearEnd={onLoadMoreQueue}

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.test.tsx
@@ -95,6 +95,44 @@ describe("CatSideBySideRow", () => {
     expect(screen.getByRole("button", { name: /Approve/i })).toBeDisabled();
   });
 
+  it("renders image upload controls for image segments", () => {
+    const state = createCatWorkspaceState({ selectedSegmentId: "seg-02" });
+    const segment = {
+      ...state.segments!.find((item) => item.id === "seg-02")!,
+      contentKind: "image_url" as const,
+      sourceText: "https://example.com/source.png",
+      sourceAssetUrl: "https://example.com/source.png",
+      targetText: "",
+      targetAssetUrl: undefined,
+    };
+
+    renderRow({
+      segment,
+      isDirty: false,
+      onUploadImage: vi.fn(),
+      onTreatAsImage: vi.fn(),
+    });
+
+    expect(screen.getByText(/Upload/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Approve/i })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: /Save as draft/i })).not.toBeInTheDocument();
+  });
+
+  it("enables approve for image segments with a target asset", () => {
+    const state = createCatWorkspaceState({ selectedSegmentId: "seg-02" });
+    const segment = {
+      ...state.segments!.find((item) => item.id === "seg-02")!,
+      contentKind: "image_file" as const,
+      sourceAssetUrl: "https://example.com/source.png",
+      targetAssetUrl: "https://example.com/target.png",
+      targetText: "",
+    };
+
+    renderRow({ segment, isDirty: false, onUploadImage: vi.fn() });
+
+    expect(screen.getByRole("button", { name: /Approve/i })).toBeEnabled();
+  });
+
   it.each([
     { isApproving: true },
     { isSavingDraft: true },
@@ -103,6 +141,7 @@ describe("CatSideBySideRow", () => {
     { isAiSuggestionLoading: true },
     { isFormatChecksLoading: true },
     { isTargetLoading: true },
+    { isImageBusy: true },
   ] as const)("disables approve during busy state %j", (busyState) => {
     renderRow(busyState);
 

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.test.tsx
@@ -94,4 +94,18 @@ describe("CatSideBySideRow", () => {
 
     expect(screen.getByRole("button", { name: /Approve/i })).toBeDisabled();
   });
+
+  it.each([
+    { isApproving: true },
+    { isSavingDraft: true },
+    { isPostingComment: true },
+    { isLookingUpContext: true },
+    { isAiSuggestionLoading: true },
+    { isFormatChecksLoading: true },
+    { isTargetLoading: true },
+  ] as const)("disables approve during busy state %j", (busyState) => {
+    renderRow(busyState);
+
+    expect(screen.getByRole("button", { name: /Approve/i })).toBeDisabled();
+  });
 });

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment happy-dom
+
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { createCatWorkspaceState } from "@/components/cat/shared/cat.fixture";
+import { renderWithCatProviders } from "@/components/cat/shared/cat-test-utils";
+
+import { CatSideBySideRow } from "./cat-side-by-side-row";
+
+function renderRow(overrides: Partial<Parameters<typeof CatSideBySideRow>[0]> = {}) {
+  const state = createCatWorkspaceState({ selectedSegmentId: "seg-02" });
+  const segment = state.segments!.find((item) => item.id === "seg-02")!;
+
+  const props: Parameters<typeof CatSideBySideRow>[0] = {
+    segment,
+    isFocused: true,
+    isHovered: false,
+    isDirty: true,
+    canEdit: true,
+    isTargetLoading: false,
+    onFocus: vi.fn(),
+    onHover: vi.fn(),
+    onLeave: vi.fn(),
+    onTargetChange: vi.fn(),
+    onApprove: vi.fn(),
+    onSaveDraft: vi.fn(),
+    ...overrides,
+  };
+
+  return {
+    props,
+    ...renderWithCatProviders(<CatSideBySideRow {...props} />),
+  };
+}
+
+describe("CatSideBySideRow", () => {
+  it("shows approve and save draft when the focused row is dirty", () => {
+    renderRow();
+
+    expect(screen.getByRole("button", { name: /Approve/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Save as draft/i })).toBeInTheDocument();
+  });
+
+  it("hides approve actions when the focused row is clean", () => {
+    renderRow({ isDirty: false });
+
+    expect(screen.queryByRole("button", { name: /Approve/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Save as draft/i })).not.toBeInTheDocument();
+  });
+
+  it("hides approve actions when the row is not focused", () => {
+    renderRow({ isFocused: false });
+
+    expect(screen.queryByRole("button", { name: /Approve/i })).not.toBeInTheDocument();
+  });
+
+  it("calls onApprove when Approve is clicked", async () => {
+    const user = userEvent.setup();
+    const onApprove = vi.fn();
+
+    renderRow({ onApprove });
+
+    await user.click(screen.getByRole("button", { name: /Approve/i }));
+    expect(onApprove).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onSaveDraft when Save as draft is clicked", async () => {
+    const user = userEvent.setup();
+    const onSaveDraft = vi.fn();
+
+    renderRow({ onSaveDraft });
+
+    await user.click(screen.getByRole("button", { name: /Save as draft/i }));
+    expect(onSaveDraft).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits save draft when onSaveDraft is not provided", () => {
+    renderRow({ onSaveDraft: undefined });
+
+    expect(screen.getByRole("button", { name: /Approve/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Save as draft/i })).not.toBeInTheDocument();
+  });
+
+  it("disables approve when the target is empty", () => {
+    const state = createCatWorkspaceState({ selectedSegmentId: "seg-02" });
+    const segment = {
+      ...state.segments!.find((item) => item.id === "seg-02")!,
+      targetText: "",
+    };
+
+    renderRow({ segment });
+
+    expect(screen.getByRole("button", { name: /Approve/i })).toBeDisabled();
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.tsx
@@ -1,11 +1,17 @@
 "use client";
 
+import { useHotkeys } from "react-hotkeys-hook";
 import { FormattedMessage } from "react-intl";
 
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Spinner } from "@/components/ui/spinner";
+import { useIsMac } from "@/hooks/use-is-mac";
 import { cn } from "@/lib/primitives/cn";
 
+import { CatEditorShortcutKbd } from "@/components/cat/editor/cat-editor-shortcut-kbd";
 import { CatMessagePreview, CatTargetEditor } from "@/components/cat/editor/cat-target-editor";
+import { catEditorPanelMessages } from "@/components/cat/shared/cat.messages";
 import type { CatSegment } from "@/components/cat/shared/types";
 
 export function CatSideBySideRow({
@@ -15,10 +21,14 @@ export function CatSideBySideRow({
   isDirty,
   canEdit,
   isTargetLoading,
+  isApproving = false,
+  isSavingDraft = false,
   onFocus,
   onHover,
   onLeave,
   onTargetChange,
+  onApprove,
+  onSaveDraft,
 }: {
   segment: CatSegment;
   isFocused: boolean;
@@ -26,12 +36,44 @@ export function CatSideBySideRow({
   isDirty: boolean;
   canEdit: boolean;
   isTargetLoading: boolean;
+  isApproving?: boolean;
+  isSavingDraft?: boolean;
   onFocus: () => void;
   onHover: () => void;
   onLeave: () => void;
   onTargetChange: (value: string) => void;
+  onApprove?: () => void;
+  onSaveDraft?: () => void;
 }) {
+  const isMac = useIsMac();
   const isActive = isFocused || isHovered;
+  const hasTargetText = segment.targetText.trim().length > 0;
+  const isActionBlocked = isApproving || isSavingDraft;
+  const canTriggerApprove =
+    Boolean(onApprove) && canEdit && isDirty && hasTargetText && !isActionBlocked;
+  const showDirtyActions = isFocused && isDirty && canEdit && Boolean(onApprove);
+
+  useHotkeys(
+    "mod+enter",
+    (event) => {
+      const activeElement = document.activeElement;
+      if (
+        activeElement instanceof HTMLElement &&
+        activeElement.dataset.catCommentInput === "true"
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      onApprove?.();
+    },
+    {
+      enabled: isFocused && canTriggerApprove,
+      enableOnFormTags: true,
+      preventDefault: true,
+    },
+    [canTriggerApprove, isFocused, onApprove],
+  );
 
   return (
     <div
@@ -58,13 +100,48 @@ export function CatSideBySideRow({
           isTargetLoading && !segment.targetText.trim() ? (
             <Skeleton className="h-10 w-full rounded-lg" />
           ) : (
-            <CatTargetEditor
-              sourceText={segment.sourceText}
-              value={segment.targetText}
-              maxLength={segment.maxLength}
-              compact
-              onChange={onTargetChange}
-            />
+            <div className="space-y-2">
+              <CatTargetEditor
+                sourceText={segment.sourceText}
+                value={segment.targetText}
+                maxLength={segment.maxLength}
+                compact
+                onChange={onTargetChange}
+              />
+              {showDirtyActions ? (
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="default"
+                    size="sm"
+                    className="h-8 gap-1.5 px-2.5"
+                    onClick={onApprove}
+                    disabled={!canTriggerApprove}
+                  >
+                    {isApproving ? <Spinner className="size-3.5 text-primary-foreground" /> : null}
+                    <FormattedMessage {...catEditorPanelMessages.approve} />
+                    <CatEditorShortcutKbd
+                      shortcut="approve"
+                      isMac={isMac}
+                      className="bg-primary-foreground/15 text-primary-foreground"
+                    />
+                  </Button>
+                  {onSaveDraft ? (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-8 gap-1.5 px-2.5"
+                      onClick={onSaveDraft}
+                      disabled={!canTriggerApprove}
+                    >
+                      {isSavingDraft ? <Spinner className="size-3.5" /> : null}
+                      <FormattedMessage {...catEditorPanelMessages.saveAsDraft} />
+                    </Button>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
           )
         ) : (
           <button type="button" className="w-full text-left" onClick={onFocus}>

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.tsx
@@ -23,6 +23,10 @@ export function CatSideBySideRow({
   isTargetLoading,
   isApproving = false,
   isSavingDraft = false,
+  isPostingComment = false,
+  isLookingUpContext = false,
+  isAiSuggestionLoading = false,
+  isFormatChecksLoading = false,
   onFocus,
   onHover,
   onLeave,
@@ -38,6 +42,10 @@ export function CatSideBySideRow({
   isTargetLoading: boolean;
   isApproving?: boolean;
   isSavingDraft?: boolean;
+  isPostingComment?: boolean;
+  isLookingUpContext?: boolean;
+  isAiSuggestionLoading?: boolean;
+  isFormatChecksLoading?: boolean;
   onFocus: () => void;
   onHover: () => void;
   onLeave: () => void;
@@ -48,7 +56,14 @@ export function CatSideBySideRow({
   const isMac = useIsMac();
   const isActive = isFocused || isHovered;
   const hasTargetText = segment.targetText.trim().length > 0;
-  const isActionBlocked = isApproving || isSavingDraft;
+  const isActionBlocked =
+    isApproving ||
+    isSavingDraft ||
+    isPostingComment ||
+    isLookingUpContext ||
+    isAiSuggestionLoading ||
+    isFormatChecksLoading ||
+    isTargetLoading;
   const canTriggerApprove =
     Boolean(onApprove) && canEdit && isDirty && hasTargetText && !isActionBlocked;
   const showDirtyActions = isFocused && isDirty && canEdit && Boolean(onApprove);

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import { ImageIcon } from "lucide-react";
 import { useHotkeys } from "react-hotkeys-hook";
-import { FormattedMessage } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -9,10 +10,26 @@ import { Spinner } from "@/components/ui/spinner";
 import { useIsMac } from "@/hooks/use-is-mac";
 import { cn } from "@/lib/primitives/cn";
 
+import {
+  CatEditorImageSourceSection,
+  CatEditorImageTargetSection,
+} from "@/components/cat/editor/cat-editor-image-sections";
 import { CatEditorShortcutKbd } from "@/components/cat/editor/cat-editor-shortcut-kbd";
+import { CatImagePreview } from "@/components/cat/editor/cat-image-preview";
 import { CatMessagePreview, CatTargetEditor } from "@/components/cat/editor/cat-target-editor";
-import { catEditorPanelMessages } from "@/components/cat/shared/cat.messages";
+import {
+  catEditorPanelMessages,
+  catSideBySidePanelMessages,
+} from "@/components/cat/shared/cat.messages";
 import type { CatSegment } from "@/components/cat/shared/types";
+
+function isImageEditorSegment(segment: CatSegment) {
+  return segment.contentKind === "image_file" || segment.contentKind === "image_url";
+}
+
+function hasImageTarget(segment: CatSegment) {
+  return Boolean(segment.targetAssetUrl || segment.targetText.trim());
+}
 
 export function CatSideBySideRow({
   segment,
@@ -27,12 +44,16 @@ export function CatSideBySideRow({
   isLookingUpContext = false,
   isAiSuggestionLoading = false,
   isFormatChecksLoading = false,
+  isImageBusy = false,
   onFocus,
   onHover,
   onLeave,
   onTargetChange,
   onApprove,
   onSaveDraft,
+  onTreatAsImage,
+  onRegenerateImage,
+  onUploadImage,
 }: {
   segment: CatSegment;
   isFocused: boolean;
@@ -46,16 +67,25 @@ export function CatSideBySideRow({
   isLookingUpContext?: boolean;
   isAiSuggestionLoading?: boolean;
   isFormatChecksLoading?: boolean;
+  isImageBusy?: boolean;
   onFocus: () => void;
   onHover: () => void;
   onLeave: () => void;
   onTargetChange: (value: string) => void;
   onApprove?: () => void;
   onSaveDraft?: () => void;
+  onTreatAsImage?: (treatAsImage: boolean) => void;
+  onRegenerateImage?: () => void;
+  onUploadImage?: (file: File) => void;
 }) {
+  const intl = useIntl();
   const isMac = useIsMac();
   const isActive = isFocused || isHovered;
-  const hasTargetText = segment.targetText.trim().length > 0;
+  const isImageSegment = isImageEditorSegment(segment);
+  const showImageSource = isImageSegment || Boolean(segment.looksLikeImageUrl);
+  const hasApprovingTarget = isImageSegment
+    ? hasImageTarget(segment)
+    : segment.targetText.trim().length > 0;
   const isActionBlocked =
     isApproving ||
     isSavingDraft ||
@@ -63,10 +93,18 @@ export function CatSideBySideRow({
     isLookingUpContext ||
     isAiSuggestionLoading ||
     isFormatChecksLoading ||
-    isTargetLoading;
+    isTargetLoading ||
+    isImageBusy;
+  // Image uploads update assets without a text dirty flag; show Approve whenever focused.
   const canTriggerApprove =
-    Boolean(onApprove) && canEdit && isDirty && hasTargetText && !isActionBlocked;
-  const showDirtyActions = isFocused && isDirty && canEdit && Boolean(onApprove);
+    Boolean(onApprove) &&
+    canEdit &&
+    hasApprovingTarget &&
+    !isActionBlocked &&
+    (isImageSegment || isDirty);
+  const showReviewActions =
+    isFocused && canEdit && Boolean(onApprove) && (isImageSegment || isDirty);
+  const canEditTarget = canEdit && !isImageBusy;
 
   useHotkeys(
     "mod+enter",
@@ -90,6 +128,40 @@ export function CatSideBySideRow({
     [canTriggerApprove, isFocused, onApprove],
   );
 
+  const reviewActions = showReviewActions ? (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button
+        type="button"
+        variant="default"
+        size="sm"
+        className="h-8 gap-1.5 px-2.5"
+        onClick={onApprove}
+        disabled={!canTriggerApprove}
+      >
+        {isApproving ? <Spinner className="size-3.5 text-primary-foreground" /> : null}
+        <FormattedMessage {...catEditorPanelMessages.approve} />
+        <CatEditorShortcutKbd
+          shortcut="approve"
+          isMac={isMac}
+          className="bg-primary-foreground/15 text-primary-foreground"
+        />
+      </Button>
+      {onSaveDraft && !isImageSegment ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-8 gap-1.5 px-2.5"
+          onClick={onSaveDraft}
+          disabled={!canTriggerApprove}
+        >
+          {isSavingDraft ? <Spinner className="size-3.5" /> : null}
+          <FormattedMessage {...catEditorPanelMessages.saveAsDraft} />
+        </Button>
+      ) : null}
+    </div>
+  ) : null;
+
   return (
     <div
       className={cn(
@@ -101,18 +173,58 @@ export function CatSideBySideRow({
       onMouseLeave={onLeave}
       onFocus={onFocus}
     >
-      <div className="flex min-w-0 flex-col gap-1 border-r border-border px-4 py-3">
-        <p className="text-sm leading-relaxed text-foreground">
-          <CatMessagePreview message={segment.sourceText} />
-        </p>
-        <p className="truncate font-mono text-[11px] text-muted-foreground" title={segment.key}>
-          {segment.key}
-        </p>
+      <div className="min-w-0 border-r border-border px-4 py-3">
+        {isFocused && showImageSource ? (
+          <CatEditorImageSourceSection
+            segment={segment}
+            canEdit={canEditTarget}
+            isBusy={isImageBusy}
+            onTreatAsImage={onTreatAsImage}
+            onRegenerate={onRegenerateImage}
+          />
+        ) : isImageSegment ? (
+          <button type="button" className="w-full space-y-2 text-left" onClick={onFocus}>
+            <CatImagePreview
+              src={
+                segment.contentKind === "image_file"
+                  ? segment.sourceAssetUrl
+                  : (segment.sourceAssetUrl ?? segment.sourceText)
+              }
+              alt={intl.formatMessage(catEditorPanelMessages.imageSourceAlt)}
+              emptyLabel={intl.formatMessage(catEditorPanelMessages.imageSourceEmpty)}
+              className="min-h-24"
+            />
+            <p className="truncate font-mono text-[11px] text-muted-foreground" title={segment.key}>
+              {segment.key}
+            </p>
+          </button>
+        ) : (
+          <div className="flex min-w-0 flex-col gap-1">
+            <p className="text-sm leading-relaxed text-foreground">
+              <CatMessagePreview message={segment.sourceText} />
+            </p>
+            <p className="truncate font-mono text-[11px] text-muted-foreground" title={segment.key}>
+              {segment.key}
+            </p>
+          </div>
+        )}
       </div>
 
       <div className="min-w-0 px-4 py-2.5">
         {isFocused && canEdit ? (
-          isTargetLoading && !segment.targetText.trim() ? (
+          isImageSegment ? (
+            <div className="space-y-2">
+              <CatEditorImageTargetSection
+                segment={segment}
+                canEdit={canEditTarget}
+                isBusy={isImageBusy}
+                isLoading={isTargetLoading}
+                onUpload={onUploadImage}
+                onRegenerate={onRegenerateImage}
+              />
+              {reviewActions}
+            </div>
+          ) : isTargetLoading && !segment.targetText.trim() ? (
             <Skeleton className="h-10 w-full rounded-lg" />
           ) : (
             <div className="space-y-2">
@@ -123,44 +235,33 @@ export function CatSideBySideRow({
                 compact
                 onChange={onTargetChange}
               />
-              {showDirtyActions ? (
-                <div className="flex flex-wrap items-center gap-2">
-                  <Button
-                    type="button"
-                    variant="default"
-                    size="sm"
-                    className="h-8 gap-1.5 px-2.5"
-                    onClick={onApprove}
-                    disabled={!canTriggerApprove}
-                  >
-                    {isApproving ? <Spinner className="size-3.5 text-primary-foreground" /> : null}
-                    <FormattedMessage {...catEditorPanelMessages.approve} />
-                    <CatEditorShortcutKbd
-                      shortcut="approve"
-                      isMac={isMac}
-                      className="bg-primary-foreground/15 text-primary-foreground"
-                    />
-                  </Button>
-                  {onSaveDraft ? (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="h-8 gap-1.5 px-2.5"
-                      onClick={onSaveDraft}
-                      disabled={!canTriggerApprove}
-                    >
-                      {isSavingDraft ? <Spinner className="size-3.5" /> : null}
-                      <FormattedMessage {...catEditorPanelMessages.saveAsDraft} />
-                    </Button>
-                  ) : null}
-                </div>
-              ) : null}
+              {reviewActions}
             </div>
           )
         ) : (
           <button type="button" className="w-full text-left" onClick={onFocus}>
-            {isTargetLoading && !segment.targetText.trim() ? (
+            {isImageSegment ? (
+              isTargetLoading && !hasImageTarget(segment) ? (
+                <Skeleton className="h-24 w-full rounded-lg" />
+              ) : hasImageTarget(segment) ? (
+                <CatImagePreview
+                  src={
+                    segment.targetAssetUrl ??
+                    (segment.contentKind === "image_url" && /^https?:\/\//i.test(segment.targetText)
+                      ? segment.targetText
+                      : null)
+                  }
+                  alt={intl.formatMessage(catEditorPanelMessages.imageTargetAlt)}
+                  emptyLabel={intl.formatMessage(catEditorPanelMessages.imageTargetEmpty)}
+                  className="min-h-24"
+                />
+              ) : (
+                <p className="flex items-center gap-2 text-sm text-muted-foreground italic">
+                  <ImageIcon className="size-4" aria-hidden />
+                  <FormattedMessage {...catSideBySidePanelMessages.clickToLocalizeImage} />
+                </p>
+              )
+            ) : isTargetLoading && !segment.targetText.trim() ? (
               <Skeleton className="h-6 w-3/4 rounded-full" />
             ) : segment.targetText.trim() ? (
               <p className="text-sm leading-relaxed text-foreground">

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-virtual-list.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-virtual-list.tsx
@@ -20,6 +20,10 @@ export function CatSideBySideVirtualList({
   loadingSegmentIds,
   isApproving = false,
   isSavingDraft = false,
+  isPostingComment = false,
+  isLookingUpContext = false,
+  isAiSuggestionLoading = false,
+  isFormatChecksLoading = false,
   onFocusSegment,
   onHoverSegment,
   onLeaveSegment,
@@ -40,6 +44,10 @@ export function CatSideBySideVirtualList({
   loadingSegmentIds?: ReadonlySet<string>;
   isApproving?: boolean;
   isSavingDraft?: boolean;
+  isPostingComment?: boolean;
+  isLookingUpContext?: boolean;
+  isAiSuggestionLoading?: boolean;
+  isFormatChecksLoading?: boolean;
   onFocusSegment: (segmentId: string) => void;
   onHoverSegment: (segmentId: string) => void;
   onLeaveSegment: () => void;
@@ -145,6 +153,10 @@ export function CatSideBySideVirtualList({
                 isTargetLoading={loadingSegmentIds?.has(segment.id) ?? false}
                 isApproving={isApproving && segment.id === focusedSegmentId}
                 isSavingDraft={isSavingDraft && segment.id === focusedSegmentId}
+                isPostingComment={isPostingComment}
+                isLookingUpContext={isLookingUpContext}
+                isAiSuggestionLoading={isAiSuggestionLoading}
+                isFormatChecksLoading={isFormatChecksLoading}
                 onFocus={() => onFocusSegment(segment.id)}
                 onHover={() => onHoverSegment(segment.id)}
                 onLeave={onLeaveSegment}

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-virtual-list.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-virtual-list.tsx
@@ -18,11 +18,15 @@ export function CatSideBySideVirtualList({
   dirtySegmentIds,
   canEdit,
   loadingSegmentIds,
+  isApproving = false,
+  isSavingDraft = false,
   onFocusSegment,
   onHoverSegment,
   onLeaveSegment,
   onVisibleSegmentIdsChange,
   onTargetChange,
+  onApprove,
+  onSaveDraft,
   hasMore = false,
   isLoadingMore = false,
   onNearEnd,
@@ -34,11 +38,15 @@ export function CatSideBySideVirtualList({
   dirtySegmentIds?: ReadonlySet<string>;
   canEdit: boolean;
   loadingSegmentIds?: ReadonlySet<string>;
+  isApproving?: boolean;
+  isSavingDraft?: boolean;
   onFocusSegment: (segmentId: string) => void;
   onHoverSegment: (segmentId: string) => void;
   onLeaveSegment: () => void;
   onVisibleSegmentIdsChange: (segmentIds: string[]) => void;
   onTargetChange: (segmentId: string, value: string) => void;
+  onApprove?: (segmentId: string) => void;
+  onSaveDraft?: (segmentId: string) => void;
   hasMore?: boolean;
   isLoadingMore?: boolean;
   onNearEnd?: () => void;
@@ -135,10 +143,14 @@ export function CatSideBySideVirtualList({
                 isDirty={dirtySegmentIds?.has(segment.id) ?? false}
                 canEdit={canEdit}
                 isTargetLoading={loadingSegmentIds?.has(segment.id) ?? false}
+                isApproving={isApproving && segment.id === focusedSegmentId}
+                isSavingDraft={isSavingDraft && segment.id === focusedSegmentId}
                 onFocus={() => onFocusSegment(segment.id)}
                 onHover={() => onHoverSegment(segment.id)}
                 onLeave={onLeaveSegment}
                 onTargetChange={(value) => onTargetChange(segment.id, value)}
+                onApprove={onApprove ? () => onApprove(segment.id) : undefined}
+                onSaveDraft={onSaveDraft ? () => onSaveDraft(segment.id) : undefined}
               />
             </div>
           );

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-virtual-list.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-virtual-list.tsx
@@ -24,6 +24,7 @@ export function CatSideBySideVirtualList({
   isLookingUpContext = false,
   isAiSuggestionLoading = false,
   isFormatChecksLoading = false,
+  isImageBusy = false,
   onFocusSegment,
   onHoverSegment,
   onLeaveSegment,
@@ -31,6 +32,9 @@ export function CatSideBySideVirtualList({
   onTargetChange,
   onApprove,
   onSaveDraft,
+  onTreatAsImage,
+  onRegenerateImage,
+  onUploadImage,
   hasMore = false,
   isLoadingMore = false,
   onNearEnd,
@@ -48,6 +52,7 @@ export function CatSideBySideVirtualList({
   isLookingUpContext?: boolean;
   isAiSuggestionLoading?: boolean;
   isFormatChecksLoading?: boolean;
+  isImageBusy?: boolean;
   onFocusSegment: (segmentId: string) => void;
   onHoverSegment: (segmentId: string) => void;
   onLeaveSegment: () => void;
@@ -55,6 +60,9 @@ export function CatSideBySideVirtualList({
   onTargetChange: (segmentId: string, value: string) => void;
   onApprove?: (segmentId: string) => void;
   onSaveDraft?: (segmentId: string) => void;
+  onTreatAsImage?: (segmentId: string, treatAsImage: boolean) => void;
+  onRegenerateImage?: (segmentId: string) => void;
+  onUploadImage?: (segmentId: string, file: File) => void;
   hasMore?: boolean;
   isLoadingMore?: boolean;
   onNearEnd?: () => void;
@@ -157,12 +165,24 @@ export function CatSideBySideVirtualList({
                 isLookingUpContext={isLookingUpContext}
                 isAiSuggestionLoading={isAiSuggestionLoading}
                 isFormatChecksLoading={isFormatChecksLoading}
+                isImageBusy={isImageBusy && segment.id === focusedSegmentId}
                 onFocus={() => onFocusSegment(segment.id)}
                 onHover={() => onHoverSegment(segment.id)}
                 onLeave={onLeaveSegment}
                 onTargetChange={(value) => onTargetChange(segment.id, value)}
                 onApprove={onApprove ? () => onApprove(segment.id) : undefined}
                 onSaveDraft={onSaveDraft ? () => onSaveDraft(segment.id) : undefined}
+                onTreatAsImage={
+                  onTreatAsImage
+                    ? (treatAsImage) => onTreatAsImage(segment.id, treatAsImage)
+                    : undefined
+                }
+                onRegenerateImage={
+                  onRegenerateImage ? () => onRegenerateImage(segment.id) : undefined
+                }
+                onUploadImage={
+                  onUploadImage ? (file) => onUploadImage(segment.id, file) : undefined
+                }
               />
             </div>
           );

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side.stories.tsx
@@ -1,0 +1,162 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
+
+import { CatWorkspaceContainer } from "@/components/cat/workspace/cat-workspace-container";
+import {
+  catIntelligenceFixture,
+  createCatWorkspaceState,
+  mockValidateFormat,
+} from "@/components/cat/shared/cat.fixture";
+import {
+  CAT_WORKSPACE_VIEW_MODE_STORAGE_KEY,
+  writeCatWorkspaceViewMode,
+} from "@/components/cat/workspace/cat-workspace-view-mode";
+
+const meta = {
+  title: "CAT/Side by side",
+  component: CatWorkspaceContainer,
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story) => {
+      writeCatWorkspaceViewMode("side-by-side");
+      return (
+        <div className="h-svh min-w-[1100px] bg-background text-foreground">
+          <Story />
+        </div>
+      );
+    },
+  ],
+} satisfies Meta<typeof CatWorkspaceContainer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const sideBySideArgs = {
+  initialState: createCatWorkspaceState({
+    segmentIntelligence: {
+      "seg-02": {
+        ...catIntelligenceFixture,
+        agentContext:
+          "Cached repository context: this card is rendered in the dashboard overview after a project sync.",
+      },
+    },
+  }),
+  navigation: {
+    onSelectSegment: fn(),
+    onPreviousSegment: fn(),
+    onNextSegment: fn(),
+    onReviewInSequence: fn(),
+  },
+  editing: {
+    onTargetChange: fn(),
+    onUseAiSuggestion: fn(),
+  },
+  review: {
+    onApprove: fn(),
+    onSaveDraft: fn(),
+    onAskQuestion: fn(),
+  },
+  services: {
+    validateFormat: mockValidateFormat,
+    lookupSegmentContext: async () =>
+      "Cached repository context: this card is rendered in the dashboard overview after a project sync.",
+  },
+} satisfies Story["args"];
+
+export const Default: Story = {
+  args: sideBySideArgs,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText("Source string")).toBeInTheDocument();
+    await expect(canvas.getByText("Translation")).toBeInTheDocument();
+    await expect(canvas.getByText("dashboard.reviews.pending.card")).toBeInTheDocument();
+    await expect(canvas.getByRole("textbox", { name: "Target translation" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: /Find context/i })).toBeInTheDocument();
+    await expect(canvas.queryByRole("button", { name: /^Approve/i })).not.toBeInTheDocument();
+  },
+};
+
+export const DirtySaveActions: Story = {
+  args: sideBySideArgs,
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const targetEditor = await canvas.findByRole("textbox", { name: "Target translation" });
+
+    await userEvent.click(targetEditor);
+    await userEvent.keyboard("{Control>}a{/Control}Updated SBS translation");
+
+    await waitFor(() =>
+      expect(canvas.getByRole("button", { name: /^Approve/i })).toBeInTheDocument(),
+    );
+    await expect(canvas.getByRole("button", { name: /Save as draft/i })).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole("button", { name: /Save as draft/i }));
+    await expect(args.review?.onSaveDraft).toHaveBeenCalled();
+
+    await waitFor(() =>
+      expect(canvas.queryByRole("button", { name: /^Approve/i })).not.toBeInTheDocument(),
+    );
+
+    await userEvent.click(targetEditor);
+    await userEvent.keyboard("!");
+
+    await waitFor(() =>
+      expect(canvas.getByRole("button", { name: /^Approve/i })).toBeInTheDocument(),
+    );
+    await userEvent.click(canvas.getByRole("button", { name: /^Approve/i }));
+    await expect(args.review?.onApprove).toHaveBeenCalled();
+  },
+};
+
+export const ComfortableFallbackOnMobile: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: "mobile1",
+    },
+  },
+  decorators: [
+    (Story) => {
+      writeCatWorkspaceViewMode("side-by-side");
+      return (
+        <div className="h-svh bg-background text-foreground">
+          <Story />
+        </div>
+      );
+    },
+  ],
+  args: sideBySideArgs,
+  play: async ({ canvasElement }) => {
+    window.resizeTo(390, 844);
+    window.dispatchEvent(new Event("resize"));
+
+    const canvas = within(canvasElement);
+
+    await waitFor(() => expect(canvas.getByRole("tab", { name: "Edit" })).toBeInTheDocument());
+    await expect(canvas.getByRole("tab", { name: "Queue" })).toBeInTheDocument();
+    await expect(canvas.getByRole("tab", { name: "AI" })).toBeInTheDocument();
+    await expect(canvas.queryByText("Source string")).not.toBeInTheDocument();
+  },
+};
+
+export const PersistenceRoundTrip: Story = {
+  args: sideBySideArgs,
+  play: async ({ canvasElement }) => {
+    await expect(window.localStorage.getItem(CAT_WORKSPACE_VIEW_MODE_STORAGE_KEY)).toBe(
+      "side-by-side",
+    );
+
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Source string")).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole("button", { name: /Side by side/i }));
+    await userEvent.click(canvas.getByRole("menuitemradio", { name: /Comfortable/i }));
+
+    await waitFor(() => expect(canvas.getByText("Queue")).toBeInTheDocument());
+    await expect(window.localStorage.getItem(CAT_WORKSPACE_VIEW_MODE_STORAGE_KEY)).toBe(
+      "comfortable",
+    );
+  },
+};

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
@@ -296,20 +296,20 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
           onFocusSegment={dependencies.navigation.onSelectSegment}
           onTargetChange={(segmentId, value) => editing.onTargetChange(segmentId, value)}
           onApprove={(segmentId) => {
-            const segment = queueSegments.find((item) => item.id === segmentId);
-            if (!segment) {
+            const targetText = store.getSegmentView(segmentId)?.targetText;
+            if (targetText === undefined) {
               return;
             }
-            void review.onApprove(segmentId, segment.targetText);
+            void review.onApprove(segmentId, targetText);
           }}
           onSaveDraft={
             review.onSaveDraft
               ? (segmentId) => {
-                  const segment = queueSegments.find((item) => item.id === segmentId);
-                  if (!segment) {
+                  const targetText = store.getSegmentView(segmentId)?.targetText;
+                  if (targetText === undefined) {
                     return;
                   }
-                  void review.onSaveDraft?.(segmentId, segment.targetText);
+                  void review.onSaveDraft?.(segmentId, targetText);
                 }
               : undefined
           }

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
@@ -295,6 +295,24 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
           onLoadMoreQueue={onLoadMoreQueue}
           onFocusSegment={dependencies.navigation.onSelectSegment}
           onTargetChange={(segmentId, value) => editing.onTargetChange(segmentId, value)}
+          onApprove={(segmentId) => {
+            const segment = queueSegments.find((item) => item.id === segmentId);
+            if (!segment) {
+              return;
+            }
+            void review.onApprove(segmentId, segment.targetText);
+          }}
+          onSaveDraft={
+            review.onSaveDraft
+              ? (segmentId) => {
+                  const segment = queueSegments.find((item) => item.id === segmentId);
+                  if (!segment) {
+                    return;
+                  }
+                  void review.onSaveDraft?.(segmentId, segment.targetText);
+                }
+              : undefined
+          }
           onAskQuestion={
             intelligenceSegment ? () => review.onAskQuestion(intelligenceSegment.id) : undefined
           }

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
@@ -275,6 +275,7 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
           isSavingDraft={isSavingDraft}
           isAiSuggestionLoading={isAiSuggestionLoading}
           isFormatChecksLoading={isFormatChecksLoading}
+          isImageBusy={isImageBusy}
           isConcordanceLoading={isConcordanceLoading}
           isVisualContextLoading={isVisualContextLoading}
           showAgentContext={
@@ -311,6 +312,21 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
                   }
                   void review.onSaveDraft?.(segmentId, targetText);
                 }
+              : undefined
+          }
+          onTreatAsImage={
+            editing.onTreatAsImage
+              ? (segmentId, treatAsImage) => void editing.onTreatAsImage?.(segmentId, treatAsImage)
+              : undefined
+          }
+          onRegenerateImage={
+            editing.onRegenerateImage
+              ? (segmentId) => void editing.onRegenerateImage?.(segmentId)
+              : undefined
+          }
+          onUploadImage={
+            editing.onUploadImage
+              ? (segmentId, file) => void editing.onUploadImage?.(segmentId, file)
               : undefined
           }
           onAskQuestion={


### PR DESCRIPTION
## What changed

Side-by-side CAT view could edit targets but had no way to persist them. Approve and Save as draft now appear under the focused dirty translation input (with Mod+Enter for approve), wired through the existing review handlers. Also added SBS Storybook stories and row unit tests.

## How to test

- [ ] Open CAT workspace, switch to Side by side (desktop ≥1024px)
- [ ] Edit a translation → Approve / Save as draft appear under the input
- [ ] Save as draft persists and hides the buttons when clean
- [ ] Approve advances / persists like Comfortable
- [ ] Mod+Enter approves when the focused row is dirty
- [ ] `vp test src/components/cat/side-by-side/`
- [ ] Storybook: `CAT/Side by side` → Default, DirtySaveActions, ComfortableFallbackOnMobile

## Checklist

- [x] I ran relevant checks locally (`vp test` for SBS; `vp check --fix` on changed files)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review