### PR TITLE
feat(issue-sheet): expose issue filters and sorting (HL-497)

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/issues/issues.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/issues/issues.route.test.ts
@@ -39,6 +39,10 @@ function organizationIssuesUrl(organizationSlug: string) {
   return `/api/orgs/${encodeURIComponent(organizationSlug)}/issues`;
 }
 
+function issueSheetUrl(organizationSlug: string, projectId: string) {
+  return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/issue-sheet`;
+}
+
 async function requestJson(
   url: string,
   input: {
@@ -59,23 +63,34 @@ async function requestJson(
   });
 }
 
+type ListBody = {
+  issues: Array<{
+    id: string;
+    title: string;
+    issueType: string;
+    status: string;
+    projectId?: string;
+    targetLocale?: string | null;
+    assigneeUserId?: string | null;
+    values?: Record<string, unknown>;
+  }>;
+  total: number;
+};
+
 describe("Organization issues routes", () => {
   it("lists issues across accessible projects", async () => {
     const { identity, project } = await projectFixture.createStoredProjectFixture();
     const headers = await projectFixture.authHeadersFor(identity);
     const organizationSlug = identity.organization.slug ?? "missing-slug";
 
-    const createResponse = await requestJson(
-      `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(project.id)}/issue-sheet`,
-      {
-        method: "POST",
-        headers,
-        body: {
-          title: "Workspace-wide issue",
-          issueType: "general_question",
-        },
+    const createResponse = await requestJson(issueSheetUrl(organizationSlug, project.id), {
+      method: "POST",
+      headers,
+      body: {
+        title: "Workspace-wide issue",
+        issueType: "general_question",
       },
-    );
+    });
     expect(createResponse.status).toBe(201);
 
     const listResponse = await requestJson(organizationIssuesUrl(organizationSlug), {
@@ -84,9 +99,7 @@ describe("Organization issues routes", () => {
     });
 
     expect(listResponse.status).toBe(200);
-    const listBody = (await listResponse.json()) as {
-      issues: Array<{ title: string; projectId: string; projectName: string }>;
-      total: number;
+    const listBody = (await listResponse.json()) as ListBody & {
       summary: { open: number };
     };
     expect(listBody.total).toBe(1);
@@ -94,7 +107,127 @@ describe("Organization issues routes", () => {
     expect(listBody.issues[0]).toMatchObject({
       title: "Workspace-wide issue",
       projectId: project.id,
-      projectName: project.name,
     });
+  });
+
+  it("supports built-in views, filters, project scoping, and stable sort pagination", async () => {
+    const { identity, project, user } = await projectFixture.createStoredProjectFixture();
+    const headers = await projectFixture.authHeadersFor(identity);
+    const organizationSlug = identity.organization.slug ?? "missing-slug";
+    const actorUserId = user.id;
+
+    const payloads = [
+      {
+        title: "QA unassigned open",
+        issueType: "qa_failure",
+        status: "open",
+        targetLocale: "de-DE",
+        priority: "P0",
+      },
+      {
+        title: "My assigned open",
+        issueType: "translation_mistake",
+        status: "open",
+        assigneeUserId: actorUserId,
+        targetLocale: "fr-FR",
+        priority: "P2",
+      },
+      {
+        title: "Source context open",
+        issueType: "context_request",
+        status: "in_progress",
+        targetLocale: "de-DE",
+        priority: "P1",
+      },
+      {
+        title: "Resolved QA",
+        issueType: "qa_failure",
+        status: "resolved",
+        targetLocale: "es-ES",
+        priority: "P1",
+      },
+    ] as const;
+
+    for (const payload of payloads) {
+      const response = await requestJson(issueSheetUrl(organizationSlug, project.id), {
+        method: "POST",
+        headers,
+        body: payload,
+      });
+      expect(response.status).toBe(201);
+    }
+
+    const qaTriage = await requestJson(organizationIssuesUrl(organizationSlug), {
+      headers,
+      query: { view: "qa_triage" },
+    });
+    expect(qaTriage.status).toBe(200);
+    const qaTriageBody = (await qaTriage.json()) as ListBody;
+    expect(qaTriageBody.issues.map((issue) => issue.title)).toEqual(["QA unassigned open"]);
+
+    const myWork = await requestJson(organizationIssuesUrl(organizationSlug), {
+      headers,
+      query: { view: "my_work" },
+    });
+    const myWorkBody = (await myWork.json()) as ListBody;
+    expect(myWorkBody.issues.map((issue) => issue.title)).toEqual(["My assigned open"]);
+
+    const sourceContext = await requestJson(organizationIssuesUrl(organizationSlug), {
+      headers,
+      query: { view: "source_context" },
+    });
+    const sourceContextBody = (await sourceContext.json()) as ListBody;
+    expect(sourceContextBody.issues.map((issue) => issue.title).sort()).toEqual([
+      "Source context open",
+    ]);
+
+    const filtered = await requestJson(organizationIssuesUrl(organizationSlug), {
+      headers,
+      query: {
+        view: "all_open",
+        locale: "de-DE",
+        priority: "P0",
+        assignee: "unassigned",
+        projectId: project.id,
+        sort: "priority",
+        sortDir: "asc",
+      },
+    });
+    expect(filtered.status).toBe(200);
+    const filteredBody = (await filtered.json()) as ListBody;
+    expect(filteredBody.total).toBe(1);
+    expect(filteredBody.issues[0]?.title).toBe("QA unassigned open");
+
+    const sorted = await requestJson(organizationIssuesUrl(organizationSlug), {
+      headers,
+      query: {
+        view: "all_open",
+        sort: "priority",
+        sortDir: "asc",
+        limit: "2",
+        offset: "0",
+      },
+    });
+    const sortedBody = (await sorted.json()) as ListBody;
+    expect(sortedBody.issues.map((issue) => issue.title)).toEqual([
+      "QA unassigned open",
+      "Source context open",
+    ]);
+
+    const pageTwo = await requestJson(organizationIssuesUrl(organizationSlug), {
+      headers,
+      query: {
+        view: "all_open",
+        sort: "priority",
+        sortDir: "asc",
+        limit: "2",
+        offset: "2",
+      },
+    });
+    const pageTwoBody = (await pageTwo.json()) as ListBody;
+    expect(pageTwoBody.issues.map((issue) => issue.title)).toEqual(["My assigned open"]);
+    expect(new Set([...sortedBody.issues, ...pageTwoBody.issues].map((issue) => issue.id)).size).toBe(
+      3,
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/issues/issues.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/issues/issues.route.test.ts
@@ -203,7 +203,6 @@ describe("Organization issues routes", () => {
       query: {
         view: "all_open",
         sort: "priority",
-        sortDir: "asc",
         limit: "2",
         offset: "0",
       },
@@ -219,7 +218,6 @@ describe("Organization issues routes", () => {
       query: {
         view: "all_open",
         sort: "priority",
-        sortDir: "asc",
         limit: "2",
         offset: "2",
       },
@@ -229,5 +227,19 @@ describe("Organization issues routes", () => {
     expect(
       new Set([...sortedBody.issues, ...pageTwoBody.issues].map((issue) => issue.id)).size,
     ).toBe(3);
+
+    const statusSorted = await requestJson(organizationIssuesUrl(organizationSlug), {
+      headers,
+      query: {
+        view: "all_open",
+        sort: "status",
+      },
+    });
+    const statusSortedBody = (await statusSorted.json()) as ListBody;
+    expect(statusSortedBody.issues.map((issue) => issue.status)).toEqual([
+      "open",
+      "open",
+      "in_progress",
+    ]);
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/issues/issues.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/issues/issues.route.test.ts
@@ -226,8 +226,8 @@ describe("Organization issues routes", () => {
     });
     const pageTwoBody = (await pageTwo.json()) as ListBody;
     expect(pageTwoBody.issues.map((issue) => issue.title)).toEqual(["My assigned open"]);
-    expect(new Set([...sortedBody.issues, ...pageTwoBody.issues].map((issue) => issue.id)).size).toBe(
-      3,
-    );
+    expect(
+      new Set([...sortedBody.issues, ...pageTwoBody.issues].map((issue) => issue.id)).size,
+    ).toBe(3);
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/issues/issues.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/issues/issues.schema.ts
@@ -18,7 +18,7 @@ export const organizationIssuesQuerySchema = z.object({
   projectId: z.string().trim().min(1).max(128).optional(),
   search: z.string().trim().max(200).optional(),
   sort: issueSheetSortSchema.default("updated_at"),
-  sortDir: issueSheetSortDirSchema.default("desc"),
+  sortDir: issueSheetSortDirSchema.optional(),
   limit: z.coerce.number().int().min(1).max(100).default(50),
   offset: z.coerce.number().int().min(0).default(0),
 });

--- a/apps/hyperlocalise-web/src/api/routes/issues/issues.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/issues/issues.schema.ts
@@ -3,15 +3,22 @@ import { z } from "zod";
 import {
   issueSheetIssueStatusSchema,
   issueSheetIssueTypeSchema,
+  issueSheetPrioritySchema,
+  issueSheetSortDirSchema,
+  issueSheetSortSchema,
 } from "@/api/routes/project/issue-sheet.schema";
 
 export const organizationIssuesQuerySchema = z.object({
   view: z.enum(["my_work", "qa_triage", "source_context", "all_open"]).optional(),
   status: issueSheetIssueStatusSchema.or(z.literal("all")).optional(),
   issueType: issueSheetIssueTypeSchema.or(z.literal("all")).optional(),
+  priority: issueSheetPrioritySchema.optional(),
   locale: z.string().trim().min(1).max(32).optional(),
   assignee: z.string().uuid().or(z.literal("me")).or(z.literal("unassigned")).optional(),
+  projectId: z.string().trim().min(1).max(128).optional(),
   search: z.string().trim().max(200).optional(),
+  sort: issueSheetSortSchema.default("updated_at"),
+  sortDir: issueSheetSortDirSchema.default("desc"),
   limit: z.coerce.number().int().min(1).max(100).default(50),
   offset: z.coerce.number().int().min(0).default(0),
 });

--- a/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.test.ts
@@ -424,7 +424,6 @@ Second import issue,Done,EXT-2,P2`;
       query: {
         view: "all_open",
         sort: "priority",
-        sortDir: "asc",
         limit: "2",
         offset: "0",
       },
@@ -434,7 +433,6 @@ Second import issue,Done,EXT-2,P2`;
       query: {
         view: "all_open",
         sort: "priority",
-        sortDir: "asc",
         limit: "2",
         offset: "2",
       },

--- a/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.test.ts
@@ -38,8 +38,9 @@ type IssueResponse = {
 };
 
 type IssueSheetListResponse = {
-  issues: { id: string }[];
+  issues: { id: string; title?: string; issueType?: string; status?: string }[];
   columns: { key: string }[];
+  total: number;
   summary: { open: number };
 };
 
@@ -131,7 +132,7 @@ describe("Issue Sheet routes", () => {
 
     expect(viewWithStatusResponse.status).toBe(200);
     const viewWithStatusBody = (await viewWithStatusResponse.json()) as IssueSheetListResponse;
-    expect(viewWithStatusBody.issues).toHaveLength(1);
+    expect(viewWithStatusBody.issues).toHaveLength(0);
 
     const issueId = createdBody.issue.id;
     const updateResponse = await requestJson(
@@ -344,6 +345,107 @@ Second import issue,Done,EXT-2,P2`;
     });
     const listBody = (await listResponse.json()) as IssueSheetListResponse;
     expect(listBody.issues).toHaveLength(2);
