### PR TITLE
fix(cat): gate All Files release flag by provider kind

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -240,9 +240,10 @@ describe("project file CAT routes", () => {
         pagination: expect.objectContaining({ paginated: true, limit: 50 }),
       }),
     );
+    expect(isReleaseCatAllFilesEnabledMock).toHaveBeenCalledWith("crowdin");
   });
 
-  it("rejects All Files CAT for unsupported providers when the flag is on", async () => {
+  it("rejects All Files CAT for unsupported providers", async () => {
     const translator = projectFixture.createWorkosIdentityWithRole("translator");
     getTmsProviderConnectionMock.mockResolvedValue({
       providerKind: "phrase",
@@ -250,7 +251,7 @@ describe("project file CAT routes", () => {
       validationStatus: "valid",
       validationMessage: null,
     });
-    isReleaseCatAllFilesEnabledMock.mockResolvedValue(true);
+    isReleaseCatAllFilesEnabledMock.mockResolvedValue(false);
 
     const response = await client.api.orgs[":organizationSlug"].projects[
       ":projectId"
@@ -272,6 +273,7 @@ describe("project file CAT routes", () => {
     expect(await response.json()).toMatchObject({
       error: "provider_cat_all_files_unsupported",
     });
+    expect(isReleaseCatAllFilesEnabledMock).toHaveBeenCalledWith("phrase");
     expect(getTmsProviderLiveCatAllFilesMock).not.toHaveBeenCalled();
   });
 

--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -243,7 +243,7 @@ describe("project file CAT routes", () => {
     expect(isReleaseCatAllFilesEnabledMock).toHaveBeenCalledWith("crowdin");
   });
 
-  it("rejects All Files CAT for unsupported providers", async () => {
+  it("rejects All Files CAT when decide disables the provider", async () => {
     const translator = projectFixture.createWorkosIdentityWithRole("translator");
     getTmsProviderConnectionMock.mockResolvedValue({
       providerKind: "phrase",
@@ -269,12 +269,50 @@ describe("project file CAT routes", () => {
       { headers: await projectFixture.authHeadersFor(translator) },
     );
 
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({ error: "feature_unavailable" });
+    expect(isReleaseCatAllFilesEnabledMock).toHaveBeenCalledWith("phrase");
+    expect(getTmsProviderLiveCatAllFilesMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects All Files CAT at the TMS layer when Flags Explorer overrides the flag on for an unsupported provider", async () => {
+    const translator = projectFixture.createWorkosIdentityWithRole("translator");
+    getTmsProviderConnectionMock.mockResolvedValue({
+      providerKind: "phrase",
+      displayName: "Phrase",
+      validationStatus: "valid",
+      validationMessage: null,
+    });
+    isReleaseCatAllFilesEnabledMock.mockResolvedValue(true);
+    getTmsProviderLiveCatAllFilesMock.mockRejectedValue(
+      new TmsProviderLiveError(
+        "provider_cat_all_files_unsupported",
+        "All Files CAT is not available for this provider yet.",
+      ),
+    );
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.queue.$get(
+      {
+        param: {
+          organizationSlug: translator.organization.slug ?? "missing-slug",
+          projectId: "ext:phrase:42",
+        },
+        query: {
+          sourcePath: "*",
+          targetLocale: "fr",
+        },
+      },
+      { headers: await projectFixture.authHeadersFor(translator) },
+    );
+
     expect(response.status).toBe(501);
     expect(await response.json()).toMatchObject({
       error: "provider_cat_all_files_unsupported",
     });
     expect(isReleaseCatAllFilesEnabledMock).toHaveBeenCalledWith("phrase");
-    expect(getTmsProviderLiveCatAllFilesMock).not.toHaveBeenCalled();
+    expect(getTmsProviderLiveCatAllFilesMock).toHaveBeenCalled();
   });
 
   it("returns Crowdin AI recommendations for an encoded provider project", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -647,19 +647,19 @@ async function loadProjectFileCatQueue(
   const sourcePathsFilter = allFiles ? parseCatSourcePathsFilter(query.sourcePaths) : null;
 
   if (allFiles) {
-    if (!(await isReleaseCatAllFilesEnabled())) {
-      return { kind: "feature_unavailable" as const };
-    }
-
     const providerKind = target.kind === "provider" ? target.providerKind : null;
-    if (!supportsCatAllFilesProvider(providerKind)) {
-      return {
-        kind: "provider_error" as const,
-        error: new TmsProviderLiveError(
-          "provider_cat_all_files_unsupported",
-          "All Files CAT is not available for this provider yet.",
-        ),
-      };
+    if (!(await isReleaseCatAllFilesEnabled(providerKind))) {
+      if (!supportsCatAllFilesProvider(providerKind)) {
+        return {
+          kind: "provider_error" as const,
+          error: new TmsProviderLiveError(
+            "provider_cat_all_files_unsupported",
+            "All Files CAT is not available for this provider yet.",
+          ),
+        };
+      }
+
+      return { kind: "feature_unavailable" as const };
     }
   }
 

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -32,12 +32,7 @@ import {
   getLatestRepositorySourceFileVersion,
 } from "@/lib/file-storage/records";
 import { sourceContentType } from "@/lib/file-storage/source-file-metadata";
-import {
-  isCatAllFilesSourcePath,
-  parseCatSourcePathsFilter,
-  supportsCatAllFilesProvider,
-} from "@/lib/projects/cat-all-files";
-import { TmsProviderLiveError } from "@/lib/providers/jobs/tms-provider-live-error";
+import { isCatAllFilesSourcePath, parseCatSourcePathsFilter } from "@/lib/projects/cat-all-files";
 
 import {
   countTmsProviderLiveOpenJobsForProject,
@@ -161,6 +156,7 @@ import {
   ownedProjectWhere,
   projectNotFoundResponse,
   providerProjectUnavailableResponse,
+  catAllFilesProviderKindFromTarget,
   resolveProjectResourceTarget,
   scheduleProjectNotFoundDiagnostics,
   tmsProviderLiveErrorResponse,
@@ -647,18 +643,9 @@ async function loadProjectFileCatQueue(
   const sourcePathsFilter = allFiles ? parseCatSourcePathsFilter(query.sourcePaths) : null;
 
   if (allFiles) {
-    const providerKind = target.kind === "provider" ? target.providerKind : null;
+    const providerKind = catAllFilesProviderKindFromTarget(target);
+    // Provider support lives in decide(); Flags Explorer overrides still win.
     if (!(await isReleaseCatAllFilesEnabled(providerKind))) {
-      if (!supportsCatAllFilesProvider(providerKind)) {
-        return {
-          kind: "provider_error" as const,
-          error: new TmsProviderLiveError(
-            "provider_cat_all_files_unsupported",
-            "All Files CAT is not available for this provider yet.",
-          ),
-        };
-      }
-
       return { kind: "feature_unavailable" as const };
     }
   }

--- a/apps/hyperlocalise-web/src/api/routes/project/project.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.shared.ts
@@ -62,7 +62,7 @@ export function forbiddenResponse(c: { json: JsonContext["json"] }) {
   return sharedForbiddenResponse(c, "forbidden", "Insufficient permissions");
 }
 
-type ProjectResourceTarget =
+export type ProjectResourceTarget =
   | { kind: "native"; projectId: string }
   | ({ kind: "provider" } & EncodedProviderProjectId)
   | {
@@ -70,6 +70,11 @@ type ProjectResourceTarget =
       error: "no_active_tms_provider" | "provider_project_not_available";
       message: string;
     };
+
+/** Provider kind for the All Files release flag — matches the API CAT queue gate. */
+export function catAllFilesProviderKindFromTarget(target: ProjectResourceTarget) {
+  return target.kind === "provider" ? target.providerKind : null;
+}
 
 export async function resolveProjectResourceTarget(
   auth: ApiAuthContext,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
@@ -17,11 +17,7 @@ import {
 import { useAppShellSidebar } from "@/components/app-shell/store/use-app-shell-sidebar";
 import { apiClient } from "@/lib/api-client-instance";
 import { supportsProviderCatFile } from "@/lib/providers/capabilities/provider-cat-capabilities";
-import {
-  CAT_ALL_FILES_SOURCE_PATH,
-  supportsCatAllFilesProvider,
-} from "@/lib/projects/cat-all-files";
-import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
+import { CAT_ALL_FILES_SOURCE_PATH } from "@/lib/projects/cat-all-files";
 import {
   buildProjectFileCatAllFilesHref,
   buildProjectFileCatHref,
@@ -151,13 +147,7 @@ export function ProjectFileCatPageContent({
     [filesQuery.data],
   );
 
-  const canUseAllFiles =
-    catAllFilesEnabled &&
-    supportsCatAllFilesProvider(
-      projectQuery.data?.externalProviderKind ??
-        parseProviderProjectId(projectId)?.providerKind ??
-        null,
-    );
+  const canUseAllFiles = catAllFilesEnabled;
 
   useEffect(() => {
     if (!allFiles || canUseAllFiles || !projectQuery.data) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/cat/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/cat/page.tsx
@@ -1,7 +1,10 @@
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 import { isReleaseCatAllFilesEnabled } from "@/lib/flags/release-flags";
-import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 import { parseProjectFileCatSearchParams } from "@/lib/projects/project-file-cat-routing";
+import {
+  catAllFilesProviderKindFromTarget,
+  resolveProjectResourceTarget,
+} from "@/api/routes/project/project.shared";
 
 import { ProjectFileCatPageContent } from "../_components/project-file-cat-page-content";
 
@@ -22,9 +25,11 @@ export default async function ProjectFileCatPage({
 }) {
   const { organizationSlug, projectId } = await params;
   const parsedSearchParams = parseProjectFileCatSearchParams(await searchParams);
-  await requireAppAuthContext({ organizationSlug });
-  const providerKind = parseProviderProjectId(projectId)?.providerKind ?? null;
-  const catAllFilesEnabled = await isReleaseCatAllFilesEnabled(providerKind);
+  const auth = await requireAppAuthContext({ organizationSlug });
+  const target = await resolveProjectResourceTarget(auth, projectId);
+  const catAllFilesEnabled = await isReleaseCatAllFilesEnabled(
+    catAllFilesProviderKindFromTarget(target),
+  );
 
   return (
     <ProjectFileCatPageContent

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/cat/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/cat/page.tsx
@@ -1,5 +1,6 @@
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 import { isReleaseCatAllFilesEnabled } from "@/lib/flags/release-flags";
+import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 import { parseProjectFileCatSearchParams } from "@/lib/projects/project-file-cat-routing";
 
 import { ProjectFileCatPageContent } from "../_components/project-file-cat-page-content";
@@ -22,7 +23,8 @@ export default async function ProjectFileCatPage({
   const { organizationSlug, projectId } = await params;
   const parsedSearchParams = parseProjectFileCatSearchParams(await searchParams);
   await requireAppAuthContext({ organizationSlug });
-  const catAllFilesEnabled = await isReleaseCatAllFilesEnabled();
+  const providerKind = parseProviderProjectId(projectId)?.providerKind ?? null;
+  const catAllFilesEnabled = await isReleaseCatAllFilesEnabled(providerKind);
 
   return (
     <ProjectFileCatPageContent

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -48,9 +48,7 @@ import {
   CAT_ALL_FILES_SOURCE_PATH,
   isCatAllFilesSourcePath,
   serializeCatSourcePathsFilter,
-  supportsCatAllFilesProvider,
 } from "@/lib/projects/cat-all-files";
-import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 
 type JobCatGithubRepository = {
   fullName: string;
@@ -172,9 +170,7 @@ export function JobCatPageContent({
   const router = useRouter();
   const pageNavigationGuardRef = useRef<CatPageNavigationGuardRef["current"]>(null);
   const taskHref = `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(jobId)}`;
-  const canUseAllFiles =
-    catAllFilesEnabled &&
-    supportsCatAllFilesProvider(parseProviderProjectId(projectId)?.providerKind ?? null);
+  const canUseAllFiles = catAllFilesEnabled;
   const requestedAllFiles = isCatAllFilesSourcePath(sourcePath) && Boolean(sourcePath);
   const allFiles = canUseAllFiles && requestedAllFiles;
   const hasFileReference = Boolean((sourcePath && !requestedAllFiles) || storedFileId) || allFiles;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
@@ -1,7 +1,10 @@
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 import { isReleaseCatAllFilesEnabled } from "@/lib/flags/release-flags";
-import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 import { resolveJobCatInitialQueueFilter } from "@/lib/projects/resolve-job-cat-initial-queue-filter";
+import {
+  catAllFilesProviderKindFromTarget,
+  resolveProjectResourceTarget,
+} from "@/api/routes/project/project.shared";
 
 import { JobCatPageContent } from "./_components/job-cat-page-content";
 
@@ -23,8 +26,10 @@ export default async function ProjectJobStringsPage({
   const { sourcePath, storedFileId, sourcePaths, targetLocale, segment, queueFilter } =
     await searchParams;
   const auth = await requireAppAuthContext({ organizationSlug });
-  const providerKind = parseProviderProjectId(projectId)?.providerKind ?? null;
-  const catAllFilesEnabled = await isReleaseCatAllFilesEnabled(providerKind);
+  const target = await resolveProjectResourceTarget(auth, projectId);
+  const catAllFilesEnabled = await isReleaseCatAllFilesEnabled(
+    catAllFilesProviderKindFromTarget(target),
+  );
 
   const initialQueueFilter = await resolveJobCatInitialQueueFilter({
     auth,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
@@ -1,5 +1,6 @@
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 import { isReleaseCatAllFilesEnabled } from "@/lib/flags/release-flags";
+import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 import { resolveJobCatInitialQueueFilter } from "@/lib/projects/resolve-job-cat-initial-queue-filter";
 
 import { JobCatPageContent } from "./_components/job-cat-page-content";
@@ -22,7 +23,8 @@ export default async function ProjectJobStringsPage({
   const { sourcePath, storedFileId, sourcePaths, targetLocale, segment, queueFilter } =
     await searchParams;
   const auth = await requireAppAuthContext({ organizationSlug });
-  const catAllFilesEnabled = await isReleaseCatAllFilesEnabled();
+  const providerKind = parseProviderProjectId(projectId)?.providerKind ?? null;
+  const catAllFilesEnabled = await isReleaseCatAllFilesEnabled(providerKind);
 
   const initialQueueFilter = await resolveJobCatInitialQueueFilter({
     auth,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/strings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/strings/page.tsx
@@ -1,6 +1,7 @@
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 import { isReleaseCatAllFilesEnabled } from "@/lib/flags/release-flags";
 import { CAT_ALL_FILES_SOURCE_PATH } from "@/lib/projects/cat-all-files";
+import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 import { parseProjectFileCatSearchParams } from "@/lib/projects/project-file-cat-routing";
 
 import { ProjectFileCatPageContent } from "../files/_components/project-file-cat-page-content";
@@ -23,7 +24,8 @@ export default async function ProjectStringsPage({
   const { organizationSlug, projectId } = await params;
   const rawSearchParams = await searchParams;
   await requireAppAuthContext({ organizationSlug });
-  const catAllFilesEnabled = await isReleaseCatAllFilesEnabled();
+  const providerKind = parseProviderProjectId(projectId)?.providerKind ?? null;
+  const catAllFilesEnabled = await isReleaseCatAllFilesEnabled(providerKind);
   const defaultSourcePath = catAllFilesEnabled
     ? CAT_ALL_FILES_SOURCE_PATH
     : rawSearchParams.sourcePath?.trim()

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/strings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/strings/page.tsx
@@ -1,8 +1,11 @@
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 import { isReleaseCatAllFilesEnabled } from "@/lib/flags/release-flags";
 import { CAT_ALL_FILES_SOURCE_PATH } from "@/lib/projects/cat-all-files";
-import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 import { parseProjectFileCatSearchParams } from "@/lib/projects/project-file-cat-routing";
+import {
+  catAllFilesProviderKindFromTarget,
+  resolveProjectResourceTarget,
+} from "@/api/routes/project/project.shared";
 
 import { ProjectFileCatPageContent } from "../files/_components/project-file-cat-page-content";
 
@@ -23,9 +26,11 @@ export default async function ProjectStringsPage({
 }) {
   const { organizationSlug, projectId } = await params;
   const rawSearchParams = await searchParams;
-  await requireAppAuthContext({ organizationSlug });
-  const providerKind = parseProviderProjectId(projectId)?.providerKind ?? null;
-  const catAllFilesEnabled = await isReleaseCatAllFilesEnabled(providerKind);
+  const auth = await requireAppAuthContext({ organizationSlug });
+  const target = await resolveProjectResourceTarget(auth, projectId);
+  const catAllFilesEnabled = await isReleaseCatAllFilesEnabled(
+    catAllFilesProviderKindFromTarget(target),
+  );
   const defaultSourcePath = catAllFilesEnabled
     ? CAT_ALL_FILES_SOURCE_PATH
     : rawSearchParams.sourcePath?.trim()

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -7,6 +7,8 @@ import {
   WORKSPACE_AUTOMATIONS_FLAG,
   WORKSPACE_KNOWLEDGE_FLAG,
 } from "@/lib/flags/workos-flag-entities";
+import { RELEASE_CAT_ALL_FILES_FLAG } from "@/lib/flags/release-flag-keys";
+import { encodeProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 
 import {
   buildGlobalNavigationGroups,
@@ -229,10 +231,31 @@ describe("parseProjectRoute", () => {
 });
 
 describe("buildProjectNavigationItems", () => {
-  it("includes a Strings item that opens the project CAT workspace", () => {
+  it("includes a Strings item for native projects", () => {
     const items = buildProjectNavigationItems("acme", "proj_1", intl);
     const stringsItem = items.find((item) => item.label === "Strings");
     expect(stringsItem?.href).toBe("/org/acme/projects/proj_1/strings");
+    expect(stringsItem?.featureFlagKey).toBe(RELEASE_CAT_ALL_FILES_FLAG);
+  });
+
+  it("shows Strings for Crowdin projects", () => {
+    const projectId = encodeProviderProjectId({
+      providerKind: "crowdin",
+      externalProjectId: "902807",
+    });
+    const items = buildProjectNavigationItems("acme", projectId, intl);
+    expect(items.find((item) => item.label === "Strings")?.href).toBe(
+      `/org/acme/projects/${encodeURIComponent(projectId)}/strings`,
+    );
+  });
+
+  it("hides Strings for unsupported TMS providers", () => {
+    const projectId = encodeProviderProjectId({
+      providerKind: "phrase",
+      externalProjectId: "42",
+    });
+    const items = buildProjectNavigationItems("acme", projectId, intl);
+    expect(items.find((item) => item.label === "Strings")).toBeUndefined();
   });
 });
 

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -2,10 +2,13 @@ import type { ComponentProps } from "react";
 import type { IntlShape } from "react-intl";
 
 import { normalizeAppLocale } from "@/lib/app-i18n/locales";
+import { RELEASE_CAT_ALL_FILES_FLAG } from "@/lib/flags/release-flag-keys";
 import {
   WORKSPACE_AUTOMATIONS_FLAG,
   WORKSPACE_KNOWLEDGE_FLAG,
 } from "@/lib/flags/workos-flag-entities";
+import { supportsCatAllFilesProvider } from "@/lib/projects/cat-all-files";
+import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 import {
   AiBrain01Icon,
   BookOpenTextIcon,
@@ -37,7 +40,10 @@ export type NavigationItem = {
   badge?: string;
   /** Non-route action; when set, the sidebar renders a button instead of a link. */
   action?: NavigationItemAction;
-  featureFlagKey?: typeof WORKSPACE_AUTOMATIONS_FLAG | typeof WORKSPACE_KNOWLEDGE_FLAG;
+  featureFlagKey?:
+    | typeof WORKSPACE_AUTOMATIONS_FLAG
+    | typeof WORKSPACE_KNOWLEDGE_FLAG
+    | typeof RELEASE_CAT_ALL_FILES_FLAG;
 };
 
 /** Sentinel href for the New Request sidebar action (never navigated). */
@@ -231,8 +237,10 @@ export function buildProjectNavigationItems(
   intl: IntlShape,
 ): readonly NavigationItem[] {
   const project = (section: string) => buildProjectPath(organizationSlug, projectId, section);
+  const providerKind = parseProviderProjectId(projectId)?.providerKind ?? null;
+  const showStrings = supportsCatAllFilesProvider(providerKind);
 
-  return [
+  const items: NavigationItem[] = [
     {
       label: intl.formatMessage({
         defaultMessage: "Overview",
@@ -251,7 +259,10 @@ export function buildProjectNavigationItems(
       href: project("files"),
       icon: File01Icon,
     },
-    {
+  ];
+
+  if (showStrings) {
+    items.push({
       label: intl.formatMessage({
         defaultMessage: "Strings",
         id: "CWdGpW4jOj",
@@ -259,7 +270,11 @@ export function buildProjectNavigationItems(
       }),
       href: project("strings"),
       icon: LanguageCircleIcon,
-    },
+      featureFlagKey: RELEASE_CAT_ALL_FILES_FLAG,
+    });
+  }
+
+  items.push(
     {
       label: intl.formatMessage({
         defaultMessage: "Jobs",
@@ -287,7 +302,9 @@ export function buildProjectNavigationItems(
       href: project("settings"),
       icon: Settings01Icon,
     },
-  ] as const;
+  );
+
+  return items;
 }
 
 export function stripAppLocalePrefix(pathname: string | null | undefined) {

--- a/apps/hyperlocalise-web/src/lib/flags/release-flag-keys.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/release-flag-keys.ts
@@ -1,0 +1,1 @@
+export const RELEASE_CAT_ALL_FILES_FLAG = "release-cat-all-files";

--- a/apps/hyperlocalise-web/src/lib/flags/release-flags.test.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/release-flags.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+const releaseCatAllFilesFlagRunMock = vi.hoisted(() => vi.fn());
+
+vi.mock("flags/next", () => ({
+  flag: () => {
+    const flagFn = Object.assign(vi.fn(), {
+      run: releaseCatAllFilesFlagRunMock,
+      key: "release-cat-all-files",
+    });
+    return flagFn;
+  },
+}));
+
+import { isReleaseCatAllFilesEnabled } from "./release-flags";
+
+describe("isReleaseCatAllFilesEnabled", () => {
+  it("passes providerKind into flag.run identify entities", async () => {
+    releaseCatAllFilesFlagRunMock.mockResolvedValue(true);
+
+    await expect(isReleaseCatAllFilesEnabled("crowdin")).resolves.toBe(true);
+
+    expect(releaseCatAllFilesFlagRunMock).toHaveBeenCalledWith({
+      identify: { providerKind: "crowdin" },
+    });
+  });
+
+  it("normalizes omitted providerKind to null for native projects", async () => {
+    releaseCatAllFilesFlagRunMock.mockResolvedValue(true);
+
+    await expect(isReleaseCatAllFilesEnabled()).resolves.toBe(true);
+
+    expect(releaseCatAllFilesFlagRunMock).toHaveBeenCalledWith({
+      identify: { providerKind: null },
+    });
+  });
+
+  it("returns false when flag evaluation throws", async () => {
+    releaseCatAllFilesFlagRunMock.mockRejectedValue(new Error("flags unavailable"));
+
+    await expect(isReleaseCatAllFilesEnabled("crowdin")).resolves.toBe(false);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/flags/release-flags.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/release-flags.ts
@@ -1,25 +1,42 @@
 import { flag } from "flags/next";
 
-export const RELEASE_CAT_ALL_FILES_FLAG = "release-cat-all-files";
+import type { ExternalTmsProviderKind } from "@/lib/providers/contracts/external-tms-provider-kind";
+import { supportsCatAllFilesProvider } from "@/lib/projects/cat-all-files";
+
+import { RELEASE_CAT_ALL_FILES_FLAG } from "./release-flag-keys";
+
+export { RELEASE_CAT_ALL_FILES_FLAG } from "./release-flag-keys";
+
+export type ReleaseCatAllFilesEntities = {
+  /** `null` / omitted = native project; otherwise the live TMS provider kind. */
+  providerKind?: ExternalTmsProviderKind | null;
+};
 
 /**
- * Release gate for CAT All Files (native + Crowdin).
+ * Release gate for CAT All Files and the project Strings sidebar.
  *
- * Defaults off via `decide`. Enable with Flags Explorer overrides (or change
- * `decide`) — not evaluated through WorkOS.
+ * `decide` enables All Files only for native projects and Crowdin. Pass
+ * `providerKind` via `.run({ identify })` / `isReleaseCatAllFilesEnabled`.
+ * Flags Explorer overrides still win over `decide`.
  */
-export const releaseCatAllFilesFlag = flag<boolean>({
+export const releaseCatAllFilesFlag = flag<boolean, ReleaseCatAllFilesEntities>({
   key: RELEASE_CAT_ALL_FILES_FLAG,
-  description: "CAT All Files scope for native and Crowdin projects.",
+  description: "CAT All Files and Strings sidebar for native and Crowdin projects.",
   defaultValue: false,
-  decide() {
-    return false;
+  decide({ entities }) {
+    return supportsCatAllFilesProvider(entities?.providerKind);
   },
 });
 
-export async function isReleaseCatAllFilesEnabled(): Promise<boolean> {
+export async function isReleaseCatAllFilesEnabled(
+  providerKind?: ExternalTmsProviderKind | null,
+): Promise<boolean> {
   try {
-    return (await releaseCatAllFilesFlag()) === true;
+    return (
+      (await releaseCatAllFilesFlag.run({
+        identify: { providerKind: providerKind ?? null },
+      })) === true
+    );
   } catch {
     return false;
   }

--- a/docs/adr/2026-07-15-release-cat-all-files-design.md
+++ b/docs/adr/2026-07-15-release-cat-all-files-design.md
@@ -12,7 +12,7 @@ For Crowdin, replace the per-file probe loop with a single project-scoped `GET /
 |------------------------------------|-----------------|--------------|--------------------|
 | Native (`null`) | Shown | Shown | Existing DB All Files path |
 | Crowdin | Shown | Shown | One project-wide strings page (+ CroQL) |
-| Phrase / Lokalise / Smartling / other | Hidden | Hidden | `provider_cat_all_files_unsupported` (501) or `feature_unavailable` when overridden off |
+| Phrase / Lokalise / Smartling / other | Hidden | Hidden | `feature_unavailable` (403) via `decide`; TMS still throws `provider_cat_all_files_unsupported` (501) if Flags Explorer forces the flag on |
 
 Deep links and job CAT that default to All Files follow the same rules: when `decide` is false for the provider (or Flags Explorer forces off), do not open All Files (pick a single file or require selection).
 

--- a/docs/adr/2026-07-15-release-cat-all-files-design.md
+++ b/docs/adr/2026-07-15-release-cat-all-files-design.md
@@ -2,20 +2,19 @@
 
 ## Decision
 
-Gate CAT **All Files** (`sourcePath=*`) behind the Flags SDK release flag `release-cat-all-files` (default off via `decide`). Enable with Flags Explorer overrides. When the flag is on, support All Files only for **native** projects and **Crowdin** live projects. Other TMS providers stay unavailable until a later release.
+Gate CAT **All Files** (`sourcePath=*`) and the project **Strings** sidebar behind the Flags SDK release flag `release-cat-all-files`. `decide({ entities })` enables the feature only when `entities.providerKind` is native (`null`) or **Crowdin**. Callers pass the provider via `isReleaseCatAllFilesEnabled(providerKind)` / `.run({ identify })`. Other TMS providers stay unavailable until a later release. Flags Explorer overrides still win over `decide`.
 
 For Crowdin, replace the per-file probe loop with a single project-scoped `GET /projects/{id}/strings` call (optional CroQL for search, queue filters, and optional file-id OR filters).
 
 ## Behavior
 
-| Flag | Project | All Files UI | API `sourcePath=*` |
-|------|---------|--------------|--------------------|
-| Off | Any | Hidden | `feature_unavailable` (403) |
-| On | Native | Shown | Existing DB All Files path |
-| On | Crowdin | Shown | One project-wide strings page (+ CroQL) |
-| On | Phrase / Lokalise / Smartling / other | Hidden | `provider_cat_all_files_unsupported` (501) |
+| Provider (`entities.providerKind`) | Strings sidebar | All Files UI | API `sourcePath=*` |
+|------------------------------------|-----------------|--------------|--------------------|
+| Native (`null`) | Shown | Shown | Existing DB All Files path |
+| Crowdin | Shown | Shown | One project-wide strings page (+ CroQL) |
+| Phrase / Lokalise / Smartling / other | Hidden | Hidden | `provider_cat_all_files_unsupported` (501) or `feature_unavailable` when overridden off |
 
-Deep links and job CAT that default to All Files follow the same rules: when the flag is off or the provider is unsupported, do not open All Files (pick a single file or require selection).
+Deep links and job CAT that default to All Files follow the same rules: when `decide` is false for the provider (or Flags Explorer forces off), do not open All Files (pick a single file or require selection).
 
 ## Crowdin fetch
 
@@ -26,9 +25,9 @@ Deep links and job CAT that default to All Files follow the same rules: when the
 
 ## Surfaces
 
-- Flag: `releaseCatAllFilesFlag` in `release-flags.ts` (`decide` → `false`; Flags Explorer overrides; not WorkOS)
-- API: `loadProjectFileCatQueue` gates before native / provider All Files loaders
-- UI: CAT file picker and `/strings` / job CAT defaults only expose All Files when the flag is on and the project is native or Crowdin
+- Flag: `releaseCatAllFilesFlag` in `release-flags.ts` (`decide` → `supportsCatAllFilesProvider(entities.providerKind)`; Flags Explorer overrides; not WorkOS)
+- API: `loadProjectFileCatQueue` evaluates the flag with the resolved provider before native / provider All Files loaders
+- UI: project Strings sidebar uses the same provider gate; `/strings` / job CAT / CAT file picker pass provider into `isReleaseCatAllFilesEnabled`
 - Provider: `getTmsProviderLiveCatAllFiles` is Crowdin-only; other providers throw `provider_cat_all_files_unsupported`
 
 ## Verification


### PR DESCRIPTION
## What changed

Move the CAT All Files / Strings release gate into `decide({ entities })`, which enables the feature only for native (`providerKind` null) and Crowdin. Call sites pass the provider via `isReleaseCatAllFilesEnabled(providerKind)`, and the project Strings sidebar uses the same provider gate so Phrase/Lokalise/Smartling do not show a dead-end Strings link.

## How to test

- Open a Crowdin or native project: Strings appears in the sidebar and `/strings` opens All Files CAT.
- Open a Phrase/Lokalise/Smartling project: Strings is hidden; All Files API with `sourcePath=*` is rejected.
- Run `vp test src/lib/flags/release-flags.test.ts src/components/app-shell/navigation-config.test.ts src/api/routes/project/project-cat.route.test.ts` from `apps/hyperlocalise-web`.

## Checklist

- [x] I ran relevant checks locally (`vp test` on affected suites, `vp check --fix` on touched files)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)