### PR TITLE
feat(cat): All Files scope and project Strings sidebar

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -27,6 +27,7 @@ import type {
 const {
   getTmsProviderConnectionMock,
   getTmsProviderLiveCatFileMock,
+  getTmsProviderLiveCatAllFilesMock,
   saveTmsProviderLiveCatTranslationMock,
   saveTmsProviderLiveCatCommentMock,
   resolveTmsProviderLiveCatCommentMock,
@@ -36,9 +37,11 @@ const {
   ensureOrganizationProjectRecordMock,
   createStoredFileMock,
   deleteStoredFileMock,
+  isReleaseCatAllFilesEnabledMock,
 } = vi.hoisted(() => ({
   getTmsProviderConnectionMock: vi.fn(),
   getTmsProviderLiveCatFileMock: vi.fn(),
+  getTmsProviderLiveCatAllFilesMock: vi.fn(),
   saveTmsProviderLiveCatTranslationMock: vi.fn(),
   saveTmsProviderLiveCatCommentMock: vi.fn(),
   resolveTmsProviderLiveCatCommentMock: vi.fn(),
@@ -48,6 +51,12 @@ const {
   ensureOrganizationProjectRecordMock: vi.fn(),
   createStoredFileMock: vi.fn(),
   deleteStoredFileMock: vi.fn(),
+  isReleaseCatAllFilesEnabledMock: vi.fn(async () => false),
+}));
+
+vi.mock("@/lib/flags/release-flags", () => ({
+  isReleaseCatAllFilesEnabled: isReleaseCatAllFilesEnabledMock,
+  RELEASE_CAT_ALL_FILES_FLAG: "release-cat-all-files",
 }));
 
 vi.mock("@/lib/translation/cat", () => ({
@@ -76,6 +85,8 @@ vi.mock("@/lib/providers/jobs/tms-provider-live", async (importOriginal) => {
     ...actual,
     getTmsProviderConnection: (...args: unknown[]) => getTmsProviderConnectionMock(...args),
     getTmsProviderLiveCatFile: (...args: unknown[]) => getTmsProviderLiveCatFileMock(...args),
+    getTmsProviderLiveCatAllFiles: (...args: unknown[]) =>
+      getTmsProviderLiveCatAllFilesMock(...args),
     saveTmsProviderLiveCatTranslation: (...args: unknown[]) =>
       saveTmsProviderLiveCatTranslationMock(...args),
     saveTmsProviderLiveCatComment: (...args: unknown[]) =>
@@ -111,10 +122,159 @@ beforeAll(async () => {
 
 afterEach(async () => {
   vi.clearAllMocks();
+  isReleaseCatAllFilesEnabledMock.mockResolvedValue(false);
   await projectFixture.cleanup();
 });
 
 describe("project file CAT routes", () => {
+  it("rejects All Files CAT when the release flag is off", async () => {
+    const translator = projectFixture.createWorkosIdentityWithRole("translator");
+    getTmsProviderConnectionMock.mockResolvedValue({
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      validationStatus: "valid",
+      validationMessage: null,
+    });
+    isReleaseCatAllFilesEnabledMock.mockResolvedValue(false);
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.queue.$get(
+      {
+        param: {
+          organizationSlug: translator.organization.slug ?? "missing-slug",
+          projectId: "ext:crowdin:42",
+        },
+        query: {
+          sourcePath: "*",
+          targetLocale: "fr",
+        },
+      },
+      { headers: await projectFixture.authHeadersFor(translator) },
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({ error: "feature_unavailable" });
+    expect(getTmsProviderLiveCatAllFilesMock).not.toHaveBeenCalled();
+  });
+
+  it("loads Crowdin All Files CAT when the release flag is on", async () => {
+    const translator = projectFixture.createWorkosIdentityWithRole("translator");
+    getTmsProviderConnectionMock.mockResolvedValue({
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      validationStatus: "valid",
+      validationMessage: null,
+    });
+    isReleaseCatAllFilesEnabledMock.mockResolvedValue(true);
+    getTmsProviderLiveCatAllFilesMock.mockResolvedValue({
+      sourcePath: "*",
+      filename: "All Files",
+      provider: {
+        kind: "crowdin",
+        resourceType: "file",
+        externalProjectId: "42",
+        externalResourceId: "101",
+        externalUrl: null,
+        syncState: "synced",
+        sourceLocale: "en",
+        targetLocales: ["fr"],
+        localeReadiness: {},
+        revision: "1",
+        format: "json",
+        lastSyncedAt: null,
+      },
+      targetLocale: "fr",
+      canEditTranslations: true,
+      truncated: false,
+      pagination: {
+        offset: 0,
+        limit: 50,
+        returnedCount: 1,
+        totalCount: 1,
+        hasMore: false,
+      },
+      segments: [
+        {
+          externalStringId: "1001",
+          key: "hello",
+          sourceText: "Hello",
+          context: null,
+          type: "text",
+          sourcePath: "crowdin/home.json",
+          externalResourceId: "101",
+          resourceType: "file",
+        },
+      ],
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.queue.$get(
+      {
+        param: {
+          organizationSlug: translator.organization.slug ?? "missing-slug",
+          projectId: "ext:crowdin:42",
+        },
+        query: {
+          sourcePath: "*",
+          targetLocale: "fr",
+          limit: 50,
+        },
+      },
+      { headers: await projectFixture.authHeadersFor(translator) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      catQueue: {
+        sourcePath: "*",
+        segments: [{ externalStringId: "1001", sourcePath: "crowdin/home.json" }],
+      },
+    });
+    expect(getTmsProviderLiveCatAllFilesMock).toHaveBeenCalledWith(
+      expect.any(String),
+      "42",
+      "fr",
+      expect.objectContaining({
+        pagination: expect.objectContaining({ paginated: true, limit: 50 }),
+      }),
+    );
+  });
+
+  it("rejects All Files CAT for unsupported providers when the flag is on", async () => {
+    const translator = projectFixture.createWorkosIdentityWithRole("translator");
+    getTmsProviderConnectionMock.mockResolvedValue({
+      providerKind: "phrase",
+      displayName: "Phrase",
+      validationStatus: "valid",
+      validationMessage: null,
+    });
+    isReleaseCatAllFilesEnabledMock.mockResolvedValue(true);
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.queue.$get(
+      {
+        param: {
+          organizationSlug: translator.organization.slug ?? "missing-slug",
+          projectId: "ext:phrase:42",
+        },
+        query: {
+          sourcePath: "*",
+          targetLocale: "fr",
+        },
+      },
+      { headers: await projectFixture.authHeadersFor(translator) },
+    );
+
+    expect(response.status).toBe(501);
+    expect(await response.json()).toMatchObject({
+      error: "provider_cat_all_files_unsupported",
+    });
+    expect(getTmsProviderLiveCatAllFilesMock).not.toHaveBeenCalled();
+  });
+
   it("returns Crowdin AI recommendations for an encoded provider project", async () => {
     const translator = projectFixture.createWorkosIdentityWithRole("translator");
     getTmsProviderConnectionMock.mockResolvedValue({

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -30,10 +30,7 @@ import {
   getLatestRepositorySourceFileVersion,
 } from "@/lib/file-storage/records";
 import { sourceContentType } from "@/lib/file-storage/source-file-metadata";
-import {
-  isCatAllFilesSourcePath,
-  parseCatSourcePathsFilter,
-} from "@/lib/projects/cat-all-files";
+import { isCatAllFilesSourcePath, parseCatSourcePathsFilter } from "@/lib/projects/cat-all-files";
 
 import {
   countTmsProviderLiveOpenJobsForProject,

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -10,6 +10,7 @@ import { workosAuthMiddleware, type ApiAuthContext, type AuthVariables } from "@
 import {
   badRequestResponse,
   conflictResponse,
+  forbiddenResponse as sharedForbiddenResponse,
   notFoundResponse,
   serviceUnavailableResponse,
 } from "@/api/errors";
@@ -23,6 +24,7 @@ import {
 import { db, schema, type DatabaseClient } from "@/lib/database";
 import type { Project } from "@/lib/database/types";
 import { getFileStorageAdapter, type FileStorageAdapter } from "@/lib/file-storage";
+import { isReleaseCatAllFilesEnabled } from "@/lib/flags/release-flags";
 import { createLogger } from "@/lib/log";
 import {
   createRepositorySourceFileVersion,
@@ -30,7 +32,12 @@ import {
   getLatestRepositorySourceFileVersion,
 } from "@/lib/file-storage/records";
 import { sourceContentType } from "@/lib/file-storage/source-file-metadata";
-import { isCatAllFilesSourcePath, parseCatSourcePathsFilter } from "@/lib/projects/cat-all-files";
+import {
+  isCatAllFilesSourcePath,
+  parseCatSourcePathsFilter,
+  supportsCatAllFilesProvider,
+} from "@/lib/projects/cat-all-files";
+import { TmsProviderLiveError } from "@/lib/providers/jobs/tms-provider-live-error";
 
 import {
   countTmsProviderLiveOpenJobsForProject,
@@ -639,6 +646,23 @@ async function loadProjectFileCatQueue(
   const allFiles = isCatAllFilesSourcePath(query.sourcePath);
   const sourcePathsFilter = allFiles ? parseCatSourcePathsFilter(query.sourcePaths) : null;
 
+  if (allFiles) {
+    if (!(await isReleaseCatAllFilesEnabled())) {
+      return { kind: "feature_unavailable" as const };
+    }
+
+    const providerKind = target.kind === "provider" ? target.providerKind : null;
+    if (!supportsCatAllFilesProvider(providerKind)) {
+      return {
+        kind: "provider_error" as const,
+        error: new TmsProviderLiveError(
+          "provider_cat_all_files_unsupported",
+          "All Files CAT is not available for this provider yet.",
+        ),
+      };
+    }
+  }
+
   if (target.kind === "provider_unavailable") {
     return { kind: "provider_unavailable" as const, target };
   }
@@ -778,6 +802,13 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         const query = c.req.valid("query");
         const result = await loadProjectFileCatQueue(c.var.auth, params.projectId, query);
 
+        if (result.kind === "feature_unavailable") {
+          return sharedForbiddenResponse(
+            c,
+            "feature_unavailable",
+            "All Files CAT is not enabled for this organization",
+          );
+        }
         if (result.kind === "provider_unavailable") {
           return providerProjectUnavailableResponse(c, result.target);
         }
@@ -807,6 +838,13 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         const query = c.req.valid("query");
         const result = await loadProjectFileCatQueue(c.var.auth, params.projectId, query);
 
+        if (result.kind === "feature_unavailable") {
+          return sharedForbiddenResponse(
+            c,
+            "feature_unavailable",
+            "All Files CAT is not enabled for this organization",
+          );
+        }
         if (result.kind === "provider_unavailable") {
           return providerProjectUnavailableResponse(c, result.target);
         }

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -31,7 +31,13 @@ import {
 } from "@/lib/file-storage/records";
 import { sourceContentType } from "@/lib/file-storage/source-file-metadata";
 import {
+  isCatAllFilesSourcePath,
+  parseCatSourcePathsFilter,
+} from "@/lib/projects/cat-all-files";
+
+import {
   countTmsProviderLiveOpenJobsForProject,
+  getTmsProviderLiveCatAllFiles,
   getTmsProviderLiveCatFile,
   getTmsProviderLiveCatSegmentComments,
   getTmsProviderLiveCatSegmentTarget,
@@ -633,6 +639,8 @@ async function loadProjectFileCatQueue(
   const pagination = resolveProjectFileCatPagination(query);
   const target = await resolveProjectResourceTarget(auth, projectId);
   const organizationSlug = auth.organization.slug ?? auth.organization.localOrganizationId;
+  const allFiles = isCatAllFilesSourcePath(query.sourcePath);
+  const sourcePathsFilter = allFiles ? parseCatSourcePathsFilter(query.sourcePaths) : null;
 
   if (target.kind === "provider_unavailable") {
     return { kind: "provider_unavailable" as const, target };
@@ -652,6 +660,7 @@ async function loadProjectFileCatQueue(
       canEditTranslations: isWriteBackTranslationAllowed(auth.membership.role),
       organizationSlug,
       pagination,
+      sourcePaths: sourcePathsFilter,
     });
 
     if (!catQueue) {
@@ -662,19 +671,31 @@ async function loadProjectFileCatQueue(
   }
 
   try {
-    const catQueue = await getTmsProviderLiveCatFile(
-      auth.organization.localOrganizationId,
-      target.externalProjectId,
-      query.sourcePath,
-      query.targetLocale,
-      {
-        actorUserId: auth.user.localUserId,
-        canEditTranslations: isWriteBackTranslationAllowed(auth.membership.role),
-        externalResourceId: query.externalResourceId,
-        resourceType: query.resourceType,
-        pagination,
-      },
-    );
+    const catQueue = allFiles
+      ? await getTmsProviderLiveCatAllFiles(
+          auth.organization.localOrganizationId,
+          target.externalProjectId,
+          query.targetLocale,
+          {
+            actorUserId: auth.user.localUserId,
+            canEditTranslations: isWriteBackTranslationAllowed(auth.membership.role),
+            pagination,
+            sourcePaths: sourcePathsFilter,
+          },
+        )
+      : await getTmsProviderLiveCatFile(
+          auth.organization.localOrganizationId,
+          target.externalProjectId,
+          query.sourcePath,
+          query.targetLocale,
+          {
+            actorUserId: auth.user.localUserId,
+            canEditTranslations: isWriteBackTranslationAllowed(auth.membership.role),
+            externalResourceId: query.externalResourceId,
+            resourceType: query.resourceType,
+            pagination,
+          },
+        );
 
     if (!catQueue) {
       return { kind: "project_not_found" as const };

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -604,6 +604,8 @@ export const projectFileCatSegmentSchema = z.object({
   looksLikeImageUrl: z.boolean().optional(),
   /** Present when the queue spans multiple files (`sourcePath=*`). */
   sourcePath: z.string().optional(),
+  /** Provider file format for this segment's file (All Files mode). */
+  format: z.string().nullable().optional(),
   externalResourceId: z.string().optional(),
   resourceType: z.enum(["file", "key"]).optional(),
 });

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -243,11 +243,17 @@ export const projectFileCatQueueFilterSchema = z.enum([
 ]);
 
 export const projectFileCatQuerySchema = z.object({
+  /** Use `"*"` to load strings across every file in scope. */
   sourcePath: z.string().trim().min(1).max(2048),
   targetLocale: z.string().trim().min(1).max(32),
   externalResourceId: z.string().trim().min(1).max(128).optional(),
   resourceType: z.enum(["file", "key"]).optional(),
   repositoryFullName: z.string().trim().min(1).max(256).optional(),
+  /**
+   * Optional comma-separated source paths that narrow all-files (`sourcePath=*`)
+   * requests — used by job CAT to scope to the job's files.
+   */
+  sourcePaths: z.string().trim().max(32_768).optional(),
   search: z.string().trim().max(256).optional(),
   queueFilter: projectFileCatQueueFilterSchema.optional(),
   offset: z.coerce.number().int().min(0).optional(),
@@ -596,6 +602,10 @@ export const projectFileCatSegmentSchema = z.object({
   targetAssetUrl: z.string().nullable().optional(),
   imageVariantId: z.string().nullable().optional(),
   looksLikeImageUrl: z.boolean().optional(),
+  /** Present when the queue spans multiple files (`sourcePath=*`). */
+  sourcePath: z.string().optional(),
+  externalResourceId: z.string().optional(),
+  resourceType: z.enum(["file", "key"]).optional(),
 });
 
 export const projectFileCatSegmentParamsSchema = z.object({

--- a/apps/hyperlocalise-web/src/app/.well-known/vercel/flags/route.ts
+++ b/apps/hyperlocalise-web/src/app/.well-known/vercel/flags/route.ts
@@ -1,5 +1,6 @@
 import { createFlagsDiscoveryEndpoint, getProviderData } from "flags/next";
 
+import { releaseCatAllFilesFlag } from "../../../../lib/flags/release-flags";
 import {
   workspaceAutomationsFlag,
   workspaceKnowledgeFlag,
@@ -9,5 +10,6 @@ export const GET = createFlagsDiscoveryEndpoint(async () =>
   getProviderData({
     workspaceAutomationsFlag,
     workspaceKnowledgeFlag,
+    releaseCatAllFilesFlag,
   }),
 );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/cat-header-pickers.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/cat-header-pickers.tsx
@@ -80,25 +80,38 @@ export function CatFileTreePicker({
   files,
   selectedSourcePath,
   onSelectFile,
+  allFilesSelected = false,
+  onSelectAllFiles,
 }: {
   files: ProjectFileRecord[];
   selectedSourcePath: string;
   onSelectFile: (sourcePath: string) => void;
+  allFilesSelected?: boolean;
+  onSelectAllFiles?: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const [dialogSourcePath, setDialogSourcePath] = useState(selectedSourcePath);
+  const [dialogAllFiles, setDialogAllFiles] = useState(allFilesSelected);
   const selectedFile = useMemo(
-    () => files.find((file) => file.sourcePath === dialogSourcePath) ?? null,
-    [dialogSourcePath, files],
+    () =>
+      dialogAllFiles ? null : (files.find((file) => file.sourcePath === dialogSourcePath) ?? null),
+    [dialogAllFiles, dialogSourcePath, files],
   );
 
   useEffect(() => {
     if (open) {
       setDialogSourcePath(selectedSourcePath);
+      setDialogAllFiles(allFilesSelected);
     }
-  }, [open, selectedSourcePath]);
+  }, [allFilesSelected, open, selectedSourcePath]);
 
   const handleOpenSelectedFile = () => {
+    if (dialogAllFiles) {
+      onSelectAllFiles?.();
+      setOpen(false);
+      return;
+    }
+
     if (!selectedFile) {
       return;
     }
@@ -108,9 +121,12 @@ export function CatFileTreePicker({
   };
 
   const handleActivateFile = (sourcePath: string) => {
+    setDialogAllFiles(false);
     onSelectFile(sourcePath);
     setOpen(false);
   };
+
+  const triggerLabel = allFilesSelected ? "All Files" : selectedSourcePath;
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -125,21 +141,38 @@ export function CatFileTreePicker({
         }
       >
         <FilePickerIcon className="size-4 text-muted-foreground" />
-        <span className="min-w-0 truncate">{selectedSourcePath}</span>
+        <span className="min-w-0 truncate">{triggerLabel}</span>
       </DialogTrigger>
       <DialogContent className="max-h-[min(720px,calc(100svh-2rem))] gap-4 overflow-hidden sm:max-w-3xl">
         <DialogHeader>
           <DialogTitle>Choose source file</DialogTitle>
           <DialogDescription>
-            Browse the project file tree. Select a file, then open it in the CAT workspace.
+            Browse the file tree, or choose All Files to view strings across every file.
           </DialogDescription>
         </DialogHeader>
+
+        {onSelectAllFiles ? (
+          <Button
+            type="button"
+            variant={dialogAllFiles ? "default" : "outline"}
+            className="h-9 justify-start"
+            onClick={() => {
+              setDialogAllFiles(true);
+              setDialogSourcePath("");
+            }}
+          >
+            All Files
+          </Button>
+        ) : null}
 
         <div className="min-h-0 rounded-lg border border-border bg-background">
           <ProjectFilesTree
             files={files}
-            selectedSourcePath={dialogSourcePath}
-            onSelectFile={setDialogSourcePath}
+            selectedSourcePath={dialogAllFiles ? "" : dialogSourcePath}
+            onSelectFile={(sourcePath) => {
+              setDialogAllFiles(false);
+              setDialogSourcePath(sourcePath);
+            }}
             onActivateFile={handleActivateFile}
             ariaLabel="Source files"
           />
@@ -147,7 +180,7 @@ export function CatFileTreePicker({
 
         <div className="rounded-lg border border-border bg-background px-4 py-3">
           <TypographyP className="truncate font-mono text-xs text-foreground">
-            {selectedFile?.sourcePath ?? "No file selected"}
+            {dialogAllFiles ? "All Files" : (selectedFile?.sourcePath ?? "No file selected")}
           </TypographyP>
           <TypographyP className="text-xs text-muted-foreground">
             Double-click a file in the tree, or use Open file.
@@ -158,7 +191,7 @@ export function CatFileTreePicker({
           <Button variant="outline" onClick={() => setOpen(false)}>
             Cancel
           </Button>
-          <Button onClick={handleOpenSelectedFile} disabled={!selectedFile}>
+          <Button onClick={handleOpenSelectedFile} disabled={!dialogAllFiles && !selectedFile}>
             Open file
           </Button>
         </DialogFooter>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
@@ -17,7 +17,11 @@ import {
 import { useAppShellSidebar } from "@/components/app-shell/store/use-app-shell-sidebar";
 import { apiClient } from "@/lib/api-client-instance";
 import { supportsProviderCatFile } from "@/lib/providers/capabilities/provider-cat-capabilities";
-import { CAT_ALL_FILES_SOURCE_PATH } from "@/lib/projects/cat-all-files";
+import {
+  CAT_ALL_FILES_SOURCE_PATH,
+  supportsCatAllFilesProvider,
+} from "@/lib/projects/cat-all-files";
+import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 import {
   buildProjectFileCatAllFilesHref,
   buildProjectFileCatHref,
@@ -66,6 +70,7 @@ export function ProjectFileCatPageContent({
   projectId,
   sourcePath,
   allFiles = false,
+  catAllFilesEnabled = false,
   highlightLocale,
   initialSegmentKey = null,
   externalResourceId = null,
@@ -77,6 +82,7 @@ export function ProjectFileCatPageContent({
   projectId: string;
   sourcePath: string | null;
   allFiles?: boolean;
+  catAllFilesEnabled?: boolean;
   highlightLocale: string | null;
   initialSegmentKey?: string | null;
   externalResourceId?: string | null;
@@ -144,6 +150,49 @@ export function ProjectFileCatPageContent({
     () => sortFilesByPath(filesQuery.data ?? []).filter((entry) => canOpenProjectFileCat(entry)),
     [filesQuery.data],
   );
+
+  const canUseAllFiles =
+    catAllFilesEnabled &&
+    supportsCatAllFilesProvider(
+      projectQuery.data?.externalProviderKind ??
+        parseProviderProjectId(projectId)?.providerKind ??
+        null,
+    );
+
+  useEffect(() => {
+    if (!allFiles || canUseAllFiles || !projectQuery.data) {
+      return;
+    }
+
+    const fallbackFile = catFiles[0];
+    if (!fallbackFile) {
+      router.replace(filesHref);
+      return;
+    }
+
+    const href = buildProjectFileCatHref(
+      organizationSlug,
+      projectId,
+      fallbackFile,
+      highlightLocale,
+      branch,
+      projectQuery.data.targetLocales,
+    );
+    if (href) {
+      router.replace(href);
+    }
+  }, [
+    allFiles,
+    branch,
+    canUseAllFiles,
+    catFiles,
+    filesHref,
+    highlightLocale,
+    organizationSlug,
+    projectId,
+    projectQuery.data,
+    router,
+  ]);
 
   const enabledRepositoryFullNames = useMemo(
     () =>
@@ -479,7 +528,7 @@ export function ProjectFileCatPageContent({
             selectedSourcePath={sourcePath ?? ""}
             onSelectFile={handleFileChange}
             allFilesSelected={allFiles}
-            onSelectAllFiles={handleSelectAllFiles}
+            onSelectAllFiles={canUseAllFiles ? handleSelectAllFiles : undefined}
           />
         ) : (
           <TypographyP className="min-w-0 truncate font-mono text-xs text-muted-foreground">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
@@ -17,10 +17,13 @@ import {
 import { useAppShellSidebar } from "@/components/app-shell/store/use-app-shell-sidebar";
 import { apiClient } from "@/lib/api-client-instance";
 import { supportsProviderCatFile } from "@/lib/providers/capabilities/provider-cat-capabilities";
+import { CAT_ALL_FILES_SOURCE_PATH } from "@/lib/projects/cat-all-files";
 import {
+  buildProjectFileCatAllFilesHref,
   buildProjectFileCatHref,
   canOpenProjectFileCat,
   hasProjectFileCatIdentityFromUrl,
+  resolveProjectCatTargetLocale,
   resolveProjectFileCatTargetLocaleResolution,
   resolveProjectFileCatTargetLocales,
 } from "@/lib/projects/project-file-cat-routing";
@@ -62,25 +65,29 @@ export function ProjectFileCatPageContent({
   organizationSlug,
   projectId,
   sourcePath,
+  allFiles = false,
   highlightLocale,
   initialSegmentKey = null,
   externalResourceId = null,
   resourceType = null,
   branch = null,
+  sourcePaths = null,
 }: {
   organizationSlug: string;
   projectId: string;
   sourcePath: string | null;
+  allFiles?: boolean;
   highlightLocale: string | null;
   initialSegmentKey?: string | null;
   externalResourceId?: string | null;
   resourceType?: "file" | "key" | null;
   branch?: string | null;
+  sourcePaths?: string | null;
 }) {
   const router = useRouter();
   const pageNavigationGuardRef = useRef<CatPageNavigationGuardRef["current"]>(null);
   const queryClient = useQueryClient();
-  const hasFileReference = Boolean(sourcePath);
+  const hasFileReference = Boolean(sourcePath) || allFiles;
   const projectQuery = useProjectPageQuery(organizationSlug, projectId, {
     enabled: hasFileReference,
   });
@@ -173,7 +180,35 @@ export function ProjectFileCatPageContent({
     preferredOpen: hasFileReference ? false : null,
   });
 
-  if (!sourcePath) {
+  useEffect(() => {
+    if (!allFiles || highlightLocale || !projectQuery.data) {
+      return;
+    }
+
+    const resolved = resolveProjectCatTargetLocale(projectQuery.data.targetLocales, null);
+    if (!resolved) {
+      return;
+    }
+
+    router.replace(
+      buildProjectFileCatAllFilesHref(organizationSlug, projectId, resolved, {
+        branch,
+        sourcePaths: sourcePaths ? sourcePaths.split(",") : null,
+        basePath: "strings",
+      }),
+    );
+  }, [
+    allFiles,
+    branch,
+    highlightLocale,
+    organizationSlug,
+    projectId,
+    projectQuery.data,
+    router,
+    sourcePaths,
+  ]);
+
+  if (!sourcePath && !allFiles) {
     return (
       <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
@@ -232,7 +267,7 @@ export function ProjectFileCatPageContent({
     externalResourceId ?? file?.provider?.externalResourceId ?? null;
   const resolvedResourceType = resourceType ?? file?.provider?.resourceType;
 
-  if (!canOpenFromUrlIdentity && !file) {
+  if (!allFiles && !canOpenFromUrlIdentity && !file) {
     return (
       <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
@@ -249,7 +284,7 @@ export function ProjectFileCatPageContent({
     );
   }
 
-  if (file?.provider && !supportsProviderCatFile(file)) {
+  if (!allFiles && file?.provider && !supportsProviderCatFile(file)) {
     return (
       <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
@@ -266,17 +301,32 @@ export function ProjectFileCatPageContent({
   }
 
   const projectTargetLocales = projectQuery.data?.targetLocales;
-  const workspaceTargetLocales = file
-    ? resolveProjectFileCatTargetLocales(file, projectTargetLocales)
-    : [];
-  const targetLocaleResolution = file
-    ? resolveProjectFileCatTargetLocaleResolution(file, highlightLocale, projectTargetLocales)
-    : {
+  const workspaceTargetLocales = allFiles
+    ? [...(projectTargetLocales ?? [])]
+    : file
+      ? resolveProjectFileCatTargetLocales(file, projectTargetLocales)
+      : [];
+  const targetLocaleResolution = allFiles
+    ? {
         requestedLocale: highlightLocale,
-        status: highlightLocale ? ("exact" as const) : ("none" as const),
-        targetLocale: highlightLocale,
-        targetLocales: [],
-      };
+        status: (
+          highlightLocale && workspaceTargetLocales.includes(highlightLocale)
+            ? "exact"
+            : workspaceTargetLocales[0]
+              ? "fallback"
+              : "none"
+        ) as "exact" | "fallback" | "none",
+        targetLocale: resolveProjectCatTargetLocale(projectTargetLocales, highlightLocale),
+        targetLocales: workspaceTargetLocales,
+      }
+    : file
+      ? resolveProjectFileCatTargetLocaleResolution(file, highlightLocale, projectTargetLocales)
+      : {
+          requestedLocale: highlightLocale,
+          status: highlightLocale ? ("exact" as const) : ("none" as const),
+          targetLocale: highlightLocale,
+          targetLocales: [],
+        };
   const targetLocale = targetLocaleResolution.targetLocale;
   const localeFallbackMessage =
     targetLocaleResolution.status === "fallback" &&
@@ -339,13 +389,23 @@ export function ProjectFileCatPageContent({
       organizationSlug,
       projectId,
       nextFile,
-      highlightLocale,
+      targetLocale ?? highlightLocale,
       branch,
       projectTargetLocales,
     );
     if (href) {
       router.push(href);
     }
+  };
+
+  const handleSelectAllFiles = () => {
+    const href = buildProjectFileCatAllFilesHref(
+      organizationSlug,
+      projectId,
+      targetLocale ?? highlightLocale,
+      { branch, basePath: "strings" },
+    );
+    router.push(href);
   };
 
   const handleRepositoryChange = (nextRepositoryFullName: string) => {
@@ -358,11 +418,26 @@ export function ProjectFileCatPageContent({
   };
 
   const handleLocaleChange = (nextLocale: string) => {
-    if (!sourcePath || nextLocale === targetLocale) {
+    if (nextLocale === targetLocale) {
       return;
     }
 
     const navigate = () => {
+      if (allFiles) {
+        router.push(
+          buildProjectFileCatAllFilesHref(organizationSlug, projectId, nextLocale, {
+            branch,
+            sourcePaths: sourcePaths ? sourcePaths.split(",") : null,
+            basePath: "strings",
+          }),
+        );
+        return;
+      }
+
+      if (!sourcePath) {
+        return;
+      }
+
       const params = new URLSearchParams({
         sourcePath,
         locale: nextLocale,
@@ -400,11 +475,13 @@ export function ProjectFileCatPageContent({
           <ArrowLeftIcon className="size-4" />
         </Button>
 
-        {catFiles.length > 0 ? (
+        {catFiles.length > 0 || allFiles ? (
           <CatFileTreePicker
             files={catFiles}
             selectedSourcePath={sourcePath ?? ""}
             onSelectFile={handleFileChange}
+            allFilesSelected={allFiles}
+            onSelectAllFiles={handleSelectAllFiles}
           />
         ) : (
           <TypographyP className="min-w-0 truncate font-mono text-xs text-muted-foreground">
@@ -460,13 +537,13 @@ export function ProjectFileCatPageContent({
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 py-2 sm:px-4 lg:px-6">
         <ProjectFileCatWorkspace
-          key={`${sourcePath}:${resolvedExternalResourceId ?? "source-path"}:${targetLocale}`}
+          key={`${allFiles ? CAT_ALL_FILES_SOURCE_PATH : sourcePath}:${resolvedExternalResourceId ?? "source-path"}:${targetLocale}`}
           organizationSlug={organizationSlug}
           projectId={projectId}
           sourceLocale={sourceLocale}
-          sourcePath={sourcePath}
-          externalResourceId={resolvedExternalResourceId}
-          resourceType={resolvedResourceType}
+          sourcePath={allFiles ? CAT_ALL_FILES_SOURCE_PATH : (sourcePath as string)}
+          externalResourceId={allFiles ? null : resolvedExternalResourceId}
+          resourceType={allFiles ? undefined : resolvedResourceType}
           targetLocale={targetLocale}
           targetLocales={workspaceTargetLocales}
           highlightLocale={highlightLocale}
@@ -476,6 +553,7 @@ export function ProjectFileCatPageContent({
             selectedRepositoryFullName,
           )}
           initialSegmentKey={initialSegmentKey}
+          sourcePathsFilter={sourcePaths}
           layout="fullscreen"
           className="min-h-0 flex-1"
           pageNavigationGuardRef={pageNavigationGuardRef}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
@@ -309,13 +309,11 @@ export function ProjectFileCatPageContent({
   const targetLocaleResolution = allFiles
     ? {
         requestedLocale: highlightLocale,
-        status: (
-          highlightLocale && workspaceTargetLocales.includes(highlightLocale)
-            ? "exact"
-            : workspaceTargetLocales[0]
-              ? "fallback"
-              : "none"
-        ) as "exact" | "fallback" | "none",
+        status: (highlightLocale && workspaceTargetLocales.includes(highlightLocale)
+          ? "exact"
+          : workspaceTargetLocales[0]
+            ? "fallback"
+            : "none") as "exact" | "fallback" | "none",
         targetLocale: resolveProjectCatTargetLocale(projectTargetLocales, highlightLocale),
         targetLocales: workspaceTargetLocales,
       }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/cat/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/cat/page.tsx
@@ -1,4 +1,5 @@
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
+import { isReleaseCatAllFilesEnabled } from "@/lib/flags/release-flags";
 import { parseProjectFileCatSearchParams } from "@/lib/projects/project-file-cat-routing";
 
 import { ProjectFileCatPageContent } from "../_components/project-file-cat-page-content";
@@ -21,13 +22,15 @@ export default async function ProjectFileCatPage({
   const { organizationSlug, projectId } = await params;
   const parsedSearchParams = parseProjectFileCatSearchParams(await searchParams);
   await requireAppAuthContext({ organizationSlug });
+  const catAllFilesEnabled = await isReleaseCatAllFilesEnabled();
 
   return (
     <ProjectFileCatPageContent
       organizationSlug={organizationSlug}
       projectId={projectId}
       sourcePath={parsedSearchParams.sourcePath}
-      allFiles={parsedSearchParams.allFiles}
+      allFiles={catAllFilesEnabled ? parsedSearchParams.allFiles : false}
+      catAllFilesEnabled={catAllFilesEnabled}
       highlightLocale={parsedSearchParams.highlightLocale}
       initialSegmentKey={parsedSearchParams.initialSegmentKey}
       externalResourceId={parsedSearchParams.externalResourceId}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.test.tsx
@@ -159,7 +159,7 @@ function mockReadyProjectQuery() {
 }
 
 describe("JobCatPageContent guard ordering", () => {
-  it("pre-selects all job files when no file reference is present", async () => {
+  it("pre-selects the default job file when All Files is disabled", async () => {
     useProjectPageQueryMock.mockReturnValue({
       isLoading: false,
       isError: false,
@@ -179,6 +179,41 @@ describe("JobCatPageContent guard ordering", () => {
           sourcePath={null}
           storedFileId={null}
           targetLocale="vi"
+        />
+      </CatTestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(routerReplaceMock).toHaveBeenCalledWith(
+        "/org/acme/projects/proj_1/jobs/job_1/strings?targetLocale=vi&sourcePath=crowdin%2Fhome.json&queueFilter=untranslated",
+      );
+    });
+    expect(
+      screen.queryByText("This project does not have a source locale."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("pre-selects all job files when All Files is enabled", async () => {
+    useProjectPageQueryMock.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      isSuccess: false,
+      data: undefined,
+      error: null,
+    });
+    loadJobCatJobSourceFilesMock.mockResolvedValue([providerFile]);
+    routerReplaceMock.mockClear();
+
+    render(
+      <CatTestProviders>
+        <JobCatPageContent
+          organizationSlug="acme"
+          projectId="proj_1"
+          jobId="job_1"
+          sourcePath={null}
+          storedFileId={null}
+          targetLocale="vi"
+          catAllFilesEnabled
         />
       </CatTestProviders>,
     );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.test.tsx
@@ -159,7 +159,7 @@ function mockReadyProjectQuery() {
 }
 
 describe("JobCatPageContent guard ordering", () => {
-  it("pre-selects the first openable file when no file reference is present", async () => {
+  it("pre-selects all job files when no file reference is present", async () => {
     useProjectPageQueryMock.mockReturnValue({
       isLoading: false,
       isError: false,
@@ -185,7 +185,7 @@ describe("JobCatPageContent guard ordering", () => {
 
     await waitFor(() => {
       expect(routerReplaceMock).toHaveBeenCalledWith(
-        "/org/acme/projects/proj_1/jobs/job_1/strings?targetLocale=vi&sourcePath=crowdin%2Fhome.json&queueFilter=untranslated",
+        "/org/acme/projects/proj_1/jobs/job_1/strings?targetLocale=vi&sourcePath=*&sourcePaths=crowdin%2Fhome.json&queueFilter=untranslated",
       );
     });
     expect(

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -334,7 +334,7 @@ export function JobCatPageContent({
     didAutoSelectDefaultFileRef.current = true;
     const jobSourcePaths = defaultFileQuery.data.files
       .map((file) => file.sourcePath)
-      .filter(Boolean);
+      .filter((path): path is string => Boolean(path?.trim()));
     const reference = defaultFileQuery.data.reference;
 
     if (canUseAllFiles) {
@@ -439,7 +439,10 @@ export function JobCatPageContent({
       sourcePaths
         ?.split(",")
         .map((value) => value.trim())
-        .filter(Boolean) ?? jobFiles.map((file) => file.sourcePath);
+        .filter(Boolean) ??
+      jobFiles
+        .map((file) => file.sourcePath)
+        .filter((path): path is string => Boolean(path?.trim()));
     const selectedTargetLocale = activeTargetLocale ?? targetLocale;
 
     if (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -402,9 +402,12 @@ export function JobCatPageContent({
     );
   }
 
-
   if (allFiles) {
-    if (projectQuery.isLoading || defaultFileQuery.isLoading || (!isNativeJob && providerFilesQuery.isLoading && !providerFilesQuery.data)) {
+    if (
+      projectQuery.isLoading ||
+      defaultFileQuery.isLoading ||
+      (!isNativeJob && providerFilesQuery.isLoading && !providerFilesQuery.data)
+    ) {
       // fall through only when we have files — wait for queries below via reused loading UI
     }
 
@@ -414,8 +417,10 @@ export function JobCatPageContent({
         ? providerFiles
         : defaultJobFiles.filter((file) => Boolean(file.storedFileId || file.provider));
     const jobSourcePaths =
-      sourcePaths?.split(",").map((value) => value.trim()).filter(Boolean) ??
-      jobFiles.map((file) => file.sourcePath);
+      sourcePaths
+        ?.split(",")
+        .map((value) => value.trim())
+        .filter(Boolean) ?? jobFiles.map((file) => file.sourcePath);
     const selectedTargetLocale = activeTargetLocale ?? targetLocale;
 
     if (projectQuery.isLoading || (!selectedTargetLocale && jobLocalesQuery.isLoading)) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -44,6 +44,11 @@ import {
 } from "@/components/cat/workspace/cat-page-navigation-guard";
 import type { CatQueueFilter } from "@/components/cat/queue/cat-queue-filter";
 import { jobCatQueueFilterParam } from "@/lib/projects/job-cat-routing";
+import {
+  CAT_ALL_FILES_SOURCE_PATH,
+  isCatAllFilesSourcePath,
+  serializeCatSourcePathsFilter,
+} from "@/lib/projects/cat-all-files";
 
 type JobCatGithubRepository = {
   fullName: string;
@@ -107,6 +112,7 @@ function stringsPageHref(input: {
   jobId: string;
   sourcePath?: string;
   storedFileId?: string;
+  sourcePaths?: readonly string[];
   targetLocale: string;
   segment?: string | null;
   queueFilter?: CatQueueFilter;
@@ -121,6 +127,10 @@ function stringsPageHref(input: {
 
   if (input.storedFileId) {
     params.set("storedFileId", input.storedFileId);
+  }
+
+  if (input.sourcePaths && input.sourcePaths.length > 0) {
+    params.set("sourcePaths", serializeCatSourcePathsFilter(input.sourcePaths));
   }
 
   if (input.segment) {
@@ -140,6 +150,7 @@ export function JobCatPageContent({
   jobId,
   sourcePath,
   storedFileId = null,
+  sourcePaths = null,
   targetLocale,
   initialSegmentKey = null,
   initialQueueFilter = "untranslated",
@@ -149,6 +160,7 @@ export function JobCatPageContent({
   jobId: string;
   sourcePath: string | null;
   storedFileId?: string | null;
+  sourcePaths?: string | null;
   targetLocale: string | null;
   initialSegmentKey?: string | null;
   initialQueueFilter?: CatQueueFilter;
@@ -156,12 +168,13 @@ export function JobCatPageContent({
   const router = useRouter();
   const pageNavigationGuardRef = useRef<CatPageNavigationGuardRef["current"]>(null);
   const taskHref = `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(jobId)}`;
-  const hasFileReference = Boolean(sourcePath || storedFileId);
-  const isNativeJob = Boolean(storedFileId);
+  const allFiles = isCatAllFilesSourcePath(sourcePath) && Boolean(sourcePath);
+  const hasFileReference = Boolean((sourcePath && !allFiles) || storedFileId) || allFiles;
+  const isNativeJob = Boolean(storedFileId) && !allFiles;
   const didAutoSelectDefaultFileRef = useRef(false);
   const defaultFileQuery = useQuery({
     queryKey: projectJobCatDefaultFileQueryKey(organizationSlug, projectId, jobId, targetLocale),
-    enabled: !hasFileReference,
+    enabled: !hasFileReference || allFiles,
     queryFn: async () => {
       const files = await loadJobCatJobSourceFiles({
         organizationSlug,
@@ -179,6 +192,7 @@ export function JobCatPageContent({
   const projectQuery = useProjectPageQuery(organizationSlug, projectId, {
     enabled: hasFileReference,
   });
+  // allFiles uses projectQuery + job file lists
   useAppShellSidebar({ forceCollapsed: hasFileReference });
   const targetFileQuery = useQuery({
     queryKey: projectJobCatTargetFileQueryKey(
@@ -187,7 +201,7 @@ export function JobCatPageContent({
       sourcePath,
       storedFileId,
     ),
-    enabled: hasFileReference,
+    enabled: hasFileReference && !allFiles,
     queryFn: () =>
       loadJobCatTargetFile({
         organizationSlug,
@@ -199,13 +213,13 @@ export function JobCatPageContent({
 
   const providerFilesQuery = useQuery({
     queryKey: projectJobCatProviderFilesQueryKey(organizationSlug, projectId, jobId),
-    enabled: hasFileReference && !isNativeJob,
+    enabled: (hasFileReference && !isNativeJob) || allFiles,
     queryFn: () => loadJobCatProviderJobFiles({ organizationSlug, projectId, jobId, targetLocale }),
   });
 
   const jobLocalesQuery = useQuery({
     queryKey: projectJobCatSelectableLocalesQueryKey(organizationSlug, projectId, jobId),
-    enabled: hasFileReference,
+    enabled: hasFileReference || allFiles,
     queryFn: () => loadJobCatSelectableTargetLocales({ organizationSlug, projectId, jobId }),
   });
 
@@ -310,13 +324,16 @@ export function JobCatPageContent({
     }
 
     didAutoSelectDefaultFileRef.current = true;
+    const jobSourcePaths = defaultFileQuery.data.files
+      .map((file) => file.sourcePath)
+      .filter(Boolean);
     router.replace(
       stringsPageHref({
         organizationSlug,
         projectId,
         jobId,
-        sourcePath: defaultFileQuery.data.reference.sourcePath ?? undefined,
-        storedFileId: defaultFileQuery.data.reference.storedFileId ?? undefined,
+        sourcePath: CAT_ALL_FILES_SOURCE_PATH,
+        sourcePaths: jobSourcePaths,
         targetLocale: defaultFileQuery.data.reference.targetLocale,
         segment: initialSegmentKey,
         queueFilter: initialQueueFilter,
@@ -382,6 +399,160 @@ export function JobCatPageContent({
           <TypographyP className="text-sm text-muted-foreground">Opening workspace…</TypographyP>
         </div>
       </ProjectPageShell>
+    );
+  }
+
+
+  if (allFiles) {
+    if (projectQuery.isLoading || defaultFileQuery.isLoading || (!isNativeJob && providerFilesQuery.isLoading && !providerFilesQuery.data)) {
+      // fall through only when we have files — wait for queries below via reused loading UI
+    }
+
+    const defaultJobFiles = defaultFileQuery.data?.files ?? [];
+    const jobFiles =
+      providerFiles.length > 0
+        ? providerFiles
+        : defaultJobFiles.filter((file) => Boolean(file.storedFileId || file.provider));
+    const jobSourcePaths =
+      sourcePaths?.split(",").map((value) => value.trim()).filter(Boolean) ??
+      jobFiles.map((file) => file.sourcePath);
+    const selectedTargetLocale = activeTargetLocale ?? targetLocale;
+
+    if (projectQuery.isLoading || (!selectedTargetLocale && jobLocalesQuery.isLoading)) {
+      return (
+        <ProjectPageShell>
+          <div className="flex min-h-48 items-center justify-center gap-2 rounded-lg border border-border bg-card p-5">
+            <Spinner />
+            <TypographyP className="text-sm text-muted-foreground">Loading workspace…</TypographyP>
+          </div>
+        </ProjectPageShell>
+      );
+    }
+
+    const sourceLocale = projectQuery.data?.sourceLocale;
+    if (projectQuery.isSuccess && !sourceLocale) {
+      return (
+        <ProjectPageShell>
+          <div className="rounded-lg border border-border bg-card p-5">
+            <TypographyP className="text-sm text-flame-100">
+              This project does not have a source locale.
+            </TypographyP>
+          </div>
+        </ProjectPageShell>
+      );
+    }
+
+    if (!sourceLocale || !selectedTargetLocale) {
+      return (
+        <ProjectPageShell>
+          <div className="rounded-lg border border-border bg-card p-5">
+            <TypographyP className="text-sm text-muted-foreground">
+              {!sourceLocale
+                ? "Loading workspace…"
+                : "No target locale is available for this task."}
+            </TypographyP>
+          </div>
+        </ProjectPageShell>
+      );
+    }
+
+    const handleAllFilesLocaleChange = (nextLocale: string) => {
+      if (!nextLocale || nextLocale === selectedTargetLocale) {
+        return;
+      }
+      attemptCatPageNavigation(pageNavigationGuardRef, () => {
+        router.push(
+          stringsPageHref({
+            organizationSlug,
+            projectId,
+            jobId,
+            sourcePath: CAT_ALL_FILES_SOURCE_PATH,
+            sourcePaths: jobSourcePaths,
+            targetLocale: nextLocale,
+            segment: initialSegmentKey,
+            queueFilter: initialQueueFilter,
+          }),
+        );
+      });
+    };
+
+    const handleJobFileChange = (nextSourcePath: string | null) => {
+      if (!nextSourcePath) {
+        return;
+      }
+      router.push(
+        stringsPageHref({
+          organizationSlug,
+          projectId,
+          jobId,
+          sourcePath: nextSourcePath,
+          targetLocale: selectedTargetLocale,
+          queueFilter: initialQueueFilter,
+        }),
+      );
+    };
+
+    const handleJobSelectAllFiles = () => {
+      router.push(
+        stringsPageHref({
+          organizationSlug,
+          projectId,
+          jobId,
+          sourcePath: CAT_ALL_FILES_SOURCE_PATH,
+          sourcePaths: jobSourcePaths,
+          targetLocale: selectedTargetLocale,
+          queueFilter: initialQueueFilter,
+        }),
+      );
+    };
+
+    return (
+      <main className="-mx-4 -my-5 flex h-[var(--app-shell-content-height)] min-h-0 flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
+        <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 sm:px-4 lg:px-6">
+          <Button
+            variant="outline"
+            size="icon-sm"
+            className="size-8 shrink-0"
+            render={<Link href={taskHref} />}
+          >
+            <ArrowLeftIcon className="size-4" />
+          </Button>
+
+          <CatFileTreePicker
+            files={jobFiles}
+            selectedSourcePath=""
+            onSelectFile={handleJobFileChange}
+            allFilesSelected
+            onSelectAllFiles={handleJobSelectAllFiles}
+          />
+
+          {jobTargetLocales.length > 0 ? (
+            <CatLocaleSelect
+              targetLocales={jobTargetLocales}
+              selectedTargetLocale={selectedTargetLocale}
+              onTargetLocaleChange={handleAllFilesLocaleChange}
+            />
+          ) : null}
+        </div>
+
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 py-2 sm:px-4 lg:px-6">
+          <ProjectFileCatWorkspace
+            key={`${CAT_ALL_FILES_SOURCE_PATH}:${selectedTargetLocale}`}
+            organizationSlug={organizationSlug}
+            projectId={projectId}
+            sourceLocale={sourceLocale}
+            sourcePath={CAT_ALL_FILES_SOURCE_PATH}
+            targetLocale={selectedTargetLocale}
+            highlightLocale={selectedTargetLocale}
+            initialSegmentKey={initialSegmentKey}
+            initialQueueFilter={initialQueueFilter}
+            sourcePathsFilter={serializeCatSourcePathsFilter(jobSourcePaths)}
+            layout="fullscreen"
+            className="min-h-0 flex-1"
+            pageNavigationGuardRef={pageNavigationGuardRef}
+          />
+        </div>
+      </main>
     );
   }
 
@@ -651,6 +822,20 @@ export function JobCatPageContent({
           files={providerFiles}
           selectedSourcePath={selectedFile.sourcePath}
           onSelectFile={handleFileChange}
+          allFilesSelected={false}
+          onSelectAllFiles={() => {
+            router.push(
+              stringsPageHref({
+                organizationSlug,
+                projectId,
+                jobId,
+                sourcePath: CAT_ALL_FILES_SOURCE_PATH,
+                sourcePaths: providerFiles.map((file) => file.sourcePath),
+                targetLocale: selectedTargetLocale,
+                queueFilter: initialQueueFilter,
+              }),
+            );
+          }}
         />
 
         {jobTargetLocales.length > 0 ? (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -48,7 +48,9 @@ import {
   CAT_ALL_FILES_SOURCE_PATH,
   isCatAllFilesSourcePath,
   serializeCatSourcePathsFilter,
+  supportsCatAllFilesProvider,
 } from "@/lib/projects/cat-all-files";
+import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 
 type JobCatGithubRepository = {
   fullName: string;
@@ -154,6 +156,7 @@ export function JobCatPageContent({
   targetLocale,
   initialSegmentKey = null,
   initialQueueFilter = "untranslated",
+  catAllFilesEnabled = false,
 }: {
   organizationSlug: string;
   projectId: string;
@@ -164,12 +167,17 @@ export function JobCatPageContent({
   targetLocale: string | null;
   initialSegmentKey?: string | null;
   initialQueueFilter?: CatQueueFilter;
+  catAllFilesEnabled?: boolean;
 }) {
   const router = useRouter();
   const pageNavigationGuardRef = useRef<CatPageNavigationGuardRef["current"]>(null);
   const taskHref = `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(jobId)}`;
-  const allFiles = isCatAllFilesSourcePath(sourcePath) && Boolean(sourcePath);
-  const hasFileReference = Boolean((sourcePath && !allFiles) || storedFileId) || allFiles;
+  const canUseAllFiles =
+    catAllFilesEnabled &&
+    supportsCatAllFilesProvider(parseProviderProjectId(projectId)?.providerKind ?? null);
+  const requestedAllFiles = isCatAllFilesSourcePath(sourcePath) && Boolean(sourcePath);
+  const allFiles = canUseAllFiles && requestedAllFiles;
+  const hasFileReference = Boolean((sourcePath && !requestedAllFiles) || storedFileId) || allFiles;
   const isNativeJob = Boolean(storedFileId) && !allFiles;
   const didAutoSelectDefaultFileRef = useRef(false);
   const defaultFileQuery = useQuery({
@@ -327,19 +335,38 @@ export function JobCatPageContent({
     const jobSourcePaths = defaultFileQuery.data.files
       .map((file) => file.sourcePath)
       .filter(Boolean);
+    const reference = defaultFileQuery.data.reference;
+
+    if (canUseAllFiles) {
+      router.replace(
+        stringsPageHref({
+          organizationSlug,
+          projectId,
+          jobId,
+          sourcePath: CAT_ALL_FILES_SOURCE_PATH,
+          sourcePaths: jobSourcePaths,
+          targetLocale: reference.targetLocale,
+          segment: initialSegmentKey,
+          queueFilter: initialQueueFilter,
+        }),
+      );
+      return;
+    }
+
     router.replace(
       stringsPageHref({
         organizationSlug,
         projectId,
         jobId,
-        sourcePath: CAT_ALL_FILES_SOURCE_PATH,
-        sourcePaths: jobSourcePaths,
-        targetLocale: defaultFileQuery.data.reference.targetLocale,
+        sourcePath: reference.sourcePath ?? undefined,
+        storedFileId: reference.storedFileId ?? undefined,
+        targetLocale: reference.targetLocale,
         segment: initialSegmentKey,
         queueFilter: initialQueueFilter,
       }),
     );
   }, [
+    canUseAllFiles,
     defaultFileQuery.data,
     hasFileReference,
     initialSegmentKey,
@@ -403,14 +430,6 @@ export function JobCatPageContent({
   }
 
   if (allFiles) {
-    if (
-      projectQuery.isLoading ||
-      defaultFileQuery.isLoading ||
-      (!isNativeJob && providerFilesQuery.isLoading && !providerFilesQuery.data)
-    ) {
-      // fall through only when we have files — wait for queries below via reused loading UI
-    }
-
     const defaultJobFiles = defaultFileQuery.data?.files ?? [];
     const jobFiles =
       providerFiles.length > 0
@@ -423,7 +442,12 @@ export function JobCatPageContent({
         .filter(Boolean) ?? jobFiles.map((file) => file.sourcePath);
     const selectedTargetLocale = activeTargetLocale ?? targetLocale;
 
-    if (projectQuery.isLoading || (!selectedTargetLocale && jobLocalesQuery.isLoading)) {
+    if (
+      projectQuery.isLoading ||
+      defaultFileQuery.isLoading ||
+      (!isNativeJob && providerFilesQuery.isLoading && !providerFilesQuery.data) ||
+      (!selectedTargetLocale && jobLocalesQuery.isLoading)
+    ) {
       return (
         <ProjectPageShell>
           <div className="flex min-h-48 items-center justify-center gap-2 rounded-lg border border-border bg-card p-5">
@@ -528,7 +552,7 @@ export function JobCatPageContent({
             selectedSourcePath=""
             onSelectFile={handleJobFileChange}
             allFilesSelected
-            onSelectAllFiles={handleJobSelectAllFiles}
+            onSelectAllFiles={canUseAllFiles ? handleJobSelectAllFiles : undefined}
           />
 
           {jobTargetLocales.length > 0 ? (
@@ -828,19 +852,23 @@ export function JobCatPageContent({
           selectedSourcePath={selectedFile.sourcePath}
           onSelectFile={handleFileChange}
           allFilesSelected={false}
-          onSelectAllFiles={() => {
-            router.push(
-              stringsPageHref({
-                organizationSlug,
-                projectId,
-                jobId,
-                sourcePath: CAT_ALL_FILES_SOURCE_PATH,
-                sourcePaths: providerFiles.map((file) => file.sourcePath),
-                targetLocale: selectedTargetLocale,
-                queueFilter: initialQueueFilter,
-              }),
-            );
-          }}
+          onSelectAllFiles={
+            canUseAllFiles
+              ? () => {
+                  router.push(
+                    stringsPageHref({
+                      organizationSlug,
+                      projectId,
+                      jobId,
+                      sourcePath: CAT_ALL_FILES_SOURCE_PATH,
+                      sourcePaths: providerFiles.map((file) => file.sourcePath),
+                      targetLocale: selectedTargetLocale,
+                      queueFilter: initialQueueFilter,
+                    }),
+                  );
+                }
+              : undefined
+          }
         />
 
         {jobTargetLocales.length > 0 ? (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
@@ -1,4 +1,5 @@
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
+import { isReleaseCatAllFilesEnabled } from "@/lib/flags/release-flags";
 import { resolveJobCatInitialQueueFilter } from "@/lib/projects/resolve-job-cat-initial-queue-filter";
 
 import { JobCatPageContent } from "./_components/job-cat-page-content";
@@ -21,6 +22,7 @@ export default async function ProjectJobStringsPage({
   const { sourcePath, storedFileId, sourcePaths, targetLocale, segment, queueFilter } =
     await searchParams;
   const auth = await requireAppAuthContext({ organizationSlug });
+  const catAllFilesEnabled = await isReleaseCatAllFilesEnabled();
 
   const initialQueueFilter = await resolveJobCatInitialQueueFilter({
     auth,
@@ -39,6 +41,7 @@ export default async function ProjectJobStringsPage({
       targetLocale={targetLocale ?? null}
       initialSegmentKey={segment ?? null}
       initialQueueFilter={initialQueueFilter}
+      catAllFilesEnabled={catAllFilesEnabled}
     />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
@@ -11,13 +11,15 @@ export default async function ProjectJobStringsPage({
   searchParams: Promise<{
     sourcePath?: string;
     storedFileId?: string;
+    sourcePaths?: string;
     targetLocale?: string;
     segment?: string;
     queueFilter?: string;
   }>;
 }) {
   const { organizationSlug, projectId, jobId } = await params;
-  const { sourcePath, storedFileId, targetLocale, segment, queueFilter } = await searchParams;
+  const { sourcePath, storedFileId, sourcePaths, targetLocale, segment, queueFilter } =
+    await searchParams;
   const auth = await requireAppAuthContext({ organizationSlug });
 
   const initialQueueFilter = await resolveJobCatInitialQueueFilter({
@@ -33,6 +35,7 @@ export default async function ProjectJobStringsPage({
       jobId={jobId}
       sourcePath={sourcePath ?? null}
       storedFileId={storedFileId ?? null}
+      sourcePaths={sourcePaths ?? null}
       targetLocale={targetLocale ?? null}
       initialSegmentKey={segment ?? null}
       initialQueueFilter={initialQueueFilter}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/strings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/strings/page.tsx
@@ -1,4 +1,5 @@
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
+import { isReleaseCatAllFilesEnabled } from "@/lib/flags/release-flags";
 import { CAT_ALL_FILES_SOURCE_PATH } from "@/lib/projects/cat-all-files";
 import { parseProjectFileCatSearchParams } from "@/lib/projects/project-file-cat-routing";
 
@@ -21,20 +22,29 @@ export default async function ProjectStringsPage({
 }) {
   const { organizationSlug, projectId } = await params;
   const rawSearchParams = await searchParams;
+  await requireAppAuthContext({ organizationSlug });
+  const catAllFilesEnabled = await isReleaseCatAllFilesEnabled();
+  const defaultSourcePath = catAllFilesEnabled
+    ? CAT_ALL_FILES_SOURCE_PATH
+    : rawSearchParams.sourcePath?.trim()
+      ? rawSearchParams.sourcePath
+      : null;
   const parsedSearchParams = parseProjectFileCatSearchParams({
     ...rawSearchParams,
     sourcePath: rawSearchParams.sourcePath?.trim()
       ? rawSearchParams.sourcePath
-      : CAT_ALL_FILES_SOURCE_PATH,
+      : (defaultSourcePath ?? undefined),
   });
-  await requireAppAuthContext({ organizationSlug });
 
   return (
     <ProjectFileCatPageContent
       organizationSlug={organizationSlug}
       projectId={projectId}
       sourcePath={parsedSearchParams.sourcePath}
-      allFiles={parsedSearchParams.allFiles || !parsedSearchParams.sourcePath}
+      allFiles={
+        catAllFilesEnabled ? parsedSearchParams.allFiles || !parsedSearchParams.sourcePath : false
+      }
+      catAllFilesEnabled={catAllFilesEnabled}
       highlightLocale={parsedSearchParams.highlightLocale}
       initialSegmentKey={parsedSearchParams.initialSegmentKey}
       externalResourceId={parsedSearchParams.externalResourceId}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/strings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/strings/page.tsx
@@ -1,9 +1,10 @@
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
+import { CAT_ALL_FILES_SOURCE_PATH } from "@/lib/projects/cat-all-files";
 import { parseProjectFileCatSearchParams } from "@/lib/projects/project-file-cat-routing";
 
-import { ProjectFileCatPageContent } from "../_components/project-file-cat-page-content";
+import { ProjectFileCatPageContent } from "../files/_components/project-file-cat-page-content";
 
-export default async function ProjectFileCatPage({
+export default async function ProjectStringsPage({
   params,
   searchParams,
 }: {
@@ -19,7 +20,13 @@ export default async function ProjectFileCatPage({
   }>;
 }) {
   const { organizationSlug, projectId } = await params;
-  const parsedSearchParams = parseProjectFileCatSearchParams(await searchParams);
+  const rawSearchParams = await searchParams;
+  const parsedSearchParams = parseProjectFileCatSearchParams({
+    ...rawSearchParams,
+    sourcePath: rawSearchParams.sourcePath?.trim()
+      ? rawSearchParams.sourcePath
+      : CAT_ALL_FILES_SOURCE_PATH,
+  });
   await requireAppAuthContext({ organizationSlug });
 
   return (
@@ -27,7 +34,7 @@ export default async function ProjectFileCatPage({
       organizationSlug={organizationSlug}
       projectId={projectId}
       sourcePath={parsedSearchParams.sourcePath}
-      allFiles={parsedSearchParams.allFiles}
+      allFiles={parsedSearchParams.allFiles || !parsedSearchParams.sourcePath}
       highlightLocale={parsedSearchParams.highlightLocale}
       initialSegmentKey={parsedSearchParams.initialSegmentKey}
       externalResourceId={parsedSearchParams.externalResourceId}

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
@@ -252,7 +252,7 @@ function formatRouteTitle(intl: IntlShape, key: RouteTitleKey): string {
     case "strings":
       return intl.formatMessage({
         defaultMessage: "Strings",
-        id: "pCatStrTitle",
+        id: "RbHK79ne0Y",
         description: "App shell breadcrumb title for the project strings CAT page",
       });
     case "teams":

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
@@ -28,6 +28,7 @@ type RouteTitleKey =
   | "qa"
   | "reviews"
   | "settings"
+  | "strings"
   | "teams"
   | "translation-memories";
 
@@ -42,6 +43,7 @@ const PROJECT_SECTION_KEYS = {
   qa: true,
   reviews: true,
   settings: true,
+  strings: true,
 } as const;
 
 type ProjectSectionKey = keyof typeof PROJECT_SECTION_KEYS;
@@ -70,6 +72,7 @@ function isRouteTitleKey(value: string): value is RouteTitleKey {
     value === "qa" ||
     value === "reviews" ||
     value === "settings" ||
+    value === "strings" ||
     value === "teams" ||
     value === "translation-memories"
   );
@@ -245,6 +248,12 @@ function formatRouteTitle(intl: IntlShape, key: RouteTitleKey): string {
         defaultMessage: "Settings",
         id: "5Xs2gSCUMi",
         description: "App shell breadcrumb title for the settings page",
+      });
+    case "strings":
+      return intl.formatMessage({
+        defaultMessage: "Strings",
+        id: "pCatStrTitle",
+        description: "App shell breadcrumb title for the project strings CAT page",
       });
     case "teams":
       return intl.formatMessage({

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -170,6 +170,7 @@ describe("path builders", () => {
     expect(items.map((item) => [item.label, item.href])).toEqual([
       ["Overview", "/org/acme/projects/proj_1"],
       ["Files", "/org/acme/projects/proj_1/files"],
+      ["Strings", "/org/acme/projects/proj_1/strings"],
       ["Jobs", "/org/acme/projects/proj_1/jobs"],
       ["Issue Sheet", "/org/acme/projects/proj_1/issue-sheet"],
       ["Settings", "/org/acme/projects/proj_1/settings"],

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -227,6 +227,14 @@ describe("parseProjectRoute", () => {
   });
 });
 
+describe("buildProjectNavigationItems", () => {
+  it("includes a Strings item that opens the project CAT workspace", () => {
+    const items = buildProjectNavigationItems("acme", "proj_1", intl);
+    const stringsItem = items.find((item) => item.label === "Strings");
+    expect(stringsItem?.href).toBe("/org/acme/projects/proj_1/strings");
+  });
+});
+
 describe("isNavigationItemActive", () => {
   it("matches exactly when the exact option is set", () => {
     expect(isNavigationItemActive("/org/acme/inbox", "/org/acme/inbox", { exact: true })).toBe(

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -254,7 +254,7 @@ export function buildProjectNavigationItems(
     {
       label: intl.formatMessage({
         defaultMessage: "Strings",
-        id: "pCatStrNav1",
+        id: "CWdGpW4jOj",
         description: "Project sidebar navigation item for the CAT strings workspace",
       }),
       href: project("strings"),

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -14,6 +14,7 @@ import {
   DashboardSquare01Icon,
   DatabaseSyncIcon,
   File01Icon,
+  LanguageCircleIcon,
   FolderKanbanIcon,
   InboxIcon,
   LinkSquare02Icon,
@@ -249,6 +250,15 @@ export function buildProjectNavigationItems(
       }),
       href: project("files"),
       icon: File01Icon,
+    },
+    {
+      label: intl.formatMessage({
+        defaultMessage: "Strings",
+        id: "pCatStrNav1",
+        description: "Project sidebar navigation item for the CAT strings workspace",
+      }),
+      href: project("strings"),
+      icon: LanguageCircleIcon,
     },
     {
       label: intl.formatMessage({

--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-image-sections.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-image-sections.tsx
@@ -4,6 +4,7 @@ import { ImageIcon, Loader2, RefreshCw, Upload } from "lucide-react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
+import { CatSegmentKeyMeta } from "@/components/cat/segment/cat-segment-key-meta";
 import { catEditorPanelMessages } from "@/components/cat/shared/cat.messages";
 import type { CatSegment } from "@/components/cat/shared/types";
 
@@ -43,12 +44,7 @@ export function CatEditorImageSourceSection({
   return (
     <section className="space-y-3">
       <div className="space-y-1">
-        <p
-          className="truncate font-mono text-[11px] leading-5 text-muted-foreground"
-          title={segment.key}
-        >
-          {segment.key}
-        </p>
+        <CatSegmentKeyMeta segmentKey={segment.key} sourcePath={segment.sourcePath} />
         <h3 className="text-xs font-medium text-muted-foreground">
           <FormattedMessage
             {...catEditorPanelMessages.sourceHeading}

--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-panel.tsx
@@ -165,6 +165,7 @@ export function CatEditorPanel({
               sourceText={segment.sourceText}
               sourceLocale={segment.sourceLocale}
               segmentKey={segment.key}
+              sourcePath={segment.sourcePath}
             />
           )}
 

--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-source-section.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-source-section.tsx
@@ -2,6 +2,7 @@
 
 import { FormattedMessage } from "react-intl";
 
+import { CatSegmentKeyMeta } from "@/components/cat/segment/cat-segment-key-meta";
 import { catEditorPanelMessages } from "@/components/cat/shared/cat.messages";
 
 import { CatMessagePreview } from "./cat-target-editor";
@@ -10,20 +11,17 @@ export function CatEditorSourceSection({
   sourceText,
   sourceLocale,
   segmentKey,
+  sourcePath,
 }: {
   sourceText: string;
   sourceLocale: string;
   segmentKey: string;
+  sourcePath?: string | null;
 }) {
   return (
     <section className="space-y-3">
       <div className="space-y-1">
-        <p
-          className="truncate font-mono text-[11px] leading-5 text-muted-foreground"
-          title={segmentKey}
-        >
-          {segmentKey}
-        </p>
+        <CatSegmentKeyMeta segmentKey={segmentKey} sourcePath={sourcePath} />
         <h3 className="text-xs font-medium text-muted-foreground">
           <FormattedMessage
             {...catEditorPanelMessages.sourceHeading}

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-api.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-api.test.ts
@@ -248,6 +248,7 @@ describe("projectFileCatQueryKey", () => {
       "needs_review",
       50,
       50,
+      null,
     ]);
   });
 
@@ -266,7 +267,7 @@ describe("projectFileCatQueryKey", () => {
     const page1 = projectFileCatQueryKey({ ...base, offset: 50 });
 
     expect(page0).not.toEqual(page1);
-    expect(page1.at(-1)).toBe(50);
+    expect(page1.at(-2)).toBe(50);
   });
 });
 
@@ -290,6 +291,7 @@ describe("projectFileCatBaseQueryKey", () => {
       "",
       "all",
       50,
+      null,
     ]);
     expect(key).not.toContain(0);
   });

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-api.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-api.ts
@@ -19,6 +19,7 @@ export function projectFileCatQueryKey(input: {
   queueFilter: ProjectFileCatQueueFilter;
   limit: number;
   offset: number;
+  sourcePaths?: string | null;
 }) {
   return [
     "project-file-cat-queue",
@@ -32,6 +33,7 @@ export function projectFileCatQueryKey(input: {
     input.queueFilter,
     input.limit,
     input.offset,
+    input.sourcePaths ?? null,
   ] as const;
 }
 
@@ -45,6 +47,7 @@ export function projectFileCatBaseQueryKey(input: {
   search: string;
   queueFilter: ProjectFileCatQueueFilter;
   limit: number;
+  sourcePaths?: string | null;
 }) {
   return [
     "project-file-cat-queue",
@@ -57,6 +60,7 @@ export function projectFileCatBaseQueryKey(input: {
     input.search,
     input.queueFilter,
     input.limit,
+    input.sourcePaths ?? null,
   ] as const;
 }
 
@@ -79,6 +83,7 @@ export async function fetchProjectFileCatQueuePage(input: {
   offset: number;
   phraseScanPage?: number;
   phraseScanSkip?: number;
+  sourcePaths?: string | null;
 }) {
   const response = await apiClient.api.orgs[":organizationSlug"].projects[
     ":projectId"
@@ -88,6 +93,7 @@ export async function fetchProjectFileCatQueuePage(input: {
       sourcePath: input.sourcePath,
       ...(input.externalResourceId ? { externalResourceId: input.externalResourceId } : {}),
       ...(input.resourceType ? { resourceType: input.resourceType } : {}),
+      ...(input.sourcePaths ? { sourcePaths: input.sourcePaths } : {}),
       targetLocale: input.targetLocale,
       offset: input.offset,
       limit: input.limit,

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-mapper.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-mapper.test.ts
@@ -142,6 +142,56 @@ describe("projectFileCatToWorkspaceState", () => {
 
     expect(state.segmentIntelligence?.["limited-string"]?.maxLength).toBeUndefined();
   });
+
+  it("prefers per-segment format over the top-level provider format for All Files", () => {
+    const state = projectFileCatToWorkspaceState(
+      catFile({
+        sourcePath: "*",
+        filename: "All Files",
+        provider: {
+          kind: "crowdin",
+          resourceType: "file",
+          externalProjectId: "crowdin-project",
+          externalResourceId: "first-file",
+          externalUrl: null,
+          syncState: "ready",
+          sourceLocale: "en-US",
+          targetLocales: ["vi"],
+          localeReadiness: {},
+          revision: null,
+          format: "android",
+          lastSyncedAt: null,
+        },
+        segments: [
+          {
+            externalStringId: "json-string",
+            key: "auth.title",
+            sourceText: "Sign in",
+            context: null,
+            type: null,
+            sourcePath: "locales/en.json",
+            format: "json",
+          },
+          {
+            externalStringId: "xml-string",
+            key: "home.title",
+            sourceText: "Home",
+            context: null,
+            type: null,
+            sourcePath: "res/values/strings.xml",
+            format: "android",
+          },
+        ],
+      }),
+      "en-US",
+      testIntl,
+    );
+
+    expect(state.segmentIntelligence?.["json-string"]?.componentName).toBe("json");
+    expect(state.segmentIntelligence?.["json-string"]?.filePath).toBe("locales/en.json");
+    expect(state.segmentIntelligence?.["xml-string"]?.componentName).toBe("android");
+    expect(state.segmentIntelligence?.["xml-string"]?.filePath).toBe("res/values/strings.xml");
+  });
 });
 
 describe("CatWorkspaceOrchestrator lazy segment ingest", () => {

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-mapper.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-mapper.ts
@@ -135,7 +135,7 @@ function intelligenceFor(catFile: CatFile): CatSegmentIntelligence {
   return {
     intent: `Translate ${catFile.filename} into ${catFile.targetLocale}.`,
     locationBreadcrumb: catFile.sourcePath,
-    filePath: catFile.sourcePath,
+    filePath: segment.sourcePath ?? catFile.sourcePath,
     componentName: catFile.provider?.format ?? providerKind ?? undefined,
     reviewerPreference: catFile.canEditTranslations
       ? providerKind
@@ -161,7 +161,7 @@ function segmentIntelligenceFor(
   return {
     intent: `Translate ${segment.key} into ${catFile.targetLocale}.`,
     locationBreadcrumb: segment.key,
-    filePath: catFile.sourcePath,
+    filePath: segment.sourcePath ?? catFile.sourcePath,
     componentName: segmentType ?? catFile.provider?.format ?? providerKind ?? undefined,
     productMeaning: context || undefined,
     ...(segmentType ? { segmentType } : {}),
@@ -211,6 +211,9 @@ export function projectFileCatToWorkspaceState(
     ...(segment.looksLikeImageUrl !== undefined
       ? { looksLikeImageUrl: segment.looksLikeImageUrl }
       : {}),
+    ...(segment.sourcePath ? { sourcePath: segment.sourcePath } : {}),
+    ...(segment.externalResourceId ? { externalResourceId: segment.externalResourceId } : {}),
+    ...(segment.resourceType ? { resourceType: segment.resourceType } : {}),
   }));
 
   return {

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-mapper.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-mapper.ts
@@ -158,11 +158,14 @@ function segmentIntelligenceFor(
   const maxLength =
     segment.maxLength != null && segment.maxLength > 0 ? segment.maxLength : undefined;
 
+  const segmentFormat = segment.format?.trim() || undefined;
+
   return {
     intent: `Translate ${segment.key} into ${catFile.targetLocale}.`,
     locationBreadcrumb: segment.key,
     filePath: segment.sourcePath ?? catFile.sourcePath,
-    componentName: segmentType ?? catFile.provider?.format ?? providerKind ?? undefined,
+    componentName:
+      segmentType ?? segmentFormat ?? catFile.provider?.format ?? providerKind ?? undefined,
     productMeaning: context || undefined,
     ...(segmentType ? { segmentType } : {}),
     ...(maxLength != null ? { maxLength } : {}),

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-mapper.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-mapper.ts
@@ -135,7 +135,7 @@ function intelligenceFor(catFile: CatFile): CatSegmentIntelligence {
   return {
     intent: `Translate ${catFile.filename} into ${catFile.targetLocale}.`,
     locationBreadcrumb: catFile.sourcePath,
-    filePath: segment.sourcePath ?? catFile.sourcePath,
+    filePath: catFile.sourcePath,
     componentName: catFile.provider?.format ?? providerKind ?? undefined,
     reviewerPreference: catFile.canEditTranslations
       ? providerKind

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
@@ -78,6 +78,7 @@ export function ProjectFileCatWorkspace({
   canLookupFreshContext = true,
   initialSegmentKey = null,
   initialQueueFilter = "all",
+  sourcePathsFilter = null,
   layout = "default",
   className,
   pageNavigationGuardRef,
@@ -95,6 +96,7 @@ export function ProjectFileCatWorkspace({
   canLookupFreshContext?: boolean;
   initialSegmentKey?: string | null;
   initialQueueFilter?: CatQueueFilter;
+  sourcePathsFilter?: string | null;
   layout?: "default" | "fullscreen";
   className?: string;
   pageNavigationGuardRef?: CatPageNavigationGuardRef;
@@ -150,6 +152,7 @@ export function ProjectFileCatWorkspace({
     enabled: Boolean(targetLocale),
     initialQueueFilter,
     pageLimit,
+    sourcePaths: sourcePathsFilter,
   });
 
   const availableQueueFilters = useMemo(

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
@@ -477,12 +477,15 @@ export function ProjectFileCatWorkspace({
             )
           : {};
 
+      const recommendationSourcePath =
+        segment.sourcePath?.trim() || intelligence?.filePath?.trim() || sourcePath;
+
       const response = await apiClient.api.orgs[":organizationSlug"].projects[
         ":projectId"
       ].files.detail.cat.recommendation.$post({
         param: { organizationSlug, projectId },
         json: {
-          sourcePath,
+          sourcePath: recommendationSourcePath,
           targetLocale,
           sourceLocale: segment.sourceLocale,
           key: segment.key,

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.ts
@@ -13,8 +13,37 @@ import { apiClient } from "@/lib/api-client-instance";
 import type { CrowdinIssueType } from "@/components/cat/shared/types";
 
 import { requireProviderExternalResourceId } from "./project-file-cat-mapper";
+import { isCatAllFilesSourcePath } from "@/lib/projects/cat-all-files";
 import { useInvalidateCatSegmentComments } from "./use-cat-segment-comments";
 import { useInvalidateCatSegmentTarget } from "./use-cat-segment-target";
+
+function resolveCatMutationFileIdentity(
+  input: {
+    sourcePath: string;
+    catFile: ProjectFileCatQueueFile | null | undefined;
+  },
+  externalStringId: string,
+) {
+  const segment = input.catFile?.segments.find(
+    (entry) => entry.externalStringId === externalStringId,
+  );
+  const sourcePath =
+    segment?.sourcePath?.trim() ||
+    (isCatAllFilesSourcePath(input.sourcePath) ? "" : input.sourcePath);
+
+  if (!sourcePath) {
+    throw new Error("Cannot save because the segment source file is missing.");
+  }
+
+  const externalResourceId = segment?.externalResourceId
+    ? segment.externalResourceId
+    : input.catFile?.provider
+      ? requireProviderExternalResourceId(input.catFile)
+      : undefined;
+  const resourceType = segment?.resourceType ?? input.catFile?.provider?.resourceType;
+
+  return { sourcePath, externalResourceId, resourceType };
+}
 
 export function useCatMutations(input: {
   organizationSlug: string;
@@ -34,9 +63,10 @@ export function useCatMutations(input: {
       text: string;
       approve?: boolean;
     }) => {
-      const externalResourceId = input.catFile?.provider
-        ? requireProviderExternalResourceId(input.catFile)
-        : undefined;
+      const { sourcePath, externalResourceId } = resolveCatMutationFileIdentity(
+        input,
+        mutationInput.externalStringId,
+      );
 
       const response = await apiClient.api.orgs[":organizationSlug"].projects[
         ":projectId"
@@ -46,7 +76,7 @@ export function useCatMutations(input: {
           projectId: input.projectId,
         },
         json: {
-          sourcePath: input.sourcePath,
+          sourcePath,
           targetLocale: input.targetLocale,
           externalStringId: mutationInput.externalStringId,
           externalResourceId,
@@ -68,17 +98,17 @@ export function useCatMutations(input: {
         variables.text,
         translation.isApproved,
       );
-      const externalResourceId = input.catFile?.provider
-        ? requireProviderExternalResourceId(input.catFile)
-        : undefined;
-      const resourceType = input.catFile?.provider?.resourceType;
+      const { sourcePath, externalResourceId, resourceType } = resolveCatMutationFileIdentity(
+        input,
+        variables.externalStringId,
+      );
 
       await Promise.all([
         input.invalidateQueue(),
         invalidateSegmentTarget({
           organizationSlug: input.organizationSlug,
           projectId: input.projectId,
-          sourcePath: input.sourcePath,
+          sourcePath,
           externalResourceId,
           resourceType,
           targetLocale: input.targetLocale,
@@ -95,9 +125,10 @@ export function useCatMutations(input: {
       type?: "comment" | "issue";
       issueType?: CrowdinIssueType;
     }) => {
-      const externalResourceId = input.catFile?.provider
-        ? requireProviderExternalResourceId(input.catFile)
-        : undefined;
+      const { sourcePath, externalResourceId } = resolveCatMutationFileIdentity(
+        input,
+        mutationInput.externalStringId,
+      );
 
       const response = await apiClient.api.orgs[":organizationSlug"].projects[
         ":projectId"
@@ -107,7 +138,7 @@ export function useCatMutations(input: {
           projectId: input.projectId,
         },
         json: {
-          sourcePath: input.sourcePath,
+          sourcePath,
           targetLocale: input.targetLocale,
           externalStringId: mutationInput.externalStringId,
           externalResourceId,
@@ -125,17 +156,17 @@ export function useCatMutations(input: {
       return body.comment;
     },
     onSuccess: async (_data, variables) => {
-      const externalResourceId = input.catFile?.provider
-        ? requireProviderExternalResourceId(input.catFile)
-        : undefined;
-      const resourceType = input.catFile?.provider?.resourceType;
+      const { sourcePath, externalResourceId, resourceType } = resolveCatMutationFileIdentity(
+        input,
+        variables.externalStringId,
+      );
 
       await Promise.all([
         input.invalidateQueue(),
         invalidateSegmentTarget({
           organizationSlug: input.organizationSlug,
           projectId: input.projectId,
-          sourcePath: input.sourcePath,
+          sourcePath,
           externalResourceId,
           resourceType,
           targetLocale: input.targetLocale,
@@ -144,7 +175,7 @@ export function useCatMutations(input: {
         invalidateSegmentComments({
           organizationSlug: input.organizationSlug,
           projectId: input.projectId,
-          sourcePath: input.sourcePath,
+          sourcePath,
           externalResourceId,
           resourceType,
           targetLocale: input.targetLocale,
@@ -156,9 +187,10 @@ export function useCatMutations(input: {
 
   const resolveCommentMutation = useMutation({
     mutationFn: async (mutationInput: { externalStringId: string; externalCommentId: string }) => {
-      const externalResourceId = input.catFile?.provider
-        ? requireProviderExternalResourceId(input.catFile)
-        : undefined;
+      const { sourcePath, externalResourceId } = resolveCatMutationFileIdentity(
+        input,
+        mutationInput.externalStringId,
+      );
 
       const response = await apiClient.api.orgs[":organizationSlug"].projects[
         ":projectId"
@@ -169,7 +201,7 @@ export function useCatMutations(input: {
           commentId: mutationInput.externalCommentId,
         },
         json: {
-          sourcePath: input.sourcePath,
+          sourcePath,
           externalResourceId,
         },
       });
@@ -182,17 +214,17 @@ export function useCatMutations(input: {
       return body.comment;
     },
     onSuccess: async (_data, variables) => {
-      const externalResourceId = input.catFile?.provider
-        ? requireProviderExternalResourceId(input.catFile)
-        : undefined;
-      const resourceType = input.catFile?.provider?.resourceType;
+      const { sourcePath, externalResourceId, resourceType } = resolveCatMutationFileIdentity(
+        input,
+        variables.externalStringId,
+      );
 
       await Promise.all([
         input.invalidateQueue(),
         invalidateSegmentTarget({
           organizationSlug: input.organizationSlug,
           projectId: input.projectId,
-          sourcePath: input.sourcePath,
+          sourcePath,
           externalResourceId,
           resourceType,
           targetLocale: input.targetLocale,
@@ -201,7 +233,7 @@ export function useCatMutations(input: {
         invalidateSegmentComments({
           organizationSlug: input.organizationSlug,
           projectId: input.projectId,
-          sourcePath: input.sourcePath,
+          sourcePath,
           externalResourceId,
           resourceType,
           targetLocale: input.targetLocale,
@@ -212,17 +244,17 @@ export function useCatMutations(input: {
   });
 
   async function invalidateAfterImageChange(externalStringId: string) {
-    const externalResourceId = input.catFile?.provider
-      ? requireProviderExternalResourceId(input.catFile)
-      : undefined;
-    const resourceType = input.catFile?.provider?.resourceType;
+    const { sourcePath, externalResourceId, resourceType } = resolveCatMutationFileIdentity(
+      input,
+      externalStringId,
+    );
 
     await Promise.all([
       input.invalidateQueue(),
       invalidateSegmentTarget({
         organizationSlug: input.organizationSlug,
         projectId: input.projectId,
-        sourcePath: input.sourcePath,
+        sourcePath,
         externalResourceId,
         resourceType,
         targetLocale: input.targetLocale,
@@ -237,6 +269,7 @@ export function useCatMutations(input: {
       instructions?: string;
       force?: boolean;
     }) => {
+      const { sourcePath } = resolveCatMutationFileIdentity(input, mutationInput.externalStringId);
       const response = await apiClient.api.orgs[":organizationSlug"].projects[
         ":projectId"
       ].files.detail.cat.images.regenerate.$post({
@@ -245,7 +278,7 @@ export function useCatMutations(input: {
           projectId: input.projectId,
         },
         json: {
-          sourcePath: input.sourcePath,
+          sourcePath,
           targetLocale: input.targetLocale,
           externalStringId: mutationInput.externalStringId,
           instructions: mutationInput.instructions,
@@ -270,8 +303,9 @@ export function useCatMutations(input: {
       file: File;
       force?: boolean;
     }) => {
+      const { sourcePath } = resolveCatMutationFileIdentity(input, mutationInput.externalStringId);
       const formData = new FormData();
-      formData.set("sourcePath", input.sourcePath);
+      formData.set("sourcePath", sourcePath);
       formData.set("targetLocale", input.targetLocale);
       formData.set("externalStringId", mutationInput.externalStringId);
       if (mutationInput.force) {
@@ -303,9 +337,10 @@ export function useCatMutations(input: {
 
   const treatAsImageMutation = useMutation({
     mutationFn: async (mutationInput: { externalStringId: string; treatAsImage: boolean }) => {
-      const externalResourceId = input.catFile?.provider
-        ? requireProviderExternalResourceId(input.catFile)
-        : undefined;
+      const { sourcePath, externalResourceId } = resolveCatMutationFileIdentity(
+        input,
+        mutationInput.externalStringId,
+      );
 
       const response = await apiClient.api.orgs[":organizationSlug"].projects[
         ":projectId"
@@ -316,7 +351,7 @@ export function useCatMutations(input: {
           externalStringId: mutationInput.externalStringId,
         },
         json: {
-          sourcePath: input.sourcePath,
+          sourcePath,
           targetLocale: input.targetLocale,
           externalStringId: mutationInput.externalStringId,
           externalResourceId,

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-segment-query.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-segment-query.ts
@@ -45,6 +45,7 @@ export function useCatSegmentQuery(input: {
   enabled?: boolean;
   initialQueueFilter?: CatQueueFilter;
   pageLimit?: number;
+  sourcePaths?: string | null;
 }) {
   const queryClient = useQueryClient();
   const [search, setSearch] = useState("");
@@ -77,6 +78,7 @@ export function useCatSegmentQuery(input: {
         search: debouncedSearch,
         queueFilter: serverQueueFilter,
         limit,
+        sourcePaths: input.sourcePaths,
       }),
     [
       debouncedSearch,
@@ -86,6 +88,7 @@ export function useCatSegmentQuery(input: {
       input.externalResourceId,
       input.resourceType,
       input.targetLocale,
+      input.sourcePaths,
       limit,
       serverQueueFilter,
     ],
@@ -127,6 +130,7 @@ export function useCatSegmentQuery(input: {
         offset: pageParam.offset,
         phraseScanPage: pageParam.phraseScanPage,
         phraseScanSkip: pageParam.phraseScanSkip,
+        sourcePaths: input.sourcePaths,
       }),
   });
 
@@ -169,6 +173,7 @@ export function useCatSegmentQuery(input: {
         queueFilter: serverQueueFilter,
         limit,
         offset: 0,
+        sourcePaths: input.sourcePaths,
       }),
     [
       debouncedSearch,
@@ -178,6 +183,7 @@ export function useCatSegmentQuery(input: {
       input.externalResourceId,
       input.resourceType,
       input.targetLocale,
+      input.sourcePaths,
       limit,
       serverQueueFilter,
     ],

--- a/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-virtual-list.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-virtual-list.tsx
@@ -6,6 +6,7 @@ import { useIntl } from "react-intl";
 
 import { cn } from "@/lib/primitives/cn";
 
+import { CatSegmentKeyMeta } from "@/components/cat/segment/cat-segment-key-meta";
 import { catQueuePanelMessages } from "@/components/cat/shared/cat.messages";
 import type { CatSegment } from "@/components/cat/shared/types";
 
@@ -136,16 +137,11 @@ export function CatQueueVirtualList({
                   </span>
                   <div className="min-w-0 flex-1 space-y-1">
                     <p className="line-clamp-2 text-sm text-foreground">{segment.sourceText}</p>
-                    <div className="flex min-w-0 flex-col gap-0.5">
-                      <span className="min-w-0 truncate font-mono text-xs text-muted-foreground">
-                        {segment.key}
-                      </span>
-                      {segment.sourcePath ? (
-                        <span className="min-w-0 truncate font-mono text-[0.6875rem] text-muted-foreground/80">
-                          {segment.sourcePath}
-                        </span>
-                      ) : null}
-                    </div>
+                    <CatSegmentKeyMeta
+                      segmentKey={segment.key}
+                      sourcePath={segment.sourcePath}
+                      keyClassName="text-xs"
+                    />
                   </div>
                   <div className="mt-1 flex shrink-0 flex-col items-center gap-1">
                     {isDirty ? (

--- a/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-virtual-list.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-virtual-list.tsx
@@ -136,10 +136,15 @@ export function CatQueueVirtualList({
                   </span>
                   <div className="min-w-0 flex-1 space-y-1">
                     <p className="line-clamp-2 text-sm text-foreground">{segment.sourceText}</p>
-                    <div className="flex min-w-0 items-center">
+                    <div className="flex min-w-0 flex-col gap-0.5">
                       <span className="min-w-0 truncate font-mono text-xs text-muted-foreground">
                         {segment.key}
                       </span>
+                      {segment.sourcePath ? (
+                        <span className="min-w-0 truncate font-mono text-[0.6875rem] text-muted-foreground/80">
+                          {segment.sourcePath}
+                        </span>
+                      ) : null}
                     </div>
                   </div>
                   <div className="mt-1 flex shrink-0 flex-col items-center gap-1">

--- a/apps/hyperlocalise-web/src/components/cat/segment/cat-segment-key-meta.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/segment/cat-segment-key-meta.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/primitives/cn";
+
+export function CatSegmentKeyMeta({
+  segmentKey,
+  sourcePath,
+  className,
+  keyClassName,
+  pathClassName,
+  trailing,
+}: {
+  segmentKey: string;
+  sourcePath?: string | null;
+  className?: string;
+  keyClassName?: string;
+  pathClassName?: string;
+  trailing?: ReactNode;
+}) {
+  return (
+    <div className={cn("flex min-w-0 flex-col gap-0.5", className)}>
+      <div className="flex min-w-0 items-center gap-1">
+        <p
+          className={cn(
+            "min-w-0 flex-1 truncate font-mono text-[11px] leading-5 text-muted-foreground",
+            keyClassName,
+          )}
+          title={segmentKey}
+        >
+          {segmentKey}
+        </p>
+        {trailing}
+      </div>
+      {sourcePath ? (
+        <p
+          className={cn(
+            "min-w-0 truncate font-mono text-[0.6875rem] leading-4 text-muted-foreground/80",
+            pathClassName,
+          )}
+          title={sourcePath}
+        >
+          {sourcePath}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/cat/shared/types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/types.ts
@@ -67,6 +67,8 @@ export interface CatSegment {
   key: string;
   sourceText: string;
   targetText: string;
+  /** Present when the queue spans multiple files. */
+  sourcePath?: string;
   sourceLocale: string;
   targetLocale: string;
   contextLabel?: string;

--- a/apps/hyperlocalise-web/src/components/cat/shared/types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/types.ts
@@ -43,6 +43,10 @@ export interface CatQueueSegment {
   targetAssetUrl?: string | null;
   imageVariantId?: string | null;
   looksLikeImageUrl?: boolean;
+  /** Set when the queue spans multiple files. */
+  sourcePath?: string;
+  externalResourceId?: string;
+  resourceType?: "file" | "key";
 }
 
 /** File and locale scope for the CAT editor, shared across all segments. */

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-intelligence-panel.tsx
@@ -12,6 +12,7 @@ import { cn } from "@/lib/primitives/cn";
 import { CatEditorCommentsSection } from "@/components/cat/editor/cat-editor-comments-section";
 import { CatEditorShortcutKbd } from "@/components/cat/editor/cat-editor-shortcut-kbd";
 import { CatIntelligencePanel } from "@/components/cat/intelligence/cat-intelligence-panel";
+import { CatSegmentKeyMeta } from "@/components/cat/segment/cat-segment-key-meta";
 import {
   catEditorPanelMessages,
   catSideBySidePanelMessages,
@@ -160,12 +161,11 @@ export function CatSideBySideIntelligencePanel({
       )}
     >
       <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border px-3 py-2">
-        <p
-          className="min-w-0 truncate font-mono text-[11px] text-muted-foreground"
-          title={segment.key}
-        >
-          {segment.key}
-        </p>
+        <CatSegmentKeyMeta
+          className="min-w-0 flex-1"
+          segmentKey={segment.key}
+          sourcePath={segment.sourcePath}
+        />
         {onAskQuestion ? (
           <Button
             type="button"

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/cat/editor/cat-target-editor";
 import { analyzeCatMessageFormat } from "@/components/cat/message-format/cat-message-format";
 import { SegmentStatusBadge } from "@/components/cat/segment/cat-segment-status";
+import { CatSegmentKeyMeta } from "@/components/cat/segment/cat-segment-key-meta";
 import { CatSegmentTags } from "@/components/cat/segment/cat-segment-tags";
 import { CatShareSegmentButton } from "@/components/cat/segment/cat-share-segment-button";
 import {
@@ -187,15 +188,11 @@ export function CatSideBySideRow({
   );
   const sourceKeyMeta = (
     <div className="flex min-w-0 flex-col gap-1.5">
-      <div className="flex min-w-0 items-center gap-1">
-        <p
-          className="min-w-0 flex-1 truncate font-mono text-[11px] text-muted-foreground"
-          title={segment.key}
-        >
-          {segment.key}
-        </p>
-        {shareButton}
-      </div>
+      <CatSegmentKeyMeta
+        segmentKey={segment.key}
+        sourcePath={segment.sourcePath}
+        trailing={shareButton}
+      />
       {statusAndTags}
     </div>
   );

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-lazy-segment-sync.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-lazy-segment-sync.tsx
@@ -33,17 +33,23 @@ function useCatSegmentLazySync(input: {
     ? (store.findSegmentIdByKeyOrId(input.segmentId) ?? input.segmentId)
     : null;
 
+  const queueSegment = segmentId
+    ? input.catFile?.segments.find((segment) => segment.externalStringId === segmentId)
+    : null;
+
   const { externalResourceId: resolvedExternalResourceId, resourceType: resolvedResourceType } =
     resolveCatFileIdentity({
-      externalResourceId: input.externalResourceId,
-      resourceType: input.resourceType,
+      externalResourceId: queueSegment?.externalResourceId ?? input.externalResourceId,
+      resourceType: queueSegment?.resourceType ?? input.resourceType,
       catFile: input.catFile,
     });
+
+  const resolvedSourcePath = queueSegment?.sourcePath?.trim() || input.sourcePath;
 
   const segmentTargetQuery = useCatSegmentTarget({
     organizationSlug: input.organizationSlug,
     projectId: input.projectId,
-    sourcePath: input.sourcePath,
+    sourcePath: resolvedSourcePath,
     externalResourceId: resolvedExternalResourceId,
     resourceType: resolvedResourceType,
     targetLocale: input.targetLocale,
@@ -54,7 +60,7 @@ function useCatSegmentLazySync(input: {
   const segmentCommentsQuery = useCatSegmentComments({
     organizationSlug: input.organizationSlug,
     projectId: input.projectId,
-    sourcePath: input.sourcePath,
+    sourcePath: resolvedSourcePath,
     externalResourceId: resolvedExternalResourceId,
     resourceType: resolvedResourceType,
     targetLocale: input.targetLocale,

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
@@ -10,6 +10,7 @@ import { cn } from "@/lib/primitives/cn";
 import { CatEditorPanel } from "@/components/cat/editor/cat-editor-panel";
 import { CatIntelligencePanel } from "@/components/cat/intelligence/cat-intelligence-panel";
 import { CatQueuePanel } from "@/components/cat/queue/cat-queue-panel";
+import { CatSegmentKeyMeta } from "@/components/cat/segment/cat-segment-key-meta";
 import { CatSideBySidePanel } from "@/components/cat/side-by-side/cat-side-by-side-panel";
 import type { CatWorkspaceViewProps } from "@/components/cat/shared/dependencies";
 import { catWorkspaceMessages } from "@/components/cat/shared/cat.messages";
@@ -534,9 +535,11 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
                 {String(segmentPosition).padStart(2, "0")}
                 {totalSegments != null ? ` / ${String(totalSegments).padStart(2, "0")}` : "+"}
               </p>
-              <p className="truncate font-mono text-sm font-medium text-foreground">
-                {editorSegment.key}
-              </p>
+              <CatSegmentKeyMeta
+                segmentKey={editorSegment.key}
+                sourcePath={editorSegment.sourcePath}
+                keyClassName="text-sm font-medium text-foreground"
+              />
             </div>
           </div>
 

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-segment-view.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-segment-view.test.ts
@@ -31,6 +31,24 @@ describe("toQueueSegment", () => {
       sourceText: "Hello",
     });
   });
+
+  it("preserves sourcePath when present", () => {
+    expect(
+      toQueueSegment({
+        id: "seg-01",
+        index: 1,
+        key: "hero.title",
+        sourceText: "Hello",
+        sourcePath: "locales/en.json",
+      }),
+    ).toEqual({
+      id: "seg-01",
+      index: 1,
+      key: "hero.title",
+      sourceText: "Hello",
+      sourcePath: "locales/en.json",
+    });
+  });
 });
 
 describe("composeSegmentView", () => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-segment-view.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-segment-view.ts
@@ -67,6 +67,7 @@ export function toQueueSegment(
     | "index"
     | "key"
     | "sourceText"
+    | "sourcePath"
     | "contentKind"
     | "sourceAssetUrl"
     | "targetAssetUrl"
@@ -79,6 +80,7 @@ export function toQueueSegment(
     index: segment.index,
     key: segment.key,
     sourceText: segment.sourceText,
+    ...(segment.sourcePath ? { sourcePath: segment.sourcePath } : {}),
     ...(segment.contentKind ? { contentKind: segment.contentKind } : {}),
     ...(segment.sourceAssetUrl !== undefined ? { sourceAssetUrl: segment.sourceAssetUrl } : {}),
     ...(segment.targetAssetUrl !== undefined ? { targetAssetUrl: segment.targetAssetUrl } : {}),

--- a/apps/hyperlocalise-web/src/lib/flags/release-flags.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/release-flags.ts
@@ -1,0 +1,26 @@
+import { flag } from "flags/next";
+
+export const RELEASE_CAT_ALL_FILES_FLAG = "release-cat-all-files";
+
+/**
+ * Release gate for CAT All Files (native + Crowdin).
+ *
+ * Defaults off via `decide`. Enable with Flags Explorer overrides (or change
+ * `decide`) — not evaluated through WorkOS.
+ */
+export const releaseCatAllFilesFlag = flag<boolean>({
+  key: RELEASE_CAT_ALL_FILES_FLAG,
+  description: "CAT All Files scope for native and Crowdin projects.",
+  defaultValue: false,
+  decide() {
+    return false;
+  },
+});
+
+export async function isReleaseCatAllFilesEnabled(): Promise<boolean> {
+  try {
+    return (await releaseCatAllFilesFlag()) === true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/projects/cat-all-files.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat-all-files.test.ts
@@ -6,6 +6,7 @@ import {
   normalizeCatSourcePathParam,
   parseCatSourcePathsFilter,
   serializeCatSourcePathsFilter,
+  supportsCatAllFilesProvider,
 } from "./cat-all-files";
 
 describe("cat-all-files", () => {
@@ -26,5 +27,14 @@ describe("cat-all-files", () => {
     expect(parseCatSourcePathsFilter("a.json, b.json, a.json")).toEqual(["a.json", "b.json"]);
     expect(parseCatSourcePathsFilter("")).toBeNull();
     expect(serializeCatSourcePathsFilter(["a.json", "b.json"])).toBe("a.json,b.json");
+  });
+
+  it("supports native and Crowdin only for All Files", () => {
+    expect(supportsCatAllFilesProvider(null)).toBe(true);
+    expect(supportsCatAllFilesProvider(undefined)).toBe(true);
+    expect(supportsCatAllFilesProvider("crowdin")).toBe(true);
+    expect(supportsCatAllFilesProvider("phrase")).toBe(false);
+    expect(supportsCatAllFilesProvider("lokalise")).toBe(false);
+    expect(supportsCatAllFilesProvider("smartling")).toBe(false);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/projects/cat-all-files.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat-all-files.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  CAT_ALL_FILES_SOURCE_PATH,
+  isCatAllFilesSourcePath,
+  normalizeCatSourcePathParam,
+  parseCatSourcePathsFilter,
+  serializeCatSourcePathsFilter,
+} from "./cat-all-files";
+
+describe("cat-all-files", () => {
+  it("detects the all-files sentinel and empty paths", () => {
+    expect(isCatAllFilesSourcePath(CAT_ALL_FILES_SOURCE_PATH)).toBe(true);
+    expect(isCatAllFilesSourcePath(null)).toBe(true);
+    expect(isCatAllFilesSourcePath("")).toBe(true);
+    expect(isCatAllFilesSourcePath("locales/en.json")).toBe(false);
+  });
+
+  it("normalizes missing paths to the all-files sentinel", () => {
+    expect(normalizeCatSourcePathParam(null)).toBe(CAT_ALL_FILES_SOURCE_PATH);
+    expect(normalizeCatSourcePathParam("  ")).toBe(CAT_ALL_FILES_SOURCE_PATH);
+    expect(normalizeCatSourcePathParam("locales/en.json")).toBe("locales/en.json");
+  });
+
+  it("parses and serializes source path filters", () => {
+    expect(parseCatSourcePathsFilter("a.json, b.json, a.json")).toEqual(["a.json", "b.json"]);
+    expect(parseCatSourcePathsFilter("")).toBeNull();
+    expect(serializeCatSourcePathsFilter(["a.json", "b.json"])).toBe("a.json,b.json");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/projects/cat-all-files.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat-all-files.test.ts
@@ -27,6 +27,9 @@ describe("cat-all-files", () => {
     expect(parseCatSourcePathsFilter("a.json, b.json, a.json")).toEqual(["a.json", "b.json"]);
     expect(parseCatSourcePathsFilter("")).toBeNull();
     expect(serializeCatSourcePathsFilter(["a.json", "b.json"])).toBe("a.json,b.json");
+    expect(serializeCatSourcePathsFilter(["a.json", null, "  ", undefined, "b.json"])).toBe(
+      "a.json,b.json",
+    );
   });
 
   it("supports native and Crowdin only for All Files", () => {

--- a/apps/hyperlocalise-web/src/lib/projects/cat-all-files.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat-all-files.ts
@@ -1,0 +1,42 @@
+/** Sentinel `sourcePath` for CAT queue requests that span every file in scope. */
+export const CAT_ALL_FILES_SOURCE_PATH = "*";
+
+export const CAT_ALL_FILES_FILENAME = "All Files";
+
+export function isCatAllFilesSourcePath(sourcePath: string | null | undefined) {
+  return !sourcePath?.trim() || sourcePath.trim() === CAT_ALL_FILES_SOURCE_PATH;
+}
+
+export function normalizeCatSourcePathParam(sourcePath: string | null | undefined) {
+  const trimmed = sourcePath?.trim() ?? "";
+  if (!trimmed || trimmed === CAT_ALL_FILES_SOURCE_PATH) {
+    return CAT_ALL_FILES_SOURCE_PATH;
+  }
+  return trimmed;
+}
+
+export function parseCatSourcePathsFilter(sourcePaths: string | null | undefined) {
+  if (!sourcePaths?.trim()) {
+    return null;
+  }
+
+  const seen = new Set<string>();
+  const paths: string[] = [];
+  for (const part of sourcePaths.split(",")) {
+    const trimmed = part.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    paths.push(trimmed);
+  }
+
+  return paths.length > 0 ? paths : null;
+}
+
+export function serializeCatSourcePathsFilter(sourcePaths: readonly string[]) {
+  return sourcePaths
+    .map((path) => path.trim())
+    .filter(Boolean)
+    .join(",");
+}

--- a/apps/hyperlocalise-web/src/lib/projects/cat-all-files.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat-all-files.ts
@@ -1,3 +1,5 @@
+import type { ExternalTmsProviderKind } from "@/lib/providers/contracts/external-tms-provider-kind";
+
 /** Sentinel `sourcePath` for CAT queue requests that span every file in scope. */
 export const CAT_ALL_FILES_SOURCE_PATH = "*";
 
@@ -5,6 +7,16 @@ export const CAT_ALL_FILES_FILENAME = "All Files";
 
 export function isCatAllFilesSourcePath(sourcePath: string | null | undefined) {
   return !sourcePath?.trim() || sourcePath.trim() === CAT_ALL_FILES_SOURCE_PATH;
+}
+
+/**
+ * All Files is release-gated and currently supported for native projects
+ * (`providerKind` null/undefined) and Crowdin only.
+ */
+export function supportsCatAllFilesProvider(
+  providerKind: ExternalTmsProviderKind | null | undefined,
+) {
+  return providerKind == null || providerKind === "crowdin";
 }
 
 export function normalizeCatSourcePathParam(sourcePath: string | null | undefined) {

--- a/apps/hyperlocalise-web/src/lib/projects/cat-all-files.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat-all-files.ts
@@ -46,9 +46,9 @@ export function parseCatSourcePathsFilter(sourcePaths: string | null | undefined
   return paths.length > 0 ? paths : null;
 }
 
-export function serializeCatSourcePathsFilter(sourcePaths: readonly string[]) {
+export function serializeCatSourcePathsFilter(sourcePaths: readonly (string | null | undefined)[]) {
   return sourcePaths
+    .filter((path): path is string => typeof path === "string" && Boolean(path.trim()))
     .map((path) => path.trim())
-    .filter(Boolean)
     .join(",");
 }

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
@@ -11,6 +11,11 @@ import { db, schema } from "@/lib/database";
 import { getLatestRepositorySourceFileVersion } from "@/lib/file-storage/records";
 import { NativeCatCommentService } from "@/lib/projects/cat/native-cat-comment-service";
 import {
+  CAT_ALL_FILES_FILENAME,
+  CAT_ALL_FILES_SOURCE_PATH,
+  isCatAllFilesSourcePath,
+} from "@/lib/projects/cat-all-files";
+import {
   buildCatFilePagination,
   type ProjectFileCatPaginationInput,
 } from "@/lib/projects/cat/project-file-cat-pagination";
@@ -53,15 +58,19 @@ function toCatTranslation(row: {
   };
 }
 
-function mapTextSegment(key: {
-  id: string;
-  key: string;
-  sourceText: string;
-  context: string | null;
-  type: string | null;
-  maxLength: number | null;
-  metadata: Record<string, unknown> | null;
-}): ProjectFileCatSegment {
+function mapTextSegment(
+  key: {
+    id: string;
+    key: string;
+    sourceText: string;
+    context: string | null;
+    type: string | null;
+    maxLength: number | null;
+    metadata: Record<string, unknown> | null;
+    sourcePath?: string;
+  },
+  options?: { includeSourcePath?: boolean },
+): ProjectFileCatSegment {
   const contentKind = isImageUrlContentKind(key.metadata) ? IMAGE_URL_CONTENT_KIND : undefined;
   const looksLikeUrl = looksLikeImageUrl(key.sourceText);
 
@@ -77,6 +86,7 @@ function mapTextSegment(key: {
     ...(looksLikeUrl || contentKind === IMAGE_URL_CONTENT_KIND
       ? { looksLikeImageUrl: looksLikeUrl || contentKind === IMAGE_URL_CONTENT_KIND }
       : {}),
+    ...(options?.includeSourcePath && key.sourcePath ? { sourcePath: key.sourcePath } : {}),
   };
 }
 
@@ -102,7 +112,12 @@ export class NativeCatService extends ProjectServiceBase {
     canEditTranslations: boolean;
     organizationSlug: string;
     pagination?: ProjectFileCatPaginationInput;
+    sourcePaths?: readonly string[] | null;
   }): Promise<ProjectFileCatQueueFile | null> {
+    if (isCatAllFilesSourcePath(input.sourcePath)) {
+      return this.getAllFilesCatQueue(input);
+    }
+
     const sourceFile = await this.translations.getRepositorySourceFileByPath({
       organizationId: input.organizationId,
       projectId: input.projectId,
@@ -247,6 +262,76 @@ export class NativeCatService extends ProjectServiceBase {
           imageVariantId: variant?.id ?? null,
         },
       ],
+    };
+  }
+
+  private async getAllFilesCatQueue(input: {
+    organizationId: string;
+    projectId: string;
+    targetLocale: string;
+    canEditTranslations: boolean;
+    pagination?: ProjectFileCatPaginationInput;
+    sourcePaths?: readonly string[] | null;
+  }): Promise<ProjectFileCatQueueFile> {
+    const paginationInput = input.pagination ?? {
+      offset: 0,
+      limit: legacyNativeCatSegmentLimit,
+      search: undefined,
+      queueFilter: "all",
+      paginated: true,
+    };
+
+    const limit = paginationInput.paginated
+      ? paginationInput.limit
+      : legacyNativeCatSegmentLimit + 1;
+    const offset = paginationInput.paginated ? paginationInput.offset : 0;
+
+    const [totalCount, keys] = await Promise.all([
+      this.translations.countKeysForProject({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        targetLocale: input.targetLocale,
+        search: paginationInput.search,
+        queueFilter: paginationInput.queueFilter,
+        sourcePaths: input.sourcePaths,
+      }),
+      this.translations.listKeysForProject({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        targetLocale: input.targetLocale,
+        limit,
+        offset,
+        search: paginationInput.search,
+        queueFilter: paginationInput.queueFilter,
+        sourcePaths: input.sourcePaths,
+      }),
+    ]);
+
+    const visibleKeys = paginationInput.paginated
+      ? keys
+      : keys.slice(0, legacyNativeCatSegmentLimit);
+    const truncated = paginationInput.paginated
+      ? offset + visibleKeys.length < totalCount
+      : keys.length > legacyNativeCatSegmentLimit;
+
+    const pagination = paginationInput.paginated
+      ? buildCatFilePagination({
+          offset,
+          limit: paginationInput.limit,
+          returnedCount: visibleKeys.length,
+          totalCount,
+        })
+      : undefined;
+
+    return {
+      sourcePath: CAT_ALL_FILES_SOURCE_PATH,
+      filename: CAT_ALL_FILES_FILENAME,
+      provider: null,
+      targetLocale: input.targetLocale,
+      canEditTranslations: input.canEditTranslations,
+      truncated,
+      pagination,
+      segments: visibleKeys.map((key) => mapTextSegment(key, { includeSourcePath: true })),
     };
   }
 

--- a/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.test.ts
@@ -3,8 +3,12 @@ import { describe, expect, it } from "vite-plus/test";
 import { createProjectFileRecord } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files.fixture";
 
 import {
+  buildProjectFileCatAllFilesHref,
   buildProjectFileCatHref,
+  buildProjectStringsHref,
   canOpenProjectFileCat,
+  parseProjectFileCatSearchParams,
+  resolveProjectCatTargetLocale,
   resolveProjectFileCatTargetLocale,
   resolveProjectFileCatTargetLocaleResolution,
   resolveProjectFileCatTargetLocales,
@@ -207,5 +211,47 @@ describe("resolveProjectFileCatTargetLocales", () => {
     });
 
     expect(resolveProjectFileCatTargetLocales(file, ["vi"])).toEqual(["fr-FR"]);
+  });
+});
+
+describe("buildProjectFileCatAllFilesHref", () => {
+  it("builds an all-files CAT href with locale", () => {
+    expect(buildProjectFileCatAllFilesHref("acme", "proj_1", "fr-FR")).toBe(
+      "/org/acme/projects/proj_1/files/cat?sourcePath=*&locale=fr-FR",
+    );
+  });
+
+  it("builds the project Strings sidebar href", () => {
+    expect(buildProjectStringsHref("acme", "proj_1", "de-DE")).toBe(
+      "/org/acme/projects/proj_1/strings?sourcePath=*&locale=de-DE",
+    );
+  });
+});
+
+describe("parseProjectFileCatSearchParams", () => {
+  it("treats sourcePath=* as all-files mode", () => {
+    expect(
+      parseProjectFileCatSearchParams({
+        sourcePath: "*",
+        locale: "fr-FR",
+      }),
+    ).toEqual({
+      sourcePath: null,
+      allFiles: true,
+      highlightLocale: "fr-FR",
+      initialSegmentKey: null,
+      externalResourceId: null,
+      resourceType: null,
+      branch: null,
+      sourcePaths: null,
+    });
+  });
+});
+
+describe("resolveProjectCatTargetLocale", () => {
+  it("prefers an exact match then falls back to the first locale", () => {
+    expect(resolveProjectCatTargetLocale(["fr-FR", "de-DE"], "de-DE")).toBe("de-DE");
+    expect(resolveProjectCatTargetLocale(["fr-FR", "de-DE"], "it-IT")).toBe("fr-FR");
+    expect(resolveProjectCatTargetLocale([], null)).toBeNull();
   });
 });

--- a/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.ts
@@ -1,7 +1,6 @@
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
 import {
   CAT_ALL_FILES_SOURCE_PATH,
-  isCatAllFilesSourcePath,
   serializeCatSourcePathsFilter,
 } from "@/lib/projects/cat-all-files";
 import { supportsProviderCatFile } from "@/lib/providers/capabilities/provider-cat-capabilities";
@@ -249,9 +248,7 @@ export function resolveProjectCatTargetLocale(
   projectTargetLocales: readonly string[] | null | undefined,
   highlightLocale: string | null,
 ) {
-  const locales = (projectTargetLocales ?? [])
-    .map((locale) => locale.trim())
-    .filter(Boolean);
+  const locales = (projectTargetLocales ?? []).map((locale) => locale.trim()).filter(Boolean);
   const unique: string[] = [];
   const seen = new Set<string>();
   for (const locale of locales) {

--- a/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-file-cat-routing.ts
@@ -1,4 +1,9 @@
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+import {
+  CAT_ALL_FILES_SOURCE_PATH,
+  isCatAllFilesSourcePath,
+  serializeCatSourcePathsFilter,
+} from "@/lib/projects/cat-all-files";
 import { supportsProviderCatFile } from "@/lib/providers/capabilities/provider-cat-capabilities";
 
 export function canOpenProjectFileCat(file: ProjectFileRecord) {
@@ -121,21 +126,27 @@ export function parseProjectFileCatSearchParams(searchParams: {
   externalResourceId?: string;
   resourceType?: string;
   branch?: string;
+  sourcePaths?: string;
 }): {
   sourcePath: string | null;
+  allFiles: boolean;
   highlightLocale: string | null;
   initialSegmentKey: string | null;
   externalResourceId: string | null;
   resourceType: "file" | "key" | null;
   branch: string | null;
+  sourcePaths: string | null;
 } {
   const resourceType =
     searchParams.resourceType === "file" || searchParams.resourceType === "key"
       ? searchParams.resourceType
       : null;
+  const rawSourcePath = searchParams.sourcePath?.trim() ? searchParams.sourcePath.trim() : null;
+  const allFiles = rawSourcePath === CAT_ALL_FILES_SOURCE_PATH;
 
   return {
-    sourcePath: searchParams.sourcePath?.trim() ? searchParams.sourcePath.trim() : null,
+    sourcePath: allFiles ? null : rawSourcePath,
+    allFiles,
     highlightLocale: searchParams.locale?.trim() ? searchParams.locale.trim() : null,
     initialSegmentKey: searchParams.segment?.trim() ? searchParams.segment.trim() : null,
     externalResourceId: searchParams.externalResourceId?.trim()
@@ -143,6 +154,7 @@ export function parseProjectFileCatSearchParams(searchParams: {
       : null,
     resourceType,
     branch: searchParams.branch?.trim() ? searchParams.branch.trim() : null,
+    sourcePaths: searchParams.sourcePaths?.trim() ? searchParams.sourcePaths.trim() : null,
   };
 }
 
@@ -189,4 +201,68 @@ export function buildProjectFileCatHref(
 
   const base = `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/files/cat`;
   return `${base}?${params.toString()}`;
+}
+
+export function buildProjectFileCatAllFilesHref(
+  organizationSlug: string,
+  projectId: string,
+  locale: string | null = null,
+  options?: {
+    branch?: string | null;
+    sourcePaths?: readonly string[] | null;
+    basePath?: "files/cat" | "strings";
+  },
+) {
+  const params = new URLSearchParams({
+    sourcePath: CAT_ALL_FILES_SOURCE_PATH,
+  });
+
+  if (locale?.trim()) {
+    params.set("locale", locale.trim());
+  }
+
+  const trimmedBranch = options?.branch?.trim();
+  if (trimmedBranch) {
+    params.set("branch", trimmedBranch);
+  }
+
+  if (options?.sourcePaths && options.sourcePaths.length > 0) {
+    params.set("sourcePaths", serializeCatSourcePathsFilter(options.sourcePaths));
+  }
+
+  const section = options?.basePath ?? "files/cat";
+  const base = `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/${section}`;
+  return `${base}?${params.toString()}`;
+}
+
+export function buildProjectStringsHref(
+  organizationSlug: string,
+  projectId: string,
+  locale: string | null = null,
+) {
+  return buildProjectFileCatAllFilesHref(organizationSlug, projectId, locale, {
+    basePath: "strings",
+  });
+}
+
+export function resolveProjectCatTargetLocale(
+  projectTargetLocales: readonly string[] | null | undefined,
+  highlightLocale: string | null,
+) {
+  const locales = (projectTargetLocales ?? [])
+    .map((locale) => locale.trim())
+    .filter(Boolean);
+  const unique: string[] = [];
+  const seen = new Set<string>();
+  for (const locale of locales) {
+    if (seen.has(locale)) continue;
+    seen.add(locale);
+    unique.push(locale);
+  }
+
+  if (highlightLocale?.trim() && unique.includes(highlightLocale.trim())) {
+    return highlightLocale.trim();
+  }
+
+  return unique[0] ?? null;
 }

--- a/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
@@ -34,7 +34,6 @@ function translationKeysFileConditions(input: {
   );
 }
 
-
 function translationKeysProjectConditions(input: ProjectKeysScopeInput) {
   return and(
     eq(schema.projectTranslationKeys.organizationId, input.organizationId),
@@ -314,7 +313,6 @@ export class ProjectTranslationService extends ProjectServiceBase {
       .limit(limit)
       .offset(offset);
   }
-
 
   async countKeysForProject(input: {
     organizationId: string;

--- a/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
@@ -9,6 +9,12 @@ import { db, schema } from "@/lib/database";
 import { ProjectServiceBase } from "@/lib/projects/project-service-base";
 import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
 
+type ProjectKeysScopeInput = {
+  organizationId: string;
+  projectId: string;
+  sourcePaths?: readonly string[] | null;
+};
+
 const maxKeysPerImport = 5_000;
 const prefillKeysPageSize = maxKeysPerImport;
 
@@ -26,6 +32,22 @@ function translationKeysFileConditions(input: {
     eq(schema.projectTranslationKeys.projectId, input.projectId),
     eq(schema.projectTranslationKeys.repositorySourceFileId, input.repositorySourceFileId),
   );
+}
+
+
+function translationKeysProjectConditions(input: ProjectKeysScopeInput) {
+  return and(
+    eq(schema.projectTranslationKeys.organizationId, input.organizationId),
+    eq(schema.projectTranslationKeys.projectId, input.projectId),
+  );
+}
+
+function translationKeysSourcePathFilter(sourcePaths: readonly string[] | null | undefined) {
+  if (!sourcePaths || sourcePaths.length === 0) {
+    return undefined;
+  }
+
+  return inArray(schema.repositorySourceFiles.sourcePath, [...sourcePaths]);
 }
 
 function translationKeysSearchCondition(search: string | undefined) {
@@ -289,6 +311,94 @@ export class ProjectTranslationService extends ProjectServiceBase {
         ),
       )
       .orderBy(asc(schema.projectTranslationKeys.key), asc(schema.projectTranslationKeys.id))
+      .limit(limit)
+      .offset(offset);
+  }
+
+
+  async countKeysForProject(input: {
+    organizationId: string;
+    projectId: string;
+    targetLocale?: string;
+    search?: string;
+    queueFilter?: ProjectFileCatQueueFilter;
+    sourcePaths?: readonly string[] | null;
+  }) {
+    const [row] = await this.database
+      .select({ total: count() })
+      .from(schema.projectTranslationKeys)
+      .innerJoin(
+        schema.repositorySourceFiles,
+        eq(schema.projectTranslationKeys.repositorySourceFileId, schema.repositorySourceFiles.id),
+      )
+      .where(
+        and(
+          translationKeysProjectConditions(input),
+          translationKeysSourcePathFilter(input.sourcePaths),
+          translationKeysSearchCondition(input.search),
+          input.targetLocale
+            ? translationKeysQueueFilterCondition({
+                organizationId: input.organizationId,
+                projectId: input.projectId,
+                targetLocale: input.targetLocale,
+                queueFilter: input.queueFilter,
+              })
+            : undefined,
+        ),
+      );
+
+    return Number(row?.total ?? 0);
+  }
+
+  async listKeysForProject(input: {
+    organizationId: string;
+    projectId: string;
+    targetLocale?: string;
+    limit?: number;
+    offset?: number;
+    search?: string;
+    queueFilter?: ProjectFileCatQueueFilter;
+    sourcePaths?: readonly string[] | null;
+  }) {
+    const limit = input.limit ?? 2_000;
+    const offset = input.offset ?? 0;
+
+    return this.database
+      .select({
+        id: schema.projectTranslationKeys.id,
+        key: schema.projectTranslationKeys.key,
+        sourceText: schema.projectTranslationKeys.sourceText,
+        context: schema.projectTranslationKeys.context,
+        type: schema.projectTranslationKeys.type,
+        maxLength: schema.projectTranslationKeys.maxLength,
+        metadata: schema.projectTranslationKeys.metadata,
+        sourcePath: schema.repositorySourceFiles.sourcePath,
+      })
+      .from(schema.projectTranslationKeys)
+      .innerJoin(
+        schema.repositorySourceFiles,
+        eq(schema.projectTranslationKeys.repositorySourceFileId, schema.repositorySourceFiles.id),
+      )
+      .where(
+        and(
+          translationKeysProjectConditions(input),
+          translationKeysSourcePathFilter(input.sourcePaths),
+          translationKeysSearchCondition(input.search),
+          input.targetLocale
+            ? translationKeysQueueFilterCondition({
+                organizationId: input.organizationId,
+                projectId: input.projectId,
+                targetLocale: input.targetLocale,
+                queueFilter: input.queueFilter,
+              })
+            : undefined,
+        ),
+      )
+      .orderBy(
+        asc(schema.repositorySourceFiles.sourcePath),
+        asc(schema.projectTranslationKeys.key),
+        asc(schema.projectTranslationKeys.id),
+      )
       .limit(limit)
       .offset(offset);
   }
@@ -868,6 +978,14 @@ export const countProjectTranslationKeysForFile = (
 export const listProjectTranslationKeysForFile = (
   input: Parameters<ProjectTranslationService["listKeysForFile"]>[0],
 ) => projectTranslationService.listKeysForFile(input);
+
+export const countProjectTranslationKeysForProject = (
+  input: Parameters<ProjectTranslationService["countKeysForProject"]>[0],
+) => projectTranslationService.countKeysForProject(input);
+
+export const listProjectTranslationKeysForProject = (
+  input: Parameters<ProjectTranslationService["listKeysForProject"]>[0],
+) => projectTranslationService.listKeysForProject(input);
 
 export const getProjectTranslationsByKeyIds = (
   input: Parameters<ProjectTranslationService["getTranslationsByKeyIds"]>[0],

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -50,12 +50,26 @@ export function escapeCrowdinCroqlString(value: string) {
 }
 
 export function buildCrowdinFileQueueCroql(input: {
-  fileId: number;
+  fileId?: number;
+  fileIds?: readonly number[];
   targetLocale: string;
   queueFilter?: ProjectFileCatQueueFilter;
   search?: string;
 }) {
-  const parts: string[] = [`id of file = ${input.fileId}`];
+  const parts: string[] = [];
+
+  const fileIds =
+    input.fileIds && input.fileIds.length > 0
+      ? input.fileIds
+      : input.fileId !== undefined
+        ? [input.fileId]
+        : [];
+
+  if (fileIds.length === 1) {
+    parts.push(`id of file = ${fileIds[0]}`);
+  } else if (fileIds.length > 1) {
+    parts.push(`(${fileIds.map((fileId) => `id of file = ${fileId}`).join(" or ")})`);
+  }
 
   if (input.search?.trim()) {
     const escaped = escapeCrowdinCroqlString(input.search.trim());
@@ -86,7 +100,7 @@ export function buildCrowdinFileQueueCroql(input: {
       break;
   }
 
-  return parts.join(" and ");
+  return parts.length > 0 ? parts.join(" and ") : undefined;
 }
 
 export function buildCrowdinFileSearchCroql(fileId: number, search: string) {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-croql.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-croql.test.ts
@@ -43,6 +43,34 @@ describe("buildCrowdinFileQueueCroql", () => {
       'id of file = 9 and count of languages summary where (language = @language:"fr" and is translated and not is approved) > 0 and count of comments where (has unresolved issue) = 0',
     );
   });
+
+  it("builds project-wide croql without a file scope", () => {
+    expect(
+      buildCrowdinFileQueueCroql({
+        targetLocale: "fr",
+        queueFilter: "untranslated",
+      }),
+    ).toBe('count of languages summary where (language = @language:"fr" and is translated) = 0');
+  });
+
+  it("scopes to multiple file ids with or", () => {
+    expect(
+      buildCrowdinFileQueueCroql({
+        fileIds: [10, 20],
+        targetLocale: "fr",
+        queueFilter: "all",
+      }),
+    ).toBe("(id of file = 10 or id of file = 20)");
+  });
+
+  it("returns undefined when there are no filters", () => {
+    expect(
+      buildCrowdinFileQueueCroql({
+        targetLocale: "fr",
+        queueFilter: "all",
+      }),
+    ).toBeUndefined();
+  });
 });
 
 describe("buildCrowdinFileSearchCroql", () => {

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.ts
@@ -41,6 +41,7 @@ export function getTmsProviderLiveErrorStatus(code: string): TmsProviderLiveErro
     case "provider_description_edit_unsupported":
     case "provider_comments_read_unsupported":
     case "provider_cat_unsupported":
+    case "provider_cat_all_files_unsupported":
       return 501;
     default:
       return 500;

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -1933,7 +1933,8 @@ export async function listTmsProviderLiveFilesForProject(
   organizationId: string,
   externalProjectId: string,
   options?: {
-    limit?: number;
+    /** Cap returned files. Pass `null` to keep the full provider list (All Files CAT). */
+    limit?: number | null;
     branch?: string | null;
     context?: ActiveTmsProviderContext;
     projects?: ExternalTmsProjectMetadata[];
@@ -1995,6 +1996,10 @@ export async function listTmsProviderLiveFilesForProject(
       project: projectMetadata,
     }),
   );
+
+  if (options?.limit === null) {
+    return mapped;
+  }
 
   return mapped.slice(0, options?.limit ?? 500);
 }
@@ -2222,7 +2227,7 @@ async function buildCrowdinLiveCatAllFiles(input: {
     {
       actorUserId: input.actorUserId,
       context: input.context,
-      limit: 1000,
+      limit: null,
     },
   );
 

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -1092,7 +1092,7 @@ async function buildCrowdinLiveCatFile(input: {
           : undefined;
       const page = await client.listSourceStringsPage(projectId, {
         fileId: croql ? undefined : fileId,
-        croql,
+        croql: croql ?? undefined,
         offset: paginationInput.offset,
         limit: paginationInput.limit,
       });
@@ -2180,23 +2180,74 @@ export async function getTmsProviderLiveCatAllFiles(
   const context = await loadActiveTmsProviderContext(organizationId, {
     actorUserId: options?.actorUserId,
   });
-  const files = await listTmsProviderLiveFilesForProject(organizationId, externalProjectId, {
-    actorUserId: options?.actorUserId,
+
+  if (context.providerKind !== "crowdin") {
+    throw new TmsProviderLiveError(
+      "provider_cat_all_files_unsupported",
+      "All Files CAT is not available for this provider yet.",
+    );
+  }
+
+  return buildCrowdinLiveCatAllFiles({
     context,
-    limit: 500,
+    externalProjectId,
+    targetLocale,
+    actorUserId: options?.actorUserId,
+    canEditTranslations: options?.canEditTranslations ?? false,
+    pagination: options?.pagination,
+    sourcePaths: options?.sourcePaths,
   });
+}
+
+async function buildCrowdinLiveCatAllFiles(input: {
+  context: ActiveTmsProviderContext;
+  externalProjectId: string;
+  targetLocale: string;
+  actorUserId?: string | null;
+  canEditTranslations: boolean;
+  pagination?: ProjectFileCatPaginationInput;
+  sourcePaths?: readonly string[] | null;
+}): Promise<TmsProviderLiveCatFile> {
+  const projectId = Number(input.externalProjectId);
+  if (Number.isNaN(projectId)) {
+    throw new TmsProviderLiveError(
+      "invalid_crowdin_project_or_file_id",
+      "Crowdin project identifier is invalid.",
+    );
+  }
+
+  const files = await listTmsProviderLiveFilesForProject(
+    input.context.organizationId,
+    input.externalProjectId,
+    {
+      actorUserId: input.actorUserId,
+      context: input.context,
+      limit: 500,
+    },
+  );
 
   const sourcePathFilter =
-    options?.sourcePaths && options.sourcePaths.length > 0 ? new Set(options.sourcePaths) : null;
+    input.sourcePaths && input.sourcePaths.length > 0 ? new Set(input.sourcePaths) : null;
 
   const catFiles = files
-    .filter((file) => supportsLiveProviderCat(context.providerKind, file))
+    .filter((file) => supportsLiveProviderCat(input.context.providerKind, file))
     .filter((file) => (sourcePathFilter ? sourcePathFilter.has(file.sourcePath) : true))
     .toSorted((left, right) =>
       left.sourcePath.localeCompare(right.sourcePath, undefined, { sensitivity: "base" }),
     );
 
-  const paginationInput = options?.pagination ?? {
+  const fileById = new Map<number, TmsProviderLiveFile>();
+  const fileIds: number[] = [];
+  for (const file of catFiles) {
+    const fileId = Number(file.provider?.externalResourceId);
+    if (Number.isNaN(fileId)) {
+      continue;
+    }
+    fileById.set(fileId, file);
+    fileIds.push(fileId);
+  }
+
+  const paginationInput = input.pagination ?? {
     offset: 0,
     limit: legacyProviderCatSegmentLimit,
     search: undefined,
@@ -2207,82 +2258,66 @@ export async function getTmsProviderLiveCatAllFiles(
   const offset = paginationInput.paginated ? paginationInput.offset : 0;
   const limit = paginationInput.paginated ? paginationInput.limit : legacyProviderCatSegmentLimit;
 
-  let remainingToSkip = offset;
-  let totalCount = 0;
-  const segments: TmsProviderLiveCatFile["segments"] = [];
-  let canEditTranslations = options?.canEditTranslations ?? false;
-  let provider: TmsProviderLiveCatFile["provider"] = null;
+  if (fileIds.length === 0) {
+    const pagination = paginationInput.paginated
+      ? buildCatFilePagination({
+          offset,
+          limit,
+          returnedCount: 0,
+          totalCount: 0,
+        })
+      : undefined;
 
-  for (const file of catFiles) {
-    const fileQueue = await getTmsProviderLiveCatFile(
-      organizationId,
-      externalProjectId,
-      file.sourcePath,
-      targetLocale,
-      {
-        actorUserId: options?.actorUserId,
-        canEditTranslations: options?.canEditTranslations,
-        externalResourceId: file.provider?.externalResourceId,
-        resourceType: file.provider?.resourceType,
-        pagination: {
-          ...paginationInput,
-          offset: 0,
-          limit: 1,
-          paginated: true,
-        },
-      },
+    return {
+      sourcePath: CAT_ALL_FILES_SOURCE_PATH,
+      filename: CAT_ALL_FILES_FILENAME,
+      provider: null,
+      targetLocale: input.targetLocale,
+      canEditTranslations: input.canEditTranslations,
+      truncated: false,
+      pagination,
+      segments: [],
+    };
+  }
+
+  const client = new CrowdinApiClient({
+    token: input.context.secretMaterial,
+    baseUrl: input.context.credential.baseUrl ?? undefined,
+  });
+
+  const croql = buildCrowdinFileQueueCroql({
+    fileIds,
+    targetLocale: input.targetLocale,
+    queueFilter: paginationInput.queueFilter,
+    search: paginationInput.search,
+  });
+  if (!croql) {
+    throw new TmsProviderLiveError(
+      "invalid_crowdin_project_or_file_id",
+      "Crowdin All Files CAT requires at least one project file.",
     );
+  }
 
-    if (!fileQueue) {
-      continue;
-    }
+  try {
+    const page = await client.listSourceStringsPage(projectId, {
+      croql,
+      offset,
+      limit,
+    });
 
-    canEditTranslations = fileQueue.canEditTranslations;
-    if (!provider && fileQueue.provider) {
-      provider = fileQueue.provider;
-    }
+    const segments: TmsProviderLiveCatFile["segments"] = [];
+    for (const sourceString of page.strings) {
+      const file = sourceString.fileId != null ? (fileById.get(sourceString.fileId) ?? null) : null;
+      if (!file) {
+        continue;
+      }
 
-    const fileTotal = fileQueue.pagination?.totalCount ?? fileQueue.segments.length;
-    totalCount += fileTotal;
-
-    if (remainingToSkip >= fileTotal) {
-      remainingToSkip -= fileTotal;
-      continue;
-    }
-
-    if (segments.length >= limit) {
-      continue;
-    }
-
-    const fileOffset = remainingToSkip;
-    remainingToSkip = 0;
-    const needed = limit - segments.length;
-    const page = await getTmsProviderLiveCatFile(
-      organizationId,
-      externalProjectId,
-      file.sourcePath,
-      targetLocale,
-      {
-        actorUserId: options?.actorUserId,
-        canEditTranslations: options?.canEditTranslations,
-        externalResourceId: file.provider?.externalResourceId,
-        resourceType: file.provider?.resourceType,
-        pagination: {
-          ...paginationInput,
-          offset: fileOffset,
-          limit: needed,
-          paginated: true,
-        },
-      },
-    );
-
-    if (!page) {
-      continue;
-    }
-
-    for (const segment of page.segments) {
       segments.push({
-        ...segment,
+        externalStringId: String(sourceString.id),
+        key: sourceString.identifier,
+        sourceText: crowdinCatSourceTextValue(sourceString.text),
+        context: sourceString.context,
+        type: sourceString.type ?? null,
         sourcePath: file.sourcePath,
         ...(file.provider?.externalResourceId
           ? { externalResourceId: file.provider.externalResourceId }
@@ -2290,27 +2325,36 @@ export async function getTmsProviderLiveCatAllFiles(
         ...(file.provider?.resourceType ? { resourceType: file.provider.resourceType } : {}),
       });
     }
+
+    const totalCount = page.hasMore ? offset + segments.length + 1 : offset + segments.length;
+
+    const pagination = paginationInput.paginated
+      ? buildCatFilePagination({
+          offset,
+          limit,
+          returnedCount: segments.length,
+          totalCount,
+          hasMore: page.hasMore,
+        })
+      : undefined;
+
+    return {
+      sourcePath: CAT_ALL_FILES_SOURCE_PATH,
+      filename: CAT_ALL_FILES_FILENAME,
+      provider: catFiles[0]?.provider ?? null,
+      targetLocale: input.targetLocale,
+      canEditTranslations: input.canEditTranslations,
+      truncated: pagination?.hasMore ?? false,
+      pagination,
+      segments,
+    };
+  } catch (error) {
+    if (error instanceof CrowdinApiError && error.status === 401) {
+      throw new TmsProviderLiveError("crowdin_auth_invalid", "Crowdin credentials are invalid.");
+    }
+
+    throw error;
   }
-
-  const pagination = paginationInput.paginated
-    ? buildCatFilePagination({
-        offset,
-        limit,
-        returnedCount: segments.length,
-        totalCount,
-      })
-    : undefined;
-
-  return {
-    sourcePath: CAT_ALL_FILES_SOURCE_PATH,
-    filename: CAT_ALL_FILES_FILENAME,
-    provider,
-    targetLocale,
-    canEditTranslations,
-    truncated: pagination?.hasMore ?? false,
-    pagination,
-    segments,
-  };
 }
 
 export async function getTmsProviderLiveCatSegmentTarget(

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -2222,7 +2222,7 @@ async function buildCrowdinLiveCatAllFiles(input: {
     {
       actorUserId: input.actorUserId,
       context: input.context,
-      limit: 500,
+      limit: 1000,
     },
   );
 

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -13,6 +13,10 @@ import {
   normalizeProjectFileContent,
 } from "@/lib/projects/files/project-file-content";
 import {
+  CAT_ALL_FILES_FILENAME,
+  CAT_ALL_FILES_SOURCE_PATH,
+} from "@/lib/projects/cat-all-files";
+import {
   buildCatFilePagination,
   type ProjectFileCatPaginationInput,
 } from "@/lib/projects/cat/project-file-cat-pagination";
@@ -2163,6 +2167,158 @@ export async function getTmsProviderLiveCatFile(
     canEditTranslations: options?.canEditTranslations ?? false,
     pagination: options?.pagination,
   });
+}
+
+
+export async function getTmsProviderLiveCatAllFiles(
+  organizationId: string,
+  externalProjectId: string,
+  targetLocale: string,
+  options?: {
+    actorUserId?: string | null;
+    canEditTranslations?: boolean;
+    pagination?: ProjectFileCatPaginationInput;
+    sourcePaths?: readonly string[] | null;
+  },
+): Promise<TmsProviderLiveCatFile> {
+  const context = await loadActiveTmsProviderContext(organizationId, {
+    actorUserId: options?.actorUserId,
+  });
+  const files = await listTmsProviderLiveFilesForProject(organizationId, externalProjectId, {
+    actorUserId: options?.actorUserId,
+    context,
+    limit: 500,
+  });
+
+  const sourcePathFilter =
+    options?.sourcePaths && options.sourcePaths.length > 0
+      ? new Set(options.sourcePaths)
+      : null;
+
+  const catFiles = files
+    .filter((file) => supportsLiveProviderCat(context.providerKind, file))
+    .filter((file) => (sourcePathFilter ? sourcePathFilter.has(file.sourcePath) : true))
+    .toSorted((left, right) =>
+      left.sourcePath.localeCompare(right.sourcePath, undefined, { sensitivity: "base" }),
+    );
+
+  const paginationInput = options?.pagination ?? {
+    offset: 0,
+    limit: legacyProviderCatSegmentLimit,
+    search: undefined,
+    queueFilter: "all",
+    paginated: true,
+  };
+
+  const offset = paginationInput.paginated ? paginationInput.offset : 0;
+  const limit = paginationInput.paginated
+    ? paginationInput.limit
+    : legacyProviderCatSegmentLimit;
+
+  let remainingToSkip = offset;
+  let totalCount = 0;
+  const segments: TmsProviderLiveCatFile["segments"] = [];
+  let canEditTranslations = options?.canEditTranslations ?? false;
+  let provider: TmsProviderLiveCatFile["provider"] = null;
+
+  for (const file of catFiles) {
+    const fileQueue = await getTmsProviderLiveCatFile(
+      organizationId,
+      externalProjectId,
+      file.sourcePath,
+      targetLocale,
+      {
+        actorUserId: options?.actorUserId,
+        canEditTranslations: options?.canEditTranslations,
+        externalResourceId: file.provider?.externalResourceId,
+        resourceType: file.provider?.resourceType,
+        pagination: {
+          ...paginationInput,
+          offset: 0,
+          limit: 1,
+          paginated: true,
+        },
+      },
+    );
+
+    if (!fileQueue) {
+      continue;
+    }
+
+    canEditTranslations = fileQueue.canEditTranslations;
+    if (!provider && fileQueue.provider) {
+      provider = fileQueue.provider;
+    }
+
+    const fileTotal = fileQueue.pagination?.totalCount ?? fileQueue.segments.length;
+    totalCount += fileTotal;
+
+    if (remainingToSkip >= fileTotal) {
+      remainingToSkip -= fileTotal;
+      continue;
+    }
+
+    if (segments.length >= limit) {
+      continue;
+    }
+
+    const fileOffset = remainingToSkip;
+    remainingToSkip = 0;
+    const needed = limit - segments.length;
+    const page = await getTmsProviderLiveCatFile(
+      organizationId,
+      externalProjectId,
+      file.sourcePath,
+      targetLocale,
+      {
+        actorUserId: options?.actorUserId,
+        canEditTranslations: options?.canEditTranslations,
+        externalResourceId: file.provider?.externalResourceId,
+        resourceType: file.provider?.resourceType,
+        pagination: {
+          ...paginationInput,
+          offset: fileOffset,
+          limit: needed,
+          paginated: true,
+        },
+      },
+    );
+
+    if (!page) {
+      continue;
+    }
+
+    for (const segment of page.segments) {
+      segments.push({
+        ...segment,
+        sourcePath: file.sourcePath,
+        ...(file.provider?.externalResourceId
+          ? { externalResourceId: file.provider.externalResourceId }
+          : {}),
+        ...(file.provider?.resourceType ? { resourceType: file.provider.resourceType } : {}),
+      });
+    }
+  }
+
+  const pagination = paginationInput.paginated
+    ? buildCatFilePagination({
+        offset,
+        limit,
+        returnedCount: segments.length,
+        totalCount,
+      })
+    : undefined;
+
+  return {
+    sourcePath: CAT_ALL_FILES_SOURCE_PATH,
+    filename: CAT_ALL_FILES_FILENAME,
+    provider,
+    targetLocale,
+    canEditTranslations,
+    truncated: pagination?.hasMore ?? false,
+    pagination,
+    segments,
+  };
 }
 
 export async function getTmsProviderLiveCatSegmentTarget(

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -2324,6 +2324,7 @@ async function buildCrowdinLiveCatAllFiles(input: {
         context: sourceString.context,
         type: sourceString.type ?? null,
         sourcePath: file.sourcePath,
+        ...(file.provider?.format != null ? { format: file.provider.format } : {}),
         ...(file.provider?.externalResourceId
           ? { externalResourceId: file.provider.externalResourceId }
           : {}),

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -12,10 +12,7 @@ import {
   buildSourceStringsPreviewContent,
   normalizeProjectFileContent,
 } from "@/lib/projects/files/project-file-content";
-import {
-  CAT_ALL_FILES_FILENAME,
-  CAT_ALL_FILES_SOURCE_PATH,
-} from "@/lib/projects/cat-all-files";
+import { CAT_ALL_FILES_FILENAME, CAT_ALL_FILES_SOURCE_PATH } from "@/lib/projects/cat-all-files";
 import {
   buildCatFilePagination,
   type ProjectFileCatPaginationInput,
@@ -2169,7 +2166,6 @@ export async function getTmsProviderLiveCatFile(
   });
 }
 
-
 export async function getTmsProviderLiveCatAllFiles(
   organizationId: string,
   externalProjectId: string,
@@ -2191,9 +2187,7 @@ export async function getTmsProviderLiveCatAllFiles(
   });
 
   const sourcePathFilter =
-    options?.sourcePaths && options.sourcePaths.length > 0
-      ? new Set(options.sourcePaths)
-      : null;
+    options?.sourcePaths && options.sourcePaths.length > 0 ? new Set(options.sourcePaths) : null;
 
   const catFiles = files
     .filter((file) => supportsLiveProviderCat(context.providerKind, file))
@@ -2211,9 +2205,7 @@ export async function getTmsProviderLiveCatAllFiles(
   };
 
   const offset = paginationInput.paginated ? paginationInput.offset : 0;
-  const limit = paginationInput.paginated
-    ? paginationInput.limit
-    : legacyProviderCatSegmentLimit;
+  const limit = paginationInput.paginated ? paginationInput.limit : legacyProviderCatSegmentLimit;
 
   let remainingToSkip = offset;
   let totalCount = 0;

--- a/docs/adr/2026-07-15-release-cat-all-files-design.md
+++ b/docs/adr/2026-07-15-release-cat-all-files-design.md
@@ -2,7 +2,7 @@
 
 ## Decision
 
-Gate CAT **All Files** (`sourcePath=*`) behind the WorkOS release flag `release-cat-all-files` (default off). When the flag is on, support All Files only for **native** projects and **Crowdin** live projects. Other TMS providers stay unavailable until a later release.
+Gate CAT **All Files** (`sourcePath=*`) behind the Flags SDK release flag `release-cat-all-files` (default off via `decide`). Enable with Flags Explorer overrides. When the flag is on, support All Files only for **native** projects and **Crowdin** live projects. Other TMS providers stay unavailable until a later release.
 
 For Crowdin, replace the per-file probe loop with a single project-scoped `GET /projects/{id}/strings` call (optional CroQL for search, queue filters, and optional file-id OR filters).
 
@@ -26,7 +26,7 @@ Deep links and job CAT that default to All Files follow the same rules: when the
 
 ## Surfaces
 
-- Flag: `releaseCatAllFilesFlag` (`release-cat-all-files`)
+- Flag: `releaseCatAllFilesFlag` in `release-flags.ts` (`decide` → `false`; Flags Explorer overrides; not WorkOS)
 - API: `loadProjectFileCatQueue` gates before native / provider All Files loaders
 - UI: CAT file picker and `/strings` / job CAT defaults only expose All Files when the flag is on and the project is native or Crowdin
 - Provider: `getTmsProviderLiveCatAllFiles` is Crowdin-only; other providers throw `provider_cat_all_files_unsupported`

--- a/docs/adr/2026-07-15-release-cat-all-files-design.md
+++ b/docs/adr/2026-07-15-release-cat-all-files-design.md
@@ -1,0 +1,38 @@
+# Release CAT All Files
+
+## Decision
+
+Gate CAT **All Files** (`sourcePath=*`) behind the WorkOS release flag `release-cat-all-files` (default off). When the flag is on, support All Files only for **native** projects and **Crowdin** live projects. Other TMS providers stay unavailable until a later release.
+
+For Crowdin, replace the per-file probe loop with a single project-scoped `GET /projects/{id}/strings` call (optional CroQL for search, queue filters, and optional file-id OR filters).
+
+## Behavior
+
+| Flag | Project | All Files UI | API `sourcePath=*` |
+|------|---------|--------------|--------------------|
+| Off | Any | Hidden | `feature_unavailable` (403) |
+| On | Native | Shown | Existing DB All Files path |
+| On | Crowdin | Shown | One project-wide strings page (+ CroQL) |
+| On | Phrase / Lokalise / Smartling / other | Hidden | `provider_cat_all_files_unsupported` (501) |
+
+Deep links and job CAT that default to All Files follow the same rules: when the flag is off or the provider is unsupported, do not open All Files (pick a single file or require selection).
+
+## Crowdin fetch
+
+- List live files once to map `fileId` → `sourcePath` / provider metadata (and to resolve optional `sourcePaths` filters into file ids).
+- Call `listSourceStringsPage` once with `offset` / `limit`, using CroQL when search or queue filters apply, or when scoping to a subset of file ids.
+- Infer `hasMore` / lower-bound `totalCount` the same way as single-file Crowdin CAT (REST has no total count).
+- Segment order follows Crowdin’s project string order, not path-sorted file walks.
+
+## Surfaces
+
+- Flag: `releaseCatAllFilesFlag` (`release-cat-all-files`)
+- API: `loadProjectFileCatQueue` gates before native / provider All Files loaders
+- UI: CAT file picker and `/strings` / job CAT defaults only expose All Files when the flag is on and the project is native or Crowdin
+- Provider: `getTmsProviderLiveCatAllFiles` is Crowdin-only; other providers throw `provider_cat_all_files_unsupported`
+
+## Verification
+
+- Unit tests for CroQL project-scope builders and Crowdin All Files one-call path
+- Route tests for flag off, Crowdin on, native on, other TMS rejected
+- Run `vp test` and `vp check --fix` from `apps/hyperlocalise-web`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an **All Files** CAT scope so translators can work without picking a single file first, plus a project **Strings** sidebar entry that opens CAT with All Files selected.

Also shows each segment’s **filepath under the key** (muted mono) in the queue, editor, side-by-side, and compact workspace when `sourcePath` is present — important in All Files mode.

### Backend
- Sentinel `sourcePath=*` for all-files queue loading (native + provider)
- Optional `sourcePaths` filter for job-scoped All Files
- Segments include optional `sourcePath` / `format` / resource identity when spanning files
- Crowdin All Files lists files with `limit: null` (no silent 500/1000 cap)

### Frontend
- File picker **All Files** option (release-flagged)
- `/projects/:id/strings` route + sidebar **Strings** item
- Job CAT defaults to All Files (job-scoped) when the flag is on
- Shared `CatSegmentKeyMeta` renders key + muted filepath under it
- Null-safe job `sourcePaths` serialization; AI recommendations use per-segment path/format

## Test plan
- [ ] Open project **Strings** — All Files selected, first locale resolved
- [ ] Queue rows show filepath under key when spanning files
- [ ] Selected segment (editor / side-by-side) shows muted filepath under key
- [ ] Single-file CAT still works; filepath omitted when not multi-file
- [ ] Job CAT defaults to All Files scoped to job files (null sourcePaths do not crash)
- [ ] Crowdin All Files AI suggestion uses the segment’s own file path/format

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f63b2-547c-7d59-ac5e-21e5f4d91168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f63b2-547c-7d59-ac5e-21e5f4d91168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

