### PR TITLE
feat(chat-dock): suggest context for the selected CAT segment

### DIFF
--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-empty-state.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-empty-state.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { MessageDescriptor } from "react-intl";
+
+import { buildChatDockSuggestions } from "./chat-dock-empty-state";
+import type { ChatDockPageContext } from "./chat-dock-store";
+
+function formatMessage(descriptor: MessageDescriptor, values?: Record<string, string>) {
+  let message = typeof descriptor.defaultMessage === "string" ? descriptor.defaultMessage : "";
+  if (values) {
+    for (const [key, value] of Object.entries(values)) {
+      message = message.replace(`{${key}}`, value);
+    }
+  }
+  return message;
+}
+
+describe("buildChatDockSuggestions", () => {
+  it("uses the generic find-context chip without page context", () => {
+    const suggestions = buildChatDockSuggestions(null, formatMessage);
+
+    expect(suggestions.map((suggestion) => suggestion.id)).toEqual([
+      "find-context",
+      "recent-changes",
+      "progress",
+      "translate",
+    ]);
+    expect(suggestions[0]?.prompt).toBe("What does this string mean, and where is it used?");
+  });
+
+  it("replaces find-context with the selected segment chip", () => {
+    const pageContext: ChatDockPageContext = {
+      kind: "cat-segment",
+      segmentId: "seg-02",
+      key: "checkout.submit",
+      sourceText: "Submit order",
+    };
+
+    const suggestions = buildChatDockSuggestions(pageContext, formatMessage);
+
+    expect(suggestions.map((suggestion) => suggestion.id)).toEqual([
+      "segment-context",
+      "recent-changes",
+      "progress",
+      "translate",
+    ]);
+    expect(suggestions[0]?.label).toBe("Context of checkout.submit");
+    expect(suggestions[0]?.prompt).toBe('What\'s the context of "checkout.submit"?');
+  });
+
+  it("truncates long keys in the pill label only", () => {
+    const longKey = "a".repeat(50);
+    const pageContext: ChatDockPageContext = {
+      kind: "cat-segment",
+      segmentId: "seg-02",
+      key: longKey,
+      sourceText: "Submit",
+    };
+
+    const suggestions = buildChatDockSuggestions(pageContext, formatMessage);
+
+    expect(suggestions[0]?.label).toBe(`Context of ${"a".repeat(35)}…`);
+    expect(suggestions[0]?.prompt).toBe(`What's the context of "${longKey}"?`);
+  });
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-empty-state.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-empty-state.tsx
@@ -9,50 +9,95 @@ import {
   TranslateIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { FormattedMessage, type MessageDescriptor, useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
 
 import { chatDockMessages } from "./chat-dock.messages";
+import type { ChatDockPageContext } from "./chat-dock-store";
 
 type Icon = ComponentProps<typeof HugeiconsIcon>["icon"];
-type MessageDescriptor = (typeof chatDockMessages)[keyof typeof chatDockMessages];
 
 type Suggestion = {
+  id: string;
   icon: Icon;
-  label: MessageDescriptor;
-  prompt: MessageDescriptor;
+  label: string;
+  prompt: string;
 };
 
-const suggestions: Suggestion[] = [
-  {
-    icon: FileSearchIcon,
-    label: chatDockMessages.suggestionFindContext,
-    prompt: chatDockMessages.promptFindContext,
-  },
-  {
+type FormatMessage = (descriptor: MessageDescriptor, values?: Record<string, string>) => string;
+
+const KEY_LABEL_MAX_LENGTH = 36;
+
+function truncateLabel(value: string, maxLength: number) {
+  const trimmed = value.trim();
+  if (trimmed.length <= maxLength) {
+    return trimmed;
+  }
+
+  return `${trimmed.slice(0, Math.max(0, maxLength - 1))}…`;
+}
+
+export function buildChatDockSuggestions(
+  pageContext: ChatDockPageContext | null,
+  formatMessage: FormatMessage,
+): Suggestion[] {
+  const recentChanges: Suggestion = {
+    id: "recent-changes",
     icon: Clock01Icon,
-    label: chatDockMessages.suggestionRecentChanges,
-    prompt: chatDockMessages.promptRecentChanges,
-  },
-  {
+    label: formatMessage(chatDockMessages.suggestionRecentChanges),
+    prompt: formatMessage(chatDockMessages.promptRecentChanges),
+  };
+  const progress: Suggestion = {
+    id: "progress",
     icon: AnalyticsUpIcon,
-    label: chatDockMessages.suggestionProgress,
-    prompt: chatDockMessages.promptProgress,
-  },
-  {
+    label: formatMessage(chatDockMessages.suggestionProgress),
+    prompt: formatMessage(chatDockMessages.promptProgress),
+  };
+  const translate: Suggestion = {
+    id: "translate",
     icon: TranslateIcon,
-    label: chatDockMessages.suggestionTranslate,
-    prompt: chatDockMessages.promptTranslate,
-  },
-];
+    label: formatMessage(chatDockMessages.suggestionTranslate),
+    prompt: formatMessage(chatDockMessages.promptTranslate),
+  };
+
+  if (pageContext?.kind === "cat-segment") {
+    const keyLabel = truncateLabel(pageContext.key, KEY_LABEL_MAX_LENGTH);
+    return [
+      {
+        id: "segment-context",
+        icon: FileSearchIcon,
+        label: formatMessage(chatDockMessages.suggestionSegmentContext, { key: keyLabel }),
+        prompt: formatMessage(chatDockMessages.promptSegmentContext, { key: pageContext.key }),
+      },
+      recentChanges,
+      progress,
+      translate,
+    ];
+  }
+
+  return [
+    {
+      id: "find-context",
+      icon: FileSearchIcon,
+      label: formatMessage(chatDockMessages.suggestionFindContext),
+      prompt: formatMessage(chatDockMessages.promptFindContext),
+    },
+    recentChanges,
+    progress,
+    translate,
+  ];
+}
 
 export function ChatDockEmptyState({
+  pageContext = null,
   onSelectSuggestion,
 }: {
+  pageContext?: ChatDockPageContext | null;
   onSelectSuggestion: (prompt: string) => void;
 }) {
   const intl = useIntl();
+  const suggestions = buildChatDockSuggestions(pageContext, intl.formatMessage);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-5 overflow-y-auto px-5 py-8 text-center">
@@ -72,15 +117,15 @@ export function ChatDockEmptyState({
       <div className="flex max-w-sm flex-wrap justify-center gap-2">
         {suggestions.map((suggestion) => (
           <Button
-            key={suggestion.label.id}
+            key={suggestion.id}
             type="button"
             variant="outline"
             size="sm"
             className="h-8 gap-1.5 rounded-full bg-background text-xs font-medium"
-            onClick={() => onSelectSuggestion(intl.formatMessage(suggestion.prompt))}
+            onClick={() => onSelectSuggestion(suggestion.prompt)}
           >
             <HugeiconsIcon icon={suggestion.icon} strokeWidth={1.8} className="size-3.5" />
-            <FormattedMessage {...suggestion.label} />
+            {suggestion.label}
           </Button>
         ))}
       </div>

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
@@ -333,6 +333,7 @@ export const ChatDockPanel = observer(function ChatDockPanel({
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {tab.isPending ? (
           <ChatDockEmptyState
+            pageContext={store.pageContext}
             onSelectSuggestion={(prompt) => {
               store.setDraft(tab.id, prompt);
               requestAnimationFrame(() => {

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.test.ts
@@ -90,4 +90,29 @@ describe("ChatDockStore", () => {
     expect(store.tabs[0]?.streamSnapshot).toBeNull();
     expect(store.tabs[0]?.isStreaming).toBe(false);
   });
+
+  it("tracks ephemeral page context without persisting it", () => {
+    const storage = createMemoryStorage();
+    const store = new ChatDockStore(storage);
+    store.setOrganizationSlug("acme");
+    store.openNewTab();
+    store.setPageContext({
+      kind: "cat-segment",
+      segmentId: "seg-02",
+      key: "checkout.submit",
+      sourceText: "Submit order",
+    });
+
+    expect(store.pageContext).toMatchObject({
+      kind: "cat-segment",
+      key: "checkout.submit",
+    });
+
+    const restored = new ChatDockStore(storage);
+    restored.setOrganizationSlug("acme");
+    expect(restored.pageContext).toBeNull();
+
+    store.clearPageContext();
+    expect(store.pageContext).toBeNull();
+  });
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.ts
@@ -30,6 +30,16 @@ export type ChatDockTab = {
   lastError: string | null;
 };
 
+/** Ephemeral page-scoped context for suggestion pills. Not persisted. */
+export type ChatDockPageContext = {
+  kind: "cat-segment";
+  segmentId: string;
+  key: string;
+  sourceText: string;
+  contextLabel?: string;
+  sourcePath?: string;
+};
+
 function createPendingTabId() {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
     return `pending-${crypto.randomUUID()}`;
@@ -94,6 +104,7 @@ export class ChatDockStore {
   activeTabId: string | null = null;
   panelOpen = false;
   hydrated = false;
+  pageContext: ChatDockPageContext | null = null;
 
   private storage: ChatDockStorage | undefined;
   private persistEnabled = true;
@@ -104,6 +115,7 @@ export class ChatDockStore {
       this,
       {
         tabs: observable.shallow,
+        pageContext: observable.ref,
       },
       { autoBind: true },
     );
@@ -248,6 +260,14 @@ export class ChatDockStore {
     this.updateTab(tabId, (tab) => {
       tab.draft = draft;
     });
+  }
+
+  setPageContext(context: ChatDockPageContext | null) {
+    this.pageContext = context;
+  }
+
+  clearPageContext() {
+    this.pageContext = null;
   }
 
   setTitle(tabId: string, title: string) {

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.messages.ts
@@ -48,6 +48,11 @@ export const chatDockMessages = defineMessages({
     defaultMessage: "Find context for a string",
     description: "Suggested prompt chip to find localisation context",
   },
+  suggestionSegmentContext: {
+    id: "tToS3qyu6G",
+    defaultMessage: "Context of {key}",
+    description: "Suggested prompt chip for the currently selected CAT segment",
+  },
   suggestionRecentChanges: {
     id: "EChSkkf+KW",
     defaultMessage: "What changed recently",
@@ -67,6 +72,11 @@ export const chatDockMessages = defineMessages({
     id: "VKjWHU/QDH",
     defaultMessage: "What does this string mean, and where is it used?",
     description: "Prefilled prompt when choosing the find-context chip",
+  },
+  promptSegmentContext: {
+    id: "084ETvW6A4",
+    defaultMessage: 'What\'s the context of "{key}"?',
+    description: "Prefilled prompt when asking for context of the selected CAT segment",
   },
   promptRecentChanges: {
     id: "N83FNjAdU2",

--- a/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store.test.ts
@@ -202,6 +202,12 @@ describe("AppShellStore", () => {
     store.navigation.setCustomNavigation(sampleGroups);
     store.sidebar.setForceCollapsed(true);
     store.sidebar.setPreferredOpen(false);
+    store.chatDock.setPageContext({
+      kind: "cat-segment",
+      segmentId: "seg-02",
+      key: "checkout.submit",
+      sourceText: "Submit",
+    });
 
     store.resetPageScope();
 
@@ -210,6 +216,7 @@ describe("AppShellStore", () => {
     expect(store.navigation.mode).toBe("route");
     expect(store.sidebar.forceCollapsed).toBe(false);
     expect(store.sidebar.preferredOpen).toBeNull();
+    expect(store.chatDock.pageContext).toBeNull();
   });
 
   it("bridges sidebar api and collapses when forced", () => {

--- a/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store.ts
@@ -37,6 +37,7 @@ export class AppShellStore {
     this.navigation.clearCustomMode();
     this.sidebar.setForceCollapsed(false);
     this.sidebar.setPreferredOpen(null);
+    this.chatDock.clearPageContext();
   }
 }
 

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-chat-dock-page-context-bridge.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-chat-dock-page-context-bridge.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+
+import { type ReactNode } from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  AppShellStoreProvider,
+  useAppShellStore,
+} from "@/components/app-shell/store/app-shell-store-context";
+import { createCatWorkspaceState } from "@/components/cat/shared/cat.fixture";
+import {
+  CatWorkspaceProvider,
+  useCatWorkspace,
+} from "@/components/cat/workspace/cat-workspace-context";
+
+import { CatChatDockPageContextBridge } from "./cat-chat-dock-page-context-bridge";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/org/acme/projects/proj_1/cat",
+}));
+
+function createWrapper(initialSegmentId = "seg-02") {
+  const initialState = createCatWorkspaceState({ selectedSegmentId: initialSegmentId });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <AppShellStoreProvider defaultNavigationGroups={[]}>
+        <CatWorkspaceProvider initialState={initialState}>
+          <CatChatDockPageContextBridge />
+          {children}
+        </CatWorkspaceProvider>
+      </AppShellStoreProvider>
+    );
+  };
+}
+
+describe("CatChatDockPageContextBridge", () => {
+  it("mirrors the selected CAT segment into chat dock page context", async () => {
+    const { result } = renderHook(
+      () => ({
+        chatDock: useAppShellStore().chatDock,
+        workspace: useCatWorkspace(),
+      }),
+      { wrapper: createWrapper("seg-02") },
+    );
+
+    await waitFor(() => {
+      expect(result.current.chatDock.pageContext).toMatchObject({
+        kind: "cat-segment",
+        segmentId: "seg-02",
+      });
+    });
+
+    const context = result.current.chatDock.pageContext;
+    expect(context?.kind).toBe("cat-segment");
+    if (context?.kind !== "cat-segment") {
+      return;
+    }
+
+    expect(context.key).toBeTruthy();
+    expect(context.sourceText).toBeTruthy();
+
+    result.current.workspace.setSelectedSegmentId("seg-01");
+
+    await waitFor(() => {
+      expect(result.current.chatDock.pageContext?.segmentId).toBe("seg-01");
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-chat-dock-page-context-bridge.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-chat-dock-page-context-bridge.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { reaction } from "mobx";
+import { useEffect } from "react";
+
+import type { ChatDockPageContext } from "@/components/app-shell/chat-dock/chat-dock-store";
+import { useOptionalAppShellStore } from "@/components/app-shell/store/app-shell-store-context";
+
+import { useCatWorkspace } from "./cat-workspace-context";
+
+function toChatDockPageContext(
+  segmentId: string,
+  key: string,
+  sourceText: string,
+  contextLabel: string | undefined,
+  sourcePath: string | undefined,
+): ChatDockPageContext {
+  return {
+    kind: "cat-segment",
+    segmentId,
+    key,
+    sourceText,
+    contextLabel,
+    sourcePath,
+  };
+}
+
+/**
+ * Mirrors the selected CAT segment into ChatDockStore.pageContext so suggestion
+ * pills can reference the current string. Chat dock sits outside CatWorkspaceProvider.
+ */
+export function CatChatDockPageContextBridge() {
+  const workspace = useCatWorkspace();
+  const appShell = useOptionalAppShellStore();
+
+  useEffect(() => {
+    const chatDock = appShell?.chatDock;
+    if (!chatDock) {
+      return;
+    }
+
+    return reaction(
+      () => {
+        const segment = workspace.selectedSegmentView;
+        if (!segment) {
+          return null;
+        }
+
+        return toChatDockPageContext(
+          segment.id,
+          segment.key,
+          segment.sourceText,
+          segment.contextLabel,
+          workspace.fileContext.sourcePath,
+        );
+      },
+      (context) => {
+        chatDock.setPageContext(context);
+      },
+      { fireImmediately: true },
+    );
+  }, [appShell, workspace]);
+
+  useEffect(() => {
+    const chatDock = appShell?.chatDock;
+    if (!chatDock) {
+      return;
+    }
+
+    return () => {
+      chatDock.clearPageContext();
+    };
+  }, [appShell]);
+
+  return null;
+}

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
@@ -26,6 +26,7 @@ import type { CatSegment, CatWorkspaceState } from "@/components/cat/shared/type
 import type { CatQueueFilter } from "@/components/cat/queue/cat-queue-filter";
 
 import { CatQueryBridge } from "./bridge/cat-query-bridge";
+import { CatChatDockPageContextBridge } from "./cat-chat-dock-page-context-bridge";
 import { CatPanelErrorBoundary } from "./cat-panel-error-boundary";
 import { CatWorkspaceLazySegmentSync } from "./cat-workspace-lazy-segment-sync";
 import { CatWorkspaceView } from "./cat-workspace";
@@ -115,6 +116,7 @@ const CatWorkspaceContainerObserver = observer(function CatWorkspaceContainerObs
 
   return (
     <>
+      <CatChatDockPageContextBridge />
       {onPageLimitChange ? (
         <CatWorkspaceViewModeSync onPageLimitChange={onPageLimitChange} />
       ) : null}


### PR DESCRIPTION
## What changed

When the CAT workspace has a selected segment, chat dock empty-state pills replace the generic “Find context” chip with a segment-aware suggestion (e.g. “Context of checkout.submit”) that fills the composer with `What's the context of "{key}"?`.

CAT selection is mirrored into ephemeral `ChatDockStore.pageContext` via a bridge component, because the dock lives outside `CatWorkspaceProvider`. Context is not persisted and clears on route change.

## How to test

- Open CAT with a selected segment, open a new chat dock tab, confirm the first pill shows the segment key and clicking it fills the composer (does not send).
- Change the selected segment and confirm the pill/prompt updates.
- Outside CAT, confirm the original static pills still appear.
- `vp test src/components/app-shell/chat-dock/chat-dock-store.test.ts src/components/app-shell/chat-dock/chat-dock-empty-state.test.ts src/components/cat/workspace/cat-chat-dock-page-context-bridge.test.tsx src/components/app-shell/store/app-shell-store.test.ts`
- `vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review