### PR TITLE
fix(cat): resolve native All Files segment target 404s

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -627,6 +627,98 @@ describe("project file CAT routes", () => {
     expect(commentsBody.comments[0]?.externalCommentId).toBeTruthy();
   });
 
+  it("loads native segment targets with All Files sourcePath=*", async () => {
+    isReleaseCatAllFilesEnabledMock.mockResolvedValue(true);
+    const { identity, project, organization } = await projectFixture.createStoredProjectFixture();
+    const headers = await projectFixture.authHeadersFor(identity);
+    const sourcePath = "locales/en.json";
+    const sourceFile = await ensureRepositorySourceFile({
+      organizationId: organization.id,
+      projectId: project.id,
+      sourcePath,
+    });
+
+    const { imported } = await upsertProjectTranslationKeysFromEntries({
+      organizationId: organization.id,
+      projectId: project.id,
+      repositorySourceFileId: sourceFile.id,
+      entries: [{ key: "greeting", text: "Hello", context: null }],
+    });
+    expect(imported).toBe(1);
+
+    const [translationKey] = await db
+      .select({ id: schema.projectTranslationKeys.id })
+      .from(schema.projectTranslationKeys)
+      .where(eq(schema.projectTranslationKeys.repositorySourceFileId, sourceFile.id))
+      .limit(1);
+    expect(translationKey).toBeDefined();
+
+    await db.insert(schema.projectTranslations).values({
+      organizationId: organization.id,
+      projectId: project.id,
+      translationKeyId: translationKey!.id,
+      targetLocale: "fr-FR",
+      text: "Bonjour",
+      status: "needs_review",
+      provenance: "manual",
+    });
+
+    const missingFileResponse = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.segments[":externalStringId"].target.$get(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+          externalStringId: translationKey!.id,
+        },
+        query: { sourcePath: "missing/file.json", targetLocale: "fr-FR" },
+      },
+      { headers },
+    );
+    expect(missingFileResponse.status).toBe(404);
+
+    const allFilesTargetResponse = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.segments[":externalStringId"].target.$get(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+          externalStringId: translationKey!.id,
+        },
+        query: { sourcePath: "*", targetLocale: "fr-FR" },
+      },
+      { headers },
+    );
+
+    expect(allFilesTargetResponse.status).toBe(200);
+    const allFilesTargetBody =
+      (await allFilesTargetResponse.json()) as ProjectFileCatSegmentTargetResponse;
+    expect(allFilesTargetBody.target).toMatchObject({
+      text: "Bonjour",
+      isApproved: false,
+      status: "needs_review",
+    });
+
+    const allFilesCommentsResponse = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.segments[":externalStringId"].comments.$get(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+          externalStringId: translationKey!.id,
+        },
+        query: { sourcePath: "*", targetLocale: "fr-FR" },
+      },
+      { headers },
+    );
+
+    expect(allFilesCommentsResponse.status).toBe(200);
+    expect(await allFilesCommentsResponse.json()).toMatchObject({ comments: [] });
+  });
+
   it("toggles treat-as-image metadata on a native CAT segment", async () => {
     const { identity, project, organization } = await projectFixture.createStoredProjectFixture();
     const headers = await projectFixture.authHeadersFor(identity);

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-segment-target.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-segment-target.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import type { ProjectFileCatTranslation } from "@/api/routes/project/project.schema";
@@ -124,7 +125,7 @@ export function useCatSegmentTargets(input: {
   }>;
   enabled?: boolean;
 }) {
-  const segments = (() => {
+  const segments = useMemo(() => {
     const seen = new Set<string>();
     const unique: typeof input.segments = [];
     for (const segment of input.segments) {
@@ -136,7 +137,8 @@ export function useCatSegmentTargets(input: {
       unique.push(segment);
     }
     return unique;
-  })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- callers memoize input.segments
+  }, [input.segments]);
 
   return useQueries({
     queries: segments.map((segment) =>

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-segment-target.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-segment-target.ts
@@ -111,27 +111,43 @@ export function useCatSegmentTarget(input: {
 export function useCatSegmentTargets(input: {
   organizationSlug: string;
   projectId: string;
+  /** Fallback when a segment does not carry its own sourcePath (single-file CAT). */
   sourcePath: string;
   externalResourceId?: string | null;
   resourceType?: "file" | "key";
   targetLocale: string;
-  externalStringIds: string[];
+  segments: Array<{
+    externalStringId: string;
+    sourcePath?: string | null;
+    externalResourceId?: string | null;
+    resourceType?: "file" | "key" | null;
+  }>;
   enabled?: boolean;
 }) {
-  const externalStringIds = Array.from(
-    new Set(input.externalStringIds.filter((id) => id.trim().length > 0)),
-  );
+  const segments = (() => {
+    const seen = new Set<string>();
+    const unique: typeof input.segments = [];
+    for (const segment of input.segments) {
+      const id = segment.externalStringId.trim();
+      if (!id || seen.has(id)) {
+        continue;
+      }
+      seen.add(id);
+      unique.push(segment);
+    }
+    return unique;
+  })();
 
   return useQueries({
-    queries: externalStringIds.map((externalStringId) =>
+    queries: segments.map((segment) =>
       catSegmentTargetQueryOptions({
         organizationSlug: input.organizationSlug,
         projectId: input.projectId,
-        sourcePath: input.sourcePath,
-        externalResourceId: input.externalResourceId,
-        resourceType: input.resourceType,
+        sourcePath: segment.sourcePath?.trim() || input.sourcePath,
+        externalResourceId: segment.externalResourceId ?? input.externalResourceId,
+        resourceType: segment.resourceType ?? input.resourceType,
         targetLocale: input.targetLocale,
-        externalStringId,
+        externalStringId: segment.externalStringId,
         enabled: input.enabled,
       }),
     ),

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-lazy-segment-sync.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-lazy-segment-sync.tsx
@@ -162,6 +162,28 @@ function useCatLoadedQueueTargetsSync(input: {
 
   const targetsEnabled = input.enabled && Boolean(input.catFile) && segmentIds.length > 0;
 
+  const targetSegments = useMemo(
+    () =>
+      segmentIds.map((externalStringId) => {
+        const queueSegment = input.catFile?.segments.find(
+          (segment) => segment.externalStringId === externalStringId,
+        );
+        return {
+          externalStringId,
+          sourcePath: queueSegment?.sourcePath?.trim() || input.sourcePath,
+          externalResourceId: queueSegment?.externalResourceId ?? resolvedExternalResourceId,
+          resourceType: queueSegment?.resourceType ?? resolvedResourceType,
+        };
+      }),
+    [
+      input.catFile?.segments,
+      input.sourcePath,
+      resolvedExternalResourceId,
+      resolvedResourceType,
+      segmentIds,
+    ],
+  );
+
   const targetQueries = useCatSegmentTargets({
     organizationSlug: input.organizationSlug,
     projectId: input.projectId,
@@ -169,7 +191,7 @@ function useCatLoadedQueueTargetsSync(input: {
     externalResourceId: resolvedExternalResourceId,
     resourceType: resolvedResourceType,
     targetLocale: input.targetLocale,
-    externalStringIds: segmentIds,
+    segments: targetSegments,
     enabled: targetsEnabled,
   });
 

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
@@ -513,6 +513,65 @@ export class NativeCatService extends ProjectServiceBase {
     return updated ? toCatTranslation(updated) : null;
   }
 
+  private async findTranslationKeyForSegment(input: {
+    organizationId: string;
+    projectId: string;
+    sourcePath: string;
+    externalStringId: string;
+  }): Promise<{
+    id: string;
+    metadata: Record<string, unknown> | null;
+  } | null> {
+    // All-files CAT uses the sentinel sourcePath `*`. Keys are scoped to the
+    // project only — callers may also send the real per-segment path.
+    if (isCatAllFilesSourcePath(input.sourcePath)) {
+      const [key] = await this.database
+        .select({
+          id: schema.projectTranslationKeys.id,
+          metadata: schema.projectTranslationKeys.metadata,
+        })
+        .from(schema.projectTranslationKeys)
+        .where(
+          and(
+            eq(schema.projectTranslationKeys.id, input.externalStringId),
+            eq(schema.projectTranslationKeys.organizationId, input.organizationId),
+            eq(schema.projectTranslationKeys.projectId, input.projectId),
+          ),
+        )
+        .limit(1);
+
+      return key ?? null;
+    }
+
+    const sourceFile = await this.translations.getRepositorySourceFileByPath({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      sourcePath: input.sourcePath,
+    });
+
+    if (!sourceFile) {
+      return null;
+    }
+
+    const [key] = await this.database
+      .select({
+        id: schema.projectTranslationKeys.id,
+        metadata: schema.projectTranslationKeys.metadata,
+      })
+      .from(schema.projectTranslationKeys)
+      .where(
+        and(
+          eq(schema.projectTranslationKeys.id, input.externalStringId),
+          eq(schema.projectTranslationKeys.organizationId, input.organizationId),
+          eq(schema.projectTranslationKeys.projectId, input.projectId),
+          eq(schema.projectTranslationKeys.repositorySourceFileId, sourceFile.id),
+        ),
+      )
+      .limit(1);
+
+    return key ?? null;
+  }
+
   async getSegmentTarget(input: {
     organizationId: string;
     projectId: string;
@@ -521,17 +580,20 @@ export class NativeCatService extends ProjectServiceBase {
     externalStringId: string;
     organizationSlug: string;
   }): Promise<ProjectFileCatTranslation | null | "not_found"> {
-    const sourceFile = await this.translations.getRepositorySourceFileByPath({
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-      sourcePath: input.sourcePath,
-    });
+    if (
+      !isCatAllFilesSourcePath(input.sourcePath) &&
+      inferSupportedImageTranslationFileFormat(input.sourcePath)
+    ) {
+      const sourceFile = await this.translations.getRepositorySourceFileByPath({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        sourcePath: input.sourcePath,
+      });
 
-    if (!sourceFile) {
-      return "not_found";
-    }
+      if (!sourceFile) {
+        return "not_found";
+      }
 
-    if (inferSupportedImageTranslationFileFormat(input.sourcePath)) {
       const expectedId = imageFileExternalStringId(sourceFile.id, input.sourcePath);
       if (
         input.externalStringId !== expectedId &&
@@ -579,21 +641,12 @@ export class NativeCatService extends ProjectServiceBase {
       });
     }
 
-    const [key] = await this.database
-      .select({
-        id: schema.projectTranslationKeys.id,
-        metadata: schema.projectTranslationKeys.metadata,
-      })
-      .from(schema.projectTranslationKeys)
-      .where(
-        and(
-          eq(schema.projectTranslationKeys.id, input.externalStringId),
-          eq(schema.projectTranslationKeys.organizationId, input.organizationId),
-          eq(schema.projectTranslationKeys.projectId, input.projectId),
-          eq(schema.projectTranslationKeys.repositorySourceFileId, sourceFile.id),
-        ),
-      )
-      .limit(1);
+    const key = await this.findTranslationKeyForSegment({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      sourcePath: input.sourcePath,
+      externalStringId: input.externalStringId,
+    });
 
     if (!key) {
       return "not_found";
@@ -632,32 +685,19 @@ export class NativeCatService extends ProjectServiceBase {
     targetLocale: string;
     externalStringId: string;
   }): Promise<ProjectFileCatComment[]> {
-    const sourceFile = await this.translations.getRepositorySourceFileByPath({
+    if (
+      !isCatAllFilesSourcePath(input.sourcePath) &&
+      inferSupportedImageTranslationFileFormat(input.sourcePath)
+    ) {
+      return [];
+    }
+
+    const key = await this.findTranslationKeyForSegment({
       organizationId: input.organizationId,
       projectId: input.projectId,
       sourcePath: input.sourcePath,
+      externalStringId: input.externalStringId,
     });
-
-    if (!sourceFile) {
-      return [];
-    }
-
-    if (inferSupportedImageTranslationFileFormat(input.sourcePath)) {
-      return [];
-    }
-
-    const [key] = await this.database
-      .select({ id: schema.projectTranslationKeys.id })
-      .from(schema.projectTranslationKeys)
-      .where(
-        and(
-          eq(schema.projectTranslationKeys.id, input.externalStringId),
-          eq(schema.projectTranslationKeys.organizationId, input.organizationId),
-          eq(schema.projectTranslationKeys.projectId, input.projectId),
-          eq(schema.projectTranslationKeys.repositorySourceFileId, sourceFile.id),
-        ),
-      )
-      .limit(1);
 
     if (!key) {
       return [];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Native All Files CAT (`sourcePath=*`) was returning `404 cat_segment_not_found` when loading segment targets (especially in side-by-side view, which batch-fetches many targets at once).

### Cause
1. **Server:** `getNativeProjectCatSegmentTarget` looked up a repository source file by path. The all-files sentinel `*` is not a real file, so every request failed.
2. **Client:** Side-by-side batch sync passed the workspace `sourcePath` (`*`) for every segment instead of each segment’s real file path (single-segment sync already resolved this correctly).

### Fix
- Native CAT segment target/comments lookup treats `sourcePath=*` as project-scoped key lookup.
- Batch target fetch resolves per-segment `sourcePath` / resource identity from the queue payload.
- Memoize segment dedupe in `useCatSegmentTargets` so `useQueries` keeps a stable segments reference when `input.segments` is unchanged.

### Test
- Added route coverage that asserts `sourcePath=*` returns the translation while a missing real path still 404s.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87c2b084-9676-4aac-86bf-a70eb9636169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87c2b084-9676-4aac-86bf-a70eb9636169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

