### PR TITLE
feat(web): add org route loading with Suspense reveal

### DIFF
--- a/apps/hyperlocalise-web/next.config.ts
+++ b/apps/hyperlocalise-web/next.config.ts
@@ -6,6 +6,9 @@ import { AGENT_MARKDOWN_TRACE_GLOB } from "./src/agents/_runtime/paths";
 const nextConfig: NextConfig = {
   /* config options here */
   reactCompiler: true,
+  experimental: {
+    viewTransition: true,
+  },
   // Agent prompts load from src/agents/**/*.md at runtime via process.cwd() (see paths.ts).
   outputFileTracingIncludes: {
     "/*": [AGENT_MARKDOWN_TRACE_GLOB, "_posts/**/*.md"],

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/organization-route-loading.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/organization-route-loading.tsx
@@ -1,0 +1,25 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+import { WorkspacePageShell } from "./workspace-resource-shared";
+
+export function OrganizationRouteLoading() {
+  return (
+    <WorkspacePageShell aria-busy="true" aria-live="polite">
+      <section className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div className="max-w-2xl space-y-3">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-8 w-56 md:w-72" />
+          <Skeleton className="h-4 w-full max-w-md" />
+        </div>
+        <Skeleton className="h-9 w-28 shrink-0" />
+      </section>
+
+      <div className="grid gap-3">
+        <Skeleton className="h-11 w-full" />
+        <Skeleton className="h-11 w-full" />
+        <Skeleton className="h-11 w-full" />
+        <Skeleton className="h-11 w-3/4" />
+      </div>
+    </WorkspacePageShell>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/workspace-resource-shared.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/workspace-resource-shared.tsx
@@ -12,15 +12,11 @@ import { TypographyH1, TypographyP } from "@/components/ui/typography";
 export type Icon = ComponentProps<typeof HugeiconsIcon>["icon"];
 export type Tone = "safe" | "watch" | "risk" | "info";
 
-export function WorkspacePageShell({
-  children,
-  className,
-}: {
-  children: ReactNode;
-  className?: string;
-}) {
+type WorkspacePageShellProps = ComponentProps<"main">;
+
+export function WorkspacePageShell({ children, className, ...props }: WorkspacePageShellProps) {
   return (
-    <main className={cn("mx-auto flex w-full max-w-6xl flex-col gap-6", className)}>
+    <main className={cn("mx-auto flex w-full max-w-6xl flex-col gap-6", className)} {...props}>
       {children}
     </main>
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/loading.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/loading.tsx
@@ -1,0 +1,11 @@
+import { ViewTransition } from "react";
+
+import { OrganizationRouteLoading } from "./_components/organization-route-loading";
+
+export default function OrganizationLoading() {
+  return (
+    <ViewTransition exit="slide-down">
+      <OrganizationRouteLoading />
+    </ViewTransition>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/template.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/template.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+import { ViewTransition } from "react";
+
+type OrganizationTemplateProps = {
+  children: ReactNode;
+};
+
+export default function OrganizationTemplate({ children }: OrganizationTemplateProps) {
+  return (
+    <ViewTransition enter="slide-up" default="none">
+      {children}
+    </ViewTransition>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/template.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/template.tsx
@@ -6,6 +6,9 @@ type OrganizationTemplateProps = {
 };
 
 export default function OrganizationTemplate({ children }: OrganizationTemplateProps) {
+  // Outermost VT owns the snapshot for this segment. Nested page-level
+  // <ViewTransition enter/exit> under here will not fire while this one animates —
+  // remove or relocate this wrapper before adding page VTs.
   return (
     <ViewTransition enter="slide-up" default="none">
       {children}

--- a/apps/hyperlocalise-web/src/app/globals.css
+++ b/apps/hyperlocalise-web/src/app/globals.css
@@ -517,3 +517,51 @@
     @apply font-sans;
   }
 }
+
+/* View Transition recipes — Suspense reveal (org route loading) */
+:root {
+  --duration-exit: 150ms;
+  --duration-enter: 210ms;
+  --duration-move: 400ms;
+}
+
+@keyframes fade {
+  from {
+    filter: blur(3px);
+    opacity: 0;
+  }
+  to {
+    filter: blur(0);
+    opacity: 1;
+  }
+}
+
+@keyframes slide-y {
+  from {
+    transform: translateY(var(--slide-y-offset, 10px));
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+::view-transition-old(.slide-down) {
+  animation:
+    var(--duration-exit) ease-out both fade reverse,
+    var(--duration-exit) ease-out both slide-y reverse;
+}
+
+::view-transition-new(.slide-up) {
+  animation:
+    var(--duration-enter) ease-in var(--duration-exit) both fade,
+    var(--duration-move) ease-in both slide-y;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(*),
+  ::view-transition-new(*),
+  ::view-transition-group(*) {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+  }
+}

--- a/docs/plans/2026-07-16-org-route-loading-design.md
+++ b/docs/plans/2026-07-16-org-route-loading-design.md
@@ -1,0 +1,28 @@
+# Org route loading UI
+
+## Problem
+
+Authenticated org routes have no route-level loading state. Navigating between
+pages under `org/[organizationSlug]` can leave the shell content area blank
+until the next page streams in.
+
+## Decision
+
+Add a single org-segment loading boundary with a Suspense reveal animation.
+
+- Place `loading.tsx` at `org/[organizationSlug]/` so every org page shares one
+  skeleton while the AppShell stays mounted.
+- Exit the skeleton with `slide-down`; enter page content with `slide-up` via
+  `template.tsx` (remounts on navigation).
+- Do not add directional nav transitions in this change.
+
+## Behavior
+
+1. Client navigations within an org show the shared skeleton immediately.
+2. Skeleton exits down; content enters up when the route resolves.
+3. Unsupported browsers skip the animation and still show the skeleton.
+
+## Out of scope
+
+Per-page skeletons, cold-start AppShell auth loading, and `nav-forward` /
+`nav-back` route transitions.


### PR DESCRIPTION
## What changed

Adds a shared `loading.tsx` for authenticated org routes so navigations show a skeleton instead of a blank content area. Pairs it with a Suspense reveal (`slide-down` exit / `slide-up` enter) via `template.tsx`, view-transition CSS recipes, and `experimental.viewTransition`.

## How to test

- [ ] From an org workspace, navigate between pages (e.g. dashboard → projects → jobs) and confirm the shared skeleton appears in the content area while the shell stays mounted
- [ ] Confirm the skeleton exits and content enters with the slide animation (or degrades cleanly if view transitions are unsupported)
- [ ] Confirm `prefers-reduced-motion: reduce` disables the animation timing
- [ ] `cd apps/hyperlocalise-web && vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)