### PR TITLE
fix(chat): stop dock composer from resetting while typing

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+
+import { useState, type ReactNode } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IntlProvider } from "react-intl";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { PromptInputProvider } from "@/components/ai-elements/prompt-input";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+import { repositoriesFixture } from "./inbox.fixture";
+import { ReplyComposerView } from "./reply-composer";
+
+function DraftBackedComposer({
+  initialDraft = "",
+  onDraftChange,
+}: {
+  initialDraft?: string;
+  onDraftChange?: (draft: string) => void;
+}) {
+  const [draft, setDraft] = useState(initialDraft);
+
+  return (
+    <PromptInputProvider initialInput={draft}>
+      <ReplyComposerView
+        disabled={false}
+        draft={draft}
+        isStreaming={false}
+        onDraftChange={(next) => {
+          setDraft(next);
+          onDraftChange?.(next);
+        }}
+        onSend={vi.fn()}
+        repositories={repositoriesFixture}
+        repositoriesIsError={false}
+        repositoriesIsLoading={false}
+      />
+    </PromptInputProvider>
+  );
+}
+
+function renderComposer(ui: ReactNode) {
+  return render(
+    <IntlProvider locale="en" messages={{}}>
+      <TooltipProvider>{ui}</TooltipProvider>
+    </IntlProvider>,
+  );
+}
+
+describe("ReplyComposerView draft sync", () => {
+  it("keeps typed characters when draft is lifted to parent state", async () => {
+    const user = userEvent.setup();
+    const onDraftChange = vi.fn();
+
+    renderComposer(<DraftBackedComposer onDraftChange={onDraftChange} />);
+
+    const textarea = screen.getByRole("textbox");
+    await user.type(textarea, "Translate the checkout page");
+
+    expect(textarea).toHaveValue("Translate the checkout page");
+    expect(onDraftChange).toHaveBeenLastCalledWith("Translate the checkout page");
+  });
+
+  it("keeps typed characters when draft is not controlled by a parent", async () => {
+    const user = userEvent.setup();
+
+    renderComposer(
+      <PromptInputProvider>
+        <ReplyComposerView
+          disabled={false}
+          isStreaming={false}
+          onSend={vi.fn()}
+          repositories={repositoriesFixture}
+          repositoriesIsError={false}
+          repositoriesIsLoading={false}
+        />
+      </PromptInputProvider>,
+    );
+
+    const textarea = screen.getByRole("textbox");
+    await user.type(textarea, "Hello dock");
+
+    expect(textarea).toHaveValue("Hello dock");
+  });
+
+  it("applies external draft updates such as suggestion chips", async () => {
+    const user = userEvent.setup();
+
+    function Harness() {
+      const [draft, setDraft] = useState("");
+
+      return (
+        <>
+          <button type="button" onClick={() => setDraft("Suggested prompt")}>
+            Apply suggestion
+          </button>
+          <PromptInputProvider initialInput={draft}>
+            <ReplyComposerView
+              disabled={false}
+              draft={draft}
+              isStreaming={false}
+              onDraftChange={setDraft}
+              onSend={vi.fn()}
+              repositories={repositoriesFixture}
+              repositoriesIsError={false}
+              repositoriesIsLoading={false}
+            />
+          </PromptInputProvider>
+        </>
+      );
+    }
+
+    renderComposer(<Harness />);
+
+    await user.click(screen.getByRole("button", { name: "Apply suggestion" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox")).toHaveValue("Suggested prompt");
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
@@ -79,14 +79,17 @@ export function ReplyComposerView({
   const [replyText, setReplyText] = useState(draft);
   const [selectedRepositoryFullName, setSelectedRepositoryFullName] = useState("");
   const promptInputController = usePromptInputController();
+  // Stable across keystrokes; the controller object itself is recreated whenever
+  // textInput changes, so it must not be an effect dependency.
+  const setInput = promptInputController.textInput.setInput;
 
+  // Sync only when the external draft prop changes (e.g. suggestion chips).
+  // Depending on the controller identity or local replyText re-ran this on every
+  // keystroke and reset the textarea when draft lagged one render behind.
   useEffect(() => {
-    if (draft === replyText) {
-      return;
-    }
     setReplyText(draft);
-    promptInputController.textInput.setInput(draft);
-  }, [draft, promptInputController, replyText]);
+    setInput(draft);
+  }, [draft, setInput]);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The chat dock composer cleared itself on every keystroke, so users could not type.

The draft sync effect in `ReplyComposerView` depended on the `PromptInput` controller object. That controller is recreated whenever the textarea value changes, so the effect re-ran on each keystroke and reset the input whenever the external `draft` prop lagged one render behind (including the uncontrolled inbox path where `draft` stays `""`).

## Fix

- Sync local/controller input **only when the external `draft` prop changes** (e.g. suggestion chips).
- Depend on the stable `setInput` callback instead of the controller object identity.
- Add regression tests covering controlled drafts, uncontrolled typing, and external suggestion updates.

## Test plan

- [x] `vp test` for `reply-composer.test.tsx`
- [x] `vp check --fix`
- [ ] Manually: open chat dock → type in composer → text should remain
- [ ] Manually: click an empty-state suggestion chip → prompt should fill the composer

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5f48-1120-758e-9781-4e4595c526a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5f48-1120-758e-9781-4e4595c526a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

