### PR TITLE
fix(cat): stop focus from marking loaded messages as draft

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-target-editor.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-target-editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { Extension, type Extensions } from "@tiptap/core";
@@ -293,6 +293,8 @@ export function CatTargetEditor({
   onChange: (value: string) => void;
 }) {
   const intl = useIntl();
+  const valueRef = useRef(value);
+  valueRef.current = value;
   const sourceAnalysis = useMemo(() => analyzeCatMessageFormat(sourceText), [sourceText]);
   const targetAnalysis = useMemo(() => analyzeCatMessageFormat(value), [value]);
   const parityIssues = useMemo(
@@ -314,7 +316,13 @@ export function CatTargetEditor({
     editable: !disabled,
     immediatelyRender: false,
     onUpdate: ({ editor: activeEditor }) => {
-      onChange(editorText(activeEditor));
+      const nextValue = editorText(activeEditor);
+      // Ignore no-op updates (e.g. mount/focus round-trips) so focusing a loaded
+      // translation does not mark the segment as an unsaved draft.
+      if (nextValue === valueRef.current) {
+        return;
+      }
+      onChange(nextValue);
     },
     editorProps: {
       attributes: {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.test.ts
@@ -352,6 +352,35 @@ describe("CatWorkspaceOrchestrator hydration", () => {
     expect(store.dirtySegmentIds.has("seg-01")).toBe(true);
   });
 
+  it("prefers the first server translation over a speculative TM auto-fill draft", () => {
+    const store = createCatWorkspace(
+      createCatWorkspaceState({
+        selectedSegmentId: "seg-01",
+        queueSegments: [{ id: "seg-01", index: 1, key: "hero.title", sourceText: "Hello" }],
+        segments: [],
+      }),
+    );
+
+    store.setTargetText("seg-01", "Bonjour depuis la MT");
+    store.autoFilledSegmentIds.add("seg-01");
+    expect(store.hasHydratedTarget("seg-01")).toBe(false);
+    expect(store.dirtySegmentIds.has("seg-01")).toBe(true);
+
+    store.applySegmentTarget("seg-01", {
+      text: "Bonjour",
+      externalTranslationId: "translation-1",
+      isApproved: false,
+    });
+
+    expect(store.getSegmentView("seg-01")).toMatchObject({
+      targetText: "Bonjour",
+      status: "needs_review",
+    });
+    expect(store.hasHydratedTarget("seg-01")).toBe(true);
+    expect(store.dirtySegmentIds.has("seg-01")).toBe(false);
+    expect(store.autoFilledSegmentIds.has("seg-01")).toBe(false);
+  });
+
   it("keeps lazy-loaded comments when queue snapshots omit comment bodies", () => {
     const queueState = createCatWorkspaceState({
       selectedSegmentId: "seg-01",

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.test.ts
@@ -361,8 +361,8 @@ describe("CatWorkspaceOrchestrator hydration", () => {
       }),
     );
 
+    store.markAutoFilledTarget("seg-01", "Bonjour depuis la MT");
     store.setTargetText("seg-01", "Bonjour depuis la MT");
-    store.autoFilledSegmentIds.add("seg-01");
     expect(store.hasHydratedTarget("seg-01")).toBe(false);
     expect(store.dirtySegmentIds.has("seg-01")).toBe(true);
 
@@ -379,6 +379,70 @@ describe("CatWorkspaceOrchestrator hydration", () => {
     expect(store.hasHydratedTarget("seg-01")).toBe(true);
     expect(store.dirtySegmentIds.has("seg-01")).toBe(false);
     expect(store.autoFilledSegmentIds.has("seg-01")).toBe(false);
+  });
+
+  it("replaces untouched TM auto-fill when a later lazy target refetch returns text", () => {
+    const store = createCatWorkspace(
+      createCatWorkspaceState({
+        selectedSegmentId: "seg-01",
+        queueSegments: [{ id: "seg-01", index: 1, key: "hero.title", sourceText: "Hello" }],
+        segments: [],
+      }),
+    );
+
+    store.applySegmentTarget("seg-01", {
+      text: "",
+      externalTranslationId: null,
+      isApproved: false,
+    });
+    store.markAutoFilledTarget("seg-01", "Bonjour depuis la MT");
+    store.setTargetText("seg-01", "Bonjour depuis la MT");
+    expect(store.hasHydratedTarget("seg-01")).toBe(true);
+    expect(store.dirtySegmentIds.has("seg-01")).toBe(true);
+
+    store.applySegmentTarget("seg-01", {
+      text: "Bonjour",
+      externalTranslationId: "translation-1",
+      isApproved: false,
+    });
+
+    expect(store.getSegmentView("seg-01")).toMatchObject({
+      targetText: "Bonjour",
+      status: "needs_review",
+    });
+    expect(store.dirtySegmentIds.has("seg-01")).toBe(false);
+    expect(store.autoFilledSegmentIds.has("seg-01")).toBe(false);
+  });
+
+  it("keeps user edits after TM auto-fill when a later server refetch arrives", () => {
+    const store = createCatWorkspace(
+      createCatWorkspaceState({
+        selectedSegmentId: "seg-01",
+        queueSegments: [{ id: "seg-01", index: 1, key: "hero.title", sourceText: "Hello" }],
+        segments: [],
+      }),
+    );
+
+    store.applySegmentTarget("seg-01", {
+      text: "",
+      externalTranslationId: null,
+      isApproved: false,
+    });
+    store.markAutoFilledTarget("seg-01", "Bonjour depuis la MT");
+    store.setTargetText("seg-01", "Bonjour depuis la MT");
+    store.setTargetText("seg-01", "Bonjour modifié");
+
+    store.applySegmentTarget("seg-01", {
+      text: "Bonjour",
+      externalTranslationId: "translation-1",
+      isApproved: true,
+    });
+
+    expect(store.getSegmentView("seg-01")).toMatchObject({
+      targetText: "Bonjour modifié",
+      status: "reviewed",
+    });
+    expect(store.dirtySegmentIds.has("seg-01")).toBe(true);
   });
 
   it("keeps lazy-loaded comments when queue snapshots omit comment bodies", () => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
@@ -170,6 +170,8 @@ export class CatWorkspaceOrchestrator {
   private lastHydratedSnapshot: CatWorkspaceState | null = null;
   private initialSegmentJumpApplied = false;
   autoFilledSegmentIds = new Set<string>();
+  /** Target text written by TM auto-fill; used to detect untouched speculative drafts. */
+  autoFilledTargetTexts = new Map<string, string>();
   /** Segment ids whose lazy (or snapshot) target payload has been applied at least once. */
   hydratedTargetSegmentIds = new Set<string>();
 
@@ -592,12 +594,30 @@ export class CatWorkspaceOrchestrator {
     this.lastHydratedSnapshot = null;
     this.initialSegmentJumpApplied = false;
     this.autoFilledSegmentIds = new Set();
+    this.autoFilledTargetTexts = new Map();
     this.hydratedTargetSegmentIds = new Set();
     this.ingestQueue(initialState, initialSegmentKeyOrId);
   }
 
   hasHydratedTarget(segmentId: string) {
     return this.hydratedTargetSegmentIds.has(segmentId);
+  }
+
+  markAutoFilledTarget(segmentId: string, targetText: string) {
+    this.autoFilledSegmentIds.add(segmentId);
+    this.autoFilledTargetTexts.set(segmentId, targetText);
+  }
+
+  clearAutoFilledTarget(segmentId: string) {
+    this.autoFilledSegmentIds.delete(segmentId);
+    this.autoFilledTargetTexts.delete(segmentId);
+  }
+
+  private isUntouchedAutoFilledDraft(segmentId: string, draft: CatSegmentDraft) {
+    return (
+      this.autoFilledSegmentIds.has(segmentId) &&
+      draft.targetText === this.autoFilledTargetTexts.get(segmentId)
+    );
   }
 
   ingestQueue(nextInitialState: CatWorkspaceState, initialSegmentKeyOrId?: string | null) {
@@ -709,19 +729,17 @@ export class CatWorkspaceOrchestrator {
     }
 
     const existingDraft = this.drafts.get(segmentId);
-    const wasHydrated = this.hydratedTargetSegmentIds.has(segmentId);
 
     if (existingDraft) {
       if (existingDraft.isDirty) {
-        // TM auto-fill can race ahead of the first lazy target fetch. Prefer the
-        // authoritative server translation over that speculative draft.
+        // Prefer authoritative server text over an untouched TM auto-fill draft,
+        // including when an empty first hydrate was later followed by a real translation.
         if (
-          !wasHydrated &&
-          this.autoFilledSegmentIds.has(segmentId) &&
-          targetText.trim().length > 0
+          targetText.trim().length > 0 &&
+          this.isUntouchedAutoFilledDraft(segmentId, existingDraft)
         ) {
           existingDraft.applyServerTarget(targetText, status);
-          this.autoFilledSegmentIds.delete(segmentId);
+          this.clearAutoFilledTarget(segmentId);
         } else {
           existingDraft.applyServerStatus(status);
         }
@@ -835,7 +853,7 @@ export class CatWorkspaceOrchestrator {
           this.segmentMeta.delete(segmentId);
           this.segmentComments.delete(segmentId);
           this.hydratedTargetSegmentIds.delete(segmentId);
-          this.autoFilledSegmentIds.delete(segmentId);
+          this.clearAutoFilledTarget(segmentId);
         }
       }
     }

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
@@ -170,6 +170,8 @@ export class CatWorkspaceOrchestrator {
   private lastHydratedSnapshot: CatWorkspaceState | null = null;
   private initialSegmentJumpApplied = false;
   autoFilledSegmentIds = new Set<string>();
+  /** Segment ids whose lazy (or snapshot) target payload has been applied at least once. */
+  hydratedTargetSegmentIds = new Set<string>();
 
   validationSequence = 0;
   reviewSequence = 0;
@@ -590,7 +592,12 @@ export class CatWorkspaceOrchestrator {
     this.lastHydratedSnapshot = null;
     this.initialSegmentJumpApplied = false;
     this.autoFilledSegmentIds = new Set();
+    this.hydratedTargetSegmentIds = new Set();
     this.ingestQueue(initialState, initialSegmentKeyOrId);
+  }
+
+  hasHydratedTarget(segmentId: string) {
+    return this.hydratedTargetSegmentIds.has(segmentId);
   }
 
   ingestQueue(nextInitialState: CatWorkspaceState, initialSegmentKeyOrId?: string | null) {
@@ -702,23 +709,39 @@ export class CatWorkspaceOrchestrator {
     }
 
     const existingDraft = this.drafts.get(segmentId);
+    const wasHydrated = this.hydratedTargetSegmentIds.has(segmentId);
 
     if (existingDraft) {
       if (existingDraft.isDirty) {
-        existingDraft.applyServerStatus(status);
+        // TM auto-fill can race ahead of the first lazy target fetch. Prefer the
+        // authoritative server translation over that speculative draft.
+        if (
+          !wasHydrated &&
+          this.autoFilledSegmentIds.has(segmentId) &&
+          targetText.trim().length > 0
+        ) {
+          existingDraft.applyServerTarget(targetText, status);
+          this.autoFilledSegmentIds.delete(segmentId);
+        } else {
+          existingDraft.applyServerStatus(status);
+        }
+        this.hydratedTargetSegmentIds.add(segmentId);
         return;
       }
 
       if (existingDraft.targetText.trim() && !targetText.trim()) {
         existingDraft.applyServerStatus(status);
+        this.hydratedTargetSegmentIds.add(segmentId);
         return;
       }
 
       existingDraft.applyServerTarget(targetText, status);
+      this.hydratedTargetSegmentIds.add(segmentId);
       return;
     }
 
     this.drafts.set(segmentId, new CatSegmentDraft(segmentId, targetText, status));
+    this.hydratedTargetSegmentIds.add(segmentId);
   }
 
   applySegmentComments(segmentId: string, comments: ProjectFileCatComment[]) {
@@ -757,6 +780,7 @@ export class CatWorkspaceOrchestrator {
     this.segmentMeta.clear();
     this.segmentComments.clear();
     this.drafts.clear();
+    this.hydratedTargetSegmentIds = new Set();
     this.segmentIntelligence = { ...segmentIntelligence };
 
     for (const meta of queueSegments) {
@@ -771,10 +795,12 @@ export class CatWorkspaceOrchestrator {
     this.segmentMeta.clear();
     this.segmentComments.clear();
     this.drafts.clear();
+    this.hydratedTargetSegmentIds = new Set();
     this.segmentIntelligence = { ...segmentIntelligence };
 
     for (const segment of segments) {
       this.segmentMeta.set(segment.id, toQueueSegment(segment));
+      this.hydratedTargetSegmentIds.add(segment.id);
       if (segment.comments !== undefined) {
         this.segmentComments.set(segment.id, segment.comments);
       }
@@ -808,6 +834,8 @@ export class CatWorkspaceOrchestrator {
           this.drafts.delete(segmentId);
           this.segmentMeta.delete(segmentId);
           this.segmentComments.delete(segmentId);
+          this.hydratedTargetSegmentIds.delete(segmentId);
+          this.autoFilledSegmentIds.delete(segmentId);
         }
       }
     }

--- a/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.test.ts
@@ -380,7 +380,9 @@ describe("CatIntelligenceController", () => {
         isApproved: false,
       });
 
-      await vi.waitFor(() => expect(workspace.getSegmentView("seg-02")?.targetText).toBe("Deuxième"));
+      await vi.waitFor(() =>
+        expect(workspace.getSegmentView("seg-02")?.targetText).toBe("Deuxième"),
+      );
 
       expect(workspace.autoFilledSegmentIds.has("seg-02")).toBe(true);
       expect(workspace.dirtySegmentIds.has("seg-02")).toBe(true);

--- a/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.test.ts
@@ -52,16 +52,22 @@ function createTestWorkspace(overrides: Parameters<typeof createCatWorkspaceStat
   );
 }
 
+let activeController: CatIntelligenceController | undefined;
+
 function createController(
   workspace = createTestWorkspace(),
   ports: ConstructorParameters<typeof CatIntelligenceController>[1] = { intl },
 ) {
+  activeController?.dispose();
   const controller = new CatIntelligenceController(workspace, ports);
   controller.start();
+  activeController = controller;
   return { controller, workspace };
 }
 
 afterEach(() => {
+  activeController?.dispose();
+  activeController = undefined;
   vi.clearAllMocks();
 });
 
@@ -240,6 +246,145 @@ describe("CatIntelligenceController", () => {
       await controller.loadConcordance("seg-02");
 
       expect(workspace.getSegmentView("seg-02")?.targetText).toBe("");
+    });
+
+    it("does not auto-fill before the lazy target has hydrated", async () => {
+      const lookup = vi.fn().mockResolvedValue({
+        glossaryTerms: [],
+        translationMemoryMatches: [
+          {
+            id: "tm-1",
+            sourceText: "Second",
+            targetText: "Deuxième",
+            matchPercent: 100,
+          },
+        ],
+      } satisfies CatSegmentConcordanceResult);
+      const workspace = createCatWorkspace(
+        createCatWorkspaceState({
+          selectedSegmentId: "seg-02",
+          queueSegments: [
+            { id: "seg-01", index: 1, key: "first", sourceText: "First" },
+            { id: "seg-02", index: 2, key: "second", sourceText: "Second" },
+          ],
+          segments: [],
+        }),
+      );
+      const { controller } = createController(workspace, {
+        intl,
+        services: { lookupSegmentConcordance: lookup },
+      });
+
+      await controller.loadConcordance("seg-02");
+
+      expect(workspace.hasHydratedTarget("seg-02")).toBe(false);
+      expect(workspace.getSegmentView("seg-02")?.targetText).toBe("");
+      expect(workspace.dirtySegmentIds.has("seg-02")).toBe(false);
+      expect(workspace.autoFilledSegmentIds.has("seg-02")).toBe(false);
+    });
+
+    it("does not mark a loaded translation dirty when concordance races ahead of target hydration", async () => {
+      let resolveLookup: ((value: CatSegmentConcordanceResult) => void) | undefined;
+      const lookup = vi.fn(
+        () =>
+          new Promise<CatSegmentConcordanceResult>((resolve) => {
+            resolveLookup = resolve;
+          }),
+      );
+      const workspace = createCatWorkspace(
+        createCatWorkspaceState({
+          selectedSegmentId: "seg-02",
+          queueSegments: [
+            { id: "seg-01", index: 1, key: "first", sourceText: "First" },
+            { id: "seg-02", index: 2, key: "second", sourceText: "Second" },
+          ],
+          segments: [],
+        }),
+      );
+      const { controller } = createController(workspace, {
+        intl,
+        services: { lookupSegmentConcordance: lookup },
+      });
+
+      const pending = controller.loadConcordance("seg-02");
+      resolveLookup?.({
+        glossaryTerms: [],
+        translationMemoryMatches: [
+          {
+            id: "tm-1",
+            sourceText: "Second",
+            targetText: "Depuis la MT",
+            matchPercent: 100,
+          },
+        ],
+      });
+      await pending;
+
+      expect(workspace.dirtySegmentIds.has("seg-02")).toBe(false);
+
+      workspace.applySegmentTarget("seg-02", {
+        text: "Traduction existante",
+        externalTranslationId: "translation-2",
+        isApproved: false,
+      });
+
+      await vi.waitFor(() => expect(workspace.hasHydratedTarget("seg-02")).toBe(true));
+
+      expect(workspace.getSegmentView("seg-02")?.targetText).toBe("Traduction existante");
+      expect(workspace.dirtySegmentIds.has("seg-02")).toBe(false);
+      expect(workspace.autoFilledSegmentIds.has("seg-02")).toBe(false);
+    });
+
+    it("auto-fills after an empty lazy target hydrates", async () => {
+      const onTargetChange = vi.fn();
+      let resolveLookup: ((value: CatSegmentConcordanceResult) => void) | undefined;
+      const lookup = vi.fn(
+        () =>
+          new Promise<CatSegmentConcordanceResult>((resolve) => {
+            resolveLookup = resolve;
+          }),
+      );
+      const workspace = createCatWorkspace(
+        createCatWorkspaceState({
+          selectedSegmentId: "seg-02",
+          queueSegments: [
+            { id: "seg-01", index: 1, key: "first", sourceText: "First" },
+            { id: "seg-02", index: 2, key: "second", sourceText: "Second" },
+          ],
+          segments: [],
+        }),
+      );
+      const { controller } = createController(workspace, {
+        intl,
+        editing: { onTargetChange },
+        services: { lookupSegmentConcordance: lookup },
+      });
+
+      const pending = controller.loadConcordance("seg-02");
+      resolveLookup?.({
+        glossaryTerms: [],
+        translationMemoryMatches: [
+          {
+            id: "tm-1",
+            sourceText: "Second",
+            targetText: "Deuxième",
+            matchPercent: 100,
+          },
+        ],
+      });
+      await pending;
+
+      workspace.applySegmentTarget("seg-02", {
+        text: "",
+        externalTranslationId: null,
+        isApproved: false,
+      });
+
+      await vi.waitFor(() => expect(workspace.getSegmentView("seg-02")?.targetText).toBe("Deuxième"));
+
+      expect(workspace.autoFilledSegmentIds.has("seg-02")).toBe(true);
+      expect(workspace.dirtySegmentIds.has("seg-02")).toBe(true);
+      expect(onTargetChange).toHaveBeenCalledWith("seg-02", "Deuxième");
     });
 
     it("records concordance lookup failures as format checks", async () => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.ts
@@ -82,8 +82,12 @@ export class CatIntelligenceController {
           return;
         }
         const hydrated = new Set(hydratedIds);
-        for (const [segmentId, concordance] of [...this.pendingAutoFill.entries()]) {
+        for (const segmentId of Array.from(this.pendingAutoFill.keys())) {
           if (!hydrated.has(segmentId)) {
+            continue;
+          }
+          const concordance = this.pendingAutoFill.get(segmentId);
+          if (!concordance) {
             continue;
           }
           this.pendingAutoFill.delete(segmentId);

--- a/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.ts
@@ -341,7 +341,7 @@ export class CatIntelligenceController {
       return;
     }
 
-    this.workspace.autoFilledSegmentIds.add(segmentId);
+    this.workspace.markAutoFilledTarget(segmentId, bestMatch.targetText);
     this.workspace.setTargetText(segmentId, bestMatch.targetText);
     this.ports.editing?.onTargetChange?.(segmentId, bestMatch.targetText);
   }

--- a/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.ts
@@ -1,3 +1,4 @@
+import { reaction, type IReactionDisposer } from "mobx";
 import type { IntlShape } from "react-intl";
 
 import {
@@ -37,6 +38,8 @@ export class CatIntelligenceController {
       promise: Promise<CatSegmentConcordanceResult | undefined>;
     }
   >();
+  private pendingAutoFill = new Map<string, CatSegmentConcordanceResult>();
+  private pendingAutoFillDisposer?: IReactionDisposer;
   private visualContextLoadingSegmentId: string | null = null;
   private disposed = false;
 
@@ -54,6 +57,7 @@ export class CatIntelligenceController {
       this.loadedSegmentIds.clear();
       this.concordanceAttempts.clear();
       this.inFlight.clear();
+      this.pendingAutoFill.clear();
     }
     if (previousServices?.lookupSegmentContext !== ports.services?.lookupSegmentContext) {
       this.invalidateContextLookupGeneration();
@@ -68,11 +72,33 @@ export class CatIntelligenceController {
 
   start() {
     this.disposed = false;
+    this.pendingAutoFillDisposer?.();
+    // Depend on the hydrated-target set (not pendingAutoFill) so lazy target
+    // arrival retriggers a flush of any concordance that resolved too early.
+    this.pendingAutoFillDisposer = reaction(
+      () => [...this.workspace.hydratedTargetSegmentIds],
+      (hydratedIds) => {
+        if (this.pendingAutoFill.size === 0) {
+          return;
+        }
+        const hydrated = new Set(hydratedIds);
+        for (const [segmentId, concordance] of [...this.pendingAutoFill.entries()]) {
+          if (!hydrated.has(segmentId)) {
+            continue;
+          }
+          this.pendingAutoFill.delete(segmentId);
+          this.applyAutoFill(segmentId, concordance);
+        }
+      },
+    );
   }
 
   dispose() {
     this.disposed = true;
     this.inFlight.clear();
+    this.pendingAutoFill.clear();
+    this.pendingAutoFillDisposer?.();
+    this.pendingAutoFillDisposer = undefined;
   }
 
   async loadConcordance(
@@ -288,6 +314,15 @@ export class CatIntelligenceController {
   }
 
   private applyAutoFill(segmentId: string, concordance: CatSegmentConcordanceResult) {
+    if (!this.workspace.hasHydratedTarget(segmentId)) {
+      // Wait for the lazy target fetch so an existing translation is not replaced
+      // by TM auto-fill (which would mark the segment dirty without a user edit).
+      this.pendingAutoFill.set(segmentId, concordance);
+      return;
+    }
+
+    this.pendingAutoFill.delete(segmentId);
+
     const segment = this.workspace.getSegmentView(segmentId);
     const bestMatch = selectBestTmMatchForAutoFill(
       concordance.translationMemoryMatches,

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-segment-store.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-segment-store.ts
@@ -60,6 +60,9 @@ export class CatSegmentStore {
   setTargetText(segmentId: string, value: string, existsInQueue: boolean) {
     const draft = this.drafts.get(segmentId);
     if (draft) {
+      if (draft.targetText === value) {
+        return;
+      }
       draft.setTargetText(value);
     } else if (existsInQueue) {
       const nextDraft = new CatSegmentDraft(segmentId, "", "pending");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

In comfortable view, focusing a segment could mark it as an unsaved draft even when the user had not edited anything.

Root cause: TM concordance auto-fill raced ahead of the lazy target fetch. While the target was still empty/loading, auto-fill wrote a TM suggestion into the draft (dirty). When the real translation arrived, the dirty draft blocked applying the server text.

This change:
- Tracks whether a segment target has been hydrated from the server/snapshot
- Defers TM auto-fill until after hydration, then retries if the target is still empty
- Prefers an authoritative server translation over an untouched TM auto-fill draft, including when an empty first hydrate is later followed by real text
- Preserves real user edits after auto-fill
- Ignores no-op TipTap `onUpdate` values so mount/focus round-trips do not dirty the draft

## How to test

1. Open CAT comfortable view on a file with existing translations and TM matches
2. Select/focus several messages without typing
3. Confirm they do not show the unsaved-changes badge or dirty state
4. Select an untranslated message with a high-confidence TM match and confirm auto-fill still happens after the empty target loads
5. If a later refetch returns a real translation for a previously empty target, confirm it replaces an untouched TM auto-fill

```bash
cd apps/hyperlocalise-web
vp test src/components/cat
vp check --fix
```

## Checklist

- [x] I ran relevant checks locally (`vp test` on orchestrator/intelligence tests, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5f49-e17a-7d55-b74e-2a9a4cd04c70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5f49-e17a-7d55-b74e-2a9a4cd04c70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

