### PR TITLE
fix(cat): limit unsaved guard to route navigation

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-hotkeys.ts
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-hotkeys.ts
@@ -66,6 +66,8 @@ export function useCatEditorHotkeys({
     {
       enabled: canTriggerApprove,
       enableOnFormTags: true,
+      // TipTap uses contenteditable; without this, ⌘↵ / Ctrl+Enter is ignored while typing.
+      enableOnContentEditable: true,
       preventDefault: true,
     },
     [canTriggerApprove, onApprove],

--- a/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
@@ -279,25 +279,15 @@ export const catWorkspaceContainerMessages = defineMessages({
     id: "pMRZvoJLzS",
     description: "Fallback error when approving or saving a CAT translation fails",
   },
-  unsavedSegmentNavigationTitle: {
-    defaultMessage: "Leave segment with unsaved changes?",
-    id: "2O/RojUz55",
-    description: "Title when navigating away from a segment with unsaved target text",
-  },
-  unsavedSegmentNavigationDescription: {
-    defaultMessage: "Your edits to this segment have not been saved. Leave without saving?",
-    id: "37yFkjafwR",
-    description: "Body when navigating away from a segment with unsaved target text",
-  },
   unsavedPageNavigationTitle: {
     defaultMessage: "Leave page with unsaved changes?",
-    id: "oeD72ehQB/",
-    description: "Title when changing CAT queue page with unsaved target text",
+    id: "mctwKXU94p",
+    description: "Title when leaving the CAT workspace with unsaved target text",
   },
   unsavedPageNavigationDescription: {
-    defaultMessage: "Some segments on this page have unsaved edits. Change page without saving?",
-    id: "+pyXMBZm58",
-    description: "Body when changing CAT queue page with unsaved target text",
+    defaultMessage: "Some segments have unsaved edits. Leave without saving?",
+    id: "mmB/r+ohDb",
+    description: "Body when leaving the CAT workspace with unsaved target text",
   },
   unsavedNavigationStay: {
     defaultMessage: "Stay",

--- a/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
@@ -281,7 +281,7 @@ export const catWorkspaceContainerMessages = defineMessages({
   },
   unsavedPageNavigationTitle: {
     defaultMessage: "Leave page with unsaved changes?",
-    id: "mctwKXU94p",
+    id: "oeD72ehQB/",
     description: "Title when leaving the CAT workspace with unsaved target text",
   },
   unsavedPageNavigationDescription: {

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vite-plus/test";
 
@@ -121,6 +121,25 @@ describe("CatSideBySideRow", () => {
     renderRow({ onApprove });
 
     await user.click(screen.getByRole("button", { name: /Approve/i }));
+    expect(onApprove).toHaveBeenCalledTimes(1);
+  });
+
+  it("approves with Ctrl+Enter while the target editor is focused", async () => {
+    const user = userEvent.setup();
+    const onApprove = vi.fn();
+
+    renderRow({ onApprove });
+
+    const targetEditor = await waitFor(() => {
+      const editor = document.querySelector(
+        '[aria-label="Target translation"][contenteditable="true"]',
+      );
+      expect(editor).toBeTruthy();
+      return editor as HTMLElement;
+    });
+    await user.click(targetEditor);
+    await user.keyboard("{Control>}{Enter}{/Control}");
+
     expect(onApprove).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.tsx
@@ -240,6 +240,8 @@ export function CatSideBySideRow({
     {
       enabled: isFocused && canTriggerApprove,
       enableOnFormTags: true,
+      // TipTap uses contenteditable; without this, ⌘↵ / Ctrl+Enter is ignored while typing.
+      enableOnContentEditable: true,
       preventDefault: true,
     },
     [canTriggerApprove, isFocused, onApprove],

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.navigation.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.navigation.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment happy-dom
 
 import type { ReactElement } from "react";
-import { screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
   catSegmentsFixture,
@@ -13,6 +13,10 @@ import {
 import { renderWithCatProviders } from "@/components/cat/shared/cat-test-utils";
 
 import { CatWorkspaceContainer } from "./cat-workspace-container";
+import {
+  CAT_WORKSPACE_VIEW_MODE_STORAGE_KEY,
+  writeCatWorkspaceViewMode,
+} from "./cat-workspace-view-mode";
 
 const ROW_HEIGHT = 88;
 
@@ -148,7 +152,7 @@ describe("CatWorkspaceContainer queue navigation", () => {
     expect(getQueueSegmentButton("Reviews awaiting approval")).toBeInTheDocument();
   });
 
-  it("shows the unsaved navigation dialog when leaving a dirty segment", async () => {
+  it("switches queue segments without prompting when the current segment is dirty", async () => {
     const user = userEvent.setup();
     const onSelectSegment = vi.fn();
 
@@ -166,45 +170,11 @@ describe("CatWorkspaceContainer queue navigation", () => {
 
     await user.click(getQueueSegmentButton("Reviews awaiting approval"));
 
-    const dialog = await screen.findByRole("alertdialog");
-    expect(within(dialog).getByText("Leave segment with unsaved changes?")).toBeInTheDocument();
-
-    await user.click(within(dialog).getByRole("button", { name: "Leave without saving" }));
-
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
     expect(onSelectSegment).toHaveBeenCalledWith("seg-01");
   });
 
-  it("stays on the current segment when cancelling unsaved navigation", async () => {
-    const user = userEvent.setup();
-    const onSelectSegment = vi.fn();
-
-    renderCatWorkspace(
-      <CatWorkspaceContainer
-        initialState={createUiCatWorkspaceState()}
-        navigation={{ onSelectSegment }}
-        services={{ validateFormat: mockValidateFormat }}
-      />,
-    );
-
-    const targetEditor = (await waitForTargetEditor()) as HTMLElement;
-    await user.click(targetEditor);
-    await user.keyboard(" unsaved");
-
-    await user.click(getQueueSegmentButton("Reviews awaiting approval"));
-
-    const dialog = await screen.findByRole("alertdialog");
-    await user.click(within(dialog).getByRole("button", { name: "Stay" }));
-
-    expect(onSelectSegment).not.toHaveBeenCalled();
-    await waitFor(() => {
-      const targetEditor = document.querySelector(
-        '[aria-label="Target translation"][contenteditable="true"]',
-      );
-      expect(targetEditor?.textContent).toContain(" unsaved");
-    });
-  });
-
-  it("prompts before a local queue filter hides the dirty segment", async () => {
+  it("applies a local queue filter without prompting when it hides the dirty segment", async () => {
     const user = userEvent.setup();
 
     renderCatWorkspace(
@@ -220,16 +190,57 @@ describe("CatWorkspaceContainer queue navigation", () => {
     await user.click(screen.getByRole("button", { name: "Filter queue" }));
     await user.click(await screen.findByRole("menuitemradio", { name: "Approved" }));
 
-    const dialog = await screen.findByRole("alertdialog");
-    expect(within(dialog).getByText("Leave segment with unsaved changes?")).toBeInTheDocument();
-    await user.click(within(dialog).getByRole("button", { name: "Stay" }));
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Filter queue" })).toHaveTextContent("Approved");
+  });
+});
 
-    expect(screen.getByRole("button", { name: "Filter queue" })).toHaveTextContent("All strings");
-    await waitFor(() => {
-      const targetEditor = document.querySelector(
-        '[aria-label="Target translation"][contenteditable="true"]',
-      );
-      expect(targetEditor?.textContent).toContain(" unsaved");
+describe("CatWorkspaceContainer side-by-side approve", () => {
+  beforeEach(() => {
+    writeCatWorkspaceViewMode("side-by-side");
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        dispatchEvent: () => false,
+      }),
     });
+  });
+
+  afterEach(() => {
+    window.localStorage.removeItem(CAT_WORKSPACE_VIEW_MODE_STORAGE_KEY);
+  });
+
+  it("approves a dirty segment without opening the unsaved navigation dialog", async () => {
+    const user = userEvent.setup();
+    const onApprove = vi.fn().mockResolvedValue("reviewed");
+
+    renderCatWorkspace(
+      <CatWorkspaceContainer
+        initialState={createUiCatWorkspaceState()}
+        review={{ onApprove }}
+        services={{ validateFormat: mockValidateFormat }}
+      />,
+    );
+
+    const targetEditor = (await waitForTargetEditor()) as HTMLElement;
+    await user.click(targetEditor);
+    await user.keyboard(" unsaved");
+
+    const approveButton = await screen.findByRole("button", { name: /Approve/i });
+    await waitFor(() => expect(approveButton).not.toBeDisabled());
+    await user.click(approveButton);
+
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(onApprove).toHaveBeenCalledWith("seg-02", expect.stringContaining(" unsaved")),
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.test.tsx
@@ -86,6 +86,29 @@ describe("CatWorkspaceContainer UI", () => {
     await waitFor(() => expect(onApprove).toHaveBeenCalledWith("seg-02", "Updated translation"));
   });
 
+  it("approves with Ctrl+Enter while typing in the comfortable target editor", async () => {
+    const user = userEvent.setup();
+    const onApprove = vi.fn().mockResolvedValue("reviewed");
+
+    renderCatWorkspace(
+      <CatWorkspaceContainer
+        initialState={createUiCatWorkspaceState()}
+        review={{ onApprove }}
+        services={{ validateFormat: mockValidateFormat }}
+      />,
+    );
+
+    const targetEditor = (await waitForTargetEditor()) as HTMLElement;
+    await user.click(targetEditor);
+    await user.keyboard("{Control>}a{/Control}Saved via shortcut");
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Approve/i })).not.toBeDisabled(),
+    );
+    await user.keyboard("{Control>}{Enter}{/Control}");
+
+    await waitFor(() => expect(onApprove).toHaveBeenCalledWith("seg-02", "Saved via shortcut"));
+  });
+
   it("applies AI suggestions from the editor recommendation panel", async () => {
     const user = userEvent.setup();
     const onUseAiSuggestion = vi.fn();

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
@@ -204,24 +204,12 @@ const CatWorkspaceContainerObserver = observer(function CatWorkspaceContainerObs
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
-              {store.unsavedNavigationPrompt?.kind === "page" ? (
-                <FormattedMessage {...catWorkspaceContainerMessages.unsavedPageNavigationTitle} />
-              ) : (
-                <FormattedMessage
-                  {...catWorkspaceContainerMessages.unsavedSegmentNavigationTitle}
-                />
-              )}
+              <FormattedMessage {...catWorkspaceContainerMessages.unsavedPageNavigationTitle} />
             </AlertDialogTitle>
             <AlertDialogDescription>
-              {store.unsavedNavigationPrompt?.kind === "page" ? (
-                <FormattedMessage
-                  {...catWorkspaceContainerMessages.unsavedPageNavigationDescription}
-                />
-              ) : (
-                <FormattedMessage
-                  {...catWorkspaceContainerMessages.unsavedSegmentNavigationDescription}
-                />
-              )}
+              <FormattedMessage
+                {...catWorkspaceContainerMessages.unsavedPageNavigationDescription}
+              />
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
@@ -41,7 +41,6 @@ import {
 } from "./store/cat-workspace-store-utils";
 
 type UnsavedNavigationPrompt = {
-  kind: "segment" | "page";
   proceed: () => void;
 };
 
@@ -1025,33 +1024,16 @@ export class CatWorkspaceOrchestrator {
     const selectionWillChange = !filtered.some(
       (segment) => segment.id === this.selectedSegmentId || segment.key === this.selectedSegmentId,
     );
-    const applyFilter = () => {
-      this.queue.setFilter(filter);
-      if (selectionWillChange) {
-        this.setSelectedSegmentId(filtered[0]?.id ?? "");
-      }
-    };
 
+    this.queue.setFilter(filter);
     if (selectionWillChange) {
-      this.attemptSegmentNavigation(applyFilter);
-      return;
+      this.setSelectedSegmentId(filtered[0]?.id ?? "");
     }
-
-    applyFilter();
-  }
-
-  attemptSegmentNavigation(proceed: () => void) {
-    if (this.selectedDraft?.isDirty) {
-      this.unsavedNavigationPrompt = { kind: "segment", proceed };
-      return;
-    }
-
-    proceed();
   }
 
   attemptPageNavigation(proceed: () => void) {
     if (this.dirtySegmentIds.size > 0) {
-      this.unsavedNavigationPrompt = { kind: "page", proceed };
+      this.unsavedNavigationPrompt = { proceed };
       return;
     }
 

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.test.tsx
@@ -676,7 +676,7 @@ describe("useCatWorkspaceRuntime", () => {
     expect(store.selectedSegmentId).toBe("seg-02");
   });
 
-  it("prompts before navigating away from a dirty segment", () => {
+  it("switches segments without prompting when the current segment is dirty", () => {
     const onSelectSegment = vi.fn();
     const { result, store } = renderController(undefined, {
       navigation: { onSelectSegment },
@@ -690,16 +690,53 @@ describe("useCatWorkspaceRuntime", () => {
       result.current.dependencies.navigation.onSelectSegment("seg-03");
     });
 
-    expect(store.unsavedNavigationPrompt).toMatchObject({ kind: "segment" });
+    expect(store.unsavedNavigationPrompt).toBeNull();
+    expect(onSelectSegment).toHaveBeenCalledWith("seg-03");
+    expect(store.selectedSegmentId).toBe("seg-03");
+    expect(store.dirtySegmentIds.has("seg-02")).toBe(true);
+  });
+
+  it("does not re-select when focusing the current dirty segment", () => {
+    const onSelectSegment = vi.fn();
+    const { result, store } = renderController(undefined, {
+      navigation: { onSelectSegment },
+    });
+
+    act(() => {
+      result.current.dependencies.editing.onTargetChange("seg-02", "Unsaved edit");
+    });
+
+    act(() => {
+      result.current.dependencies.navigation.onSelectSegment("seg-02");
+    });
+
+    expect(store.unsavedNavigationPrompt).toBeNull();
     expect(onSelectSegment).not.toHaveBeenCalled();
     expect(store.selectedSegmentId).toBe("seg-02");
+    expect(store.dirtySegmentIds.has("seg-02")).toBe(true);
+  });
+
+  it("prompts before route navigation when any segment is dirty", () => {
+    const { result, store } = renderController();
+    const proceed = vi.fn();
+
+    act(() => {
+      result.current.dependencies.editing.onTargetChange("seg-02", "Unsaved edit");
+    });
+
+    act(() => {
+      store.attemptPageNavigation(proceed);
+    });
+
+    expect(store.unsavedNavigationPrompt).not.toBeNull();
+    expect(proceed).not.toHaveBeenCalled();
 
     act(() => {
       store.confirmUnsavedNavigation();
     });
 
-    expect(onSelectSegment).toHaveBeenCalledWith("seg-03");
-    expect(store.selectedSegmentId).toBe("seg-03");
+    expect(proceed).toHaveBeenCalledTimes(1);
+    expect(store.unsavedNavigationPrompt).toBeNull();
   });
 
   it("bulk approves checked segments through the review handler", async () => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.ts
@@ -183,37 +183,31 @@ export function useCatWorkspaceRuntime({
 
     const navigation: CatWorkspaceNavigation = {
       onSelectSegment: (segmentId: string) => {
-        store.attemptSegmentNavigation(() => {
-          const selectedSegmentId = store.findSegmentIdByKeyOrId(segmentId) ?? segmentId;
-          store.setSelectedSegmentId(selectedSegmentId);
-          onSelectSegment?.(segmentId);
-        });
+        const selectedSegmentId = store.findSegmentIdByKeyOrId(segmentId) ?? segmentId;
+        const currentSegmentId =
+          store.findSegmentIdByKeyOrId(store.selectedSegmentId) ?? store.selectedSegmentId;
+        if (selectedSegmentId === currentSegmentId) {
+          return;
+        }
+
+        store.setSelectedSegmentId(selectedSegmentId);
+        onSelectSegment?.(segmentId);
       },
       onPreviousSegment: () => {
-        store.attemptSegmentNavigation(() => {
-          const visibleSegments = store.getFilteredQueueSegments(
-            queueFilter,
-            usesServerQueueFilter,
-          );
-          const previousId = getAdjacentSegmentId(visibleSegments, store.selectedSegmentId, -1);
-          if (previousId) {
-            store.setSelectedSegmentId(previousId);
-          }
-          onPreviousSegment?.();
-        });
+        const visibleSegments = store.getFilteredQueueSegments(queueFilter, usesServerQueueFilter);
+        const previousId = getAdjacentSegmentId(visibleSegments, store.selectedSegmentId, -1);
+        if (previousId) {
+          store.setSelectedSegmentId(previousId);
+        }
+        onPreviousSegment?.();
       },
       onNextSegment: () => {
-        store.attemptSegmentNavigation(() => {
-          const visibleSegments = store.getFilteredQueueSegments(
-            queueFilter,
-            usesServerQueueFilter,
-          );
-          const nextId = getAdjacentSegmentId(visibleSegments, store.selectedSegmentId, 1);
-          if (nextId) {
-            store.setSelectedSegmentId(nextId);
-          }
-          onNextSegment?.();
-        });
+        const visibleSegments = store.getFilteredQueueSegments(queueFilter, usesServerQueueFilter);
+        const nextId = getAdjacentSegmentId(visibleSegments, store.selectedSegmentId, 1);
+        if (nextId) {
+          store.setSelectedSegmentId(nextId);
+        }
+        onNextSegment?.();
       },
       onReviewInSequence: () => {
         onReviewInSequence?.();


### PR DESCRIPTION
## What changed

Side-by-side Approve/Save was blocked by the unsaved-segment dialog: focusing the button re-selected the same dirty segment and opened the leave prompt. The guard now only runs for route-level CAT leaves (file/locale/route change). Segment switches and in-workspace actions proceed without prompting. Also enable `enableOnContentEditable` so ⌘↵ / Ctrl+Enter works while typing in TipTap.

## How to test

- [ ] In side-by-side, edit a translation and click **Approve** — save succeeds, no unsaved dialog
- [ ] Switch segments / change queue filter with dirty edits — no dialog; drafts preserved
- [ ] Leave CAT (back/file/locale) with dirty edits — dialog still appears
- [ ] ⌘↵ / Ctrl+Enter while focused in the target editor approves
- [ ] `cd apps/hyperlocalise-web && vp test src/components/cat/workspace/cat-workspace-container.navigation.test.tsx src/components/cat/workspace/use-cat-workspace-runtime.test.tsx src/components/cat/side-by-side/cat-side-by-side-row.test.tsx`

## Checklist

- [x] I ran relevant checks locally (`vp test` on affected CAT tests, `vp check --fix` on touched files)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)