### PR TITLE
fix(cat): write AI recommendation reasoning in display locale

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -343,6 +343,7 @@ describe("project file CAT routes", () => {
           sourcePath: "crowdin/home.json",
           sourceLocale: "en",
           targetLocale: "fr",
+          displayLocale: "de-DE",
           key: "hello",
           sourceText: "Hello",
           targetText: "Bonjour",
@@ -370,6 +371,7 @@ describe("project file CAT routes", () => {
         sourcePath: "crowdin/home.json",
         key: "hello",
         sourceText: "Hello",
+        displayLocale: "de-DE",
       }),
     );
   });

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -1304,6 +1304,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           filename,
           sourceLocale: body.sourceLocale,
           targetLocale: body.targetLocale,
+          displayLocale: body.displayLocale,
           key: body.key,
           sourceText: body.sourceText,
           targetText: body.targetText,

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -447,6 +447,8 @@ export const projectFileCatRecommendationBodySchema = z.object({
   sourcePath: z.string().trim().min(1).max(2048),
   targetLocale: z.string().trim().min(1).max(32),
   sourceLocale: z.string().trim().min(1).max(32),
+  /** Reviewer UI/display locale for AI reasoning text (not the translation target). */
+  displayLocale: z.string().trim().min(1).max(32).optional(),
   key: z.string().trim().min(1).max(2048),
   sourceText: z.string().min(1).max(100_000),
   targetText: z.string().max(100_000).optional(),

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
@@ -488,6 +488,7 @@ export function ProjectFileCatWorkspace({
           sourcePath: recommendationSourcePath,
           targetLocale,
           sourceLocale: segment.sourceLocale,
+          displayLocale: intl.locale,
           key: segment.key,
           sourceText: segment.sourceText,
           targetText,
@@ -505,7 +506,7 @@ export function ProjectFileCatWorkspace({
       const body = (await response.json()) as ProjectFileCatRecommendationResponse;
       return body.recommendation;
     },
-    [organizationSlug, projectId, sourcePath, targetLocale],
+    [intl.locale, organizationSlug, projectId, sourcePath, targetLocale],
   );
 
   if (showLocaleSelector && (targetLocales?.length ?? 0) === 0) {

--- a/apps/hyperlocalise-web/src/lib/translation/domain.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/domain.ts
@@ -116,6 +116,8 @@ export type CatAiRecommendationInput = {
   filename: string;
   sourceLocale: string;
   targetLocale: string;
+  /** Locale for reviewer-facing reasoning text (UI/display locale), not the translation target. */
+  displayLocale?: string;
   key: string;
   sourceText: string;
   targetText?: string;

--- a/apps/hyperlocalise-web/src/lib/translation/generate-cat-ai-recommendation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/generate-cat-ai-recommendation.test.ts
@@ -68,6 +68,7 @@ describe("generateCatAiRecommendation", () => {
       filename: "en-US.json",
       sourceLocale: "en-US",
       targetLocale: "vi",
+      displayLocale: "en",
       key: "auth.signIn.title",
       sourceText: "Sign in to your workspace",
       targetText: "",
@@ -91,6 +92,64 @@ describe("generateCatAiRecommendation", () => {
     expect(generateTextMock).toHaveBeenCalledWith(
       expect.objectContaining({
         system: expect.stringContaining("Hero title on the sign-in page."),
+      }),
+    );
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        system: expect.stringContaining(
+          "Write the reasoning in the reviewer's display locale (en), not in the target translation locale.",
+        ),
+        prompt: expect.stringContaining("Reviewer display locale: en"),
+      }),
+    );
+  });
+
+  it("defaults reasoning display locale to en when omitted", async () => {
+    loadOrganizationTranslationModelMock.mockResolvedValue({
+      ok: true,
+      project: {
+        name: "Hyperlocalise",
+        translationContext: "Use concise product UI language.",
+      },
+      model: {},
+    });
+    assembleStringTranslationContextSnapshotMock.mockResolvedValue({
+      ok: true,
+      snapshot: {
+        project: {
+          id: "proj_1",
+          name: "Hyperlocalise",
+          translationContext: "Use concise product UI language.",
+        },
+        glossaryTerms: [],
+        translationMemoryMatches: [],
+      },
+    });
+    generateTextMock.mockResolvedValue({
+      output: {
+        suggestion: "Bonjour",
+        reasoning: "Natural French greeting.",
+      },
+    });
+
+    const result = await generateCatAiRecommendation({
+      projectId: "proj_1",
+      organizationId: "org_1",
+      sourcePath: "en-US.json",
+      filename: "en-US.json",
+      sourceLocale: "en-US",
+      targetLocale: "fr-FR",
+      key: "greeting",
+      sourceText: "Hello",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        system: expect.stringContaining(
+          "Write the reasoning in the reviewer's display locale (en), not in the target translation locale.",
+        ),
+        prompt: expect.stringContaining("Reviewer display locale: en"),
       }),
     );
   });

--- a/apps/hyperlocalise-web/src/lib/translation/generation.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/generation.ts
@@ -4,6 +4,7 @@ import { generateText, Output, type LanguageModel } from "ai";
 import { desc, eq } from "drizzle-orm";
 import { z } from "zod";
 
+import { DEFAULT_APP_LOCALE, normalizeAppLocale } from "@/lib/app-i18n/locales";
 import { db, schema } from "@/lib/database";
 import type { LlmProvider } from "@/lib/database/types";
 import { hyperlocaliseAgentModelId } from "@/lib/agent-runtime/loops/model";
@@ -20,6 +21,15 @@ import type {
   StringTranslationGeneratorInput,
   StringTranslationJobResult,
 } from "@/lib/translation/domain";
+
+function resolveCatRecommendationDisplayLocale(displayLocale?: string): string {
+  const trimmed = displayLocale?.trim();
+  if (!trimmed) {
+    return DEFAULT_APP_LOCALE;
+  }
+
+  return normalizeAppLocale(trimmed) ?? trimmed;
+}
 
 const stringTranslationOutputSchema = z.object({
   translations: z.array(
@@ -77,10 +87,15 @@ export class TranslationPromptPolicy {
     fileContext?: string | null;
     repositoryContext?: string | null;
     includeContextSections?: boolean;
+    displayLocale?: string;
   }): string {
     const glossaryTerms = input.glossaryTerms ?? [];
     const translationMemoryMatches = input.translationMemoryMatches ?? [];
     const knowledgeMemory = input.knowledgeMemory?.trim();
+    const displayLocale =
+      input.mode === "cat-suggest"
+        ? resolveCatRecommendationDisplayLocale(input.displayLocale)
+        : undefined;
 
     const instructions =
       input.mode === "cat-suggest"
@@ -94,6 +109,7 @@ export class TranslationPromptPolicy {
             "Use approved translation memory matches as consistency references when they apply.",
             "If constraints conflict, prioritize placeholder and markup preservation first, then glossary rules, then project context, file context, repository context, workspace knowledge memory, then translation memory examples.",
             "When a current target draft is provided, improve it when needed instead of repeating it unchanged.",
+            `Write the suggestion in the target locale. Write the reasoning in the reviewer's display locale (${displayLocale}), not in the target translation locale.`,
             "Return concise reasoning that explains terminology, tone, or product-fit choices.",
           ]
         : input.mode === "sandbox"
@@ -135,6 +151,7 @@ export class TranslationPromptPolicy {
     if (input.mode === "cat-suggest") {
       sections.push(
         `Project name: ${input.projectName ?? "(none)"}`,
+        `Reviewer display locale: ${displayLocale}`,
         `Project translation context: ${input.projectTranslationContext?.trim() || "(none)"}`,
         `Workspace knowledge memory: ${knowledgeMemory || "(none)"}`,
       );
@@ -511,6 +528,7 @@ export class CatRecommendationEngine {
         maxLength: input.maxLength,
         fileContext: input.context,
         repositoryContext: input.agentContext,
+        displayLocale: input.displayLocale,
       }),
       prompt: [
         `Project file: ${input.filename}`,
@@ -518,6 +536,7 @@ export class CatRecommendationEngine {
         `String key: ${input.key}`,
         `Source locale: ${input.sourceLocale}`,
         `Target locale: ${input.targetLocale}`,
+        `Reviewer display locale: ${resolveCatRecommendationDisplayLocale(input.displayLocale)}`,
         input.maxLength ? `Maximum length: ${input.maxLength} characters` : null,
         input.targetText?.trim() ? ["Current target draft:", input.targetText].join("\n") : null,
         "Source text:",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CAT AI recommendation reasoning was being written in the target translation locale (e.g. German) because the model prompt never distinguished the reviewer's UI language from the translation target.

This change passes the reviewer's display locale (`intl.locale`) into the recommendation API and instructs the model to:

- keep the **suggestion** in the target locale
- write the **reasoning** in the reviewer's display locale

## Changes

- Add optional `displayLocale` to the CAT recommendation request body and domain input
- Include display-locale guidance in the `cat-suggest` system/user prompts
- Send `intl.locale` from the CAT workspace client
- Cover the new behavior in route and generation tests

## Test plan

- [x] `vp test src/lib/translation/generate-cat-ai-recommendation.test.ts src/api/routes/project/project-cat.route.test.ts` (30 passed)
- [x] `vp check --fix`
- [ ] Manually: open CAT for a non-English target locale while UI is English, regenerate AI recommendation, confirm reasoning is English while suggestion stays in the target locale

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9e38391-adfb-46ab-82aa-57f7b1e5ab13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9e38391-adfb-46ab-82aa-57f7b1e5ab13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

