### PR TITLE
fix(auth): grant team membership on project create and invite

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
@@ -5,6 +5,7 @@ import { Hono } from "hono";
 import { validator } from "hono/validator";
 
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
+import { hasCapability } from "@/api/auth/policy";
 import { reconcileWorkosMembershipsForUser } from "@/api/auth/workos-membership-reconcile";
 import {
   clearPendingMembershipReplacingInvitation,
@@ -25,6 +26,7 @@ import {
 import { db, schema, type DatabaseClient } from "@/lib/database";
 import type { OrganizationMembershipRole } from "@/lib/database/types";
 import { createLogger, serializeErrorForLog } from "@/lib/log";
+import { ensureDefaultWorkspaceTeamMembership } from "@/lib/teams/default-workspace-team";
 import { membershipRoleToWorkosRoleSlug } from "@/lib/workos/membership-role";
 import { getWorkosServerClient } from "@/lib/workos/server-client";
 
@@ -102,6 +104,26 @@ async function reconcileMemberMembershipFromWorkos(input: {
   });
 }
 
+async function ensureDefaultTeamAccessForInvitedMember(input: {
+  organizationId: string;
+  userId: string;
+  role: OrganizationMembershipRole;
+  database: DatabaseClient;
+}) {
+  // Operators already see every project via teams:write. Non-operators need an
+  // explicit default-team membership or projects they create stay invisible.
+  if (hasCapability(input.role, "teams:write")) {
+    return;
+  }
+
+  await ensureDefaultWorkspaceTeamMembership({
+    organizationId: input.organizationId,
+    userId: input.userId,
+    role: "member",
+    database: input.database,
+  });
+}
+
 async function inviteOrganizationMember(input: {
   organizationId: string;
   email: string;
@@ -151,6 +173,13 @@ async function inviteOrganizationMember(input: {
         .set({ role: input.role })
         .where(eq(schema.organizationMemberships.id, existingMembership.membershipId));
     }
+
+    await ensureDefaultTeamAccessForInvitedMember({
+      organizationId: input.organizationId,
+      userId: existingMembership.localUserId,
+      role: input.role,
+      database,
+    });
 
     return {
       resend: true as const,
@@ -219,6 +248,13 @@ async function inviteOrganizationMember(input: {
       role: schema.organizationMemberships.role,
       createdAt: schema.organizationMemberships.createdAt,
     });
+
+  await ensureDefaultTeamAccessForInvitedMember({
+    organizationId: input.organizationId,
+    userId: user.id,
+    role: input.role,
+    database,
+  });
 
   return {
     membershipId: membership.id,

--- a/apps/hyperlocalise-web/src/api/routes/member/member.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.test.ts
@@ -150,6 +150,88 @@ describe("memberRoutes", () => {
     expect(body.member.role).toBe("admin");
   });
 
+  it("adds invited developers to the default workspace team", async () => {
+    const ownerIdentity = createWorkosIdentity();
+    const headers = await authHeadersFor(ownerIdentity);
+
+    const response = await inviteMemberViaApi(
+      ownerIdentity,
+      { email: "developer-invite@example.com", role: "developer" },
+      headers,
+    );
+
+    expect(response.status).toBe(201);
+
+    const organization = (
+      await db
+        .select({ id: schema.organizations.id })
+        .from(schema.organizations)
+        .where(eq(schema.organizations.slug, ownerIdentity.organization.slug ?? ""))
+        .limit(1)
+    )[0]!;
+
+    const invitedUser = (
+      await db
+        .select({ id: schema.users.id })
+        .from(schema.users)
+        .where(eq(schema.users.email, "developer-invite@example.com"))
+        .limit(1)
+    )[0]!;
+
+    const defaultTeam = (
+      await db
+        .select({ id: schema.teams.id })
+        .from(schema.teams)
+        .where(
+          and(eq(schema.teams.organizationId, organization.id), eq(schema.teams.slug, "default")),
+        )
+        .limit(1)
+    )[0];
+
+    expect(defaultTeam).toBeDefined();
+
+    const [membership] = await db
+      .select({ role: schema.teamMemberships.role })
+      .from(schema.teamMemberships)
+      .where(
+        and(
+          eq(schema.teamMemberships.teamId, defaultTeam!.id),
+          eq(schema.teamMemberships.userId, invitedUser.id),
+        ),
+      )
+      .limit(1);
+
+    expect(membership?.role).toBe("member");
+  });
+
+  it("does not add invited operators to the default workspace team", async () => {
+    const ownerIdentity = createWorkosIdentity();
+    const headers = await authHeadersFor(ownerIdentity);
+
+    const response = await inviteMemberViaApi(
+      ownerIdentity,
+      { email: "manager-invite@example.com", role: "localization_manager" },
+      headers,
+    );
+
+    expect(response.status).toBe(201);
+
+    const invitedUser = (
+      await db
+        .select({ id: schema.users.id })
+        .from(schema.users)
+        .where(eq(schema.users.email, "manager-invite@example.com"))
+        .limit(1)
+    )[0]!;
+
+    const memberships = await db
+      .select({ id: schema.teamMemberships.id })
+      .from(schema.teamMemberships)
+      .where(eq(schema.teamMemberships.userId, invitedUser.id));
+
+    expect(memberships).toEqual([]);
+  });
+
   it("updates a member role", async () => {
     const ownerIdentity = createWorkosIdentity();
     const headers = await authHeadersFor(ownerIdentity);

--- a/apps/hyperlocalise-web/src/api/routes/project/project-team-access.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-team-access.test.ts
@@ -2,7 +2,7 @@ import "dotenv/config";
 
 import { randomUUID } from "node:crypto";
 
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { testClient } from "hono/testing";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
@@ -313,5 +313,59 @@ describe("team-scoped project access", () => {
     const listBody = (await listResponse.json()) as ProjectsResponse;
     const legacyProject = listBody.projects.find((project) => project.id === legacyProjectId);
     expect(legacyProject?.teamId).toBe(defaultTeam.id);
+  });
+
+  it("lets developers list projects they create without a prior team membership", async () => {
+    const admin = createWorkosIdentityWithRole("admin");
+    const developer = createWorkosIdentityForOrganization(admin.organization, "developer");
+
+    await authHeadersFor(admin);
+    await authHeadersFor(developer);
+
+    const createResponse = await client.api.orgs[":organizationSlug"].projects.$post(
+      {
+        param: { organizationSlug: admin.organization.slug ?? "missing-slug" },
+        json: {
+          name: "Developer Created Project",
+          sourceLocale: "en-US",
+          targetLocales: ["fr-FR"],
+        },
+      },
+      { headers: await authHeadersFor(developer) },
+    );
+
+    expect(createResponse.status).toBe(201);
+    const createBody = (await createResponse.json()) as ProjectResponse;
+
+    const listResponse = await client.api.orgs[":organizationSlug"].projects.$get(
+      {
+        param: { organizationSlug: admin.organization.slug ?? "missing-slug" },
+      },
+      { headers: await authHeadersFor(developer) },
+    );
+
+    expect(listResponse.status).toBe(200);
+    const listBody = (await listResponse.json()) as ProjectsResponse;
+    expect(listBody.projects.map((project) => project.id)).toContain(createBody.project.id);
+
+    const developerUserId = await projectFixture.getLocalUserId(developer.user.workosUserId);
+    const [membership] = await db
+      .select({
+        teamId: schema.teamMemberships.teamId,
+        role: schema.teamMemberships.role,
+      })
+      .from(schema.teamMemberships)
+      .where(
+        and(
+          eq(schema.teamMemberships.userId, developerUserId),
+          eq(schema.teamMemberships.teamId, createBody.project.teamId!),
+        ),
+      )
+      .limit(1);
+
+    expect(membership).toEqual({
+      teamId: createBody.project.teamId,
+      role: "member",
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -135,7 +135,10 @@ import {
 import { getVisibleTeamIds, hasOrganizationWideProjectAccess } from "@/api/auth/team-access";
 import { normalizeProjectLocalePatch, type ProjectLocalePatchError } from "@/lib/i18n/locales";
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
-import { ensureDefaultWorkspaceTeam } from "@/lib/teams/default-workspace-team";
+import {
+  ensureDefaultWorkspaceTeam,
+  ensureTeamMembership,
+} from "@/lib/teams/default-workspace-team";
 import { ensureOrganizationProjectRecord } from "@/lib/projects/organization/organization-project-service";
 import { normalizeProjectId } from "@/lib/projects/identity/project-id";
 import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
@@ -289,6 +292,15 @@ const projectStore: ProjectStore = {
         targetLocales: payload.targetLocales,
       })
       .returning();
+
+    // Creators without teams:write only see projects on teams they belong to.
+    // Mirror team-create behavior so the new project is immediately listable.
+    await ensureTeamMembership({
+      teamId,
+      userId: auth.user.localUserId,
+      role: "member",
+      database,
+    });
 
     return project;
   },

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -295,12 +295,14 @@ const projectStore: ProjectStore = {
 
     // Creators without teams:write only see projects on teams they belong to.
     // Mirror team-create behavior so the new project is immediately listable.
-    await ensureTeamMembership({
-      teamId,
-      userId: auth.user.localUserId,
-      role: "member",
-      database,
-    });
+    if (!hasOrganizationWideProjectAccess(auth)) {
+      await ensureTeamMembership({
+        teamId,
+        userId: auth.user.localUserId,
+        role: "member",
+        database,
+      });
+    }
 
     return project;
   },

--- a/apps/hyperlocalise-web/src/lib/onboarding/workspace.test.ts
+++ b/apps/hyperlocalise-web/src/lib/onboarding/workspace.test.ts
@@ -1,0 +1,86 @@
+import { and, eq } from "drizzle-orm";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { provisionWorkspaceInWorkosMock, deleteProvisionedWorkosOrganizationMock } = vi.hoisted(
+  () => ({
+    provisionWorkspaceInWorkosMock: vi.fn(),
+    deleteProvisionedWorkosOrganizationMock: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/workos/provision-workspace-in-workos", () => ({
+  provisionWorkspaceInWorkos: provisionWorkspaceInWorkosMock,
+  deleteProvisionedWorkosOrganization: deleteProvisionedWorkosOrganizationMock,
+}));
+
+import { db, schema } from "@/lib/database";
+import { DEFAULT_WORKSPACE_TEAM_SLUG } from "@/lib/teams/default-workspace-team";
+
+import { createWorkspaceForSessionUser } from "./workspace";
+
+describe("createWorkspaceForSessionUser", () => {
+  const createdOrganizationIds: string[] = [];
+  const createdUserWorkosIds: string[] = [];
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+
+    for (const organizationId of createdOrganizationIds.splice(0)) {
+      await db.delete(schema.organizations).where(eq(schema.organizations.id, organizationId));
+    }
+
+    for (const workosUserId of createdUserWorkosIds.splice(0)) {
+      await db.delete(schema.users).where(eq(schema.users.workosUserId, workosUserId));
+    }
+  });
+
+  it("creates the default team and adds the workspace owner as manager", async () => {
+    const workosUserId = `user_${crypto.randomUUID()}`;
+    const workosOrganizationId = `org_${crypto.randomUUID()}`;
+    const workosMembershipId = `membership_${crypto.randomUUID()}`;
+    createdUserWorkosIds.push(workosUserId);
+
+    provisionWorkspaceInWorkosMock.mockResolvedValue({
+      workosOrganizationId,
+      members: [{ workosUserId, workosMembershipId, role: "admin" }],
+    });
+
+    const result = await createWorkspaceForSessionUser({
+      sessionUser: {
+        id: workosUserId,
+        email: `owner-${crypto.randomUUID()}@example.com`,
+        firstName: "Owner",
+        lastName: "User",
+      },
+      organizationName: "Onboarding Team Workspace",
+    });
+
+    createdOrganizationIds.push(result.organization.id);
+
+    const [team] = await db
+      .select({ id: schema.teams.id, slug: schema.teams.slug })
+      .from(schema.teams)
+      .where(
+        and(
+          eq(schema.teams.organizationId, result.organization.id),
+          eq(schema.teams.slug, DEFAULT_WORKSPACE_TEAM_SLUG),
+        ),
+      )
+      .limit(1);
+
+    expect(team?.slug).toBe(DEFAULT_WORKSPACE_TEAM_SLUG);
+
+    const [membership] = await db
+      .select({ role: schema.teamMemberships.role })
+      .from(schema.teamMemberships)
+      .where(
+        and(
+          eq(schema.teamMemberships.teamId, team!.id),
+          eq(schema.teamMemberships.userId, result.user.id),
+        ),
+      )
+      .limit(1);
+
+    expect(membership?.role).toBe("manager");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/onboarding/workspace.ts
+++ b/apps/hyperlocalise-web/src/lib/onboarding/workspace.ts
@@ -5,6 +5,7 @@ import { eq } from "drizzle-orm";
 import { syncWorkosUser } from "@/api/auth/workos-sync";
 import { db, schema } from "@/lib/database";
 import { slugifyOrganizationName } from "@/lib/onboarding/slugify-organization-name";
+import { ensureDefaultWorkspaceTeamMembership } from "@/lib/teams/default-workspace-team";
 import {
   deleteProvisionedWorkosOrganization,
   provisionWorkspaceInWorkos,
@@ -101,6 +102,13 @@ export async function createWorkspaceForSessionUser(input: {
           userId: user.id,
           role: "admin",
           workosMembershipId: adminMembership.workosMembershipId,
+        });
+
+        await ensureDefaultWorkspaceTeamMembership({
+          organizationId: organization.id,
+          userId: user.id,
+          role: "manager",
+          database: tx,
         });
 
         return {

--- a/apps/hyperlocalise-web/src/lib/teams/default-workspace-team.test.ts
+++ b/apps/hyperlocalise-web/src/lib/teams/default-workspace-team.test.ts
@@ -1,0 +1,91 @@
+import { and, eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+
+import { db, schema } from "@/lib/database";
+import { syncWorkosIdentity } from "@/api/auth/workos-sync";
+
+import {
+  DEFAULT_WORKSPACE_TEAM_NAME,
+  DEFAULT_WORKSPACE_TEAM_SLUG,
+  ensureDefaultWorkspaceTeam,
+  ensureDefaultWorkspaceTeamMembership,
+  ensureTeamMembership,
+} from "./default-workspace-team";
+
+describe("default workspace team membership helpers", () => {
+  const createdOrganizationIds: string[] = [];
+  const createdUserIds: string[] = [];
+
+  beforeEach(async () => {
+    for (const organizationId of createdOrganizationIds.splice(0)) {
+      await db.delete(schema.organizations).where(eq(schema.organizations.id, organizationId));
+    }
+    for (const userId of createdUserIds.splice(0)) {
+      await db.delete(schema.users).where(eq(schema.users.id, userId));
+    }
+  });
+
+  async function createOrganizationAndUser() {
+    const identity = await syncWorkosIdentity(db, {
+      user: {
+        workosUserId: `user_${crypto.randomUUID()}`,
+        email: `dev-${crypto.randomUUID()}@example.com`,
+      },
+      organization: {
+        workosOrganizationId: `org_${crypto.randomUUID()}`,
+        name: "Membership Test Org",
+        slug: `membership-test-${crypto.randomUUID().slice(0, 8)}`,
+      },
+      membership: {
+        workosMembershipId: `membership_${crypto.randomUUID()}`,
+        role: "developer",
+      },
+    });
+
+    createdOrganizationIds.push(identity.organization.id);
+    createdUserIds.push(identity.user.id);
+
+    return identity;
+  }
+
+  it("creates the default workspace team once and reuses it", async () => {
+    const identity = await createOrganizationAndUser();
+
+    const first = await ensureDefaultWorkspaceTeam(identity.organization.id);
+    const second = await ensureDefaultWorkspaceTeam(identity.organization.id);
+
+    expect(first.id).toBe(second.id);
+    expect(first.slug).toBe(DEFAULT_WORKSPACE_TEAM_SLUG);
+    expect(first.name).toBe(DEFAULT_WORKSPACE_TEAM_NAME);
+  });
+
+  it("adds a user to the default team without demoting an existing manager role", async () => {
+    const identity = await createOrganizationAndUser();
+    const team = await ensureDefaultWorkspaceTeam(identity.organization.id);
+
+    await ensureTeamMembership({
+      teamId: team.id,
+      userId: identity.user.id,
+      role: "manager",
+    });
+
+    await ensureDefaultWorkspaceTeamMembership({
+      organizationId: identity.organization.id,
+      userId: identity.user.id,
+      role: "member",
+    });
+
+    const [membership] = await db
+      .select({ role: schema.teamMemberships.role })
+      .from(schema.teamMemberships)
+      .where(
+        and(
+          eq(schema.teamMemberships.teamId, team.id),
+          eq(schema.teamMemberships.userId, identity.user.id),
+        ),
+      )
+      .limit(1);
+
+    expect(membership?.role).toBe("manager");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/teams/default-workspace-team.ts
+++ b/apps/hyperlocalise-web/src/lib/teams/default-workspace-team.ts
@@ -1,12 +1,16 @@
 import { and, eq, isNull } from "drizzle-orm";
 
-import { db, schema } from "@/lib/database";
+import { db, schema, type DatabaseClient } from "@/lib/database";
+import type { TeamMembershipRole } from "@/lib/database/types";
 
 export const DEFAULT_WORKSPACE_TEAM_SLUG = "default";
 export const DEFAULT_WORKSPACE_TEAM_NAME = "Default team";
 
-export async function ensureDefaultWorkspaceTeam(organizationId: string) {
-  const [existingTeam] = await db
+export async function ensureDefaultWorkspaceTeam(
+  organizationId: string,
+  database: DatabaseClient = db,
+) {
+  const [existingTeam] = await database
     .select()
     .from(schema.teams)
     .where(
@@ -21,7 +25,7 @@ export async function ensureDefaultWorkspaceTeam(organizationId: string) {
     return existingTeam;
   }
 
-  const [createdTeam] = await db
+  const [createdTeam] = await database
     .insert(schema.teams)
     .values({
       organizationId,
@@ -37,7 +41,7 @@ export async function ensureDefaultWorkspaceTeam(organizationId: string) {
     return createdTeam;
   }
 
-  const [racedTeam] = await db
+  const [racedTeam] = await database
     .select()
     .from(schema.teams)
     .where(
@@ -53,6 +57,49 @@ export async function ensureDefaultWorkspaceTeam(organizationId: string) {
   }
 
   return racedTeam;
+}
+
+/**
+ * Ensures a team membership exists. Existing roles are left unchanged so
+ * managers are not demoted when a later path only needs member visibility.
+ */
+export async function ensureTeamMembership(input: {
+  teamId: string;
+  userId: string;
+  role?: TeamMembershipRole;
+  database?: DatabaseClient;
+}) {
+  const database = input.database ?? db;
+
+  await database
+    .insert(schema.teamMemberships)
+    .values({
+      teamId: input.teamId,
+      userId: input.userId,
+      role: input.role ?? "member",
+    })
+    .onConflictDoNothing({
+      target: [schema.teamMemberships.teamId, schema.teamMemberships.userId],
+    });
+}
+
+export async function ensureDefaultWorkspaceTeamMembership(input: {
+  organizationId: string;
+  userId: string;
+  role?: TeamMembershipRole;
+  database?: DatabaseClient;
+}) {
+  const database = input.database ?? db;
+  const team = await ensureDefaultWorkspaceTeam(input.organizationId, database);
+
+  await ensureTeamMembership({
+    teamId: team.id,
+    userId: input.userId,
+    role: input.role,
+    database,
+  });
+
+  return team;
 }
 
 export async function backfillOrganizationProjectTeams(organizationId: string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users with the `developer` role could create projects successfully, but the projects page stayed empty. Create assigned projects to the default team without adding the creator to `team_memberships`, and list visibility for non-operators is team-membership–scoped (`teams:write` only for admin / localization_manager). Invites also created org membership without default-team membership, so the same gap appeared right after invite.

## Fix

1. **Project create** — for creators without org-wide access (`!hasOrganizationWideProjectAccess`), upsert them onto the project’s team as `member` (`onConflictDoNothing` so existing managers are not demoted). Operators are skipped, matching invite behavior.
2. **Member invite** — for roles without `teams:write` (developer, reviewer, translator, member), ensure membership on the default workspace team.
3. **Onboarding** — when creating a workspace, ensure the default team exists and add the owner as `manager`.

Shared helpers live in `default-workspace-team.ts`.

## Tests

- Developer creates a project with no prior team membership → list includes it and team membership exists
- Inviting a developer adds default-team membership; inviting localization_manager does not
- Onboarding seeds default-team manager membership
- Helper unit coverage for idempotent default team + non-demoting membership upsert

`vp test` (targeted) and `vp check --fix` passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f68b4-127c-7bdd-b655-022c5ffd90a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f68b4-127c-7bdd-b655-022c5ffd90a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

