### PR TITLE
feat(jobs): create/delete UI for native and Crowdin jobs

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -385,13 +385,53 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
       }
 
       const inputPayload = payload.type === "string" ? payload.stringInput : payload.fileInput;
+      const enrichedInputPayload =
+        payload.title && payload.title.trim().length > 0
+          ? {
+              ...inputPayload,
+              metadata: {
+                ...inputPayload.metadata,
+                title: payload.title.trim(),
+              },
+            }
+          : inputPayload;
 
       const localeValidation = validateJobLocalesAgainstProject(project, {
-        sourceLocale: inputPayload.sourceLocale,
-        targetLocales: inputPayload.targetLocales,
+        sourceLocale: enrichedInputPayload.sourceLocale,
+        targetLocales: enrichedInputPayload.targetLocales,
       });
       if (isErr(localeValidation)) {
         return badRequestResponse(c, localeValidation.error.code, localeValidation.error.message);
+      }
+
+      let ownerUserId: string | null = null;
+      if (payload.ownerWorkosUserId) {
+        const [owner] = await db
+          .select({ id: schema.users.id })
+          .from(schema.users)
+          .innerJoin(
+            schema.organizationMemberships,
+            eq(schema.organizationMemberships.userId, schema.users.id),
+          )
+          .where(
+            and(
+              eq(schema.users.workosUserId, payload.ownerWorkosUserId),
+              eq(
+                schema.organizationMemberships.organizationId,
+                c.var.auth.organization.localOrganizationId,
+              ),
+            ),
+          )
+          .limit(1);
+
+        if (!owner) {
+          return badRequestResponse(
+            c,
+            "owner_not_found",
+            "Assigned owner must be an organization member",
+          );
+        }
+        ownerUserId = owner.id;
       }
 
       if (payload.type === "file") {
@@ -455,9 +495,10 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
               organizationId: c.var.auth.organization.localOrganizationId,
               projectId: params.projectId,
               createdByUserId: c.var.auth.user.localUserId,
+              ownerUserId,
               kind: "translation",
               status: "queued",
-              inputPayload,
+              inputPayload: enrichedInputPayload,
             })
             .returning();
 
@@ -1340,6 +1381,69 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
             .set({ outcomeKind: "error" })
             .where(eq(schema.translationJobDetails.jobId, params.jobId));
         }
+
+        return job;
+      });
+
+      if (!updatedJob) {
+        const [existingJob] = await db
+          .select({ id: schema.jobs.id })
+          .from(schema.jobs)
+          .where(and(eq(schema.jobs.id, params.jobId), await buildAccessibleJobsWhere(c.var.auth)))
+          .limit(1);
+
+        return existingJob
+          ? conflictResponse(c, "job_action_unavailable", "Job action is not available")
+          : notFoundResponse(c, "job_not_found", "Job not found");
+      }
+
+      const [job] = await db
+        .select(jobWithProjectSelect)
+        .from(schema.jobs)
+        .leftJoin(
+          schema.translationJobDetails,
+          eq(schema.translationJobDetails.jobId, schema.jobs.id),
+        )
+        .leftJoin(schema.reviewJobDetails, eq(schema.reviewJobDetails.jobId, schema.jobs.id))
+        .leftJoin(schema.syncJobDetails, eq(schema.syncJobDetails.jobId, schema.jobs.id))
+        .leftJoin(
+          schema.assetManagementJobDetails,
+          eq(schema.assetManagementJobDetails.jobId, schema.jobs.id),
+        )
+        .leftJoin(schema.externalJobDetails, eq(schema.externalJobDetails.jobId, schema.jobs.id))
+        .leftJoin(
+          schema.projects,
+          and(
+            eq(schema.projects.id, schema.jobs.projectId),
+            eq(schema.projects.organizationId, schema.jobs.organizationId),
+          ),
+        )
+        .where(and(eq(schema.jobs.id, params.jobId), await buildAccessibleJobsWhere(c.var.auth)))
+        .limit(1);
+
+      return c.json({ job }, 200);
+    })
+    .post("/:jobId/cancel", validateWorkspaceJobParams, async (c) => {
+      if (!isJobMutationAllowed(c.var.auth.membership.role)) {
+        return forbiddenResponse(c);
+      }
+
+      const params = c.req.valid("param");
+      const updatedJob = await db.transaction(async (tx) => {
+        const [job] = await tx
+          .update(schema.jobs)
+          .set({
+            status: "cancelled",
+            workflowRunId: null,
+            lastError: null,
+            outcomePayload: {
+              code: "cancelled_by_user",
+              message: "Cancelled by user",
+            },
+            completedAt: new Date(),
+          })
+          .where(await activeJobWhere(c.var.auth, params.jobId))
+          .returning({ id: schema.jobs.id, kind: schema.jobs.kind });
 
         return job;
       });

--- a/apps/hyperlocalise-web/src/api/routes/project/job.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.schema.ts
@@ -49,10 +49,14 @@ export const createJobBodySchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("string"),
     stringInput: stringTranslationJobInputSchema,
+    ownerWorkosUserId: z.string().trim().min(1).max(256).optional(),
+    title: z.string().trim().min(1).max(256).optional(),
   }),
   z.object({
     type: z.literal("file"),
     fileInput: fileTranslationJobInputSchema,
+    ownerWorkosUserId: z.string().trim().min(1).max(256).optional(),
+    title: z.string().trim().min(1).max(256).optional(),
   }),
 ]);
 

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
@@ -464,7 +464,7 @@ export function createTmsProviderRoutes(options: CreateTmsProviderRoutesOptions 
           return c.json({ error: "job_not_found" }, 404);
         }
 
-        return c.json({ deleted: true }, 200);
+        return c.body(null, 204);
       } catch (error) {
         return tmsProviderLiveErrorResponse(c, error);
       }

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
@@ -2,7 +2,11 @@ import { Hono } from "hono";
 import { validator } from "hono/validator";
 import { z } from "zod";
 
-import { isJobProviderActionAllowed } from "@/api/auth/capability-guards";
+import {
+  isJobCreateAllowed,
+  isJobMutationAllowed,
+  isJobProviderActionAllowed,
+} from "@/api/auth/capability-guards";
 import { hasCapability } from "@/api/auth/policy";
 import { ownedProjectWhere } from "@/api/auth/team-access";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
