### PR TITLE
fix(cat): stop side-by-side MobX loop when loading targets

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-lazy-segment-sync.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-lazy-segment-sync.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { observer } from "mobx-react-lite";
 
 import type { ProjectFileCatQueueFile } from "@/api/routes/project/project.schema";
@@ -167,8 +167,19 @@ function useCatLoadedQueueTargetsSync(input: {
     enabled: targetsEnabled,
   });
 
+  // useQueries() returns a new array every render. Depend on result fingerprints
+  // instead so applying targets / loading ids does not form a MobX update loop.
+  const targetQueriesRef = useRef(targetQueries);
+  targetQueriesRef.current = targetQueries;
+  const targetDataSyncKey = targetQueries
+    .map((query) => `${query.dataUpdatedAt}:${query.status}`)
+    .join("|");
+  const targetLoadingSyncKey = targetQueries
+    .map((query) => `${query.isFetching}:${query.data === undefined}`)
+    .join("|");
+
   useEffect(() => {
-    targetQueries.forEach((query, index) => {
+    targetQueriesRef.current.forEach((query, index) => {
       const segmentId = segmentIds[index];
       if (!segmentId || query.data === undefined) {
         return;
@@ -176,7 +187,7 @@ function useCatLoadedQueueTargetsSync(input: {
 
       store.applySegmentTarget(segmentId, query.data);
     });
-  }, [segmentIds, store, targetQueries]);
+  }, [segmentIds, store, targetDataSyncKey]);
 
   useEffect(() => {
     if (!targetsEnabled) {
@@ -188,12 +199,12 @@ function useCatLoadedQueueTargetsSync(input: {
     // so typing during a fetch clears the skeleton without needing this effect
     // to re-run on draft changes.
     const loadingIds = segmentIds.filter((_segmentId, index) => {
-      const query = targetQueries[index];
+      const query = targetQueriesRef.current[index];
       return Boolean(query?.isFetching && query.data === undefined);
     });
 
     store.setQueueTargetLoadingSegmentIds(loadingIds);
-  }, [segmentIds, store, targetQueries, targetsEnabled]);
+  }, [segmentIds, store, targetLoadingSyncKey, targetsEnabled]);
 }
 
 export const CatWorkspaceLazySegmentSync = observer(function CatWorkspaceLazySegmentSync({

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.test.ts
@@ -1,3 +1,4 @@
+import { autorun } from "mobx";
 import { describe, expect, it } from "vite-plus/test";
 
 import { createCatWorkspaceState } from "@/components/cat/shared/cat.fixture";
@@ -323,6 +324,40 @@ describe("CatWorkspaceOrchestrator hydration", () => {
       status: "reviewed",
     });
     expect(store.dirtySegmentIds.has("seg-01")).toBe(true);
+  });
+
+  it("does not notify observers when applying an identical lazy target again", () => {
+    const store = createCatWorkspace(
+      createCatWorkspaceState({
+        selectedSegmentId: "seg-01",
+        queueSegments: [{ id: "seg-01", index: 1, key: "hero.title", sourceText: "Hello" }],
+      }),
+    );
+
+    store.applySegmentTarget("seg-01", {
+      text: "Bonjour",
+      externalTranslationId: "translation-1",
+      isApproved: false,
+    });
+
+    const metaBefore = store.segmentMeta.get("seg-01");
+    let notifications = 0;
+    const dispose = autorun(() => {
+      void store.getSegmentView("seg-01")?.targetText;
+      void store.segmentMeta.get("seg-01");
+      notifications += 1;
+    });
+
+    notifications = 0;
+    store.applySegmentTarget("seg-01", {
+      text: "Bonjour",
+      externalTranslationId: "translation-1",
+      isApproved: false,
+    });
+
+    expect(notifications).toBe(0);
+    expect(store.segmentMeta.get("seg-01")).toBe(metaBefore);
+    dispose();
   });
 
   it("keeps dirty draft text when lazy target sync returns an empty server target", () => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
@@ -698,12 +698,23 @@ export class CatWorkspaceOrchestrator {
     );
     const existingMeta = this.segmentMeta.get(segmentId);
     if (existingMeta) {
-      this.segmentMeta.set(segmentId, {
-        ...existingMeta,
-        ...(target?.contentKind ? { contentKind: target.contentKind } : {}),
-        ...(target?.targetAssetUrl !== undefined ? { targetAssetUrl: target.targetAssetUrl } : {}),
-        ...(target?.imageVariantId !== undefined ? { imageVariantId: target.imageVariantId } : {}),
-      });
+      const nextContentKind = target?.contentKind ?? existingMeta.contentKind;
+      const nextTargetAssetUrl =
+        target?.targetAssetUrl !== undefined ? target.targetAssetUrl : existingMeta.targetAssetUrl;
+      const nextImageVariantId =
+        target?.imageVariantId !== undefined ? target.imageVariantId : existingMeta.imageVariantId;
+      if (
+        existingMeta.contentKind !== nextContentKind ||
+        existingMeta.targetAssetUrl !== nextTargetAssetUrl ||
+        existingMeta.imageVariantId !== nextImageVariantId
+      ) {
+        this.segmentMeta.set(segmentId, {
+          ...existingMeta,
+          ...(nextContentKind ? { contentKind: nextContentKind } : {}),
+          ...(nextTargetAssetUrl !== undefined ? { targetAssetUrl: nextTargetAssetUrl } : {}),
+          ...(nextImageVariantId !== undefined ? { imageVariantId: nextImageVariantId } : {}),
+        });
+      }
     }
 
     const existingDraft = this.drafts.get(segmentId);

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-domain-stores.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-domain-stores.test.ts
@@ -1,3 +1,4 @@
+import { autorun } from "mobx";
 import { describe, expect, it } from "vite-plus/test";
 
 import { CatIntelligenceStore } from "./cat-intelligence-store";
@@ -100,6 +101,24 @@ describe("CatSegmentDraft", () => {
     expect(draft.targetText).toBe("Server");
     expect(draft.isDirty).toBe(false);
     expect(draft.status).toBe("reviewed");
+  });
+
+  it("ignores no-op server target and status updates", () => {
+    const draft = new CatSegmentDraft("seg-01", "Saved", "reviewed");
+    let notifications = 0;
+    const dispose = autorun(() => {
+      void draft.targetText;
+      void draft.savedTargetText;
+      void draft.status;
+      notifications += 1;
+    });
+
+    notifications = 0;
+    draft.applyServerTarget("Saved", "reviewed");
+    draft.applyServerStatus("reviewed");
+
+    expect(notifications).toBe(0);
+    dispose();
   });
 
   it("updates status from server without changing the target baseline", () => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-segment-draft.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-segment-draft.ts
@@ -37,12 +37,22 @@ export class CatSegmentDraft {
   }
 
   applyServerTarget(targetText: string, status: CatSegmentStatus) {
+    if (
+      this.targetText === targetText &&
+      this.savedTargetText === targetText &&
+      this.status === status
+    ) {
+      return;
+    }
     this.targetText = targetText;
     this.savedTargetText = targetText;
     this.status = status;
   }
 
   applyServerStatus(status: CatSegmentStatus) {
+    if (this.status === status) {
+      return;
+    }
     this.status = status;
   }
 }


### PR DESCRIPTION
## What changed

Opening CAT in side-by-side view could lock the UI in a MobX update loop: lazy target sync’s effects depended on the unstable `useQueries()` array, and `applySegmentTarget` always rewrote `segmentMeta`, so observers kept re-rendering and re-applying. That produced hundreds of `[mobx] uncaught error in 'Reaction[observer]'` errors and left many `target` / concordance / context requests pending.

This PR:
- Syncs queue targets / loading ids from stable query fingerprints instead of the queries array identity
- Skips draft and `segmentMeta` writes when the server payload is unchanged
- Adds tests that identical re-applies do not notify observers

## How to test

- [ ] Open a Crowdin (or other external) project CAT workspace in **Side by side**
- [ ] Confirm the console does not spam MobX `Reaction[observer]` errors
- [ ] Confirm visible-row `target?sourcePath=...` requests complete once (no ongoing storm)
- [ ] Scroll and hover rows; targets and intelligence still load as expected
- [ ] `cd apps/hyperlocalise-web && vp test src/components/cat/workspace/cat-workspace-orchestrator.test.ts src/components/cat/workspace/store/cat-domain-stores.test.ts`
- [ ] `cd apps/hyperlocalise-web && vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review