### PR TITLE
🧪 Scout: improve printf placeholder detection

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -143,3 +143,7 @@
 ## 2025-07-20 - [QA Mode and Profile Parity Interaction]
 **Learning:** In `ValidateSegment`, QA checks (like `whitespace_only`) are executed after core format and profile parity checks. If a target string contains only whitespace while the source contains text, `validateWhitespaceProfile` will trigger a `format-whitespace-profile` failure (StatusFail) before the `qa-whitespace-only` warning (StatusWarn) is even evaluated.
 **Action:** When testing QA modes via the top-level `ValidateSegment` entry point, ensure the source and target strings are chosen to either specifically trigger or specifically avoid overlapping profile parity violations to maintain test determinism.
+
+## 2026-07-20 - [Comprehensive Printf Placeholder Detection]
+**Learning:** Naive printf placeholder detection (e.g., matching only %s, %d) misses common specifiers like %i, %x, %u and modifiers like width (%02d), precision (%.2f), or length (%ld). This allows critical placeholders to be omitted from translations without triggering validation failures.
+**Action:** Use a comprehensive regex that supports the full range of standard printf specifiers, flags, width, precision, and length modifiers to ensure structural parity is strictly enforced for all placeholder types.

--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -144,6 +144,6 @@
 **Learning:** In `ValidateSegment`, QA checks (like `whitespace_only`) are executed after core format and profile parity checks. If a target string contains only whitespace while the source contains text, `validateWhitespaceProfile` will trigger a `format-whitespace-profile` failure (StatusFail) before the `qa-whitespace-only` warning (StatusWarn) is even evaluated.
 **Action:** When testing QA modes via the top-level `ValidateSegment` entry point, ensure the source and target strings are chosen to either specifically trigger or specifically avoid overlapping profile parity violations to maintain test determinism.
 
-## 2026-07-20 - [Comprehensive Printf Placeholder Detection]
+## 2025-07-20 - [Comprehensive Printf Placeholder Detection]
 **Learning:** Naive printf placeholder detection (e.g., matching only %s, %d) misses common specifiers like %i, %x, %u and modifiers like width (%02d), precision (%.2f), or length (%ld). This allows critical placeholders to be omitted from translations without triggering validation failures.
 **Action:** Use a comprehensive regex that supports the full range of standard printf specifiers, flags, width, precision, and length modifiers to ensure structural parity is strictly enforced for all placeholder types.

