### PR TITLE
fix(crowdin): add missing branch webhook events and improve documentation

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -235,3 +235,9 @@
 ## 2026-11-28 - Improve Workflows ListSteps parity and pagination
 **Learning:** The `Workflows.ListSteps` endpoint in the Crowdin API v2 uses an integer for the project ID and supports pagination via `limit` and `offset`. The Go SDK was incorrectly using a string for the project ID and was missing pagination support for both the request and response models.
 **Action:** Updated `WorkflowsService.ListSteps` to accept `projectID` as an `int` and added `WorkflowStepsListOptions` for pagination. Added the `Pagination` field to `WorkflowStepsResponse`. Note that `WorkflowStep.Languages` at the project level uses string identifiers (e.g., "de"), which differs from the numeric IDs used at the workflow template level. Verified with updated contract tests in `workflows_test.go`.
+
+## 2026-12-05 - Improve Webhook model parity for Branch events and documentation
+
+**Learning:** Crowdin API v2 supports branch-level webhooks (`branch.translated`, `branch.approved`) which were missing from the SDK's `Event` type. Additionally, the service documentation was missing many modern events like file lifecycle, tasks, and groups, which can lead to confusion about supported capabilities.
+
+**Action:** Added `BranchTranslated` and `BranchApproved` constants to the `Event` model in `model/webhooks.go`. Comprehensively updated the docstrings for `WebhooksService` and `OrganizationWebhooksService` to list all supported events confirmed by documentation. Verified correct serialization of the new branch events with `TestWebhooksService_Add_BranchEvents`.

--- a/third_party/crowdin-api-client-go/crowdin/model/webhooks.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/webhooks.go
@@ -23,6 +23,10 @@ const (
 	FileTranslated Event = "file.translated"
 	// Project file is fully reviewed.
 	FileApproved Event = "file.approved"
+	// Project branch is fully translated.
+	BranchTranslated Event = "branch.translated"
+	// Project branch is fully reviewed.
+	BranchApproved Event = "branch.approved"
 	// File QA check is finished.
 	FileQAFinished Event = "file.qa.finished"
 	// All strings in project are translated.

--- a/third_party/crowdin-api-client-go/crowdin/webhooks.go
+++ b/third_party/crowdin-api-client-go/crowdin/webhooks.go
@@ -14,17 +14,32 @@ import (
 // Webhooks can be configured for the following events:
 //   - Project file is fully translated
 //   - Project file is fully reviewed
+//   - Project file is added
+//   - Project file is updated
+//   - Project file is reverted
+//   - Project file is deleted
+//   - Project branch is fully translated
+//   - Project branch is fully reviewed
 //   - All strings in project are translated
 //   - All strings in project are reviewed
+//   - Project is successfully built
 //   - Final translation of string is updated (using Replace in suggestions feature)
 //   - Source string is added
 //   - Source string is updated
 //   - Source string is deleted
-//   - Source string is translated
+//   - String comment/issue is created
+//   - String comment/issue is updated
+//   - String comment/issue is deleted
+//   - String comment/issue is restored
+//   - One of source strings is translated
 //   - Translation for source string is updated (using Replace in suggestions feature)
 //   - One of translations is deleted
 //   - Translation for string is approved
 //   - Approval for previously added translation is removed
+//   - Task is added
+//   - Task status is changed
+//   - Task is updated
+//   - Task is deleted
 //
 // Use API to create, modify, and delete specific webhooks.
 //

--- a/third_party/crowdin-api-client-go/crowdin/webhooks_organization.go
+++ b/third_party/crowdin-api-client-go/crowdin/webhooks_organization.go
@@ -14,6 +14,8 @@ import (
 // Webhooks can be configured for the following events:
 //   - Project is created
 //   - Project is deleted
+//   - Group is created
+//   - Group is deleted
 //
 // Use API to create, modify, and delete specific webhooks.
 //

--- a/third_party/crowdin-api-client-go/crowdin/webhooks_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/webhooks_test.go
@@ -323,6 +323,39 @@ func TestWebhooksService_Add(t *testing.T) {
 	assert.Equal(t, 4, webhook.ID)
 }
 
+func TestWebhooksService_Add_BranchEvents(t *testing.T) {
+	client, mux, teardown := setupClient()
+	defer teardown()
+
+	const path = "/api/v2/projects/1/webhooks"
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testURL(t, r, path)
+		testJSONBody(t, r, `{
+			"name":"Branch Webhook",
+			"url":"https://webhook.site/123",
+			"events":[
+				"branch.translated",
+				"branch.approved"
+			],
+			"requestType":"POST"
+		}`)
+
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"data": {"id": 10}}`)
+	})
+
+	req := &model.WebhookAddRequest{
+		Name:        "Branch Webhook",
+		URL:         "https://webhook.site/123",
+		Events:      []model.Event{model.BranchTranslated, model.BranchApproved},
+		RequestType: "POST",
+	}
+	webhook, _, err := client.Webhooks.Add(context.Background(), 1, req)
+	require.NoError(t, err)
+	assert.Equal(t, 10, webhook.ID)
+}
+
 func TestWebhooksService_Add_requiredFields(t *testing.T) {
 	client, mux, teardown := setupClient()
 	defer teardown()


### PR DESCRIPTION
This PR improves the parity of the Crowdin SDK with the official API v2 contract for Webhooks.

### What
1. Added missing `branch.translated` and `branch.approved` event constants to the `model.Event` type.
2. Updated the documentation for `WebhooksService` and `OrganizationWebhooksService` to list a more complete set of supported events (file lifecycle, branches, tasks, groups, etc.).

### Why
The SDK was missing type constants for branch-level webhook events, making it harder for users to configure them safely. Additionally, the service documentation was outdated and didn't reflect the full range of events Crowdin now supports.

### Docs
- Webhook Events: https://support.crowdin.com/developer/webhooks/#events

### Scope
- `third_party/crowdin-api-client-go/crowdin/model/webhooks.go`: Model additions.
- `third_party/crowdin-api-client-go/crowdin/webhooks.go`: Doc updates.
- `third_party/crowdin-api-client-go/crowdin/webhooks_organization.go`: Doc updates.
- `third_party/crowdin-api-client-go/crowdin/webhooks_test.go`: Verification tests.

### Verification
- Ran `go test ./...` in the Crowdin module; all tests passed, including the new `TestWebhooksService_Add_BranchEvents`.
- Ran `go fmt` and `go vet` to ensure code quality.

---
*PR created automatically by Jules for task [16507237218357721399](https://jules.google.com/task/16507237218357721399) started by @cungminh2710*