### PR TITLE
feat(i18n): localize API keys settings and remaining CAT editor strings

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/api-keys-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/api-keys-page-content.messages.ts
@@ -1,0 +1,199 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const apiKeysPageContentMessages = defineMessages({
+  neverUsed: {
+    defaultMessage: "Never",
+    id: "RcUcWXknuU",
+    description: "Shown when an API key has never been used",
+  },
+  loadFailed: {
+    defaultMessage: "Failed to load API keys",
+    id: "sCwvAHmqAI",
+    description: "Error when the API keys list request fails",
+  },
+  createFailed: {
+    defaultMessage: "Failed to create API key",
+    id: "vHkuFGKp7T",
+    description: "Error when creating an API key fails",
+  },
+  revokeFailed: {
+    defaultMessage: "Failed to revoke API key",
+    id: "NisKtP5fCJ",
+    description: "Error when revoking an API key fails",
+  },
+  revokedToast: {
+    defaultMessage: "API key revoked",
+    id: "4Nb8hxfYt5",
+    description: "Success toast after revoking an API key",
+  },
+  copiedToast: {
+    defaultMessage: "API key copied to clipboard",
+    id: "bXM2sr8gtz",
+    description: "Success toast after copying a newly created API key",
+  },
+  copyFailedToast: {
+    defaultMessage: "Failed to copy to clipboard",
+    id: "TrnH0+MELk",
+    description: "Error toast when clipboard copy fails",
+  },
+  pageLabel: {
+    defaultMessage: "Workspace settings",
+    id: "ksrwIvV64s",
+    description: "Breadcrumb-style label above the API keys page title",
+  },
+  pageTitle: {
+    defaultMessage: "API Keys",
+    id: "VZ/tPAEVdg",
+    description: "API keys settings page heading",
+  },
+  pageDescription: {
+    defaultMessage:
+      "Create and manage API keys for programmatic access to translation jobs and workspace resources. Keep keys secure and rotate them regularly.",
+    id: "nE4gAmZP2R",
+    description: "API keys settings page description",
+  },
+  createButton: {
+    defaultMessage: "Create API key",
+    id: "VH9bOCu5nr",
+    description: "Button to open the create API key dialog",
+  },
+  sectionAriaLabel: {
+    defaultMessage: "API keys",
+    id: "P8buB19/yY",
+    description: "Accessible label for the API keys list section",
+  },
+  loading: {
+    defaultMessage: "Loading API keys...",
+    id: "ZC65JlwD3i",
+    description: "Loading state while fetching API keys",
+  },
+  loadErrorTitle: {
+    defaultMessage: "API keys failed to load.",
+    id: "z5++P6iegy",
+    description: "Error title when the API keys list fails to load",
+  },
+  loadErrorFallback: {
+    defaultMessage: "Refresh the page to try again.",
+    id: "Bh7oPsMHrP",
+    description: "Fallback error guidance when loading API keys fails",
+  },
+  emptyTitle: {
+    defaultMessage: "No API keys yet",
+    id: "K0Maj++lc6",
+    description: "Empty state title when the workspace has no API keys",
+  },
+  emptyDescription: {
+    defaultMessage:
+      "Create a key to authenticate scripts, CI jobs, and integrations against this workspace.",
+    id: "V/CBn2NY6n",
+    description: "Empty state description for the API keys list",
+  },
+  maskedKeyPrefix: {
+    defaultMessage: "{prefix}••••••••",
+    id: "CWXh32oIoB",
+    description: "Masked API key prefix shown in the keys list",
+  },
+  permissions: {
+    defaultMessage: "Permissions: {permissions}",
+    id: "VUwFgX4OmD",
+    description: "API key row showing granted permissions",
+  },
+  createdAt: {
+    defaultMessage: "Created {date}",
+    id: "NX9i6pdgvw",
+    description: "API key row showing creation timestamp",
+  },
+  lastUsed: {
+    defaultMessage: "Last used {date}",
+    id: "60PQQ7C+fN",
+    description: "API key row showing last-used timestamp",
+  },
+  revoke: {
+    defaultMessage: "Revoke",
+    id: "6RuyJHJCyu",
+    description: "Button to open the revoke API key confirmation dialog",
+  },
+  createDialogTitle: {
+    defaultMessage: "Create API key",
+    id: "IJDgzVk+ER",
+    description: "Title of the create API key dialog before the key is generated",
+  },
+  createdDialogTitle: {
+    defaultMessage: "API key created",
+    id: "0+lekb0oBh",
+    description: "Title of the create API key dialog after the key is generated",
+  },
+  createDialogDescription: {
+    defaultMessage: "Give your key a name so you can identify it later.",
+    id: "ScpiJIZOJM",
+    description: "Description in the create API key dialog before generation",
+  },
+  createdDialogDescription: {
+    defaultMessage: "Copy this key now. You will not be able to see it again.",
+    id: "HZrRUnuo70",
+    description: "Warning shown after an API key is created",
+  },
+  copied: {
+    defaultMessage: "Copied",
+    id: "++VvL4EEbo",
+    description: "Copy button label after the API key was copied",
+  },
+  copy: {
+    defaultMessage: "Copy",
+    id: "5eoi21fmqC",
+    description: "Button to copy the newly created API key",
+  },
+  keyNameLabel: {
+    defaultMessage: "Key name",
+    id: "ZuaK6pQTdl",
+    description: "Label for the API key name field",
+  },
+  keyNamePlaceholder: {
+    defaultMessage: "e.g. Production CI",
+    id: "9uVn8mc+mK",
+    description: "Placeholder for the API key name field",
+  },
+  done: {
+    defaultMessage: "Done",
+    id: "jh2RfUdWl3",
+    description: "Button to close the create API key dialog after copying the key",
+  },
+  cancel: {
+    defaultMessage: "Cancel",
+    id: "whnz/Xptx4",
+    description: "Cancel button in API key dialogs",
+  },
+  creating: {
+    defaultMessage: "Creating...",
+    id: "d4ixdVNgC5",
+    description: "Create API key button label while the request is pending",
+  },
+  createKey: {
+    defaultMessage: "Create key",
+    id: "pwrS5bq0q7",
+    description: "Submit button to create an API key",
+  },
+  revokeDialogTitle: {
+    defaultMessage: "Revoke API key",
+    id: "DSm/l7fomX",
+    description: "Title of the revoke API key confirmation dialog",
+  },
+  revokeDialogDescription: {
+    defaultMessage:
+      "This key will immediately lose access to the workspace API. Any integrations using it will stop working.",
+    id: "sishbO9DCq",
+    description: "Description in the revoke API key confirmation dialog",
+  },
+  revoking: {
+    defaultMessage: "Revoking...",
+    id: "zMB0hQFeRq",
+    description: "Revoke API key button label while the request is pending",
+  },
+  revokeKey: {
+    defaultMessage: "Revoke key",
+    id: "S2pzZyn+jp",
+    description: "Confirm button to revoke an API key",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/api-keys-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/api-keys-page-content.tsx
@@ -10,6 +10,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -27,6 +28,7 @@ import { apiClient } from "@/lib/api-client-instance";
 
 import { PageHeader } from "../../_components/workspace-resource-shared";
 import { TypographyP } from "@/components/ui/typography";
+import { apiKeysPageContentMessages } from "./api-keys-page-content.messages";
 
 type ApiKey = {
   id: string;
@@ -40,25 +42,22 @@ type ApiKey = {
 
 const apiKeysQueryKey = (organizationSlug: string) => ["api-keys", organizationSlug];
 
-/**
- * BOLT OPTIMIZATION: Reuse Intl.DateTimeFormat instance.
- * Creating Intl objects is expensive (~0.18ms per instance).
- * Reusing a single instance reduces overhead by >95%.
- */
-const DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
-  month: "short",
-  day: "numeric",
-  year: "numeric",
-  hour: "2-digit",
-  minute: "2-digit",
-});
+function formatApiKeyDate(intl: IntlShape, date: string | null) {
+  if (!date) {
+    return intl.formatMessage(apiKeysPageContentMessages.neverUsed);
+  }
 
-function formatDate(date: string | null) {
-  if (!date) return "Never";
-  return DATE_FORMATTER.format(new Date(date));
+  return intl.formatDate(new Date(date), {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }
 
 export function ApiKeySettingsPageContent({ organizationSlug }: { organizationSlug: string }) {
+  const intl = useIntl();
   const queryClient = useQueryClient();
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [newKeyName, setNewKeyName] = useState("");
@@ -73,7 +72,7 @@ export function ApiKeySettingsPageContent({ organizationSlug }: { organizationSl
         param: { organizationSlug },
       });
       if (!response.ok) {
-        throw new Error("Failed to load API keys");
+        throw new Error(intl.formatMessage(apiKeysPageContentMessages.loadFailed));
       }
       const body = await response.json();
       return (body.apiKeys ?? []) as ApiKey[];
@@ -91,7 +90,7 @@ export function ApiKeySettingsPageContent({ organizationSlug }: { organizationSl
         if (body && typeof body === "object" && "error" in body) {
           throw new Error(String(body.error));
         }
-        throw new Error("Failed to create API key");
+        throw new Error(intl.formatMessage(apiKeysPageContentMessages.createFailed));
       }
       return response.json() as Promise<{
         apiKey: { id: string; name: string; key: string; keyPrefix: string };
@@ -115,13 +114,13 @@ export function ApiKeySettingsPageContent({ organizationSlug }: { organizationSl
         param: { organizationSlug, apiKeyId },
       });
       if (!response.ok) {
-        throw new Error("Failed to revoke API key");
+        throw new Error(intl.formatMessage(apiKeysPageContentMessages.revokeFailed));
       }
     },
     onSuccess: async () => {
       setRevokingKeyId(null);
       await queryClient.invalidateQueries({ queryKey: apiKeysQueryKey(organizationSlug) });
-      toast.success("API key revoked");
+      toast.success(intl.formatMessage(apiKeysPageContentMessages.revokedToast));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -139,11 +138,11 @@ export function ApiKeySettingsPageContent({ organizationSlug }: { organizationSl
       .writeText(key)
       .then(() => {
         setCopied(true);
-        toast.success("API key copied to clipboard");
+        toast.success(intl.formatMessage(apiKeysPageContentMessages.copiedToast));
         setTimeout(() => setCopied(false), 2000);
       })
       .catch(() => {
-        toast.error("Failed to copy to clipboard");
+        toast.error(intl.formatMessage(apiKeysPageContentMessages.copyFailedToast));
       });
   }
 
@@ -161,9 +160,9 @@ export function ApiKeySettingsPageContent({ organizationSlug }: { organizationSl
     <main className="mx-auto flex w-full max-w-6xl flex-col gap-6">
       <PageHeader
         icon={Key01Icon}
-        label="Workspace settings"
-        title="API Keys"
-        description="Create and manage API keys for programmatic access to translation jobs and workspace resources. Keep keys secure and rotate them regularly."
+        label={intl.formatMessage(apiKeysPageContentMessages.pageLabel)}
+        title={intl.formatMessage(apiKeysPageContentMessages.pageTitle)}
+        description={intl.formatMessage(apiKeysPageContentMessages.pageDescription)}
         actions={
           <Button
             type="button"
@@ -172,38 +171,37 @@ export function ApiKeySettingsPageContent({ organizationSlug }: { organizationSl
             disabled={createKey.isPending}
           >
             <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
-            Create API key
+            <FormattedMessage {...apiKeysPageContentMessages.createButton} />
           </Button>
         }
       />
 
       <section
-        aria-label="API keys"
+        aria-label={intl.formatMessage(apiKeysPageContentMessages.sectionAriaLabel)}
         className="overflow-hidden rounded-lg border border-border bg-card text-card-foreground"
       >
         {apiKeysQuery.isLoading ? (
           <TypographyP className="px-5 py-8 text-sm text-muted-foreground">
-            Loading API keys...
+            <FormattedMessage {...apiKeysPageContentMessages.loading} />
           </TypographyP>
         ) : apiKeysQuery.isError ? (
           <div className="px-5 py-8">
             <TypographyP className="text-sm font-medium text-destructive">
-              API keys failed to load.
+              <FormattedMessage {...apiKeysPageContentMessages.loadErrorTitle} />
             </TypographyP>
             <TypographyP className="mt-1 text-sm text-muted-foreground">
               {apiKeysQuery.error instanceof Error
                 ? apiKeysQuery.error.message
-                : "Refresh the page to try again."}
+                : intl.formatMessage(apiKeysPageContentMessages.loadErrorFallback)}
             </TypographyP>
           </div>
         ) : activeKeys.length === 0 ? (
           <div className="px-5 py-10">
             <TypographyP className="text-sm font-medium text-foreground">
-              No API keys yet
+              <FormattedMessage {...apiKeysPageContentMessages.emptyTitle} />
             </TypographyP>
             <TypographyP className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
-              Create a key to authenticate scripts, CI jobs, and integrations against this
-              workspace.
+              <FormattedMessage {...apiKeysPageContentMessages.emptyDescription} />
             </TypographyP>
           </div>
         ) : (
@@ -216,13 +214,31 @@ export function ApiKeySettingsPageContent({ organizationSlug }: { organizationSl
                       {key.name}
                     </TypographyP>
                     <span className="rounded-full border border-border bg-muted px-2 py-0.5 font-mono text-xs text-muted-foreground">
-                      {key.keyPrefix}••••••••
+                      <FormattedMessage
+                        {...apiKeysPageContentMessages.maskedKeyPrefix}
+                        values={{ prefix: key.keyPrefix }}
+                      />
                     </span>
                   </div>
                   <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-                    <span>Permissions: {key.permissions.join(", ")}</span>
-                    <span>Created {formatDate(key.createdAt)}</span>
-                    <span>Last used {formatDate(key.lastUsedAt)}</span>
+                    <span>
+                      <FormattedMessage
+                        {...apiKeysPageContentMessages.permissions}
+                        values={{ permissions: key.permissions.join(", ") }}
+                      />
+                    </span>
+                    <span>
+                      <FormattedMessage
+                        {...apiKeysPageContentMessages.createdAt}
+                        values={{ date: formatApiKeyDate(intl, key.createdAt) }}
+                      />
+                    </span>
+                    <span>
+                      <FormattedMessage
+                        {...apiKeysPageContentMessages.lastUsed}
+                        values={{ date: formatApiKeyDate(intl, key.lastUsedAt) }}
+                      />
+                    </span>
                   </div>
                 </div>
                 <Button
@@ -233,7 +249,7 @@ export function ApiKeySettingsPageContent({ organizationSlug }: { organizationSl
                   disabled={revokeKey.isPending}
                 >
                   <HugeiconsIcon icon={Delete01Icon} strokeWidth={1.8} className="size-4" />
-                  Revoke
+                  <FormattedMessage {...apiKeysPageContentMessages.revoke} />
                 </Button>
               </div>
             ))}
@@ -250,11 +266,19 @@ export function ApiKeySettingsPageContent({ organizationSlug }: { organizationSl
       >
         <DialogContent className="sm:max-w-lg">
           <DialogHeader>
-            <DialogTitle>{createdKey ? "API key created" : "Create API key"}</DialogTitle>
+            <DialogTitle>
+              {createdKey ? (
+                <FormattedMessage {...apiKeysPageContentMessages.createdDialogTitle} />
+              ) : (
+                <FormattedMessage {...apiKeysPageContentMessages.createDialogTitle} />
+              )}
+            </DialogTitle>
             <DialogDescription>
-              {createdKey
-                ? "Copy this key now. You will not be able to see it again."
-                : "Give your key a name so you can identify it later."}
+              {createdKey ? (
+                <FormattedMessage {...apiKeysPageContentMessages.createdDialogDescription} />
+              ) : (
+                <FormattedMessage {...apiKeysPageContentMessages.createDialogDescription} />
+              )}
             </DialogDescription>
           </DialogHeader>
 
@@ -272,12 +296,12 @@ export function ApiKeySettingsPageContent({ organizationSlug }: { organizationSl
                   {copied ? (
                     <>
                       <HugeiconsIcon icon={Tick02Icon} strokeWidth={1.8} className="size-4" />
-                      Copied
+                      <FormattedMessage {...apiKeysPageContentMessages.copied} />
                     </>
                   ) : (
                     <>
                       <HugeiconsIcon icon={Copy01Icon} strokeWidth={1.8} className="size-4" />
-                      Copy
+                      <FormattedMessage {...apiKeysPageContentMessages.copy} />
                     </>
                   )}
                 </Button>
@@ -286,12 +310,14 @@ export function ApiKeySettingsPageContent({ organizationSlug }: { organizationSl
           ) : (
             <form onSubmit={handleCreateSubmit} className="grid gap-4">
               <Field className="gap-2">
-                <FieldLabel htmlFor="key-name">Key name</FieldLabel>
+                <FieldLabel htmlFor="key-name">
+                  <FormattedMessage {...apiKeysPageContentMessages.keyNameLabel} />
+                </FieldLabel>
                 <Input
                   id="key-name"
                   value={newKeyName}
                   onChange={(e) => setNewKeyName(e.target.value)}
-                  placeholder="e.g. Production CI"
+                  placeholder={intl.formatMessage(apiKeysPageContentMessages.keyNamePlaceholder)}
                 />
               </Field>
             </form>
@@ -300,7 +326,7 @@ export function ApiKeySettingsPageContent({ organizationSlug }: { organizationSl
           <DialogFooter>
             {createdKey ? (
               <Button type="button" onClick={handleCloseCreateDialog} className="w-full sm:w-fit">
-                Done
+                <FormattedMessage {...apiKeysPageContentMessages.done} />
               </Button>
             ) : (
               <>
@@ -310,7 +336,7 @@ export function ApiKeySettingsPageContent({ organizationSlug }: { organizationSl
                   onClick={handleCloseCreateDialog}
                   className="w-full sm:w-fit"
                 >
-                  Cancel
+                  <FormattedMessage {...apiKeysPageContentMessages.cancel} />
                 </Button>
                 <Button
                   type="button"
@@ -318,7 +344,11 @@ export function ApiKeySettingsPageContent({ organizationSlug }: { organizationSl
                   disabled={!newKeyName.trim() || createKey.isPending}
                   className="w-full sm:w-fit"
                 >
-                  {createKey.isPending ? "Creating..." : "Create key"}
+                  {createKey.isPending ? (
+                    <FormattedMessage {...apiKeysPageContentMessages.creating} />
+                  ) : (
+                    <FormattedMessage {...apiKeysPageContentMessages.createKey} />
+                  )}
                 </Button>
               </>
             )}
@@ -332,10 +362,11 @@ export function ApiKeySettingsPageContent({ organizationSlug }: { organizationSl
       >
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>Revoke API key</DialogTitle>
+            <DialogTitle>
+              <FormattedMessage {...apiKeysPageContentMessages.revokeDialogTitle} />
+            </DialogTitle>
             <DialogDescription>
-              This key will immediately lose access to the workspace API. Any integrations using it
-              will stop working.
+              <FormattedMessage {...apiKeysPageContentMessages.revokeDialogDescription} />
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -345,7 +376,7 @@ export function ApiKeySettingsPageContent({ organizationSlug }: { organizationSl
               onClick={() => setRevokingKeyId(null)}
               className="w-full sm:w-fit"
             >
-              Cancel
+              <FormattedMessage {...apiKeysPageContentMessages.cancel} />
             </Button>
             <Button
               type="button"
@@ -356,7 +387,11 @@ export function ApiKeySettingsPageContent({ organizationSlug }: { organizationSl
               disabled={revokeKey.isPending}
               className="w-full sm:w-fit"
             >
-              {revokeKey.isPending ? "Revoking..." : "Revoke key"}
+              {revokeKey.isPending ? (
+                <FormattedMessage {...apiKeysPageContentMessages.revoking} />
+              ) : (
+                <FormattedMessage {...apiKeysPageContentMessages.revokeKey} />
+              )}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-ai-recommendation.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-ai-recommendation.tsx
@@ -77,10 +77,15 @@ export function CatEditorAiRecommendation({
           <p className="text-sm leading-relaxed text-foreground">{intelligence.aiSuggestion}</p>
           {intelligence.aiReasoning ? (
             <p className="text-xs leading-relaxed text-muted-foreground">
-              <span className="font-medium text-subtle-foreground">
-                <FormattedMessage {...catEditorPanelMessages.reasoningPrefix} />
-              </span>{" "}
-              {intelligence.aiReasoning}
+              <FormattedMessage
+                {...catEditorPanelMessages.aiReasoning}
+                values={{
+                  reasoning: intelligence.aiReasoning,
+                  b: (chunks) => (
+                    <span className="font-medium text-subtle-foreground">{chunks}</span>
+                  ),
+                }}
+              />
             </p>
           ) : null}
         </div>

--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-header.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-header.tsx
@@ -43,7 +43,13 @@ export function CatEditorHeader({
     <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-4 py-3 lg:px-5">
       <div className="flex flex-wrap items-center gap-2">
         <span className="font-mono text-xs text-muted-foreground tabular-nums">
-          {String(segmentPosition).padStart(2, "0")} / {String(totalSegments).padStart(2, "0")}
+          <FormattedMessage
+            {...catEditorPanelMessages.segmentPosition}
+            values={{
+              position: String(segmentPosition).padStart(2, "0"),
+              total: String(totalSegments).padStart(2, "0"),
+            }}
+          />
         </span>
         <SegmentStatusBadge status={segment.status} />
         {isTargetDirty ? (

--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-image-preview.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-image-preview.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { ImageIcon } from "lucide-react";
+import { FormattedMessage } from "react-intl";
 
 import { ImageLightbox } from "@/components/ui/image-lightbox/image-lightbox";
 import { cn } from "@/lib/primitives/cn";
+
+import { catEditorPanelMessages } from "@/components/cat/shared/cat.messages";
 
 export function CatImagePreview({
   src,
@@ -26,7 +29,7 @@ export function CatImagePreview({
       >
         <div className="flex flex-col items-center gap-2 px-4 text-center">
           <ImageIcon className="size-6 opacity-60" aria-hidden />
-          <span>{emptyLabel ?? "No image yet"}</span>
+          <span>{emptyLabel ?? <FormattedMessage {...catEditorPanelMessages.imageEmpty} />}</span>
         </div>
       </div>
     );

--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-target-editor.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-target-editor.tsx
@@ -248,17 +248,23 @@ export function CatIcuStructureSummary({ blocks }: { blocks: CatIcuBlockSummary[
       <ul className="space-y-2">
         {blocks.map((block) => (
           <li key={block.id} className="space-y-1">
-            <div className="flex flex-wrap items-center gap-1.5 text-xs">
-              <span
-                className={cn(
-                  "rounded-md border px-1.5 py-0.5 font-mono",
-                  catMessageTokenToneClass("icu"),
-                )}
-              >
-                {block.arg}
-              </span>
-              <span className="text-muted-foreground">·</span>
-              <span className="font-mono text-muted-foreground">{block.type}</span>
+            <div className="flex flex-wrap items-center gap-1.5 text-xs font-mono text-muted-foreground">
+              <FormattedMessage
+                {...catTargetEditorMessages.icuBlockSummary}
+                values={{
+                  arg: (
+                    <span
+                      className={cn(
+                        "rounded-md border px-1.5 py-0.5 text-foreground",
+                        catMessageTokenToneClass("icu"),
+                      )}
+                    >
+                      {block.arg}
+                    </span>
+                  ),
+                  type: block.type,
+                }}
+              />
             </div>
             <div className="flex flex-wrap gap-1">
               {block.options.map((option) => (

--- a/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
@@ -281,7 +281,7 @@ export const catWorkspaceContainerMessages = defineMessages({
   },
   unsavedPageNavigationTitle: {
     defaultMessage: "Leave page with unsaved changes?",
-    id: "oeD72ehQB/",
+    id: "mctwKXU94p",
     description: "Title when leaving the CAT workspace with unsaved target text",
   },
   unsavedPageNavigationDescription: {
@@ -341,6 +341,11 @@ export const catTargetEditorMessages = defineMessages({
     defaultMessage: "{count} characters used",
     id: "8eFLCTVPnq",
     description: "Accessible label for the CAT target character counter without a max length",
+  },
+  icuBlockSummary: {
+    defaultMessage: "{arg} · {type}",
+    id: "iXddAxYfyx",
+    description: "ICU plural/select block argument and type summary in the CAT target editor",
   },
 });
 
@@ -544,6 +549,16 @@ export const catEditorPanelMessages = defineMessages({
     id: "V04dsqCSZQ",
     description: "Empty state when the CAT target image has not been created",
   },
+  imageEmpty: {
+    defaultMessage: "No image yet",
+    id: "aMf9NbDyem",
+    description: "Fallback empty state when a CAT image preview has no source URL",
+  },
+  segmentPosition: {
+    defaultMessage: "{position} / {total}",
+    id: "uadZLjPGYZ",
+    description: "Current segment index and total count in the CAT editor header",
+  },
   targetHeading: {
     defaultMessage: "Target ({locale})",
     id: "1PcszZ/Z93",
@@ -619,10 +634,10 @@ export const catEditorPanelMessages = defineMessages({
     id: "MN2GW5Szxo",
     description: "Button to request an AI translation recommendation",
   },
-  reasoningPrefix: {
-    defaultMessage: "Reasoning:",
-    id: "0zYUPddzdy",
-    description: "Label prefix before AI recommendation reasoning text",
+  aiReasoning: {
+    defaultMessage: "<b>Reasoning:</b> {reasoning}",
+    id: "TE3bLZyBSZ",
+    description: "AI recommendation reasoning with bold label prefix; b wraps the label",
   },
   aiSuggestionEmpty: {
     defaultMessage: "Generate a translation suggestion for this string.",


### PR DESCRIPTION
## What changed

Localize hardcoded user-facing copy in the workspace API keys settings page and finish remaining CAT editor `formatjs` literal-string gaps.

- Add colocated `api-keys-page-content.messages.ts` and wire the settings UI (page chrome, list states, dialogs, toasts, dates) through `react-intl`
- Localize leftover CAT editor strings: segment counter, AI reasoning line, image empty fallback, and ICU block summary
- Extend shared `cat.messages.ts` with the new CAT message descriptors

## How to test

- [ ] Open Workspace settings → API Keys and confirm UI copy, create/revoke dialogs, and toasts still render correctly
- [ ] In CAT editor, confirm segment counter, AI reasoning label, image empty state, and ICU structure summary still look correct
- [ ] `cd apps/hyperlocalise-web && vp lint "src/components/cat/editor" "src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/api-keys-page-content.tsx" "src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/api-keys-page-content.messages.ts"`

## Checklist

- [x] I ran relevant checks locally (`vp lint` on touched web files)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)