### PR TITLE
fix(web): restore Crowdin inbox iframe access

### DIFF
--- a/apps/hyperlocalise-web/src/lib/crowdin-app/manifest.test.ts
+++ b/apps/hyperlocalise-web/src/lib/crowdin-app/manifest.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildCrowdinAppManifest } from "./manifest";
+
+describe("buildCrowdinAppManifest", () => {
+  it("exposes the inbox in the project menu and editor right panel", () => {
+    const manifest = buildCrowdinAppManifest();
+
+    expect(manifest.modules["project-menu"]).toEqual([
+      {
+        key: "inbox",
+        name: "Hyperlocalise",
+        url: "/crowdin-app/inbox",
+      },
+    ]);
+    expect(manifest.modules["editor-right-panel"]).toEqual([
+      {
+        key: "inbox-editor",
+        name: "Hyperlocalise",
+        modes: ["translate"],
+        supportsMultipleStrings: false,
+        url: "/crowdin-app/inbox",
+      },
+    ]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/crowdin-app/manifest.ts
+++ b/apps/hyperlocalise-web/src/lib/crowdin-app/manifest.ts
@@ -38,6 +38,15 @@ export function buildCrowdinAppManifest() {
           url: "/crowdin-app/inbox",
         },
       ],
+      "editor-right-panel": [
+        {
+          key: "inbox-editor",
+          name: "Hyperlocalise",
+          modes: ["translate"],
+          supportsMultipleStrings: false,
+          url: "/crowdin-app/inbox",
+        },
+      ],
     },
   };
 }

--- a/apps/hyperlocalise-web/src/proxy.test.ts
+++ b/apps/hyperlocalise-web/src/proxy.test.ts
@@ -151,4 +151,22 @@ describe("proxy", () => {
     );
     expect(response?.headers.get("X-Frame-Options")).toBeNull();
   });
+
+  it("keeps AuthKit redirects inside the Crowdin App iframe", async () => {
+    authkitProxyMock.mockReset();
+    authkitProxyMock.mockResolvedValueOnce(
+      NextResponse.redirect("https://www.hyperlocalise.com/auth/sign-in"),
+    );
+
+    const response = await proxy(createRequest("/crowdin-app/inbox"), {} as never);
+
+    expect(response?.status).toBe(503);
+    expect(await response?.text()).toBe("Crowdin app unavailable");
+    expect(response?.headers.get("location")).toBeNull();
+    expect(response?.headers.get("Cache-Control")).toBe("no-store");
+    expect(response?.headers.get("Content-Security-Policy")).toBe(
+      buildCrowdinAppFrameAncestorsCsp(),
+    );
+    expect(response?.headers.get("X-Frame-Options")).toBeNull();
+  });
 });

--- a/apps/hyperlocalise-web/src/proxy.test.ts
+++ b/apps/hyperlocalise-web/src/proxy.test.ts
@@ -135,13 +135,17 @@ describe("proxy", () => {
     expect(response?.status).toBe(200);
   });
 
