### PR TITLE
fix(cat): keep source file dialog actions visible with All Files

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/cat-header-pickers.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/cat-header-pickers.tsx
@@ -21,7 +21,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { TypographyP } from "@/components/ui/typography";
 import {
   formatLocaleDisplayName,
   formatLocaleOptionLabel,
@@ -181,25 +180,14 @@ export function CatFileTreePicker({
           </div>
         </div>
 
-        <div className="shrink-0 space-y-3 border-t border-border px-6 pt-4 pb-6">
-          <div className="rounded-lg border border-border bg-background px-4 py-3">
-            <TypographyP className="truncate font-mono text-xs text-foreground">
-              {dialogAllFiles ? "All Files" : (selectedFile?.sourcePath ?? "No file selected")}
-            </TypographyP>
-            <TypographyP className="text-xs text-muted-foreground">
-              Double-click a file in the tree, or use Open file.
-            </TypographyP>
-          </div>
-
-          <DialogFooter className="gap-2 sm:justify-end">
-            <Button variant="outline" onClick={() => setOpen(false)}>
-              Cancel
-            </Button>
-            <Button onClick={handleOpenSelectedFile} disabled={!dialogAllFiles && !selectedFile}>
-              Open file
-            </Button>
-          </DialogFooter>
-        </div>
+        <DialogFooter className="shrink-0 gap-2 border-t border-border px-6 pt-4 pb-6 sm:justify-end">
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleOpenSelectedFile} disabled={!dialogAllFiles && !selectedFile}>
+            Open file
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/cat-header-pickers.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/cat-header-pickers.tsx
@@ -143,59 +143,63 @@ export function CatFileTreePicker({
         <FilePickerIcon className="size-4 text-muted-foreground" />
         <span className="min-w-0 truncate">{triggerLabel}</span>
       </DialogTrigger>
-      <DialogContent className="flex h-[min(720px,calc(100svh-2rem))] flex-col gap-4 overflow-hidden sm:max-w-3xl">
-        <DialogHeader className="shrink-0">
+      <DialogContent className="flex h-[min(720px,calc(100svh-2rem))] flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl">
+        <DialogHeader className="shrink-0 gap-2 px-6 pt-6 pe-12 pb-4">
           <DialogTitle>Choose source file</DialogTitle>
           <DialogDescription>
             Browse the file tree, or choose All Files to view strings across every file.
           </DialogDescription>
         </DialogHeader>
 
-        {onSelectAllFiles ? (
-          <Button
-            type="button"
-            variant={dialogAllFiles ? "default" : "outline"}
-            className="h-9 shrink-0 justify-start"
-            onClick={() => {
-              setDialogAllFiles(true);
-              setDialogSourcePath("");
-            }}
-          >
-            All Files
-          </Button>
-        ) : null}
+        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden px-6 py-2">
+          {onSelectAllFiles ? (
+            <Button
+              type="button"
+              variant={dialogAllFiles ? "default" : "outline"}
+              className="h-9 shrink-0 justify-start"
+              onClick={() => {
+                setDialogAllFiles(true);
+                setDialogSourcePath("");
+              }}
+            >
+              All Files
+            </Button>
+          ) : null}
 
-        <div className="min-h-0 flex-1 overflow-hidden rounded-lg border border-border bg-background">
-          <ProjectFilesTree
-            files={files}
-            selectedSourcePath={dialogAllFiles ? "" : dialogSourcePath}
-            onSelectFile={(sourcePath) => {
-              setDialogAllFiles(false);
-              setDialogSourcePath(sourcePath);
-            }}
-            onActivateFile={handleActivateFile}
-            ariaLabel="Source files"
-            fillHeight
-          />
+          <div className="min-h-0 flex-1 overflow-hidden rounded-lg border border-border bg-background">
+            <ProjectFilesTree
+              files={files}
+              selectedSourcePath={dialogAllFiles ? "" : dialogSourcePath}
+              onSelectFile={(sourcePath) => {
+                setDialogAllFiles(false);
+                setDialogSourcePath(sourcePath);
+              }}
+              onActivateFile={handleActivateFile}
+              ariaLabel="Source files"
+              fillHeight
+            />
+          </div>
         </div>
 
-        <div className="shrink-0 rounded-lg border border-border bg-background px-4 py-3">
-          <TypographyP className="truncate font-mono text-xs text-foreground">
-            {dialogAllFiles ? "All Files" : (selectedFile?.sourcePath ?? "No file selected")}
-          </TypographyP>
-          <TypographyP className="text-xs text-muted-foreground">
-            Double-click a file in the tree, or use Open file.
-          </TypographyP>
-        </div>
+        <div className="shrink-0 space-y-3 border-t border-border px-6 pt-4 pb-6">
+          <div className="rounded-lg border border-border bg-background px-4 py-3">
+            <TypographyP className="truncate font-mono text-xs text-foreground">
+              {dialogAllFiles ? "All Files" : (selectedFile?.sourcePath ?? "No file selected")}
+            </TypographyP>
+            <TypographyP className="text-xs text-muted-foreground">
+              Double-click a file in the tree, or use Open file.
+            </TypographyP>
+          </div>
 
-        <DialogFooter className="shrink-0">
-          <Button variant="outline" onClick={() => setOpen(false)}>
-            Cancel
-          </Button>
-          <Button onClick={handleOpenSelectedFile} disabled={!dialogAllFiles && !selectedFile}>
-            Open file
-          </Button>
-        </DialogFooter>
+          <DialogFooter className="gap-2 sm:justify-end">
+            <Button variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleOpenSelectedFile} disabled={!dialogAllFiles && !selectedFile}>
+              Open file
+            </Button>
+          </DialogFooter>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/cat-header-pickers.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/cat-header-pickers.tsx
@@ -143,8 +143,8 @@ export function CatFileTreePicker({
         <FilePickerIcon className="size-4 text-muted-foreground" />
         <span className="min-w-0 truncate">{triggerLabel}</span>
       </DialogTrigger>
-      <DialogContent className="max-h-[min(720px,calc(100svh-2rem))] gap-4 overflow-hidden sm:max-w-3xl">
-        <DialogHeader>
+      <DialogContent className="flex h-[min(720px,calc(100svh-2rem))] flex-col gap-4 overflow-hidden sm:max-w-3xl">
+        <DialogHeader className="shrink-0">
           <DialogTitle>Choose source file</DialogTitle>
           <DialogDescription>
             Browse the file tree, or choose All Files to view strings across every file.
@@ -155,7 +155,7 @@ export function CatFileTreePicker({
           <Button
             type="button"
             variant={dialogAllFiles ? "default" : "outline"}
-            className="h-9 justify-start"
+            className="h-9 shrink-0 justify-start"
             onClick={() => {
               setDialogAllFiles(true);
               setDialogSourcePath("");
@@ -165,7 +165,7 @@ export function CatFileTreePicker({
           </Button>
         ) : null}
 
-        <div className="min-h-0 rounded-lg border border-border bg-background">
+        <div className="min-h-0 flex-1 overflow-hidden rounded-lg border border-border bg-background">
           <ProjectFilesTree
             files={files}
             selectedSourcePath={dialogAllFiles ? "" : dialogSourcePath}
@@ -175,10 +175,11 @@ export function CatFileTreePicker({
             }}
             onActivateFile={handleActivateFile}
             ariaLabel="Source files"
+            fillHeight
           />
         </div>
 
-        <div className="rounded-lg border border-border bg-background px-4 py-3">
+        <div className="shrink-0 rounded-lg border border-border bg-background px-4 py-3">
           <TypographyP className="truncate font-mono text-xs text-foreground">
             {dialogAllFiles ? "All Files" : (selectedFile?.sourcePath ?? "No file selected")}
           </TypographyP>
@@ -187,7 +188,7 @@ export function CatFileTreePicker({
           </TypographyP>
         </div>
 
-        <DialogFooter>
+        <DialogFooter className="shrink-0">
           <Button variant="outline" onClick={() => setOpen(false)}>
             Cancel
           </Button>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
@@ -43,7 +43,7 @@ function buildProjectFilesTreeStyle(fillHeight: boolean): CSSProperties {
     "--trees-selected-bg-override": "var(--muted)",
     "--trees-selected-fg-override": "var(--foreground)",
     "--trees-selected-focused-border-color-override": "var(--ring)",
-  };
+  } as CSSProperties;
 }
 
 function formatNullableDate(value: string | null | undefined) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
@@ -22,26 +22,29 @@ const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
   timeStyle: "short",
 });
 
-const projectFilesTreeStyle = {
-  width: "100%",
-  minWidth: "100%",
-  height: `${TREE_HEIGHT_PX}px`,
-  backgroundColor: "transparent",
-  color: "var(--foreground)",
-  borderColor: "var(--border)",
-  "--trees-bg-override": "var(--background)",
-  "--trees-bg-muted-override": "var(--muted)",
-  "--trees-border-color-override": "var(--border)",
-  "--trees-fg-override": "var(--foreground)",
-  "--trees-fg-muted-override": "var(--muted-foreground)",
-  "--trees-focus-ring-color-override": "var(--ring)",
-  "--trees-input-bg-override": "var(--background)",
-  "--trees-search-bg-override": "var(--background)",
-  "--trees-search-fg-override": "var(--foreground)",
-  "--trees-selected-bg-override": "var(--muted)",
-  "--trees-selected-fg-override": "var(--foreground)",
-  "--trees-selected-focused-border-color-override": "var(--ring)",
-} as CSSProperties;
+function buildProjectFilesTreeStyle(fillHeight: boolean): CSSProperties {
+  return {
+    width: "100%",
+    minWidth: "100%",
+    height: fillHeight ? "100%" : `${TREE_HEIGHT_PX}px`,
+    minHeight: fillHeight ? 0 : undefined,
+    backgroundColor: "transparent",
+    color: "var(--foreground)",
+    borderColor: "var(--border)",
+    "--trees-bg-override": "var(--background)",
+    "--trees-bg-muted-override": "var(--muted)",
+    "--trees-border-color-override": "var(--border)",
+    "--trees-fg-override": "var(--foreground)",
+    "--trees-fg-muted-override": "var(--muted-foreground)",
+    "--trees-focus-ring-color-override": "var(--ring)",
+    "--trees-input-bg-override": "var(--background)",
+    "--trees-search-bg-override": "var(--background)",
+    "--trees-search-fg-override": "var(--foreground)",
+    "--trees-selected-bg-override": "var(--muted)",
+    "--trees-selected-fg-override": "var(--foreground)",
+    "--trees-selected-focused-border-color-override": "var(--ring)",
+  };
+}
 
 function formatNullableDate(value: string | null | undefined) {
   if (!value) return null;
@@ -72,6 +75,7 @@ export function ProjectFilesTree({
   onActivateFile,
   fileActions,
   ariaLabel = "Project files",
+  fillHeight = false,
 }: {
   files: ProjectFileRecord[];
   selectedSourcePath: string | null;
@@ -79,6 +83,8 @@ export function ProjectFilesTree({
   onActivateFile?: (sourcePath: string) => void;
   fileActions?: ProjectFileTreeActionsConfig;
   ariaLabel?: string;
+  /** Stretch to the parent height instead of the fixed TREE_HEIGHT_PX. */
+  fillHeight?: boolean;
 }) {
   if (fileActions) {
     return (
@@ -89,6 +95,7 @@ export function ProjectFilesTree({
         onActivateFile={onActivateFile}
         fileActions={fileActions}
         ariaLabel={ariaLabel}
+        fillHeight={fillHeight}
       />
     );
   }
@@ -100,6 +107,7 @@ export function ProjectFilesTree({
       onSelectFile={onSelectFile}
       onActivateFile={onActivateFile}
       ariaLabel={ariaLabel}
+      fillHeight={fillHeight}
     />
   );
 }
@@ -111,6 +119,7 @@ function ProjectFilesTreeView({
   onActivateFile,
   fileActions,
   ariaLabel = "Project files",
+  fillHeight = false,
 }: {
   files: ProjectFileRecord[];
   selectedSourcePath: string | null;
@@ -118,8 +127,10 @@ function ProjectFilesTreeView({
   onActivateFile?: (sourcePath: string) => void;
   fileActions?: ProjectFileTreeActionsConfig;
   ariaLabel?: string;
+  fillHeight?: boolean;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const treeStyle = useMemo(() => buildProjectFilesTreeStyle(fillHeight), [fillHeight]);
   const displayFiles = useMemo(() => dedupeProjectFilesBySourcePath(files), [files]);
   const paths = useMemo(() => displayFiles.map((file) => file.sourcePath), [displayFiles]);
   const fileByPath = useMemo(
@@ -257,7 +268,12 @@ function ProjectFilesTreeView({
   }
 
   return (
-    <div ref={containerRef} className="flex w-full min-w-0 flex-col">
+    <div
+      ref={containerRef}
+      className={
+        fillHeight ? "flex h-full min-h-0 w-full min-w-0 flex-col" : "flex w-full min-w-0 flex-col"
+      }
+    >
       <PierreFileTree
         aria-label={ariaLabel}
         className="w-full min-w-0 border-0 bg-transparent"
@@ -297,7 +313,7 @@ function ProjectFilesTreeView({
               }
             : undefined
         }
-        style={projectFilesTreeStyle}
+        style={treeStyle}
       />
     </div>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The “Choose source file” dialog clipped **Cancel** / **Open file** when All Files was shown. Content was a flat stack inside a max-height dialog with `overflow-hidden`, so there was no pinned footer for long content.

## Fix

- Restructure to fixed header, flexible body (All Files + tree), and pinned action footer
- Let the tree fill remaining height via `fillHeight`
- Remove the selected-path preview and “Double-click…” hint from the footer

## Verification

- `vp check --fix`: passed
- Related CAT/tree unit tests: passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5dcb507-5eb1-45a9-b5b9-e094a7680746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5dcb507-5eb1-45a9-b5b9-e094a7680746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