@@ -21,6 +25,8 @@ import {
 import { parseProviderJobId } from "@/lib/providers/jobs/tms-provider-resource-id";
 import type { ProviderAgentTranslationQueue } from "@/lib/workflow/types";
 import {
+  createTmsProviderLiveJobs,
+  deleteTmsProviderLiveJob,
   getTmsProviderConnection,
   getTmsProviderLiveJobFileDetail,
   listTmsProviderLiveJobComments,
@@ -33,6 +39,7 @@ import {
   listTmsProviderLiveGlossaries,
   listTmsProviderLiveJobs,
   listTmsProviderLiveJobsForProject,
+  listTmsProviderLiveProjectMembers,
   listTmsProviderLiveProjects,
   listTmsProviderLiveTranslationMemories,
 } from "@/lib/providers/jobs/tms-provider-live";
@@ -66,6 +73,15 @@ const updateJobDescriptionBodySchema = z.object({
 const createTmsProviderJobAgentRunBodySchema = z.object({
   projectId: projectIdSchema,
   action: z.literal("translate_with_agent"),
+});
+
+const createTmsProviderJobsBodySchema = z.object({
+  title: z.string().trim().min(1).max(256),
+  targetLocales: z.array(z.string().trim().min(1).max(32)).min(1).max(20),
+  fileIds: z.array(z.string().trim().min(1).max(128)).min(1).max(100),
+  assigneeExternalUserIds: z.array(z.string().trim().min(1).max(128)).max(50).optional(),
+  kind: z.enum(["translation", "proofread", "review"]).optional().default("translation"),
+  description: z.string().trim().max(2_048).optional(),
 });
 
 function serializeAgentRun(run: typeof schema.agentRuns.$inferSelect) {
@@ -140,6 +156,15 @@ const validateCreateTmsProviderJobAgentRunBody = validator("json", (value, c) =>
   const parsed = createTmsProviderJobAgentRunBodySchema.safeParse(value);
   if (!parsed.success) {
     return badRequestResponse(c, "invalid_request_body", "Invalid provider agent run payload");
+  }
+
+  return parsed.data;
+});
+
+const validateCreateTmsProviderJobsBody = validator("json", (value, c) => {
+  const parsed = createTmsProviderJobsBodySchema.safeParse(value);
+  if (!parsed.success) {
+    return badRequestResponse(c, "invalid_request_body", "Invalid create job payload");
   }
 
   return parsed.data;
@@ -231,6 +256,48 @@ export function createTmsProviderRoutes(options: CreateTmsProviderRoutesOptions 
           },
         );
         return c.json({ jobs }, 200);
+      } catch (error) {
+        return tmsProviderLiveErrorResponse(c, error);
+      }
+    })
+    .post("/projects/:externalProjectId/jobs", validateCreateTmsProviderJobsBody, async (c) => {
+      if (!isJobCreateAllowed(c.var.auth.membership.role)) {
+        return c.json({ error: "forbidden" }, 403);
+      }
+
+      const payload = c.req.valid("json");
+
+      try {
+        const jobs = await createTmsProviderLiveJobs(
+          c.var.auth.organization.localOrganizationId,
+          c.req.param("externalProjectId"),
+          {
+            title: payload.title,
+            targetLocales: payload.targetLocales,
+            fileIds: payload.fileIds,
+            assigneeExternalUserIds: payload.assigneeExternalUserIds,
+            kind: payload.kind,
+            description: payload.description,
+            actorUserId: c.var.auth.user.localUserId,
+          },
+        );
+        return c.json({ jobs }, 201);
+      } catch (error) {
+        return tmsProviderLiveErrorResponse(c, error);
+      }
+    })
+    .get("/projects/:externalProjectId/members", async (c) => {
+      if (!hasCapability(c.var.auth.membership.role, "jobs:read")) {
+        return c.json({ error: "forbidden" }, 403);
+      }
+
+      try {
+        const members = await listTmsProviderLiveProjectMembers(
+          c.var.auth.organization.localOrganizationId,
+          c.req.param("externalProjectId"),
+          { actorUserId: c.var.auth.user.localUserId },
+        );
+        return c.json({ members }, 200);
       } catch (error) {
         return tmsProviderLiveErrorResponse(c, error);
       }
@@ -378,6 +445,26 @@ export function createTmsProviderRoutes(options: CreateTmsProviderRoutesOptions 
         }
 
         return c.json({ comments }, 200);
+      } catch (error) {
+        return tmsProviderLiveErrorResponse(c, error);
+      }
+    })
+    .delete("/jobs/:encodedJobId", async (c) => {
+      if (!isJobMutationAllowed(c.var.auth.membership.role)) {
+        return c.json({ error: "forbidden" }, 403);
+      }
+
+      try {
+        const deleted = await deleteTmsProviderLiveJob(
+          c.var.auth.organization.localOrganizationId,
+          c.req.param("encodedJobId"),
+          c.var.auth.user.localUserId,
+        );
+        if (!deleted) {
+          return c.json({ error: "job_not_found" }, 404);
+        }
+
+        return c.json({ deleted: true }, 200);
       } catch (error) {
         return tmsProviderLiveErrorResponse(c, error);
       }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
@@ -373,10 +373,7 @@ export function CreateJobDialog({
           },
         });
         if (!response.ok) {
-          const failure = await readApiResponseError(
-            response,
-            "Failed to create translation job",
-          );
+          const failure = await readApiResponseError(response, "Failed to create translation job");
           if (createdIds.length > 0) {
             throw new PartialCreateJobsError(
               `Created ${createdIds.length} of ${eligibleFiles.length} jobs, then failed: ${failure.message}`,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
@@ -1,0 +1,566 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Spinner } from "@/components/ui/spinner";
+import { Textarea } from "@/components/ui/textarea";
+import { readApiResponseError } from "@/lib/api-error";
+import { apiClient } from "@/lib/api-client-instance";
+import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
+import {
+  inferSupportedTranslationFileFormat,
+  type SupportedTranslationFileFormat,
+} from "@/lib/translation/file-formats";
+import { cn } from "@/lib/primitives/cn";
+
+type CreateJobDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationSlug: string;
+  projectId: string;
+  sourceLocale: string;
+  targetLocales: string[];
+  onCreated?: () => void;
+};
+
+type AssigneeOption = {
+  id: string;
+  label: string;
+  secondary?: string | null;
+};
+
+type FileOption = {
+  id: string;
+  label: string;
+  storedFileId?: string | null;
+  fileFormat?: SupportedTranslationFileFormat | null;
+};
+
+function toggleValue(values: string[], value: string) {
+  return values.includes(value)
+    ? values.filter((entry) => entry !== value)
+    : [...values, value].toSorted((a, b) => a.localeCompare(b));
+}
+
+function SelectionList({
+  items,
+  selected,
+  onToggle,
+  emptyLabel,
+  disabled,
+}: {
+  items: { id: string; label: string; secondary?: string | null }[];
+  selected: string[];
+  onToggle: (id: string) => void;
+  emptyLabel: string;
+  disabled?: boolean;
+}) {
+  if (items.length === 0) {
+    return <p className="text-sm text-muted-foreground">{emptyLabel}</p>;
+  }
+
+  return (
+    <ScrollArea className="h-40 rounded-md border border-border">
+      <div className="space-y-1 p-2">
+        {items.map((item) => {
+          const checked = selected.includes(item.id);
+          return (
+            <label
+              key={item.id}
+              className={cn(
+                "flex cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted/60",
+                disabled && "pointer-events-none opacity-60",
+              )}
+            >
+              <input
+                type="checkbox"
+                className="mt-0.5 size-4 rounded border border-input accent-primary"
+                checked={checked}
+                disabled={disabled}
+                onChange={() => onToggle(item.id)}
+              />
+              <span className="min-w-0">
+                <span className="block truncate font-medium text-foreground">{item.label}</span>
+                {item.secondary ? (
+                  <span className="block truncate text-xs text-muted-foreground">
+                    {item.secondary}
+                  </span>
+                ) : null}
+              </span>
+            </label>
+          );
+        })}
+      </div>
+    </ScrollArea>
+  );
+}
+
+export function CreateJobDialog({
+  open,
+  onOpenChange,
+  organizationSlug,
+  projectId,
+  sourceLocale,
+  targetLocales,
+  onCreated,
+}: CreateJobDialogProps) {
+  const queryClient = useQueryClient();
+  const parsedProviderProject = parseProviderProjectId(projectId);
+  const isProviderProject = Boolean(parsedProviderProject);
+
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [selectedLocales, setSelectedLocales] = useState<string[]>(targetLocales);
+  const [selectedFileIds, setSelectedFileIds] = useState<string[]>([]);
+  const [selectedAssignees, setSelectedAssignees] = useState<string[]>([]);
+  const [kind, setKind] = useState<"translation" | "proofread">("translation");
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setTitle("");
+    setDescription("");
+    setSelectedLocales(targetLocales);
+    setSelectedFileIds([]);
+    setSelectedAssignees([]);
+    setKind("translation");
+  }, [open, targetLocales]);
+
+  const nativeFilesQuery = useQuery({
+    queryKey: ["project-files", organizationSlug, projectId, "create-job"],
+    enabled: open && !isProviderProject,
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[
+        ":projectId"
+      ].files.$get({
+        param: { organizationSlug, projectId },
+        query: { limit: "500" },
+      });
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to load files");
+      }
+      const body = (await response.json()) as { files: ProjectFileRecord[] };
+      return body.files;
+    },
+  });
+
+  const providerFilesQuery = useQuery({
+    queryKey: ["tms-project-files", organizationSlug, projectId, "create-job"],
+    enabled: open && Boolean(parsedProviderProject),
+    queryFn: async () => {
+      if (!parsedProviderProject) {
+        return [];
+      }
+      const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].projects[
+        ":externalProjectId"
+      ].files.$get({
+        param: {
+          organizationSlug,
+          externalProjectId: parsedProviderProject.externalProjectId,
+        },
+        query: { limit: "500" },
+      });
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to load provider files");
+      }
+      const body = (await response.json()) as {
+        files: Array<{
+          sourcePath: string;
+          filename: string;
+          provider?: { externalResourceId: string; resourceType: string } | null;
+        }>;
+      };
+      return body.files;
+    },
+  });
+
+  const nativeAssigneesQuery = useQuery({
+    queryKey: ["org-members", organizationSlug, "create-job"],
+    enabled: open && !isProviderProject,
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].members.$get({
+        param: { organizationSlug },
+      });
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to load members");
+      }
+      const body = (await response.json()) as {
+        members: Array<{
+          workosUserId: string;
+          displayName: string;
+          email: string;
+          status: string;
+        }>;
+      };
+      return body.members.filter((member) => member.status === "active");
+    },
+  });
+
+  const providerAssigneesQuery = useQuery({
+    queryKey: ["tms-project-members", organizationSlug, projectId, "create-job"],
+    enabled: open && Boolean(parsedProviderProject),
+    queryFn: async () => {
+      if (!parsedProviderProject) {
+        return [];
+      }
+      const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].projects[
+        ":externalProjectId"
+      ].members.$get({
+        param: {
+          organizationSlug,
+          externalProjectId: parsedProviderProject.externalProjectId,
+        },
+      });
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to load project members");
+      }
+      const body = (await response.json()) as {
+        members: Array<{
+          externalUserId: string;
+          username: string;
+          displayName: string;
+          role?: string | null;
+        }>;
+      };
+      return body.members;
+    },
+  });
+
+  const fileOptions = useMemo((): FileOption[] => {
+    if (isProviderProject) {
+      return (providerFilesQuery.data ?? [])
+        .filter(
+          (file) => file.provider?.resourceType === "file" && file.provider.externalResourceId,
+        )
+        .map((file) => ({
+          id: file.provider!.externalResourceId,
+          label: file.sourcePath || file.filename,
+        }));
+    }
+
+    return (nativeFilesQuery.data ?? [])
+      .filter((file) => Boolean(file.storedFileId))
+      .flatMap((file) => {
+        const fileFormat = inferSupportedTranslationFileFormat(file.sourcePath);
+        if (!fileFormat || !file.storedFileId) {
+          return [];
+        }
+        return [
+          {
+            id: file.storedFileId,
+            label: file.sourcePath,
+            storedFileId: file.storedFileId,
+            fileFormat,
+          },
+        ];
+      });
+  }, [isProviderProject, nativeFilesQuery.data, providerFilesQuery.data]);
+
+  const assigneeOptions = useMemo((): AssigneeOption[] => {
+    if (isProviderProject) {
+      return (providerAssigneesQuery.data ?? []).map((member) => ({
+        id: member.externalUserId,
+        label: member.displayName || member.username,
+        secondary: member.role ? `${member.username} · ${member.role}` : member.username,
+      }));
+    }
+
+    return (nativeAssigneesQuery.data ?? []).map((member) => ({
+      id: member.workosUserId,
+      label: member.displayName,
+      secondary: member.email,
+    }));
+  }, [isProviderProject, nativeAssigneesQuery.data, providerAssigneesQuery.data]);
+
+  const filesLoading = isProviderProject
+    ? providerFilesQuery.isLoading
+    : nativeFilesQuery.isLoading;
+  const assigneesLoading = isProviderProject
+    ? providerAssigneesQuery.isLoading
+    : nativeAssigneesQuery.isLoading;
+
+  const createJob = useMutation({
+    mutationFn: async () => {
+      if (!title.trim()) {
+        throw new Error("Enter a job title.");
+      }
+      if (selectedLocales.length === 0) {
+        throw new Error("Select at least one target locale.");
+      }
+      if (selectedFileIds.length === 0) {
+        throw new Error("Select at least one file.");
+      }
+
+      if (parsedProviderProject) {
+        const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].projects[
+          ":externalProjectId"
+        ].jobs.$post({
+          param: {
+            organizationSlug,
+            externalProjectId: parsedProviderProject.externalProjectId,
+          },
+          json: {
+            title: title.trim(),
+            targetLocales: selectedLocales,
+            fileIds: selectedFileIds,
+            kind,
+            ...(description.trim() ? { description: description.trim() } : {}),
+            ...(selectedAssignees.length > 0 ? { assigneeExternalUserIds: selectedAssignees } : {}),
+          },
+        });
+        if (!response.ok) {
+          throw await readApiResponseError(response, "Failed to create Crowdin jobs");
+        }
+        const body = (await response.json()) as { jobs: unknown[] };
+        return { count: body.jobs.length };
+      }
+
+      const selectedFiles = fileOptions.filter((file) => selectedFileIds.includes(file.id));
+      const ownerWorkosUserId = selectedAssignees[0];
+      const createdIds: string[] = [];
+
+      for (const file of selectedFiles) {
+        if (!file.storedFileId || !file.fileFormat) {
+          continue;
+        }
+        const response = await apiClient.api.orgs[":organizationSlug"].projects[
+          ":projectId"
+        ].jobs.$post({
+          param: { organizationSlug, projectId },
+          json: {
+            type: "file",
+            title: title.trim(),
+            ...(ownerWorkosUserId ? { ownerWorkosUserId } : {}),
+            fileInput: {
+              sourceFileId: file.storedFileId,
+              fileFormat: file.fileFormat,
+              sourceLocale,
+              targetLocales: selectedLocales,
+            },
+          },
+        });
+        if (!response.ok) {
+          throw await readApiResponseError(response, "Failed to create translation job");
+        }
+        const body = (await response.json()) as { job: { id: string } };
+        createdIds.push(body.job.id);
+      }
+
+      if (createdIds.length === 0) {
+        throw new Error("No supported files were selected.");
+      }
+
+      return { count: createdIds.length };
+    },
+    onSuccess: async (result) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["jobs", organizationSlug] }),
+        queryClient.invalidateQueries({
+          queryKey: ["project-overview-jobs", organizationSlug, projectId],
+        }),
+        queryClient.invalidateQueries({ queryKey: ["project-files", organizationSlug, projectId] }),
+      ]);
+      toast.success(result.count === 1 ? "Job created" : `${result.count} jobs created`);
+      onCreated?.();
+      onOpenChange(false);
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Failed to create job");
+    },
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[90vh] flex-col gap-0 overflow-hidden p-0 sm:max-w-xl">
+        <DialogHeader className="border-b border-border px-6 py-4">
+          <DialogTitle>Create job</DialogTitle>
+          <DialogDescription>
+            {isProviderProject
+              ? "Create Crowdin tasks with files, locales, and assignees."
+              : "Create native translation jobs with files, locales, and an assignee."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5 overflow-y-auto px-6 py-4">
+          <div className="space-y-2">
+            <Label htmlFor="create-job-title">Title</Label>
+            <Input
+              id="create-job-title"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              placeholder="Release notes · JP + KO"
+              maxLength={256}
+            />
+          </div>
+
+          {isProviderProject ? (
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label>Task type</Label>
+                <Select
+                  value={kind}
+                  onValueChange={(value) => {
+                    if (value === "translation" || value === "proofread") {
+                      setKind(value);
+                    }
+                  }}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="translation">Translation</SelectItem>
+                    <SelectItem value="proofread">Proofread</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="create-job-description">Description</Label>
+                <Textarea
+                  id="create-job-description"
+                  value={description}
+                  onChange={(event) => setDescription(event.target.value)}
+                  rows={2}
+                  maxLength={2048}
+                  placeholder="Optional notes for translators"
+                />
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Source locale: <span className="font-medium text-foreground">{sourceLocale}</span>
+            </p>
+          )}
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between gap-2">
+              <Label>Target locales</Label>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-xs"
+                onClick={() =>
+                  setSelectedLocales(
+                    selectedLocales.length === targetLocales.length ? [] : targetLocales,
+                  )
+                }
+              >
+                {selectedLocales.length === targetLocales.length ? "Clear" : "Select all"}
+              </Button>
+            </div>
+            {targetLocales.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                Add target locales in project settings before creating jobs.
+              </p>
+            ) : (
+              <SelectionList
+                items={targetLocales.map((locale) => ({ id: locale, label: locale }))}
+                selected={selectedLocales}
+                onToggle={(locale) => setSelectedLocales((current) => toggleValue(current, locale))}
+                emptyLabel="No locales available"
+              />
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between gap-2">
+              <Label>Files</Label>
+              <span className="text-xs text-muted-foreground">
+                {selectedFileIds.length} selected
+              </span>
+            </div>
+            {filesLoading ? (
+              <div className="flex h-40 items-center justify-center rounded-md border border-border">
+                <Spinner className="size-4" />
+              </div>
+            ) : (
+              <SelectionList
+                items={fileOptions.map((file) => ({ id: file.id, label: file.label }))}
+                selected={selectedFileIds}
+                onToggle={(fileId) => setSelectedFileIds((current) => toggleValue(current, fileId))}
+                emptyLabel="No files available in this project."
+              />
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label>{isProviderProject ? "Assignees" : "Assignee"}</Label>
+            {assigneesLoading ? (
+              <div className="flex h-40 items-center justify-center rounded-md border border-border">
+                <Spinner className="size-4" />
+              </div>
+            ) : (
+              <SelectionList
+                items={assigneeOptions}
+                selected={selectedAssignees}
+                onToggle={(assigneeId) => {
+                  if (isProviderProject) {
+                    setSelectedAssignees((current) => toggleValue(current, assigneeId));
+                    return;
+                  }
+                  setSelectedAssignees((current) =>
+                    current.includes(assigneeId) ? [] : [assigneeId],
+                  );
+                }}
+                emptyLabel={
+                  isProviderProject
+                    ? "No Crowdin project members found."
+                    : "No organization members available."
+                }
+              />
+            )}
+            {!isProviderProject ? (
+              <p className="text-xs text-muted-foreground">
+                Optional. Native jobs currently support one assignee.
+              </p>
+            ) : null}
+          </div>
+        </div>
+
+        <DialogFooter className="border-t border-border px-6 py-4">
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={
+              createJob.isPending ||
+              !title.trim() ||
+              selectedLocales.length === 0 ||
+              selectedFileIds.length === 0 ||
+              targetLocales.length === 0
+            }
+            onClick={() => createJob.mutate()}
+          >
+            {createJob.isPending ? <Spinner className="size-4" /> : null}
+            Create job
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
@@ -342,7 +342,30 @@ export function CreateJobDialog({
           },
         });
         if (!response.ok) {
-          throw await readApiResponseError(response, "Failed to create Crowdin jobs");
+          const body: unknown = await response.json().catch(() => null);
+          const createdCount =
+            body &&
+            typeof body === "object" &&
+            "createdCount" in body &&
+            typeof (body as { createdCount: unknown }).createdCount === "number"
+              ? (body as { createdCount: number }).createdCount
+              : body &&
+                  typeof body === "object" &&
+                  "jobs" in body &&
+                  Array.isArray((body as { jobs: unknown }).jobs)
+                ? (body as { jobs: unknown[] }).jobs.length
+                : 0;
+          const message =
+            body &&
+            typeof body === "object" &&
+            "message" in body &&
+            typeof (body as { message: unknown }).message === "string"
+              ? (body as { message: string }).message
+              : "Failed to create Crowdin jobs";
+          if (createdCount > 0) {
+            throw new PartialCreateJobsError(message, createdCount);
+          }
+          throw new Error(message);
         }
         const body = (await response.json()) as { jobs: unknown[] };
         return { count: body.jobs.length };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
@@ -35,6 +35,16 @@ import {
 } from "@/lib/translation/file-formats";
 import { cn } from "@/lib/primitives/cn";
 
+class PartialCreateJobsError extends Error {
+  readonly createdCount: number;
+
+  constructor(message: string, createdCount: number) {
+    super(message);
+    this.name = "PartialCreateJobsError";
+    this.createdCount = createdCount;
+  }
+}
+
 type CreateJobDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -339,13 +349,13 @@ export function CreateJobDialog({
       }
 
       const selectedFiles = fileOptions.filter((file) => selectedFileIds.includes(file.id));
+      const eligibleFiles = selectedFiles.filter(
+        (file) => Boolean(file.storedFileId) && Boolean(file.fileFormat),
+      );
       const ownerWorkosUserId = selectedAssignees[0];
       const createdIds: string[] = [];
 
-      for (const file of selectedFiles) {
-        if (!file.storedFileId || !file.fileFormat) {
-          continue;
-        }
+      for (const file of eligibleFiles) {
         const response = await apiClient.api.orgs[":organizationSlug"].projects[
           ":projectId"
         ].jobs.$post({
@@ -355,15 +365,25 @@ export function CreateJobDialog({
             title: title.trim(),
             ...(ownerWorkosUserId ? { ownerWorkosUserId } : {}),
             fileInput: {
-              sourceFileId: file.storedFileId,
-              fileFormat: file.fileFormat,
+              sourceFileId: file.storedFileId!,
+              fileFormat: file.fileFormat!,
               sourceLocale,
               targetLocales: selectedLocales,
             },
           },
         });
         if (!response.ok) {
-          throw await readApiResponseError(response, "Failed to create translation job");
+          const failure = await readApiResponseError(
+            response,
+            "Failed to create translation job",
+          );
+          if (createdIds.length > 0) {
+            throw new PartialCreateJobsError(
+              `Created ${createdIds.length} of ${eligibleFiles.length} jobs, then failed: ${failure.message}`,
+              createdIds.length,
+            );
+          }
+          throw failure;
         }
         const body = (await response.json()) as { job: { id: string } };
         createdIds.push(body.job.id);
@@ -387,7 +407,21 @@ export function CreateJobDialog({
       onCreated?.();
       onOpenChange(false);
     },
-    onError: (error) => {
+    onError: async (error) => {
+      if (error instanceof PartialCreateJobsError && error.createdCount > 0) {
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: ["jobs", organizationSlug] }),
+          queryClient.invalidateQueries({
+            queryKey: ["project-overview-jobs", organizationSlug, projectId],
+          }),
+          queryClient.invalidateQueries({
+            queryKey: ["project-files", organizationSlug, projectId],
+          }),
+        ]);
+        toast.warning(
+          `${error.createdCount} job${error.createdCount === 1 ? "" : "s"} created before the error. Refresh the jobs list before retrying to avoid duplicates.`,
+        );
+      }
       toast.error(error instanceof Error ? error.message : "Failed to create job");
     },
   });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
@@ -341,7 +341,7 @@ export function CreateJobDialog({
             ...(selectedAssignees.length > 0 ? { assigneeExternalUserIds: selectedAssignees } : {}),
           },
         });
-        if (!response.ok) {
+        if (!response.ok || response.status === 207) {
           const body: unknown = await response.json().catch(() => null);
           const createdCount =
             body &&

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
-import { TranslateIcon } from "@hugeicons/core-free-icons";
+import { Add01Icon, TranslateIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
 import { TmsUserConnectionErrorPanel } from "@/components/app-shell/tms-user-connection-prompt";
@@ -17,7 +17,9 @@ import { readTmsProviderListResponse } from "@/lib/providers/jobs/tms-provider-l
 import { isTmsUserConnectionRequiredError } from "@/lib/providers/credentials/tms-user-connection-shared";
 
 import { useActiveTmsProvider } from "../../_hooks/use-active-tms-provider";
+import { useProjectPageQuery } from "../../projects/[projectId]/_components/project-page-shell";
 
+import { CreateJobDialog } from "./create-job-dialog";
 import {
   JobsPageErrorMessage,
   JobsPageView,
@@ -189,10 +191,14 @@ export function JobsPageContent({
 }) {
   const searchParams = useSearchParams();
   const [statusFilter, setStatusFilter] = useState(() => readInitialStatusFilter(searchParams));
+  const [createJobOpen, setCreateJobOpen] = useState(false);
   const parsedProviderProject = projectId ? parseProviderProjectId(projectId) : null;
   const isProviderProjectScope = Boolean(parsedProviderProject);
   const activeTmsProviderQuery = useActiveTmsProvider(organizationSlug);
   const hasActiveTmsConnection = Boolean(activeTmsProviderQuery.data);
+  const projectQuery = useProjectPageQuery(organizationSlug, projectId ?? "", {
+    enabled: Boolean(projectId),
+  });
 
   const nativeJobsQueryKey = [
     "jobs",
@@ -260,27 +266,54 @@ export function JobsPageContent({
       ? assignedNativeJobsQuery.isLoading || createdNativeJobsQuery.isLoading
       : nativeJobsQuery.isLoading;
 
+  const canCreateJob = Boolean(projectId);
+  const sourceLocale = projectQuery.data?.sourceLocale?.trim() || "en";
+  const targetLocales = projectQuery.data?.targetLocales ?? [];
+
   return (
-    <JobsPageView
-      assignedNativeJobs={assignedNativeJobs}
-      createdNativeJobs={createdNativeJobs}
-      hasActiveTmsConnection={
-        hasActiveTmsConnection || tmsJobsQuery.isLoading || tmsJobsQuery.isFetching
-      }
-      isNativeLoading={isNativeLoading}
-      isProviderProjectScope={isProviderProjectScope}
-      isTmsLoading={tmsJobsQuery.isLoading || tmsJobsQuery.isFetching}
-      nativeError={nativeError}
-      nativeJobs={nativeJobs}
-      onStatusFilterChange={setStatusFilter}
-      organizationSlug={organizationSlug}
-      projectId={projectId}
-      renderError={renderProductionJobsError}
-      renderJobLink={renderProductionJobLink}
-      scope={scope}
-      statusFilter={statusFilter}
-      tmsError={tmsJobsQuery.error}
-      tmsJobs={tmsJobs}
-    />
+    <>
+      <JobsPageView
+        assignedNativeJobs={assignedNativeJobs}
+        createdNativeJobs={createdNativeJobs}
+        hasActiveTmsConnection={
+          hasActiveTmsConnection || tmsJobsQuery.isLoading || tmsJobsQuery.isFetching
+        }
+        headerActions={
+          canCreateJob ? (
+            <Button type="button" size="sm" onClick={() => setCreateJobOpen(true)}>
+              <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
+              Create job
+            </Button>
+          ) : null
+        }
+        isNativeLoading={isNativeLoading}
+        isProviderProjectScope={isProviderProjectScope}
+        isTmsLoading={tmsJobsQuery.isLoading || tmsJobsQuery.isFetching}
+        nativeError={nativeError}
+        nativeJobs={nativeJobs}
+        onStatusFilterChange={setStatusFilter}
+        organizationSlug={organizationSlug}
+        projectId={projectId}
+        renderError={renderProductionJobsError}
+        renderJobLink={renderProductionJobLink}
+        scope={scope}
+        statusFilter={statusFilter}
+        tmsError={tmsJobsQuery.error}
+        tmsJobs={tmsJobs}
+      />
+      {projectId ? (
+        <CreateJobDialog
+          open={createJobOpen}
+          onOpenChange={setCreateJobOpen}
+          organizationSlug={organizationSlug}
+          projectId={projectId}
+          sourceLocale={sourceLocale}
+          targetLocales={targetLocales}
+          onCreated={async () => {
+            await Promise.all([nativeJobsQuery.refetch(), tmsJobsQuery.refetch()]);
+          }}
+        />
+      ) : null}
+    </>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
@@ -228,6 +228,16 @@ function getInputPayloadString(job: ApiJob, key: string) {
 
 export function getJobName(job: ApiJob) {
   if (job.externalTitle) return formatJobName(job.externalTitle);
+  const metadataTitle =
+    typeof job.inputPayload === "object" &&
+    job.inputPayload &&
+    "metadata" in job.inputPayload &&
+    typeof (job.inputPayload as { metadata?: unknown }).metadata === "object" &&
+    (job.inputPayload as { metadata?: { title?: unknown } }).metadata &&
+    typeof (job.inputPayload as { metadata: { title?: unknown } }).metadata.title === "string"
+      ? (job.inputPayload as { metadata: { title: string } }).metadata.title
+      : null;
+  if (metadataTitle) return formatJobName(metadataTitle);
   if (job.kind === "review" && job.reviewCriteria)
     return formatJobName(`Review: ${job.reviewCriteria}`);
   if (job.kind === "sync" && job.syncConnectorKind)
@@ -587,6 +597,7 @@ export function JobsPageView({
   buildJobDetailHref: buildDetailHref = buildJobDetailHref,
   createdNativeJobs = [],
   hasActiveTmsConnection = false,
+  headerActions,
   initialSearch = "",
   initialStatusFilter = "all",
   isNativeLoading,
@@ -609,6 +620,7 @@ export function JobsPageView({
   buildJobDetailHref?: typeof buildJobDetailHref;
   createdNativeJobs?: JobRow[];
   hasActiveTmsConnection?: boolean;
+  headerActions?: ReactNode;
   initialSearch?: string;
   initialStatusFilter?: JobsStatusFilter;
   isNativeLoading: boolean;
@@ -830,6 +842,7 @@ export function JobsPageView({
           icon={Task01Icon}
           section="Jobs"
           description="Translation, review, QA, and sync work from Hyperlocalise and your TMS."
+          actions={headerActions}
         />
         {jobsSection}
       </ProjectPageShell>
@@ -847,6 +860,7 @@ export function JobsPageView({
             ? "Hyperlocalise and live TMS work assigned to you or created by you."
             : "Hyperlocalise jobs and live TMS jobs tracked across the workspace."
         }
+        actions={headerActions}
       />
       {jobsSection}
     </WorkspacePageShell>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-types.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-types.ts
@@ -161,6 +161,10 @@ export function canMarkJobFailed(job: JobDetailRecord) {
   return job.status === "queued" || job.status === "running";
 }
 
+export function canCancelJob(job: JobDetailRecord) {
+  return !isProviderBackedJob(job) && (job.status === "queued" || job.status === "running");
+}
+
 export function buildJobsListHref(organizationSlug: string, projectId: string) {
   return `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs`;
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-content.tsx
@@ -33,7 +33,12 @@ import {
   isNativeFileTranslationJob,
   NativeJobSourceFilesSection,
 } from "./native-job-detail-helpers";
-import { canMarkJobFailed, canRetryJob, isProviderBackedJob } from "./job-detail-types";
+import {
+  canCancelJob,
+  canMarkJobFailed,
+  canRetryJob,
+  isProviderBackedJob,
+} from "./job-detail-types";
 
 async function parseActionError(response: Response, fallback: string) {
   let error: string | undefined;
@@ -58,6 +63,7 @@ export function NativeJobDetailContent({
   projectId: string;
 }) {
   const [markFailedDialogOpen, setMarkFailedDialogOpen] = useState(false);
+  const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
   const queryClient = useQueryClient();
   const jobQueryKey = ["job", organizationSlug, projectId, jobId] as const;
 
@@ -129,6 +135,30 @@ export function NativeJobDetailContent({
     },
   });
 
+  const cancelJob = useMutation({
+    mutationFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].jobs[":jobId"].cancel.$post({
+        param: { organizationSlug, jobId },
+      });
+
+      if (!response.ok) {
+        throw new Error(await parseActionError(response, "Failed to cancel job"));
+      }
+
+      const body = (await response.json()) as { job: JobDetailRecord };
+      return body.job;
+    },
+    onSuccess: async (updatedJob) => {
+      queryClient.setQueryData(jobQueryKey, updatedJob);
+      await queryClient.invalidateQueries({ queryKey: ["jobs", organizationSlug] });
+      setCancelDialogOpen(false);
+      toast.success("Job cancelled");
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Failed to cancel job");
+    },
+  });
+
   const job = jobQuery.data;
   const layout = job ? jobDetailTaskLayoutFromRecord(job) : null;
   const catHref = job ? buildJobCatHref(organizationSlug, projectId, job) : null;
@@ -161,18 +191,28 @@ export function NativeJobDetailContent({
         <Button
           size="sm"
           variant="outline"
-          disabled={retryJob.isPending || markJobFailed.isPending}
+          disabled={retryJob.isPending || markJobFailed.isPending || cancelJob.isPending}
           onClick={() => retryJob.mutate()}
         >
           <HugeiconsIcon icon={RefreshIcon} strokeWidth={1.8} />
           {retryJob.isPending ? "Retrying..." : "Retry job"}
         </Button>
       ) : null}
+      {canCancelJob(job) ? (
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={retryJob.isPending || markJobFailed.isPending || cancelJob.isPending}
+          onClick={() => setCancelDialogOpen(true)}
+        >
+          Cancel job
+        </Button>
+      ) : null}
       {canMarkJobFailed(job) ? (
         <Button
           size="sm"
           variant="destructive"
-          disabled={retryJob.isPending || markJobFailed.isPending}
+          disabled={retryJob.isPending || markJobFailed.isPending || cancelJob.isPending}
           onClick={() => setMarkFailedDialogOpen(true)}
         >
           <HugeiconsIcon icon={StopCircleIcon} strokeWidth={1.8} />
@@ -261,6 +301,35 @@ export function NativeJobDetailContent({
             >
               <HugeiconsIcon icon={StopCircleIcon} strokeWidth={1.8} />
               {markJobFailed.isPending ? "Marking..." : "Mark failed"}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={cancelDialogOpen}
+        onOpenChange={(open) => {
+          if (!cancelJob.isPending) {
+            setCancelDialogOpen(open);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Cancel this job?</AlertDialogTitle>
+            <AlertDialogDescription>
+              The job will move to cancelled and stop running. You can create a new job if you need
+              the work again.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={cancelJob.isPending}>Keep job</AlertDialogCancel>
+            <Button
+              variant="destructive"
+              disabled={cancelJob.isPending}
+              onClick={() => cancelJob.mutate()}
+            >
+              {cancelJob.isPending ? "Cancelling..." : "Cancel job"}
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
@@ -1,7 +1,20 @@
 "use client";
 
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 import { useAppShellBreadcrumbAppend } from "@/components/app-shell/store/use-app-shell-breadcrumb";
 import { apiClient } from "@/lib/api-client-instance";
 import type { TmsProviderLiveJobDetail } from "@/lib/providers/jobs/tms-provider-live";
@@ -12,6 +25,7 @@ import { ProviderJobDescriptionField } from "../../../../../jobs/_components/pro
 import { useProviderJobLocaleReadiness } from "../../../../../_hooks/use-provider-job-locale-readiness";
 import { ProviderLiveJobDetailView } from "./provider-live-job-detail-view";
 import { TmsLiveJobFilesSection } from "./tms/tms-live-job-files-section";
+import { buildJobsListHref } from "./job-detail-types";
 
 export function ProviderLiveJobDetailContent({
   jobId,
@@ -24,11 +38,14 @@ export function ProviderLiveJobDetailContent({
   projectId: string;
   canEditProviderJobDescription: boolean;
 }) {
+  const router = useRouter();
   const queryClient = useQueryClient();
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const jobQueryKey = ["tms-provider-job", organizationSlug, jobId] as const;
   const parsedJobId = parseProviderJobId(jobId);
   const showComments =
     parsedJobId?.providerKind === "crowdin" || parsedJobId?.providerKind === "lokalise";
+  const canDeleteJob = parsedJobId?.providerKind === "crowdin";
 
   const jobQuery = useQuery({
     queryKey: jobQueryKey,
@@ -48,6 +65,28 @@ export function ProviderLiveJobDetailContent({
     },
   });
 
+  const deleteJob = useMutation({
+    mutationFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].jobs[
+        ":encodedJobId"
+      ].$delete({
+        param: { organizationSlug, encodedJobId: jobId },
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to delete job (${response.status})`);
+      }
+    },
+    onSuccess: async () => {
+      setDeleteDialogOpen(false);
+      await queryClient.invalidateQueries({ queryKey: ["jobs", organizationSlug] });
+      toast.success("Crowdin task deleted");
+      router.push(buildJobsListHref(organizationSlug, projectId));
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Failed to delete job");
+    },
+  });
+
   const localeReadinessQuery = useProviderJobLocaleReadiness({
     organizationSlug,
     externalProjectId: parsedJobId?.externalProjectId,
@@ -61,48 +100,81 @@ export function ProviderLiveJobDetailContent({
   });
 
   return (
-    <ProviderLiveJobDetailView
-      jobId={jobId}
-      organizationSlug={organizationSlug}
-      projectId={projectId}
-      canEditProviderJobDescription={canEditProviderJobDescription}
-      job={jobQuery.data}
-      isLoading={jobQuery.isLoading}
-      error={jobQuery.isError ? jobQuery.error : undefined}
-      localeReadinessLoading={localeReadinessQuery.isLoading}
-      localeReadinessOverride={localeReadinessQuery.data ?? null}
-      isRefreshing={jobQuery.isFetching}
-      onRefresh={() => {
-        void queryClient.invalidateQueries({ queryKey: jobQueryKey });
-      }}
-      showComments={showComments}
-      renderDescriptionField={({ description, editable }) => (
-        <ProviderJobDescriptionField
-          organizationSlug={organizationSlug}
-          encodedJobId={jobId}
-          description={description}
-          editable={editable}
-          queryKey={jobQueryKey}
-        />
-      )}
-      renderFilesSection={({
-        job,
-        jobId: encodedJobId,
-        organizationSlug: orgSlug,
-        projectId: projId,
-      }) => (
-        <TmsLiveJobFilesSection
-          organizationSlug={orgSlug}
-          projectId={projId}
-          encodedJobId={encodedJobId}
-          highlightLocale={
-            typeof job.externalProviderPayload.languageId === "string"
-              ? job.externalProviderPayload.languageId
-              : (job.externalTargetLocales?.[0] ?? null)
+    <>
+      <ProviderLiveJobDetailView
+        jobId={jobId}
+        organizationSlug={organizationSlug}
+        projectId={projectId}
+        canEditProviderJobDescription={canEditProviderJobDescription}
+        job={jobQuery.data}
+        isLoading={jobQuery.isLoading}
+        error={jobQuery.isError ? jobQuery.error : undefined}
+        localeReadinessLoading={localeReadinessQuery.isLoading}
+        localeReadinessOverride={localeReadinessQuery.data ?? null}
+        isRefreshing={jobQuery.isFetching}
+        onRefresh={() => {
+          void queryClient.invalidateQueries({ queryKey: jobQueryKey });
+        }}
+        onDelete={canDeleteJob ? () => setDeleteDialogOpen(true) : undefined}
+        isDeleting={deleteJob.isPending}
+        showComments={showComments}
+        renderDescriptionField={({ description, editable }) => (
+          <ProviderJobDescriptionField
+            organizationSlug={organizationSlug}
+            encodedJobId={jobId}
+            description={description}
+            editable={editable}
+            queryKey={jobQueryKey}
+          />
+        )}
+        renderFilesSection={({
+          job,
+          jobId: encodedJobId,
+          organizationSlug: orgSlug,
+          projectId: projId,
+        }) => (
+          <TmsLiveJobFilesSection
+            organizationSlug={orgSlug}
+            projectId={projId}
+            encodedJobId={encodedJobId}
+            highlightLocale={
+              typeof job.externalProviderPayload.languageId === "string"
+                ? job.externalProviderPayload.languageId
+                : (job.externalTargetLocales?.[0] ?? null)
+            }
+            queueFilter={resolveDefaultJobCatQueueFilter(job)}
+          />
+        )}
+      />
+
+      <AlertDialog
+        open={deleteDialogOpen}
+        onOpenChange={(open) => {
+          if (!deleteJob.isPending) {
+            setDeleteDialogOpen(open);
           }
-          queueFilter={resolveDefaultJobCatQueueFilter(job)}
-        />
-      )}
-    />
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Crowdin task?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This permanently deletes the task in Crowdin. This cannot be undone from
+              Hyperlocalise.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteJob.isPending}>Keep task</AlertDialogCancel>
+            <Button
+              variant="destructive"
+              disabled={deleteJob.isPending}
+              onClick={() => deleteJob.mutate()}
+            >
+              {deleteJob.isPending ? "Deleting..." : "Delete task"}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
@@ -72,7 +72,7 @@ export function ProviderLiveJobDetailContent({
       ].$delete({
         param: { organizationSlug, encodedJobId: jobId },
       });
-      if (!response.ok) {
+      if (response.status !== 204 && !response.ok) {
         throw new Error(`Failed to delete job (${response.status})`);
       }
     },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-view.tsx
@@ -45,6 +45,8 @@ export function ProviderLiveJobDetailView({
   jobId,
   localeReadinessLoading = false,
   localeReadinessOverride,
+  onDelete,
+  isDeleting = false,
   onRefresh,
   organizationSlug,
   projectId,
@@ -60,10 +62,12 @@ export function ProviderLiveJobDetailView({
   error?: unknown;
   isLoading: boolean;
   isRefreshing?: boolean;
+  isDeleting?: boolean;
   job?: TmsProviderLiveJobDetail;
   jobId: string;
   localeReadinessLoading?: boolean;
   localeReadinessOverride?: Record<string, unknown> | null;
+  onDelete?: () => void;
   onRefresh?: () => void;
   organizationSlug: string;
   projectId: string;
@@ -112,9 +116,24 @@ export function ProviderLiveJobDetailView({
         )
       ) : null}
       {onRefresh ? (
-        <Button size="sm" variant="outline" disabled={isRefreshing} onClick={onRefresh}>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={isRefreshing || isDeleting}
+          onClick={onRefresh}
+        >
           <HugeiconsIcon icon={RefreshIcon} strokeWidth={1.8} />
           {isRefreshing ? "Refreshing..." : "Refresh"}
+        </Button>
+      ) : null}
+      {onDelete ? (
+        <Button
+          size="sm"
+          variant="destructive"
+          disabled={isRefreshing || isDeleting}
+          onClick={onDelete}
+        >
+          {isDeleting ? "Deleting..." : "Delete task"}
         </Button>
       ) : null}
       {showViewStrings && catHref ? (

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -298,6 +298,16 @@ export interface CrowdinCreateTaskRequest {
   dateTo?: string;
 }
 
+export interface CrowdinProjectMember {
+  id: number;
+  username: string;
+  fullName?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  avatarUrl?: string | null;
+  role?: string | null;
+}
+
 export interface CrowdinLanguageTranslation {
   stringId: number;
   contentType: string;
@@ -1094,6 +1104,14 @@ export class CrowdinApiClient {
       request,
     );
     return response.data;
+  }
+
+  async deleteTask(projectId: number, taskId: number): Promise<void> {
+    await this.delete(`/projects/${projectId}/tasks/${taskId}`);
+  }
+
+  async listProjectMembers(projectId: number): Promise<CrowdinProjectMember[]> {
+    return this.listPaginated<CrowdinProjectMember>(`/projects/${projectId}/members`);
   }
 
   async editTaskDescription(

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-job-task-fetcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-job-task-fetcher.test.ts
@@ -418,4 +418,46 @@ describe("fetchCrowdinJobTasks", () => {
       }),
     ).rejects.toThrow("crowdin_task_source_scope_ambiguous");
   });
+
+  it("lists Crowdin project members through the provider adapter", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      expect(String(url)).toContain("/projects/1/members");
+      return Response.json({
+        data: [
+          {
+            data: {
+              id: 42,
+              username: "translator1",
+              fullName: "Ada Translator",
+              avatarUrl: "https://example.com/a.png",
+              role: "translator",
+            },
+          },
+        ],
+        pagination: { offset: 0, limit: 1 },
+      });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const result = await crowdinTmsProvider.listProjectMembers({
+      organizationId: "org-1",
+      projectId: "project-1",
+      externalProjectId: "1",
+      credential: { baseUrl: "https://api.crowdin.test/api/v2" } as never,
+      project: {} as never,
+      secretMaterial: "test-token",
+    });
+
+    expect(result).toEqual([
+      {
+        externalUserId: "42",
+        username: "translator1",
+        displayName: "Ada Translator",
+        avatarUrl: "https://example.com/a.png",
+        role: "translator",
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
@@ -380,7 +380,9 @@ export class CrowdinTmsProvider extends TmsProvider {
   /**
    * Lists Crowdin project members and maps them to shared assignee metadata.
    */
-  async listProjectMembers(scope: TmsProviderProjectScope): Promise<ExternalTmsProjectMemberMetadata[]> {
+  async listProjectMembers(
+    scope: TmsProviderProjectScope,
+  ): Promise<ExternalTmsProjectMemberMetadata[]> {
     const client = this.createClient(scope);
     const projectId = this.parseProjectId(scope.externalProjectId);
 

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
@@ -57,6 +57,7 @@ import { normalizeProviderTranslationMemoryMatch } from "@/lib/providers/contrac
 import type { NormalizedTranslationMemoryMatch } from "@/lib/providers/contracts/translation-memory-match";
 import type {
   ExternalTmsJobTaskMetadata,
+  ExternalTmsProjectMemberMetadata,
   ExternalTmsProjectMetadata,
 } from "@/lib/providers/jobs/tms-provider-types";
 import { TmsProviderLiveError } from "@/lib/providers/jobs/tms-provider-live-error";
@@ -374,6 +375,36 @@ export class CrowdinTmsProvider extends TmsProvider {
     }
 
     return true;
+  }
+
+  /**
+   * Lists Crowdin project members and maps them to shared assignee metadata.
+   */
+  async listProjectMembers(scope: TmsProviderProjectScope): Promise<ExternalTmsProjectMemberMetadata[]> {
+    const client = this.createClient(scope);
+    const projectId = this.parseProjectId(scope.externalProjectId);
+
+    let members: Awaited<ReturnType<CrowdinApiClient["listProjectMembers"]>>;
+    try {
+      members = await client.listProjectMembers(projectId);
+    } catch (error) {
+      this.rethrowAuthError(error);
+      throw error;
+    }
+
+    return members.map((member) => {
+      const displayName =
+        member.fullName?.trim() ||
+        [member.firstName, member.lastName].filter(Boolean).join(" ").trim() ||
+        member.username;
+      return {
+        externalUserId: String(member.id),
+        username: member.username,
+        displayName,
+        avatarUrl: member.avatarUrl ?? null,
+        role: member.role ?? null,
+      };
+    });
   }
 
   /**

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
@@ -361,6 +361,21 @@ export class CrowdinTmsProvider extends TmsProvider {
     return this.mapTaskToJobTaskMetadata(created, {});
   }
 
+  async deleteJobTask(scope: TmsProviderJobScope) {
+    const client = this.createClient(scope);
+    const projectId = this.parseProjectId(scope.externalProjectId);
+    const taskId = this.parseCrowdinId(scope.externalJobId, "taskId");
+
+    try {
+      await client.deleteTask(projectId, taskId);
+    } catch (error) {
+      this.rethrowAuthError(error);
+      throw error;
+    }
+
+    return true;
+  }
+
   /**
    * Imports glossaries linked to the Crowdin project, including term rows per target locale.
    *

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/tms-provider-registry.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/tms-provider-registry.ts
@@ -19,6 +19,7 @@ import type {
   ExternalTmsJobTaskDeleter,
   ExternalTmsJobTaskFetcher,
   ExternalTmsProjectFetcher,
+  ExternalTmsProjectMemberFetcher,
   ExternalTmsReviewPuller,
   ExternalTmsTranslationMemoryFetcher,
   ExternalTmsTranslationPusher,
@@ -42,6 +43,7 @@ function hasProviderMethodOverride(
     | "pushComments"
     | "createJobTask"
     | "deleteJobTask"
+    | "listProjectMembers"
     | "searchGlossaryMatches"
     | "searchTranslationMemoryMatches",
 ): boolean {
@@ -134,6 +136,19 @@ function asJobTaskDeleter(provider: TmsProvider): ExternalTmsJobTaskDeleter {
       project: input.project,
       secretMaterial: input.secretMaterial,
       externalJobId: input.externalJobId,
+    });
+}
+
+function asProjectMemberFetcher(provider: TmsProvider): ExternalTmsProjectMemberFetcher {
+  const bound = provider.listProjectMembers.bind(provider);
+  return async (input) =>
+    bound({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      externalProjectId: input.externalProjectId,
+      credential: input.credential,
+      project: input.project,
+      secretMaterial: input.secretMaterial,
     });
 }
 
@@ -315,6 +330,10 @@ export function providerSupportsTaskDelete(providerKind: ExternalTmsProviderKind
   return hasProviderMethodOverride(tmsProviders[providerKind], "deleteJobTask");
 }
 
+export function providerSupportsProjectMemberList(providerKind: ExternalTmsProviderKind): boolean {
+  return hasProviderMethodOverride(tmsProviders[providerKind], "listProjectMembers");
+}
+
 export function providerSupportsGlossaryMatch(providerKind: ExternalTmsProviderKind): boolean {
   return (
     providerSupportsFeature(providerKind, "glossary.search") &&
@@ -365,6 +384,15 @@ export function getProviderJobTaskDeleter(
     return null;
   }
   return asJobTaskDeleter(tmsProviders[providerKind]);
+}
+
+export function getProviderProjectMemberFetcher(
+  providerKind: ExternalTmsProviderKind,
+): ExternalTmsProjectMemberFetcher | null {
+  if (!providerSupportsProjectMemberList(providerKind)) {
+    return null;
+  }
+  return asProjectMemberFetcher(tmsProviders[providerKind]);
 }
 
 export function getProviderGlossaryMatcher(

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/tms-provider-registry.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/tms-provider-registry.ts
@@ -16,6 +16,7 @@ import type {
   ExternalTmsFileKeyFetcher,
   ExternalTmsGlossaryFetcher,
   ExternalTmsJobTaskCreator,
+  ExternalTmsJobTaskDeleter,
   ExternalTmsJobTaskFetcher,
   ExternalTmsProjectFetcher,
   ExternalTmsReviewPuller,
@@ -40,6 +41,7 @@ function hasProviderMethodOverride(
     | "pullReview"
     | "pushComments"
     | "createJobTask"
+    | "deleteJobTask"
     | "searchGlossaryMatches"
     | "searchTranslationMemoryMatches",
 ): boolean {
@@ -119,6 +121,20 @@ function asJobTaskCreator(provider: TmsProvider): ExternalTmsJobTaskCreator {
     }
     return created;
   };
+}
+
+function asJobTaskDeleter(provider: TmsProvider): ExternalTmsJobTaskDeleter {
+  const bound = provider.deleteJobTask.bind(provider);
+  return async (input) =>
+    bound({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      externalProjectId: input.externalProjectId,
+      credential: input.credential,
+      project: input.project,
+      secretMaterial: input.secretMaterial,
+      externalJobId: input.externalJobId,
+    });
 }
 
 function asGlossaryFetcher(provider: TmsProvider): ExternalTmsGlossaryFetcher {
@@ -295,6 +311,10 @@ export function providerSupportsTaskCreate(providerKind: ExternalTmsProviderKind
   );
 }
 
+export function providerSupportsTaskDelete(providerKind: ExternalTmsProviderKind): boolean {
+  return hasProviderMethodOverride(tmsProviders[providerKind], "deleteJobTask");
+}
+
 export function providerSupportsGlossaryMatch(providerKind: ExternalTmsProviderKind): boolean {
   return (
     providerSupportsFeature(providerKind, "glossary.search") &&
@@ -336,6 +356,15 @@ export function getProviderJobTaskCreator(
     return null;
   }
   return asJobTaskCreator(tmsProviders[providerKind]);
+}
+
+export function getProviderJobTaskDeleter(
+  providerKind: ExternalTmsProviderKind,
+): ExternalTmsJobTaskDeleter | null {
+  if (!providerSupportsTaskDelete(providerKind)) {
+    return null;
+  }
+  return asJobTaskDeleter(tmsProviders[providerKind]);
 }
 
 export function getProviderGlossaryMatcher(

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/tms-provider-task-mutations.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/tms-provider-task-mutations.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  providerSupportsTaskCreate,
+  providerSupportsTaskDelete,
+} from "@/lib/providers/adapters/tms-provider-registry";
+
+describe("tms provider task create/delete support", () => {
+  it("supports Crowdin task create and delete", () => {
+    expect(providerSupportsTaskCreate("crowdin")).toBe(true);
+    expect(providerSupportsTaskDelete("crowdin")).toBe(true);
+  });
+
+  it("does not support task create/delete for providers without overrides", () => {
+    expect(providerSupportsTaskCreate("smartling")).toBe(false);
+    expect(providerSupportsTaskDelete("smartling")).toBe(false);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/contracts/tms-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/contracts/tms-provider.ts
@@ -7,6 +7,7 @@ import type {
   ExternalTmsGlossaryMetadata,
   ExternalTmsJobTaskCreateRequest,
   ExternalTmsJobTaskMetadata,
+  ExternalTmsProjectMemberMetadata,
   ExternalTmsProjectMetadata,
   ExternalTmsSourceFileUpload,
   ExternalTmsSourceFileUploadError,
@@ -215,6 +216,10 @@ export abstract class TmsProvider {
 
   deleteJobTask(_scope: TmsProviderJobScope): Promise<boolean> {
     return Promise.resolve(false);
+  }
+
+  listProjectMembers(_scope: TmsProviderProjectScope): Promise<ExternalTmsProjectMemberMetadata[]> {
+    return Promise.resolve([]);
   }
 
   abstract fetchGlossaries(scope: TmsProviderProjectScope): Promise<ExternalTmsGlossaryMetadata[]>;

--- a/apps/hyperlocalise-web/src/lib/providers/contracts/tms-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/contracts/tms-provider.ts
@@ -213,6 +213,10 @@ export abstract class TmsProvider {
     return Promise.resolve(null);
   }
 
+  deleteJobTask(_scope: TmsProviderJobScope): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+
   abstract fetchGlossaries(scope: TmsProviderProjectScope): Promise<ExternalTmsGlossaryMetadata[]>;
 
   abstract fetchTranslationMemories(

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.test.ts
@@ -21,7 +21,7 @@ describe("getTmsProviderLiveErrorStatus", () => {
     ["smartling_auth_invalid", 401],
     ["provider_fetcher_unavailable", 501],
     ["provider_description_edit_unsupported", 501],
-    ["provider_task_create_partial", 500],
+    ["provider_task_create_partial", 207],
     ["unknown_code", 500],
   ] as const)("maps %s to %i", (code, status) => {
     expect(getTmsProviderLiveErrorStatus(code)).toBe(status);
@@ -49,7 +49,7 @@ describe("tmsProviderLiveErrorResponse", () => {
     );
 
     expect(captured).toEqual({
-      status: 500,
+      status: 207,
       body: {
         error: "provider_task_create_partial",
         message: "Created 2 of 3 jobs, then failed: boom",

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { getTmsProviderLiveErrorStatus } from "./tms-provider-live-error-response";
+import { TmsProviderLivePartialCreateError } from "./tms-provider-live-error";
+import {
+  getTmsProviderLiveErrorStatus,
+  tmsProviderLiveErrorResponse,
+} from "./tms-provider-live-error-response";
 
 describe("getTmsProviderLiveErrorStatus", () => {
   it.each([
@@ -17,8 +21,41 @@ describe("getTmsProviderLiveErrorStatus", () => {
     ["smartling_auth_invalid", 401],
     ["provider_fetcher_unavailable", 501],
     ["provider_description_edit_unsupported", 501],
+    ["provider_task_create_partial", 500],
     ["unknown_code", 500],
   ] as const)("maps %s to %i", (code, status) => {
     expect(getTmsProviderLiveErrorStatus(code)).toBe(status);
+  });
+});
+
+describe("tmsProviderLiveErrorResponse", () => {
+  it("includes created jobs for partial provider create failures", async () => {
+    const jobs = [{ id: "job-1" }, { id: "job-2" }];
+    let captured: { body: unknown; status: number } | null = null;
+    const c = {
+      json(body: object, status: number) {
+        captured = { body, status };
+        return new Response(JSON.stringify(body), { status }) as never;
+      },
+    };
+
+    tmsProviderLiveErrorResponse(
+      c,
+      new TmsProviderLivePartialCreateError(
+        "Created 2 of 3 jobs, then failed: boom",
+        jobs.length,
+        jobs,
+      ),
+    );
+
+    expect(captured).toEqual({
+      status: 500,
+      body: {
+        error: "provider_task_create_partial",
+        message: "Created 2 of 3 jobs, then failed: boom",
+        createdCount: 2,
+        jobs,
+      },
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.ts
@@ -13,7 +13,7 @@ type JsonContext = {
   ): Response & TypedResponse<T, U, "json">;
 };
 
-export type TmsProviderLiveErrorStatus = 400 | 401 | 404 | 500 | 501;
+export type TmsProviderLiveErrorStatus = 207 | 400 | 401 | 404 | 500 | 501;
 export type TmsProviderLiveErrorBody = {
   error: string;
   message: string;
@@ -51,6 +51,8 @@ export function getTmsProviderLiveErrorStatus(code: string): TmsProviderLiveErro
     case "provider_cat_unsupported":
     case "provider_cat_all_files_unsupported":
       return 501;
+    case "provider_task_create_partial":
+      return 207;
     default:
       return 500;
   }

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.ts
@@ -1,7 +1,10 @@
 import type { TypedResponse } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 
-import { TmsProviderLiveError } from "@/lib/providers/jobs/tms-provider-live-error";
+import {
+  TmsProviderLiveError,
+  TmsProviderLivePartialCreateError,
+} from "@/lib/providers/jobs/tms-provider-live-error";
 
 type JsonContext = {
   json<T extends object, U extends ContentfulStatusCode>(
@@ -11,7 +14,12 @@ type JsonContext = {
 };
 
 export type TmsProviderLiveErrorStatus = 400 | 401 | 404 | 500 | 501;
-export type TmsProviderLiveErrorBody = { error: string; message: string };
+export type TmsProviderLiveErrorBody = {
+  error: string;
+  message: string;
+  createdCount?: number;
+  jobs?: unknown[];
+};
 
 export function getTmsProviderLiveErrorStatus(code: string): TmsProviderLiveErrorStatus {
   switch (code) {
@@ -52,6 +60,18 @@ export function tmsProviderLiveErrorResponse(
   c: JsonContext,
   error: unknown,
 ): Response & TypedResponse<TmsProviderLiveErrorBody, TmsProviderLiveErrorStatus, "json"> {
+  if (error instanceof TmsProviderLivePartialCreateError) {
+    return c.json(
+      {
+        error: error.code,
+        message: error.message,
+        createdCount: error.createdCount,
+        jobs: error.jobs,
+      },
+      getTmsProviderLiveErrorStatus(error.code),
+    );
+  }
+
   if (error instanceof TmsProviderLiveError) {
     return c.json(
       { error: error.code, message: error.message },

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error.ts
@@ -7,3 +7,19 @@ export class TmsProviderLiveError extends Error {
     this.name = "TmsProviderLiveError";
   }
 }
+
+/**
+ * Raised when some provider jobs were created before a later locale/task failed.
+ * Callers should expose {@link createdCount} / {@link jobs} so clients can refresh
+ * and avoid duplicate retries for the locales that already succeeded.
+ */
+export class TmsProviderLivePartialCreateError extends TmsProviderLiveError {
+  constructor(
+    message: string,
+    readonly createdCount: number,
+    readonly jobs: unknown[],
+  ) {
+    super("provider_task_create_partial", message);
+    this.name = "TmsProviderLivePartialCreateError";
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -56,7 +56,10 @@ import {
 } from "@/lib/providers/adapters/smartling/smartling-provider";
 import { sourceContentType } from "@/lib/file-storage/source-file-metadata";
 import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-with-concurrency";
-import { TmsProviderLiveError } from "@/lib/providers/jobs/tms-provider-live-error";
+import {
+  TmsProviderLiveError,
+  TmsProviderLivePartialCreateError,
+} from "@/lib/providers/jobs/tms-provider-live-error";
 import { normalizeProviderAssigneeCandidates } from "@/lib/providers/jobs/tms-provider-assignee-match";
 import {
   API_TOKEN_AUTH_MODE,
@@ -161,7 +164,7 @@ function mapCrowdinLiveProjectToMetadata(project: CrowdinProject): ExternalTmsPr
 
 type ExternalTmsProject = typeof schema.projects.$inferSelect;
 
-export { TmsProviderLiveError };
+export { TmsProviderLiveError, TmsProviderLivePartialCreateError };
 
 export type TmsProviderConnection = {
   providerKind: ExternalTmsProviderKind;
@@ -3317,6 +3320,7 @@ export async function createTmsProviderLiveJobs(
       `Creating jobs is not supported for ${context.providerKind}.`,
     );
   }
+  const createJobTask = creator;
 
   const targetLocales = [
     ...new Set(input.targetLocales.map((locale) => locale.trim()).filter(Boolean)),
@@ -3353,32 +3357,69 @@ export async function createTmsProviderLiveJobs(
       .filter(Boolean)
       .map((externalUserId) => ({ externalUserId })) ?? [];
 
-  const createdTasks = await mapWithConcurrency(targetLocales, 3, async (targetLocale) => {
-    try {
-      return await creator({
-        organizationId: context.organizationId,
-        projectId: liveProject.id,
-        providerKind: context.providerKind,
-        externalProjectId,
-        credential: context.credential,
-        project: liveProject,
-        secretMaterial: context.secretMaterial,
-        task: {
-          title: input.title,
-          targetLocale,
-          fileIds,
-          kind: input.kind ?? "translation",
-          description: input.description ?? null,
-          ...(assignees.length > 0 ? { assignees } : {}),
-        },
-      });
-    } catch (error) {
-      rethrowProviderFetcherError(error);
-      throw error;
-    }
-  });
+  // Settle in-flight locale creates instead of aborting via mapWithConcurrency:
+  // already-started Crowdin API calls may still succeed, and discarding those
+  // results leaves the client unaware of tasks that already exist on retry.
+  const createdByLocale: Array<ExternalTmsJobTaskMetadata | null> = Array.from(
+    { length: targetLocales.length },
+    () => null,
+  );
+  const errorsByLocale: Array<Error | null> = Array.from(
+    { length: targetLocales.length },
+    () => null,
+  );
+  let nextIndex = 0;
+  let stopScheduling = false;
+  const concurrency = Math.min(3, targetLocales.length);
 
-  return createdTasks.map((task) =>
+  async function createLocaleWorker() {
+    while (true) {
+      if (stopScheduling) {
+        return;
+      }
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      if (currentIndex >= targetLocales.length) {
+        return;
+      }
+
+      const targetLocale = targetLocales[currentIndex]!;
+      try {
+        createdByLocale[currentIndex] = await createJobTask({
+          organizationId: context.organizationId,
+          projectId: liveProject.id,
+          providerKind: context.providerKind,
+          externalProjectId,
+          credential: context.credential,
+          project: liveProject,
+          secretMaterial: context.secretMaterial,
+          task: {
+            title: input.title,
+            targetLocale,
+            fileIds,
+            kind: input.kind ?? "translation",
+            description: input.description ?? null,
+            ...(assignees.length > 0 ? { assignees } : {}),
+          },
+        });
+      } catch (error) {
+        stopScheduling = true;
+        try {
+          rethrowProviderFetcherError(error);
+        } catch (mapped) {
+          errorsByLocale[currentIndex] =
+            mapped instanceof Error ? mapped : new Error("Failed to create provider jobs");
+        }
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: concurrency }, () => createLocaleWorker()));
+
+  const createdTasks = createdByLocale.flatMap((task) => (task ? [task] : []));
+  const firstError = errorsByLocale.find((error) => error != null) ?? null;
+
+  const jobs = createdTasks.map((task) =>
     mapLiveJob({
       providerKind: context.providerKind,
       externalProjectId,
@@ -3386,6 +3427,19 @@ export async function createTmsProviderLiveJobs(
       task,
     }),
   );
+
+  if (firstError) {
+    if (jobs.length > 0) {
+      throw new TmsProviderLivePartialCreateError(
+        `Created ${jobs.length} of ${targetLocales.length} jobs, then failed: ${firstError.message}`,
+        jobs.length,
+        jobs,
+      );
+    }
+    throw firstError;
+  }
+
+  return jobs;
 }
 
 export async function deleteTmsProviderLiveJob(

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -69,6 +69,8 @@ import {
   type ExternalTmsProviderCredentialSummary,
 } from "@/lib/providers/credentials/organization-external-tms-provider-credentials";
 import {
+  getProviderJobTaskCreator,
+  getProviderJobTaskDeleter,
   tmsProviderGlossaryFetchers,
   tmsProviderFileKeyFetchers,
   tmsProviderJobTaskFetchers,
@@ -87,7 +89,9 @@ import {
   mapProviderStatusToNormalized,
   type ExternalTmsFileKeyMetadata,
   type ExternalTmsGlossaryMetadata,
+  type ExternalTmsJobTaskCreateRequest,
   type ExternalTmsJobTaskMetadata,
+  type ExternalTmsProjectMemberMetadata,
   type ExternalTmsProjectMetadata,
   type ExternalTmsTranslationMemoryMetadata,
 } from "@/lib/providers/jobs/tms-provider-types";
@@ -3287,6 +3291,210 @@ export async function listTmsProviderLiveJobComments(
     createdAt: comment.createdAt,
     updatedAt: comment.updatedAt,
   }));
+}
+
+export async function createTmsProviderLiveJobs(
+  organizationId: string,
+  externalProjectId: string,
+  input: {
+    title: string;
+    targetLocales: string[];
+    fileIds: string[];
+    assigneeExternalUserIds?: string[];
+    kind?: Extract<ExternalTmsJobTaskCreateRequest["kind"], "translation" | "proofread" | "review">;
+    description?: string | null;
+    actorUserId: string;
+  },
+): Promise<TmsProviderLiveJob[]> {
+  const context = await loadActiveTmsProviderContext(organizationId, {
+    actorUserId: input.actorUserId,
+  });
+  const creator = getProviderJobTaskCreator(context.providerKind);
+  if (!creator) {
+    throw new TmsProviderLiveError(
+      "provider_task_create_unsupported",
+      `Creating jobs is not supported for ${context.providerKind}.`,
+    );
+  }
+
+  const targetLocales = [
+    ...new Set(input.targetLocales.map((locale) => locale.trim()).filter(Boolean)),
+  ];
+  if (targetLocales.length === 0) {
+    throw new TmsProviderLiveError("target_locales_required", "Select at least one target locale.");
+  }
+
+  const fileIds = [...new Set(input.fileIds.map((fileId) => fileId.trim()).filter(Boolean))];
+  if (fileIds.length === 0) {
+    throw new TmsProviderLiveError("file_ids_required", "Select at least one file.");
+  }
+
+  const projectMetadata = await resolveLiveProjectMetadata(context, externalProjectId);
+  if (!projectMetadata) {
+    throw new TmsProviderLiveError("project_not_found", "Provider project was not found.");
+  }
+
+  const liveProject = buildLiveProviderProject({
+    organizationId: context.organizationId,
+    credentialId: context.credential.id,
+    providerKind: context.providerKind,
+    externalProjectId: projectMetadata.externalProjectId,
+    name: projectMetadata.name,
+    sourceLocale: projectMetadata.sourceLocale ?? "en",
+    targetLocales: projectMetadata.targetLocales ?? [],
+    externalProjectUrl: projectMetadata.externalProjectUrl,
+    isActive: projectMetadata.isActive,
+  });
+
+  const assignees =
+    input.assigneeExternalUserIds
+      ?.map((externalUserId) => externalUserId.trim())
+      .filter(Boolean)
+      .map((externalUserId) => ({ externalUserId })) ?? [];
+
+  const createdTasks = await mapWithConcurrency(targetLocales, 3, async (targetLocale) => {
+    try {
+      return await creator({
+        organizationId: context.organizationId,
+        projectId: liveProject.id,
+        providerKind: context.providerKind,
+        externalProjectId,
+        credential: context.credential,
+        project: liveProject,
+        secretMaterial: context.secretMaterial,
+        task: {
+          title: input.title,
+          targetLocale,
+          fileIds,
+          kind: input.kind ?? "translation",
+          description: input.description ?? null,
+          ...(assignees.length > 0 ? { assignees } : {}),
+        },
+      });
+    } catch (error) {
+      rethrowProviderFetcherError(error);
+      throw error;
+    }
+  });
+
+  return createdTasks.map((task) =>
+    mapLiveJob({
+      providerKind: context.providerKind,
+      externalProjectId,
+      projectName: projectMetadata.name,
+      task,
+    }),
+  );
+}
+
+export async function deleteTmsProviderLiveJob(
+  organizationId: string,
+  encodedJobId: string,
+  actorUserId: string,
+): Promise<boolean> {
+  const parsed = parseProviderJobId(encodedJobId);
+  if (!parsed) {
+    throw new TmsProviderLiveError("invalid_encoded_job_id", "Job id is not a provider job id.");
+  }
+
+  const context = await loadActiveTmsProviderContext(organizationId, { actorUserId });
+  if (context.providerKind !== parsed.providerKind) {
+    return false;
+  }
+
+  const deleter = getProviderJobTaskDeleter(context.providerKind);
+  if (!deleter) {
+    throw new TmsProviderLiveError(
+      "provider_task_delete_unsupported",
+      `Deleting jobs is not supported for ${context.providerKind}.`,
+    );
+  }
+
+  const projectMetadata = await resolveLiveProjectMetadata(context, parsed.externalProjectId);
+  if (!projectMetadata) {
+    return false;
+  }
+
+  const liveProject = buildLiveProviderProject({
+    organizationId: context.organizationId,
+    credentialId: context.credential.id,
+    providerKind: context.providerKind,
+    externalProjectId: projectMetadata.externalProjectId,
+    name: projectMetadata.name,
+    sourceLocale: projectMetadata.sourceLocale ?? "en",
+    targetLocales: projectMetadata.targetLocales ?? [],
+    externalProjectUrl: projectMetadata.externalProjectUrl,
+    isActive: projectMetadata.isActive,
+  });
+
+  try {
+    return await deleter({
+      organizationId: context.organizationId,
+      projectId: liveProject.id,
+      providerKind: context.providerKind,
+      externalProjectId: parsed.externalProjectId,
+      credential: context.credential,
+      project: liveProject,
+      secretMaterial: context.secretMaterial,
+      externalJobId: parsed.externalJobId,
+    });
+  } catch (error) {
+    rethrowProviderFetcherError(error);
+    throw error;
+  }
+}
+
+export async function listTmsProviderLiveProjectMembers(
+  organizationId: string,
+  externalProjectId: string,
+  options?: { actorUserId?: string | null },
+): Promise<ExternalTmsProjectMemberMetadata[]> {
+  const context = await loadActiveTmsProviderContext(organizationId, {
+    actorUserId: options?.actorUserId,
+  });
+
+  if (context.providerKind !== "crowdin") {
+    throw new TmsProviderLiveError(
+      "provider_members_unsupported",
+      `Listing project members is not supported for ${context.providerKind}.`,
+    );
+  }
+
+  const projectId = Number(externalProjectId);
+  if (!Number.isInteger(projectId) || projectId <= 0) {
+    throw new TmsProviderLiveError(
+      "invalid_crowdin_project_id",
+      "Crowdin project identifier is invalid.",
+    );
+  }
+
+  const client = new CrowdinApiClient({
+    token: context.secretMaterial,
+    baseUrl: context.credential.baseUrl ?? undefined,
+  });
+
+  try {
+    const members = await client.listProjectMembers(projectId);
+    return members.map((member) => {
+      const displayName =
+        member.fullName?.trim() ||
+        [member.firstName, member.lastName].filter(Boolean).join(" ").trim() ||
+        member.username;
+      return {
+        externalUserId: String(member.id),
+        username: member.username,
+        displayName,
+        avatarUrl: member.avatarUrl ?? null,
+        role: member.role ?? null,
+      };
+    });
+  } catch (error) {
+    if (error instanceof CrowdinApiError && error.status === 401) {
+      throw new TmsProviderLiveError("crowdin_auth_invalid", "Crowdin credentials are invalid.");
+    }
+    rethrowProviderFetcherError(error);
+    throw error;
+  }
 }
 
 export async function updateTmsProviderLiveJobDescription(

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -71,6 +71,7 @@ import {
 import {
   getProviderJobTaskCreator,
   getProviderJobTaskDeleter,
+  getProviderProjectMemberFetcher,
   tmsProviderGlossaryFetchers,
   tmsProviderFileKeyFetchers,
   tmsProviderJobTaskFetchers,
@@ -3453,45 +3454,42 @@ export async function listTmsProviderLiveProjectMembers(
     actorUserId: options?.actorUserId,
   });
 
-  if (context.providerKind !== "crowdin") {
+  const fetcher = getProviderProjectMemberFetcher(context.providerKind);
+  if (!fetcher) {
     throw new TmsProviderLiveError(
       "provider_members_unsupported",
       `Listing project members is not supported for ${context.providerKind}.`,
     );
   }
 
-  const projectId = Number(externalProjectId);
-  if (!Number.isInteger(projectId) || projectId <= 0) {
-    throw new TmsProviderLiveError(
-      "invalid_crowdin_project_id",
-      "Crowdin project identifier is invalid.",
-    );
+  const projectMetadata = await resolveLiveProjectMetadata(context, externalProjectId);
+  if (!projectMetadata) {
+    throw new TmsProviderLiveError("project_not_found", "Provider project was not found.");
   }
 
-  const client = new CrowdinApiClient({
-    token: context.secretMaterial,
-    baseUrl: context.credential.baseUrl ?? undefined,
+  const liveProject = buildLiveProviderProject({
+    organizationId: context.organizationId,
+    credentialId: context.credential.id,
+    providerKind: context.providerKind,
+    externalProjectId: projectMetadata.externalProjectId,
+    name: projectMetadata.name,
+    sourceLocale: projectMetadata.sourceLocale ?? "en",
+    targetLocales: projectMetadata.targetLocales ?? [],
+    externalProjectUrl: projectMetadata.externalProjectUrl,
+    isActive: projectMetadata.isActive,
   });
 
   try {
-    const members = await client.listProjectMembers(projectId);
-    return members.map((member) => {
-      const displayName =
-        member.fullName?.trim() ||
-        [member.firstName, member.lastName].filter(Boolean).join(" ").trim() ||
-        member.username;
-      return {
-        externalUserId: String(member.id),
-        username: member.username,
-        displayName,
-        avatarUrl: member.avatarUrl ?? null,
-        role: member.role ?? null,
-      };
+    return await fetcher({
+      organizationId: context.organizationId,
+      projectId: liveProject.id,
+      providerKind: context.providerKind,
+      externalProjectId,
+      credential: context.credential,
+      project: liveProject,
+      secretMaterial: context.secretMaterial,
     });
   } catch (error) {
-    if (error instanceof CrowdinApiError && error.status === 401) {
-      throw new TmsProviderLiveError("crowdin_auth_invalid", "Crowdin credentials are invalid.");
-    }
     rethrowProviderFetcherError(error);
     throw error;
   }

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-types.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-types.ts
@@ -170,6 +170,16 @@ export type ExternalTmsProjectMemberMetadata = {
   role?: string | null;
 };
 
+export type ExternalTmsProjectMemberFetcher = (input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  externalProjectId: string;
+  credential: ExternalTmsCredential;
+  project: ExternalTmsProject;
+  secretMaterial: string;
+}) => Promise<ExternalTmsProjectMemberMetadata[]>;
+
 export type ExternalTmsJobTaskFetcher = (input: {
   organizationId: string;
   projectId: string;

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-types.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-types.ts
@@ -151,6 +151,25 @@ export type ExternalTmsJobTaskCreator = (input: {
   task: ExternalTmsJobTaskCreateRequest;
 }) => Promise<ExternalTmsJobTaskMetadata>;
 
+export type ExternalTmsJobTaskDeleter = (input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  externalProjectId: string;
+  credential: ExternalTmsCredential;
+  project: ExternalTmsProject;
+  secretMaterial: string;
+  externalJobId: string;
+}) => Promise<boolean>;
+
+export type ExternalTmsProjectMemberMetadata = {
+  externalUserId: string;
+  username: string;
+  displayName: string;
+  avatarUrl?: string | null;
+  role?: string | null;
+};
+
 export type ExternalTmsJobTaskFetcher = (input: {
   organizationId: string;
   projectId: string;

--- a/docs/adr/2026-07-15-create-job-ui-native-crowdin-design.md
+++ b/docs/adr/2026-07-15-create-job-ui-native-crowdin-design.md
@@ -1,0 +1,22 @@
+# Create job UI for native and Crowdin
+
+## Context
+
+Project Jobs pages could list and inspect work, but humans had no dedicated create surface for locales, files, and assignees. Crowdin task create lived only in the adapter. Deletion/cancel was missing.
+
+## Decision
+
+1. Add a **Create job** dialog on project Jobs pages for both native and Crowdin (`ext:crowdin:*`) projects.
+2. Wire Crowdin through `POST /tms-provider/projects/:id/jobs` (one Crowdin task per locale) and `DELETE /tms-provider/jobs/:id`.
+3. Extend native create with optional title + assignee (`ownerWorkosUserId`) and add `POST .../jobs/:id/cancel`.
+
+## UI
+
+- Title, target locales, multi-file selection, assignees
+- Crowdin: task type (translation/proofread), description, multi-assignee
+- Native: one assignee, one AI translation job per selected file
+
+## Non-goals
+
+- Multi-assignee native jobs
+- Create/delete for Phrase / Lokalise / Smartling in this change


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds dedicated create-job UI for native and Crowdin projects (locales, files, assignees), plus Crowdin task create/delete and native cancel flows.

## Review fixes

1. **DELETE 204** — Crowdin job DELETE returns `c.body(null, 204)` per API conventions; client treats 204 as success.
2. **Partial native create** — Multi-file native create invalidates jobs queries and warns on partial success before surfacing the error, so retries don’t silently duplicate.
3. **Provider members** — `listProjectMembers` is now a `TmsProvider` method with Crowdin override + registry fetcher; live listing no longer instantiates `CrowdinApiClient` directly.
4. **Partial Crowdin create** — Per-locale create settles in-flight tasks, returns `provider_task_create_partial` with `createdCount`/`jobs` as **207 Multi-Status** (not 500), and the dialog treats 207 as partial failure with cache invalidation before retry.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f656e-8f83-73e7-927e-6b09ad756786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f656e-8f83-73e7-927e-6b09ad756786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

