### PR TITLE
feat(web): localize automations, CAT skeleton, and principles section

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.messages.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const automationDetailPageContentMessages = defineMessages({
+  updateSuccess: {
+    defaultMessage: "Automation updated",
+    id: "TqKPfOkj7i",
+    description: "Toast when a workspace automation is saved successfully",
+  },
+  updateError: {
+    defaultMessage: "Unable to save automation right now",
+    id: "YzNLnailQi",
+    description: "Toast when saving a workspace automation fails",
+  },
+  runQueued: {
+    defaultMessage: "Manual run queued",
+    id: "pMNkzc+47V",
+    description: "Toast when a manual automation run is queued successfully",
+  },
+  runError: {
+    defaultMessage: "Unable to queue a manual run right now",
+    id: "6zAmu9E3FT",
+    description: "Toast when queueing a manual automation run fails",
+  },
+  loading: {
+    defaultMessage: "Loading automation...",
+    id: "YGyu9mb0BB",
+    description: "Loading state while an automation detail page is fetching",
+  },
+  runNow: {
+    defaultMessage: "Run now",
+    id: "P5eC/nlEOZ",
+    description: "Button to queue a manual automation run",
+  },
+  saving: {
+    defaultMessage: "Saving...",
+    id: "4mzmyHsHW0",
+    description: "Save button label while the automation update request is pending",
+  },
+  saveChanges: {
+    defaultMessage: "Save changes",
+    id: "F6jskX12It",
+    description: "Button to save automation detail changes",
+  },
+  backToAutomations: {
+    defaultMessage: "Back to automations",
+    id: "aEJ2kyKHZN",
+    description: "Link back to the workspace automations list",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -14,6 +15,7 @@ import {
   validateWorkspaceAutomationFormState,
 } from "@/lib/agents/workspace-automation-view-model";
 import { WorkspacePageShell } from "../../_components/workspace-resource-shared";
+import { automationDetailPageContentMessages } from "./automation-detail-page-content.messages";
 import { WorkspaceAutomationEditor } from "./workspace-automation-form";
 
 export function AutomationDetailPageContent({
@@ -23,6 +25,7 @@ export function AutomationDetailPageContent({
   organizationSlug: string;
   automationId: string;
 }) {
+  const intl = useIntl();
   const queryClient = useQueryClient();
 
   const automationQuery = useQuery({
@@ -86,7 +89,7 @@ export function AutomationDetailPageContent({
       return response.json();
     },
     onSuccess: () => {
-      toast.success("Automation updated");
+      toast.success(intl.formatMessage(automationDetailPageContentMessages.updateSuccess));
       void queryClient.invalidateQueries({
         queryKey: ["workspace-automation", organizationSlug, automationId],
       });
@@ -98,7 +101,7 @@ export function AutomationDetailPageContent({
       if (error.message === "validation_failed") {
         return;
       }
-      toast.error("Unable to save automation right now");
+      toast.error(intl.formatMessage(automationDetailPageContentMessages.updateError));
     },
   });
 
@@ -118,20 +121,22 @@ export function AutomationDetailPageContent({
       return response.json();
     },
     onSuccess: () => {
-      toast.success("Manual run queued");
+      toast.success(intl.formatMessage(automationDetailPageContentMessages.runQueued));
       void queryClient.invalidateQueries({
         queryKey: ["workspace-automation", organizationSlug, automationId],
       });
     },
     onError: () => {
-      toast.error("Unable to queue a manual run right now");
+      toast.error(intl.formatMessage(automationDetailPageContentMessages.runError));
     },
   });
 
   if (automationQuery.isLoading || !form || !automation) {
     return (
       <WorkspacePageShell>
-        <p className="text-sm text-muted-foreground">Loading automation...</p>
+        <p className="text-sm text-muted-foreground">
+          <FormattedMessage {...automationDetailPageContentMessages.loading} />
+        </p>
       </WorkspacePageShell>
     );
   }
@@ -152,10 +157,14 @@ export function AutomationDetailPageContent({
               onClick={() => runMutation.mutate()}
               disabled={runMutation.isPending || automation.status !== "active"}
             >
-              Run now
+              <FormattedMessage {...automationDetailPageContentMessages.runNow} />
             </Button>
             <Button onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending}>
-              {saveMutation.isPending ? "Saving..." : "Save changes"}
+              {saveMutation.isPending ? (
+                <FormattedMessage {...automationDetailPageContentMessages.saving} />
+              ) : (
+                <FormattedMessage {...automationDetailPageContentMessages.saveChanges} />
+              )}
             </Button>
           </div>
         }
@@ -167,7 +176,7 @@ export function AutomationDetailPageContent({
           nativeButton={false}
           render={<Link href={`/org/${organizationSlug}/automations`} />}
         >
-          Back to automations
+          <FormattedMessage {...automationDetailPageContentMessages.backToAutomations} />
         </Button>
       </div>
     </WorkspacePageShell>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-new-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-new-page-content.messages.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const automationsNewPageContentMessages = defineMessages({
+  createFailed: {
+    defaultMessage: "Failed to create automation",
+    id: "v/lSaCxqUY",
+    description: "Error when creating a workspace automation fails without an API message",
+  },
+  createSuccess: {
+    defaultMessage: "Automation created",
+    id: "7zni895OkR",
+    description: "Toast when a new workspace automation is created successfully",
+  },
+  createError: {
+    defaultMessage: "Unable to create automation right now",
+    id: "sUjt/GKyKZ",
+    description: "Toast when creating a workspace automation fails",
+  },
+  cancel: {
+    defaultMessage: "Cancel",
+    id: "X4qUUPKAse",
+    description: "Button to cancel creating a new automation",
+  },
+  creating: {
+    defaultMessage: "Creating...",
+    id: "EavgCh3/dm",
+    description: "Create button label while the automation create request is pending",
+  },
+  createAutomation: {
+    defaultMessage: "Create automation",
+    id: "45owmhJRGR",
+    description: "Button to submit the new automation form",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-new-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-new-page-content.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useMutation } from "@tanstack/react-query";
+import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -16,6 +17,7 @@ import {
   type WorkspaceAutomationFormState,
 } from "@/lib/agents/workspace-automation-view-model";
 import { WorkspacePageShell } from "../../_components/workspace-resource-shared";
+import { automationsNewPageContentMessages } from "./automations-new-page-content.messages";
 import { WorkspaceAutomationEditor } from "./workspace-automation-form";
 
 export function AutomationsNewPageContent({
@@ -25,6 +27,7 @@ export function AutomationsNewPageContent({
   organizationSlug: string;
   initialForm?: WorkspaceAutomationFormState;
 }) {
+  const intl = useIntl();
   const router = useRouter();
   const [form, setForm] = useState(initialForm);
   const [errors, setErrors] = useState<Record<string, string | undefined>>({});
@@ -51,20 +54,22 @@ export function AutomationsNewPageContent({
         if (body?.error) {
           setErrors(mapWorkspaceAutomationApiErrorToFieldErrors(body.error));
         }
-        throw new Error(body?.message ?? "Failed to create automation");
+        throw new Error(
+          body?.message ?? intl.formatMessage(automationsNewPageContentMessages.createFailed),
+        );
       }
 
       return response.json();
     },
     onSuccess: (body) => {
-      toast.success("Automation created");
+      toast.success(intl.formatMessage(automationsNewPageContentMessages.createSuccess));
       router.push(`/org/${organizationSlug}/automations/${body.automation.id}`);
     },
     onError: (error) => {
       if (error.message === "validation_failed") {
         return;
       }
-      toast.error("Unable to create automation right now");
+      toast.error(intl.formatMessage(automationsNewPageContentMessages.createError));
     },
   });
 
@@ -83,10 +88,14 @@ export function AutomationsNewPageContent({
               nativeButton={false}
               render={<Link href={`/org/${organizationSlug}/automations`} />}
             >
-              Cancel
+              <FormattedMessage {...automationsNewPageContentMessages.cancel} />
             </Button>
             <Button onClick={() => createMutation.mutate()} disabled={createMutation.isPending}>
-              {createMutation.isPending ? "Creating..." : "Create automation"}
+              {createMutation.isPending ? (
+                <FormattedMessage {...automationsNewPageContentMessages.creating} />
+              ) : (
+                <FormattedMessage {...automationsNewPageContentMessages.createAutomation} />
+              )}
             </Button>
           </>
         }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.messages.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const automationsPageViewModelMessages = defineMessages({
+  relativeHours: {
+    defaultMessage: "{hours}h",
+    id: "F/BtD1KZKq",
+    description: "Relative age of an automation created less than a day ago",
+  },
+  relativeDays: {
+    defaultMessage: "{days}d",
+    id: "BFQt98qExR",
+    description: "Relative age of an automation created one or more days ago",
+  },
+  triggerScheduled: {
+    defaultMessage: "Scheduled",
+    id: "MXyOWGXSz8",
+    description: "Trigger label for a scheduled automation in the list",
+  },
+  triggerGithub: {
+    defaultMessage: "GitHub push",
+    id: "uycq9iF49K",
+    description: "Trigger label for a GitHub push automation in the list",
+  },
+  triggerManual: {
+    defaultMessage: "Manual",
+    id: "sbr8qd8WgZ",
+    description: "Trigger label for a manual automation in the list",
+  },
+  toolGithub: {
+    defaultMessage: "GitHub",
+    id: "LKQXtMkDON",
+    description: "Tool badge when an automation uses GitHub",
+  },
+  toolSlack: {
+    defaultMessage: "Slack",
+    id: "y5oeiThV/6",
+    description: "Tool badge when an automation uses Slack",
+  },
+  toolEmail: {
+    defaultMessage: "Email",
+    id: "6QqDATp4yt",
+    description: "Tool badge when an automation uses email",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.ts
@@ -1,3 +1,5 @@
+import type { IntlShape } from "react-intl";
+
 import {
   WORKSPACE_AUTOMATION_TEMPLATE_CATEGORIES,
   listWorkspaceAutomationTemplates,
@@ -8,6 +10,8 @@ import type {
   WorkspaceAutomationRecord,
   WorkspaceAutomationTriggerConfig,
 } from "@/lib/agents/workspace-automations";
+
+import { automationsPageViewModelMessages } from "./automations-page-view-model.messages";
 
 export function resolveVisibleAutomations(automations: WorkspaceAutomationRecord[]) {
   return automations.filter((automation) => automation.status !== "archived");
@@ -47,38 +51,49 @@ export function resolveTemplateCategoryTabs(templates: WorkspaceAutomationTempla
   return WORKSPACE_AUTOMATION_TEMPLATE_CATEGORIES.filter((category) => counts.has(category.id));
 }
 
-export function formatAutomationRelativeTimestamp(value: string, now = Date.now()) {
+export function formatAutomationRelativeTimestamp(
+  intl: IntlShape,
+  value: string,
+  now = Date.now(),
+) {
   const date = new Date(value);
   const diffMs = now - date.getTime();
   const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
   if (diffHours < 24) {
-    return `${Math.max(diffHours, 1)}h`;
+    return intl.formatMessage(automationsPageViewModelMessages.relativeHours, {
+      hours: Math.max(diffHours, 1),
+    });
   }
 
   const diffDays = Math.floor(diffHours / 24);
-  return `${diffDays}d`;
+  return intl.formatMessage(automationsPageViewModelMessages.relativeDays, {
+    days: diffDays,
+  });
 }
 
-export function resolveAutomationTriggerLabel(triggerConfig: WorkspaceAutomationTriggerConfig) {
+export function resolveAutomationTriggerLabel(
+  intl: IntlShape,
+  triggerConfig: WorkspaceAutomationTriggerConfig,
+) {
   if (triggerConfig.mode === "scheduled") {
-    return "Scheduled";
+    return intl.formatMessage(automationsPageViewModelMessages.triggerScheduled);
   }
   if (triggerConfig.mode === "github") {
-    return "GitHub push";
+    return intl.formatMessage(automationsPageViewModelMessages.triggerGithub);
   }
-  return "Manual";
+  return intl.formatMessage(automationsPageViewModelMessages.triggerManual);
 }
 
-export function resolveAutomationTools(automation: WorkspaceAutomationRecord) {
+export function resolveAutomationTools(intl: IntlShape, automation: WorkspaceAutomationRecord) {
   const tools: string[] = [];
   if (automation.toolConfig.github?.enabled) {
-    tools.push("GitHub");
+    tools.push(intl.formatMessage(automationsPageViewModelMessages.toolGithub));
   }
   if (automation.toolConfig.slack?.enabled) {
-    tools.push("Slack");
+    tools.push(intl.formatMessage(automationsPageViewModelMessages.toolSlack));
   }
   if (automation.toolConfig.email?.enabled) {
-    tools.push("Email");
+    tools.push(intl.formatMessage(automationsPageViewModelMessages.toolEmail));
   }
   return tools;
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.messages.ts
@@ -1,0 +1,143 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const automationsPageViewMessages = defineMessages({
+  pageLabel: {
+    defaultMessage: "Workspace",
+    id: "22cLivfsp0",
+    description: "Automations page header eyebrow label",
+  },
+  pageTitle: {
+    defaultMessage: "Automations",
+    id: "hScQeR54rc",
+    description: "Automations page heading",
+  },
+  pageDescription: {
+    defaultMessage:
+      "Automate repetitive tasks with always-on workflows that respond to schedules and GitHub pushes.",
+    id: "9xPbF7DCJr",
+    description: "Automations page description under the heading",
+  },
+  newAutomation: {
+    defaultMessage: "New Automation",
+    id: "1um5cM9poq",
+    description: "Button to create a new workspace automation",
+  },
+  loadingAutomations: {
+    defaultMessage: "Loading automations",
+    id: "o1Kg4Vat6I",
+    description: "Accessible label while the automations list is loading",
+  },
+  totalAutomations: {
+    defaultMessage: "Total automations",
+    id: "LWbZAQ/S/H",
+    description: "Stat card label for total automation count",
+  },
+  activeCount: {
+    defaultMessage: "Active",
+    id: "SluNUViHRX",
+    description: "Stat card label for active automation count",
+  },
+  pausedCount: {
+    defaultMessage: "Paused",
+    id: "zxNwuNh3O4",
+    description: "Stat card label for paused automation count",
+  },
+  columnAutomation: {
+    defaultMessage: "Automation",
+    id: "phMXmlQCix",
+    description: "Automations list column header for name",
+  },
+  columnTools: {
+    defaultMessage: "Tools",
+    id: "DWXDNH6bM+",
+    description: "Automations list column header for tools",
+  },
+  columnStatus: {
+    defaultMessage: "Status",
+    id: "g/SyG0phTI",
+    description: "Automations list column header for status",
+  },
+  columnCreated: {
+    defaultMessage: "Created",
+    id: "z5k8iKEIXN",
+    description: "Automations list column header for created date",
+  },
+  loadError: {
+    defaultMessage: "Automations failed to load.",
+    id: "qfAtSAXlkS",
+    description: "Error title when the automations list request fails",
+  },
+  loadErrorFallback: {
+    defaultMessage: "Refresh the page to try again.",
+    id: "XMW6IBe3PH",
+    description: "Fallback error description when no API message is available",
+  },
+  emptyList: {
+    defaultMessage: "No automations yet. Start from a template below or create a new automation.",
+    id: "Z7EtcHtkyS",
+    description: "Empty state when the workspace has no automations",
+  },
+  statusActive: {
+    defaultMessage: "Active",
+    id: "MyhfQjH0sE",
+    description: "Badge label when an automation is active",
+  },
+  statusPaused: {
+    defaultMessage: "Paused",
+    id: "+5c87/Ii+m",
+    description: "Badge label when an automation is paused",
+  },
+  templatesTitle: {
+    defaultMessage: "Templates",
+    id: "EGX8+adWDn",
+    description: "Section heading for automation templates",
+  },
+  templatesDescription: {
+    defaultMessage:
+      "Start from a curated workflow. Templates prefill the creation form with instructions, triggers, and tools.",
+    id: "HTsdqd2HP4",
+    description: "Section description for automation templates",
+  },
+  categoryPopular: {
+    defaultMessage: "Popular",
+    id: "EJdAEUdkMf",
+    description: "Template category filter tab for popular templates",
+  },
+  categorySourceContent: {
+    defaultMessage: "Source Content",
+    id: "DI7vTror/h",
+    description: "Template category filter tab for source content templates",
+  },
+  categoryMarketing: {
+    defaultMessage: "Marketing",
+    id: "H/CmKBQumj",
+    description: "Template category filter tab for marketing templates",
+  },
+  categoryTranslationDelivery: {
+    defaultMessage: "Translation Delivery",
+    id: "jCORO6tbhT",
+    description: "Template category filter tab for translation delivery templates",
+  },
+  categoryQuality: {
+    defaultMessage: "Quality",
+    id: "QZITZRdJzR",
+    description: "Template category filter tab for quality templates",
+  },
+  categoryRelease: {
+    defaultMessage: "Release Readiness",
+    id: "EvF3cGlK0a",
+    description: "Template category filter tab for release readiness templates",
+  },
+  addTemplate: {
+    defaultMessage: "Add",
+    id: "rIuVU6iths",
+    description: "Button to create an automation from a template",
+  },
+  comingSoon: {
+    defaultMessage: "Coming soon",
+    id: "Oyb9LX/sl2",
+    description: "Disabled button when a template is not yet activatable",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { Fragment, useMemo, useState, type ReactNode } from "react";
 import { Add01Icon, SparklesIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -19,6 +20,7 @@ import type { WorkspaceAutomationRecord } from "@/lib/agents/workspace-automatio
 
 import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
 import { AutomationTemplateFlow } from "./automation-template-flow";
+import { automationsPageViewMessages } from "./automations-page-view.messages";
 import {
   formatAutomationRelativeTimestamp,
   resolveAutomationPageStats,
@@ -35,9 +37,23 @@ const TEMPLATE_FILTER_TABS_CLASS =
 const AUTOMATION_LIST_GRID_CLASS =
   "grid grid-cols-[minmax(0,1.6fr)_minmax(0,0.8fr)_minmax(0,0.8fr)_minmax(0,0.5fr)] gap-4";
 
+const TEMPLATE_CATEGORY_MESSAGES = {
+  popular: automationsPageViewMessages.categoryPopular,
+  "source-content": automationsPageViewMessages.categorySourceContent,
+  marketing: automationsPageViewMessages.categoryMarketing,
+  "translation-delivery": automationsPageViewMessages.categoryTranslationDelivery,
+  quality: automationsPageViewMessages.categoryQuality,
+  release: automationsPageViewMessages.categoryRelease,
+} as const;
+
 function AutomationListSkeleton() {
+  const intl = useIntl();
+
   return (
-    <div aria-busy="true" aria-label="Loading automations">
+    <div
+      aria-busy="true"
+      aria-label={intl.formatMessage(automationsPageViewMessages.loadingAutomations)}
+    >
       {Array.from({ length: 5 }).map((_, index) => (
         <div
           key={index}
@@ -100,7 +116,8 @@ function defaultRenderActionLink({
 }
 
 function AutomationToolsSummary({ automation }: { automation: WorkspaceAutomationRecord }) {
-  const tools = resolveAutomationTools(automation);
+  const intl = useIntl();
+  const tools = resolveAutomationTools(intl, automation);
 
   return (
     <div className="flex flex-wrap gap-1">
@@ -132,6 +149,7 @@ export function AutomationsPageView({
   renderAutomationLink?: AutomationsLinkRenderer;
   renderActionLink?: AutomationsActionLinkRenderer;
 }) {
+  const intl = useIntl();
   const [templateCategoryFilter, setTemplateCategoryFilter] =
     useState<WorkspaceAutomationTemplateCategory>("popular");
 
@@ -151,16 +169,16 @@ export function AutomationsPageView({
     <WorkspacePageShell>
       <PageHeader
         icon={SparklesIcon}
-        label="Workspace"
-        title="Automations"
-        description="Automate repetitive tasks with always-on workflows that respond to schedules and GitHub pushes."
+        label={intl.formatMessage(automationsPageViewMessages.pageLabel)}
+        title={intl.formatMessage(automationsPageViewMessages.pageTitle)}
+        description={intl.formatMessage(automationsPageViewMessages.pageDescription)}
         actions={renderActionLink({
           href: `/org/${organizationSlug}/automations/new`,
           kind: "header",
           children: (
             <>
               <HugeiconsIcon icon={Add01Icon} strokeWidth={2} />
-              New Automation
+              <FormattedMessage {...automationsPageViewMessages.newAutomation} />
             </>
           ),
         })}
@@ -169,19 +187,25 @@ export function AutomationsPageView({
       <section className="grid gap-4 md:grid-cols-3">
         <Card>
           <CardHeader>
-            <CardDescription>Total automations</CardDescription>
+            <CardDescription>
+              <FormattedMessage {...automationsPageViewMessages.totalAutomations} />
+            </CardDescription>
             <CardTitle className="text-3xl">{stats.total}</CardTitle>
           </CardHeader>
         </Card>
         <Card>
           <CardHeader>
-            <CardDescription>Active</CardDescription>
+            <CardDescription>
+              <FormattedMessage {...automationsPageViewMessages.activeCount} />
+            </CardDescription>
             <CardTitle className="text-3xl">{stats.active}</CardTitle>
           </CardHeader>
         </Card>
         <Card>
           <CardHeader>
-            <CardDescription>Paused</CardDescription>
+            <CardDescription>
+              <FormattedMessage {...automationsPageViewMessages.pausedCount} />
+            </CardDescription>
             <CardTitle className="text-3xl">{stats.paused}</CardTitle>
           </CardHeader>
         </Card>
@@ -192,25 +216,35 @@ export function AutomationsPageView({
           <div
             className={`${AUTOMATION_LIST_GRID_CLASS} border-b border-border px-4 py-3 text-xs font-medium text-muted-foreground`}
           >
-            <span>Automation</span>
-            <span>Tools</span>
-            <span>Status</span>
-            <span>Created</span>
+            <span>
+              <FormattedMessage {...automationsPageViewMessages.columnAutomation} />
+            </span>
+            <span>
+              <FormattedMessage {...automationsPageViewMessages.columnTools} />
+            </span>
+            <span>
+              <FormattedMessage {...automationsPageViewMessages.columnStatus} />
+            </span>
+            <span>
+              <FormattedMessage {...automationsPageViewMessages.columnCreated} />
+            </span>
           </div>
           {isLoading ? (
             <AutomationListSkeleton />
           ) : error ? (
             <div className="px-4 py-10">
               <TypographyP className="text-sm font-medium text-flame-100">
-                Automations failed to load.
+                <FormattedMessage {...automationsPageViewMessages.loadError} />
               </TypographyP>
               <TypographyP className="mt-1 text-xs text-muted-foreground">
-                {error instanceof Error ? error.message : "Refresh the page to try again."}
+                {error instanceof Error
+                  ? error.message
+                  : intl.formatMessage(automationsPageViewMessages.loadErrorFallback)}
               </TypographyP>
             </div>
           ) : visibleAutomations.length === 0 ? (
             <div className="px-4 py-10 text-sm text-muted-foreground">
-              No automations yet. Start from a template below or create a new automation.
+              <FormattedMessage {...automationsPageViewMessages.emptyList} />
             </div>
           ) : (
             visibleAutomations.map((automation) => (
@@ -223,15 +257,19 @@ export function AutomationsPageView({
                       <div className="min-w-0">
                         <p className="truncate text-sm font-medium">{automation.name}</p>
                         <p className="truncate text-xs text-muted-foreground">
-                          {resolveAutomationTriggerLabel(automation.triggerConfig)}
+                          {resolveAutomationTriggerLabel(intl, automation.triggerConfig)}
                         </p>
                       </div>
                       <AutomationToolsSummary automation={automation} />
                       <Badge variant={automation.status === "active" ? "default" : "secondary"}>
-                        {automation.status}
+                        {automation.status === "active" ? (
+                          <FormattedMessage {...automationsPageViewMessages.statusActive} />
+                        ) : (
+                          <FormattedMessage {...automationsPageViewMessages.statusPaused} />
+                        )}
                       </Badge>
                       <span className="text-sm text-muted-foreground">
-                        {formatAutomationRelativeTimestamp(automation.createdAt, now)}
+                        {formatAutomationRelativeTimestamp(intl, automation.createdAt, now)}
                       </span>
                     </>
                   ),
@@ -245,11 +283,10 @@ export function AutomationsPageView({
       <section className="mt-6 flex flex-col gap-4">
         <div>
           <h2 className="font-sans text-base font-medium text-balance text-foreground">
-            Templates
+            <FormattedMessage {...automationsPageViewMessages.templatesTitle} />
           </h2>
           <TypographyP className="text-muted-foreground">
-            Start from a curated workflow. Templates prefill the creation form with instructions,
-            triggers, and tools.
+            <FormattedMessage {...automationsPageViewMessages.templatesDescription} />
           </TypographyP>
         </div>
         <Tabs
@@ -269,7 +306,7 @@ export function AutomationsPageView({
                 value={category.id}
                 className={TEMPLATE_FILTER_TABS_CLASS}
               >
-                {category.label}
+                <FormattedMessage {...TEMPLATE_CATEGORY_MESSAGES[category.id]} />
               </TabsTrigger>
             ))}
           </TabsList>
@@ -288,11 +325,11 @@ export function AutomationsPageView({
                     renderActionLink({
                       href: `/org/${organizationSlug}/automations/new?template=${template.id}`,
                       kind: "template",
-                      children: "Add",
+                      children: <FormattedMessage {...automationsPageViewMessages.addTemplate} />,
                     })
                   ) : (
                     <Button size="sm" variant="outline" className="rounded-full" disabled>
-                      Coming soon
+                      <FormattedMessage {...automationsPageViewMessages.comingSoon} />
                     </Button>
                   )}
                 </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -18,4 +18,613 @@ export const workspaceAutomationFormMessages = defineMessages({
     id: "8d4Iw9Q9DE",
     description: "Summary for a scheduled automation that runs weekly on a specific day and hour",
   },
+  githubPushSummary: {
+    defaultMessage: "GitHub push · {repository} · {branches}",
+    id: "feBDOpIUbJ",
+    description: "Header summary for a GitHub push trigger",
+  },
+  repositoryRequired: {
+    defaultMessage: "repository required",
+    id: "+UD+5d3g3H",
+    description: "Placeholder in GitHub push summary when no repository is selected",
+  },
+  branchesRequired: {
+    defaultMessage: "branches required",
+    id: "YcomzE3n8l",
+    description: "Placeholder in GitHub push summary when no branch patterns are set",
+  },
+  contentfulWebhook: {
+    defaultMessage: "Contentful webhook",
+    id: "1krX2eFo9o",
+    description: "Label for the Contentful webhook trigger",
+  },
+  sourceUploadSummary: {
+    defaultMessage: "Source upload · {project}",
+    id: "3xhOvPA3lu",
+    description: "Header summary for a source upload trigger with a project name",
+  },
+  sourceUploadProjectRequired: {
+    defaultMessage: "Source upload · project required",
+    id: "fBOGoQ4jb4",
+    description: "Header summary for a source upload trigger when no project is selected",
+  },
+  selectRepository: {
+    defaultMessage: "Select repository",
+    id: "Tmw2QL/c7u",
+    description: "Placeholder when no GitHub repository is selected",
+  },
+  unknownRepository: {
+    defaultMessage: "Unknown repository",
+    id: "5Yf/LdtZRn",
+    description: "Label when a selected repository id is not in the loaded list",
+  },
+  repositoryDisabledSuffix: {
+    defaultMessage: "{name} (disabled)",
+    id: "LJSVMM6T2P",
+    description: "Repository option label when the repository is disabled",
+  },
+  repositoryLabel: {
+    defaultMessage: "Repository",
+    id: "Omhk26keD1",
+    description: "Label for the GitHub repository select",
+  },
+  connectGithubForRepository: {
+    defaultMessage: "Connect GitHub to choose a repository",
+    id: "StXIOq7nWw",
+    description: "Placeholder when GitHub is not connected so repositories cannot be chosen",
+  },
+  selectChannel: {
+    defaultMessage: "Select channel",
+    id: "J7Yta0PrqK",
+    description: "Placeholder when no Slack channel is selected",
+  },
+  selectConnection: {
+    defaultMessage: "Select connection",
+    id: "x6H592pqcv",
+    description: "Placeholder when no Contentful connection is selected",
+  },
+  selectProject: {
+    defaultMessage: "Select project",
+    id: "CQAPVFsXtD",
+    description: "Placeholder when no project is selected",
+  },
+  unknownProject: {
+    defaultMessage: "Unknown project",
+    id: "avoSAOCHz4",
+    description: "Label when a selected project id is not in the loaded list",
+  },
+  projectsMenu: {
+    defaultMessage: "Projects",
+    id: "5OJwSyhCmS",
+    description: "Dropdown label for the project selector",
+  },
+  unableToLoadProjects: {
+    defaultMessage: "Unable to load projects",
+    id: "/RotSbukS0",
+    description: "Error item when projects fail to load in the selector",
+  },
+  noProjectsFound: {
+    defaultMessage: "No projects found",
+    id: "9actmxeaKu",
+    description: "Empty state when there are no projects to select",
+  },
+  selectedShortcut: {
+    defaultMessage: "Selected",
+    id: "JUfajjODRg",
+    description: "Shortcut hint for the currently selected project",
+  },
+  branchesPlaceholder: {
+    defaultMessage: "Branches",
+    id: "xx4TyhA9Af",
+    description: "Branch pattern selector label when no branches are added",
+  },
+  branchPatternsMenu: {
+    defaultMessage: "Branch patterns",
+    id: "iL0uh6nGuj",
+    description: "Dropdown label for branch pattern management",
+  },
+  noBranchesAdded: {
+    defaultMessage: "No branches added",
+    id: "Tm/8Q9uIIU",
+    description: "Empty state when no branch patterns are configured",
+  },
+  removeShortcut: {
+    defaultMessage: "Remove",
+    id: "LDFu1kaYeg",
+    description: "Shortcut hint to remove a branch pattern",
+  },
+  branchPatternAriaLabel: {
+    defaultMessage: "Branch pattern",
+    id: "Mo34UnIccj",
+    description: "Accessible label for the branch pattern input",
+  },
+  addBranch: {
+    defaultMessage: "Add",
+    id: "uqGZNAVfVF",
+    description: "Button to add a branch pattern",
+  },
+  addTrigger: {
+    defaultMessage: "Add Trigger",
+    id: "DPE4D8nJkF",
+    description: "Button to open the add-trigger menu",
+  },
+  supportedTriggers: {
+    defaultMessage: "Supported triggers",
+    id: "peYw3ULGLY",
+    description: "Dropdown section label for available automation triggers",
+  },
+  manualRun: {
+    defaultMessage: "Manual run",
+    id: "Ya1gnhy/x1",
+    description: "Menu item to select a manual trigger",
+  },
+  scheduled: {
+    defaultMessage: "Scheduled",
+    id: "bCXvSTPFsb",
+    description: "Menu item to select a scheduled trigger",
+  },
+  githubPush: {
+    defaultMessage: "GitHub push",
+    id: "6YRqpDlcKq",
+    description: "Label for the GitHub push trigger",
+  },
+  sourceUpload: {
+    defaultMessage: "Source upload",
+    id: "91uWukrQcJ",
+    description: "Label for the source upload trigger",
+  },
+  addedShortcut: {
+    defaultMessage: "Added",
+    id: "UQM29Qy4Ux",
+    description: "Shortcut hint when a trigger or tool is already added",
+  },
+  connectFirstShortcut: {
+    defaultMessage: "Connect first",
+    id: "dYlXc1BTpY",
+    description: "Shortcut hint when an integration must be connected first",
+  },
+  syncOnlyShortcut: {
+    defaultMessage: "Sync only",
+    id: "Qr6HIhIqfm",
+    description: "Shortcut hint when GitHub push is unavailable because agent mode is enabled",
+  },
+  enableFirstShortcut: {
+    defaultMessage: "Enable first",
+    id: "ZQbvwhJWXn",
+    description: "Shortcut hint when email must be enabled first",
+  },
+  triggersSection: {
+    defaultMessage: "Triggers",
+    id: "3kjfANjxLP",
+    description: "Section heading for automation trigger settings",
+  },
+  every: {
+    defaultMessage: "Every",
+    id: "tr/WtfszIz",
+    description: "Prefix label before the schedule cadence select",
+  },
+  cadenceHour: {
+    defaultMessage: "Hour",
+    id: "gXZ1TC7mZA",
+    description: "Hourly schedule cadence option",
+  },
+  cadenceDay: {
+    defaultMessage: "Day",
+    id: "+ixHu5wBKG",
+    description: "Daily schedule cadence option",
+  },
+  cadenceWeek: {
+    defaultMessage: "Week",
+    id: "4Iy9AzpaNC",
+    description: "Weekly schedule cadence option",
+  },
+  at: {
+    defaultMessage: "at",
+    id: "yC7UjRaWKX",
+    description: "Preposition between cadence and time in the schedule row",
+  },
+  scheduleTimezoneAriaLabel: {
+    defaultMessage: "Schedule timezone",
+    id: "VFS/q4p0GR",
+    description: "Accessible label for the schedule timezone input",
+  },
+  manualOnlyTitle: {
+    defaultMessage: "Manual only",
+    id: "YPT/4ux3Z/",
+    description: "Title when the automation only supports manual runs",
+  },
+  manualOnlyDescription: {
+    defaultMessage: "Runs only start when a teammate queues one from this automation.",
+    id: "yc2ziR1Owc",
+    description: "Description for the manual-only trigger",
+  },
+  contentfulWebhookConnectedDescription: {
+    defaultMessage: "Runs when Contentful sends a matching entry create or update webhook.",
+    id: "GdV4Jl3WMg",
+    description: "Description for Contentful webhook trigger when Contentful is connected",
+  },
+  contentfulWebhookDisconnectedDescription: {
+    defaultMessage: "Connect Contentful in Integrations before this trigger can run.",
+    id: "PsCe6RXT6P",
+    description: "Description for Contentful webhook trigger when Contentful is not connected",
+  },
+  sourceUploadDescription: {
+    defaultMessage: "Runs when a source file is uploaded to the project selected above.",
+    id: "1QEv3c/AxW",
+    description: "Description for the source upload trigger",
+  },
+  addTool: {
+    defaultMessage: "Add Tool",
+    id: "FCdijMuIQ9",
+    description: "Button to open the add-tool menu",
+  },
+  supportedTools: {
+    defaultMessage: "Supported tools",
+    id: "WsiwWcs52J",
+    description: "Dropdown section label for available automation tools",
+  },
+  useGithubRepo: {
+    defaultMessage: "Use GitHub repo",
+    id: "l9fbW9HiTx",
+    description: "Menu item and tool title for the GitHub agent repository tool",
+  },
+  githubSyncWorkflows: {
+    defaultMessage: "GitHub sync workflows",
+    id: "wewNVYT5+w",
+    description: "Menu item and tool title for GitHub sync workflows",
+  },
+  sendToSlack: {
+    defaultMessage: "Send to Slack",
+    id: "rxbmdOIAMH",
+    description: "Menu item and tool title for Slack notifications",
+  },
+  sendEmail: {
+    defaultMessage: "Send email",
+    id: "8rom3KX2rX",
+    description: "Menu item and tool title for email notifications",
+  },
+  contentfulTranslate: {
+    defaultMessage: "Contentful translate",
+    id: "ywFNKJfKqp",
+    description: "Menu item and tool title for Contentful translation",
+  },
+  translate: {
+    defaultMessage: "Translate",
+    id: "rVbcl0T6/F",
+    description: "Menu item and tool title for translation jobs",
+  },
+  comingSoon: {
+    defaultMessage: "Coming soon",
+    id: "lvwFhMaVAT",
+    description: "Dropdown section label for tools that are not yet available",
+  },
+  contentfulTargetLocalesEmpty: {
+    defaultMessage: "Select a Contentful connection to choose target locales.",
+    id: "DCeid5ejmn",
+    description: "Empty state when Contentful target locales cannot be chosen yet",
+  },
+  toolsSection: {
+    defaultMessage: "Tools",
+    id: "Z39eNFe81L",
+    description: "Section heading for automation tool settings",
+  },
+  useGithubRepoDescription: {
+    defaultMessage:
+      "Read the repository and follow your instructions. GitHub skills apply automatically.",
+    id: "hpOVndgWkJ",
+    description: "Description for the GitHub agent repository tool",
+  },
+  removeGithubRepoTool: {
+    defaultMessage: "Remove GitHub repo tool",
+    id: "Dz+BYN4QJV",
+    description: "Accessible label to remove the GitHub agent repository tool",
+  },
+  githubSyncWorkflowsDescription: {
+    defaultMessage: "Push source, pull translations, and validation checks.",
+    id: "YJJ6zC95OW",
+    description: "Description for GitHub sync workflows",
+  },
+  removeGithubSyncWorkflows: {
+    defaultMessage: "Remove GitHub sync workflows",
+    id: "FlXBmFercA",
+    description: "Accessible label to remove GitHub sync workflows",
+  },
+  pushSource: {
+    defaultMessage: "Push source",
+    id: "CXxeX4tNjR",
+    description: "Toggle label for the push source GitHub sync workflow",
+  },
+  pullTranslations: {
+    defaultMessage: "Pull translations",
+    id: "N1gb0F1ogJ",
+    description: "Toggle label for the pull translations GitHub sync workflow",
+  },
+  validation: {
+    defaultMessage: "Validation",
+    id: "jCbFiXpIeD",
+    description: "Toggle label for the validation GitHub sync workflow",
+  },
+  connectFirstBadge: {
+    defaultMessage: "Connect first",
+    id: "e9TsGisohb",
+    description: "Badge when a tool requires connecting an integration first",
+  },
+  enableFirstBadge: {
+    defaultMessage: "Enable first",
+    id: "33PBu8aQXh",
+    description: "Badge when email notifications require enabling the email agent first",
+  },
+  slackConnectedDescription: {
+    defaultMessage: "Notify a channel when runs reach a terminal state.",
+    id: "7vHEse/Aa+",
+    description: "Description for Slack notifications when Slack is connected",
+  },
+  slackDisconnectedDescription: {
+    defaultMessage: "Connect Slack in <link>Integrations</link> to use this tool.",
+    id: "so9cmZxAcw",
+    description: "Description for Slack notifications when Slack is not connected",
+  },
+  removeSlackNotifications: {
+    defaultMessage: "Remove Slack notifications",
+    id: "r8GjXoDLd7",
+    description: "Accessible label to remove Slack notifications",
+  },
+  channelLabel: {
+    defaultMessage: "Channel",
+    id: "T8F8lD+KK1",
+    description: "Label for the Slack channel select",
+  },
+  loadingChannels: {
+    defaultMessage: "Loading channels...",
+    id: "D0mCtflyKZ",
+    description: "Placeholder while Slack channels are loading",
+  },
+  noChannelsFound: {
+    defaultMessage: "No channels found",
+    id: "AiZ8NmX54q",
+    description: "Empty state when no Slack channels are available",
+  },
+  privateChannelSuffix: {
+    defaultMessage: "#{name} (private)",
+    id: "PYB6jMwARG",
+    description: "Slack channel option label for a private channel",
+  },
+  publicChannelLabel: {
+    defaultMessage: "#{name}",
+    id: "ZH8KR1tpOB",
+    description: "Slack channel option label for a public channel",
+  },
+  emailConnectedDescription: {
+    defaultMessage: "Send terminal run summaries to specific recipients.",
+    id: "DdTfqNy1em",
+    description: "Description for email notifications when email is enabled",
+  },
+  emailDisconnectedDescription: {
+    defaultMessage:
+      "Enable the email agent in <link>Integrations</link> to use email notifications.",
+    id: "QlWnr3uEAw",
+    description: "Description for email notifications when email is not enabled",
+  },
+  removeEmailNotifications: {
+    defaultMessage: "Remove email notifications",
+    id: "/fmhRd2i7v",
+    description: "Accessible label to remove email notifications",
+  },
+  recipientsLabel: {
+    defaultMessage: "Recipients",
+    id: "S7JuKVNtvx",
+    description: "Label for the email recipients field",
+  },
+  contentfulTranslateConnectedDescription: {
+    defaultMessage:
+      "Translate detected Contentful fields, run QA, and write drafts back for review.",
+    id: "t11/mMIbiZ",
+    description: "Description for Contentful translate when Contentful is connected",
+  },
+  contentfulTranslateDisconnectedDescription: {
+    defaultMessage: "Connect Contentful in <link>Integrations</link> to use this tool.",
+    id: "E0kqf33f8D",
+    description: "Description for Contentful translate when Contentful is not connected",
+  },
+  removeContentfulTranslate: {
+    defaultMessage: "Remove Contentful translate",
+    id: "8pW28B/viJ",
+    description: "Accessible label to remove the Contentful translate tool",
+  },
+  connectionLabel: {
+    defaultMessage: "Connection",
+    id: "BntV+FD+ax",
+    description: "Label for the Contentful connection select",
+  },
+  connectionDisabledSuffix: {
+    defaultMessage: "{name} (disabled)",
+    id: "dCR6D4Achx",
+    description: "Contentful connection option label when the connection is disabled",
+  },
+  projectLabel: {
+    defaultMessage: "Project",
+    id: "JqELr8GP9s",
+    description: "Label for the project select in Contentful settings",
+  },
+  entryIdLabel: {
+    defaultMessage: "Entry ID",
+    id: "auMBZJ74kN",
+    description: "Label for the Contentful entry ID field",
+  },
+  contentfulEntryIdPlaceholder: {
+    defaultMessage: "Contentful entry ID",
+    id: "YDQwelYneJ",
+    description: "Placeholder for the Contentful entry ID input",
+  },
+  targetLocalesLabel: {
+    defaultMessage: "Target locales",
+    id: "45uXWs1VTb",
+    description: "Label for the target locales picker",
+  },
+  runQa: {
+    defaultMessage: "Run QA",
+    id: "Y89oWQA4Iq",
+    description: "Toggle label for running QA on Contentful translations",
+  },
+  writeDrafts: {
+    defaultMessage: "Write drafts",
+    id: "tHTaRJpN/S",
+    description: "Toggle label for writing Contentful drafts",
+  },
+  overwriteTargets: {
+    defaultMessage: "Overwrite targets",
+    id: "GuEU+qQCHt",
+    description: "Toggle label for overwriting Contentful target locales",
+  },
+  translateDescription: {
+    defaultMessage:
+      "Queue translation jobs for uploaded source files in the project selected above.",
+    id: "1AN+Q/JkbE",
+    description: "Description for the translate tool",
+  },
+  removeTranslate: {
+    defaultMessage: "Remove Translate",
+    id: "xKI0yR66AU",
+    description: "Accessible label to remove the translate tool",
+  },
+  useProjectTargetLocales: {
+    defaultMessage: "Use project target locales",
+    id: "gDkh3u6Ds/",
+    description: "Toggle label to use the project’s configured target locales",
+  },
+  chooseProjectForTargetLocales: {
+    defaultMessage: "Choose a project above to pick target locales.",
+    id: "dn9Ff93vY2",
+    description: "Empty state when translation target locales need a project first",
+  },
+  noRunsYet: {
+    defaultMessage: "No runs yet.",
+    id: "kSA5sHlbN9",
+    description: "Empty state when an automation has no run history",
+  },
+  historyStatus: {
+    defaultMessage: "Status",
+    id: "tK7acLhoUb",
+    description: "Run history column header for status",
+  },
+  historyTrigger: {
+    defaultMessage: "Trigger",
+    id: "B49vrN6vd7",
+    description: "Run history column header for trigger source",
+  },
+  historySummary: {
+    defaultMessage: "Summary",
+    id: "gfTpniOS4y",
+    description: "Run history column header for output summary",
+  },
+  historyCompleted: {
+    defaultMessage: "Completed",
+    id: "SKhTQyZkDY",
+    description: "Run history column header for completion time",
+  },
+  runStatusQueued: {
+    defaultMessage: "Queued",
+    id: "x8HYMdg8Zs",
+    description: "Automation run status badge for queued",
+  },
+  runStatusRunning: {
+    defaultMessage: "Running",
+    id: "2QksXdo4Pa",
+    description: "Automation run status badge for running",
+  },
+  runStatusSucceeded: {
+    defaultMessage: "Succeeded",
+    id: "N9BYBbfFW0",
+    description: "Automation run status badge for succeeded",
+  },
+  runStatusFailed: {
+    defaultMessage: "Failed",
+    id: "ImJlsQdxZz",
+    description: "Automation run status badge for failed",
+  },
+  runStatusCancelled: {
+    defaultMessage: "Cancelled",
+    id: "jbZqr4hs7O",
+    description: "Automation run status badge for cancelled",
+  },
+  runStatusSkipped: {
+    defaultMessage: "Skipped",
+    id: "rDkQbK1OIB",
+    description: "Automation run status badge for skipped",
+  },
+  triggerSourceManual: {
+    defaultMessage: "Manual",
+    id: "xkthiVH+yt",
+    description: "Run history trigger source for manual runs",
+  },
+  triggerSourceScheduled: {
+    defaultMessage: "Scheduled",
+    id: "R7vhxRuwOx",
+    description: "Run history trigger source for scheduled runs",
+  },
+  triggerSourceGithub: {
+    defaultMessage: "GitHub",
+    id: "USEpvu/QYB",
+    description: "Run history trigger source for GitHub runs",
+  },
+  triggerSourceContentful: {
+    defaultMessage: "Contentful",
+    id: "RDYoEaU2oe",
+    description: "Run history trigger source for Contentful runs",
+  },
+  triggerSourceSourceUpload: {
+    defaultMessage: "Source upload",
+    id: "HS6xLp94fT",
+    description: "Run history trigger source for source upload runs",
+  },
+  automationNameLabel: {
+    defaultMessage: "Automation name",
+    id: "0wt+Elr1cE",
+    description: "Accessible label for the automation name field",
+  },
+  untitledAutomationPlaceholder: {
+    defaultMessage: "Untitled automation",
+    id: "DTYOuQdye9",
+    description: "Placeholder for the automation name field",
+  },
+  statusActive: {
+    defaultMessage: "Active",
+    id: "ibTu9Z1u2B",
+    description: "Status toggle label when the automation is active",
+  },
+  statusPaused: {
+    defaultMessage: "Paused",
+    id: "Zm6E60imOZ",
+    description: "Status toggle label when the automation is paused",
+  },
+  toolCount: {
+    defaultMessage: "{count, plural, one {# tool} other {# tools}}",
+    id: "6z9r7qs8fj",
+    description: "Summary of how many tools are configured on the automation",
+  },
+  activateRequiresTool: {
+    defaultMessage: "Add at least one supported tool to activate this automation.",
+    id: "QL/gA8x5xr",
+    description: "Hint when the automation cannot be activated without a tool",
+  },
+  settingsTab: {
+    defaultMessage: "Settings",
+    id: "+0cpswe8Tj",
+    description: "Tab label for automation settings",
+  },
+  runHistoryTab: {
+    defaultMessage: "Run History",
+    id: "GERghL+Meu",
+    description: "Tab label for automation run history",
+  },
+  agentInstructionsSection: {
+    defaultMessage: "Agent Instructions",
+    id: "Ej5U0a0604",
+    description: "Section heading for automation agent instructions",
+  },
+  instructionsPlaceholder: {
+    defaultMessage: "Tell the automation what to do, what to inspect, and what to ignore.",
+    id: "rkQ7AmKMrt",
+    description: "Placeholder for the automation instructions textarea",
+  },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -13,7 +13,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useQuery } from "@tanstack/react-query";
 import { ClockIcon, MailIcon, SearchIcon, Trash2Icon } from "lucide-react";
-import { useIntl, type IntlShape } from "react-intl";
+import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
 import type { SimpleIcon } from "simple-icons";
 import {
   siGoogle,
@@ -98,6 +98,11 @@ type ComingSoonAutomationTool = {
   name: string;
   icon?: SimpleIcon;
 };
+
+const COMING_SOON_GOOGLE_MENU_LABEL = "Google";
+const COMING_SOON_LINEAR_MENU_LABEL = "Linear";
+const METADATA_SEPARATOR = "|";
+const EMPTY_CELL = "—";
 
 const COMING_SOON_SERP_TOOLS: readonly ComingSoonAutomationTool[] = [
   { id: "semrush", name: "Semrush", icon: siSemrush },
@@ -254,18 +259,29 @@ function triggerSummary(
     const repository = repositories.find(
       (entry) => entry.id === form.githubInstallationRepositoryId,
     );
-    const repositoryLabel = repository?.fullName ?? "repository required";
-    const branchLabel = form.pushBranches.join(", ") || "branches required";
-    return `GitHub push · ${repositoryLabel} · ${branchLabel}`;
+    const repositoryLabel =
+      repository?.fullName ??
+      intl.formatMessage(workspaceAutomationFormMessages.repositoryRequired);
+    const branchLabel =
+      form.pushBranches.join(", ") ||
+      intl.formatMessage(workspaceAutomationFormMessages.branchesRequired);
+    return intl.formatMessage(workspaceAutomationFormMessages.githubPushSummary, {
+      repository: repositoryLabel,
+      branches: branchLabel,
+    });
   }
 
   if (form.triggerMode === "contentful") {
-    return "Contentful webhook";
+    return intl.formatMessage(workspaceAutomationFormMessages.contentfulWebhook);
   }
 
   if (form.triggerMode === "source_upload") {
     const project = projects.find((entry) => entry.id === form.translationProjectId);
-    return project?.name ? `Source upload · ${project.name}` : "Source upload · project required";
+    return project?.name
+      ? intl.formatMessage(workspaceAutomationFormMessages.sourceUploadSummary, {
+          project: project.name,
+        })
+      : intl.formatMessage(workspaceAutomationFormMessages.sourceUploadProjectRequired);
   }
 
   return "";
@@ -281,22 +297,29 @@ function toolCount(form: WorkspaceAutomationFormState) {
   );
 }
 
-function formatRepositoryOptionLabel(repository: GithubRepositoryOption) {
-  return `${repository.fullName}${repository.enabled ? "" : " (disabled)"}`;
+function formatRepositoryOptionLabel(intl: IntlShape, repository: GithubRepositoryOption) {
+  if (repository.enabled) {
+    return repository.fullName;
+  }
+
+  return intl.formatMessage(workspaceAutomationFormMessages.repositoryDisabledSuffix, {
+    name: repository.fullName,
+  });
 }
 
 function selectedRepositoryLabel(
+  intl: IntlShape,
   repositoryId: string,
   repositories: GithubRepositoryOption[],
-  placeholder = "Select repository",
+  placeholder?: string,
 ) {
   if (!repositoryId) {
-    return placeholder;
+    return placeholder ?? intl.formatMessage(workspaceAutomationFormMessages.selectRepository);
   }
 
   return (
     repositories.find((repository) => repository.id === repositoryId)?.fullName ??
-    "Unknown repository"
+    intl.formatMessage(workspaceAutomationFormMessages.unknownRepository)
   );
 }
 
@@ -327,9 +350,13 @@ function GithubRepositorySelect({
   onChange: (next: WorkspaceAutomationFormState) => void;
   repositories: GithubRepositoryOption[];
 }) {
+  const intl = useIntl();
+
   return (
     <div className="grid gap-1.5">
-      <Label className="text-xs text-muted-foreground">Repository</Label>
+      <Label className="text-xs text-muted-foreground">
+        <FormattedMessage {...workspaceAutomationFormMessages.repositoryLabel} />
+      </Label>
       <Select
         value={form.githubInstallationRepositoryId || undefined}
         onValueChange={(value) => {
@@ -347,14 +374,14 @@ function GithubRepositorySelect({
         <SelectTrigger className="h-8 w-full rounded-lg">
           <span className="truncate">
             {repositories.length === 0
-              ? "Connect GitHub to choose a repository"
-              : selectedRepositoryLabel(form.githubInstallationRepositoryId, repositories)}
+              ? intl.formatMessage(workspaceAutomationFormMessages.connectGithubForRepository)
+              : selectedRepositoryLabel(intl, form.githubInstallationRepositoryId, repositories)}
           </span>
         </SelectTrigger>
         <SelectContent>
           {repositories.map((repository) => (
             <SelectItem key={repository.id} value={repository.id}>
-              {formatRepositoryOptionLabel(repository)}
+              {formatRepositoryOptionLabel(intl, repository)}
             </SelectItem>
           ))}
         </SelectContent>
@@ -364,21 +391,36 @@ function GithubRepositorySelect({
   );
 }
 
-function selectedSlackChannelLabel(channelId: string, channels: SlackChannelOption[]) {
+function selectedSlackChannelLabel(
+  intl: IntlShape,
+  channelId: string,
+  channels: SlackChannelOption[],
+) {
   if (!channelId) {
-    return "Select channel";
+    return intl.formatMessage(workspaceAutomationFormMessages.selectChannel);
   }
 
   const channel = channels.find((entry) => entry.id === channelId);
-  return channel ? `#${channel.name}` : channelId;
+  if (!channel) {
+    return channelId;
+  }
+
+  return channel.private
+    ? intl.formatMessage(workspaceAutomationFormMessages.privateChannelSuffix, {
+        name: channel.name,
+      })
+    : intl.formatMessage(workspaceAutomationFormMessages.publicChannelLabel, {
+        name: channel.name,
+      });
 }
 
 function selectedContentfulConnectionLabel(
+  intl: IntlShape,
   connectionId: string,
   connections: ContentfulConnectionOption[],
 ) {
   if (!connectionId) {
-    return "Select connection";
+    return intl.formatMessage(workspaceAutomationFormMessages.selectConnection);
   }
 
   return (
@@ -401,6 +443,7 @@ function HeaderProjectSelector({
   onChange: (next: WorkspaceAutomationFormState) => void;
   projects: ProjectOption[];
 }) {
+  const intl = useIntl();
   const usesTranslationProject =
     form.triggerMode === "source_upload" ||
     (form.translationEnabled && (form.triggerMode !== "github" || !form.githubEnabled));
@@ -410,7 +453,10 @@ function HeaderProjectSelector({
   const activeProjectId = usesTranslationProject ? form.translationProjectId : form.githubProjectId;
   const selectedProject = selectableProjects.find((project) => project.id === activeProjectId);
   const triggerLabel =
-    selectedProject?.name ?? (activeProjectId ? "Unknown project" : "Select project");
+    selectedProject?.name ??
+    (activeProjectId
+      ? intl.formatMessage(workspaceAutomationFormMessages.unknownProject)
+      : intl.formatMessage(workspaceAutomationFormMessages.selectProject));
 
   function handleProjectSelect(projectId: string) {
     if (usesTranslationProject) {
@@ -447,17 +493,27 @@ function HeaderProjectSelector({
       </DropdownMenuTrigger>
       <DropdownMenuContent className="min-w-56" align="start">
         <DropdownMenuGroup>
-          <DropdownMenuLabel>Projects</DropdownMenuLabel>
-          {isError ? <DropdownMenuItem disabled>Unable to load projects</DropdownMenuItem> : null}
+          <DropdownMenuLabel>
+            <FormattedMessage {...workspaceAutomationFormMessages.projectsMenu} />
+          </DropdownMenuLabel>
+          {isError ? (
+            <DropdownMenuItem disabled>
+              <FormattedMessage {...workspaceAutomationFormMessages.unableToLoadProjects} />
+            </DropdownMenuItem>
+          ) : null}
           {!isLoading && selectableProjects.length === 0 ? (
-            <DropdownMenuItem disabled>No projects found</DropdownMenuItem>
+            <DropdownMenuItem disabled>
+              <FormattedMessage {...workspaceAutomationFormMessages.noProjectsFound} />
+            </DropdownMenuItem>
           ) : null}
           {selectableProjects.map((project) => (
             <DropdownMenuItem key={project.id} onClick={() => handleProjectSelect(project.id)}>
               <HugeiconsIcon icon={FolderLibraryIcon} strokeWidth={1.8} className="size-4" />
               {project.name}
               {activeProjectId === project.id ? (
-                <DropdownMenuShortcut>Selected</DropdownMenuShortcut>
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.selectedShortcut} />
+                </DropdownMenuShortcut>
               ) : null}
             </DropdownMenuItem>
           ))}
@@ -467,9 +523,9 @@ function HeaderProjectSelector({
   );
 }
 
-function formatBranchPatternLabel(branches: string[]) {
+function formatBranchPatternLabel(intl: IntlShape, branches: string[]) {
   if (branches.length === 0) {
-    return "Branches";
+    return intl.formatMessage(workspaceAutomationFormMessages.branchesPlaceholder);
   }
 
   if (branches.length === 1) {
@@ -523,7 +579,7 @@ function BranchPatternSelector({
             />
           }
         >
-          <span className="truncate">{formatBranchPatternLabel(branches)}</span>
+          <span className="truncate">{formatBranchPatternLabel(intl, branches)}</span>
           <HugeiconsIcon
             icon={ArrowDown01Icon}
             strokeWidth={1.8}
@@ -532,9 +588,13 @@ function BranchPatternSelector({
         </DropdownMenuTrigger>
         <DropdownMenuContent className="min-w-56" align="start">
           <DropdownMenuGroup>
-            <DropdownMenuLabel>Branch patterns</DropdownMenuLabel>
+            <DropdownMenuLabel>
+              <FormattedMessage {...workspaceAutomationFormMessages.branchPatternsMenu} />
+            </DropdownMenuLabel>
             {branches.length === 0 ? (
-              <DropdownMenuItem disabled>No branches added</DropdownMenuItem>
+              <DropdownMenuItem disabled>
+                <FormattedMessage {...workspaceAutomationFormMessages.noBranchesAdded} />
+              </DropdownMenuItem>
             ) : (
               branches.map((branch) => (
                 <DropdownMenuItem
@@ -542,7 +602,9 @@ function BranchPatternSelector({
                   onClick={() => onChange(branches.filter((value) => value !== branch))}
                 >
                   <span className="min-w-0 flex-1 truncate">{branch}</span>
-                  <DropdownMenuShortcut>Remove</DropdownMenuShortcut>
+                  <DropdownMenuShortcut>
+                    <FormattedMessage {...workspaceAutomationFormMessages.removeShortcut} />
+                  </DropdownMenuShortcut>
                 </DropdownMenuItem>
               ))
             )}
@@ -554,7 +616,9 @@ function BranchPatternSelector({
             onClick={(event) => event.stopPropagation()}
           >
             <Input
-              aria-label="Branch pattern"
+              aria-label={intl.formatMessage(
+                workspaceAutomationFormMessages.branchPatternAriaLabel,
+              )}
               value={branchInput}
               disabled={disabled}
               placeholder="main"
@@ -578,7 +642,7 @@ function BranchPatternSelector({
               className="h-8 shrink-0"
               onClick={handleAdd}
             >
-              Add
+              <FormattedMessage {...workspaceAutomationFormMessages.addBranch} />
             </Button>
           </div>
           {inputError ? <p className="px-2 pb-2 text-xs text-destructive">{inputError}</p> : null}
@@ -619,19 +683,23 @@ function AddTriggerMenu({
           }
         >
           <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} className="size-4" />
-          Add Trigger
+          <FormattedMessage {...workspaceAutomationFormMessages.addTrigger} />
         </DropdownMenuTrigger>
         <DropdownMenuContent className="w-72" align="start" sideOffset={2}>
           <DropdownMenuGroup>
-            <DropdownMenuLabel>Supported triggers</DropdownMenuLabel>
+            <DropdownMenuLabel>
+              <FormattedMessage {...workspaceAutomationFormMessages.supportedTriggers} />
+            </DropdownMenuLabel>
             <DropdownMenuItem
               disabled={form.triggerMode === "manual"}
               onClick={() => onChange({ ...form, triggerMode: "manual" })}
             >
               <ClockIcon className="size-4" />
-              Manual run
+              <FormattedMessage {...workspaceAutomationFormMessages.manualRun} />
               {form.triggerMode === "manual" ? (
-                <DropdownMenuShortcut>Added</DropdownMenuShortcut>
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                </DropdownMenuShortcut>
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -639,9 +707,11 @@ function AddTriggerMenu({
               onClick={() => onChange({ ...form, triggerMode: "scheduled" })}
             >
               <ClockIcon className="size-4" />
-              Scheduled
+              <FormattedMessage {...workspaceAutomationFormMessages.scheduled} />
               {form.triggerMode === "scheduled" ? (
-                <DropdownMenuShortcut>Added</DropdownMenuShortcut>
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                </DropdownMenuShortcut>
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -671,13 +741,19 @@ function AddTriggerMenu({
               }}
             >
               <HugeiconsIcon icon={GitBranchIcon} strokeWidth={1.8} className="size-4" />
-              GitHub push
+              <FormattedMessage {...workspaceAutomationFormMessages.githubPush} />
               {form.triggerMode === "github" ? (
-                <DropdownMenuShortcut>Added</DropdownMenuShortcut>
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                </DropdownMenuShortcut>
               ) : !githubConnected ? (
-                <DropdownMenuShortcut>Connect first</DropdownMenuShortcut>
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
+                </DropdownMenuShortcut>
               ) : form.githubEnabled && form.githubMode === "agent" ? (
-                <DropdownMenuShortcut>Sync only</DropdownMenuShortcut>
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.syncOnlyShortcut} />
+                </DropdownMenuShortcut>
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -691,11 +767,15 @@ function AddTriggerMenu({
               }
             >
               <SearchIcon className="size-4" />
-              Contentful webhook
+              <FormattedMessage {...workspaceAutomationFormMessages.contentfulWebhook} />
               {form.triggerMode === "contentful" ? (
-                <DropdownMenuShortcut>Added</DropdownMenuShortcut>
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                </DropdownMenuShortcut>
               ) : !contentfulConnected ? (
-                <DropdownMenuShortcut>Connect first</DropdownMenuShortcut>
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
+                </DropdownMenuShortcut>
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -711,9 +791,11 @@ function AddTriggerMenu({
               }
             >
               <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} className="size-4" />
-              Source upload
+              <FormattedMessage {...workspaceAutomationFormMessages.sourceUpload} />
               {form.triggerMode === "source_upload" ? (
-                <DropdownMenuShortcut>Added</DropdownMenuShortcut>
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                </DropdownMenuShortcut>
               ) : null}
             </DropdownMenuItem>
           </DropdownMenuGroup>
@@ -743,14 +825,16 @@ function TriggerSettings({
   const intl = useIntl();
 
   return (
-    <EditorSection title="Triggers">
+    <EditorSection title={intl.formatMessage(workspaceAutomationFormMessages.triggersSection)}>
       <EditorPanel>
         {form.triggerMode === "scheduled" ? (
           <EditorRow
             icon={<ClockIcon className="size-4" />}
             title={
               <>
-                <span>Every</span>
+                <span>
+                  <FormattedMessage {...workspaceAutomationFormMessages.every} />
+                </span>
                 <Select
                   value={form.scheduledCadence}
                   onValueChange={(value) =>
@@ -765,9 +849,15 @@ function TriggerSettings({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="hourly">Hour</SelectItem>
-                    <SelectItem value="daily">Day</SelectItem>
-                    <SelectItem value="weekly">Week</SelectItem>
+                    <SelectItem value="hourly">
+                      <FormattedMessage {...workspaceAutomationFormMessages.cadenceHour} />
+                    </SelectItem>
+                    <SelectItem value="daily">
+                      <FormattedMessage {...workspaceAutomationFormMessages.cadenceDay} />
+                    </SelectItem>
+                    <SelectItem value="weekly">
+                      <FormattedMessage {...workspaceAutomationFormMessages.cadenceWeek} />
+                    </SelectItem>
                   </SelectContent>
                 </Select>
                 {form.scheduledCadence === "weekly" ? (
@@ -795,7 +885,9 @@ function TriggerSettings({
                 ) : null}
                 {form.scheduledCadence !== "hourly" ? (
                   <>
-                    <span>at</span>
+                    <span>
+                      <FormattedMessage {...workspaceAutomationFormMessages.at} />
+                    </span>
                     <Select
                       value={String(form.scheduledHourUtc)}
                       onValueChange={(value) =>
@@ -820,7 +912,9 @@ function TriggerSettings({
                   </>
                 ) : null}
                 <Input
-                  aria-label="Schedule timezone"
+                  aria-label={intl.formatMessage(
+                    workspaceAutomationFormMessages.scheduleTimezoneAriaLabel,
+                  )}
                   value={form.scheduledTimezone}
                   disabled={disabled}
                   className="h-8 w-32 rounded-lg px-2 text-sm"
@@ -839,7 +933,7 @@ function TriggerSettings({
         {form.triggerMode === "github" ? (
           <EditorRow
             icon={<HugeiconsIcon icon={GitBranchIcon} strokeWidth={1.8} className="size-4" />}
-            title="GitHub push"
+            title={<FormattedMessage {...workspaceAutomationFormMessages.githubPush} />}
             className="md:items-center"
           >
             <div className="flex w-full min-w-0 flex-col gap-1.5">
@@ -863,16 +957,17 @@ function TriggerSettings({
                   <SelectTrigger className="h-8 w-full rounded-lg md:min-w-44 md:max-w-xs">
                     <span className="truncate">
                       {selectedRepositoryLabel(
+                        intl,
                         form.githubInstallationRepositoryId,
                         repositories,
-                        "Repository",
+                        intl.formatMessage(workspaceAutomationFormMessages.repositoryLabel),
                       )}
                     </span>
                   </SelectTrigger>
                   <SelectContent>
                     {repositories.map((repository) => (
                       <SelectItem key={repository.id} value={repository.id}>
-                        {formatRepositoryOptionLabel(repository)}
+                        {formatRepositoryOptionLabel(intl, repository)}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -892,19 +987,27 @@ function TriggerSettings({
         {form.triggerMode === "manual" ? (
           <EditorRow
             icon={<ClockIcon className="size-4" />}
-            title="Manual only"
-            description="Runs only start when a teammate queues one from this automation."
+            title={<FormattedMessage {...workspaceAutomationFormMessages.manualOnlyTitle} />}
+            description={
+              <FormattedMessage {...workspaceAutomationFormMessages.manualOnlyDescription} />
+            }
           />
         ) : null}
 
         {form.triggerMode === "contentful" ? (
           <EditorRow
             icon={<SearchIcon className="size-4" />}
-            title="Contentful webhook"
+            title={<FormattedMessage {...workspaceAutomationFormMessages.contentfulWebhook} />}
             description={
-              contentfulConnected
-                ? "Runs when Contentful sends a matching entry create or update webhook."
-                : "Connect Contentful in Integrations before this trigger can run."
+              contentfulConnected ? (
+                <FormattedMessage
+                  {...workspaceAutomationFormMessages.contentfulWebhookConnectedDescription}
+                />
+              ) : (
+                <FormattedMessage
+                  {...workspaceAutomationFormMessages.contentfulWebhookDisconnectedDescription}
+                />
+              )
             }
           />
         ) : null}
@@ -912,8 +1015,10 @@ function TriggerSettings({
         {form.triggerMode === "source_upload" ? (
           <EditorRow
             icon={<HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} className="size-4" />}
-            title="Source upload"
-            description="Runs when a source file is uploaded to the project selected above."
+            title={<FormattedMessage {...workspaceAutomationFormMessages.sourceUpload} />}
+            description={
+              <FormattedMessage {...workspaceAutomationFormMessages.sourceUploadDescription} />
+            }
           />
         ) : null}
 
@@ -965,7 +1070,7 @@ function AddToolMenu({
           }
         >
           <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} className="size-4" />
-          Add Tool
+          <FormattedMessage {...workspaceAutomationFormMessages.addTool} />
         </DropdownMenuTrigger>
         <DropdownMenuContent
           className="max-h-(--available-height) w-80 overflow-y-auto"
@@ -973,7 +1078,9 @@ function AddToolMenu({
           sideOffset={2}
         >
           <DropdownMenuGroup>
-            <DropdownMenuLabel>Supported tools</DropdownMenuLabel>
+            <DropdownMenuLabel>
+              <FormattedMessage {...workspaceAutomationFormMessages.supportedTools} />
+            </DropdownMenuLabel>
             <DropdownMenuItem
               disabled={form.githubEnabled || !githubConnected}
               onClick={() => {
@@ -993,11 +1100,15 @@ function AddToolMenu({
               }}
             >
               <HugeiconsIcon icon={GitBranchIcon} strokeWidth={1.8} className="size-4" />
-              Use GitHub repo
+              <FormattedMessage {...workspaceAutomationFormMessages.useGithubRepo} />
               {form.githubEnabled && form.githubMode === "agent" ? (
-                <DropdownMenuShortcut>Added</DropdownMenuShortcut>
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                </DropdownMenuShortcut>
               ) : !githubConnected ? (
-                <DropdownMenuShortcut>Connect first</DropdownMenuShortcut>
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
+                </DropdownMenuShortcut>
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -1019,11 +1130,15 @@ function AddToolMenu({
               }}
             >
               <HugeiconsIcon icon={GitBranchIcon} strokeWidth={1.8} className="size-4" />
-              GitHub sync workflows
+              <FormattedMessage {...workspaceAutomationFormMessages.githubSyncWorkflows} />
               {form.githubEnabled && form.githubMode === "sync" ? (
-                <DropdownMenuShortcut>Added</DropdownMenuShortcut>
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                </DropdownMenuShortcut>
               ) : !githubConnected ? (
-                <DropdownMenuShortcut>Connect first</DropdownMenuShortcut>
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
+                </DropdownMenuShortcut>
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -1031,11 +1146,15 @@ function AddToolMenu({
               onClick={() => onChange({ ...form, slackEnabled: true })}
             >
               <HugeiconsIcon icon={SlackIcon} strokeWidth={1.8} className="size-4" />
-              Send to Slack
+              <FormattedMessage {...workspaceAutomationFormMessages.sendToSlack} />
               {form.slackEnabled ? (
-                <DropdownMenuShortcut>Added</DropdownMenuShortcut>
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                </DropdownMenuShortcut>
               ) : !slackConnected ? (
-                <DropdownMenuShortcut>Connect first</DropdownMenuShortcut>
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
+                </DropdownMenuShortcut>
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -1043,11 +1162,15 @@ function AddToolMenu({
               onClick={() => onChange({ ...form, emailEnabled: true })}
             >
               <MailIcon className="size-4" />
-              Send email
+              <FormattedMessage {...workspaceAutomationFormMessages.sendEmail} />
               {form.emailEnabled ? (
-                <DropdownMenuShortcut>Added</DropdownMenuShortcut>
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                </DropdownMenuShortcut>
               ) : !emailConnected ? (
-                <DropdownMenuShortcut>Enable first</DropdownMenuShortcut>
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.enableFirstShortcut} />
+                </DropdownMenuShortcut>
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -1063,11 +1186,15 @@ function AddToolMenu({
               }
             >
               <SearchIcon className="size-4" />
-              Contentful translate
+              <FormattedMessage {...workspaceAutomationFormMessages.contentfulTranslate} />
               {form.contentfulEnabled ? (
-                <DropdownMenuShortcut>Added</DropdownMenuShortcut>
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                </DropdownMenuShortcut>
               ) : !contentfulConnected ? (
-                <DropdownMenuShortcut>Connect first</DropdownMenuShortcut>
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
+                </DropdownMenuShortcut>
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -1083,13 +1210,19 @@ function AddToolMenu({
               }
             >
               <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} className="size-4" />
-              Translate
-              {form.translationEnabled ? <DropdownMenuShortcut>Added</DropdownMenuShortcut> : null}
+              <FormattedMessage {...workspaceAutomationFormMessages.translate} />
+              {form.translationEnabled ? (
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                </DropdownMenuShortcut>
+              ) : null}
             </DropdownMenuItem>
           </DropdownMenuGroup>
           <DropdownMenuSeparator />
           <DropdownMenuGroup>
-            <DropdownMenuLabel>Coming soon</DropdownMenuLabel>
+            <DropdownMenuLabel>
+              <FormattedMessage {...workspaceAutomationFormMessages.comingSoon} />
+            </DropdownMenuLabel>
             {COMING_SOON_SERP_TOOLS.map((tool) => (
               <DropdownMenuItem key={tool.id} disabled>
                 <AutomationToolMenuIcon icon={tool.icon} />
@@ -1100,7 +1233,7 @@ function AddToolMenu({
             <DropdownMenuSub>
               <DropdownMenuSubTrigger>
                 <AutomationToolMenuIcon icon={siGoogle} />
-                <span className="min-w-0 flex-1">Google</span>
+                <span className="min-w-0 flex-1">{COMING_SOON_GOOGLE_MENU_LABEL}</span>
                 <ComingSoonBadge className="ms-0" />
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent className="min-w-56">
@@ -1114,7 +1247,7 @@ function AddToolMenu({
             </DropdownMenuSub>
             <DropdownMenuItem disabled>
               <AutomationToolMenuIcon icon={siLinear} />
-              Linear
+              {COMING_SOON_LINEAR_MENU_LABEL}
               <ComingSoonBadge />
             </DropdownMenuItem>
           </DropdownMenuGroup>
@@ -1124,10 +1257,14 @@ function AddToolMenu({
   );
 }
 
+function formatLocalePill(locale: string) {
+  return `${getLocaleLabel(locale)} (${locale})`;
+}
+
 function ContentfulTargetLocalesPicker({
   availableLocales,
   disabled,
-  emptyMessage = "Select a Contentful connection to choose target locales.",
+  emptyMessage,
   error,
   labelledBy,
   selectedLocales,
@@ -1135,7 +1272,7 @@ function ContentfulTargetLocalesPicker({
 }: {
   availableLocales: string[];
   disabled?: boolean;
-  emptyMessage?: string;
+  emptyMessage: string;
   error?: string;
   labelledBy: string;
   selectedLocales: string[];
@@ -1174,7 +1311,7 @@ function ContentfulTargetLocalesPicker({
               onClick={() => toggleLocale(locale)}
               className="h-8 px-2.5 text-xs"
             >
-              {getLocaleLabel(locale)} ({locale})
+              {formatLocalePill(locale)}
             </Button>
           );
         })}
@@ -1225,19 +1362,22 @@ function ToolsSettings({
   );
   const translationAvailableTargetLocales = selectedTranslationProject?.targetLocales ?? [];
   const translationTargetLocalesFieldId = "translation-target-locales";
+  const intl = useIntl();
 
   return (
-    <EditorSection title="Tools">
+    <EditorSection title={intl.formatMessage(workspaceAutomationFormMessages.toolsSection)}>
       <EditorPanel>
         {form.githubEnabled && form.githubMode === "agent" ? (
           <EditorRow
             icon={<HugeiconsIcon icon={GitBranchIcon} strokeWidth={1.8} className="size-4" />}
-            title="Use GitHub repo"
-            description="Read the repository and follow your instructions. GitHub skills apply automatically."
+            title={<FormattedMessage {...workspaceAutomationFormMessages.useGithubRepo} />}
+            description={
+              <FormattedMessage {...workspaceAutomationFormMessages.useGithubRepoDescription} />
+            }
             action={
               <DeleteToolButton
                 disabled={disabled}
-                label="Remove GitHub repo tool"
+                label={intl.formatMessage(workspaceAutomationFormMessages.removeGithubRepoTool)}
                 onClick={() =>
                   onChange({
                     ...form,
@@ -1262,12 +1402,18 @@ function ToolsSettings({
         {form.githubEnabled && form.githubMode === "sync" ? (
           <EditorRow
             icon={<HugeiconsIcon icon={GitBranchIcon} strokeWidth={1.8} className="size-4" />}
-            title="GitHub sync workflows"
-            description="Push source, pull translations, and validation checks."
+            title={<FormattedMessage {...workspaceAutomationFormMessages.githubSyncWorkflows} />}
+            description={
+              <FormattedMessage
+                {...workspaceAutomationFormMessages.githubSyncWorkflowsDescription}
+              />
+            }
             action={
               <DeleteToolButton
                 disabled={disabled}
-                label="Remove GitHub sync workflows"
+                label={intl.formatMessage(
+                  workspaceAutomationFormMessages.removeGithubSyncWorkflows,
+                )}
                 onClick={() =>
                   onChange({
                     ...form,
@@ -1291,7 +1437,9 @@ function ToolsSettings({
               />
               <div className="grid gap-2 md:grid-cols-3">
                 <label className="flex items-center justify-between gap-3 rounded-lg border border-border px-3 py-2">
-                  <span className="text-xs text-foreground">Push source</span>
+                  <span className="text-xs text-foreground">
+                    <FormattedMessage {...workspaceAutomationFormMessages.pushSource} />
+                  </span>
                   <Switch
                     size="sm"
                     checked={form.pushSourceEnabled}
@@ -1300,7 +1448,9 @@ function ToolsSettings({
                   />
                 </label>
                 <label className="flex items-center justify-between gap-3 rounded-lg border border-border px-3 py-2">
-                  <span className="text-xs text-foreground">Pull translations</span>
+                  <span className="text-xs text-foreground">
+                    <FormattedMessage {...workspaceAutomationFormMessages.pullTranslations} />
+                  </span>
                   <Switch
                     size="sm"
                     checked={form.pullTranslationsEnabled}
@@ -1314,7 +1464,9 @@ function ToolsSettings({
                   />
                 </label>
                 <label className="flex items-center justify-between gap-3 rounded-lg border border-border px-3 py-2">
-                  <span className="text-xs text-foreground">Validation</span>
+                  <span className="text-xs text-foreground">
+                    <FormattedMessage {...workspaceAutomationFormMessages.validation} />
+                  </span>
                   <Switch
                     size="sm"
                     checked={form.validationEnabled}
@@ -1332,33 +1484,39 @@ function ToolsSettings({
             icon={<HugeiconsIcon icon={SlackIcon} strokeWidth={1.8} className="size-4" />}
             title={
               <>
-                <span>Send to Slack</span>
-                {!slackConnected ? <Badge variant="secondary">Connect first</Badge> : null}
+                <span>
+                  <FormattedMessage {...workspaceAutomationFormMessages.sendToSlack} />
+                </span>
+                {!slackConnected ? (
+                  <Badge variant="secondary">
+                    <FormattedMessage {...workspaceAutomationFormMessages.connectFirstBadge} />
+                  </Badge>
+                ) : null}
               </>
             }
             description={
-              slackConnected ? (
-                "Notify a channel when runs reach a terminal state."
-              ) : (
-                <>
-                  Connect Slack in{" "}
-                  <Link href={`/org/${organizationSlug}/integrations`} className="underline">
-                    Integrations
-                  </Link>{" "}
-                  to use this tool.
-                </>
-              )
+              slackConnected
+                ? intl.formatMessage(workspaceAutomationFormMessages.slackConnectedDescription)
+                : intl.formatMessage(workspaceAutomationFormMessages.slackDisconnectedDescription, {
+                    link: (chunks) => (
+                      <Link href={`/org/${organizationSlug}/integrations`} className="underline">
+                        {chunks}
+                      </Link>
+                    ),
+                  })
             }
             action={
               <DeleteToolButton
                 disabled={disabled}
-                label="Remove Slack notifications"
+                label={intl.formatMessage(workspaceAutomationFormMessages.removeSlackNotifications)}
                 onClick={() => onChange({ ...form, slackEnabled: false, slackChannelId: "" })}
               />
             }
           >
             <div className="grid gap-1.5">
-              <Label className="text-xs text-muted-foreground">Channel</Label>
+              <Label className="text-xs text-muted-foreground">
+                <FormattedMessage {...workspaceAutomationFormMessages.channelLabel} />
+              </Label>
               <Select
                 value={form.slackChannelId || undefined}
                 onValueChange={(value) => {
@@ -1372,20 +1530,25 @@ function ToolsSettings({
                 <SelectTrigger className="h-8 w-full rounded-lg">
                   <span className="truncate">
                     {slackChannelsLoading
-                      ? "Loading channels..."
-                      : selectedSlackChannelLabel(form.slackChannelId, slackChannels)}
+                      ? intl.formatMessage(workspaceAutomationFormMessages.loadingChannels)
+                      : selectedSlackChannelLabel(intl, form.slackChannelId, slackChannels)}
                   </span>
                 </SelectTrigger>
                 <SelectContent>
                   {!slackChannelsLoading && slackChannels.length === 0 ? (
                     <SelectItem value="__no_slack_channels" disabled>
-                      No channels found
+                      {intl.formatMessage(workspaceAutomationFormMessages.noChannelsFound)}
                     </SelectItem>
                   ) : null}
                   {slackChannels.map((channel) => (
                     <SelectItem key={channel.id} value={channel.id}>
-                      #{channel.name}
-                      {channel.private ? " (private)" : ""}
+                      {channel.private
+                        ? intl.formatMessage(workspaceAutomationFormMessages.privateChannelSuffix, {
+                            name: channel.name,
+                          })
+                        : intl.formatMessage(workspaceAutomationFormMessages.publicChannelLabel, {
+                            name: channel.name,
+                          })}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -1400,34 +1563,38 @@ function ToolsSettings({
             icon={<MailIcon className="size-4" />}
             title={
               <>
-                <span>Send email</span>
-                {!emailConnected ? <Badge variant="secondary">Enable first</Badge> : null}
+                <span>
+                  <FormattedMessage {...workspaceAutomationFormMessages.sendEmail} />
+                </span>
+                {!emailConnected ? (
+                  <Badge variant="secondary">
+                    <FormattedMessage {...workspaceAutomationFormMessages.enableFirstBadge} />
+                  </Badge>
+                ) : null}
               </>
             }
             description={
-              emailConnected ? (
-                "Send terminal run summaries to specific recipients."
-              ) : (
-                <>
-                  Enable the email agent in{" "}
-                  <Link href={`/org/${organizationSlug}/integrations`} className="underline">
-                    Integrations
-                  </Link>{" "}
-                  to use email notifications.
-                </>
-              )
+              emailConnected
+                ? intl.formatMessage(workspaceAutomationFormMessages.emailConnectedDescription)
+                : intl.formatMessage(workspaceAutomationFormMessages.emailDisconnectedDescription, {
+                    link: (chunks) => (
+                      <Link href={`/org/${organizationSlug}/integrations`} className="underline">
+                        {chunks}
+                      </Link>
+                    ),
+                  })
             }
             action={
               <DeleteToolButton
                 disabled={disabled}
-                label="Remove email notifications"
+                label={intl.formatMessage(workspaceAutomationFormMessages.removeEmailNotifications)}
                 onClick={() => onChange({ ...form, emailEnabled: false, emailRecipients: [] })}
               />
             }
           >
             <div className="grid gap-1.5">
               <Label htmlFor="email-recipients" className="text-xs text-muted-foreground">
-                Recipients
+                <FormattedMessage {...workspaceAutomationFormMessages.recipientsLabel} />
               </Label>
               <Textarea
                 id="email-recipients"
@@ -1455,34 +1622,47 @@ function ToolsSettings({
             icon={<SearchIcon className="size-4" />}
             title={
               <>
-                <span>Contentful translate</span>
-                {!contentfulConnected ? <Badge variant="secondary">Connect first</Badge> : null}
+                <span>
+                  <FormattedMessage {...workspaceAutomationFormMessages.contentfulTranslate} />
+                </span>
+                {!contentfulConnected ? (
+                  <Badge variant="secondary">
+                    <FormattedMessage {...workspaceAutomationFormMessages.connectFirstBadge} />
+                  </Badge>
+                ) : null}
               </>
             }
             description={
-              contentfulConnected ? (
-                "Translate detected Contentful fields, run QA, and write drafts back for review."
-              ) : (
-                <>
-                  Connect Contentful in{" "}
-                  <Link href={`/org/${organizationSlug}/integrations`} className="underline">
-                    Integrations
-                  </Link>{" "}
-                  to use this tool.
-                </>
-              )
+              contentfulConnected
+                ? intl.formatMessage(
+                    workspaceAutomationFormMessages.contentfulTranslateConnectedDescription,
+                  )
+                : intl.formatMessage(
+                    workspaceAutomationFormMessages.contentfulTranslateDisconnectedDescription,
+                    {
+                      link: (chunks) => (
+                        <Link href={`/org/${organizationSlug}/integrations`} className="underline">
+                          {chunks}
+                        </Link>
+                      ),
+                    },
+                  )
             }
             action={
               <DeleteToolButton
                 disabled={disabled}
-                label="Remove Contentful translate"
+                label={intl.formatMessage(
+                  workspaceAutomationFormMessages.removeContentfulTranslate,
+                )}
                 onClick={() => onChange({ ...form, contentfulEnabled: false })}
               />
             }
           >
             <div className="grid gap-3">
               <div className="grid gap-1.5">
-                <Label className="text-xs text-muted-foreground">Connection</Label>
+                <Label className="text-xs text-muted-foreground">
+                  <FormattedMessage {...workspaceAutomationFormMessages.connectionLabel} />
+                </Label>
                 <Select
                   value={form.contentfulConnectionId || undefined}
                   disabled={disabled || !contentfulConnected}
@@ -1502,6 +1682,7 @@ function ToolsSettings({
                   <SelectTrigger className="h-8 w-full rounded-lg">
                     <span className="truncate">
                       {selectedContentfulConnectionLabel(
+                        intl,
                         form.contentfulConnectionId,
                         contentfulConnections,
                       )}
@@ -1510,8 +1691,12 @@ function ToolsSettings({
                   <SelectContent>
                     {contentfulConnections.map((connection) => (
                       <SelectItem key={connection.id} value={connection.id}>
-                        {connection.displayName}
-                        {connection.enabled ? "" : " (disabled)"}
+                        {connection.enabled
+                          ? connection.displayName
+                          : intl.formatMessage(
+                              workspaceAutomationFormMessages.connectionDisabledSuffix,
+                              { name: connection.displayName },
+                            )}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -1525,7 +1710,9 @@ function ToolsSettings({
                 )}
               >
                 <div className="grid gap-1.5">
-                  <Label className="text-xs text-muted-foreground">Project</Label>
+                  <Label className="text-xs text-muted-foreground">
+                    <FormattedMessage {...workspaceAutomationFormMessages.projectLabel} />
+                  </Label>
                   <Select
                     value={form.contentfulProjectId || undefined}
                     disabled={disabled}
@@ -1551,7 +1738,8 @@ function ToolsSettings({
                     <SelectTrigger className="h-8 w-full rounded-lg">
                       <span className="truncate">
                         {projects.find((project) => project.id === form.contentfulProjectId)
-                          ?.name ?? "Select project"}
+                          ?.name ??
+                          intl.formatMessage(workspaceAutomationFormMessages.selectProject)}
                       </span>
                     </SelectTrigger>
                     <SelectContent>
@@ -1567,14 +1755,16 @@ function ToolsSettings({
                 {showContentfulEntryId ? (
                   <div className="grid gap-1.5">
                     <Label htmlFor="contentful-entry-id" className="text-xs text-muted-foreground">
-                      Entry ID
+                      <FormattedMessage {...workspaceAutomationFormMessages.entryIdLabel} />
                     </Label>
                     <Input
                       id="contentful-entry-id"
                       value={form.contentfulEntryId}
                       disabled={disabled}
                       className="h-8 rounded-lg text-sm"
-                      placeholder="Contentful entry ID"
+                      placeholder={intl.formatMessage(
+                        workspaceAutomationFormMessages.contentfulEntryIdPlaceholder,
+                      )}
                       onChange={(event) =>
                         onChange({ ...form, contentfulEntryId: event.target.value })
                       }
@@ -1588,11 +1778,14 @@ function ToolsSettings({
                   id={contentfulTargetLocalesFieldId}
                   className="text-xs text-muted-foreground"
                 >
-                  Target locales
+                  <FormattedMessage {...workspaceAutomationFormMessages.targetLocalesLabel} />
                 </Label>
                 <ContentfulTargetLocalesPicker
                   availableLocales={contentfulAvailableTargetLocales}
                   disabled={disabled}
+                  emptyMessage={intl.formatMessage(
+                    workspaceAutomationFormMessages.contentfulTargetLocalesEmpty,
+                  )}
                   error={errors.contentfulTargetLocales}
                   labelledBy={contentfulTargetLocalesFieldId}
                   selectedLocales={form.contentfulTargetLocales}
@@ -1603,7 +1796,9 @@ function ToolsSettings({
               </div>
               <div className="grid gap-2 md:grid-cols-3">
                 <label className="flex items-center justify-between gap-3 rounded-lg border border-border px-3 py-2">
-                  <span className="text-xs text-foreground">Run QA</span>
+                  <span className="text-xs text-foreground">
+                    <FormattedMessage {...workspaceAutomationFormMessages.runQa} />
+                  </span>
                   <Switch
                     size="sm"
                     checked={form.contentfulRunQa}
@@ -1612,7 +1807,9 @@ function ToolsSettings({
                   />
                 </label>
                 <label className="flex items-center justify-between gap-3 rounded-lg border border-border px-3 py-2">
-                  <span className="text-xs text-foreground">Write drafts</span>
+                  <span className="text-xs text-foreground">
+                    <FormattedMessage {...workspaceAutomationFormMessages.writeDrafts} />
+                  </span>
                   <Switch
                     size="sm"
                     checked={form.contentfulWriteDrafts}
@@ -1623,7 +1820,9 @@ function ToolsSettings({
                   />
                 </label>
                 <label className="flex items-center justify-between gap-3 rounded-lg border border-border px-3 py-2">
-                  <span className="text-xs text-foreground">Overwrite targets</span>
+                  <span className="text-xs text-foreground">
+                    <FormattedMessage {...workspaceAutomationFormMessages.overwriteTargets} />
+                  </span>
                   <Switch
                     size="sm"
                     checked={form.contentfulOverwriteDraftLocales}
@@ -1641,12 +1840,14 @@ function ToolsSettings({
         {form.translationEnabled ? (
           <EditorRow
             icon={<HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} className="size-4" />}
-            title="Translate"
-            description="Queue translation jobs for uploaded source files in the project selected above."
+            title={<FormattedMessage {...workspaceAutomationFormMessages.translate} />}
+            description={
+              <FormattedMessage {...workspaceAutomationFormMessages.translateDescription} />
+            }
             action={
               <DeleteToolButton
                 disabled={disabled}
-                label="Remove Translate"
+                label={intl.formatMessage(workspaceAutomationFormMessages.removeTranslate)}
                 onClick={() =>
                   onChange({
                     ...form,
@@ -1661,7 +1862,9 @@ function ToolsSettings({
           >
             <div className="grid gap-3">
               <label className="flex items-center justify-between gap-3 rounded-lg border border-border px-3 py-2">
-                <span className="text-xs text-foreground">Use project target locales</span>
+                <span className="text-xs text-foreground">
+                  <FormattedMessage {...workspaceAutomationFormMessages.useProjectTargetLocales} />
+                </span>
                 <Switch
                   size="sm"
                   checked={form.translationUseProjectTargetLocales}
@@ -1681,12 +1884,14 @@ function ToolsSettings({
                     id={translationTargetLocalesFieldId}
                     className="text-xs text-muted-foreground"
                   >
-                    Target locales
+                    <FormattedMessage {...workspaceAutomationFormMessages.targetLocalesLabel} />
                   </Label>
                   <ContentfulTargetLocalesPicker
                     availableLocales={translationAvailableTargetLocales}
                     disabled={disabled}
-                    emptyMessage="Choose a project above to pick target locales."
+                    emptyMessage={intl.formatMessage(
+                      workspaceAutomationFormMessages.chooseProjectForTargetLocales,
+                    )}
                     error={errors.translationTargetLocales}
                     labelledBy={translationTargetLocalesFieldId}
                     selectedLocales={form.translationTargetLocales}
@@ -1715,11 +1920,42 @@ function ToolsSettings({
   );
 }
 
+function formatRunStatus(intl: IntlShape, status: string) {
+  const statusMessages = {
+    queued: workspaceAutomationFormMessages.runStatusQueued,
+    running: workspaceAutomationFormMessages.runStatusRunning,
+    succeeded: workspaceAutomationFormMessages.runStatusSucceeded,
+    failed: workspaceAutomationFormMessages.runStatusFailed,
+    cancelled: workspaceAutomationFormMessages.runStatusCancelled,
+    skipped: workspaceAutomationFormMessages.runStatusSkipped,
+  } as const;
+
+  const message = statusMessages[status as keyof typeof statusMessages];
+  return message ? intl.formatMessage(message) : status;
+}
+
+function formatTriggerSource(intl: IntlShape, triggerSource: string) {
+  const triggerMessages = {
+    manual: workspaceAutomationFormMessages.triggerSourceManual,
+    scheduled: workspaceAutomationFormMessages.triggerSourceScheduled,
+    github: workspaceAutomationFormMessages.triggerSourceGithub,
+    contentful: workspaceAutomationFormMessages.triggerSourceContentful,
+    source_upload: workspaceAutomationFormMessages.triggerSourceSourceUpload,
+  } as const;
+
+  const message = triggerMessages[triggerSource as keyof typeof triggerMessages];
+  return message ? intl.formatMessage(message) : triggerSource;
+}
+
 function RunHistoryTable({ runs }: { runs: WorkspaceAutomationRunRecord[] }) {
+  const intl = useIntl();
+
   if (runs.length === 0) {
     return (
       <EditorPanel className="px-4 py-10">
-        <p className="text-sm text-muted-foreground">No runs yet.</p>
+        <p className="text-sm text-muted-foreground">
+          <FormattedMessage {...workspaceAutomationFormMessages.noRunsYet} />
+        </p>
       </EditorPanel>
     );
   }
@@ -1727,10 +1963,18 @@ function RunHistoryTable({ runs }: { runs: WorkspaceAutomationRunRecord[] }) {
   return (
     <EditorPanel>
       <div className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,0.8fr)_minmax(0,1fr)_minmax(0,0.8fr)] gap-4 border-b border-border px-4 py-3 text-xs font-medium text-muted-foreground">
-        <span>Status</span>
-        <span>Trigger</span>
-        <span>Summary</span>
-        <span>Completed</span>
+        <span>
+          <FormattedMessage {...workspaceAutomationFormMessages.historyStatus} />
+        </span>
+        <span>
+          <FormattedMessage {...workspaceAutomationFormMessages.historyTrigger} />
+        </span>
+        <span>
+          <FormattedMessage {...workspaceAutomationFormMessages.historySummary} />
+        </span>
+        <span>
+          <FormattedMessage {...workspaceAutomationFormMessages.historyCompleted} />
+        </span>
       </div>
       {runs.map((run) => (
         <div
@@ -1738,14 +1982,16 @@ function RunHistoryTable({ runs }: { runs: WorkspaceAutomationRunRecord[] }) {
           className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,0.8fr)_minmax(0,1fr)_minmax(0,0.8fr)] gap-4 border-b border-border px-4 py-4 text-sm last:border-b-0"
         >
           <Badge variant="outline" className="w-fit">
-            {run.status}
+            {formatRunStatus(intl, run.status)}
           </Badge>
-          <span>{run.triggerSource}</span>
+          <span>{formatTriggerSource(intl, run.triggerSource)}</span>
           <span className="truncate text-muted-foreground">
-            {Object.keys(run.outputSummary).length > 0 ? JSON.stringify(run.outputSummary) : "—"}
+            {Object.keys(run.outputSummary).length > 0
+              ? JSON.stringify(run.outputSummary)
+              : EMPTY_CELL}
           </span>
           <span className="text-muted-foreground">
-            {run.completedAt ? new Date(run.completedAt).toLocaleString() : "—"}
+            {run.completedAt ? new Date(run.completedAt).toLocaleString() : EMPTY_CELL}
           </span>
         </div>
       ))}
@@ -1897,13 +2143,15 @@ export function WorkspaceAutomationEditor({
         <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
           <div className="min-w-0 flex-1">
             <Label htmlFor="automation-name" className="sr-only">
-              Automation name
+              <FormattedMessage {...workspaceAutomationFormMessages.automationNameLabel} />
             </Label>
             <Input
               id="automation-name"
               value={form.name}
               disabled={disabled}
-              placeholder="Untitled automation"
+              placeholder={intl.formatMessage(
+                workspaceAutomationFormMessages.untitledAutomationPlaceholder,
+              )}
               className="h-auto rounded-none border-0 bg-transparent px-0 py-0 text-2xl font-medium shadow-none ring-0 focus-visible:ring-0 md:text-2xl"
               onChange={(event) => onChange({ ...form, name: event.target.value })}
             />
@@ -1926,14 +2174,20 @@ export function WorkspaceAutomationEditor({
                 })
               }
             />
-            <span>{form.status === "active" ? "Active" : "Paused"}</span>
+            <span>
+              {form.status === "active" ? (
+                <FormattedMessage {...workspaceAutomationFormMessages.statusActive} />
+              ) : (
+                <FormattedMessage {...workspaceAutomationFormMessages.statusPaused} />
+              )}
+            </span>
           </label>
           {form.translationEnabled ||
           form.contentfulEnabled ||
           (form.githubEnabled && form.githubMode === "sync") ||
           form.triggerMode === "source_upload" ? (
             <>
-              <span className="text-border">|</span>
+              <span className="text-border">{METADATA_SEPARATOR}</span>
               <HeaderProjectSelector
                 disabled={disabled}
                 form={form}
@@ -1946,20 +2200,22 @@ export function WorkspaceAutomationEditor({
           ) : null}
           {form.triggerMode !== "manual" ? (
             <>
-              <span className="text-border">|</span>
+              <span className="text-border">{METADATA_SEPARATOR}</span>
               <span>{triggerSummary(intl, form, repositories, projectsQuery.data ?? [])}</span>
             </>
           ) : null}
-          <span className="text-border">|</span>
+          <span className="text-border">{METADATA_SEPARATOR}</span>
           <span>
-            {toolCount(form)} tool{toolCount(form) === 1 ? "" : "s"}
+            {intl.formatMessage(workspaceAutomationFormMessages.toolCount, {
+              count: toolCount(form),
+            })}
           </span>
         </div>
         <FieldError message={errors.githubProjectId} />
         <FieldError message={errors.translationProjectId} />
         {!canActivate ? (
           <p className="text-xs text-muted-foreground">
-            Add at least one supported tool to activate this automation.
+            <FormattedMessage {...workspaceAutomationFormMessages.activateRequiresTool} />
           </p>
         ) : null}
         <FieldError message={errors.form} />
@@ -1967,8 +2223,14 @@ export function WorkspaceAutomationEditor({
 
       <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as AutomationEditorTab)}>
         <TabsList>
-          <TabsTrigger value="settings">Settings</TabsTrigger>
-          {hasHistory ? <TabsTrigger value="history">Run History</TabsTrigger> : null}
+          <TabsTrigger value="settings">
+            <FormattedMessage {...workspaceAutomationFormMessages.settingsTab} />
+          </TabsTrigger>
+          {hasHistory ? (
+            <TabsTrigger value="history">
+              <FormattedMessage {...workspaceAutomationFormMessages.runHistoryTab} />
+            </TabsTrigger>
+          ) : null}
         </TabsList>
 
         <TabsContent value="settings" className="mt-4 flex flex-col gap-6">
@@ -1982,14 +2244,18 @@ export function WorkspaceAutomationEditor({
             repositories={repositories}
           />
 
-          <EditorSection title="Agent Instructions">
+          <EditorSection
+            title={intl.formatMessage(workspaceAutomationFormMessages.agentInstructionsSection)}
+          >
             <div className="relative rounded-xl">
               <Textarea
                 id="automation-instructions"
                 value={form.instructions}
                 disabled={disabled}
                 className="relative z-0 min-h-80 resize-y rounded-xl border-border bg-muted pb-10 font-sans text-sm leading-6"
-                placeholder="Tell the automation what to do, what to inspect, and what to ignore."
+                placeholder={intl.formatMessage(
+                  workspaceAutomationFormMessages.instructionsPlaceholder,
+                )}
                 onChange={(event) => onChange({ ...form, instructions: event.target.value })}
               />
               <div

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-skeleton.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-skeleton.messages.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const catWorkspaceSkeletonMessages = defineMessages({
+  loadingEditor: {
+    defaultMessage: "Loading editor",
+    id: "jfJtnvEq80",
+    description: "Accessible label while the CAT editor panel skeleton is shown",
+  },
+  loadingIntelligence: {
+    defaultMessage: "Loading intelligence",
+    id: "WKx3yZHQjo",
+    description: "Accessible label while the CAT intelligence panel skeleton is shown",
+  },
+  loadingQueue: {
+    defaultMessage: "Loading queue",
+    id: "CHxu7ekWGa",
+    description: "Accessible label while the CAT queue panel skeleton is shown",
+  },
+  loadingWorkspace: {
+    defaultMessage: "Loading CAT workspace",
+    id: "eXEsN78hyb",
+    description: "Accessible label while the full CAT workspace skeleton is shown",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-skeleton.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-skeleton.tsx
@@ -1,16 +1,21 @@
 "use client";
 
+import { useIntl } from "react-intl";
+
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/primitives/cn";
 
 import { CatQueueSkeletonList } from "@/components/cat/queue/cat-queue-skeleton-list";
+import { catWorkspaceSkeletonMessages } from "./cat-workspace-skeleton.messages";
 
 function CatEditorPanelSkeleton() {
+  const intl = useIntl();
+
   return (
     <div
       className="flex h-full min-h-0 flex-col bg-background"
       aria-busy="true"
-      aria-label="Loading editor"
+      aria-label={intl.formatMessage(catWorkspaceSkeletonMessages.loadingEditor)}
     >
       <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-border px-4 py-3 lg:px-5">
         <div className="flex flex-wrap items-center gap-2">
@@ -78,11 +83,13 @@ function CatEditorPanelSkeleton() {
 }
 
 function CatIntelligencePanelSkeleton() {
+  const intl = useIntl();
+
   return (
     <div
       className="flex h-full min-h-0 flex-col bg-background lg:border-l lg:border-border"
       aria-busy="true"
-      aria-label="Loading intelligence"
+      aria-label={intl.formatMessage(catWorkspaceSkeletonMessages.loadingIntelligence)}
     >
       <div className="shrink-0 border-b border-border px-4 py-3">
         <Skeleton className="h-4 w-32 rounded-full bg-skeleton" />
@@ -101,11 +108,13 @@ function CatIntelligencePanelSkeleton() {
 }
 
 function CatQueuePanelSkeleton() {
+  const intl = useIntl();
+
   return (
     <div
       className="flex h-full min-h-0 flex-col bg-background lg:border-r lg:border-border"
       aria-busy="true"
-      aria-label="Loading queue"
+      aria-label={intl.formatMessage(catWorkspaceSkeletonMessages.loadingQueue)}
     >
       <div className="shrink-0 space-y-3 border-b border-border px-4 py-3">
         <div className="space-y-2">
@@ -159,6 +168,8 @@ function CatCompactWorkspaceSkeleton() {
 }
 
 export function CatWorkspaceSkeleton({ className }: { className?: string }) {
+  const intl = useIntl();
+
   return (
     <div
       className={cn(
@@ -166,7 +177,7 @@ export function CatWorkspaceSkeleton({ className }: { className?: string }) {
         className,
       )}
       aria-busy="true"
-      aria-label="Loading CAT workspace"
+      aria-label={intl.formatMessage(catWorkspaceSkeletonMessages.loadingWorkspace)}
     >
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden lg:hidden">
         <CatCompactWorkspaceSkeleton />

--- a/apps/hyperlocalise-web/src/components/marketing/principles-section.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/principles-section.messages.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const principlesSectionMessages = defineMessages({
+  headline: {
+    defaultMessage:
+      "A localization operating system in AI era. <muted>Built for modern teams with translation, review, sync, and quality control in one workflow.</muted>",
+    id: "fK68dbaITk",
+    description:
+      "Marketing homepage principles section headline; muted wraps the supporting sentence",
+  },
+  learnMore: {
+    defaultMessage: "Learn more",
+    id: "mwCo4y1n7b",
+    description: "Link from a principles card to the related homepage chapter",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/marketing/principles-section.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/principles-section.tsx
@@ -8,17 +8,19 @@ import { TypographyH2, TypographyH3, TypographyP } from "@/components/ui/typogra
 
 import { marketingPageMessages } from "./marketing-page-content.messages";
 import { principles } from "./marketing-page-content";
+import { principlesSectionMessages } from "./principles-section.messages";
 
 export function PrinciplesSection() {
   return (
     <section id="overview">
       <div className="max-w-5xl">
         <TypographyH2>
-          A localization operating system in AI era.{" "}
-          <span className="text-muted-foreground">
-            Built for modern teams with translation, review, sync, and quality control in one
-            workflow.
-          </span>
+          <FormattedMessage
+            {...principlesSectionMessages.headline}
+            values={{
+              muted: (chunks) => <span className="text-muted-foreground">{chunks}</span>,
+            }}
+          />
         </TypographyH2>
       </div>
 
@@ -54,7 +56,9 @@ export function PrinciplesSection() {
                     href={href}
                     className="inline-flex items-center gap-2 text-[1rem] tracking-[-0.02em] transition-colors duration-300 hover:text-subtle-foreground sm:text-[1.05rem]"
                   >
-                    <span>Learn more</span>
+                    <span>
+                      <FormattedMessage {...principlesSectionMessages.learnMore} />
+                    </span>
                     <HugeiconsIcon icon={ArrowRightIcon} className="size-4" strokeWidth={1.7} />
                   </a>
                 </div>


### PR DESCRIPTION
## What changed

Localize remaining hardcoded user-facing copy in:

- Workspace automations list, create/detail pages, and automation editor
- CAT workspace skeleton accessible loading labels
- Marketing principles section headline and “Learn more” links

Copy is colocated in `*.messages.ts` modules with `defineMessages` / `<FormattedMessage>` / `useIntl().formatMessage`.

## How to test

- [ ] Open `/org/{slug}/automations` and confirm list, templates, and empty/error states still render correctly
- [ ] Create and edit an automation; confirm form labels, toasts, and tool/trigger menus look correct
- [ ] Load the CAT workspace and confirm skeleton aria-labels are present for screen readers
- [ ] Check the marketing homepage principles section headline and Learn more links
- [ ] `cd apps/hyperlocalise-web && vp lint src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components src/components/cat/workspace/cat-workspace-skeleton.tsx src/components/marketing/principles-section.tsx`

## Checklist

- [x] I ran relevant checks locally (`vp lint --fix` on touched paths)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)