### PR TITLE
fix(cat): stop prefilling targets from translation memory

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/intelligence/tm-match-quality.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/tm-match-quality.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import {
-  inferTmMatchKind,
-  requiresLowMatchConfirmation,
-  selectBestTmMatchForAutoFill,
-} from "./tm-match-quality";
-import type { CatTranslationMemoryMatch } from "@/components/cat/shared/types";
+import { inferTmMatchKind, requiresLowMatchConfirmation } from "./tm-match-quality";
 
 describe("inferTmMatchKind", () => {
   it("classifies below-100 scores as fuzzy", () => {
@@ -25,32 +20,5 @@ describe("requiresLowMatchConfirmation", () => {
   it("requires confirmation below 70%", () => {
     expect(requiresLowMatchConfirmation(69)).toBe(true);
     expect(requiresLowMatchConfirmation(70)).toBe(false);
-  });
-});
-
-describe("selectBestTmMatchForAutoFill", () => {
-  const matches: CatTranslationMemoryMatch[] = [
-    {
-      id: "tm-1",
-      sourceText: "A",
-      targetText: "Alpha",
-      matchPercent: 95,
-    },
-    {
-      id: "tm-2",
-      sourceText: "B",
-      targetText: "Beta",
-      matchPercent: 100,
-      matchKind: "exact",
-    },
-  ];
-
-  it("returns the highest match when it meets the threshold", () => {
-    expect(selectBestTmMatchForAutoFill(matches, 100)?.id).toBe("tm-2");
-  });
-
-  it("returns undefined when the best match is below the threshold", () => {
-    expect(selectBestTmMatchForAutoFill(matches, 100)).toBeDefined();
-    expect(selectBestTmMatchForAutoFill([matches[0]], 100)).toBeUndefined();
   });
 });

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/tm-match-quality.ts
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/tm-match-quality.ts
@@ -1,7 +1,6 @@
-import type { CatTmMatchKind, CatTranslationMemoryMatch } from "@/components/cat/shared/types";
+import type { CatTmMatchKind } from "@/components/cat/shared/types";
 
 export const TM_LOW_MATCH_CONFIRM_THRESHOLD = 70;
-export const TM_AUTO_FILL_MIN_MATCH_PERCENT_DEFAULT = 100;
 
 export function inferTmMatchKind(
   matchPercent: number,
@@ -21,20 +20,4 @@ export function inferTmMatchKind(
 
 export function requiresLowMatchConfirmation(matchPercent: number): boolean {
   return matchPercent < TM_LOW_MATCH_CONFIRM_THRESHOLD;
-}
-
-export function selectBestTmMatchForAutoFill(
-  matches: CatTranslationMemoryMatch[] | undefined,
-  minMatchPercent: number,
-): CatTranslationMemoryMatch | undefined {
-  if (!matches?.length) {
-    return undefined;
-  }
-
-  const best = matches.toSorted((left, right) => right.matchPercent - left.matchPercent)[0];
-  if (best.matchPercent >= minMatchPercent) {
-    return best;
-  }
-
-  return undefined;
 }

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
@@ -68,7 +68,6 @@ export interface CatWorkspaceContainerProps {
   onLoadMoreQueue?: () => void;
   initialSegmentKeyOrId?: string | null;
   buildSegmentShareUrl?: (segment: CatSegment) => string | null;
-  tmAutoFillMinMatchPercent?: number;
   canLookupFreshContext?: boolean;
   onPageLimitChange?: (pageLimit: number) => void;
   pageNavigationGuardRef?: CatPageNavigationGuardRef;
@@ -98,7 +97,6 @@ const CatWorkspaceContainerObserver = observer(function CatWorkspaceContainerObs
   hasMoreQueue,
   onLoadMoreQueue,
   buildSegmentShareUrl,
-  tmAutoFillMinMatchPercent,
   canLookupFreshContext,
   onPageLimitChange,
 }: CatWorkspaceContainerProps & { store: CatWorkspaceOrchestrator }) {
@@ -112,7 +110,6 @@ const CatWorkspaceContainerObserver = observer(function CatWorkspaceContainerObs
     queueFilter,
     onQueueFilterChange,
     buildSegmentShareUrl,
-    tmAutoFillMinMatchPercent,
     canLookupFreshContext,
   });
 

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.test.ts
@@ -325,7 +325,7 @@ describe("CatWorkspaceOrchestrator hydration", () => {
     expect(store.dirtySegmentIds.has("seg-01")).toBe(true);
   });
 
-  it("does not clear TM autofill when lazy target sync returns an empty server target", () => {
+  it("keeps dirty draft text when lazy target sync returns an empty server target", () => {
     const store = createCatWorkspace(
       createCatWorkspaceState({
         selectedSegmentId: "seg-01",
@@ -338,7 +338,7 @@ describe("CatWorkspaceOrchestrator hydration", () => {
       externalTranslationId: null,
       isApproved: false,
     });
-    store.setTargetText("seg-01", "Bonjour depuis la MT");
+    store.setTargetText("seg-01", "Bonjour modifié");
 
     store.applySegmentTarget("seg-01", {
       text: "",
@@ -347,41 +347,12 @@ describe("CatWorkspaceOrchestrator hydration", () => {
     });
 
     expect(store.getSegmentView("seg-01")).toMatchObject({
-      targetText: "Bonjour depuis la MT",
+      targetText: "Bonjour modifié",
     });
     expect(store.dirtySegmentIds.has("seg-01")).toBe(true);
   });
 
-  it("prefers the first server translation over a speculative TM auto-fill draft", () => {
-    const store = createCatWorkspace(
-      createCatWorkspaceState({
-        selectedSegmentId: "seg-01",
-        queueSegments: [{ id: "seg-01", index: 1, key: "hero.title", sourceText: "Hello" }],
-        segments: [],
-      }),
-    );
-
-    store.markAutoFilledTarget("seg-01", "Bonjour depuis la MT");
-    store.setTargetText("seg-01", "Bonjour depuis la MT");
-    expect(store.hasHydratedTarget("seg-01")).toBe(false);
-    expect(store.dirtySegmentIds.has("seg-01")).toBe(true);
-
-    store.applySegmentTarget("seg-01", {
-      text: "Bonjour",
-      externalTranslationId: "translation-1",
-      isApproved: false,
-    });
-
-    expect(store.getSegmentView("seg-01")).toMatchObject({
-      targetText: "Bonjour",
-      status: "needs_review",
-    });
-    expect(store.hasHydratedTarget("seg-01")).toBe(true);
-    expect(store.dirtySegmentIds.has("seg-01")).toBe(false);
-    expect(store.autoFilledSegmentIds.has("seg-01")).toBe(false);
-  });
-
-  it("replaces untouched TM auto-fill when a later lazy target refetch returns text", () => {
+  it("keeps dirty user edits when a later server refetch arrives", () => {
     const store = createCatWorkspace(
       createCatWorkspaceState({
         selectedSegmentId: "seg-01",
@@ -395,41 +366,6 @@ describe("CatWorkspaceOrchestrator hydration", () => {
       externalTranslationId: null,
       isApproved: false,
     });
-    store.markAutoFilledTarget("seg-01", "Bonjour depuis la MT");
-    store.setTargetText("seg-01", "Bonjour depuis la MT");
-    expect(store.hasHydratedTarget("seg-01")).toBe(true);
-    expect(store.dirtySegmentIds.has("seg-01")).toBe(true);
-
-    store.applySegmentTarget("seg-01", {
-      text: "Bonjour",
-      externalTranslationId: "translation-1",
-      isApproved: false,
-    });
-
-    expect(store.getSegmentView("seg-01")).toMatchObject({
-      targetText: "Bonjour",
-      status: "needs_review",
-    });
-    expect(store.dirtySegmentIds.has("seg-01")).toBe(false);
-    expect(store.autoFilledSegmentIds.has("seg-01")).toBe(false);
-  });
-
-  it("keeps user edits after TM auto-fill when a later server refetch arrives", () => {
-    const store = createCatWorkspace(
-      createCatWorkspaceState({
-        selectedSegmentId: "seg-01",
-        queueSegments: [{ id: "seg-01", index: 1, key: "hero.title", sourceText: "Hello" }],
-        segments: [],
-      }),
-    );
-
-    store.applySegmentTarget("seg-01", {
-      text: "",
-      externalTranslationId: null,
-      isApproved: false,
-    });
-    store.markAutoFilledTarget("seg-01", "Bonjour depuis la MT");
-    store.setTargetText("seg-01", "Bonjour depuis la MT");
     store.setTargetText("seg-01", "Bonjour modifié");
 
     store.applySegmentTarget("seg-01", {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
@@ -169,9 +169,6 @@ export class CatWorkspaceOrchestrator {
 
   private lastHydratedSnapshot: CatWorkspaceState | null = null;
   private initialSegmentJumpApplied = false;
-  autoFilledSegmentIds = new Set<string>();
-  /** Target text written by TM auto-fill; used to detect untouched speculative drafts. */
-  autoFilledTargetTexts = new Map<string, string>();
   /** Segment ids whose lazy (or snapshot) target payload has been applied at least once. */
   hydratedTargetSegmentIds = new Set<string>();
 
@@ -593,31 +590,12 @@ export class CatWorkspaceOrchestrator {
   reset(initialState: CatWorkspaceState, initialSegmentKeyOrId?: string | null) {
     this.lastHydratedSnapshot = null;
     this.initialSegmentJumpApplied = false;
-    this.autoFilledSegmentIds = new Set();
-    this.autoFilledTargetTexts = new Map();
     this.hydratedTargetSegmentIds = new Set();
     this.ingestQueue(initialState, initialSegmentKeyOrId);
   }
 
   hasHydratedTarget(segmentId: string) {
     return this.hydratedTargetSegmentIds.has(segmentId);
-  }
-
-  markAutoFilledTarget(segmentId: string, targetText: string) {
-    this.autoFilledSegmentIds.add(segmentId);
-    this.autoFilledTargetTexts.set(segmentId, targetText);
-  }
-
-  clearAutoFilledTarget(segmentId: string) {
-    this.autoFilledSegmentIds.delete(segmentId);
-    this.autoFilledTargetTexts.delete(segmentId);
-  }
-
-  private isUntouchedAutoFilledDraft(segmentId: string, draft: CatSegmentDraft) {
-    return (
-      this.autoFilledSegmentIds.has(segmentId) &&
-      draft.targetText === this.autoFilledTargetTexts.get(segmentId)
-    );
   }
 
   ingestQueue(nextInitialState: CatWorkspaceState, initialSegmentKeyOrId?: string | null) {
@@ -732,17 +710,7 @@ export class CatWorkspaceOrchestrator {
 
     if (existingDraft) {
       if (existingDraft.isDirty) {
-        // Prefer authoritative server text over an untouched TM auto-fill draft,
-        // including when an empty first hydrate was later followed by a real translation.
-        if (
-          targetText.trim().length > 0 &&
-          this.isUntouchedAutoFilledDraft(segmentId, existingDraft)
-        ) {
-          existingDraft.applyServerTarget(targetText, status);
-          this.clearAutoFilledTarget(segmentId);
-        } else {
-          existingDraft.applyServerStatus(status);
-        }
+        existingDraft.applyServerStatus(status);
         this.hydratedTargetSegmentIds.add(segmentId);
         return;
       }
@@ -853,7 +821,6 @@ export class CatWorkspaceOrchestrator {
           this.segmentMeta.delete(segmentId);
           this.segmentComments.delete(segmentId);
           this.hydratedTargetSegmentIds.delete(segmentId);
-          this.clearAutoFilledTarget(segmentId);
         }
       }
     }

--- a/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.test.ts
@@ -131,8 +131,7 @@ describe("CatIntelligenceController", () => {
       expect(cached).toEqual(concordance);
     });
 
-    it("auto-fills empty targets from high-confidence TM matches", async () => {
-      const onTargetChange = vi.fn();
+    it("does not prefill empty targets from TM matches", async () => {
       const lookup = vi.fn().mockResolvedValue({
         glossaryTerms: [],
         translationMemoryMatches: [
@@ -146,42 +145,19 @@ describe("CatIntelligenceController", () => {
       } satisfies CatSegmentConcordanceResult);
       const { controller, workspace } = createController(undefined, {
         intl,
-        editing: { onTargetChange },
         services: { lookupSegmentConcordance: lookup },
       });
 
       await controller.loadConcordance("seg-02");
 
-      expect(workspace.getSegmentView("seg-02")?.targetText).toBe("Deuxième");
-      expect(workspace.autoFilledSegmentIds.has("seg-02")).toBe(true);
-      expect(workspace.dirtySegmentIds.has("seg-02")).toBe(true);
-      expect(onTargetChange).toHaveBeenCalledWith("seg-02", "Deuxième");
-    });
-
-    it("does not auto-fill when autoFill is false", async () => {
-      const lookup = vi.fn().mockResolvedValue({
-        glossaryTerms: [],
-        translationMemoryMatches: [
-          {
-            id: "tm-1",
-            sourceText: "Second",
-            targetText: "Deuxième",
-            matchPercent: 100,
-          },
-        ],
-      } satisfies CatSegmentConcordanceResult);
-      const { controller, workspace } = createController(undefined, {
-        intl,
-        services: { lookupSegmentConcordance: lookup },
-      });
-
-      await controller.loadConcordance("seg-02", { autoFill: false });
-
       expect(workspace.getSegmentView("seg-02")?.targetText).toBe("");
-      expect(workspace.autoFilledSegmentIds.has("seg-02")).toBe(false);
+      expect(workspace.dirtySegmentIds.has("seg-02")).toBe(false);
+      expect(workspace.segmentIntelligence["seg-02"]?.translationMemoryMatches).toEqual([
+        expect.objectContaining({ id: "tm-1", targetText: "Deuxième" }),
+      ]);
     });
 
-    it("does not auto-fill when the target already has text", async () => {
+    it("does not overwrite an existing fetched translation with TM matches", async () => {
       const lookup = vi.fn().mockResolvedValue({
         glossaryTerms: [],
         translationMemoryMatches: [
@@ -201,65 +177,17 @@ describe("CatIntelligenceController", () => {
       await controller.loadConcordance("seg-03");
 
       expect(workspace.getSegmentView("seg-03")?.targetText).toBe("Troisième");
+      expect(workspace.dirtySegmentIds.has("seg-03")).toBe(false);
     });
 
-    it("does not auto-fill when the best match is below the threshold", async () => {
-      const lookup = vi.fn().mockResolvedValue({
-        glossaryTerms: [],
-        translationMemoryMatches: [
-          {
-            id: "tm-1",
-            sourceText: "Second",
-            targetText: "Deuxième",
-            matchPercent: 85,
-          },
-        ],
-      } satisfies CatSegmentConcordanceResult);
-      const { controller, workspace } = createController(undefined, {
-        intl,
-        services: { lookupSegmentConcordance: lookup },
-      });
-
-      await controller.loadConcordance("seg-02");
-
-      expect(workspace.getSegmentView("seg-02")?.targetText).toBe("");
-    });
-
-    it("does not auto-fill the same segment twice", async () => {
-      const lookup = vi.fn().mockResolvedValue({
-        glossaryTerms: [],
-        translationMemoryMatches: [
-          {
-            id: "tm-1",
-            sourceText: "Second",
-            targetText: "Deuxième",
-            matchPercent: 100,
-          },
-        ],
-      } satisfies CatSegmentConcordanceResult);
-      const { controller, workspace } = createController(undefined, {
-        intl,
-        services: { lookupSegmentConcordance: lookup },
-      });
-
-      workspace.autoFilledSegmentIds.add("seg-02");
-      await controller.loadConcordance("seg-02");
-
-      expect(workspace.getSegmentView("seg-02")?.targetText).toBe("");
-    });
-
-    it("does not auto-fill before the lazy target has hydrated", async () => {
-      const lookup = vi.fn().mockResolvedValue({
-        glossaryTerms: [],
-        translationMemoryMatches: [
-          {
-            id: "tm-1",
-            sourceText: "Second",
-            targetText: "Deuxième",
-            matchPercent: 100,
-          },
-        ],
-      } satisfies CatSegmentConcordanceResult);
+    it("keeps an empty target empty after lazy hydration when only TM matches exist", async () => {
+      let resolveLookup: ((value: CatSegmentConcordanceResult) => void) | undefined;
+      const lookup = vi.fn(
+        () =>
+          new Promise<CatSegmentConcordanceResult>((resolve) => {
+            resolveLookup = resolve;
+          }),
+      );
       const workspace = createCatWorkspace(
         createCatWorkspaceState({
           selectedSegmentId: "seg-02",
@@ -275,15 +203,33 @@ describe("CatIntelligenceController", () => {
         services: { lookupSegmentConcordance: lookup },
       });
 
-      await controller.loadConcordance("seg-02");
+      const pending = controller.loadConcordance("seg-02");
+      resolveLookup?.({
+        glossaryTerms: [],
+        translationMemoryMatches: [
+          {
+            id: "tm-1",
+            sourceText: "Second",
+            targetText: "Deuxième",
+            matchPercent: 100,
+          },
+        ],
+      });
+      await pending;
 
-      expect(workspace.hasHydratedTarget("seg-02")).toBe(false);
+      workspace.applySegmentTarget("seg-02", {
+        text: "",
+        externalTranslationId: null,
+        isApproved: false,
+      });
+
+      await vi.waitFor(() => expect(workspace.hasHydratedTarget("seg-02")).toBe(true));
+
       expect(workspace.getSegmentView("seg-02")?.targetText).toBe("");
       expect(workspace.dirtySegmentIds.has("seg-02")).toBe(false);
-      expect(workspace.autoFilledSegmentIds.has("seg-02")).toBe(false);
     });
 
-    it("does not mark a loaded translation dirty when concordance races ahead of target hydration", async () => {
+    it("keeps a fetched translation when concordance resolves before target hydration", async () => {
       let resolveLookup: ((value: CatSegmentConcordanceResult) => void) | undefined;
       const lookup = vi.fn(
         () =>
@@ -332,61 +278,6 @@ describe("CatIntelligenceController", () => {
 
       expect(workspace.getSegmentView("seg-02")?.targetText).toBe("Traduction existante");
       expect(workspace.dirtySegmentIds.has("seg-02")).toBe(false);
-      expect(workspace.autoFilledSegmentIds.has("seg-02")).toBe(false);
-    });
-
-    it("auto-fills after an empty lazy target hydrates", async () => {
-      const onTargetChange = vi.fn();
-      let resolveLookup: ((value: CatSegmentConcordanceResult) => void) | undefined;
-      const lookup = vi.fn(
-        () =>
-          new Promise<CatSegmentConcordanceResult>((resolve) => {
-            resolveLookup = resolve;
-          }),
-      );
-      const workspace = createCatWorkspace(
-        createCatWorkspaceState({
-          selectedSegmentId: "seg-02",
-          queueSegments: [
-            { id: "seg-01", index: 1, key: "first", sourceText: "First" },
-            { id: "seg-02", index: 2, key: "second", sourceText: "Second" },
-          ],
-          segments: [],
-        }),
-      );
-      const { controller } = createController(workspace, {
-        intl,
-        editing: { onTargetChange },
-        services: { lookupSegmentConcordance: lookup },
-      });
-
-      const pending = controller.loadConcordance("seg-02");
-      resolveLookup?.({
-        glossaryTerms: [],
-        translationMemoryMatches: [
-          {
-            id: "tm-1",
-            sourceText: "Second",
-            targetText: "Deuxième",
-            matchPercent: 100,
-          },
-        ],
-      });
-      await pending;
-
-      workspace.applySegmentTarget("seg-02", {
-        text: "",
-        externalTranslationId: null,
-        isApproved: false,
-      });
-
-      await vi.waitFor(() =>
-        expect(workspace.getSegmentView("seg-02")?.targetText).toBe("Deuxième"),
-      );
-
-      expect(workspace.autoFilledSegmentIds.has("seg-02")).toBe(true);
-      expect(workspace.dirtySegmentIds.has("seg-02")).toBe(true);
-      expect(onTargetChange).toHaveBeenCalledWith("seg-02", "Deuxième");
     });
 
     it("records concordance lookup failures as format checks", async () => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-intelligence-controller.ts
@@ -1,17 +1,11 @@
-import { reaction, type IReactionDisposer } from "mobx";
 import type { IntlShape } from "react-intl";
 
-import {
-  selectBestTmMatchForAutoFill,
-  TM_AUTO_FILL_MIN_MATCH_PERCENT_DEFAULT,
-} from "@/components/cat/intelligence/tm-match-quality";
 import {
   catIntelligencePanelMessages,
   catWorkspaceContainerMessages,
 } from "@/components/cat/shared/cat.messages";
 import type {
   CatSegmentConcordanceResult,
-  CatWorkspaceEditing,
   CatWorkspaceServices,
 } from "@/components/cat/shared/dependencies";
 
@@ -20,8 +14,6 @@ import type { CatWorkspaceOrchestrator } from "../cat-workspace-orchestrator";
 export interface CatIntelligenceControllerPorts {
   intl: IntlShape;
   services?: CatWorkspaceServices;
-  editing?: Partial<CatWorkspaceEditing>;
-  tmAutoFillMinMatchPercent?: number;
 }
 
 export class CatIntelligenceController {
@@ -31,15 +23,7 @@ export class CatIntelligenceController {
   private contextAttempts = new Set<string>();
   private contextGeneration = 0;
   private visualContextAttempts = new Set<string>();
-  private inFlight = new Map<
-    string,
-    {
-      autoFill: boolean;
-      promise: Promise<CatSegmentConcordanceResult | undefined>;
-    }
-  >();
-  private pendingAutoFill = new Map<string, CatSegmentConcordanceResult>();
-  private pendingAutoFillDisposer?: IReactionDisposer;
+  private inFlight = new Map<string, Promise<CatSegmentConcordanceResult | undefined>>();
   private visualContextLoadingSegmentId: string | null = null;
   private disposed = false;
 
@@ -57,7 +41,6 @@ export class CatIntelligenceController {
       this.loadedSegmentIds.clear();
       this.concordanceAttempts.clear();
       this.inFlight.clear();
-      this.pendingAutoFill.clear();
     }
     if (previousServices?.lookupSegmentContext !== ports.services?.lookupSegmentContext) {
       this.invalidateContextLookupGeneration();
@@ -72,43 +55,14 @@ export class CatIntelligenceController {
 
   start() {
     this.disposed = false;
-    this.pendingAutoFillDisposer?.();
-    // Depend on the hydrated-target set (not pendingAutoFill) so lazy target
-    // arrival retriggers a flush of any concordance that resolved too early.
-    this.pendingAutoFillDisposer = reaction(
-      () => [...this.workspace.hydratedTargetSegmentIds],
-      (hydratedIds) => {
-        if (this.pendingAutoFill.size === 0) {
-          return;
-        }
-        const hydrated = new Set(hydratedIds);
-        for (const segmentId of Array.from(this.pendingAutoFill.keys())) {
-          if (!hydrated.has(segmentId)) {
-            continue;
-          }
-          const concordance = this.pendingAutoFill.get(segmentId);
-          if (!concordance) {
-            continue;
-          }
-          this.pendingAutoFill.delete(segmentId);
-          this.applyAutoFill(segmentId, concordance);
-        }
-      },
-    );
   }
 
   dispose() {
     this.disposed = true;
     this.inFlight.clear();
-    this.pendingAutoFill.clear();
-    this.pendingAutoFillDisposer?.();
-    this.pendingAutoFillDisposer = undefined;
   }
 
-  async loadConcordance(
-    segmentId: string,
-    options?: { autoFill?: boolean },
-  ): Promise<CatSegmentConcordanceResult | undefined> {
+  async loadConcordance(segmentId: string): Promise<CatSegmentConcordanceResult | undefined> {
     const lookup = this.ports.services?.lookupSegmentConcordance;
     if (!lookup) {
       return undefined;
@@ -124,10 +78,7 @@ export class CatIntelligenceController {
 
     const existing = this.inFlight.get(segmentId);
     if (existing) {
-      if (options?.autoFill !== false) {
-        existing.autoFill = true;
-      }
-      return existing.promise;
+      return existing;
     }
 
     const segment = this.workspace.getSegmentView(segmentId);
@@ -135,11 +86,7 @@ export class CatIntelligenceController {
       return undefined;
     }
 
-    const entry = {
-      autoFill: options?.autoFill !== false,
-      promise: Promise.resolve(undefined) as Promise<CatSegmentConcordanceResult | undefined>,
-    };
-    entry.promise = (async () => {
+    const promise = (async () => {
       this.workspace.beginConcordanceLoad(segmentId);
       try {
         const concordance = await lookup(segment);
@@ -148,9 +95,6 @@ export class CatIntelligenceController {
         }
         this.loadedSegmentIds.add(segmentId);
         this.workspace.mergeSegmentIntelligence(segmentId, concordance);
-        if (this.inFlight.get(segmentId)?.autoFill) {
-          this.applyAutoFill(segmentId, concordance);
-        }
         return concordance;
       } catch (error) {
         if (!this.disposed) {
@@ -175,8 +119,8 @@ export class CatIntelligenceController {
         this.inFlight.delete(segmentId);
       }
     })();
-    this.inFlight.set(segmentId, entry);
-    return entry.promise;
+    this.inFlight.set(segmentId, promise);
+    return promise;
   }
 
   panelVisible(segmentId: string) {
@@ -315,34 +259,5 @@ export class CatIntelligenceController {
     // askQuestion handlers whose finally blocks skip endContextLookup on stale generations.
     this.workspace.clearAgentContexts();
     this.contextGeneration += 1;
-  }
-
-  private applyAutoFill(segmentId: string, concordance: CatSegmentConcordanceResult) {
-    if (!this.workspace.hasHydratedTarget(segmentId)) {
-      // Wait for the lazy target fetch so an existing translation is not replaced
-      // by TM auto-fill (which would mark the segment dirty without a user edit).
-      this.pendingAutoFill.set(segmentId, concordance);
-      return;
-    }
-
-    this.pendingAutoFill.delete(segmentId);
-
-    const segment = this.workspace.getSegmentView(segmentId);
-    const bestMatch = selectBestTmMatchForAutoFill(
-      concordance.translationMemoryMatches,
-      this.ports.tmAutoFillMinMatchPercent ?? TM_AUTO_FILL_MIN_MATCH_PERCENT_DEFAULT,
-    );
-    if (
-      !segment ||
-      segment.targetText.trim() ||
-      !bestMatch ||
-      this.workspace.autoFilledSegmentIds.has(segmentId)
-    ) {
-      return;
-    }
-
-    this.workspace.markAutoFilledTarget(segmentId, bestMatch.targetText);
-    this.workspace.setTargetText(segmentId, bestMatch.targetText);
-    this.ports.editing?.onTargetChange?.(segmentId, bestMatch.targetText);
   }
 }

--- a/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-review-controller.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-review-controller.ts
@@ -29,10 +29,7 @@ export interface CatReviewControllerPorts {
   intl: IntlShape;
   services?: CatWorkspaceServices;
   review?: Partial<CatWorkspaceReview>;
-  loadConcordance?: (
-    segmentId: string,
-    options?: { autoFill?: boolean },
-  ) => Promise<CatSegmentConcordanceResult | undefined>;
+  loadConcordance?: (segmentId: string) => Promise<CatSegmentConcordanceResult | undefined>;
   queueFilter: CatQueueFilter;
   usesServerQueueFilter: boolean;
 }
@@ -251,7 +248,7 @@ export class CatReviewController {
 
     try {
       if (includeAi && lookupSegmentConcordance) {
-        await this.ports.loadConcordance?.(segmentId, { autoFill: false });
+        await this.ports.loadConcordance?.(segmentId);
         if (this.disposed || !this.workspace.isReviewCurrent(sequence)) {
           return;
         }

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.test.tsx
@@ -181,7 +181,7 @@ describe("useCatWorkspaceRuntime", () => {
     expect(lookupSegmentConcordance).not.toHaveBeenCalled();
   });
 
-  it("auto-fills empty targets from high-confidence TM matches after intelligence loads", async () => {
+  it("loads TM matches into intelligence without prefilling the target", async () => {
     const concordance: CatSegmentConcordanceResult = {
       glossaryTerms: [],
       translationMemoryMatches: [
@@ -205,8 +205,13 @@ describe("useCatWorkspaceRuntime", () => {
       result.current.handleIntelligencePanelVisible("seg-02");
     });
 
-    await waitFor(() => expect(store.getSegmentView("seg-02")?.targetText).toBe("Deuxième"));
-    expect(store.autoFilledSegmentIds.has("seg-02")).toBe(true);
+    await waitFor(() =>
+      expect(store.segmentIntelligence["seg-02"]?.translationMemoryMatches).toEqual([
+        expect.objectContaining({ id: "tm-1", targetText: "Deuxième" }),
+      ]),
+    );
+    expect(store.getSegmentView("seg-02")?.targetText).toBe("");
+    expect(store.dirtySegmentIds.has("seg-02")).toBe(false);
     expect(store.isLoadingConcordance).toBe(false);
   });
 
@@ -302,7 +307,7 @@ describe("useCatWorkspaceRuntime", () => {
     );
   });
 
-  it("auto-fills when intelligence panel joins an in-flight AI review concordance lookup", async () => {
+  it("does not prefill the target when intelligence panel joins an in-flight AI review concordance lookup", async () => {
     let resolveConcordance: ((value: CatSegmentConcordanceResult) => void) | undefined;
     const concordancePromise = new Promise<CatSegmentConcordanceResult>((resolve) => {
       resolveConcordance = resolve;
@@ -342,8 +347,11 @@ describe("useCatWorkspaceRuntime", () => {
     });
 
     expect(lookupSegmentConcordance).toHaveBeenCalledTimes(1);
-    expect(store.getSegmentView("seg-02")?.targetText).toBe("Deuxième");
-    expect(store.autoFilledSegmentIds.has("seg-02")).toBe(true);
+    expect(store.getSegmentView("seg-02")?.targetText).toBe("");
+    expect(store.dirtySegmentIds.has("seg-02")).toBe(false);
+    expect(store.segmentIntelligence["seg-02"]?.translationMemoryMatches).toEqual([
+      expect.objectContaining({ id: "tm-1", targetText: "Deuxième" }),
+    ]);
   });
 
   it("does not start a duplicate concordance lookup when AI review runs during an in-flight lookup", async () => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.ts
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { useIntl } from "react-intl";
 
-import { TM_AUTO_FILL_MIN_MATCH_PERCENT_DEFAULT } from "@/components/cat/intelligence/tm-match-quality";
 import {
   findSegmentIdByKeyOrIdInQueue,
   type CatQueueFilter,
@@ -63,7 +62,6 @@ export interface UseCatWorkspaceRuntimeInput {
   queueFilter?: CatQueueFilter;
   onQueueFilterChange?: (filter: CatQueueFilter) => void;
   buildSegmentShareUrl?: (segment: CatSegment) => string | null;
-  tmAutoFillMinMatchPercent?: number;
   canLookupFreshContext?: boolean;
 }
 
@@ -77,7 +75,6 @@ export function useCatWorkspaceRuntime({
   queueFilter: queueFilterProp,
   onQueueFilterChange,
   buildSegmentShareUrl,
-  tmAutoFillMinMatchPercent = TM_AUTO_FILL_MIN_MATCH_PERCENT_DEFAULT,
   canLookupFreshContext = true,
 }: UseCatWorkspaceRuntimeInput) {
   const intl = useIntl();
@@ -110,10 +107,8 @@ export function useCatWorkspaceRuntime({
     () => ({
       intl,
       services: serviceOverrides,
-      editing: editingOverrides,
-      tmAutoFillMinMatchPercent,
     }),
-    [editingOverrides, intl, serviceOverrides, tmAutoFillMinMatchPercent],
+    [intl, serviceOverrides],
   );
   const intelligenceController = useMemo(
     () => new CatIntelligenceController(store, intelligencePorts),

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.ts
@@ -120,8 +120,7 @@ export function useCatWorkspaceRuntime({
       intl,
       services: serviceOverrides,
       review: reviewOverrides,
-      loadConcordance: (segmentId, options) =>
-        intelligenceController.loadConcordance(segmentId, options),
+      loadConcordance: (segmentId) => intelligenceController.loadConcordance(segmentId),
       queueFilter,
       usesServerQueueFilter,
     }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CAT tool no longer auto-fills empty translation targets from translation memory matches. Targets are only populated from existing fetched translations.

TM matches still load into the intelligence panel so translators can apply them manually.

## Changes

- Remove TM auto-fill from `CatIntelligenceController` (including pending-hydration race handling)
- Drop `tmAutoFillMinMatchPercent` plumbing from the workspace runtime/container
- Remove speculative autofill draft tracking from the workspace orchestrator
- Update unit tests to assert empty targets stay empty when only TM matches exist

## Test plan

- [ ] Open CAT with an empty segment that has a 100% TM match — target stays empty
- [ ] Open CAT with an existing translation — target shows the fetched text
- [ ] Confirm TM matches still appear in the intelligence panel and can be applied manually
- [ ] `vp test` / `vp check --fix` in `apps/hyperlocalise-web`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f62b3-ed4f-7bcd-ac84-25bf70165919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f62b3-ed4f-7bcd-ac84-25bf70165919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