--- a/internal/i18n/segmentvalidate/extra_placeholders.go
+++ b/internal/i18n/segmentvalidate/extra_placeholders.go
@@ -11,10 +11,10 @@ import (
 // regex to reduce the number of passes over the input string. The order of
 // alternations is preserved from the original set to maintain priority.
 var combinedPlaceholderPattern = regexp.MustCompile(
-	`%[0-9]+\$[sdf@]|` +
-		`%\([A-Za-z_][\w]*\)[sdf@]|` +
-		`%[sdf]\b|` +
-		`%@|` +
+	`%[0-9]+\$[-+ #0]*[0-9]*(?:\.[0-9]*)?(?:ll|l|hh|h)?[diuXxfsSFeEgG@]|` +
+		`%\([A-Za-z_][\w]*\)[-+ #0]*[0-9]*(?:\.[0-9]*)?(?:ll|l|hh|h)?[diuXxfsSFeEgG@]|` +
+		`%[-+ #0]*[0-9]*(?:\.[0-9]*)?(?:ll|l|hh|h)?[diuXxfsSFeEgG]\b|` +
+		`%[-+ #0]*[0-9]*(?:\.[0-9]*)?(?:ll|l|hh|h)?@|` +
 		`%\{[ \w.-]+\}|` +
 		`\$\{[A-Za-z_][\w.-]*\}|` +
 		`\$[A-Za-z_][\w.+-]*\$`,

--- a/internal/i18n/segmentvalidate/extra_placeholders.go
+++ b/internal/i18n/segmentvalidate/extra_placeholders.go
@@ -11,10 +11,10 @@ import (
 // regex to reduce the number of passes over the input string. The order of
 // alternations is preserved from the original set to maintain priority.
 var combinedPlaceholderPattern = regexp.MustCompile(
-	`%[0-9]+\$[-+ #0]*[0-9]*(?:\.[0-9]*)?(?:ll|l|hh|h)?[diuXxfsSFeEgG@]|` +
-		`%\([A-Za-z_][\w]*\)[-+ #0]*[0-9]*(?:\.[0-9]*)?(?:ll|l|hh|h)?[diuXxfsSFeEgG@]|` +
-		`%[-+ #0]*[0-9]*(?:\.[0-9]*)?(?:ll|l|hh|h)?[diuXxfsSFeEgG]\b|` +
-		`%[-+ #0]*[0-9]*(?:\.[0-9]*)?(?:ll|l|hh|h)?@|` +
+	`%[0-9]+\$[-+ #0]*[0-9]*(?:\.[0-9]*)?(?:ll|l|hh|h)?[diuXxfsSFeEgGcC]|` +
+		`%\([A-Za-z_][\w]*\)[-+ #0]*[0-9]*(?:\.[0-9]*)?(?:ll|l|hh|h)?[diuXxfsSFeEgGcC]|` +
+		`%[-+ #0]*[0-9]*(?:\.[0-9]*)?(?:ll|l|hh|h)?[diuXxfsSFeEgGcC]\b|` +
+		`%(?:[0-9]+\$|\([A-Za-z_][\w]*\))?@|` +
 		`%\{[ \w.-]+\}|` +
 		`\$\{[A-Za-z_][\w.-]*\}|` +
 		`\$[A-Za-z_][\w.+-]*\$`,

--- a/internal/i18n/segmentvalidate/printf_scout_test.go
+++ b/internal/i18n/segmentvalidate/printf_scout_test.go
@@ -15,6 +15,14 @@ func TestExtractExtraPlaceholdersPrintfExtended(t *testing.T) {
 			want: []string{"%i"},
 		},
 		{
+			text: "Char: %c",
+			want: []string{"%c"},
+		},
+		{
+			text: "Wide Char: %C",
+			want: []string{"%C"},
+		},
+		{
 			text: "Hex: %x",
 			want: []string{"%x"},
 		},
@@ -49,6 +57,18 @@ func TestExtractExtraPlaceholdersPrintfExtended(t *testing.T) {
 		{
 			text: "Named: %(count)i",
 			want: []string{"%(count)i"},
+		},
+		{
+			text: "Positional Object: %1$@",
+			want: []string{"%1$@"},
+		},
+		{
+			text: "Named Object: %(obj)@",
+			want: []string{"%(obj)@"},
+		},
+		{
+			text: "Non-standard object with width: %10@",
+			want: nil,
 		},
 	}
 

--- a/internal/i18n/segmentvalidate/printf_scout_test.go
+++ b/internal/i18n/segmentvalidate/printf_scout_test.go
@@ -1,0 +1,122 @@
+package segmentvalidate
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractExtraPlaceholdersPrintfExtended(t *testing.T) {
+	tests := []struct {
+		text string
+		want []string
+	}{
+		{
+			text: "Count: %i",
+			want: []string{"%i"},
+		},
+		{
+			text: "Hex: %x",
+			want: []string{"%x"},
+		},
+		{
+			text: "HEX: %X",
+			want: []string{"%X"},
+		},
+		{
+			text: "Unsigned: %u",
+			want: []string{"%u"},
+		},
+		{
+			text: "Price: %.2f",
+			want: []string{"%.2f"},
+		},
+		{
+			text: "Padded: %02d",
+			want: []string{"%02d"},
+		},
+		{
+			text: "Long: %ld",
+			want: []string{"%ld"},
+		},
+		{
+			text: "Long Unsigned: %lu",
+			want: []string{"%lu"},
+		},
+		{
+			text: "Positional: %1$i",
+			want: []string{"%1$i"},
+		},
+		{
+			text: "Named: %(count)i",
+			want: []string{"%(count)i"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.text, func(t *testing.T) {
+			got := extractExtraPlaceholders(tt.text)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("extractExtraPlaceholders(%q) = %v, want %v", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateSegmentPrintfExtendedParity(t *testing.T) {
+	tests := []struct {
+		name       string
+		source     string
+		target     string
+		wantTokens []string
+		wantID     string
+	}{
+		{
+			name:       "missing %i",
+			source:     "Count: %i",
+			target:     "Count:",
+			wantTokens: []string{"%i"},
+			wantID:     "format-extra-placeholder-mismatch",
+		},
+		{
+			name:       "missing %.2f",
+			source:     "Price: %.2f",
+			target:     "Price:",
+			wantTokens: []string{"%.2f"},
+			wantID:     "format-extra-placeholder-mismatch",
+		},
+		{
+			name:       "missing %02d",
+			source:     "Value: %02d",
+			target:     "Value:",
+			wantTokens: []string{"%02d"},
+			wantID:     "format-extra-placeholder-mismatch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := Request{
+				SourceText: tt.source,
+				TargetText: tt.target,
+				SourcePath: "/pkg/en.json",
+			}
+
+			checks := ValidateSegment(req)
+			var formatCheck *Check
+			for i := range checks {
+				if checks[i].ID == tt.wantID {
+					formatCheck = &checks[i]
+					break
+				}
+			}
+
+			if formatCheck == nil {
+				t.Fatalf("expected %s check, but none found in %+v", tt.wantID, checks)
+			}
+
+			if !reflect.DeepEqual(formatCheck.RelatedTokens, tt.wantTokens) {
+				t.Errorf("RelatedTokens = %v, want %v", formatCheck.RelatedTokens, tt.wantTokens)
+			}
+		})
+	}
+}

--- a/internal/i18n/segmentvalidate/profile_test.go
+++ b/internal/i18n/segmentvalidate/profile_test.go
@@ -14,7 +14,7 @@ func TestExtractExtraPlaceholders(t *testing.T) {
 		{"Path ${HOME}/file", []string{"${HOME}"}},
 		{"Wrap $token$ here", []string{"$token$"}},
 		{"Hello {name}", nil},
-		{"step %i of %d", []string{"%d"}},
+		{"step %i of %d", []string{"%d", "%i"}},
 	}
 	for _, tt := range tests {
 		got := extractExtraPlaceholders(tt.text)


### PR DESCRIPTION
Improved printf-style placeholder detection in `extractExtraPlaceholders` to support a broader range of standard specifiers and modifiers. This ensures that placeholders like `%i`, `%x`, `%u`, or those with width/precision (e.g., `%02d`, `%.2f`) are correctly identified and their presence is enforced during translation validation.

💡 What: Improved printf-style placeholder detection in `extractExtraPlaceholders` to support a broader range of standard specifiers and modifiers.
🎯 Why: The previous implementation missed common specifiers (like `%i`, `%x`, `%u`) and modifiers (width, precision, flags), allowing critical placeholders to be omitted from translations without detection.
🧩 Scope: `internal/i18n/segmentvalidate/extra_placeholders.go` and associated tests.
✅ Verification: Added comprehensive unit tests in `printf_scout_test.go` covering various printf formats. Verified all tests pass in `internal/i18n/segmentvalidate`, `internal/i18n/icuparser`, and `internal/i18n/translationfileparser`.
🛡️ Confidence: Ensures structural parity is strictly enforced for a wider variety of printf-based localization formats, preventing common translation errors.

---
*PR created automatically by Jules for task [8894716972141907948](https://jules.google.com/task/8894716972141907948) started by @cungminh2710*