+  });
+
+  it("filters and sorts built-in views with stable pagination", async () => {
+    const { identity, project, user } = await projectFixture.createStoredProjectFixture();
+    const headers = await projectFixture.authHeadersFor(identity);
+    const organizationSlug = identity.organization.slug ?? "missing-slug";
+
+    const payloads = [
+      {
+        title: "QA triage candidate",
+        issueType: "qa_failure",
+        status: "open",
+        targetLocale: "de-DE",
+        priority: "P0",
+      },
+      {
+        title: "My work candidate",
+        issueType: "translation_mistake",
+        status: "open",
+        assigneeUserId: user.id,
+        targetLocale: "fr-FR",
+        priority: "P2",
+      },
+      {
+        title: "Source context candidate",
+        issueType: "source_mistake",
+        status: "in_progress",
+        targetLocale: "de-DE",
+        priority: "P1",
+      },
+    ] as const;
+
+    for (const payload of payloads) {
+      const response = await requestJson(issueSheetUrl(organizationSlug, project.id), {
+        method: "POST",
+        headers,
+        body: payload,
+      });
+      expect(response.status).toBe(201);
+    }
+
+    const qaTriage = await requestJson(issueSheetUrl(organizationSlug, project.id), {
+      headers,
+      query: { view: "qa_triage" },
+    });
+    const qaTriageBody = (await qaTriage.json()) as IssueSheetListResponse;
+    expect(qaTriageBody.issues.map((issue) => issue.title)).toEqual(["QA triage candidate"]);
+    expect(qaTriageBody.total).toBe(1);
+
+    const myWork = await requestJson(issueSheetUrl(organizationSlug, project.id), {
+      headers,
+      query: { view: "my_work" },
+    });
+    const myWorkBody = (await myWork.json()) as IssueSheetListResponse;
+    expect(myWorkBody.issues.map((issue) => issue.title)).toEqual(["My work candidate"]);
+
+    const filtered = await requestJson(issueSheetUrl(organizationSlug, project.id), {
+      headers,
+      query: {
+        view: "all_open",
+        locale: "de-DE",
+        assignee: "unassigned",
+        sort: "priority",
+        sortDir: "asc",
+        limit: "10",
+        offset: "0",
+      },
+    });
+    const filteredBody = (await filtered.json()) as IssueSheetListResponse;
+    expect(filteredBody.issues.map((issue) => issue.title)).toEqual([
+      "QA triage candidate",
+      "Source context candidate",
+    ]);
+
+    const pageOne = await requestJson(issueSheetUrl(organizationSlug, project.id), {
+      headers,
+      query: {
+        view: "all_open",
+        sort: "priority",
+        sortDir: "asc",
+        limit: "2",
+        offset: "0",
+      },
+    });
+    const pageTwo = await requestJson(issueSheetUrl(organizationSlug, project.id), {
+      headers,
+      query: {
+        view: "all_open",
+        sort: "priority",
+        sortDir: "asc",
+        limit: "2",
+        offset: "2",
+      },
+    });
+    const pageOneBody = (await pageOne.json()) as IssueSheetListResponse;
+    const pageTwoBody = (await pageTwo.json()) as IssueSheetListResponse;
+    expect(pageOneBody.issues).toHaveLength(2);
+    expect(pageTwoBody.issues).toHaveLength(1);
+    expect(
+      new Set([...pageOneBody.issues, ...pageTwoBody.issues].map((issue) => issue.id)).size,
+    ).toBe(3);
   });
 
   it("rejects duplicate system field mappings", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.schema.ts
@@ -39,13 +39,20 @@ export const issueSheetColumnParamsSchema = projectIdParamsSchema.extend({
   columnId: z.string().uuid(),
 });
 
+export const issueSheetSortSchema = z.enum(["updated_at", "created_at", "priority", "status"]);
+export const issueSheetSortDirSchema = z.enum(["asc", "desc"]);
+export const issueSheetPrioritySchema = z.enum(["P0", "P1", "P2"]);
+
 export const issueSheetQuerySchema = z.object({
   view: z.enum(["my_work", "qa_triage", "source_context", "all_open"]).optional(),
   status: issueSheetIssueStatusSchema.or(z.literal("all")).optional(),
   issueType: issueSheetIssueTypeSchema.or(z.literal("all")).optional(),
+  priority: issueSheetPrioritySchema.optional(),
   locale: z.string().trim().min(1).max(32).optional(),
   assignee: z.string().uuid().or(z.literal("me")).or(z.literal("unassigned")).optional(),
   search: z.string().trim().max(200).optional(),
+  sort: issueSheetSortSchema.default("updated_at"),
+  sortDir: issueSheetSortDirSchema.default("desc"),
   limit: z.coerce.number().int().min(1).max(100).default(50),
   offset: z.coerce.number().int().min(0).default(0),
 });

--- a/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.schema.ts
@@ -52,7 +52,7 @@ export const issueSheetQuerySchema = z.object({
   assignee: z.string().uuid().or(z.literal("me")).or(z.literal("unassigned")).optional(),
   search: z.string().trim().max(200).optional(),
   sort: issueSheetSortSchema.default("updated_at"),
-  sortDir: issueSheetSortDirSchema.default("desc"),
+  sortDir: issueSheetSortDirSchema.optional(),
   limit: z.coerce.number().int().min(1).max(100).default(50),
   offset: z.coerce.number().int().min(0).default(0),
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-list-filters-bar.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-list-filters-bar.tsx
@@ -23,7 +23,7 @@ import {
   type IssueListUrlState,
 } from "./issue-list-url-state";
 import { WorkspaceFilterField, workspaceFilterTriggerClassName } from "./workspace-resource-shared";
-import { ISSUE_PRIORITIES } from "@/lib/projects/issue-sheet/issue-list-query";
+import { ISSUE_PRIORITIES } from "@/lib/projects/issue-sheet/issue-list-constants";
 
 const viewOptions = [
   { value: "all_open", label: "All open" },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-list-filters-bar.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-list-filters-bar.tsx
@@ -63,7 +63,9 @@ export function IssueListFiltersBar({
   projects?: ProjectOption[];
   searchPlaceholder?: string;
 }) {
-  const projectNameById = Object.fromEntries((projects ?? []).map((project) => [project.id, project.name]));
+  const projectNameById = Object.fromEntries(
+    (projects ?? []).map((project) => [project.id, project.name]),
+  );
   const chips = getActiveIssueFilterChips(state, {
     includeProject: Boolean(projects),
     projectNameById,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-list-filters-bar.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-list-filters-bar.tsx
@@ -1,0 +1,352 @@
+"use client";
+
+import { Cancel01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+import {
+  formatIssueFilterLabel,
+  getActiveIssueFilterChips,
+  ISSUE_ASSIGNEE_FILTERS,
+  ISSUE_STATUS_FILTERS,
+  ISSUE_TYPE_FILTERS,
+  type IssueListUrlState,
+} from "./issue-list-url-state";
+import { WorkspaceFilterField, workspaceFilterTriggerClassName } from "./workspace-resource-shared";
+import { ISSUE_PRIORITIES } from "@/lib/projects/issue-sheet/issue-list-query";
+
+const viewOptions = [
+  { value: "all_open", label: "All open" },
+  { value: "my_work", label: "My work" },
+  { value: "qa_triage", label: "QA triage" },
+  { value: "source_context", label: "Source & context" },
+] as const;
+
+const sortOptions = [
+  { value: "updated_at", label: "Updated" },
+  { value: "created_at", label: "Created" },
+  { value: "priority", label: "Priority" },
+  { value: "status", label: "Status" },
+] as const;
+
+const sortDirOptions = [
+  { value: "asc", label: "Ascending" },
+  { value: "desc", label: "Descending" },
+] as const;
+
+type ProjectOption = { id: string; name: string };
+
+export function IssueListFiltersBar({
+  state,
+  searchDraft,
+  onSearchDraftChange,
+  onStateChange,
+  onClearFilters,
+  projects,
+  searchPlaceholder = "Search title, description, or source path",
+}: {
+  state: IssueListUrlState;
+  searchDraft: string;
+  onSearchDraftChange: (value: string) => void;
+  onStateChange: (patch: Partial<IssueListUrlState>) => void;
+  onClearFilters: () => void;
+  projects?: ProjectOption[];
+  searchPlaceholder?: string;
+}) {
+  const projectNameById = Object.fromEntries((projects ?? []).map((project) => [project.id, project.name]));
+  const chips = getActiveIssueFilterChips(state, {
+    includeProject: Boolean(projects),
+    projectNameById,
+  });
+  const hasActiveFilters = chips.length > 0;
+
+  return (
+    <div className="space-y-3 rounded-2xl border bg-card p-4">
+      <div className="grid gap-3 md:grid-cols-[200px_minmax(0,1fr)_160px_140px]">
+        <WorkspaceFilterField label="View">
+          <Select
+            value={state.view}
+            items={viewOptions}
+            onValueChange={(value) =>
+              onStateChange({
+                view: (value ?? "all_open") as IssueListUrlState["view"],
+              })
+            }
+          >
+            <SelectTrigger className={workspaceFilterTriggerClassName}>
+              <SelectValue placeholder="View" />
+            </SelectTrigger>
+            <SelectContent>
+              {viewOptions.map((item) => (
+                <SelectItem key={item.value} value={item.value} label={item.label}>
+                  {item.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </WorkspaceFilterField>
+
+        <WorkspaceFilterField label="Search">
+          <Input
+            value={searchDraft}
+            onChange={(event) => onSearchDraftChange(event.currentTarget.value)}
+            placeholder={searchPlaceholder}
+          />
+        </WorkspaceFilterField>
+
+        <WorkspaceFilterField label="Sort by">
+          <Select
+            value={state.sort}
+            items={sortOptions}
+            onValueChange={(value) =>
+              onStateChange({
+                sort: (value ?? "updated_at") as IssueListUrlState["sort"],
+              })
+            }
+          >
+            <SelectTrigger className={workspaceFilterTriggerClassName}>
+              <SelectValue placeholder="Sort" />
+            </SelectTrigger>
+            <SelectContent>
+              {sortOptions.map((item) => (
+                <SelectItem key={item.value} value={item.value} label={item.label}>
+                  {item.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </WorkspaceFilterField>
+
+        <WorkspaceFilterField label="Order">
+          <Select
+            value={state.sortDir}
+            items={sortDirOptions}
+            onValueChange={(value) =>
+              onStateChange({
+                sortDir: (value ?? "desc") as IssueListUrlState["sortDir"],
+              })
+            }
+          >
+            <SelectTrigger className={workspaceFilterTriggerClassName}>
+              <SelectValue placeholder="Order" />
+            </SelectTrigger>
+            <SelectContent>
+              {sortDirOptions.map((item) => (
+                <SelectItem key={item.value} value={item.value} label={item.label}>
+                  {item.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </WorkspaceFilterField>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+        <WorkspaceFilterField label="Status">
+          <Select
+            value={state.status ?? "all"}
+            onValueChange={(value) =>
+              onStateChange({
+                status:
+                  value && value !== "all"
+                    ? (value as NonNullable<IssueListUrlState["status"]>)
+                    : undefined,
+              })
+            }
+          >
+            <SelectTrigger className={workspaceFilterTriggerClassName}>
+              <SelectValue>
+                {state.status ? formatIssueFilterLabel(state.status) : "All statuses"}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all" label="All statuses">
+                All statuses
+              </SelectItem>
+              {ISSUE_STATUS_FILTERS.map((status) => (
+                <SelectItem key={status} value={status} label={formatIssueFilterLabel(status)}>
+                  {formatIssueFilterLabel(status)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </WorkspaceFilterField>
+
+        <WorkspaceFilterField label="Type">
+          <Select
+            value={state.issueType ?? "all"}
+            onValueChange={(value) =>
+              onStateChange({
+                issueType:
+                  value && value !== "all"
+                    ? (value as NonNullable<IssueListUrlState["issueType"]>)
+                    : undefined,
+              })
+            }
+          >
+            <SelectTrigger className={workspaceFilterTriggerClassName}>
+              <SelectValue>
+                {state.issueType ? formatIssueFilterLabel(state.issueType) : "All types"}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all" label="All types">
+                All types
+              </SelectItem>
+              {ISSUE_TYPE_FILTERS.map((type) => (
+                <SelectItem key={type} value={type} label={formatIssueFilterLabel(type)}>
+                  {formatIssueFilterLabel(type)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </WorkspaceFilterField>
+
+        <WorkspaceFilterField label="Priority">
+          <Select
+            value={state.priority ?? "all"}
+            onValueChange={(value) =>
+              onStateChange({
+                priority:
+                  value && value !== "all"
+                    ? (value as NonNullable<IssueListUrlState["priority"]>)
+                    : undefined,
+              })
+            }
+          >
+            <SelectTrigger className={workspaceFilterTriggerClassName}>
+              <SelectValue>{state.priority ?? "All priorities"}</SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all" label="All priorities">
+                All priorities
+              </SelectItem>
+              {ISSUE_PRIORITIES.map((priority) => (
+                <SelectItem key={priority} value={priority} label={priority}>
+                  {priority}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </WorkspaceFilterField>
+
+        <WorkspaceFilterField label="Locale">
+          <Input
+            defaultValue={state.locale ?? ""}
+            key={state.locale ?? "locale-empty"}
+            onBlur={(event) => {
+              const value = event.currentTarget.value.trim();
+              onStateChange({ locale: value || undefined });
+            }}
+            placeholder="e.g. de-DE"
+          />
+        </WorkspaceFilterField>
+
+        <WorkspaceFilterField label="Assignee">
+          <Select
+            value={state.assignee ?? "all"}
+            onValueChange={(value) =>
+              onStateChange({
+                assignee:
+                  value && value !== "all"
+                    ? (value as NonNullable<IssueListUrlState["assignee"]>)
+                    : undefined,
+              })
+            }
+          >
+            <SelectTrigger className={workspaceFilterTriggerClassName}>
+              <SelectValue>
+                {state.assignee === "me"
+                  ? "Me"
+                  : state.assignee === "unassigned"
+                    ? "Unassigned"
+                    : "Anyone"}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all" label="Anyone">
+                Anyone
+              </SelectItem>
+              {ISSUE_ASSIGNEE_FILTERS.map((assignee) => (
+                <SelectItem
+                  key={assignee}
+                  value={assignee}
+                  label={assignee === "me" ? "Me" : "Unassigned"}
+                >
+                  {assignee === "me" ? "Me" : "Unassigned"}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </WorkspaceFilterField>
+
+        {projects ? (
+          <WorkspaceFilterField label="Project">
+            <Select
+              value={state.projectId ?? "all"}
+              onValueChange={(value) =>
+                onStateChange({
+                  projectId: value && value !== "all" ? value : undefined,
+                })
+              }
+            >
+              <SelectTrigger className={workspaceFilterTriggerClassName}>
+                <SelectValue>
+                  {state.projectId
+                    ? (projectNameById[state.projectId] ?? state.projectId)
+                    : "All projects"}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all" label="All projects">
+                  All projects
+                </SelectItem>
+                {projects.map((project) => (
+                  <SelectItem key={project.id} value={project.id} label={project.name}>
+                    {project.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </WorkspaceFilterField>
+        ) : null}
+      </div>
+
+      {hasActiveFilters ? (
+        <div className="flex flex-wrap items-center gap-2">
+          {chips.map((chip) => (
+            <Badge key={chip.key} variant="secondary" className="gap-1 rounded-full pr-1">
+              <span>{chip.label}</span>
+              <button
+                type="button"
+                className="rounded-full p-0.5 hover:bg-muted"
+                aria-label={`Remove ${chip.label}`}
+                onClick={() => {
+                  if (chip.key === "search") {
+                    onSearchDraftChange("");
+                  }
+                  onStateChange({ [chip.key]: chip.key === "search" ? "" : undefined });
+                }}
+              >
+                <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} className="size-3.5" />
+              </button>
+            </Badge>
+          ))}
+          <Button type="button" variant="ghost" size="sm" onClick={onClearFilters}>
+            Clear filters
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-list-url-state.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-list-url-state.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildIssueListHref,
+  buildIssueListSearchParams,
+  clearIssueListFilters,
+  getActiveIssueFilterChips,
+  issueListStateToApiQuery,
+  parseIssueListSearchParams,
+} from "./issue-list-url-state";
+
+describe("issue list URL state", () => {
+  it("parses supported filters, sort, and defaults", () => {
+    const state = parseIssueListSearchParams(
+      new URLSearchParams(
+        "view=qa_triage&status=open&issueType=qa_failure&priority=P0&locale=de-DE&assignee=unassigned&projectId=proj_1&search=hero&sort=priority&sortDir=asc",
+      ),
+      { includeProject: true },
+    );
+
+    expect(state).toEqual({
+      view: "qa_triage",
+      status: "open",
+      issueType: "qa_failure",
+      priority: "P0",
+      locale: "de-DE",
+      assignee: "unassigned",
+      projectId: "proj_1",
+      search: "hero",
+      sort: "priority",
+      sortDir: "asc",
+    });
+  });
+
+  it("omits default view and sort from the URL", () => {
+    const params = buildIssueListSearchParams({
+      view: "all_open",
+      search: "",
+      sort: "updated_at",
+      sortDir: "desc",
+      status: "in_progress",
+    });
+
+    expect(params.toString()).toBe("status=in_progress");
+    expect(buildIssueListHref("/org/acme/issues", {
+      view: "all_open",
+      search: "",
+      sort: "updated_at",
+      sortDir: "desc",
+    })).toBe("/org/acme/issues");
+  });
+
+  it("clears filters while preserving the selected preset and sort", () => {
+    const cleared = clearIssueListFilters({
+      view: "my_work",
+      status: "open",
+      issueType: "qa_failure",
+      priority: "P1",
+      locale: "fr-FR",
+      assignee: "me",
+      projectId: "proj_1",
+      search: "cta",
+      sort: "created_at",
+      sortDir: "asc",
+    });
+
+    expect(cleared).toEqual({
+      view: "my_work",
+      search: "",
+      sort: "created_at",
+      sortDir: "asc",
+    });
+  });
+
+  it("exposes active filter chips without opening a menu", () => {
+    const chips = getActiveIssueFilterChips(
+      {
+        view: "all_open",
+        status: "open",
+        assignee: "unassigned",
+        projectId: "proj_1",
+        search: "hero",
+        sort: "updated_at",
+        sortDir: "desc",
+      },
+      {
+        includeProject: true,
+        projectNameById: { proj_1: "Website" },
+      },
+    );
+
+    expect(chips.map((chip) => chip.label)).toEqual([
+      "Status: Open",
+      "Assignee: Unassigned",
+      "Project: Website",
+      "Search: hero",
+    ]);
+  });
+
+  it("maps URL state into API query params used by built-in views", () => {
+    expect(
+      issueListStateToApiQuery(
+        {
+          view: "source_context",
+          issueType: "context_request",
+          search: "",
+          sort: "status",
+          sortDir: "asc",
+        },
+        { limit: 25, offset: 50 },
+      ),
+    ).toEqual({
+      view: "source_context",
+      issueType: "context_request",
+      sort: "status",
+      sortDir: "asc",
+      limit: "25",
+      offset: "50",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-list-url-state.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-list-url-state.test.ts
@@ -42,12 +42,14 @@ describe("issue list URL state", () => {
     });
 
     expect(params.toString()).toBe("status=in_progress");
-    expect(buildIssueListHref("/org/acme/issues", {
-      view: "all_open",
-      search: "",
-      sort: "updated_at",
-      sortDir: "desc",
-    })).toBe("/org/acme/issues");
+    expect(
+      buildIssueListHref("/org/acme/issues", {
+        view: "all_open",
+        search: "",
+        sort: "updated_at",
+        sortDir: "desc",
+      }),
+    ).toBe("/org/acme/issues");
   });
 
   it("clears filters while preserving the selected preset and sort", () => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-list-url-state.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-list-url-state.ts
@@ -7,7 +7,7 @@ import {
   type IssueListSortField,
   type IssueListView,
   type IssuePriority,
-} from "@/lib/projects/issue-sheet/issue-list-query";
+} from "@/lib/projects/issue-sheet/issue-list-constants";
 
 export const ISSUE_STATUS_FILTERS = ["open", "in_progress", "resolved", "wont_fix"] as const;
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-list-url-state.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-list-url-state.ts
@@ -1,0 +1,236 @@
+import {
+  ISSUE_LIST_SORT_DIRECTIONS,
+  ISSUE_LIST_SORT_FIELDS,
+  ISSUE_LIST_VIEWS,
+  ISSUE_PRIORITIES,
+  type IssueListSortDirection,
+  type IssueListSortField,
+  type IssueListView,
+  type IssuePriority,
+} from "@/lib/projects/issue-sheet/issue-list-query";
+
+export const ISSUE_STATUS_FILTERS = [
+  "open",
+  "in_progress",
+  "resolved",
+  "wont_fix",
+] as const;
+
+export const ISSUE_TYPE_FILTERS = [
+  "general_question",
+  "translation_mistake",
+  "context_request",
+  "source_mistake",
+  "glossary_violation",
+  "qa_failure",
+] as const;
+
+export const ISSUE_ASSIGNEE_FILTERS = ["me", "unassigned"] as const;
+
+export type IssueStatusFilter = (typeof ISSUE_STATUS_FILTERS)[number];
+export type IssueTypeFilter = (typeof ISSUE_TYPE_FILTERS)[number];
+export type IssueAssigneeFilter = (typeof ISSUE_ASSIGNEE_FILTERS)[number];
+
+export type IssueListUrlState = {
+  view: IssueListView;
+  status?: IssueStatusFilter;
+  issueType?: IssueTypeFilter;
+  priority?: IssuePriority;
+  locale?: string;
+  assignee?: IssueAssigneeFilter;
+  projectId?: string;
+  search: string;
+  sort: IssueListSortField;
+  sortDir: IssueListSortDirection;
+};
+
+const DEFAULT_STATE: IssueListUrlState = {
+  view: "all_open",
+  search: "",
+  sort: "updated_at",
+  sortDir: "desc",
+};
+
+function readAllowedValue<T extends string>(
+  searchParams: URLSearchParams,
+  key: string,
+  allowed: readonly T[],
+): T | undefined {
+  const value = searchParams.get(key);
+  if (value && (allowed as readonly string[]).includes(value)) {
+    return value as T;
+  }
+  return undefined;
+}
+
+export function parseIssueListSearchParams(
+  searchParams: URLSearchParams,
+  options?: { includeProject?: boolean },
+): IssueListUrlState {
+  const view = readAllowedValue(searchParams, "view", ISSUE_LIST_VIEWS) ?? DEFAULT_STATE.view;
+  const sort = readAllowedValue(searchParams, "sort", ISSUE_LIST_SORT_FIELDS) ?? DEFAULT_STATE.sort;
+  const sortDir =
+    readAllowedValue(searchParams, "sortDir", ISSUE_LIST_SORT_DIRECTIONS) ??
+    DEFAULT_STATE.sortDir;
+  const status = readAllowedValue(searchParams, "status", ISSUE_STATUS_FILTERS);
+  const issueType = readAllowedValue(searchParams, "issueType", ISSUE_TYPE_FILTERS);
+  const priority = readAllowedValue(searchParams, "priority", ISSUE_PRIORITIES);
+  const assignee = readAllowedValue(searchParams, "assignee", ISSUE_ASSIGNEE_FILTERS);
+  const locale = searchParams.get("locale")?.trim() || undefined;
+  const search = searchParams.get("search")?.trim() ?? "";
+  const projectId = options?.includeProject
+    ? searchParams.get("projectId")?.trim() || undefined
+    : undefined;
+
+  return {
+    view,
+    status,
+    issueType,
+    priority,
+    locale,
+    assignee,
+    projectId,
+    search,
+    sort,
+    sortDir,
+  };
+}
+
+export function buildIssueListSearchParams(
+  state: IssueListUrlState,
+  options?: { includeProject?: boolean },
+): URLSearchParams {
+  const params = new URLSearchParams();
+  if (state.view !== DEFAULT_STATE.view) {
+    params.set("view", state.view);
+  }
+  if (state.status) {
+    params.set("status", state.status);
+  }
+  if (state.issueType) {
+    params.set("issueType", state.issueType);
+  }
+  if (state.priority) {
+    params.set("priority", state.priority);
+  }
+  if (state.locale) {
+    params.set("locale", state.locale);
+  }
+  if (state.assignee) {
+    params.set("assignee", state.assignee);
+  }
+  if (options?.includeProject && state.projectId) {
+    params.set("projectId", state.projectId);
+  }
+  if (state.search.trim()) {
+    params.set("search", state.search.trim());
+  }
+  if (state.sort !== DEFAULT_STATE.sort) {
+    params.set("sort", state.sort);
+  }
+  if (state.sortDir !== DEFAULT_STATE.sortDir) {
+    params.set("sortDir", state.sortDir);
+  }
+  return params;
+}
+
+export function buildIssueListHref(
+  pathname: string,
+  state: IssueListUrlState,
+  options?: { includeProject?: boolean },
+) {
+  const params = buildIssueListSearchParams(state, options);
+  const query = params.toString();
+  return query ? `${pathname}?${query}` : pathname;
+}
+
+export function clearIssueListFilters(state: IssueListUrlState): IssueListUrlState {
+  return {
+    view: state.view,
+    search: "",
+    sort: state.sort,
+    sortDir: state.sortDir,
+  };
+}
+
+export function getActiveIssueFilterChips(
+  state: IssueListUrlState,
+  options?: {
+    includeProject?: boolean;
+    projectNameById?: Record<string, string>;
+  },
+) {
+  const chips: Array<{ key: keyof IssueListUrlState; label: string }> = [];
+  if (state.status) {
+    chips.push({ key: "status", label: `Status: ${formatIssueFilterLabel(state.status)}` });
+  }
+  if (state.issueType) {
+    chips.push({ key: "issueType", label: `Type: ${formatIssueFilterLabel(state.issueType)}` });
+  }
+  if (state.priority) {
+    chips.push({ key: "priority", label: `Priority: ${state.priority}` });
+  }
+  if (state.locale) {
+    chips.push({ key: "locale", label: `Locale: ${state.locale}` });
+  }
+  if (state.assignee) {
+    chips.push({
+      key: "assignee",
+      label: state.assignee === "me" ? "Assignee: Me" : "Assignee: Unassigned",
+    });
+  }
+  if (options?.includeProject && state.projectId) {
+    const projectName = options.projectNameById?.[state.projectId] ?? state.projectId;
+    chips.push({ key: "projectId", label: `Project: ${projectName}` });
+  }
+  if (state.search.trim()) {
+    chips.push({ key: "search", label: `Search: ${state.search.trim()}` });
+  }
+  return chips;
+}
+
+export function formatIssueFilterLabel(value: string) {
+  return value
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function defaultSortDirForField(sort: IssueListSortField): IssueListSortDirection {
+  return sort === "priority" || sort === "status" ? "asc" : "desc";
+}
+
+export function issueListStateToApiQuery(
+  state: IssueListUrlState,
+  options?: { includeProject?: boolean; limit?: number; offset?: number },
+) {
+  const query: Record<string, string> = {
+    view: state.view,
+    sort: state.sort,
+    sortDir: state.sortDir,
+    limit: String(options?.limit ?? 50),
+    offset: String(options?.offset ?? 0),
+  };
+  if (state.status) {
+    query.status = state.status;
+  }
+  if (state.issueType) {
+    query.issueType = state.issueType;
+  }
+  if (state.priority) {
+    query.priority = state.priority;
+  }
+  if (state.locale) {
+    query.locale = state.locale;
+  }
+  if (state.assignee) {
+    query.assignee = state.assignee;
+  }
+  if (options?.includeProject && state.projectId) {
+    query.projectId = state.projectId;
+  }
+  if (state.search.trim()) {
+    query.search = state.search.trim();
+  }
+  return query;
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-list-url-state.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-list-url-state.ts
@@ -9,12 +9,7 @@ import {
   type IssuePriority,
 } from "@/lib/projects/issue-sheet/issue-list-query";
 
-export const ISSUE_STATUS_FILTERS = [
-  "open",
-  "in_progress",
-  "resolved",
-  "wont_fix",
-] as const;
+export const ISSUE_STATUS_FILTERS = ["open", "in_progress", "resolved", "wont_fix"] as const;
 
 export const ISSUE_TYPE_FILTERS = [
   "general_question",
@@ -70,8 +65,7 @@ export function parseIssueListSearchParams(
   const view = readAllowedValue(searchParams, "view", ISSUE_LIST_VIEWS) ?? DEFAULT_STATE.view;
   const sort = readAllowedValue(searchParams, "sort", ISSUE_LIST_SORT_FIELDS) ?? DEFAULT_STATE.sort;
   const sortDir =
-    readAllowedValue(searchParams, "sortDir", ISSUE_LIST_SORT_DIRECTIONS) ??
-    DEFAULT_STATE.sortDir;
+    readAllowedValue(searchParams, "sortDir", ISSUE_LIST_SORT_DIRECTIONS) ?? DEFAULT_STATE.sortDir;
   const status = readAllowedValue(searchParams, "status", ISSUE_STATUS_FILTERS);
   const issueType = readAllowedValue(searchParams, "issueType", ISSUE_TYPE_FILTERS);
   const priority = readAllowedValue(searchParams, "priority", ISSUE_PRIORITIES);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/use-issue-list-url-state.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/use-issue-list-url-state.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import {
+  buildIssueListHref,
+  clearIssueListFilters,
+  defaultSortDirForField,
+  parseIssueListSearchParams,
+  type IssueListUrlState,
+} from "./issue-list-url-state";
+
+export function useIssueListUrlState(options?: { includeProject?: boolean }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const includeProject = options?.includeProject ?? false;
+  const searchParamsKey = searchParams.toString();
+
+  const [state, setState] = useState(() =>
+    parseIssueListSearchParams(new URLSearchParams(searchParamsKey), { includeProject }),
+  );
+  const [searchDraft, setSearchDraft] = useState(state.search);
+  const skipNextUrlSync = useRef(false);
+
+  useEffect(() => {
+    const next = parseIssueListSearchParams(new URLSearchParams(searchParamsKey), {
+      includeProject,
+    });
+    skipNextUrlSync.current = true;
+    setState(next);
+    setSearchDraft(next.search);
+  }, [includeProject, searchParamsKey]);
+
+  useEffect(() => {
+    if (skipNextUrlSync.current) {
+      skipNextUrlSync.current = false;
+      return;
+    }
+    const href = buildIssueListHref(pathname, state, { includeProject });
+    const current = searchParamsKey ? `${pathname}?${searchParamsKey}` : pathname;
+    if (href !== current) {
+      router.replace(href, { scroll: false });
+    }
+  }, [includeProject, pathname, router, searchParamsKey, state]);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setState((current) =>
+        current.search === searchDraft ? current : { ...current, search: searchDraft },
+      );
+    }, 250);
+    return () => window.clearTimeout(timeout);
+  }, [searchDraft]);
+
+  const updateState = useCallback((patch: Partial<IssueListUrlState>) => {
+    setState((current) => {
+      const next = { ...current, ...patch };
+      if (patch.sort && patch.sortDir === undefined && patch.sort !== current.sort) {
+        next.sortDir = defaultSortDirForField(patch.sort);
+      }
+      return next;
+    });
+  }, []);
+
+  const clearFilters = useCallback(() => {
+    setState((current) => clearIssueListFilters(current));
+    setSearchDraft("");
+  }, []);
+
+  return {
+    state,
+    searchDraft,
+    setSearchDraft,
+    updateState,
+    clearFilters,
+  };
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/use-issue-list-url-state.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/use-issue-list-url-state.ts
@@ -17,6 +17,7 @@ export function useIssueListUrlState(options?: { includeProject?: boolean }) {
   const searchParams = useSearchParams();
   const includeProject = options?.includeProject ?? false;
   const searchParamsKey = searchParams.toString();
+  const searchParamsKeyRef = useRef(searchParamsKey);
 
   const [state, setState] = useState(() =>
     parseIssueListSearchParams(new URLSearchParams(searchParamsKey), { includeProject }),
@@ -25,6 +26,7 @@ export function useIssueListUrlState(options?: { includeProject?: boolean }) {
   const skipNextUrlSync = useRef(false);
 
   useEffect(() => {
+    searchParamsKeyRef.current = searchParamsKey;
     const next = parseIssueListSearchParams(new URLSearchParams(searchParamsKey), {
       includeProject,
     });
@@ -39,11 +41,12 @@ export function useIssueListUrlState(options?: { includeProject?: boolean }) {
       return;
     }
     const href = buildIssueListHref(pathname, state, { includeProject });
-    const current = searchParamsKey ? `${pathname}?${searchParamsKey}` : pathname;
+    const currentKey = searchParamsKeyRef.current;
+    const current = currentKey ? `${pathname}?${currentKey}` : pathname;
     if (href !== current) {
       router.replace(href, { scroll: false });
     }
-  }, [includeProject, pathname, router, searchParamsKey, state]);
+  }, [includeProject, pathname, router, state]);
 
   useEffect(() => {
     const timeout = window.setTimeout(() => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-content.tsx
@@ -1,15 +1,18 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { useInfiniteQuery, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { readApiResponseError } from "@/lib/api-error";
 
+import { IssueListFiltersBar } from "../../_components/issue-list-filters-bar";
+import { issueListStateToApiQuery } from "../../_components/issue-list-url-state";
+import { useIssueListUrlState } from "../../_components/use-issue-list-url-state";
 import { IssuesActions } from "./issues-actions";
 import { ISSUES_PAGE_SIZE, IssuesPageView, type OrganizationIssue } from "./issues-page-view";
 
-const issuesQueryKey = (organizationSlug: string, view: string, search: string) =>
-  ["organization-issues", organizationSlug, view, search] as const;
+const issuesQueryKey = (organizationSlug: string, query: Record<string, string>) =>
+  ["organization-issues", organizationSlug, query] as const;
 
 function organizationIssuesPath(organizationSlug: string) {
   return `/api/orgs/${encodeURIComponent(organizationSlug)}/issues`;
@@ -27,26 +30,42 @@ type OrganizationIssuesResponse = {
   };
 };
 
+type ProjectOption = { id: string; name: string };
+
 export function IssuesPageContent({ organizationSlug }: { organizationSlug: string }) {
   const queryClient = useQueryClient();
-  const [view, setView] = useState<"all_open" | "my_work" | "qa_triage" | "source_context">(
-    "all_open",
-  );
-  const [search, setSearch] = useState("");
+  const { state, searchDraft, setSearchDraft, updateState, clearFilters } = useIssueListUrlState({
+    includeProject: true,
+  });
+  const apiQuery = issueListStateToApiQuery(state, {
+    includeProject: true,
+    limit: ISSUES_PAGE_SIZE,
+    offset: 0,
+  });
+
+  const projectsQuery = useQuery({
+    queryKey: ["organization-issues-projects", organizationSlug],
+    queryFn: async () => {
+      const response = await fetch(`/api/orgs/${encodeURIComponent(organizationSlug)}/projects`);
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to load projects");
+      }
+      const body = (await response.json()) as { projects: ProjectOption[] };
+      return body.projects.map((project) => ({ id: project.id, name: project.name }));
+    },
+  });
 
   const issuesQuery = useInfiniteQuery({
-    queryKey: issuesQueryKey(organizationSlug, view, search),
+    queryKey: issuesQueryKey(organizationSlug, apiQuery),
     initialPageParam: 0,
     queryFn: async ({ pageParam }) => {
-      const params = new URLSearchParams({
-        view,
-        limit: String(ISSUES_PAGE_SIZE),
-        offset: String(pageParam),
-      });
-      const trimmedSearch = search.trim();
-      if (trimmedSearch) {
-        params.set("search", trimmedSearch);
-      }
+      const params = new URLSearchParams(
+        issueListStateToApiQuery(state, {
+          includeProject: true,
+          limit: ISSUES_PAGE_SIZE,
+          offset: pageParam,
+        }),
+      );
 
       const response = await fetch(
         `${organizationIssuesPath(organizationSlug)}?${params.toString()}`,
@@ -83,17 +102,24 @@ export function IssuesPageContent({ organizationSlug }: { organizationSlug: stri
       organizationSlug={organizationSlug}
       issues={issues}
       summary={summary}
-      view={view}
-      search={search}
       isLoading={issuesQuery.isLoading}
       isError={issuesQuery.isError}
       isFetchingMore={issuesQuery.isFetchingNextPage}
       hasMore={hasMore}
+      filterBar={
+        <IssueListFiltersBar
+          state={state}
+          searchDraft={searchDraft}
+          onSearchDraftChange={setSearchDraft}
+          onStateChange={updateState}
+          onClearFilters={clearFilters}
+          projects={projectsQuery.data ?? []}
+          searchPlaceholder="Search title, description, project, or source path"
+        />
+      }
       actions={
         <IssuesActions organizationSlug={organizationSlug} onIssuesChanged={refreshIssues} />
       }
-      onViewChange={setView}
-      onSearchChange={setSearch}
       onLoadMore={() => {
         void issuesQuery.fetchNextPage();
       }}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.stories.tsx
@@ -19,14 +19,11 @@ const meta = {
     organizationSlug: issuesOrganizationSlug,
     issues: organizationIssuesFixture,
     summary: issuesSummaryFixture,
-    view: "all_open",
-    search: "",
     isLoading: false,
     isError: false,
     isFetchingMore: false,
     hasMore: false,
-    onViewChange: fn(),
-    onSearchChange: fn(),
+    filterBar: <div data-testid="issue-filters">Filters</div>,
     onLoadMore: fn(),
   },
 } satisfies Meta<typeof IssuesPageView>;
@@ -108,7 +105,6 @@ export const WithActions: Story = {
 
 export const QaTriageView: Story = {
   args: {
-    view: "qa_triage",
     issues: organizationIssuesFixture.filter((issue) => issue.issueType === "qa_failure"),
     summary: {
       total: 1,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.tsx
@@ -6,29 +6,12 @@ import { ClipboardListIcon } from "@hugeicons/core-free-icons";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 
 import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
 import { formatRelativeTimestamp } from "../../_components/workspace-files-shared";
 
 export const ISSUES_PAGE_SIZE = 50;
-
-const views = [
-  { value: "all_open", label: "All open" },
-  { value: "my_work", label: "My work" },
-  { value: "qa_triage", label: "QA triage" },
-  { value: "source_context", label: "Source & context" },
-] as const;
-
-type IssueView = (typeof views)[number]["value"];
 
 export type OrganizationIssue = {
   id: string;
@@ -93,15 +76,12 @@ export function IssuesPageView({
   organizationSlug,
   issues,
   summary,
-  view,
-  search,
   isLoading,
   isError,
   isFetchingMore,
   hasMore,
   actions,
-  onViewChange,
-  onSearchChange,
+  filterBar,
   onLoadMore,
 }: {
   organizationSlug: string;
@@ -113,15 +93,12 @@ export function IssuesPageView({
     resolved: number;
     wontFix: number;
   };
-  view: IssueView;
-  search: string;
   isLoading: boolean;
   isError: boolean;
   isFetchingMore: boolean;
   hasMore: boolean;
   actions?: ReactNode;
-  onViewChange: (view: IssueView) => void;
-  onSearchChange: (search: string) => void;
+  filterBar: ReactNode;
   onLoadMore: () => void;
 }) {
   return (
@@ -134,29 +111,7 @@ export function IssuesPageView({
         actions={actions}
       />
 
-      <div className="grid gap-3 rounded-2xl border bg-card p-4 md:grid-cols-[220px_1fr]">
-        <Select
-          value={view}
-          items={views}
-          onValueChange={(value) => onViewChange((value ?? "all_open") as IssueView)}
-        >
-          <SelectTrigger className="w-full">
-            <SelectValue placeholder="View" />
-          </SelectTrigger>
-          <SelectContent>
-            {views.map((item) => (
-              <SelectItem key={item.value} value={item.value} label={item.label}>
-                {item.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <Input
-          value={search}
-          onChange={(event) => onSearchChange(event.currentTarget.value)}
-          placeholder="Search title, description, project, or source path"
-        />
-      </div>
+      {filterBar}
 
       {summary ? (
         <div className="flex flex-wrap gap-2">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/page.tsx
@@ -1,3 +1,6 @@
+import { Suspense } from "react";
+
+import { TypographyP } from "@/components/ui/typography";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { IssuesPageContent } from "./_components/issues-page-content";
@@ -10,5 +13,13 @@ export default async function IssuesPage({
   const { organizationSlug } = await params;
   await requireAppAuthContext({ organizationSlug });
 
-  return <IssuesPageContent organizationSlug={organizationSlug} />;
+  return (
+    <Suspense
+      fallback={
+        <TypographyP className="text-sm text-muted-foreground">Loading issues...</TypographyP>
+      }
+    >
+      <IssuesPageContent organizationSlug={organizationSlug} />
+    </Suspense>
+  );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-msw-handlers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-msw-handlers.ts
@@ -84,6 +84,7 @@ export const issueSheetEmptyMswHandlers = [
     HttpResponse.json({
       issues: [],
       columns: issueSheetResponseFixture.columns,
+      total: 0,
       summary: {
         total: 0,
         open: 0,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
@@ -28,6 +28,9 @@ import { Textarea } from "@/components/ui/textarea";
 import { TypographyP } from "@/components/ui/typography";
 import { readApiResponseError } from "@/lib/api-error";
 
+import { IssueListFiltersBar } from "../../../../_components/issue-list-filters-bar";
+import { issueListStateToApiQuery } from "../../../../_components/issue-list-url-state";
+import { useIssueListUrlState } from "../../../../_components/use-issue-list-url-state";
 import { issueTypes } from "./issue-sheet-constants";
 
 import { ProjectPageShell, ProjectSectionHeader } from "../../_components/project-page-shell";
@@ -71,6 +74,7 @@ type IssueSheetIssue = {
 type IssueSheetResponse = {
   issues: IssueSheetIssue[];
   columns: IssueSheetColumn[];
+  total: number;
   summary: {
     total: number;
     open: number;
@@ -79,13 +83,6 @@ type IssueSheetResponse = {
     wontFix: number;
   };
 };
-
-const views = [
-  { value: "all_open", label: "All open" },
-  { value: "my_work", label: "My work" },
-  { value: "qa_triage", label: "QA triage" },
-  { value: "source_context", label: "Source & context" },
-] as const;
 
 const statuses = [
   { value: "open", label: "Open" },
@@ -180,20 +177,17 @@ export function IssueSheetPageContent({
 }) {
   useProjectPageQuery(organizationSlug, projectId);
   const queryClient = useQueryClient();
-  const [view, setView] = useState<(typeof views)[number]["value"]>("all_open");
-  const [search, setSearch] = useState("");
+  const { state, searchDraft, setSearchDraft, updateState, clearFilters } = useIssueListUrlState();
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [columnDialogOpen, setColumnDialogOpen] = useState(false);
   const [importDialogOpen, setImportDialogOpen] = useState(false);
 
-  const queryKey = ["issue-sheet", organizationSlug, projectId, view, search];
+  const apiQuery = issueListStateToApiQuery(state);
+  const queryKey = ["issue-sheet", organizationSlug, projectId, apiQuery];
   const issueSheetQuery = useQuery({
     queryKey,
     queryFn: async () => {
-      const params = new URLSearchParams({ view });
-      if (search.trim()) {
-        params.set("search", search.trim());
-      }
+      const params = new URLSearchParams(apiQuery);
       const response = await fetch(`${issueSheetPath(organizationSlug, projectId)}?${params}`);
       return readJsonOrThrow<IssueSheetResponse>(response);
     },
@@ -270,29 +264,13 @@ export function IssueSheetPageContent({
           }
         />
 
-        <div className="grid gap-3 rounded-2xl border bg-card p-4 md:grid-cols-[220px_1fr]">
-          <Select
-            value={view}
-            items={views}
-            onValueChange={(value) => setView((value ?? "all_open") as typeof view)}
-          >
-            <SelectTrigger className="w-full">
-              <SelectValue placeholder="View" />
-            </SelectTrigger>
-            <SelectContent>
-              {views.map((item) => (
-                <SelectItem key={item.value} value={item.value} label={item.label}>
-                  {item.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Input
-            value={search}
-            onChange={(event) => setSearch(event.currentTarget.value)}
-            placeholder="Search title, description, or source path"
-          />
-        </div>
+        <IssueListFiltersBar
+          state={state}
+          searchDraft={searchDraft}
+          onSearchDraftChange={setSearchDraft}
+          onStateChange={updateState}
+          onClearFilters={clearFilters}
+        />
 
         {data ? (
           <div className="flex flex-wrap gap-2">
@@ -300,6 +278,7 @@ export function IssueSheetPageContent({
             <Badge variant="secondary">{data.summary.open} open</Badge>
             <Badge variant="warning">{data.summary.inProgress} in progress</Badge>
             <Badge variant="success">{data.summary.resolved} resolved</Badge>
+            <Badge variant="outline">{data.total} matching</Badge>
           </div>
         ) : null}
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet.fixture.ts
@@ -164,6 +164,7 @@ export const issueSheetIssuesFixture: IssueSheetIssueFixture[] = [
 export const issueSheetResponseFixture = {
   issues: issueSheetIssuesFixture,
   columns: issueSheetColumnsFixture,
+  total: issueSheetIssuesFixture.length,
   summary: issueSheetSummaryFixture,
 };
 

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-list-constants.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-list-constants.ts
@@ -1,0 +1,9 @@
+export const ISSUE_LIST_VIEWS = ["my_work", "qa_triage", "source_context", "all_open"] as const;
+export const ISSUE_LIST_SORT_FIELDS = ["updated_at", "created_at", "priority", "status"] as const;
+export const ISSUE_LIST_SORT_DIRECTIONS = ["asc", "desc"] as const;
+export const ISSUE_PRIORITIES = ["P0", "P1", "P2"] as const;
+
+export type IssueListView = (typeof ISSUE_LIST_VIEWS)[number];
+export type IssueListSortField = (typeof ISSUE_LIST_SORT_FIELDS)[number];
+export type IssueListSortDirection = (typeof ISSUE_LIST_SORT_DIRECTIONS)[number];
+export type IssuePriority = (typeof ISSUE_PRIORITIES)[number];

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-list-query.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-list-query.ts
@@ -3,15 +3,25 @@ import { alias } from "drizzle-orm/pg-core";
 
 import { schema } from "@/lib/database";
 
-export const ISSUE_LIST_VIEWS = ["my_work", "qa_triage", "source_context", "all_open"] as const;
-export const ISSUE_LIST_SORT_FIELDS = ["updated_at", "created_at", "priority", "status"] as const;
-export const ISSUE_LIST_SORT_DIRECTIONS = ["asc", "desc"] as const;
-export const ISSUE_PRIORITIES = ["P0", "P1", "P2"] as const;
+import {
+  type IssueListSortDirection,
+  type IssueListSortField,
+  type IssueListView,
+  type IssuePriority,
+} from "./issue-list-constants";
 
-export type IssueListView = (typeof ISSUE_LIST_VIEWS)[number];
-export type IssueListSortField = (typeof ISSUE_LIST_SORT_FIELDS)[number];
-export type IssueListSortDirection = (typeof ISSUE_LIST_SORT_DIRECTIONS)[number];
-export type IssuePriority = (typeof ISSUE_PRIORITIES)[number];
+export type {
+  IssueListSortDirection,
+  IssueListSortField,
+  IssueListView,
+  IssuePriority,
+} from "./issue-list-constants";
+export {
+  ISSUE_LIST_SORT_DIRECTIONS,
+  ISSUE_LIST_SORT_FIELDS,
+  ISSUE_LIST_VIEWS,
+  ISSUE_PRIORITIES,
+} from "./issue-list-constants";
 
 export type IssueListFilterQuery = {
   view?: IssueListView;
@@ -136,7 +146,12 @@ export function buildIssueListFilterConditions(input: {
       ilike(schema.issueSheetIssues.description, search),
       ilike(schema.issueSheetIssues.sourcePath, search),
     ];
-    conditions.push(or(...targets)!);
+    if (targets.length > 0) {
+      const searchCondition = or(...targets);
+      if (searchCondition) {
+        conditions.push(searchCondition);
+      }
+    }
   }
 
   return conditions;
@@ -162,4 +177,9 @@ export function buildIssueListOrderBy(query: Pick<IssueListFilterQuery, "sort" |
 
 export function issueListNeedsPriorityJoin(query: Pick<IssueListFilterQuery, "priority" | "sort">) {
   return Boolean(query.priority) || query.sort === "priority";
+}
+
+/** True only when the priority JOIN is required for WHERE conditions (filtering). */
+export function issueListNeedsCountPriorityJoin(query: Pick<IssueListFilterQuery, "priority">) {
+  return Boolean(query.priority);
 }

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-list-query.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-list-query.ts
@@ -1,15 +1,4 @@
-import {
-  and,
-  asc,
-  desc,
-  eq,
-  ilike,
-  inArray,
-  isNull,
-  or,
-  sql,
-  type SQL,
-} from "drizzle-orm";
+import { and, asc, desc, eq, ilike, inArray, isNull, or, sql, type SQL } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
 import { schema } from "@/lib/database";

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-list-query.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-list-query.ts
@@ -1,0 +1,176 @@
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  ilike,
+  inArray,
+  isNull,
+  or,
+  sql,
+  type SQL,
+} from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
+
+import { schema } from "@/lib/database";
+
+export const ISSUE_LIST_VIEWS = ["my_work", "qa_triage", "source_context", "all_open"] as const;
+export const ISSUE_LIST_SORT_FIELDS = ["updated_at", "created_at", "priority", "status"] as const;
+export const ISSUE_LIST_SORT_DIRECTIONS = ["asc", "desc"] as const;
+export const ISSUE_PRIORITIES = ["P0", "P1", "P2"] as const;
+
+export type IssueListView = (typeof ISSUE_LIST_VIEWS)[number];
+export type IssueListSortField = (typeof ISSUE_LIST_SORT_FIELDS)[number];
+export type IssueListSortDirection = (typeof ISSUE_LIST_SORT_DIRECTIONS)[number];
+export type IssuePriority = (typeof ISSUE_PRIORITIES)[number];
+
+export type IssueListFilterQuery = {
+  view?: IssueListView;
+  status?: "open" | "in_progress" | "resolved" | "wont_fix" | "all";
+  issueType?:
+    | "general_question"
+    | "translation_mistake"
+    | "context_request"
+    | "source_mistake"
+    | "glossary_violation"
+    | "qa_failure"
+    | "all";
+  priority?: IssuePriority;
+  locale?: string;
+  assignee?: string;
+  projectId?: string;
+  search?: string;
+  sort?: IssueListSortField;
+  sortDir?: IssueListSortDirection;
+};
+
+const OPEN_STATUSES = ["open", "in_progress"] as const;
+const SOURCE_CONTEXT_TYPES = ["source_mistake", "context_request", "general_question"] as const;
+
+export const priorityColumns = alias(schema.issueSheetColumns, "issue_priority_columns");
+export const priorityValues = alias(schema.issueSheetRowValues, "issue_priority_values");
+
+export const priorityColumnJoin = and(
+  eq(priorityColumns.organizationId, schema.issueSheetIssues.organizationId),
+  eq(priorityColumns.projectId, schema.issueSheetIssues.projectId),
+  eq(priorityColumns.key, "priority"),
+);
+
+export const priorityValueJoin = and(
+  eq(priorityValues.issueId, schema.issueSheetIssues.id),
+  eq(priorityValues.columnId, priorityColumns.id),
+);
+
+const priorityRankExpression = sql<number>`case
+  when ${priorityValues.value} #>> '{}' = 'P0' then 0
+  when ${priorityValues.value} #>> '{}' = 'P1' then 1
+  when ${priorityValues.value} #>> '{}' = 'P2' then 2
+  else 3
+end`;
+
+const statusRankExpression = sql<number>`case
+  when ${schema.issueSheetIssues.status} = 'open' then 0
+  when ${schema.issueSheetIssues.status} = 'in_progress' then 1
+  when ${schema.issueSheetIssues.status} = 'resolved' then 2
+  when ${schema.issueSheetIssues.status} = 'wont_fix' then 3
+  else 4
+end`;
+
+export function buildIssueListFilterConditions(input: {
+  actorUserId: string;
+  query: IssueListFilterQuery;
+  searchTargets?: SQL[];
+}) {
+  const conditions: SQL[] = [];
+  const query = input.query;
+  const view = query.view;
+  const hasStatusFilter = Boolean(query.status && query.status !== "all");
+  const hasTypeFilter = Boolean(query.issueType && query.issueType !== "all");
+  const hasAssigneeFilter = Boolean(query.assignee);
+
+  if (view === "my_work") {
+    if (!hasAssigneeFilter) {
+      conditions.push(eq(schema.issueSheetIssues.assigneeUserId, input.actorUserId));
+    }
+    if (!hasStatusFilter) {
+      conditions.push(inArray(schema.issueSheetIssues.status, [...OPEN_STATUSES]));
+    }
+  } else if (view === "qa_triage") {
+    if (!hasTypeFilter) {
+      conditions.push(eq(schema.issueSheetIssues.issueType, "qa_failure"));
+    }
+    if (!hasAssigneeFilter) {
+      conditions.push(isNull(schema.issueSheetIssues.assigneeUserId));
+    }
+    if (!hasStatusFilter) {
+      conditions.push(inArray(schema.issueSheetIssues.status, [...OPEN_STATUSES]));
+    }
+  } else if (view === "source_context") {
+    if (!hasTypeFilter) {
+      conditions.push(inArray(schema.issueSheetIssues.issueType, [...SOURCE_CONTEXT_TYPES]));
+    }
+    if (!hasStatusFilter) {
+      conditions.push(inArray(schema.issueSheetIssues.status, [...OPEN_STATUSES]));
+    }
+  } else if (view === "all_open") {
+    if (!hasStatusFilter) {
+      conditions.push(inArray(schema.issueSheetIssues.status, [...OPEN_STATUSES]));
+    }
+  }
+
+  if (hasStatusFilter && query.status && query.status !== "all") {
+    conditions.push(eq(schema.issueSheetIssues.status, query.status));
+  }
+  if (hasTypeFilter && query.issueType && query.issueType !== "all") {
+    conditions.push(eq(schema.issueSheetIssues.issueType, query.issueType));
+  }
+  if (query.priority) {
+    conditions.push(sql`${priorityValues.value} #>> '{}' = ${query.priority}`);
+  }
+  if (query.locale) {
+    conditions.push(eq(schema.issueSheetIssues.targetLocale, query.locale));
+  }
+  if (query.assignee === "me") {
+    conditions.push(eq(schema.issueSheetIssues.assigneeUserId, input.actorUserId));
+  } else if (query.assignee === "unassigned") {
+    conditions.push(isNull(schema.issueSheetIssues.assigneeUserId));
+  } else if (query.assignee) {
+    conditions.push(eq(schema.issueSheetIssues.assigneeUserId, query.assignee));
+  }
+  if (query.projectId) {
+    conditions.push(eq(schema.issueSheetIssues.projectId, query.projectId));
+  }
+  if (query.search) {
+    const search = `%${query.search}%`;
+    const targets = input.searchTargets ?? [
+      ilike(schema.issueSheetIssues.title, search),
+      ilike(schema.issueSheetIssues.description, search),
+      ilike(schema.issueSheetIssues.sourcePath, search),
+    ];
+    conditions.push(or(...targets)!);
+  }
+
+  return conditions;
+}
+
+export function buildIssueListOrderBy(query: Pick<IssueListFilterQuery, "sort" | "sortDir">) {
+  const sort = query.sort ?? "updated_at";
+  const direction = query.sortDir ?? (sort === "priority" || sort === "status" ? "asc" : "desc");
+  const ordered = direction === "asc" ? asc : desc;
+  const idTieBreaker = asc(schema.issueSheetIssues.id);
+
+  if (sort === "created_at") {
+    return [ordered(schema.issueSheetIssues.createdAt), idTieBreaker];
+  }
+  if (sort === "priority") {
+    return [ordered(priorityRankExpression), idTieBreaker];
+  }
+  if (sort === "status") {
+    return [ordered(statusRankExpression), idTieBreaker];
+  }
+  return [ordered(schema.issueSheetIssues.updatedAt), idTieBreaker];
+}
+
+export function issueListNeedsPriorityJoin(query: Pick<IssueListFilterQuery, "priority" | "sort">) {
+  return Boolean(query.priority) || query.sort === "priority";
+}

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-csv-import-runner.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-csv-import-runner.test.ts
@@ -190,7 +190,7 @@ Check copy,missing-assignee@example.com,Low`,
       organizationId: organization.id,
       projectId: project.id,
       actorUserId: user.id,
-      query: { status: "all", limit: 10, offset: 0 },
+      query: { status: "all", sort: "updated_at", sortDir: "desc", limit: 10, offset: 0 },
     });
 
     const assignedIssue = issues.issues.find((issue) => issue.title === "Fix context");

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, ilike, inArray, isNull, or, sql, type SQL } from "drizzle-orm";
+import { and, count, desc, eq, inArray, or, sql, type SQL } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
 import {
@@ -15,6 +15,15 @@ import {
   runIssueSheetCsvImport,
   type IssueSheetImportResult,
 } from "./issue-sheet-csv-import-runner";
+import {
+  buildIssueListFilterConditions,
+  buildIssueListOrderBy,
+  issueListNeedsPriorityJoin,
+  priorityColumnJoin,
+  priorityColumns,
+  priorityValueJoin,
+  priorityValues,
+} from "./issue-list-query";
 
 export type IssueSheetColumn = {
   id: string;
@@ -56,6 +65,7 @@ export type IssueSheetIssue = {
 export type IssueSheetListResult = {
   issues: IssueSheetIssue[];
   columns: IssueSheetColumn[];
+  total: number;
   summary: {
     total: number;
     open: number;
@@ -296,10 +306,15 @@ export class IssueSheetService {
   }): Promise<IssueSheetListResult> {
     const columns = await this.listColumns(input);
     const conditions = this.buildIssueConditions(input);
-    const rows = await this.fetchIssueRows(conditions, {
-      limit: input.query.limit,
-      offset: input.query.offset,
-    });
+    const [rows, totalRow, summary] = await Promise.all([
+      this.fetchIssueRows(conditions, {
+        limit: input.query.limit,
+        offset: input.query.offset,
+        query: input.query,
+      }),
+      this.countIssueRows(conditions, input.query),
+      this.loadSummary(input),
+    ]);
     const issueIds = rows.map((row) => row.id);
     const valuesByIssueId = await this.loadValuesByIssueId({
       organizationId: input.organizationId,
@@ -308,10 +323,9 @@ export class IssueSheetService {
       columns,
     });
 
-    const summary = await this.loadSummary(input);
-
     return {
       columns,
+      total: totalRow,
       summary,
       issues: rows.map((row) => mapIssueRow(row, valuesByIssueId.get(row.id) ?? {})),
     };
@@ -596,7 +610,15 @@ export class IssueSheetService {
         eq(schema.issueSheetIssues.projectId, input.projectId),
         eq(schema.issueSheetIssues.id, input.issueId),
       ],
-      { limit: 1 },
+      {
+        limit: 1,
+        query: {
+          sort: "updated_at",
+          sortDir: "desc",
+          limit: 1,
+          offset: 0,
+        },
+      },
     );
     const row = rows[0];
     if (!row) {
@@ -613,11 +635,28 @@ export class IssueSheetService {
     return mapIssueRow(row, valuesByIssueId.get(row.id) ?? {});
   }
 
+  private async countIssueRows(conditions: SQL[], query: IssueSheetQuery): Promise<number> {
+    let countQuery = this.database
+      .select({ value: count() })
+      .from(schema.issueSheetIssues)
+      .$dynamic();
+
+    if (issueListNeedsPriorityJoin(query)) {
+      countQuery = countQuery
+        .leftJoin(priorityColumns, priorityColumnJoin)
+        .leftJoin(priorityValues, priorityValueJoin);
+    }
+
+    const totalRow = await countQuery.where(and(...conditions));
+    return totalRow[0]?.value ?? 0;
+  }
+
   private fetchIssueRows(
     conditions: SQL[],
-    pagination: { limit: number; offset?: number },
+    pagination: { limit: number; offset?: number; query: IssueSheetQuery },
   ): Promise<IssueRow[]> {
-    return this.database
+    const orderBy = buildIssueListOrderBy(pagination.query);
+    let listQuery = this.database
       .select({
         id: schema.issueSheetIssues.id,
         title: schema.issueSheetIssues.title,
@@ -654,8 +693,17 @@ export class IssueSheetService {
         schema.projectTranslationKeys,
         eq(schema.issueSheetIssues.translationKeyId, schema.projectTranslationKeys.id),
       )
+      .$dynamic();
+
+    if (issueListNeedsPriorityJoin(pagination.query)) {
+      listQuery = listQuery
+        .leftJoin(priorityColumns, priorityColumnJoin)
+        .leftJoin(priorityValues, priorityValueJoin);
+    }
+
+    return listQuery
       .where(and(...conditions))
-      .orderBy(desc(schema.issueSheetIssues.createdAt))
+      .orderBy(...orderBy)
       .limit(pagination.limit)
       .offset(pagination.offset ?? 0);
   }
@@ -670,57 +718,13 @@ export class IssueSheetService {
     const conditions: SQL[] = [
       eq(schema.issueSheetIssues.organizationId, input.organizationId),
       eq(schema.issueSheetIssues.projectId, input.projectId),
+      ...buildIssueListFilterConditions({
+        actorUserId: input.actorUserId,
+        query: input.query,
+      }),
     ];
     if ("issueId" in input && input.issueId) {
       conditions.push(eq(schema.issueSheetIssues.id, input.issueId));
-    }
-
-    const view = input.query.view;
-    if (view === "my_work") {
-      conditions.push(eq(schema.issueSheetIssues.assigneeUserId, input.actorUserId));
-      conditions.push(inArray(schema.issueSheetIssues.status, ["open", "in_progress"]));
-    } else if (view === "qa_triage") {
-      conditions.push(eq(schema.issueSheetIssues.issueType, "qa_failure"));
-      conditions.push(isNull(schema.issueSheetIssues.assigneeUserId));
-      conditions.push(inArray(schema.issueSheetIssues.status, ["open", "in_progress"]));
-    } else if (view === "source_context") {
-      conditions.push(
-        inArray(schema.issueSheetIssues.issueType, [
-          "source_mistake",
-          "context_request",
-          "general_question",
-        ]),
-      );
-      conditions.push(inArray(schema.issueSheetIssues.status, ["open", "in_progress"]));
-    } else if (view === "all_open") {
-      conditions.push(inArray(schema.issueSheetIssues.status, ["open", "in_progress"]));
-    }
-
-    if (!view && input.query.status && input.query.status !== "all") {
-      conditions.push(eq(schema.issueSheetIssues.status, input.query.status));
-    }
-    if (input.query.issueType && input.query.issueType !== "all") {
-      conditions.push(eq(schema.issueSheetIssues.issueType, input.query.issueType));
-    }
-    if (input.query.locale) {
-      conditions.push(eq(schema.issueSheetIssues.targetLocale, input.query.locale));
-    }
-    if (input.query.assignee === "me") {
-      conditions.push(eq(schema.issueSheetIssues.assigneeUserId, input.actorUserId));
-    } else if (input.query.assignee === "unassigned") {
-      conditions.push(isNull(schema.issueSheetIssues.assigneeUserId));
-    } else if (input.query.assignee) {
-      conditions.push(eq(schema.issueSheetIssues.assigneeUserId, input.query.assignee));
-    }
-    if (input.query.search) {
-      const search = `%${input.query.search}%`;
-      conditions.push(
-        or(
-          ilike(schema.issueSheetIssues.title, search),
-          ilike(schema.issueSheetIssues.description, search),
-          ilike(schema.issueSheetIssues.sourcePath, search),
-        )!,
-      );
     }
 
     return conditions;

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, inArray, or, sql, type SQL } from "drizzle-orm";
+import { and, asc, count, desc, eq, inArray, or, sql, type SQL } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
 import {

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
@@ -18,6 +18,7 @@ import {
 import {
   buildIssueListFilterConditions,
   buildIssueListOrderBy,
+  issueListNeedsCountPriorityJoin,
   issueListNeedsPriorityJoin,
   priorityColumnJoin,
   priorityColumns,
@@ -641,7 +642,7 @@ export class IssueSheetService {
       .from(schema.issueSheetIssues)
       .$dynamic();
 
-    if (issueListNeedsPriorityJoin(query)) {
+    if (issueListNeedsCountPriorityJoin(query)) {
       countQuery = countQuery
         .leftJoin(priorityColumns, priorityColumnJoin)
         .leftJoin(priorityValues, priorityValueJoin);

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/organization-issue-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/organization-issue-service.ts
@@ -9,6 +9,7 @@ import { db, schema } from "@/lib/database";
 import {
   buildIssueListFilterConditions,
   buildIssueListOrderBy,
+  issueListNeedsCountPriorityJoin,
   issueListNeedsPriorityJoin,
   priorityColumnJoin,
   priorityColumns,
@@ -96,6 +97,7 @@ export class OrganizationIssueService {
     ];
     const where = and(...conditions, issueProjectJoin);
     const needsPriorityJoin = issueListNeedsPriorityJoin(query);
+    const needsCountPriorityJoin = issueListNeedsCountPriorityJoin(query);
     const orderBy = buildIssueListOrderBy(query);
 
     let listQuery = this.database
@@ -146,6 +148,8 @@ export class OrganizationIssueService {
       listQuery = listQuery
         .leftJoin(priorityColumns, priorityColumnJoin)
         .leftJoin(priorityValues, priorityValueJoin);
+    }
+    if (needsCountPriorityJoin) {
       countQuery = countQuery
         .leftJoin(priorityColumns, priorityColumnJoin)
         .leftJoin(priorityValues, priorityValueJoin);

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/organization-issue-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/organization-issue-service.ts
@@ -152,7 +152,11 @@ export class OrganizationIssueService {
     }
 
     const [rows, totalRow, summary] = await Promise.all([
-      listQuery.where(where).orderBy(...orderBy).limit(query.limit).offset(query.offset),
+      listQuery
+        .where(where)
+        .orderBy(...orderBy)
+        .limit(query.limit)
+        .offset(query.offset),
       countQuery.where(where),
       this.loadSummary(organizationId, accessibleProjectsWhere),
     ]);

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/organization-issue-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/organization-issue-service.ts
@@ -1,10 +1,20 @@
-import { and, count, desc, eq, ilike, inArray, isNull, or, sql, type SQL } from "drizzle-orm";
+import { and, count, eq, ilike, sql, type SQL } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
 import type { OrganizationIssuesQuery } from "@/api/routes/issues/issues.schema";
 import { buildAccessibleProjectsWhere } from "@/api/auth/team-access";
 import type { ApiAuthContext } from "@/api/auth/workos";
 import { db, schema } from "@/lib/database";
+
+import {
+  buildIssueListFilterConditions,
+  buildIssueListOrderBy,
+  issueListNeedsPriorityJoin,
+  priorityColumnJoin,
+  priorityColumns,
+  priorityValueJoin,
+  priorityValues,
+} from "./issue-list-query";
 
 const assigneeUsers = alias(schema.users, "org_issue_assignee_users");
 
@@ -56,69 +66,6 @@ function formatUser(row: {
   return name || row.email;
 }
 
-function buildOrganizationIssueConditions(input: {
-  organizationId: string;
-  actorUserId: string;
-  query: OrganizationIssuesQuery;
-  accessibleProjectsWhere: SQL;
-}) {
-  const conditions: SQL[] = [
-    eq(schema.issueSheetIssues.organizationId, input.organizationId),
-    input.accessibleProjectsWhere,
-  ];
-
-  const view = input.query.view;
-  if (view === "my_work") {
-    conditions.push(eq(schema.issueSheetIssues.assigneeUserId, input.actorUserId));
-    conditions.push(inArray(schema.issueSheetIssues.status, ["open", "in_progress"]));
-  } else if (view === "qa_triage") {
-    conditions.push(eq(schema.issueSheetIssues.issueType, "qa_failure"));
-    conditions.push(isNull(schema.issueSheetIssues.assigneeUserId));
-    conditions.push(inArray(schema.issueSheetIssues.status, ["open", "in_progress"]));
-  } else if (view === "source_context") {
-    conditions.push(
-      inArray(schema.issueSheetIssues.issueType, [
-        "source_mistake",
-        "context_request",
-        "general_question",
-      ]),
-    );
-    conditions.push(inArray(schema.issueSheetIssues.status, ["open", "in_progress"]));
-  } else if (view === "all_open") {
-    conditions.push(inArray(schema.issueSheetIssues.status, ["open", "in_progress"]));
-  }
-
-  if (!view && input.query.status && input.query.status !== "all") {
-    conditions.push(eq(schema.issueSheetIssues.status, input.query.status));
-  }
-  if (input.query.issueType && input.query.issueType !== "all") {
-    conditions.push(eq(schema.issueSheetIssues.issueType, input.query.issueType));
-  }
-  if (input.query.locale) {
-    conditions.push(eq(schema.issueSheetIssues.targetLocale, input.query.locale));
-  }
-  if (input.query.assignee === "me") {
-    conditions.push(eq(schema.issueSheetIssues.assigneeUserId, input.actorUserId));
-  } else if (input.query.assignee === "unassigned") {
-    conditions.push(isNull(schema.issueSheetIssues.assigneeUserId));
-  } else if (input.query.assignee) {
-    conditions.push(eq(schema.issueSheetIssues.assigneeUserId, input.query.assignee));
-  }
-  if (input.query.search) {
-    const search = `%${input.query.search}%`;
-    conditions.push(
-      or(
-        ilike(schema.issueSheetIssues.title, search),
-        ilike(schema.issueSheetIssues.description, search),
-        ilike(schema.issueSheetIssues.sourcePath, search),
-        ilike(schema.projects.name, search),
-      )!,
-    );
-  }
-
-  return conditions;
-}
-
 export class OrganizationIssueService {
   constructor(private readonly database = db) {}
 
@@ -129,60 +76,84 @@ export class OrganizationIssueService {
     const organizationId = auth.organization.localOrganizationId;
     const accessibleProjectsWhere = await buildAccessibleProjectsWhere(auth);
     const issueProjectJoin = eq(schema.issueSheetIssues.projectId, schema.projects.id);
-    const conditions = buildOrganizationIssueConditions({
-      organizationId,
+    const search = query.search ? `%${query.search}%` : null;
+    const filterConditions = buildIssueListFilterConditions({
       actorUserId: auth.user.localUserId,
       query,
-      accessibleProjectsWhere,
+      searchTargets: search
+        ? [
+            ilike(schema.issueSheetIssues.title, search),
+            ilike(schema.issueSheetIssues.description, search),
+            ilike(schema.issueSheetIssues.sourcePath, search),
+            ilike(schema.projects.name, search),
+          ]
+        : undefined,
     });
+    const conditions: SQL[] = [
+      eq(schema.issueSheetIssues.organizationId, organizationId),
+      accessibleProjectsWhere,
+      ...filterConditions,
+    ];
     const where = and(...conditions, issueProjectJoin);
+    const needsPriorityJoin = issueListNeedsPriorityJoin(query);
+    const orderBy = buildIssueListOrderBy(query);
+
+    let listQuery = this.database
+      .select({
+        id: schema.issueSheetIssues.id,
+        projectId: schema.issueSheetIssues.projectId,
+        projectName: schema.projects.name,
+        title: schema.issueSheetIssues.title,
+        description: schema.issueSheetIssues.description,
+        issueType: schema.issueSheetIssues.issueType,
+        status: schema.issueSheetIssues.status,
+        targetLocale: schema.issueSheetIssues.targetLocale,
+        sourcePath: schema.issueSheetIssues.sourcePath,
+        segmentId: schema.issueSheetIssues.segmentId,
+        linkKind: schema.issueSheetIssues.linkKind,
+        linkLabel: schema.issueSheetIssues.linkLabel,
+        linkUrl: schema.issueSheetIssues.linkUrl,
+        assigneeUserId: schema.issueSheetIssues.assigneeUserId,
+        reporterFirstName: schema.users.firstName,
+        reporterLastName: schema.users.lastName,
+        reporterEmail: schema.users.email,
+        assigneeFirstName: assigneeUsers.firstName,
+        assigneeLastName: assigneeUsers.lastName,
+        assigneeEmail: assigneeUsers.email,
+        key: schema.projectTranslationKeys.key,
+        sourceText: schema.projectTranslationKeys.sourceText,
+        createdAt: schema.issueSheetIssues.createdAt,
+        updatedAt: schema.issueSheetIssues.updatedAt,
+        resolvedAt: schema.issueSheetIssues.resolvedAt,
+      })
+      .from(schema.issueSheetIssues)
+      .innerJoin(schema.projects, issueProjectJoin)
+      .leftJoin(schema.users, eq(schema.issueSheetIssues.reporterUserId, schema.users.id))
+      .leftJoin(assigneeUsers, eq(schema.issueSheetIssues.assigneeUserId, assigneeUsers.id))
+      .leftJoin(
+        schema.projectTranslationKeys,
+        eq(schema.issueSheetIssues.translationKeyId, schema.projectTranslationKeys.id),
+      )
+      .$dynamic();
+
+    let countQuery = this.database
+      .select({ value: count() })
+      .from(schema.issueSheetIssues)
+      .innerJoin(schema.projects, issueProjectJoin)
+      .$dynamic();
+
+    if (needsPriorityJoin) {
+      listQuery = listQuery
+        .leftJoin(priorityColumns, priorityColumnJoin)
+        .leftJoin(priorityValues, priorityValueJoin);
+      countQuery = countQuery
+        .leftJoin(priorityColumns, priorityColumnJoin)
+        .leftJoin(priorityValues, priorityValueJoin);
+    }
 
     const [rows, totalRow, summary] = await Promise.all([
-      this.database
-        .select({
-          id: schema.issueSheetIssues.id,
-          projectId: schema.issueSheetIssues.projectId,
-          projectName: schema.projects.name,
-          title: schema.issueSheetIssues.title,
-          description: schema.issueSheetIssues.description,
-          issueType: schema.issueSheetIssues.issueType,
-          status: schema.issueSheetIssues.status,
-          targetLocale: schema.issueSheetIssues.targetLocale,
-          sourcePath: schema.issueSheetIssues.sourcePath,
-          segmentId: schema.issueSheetIssues.segmentId,
-          linkKind: schema.issueSheetIssues.linkKind,
-          linkLabel: schema.issueSheetIssues.linkLabel,
-          linkUrl: schema.issueSheetIssues.linkUrl,
-          assigneeUserId: schema.issueSheetIssues.assigneeUserId,
-          reporterFirstName: schema.users.firstName,
-          reporterLastName: schema.users.lastName,
-          reporterEmail: schema.users.email,
-          assigneeFirstName: assigneeUsers.firstName,
-          assigneeLastName: assigneeUsers.lastName,
-          assigneeEmail: assigneeUsers.email,
-          key: schema.projectTranslationKeys.key,
-          sourceText: schema.projectTranslationKeys.sourceText,
-          createdAt: schema.issueSheetIssues.createdAt,
-          updatedAt: schema.issueSheetIssues.updatedAt,
-          resolvedAt: schema.issueSheetIssues.resolvedAt,
-        })
-        .from(schema.issueSheetIssues)
-        .innerJoin(schema.projects, issueProjectJoin)
-        .leftJoin(schema.users, eq(schema.issueSheetIssues.reporterUserId, schema.users.id))
-        .leftJoin(assigneeUsers, eq(schema.issueSheetIssues.assigneeUserId, assigneeUsers.id))
-        .leftJoin(
-          schema.projectTranslationKeys,
-          eq(schema.issueSheetIssues.translationKeyId, schema.projectTranslationKeys.id),
-        )
-        .where(where)
-        .orderBy(desc(schema.issueSheetIssues.updatedAt))
-        .limit(query.limit)
-        .offset(query.offset),
-      this.database
-        .select({ value: count() })
-        .from(schema.issueSheetIssues)
-        .innerJoin(schema.projects, issueProjectJoin)
-        .where(where),
+      listQuery.where(where).orderBy(...orderBy).limit(query.limit).offset(query.offset),
+      countQuery.where(where),
       this.loadSummary(organizationId, accessibleProjectsWhere),
     ]);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements HL-497 so PMs, LQA leads, and translators can focus issues relevant to their current task.

### Backend
- Extended project and workspace issue list APIs with filters: status, type, priority, locale, assignee (`me` / `unassigned`), plus workspace `projectId`
- Added sort by `updated_at`, `created_at`, `priority`, and `status` with a stable `id` tie-breaker for pagination
- Field-aware defaults are applied when `sortDir` is omitted: priority/status ascending, dates descending
- Built-in views (`all_open`, `my_work`, `qa_triage`, `source_context`) still apply as presets; explicit filters override the matching view dimension and **Clear filters** restores the preset
- Project issue sheet list responses now include filtered `total`
- Count queries only join priority when filtering by priority (avoids inflated totals)

### Frontend
- Shared filter/sort bar on workspace Issues and project Issue Sheet
- Filter and sort state lives in the URL (share/refresh safe)
- Active filter chips stay visible; Clear filters keeps the selected view/sort
- Client-safe constants live outside the drizzle query module (fixes Web CI build / `pg` in browser)

### Tests
- Route tests for built-in view combinations, filters, project scoping, field-aware sort defaults, and stable pagination
- Unit tests for URL parse/serialize, clear-filters, and active chips
- `vp test` (issue list / issue-sheet related) and `vp check --fix` both pass

## Test plan
- [x] `vp test` for issue list / issue-sheet / URL state
- [x] `vp check --fix`
- [ ] Confirm Web CI build is green
- [ ] Manually verify workspace `/issues` and project Issue Sheet filter chips + URL round-trip
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-497](https://linear.app/hyperlocalise/issue/HL-497/expose-issue-filters-and-sorting)

<div><a href="https://cursor.com/agents/bc-0ebe3b7f-9cab-4be1-af64-5dc773110cbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ebe3b7f-9cab-4be1-af64-5dc773110cbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

