### PR TITLE
fix(cat): show GitHub repo selection in All Files view

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.test.tsx
@@ -329,4 +329,50 @@ describe("ProjectFileCatPageContent CAT shell", () => {
       screen.queryByText("Select a GitHub repository to look up string context."),
     ).not.toBeInTheDocument();
   });
+
+  it("shows the saved GitHub repository when viewing All Files", async () => {
+    localStorage.setItem("job-cat-repository:acme:proj_1:*", "acme/docs");
+
+    render(
+      <CatTestProviders>
+        <ProjectFileCatPageContent
+          organizationSlug="acme"
+          projectId="proj_1"
+          sourcePath={null}
+          allFiles
+          catAllFilesEnabled
+          highlightLocale="vi"
+        />
+      </CatTestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("GitHub repository")).toBeInTheDocument();
+      expect(screen.getByTestId("cat-workspace")).toHaveAttribute("data-repo", "acme/docs");
+      expect(screen.getByTestId("cat-workspace")).toHaveAttribute("data-source-path", "*");
+    });
+    expect(screen.getByLabelText("Source file")).toHaveTextContent("All Files");
+  });
+
+  it("auto-selects the only enabled repository when viewing All Files", async () => {
+    mockRepositories([{ fullName: "acme/web", enabled: true, archived: false }]);
+
+    render(
+      <CatTestProviders>
+        <ProjectFileCatPageContent
+          organizationSlug="acme"
+          projectId="proj_1"
+          sourcePath={null}
+          allFiles
+          catAllFilesEnabled
+          highlightLocale="vi"
+        />
+      </CatTestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("GitHub repository")).toBeInTheDocument();
+      expect(screen.getByTestId("cat-workspace")).toHaveAttribute("data-repo", "acme/web");
+    });
+  });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
@@ -192,8 +192,9 @@ export function ProjectFileCatPageContent({
     [repositoriesQuery.data],
   );
 
-  const repositoryPreferenceKey = sourcePath
-    ? catFileRepositoryPreferenceKey(organizationSlug, projectId, sourcePath)
+  const repositoryPreferencePath = allFiles ? CAT_ALL_FILES_SOURCE_PATH : sourcePath;
+  const repositoryPreferenceKey = repositoryPreferencePath
+    ? catFileRepositoryPreferenceKey(organizationSlug, projectId, repositoryPreferencePath)
     : null;
 
   const [repositoryOverride, setRepositoryOverride] = useState<string | null>(null);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.test.tsx
@@ -429,4 +429,32 @@ describe("JobCatPageContent CAT shell", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it("shows the saved GitHub repository when viewing All Files", async () => {
+    localStorage.setItem("job-cat-repository:acme:proj_1:*", "acme/docs");
+    loadJobCatJobSourceFilesMock.mockResolvedValue([providerFile]);
+    loadJobCatProviderJobFilesMock.mockResolvedValue([providerFile]);
+    loadJobCatSelectableTargetLocalesMock.mockResolvedValue(["vi", "de-DE"]);
+
+    render(
+      <CatTestProviders>
+        <JobCatPageContent
+          organizationSlug="acme"
+          projectId="proj_1"
+          jobId="job_1"
+          sourcePath="*"
+          storedFileId={null}
+          targetLocale="vi"
+          catAllFilesEnabled
+        />
+      </CatTestProviders>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("GitHub repository")).toBeInTheDocument();
+      expect(screen.getByTestId("cat-workspace")).toHaveAttribute("data-repo", "acme/docs");
+      expect(screen.getByTestId("cat-workspace")).toHaveAttribute("data-source-path", "*");
+    });
+    expect(screen.getByLabelText("Source file")).toHaveTextContent("All Files");
+  });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -266,8 +266,9 @@ export function JobCatPageContent({
     [repositoriesQuery.data],
   );
 
-  const repositoryPreferenceKey = selectedFile
-    ? catFileRepositoryPreferenceKey(organizationSlug, projectId, selectedFile.sourcePath)
+  const repositoryPreferencePath = allFiles ? CAT_ALL_FILES_SOURCE_PATH : selectedFile?.sourcePath;
+  const repositoryPreferenceKey = repositoryPreferencePath
+    ? catFileRepositoryPreferenceKey(organizationSlug, projectId, repositoryPreferencePath)
     : null;
 
   const [repositoryOverride, setRepositoryOverride] = useState<string | null>(null);
@@ -288,6 +289,32 @@ export function JobCatPageContent({
   }, [enabledRepositoryFullNames, repositoryPreferenceKey]);
 
   const selectedRepositoryFullName = repositoryOverride ?? autoSelectedRepositoryFullName;
+
+  const handleRepositoryChange = (nextRepositoryFullName: string) => {
+    if (!repositoryPreferenceKey) {
+      return;
+    }
+
+    writeCatFileRepositoryPreference(repositoryPreferenceKey, nextRepositoryFullName);
+    setRepositoryOverride(nextRepositoryFullName);
+  };
+
+  const repositoryBanner =
+    repositoriesQuery.isError ||
+    (enabledRepositoryFullNames.length > 1 && !selectedRepositoryFullName) ? (
+      <div className="shrink-0 border-b border-border px-3 py-1.5 sm:px-4 lg:px-6">
+        {repositoriesQuery.isError ? (
+          <TypographyP className="text-xs text-muted-foreground">
+            GitHub repositories could not be loaded. Repository context lookup is unavailable.
+          </TypographyP>
+        ) : (
+          <TypographyP className="text-xs text-muted-foreground">
+            Select a GitHub repository to look up string context.
+          </TypographyP>
+        )}
+      </div>
+    ) : null;
+
   const jobTargetLocales = jobLocalesQuery.data ?? [];
   const activeTargetLocale = selectJobCatTargetLocale({
     requestedTargetLocale: targetLocale,
@@ -554,6 +581,14 @@ export function JobCatPageContent({
             onSelectAllFiles={canUseAllFiles ? handleJobSelectAllFiles : undefined}
           />
 
+          {enabledRepositoryFullNames.length > 0 ? (
+            <CatRepositorySelect
+              repositoryFullNames={enabledRepositoryFullNames}
+              selectedRepositoryFullName={selectedRepositoryFullName}
+              onRepositoryChange={handleRepositoryChange}
+            />
+          ) : null}
+
           {jobTargetLocales.length > 0 ? (
             <CatLocaleSelect
               targetLocales={jobTargetLocales}
@@ -562,6 +597,8 @@ export function JobCatPageContent({
             />
           ) : null}
         </div>
+
+        {repositoryBanner}
 
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 py-2 sm:px-4 lg:px-6">
           <ProjectFileCatWorkspace
@@ -572,6 +609,11 @@ export function JobCatPageContent({
             sourcePath={CAT_ALL_FILES_SOURCE_PATH}
             targetLocale={selectedTargetLocale}
             highlightLocale={selectedTargetLocale}
+            repositoryFullName={selectedRepositoryFullName}
+            canLookupFreshContext={canLookupFreshCatRepositoryContext(
+              enabledRepositoryFullNames,
+              selectedRepositoryFullName,
+            )}
             initialSegmentKey={initialSegmentKey}
             initialQueueFilter={initialQueueFilter}
             sourcePathsFilter={serializeCatSourcePathsFilter(jobSourcePaths)}
@@ -677,31 +719,6 @@ export function JobCatPageContent({
       </ProjectPageShell>
     );
   }
-
-  const handleRepositoryChange = (nextRepositoryFullName: string) => {
-    if (!repositoryPreferenceKey) {
-      return;
-    }
-
-    writeCatFileRepositoryPreference(repositoryPreferenceKey, nextRepositoryFullName);
-    setRepositoryOverride(nextRepositoryFullName);
-  };
-
-  const repositoryBanner =
-    repositoriesQuery.isError ||
-    (enabledRepositoryFullNames.length > 1 && !selectedRepositoryFullName) ? (
-      <div className="shrink-0 border-b border-border px-3 py-1.5 sm:px-4 lg:px-6">
-        {repositoriesQuery.isError ? (
-          <TypographyP className="text-xs text-muted-foreground">
-            GitHub repositories could not be loaded. Repository context lookup is unavailable.
-          </TypographyP>
-        ) : (
-          <TypographyP className="text-xs text-muted-foreground">
-            Select a GitHub repository to look up string context.
-          </TypographyP>
-        )}
-      </div>
-    ) : null;
 
   if (isNativeFile) {
     if (!activeTargetLocale) {


### PR DESCRIPTION
## What changed

All Files CAT used an empty `sourcePath` for the repository preference key, so the GitHub selector stayed on the placeholder and could not persist a choice. It now keys preferences on `CAT_ALL_FILES_SOURCE_PATH` for project and job CAT, and job All Files also renders the selector and passes the selection into the workspace.

## How to test

- Open project Strings (All Files) with at least one enabled GitHub repo
- Confirm the selector shows the sole enabled repo, or a previously saved All Files preference
- Change the repo and reload; the selection should stick
- On a job Strings All Files view, confirm the GitHub selector appears and behaves the same
- `vp test` on the two CAT page content test files
- `vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)