-  it("sets Crowdin App frame-ancestors CSP on iframe pages without AuthKit", async () => {
+  it("runs Crowdin App iframe pages through AuthKit before applying frame-ancestors CSP", async () => {
     authkitProxyMock.mockReset();
+    authkitProxyMock.mockResolvedValueOnce(NextResponse.next());
 
     const response = await proxy(createRequest("/crowdin-app/inbox"), {} as never);
 
-    expect(authkitProxyMock).not.toHaveBeenCalled();
+    expect(authkitProxyMock).toHaveBeenCalledOnce();
     expect(response?.status).toBe(200);
+    expect(response?.headers.get(`x-middleware-request-${REQUEST_URL_HEADER}`)).toBe(
+      "https://www.hyperlocalise.com/crowdin-app/inbox",
+    );
     expect(response?.headers.get("Content-Security-Policy")).toBe(
       buildCrowdinAppFrameAncestorsCsp(),
     );

--- a/apps/hyperlocalise-web/src/proxy.ts
+++ b/apps/hyperlocalise-web/src/proxy.ts
@@ -29,11 +29,6 @@ function applyCrowdinAppFrameAncestors(response: NextResponse): NextResponse {
 function shouldBypassWorkosProxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  // Crowdin App iframe pages authenticate via Crowdin JWT + embed session.
-  if (isCrowdinAppPath(pathname)) {
-    return true;
-  }
-
   if (!isFixtureAuthEnabled()) {
     return false;
   }
@@ -98,11 +93,7 @@ export function ensureRequestUrlHeader(request: NextRequest, response: NextRespo
 
 async function maybeWorkosProxy(request: NextRequest, event: NextFetchEvent) {
   if (shouldBypassWorkosProxy(request)) {
-    const response = nextWithRequestUrl(request);
-    if (isCrowdinAppPath(request.nextUrl.pathname)) {
-      return applyCrowdinAppFrameAncestors(response);
-    }
-    return response;
+    return nextWithRequestUrl(request);
   }
 
   const response = await workosProxy(request, event);
@@ -110,7 +101,12 @@ async function maybeWorkosProxy(request: NextRequest, event: NextFetchEvent) {
     return response;
   }
 
-  return ensureRequestUrlHeader(request, response);
+  const nextResponse = ensureRequestUrlHeader(request, response);
+  if (isCrowdinAppPath(request.nextUrl.pathname)) {
+    return applyCrowdinAppFrameAncestors(nextResponse);
+  }
+
+  return nextResponse;
 }
 
 const PUBLIC_LOCALIZED_PREFIXES = ["/product", "/use-cases", "/blog"];

--- a/apps/hyperlocalise-web/src/proxy.ts
+++ b/apps/hyperlocalise-web/src/proxy.ts
@@ -101,8 +101,18 @@ async function maybeWorkosProxy(request: NextRequest, event: NextFetchEvent) {
     return response;
   }
 
+  const isCrowdinAppRequest = isCrowdinAppPath(request.nextUrl.pathname);
+  if (isCrowdinAppRequest && response.headers.has("location")) {
+    return applyCrowdinAppFrameAncestors(
+      new NextResponse("Crowdin app unavailable", {
+        status: 503,
+        headers: { "Cache-Control": "no-store" },
+      }),
+    );
+  }
+
   const nextResponse = ensureRequestUrlHeader(request, response);
-  if (isCrowdinAppPath(request.nextUrl.pathname)) {
+  if (isCrowdinAppRequest) {
     return applyCrowdinAppFrameAncestors(nextResponse);
   }
 

--- a/docs/plans/2026-07-16-crowdin-app-inbox-design.md
+++ b/docs/plans/2026-07-16-crowdin-app-inbox-design.md
@@ -123,7 +123,9 @@ Allow framing only for `/crowdin-app/*` from Crowdin origins
 frame policy elsewhere. Run iframe page requests through the WorkOS AuthKit
 proxy because the shared root layout reads its middleware context, then apply
 the Crowdin-specific `frame-ancestors` CSP to the response. Crowdin JWT and
-embed-session verification remain the authorization boundary.
+embed-session verification remain the authorization boundary. If AuthKit
+returns a redirect for an iframe page, replace it with a non-cacheable `503`
+response so the iframe never navigates to WorkOS sign-in.
 
 ## Data flow
 

--- a/docs/plans/2026-07-16-crowdin-app-inbox-design.md
+++ b/docs/plans/2026-07-16-crowdin-app-inbox-design.md
@@ -10,7 +10,7 @@ inbox in a Crowdin project.
 ## Decision
 
 Host a Crowdin App inside `hyperlocalise-web` that exposes a **project-scoped**
-agent chat inbox in a Crowdin `project-menu` iframe.
+agent chat inbox in Crowdin `project-menu` and `editor-right-panel` iframes.
 
 - Reuse inbox UI and conversation/chat APIs.
 - Resolve the Hyperlocalise org from the Crowdin JWT against the org Crowdin
@@ -120,7 +120,10 @@ install rows are metadata for later Crowdin-as-app API use.
 
 Allow framing only for `/crowdin-app/*` from Crowdin origins
 (`*.crowdin.com` and configurable Enterprise domains). Keep restrictive
-frame policy elsewhere.
+frame policy elsewhere. Run iframe page requests through the WorkOS AuthKit
+proxy because the shared root layout reads its middleware context, then apply
+the Crowdin-specific `frame-ancestors` CSP to the response. Crowdin JWT and
+embed-session verification remain the authorization boundary.
 
 ## Data flow
 


### PR DESCRIPTION
## What changed

- Route `/crowdin-app/*` through AuthKit before applying the Crowdin `frame-ancestors` CSP, preventing the shared layout’s `withAuth()` middleware-coverage error.
- Expose the existing inbox through an `editor-right-panel` module in translate mode.
- Add focused proxy and manifest tests.
- Update the Crowdin App design documentation.

## How to test

- `vp test src/proxy.test.ts src/lib/crowdin-app/manifest.test.ts`
- `vp check --fix`
- `vp test`
  - The full suite reaches 2,857 passing tests but fails because the local database is missing `organization_external_tms_provider_credentials.external_organization_id`.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review