### PR TITLE
feat(web): gate Issues behind workspace-issues flag

### DIFF
--- a/apps/hyperlocalise-web/src/api/middleware/workspace-feature-flag.ts
+++ b/apps/hyperlocalise-web/src/api/middleware/workspace-feature-flag.ts
@@ -1,0 +1,38 @@
+import type { Flag } from "flags/next";
+import { createMiddleware } from "hono/factory";
+
+import type { AuthVariables } from "@/api/auth/workos";
+import { forbiddenResponse } from "@/api/response.schema";
+import type { WorkosFlagEntities } from "@/lib/flags/workos-flag-entities";
+
+async function isWorkspaceFeatureFlagEnabled(
+  workspaceFlag: Flag<boolean, WorkosFlagEntities>,
+  auth: AuthVariables["auth"],
+) {
+  try {
+    return (
+      (await workspaceFlag.run({
+        identify: () => ({
+          organization: { id: auth.organization.workosOrganizationId },
+          user: { id: auth.user.workosUserId },
+        }),
+      })) === true
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function createWorkspaceFeatureFlagMiddleware(
+  workspaceFlag: Flag<boolean, WorkosFlagEntities>,
+  message: string,
+) {
+  return createMiddleware<{ Variables: AuthVariables }>(async (c, next) => {
+    const enabled = await isWorkspaceFeatureFlagEnabled(workspaceFlag, c.var.auth);
+    if (!enabled) {
+      return forbiddenResponse(c, "feature_unavailable", message);
+    }
+
+    await next();
+  });
+}

--- a/apps/hyperlocalise-web/src/api/routes/issues/issues.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/issues/issues.route.test.ts
@@ -1,19 +1,20 @@
 import "dotenv/config";
 
-import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { app } from "@/api/app";
 import { db } from "@/lib/database";
 
 import { createProjectTestFixture } from "../project/project.fixture";
 
-const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
+const { resolveApiAuthContextFromSessionMock, workspaceIssuesFlagRunMock } = vi.hoisted(() => ({
   resolveApiAuthContextFromSessionMock: vi.fn(
     (options) =>
       globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
       globalThis.__testApiAuthContext ??
       null,
   ),
+  workspaceIssuesFlagRunMock: vi.fn(async () => true),
 }));
 
 vi.mock("@/api/auth/workos-session", async (importOriginal) => {
@@ -24,10 +25,22 @@ vi.mock("@/api/auth/workos-session", async (importOriginal) => {
   };
 });
 
+vi.mock("@/lib/flags/workspace-flags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/flags/workspace-flags")>();
+  return {
+    ...actual,
+    workspaceIssuesFlag: { run: workspaceIssuesFlagRunMock },
+  };
+});
+
 const projectFixture = createProjectTestFixture();
 
 beforeAll(async () => {
   await db.$client.query("select 1");
+});
+
+beforeEach(() => {
+  workspaceIssuesFlagRunMock.mockResolvedValue(true);
 });
 
 afterEach(async () => {
@@ -78,6 +91,23 @@ type ListBody = {
 };
 
 describe("Organization issues routes", () => {
+  it("denies organization issues access when the feature flag is disabled", async () => {
+    workspaceIssuesFlagRunMock.mockResolvedValue(false);
+    const { identity } = await projectFixture.createStoredProjectFixture();
+    const headers = await projectFixture.authHeadersFor(identity);
+    const organizationSlug = identity.organization.slug ?? "missing-slug";
+
+    const response = await requestJson(organizationIssuesUrl(organizationSlug), {
+      headers,
+      query: { view: "all_open" },
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "feature_unavailable",
+    });
+  });
+
   it("lists issues across accessible projects", async () => {
     const { identity, project } = await projectFixture.createStoredProjectFixture();
     const headers = await projectFixture.authHeadersFor(identity);

--- a/apps/hyperlocalise-web/src/api/routes/issues/issues.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/issues/issues.route.ts
@@ -4,6 +4,7 @@ import { hasCapability } from "@/api/auth/policy";
 import { createZodValidator } from "@/api/errors";
 import { forbiddenResponse } from "@/api/response.schema";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
+import { workspaceIssuesFlag } from "@/lib/flags/workspace-flags";
 import { organizationIssueService } from "@/lib/projects/issue-sheet/organization-issue-service";
 
 import { organizationIssuesQuerySchema } from "./issues.schema";
@@ -14,9 +15,36 @@ const validateOrganizationIssuesQuery = createZodValidator(
   "invalid_organization_issues_query",
 );
 
+async function isWorkspaceIssuesFeatureEnabled(auth: AuthVariables["auth"]) {
+  try {
+    return (
+      (await workspaceIssuesFlag.run({
+        identify: () => ({
+          organization: { id: auth.organization.workosOrganizationId },
+          user: { id: auth.user.workosUserId },
+        }),
+      })) === true
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function createOrganizationIssuesRoutes() {
   return new Hono<{ Variables: AuthVariables }>()
     .use("*", workosAuthMiddleware)
+    .use("*", async (c, next) => {
+      const enabled = await isWorkspaceIssuesFeatureEnabled(c.var.auth);
+      if (!enabled) {
+        return forbiddenResponse(
+          c,
+          "feature_unavailable",
+          "Workspace issues is not enabled for this organization",
+        );
+      }
+
+      await next();
+    })
     .get("/", validateOrganizationIssuesQuery, async (c) => {
       if (!hasCapability(c.var.auth.membership.role, "projects:read")) {
         return forbiddenResponse(c, "forbidden");

--- a/apps/hyperlocalise-web/src/api/routes/issues/issues.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/issues/issues.route.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 
 import { hasCapability } from "@/api/auth/policy";
 import { createZodValidator } from "@/api/errors";
+import { createWorkspaceFeatureFlagMiddleware } from "@/api/middleware/workspace-feature-flag";
 import { forbiddenResponse } from "@/api/response.schema";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
 import { workspaceIssuesFlag } from "@/lib/flags/workspace-flags";
@@ -15,36 +16,15 @@ const validateOrganizationIssuesQuery = createZodValidator(
   "invalid_organization_issues_query",
 );
 
-async function isWorkspaceIssuesFeatureEnabled(auth: AuthVariables["auth"]) {
-  try {
-    return (
-      (await workspaceIssuesFlag.run({
-        identify: () => ({
-          organization: { id: auth.organization.workosOrganizationId },
-          user: { id: auth.user.workosUserId },
-        }),
-      })) === true
-    );
-  } catch {
-    return false;
-  }
-}
+const requireWorkspaceIssuesFeature = createWorkspaceFeatureFlagMiddleware(
+  workspaceIssuesFlag,
+  "Workspace issues is not enabled for this organization",
+);
 
 export function createOrganizationIssuesRoutes() {
   return new Hono<{ Variables: AuthVariables }>()
     .use("*", workosAuthMiddleware)
-    .use("*", async (c, next) => {
-      const enabled = await isWorkspaceIssuesFeatureEnabled(c.var.auth);
-      if (!enabled) {
-        return forbiddenResponse(
-          c,
-          "feature_unavailable",
-          "Workspace issues is not enabled for this organization",
-        );
-      }
-
-      await next();
-    })
+    .use("*", requireWorkspaceIssuesFeature)
     .get("/", validateOrganizationIssuesQuery, async (c) => {
       if (!hasCapability(c.var.auth.membership.role, "projects:read")) {
         return forbiddenResponse(c, "forbidden");

--- a/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.test.ts
@@ -1,19 +1,20 @@
 import "dotenv/config";
 
-import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { app } from "@/api/app";
 import { db } from "@/lib/database";
 
 import { createProjectTestFixture } from "./project.fixture";
 
-const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
+const { resolveApiAuthContextFromSessionMock, workspaceIssuesFlagRunMock } = vi.hoisted(() => ({
   resolveApiAuthContextFromSessionMock: vi.fn(
     (options) =>
       globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
       globalThis.__testApiAuthContext ??
       null,
   ),
+  workspaceIssuesFlagRunMock: vi.fn(async () => true),
 }));
 
 vi.mock("@/api/auth/workos-session", async (importOriginal) => {
@@ -21,6 +22,14 @@ vi.mock("@/api/auth/workos-session", async (importOriginal) => {
   return {
     ...actual,
     resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
+  };
+});
+
+vi.mock("@/lib/flags/workspace-flags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/flags/workspace-flags")>();
+  return {
+    ...actual,
+    workspaceIssuesFlag: { run: workspaceIssuesFlagRunMock },
   };
 });
 
@@ -46,6 +55,10 @@ type IssueSheetListResponse = {
 
 beforeAll(async () => {
   await db.$client.query("select 1");
+});
+
+beforeEach(() => {
+  workspaceIssuesFlagRunMock.mockResolvedValue(true);
 });
 
 afterEach(async () => {
@@ -78,6 +91,22 @@ async function requestJson(
 }
 
 describe("Issue Sheet routes", () => {
+  it("denies issue sheet access when the feature flag is disabled", async () => {
+    workspaceIssuesFlagRunMock.mockResolvedValue(false);
+    const { identity, project } = await projectFixture.createStoredProjectFixture();
+    const headers = await projectFixture.authHeadersFor(identity);
+    const organizationSlug = identity.organization.slug ?? "missing-slug";
+
+    const response = await requestJson(issueSheetUrl(organizationSlug, project.id), {
+      headers,
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "feature_unavailable",
+    });
+  });
+
   it("creates, lists, updates, and enriches generic issue rows", async () => {
     const { identity, project } = await projectFixture.createStoredProjectFixture();
     const headers = await projectFixture.authHeadersFor(identity);

--- a/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.ts
@@ -6,7 +6,12 @@ import {
   isProjectMutationAllowed,
   isWriteBackTranslationAllowed,
 } from "@/api/auth/capability-guards";
-import { badRequestResponse, conflictResponse } from "@/api/response.schema";
+import {
+  badRequestResponse,
+  conflictResponse,
+  forbiddenResponse as featureForbiddenResponse,
+} from "@/api/response.schema";
+import { workspaceIssuesFlag } from "@/lib/flags/workspace-flags";
 import { IssueSheetService } from "@/lib/projects/issue-sheet/issue-sheet-service";
 
 import {
@@ -78,8 +83,35 @@ async function requireProject(c: { var: { auth: AuthVariables["auth"] } }, proje
   return project;
 }
 
+async function isWorkspaceIssuesFeatureEnabled(auth: AuthVariables["auth"]) {
+  try {
+    return (
+      (await workspaceIssuesFlag.run({
+        identify: () => ({
+          organization: { id: auth.organization.workosOrganizationId },
+          user: { id: auth.user.workosUserId },
+        }),
+      })) === true
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function createIssueSheetRoutes() {
   return new Hono<{ Variables: AuthVariables }>()
+    .use("*", async (c, next) => {
+      const enabled = await isWorkspaceIssuesFeatureEnabled(c.var.auth);
+      if (!enabled) {
+        return featureForbiddenResponse(
+          c,
+          "feature_unavailable",
+          "Workspace issues is not enabled for this organization",
+        );
+      }
+
+      await next();
+    })
     .get("/", validateIssueSheetParams, validateIssueSheetQuery, async (c) => {
       const params = c.req.valid("param");
       const project = await requireProject(c, params.projectId);

--- a/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.ts
@@ -6,11 +6,8 @@ import {
   isProjectMutationAllowed,
   isWriteBackTranslationAllowed,
 } from "@/api/auth/capability-guards";
-import {
-  badRequestResponse,
-  conflictResponse,
-  forbiddenResponse as featureForbiddenResponse,
-} from "@/api/response.schema";
+import { badRequestResponse, conflictResponse } from "@/api/response.schema";
+import { createWorkspaceFeatureFlagMiddleware } from "@/api/middleware/workspace-feature-flag";
 import { workspaceIssuesFlag } from "@/lib/flags/workspace-flags";
 import { IssueSheetService } from "@/lib/projects/issue-sheet/issue-sheet-service";
 
@@ -25,7 +22,11 @@ import {
   issueSheetSetValueBodySchema,
   issueSheetUpdateIssueBodySchema,
 } from "./issue-sheet.schema";
-import { forbiddenResponse, getOwnedProject, projectNotFoundResponse } from "./project.shared";
+import {
+  getOwnedProject,
+  projectForbiddenResponse,
+  projectNotFoundResponse,
+} from "./project.shared";
 
 const service = new IssueSheetService();
 
@@ -75,6 +76,11 @@ const validateImportBody = createZodValidator(
   "invalid_issue_sheet_import_payload",
 );
 
+const requireWorkspaceIssuesFeature = createWorkspaceFeatureFlagMiddleware(
+  workspaceIssuesFlag,
+  "Workspace issues is not enabled for this organization",
+);
+
 async function requireProject(c: { var: { auth: AuthVariables["auth"] } }, projectId: string) {
   const project = await getOwnedProject(c.var.auth, projectId);
   if (!project) {
@@ -83,35 +89,9 @@ async function requireProject(c: { var: { auth: AuthVariables["auth"] } }, proje
   return project;
 }
 
-async function isWorkspaceIssuesFeatureEnabled(auth: AuthVariables["auth"]) {
-  try {
-    return (
-      (await workspaceIssuesFlag.run({
-        identify: () => ({
-          organization: { id: auth.organization.workosOrganizationId },
-          user: { id: auth.user.workosUserId },
-        }),
-      })) === true
-    );
-  } catch {
-    return false;
-  }
-}
-
 export function createIssueSheetRoutes() {
   return new Hono<{ Variables: AuthVariables }>()
-    .use("*", async (c, next) => {
-      const enabled = await isWorkspaceIssuesFeatureEnabled(c.var.auth);
-      if (!enabled) {
-        return featureForbiddenResponse(
-          c,
-          "feature_unavailable",
-          "Workspace issues is not enabled for this organization",
-        );
-      }
-
-      await next();
-    })
+    .use("*", requireWorkspaceIssuesFeature)
     .get("/", validateIssueSheetParams, validateIssueSheetQuery, async (c) => {
       const params = c.req.valid("param");
       const project = await requireProject(c, params.projectId);
@@ -129,7 +109,7 @@ export function createIssueSheetRoutes() {
     })
     .post("/", validateIssueSheetParams, validateCreateIssueBody, async (c) => {
       if (!isWriteBackTranslationAllowed(c.var.auth.membership.role)) {
-        return forbiddenResponse(c);
+        return projectForbiddenResponse(c);
       }
       const params = c.req.valid("param");
       const project = await requireProject(c, params.projectId);
@@ -157,7 +137,7 @@ export function createIssueSheetRoutes() {
     })
     .post("/import", validateIssueSheetParams, validateImportBody, async (c) => {
       if (!isWriteBackTranslationAllowed(c.var.auth.membership.role)) {
-        return forbiddenResponse(c);
+        return projectForbiddenResponse(c);
       }
       const params = c.req.valid("param");
       const project = await requireProject(c, params.projectId);
@@ -204,7 +184,7 @@ export function createIssueSheetRoutes() {
     })
     .patch("/:issueId", validateIssueSheetIssueParams, validateUpdateIssueBody, async (c) => {
       if (!isWriteBackTranslationAllowed(c.var.auth.membership.role)) {
-        return forbiddenResponse(c);
+        return projectForbiddenResponse(c);
       }
       const projectParams = c.req.valid("param");
       const project = await requireProject(c, projectParams.projectId);
@@ -240,7 +220,7 @@ export function createIssueSheetRoutes() {
     })
     .post("/columns", validateIssueSheetParams, validateCreateColumnBody, async (c) => {
       if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
-        return forbiddenResponse(c);
+        return projectForbiddenResponse(c);
       }
       const params = c.req.valid("param");
       const project = await requireProject(c, params.projectId);
@@ -265,7 +245,7 @@ export function createIssueSheetRoutes() {
     })
     .patch("/:issueId/values", validateIssueSheetIssueParams, validateSetValueBody, async (c) => {
       if (!isWriteBackTranslationAllowed(c.var.auth.membership.role)) {
-        return forbiddenResponse(c);
+        return projectForbiddenResponse(c);
       }
       const projectParams = c.req.valid("param");
       const project = await requireProject(c, projectParams.projectId);

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -54,7 +54,7 @@ import type {
 import { validateJobLocalesAgainstProject } from "@/lib/i18n/project-job-locales";
 
 import {
-  forbiddenResponse,
+  projectForbiddenResponse,
   getOwnedProject,
   getOwnedProjectRecord,
   projectNotFoundResponse,
@@ -368,7 +368,7 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
     })
     .post("/", validateProjectParams, validateCreateJobBody, async (c) => {
       if (!isJobCreateAllowed(c.var.auth.membership.role)) {
-        return forbiddenResponse(c);
+        return projectForbiddenResponse(c);
       }
 
       const params = c.req.valid("param");
@@ -684,7 +684,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
       validateUpdateAgentRunProposalReviewBody,
       async (c) => {
         if (!isReviewApproveAllowed(c.var.auth.membership.role)) {
-          return forbiddenResponse(c);
+          return projectForbiddenResponse(c);
         }
 
         const params = c.req.valid("param");
@@ -862,7 +862,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
         const payload = c.req.valid("json");
 
         if (!isJobProviderActionAllowed(c.var.auth.membership.role, payload.action)) {
-          return forbiddenResponse(c);
+          return projectForbiddenResponse(c);
         }
 
         const organizationId = c.var.auth.organization.localOrganizationId;
@@ -1023,7 +1023,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
     )
     .post("/:jobId/qa", validateWorkspaceJobParams, async (c) => {
       if (!isAiActionAllowed(c.var.auth.membership.role)) {
-        return forbiddenResponse(c);
+        return projectForbiddenResponse(c);
       }
 
       const params = c.req.valid("param");
@@ -1102,7 +1102,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
     })
     .post("/:jobId/run-agent", validateWorkspaceJobParams, async (c) => {
       if (!isAiActionAllowed(c.var.auth.membership.role)) {
-        return forbiddenResponse(c);
+        return projectForbiddenResponse(c);
       }
 
       const params = c.req.valid("param");
@@ -1231,7 +1231,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
     })
     .post("/:jobId/retry", validateWorkspaceJobParams, async (c) => {
       if (!isJobMutationAllowed(c.var.auth.membership.role)) {
-        return forbiddenResponse(c);
+        return projectForbiddenResponse(c);
       }
 
       const params = c.req.valid("param");
@@ -1355,7 +1355,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
     })
     .post("/:jobId/mark-failed", validateWorkspaceJobParams, async (c) => {
       if (!isJobMutationAllowed(c.var.auth.membership.role)) {
-        return forbiddenResponse(c);
+        return projectForbiddenResponse(c);
       }
 
       const params = c.req.valid("param");
@@ -1425,7 +1425,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
     })
     .post("/:jobId/cancel", validateWorkspaceJobParams, async (c) => {
       if (!isJobMutationAllowed(c.var.auth.membership.role)) {
-        return forbiddenResponse(c);
+        return projectForbiddenResponse(c);
       }
 
       const params = c.req.valid("param");

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -150,7 +150,7 @@ import {
 } from "@/api/auth/capability-guards";
 import {
   buildAccessibleProjectsWhere,
-  forbiddenResponse,
+  projectForbiddenResponse,
   getOwnedProject,
   getOwnedProjectRecord,
   invalidProjectPayloadResponse,
@@ -748,7 +748,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
     })
     .post("/", validateCreateProjectBody, async (c) => {
       if (!isProjectCreateAllowed(c.var.auth.membership.role)) {
-        return forbiddenResponse(c);
+        return projectForbiddenResponse(c);
       }
 
       const payload = c.req.valid("json");
@@ -1000,7 +1000,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       validateProjectFileCatTranslationBody,
       async (c) => {
         if (!isWriteBackTranslationAllowed(c.var.auth.membership.role)) {
-          return forbiddenResponse(c);
+          return projectForbiddenResponse(c);
         }
 
         const params = c.req.valid("param");
@@ -1077,7 +1077,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       validateProjectFileCatCommentBody,
       async (c) => {
         if (!isWriteBackTranslationAllowed(c.var.auth.membership.role)) {
-          return forbiddenResponse(c);
+          return projectForbiddenResponse(c);
         }
 
         const params = c.req.valid("param");
@@ -1147,7 +1147,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       validateProjectFileCatCommentResolveBody,
       async (c) => {
         if (!isWriteBackTranslationAllowed(c.var.auth.membership.role)) {
-          return forbiddenResponse(c);
+          return projectForbiddenResponse(c);
         }
 
         const params = c.req.valid("param");
@@ -1281,7 +1281,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       validateProjectFileCatRecommendationBody,
       async (c) => {
         if (!isAiActionAllowed(c.var.auth.membership.role)) {
-          return forbiddenResponse(c);
+          return projectForbiddenResponse(c);
         }
 
         const params = c.req.valid("param");
@@ -1342,7 +1342,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       validateProjectFileCatStatusBody,
       async (c) => {
         if (!isWriteBackTranslationAllowed(c.var.auth.membership.role)) {
-          return forbiddenResponse(c);
+          return projectForbiddenResponse(c);
         }
 
         const params = c.req.valid("param");
@@ -1387,7 +1387,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       validateProjectFileCatImageRegenerateBody,
       async (c) => {
         if (!isAiActionAllowed(c.var.auth.membership.role)) {
-          return forbiddenResponse(c);
+          return projectForbiddenResponse(c);
         }
 
         const params = c.req.valid("param");
@@ -1522,7 +1522,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       }),
       async (c) => {
         if (!isWriteBackTranslationAllowed(c.var.auth.membership.role)) {
-          return forbiddenResponse(c);
+          return projectForbiddenResponse(c);
         }
 
         const params = c.req.valid("param");
@@ -1761,7 +1761,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       validateProjectFileCatImageStatusBody,
       async (c) => {
         if (!isWriteBackTranslationAllowed(c.var.auth.membership.role)) {
-          return forbiddenResponse(c);
+          return projectForbiddenResponse(c);
         }
 
         const params = c.req.valid("param");
@@ -1836,7 +1836,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       validateProjectFileCatTreatAsImageBody,
       async (c) => {
         if (!isWriteBackTranslationAllowed(c.var.auth.membership.role)) {
-          return forbiddenResponse(c);
+          return projectForbiddenResponse(c);
         }
 
         const params = c.req.valid("param");
@@ -1993,7 +1993,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         const body = c.req.valid("json");
 
         if (!isAiActionAllowed(c.var.auth.membership.role)) {
-          return forbiddenResponse(c);
+          return projectForbiddenResponse(c);
         }
 
         const target = await resolveProjectResourceTarget(c.var.auth, params.projectId);
@@ -2227,7 +2227,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       }),
       async (c) => {
         if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
-          return forbiddenResponse(c);
+          return projectForbiddenResponse(c);
         }
 
         const params = c.req.valid("param");
@@ -2350,7 +2350,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       }),
       async (c) => {
         if (!isWriteBackTranslationAllowed(c.var.auth.membership.role)) {
-          return forbiddenResponse(c);
+          return projectForbiddenResponse(c);
         }
 
         const params = c.req.valid("param");
@@ -2654,7 +2654,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
     })
     .patch("/:projectId", validateProjectParams, validateUpdateProjectBody, async (c) => {
       if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
-        return forbiddenResponse(c);
+        return projectForbiddenResponse(c);
       }
 
       const params = c.req.valid("param");
@@ -2678,7 +2678,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
     })
     .delete("/:projectId", validateProjectParams, async (c) => {
       if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
-        return forbiddenResponse(c);
+        return projectForbiddenResponse(c);
       }
 
       const params = c.req.valid("param");

--- a/apps/hyperlocalise-web/src/api/routes/project/project.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.shared.ts
@@ -58,7 +58,7 @@ export function unsupportedProjectFileResponse(c: { json: JsonContext["json"] },
   });
 }
 
-export function forbiddenResponse(c: { json: JsonContext["json"] }) {
+export function projectForbiddenResponse(c: { json: JsonContext["json"] }) {
   return sharedForbiddenResponse(c, "forbidden", "Insufficient permissions");
 }
 

--- a/apps/hyperlocalise-web/src/app/.well-known/vercel/flags/route.ts
+++ b/apps/hyperlocalise-web/src/app/.well-known/vercel/flags/route.ts
@@ -3,12 +3,14 @@ import { createFlagsDiscoveryEndpoint, getProviderData } from "flags/next";
 import { releaseCatAllFilesFlag } from "../../../../lib/flags/release-flags";
 import {
   workspaceAutomationsFlag,
+  workspaceIssuesFlag,
   workspaceKnowledgeFlag,
 } from "../../../../lib/flags/workspace-flags";
 
 export const GET = createFlagsDiscoveryEndpoint(async () =>
   getProviderData({
     workspaceAutomationsFlag,
+    workspaceIssuesFlag,
     workspaceKnowledgeFlag,
     releaseCatAllFilesFlag,
   }),

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 
 import { TypographyP } from "@/components/ui/typography";
+import { requireWorkspaceFeatureFlag, workspaceIssuesFlag } from "@/lib/flags/workspace-flags";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { IssuesPageContent } from "./_components/issues-page-content";
@@ -11,7 +12,8 @@ export default async function IssuesPage({
   params: Promise<{ organizationSlug: string }>;
 }) {
   const { organizationSlug } = await params;
-  await requireAppAuthContext({ organizationSlug });
+  const auth = await requireAppAuthContext({ organizationSlug });
+  await requireWorkspaceFeatureFlag(workspaceIssuesFlag, auth);
 
   return (
     <Suspense

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 
 import { TypographyP } from "@/components/ui/typography";
+import { requireWorkspaceFeatureFlag, workspaceIssuesFlag } from "@/lib/flags/workspace-flags";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { IssueSheetPageContent } from "./_components/issue-sheet-page-content";
@@ -11,7 +12,8 @@ export default async function IssueSheetPage({
   params: Promise<{ organizationSlug: string; projectId: string }>;
 }) {
   const { organizationSlug, projectId } = await params;
-  await requireAppAuthContext({ organizationSlug });
+  const auth = await requireAppAuthContext({ organizationSlug });
+  await requireWorkspaceFeatureFlag(workspaceIssuesFlag, auth);
 
   return (
     <Suspense

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
@@ -23,6 +23,7 @@ import type { NavigationGroup } from "./navigation-config";
 import { AppShellHeaderActions } from "./store/app-shell-header-actions";
 import { AppShellStoreProvider } from "./store/app-shell-store-context";
 import { SidebarStoreBridge } from "./store/sidebar-store-bridge";
+import type { WorkspaceFeatureFlagState } from "@/lib/flags/workos-flag-entities";
 import type { TmsUserConnectCta } from "@/lib/providers/credentials/tms-user-connection-shared";
 import { useTmsUserConnectCta } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/_hooks/use-tms-user-connect-cta";
 import { NavUser } from "./nav-user";
@@ -36,6 +37,7 @@ type AppShellClientProps = {
   autumnConfigured?: boolean;
   children: ReactNode;
   navigationGroups: readonly NavigationGroup[];
+  workspaceFeatureFlags: WorkspaceFeatureFlagState;
   activeOrganization: {
     name: string;
     slug?: string | null;
@@ -59,6 +61,7 @@ export function AppShellClient({
   autumnConfigured = false,
   children,
   navigationGroups,
+  workspaceFeatureFlags,
   activeOrganization,
   organizations,
   tmsUserConnectCta = { showConnectCta: false },
@@ -76,7 +79,10 @@ export function AppShellClient({
   const resolvedTmsUserConnectCta = tmsUserConnectQuery.data ?? tmsUserConnectCta;
 
   return (
-    <AppShellStoreProvider defaultNavigationGroups={navigationGroups}>
+    <AppShellStoreProvider
+      defaultNavigationGroups={navigationGroups}
+      workspaceFeatureFlags={workspaceFeatureFlags}
+    >
       <TmsUserOAuthErrorToast />
       <SidebarProvider
         defaultOpen

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
@@ -22,6 +22,8 @@ import { apiClient } from "@/lib/api-client-instance";
 import { cn } from "@/lib/primitives/cn";
 
 import { appShellNavigationMessages } from "./app-shell-navigation.messages";
+import { filterNavigationItemsByWorkspaceFlags } from "@/lib/flags/workspace-flags";
+
 import {
   buildOrganizationPath,
   buildProjectNavigationItems,
@@ -163,7 +165,11 @@ function ProjectNavigation({
     },
   });
 
-  const resolvedItems = items ?? buildProjectNavigationItems(organizationSlug, projectId, intl);
+  const store = useAppShellStore();
+  const resolvedItems = filterNavigationItemsByWorkspaceFlags(
+    items ?? buildProjectNavigationItems(organizationSlug, projectId, intl),
+    store.workspaceFeatureFlags,
+  );
   const resolvedProjectName =
     projectName ??
     projectQuery.data?.name ??

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
@@ -22,7 +22,7 @@ import { apiClient } from "@/lib/api-client-instance";
 import { cn } from "@/lib/primitives/cn";
 
 import { appShellNavigationMessages } from "./app-shell-navigation.messages";
-import { filterNavigationItemsByWorkspaceFlags } from "@/lib/flags/workspace-flags";
+import { filterNavigationItemsByWorkspaceFlags } from "@/lib/flags/workspace-flag-navigation";
 
 import {
   buildOrganizationPath,

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
@@ -78,6 +78,7 @@ export async function AppShell({
         avatarUrl: auth.sessionUser.profilePictureUrl ?? undefined,
       }}
       navigationGroups={navigationGroups}
+      workspaceFeatureFlags={workspaceFeatureFlags}
     >
       <OrgTmsQueryProvider
         organizationSlug={activeOrganizationSlug}

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
@@ -5,10 +5,8 @@ import { AppShellClient } from "@/components/app-shell/app-shell-client";
 import { buildGlobalNavigationGroups } from "@/components/app-shell/navigation-config";
 import { getIntlShape } from "@/lib/app-i18n/intl";
 import { getAppLocale } from "@/lib/app-i18n/server-locale";
-import {
-  evaluateWorkspaceFeatureFlags,
-  filterNavigationByWorkspaceFlags,
-} from "@/lib/flags/workspace-flags";
+import { filterNavigationByWorkspaceFlags } from "@/lib/flags/workspace-flag-navigation";
+import { evaluateWorkspaceFeatureFlags } from "@/lib/flags/workspace-flags";
 import { getTmsProviderConnection } from "@/lib/providers/jobs/tms-provider-live";
 import {
   getTmsUserConnectCtaState,

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -5,6 +5,7 @@ import { getIntlShape } from "@/lib/app-i18n/intl";
 
 import {
   WORKSPACE_AUTOMATIONS_FLAG,
+  WORKSPACE_ISSUES_FLAG,
   WORKSPACE_KNOWLEDGE_FLAG,
 } from "@/lib/flags/workos-flag-entities";
 import { RELEASE_CAT_ALL_FILES_FLAG } from "@/lib/flags/release-flag-keys";
@@ -164,6 +165,7 @@ describe("path builders", () => {
     });
     expect(byLabel.get("Automations")?.featureFlagKey).toBe(WORKSPACE_AUTOMATIONS_FLAG);
     expect(byLabel.get("Knowledge")?.featureFlagKey).toBe(WORKSPACE_KNOWLEDGE_FLAG);
+    expect(byLabel.get("Issues")?.featureFlagKey).toBe(WORKSPACE_ISSUES_FLAG);
   });
 
   it("builds project navigation items scoped to the project", () => {
@@ -177,6 +179,9 @@ describe("path builders", () => {
       ["Issue Sheet", "/org/acme/projects/proj_1/issue-sheet"],
       ["Settings", "/org/acme/projects/proj_1/settings"],
     ]);
+    expect(items.find((item) => item.label === "Issue Sheet")?.featureFlagKey).toBe(
+      WORKSPACE_ISSUES_FLAG,
+    );
   });
 });
 

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -5,6 +5,7 @@ import { normalizeAppLocale } from "@/lib/app-i18n/locales";
 import { RELEASE_CAT_ALL_FILES_FLAG } from "@/lib/flags/release-flag-keys";
 import {
   WORKSPACE_AUTOMATIONS_FLAG,
+  WORKSPACE_ISSUES_FLAG,
   WORKSPACE_KNOWLEDGE_FLAG,
 } from "@/lib/flags/workos-flag-entities";
 import { supportsCatAllFilesProvider } from "@/lib/projects/cat-all-files";
@@ -43,6 +44,7 @@ export type NavigationItem = {
   featureFlagKey?:
     | typeof WORKSPACE_AUTOMATIONS_FLAG
     | typeof WORKSPACE_KNOWLEDGE_FLAG
+    | typeof WORKSPACE_ISSUES_FLAG
     | typeof RELEASE_CAT_ALL_FILES_FLAG;
 };
 
@@ -113,6 +115,7 @@ export function buildGlobalNavigationGroups(
           }),
           href: org("issues"),
           icon: ClipboardListIcon,
+          featureFlagKey: WORKSPACE_ISSUES_FLAG,
         },
         {
           label: intl.formatMessage({
@@ -292,6 +295,7 @@ export function buildProjectNavigationItems(
       }),
       href: project("issue-sheet"),
       icon: ClipboardListIcon,
+      featureFlagKey: WORKSPACE_ISSUES_FLAG,
     },
     {
       label: intl.formatMessage({

--- a/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store-context.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store-context.tsx
@@ -4,6 +4,10 @@ import { createContext, useContext, useRef, useState, type ReactNode } from "rea
 import { usePathname } from "next/navigation";
 
 import type { NavigationGroup } from "@/components/app-shell/navigation-config";
+import {
+  DISABLED_WORKSPACE_FEATURE_FLAGS,
+  type WorkspaceFeatureFlagState,
+} from "@/lib/flags/workos-flag-entities";
 
 import { AppShellStore, createAppShellStore } from "./app-shell-store";
 
@@ -11,12 +15,16 @@ const AppShellStoreContext = createContext<AppShellStore | null>(null);
 
 export function AppShellStoreProvider({
   defaultNavigationGroups,
+  workspaceFeatureFlags = DISABLED_WORKSPACE_FEATURE_FLAGS,
   children,
 }: {
   defaultNavigationGroups: readonly NavigationGroup[];
+  workspaceFeatureFlags?: WorkspaceFeatureFlagState;
   children: ReactNode;
 }) {
-  const [store] = useState(() => createAppShellStore(defaultNavigationGroups));
+  const [store] = useState(() =>
+    createAppShellStore(defaultNavigationGroups, workspaceFeatureFlags),
+  );
   const pathname = usePathname();
   const previousPathnameRef = useRef(pathname);
 

--- a/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/store/app-shell-store.ts
@@ -2,6 +2,10 @@ import { makeAutoObservable } from "mobx";
 
 import { ChatDockStore } from "@/components/app-shell/chat-dock/chat-dock-store";
 import type { NavigationGroup } from "@/components/app-shell/navigation-config";
+import {
+  DISABLED_WORKSPACE_FEATURE_FLAGS,
+  type WorkspaceFeatureFlagState,
+} from "@/lib/flags/workos-flag-entities";
 
 import { BreadcrumbStore } from "./breadcrumb-store";
 import { HeaderActionsStore } from "./header-actions-store";
@@ -14,13 +18,18 @@ export class AppShellStore {
   breadcrumb: BreadcrumbStore;
   headerActions: HeaderActionsStore;
   chatDock: ChatDockStore;
+  workspaceFeatureFlags: WorkspaceFeatureFlagState;
 
-  constructor(defaultNavigationGroups: readonly NavigationGroup[]) {
+  constructor(
+    defaultNavigationGroups: readonly NavigationGroup[],
+    workspaceFeatureFlags: WorkspaceFeatureFlagState,
+  ) {
     this.sidebar = new SidebarStore();
     this.navigation = new NavigationStore(defaultNavigationGroups);
     this.breadcrumb = new BreadcrumbStore();
     this.headerActions = new HeaderActionsStore();
     this.chatDock = new ChatDockStore();
+    this.workspaceFeatureFlags = workspaceFeatureFlags;
 
     makeAutoObservable(
       this,
@@ -41,6 +50,9 @@ export class AppShellStore {
   }
 }
 
-export function createAppShellStore(defaultNavigationGroups: readonly NavigationGroup[]) {
-  return new AppShellStore(defaultNavigationGroups);
+export function createAppShellStore(
+  defaultNavigationGroups: readonly NavigationGroup[],
+  workspaceFeatureFlags: WorkspaceFeatureFlagState = DISABLED_WORKSPACE_FEATURE_FLAGS,
+) {
+  return new AppShellStore(defaultNavigationGroups, workspaceFeatureFlags);
 }

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
@@ -51,6 +51,8 @@ import {
   readCatWorkspaceViewMode,
 } from "@/components/cat/workspace/cat-workspace-view-mode";
 
+import { useOptionalAppShellStore } from "@/components/app-shell/store/app-shell-store-context";
+
 import { projectFileCatToWorkspaceState } from "./project-file-cat-mapper";
 import { fetchCatSegmentValidation } from "./project-file-cat-validation";
 import { useCatMutations } from "./use-cat-mutations";
@@ -102,6 +104,8 @@ export function ProjectFileCatWorkspace({
   pageNavigationGuardRef?: CatPageNavigationGuardRef;
 }) {
   const intl = useIntl();
+  const appShellStore = useOptionalAppShellStore();
+  const issuesEnabled = appShellStore?.workspaceFeatureFlags.issues ?? false;
   const internalPageNavigationGuardRef = useRef<CatPageNavigationGuard | null>(null);
   const resolvedPageNavigationGuardRef = pageNavigationGuardRef ?? internalPageNavigationGuardRef;
   const [pageLimit, setPageLimit] = useState(() =>
@@ -647,7 +651,7 @@ export function ProjectFileCatWorkspace({
           onApprove: handleApprove,
           onSaveDraft: isNativeProject ? handleSaveDraft : undefined,
           onAddComment: handleAddComment,
-          onAddToIssueSheet: handleAddToIssueSheet,
+          onAddToIssueSheet: issuesEnabled ? handleAddToIssueSheet : undefined,
           onResolveComment:
             catFile?.provider?.kind === "crowdin" ? handleResolveComment : undefined,
         }}

--- a/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
@@ -139,32 +139,36 @@ describe("workosAdapter", () => {
 const intl = getIntlShape("en") as IntlShape;
 
 describe("filterNavigationByWorkspaceFlags", () => {
-  it("removes Automations and Knowledge when workspace flags are disabled", () => {
+  it("removes Automations, Knowledge, and Issues when workspace flags are disabled", () => {
     const groups = buildGlobalNavigationGroups("acme", intl);
     const filtered = filterNavigationByWorkspaceFlags(groups, {
       automations: false,
       knowledge: false,
       visualMock: false,
+      issues: false,
     });
 
     const itemLabels = filtered.flatMap((group) => group.items.map((item) => item.label));
 
     expect(itemLabels).not.toContain("Automations");
     expect(itemLabels).not.toContain("Knowledge");
+    expect(itemLabels).not.toContain("Issues");
     expect(itemLabels).toContain("Projects");
   });
 
-  it("keeps Automations and Knowledge when workspace flags are enabled", () => {
+  it("keeps Automations, Knowledge, and Issues when workspace flags are enabled", () => {
     const groups = buildGlobalNavigationGroups("acme", intl);
     const filtered = filterNavigationByWorkspaceFlags(groups, {
       automations: true,
       knowledge: true,
       visualMock: true,
+      issues: true,
     });
 
     const itemLabels = filtered.flatMap((group) => group.items.map((item) => item.label));
 
     expect(itemLabels).toContain("Automations");
     expect(itemLabels).toContain("Knowledge");
+    expect(itemLabels).toContain("Issues");
   });
 });

--- a/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
@@ -7,7 +7,7 @@ import {
   WORKSPACE_AUTOMATIONS_FLAG,
   WORKSPACE_KNOWLEDGE_FLAG,
 } from "@/lib/flags/workos-flag-entities";
-import { filterNavigationByWorkspaceFlags } from "@/lib/flags/workspace-flags";
+import { filterNavigationByWorkspaceFlags } from "@/lib/flags/workspace-flag-navigation";
 import { getIntlShape } from "@/lib/app-i18n/intl";
 
 const isEnabled = vi.fn();

--- a/apps/hyperlocalise-web/src/lib/flags/workos-flag-entities.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-flag-entities.ts
@@ -1,6 +1,7 @@
 export const WORKSPACE_AUTOMATIONS_FLAG = "workspace-automations";
 export const WORKSPACE_KNOWLEDGE_FLAG = "workspace-knowledge";
 export const WORKSPACE_VISUAL_MOCK_FLAG = "workspace-visual-mock";
+export const WORKSPACE_ISSUES_FLAG = "workspace-issues";
 export const WORKSPACE_FEATURE_UNAVAILABLE_REASON = "feature-unavailable";
 
 export type WorkosFlagEntities = {
@@ -12,4 +13,12 @@ export type WorkspaceFeatureFlagState = {
   automations: boolean;
   knowledge: boolean;
   visualMock: boolean;
+  issues: boolean;
+};
+
+export const DISABLED_WORKSPACE_FEATURE_FLAGS: WorkspaceFeatureFlagState = {
+  automations: false,
+  knowledge: false,
+  visualMock: false,
+  issues: false,
 };

--- a/apps/hyperlocalise-web/src/lib/flags/workspace-flag-navigation.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workspace-flag-navigation.ts
@@ -1,0 +1,57 @@
+import type { NavigationGroup, NavigationItem } from "@/components/app-shell/navigation-config";
+
+import {
+  WORKSPACE_AUTOMATIONS_FLAG,
+  WORKSPACE_ISSUES_FLAG,
+  WORKSPACE_KNOWLEDGE_FLAG,
+  WORKSPACE_VISUAL_MOCK_FLAG,
+  type WorkspaceFeatureFlagState,
+} from "./workos-flag-entities";
+
+function workspaceFlagEnabledByKey(flags: WorkspaceFeatureFlagState): Record<string, boolean> {
+  return {
+    [WORKSPACE_AUTOMATIONS_FLAG]: flags.automations,
+    [WORKSPACE_KNOWLEDGE_FLAG]: flags.knowledge,
+    [WORKSPACE_VISUAL_MOCK_FLAG]: flags.visualMock,
+    [WORKSPACE_ISSUES_FLAG]: flags.issues,
+  };
+}
+
+function isNavigationItemEnabledByWorkspaceFlags(
+  item: Pick<NavigationItem, "featureFlagKey">,
+  enabledByKey: Record<string, boolean>,
+) {
+  if (!item.featureFlagKey) {
+    return true;
+  }
+
+  if (!(item.featureFlagKey in enabledByKey)) {
+    return true;
+  }
+
+  return enabledByKey[item.featureFlagKey] ?? false;
+}
+
+export function filterNavigationItemsByWorkspaceFlags(
+  items: readonly NavigationItem[],
+  flags: WorkspaceFeatureFlagState,
+): readonly NavigationItem[] {
+  const enabledByKey = workspaceFlagEnabledByKey(flags);
+  return items.filter((item) => isNavigationItemEnabledByWorkspaceFlags(item, enabledByKey));
+}
+
+export function filterNavigationByWorkspaceFlags(
+  groups: readonly NavigationGroup[],
+  flags: WorkspaceFeatureFlagState,
+): readonly NavigationGroup[] {
+  const enabledByKey = workspaceFlagEnabledByKey(flags);
+
+  return groups
+    .map((group) => ({
+      ...group,
+      items: group.items.filter((item) =>
+        isNavigationItemEnabledByWorkspaceFlags(item, enabledByKey),
+      ),
+    }))
+    .filter((group) => group.items.length > 0);
+}

--- a/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 import { flag, type Flag } from "flags/next";
 import { and, eq } from "drizzle-orm";
 
-import type { NavigationGroup } from "@/components/app-shell/navigation-config";
+import type { NavigationGroup, NavigationItem } from "@/components/app-shell/navigation-config";
 import { db, schema } from "@/lib/database";
 import type { AppAuthContext } from "@/lib/workos/app-auth";
 
@@ -11,6 +11,7 @@ import { workosAdapter } from "./workos-adapter";
 import {
   WORKSPACE_AUTOMATIONS_FLAG,
   WORKSPACE_FEATURE_UNAVAILABLE_REASON,
+  WORKSPACE_ISSUES_FLAG,
   WORKSPACE_KNOWLEDGE_FLAG,
   WORKSPACE_VISUAL_MOCK_FLAG,
   type WorkosFlagEntities,
@@ -38,18 +39,50 @@ export const workspaceVisualMockFlag = flag<boolean, WorkosFlagEntities>({
   adapter: workosAdapter(),
 });
 
+export const workspaceIssuesFlag = flag<boolean, WorkosFlagEntities>({
+  key: WORKSPACE_ISSUES_FLAG,
+  defaultValue: false,
+  description: "Workspace issues and project Issue Sheet for localization issue tracking.",
+  adapter: workosAdapter(),
+});
+
+function workspaceFlagEnabledByKey(flags: WorkspaceFeatureFlagState): Record<string, boolean> {
+  return {
+    [WORKSPACE_AUTOMATIONS_FLAG]: flags.automations,
+    [WORKSPACE_KNOWLEDGE_FLAG]: flags.knowledge,
+    [WORKSPACE_VISUAL_MOCK_FLAG]: flags.visualMock,
+    [WORKSPACE_ISSUES_FLAG]: flags.issues,
+  };
+}
+
+function isNavigationItemEnabledByWorkspaceFlags(
+  item: Pick<NavigationItem, "featureFlagKey">,
+  enabledByKey: Record<string, boolean>,
+) {
+  if (!item.featureFlagKey) {
+    return true;
+  }
+
+  if (!(item.featureFlagKey in enabledByKey)) {
+    return true;
+  }
+
+  return enabledByKey[item.featureFlagKey] ?? false;
+}
+
 export async function evaluateWorkspaceFeatureFlags(
   auth: Pick<AppAuthContext, "activeOrganization" | "user">,
 ): Promise<WorkspaceFeatureFlagState> {
   const identify = () => createWorkosIdentify(auth);
 
-  const [automations, knowledge, visualMock] = await Promise.all([
+  const [automations, knowledge, visualMock, issues] = await Promise.all([
     workspaceAutomationsFlag.run({ identify }),
     workspaceKnowledgeFlag.run({ identify }),
     workspaceVisualMockFlag.run({ identify }),
+    workspaceIssuesFlag.run({ identify }),
   ]);
 
-  return { automations, knowledge, visualMock };
+  return { automations, knowledge, visualMock, issues };
 }
 
 export async function resolveWorkspaceVisualMockFlag(input: {
@@ -115,26 +148,26 @@ export async function requireWorkspaceFeatureFlag(
   redirect("/auth/select-organization");
 }
 
+export function filterNavigationItemsByWorkspaceFlags(
+  items: readonly NavigationItem[],
+  flags: WorkspaceFeatureFlagState,
+): readonly NavigationItem[] {
+  const enabledByKey = workspaceFlagEnabledByKey(flags);
+  return items.filter((item) => isNavigationItemEnabledByWorkspaceFlags(item, enabledByKey));
+}
+
 export function filterNavigationByWorkspaceFlags(
   groups: readonly NavigationGroup[],
   flags: WorkspaceFeatureFlagState,
 ): readonly NavigationGroup[] {
-  const enabledByKey: Record<string, boolean> = {
-    [WORKSPACE_AUTOMATIONS_FLAG]: flags.automations,
-    [WORKSPACE_KNOWLEDGE_FLAG]: flags.knowledge,
-    [WORKSPACE_VISUAL_MOCK_FLAG]: flags.visualMock,
-  };
+  const enabledByKey = workspaceFlagEnabledByKey(flags);
 
   return groups
     .map((group) => ({
       ...group,
-      items: group.items.filter((item) => {
-        if (!item.featureFlagKey) {
-          return true;
-        }
-
-        return enabledByKey[item.featureFlagKey] ?? false;
-      }),
+      items: group.items.filter((item) =>
+        isNavigationItemEnabledByWorkspaceFlags(item, enabledByKey),
+      ),
     }))
     .filter((group) => group.items.length > 0);
 }

--- a/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
@@ -2,7 +2,6 @@ import { redirect } from "next/navigation";
 import { flag, type Flag } from "flags/next";
 import { and, eq } from "drizzle-orm";
 
-import type { NavigationGroup, NavigationItem } from "@/components/app-shell/navigation-config";
 import { db, schema } from "@/lib/database";
 import type { AppAuthContext } from "@/lib/workos/app-auth";
 
@@ -17,6 +16,11 @@ import {
   type WorkosFlagEntities,
   type WorkspaceFeatureFlagState,
 } from "./workos-flag-entities";
+
+export {
+  filterNavigationByWorkspaceFlags,
+  filterNavigationItemsByWorkspaceFlags,
+} from "./workspace-flag-navigation";
 
 export const workspaceAutomationsFlag = flag<boolean, WorkosFlagEntities>({
   key: WORKSPACE_AUTOMATIONS_FLAG,
@@ -45,30 +49,6 @@ export const workspaceIssuesFlag = flag<boolean, WorkosFlagEntities>({
   description: "Workspace issues and project Issue Sheet for localization issue tracking.",
   adapter: workosAdapter(),
 });
-
-function workspaceFlagEnabledByKey(flags: WorkspaceFeatureFlagState): Record<string, boolean> {
-  return {
-    [WORKSPACE_AUTOMATIONS_FLAG]: flags.automations,
-    [WORKSPACE_KNOWLEDGE_FLAG]: flags.knowledge,
-    [WORKSPACE_VISUAL_MOCK_FLAG]: flags.visualMock,
-    [WORKSPACE_ISSUES_FLAG]: flags.issues,
-  };
-}
-
-function isNavigationItemEnabledByWorkspaceFlags(
-  item: Pick<NavigationItem, "featureFlagKey">,
-  enabledByKey: Record<string, boolean>,
-) {
-  if (!item.featureFlagKey) {
-    return true;
-  }
-
-  if (!(item.featureFlagKey in enabledByKey)) {
-    return true;
-  }
-
-  return enabledByKey[item.featureFlagKey] ?? false;
-}
 
 export async function evaluateWorkspaceFeatureFlags(
   auth: Pick<AppAuthContext, "activeOrganization" | "user">,
@@ -146,28 +126,4 @@ export async function requireWorkspaceFeatureFlag(
   }
 
   redirect("/auth/select-organization");
-}
-
-export function filterNavigationItemsByWorkspaceFlags(
-  items: readonly NavigationItem[],
-  flags: WorkspaceFeatureFlagState,
-): readonly NavigationItem[] {
-  const enabledByKey = workspaceFlagEnabledByKey(flags);
-  return items.filter((item) => isNavigationItemEnabledByWorkspaceFlags(item, enabledByKey));
-}
-
-export function filterNavigationByWorkspaceFlags(
-  groups: readonly NavigationGroup[],
-  flags: WorkspaceFeatureFlagState,
-): readonly NavigationGroup[] {
-  const enabledByKey = workspaceFlagEnabledByKey(flags);
-
-  return groups
-    .map((group) => ({
-      ...group,
-      items: group.items.filter((item) =>
-        isNavigationItemEnabledByWorkspaceFlags(item, enabledByKey),
-      ),
-    }))
-    .filter((group) => group.items.length > 0);
 }

--- a/docs/plans/2026-07-16-workspace-issues-flag-design.md
+++ b/docs/plans/2026-07-16-workspace-issues-flag-design.md
@@ -1,0 +1,45 @@
+# Workspace Issues feature flag
+
+## Problem
+
+Issues (org Issues page, project Issue Sheet, CAT “Add to Issue Sheet”) is
+always visible. We need a WorkOS workspace flag so orgs can enable the product
+when ready.
+
+## Decision
+
+Add `workspace-issues` and gate the product the same way as Knowledge
+(Approach A: nav, pages, APIs, and CAT).
+
+## Flag
+
+- Key: `workspace-issues`
+- Source: WorkOS Feature Flags via existing `workosAdapter`
+- Default: `false` (fail closed)
+- No DB migration; toggle in WorkOS (optional Flags Explorer discovery)
+
+## Surfaces
+
+| Surface | When disabled |
+|---------|---------------|
+| Workspace sidebar **Issues** | Hidden (`featureFlagKey`) |
+| Project sidebar **Issue Sheet** | Hidden (filter project nav with stored flags) |
+| `/org/.../issues` | Redirect to dashboard `?reason=feature-unavailable` |
+| `/org/.../projects/.../issue-sheet` | Same redirect |
+| Org issues + project issue-sheet APIs | `403` / `feature_unavailable` |
+| CAT **Add to Issue Sheet** | Handler omitted so buttons do not render |
+
+## Implementation notes
+
+1. Extend `WorkspaceFeatureFlagState` with `issues` and evaluate
+   `workspaceIssuesFlag` in `evaluateWorkspaceFeatureFlags`.
+2. Pass flags from `AppShell` into `AppShellStore` so project nav and CAT can
+   read them without a second evaluation.
+3. Filter project nav items with the same `featureFlagKey` rules as global nav.
+4. Reuse `requireWorkspaceFeatureFlag` on pages; Knowledge-style middleware on
+   API routes.
+
+## Out of scope
+
+CAT queue `has_issues`, TMS provider issues, Format & QA issue counts, and
+in-app flag admin UI.


### PR DESCRIPTION
## What changed

Adds WorkOS workspace flag `workspace-issues` (default off) and gates Issues the same way as Knowledge: workspace/project sidebar, pages, org/project APIs, and CAT **Add to Issue Sheet**.

Design: `docs/plans/2026-07-16-workspace-issues-flag-design.md`.

## How to test

- [ ] With flag off: Issues / Issue Sheet hidden in sidebars; deep links redirect to dashboard `?reason=feature-unavailable`; APIs return `403` / `feature_unavailable`; CAT has no Add to Issue Sheet action
- [ ] With flag on in WorkOS: Issues UI and APIs work as before
- [ ] `vp check --fix` and targeted route/nav flag tests

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, issues/issue-sheet route tests, nav/flag unit tests)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)