### PR TITLE
feat(web): localize jobs, projects, CAT workspace, and app shell footer

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-content.tsx
@@ -114,7 +114,7 @@ async function fetchNativeProjects(organizationSlug: string) {
   }
 
   const body = await response.json();
-  return body.projects.map((project) => mapProjectToListRow(project));
+  return body.projects;
 }
 
 async function fetchSlackConnected(organizationSlug: string) {
@@ -250,6 +250,7 @@ export function DashboardPageContent({
   const nativeProjectsQuery = useQuery({
     queryKey: ["dashboard-projects", organizationSlug],
     queryFn: () => fetchNativeProjects(organizationSlug),
+    select: (projects) => projects.map((project) => mapProjectToListRow(project, intl)),
   });
 
   const assignedJobsQuery = useQuery({

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-content.tsx
@@ -114,7 +114,7 @@ async function fetchNativeProjects(organizationSlug: string) {
   }
 
   const body = await response.json();
-  return body.projects.map(mapProjectToListRow);
+  return body.projects.map((project) => mapProjectToListRow(project));
 }
 
 async function fetchSlackConnected(organizationSlug: string) {
@@ -287,7 +287,7 @@ export function DashboardPageContent({
   const tmsProjectsQuery = useQuery({
     queryKey: tmsLiveProjectsQueryKey(organizationSlug),
     queryFn: () => fetchTmsLiveProjects(organizationSlug),
-    select: (projects) => projects.map(mapProjectToListRow),
+    select: (projects) => projects.map((project) => mapProjectToListRow(project, intl)),
     enabled: hasTmsConnection,
   });
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.messages.ts
@@ -89,8 +89,8 @@ export const createJobDialogMessages = defineMessages({
     description: "Label for the files selection list",
   },
   filesSelectedCount: {
-    defaultMessage: "{count, plural, one {# selected} other {# selected}}",
-    id: "AeHmzaIHst",
+    defaultMessage: "{count, plural, one {# file selected} other {# files selected}}",
+    id: "pckObbKjS/",
     description: "Count of files selected for the new job",
   },
   noFilesAvailable: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.messages.ts
@@ -1,0 +1,212 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const createJobDialogMessages = defineMessages({
+  title: {
+    defaultMessage: "Create job",
+    id: "RQv/LERmVL",
+    description: "Create job dialog title",
+  },
+  descriptionProvider: {
+    defaultMessage: "Create Crowdin tasks with files, locales, and assignees.",
+    id: "nqQ9RngvcW",
+    description: "Create job dialog description for Crowdin provider projects",
+  },
+  descriptionNative: {
+    defaultMessage: "Create native translation jobs with files, locales, and an assignee.",
+    id: "UASZI6ojDa",
+    description: "Create job dialog description for native Hyperlocalise projects",
+  },
+  titleLabel: {
+    defaultMessage: "Title",
+    id: "vGwY2igpU6",
+    description: "Label for the job title field",
+  },
+  titlePlaceholder: {
+    defaultMessage: "Release notes · JP + KO",
+    id: "LKmO3hc5Vz",
+    description: "Placeholder for the job title field",
+  },
+  taskTypeLabel: {
+    defaultMessage: "Task type",
+    id: "CTLXW62s69",
+    description: "Label for the Crowdin task type select",
+  },
+  taskTypeTranslation: {
+    defaultMessage: "Translation",
+    id: "2ghn1bUXd2",
+    description: "Crowdin task type option for translation",
+  },
+  taskTypeProofread: {
+    defaultMessage: "Proofread",
+    id: "39i3huA7AM",
+    description: "Crowdin task type option for proofread",
+  },
+  descriptionLabel: {
+    defaultMessage: "Description",
+    id: "evmQYH9X0j",
+    description: "Label for the optional job description field",
+  },
+  descriptionPlaceholder: {
+    defaultMessage: "Optional notes for translators",
+    id: "W87BMcVF5T",
+    description: "Placeholder for the optional job description field",
+  },
+  sourceLocale: {
+    defaultMessage: "Source locale: {locale}",
+    id: "jvDZaWTAOJ",
+    description: "Shows the project source locale in the create job dialog",
+  },
+  targetLocalesLabel: {
+    defaultMessage: "Target locales",
+    id: "zedkthWR8N",
+    description: "Label for the target locales selection list",
+  },
+  selectAll: {
+    defaultMessage: "Select all",
+    id: "rGfiaZLTZ0",
+    description: "Button to select all target locales",
+  },
+  clear: {
+    defaultMessage: "Clear",
+    id: "mAyP67aqS8",
+    description: "Button to clear all selected target locales",
+  },
+  noTargetLocalesConfigured: {
+    defaultMessage: "Add target locales in project settings before creating jobs.",
+    id: "Ho5CjjaEBq",
+    description: "Hint when the project has no target locales configured",
+  },
+  noLocalesAvailable: {
+    defaultMessage: "No locales available",
+    id: "Lzjyu+8nDt",
+    description: "Empty state when the locale selection list has no items",
+  },
+  filesLabel: {
+    defaultMessage: "Files",
+    id: "1ToGNDd6TO",
+    description: "Label for the files selection list",
+  },
+  filesSelectedCount: {
+    defaultMessage: "{count, plural, one {# selected} other {# selected}}",
+    id: "AeHmzaIHst",
+    description: "Count of files selected for the new job",
+  },
+  noFilesAvailable: {
+    defaultMessage: "No files available in this project.",
+    id: "izy21loiHb",
+    description: "Empty state when the project has no selectable files",
+  },
+  assigneesLabel: {
+    defaultMessage: "Assignees",
+    id: "0A/FtMSjnF",
+    description: "Label for multi-assignee selection on Crowdin jobs",
+  },
+  assigneeLabel: {
+    defaultMessage: "Assignee",
+    id: "2VWwjqjclF",
+    description: "Label for single-assignee selection on native jobs",
+  },
+  noCrowdinMembers: {
+    defaultMessage: "No Crowdin project members found.",
+    id: "Qao/O64dbg",
+    description: "Empty state when Crowdin project members cannot be listed",
+  },
+  noOrgMembers: {
+    defaultMessage: "No organization members available.",
+    id: "vvT35LUoRE",
+    description: "Empty state when organization members cannot be listed",
+  },
+  assigneeHintNative: {
+    defaultMessage: "Optional. Native jobs currently support one assignee.",
+    id: "+WPReqq8Dt",
+    description: "Hint under the native job assignee picker",
+  },
+  cancel: {
+    defaultMessage: "Cancel",
+    id: "1eCICarqN0",
+    description: "Cancel button in the create job dialog footer",
+  },
+  submit: {
+    defaultMessage: "Create job",
+    id: "dTKdfkqH71",
+    description: "Submit button in the create job dialog footer",
+  },
+  titleRequired: {
+    defaultMessage: "Enter a job title.",
+    id: "Kx/HoZ+1yJ",
+    description: "Validation error when creating a job without a title",
+  },
+  localesRequired: {
+    defaultMessage: "Select at least one target locale.",
+    id: "YQqA4dnF4n",
+    description: "Validation error when creating a job without target locales",
+  },
+  filesRequired: {
+    defaultMessage: "Select at least one file.",
+    id: "Th3qMjLdD4",
+    description: "Validation error when creating a job without files",
+  },
+  createCrowdinFailed: {
+    defaultMessage: "Failed to create Crowdin jobs",
+    id: "OJm01EvxZW",
+    description: "Fallback error when Crowdin job creation fails without a server message",
+  },
+  createNativeFailed: {
+    defaultMessage: "Failed to create translation job",
+    id: "7qHTh1/iSP",
+    description: "Fallback error when a native translation job fails to create",
+  },
+  partialCreateNative: {
+    defaultMessage: "Created {createdCount} of {totalCount} jobs, then failed: {errorMessage}",
+    id: "vjXHRG767Q",
+    description: "Error after some native jobs were created before a later failure",
+  },
+  noSupportedFiles: {
+    defaultMessage: "No supported files were selected.",
+    id: "TDQxQUihFM",
+    description: "Validation error when selected files are not supported for translation",
+  },
+  createSuccessOne: {
+    defaultMessage: "Job created",
+    id: "US//RTOcgM",
+    description: "Toast when a single job is created successfully",
+  },
+  createSuccessMany: {
+    defaultMessage: "{count} jobs created",
+    id: "8L0EFFuXJa",
+    description: "Toast when multiple jobs are created successfully",
+  },
+  partialCreateWarning: {
+    defaultMessage:
+      "{count, plural, one {# job} other {# jobs}} created before the error. Refresh the jobs list before retrying to avoid duplicates.",
+    id: "In9Z4CgwLT",
+    description: "Warning toast when some jobs were created before an error",
+  },
+  createFailedFallback: {
+    defaultMessage: "Failed to create job",
+    id: "mF3XaS/Oxa",
+    description: "Fallback toast when job creation fails without an error message",
+  },
+  loadFilesFailed: {
+    defaultMessage: "Failed to load files",
+    id: "7OFNvD/Tg3",
+    description: "Fallback error when native project files fail to load",
+  },
+  loadProviderFilesFailed: {
+    defaultMessage: "Failed to load provider files",
+    id: "Wtnws5pYza",
+    description: "Fallback error when provider project files fail to load",
+  },
+  loadMembersFailed: {
+    defaultMessage: "Failed to load members",
+    id: "t7l1acivlq",
+    description: "Fallback error when organization members fail to load",
+  },
+  loadProjectMembersFailed: {
+    defaultMessage: "Failed to load project members",
+    id: "/+sp7OInTO",
+    description: "Fallback error when Crowdin project members fail to load",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
 
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
@@ -34,6 +35,8 @@ import {
   type SupportedTranslationFileFormat,
 } from "@/lib/translation/file-formats";
 import { cn } from "@/lib/primitives/cn";
+
+import { createJobDialogMessages } from "./create-job-dialog.messages";
 
 class PartialCreateJobsError extends Error {
   readonly createdCount: number;
@@ -136,6 +139,7 @@ export function CreateJobDialog({
   targetLocales,
   onCreated,
 }: CreateJobDialogProps) {
+  const intl = useIntl();
   const queryClient = useQueryClient();
   const parsedProviderProject = parseProviderProjectId(projectId);
   const isProviderProject = Boolean(parsedProviderProject);
@@ -170,7 +174,10 @@ export function CreateJobDialog({
         query: { limit: "500" },
       });
       if (!response.ok) {
-        throw await readApiResponseError(response, "Failed to load files");
+        throw await readApiResponseError(
+          response,
+          intl.formatMessage(createJobDialogMessages.loadFilesFailed),
+        );
       }
       const body = (await response.json()) as { files: ProjectFileRecord[] };
       return body.files;
@@ -194,7 +201,10 @@ export function CreateJobDialog({
         query: { limit: "500" },
       });
       if (!response.ok) {
-        throw await readApiResponseError(response, "Failed to load provider files");
+        throw await readApiResponseError(
+          response,
+          intl.formatMessage(createJobDialogMessages.loadProviderFilesFailed),
+        );
       }
       const body = (await response.json()) as {
         files: Array<{
@@ -215,7 +225,10 @@ export function CreateJobDialog({
         param: { organizationSlug },
       });
       if (!response.ok) {
-        throw await readApiResponseError(response, "Failed to load members");
+        throw await readApiResponseError(
+          response,
+          intl.formatMessage(createJobDialogMessages.loadMembersFailed),
+        );
       }
       const body = (await response.json()) as {
         members: Array<{
@@ -245,7 +258,10 @@ export function CreateJobDialog({
         },
       });
       if (!response.ok) {
-        throw await readApiResponseError(response, "Failed to load project members");
+        throw await readApiResponseError(
+          response,
+          intl.formatMessage(createJobDialogMessages.loadProjectMembersFailed),
+        );
       }
       const body = (await response.json()) as {
         members: Array<{
@@ -315,13 +331,13 @@ export function CreateJobDialog({
   const createJob = useMutation({
     mutationFn: async () => {
       if (!title.trim()) {
-        throw new Error("Enter a job title.");
+        throw new Error(intl.formatMessage(createJobDialogMessages.titleRequired));
       }
       if (selectedLocales.length === 0) {
-        throw new Error("Select at least one target locale.");
+        throw new Error(intl.formatMessage(createJobDialogMessages.localesRequired));
       }
       if (selectedFileIds.length === 0) {
-        throw new Error("Select at least one file.");
+        throw new Error(intl.formatMessage(createJobDialogMessages.filesRequired));
       }
 
       if (parsedProviderProject) {
@@ -361,7 +377,7 @@ export function CreateJobDialog({
             "message" in body &&
             typeof (body as { message: unknown }).message === "string"
               ? (body as { message: string }).message
-              : "Failed to create Crowdin jobs";
+              : intl.formatMessage(createJobDialogMessages.createCrowdinFailed);
           if (createdCount > 0) {
             throw new PartialCreateJobsError(message, createdCount);
           }
@@ -396,10 +412,17 @@ export function CreateJobDialog({
           },
         });
         if (!response.ok) {
-          const failure = await readApiResponseError(response, "Failed to create translation job");
+          const failure = await readApiResponseError(
+            response,
+            intl.formatMessage(createJobDialogMessages.createNativeFailed),
+          );
           if (createdIds.length > 0) {
             throw new PartialCreateJobsError(
-              `Created ${createdIds.length} of ${eligibleFiles.length} jobs, then failed: ${failure.message}`,
+              intl.formatMessage(createJobDialogMessages.partialCreateNative, {
+                createdCount: createdIds.length,
+                totalCount: eligibleFiles.length,
+                errorMessage: failure.message,
+              }),
               createdIds.length,
             );
           }
@@ -410,7 +433,7 @@ export function CreateJobDialog({
       }
 
       if (createdIds.length === 0) {
-        throw new Error("No supported files were selected.");
+        throw new Error(intl.formatMessage(createJobDialogMessages.noSupportedFiles));
       }
 
       return { count: createdIds.length };
@@ -423,7 +446,11 @@ export function CreateJobDialog({
         }),
         queryClient.invalidateQueries({ queryKey: ["project-files", organizationSlug, projectId] }),
       ]);
-      toast.success(result.count === 1 ? "Job created" : `${result.count} jobs created`);
+      toast.success(
+        result.count === 1
+          ? intl.formatMessage(createJobDialogMessages.createSuccessOne)
+          : intl.formatMessage(createJobDialogMessages.createSuccessMany, { count: result.count }),
+      );
       onCreated?.();
       onOpenChange(false);
     },
@@ -439,10 +466,16 @@ export function CreateJobDialog({
           }),
         ]);
         toast.warning(
-          `${error.createdCount} job${error.createdCount === 1 ? "" : "s"} created before the error. Refresh the jobs list before retrying to avoid duplicates.`,
+          intl.formatMessage(createJobDialogMessages.partialCreateWarning, {
+            count: error.createdCount,
+          }),
         );
       }
-      toast.error(error instanceof Error ? error.message : "Failed to create job");
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : intl.formatMessage(createJobDialogMessages.createFailedFallback),
+      );
     },
   });
 
@@ -450,22 +483,28 @@ export function CreateJobDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="flex max-h-[90vh] flex-col gap-0 overflow-hidden p-0 sm:max-w-xl">
         <DialogHeader className="border-b border-border px-6 py-4">
-          <DialogTitle>Create job</DialogTitle>
+          <DialogTitle>
+            <FormattedMessage {...createJobDialogMessages.title} />
+          </DialogTitle>
           <DialogDescription>
-            {isProviderProject
-              ? "Create Crowdin tasks with files, locales, and assignees."
-              : "Create native translation jobs with files, locales, and an assignee."}
+            {isProviderProject ? (
+              <FormattedMessage {...createJobDialogMessages.descriptionProvider} />
+            ) : (
+              <FormattedMessage {...createJobDialogMessages.descriptionNative} />
+            )}
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-5 overflow-y-auto px-6 py-4">
           <div className="space-y-2">
-            <Label htmlFor="create-job-title">Title</Label>
+            <Label htmlFor="create-job-title">
+              <FormattedMessage {...createJobDialogMessages.titleLabel} />
+            </Label>
             <Input
               id="create-job-title"
               value={title}
               onChange={(event) => setTitle(event.target.value)}
-              placeholder="Release notes · JP + KO"
+              placeholder={intl.formatMessage(createJobDialogMessages.titlePlaceholder)}
               maxLength={256}
             />
           </div>
@@ -473,7 +512,9 @@ export function CreateJobDialog({
           {isProviderProject ? (
             <div className="grid gap-4 sm:grid-cols-2">
               <div className="space-y-2">
-                <Label>Task type</Label>
+                <Label>
+                  <FormattedMessage {...createJobDialogMessages.taskTypeLabel} />
+                </Label>
                 <Select
                   value={kind}
                   onValueChange={(value) => {
@@ -486,32 +527,45 @@ export function CreateJobDialog({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="translation">Translation</SelectItem>
-                    <SelectItem value="proofread">Proofread</SelectItem>
+                    <SelectItem value="translation">
+                      <FormattedMessage {...createJobDialogMessages.taskTypeTranslation} />
+                    </SelectItem>
+                    <SelectItem value="proofread">
+                      <FormattedMessage {...createJobDialogMessages.taskTypeProofread} />
+                    </SelectItem>
                   </SelectContent>
                 </Select>
               </div>
               <div className="space-y-2">
-                <Label htmlFor="create-job-description">Description</Label>
+                <Label htmlFor="create-job-description">
+                  <FormattedMessage {...createJobDialogMessages.descriptionLabel} />
+                </Label>
                 <Textarea
                   id="create-job-description"
                   value={description}
                   onChange={(event) => setDescription(event.target.value)}
                   rows={2}
                   maxLength={2048}
-                  placeholder="Optional notes for translators"
+                  placeholder={intl.formatMessage(createJobDialogMessages.descriptionPlaceholder)}
                 />
               </div>
             </div>
           ) : (
             <p className="text-sm text-muted-foreground">
-              Source locale: <span className="font-medium text-foreground">{sourceLocale}</span>
+              <FormattedMessage
+                {...createJobDialogMessages.sourceLocale}
+                values={{
+                  locale: <span className="font-medium text-foreground">{sourceLocale}</span>,
+                }}
+              />
             </p>
           )}
 
           <div className="space-y-2">
             <div className="flex items-center justify-between gap-2">
-              <Label>Target locales</Label>
+              <Label>
+                <FormattedMessage {...createJobDialogMessages.targetLocalesLabel} />
+              </Label>
               <Button
                 type="button"
                 variant="ghost"
@@ -523,28 +577,37 @@ export function CreateJobDialog({
                   )
                 }
               >
-                {selectedLocales.length === targetLocales.length ? "Clear" : "Select all"}
+                {selectedLocales.length === targetLocales.length ? (
+                  <FormattedMessage {...createJobDialogMessages.clear} />
+                ) : (
+                  <FormattedMessage {...createJobDialogMessages.selectAll} />
+                )}
               </Button>
             </div>
             {targetLocales.length === 0 ? (
               <p className="text-sm text-muted-foreground">
-                Add target locales in project settings before creating jobs.
+                <FormattedMessage {...createJobDialogMessages.noTargetLocalesConfigured} />
               </p>
             ) : (
               <SelectionList
                 items={targetLocales.map((locale) => ({ id: locale, label: locale }))}
                 selected={selectedLocales}
                 onToggle={(locale) => setSelectedLocales((current) => toggleValue(current, locale))}
-                emptyLabel="No locales available"
+                emptyLabel={intl.formatMessage(createJobDialogMessages.noLocalesAvailable)}
               />
             )}
           </div>
 
           <div className="space-y-2">
             <div className="flex items-center justify-between gap-2">
-              <Label>Files</Label>
+              <Label>
+                <FormattedMessage {...createJobDialogMessages.filesLabel} />
+              </Label>
               <span className="text-xs text-muted-foreground">
-                {selectedFileIds.length} selected
+                <FormattedMessage
+                  {...createJobDialogMessages.filesSelectedCount}
+                  values={{ count: selectedFileIds.length }}
+                />
               </span>
             </div>
             {filesLoading ? (
@@ -556,13 +619,19 @@ export function CreateJobDialog({
                 items={fileOptions.map((file) => ({ id: file.id, label: file.label }))}
                 selected={selectedFileIds}
                 onToggle={(fileId) => setSelectedFileIds((current) => toggleValue(current, fileId))}
-                emptyLabel="No files available in this project."
+                emptyLabel={intl.formatMessage(createJobDialogMessages.noFilesAvailable)}
               />
             )}
           </div>
 
           <div className="space-y-2">
-            <Label>{isProviderProject ? "Assignees" : "Assignee"}</Label>
+            <Label>
+              {isProviderProject ? (
+                <FormattedMessage {...createJobDialogMessages.assigneesLabel} />
+              ) : (
+                <FormattedMessage {...createJobDialogMessages.assigneeLabel} />
+              )}
+            </Label>
             {assigneesLoading ? (
               <div className="flex h-40 items-center justify-center rounded-md border border-border">
                 <Spinner className="size-4" />
@@ -580,16 +649,16 @@ export function CreateJobDialog({
                     current.includes(assigneeId) ? [] : [assigneeId],
                   );
                 }}
-                emptyLabel={
+                emptyLabel={intl.formatMessage(
                   isProviderProject
-                    ? "No Crowdin project members found."
-                    : "No organization members available."
-                }
+                    ? createJobDialogMessages.noCrowdinMembers
+                    : createJobDialogMessages.noOrgMembers,
+                )}
               />
             )}
             {!isProviderProject ? (
               <p className="text-xs text-muted-foreground">
-                Optional. Native jobs currently support one assignee.
+                <FormattedMessage {...createJobDialogMessages.assigneeHintNative} />
               </p>
             ) : null}
           </div>
@@ -597,7 +666,7 @@ export function CreateJobDialog({
 
         <DialogFooter className="border-t border-border px-6 py-4">
           <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
+            <FormattedMessage {...createJobDialogMessages.cancel} />
           </Button>
           <Button
             type="button"
@@ -611,7 +680,7 @@ export function CreateJobDialog({
             onClick={() => createJob.mutate()}
           >
             {createJob.isPending ? <Spinner className="size-4" /> : null}
-            Create job
+            <FormattedMessage {...createJobDialogMessages.submit} />
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-kanban-board.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-kanban-board.messages.ts
@@ -3,54 +3,52 @@
 import type { MessageDescriptor } from "react-intl";
 import { defineMessages } from "react-intl";
 
+import { getJobStatusMessage } from "./jobs-page-view.messages";
 import type { KanbanStatus } from "./jobs-view-helpers";
 
 export const jobsKanbanBoardMessages = defineMessages({
-  queued: {
-    defaultMessage: "Queued",
-    id: "8rr2LhuMpW",
-    description: "Kanban column label for queued jobs",
+  details: {
+    defaultMessage: "Details",
+    id: "TotmChYda4",
+    description: "Button or link to open the job detail page",
   },
-  running: {
-    defaultMessage: "Running",
-    id: "nEBGfsZw1I",
-    description: "Kanban column label for running jobs",
+  viewStrings: {
+    defaultMessage: "View strings",
+    id: "21nIG8nStI",
+    description: "Button or link to open the job CAT workspace",
   },
-  waitingForReview: {
-    defaultMessage: "Waiting for review",
-    id: "xsAaVb0T8m",
-    description: "Kanban column label for jobs waiting for review",
+  workspaceFallback: {
+    defaultMessage: "Workspace",
+    id: "mYcDqMLO3I",
+    description: "Fallback project badge when a kanban job has no project name",
   },
-  succeeded: {
-    defaultMessage: "Succeeded",
-    id: "hKQGjL6KUM",
-    description: "Kanban column label for succeeded jobs",
+  dueSyncedMeta: {
+    defaultMessage: "Due {due} · Synced {synced}",
+    id: "WL/j4jcqMB",
+    description: "Relative due date and last sync time on a kanban job card",
   },
-  failed: {
-    defaultMessage: "Failed",
-    id: "vUMdCurROo",
-    description: "Kanban column label for failed jobs",
+  noJobs: {
+    defaultMessage: "No jobs",
+    id: "O3GC76fqH9",
+    description: "Empty state inside a kanban column with no jobs",
   },
-  cancelled: {
-    defaultMessage: "Cancelled",
-    id: "/UI9Zob6RC",
-    description: "Kanban column label for cancelled jobs",
+  otherColumn: {
+    defaultMessage: "Other",
+    id: "XpdC3tQD4o",
+    description: "Kanban column label for jobs with an unrecognized status",
+  },
+  loadingBoardAriaLabel: {
+    defaultMessage: "Loading jobs board",
+    id: "6fRdYraA0j",
+    description: "Accessible label while the kanban board skeleton is shown",
+  },
+  kindWithTaskId: {
+    defaultMessage: "{kind} · {taskId}",
+    id: "H0Rnoert6W",
+    description: "Job kind and task identifier shown under the kanban card title",
   },
 });
 
 export function getKanbanStatusMessage(status: KanbanStatus): MessageDescriptor {
-  switch (status) {
-    case "queued":
-      return jobsKanbanBoardMessages.queued;
-    case "running":
-      return jobsKanbanBoardMessages.running;
-    case "waiting_for_review":
-      return jobsKanbanBoardMessages.waitingForReview;
-    case "succeeded":
-      return jobsKanbanBoardMessages.succeeded;
-    case "failed":
-      return jobsKanbanBoardMessages.failed;
-    case "cancelled":
-      return jobsKanbanBoardMessages.cancelled;
-  }
+  return getJobStatusMessage(status);
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-kanban-board.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-kanban-board.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -10,7 +10,6 @@ import { cn } from "@/lib/primitives/cn";
 
 import {
   formatJobKind,
-  formatJobStatusLabel,
   formatRelativeTime,
   getJobName,
   JobSourceLabel,
@@ -26,7 +25,8 @@ import {
   kanbanStatusColumns,
   type KanbanStatus,
 } from "./jobs-view-helpers";
-import { getKanbanStatusMessage } from "./jobs-kanban-board.messages";
+import { getKanbanStatusMessage, jobsKanbanBoardMessages } from "./jobs-kanban-board.messages";
+import { getJobStatusMessage } from "./jobs-page-view.messages";
 import { toneClass, type Tone } from "../../_components/workspace-resource-shared";
 
 type KanbanColumnDef = {
@@ -49,20 +49,23 @@ export function JobRowActions({
   projectId?: string;
   renderJobLink: JobsLinkRenderer;
 }) {
+  const intl = useIntl();
   const resolvedProjectId = projectId ?? job.projectId;
   const detailHref = buildDetailHref(organizationSlug, resolvedProjectId, job.id);
   const catHref = buildJobCatHref(organizationSlug, resolvedProjectId, job);
+  const detailsLabel = intl.formatMessage(jobsKanbanBoardMessages.details);
+  const viewStringsLabel = intl.formatMessage(jobsKanbanBoardMessages.viewStrings);
 
   return (
     <div className="flex flex-wrap items-center justify-end gap-2">
       {detailHref ? (
-        renderJobLink({ href: detailHref, kind: "details", children: "Details" })
+        renderJobLink({ href: detailHref, kind: "details", children: detailsLabel })
       ) : (
         <Button variant="outline" size="sm" className="w-fit" disabled>
-          Details
+          {detailsLabel}
         </Button>
       )}
-      {catHref ? renderJobLink({ href: catHref, kind: "cat", children: "View strings" }) : null}
+      {catHref ? renderJobLink({ href: catHref, kind: "cat", children: viewStringsLabel }) : null}
     </div>
   );
 }
@@ -82,6 +85,7 @@ function JobKanbanCard({
   projectId?: string;
   renderJobLink: JobsLinkRenderer;
 }) {
+  const intl = useIntl();
   const resolvedProjectId = projectId ?? job.projectId;
   const detailHref = buildDetailHref(organizationSlug, resolvedProjectId, job.id);
 
@@ -94,10 +98,16 @@ function JobKanbanCard({
           children: (
             <span className="min-w-0">
               <span className="block truncate text-sm font-medium text-foreground">
-                {getJobName(job)}
+                {getJobName(job, intl)}
               </span>
               <span className="mt-1 block truncate text-xs font-normal text-muted-foreground">
-                {formatJobKind(job)} · {job.externalTaskId ?? job.id}
+                <FormattedMessage
+                  {...jobsKanbanBoardMessages.kindWithTaskId}
+                  values={{
+                    kind: formatJobKind(job, intl),
+                    taskId: job.externalTaskId ?? job.id,
+                  }}
+                />
               </span>
             </span>
           ),
@@ -105,10 +115,16 @@ function JobKanbanCard({
       ) : (
         <div className="min-w-0">
           <TypographyP className="truncate text-sm font-medium text-foreground">
-            {getJobName(job)}
+            {getJobName(job, intl)}
           </TypographyP>
           <TypographyP className="mt-1 truncate text-xs text-muted-foreground">
-            {formatJobKind(job)} · {job.externalTaskId ?? job.id}
+            <FormattedMessage
+              {...jobsKanbanBoardMessages.kindWithTaskId}
+              values={{
+                kind: formatJobKind(job, intl),
+                taskId: job.externalTaskId ?? job.id,
+              }}
+            />
           </TypographyP>
         </div>
       )}
@@ -117,17 +133,24 @@ function JobKanbanCard({
         <JobSourceLabel job={job} compact />
         {!projectId ? (
           <Badge variant="outline" className="w-fit rounded-full text-[11px]">
-            {job.projectName ?? job.projectId ?? "Workspace"}
+            {job.projectName ??
+              job.projectId ??
+              intl.formatMessage(jobsKanbanBoardMessages.workspaceFallback)}
           </Badge>
         ) : null}
       </div>
 
       <TypographyP className="mt-3 line-clamp-2 text-xs text-subtle-foreground">
-        {taskDetailSummary(job)}
+        {taskDetailSummary(job, intl)}
       </TypographyP>
       <TypographyP className="mt-1 text-[11px] text-muted-foreground">
-        Due {formatRelativeTime(job.externalDueDate, now)} · Synced{" "}
-        {formatRelativeTime(job.updatedAt, now)}
+        <FormattedMessage
+          {...jobsKanbanBoardMessages.dueSyncedMeta}
+          values={{
+            due: formatRelativeTime(job.externalDueDate, now),
+            synced: formatRelativeTime(job.updatedAt, now),
+          }}
+        />
       </TypographyP>
 
       <div className="mt-3 border-t border-border pt-3">
@@ -164,7 +187,7 @@ function KanbanColumn({
       <div className="flex flex-1 flex-col gap-3 p-3">
         {jobs.length === 0 ? (
           <TypographyP className="px-1 py-6 text-center text-xs text-muted-foreground">
-            No jobs
+            <FormattedMessage {...jobsKanbanBoardMessages.noJobs} />
           </TypographyP>
         ) : (
           jobs.map((job) => <JobKanbanCard key={job.id} job={job} {...cardProps} />)
@@ -209,7 +232,11 @@ function JobsKanbanBoardSkeleton() {
   const intl = useIntl();
 
   return (
-    <div className="overflow-x-auto pb-1" aria-busy="true" aria-label="Loading jobs board">
+    <div
+      className="overflow-x-auto pb-1"
+      aria-busy="true"
+      aria-label={intl.formatMessage(jobsKanbanBoardMessages.loadingBoardAriaLabel)}
+    >
       <div className="flex min-w-max gap-3">
         {kanbanStatusColumns.map((status) => (
           <KanbanColumnSkeleton
@@ -241,6 +268,8 @@ export function JobsKanbanBoard({
   projectId?: string;
   renderJobLink: JobsLinkRenderer;
 }) {
+  const intl = useIntl();
+
   if (isLoading) {
     return <JobsKanbanBoardSkeleton />;
   }
@@ -274,7 +303,7 @@ export function JobsKanbanBoard({
     .filter((status) => (jobsByStatus.get(status)?.length ?? 0) > 0)
     .map((status) => ({
       key: status,
-      label: formatJobStatusLabel(status),
+      label: intl.formatMessage(getJobStatusMessage(status)),
       statusTone: jobTone(status),
       jobs: jobsByStatus.get(status) ?? [],
     }));
@@ -282,7 +311,7 @@ export function JobsKanbanBoard({
   if (unknownStatusJobs.length > 0) {
     columns.push({
       key: "other",
-      label: "Other",
+      label: intl.formatMessage(jobsKanbanBoardMessages.otherColumn),
       statusTone: "watch",
       jobs: unknownStatusJobs,
     });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.messages.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const jobsPageContentMessages = defineMessages({
+  createJob: {
+    defaultMessage: "Create job",
+    id: "+imNjDj2UT",
+    description: "Button to open the create job dialog from the jobs page",
+  },
+  loadJobsFailed: {
+    defaultMessage: "Failed to load jobs",
+    id: "tuH9VcQWRE",
+    description: "Fallback error when native jobs fail to load",
+  },
+  loadTmsJobsFailed: {
+    defaultMessage: "Failed to load TMS jobs",
+    id: "PhiMU1WefX",
+    description: "Fallback error when TMS jobs fail to load",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { Add01Icon, TranslateIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { TmsUserConnectionErrorPanel } from "@/components/app-shell/tms-user-connection-prompt";
 import { Button } from "@/components/ui/button";
@@ -31,6 +32,7 @@ import {
   type JobsScope,
   type JobsStatusFilter,
 } from "./jobs-page-view";
+import { jobsPageContentMessages } from "./jobs-page-content.messages";
 
 import {
   JOB_STATUS_FILTERS,
@@ -118,6 +120,7 @@ function toNativeJobRows(jobs: JobRow[]): JobRow[] {
 async function fetchNativeWorkspaceJobs(
   organizationSlug: string,
   statusFilter: JobsStatusFilter,
+  loadJobsFailedMessage: string,
   relationship?: "assigned" | "created",
 ) {
   const response = await apiClient.api.orgs[":organizationSlug"].jobs.$get({
@@ -129,7 +132,7 @@ async function fetchNativeWorkspaceJobs(
     },
   });
   if (!response.ok) {
-    throw await readApiResponseError(response, "Failed to load jobs");
+    throw await readApiResponseError(response, loadJobsFailedMessage);
   }
 
   const body = await response.json();
@@ -140,6 +143,7 @@ async function fetchNativeProjectJobs(
   organizationSlug: string,
   projectId: string,
   statusFilter: JobsStatusFilter,
+  loadJobsFailedMessage: string,
 ) {
   const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"].jobs.$get({
     param: { organizationSlug, projectId },
@@ -149,25 +153,30 @@ async function fetchNativeProjectJobs(
     },
   });
   if (!response.ok) {
-    throw await readApiResponseError(response, "Failed to load jobs");
+    throw await readApiResponseError(response, loadJobsFailedMessage);
   }
 
   const body = await response.json();
   return body.jobs as JobListResponse[];
 }
 
-async function fetchTmsWorkspaceJobs(organizationSlug: string, mine = false) {
+async function fetchTmsWorkspaceJobs(
+  organizationSlug: string,
+  loadTmsJobsFailedMessage: string,
+  mine = false,
+) {
   const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].jobs.$get({
     param: { organizationSlug },
     query: { mine: mine ? "true" : "false" },
   });
 
-  return readTmsProviderListResponse<JobListResponse>(response, "jobs", "Failed to load TMS jobs");
+  return readTmsProviderListResponse<JobListResponse>(response, "jobs", loadTmsJobsFailedMessage);
 }
 
 async function fetchTmsProjectJobs(
   organizationSlug: string,
   externalProjectId: string,
+  loadTmsJobsFailedMessage: string,
   mine = false,
 ) {
   const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].projects[
@@ -177,7 +186,7 @@ async function fetchTmsProjectJobs(
     query: { mine: mine ? "true" : "false" },
   });
 
-  return readTmsProviderListResponse<JobListResponse>(response, "jobs", "Failed to load TMS jobs");
+  return readTmsProviderListResponse<JobListResponse>(response, "jobs", loadTmsJobsFailedMessage);
 }
 
 export function JobsPageContent({
@@ -189,6 +198,7 @@ export function JobsPageContent({
   scope?: JobsScope;
   projectId?: string;
 }) {
+  const intl = useIntl();
   const searchParams = useSearchParams();
   const [statusFilter, setStatusFilter] = useState(() => readInitialStatusFilter(searchParams));
   const [createJobOpen, setCreateJobOpen] = useState(false);
@@ -199,6 +209,8 @@ export function JobsPageContent({
   const projectQuery = useProjectPageQuery(organizationSlug, projectId ?? "", {
     enabled: Boolean(projectId),
   });
+  const loadJobsFailedMessage = intl.formatMessage(jobsPageContentMessages.loadJobsFailed);
+  const loadTmsJobsFailedMessage = intl.formatMessage(jobsPageContentMessages.loadTmsJobsFailed);
 
   const nativeJobsQueryKey = [
     "jobs",
@@ -222,21 +234,28 @@ export function JobsPageContent({
     enabled: !isProviderProjectScope && (scope !== "personal" || !projectId),
     queryFn: async () => {
       if (projectId) {
-        return fetchNativeProjectJobs(organizationSlug, projectId, statusFilter);
+        return fetchNativeProjectJobs(
+          organizationSlug,
+          projectId,
+          statusFilter,
+          loadJobsFailedMessage,
+        );
       }
 
-      return fetchNativeWorkspaceJobs(organizationSlug, statusFilter);
+      return fetchNativeWorkspaceJobs(organizationSlug, statusFilter, loadJobsFailedMessage);
     },
   });
   const assignedNativeJobsQuery = useQuery({
     queryKey: [...nativeJobsQueryKey, "assigned"],
     enabled: scope === "personal" && !projectId,
-    queryFn: async () => fetchNativeWorkspaceJobs(organizationSlug, statusFilter, "assigned"),
+    queryFn: async () =>
+      fetchNativeWorkspaceJobs(organizationSlug, statusFilter, loadJobsFailedMessage, "assigned"),
   });
   const createdNativeJobsQuery = useQuery({
     queryKey: [...nativeJobsQueryKey, "created"],
     enabled: scope === "personal" && !projectId,
-    queryFn: async () => fetchNativeWorkspaceJobs(organizationSlug, statusFilter, "created"),
+    queryFn: async () =>
+      fetchNativeWorkspaceJobs(organizationSlug, statusFilter, loadJobsFailedMessage, "created"),
   });
   const tmsJobsQuery = useQuery({
     queryKey: tmsJobsQueryKey,
@@ -246,11 +265,16 @@ export function JobsPageContent({
         return fetchTmsProjectJobs(
           organizationSlug,
           parsedProviderProject.externalProjectId,
+          loadTmsJobsFailedMessage,
           scope === "personal",
         );
       }
 
-      return fetchTmsWorkspaceJobs(organizationSlug, scope === "personal");
+      return fetchTmsWorkspaceJobs(
+        organizationSlug,
+        loadTmsJobsFailedMessage,
+        scope === "personal",
+      );
     },
   });
 
@@ -282,7 +306,7 @@ export function JobsPageContent({
           canCreateJob ? (
             <Button type="button" size="sm" onClick={() => setCreateJobOpen(true)}>
               <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
-              Create job
+              <FormattedMessage {...jobsPageContentMessages.createJob} />
             </Button>
           ) : null
         }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.messages.ts
@@ -1,0 +1,346 @@
+"use client";
+
+import type { MessageDescriptor } from "react-intl";
+import { defineMessages } from "react-intl";
+
+type JobStatus = "queued" | "running" | "succeeded" | "failed" | "waiting_for_review" | "cancelled";
+
+type JobsStatusFilter = "all" | JobStatus;
+
+export const jobsPageViewMessages = defineMessages({
+  statusQueued: {
+    defaultMessage: "Queued",
+    id: "XuiVUmGIu9",
+    description: "Job status label for queued jobs",
+  },
+  statusRunning: {
+    defaultMessage: "Running",
+    id: "WzUqM2nTU8",
+    description: "Job status label for running jobs",
+  },
+  statusSucceeded: {
+    defaultMessage: "Succeeded",
+    id: "FcadZC4Ojx",
+    description: "Job status label for succeeded jobs",
+  },
+  statusFailed: {
+    defaultMessage: "Failed",
+    id: "6v642AIPEK",
+    description: "Job status label for failed jobs",
+  },
+  statusWaitingForReview: {
+    defaultMessage: "Waiting for review",
+    id: "iGnaQ/kXrJ",
+    description: "Job status label for jobs waiting for review",
+  },
+  statusCancelled: {
+    defaultMessage: "Cancelled",
+    id: "7AiYKudhqp",
+    description: "Job status label for cancelled jobs",
+  },
+  statusFilterAll: {
+    defaultMessage: "All status",
+    id: "fdNYFpldO1",
+    description: "Jobs status filter option to show all statuses",
+  },
+  loadErrorTitle: {
+    defaultMessage: "Jobs failed to load.",
+    id: "FHqHBUJ88J",
+    description: "Error title when the jobs list request fails",
+  },
+  loadErrorFallback: {
+    defaultMessage: "Failed to load jobs.",
+    id: "qcbg+R1kQS",
+    description: "Fallback error description when no API message is available",
+  },
+  loadingJobs: {
+    defaultMessage: "Loading jobs…",
+    id: "Dwu72TwwL/",
+    description: "Loading state while the jobs list is fetching",
+  },
+  columnName: {
+    defaultMessage: "Name",
+    id: "gApOTEuTv4",
+    description: "Jobs list column header for job name",
+  },
+  columnSource: {
+    defaultMessage: "Source",
+    id: "tg/aV3KaU6",
+    description: "Jobs list column header for job source provider",
+  },
+  columnProject: {
+    defaultMessage: "Project",
+    id: "e+qzXq1bUT",
+    description: "Jobs list column header for project name",
+  },
+  columnStatus: {
+    defaultMessage: "Status",
+    id: "jFmVURLI4A",
+    description: "Jobs list column header for job status",
+  },
+  columnTaskDetails: {
+    defaultMessage: "Task details",
+    id: "1FrqZ8RCIU",
+    description: "Jobs list column header for locales and assignees",
+  },
+  columnActions: {
+    defaultMessage: "Actions",
+    id: "k8AGhyD7g4",
+    description: "Jobs list column header for row actions",
+  },
+  workspaceFallback: {
+    defaultMessage: "Workspace",
+    id: "3n0F65flH2",
+    description: "Fallback label when a job has no project name",
+  },
+  dueSyncedMeta: {
+    defaultMessage: "Due {due} · Synced {synced}",
+    id: "7M3ajU1pAe",
+    description: "Relative due date and last sync time under job task details",
+  },
+  viewModeAriaLabel: {
+    defaultMessage: "Jobs view mode",
+    id: "9yljEAQK89",
+    description: "Accessible label for the row versus board view toggle",
+  },
+  viewModeRow: {
+    defaultMessage: "Row",
+    id: "dsAsLnB2MG",
+    description: "Button label to show jobs as a list",
+  },
+  viewModeBoard: {
+    defaultMessage: "Board",
+    id: "KG5OUSGbKU",
+    description: "Button label to show jobs as a kanban board",
+  },
+  filterSearch: {
+    defaultMessage: "Search",
+    id: "kC3PfwuLdP",
+    description: "Label above the jobs search field",
+  },
+  filterSearchPlaceholder: {
+    defaultMessage: "Jobs, providers, locales, assignees...",
+    id: "JnBi/qJh07",
+    description: "Placeholder text in the jobs search field",
+  },
+  filterStatus: {
+    defaultMessage: "Status",
+    id: "HxcjgjcAgw",
+    description: "Label above the jobs status filter",
+  },
+  filterView: {
+    defaultMessage: "View",
+    id: "PATshCyE6V",
+    description: "Label above the jobs view mode toggle",
+  },
+  sectionAssignedToMe: {
+    defaultMessage: "Assigned to me",
+    id: "qeeSJl75WM",
+    description: "Section heading for jobs assigned to the current user",
+  },
+  sectionCreatedByMe: {
+    defaultMessage: "Created by me",
+    id: "zirutH7PO0",
+    description: "Section heading for jobs created by the current user",
+  },
+  nativeJobsTitle: {
+    defaultMessage: "Hyperlocalise jobs",
+    id: "KOI3KSEDDk",
+    description: "Section title for native Hyperlocalise jobs",
+  },
+  nativeJobsDescription: {
+    defaultMessage: "Jobs created and tracked in this workspace.",
+    id: "k3TrZpmKkB",
+    description: "Description under the native jobs section title",
+  },
+  tmsJobsTitle: {
+    defaultMessage: "TMS jobs",
+    id: "Ze+mVOXG0h",
+    description: "Section title for live TMS provider jobs",
+  },
+  tmsJobsDescription: {
+    defaultMessage: "Live jobs fetched from your connected TMS provider.",
+    id: "1e/ZaE2rH7",
+    description: "Description under the TMS jobs section for workspace scope",
+  },
+  tmsJobsAssignedDescription: {
+    defaultMessage: "Live jobs assigned to you in the connected provider.",
+    id: "TFnG73Az5B",
+    description: "Description under the TMS jobs section for personal assigned scope",
+  },
+  emptyAssignedNative: {
+    defaultMessage: "No assigned Hyperlocalise jobs found.",
+    id: "YTRbiRB1qL",
+    description: "Empty state when the user has no assigned native jobs",
+  },
+  emptyAssignedTms: {
+    defaultMessage: "No assigned TMS jobs found.",
+    id: "QkxwQQPimv",
+    description: "Empty state when the user has no assigned TMS jobs",
+  },
+  emptyCreatedNative: {
+    defaultMessage: "No Hyperlocalise jobs created by you found.",
+    id: "0JvtLHpNGT",
+    description: "Empty state when the user has created no native jobs",
+  },
+  emptyNativeProject: {
+    defaultMessage: "No Hyperlocalise jobs found for this project yet.",
+    id: "SusA/f3CfU",
+    description: "Empty state for native jobs in a project",
+  },
+  emptyNativePersonal: {
+    defaultMessage: "No Hyperlocalise work items found for your account.",
+    id: "TtcvnbdV7R",
+    description: "Empty state for native jobs in personal workspace scope",
+  },
+  emptyNativeWorkspace: {
+    defaultMessage: "No Hyperlocalise jobs found for this workspace.",
+    id: "V/nJMxzENN",
+    description: "Empty state for native jobs in workspace scope",
+  },
+  emptyTmsProject: {
+    defaultMessage: "No TMS jobs found for this project.",
+    id: "SKW9qV8rtN",
+    description: "Empty state for TMS jobs in a project",
+  },
+  emptyTmsPersonal: {
+    defaultMessage: "No TMS jobs assigned to you were returned from the live provider API.",
+    id: "t3RhAFC8NZ",
+    description: "Empty state for TMS jobs in personal workspace scope",
+  },
+  emptyTmsWorkspace: {
+    defaultMessage: "No TMS jobs were returned from the live provider API.",
+    id: "D6uFQeF0q1",
+    description: "Empty state for TMS jobs in workspace scope",
+  },
+  projectSectionLabel: {
+    defaultMessage: "Jobs",
+    id: "q4g35VNiZ5",
+    description: "Project page section label for the jobs view",
+  },
+  projectSectionDescription: {
+    defaultMessage: "Translation, review, QA, and sync work from Hyperlocalise and your TMS.",
+    id: "v0xJPzewtL",
+    description: "Project page section description for the jobs view",
+  },
+  workspaceLabel: {
+    defaultMessage: "Workspace",
+    id: "xSmzy2H6ua",
+    description: "Workspace page header eyebrow label for jobs",
+  },
+  pageTitleJobs: {
+    defaultMessage: "Jobs",
+    id: "Q+H5CN9hp3",
+    description: "Workspace jobs page heading",
+  },
+  pageTitleMyJobs: {
+    defaultMessage: "My Jobs",
+    id: "AeHzXlSphR",
+    description: "Personal jobs page heading",
+  },
+  pageDescriptionWorkspace: {
+    defaultMessage: "Hyperlocalise jobs and live TMS jobs tracked across the workspace.",
+    id: "OLljhH3V9D",
+    description: "Workspace jobs page description under the heading",
+  },
+  pageDescriptionPersonal: {
+    defaultMessage: "Hyperlocalise and live TMS work assigned to you or created by you.",
+    id: "/s8HFQ46mj",
+    description: "Personal jobs page description under the heading",
+  },
+  noLocalesOrAssignees: {
+    defaultMessage: "No locales or assignees",
+    id: "c4wtcYLzS0",
+    description: "Task details fallback when a job has neither locales nor assignees",
+  },
+  kindTranslation: {
+    defaultMessage: "translation",
+    id: "Fkgfxe1y6x",
+    description: "Job kind label for translation jobs",
+  },
+  kindResearch: {
+    defaultMessage: "research",
+    id: "knhexLkbYQ",
+    description: "Job kind label for research jobs",
+  },
+  kindReview: {
+    defaultMessage: "review",
+    id: "+zez4H8ovm",
+    description: "Job kind label for review jobs",
+  },
+  kindProofread: {
+    defaultMessage: "proofread",
+    id: "4wrSufGtmm",
+    description: "Job kind label for proofread jobs",
+  },
+  kindSync: {
+    defaultMessage: "sync",
+    id: "QdvsoHtp53",
+    description: "Job kind label for sync jobs",
+  },
+  kindAssetManagement: {
+    defaultMessage: "asset management",
+    id: "w7sk9jcVLD",
+    description: "Job kind label for asset management jobs",
+  },
+  kindTranslationWithType: {
+    defaultMessage: "translation · {type}",
+    id: "YkxvISUXc3",
+    description: "Translation job kind label including string or file type",
+  },
+  reviewJobName: {
+    defaultMessage: "Review: {criteria}",
+    id: "/S7W2Oty8S",
+    description: "Fallback job name for a review job using its criteria",
+  },
+  syncJobName: {
+    defaultMessage: "{direction} {connector}",
+    id: "4gW2ktRuC/",
+    description: "Fallback job name for a sync job",
+  },
+  assetJobName: {
+    defaultMessage: "{operation} {assetType}",
+    id: "hTbl8aKMIU",
+    description: "Fallback job name for an asset management job",
+  },
+  researchJobName: {
+    defaultMessage: "Research: {scope}",
+    id: "0P12MNf4ZM",
+    description: "Fallback job name for a research job using its scope",
+  },
+  syncDirectionFallback: {
+    defaultMessage: "sync",
+    id: "Z6XcD4K+oU",
+    description: "Fallback sync direction word in a sync job name",
+  },
+  assetOperationFallback: {
+    defaultMessage: "manage",
+    id: "MR3nUfsG07",
+    description: "Fallback asset operation word in an asset job name",
+  },
+  kindWithTaskId: {
+    defaultMessage: "{kind} · {taskId}",
+    id: "Ckw9uq26zb",
+    description: "Job kind and task identifier shown under the job name",
+  },
+});
+
+const jobStatusMessages = {
+  queued: jobsPageViewMessages.statusQueued,
+  running: jobsPageViewMessages.statusRunning,
+  succeeded: jobsPageViewMessages.statusSucceeded,
+  failed: jobsPageViewMessages.statusFailed,
+  waiting_for_review: jobsPageViewMessages.statusWaitingForReview,
+  cancelled: jobsPageViewMessages.statusCancelled,
+} as const satisfies Record<JobStatus, MessageDescriptor>;
+
+export function getJobStatusMessage(status: JobStatus): MessageDescriptor {
+  return jobStatusMessages[status];
+}
+
+export function getJobsStatusFilterMessage(status: JobsStatusFilter): MessageDescriptor {
+  if (status === "all") {
+    return jobsPageViewMessages.statusFilterAll;
+  }
+  return getJobStatusMessage(status);
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
@@ -10,6 +10,7 @@ import {
   WorkHistoryIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -35,6 +36,11 @@ import {
   writeJobsViewMode,
   type JobsViewMode,
 } from "./jobs-view-helpers";
+import {
+  getJobStatusMessage,
+  getJobsStatusFilterMessage,
+  jobsPageViewMessages,
+} from "./jobs-page-view.messages";
 import { formatLocaleList, getCrowdinTargetLocales } from "./provider-crowdin-job-display";
 
 import {
@@ -116,11 +122,6 @@ const jobStatusLabels = {
   waiting_for_review: "Waiting for review",
   cancelled: "Cancelled",
 } as const satisfies Record<ApiJob["status"], string>;
-
-const statusFilterLabels = {
-  all: "All status",
-  ...jobStatusLabels,
-} as const satisfies Record<JobsStatusFilter, string>;
 
 export function formatJobStatusLabel(status: ApiJob["status"]) {
   return jobStatusLabels[status];
@@ -226,7 +227,7 @@ function getInputPayloadString(job: ApiJob, key: string) {
   return typeof value === "string" && value.length > 0 ? value : null;
 }
 
-export function getJobName(job: ApiJob) {
+export function getJobName(job: ApiJob, intl?: IntlShape) {
   if (job.externalTitle) return formatJobName(job.externalTitle);
   const metadataTitle =
     typeof job.inputPayload === "object" &&
@@ -238,14 +239,47 @@ export function getJobName(job: ApiJob) {
       ? (job.inputPayload as { metadata: { title: string } }).metadata.title
       : null;
   if (metadataTitle) return formatJobName(metadataTitle);
-  if (job.kind === "review" && job.reviewCriteria)
-    return formatJobName(`Review: ${job.reviewCriteria}`);
-  if (job.kind === "sync" && job.syncConnectorKind)
-    return formatJobName(`${job.syncDirection ?? "sync"} ${job.syncConnectorKind}`);
-  if (job.kind === "asset_management" && job.assetType)
-    return formatJobName(`${job.assetOperation ?? "manage"} ${job.assetType}`);
+  if (job.kind === "review" && job.reviewCriteria) {
+    return formatJobName(
+      intl
+        ? intl.formatMessage(jobsPageViewMessages.reviewJobName, { criteria: job.reviewCriteria })
+        : `Review: ${job.reviewCriteria}`,
+    );
+  }
+  if (job.kind === "sync" && job.syncConnectorKind) {
+    const direction =
+      job.syncDirection ??
+      (intl ? intl.formatMessage(jobsPageViewMessages.syncDirectionFallback) : "sync");
+    return formatJobName(
+      intl
+        ? intl.formatMessage(jobsPageViewMessages.syncJobName, {
+            direction,
+            connector: job.syncConnectorKind,
+          })
+        : `${direction} ${job.syncConnectorKind}`,
+    );
+  }
+  if (job.kind === "asset_management" && job.assetType) {
+    const operation =
+      job.assetOperation ??
+      (intl ? intl.formatMessage(jobsPageViewMessages.assetOperationFallback) : "manage");
+    return formatJobName(
+      intl
+        ? intl.formatMessage(jobsPageViewMessages.assetJobName, {
+            operation,
+            assetType: job.assetType,
+          })
+        : `${operation} ${job.assetType}`,
+    );
+  }
   const researchScope = getInputPayloadString(job, "scope");
-  if (job.kind === "research" && researchScope) return formatJobName(`Research: ${researchScope}`);
+  if (job.kind === "research" && researchScope) {
+    return formatJobName(
+      intl
+        ? intl.formatMessage(jobsPageViewMessages.researchJobName, { scope: researchScope })
+        : `Research: ${researchScope}`,
+    );
+  }
   const sourceText = getInputPayloadString(job, "sourceText");
   if (sourceText) return formatJobName(sourceText);
   const sourceFileId = getInputPayloadString(job, "sourceFileId");
@@ -253,7 +287,22 @@ export function getJobName(job: ApiJob) {
   return job.id;
 }
 
-export function formatJobKind(job: ApiJob) {
+const jobKindMessages = {
+  translation: jobsPageViewMessages.kindTranslation,
+  research: jobsPageViewMessages.kindResearch,
+  review: jobsPageViewMessages.kindReview,
+  proofread: jobsPageViewMessages.kindProofread,
+  sync: jobsPageViewMessages.kindSync,
+  asset_management: jobsPageViewMessages.kindAssetManagement,
+} as const;
+
+export function formatJobKind(job: ApiJob, intl?: IntlShape) {
+  if (intl) {
+    if (job.kind === "translation" && job.type) {
+      return intl.formatMessage(jobsPageViewMessages.kindTranslationWithType, { type: job.type });
+    }
+    return intl.formatMessage(jobKindMessages[job.kind]);
+  }
   if (job.kind === "translation" && job.type) return `${job.kind.replace("_", " ")} · ${job.type}`;
   return job.kind.replace("_", " ");
 }
@@ -278,7 +327,7 @@ function jobMatchesFilters(job: JobRow, input: { search: string; statusFilter: J
   return matchesStatus && matchesSearch;
 }
 
-export function taskDetailSummary(job: ApiJob) {
+export function taskDetailSummary(job: ApiJob, intl?: IntlShape) {
   const fallbackTargetLocales = job.externalTargetLocales?.length
     ? job.externalTargetLocales
     : job.reviewTargetLocale
@@ -286,7 +335,11 @@ export function taskDetailSummary(job: ApiJob) {
       : [];
   const locales = formatLocaleList(getCrowdinTargetLocales(null, fallbackTargetLocales));
   const people = assignees(job);
-  if (locales === "—" && people === "—") return "No locales or assignees";
+  if (locales === "—" && people === "—") {
+    return intl
+      ? intl.formatMessage(jobsPageViewMessages.noLocalesOrAssignees)
+      : "No locales or assignees";
+  }
   if (locales === "—") return people;
   if (people === "—") return locales;
   return `${locales} · ${people}`;
@@ -329,11 +382,17 @@ function defaultRenderJobLink({ href, kind, children }: Parameters<JobsLinkRende
 }
 
 export function JobsPageErrorMessage({ error }: { error: unknown }) {
+  const intl = useIntl();
+
   return (
     <>
-      <TypographyP className="text-sm font-medium text-flame-100">Jobs failed to load.</TypographyP>
+      <TypographyP className="text-sm font-medium text-flame-100">
+        <FormattedMessage {...jobsPageViewMessages.loadErrorTitle} />
+      </TypographyP>
       <TypographyP className="mt-1 text-sm text-muted-foreground">
-        {error instanceof Error ? error.message : "Failed to load jobs."}
+        {error instanceof Error
+          ? error.message
+          : intl.formatMessage(jobsPageViewMessages.loadErrorFallback)}
       </TypographyP>
     </>
   );
@@ -358,9 +417,13 @@ function JobsList({
   projectId?: string;
   renderJobLink: JobsLinkRenderer;
 }) {
+  const intl = useIntl();
+
   if (isLoading)
     return (
-      <TypographyP className="px-3 py-8 text-sm text-muted-foreground">Loading jobs…</TypographyP>
+      <TypographyP className="px-3 py-8 text-sm text-muted-foreground">
+        <FormattedMessage {...jobsPageViewMessages.loadingJobs} />
+      </TypographyP>
     );
   if (jobs.length === 0) {
     return (
@@ -377,12 +440,24 @@ function JobsList({
             "px-3 py-3 text-sm font-medium text-muted-foreground",
           )}
         >
-          <TypographyP>Name</TypographyP>
-          <TypographyP>Source</TypographyP>
-          <TypographyP>Project</TypographyP>
-          <TypographyP>Status</TypographyP>
-          <TypographyP>Task details</TypographyP>
-          <TypographyP className="text-end">Actions</TypographyP>
+          <TypographyP>
+            <FormattedMessage {...jobsPageViewMessages.columnName} />
+          </TypographyP>
+          <TypographyP>
+            <FormattedMessage {...jobsPageViewMessages.columnSource} />
+          </TypographyP>
+          <TypographyP>
+            <FormattedMessage {...jobsPageViewMessages.columnProject} />
+          </TypographyP>
+          <TypographyP>
+            <FormattedMessage {...jobsPageViewMessages.columnStatus} />
+          </TypographyP>
+          <TypographyP>
+            <FormattedMessage {...jobsPageViewMessages.columnTaskDetails} />
+          </TypographyP>
+          <TypographyP className="text-end">
+            <FormattedMessage {...jobsPageViewMessages.columnActions} />
+          </TypographyP>
         </div>
         {jobs.map((job, index) => {
           const detailHref = buildDetailHref(organizationSlug, projectId ?? job.projectId, job.id);
@@ -403,21 +478,28 @@ function JobsList({
                 )}
                 <JobSourceLabel job={job} />
                 <TypographyP className="truncate text-sm text-muted-foreground">
-                  {job.projectName ?? job.projectId ?? "Workspace"}
+                  {job.projectName ??
+                    job.projectId ??
+                    intl.formatMessage(jobsPageViewMessages.workspaceFallback)}
                 </TypographyP>
                 <Badge
                   variant="outline"
                   className={cn("w-fit rounded-full", toneClass(jobTone(job.status)))}
                 >
-                  {formatJobStatusLabel(job.status)}
+                  {intl.formatMessage(getJobStatusMessage(job.status))}
                 </Badge>
                 <div className="min-w-0">
                   <TypographyP className="truncate text-sm text-subtle-foreground">
-                    {taskDetailSummary(job)}
+                    {taskDetailSummary(job, intl)}
                   </TypographyP>
                   <TypographyP className="mt-1 truncate text-xs text-muted-foreground">
-                    Due {formatRelativeTime(job.externalDueDate, now)} · Synced{" "}
-                    {formatRelativeTime(job.updatedAt, now)}
+                    <FormattedMessage
+                      {...jobsPageViewMessages.dueSyncedMeta}
+                      values={{
+                        due: formatRelativeTime(job.externalDueDate, now),
+                        synced: formatRelativeTime(job.updatedAt, now),
+                      }}
+                    />
                   </TypographyP>
                 </div>
                 <JobRowActions
@@ -438,13 +520,21 @@ function JobsList({
 }
 
 function JobListItemTitle({ job }: { job: ApiJob }) {
+  const intl = useIntl();
+
   return (
     <span className="min-w-0">
       <span className="block truncate text-base font-medium text-foreground">
-        {getJobName(job)}
+        {getJobName(job, intl)}
       </span>
       <span className="mt-1 block truncate text-xs font-normal text-muted-foreground">
-        {formatJobKind(job)} · {job.externalTaskId ?? job.id}
+        <FormattedMessage
+          {...jobsPageViewMessages.kindWithTaskId}
+          values={{
+            kind: formatJobKind(job, intl),
+            taskId: job.externalTaskId ?? job.id,
+          }}
+        />
       </span>
     </span>
   );
@@ -457,8 +547,10 @@ function JobsViewModeToggle({
   viewMode: JobsViewMode;
   onViewModeChange: (viewMode: JobsViewMode) => void;
 }) {
+  const intl = useIntl();
+
   return (
-    <ButtonGroup aria-label="Jobs view mode">
+    <ButtonGroup aria-label={intl.formatMessage(jobsPageViewMessages.viewModeAriaLabel)}>
       <Button
         type="button"
         variant={viewMode === "row" ? "default" : "outline"}
@@ -467,7 +559,7 @@ function JobsViewModeToggle({
         onClick={() => onViewModeChange("row")}
       >
         <HugeiconsIcon icon={ListViewIcon} strokeWidth={1.8} />
-        Row
+        <FormattedMessage {...jobsPageViewMessages.viewModeRow} />
       </Button>
       <Button
         type="button"
@@ -477,7 +569,7 @@ function JobsViewModeToggle({
         onClick={() => onViewModeChange("kanban")}
       >
         <HugeiconsIcon icon={KanbanIcon} strokeWidth={1.8} />
-        Board
+        <FormattedMessage {...jobsPageViewMessages.viewModeBoard} />
       </Button>
     </ButtonGroup>
   );
@@ -639,6 +731,7 @@ export function JobsPageView({
   tmsError?: unknown;
   tmsJobs?: JobRow[];
 }) {
+  const intl = useIntl();
   const searchId = useId();
   const [search, setSearch] = useState(initialSearch);
   const [viewMode, setViewMode] = useState<JobsViewMode>("kanban");
@@ -679,20 +772,26 @@ export function JobsPageView({
   const showTmsSection = isProviderProjectScope || (!projectId && hasActiveTmsConnection);
 
   const nativeEmptyLabel = projectId
-    ? "No Hyperlocalise jobs found for this project yet."
+    ? intl.formatMessage(jobsPageViewMessages.emptyNativeProject)
     : scope === "personal"
-      ? "No Hyperlocalise work items found for your account."
-      : "No Hyperlocalise jobs found for this workspace.";
+      ? intl.formatMessage(jobsPageViewMessages.emptyNativePersonal)
+      : intl.formatMessage(jobsPageViewMessages.emptyNativeWorkspace);
   const tmsEmptyLabel = projectId
-    ? "No TMS jobs found for this project."
+    ? intl.formatMessage(jobsPageViewMessages.emptyTmsProject)
     : scope === "personal"
-      ? "No TMS jobs assigned to you were returned from the live provider API."
-      : "No TMS jobs were returned from the live provider API.";
+      ? intl.formatMessage(jobsPageViewMessages.emptyTmsPersonal)
+      : intl.formatMessage(jobsPageViewMessages.emptyTmsWorkspace);
+  const statusFilterLabel = intl.formatMessage(getJobsStatusFilterMessage(statusFilter));
+  const nativeJobsTitle = intl.formatMessage(jobsPageViewMessages.nativeJobsTitle);
+  const tmsJobsTitle = intl.formatMessage(jobsPageViewMessages.tmsJobsTitle);
 
   const jobsSection = (
     <section className="space-y-8">
       <div className="flex flex-col gap-3 lg:flex-row lg:items-end">
-        <JobsFilterField label="Search" className="min-w-0 flex-1">
+        <JobsFilterField
+          label={intl.formatMessage(jobsPageViewMessages.filterSearch)}
+          className="min-w-0 flex-1"
+        >
           <div className="relative">
             <HugeiconsIcon
               icon={SearchIcon}
@@ -703,12 +802,15 @@ export function JobsPageView({
               id={searchId}
               value={search}
               onChange={(event) => setSearch(event.target.value)}
-              placeholder="Jobs, providers, locales, assignees..."
+              placeholder={intl.formatMessage(jobsPageViewMessages.filterSearchPlaceholder)}
               className="h-9 border-border bg-transparent pl-9 text-foreground placeholder:text-muted-foreground"
             />
           </div>
         </JobsFilterField>
-        <JobsFilterField label="Status" className="w-full lg:w-40">
+        <JobsFilterField
+          label={intl.formatMessage(jobsPageViewMessages.filterStatus)}
+          className="w-full lg:w-40"
+        >
           <Select
             value={statusFilter}
             onValueChange={(value) => {
@@ -720,19 +822,25 @@ export function JobsPageView({
             }}
           >
             <SelectTrigger className={jobsFilterTriggerClassName}>
-              <SelectValue>{statusFilterLabels[statusFilter]}</SelectValue>
+              <SelectValue>{statusFilterLabel}</SelectValue>
             </SelectTrigger>
             <SelectContent className={jobsFilterSelectContentClassName}>
-              {jobsStatusOptions.map((status) => (
-                <SelectItem key={status} value={status} label={statusFilterLabels[status]}>
-                  {statusFilterLabels[status]}
-                </SelectItem>
-              ))}
+              {jobsStatusOptions.map((status) => {
+                const label = intl.formatMessage(getJobsStatusFilterMessage(status));
+                return (
+                  <SelectItem key={status} value={status} label={label}>
+                    {label}
+                  </SelectItem>
+                );
+              })}
             </SelectContent>
           </Select>
         </JobsFilterField>
         {projectId ? (
-          <JobsFilterField label="View" className="w-full lg:w-auto">
+          <JobsFilterField
+            label={intl.formatMessage(jobsPageViewMessages.filterView)}
+            className="w-full lg:w-auto"
+          >
             <JobsViewModeToggle viewMode={viewMode} onViewModeChange={handleViewModeChange} />
           </JobsFilterField>
         ) : null}
@@ -741,11 +849,13 @@ export function JobsPageView({
       {isPersonalWork ? (
         <>
           <div className="space-y-8">
-            <JobsSectionHeader title="Assigned to me" />
+            <JobsSectionHeader
+              title={intl.formatMessage(jobsPageViewMessages.sectionAssignedToMe)}
+            />
             {showNativeSection ? (
               <JobsResourceSection
                 buildJobDetailHref={buildDetailHref}
-                emptyLabel="No assigned Hyperlocalise jobs found."
+                emptyLabel={intl.formatMessage(jobsPageViewMessages.emptyAssignedNative)}
                 error={nativeError}
                 isLoading={isNativeLoading}
                 jobs={visibleAssignedNativeJobs}
@@ -754,14 +864,14 @@ export function JobsPageView({
                 projectId={projectId}
                 renderError={renderError}
                 renderJobLink={renderJobLink}
-                title="Hyperlocalise jobs"
+                title={nativeJobsTitle}
                 viewMode={viewMode}
               />
             ) : null}
             {showTmsSection ? (
               <JobsResourceSection
                 buildJobDetailHref={buildDetailHref}
-                emptyLabel="No assigned TMS jobs found."
+                emptyLabel={intl.formatMessage(jobsPageViewMessages.emptyAssignedTms)}
                 error={tmsError}
                 isLoading={isTmsLoading}
                 jobs={visibleTmsJobs}
@@ -770,17 +880,19 @@ export function JobsPageView({
                 projectId={projectId}
                 renderError={renderError}
                 renderJobLink={renderJobLink}
-                title="TMS jobs"
-                description="Live jobs assigned to you in the connected provider."
+                title={tmsJobsTitle}
+                description={intl.formatMessage(jobsPageViewMessages.tmsJobsAssignedDescription)}
                 viewMode={viewMode}
               />
             ) : null}
           </div>
           <div className="space-y-8">
-            <JobsSectionHeader title="Created by me" />
+            <JobsSectionHeader
+              title={intl.formatMessage(jobsPageViewMessages.sectionCreatedByMe)}
+            />
             <JobsResourceSection
               buildJobDetailHref={buildDetailHref}
-              emptyLabel="No Hyperlocalise jobs created by you found."
+              emptyLabel={intl.formatMessage(jobsPageViewMessages.emptyCreatedNative)}
               error={nativeError}
               isLoading={isNativeLoading}
               jobs={visibleCreatedNativeJobs}
@@ -789,7 +901,7 @@ export function JobsPageView({
               projectId={projectId}
               renderError={renderError}
               renderJobLink={renderJobLink}
-              title="Hyperlocalise jobs"
+              title={nativeJobsTitle}
               viewMode={viewMode}
             />
           </div>
@@ -808,8 +920,8 @@ export function JobsPageView({
               projectId={projectId}
               renderError={renderError}
               renderJobLink={renderJobLink}
-              title="Hyperlocalise jobs"
-              description="Jobs created and tracked in this workspace."
+              title={nativeJobsTitle}
+              description={intl.formatMessage(jobsPageViewMessages.nativeJobsDescription)}
               viewMode={viewMode}
             />
           ) : null}
@@ -825,8 +937,8 @@ export function JobsPageView({
               projectId={projectId}
               renderError={renderError}
               renderJobLink={renderJobLink}
-              title="TMS jobs"
-              description="Live jobs fetched from your connected TMS provider."
+              title={tmsJobsTitle}
+              description={intl.formatMessage(jobsPageViewMessages.tmsJobsDescription)}
               viewMode={viewMode}
             />
           ) : null}
@@ -840,8 +952,8 @@ export function JobsPageView({
       <ProjectPageShell>
         <ProjectSectionHeader
           icon={Task01Icon}
-          section="Jobs"
-          description="Translation, review, QA, and sync work from Hyperlocalise and your TMS."
+          section={intl.formatMessage(jobsPageViewMessages.projectSectionLabel)}
+          description={intl.formatMessage(jobsPageViewMessages.projectSectionDescription)}
           actions={headerActions}
         />
         {jobsSection}
@@ -853,12 +965,16 @@ export function JobsPageView({
     <WorkspacePageShell>
       <PageHeader
         icon={isPersonalWork ? WorkHistoryIcon : Task01Icon}
-        label="Workspace"
-        title={isPersonalWork ? "My Jobs" : "Jobs"}
+        label={intl.formatMessage(jobsPageViewMessages.workspaceLabel)}
+        title={
+          isPersonalWork
+            ? intl.formatMessage(jobsPageViewMessages.pageTitleMyJobs)
+            : intl.formatMessage(jobsPageViewMessages.pageTitleJobs)
+        }
         description={
           isPersonalWork
-            ? "Hyperlocalise and live TMS work assigned to you or created by you."
-            : "Hyperlocalise jobs and live TMS jobs tracked across the workspace."
+            ? intl.formatMessage(jobsPageViewMessages.pageDescriptionPersonal)
+            : intl.formatMessage(jobsPageViewMessages.pageDescriptionWorkspace)
         }
         actions={headerActions}
       />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/provider-crowdin-job-detail-rows.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/provider-crowdin-job-detail-rows.messages.ts
@@ -1,0 +1,116 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const providerCrowdinJobDetailRowsMessages = defineMessages({
+  taskType: {
+    defaultMessage: "Task type",
+    id: "mC64PC89AZ",
+    description: "Detail row label for the job or Crowdin task type",
+  },
+  language: {
+    defaultMessage: "Language",
+    id: "A4xm05eQSM",
+    description: "Detail row label for the Crowdin task language",
+  },
+  project: {
+    defaultMessage: "Project",
+    id: "JpCXnGpMeh",
+    description: "Detail row label for the job project name",
+  },
+  targetLocales: {
+    defaultMessage: "Target locales",
+    id: "kp53zYBeIw",
+    description: "Detail row label for target locales",
+  },
+  description: {
+    defaultMessage: "Description",
+    id: "FuoKPzKv08",
+    description: "Detail row label for the Crowdin task description",
+  },
+  progress: {
+    defaultMessage: "Progress",
+    id: "Ty0GwUvHBg",
+    description: "Detail row label for translation and approval progress",
+  },
+  wordsToDo: {
+    defaultMessage: "Words to do",
+    id: "fIcVSh09FH",
+    description: "Detail row label for remaining words to translate",
+  },
+  dueDate: {
+    defaultMessage: "Due date",
+    id: "NP2wAmeM1j",
+    description: "Detail row label for the job due date",
+  },
+  externalJobId: {
+    defaultMessage: "External job ID",
+    id: "YUmBaBzXHy",
+    description: "Detail row label for the provider job identifier",
+  },
+  providerLink: {
+    defaultMessage: "Provider link",
+    id: "thAleOBSL6",
+    description: "Detail row label for the external provider URL",
+  },
+  openInProvider: {
+    defaultMessage: "Open in {provider}",
+    id: "VwQyWH3M7V",
+    description: "Link text to open the job in the external TMS provider",
+  },
+  workspaceFallback: {
+    defaultMessage: "Workspace",
+    id: "0bdrX6gjre",
+    description: "Fallback project name when a job has no project",
+  },
+  loadingProgress: {
+    defaultMessage: "Loading progress...",
+    id: "PapSWiA4OI",
+    description: "Placeholder while Crowdin locale readiness is loading",
+  },
+  translatedPercent: {
+    defaultMessage: "{percent}% translated",
+    id: "WX/L/z1wMm",
+    description: "Crowdin readiness when only translation progress is available",
+  },
+  approvedPercent: {
+    defaultMessage: "{percent}% approved",
+    id: "cndt0P/SRd",
+    description: "Crowdin readiness when only approval progress is available",
+  },
+  translatedAndApprovedPercent: {
+    defaultMessage: "{translatedPercent}% translated · {approvedPercent}% approved",
+    id: "T+85xLIwTA",
+    description: "Crowdin readiness with both translation and approval progress",
+  },
+  wordsLeftOfTotal: {
+    defaultMessage: "{remaining} words left of {total}",
+    id: "2rqS6tRROV",
+    description: "Crowdin words remaining versus total words for a task",
+  },
+  crowdinTypeTranslateOwn: {
+    defaultMessage: "Translate by own translators",
+    id: "VylAO2QrNw",
+    description: "Crowdin task type label for in-house translation",
+  },
+  crowdinTypeProofreadOwn: {
+    defaultMessage: "Proofread by own proofreaders",
+    id: "WkiVAJgo82",
+    description: "Crowdin task type label for in-house proofreading",
+  },
+  crowdinTypeTranslateVendor: {
+    defaultMessage: "Translate by vendor",
+    id: "a0yFgx40Tg",
+    description: "Crowdin task type label for vendor translation",
+  },
+  crowdinTypeProofreadVendor: {
+    defaultMessage: "Proofread by vendor",
+    id: "Mq9r073tq8",
+    description: "Crowdin task type label for vendor proofreading",
+  },
+  emptyValue: {
+    defaultMessage: "—",
+    id: "HCHtNgw+mH",
+    description: "Placeholder shown when a job detail field has no value",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/provider-crowdin-job-detail-rows.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/provider-crowdin-job-detail-rows.tsx
@@ -1,26 +1,88 @@
 "use client";
 
 import type { ReactNode } from "react";
+import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
 
 import {
   formatLocaleList,
-  formatReadinessProgress,
-  formatWordsToDo,
   getCrowdinLanguageLabel,
   getCrowdinTargetLocales,
-  getCrowdinTaskTypeLabel,
+  getProviderPayloadNumber,
   getProviderPayloadString,
+  getReadinessNumber,
+  getReadinessWords,
   resolveCrowdinLocaleReadiness,
 } from "./provider-crowdin-job-display";
 import { ProviderJobDescriptionField } from "./provider-job-description-field";
+import { providerCrowdinJobDetailRowsMessages } from "./provider-crowdin-job-detail-rows.messages";
 
 function JobDetailRow({ label, value }: { label: string; value: ReactNode }) {
+  const intl = useIntl();
+  const emptyValue = intl.formatMessage(providerCrowdinJobDetailRowsMessages.emptyValue);
+
   return (
     <div className="grid gap-1 py-3 sm:grid-cols-[9rem_minmax(0,1fr)] sm:gap-4">
       <dt className="text-sm text-muted-foreground">{label}</dt>
-      <dd className="min-w-0 wrap-break-word text-sm text-subtle-foreground">{value ?? "—"}</dd>
+      <dd className="min-w-0 wrap-break-word text-sm text-subtle-foreground">
+        {value ?? emptyValue}
+      </dd>
     </div>
   );
+}
+
+function formatCrowdinTaskTypeLabel(
+  providerPayload: Record<string, unknown> | null,
+  intl: IntlShape,
+) {
+  switch (getProviderPayloadNumber(providerPayload, "type")) {
+    case 0:
+      return intl.formatMessage(providerCrowdinJobDetailRowsMessages.crowdinTypeTranslateOwn);
+    case 1:
+      return intl.formatMessage(providerCrowdinJobDetailRowsMessages.crowdinTypeProofreadOwn);
+    case 2:
+      return intl.formatMessage(providerCrowdinJobDetailRowsMessages.crowdinTypeTranslateVendor);
+    case 3:
+      return intl.formatMessage(providerCrowdinJobDetailRowsMessages.crowdinTypeProofreadVendor);
+    default:
+      return null;
+  }
+}
+
+function formatLocalizedReadinessProgress(
+  readiness: Record<string, unknown> | null,
+  intl: IntlShape,
+) {
+  const translationProgress = getReadinessNumber(readiness, "translationProgress");
+  const approvalProgress = getReadinessNumber(readiness, "approvalProgress");
+  if (translationProgress === null && approvalProgress === null) return null;
+  if (approvalProgress === null) {
+    return intl.formatMessage(providerCrowdinJobDetailRowsMessages.translatedPercent, {
+      percent: Math.round(translationProgress ?? 0),
+    });
+  }
+  if (translationProgress === null) {
+    return intl.formatMessage(providerCrowdinJobDetailRowsMessages.approvedPercent, {
+      percent: Math.round(approvalProgress),
+    });
+  }
+  return intl.formatMessage(providerCrowdinJobDetailRowsMessages.translatedAndApprovedPercent, {
+    translatedPercent: Math.round(translationProgress),
+    approvedPercent: Math.round(approvalProgress),
+  });
+}
+
+function formatLocalizedWordsToDo(readiness: Record<string, unknown> | null, intl: IntlShape) {
+  const words = getReadinessWords(readiness);
+  const total = getReadinessNumber(words, "total");
+  const translated = getReadinessNumber(words, "translated");
+  const approved = getReadinessNumber(words, "approved");
+  if (total === null) return null;
+  const completed = translated ?? approved ?? 0;
+  const remaining = Math.max(total - completed, 0);
+  return intl.formatMessage(providerCrowdinJobDetailRowsMessages.wordsLeftOfTotal, {
+    remaining,
+    total,
+  });
 }
 
 export type CrowdinJobDetailSource = {
@@ -77,8 +139,9 @@ export function ProviderCrowdinJobDetailRows<J extends CrowdinJobDetailSource>({
   renderDescriptionField?: ProviderJobDescriptionFieldRenderer;
   extraRows?: ReactNode;
 }) {
+  const intl = useIntl();
   const isCrowdin = job.externalProviderKind === "crowdin";
-  const crowdinTaskType = isCrowdin ? getCrowdinTaskTypeLabel(providerPayload) : null;
+  const crowdinTaskType = isCrowdin ? formatCrowdinTaskTypeLabel(providerPayload, intl) : null;
   const crowdinLanguage = isCrowdin ? getCrowdinLanguageLabel(providerPayload) : null;
   const crowdinTargetLocales = isCrowdin
     ? formatLocaleList(getCrowdinTargetLocales(providerPayload, job.externalTargetLocales ?? []))
@@ -89,22 +152,46 @@ export function ProviderCrowdinJobDetailRows<J extends CrowdinJobDetailSource>({
   const crowdinLocaleReadiness = isCrowdin
     ? (localeReadinessOverride ?? resolveCrowdinLocaleReadiness(providerPayload))
     : null;
+  const loadingProgress = intl.formatMessage(providerCrowdinJobDetailRowsMessages.loadingProgress);
   const crowdinProgress = localeReadinessLoading
-    ? "Loading progress..."
-    : formatReadinessProgress(crowdinLocaleReadiness);
-  const crowdinWordsToDo = localeReadinessLoading ? null : formatWordsToDo(crowdinLocaleReadiness);
+    ? loadingProgress
+    : formatLocalizedReadinessProgress(crowdinLocaleReadiness, intl);
+  const crowdinWordsToDo = localeReadinessLoading
+    ? null
+    : formatLocalizedWordsToDo(crowdinLocaleReadiness, intl);
   const canEditProviderDescription =
     isCrowdin && job.id.startsWith("ext:") && Boolean(descriptionQueryKey?.length);
 
   return (
     <>
-      <JobDetailRow label="Task type" value={crowdinTaskType ?? formatJobKind(job)} />
-      {isCrowdin ? <JobDetailRow label="Language" value={crowdinLanguage ?? "—"} /> : null}
-      <JobDetailRow label="Project" value={job.projectName ?? "Workspace"} />
-      <JobDetailRow label="Target locales" value={crowdinTargetLocales} />
+      <JobDetailRow
+        label={intl.formatMessage(providerCrowdinJobDetailRowsMessages.taskType)}
+        value={crowdinTaskType ?? formatJobKind(job)}
+      />
+      {isCrowdin ? (
+        <JobDetailRow
+          label={intl.formatMessage(providerCrowdinJobDetailRowsMessages.language)}
+          value={
+            crowdinLanguage ?? intl.formatMessage(providerCrowdinJobDetailRowsMessages.emptyValue)
+          }
+        />
+      ) : null}
+      <JobDetailRow
+        label={intl.formatMessage(providerCrowdinJobDetailRowsMessages.project)}
+        value={
+          job.projectName ??
+          intl.formatMessage(providerCrowdinJobDetailRowsMessages.workspaceFallback)
+        }
+      />
+      <JobDetailRow
+        label={intl.formatMessage(providerCrowdinJobDetailRowsMessages.targetLocales)}
+        value={crowdinTargetLocales}
+      />
       {isCrowdin ? (
         <div className="grid gap-1 py-3 sm:grid-cols-[9rem_minmax(0,1fr)] sm:gap-4">
-          <dt className="text-sm text-muted-foreground">Description</dt>
+          <dt className="text-sm text-muted-foreground">
+            <FormattedMessage {...providerCrowdinJobDetailRowsMessages.description} />
+          </dt>
           <dd className="min-w-0">
             {renderDescriptionField({
               organizationSlug,
@@ -119,16 +206,30 @@ export function ProviderCrowdinJobDetailRows<J extends CrowdinJobDetailSource>({
         </div>
       ) : null}
       {crowdinProgress || localeReadinessLoading ? (
-        <JobDetailRow label="Progress" value={crowdinProgress ?? "Loading progress..."} />
+        <JobDetailRow
+          label={intl.formatMessage(providerCrowdinJobDetailRowsMessages.progress)}
+          value={crowdinProgress ?? loadingProgress}
+        />
       ) : null}
-      {crowdinWordsToDo ? <JobDetailRow label="Words to do" value={crowdinWordsToDo} /> : null}
-      <JobDetailRow label="Due date" value={formatDateTime(job.externalDueDate)} />
+      {crowdinWordsToDo ? (
+        <JobDetailRow
+          label={intl.formatMessage(providerCrowdinJobDetailRowsMessages.wordsToDo)}
+          value={crowdinWordsToDo}
+        />
+      ) : null}
+      <JobDetailRow
+        label={intl.formatMessage(providerCrowdinJobDetailRowsMessages.dueDate)}
+        value={formatDateTime(job.externalDueDate)}
+      />
       {job.externalJobId ? (
-        <JobDetailRow label="External job ID" value={job.externalJobId} />
+        <JobDetailRow
+          label={intl.formatMessage(providerCrowdinJobDetailRowsMessages.externalJobId)}
+          value={job.externalJobId}
+        />
       ) : null}
       {showProviderLink && job.externalUrl ? (
         <JobDetailRow
-          label="Provider link"
+          label={intl.formatMessage(providerCrowdinJobDetailRowsMessages.providerLink)}
           value={
             <a
               href={job.externalUrl}
@@ -136,7 +237,10 @@ export function ProviderCrowdinJobDetailRows<J extends CrowdinJobDetailSource>({
               rel="noreferrer noopener"
               className="text-foreground underline decoration-border underline-offset-4 hover:decoration-muted-foreground"
             >
-              Open in {job.externalProviderKind}
+              <FormattedMessage
+                {...providerCrowdinJobDetailRowsMessages.openInProvider}
+                values={{ provider: job.externalProviderKind }}
+              />
             </a>
           }
         />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/provider-job-description-field.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/provider-job-description-field.messages.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const providerJobDescriptionFieldMessages = defineMessages({
+  noDescription: {
+    defaultMessage: "No description",
+    id: "spGomVccm5",
+    description: "Empty state when a provider job has no description",
+  },
+  editAriaLabel: {
+    defaultMessage: "Edit description",
+    id: "jyIUsQefkI",
+    description: "Accessible label for the button that edits a job description",
+  },
+  saving: {
+    defaultMessage: "Saving…",
+    id: "EY7508Falv",
+    description: "Button label while a job description save is in progress",
+  },
+  saveDescription: {
+    defaultMessage: "Save description",
+    id: "fNe2j52ZZs",
+    description: "Button label to save an edited job description",
+  },
+  reset: {
+    defaultMessage: "Reset",
+    id: "secVzHMFB2",
+    description: "Button to reset an edited job description to the saved value",
+  },
+  cancel: {
+    defaultMessage: "Cancel",
+    id: "WeOiVualPW",
+    description: "Button to cancel editing a job description",
+  },
+  saveSuccess: {
+    defaultMessage: "Description saved",
+    id: "MDFHda6r2V",
+    description: "Toast after a job description is saved successfully",
+  },
+  saveFailedFallback: {
+    defaultMessage: "Failed to save description",
+    id: "dWtFeDmgHv",
+    description: "Fallback toast when saving a job description fails without a message",
+  },
+  saveFailedWithStatus: {
+    defaultMessage: "Failed to save description ({status})",
+    id: "jASVM8wdeJ",
+    description: "Error when saving a job description fails with an HTTP status",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/provider-job-description-field.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/provider-job-description-field.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Edit02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
 
 import {
@@ -12,6 +13,8 @@ import {
 } from "@/components/markdown-description-editor/markdown-description-editor";
 import { Button } from "@/components/ui/button";
 import { apiClient } from "@/lib/api-client-instance";
+
+import { providerJobDescriptionFieldMessages } from "./provider-job-description-field.messages";
 
 export function ProviderJobDescriptionFieldView({
   description,
@@ -30,6 +33,7 @@ export function ProviderJobDescriptionFieldView({
   onSaveDescription?: (description: string) => Promise<string | void>;
   onSaveError?: (error: unknown) => void;
 }) {
+  const intl = useIntl();
   const [isEditing, setIsEditing] = useState(initialIsEditing);
   const [draftState, setDraftState] = useState({
     baseDescription: description,
@@ -39,10 +43,11 @@ export function ProviderJobDescriptionFieldView({
   const isDirty = draft !== description;
   const [internalIsSaving, setInternalIsSaving] = useState(false);
   const savePending = isSaving || internalIsSaving;
+  const noDescription = intl.formatMessage(providerJobDescriptionFieldMessages.noDescription);
 
   if (!editable) {
     if (!description.trim()) {
-      return <p className="text-sm text-muted-foreground">No description</p>;
+      return <p className="text-sm text-muted-foreground">{noDescription}</p>;
     }
 
     return (
@@ -55,14 +60,14 @@ export function ProviderJobDescriptionFieldView({
       <div className="group/description relative">
         <MarkdownDescriptionPreview
           value={description}
-          emptyMessage="No description"
+          emptyMessage={noDescription}
           className="border-border bg-transparent pr-12"
         />
         <Button
           type="button"
           size="icon-sm"
           variant="ghost"
-          aria-label="Edit description"
+          aria-label={intl.formatMessage(providerJobDescriptionFieldMessages.editAriaLabel)}
           className="absolute top-2 right-2 text-muted-foreground hover:text-foreground"
           onClick={() => {
             setDraftState({ baseDescription: description, draft: description });
@@ -105,7 +110,11 @@ export function ProviderJobDescriptionFieldView({
             }
           }}
         >
-          {savePending ? "Saving…" : "Save description"}
+          {savePending ? (
+            <FormattedMessage {...providerJobDescriptionFieldMessages.saving} />
+          ) : (
+            <FormattedMessage {...providerJobDescriptionFieldMessages.saveDescription} />
+          )}
         </Button>
         <Button
           size="sm"
@@ -115,7 +124,7 @@ export function ProviderJobDescriptionFieldView({
             setDraftState({ baseDescription: description, draft: description });
           }}
         >
-          Reset
+          <FormattedMessage {...providerJobDescriptionFieldMessages.reset} />
         </Button>
         <Button
           size="sm"
@@ -126,7 +135,7 @@ export function ProviderJobDescriptionFieldView({
             setIsEditing(false);
           }}
         >
-          Cancel
+          <FormattedMessage {...providerJobDescriptionFieldMessages.cancel} />
         </Button>
       </div>
     </div>
@@ -146,6 +155,7 @@ export function ProviderJobDescriptionField({
   editable: boolean;
   queryKey: readonly unknown[];
 }) {
+  const intl = useIntl();
   const queryClient = useQueryClient();
 
   const saveMutation = useMutation({
@@ -163,7 +173,11 @@ export function ProviderJobDescriptionField({
           message?: string;
         } | null;
         throw new Error(
-          body?.message ?? body?.error ?? `Failed to save description (${response.status})`,
+          body?.message ??
+            body?.error ??
+            intl.formatMessage(providerJobDescriptionFieldMessages.saveFailedWithStatus, {
+              status: response.status,
+            }),
         );
       }
 
@@ -193,7 +207,7 @@ export function ProviderJobDescriptionField({
       return nextDescription;
     },
     onSuccess: () => {
-      toast.success("Description saved");
+      toast.success(intl.formatMessage(providerJobDescriptionFieldMessages.saveSuccess));
     },
   });
 
@@ -204,7 +218,11 @@ export function ProviderJobDescriptionField({
       isSaving={saveMutation.isPending}
       onSaveDescription={(nextDescription) => saveMutation.mutateAsync(nextDescription)}
       onSaveError={(error) => {
-        toast.error(error instanceof Error ? error.message : "Failed to save description");
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : intl.formatMessage(providerJobDescriptionFieldMessages.saveFailedFallback),
+        );
       }}
     />
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.messages.ts
@@ -1,0 +1,89 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const jobCatPageContentMessages = defineMessages({
+  loadingWorkspace: {
+    defaultMessage: "Loading workspace…",
+    id: "I6/kYi4M/3",
+    description: "Loading state while the job CAT workspace is preparing",
+  },
+  openingWorkspace: {
+    defaultMessage: "Opening workspace…",
+    id: "HbZmRDMHs3",
+    description: "Loading state while navigating into the job CAT workspace",
+  },
+  unableToLoadTaskFiles: {
+    defaultMessage: "Unable to load task files.",
+    id: "ZLaHigyIGc",
+    description: "Fallback error when job CAT task files fail to load",
+  },
+  noTargetLocaleSpecified: {
+    defaultMessage: "No target locale is specified for this task.",
+    id: "L402PDLeoZ",
+    description: "Empty state when the job has files but no target locale query param",
+  },
+  noSourceFileLinked: {
+    defaultMessage: "No source file is linked to this task.",
+    id: "3yxRiqmgnG",
+    description: "Empty state when the job has no linked source file for CAT",
+  },
+  noTargetLocaleForTask: {
+    defaultMessage: "No target locale is available for this task.",
+    id: "enjVtZumks",
+    description: "Empty state when all-files CAT mode has no selectable target locale",
+  },
+  noTargetLocaleForTaskFile: {
+    defaultMessage: "No target locale is available for this task file.",
+    id: "c0YVbiffzK",
+    description: "Empty state when a native job CAT file has no target locale",
+  },
+  noTargetLocaleForProviderFile: {
+    defaultMessage: "No target locale is available for this provider task file.",
+    id: "hCivyG+QTC",
+    description: "Empty state when a provider job CAT file has no target locale",
+  },
+  projectMissingSourceLocale: {
+    defaultMessage: "This project does not have a source locale.",
+    id: "DQ07Hv8A9f",
+    description: "Error when the project has no configured source locale for CAT",
+  },
+  repositoriesLoadFailed: {
+    defaultMessage:
+      "GitHub repositories could not be loaded. Repository context lookup is unavailable.",
+    id: "9c0o1d89j+",
+    description: "Banner when GitHub repositories fail to load on the job CAT page",
+  },
+  selectRepositoryForContext: {
+    defaultMessage: "Select a GitHub repository to look up string context.",
+    id: "GnhXacyqeM",
+    description: "Banner prompting the user to pick a repository for CAT context lookup",
+  },
+  listTruncated: {
+    defaultMessage:
+      "This project has more than {fetchedCount, number} files, so the source file could not be resolved from the loaded file list. Open CAT from the project Files page instead, or ask support to narrow the project file list.",
+    id: "LWxfVFhHEJ",
+    description:
+      "Error when the project file list was truncated before the CAT source file could be found",
+  },
+  sourceFileNoLongerLinked: {
+    defaultMessage: "This source file is not linked to the task anymore.",
+    id: "3Ze8wX3xRS",
+    description: "Empty state when the requested CAT source file is missing from the job",
+  },
+  stringEditingUnsupported: {
+    defaultMessage: "String editing is only available for supported provider task files.",
+    id: "BGQKZth3v0",
+    description: "Empty state when the selected provider file cannot open in CAT",
+  },
+  providerKindAndFormat: {
+    defaultMessage: "{kind} · {format}",
+    id: "j7qlYfJ6Qt",
+    description: "Provider kind and file format shown in the job CAT header",
+  },
+  fileFormatFallback: {
+    defaultMessage: "file",
+    id: "B9aG0nitRg",
+    description: "Fallback label when a provider task file has no format metadata",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { ArrowLeftIcon } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
@@ -37,6 +38,7 @@ import {
   selectJobCatRepository,
   sortJobCatProviderFiles,
 } from "./select-job-cat-repository";
+import { jobCatPageContentMessages } from "./job-cat-page-content.messages";
 import { ProjectFileCatWorkspace } from "@/components/cat/project-file/project-file-cat-workspace";
 import {
   attemptCatPageNavigation,
@@ -167,6 +169,7 @@ export function JobCatPageContent({
   initialQueueFilter?: CatQueueFilter;
   catAllFilesEnabled?: boolean;
 }) {
+  const intl = useIntl();
   const router = useRouter();
   const pageNavigationGuardRef = useRef<CatPageNavigationGuardRef["current"]>(null);
   const taskHref = `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(jobId)}`;
@@ -305,11 +308,11 @@ export function JobCatPageContent({
       <div className="shrink-0 border-b border-border px-3 py-1.5 sm:px-4 lg:px-6">
         {repositoriesQuery.isError ? (
           <TypographyP className="text-xs text-muted-foreground">
-            GitHub repositories could not be loaded. Repository context lookup is unavailable.
+            <FormattedMessage {...jobCatPageContentMessages.repositoriesLoadFailed} />
           </TypographyP>
         ) : (
           <TypographyP className="text-xs text-muted-foreground">
-            Select a GitHub repository to look up string context.
+            <FormattedMessage {...jobCatPageContentMessages.selectRepositoryForContext} />
           </TypographyP>
         )}
       </div>
@@ -406,7 +409,9 @@ export function JobCatPageContent({
         <ProjectPageShell>
           <div className="flex min-h-48 items-center justify-center gap-2 rounded-lg border border-border bg-card p-5">
             <Spinner />
-            <TypographyP className="text-sm text-muted-foreground">Loading workspace…</TypographyP>
+            <TypographyP className="text-sm text-muted-foreground">
+              <FormattedMessage {...jobCatPageContentMessages.loadingWorkspace} />
+            </TypographyP>
           </div>
         </ProjectPageShell>
       );
@@ -419,7 +424,7 @@ export function JobCatPageContent({
             <TypographyP className="text-sm text-flame-100">
               {defaultFileQuery.error instanceof Error
                 ? defaultFileQuery.error.message
-                : "Unable to load task files."}
+                : intl.formatMessage(jobCatPageContentMessages.unableToLoadTaskFiles)}
             </TypographyP>
           </div>
         </ProjectPageShell>
@@ -430,8 +435,8 @@ export function JobCatPageContent({
       const hasSourceFiles = (defaultFileQuery.data?.files.length ?? 0) > 0;
       const emptyStateMessage =
         hasSourceFiles && !targetLocale
-          ? "No target locale is specified for this task."
-          : "No source file is linked to this task.";
+          ? intl.formatMessage(jobCatPageContentMessages.noTargetLocaleSpecified)
+          : intl.formatMessage(jobCatPageContentMessages.noSourceFileLinked);
 
       return (
         <ProjectPageShell>
@@ -446,7 +451,9 @@ export function JobCatPageContent({
       <ProjectPageShell>
         <div className="flex min-h-48 items-center justify-center gap-2 rounded-lg border border-border bg-card p-5">
           <Spinner />
-          <TypographyP className="text-sm text-muted-foreground">Opening workspace…</TypographyP>
+          <TypographyP className="text-sm text-muted-foreground">
+            <FormattedMessage {...jobCatPageContentMessages.openingWorkspace} />
+          </TypographyP>
         </div>
       </ProjectPageShell>
     );
@@ -478,7 +485,9 @@ export function JobCatPageContent({
         <ProjectPageShell>
           <div className="flex min-h-48 items-center justify-center gap-2 rounded-lg border border-border bg-card p-5">
             <Spinner />
-            <TypographyP className="text-sm text-muted-foreground">Loading workspace…</TypographyP>
+            <TypographyP className="text-sm text-muted-foreground">
+              <FormattedMessage {...jobCatPageContentMessages.loadingWorkspace} />
+            </TypographyP>
           </div>
         </ProjectPageShell>
       );
@@ -490,7 +499,7 @@ export function JobCatPageContent({
         <ProjectPageShell>
           <div className="rounded-lg border border-border bg-card p-5">
             <TypographyP className="text-sm text-flame-100">
-              This project does not have a source locale.
+              <FormattedMessage {...jobCatPageContentMessages.projectMissingSourceLocale} />
             </TypographyP>
           </div>
         </ProjectPageShell>
@@ -502,9 +511,11 @@ export function JobCatPageContent({
         <ProjectPageShell>
           <div className="rounded-lg border border-border bg-card p-5">
             <TypographyP className="text-sm text-muted-foreground">
-              {!sourceLocale
-                ? "Loading workspace…"
-                : "No target locale is available for this task."}
+              {!sourceLocale ? (
+                <FormattedMessage {...jobCatPageContentMessages.loadingWorkspace} />
+              ) : (
+                <FormattedMessage {...jobCatPageContentMessages.noTargetLocaleForTask} />
+              )}
             </TypographyP>
           </div>
         </ProjectPageShell>
@@ -631,7 +642,9 @@ export function JobCatPageContent({
       <ProjectPageShell>
         <div className="flex min-h-48 items-center justify-center gap-2 rounded-lg border border-border bg-card p-5">
           <Spinner />
-          <TypographyP className="text-sm text-muted-foreground">Loading workspace…</TypographyP>
+          <TypographyP className="text-sm text-muted-foreground">
+            <FormattedMessage {...jobCatPageContentMessages.loadingWorkspace} />
+          </TypographyP>
         </div>
       </ProjectPageShell>
     );
@@ -646,7 +659,7 @@ export function JobCatPageContent({
               ? projectQuery.error.message
               : targetFileQuery.error instanceof Error
                 ? targetFileQuery.error.message
-                : "Unable to load task files."}
+                : intl.formatMessage(jobCatPageContentMessages.unableToLoadTaskFiles)}
           </TypographyP>
         </div>
       </ProjectPageShell>
@@ -661,9 +674,10 @@ export function JobCatPageContent({
             {targetFileQuery.data.reference}
           </TypographyP>
           <TypographyP className="mt-2 text-sm text-muted-foreground">
-            This project has more than {targetFileQuery.data.fetchedCount.toLocaleString()} files,
-            so the source file could not be resolved from the loaded file list. Open CAT from the
-            project Files page instead, or ask support to narrow the project file list.
+            <FormattedMessage
+              {...jobCatPageContentMessages.listTruncated}
+              values={{ fetchedCount: targetFileQuery.data.fetchedCount }}
+            />
           </TypographyP>
         </div>
       </ProjectPageShell>
@@ -678,7 +692,7 @@ export function JobCatPageContent({
             {sourcePath ?? storedFileId}
           </TypographyP>
           <TypographyP className="mt-2 text-sm text-muted-foreground">
-            This source file is not linked to the task anymore.
+            <FormattedMessage {...jobCatPageContentMessages.sourceFileNoLongerLinked} />
           </TypographyP>
         </div>
       </ProjectPageShell>
@@ -691,7 +705,7 @@ export function JobCatPageContent({
       <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
           <TypographyP className="text-sm text-flame-100">
-            This project does not have a source locale.
+            <FormattedMessage {...jobCatPageContentMessages.projectMissingSourceLocale} />
           </TypographyP>
         </div>
       </ProjectPageShell>
@@ -703,7 +717,9 @@ export function JobCatPageContent({
       <ProjectPageShell>
         <div className="flex min-h-48 items-center justify-center gap-2 rounded-lg border border-border bg-card p-5">
           <Spinner />
-          <TypographyP className="text-sm text-muted-foreground">Loading workspace…</TypographyP>
+          <TypographyP className="text-sm text-muted-foreground">
+            <FormattedMessage {...jobCatPageContentMessages.loadingWorkspace} />
+          </TypographyP>
         </div>
       </ProjectPageShell>
     );
@@ -714,7 +730,9 @@ export function JobCatPageContent({
       <ProjectPageShell>
         <div className="flex min-h-48 items-center justify-center gap-2 rounded-lg border border-border bg-card p-5">
           <Spinner />
-          <TypographyP className="text-sm text-muted-foreground">Loading workspace…</TypographyP>
+          <TypographyP className="text-sm text-muted-foreground">
+            <FormattedMessage {...jobCatPageContentMessages.loadingWorkspace} />
+          </TypographyP>
         </div>
       </ProjectPageShell>
     );
@@ -726,7 +744,7 @@ export function JobCatPageContent({
         <ProjectPageShell>
           <div className="rounded-lg border border-border bg-card p-5">
             <TypographyP className="text-sm text-muted-foreground">
-              No target locale is available for this task file.
+              <FormattedMessage {...jobCatPageContentMessages.noTargetLocaleForTaskFile} />
             </TypographyP>
           </div>
         </ProjectPageShell>
@@ -798,7 +816,7 @@ export function JobCatPageContent({
       <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
           <TypographyP className="text-sm text-muted-foreground">
-            String editing is only available for supported provider task files.
+            <FormattedMessage {...jobCatPageContentMessages.stringEditingUnsupported} />
           </TypographyP>
         </div>
       </ProjectPageShell>
@@ -812,7 +830,7 @@ export function JobCatPageContent({
       <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
           <TypographyP className="text-sm text-muted-foreground">
-            No target locale is available for this provider task file.
+            <FormattedMessage {...jobCatPageContentMessages.noTargetLocaleForProviderFile} />
           </TypographyP>
         </div>
       </ProjectPageShell>
@@ -904,7 +922,12 @@ export function JobCatPageContent({
         ) : null}
 
         <TypographyP className="hidden min-w-0 truncate text-xs text-muted-foreground sm:block lg:max-w-48">
-          {selectedFile.provider.kind} · {selectedFile.provider.format ?? "file"}
+          {intl.formatMessage(jobCatPageContentMessages.providerKindAndFormat, {
+            kind: selectedFile.provider.kind,
+            format:
+              selectedFile.provider.format ??
+              intl.formatMessage(jobCatPageContentMessages.fileFormatFallback),
+          })}
         </TypographyP>
       </div>
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/delete-project-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/delete-project-dialog.messages.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const deleteProjectDialogMessages = defineMessages({
+  title: {
+    defaultMessage: "Delete project?",
+    id: "9u8Sq8abiS",
+    description: "Title of the delete project confirmation dialog",
+  },
+  descriptionWithName: {
+    defaultMessage:
+      "{projectName} will be permanently deleted. Jobs, files, and shared context linked to it will lose their project association.",
+    id: "JKFwC5ViAc",
+    description: "Delete project confirmation when the project name is known",
+  },
+  descriptionWithoutName: {
+    defaultMessage:
+      "This project will be permanently deleted. Jobs, files, and shared context linked to it will lose their project association.",
+    id: "qVzcsOoWpu",
+    description: "Delete project confirmation when the project name is unavailable",
+  },
+  cancel: {
+    defaultMessage: "Cancel",
+    id: "qdoDJ+aaOm",
+    description: "Cancel button in the delete project dialog",
+  },
+  deleting: {
+    defaultMessage: "Deleting...",
+    id: "gLjdVIWCoD",
+    description: "Delete button label while a project is being deleted",
+  },
+  delete: {
+    defaultMessage: "Delete",
+    id: "aI9OdzlmW1",
+    description: "Confirm button to delete a project",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/delete-project-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/delete-project-dialog.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import { Delete02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { Spinner } from "@/components/ui/spinner";
 import {
@@ -13,6 +16,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 
+import { deleteProjectDialogMessages } from "./delete-project-dialog.messages";
 import type { ProjectListRow } from "./project-list";
 
 export function DeleteProjectDialog({
@@ -26,19 +30,27 @@ export function DeleteProjectDialog({
   onOpenChange: (open: boolean) => void;
   onDelete: (projectId: string) => void;
 }) {
+  const intl = useIntl();
+
   return (
     <AlertDialog open={project !== null} onOpenChange={onOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Delete project?</AlertDialogTitle>
+          <AlertDialogTitle>
+            <FormattedMessage {...deleteProjectDialogMessages.title} />
+          </AlertDialogTitle>
           <AlertDialogDescription>
             {project
-              ? `${project.name} will be permanently deleted. Jobs, files, and shared context linked to it will lose their project association.`
-              : "This project will be permanently deleted. Jobs, files, and shared context linked to it will lose their project association."}
+              ? intl.formatMessage(deleteProjectDialogMessages.descriptionWithName, {
+                  projectName: project.name,
+                })
+              : intl.formatMessage(deleteProjectDialogMessages.descriptionWithoutName)}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+          <AlertDialogCancel disabled={isDeleting}>
+            <FormattedMessage {...deleteProjectDialogMessages.cancel} />
+          </AlertDialogCancel>
           <Button
             variant="destructive"
             disabled={isDeleting || !project}
@@ -49,7 +61,11 @@ export function DeleteProjectDialog({
             }}
           >
             {isDeleting ? <Spinner /> : <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />}
-            {isDeleting ? "Deleting..." : "Delete"}
+            {isDeleting ? (
+              <FormattedMessage {...deleteProjectDialogMessages.deleting} />
+            ) : (
+              <FormattedMessage {...deleteProjectDialogMessages.delete} />
+            )}
           </Button>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-dialog.messages.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const projectDialogMessages = defineMessages({
+  nameLabel: {
+    defaultMessage: "Name",
+    id: "6Lz1ZPrrNj",
+    description: "Label for the project name field",
+  },
+  namePlaceholder: {
+    defaultMessage: "Marketing site launch",
+    id: "CtXpaStJTy",
+    description: "Placeholder for the project name field",
+  },
+  characterCount: {
+    defaultMessage: "{current} / {max}",
+    id: "Gb5iBYRxAb",
+    description: "Character count indicator for project form fields",
+  },
+  settings: {
+    defaultMessage: "Settings",
+    id: "nK49UEgaqE",
+    description: "Collapsible section trigger for optional project settings",
+  },
+  descriptionLabel: {
+    defaultMessage: "Description",
+    id: "Vd2zLJN2br",
+    description: "Label for the project description field",
+  },
+  descriptionPlaceholder: {
+    defaultMessage: "Project scope, release, or ownership notes",
+    id: "6x6KaRjdJB",
+    description: "Placeholder for the project description field",
+  },
+  cancel: {
+    defaultMessage: "Cancel",
+    id: "/o1j6afCQe",
+    description: "Cancel button in the project dialog footer",
+  },
+  saving: {
+    defaultMessage: "Saving...",
+    id: "SrLx97k5Qr",
+    description: "Submit button label while a project is being saved",
+  },
+  saveProject: {
+    defaultMessage: "Save project",
+    id: "pFpARtxHD8",
+    description: "Submit button to save a project",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-dialog.tsx
@@ -4,6 +4,7 @@ import { type FormEvent, useEffect, useId, useState } from "react";
 import { ChevronDownIcon } from "lucide-react";
 import { SaveIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { Spinner } from "@/components/ui/spinner";
 import { Button } from "@/components/ui/button";
@@ -21,6 +22,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Field, FieldError, FieldLabel } from "@/components/ui/field";
 import { cn } from "@/lib/primitives/cn";
 
+import { projectDialogMessages } from "./project-dialog.messages";
 import { ProjectSourceLocalePicker, ProjectTargetLocalesPicker } from "./project-locale-picker";
 import {
   projectFormHasErrors,
@@ -52,6 +54,7 @@ export function ProjectDialog({
   onOpenChange: (open: boolean) => void;
   onSubmit: (values: ProjectFormValues) => void;
 }) {
+  const intl = useIntl();
   const [values, setValues] = useState<ProjectFormValues>(initialValues);
   const [errors, setErrors] = useState<ProjectFormErrors>({});
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -73,7 +76,10 @@ export function ProjectDialog({
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
-    const nextErrors = validateProjectForm(values, { requireLocales: showLocaleFields });
+    const nextErrors = validateProjectForm(values, {
+      requireLocales: showLocaleFields,
+      intl,
+    });
     setErrors(nextErrors);
 
     if (nextErrors.description) {
@@ -106,7 +112,9 @@ export function ProjectDialog({
           </DialogHeader>
           <div className="grid min-h-0 flex-1 gap-4 overflow-y-auto px-6 py-4">
             <Field className="gap-1.5">
-              <FieldLabel htmlFor={nameId}>Name</FieldLabel>
+              <FieldLabel htmlFor={nameId}>
+                <FormattedMessage {...projectDialogMessages.nameLabel} />
+              </FieldLabel>
               <Input
                 id={nameId}
                 value={values.name}
@@ -116,7 +124,7 @@ export function ProjectDialog({
                 aria-invalid={Boolean(errors.name)}
                 aria-describedby={nameCountId}
                 disabled={isSaving}
-                placeholder="Marketing site launch"
+                placeholder={intl.formatMessage(projectDialogMessages.namePlaceholder)}
                 className="border-border bg-muted text-foreground placeholder:text-muted-foreground"
               />
               <div className="flex items-center justify-between gap-2">
@@ -125,7 +133,10 @@ export function ProjectDialog({
                   id={nameCountId}
                   className="ml-auto tabular-nums text-[10px] font-medium text-muted-foreground"
                 >
-                  {values.name.length} / 200
+                  {intl.formatMessage(projectDialogMessages.characterCount, {
+                    current: values.name.length,
+                    max: 200,
+                  })}
                 </span>
               </div>
             </Field>
@@ -161,7 +172,7 @@ export function ProjectDialog({
                     size="sm"
                     className="h-9 w-full justify-between px-3 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
                   >
-                    Settings
+                    <FormattedMessage {...projectDialogMessages.settings} />
                     <ChevronDownIcon
                       className={cn(
                         "size-4 shrink-0 transition-transform",
@@ -174,7 +185,9 @@ export function ProjectDialog({
               />
               <CollapsibleContent className="pt-2">
                 <Field className="gap-1.5">
-                  <FieldLabel htmlFor={descriptionId}>Description</FieldLabel>
+                  <FieldLabel htmlFor={descriptionId}>
+                    <FormattedMessage {...projectDialogMessages.descriptionLabel} />
+                  </FieldLabel>
                   <Textarea
                     id={descriptionId}
                     value={values.description}
@@ -184,7 +197,7 @@ export function ProjectDialog({
                     aria-invalid={Boolean(errors.description)}
                     aria-describedby={descriptionCountId}
                     disabled={isSaving}
-                    placeholder="Project scope, release, or ownership notes"
+                    placeholder={intl.formatMessage(projectDialogMessages.descriptionPlaceholder)}
                     className="min-h-20 border-border bg-muted text-foreground placeholder:text-muted-foreground"
                   />
                   <div className="flex items-center justify-between gap-2">
@@ -195,7 +208,10 @@ export function ProjectDialog({
                       id={descriptionCountId}
                       className="ml-auto tabular-nums text-[10px] font-medium text-muted-foreground"
                     >
-                      {values.description.length.toLocaleString()} / 10,000
+                      {intl.formatMessage(projectDialogMessages.characterCount, {
+                        current: values.description.length.toLocaleString(),
+                        max: "10,000",
+                      })}
                     </span>
                   </div>
                 </Field>
@@ -209,11 +225,15 @@ export function ProjectDialog({
               disabled={isSaving}
               onClick={() => onOpenChange(false)}
             >
-              Cancel
+              <FormattedMessage {...projectDialogMessages.cancel} />
             </Button>
             <Button type="submit" disabled={isSaving}>
               {isSaving ? <Spinner /> : <HugeiconsIcon icon={SaveIcon} strokeWidth={1.8} />}
-              {isSaving ? "Saving..." : "Save project"}
+              {isSaving ? (
+                <FormattedMessage {...projectDialogMessages.saving} />
+              ) : (
+                <FormattedMessage {...projectDialogMessages.saveProject} />
+              )}
             </Button>
           </DialogFooter>
         </form>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-dialog.tsx
@@ -209,8 +209,8 @@ export function ProjectDialog({
                       className="ml-auto tabular-nums text-[10px] font-medium text-muted-foreground"
                     >
                       {intl.formatMessage(projectDialogMessages.characterCount, {
-                        current: values.description.length.toLocaleString(),
-                        max: "10,000",
+                        current: values.description.length,
+                        max: 10_000,
                       })}
                     </span>
                   </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-form.messages.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const projectFormMessages = defineMessages({
+  nameRequired: {
+    defaultMessage: "Project name is required.",
+    id: "WXIoLiZoe5",
+    description: "Validation error when the project name is empty",
+  },
+  nameTooLong: {
+    defaultMessage: "Project name must be 200 characters or fewer.",
+    id: "yDkVK1WUtt",
+    description: "Validation error when the project name exceeds 200 characters",
+  },
+  descriptionTooLong: {
+    defaultMessage: "Description must be 10,000 characters or fewer.",
+    id: "Ckfjf7HRih",
+    description: "Validation error when the project description exceeds 10,000 characters",
+  },
+  translationContextTooLong: {
+    defaultMessage: "Translation context must be 20,000 characters or fewer.",
+    id: "Ic0GDPpTRm",
+    description: "Validation error when translation context exceeds 20,000 characters",
+  },
+  invalidSourceLocale: {
+    defaultMessage: "Select a valid source locale.",
+    id: "QhAcz8vXW1",
+    description: "Validation error when the source locale is invalid",
+  },
+  sourceInTargets: {
+    defaultMessage: "Remove the source locale from target locales.",
+    id: "g2vXuLe4hc",
+    description: "Validation error when the source locale is also selected as a target",
+  },
+  targetLocalesRequired: {
+    defaultMessage: "Select at least one valid target locale.",
+    id: "X9X74tk3Lj",
+    description: "Validation error when no valid target locales are selected",
+  },
+  noLocalesConfigured: {
+    defaultMessage: "No locales configured",
+    id: "Up5yLUnVpF",
+    description: "Summary when a project has no source or target locales",
+  },
+  localeSummary: {
+    defaultMessage: "{source} → {targets}",
+    id: "y0gXcEiYv6",
+    description: "Summary of a project’s source locale and target locales",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-form.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-form.ts
@@ -1,5 +1,8 @@
+import type { IntlShape } from "@formatjs/intl";
+
 import { canonicalizeLocale, normalizeProjectLocales } from "@/lib/i18n/locales";
 
+import { projectFormMessages } from "./project-form.messages";
 import type { ProjectListRow } from "./project-list";
 
 export type ProjectFormValues = {
@@ -14,9 +17,23 @@ export type ProjectFormErrors = Partial<Record<keyof ProjectFormValues, string>>
   targetLocales?: string;
 };
 
+export type ProjectFormIntl = Pick<IntlShape, "formatMessage">;
+
 export const defaultNativeProjectSourceLocale = "en-US";
 
 export const defaultNativeProjectTargetLocales = ["fr-FR", "de-DE"];
+
+function resolveMessage(
+  intl: ProjectFormIntl | undefined,
+  descriptor: (typeof projectFormMessages)[keyof typeof projectFormMessages],
+  values?: Record<string, string>,
+) {
+  if (intl) {
+    return intl.formatMessage(descriptor, values);
+  }
+
+  return typeof descriptor.defaultMessage === "string" ? descriptor.defaultMessage : "";
+}
 
 export function createEmptyProjectForm(): ProjectFormValues {
   return {
@@ -43,24 +60,25 @@ export function createProjectFormFromRow(project: ProjectListRow): ProjectFormVa
 
 export function validateProjectForm(
   values: ProjectFormValues,
-  options?: { requireLocales?: boolean },
+  options?: { requireLocales?: boolean; intl?: ProjectFormIntl },
 ): ProjectFormErrors {
   const errors: ProjectFormErrors = {};
   const name = values.name.trim();
   const requireLocales = options?.requireLocales ?? true;
+  const intl = options?.intl;
 
   if (!name) {
-    errors.name = "Project name is required.";
+    errors.name = resolveMessage(intl, projectFormMessages.nameRequired);
   } else if (name.length > 200) {
-    errors.name = "Project name must be 200 characters or fewer.";
+    errors.name = resolveMessage(intl, projectFormMessages.nameTooLong);
   }
 
   if (values.description.trim().length > 10_000) {
-    errors.description = "Description must be 10,000 characters or fewer.";
+    errors.description = resolveMessage(intl, projectFormMessages.descriptionTooLong);
   }
 
   if (values.translationContext.trim().length > 20_000) {
-    errors.translationContext = "Translation context must be 20,000 characters or fewer.";
+    errors.translationContext = resolveMessage(intl, projectFormMessages.translationContextTooLong);
   }
 
   if (requireLocales) {
@@ -71,11 +89,11 @@ export function validateProjectForm(
 
     if ("error" in normalized) {
       if (normalized.error === "invalid_source_locale") {
-        errors.sourceLocale = "Select a valid source locale.";
+        errors.sourceLocale = resolveMessage(intl, projectFormMessages.invalidSourceLocale);
       } else if (normalized.error === "source_in_targets") {
-        errors.targetLocales = "Remove the source locale from target locales.";
+        errors.targetLocales = resolveMessage(intl, projectFormMessages.sourceInTargets);
       } else {
-        errors.targetLocales = "Select at least one valid target locale.";
+        errors.targetLocales = resolveMessage(intl, projectFormMessages.targetLocalesRequired);
       }
     }
   }
@@ -159,9 +177,13 @@ export function projectFormRequiresLocales(
   return mode === "create" || source === "native";
 }
 
-export function formatProjectLocaleSummary(sourceLocale: string | null, targetLocales: string[]) {
+export function formatProjectLocaleSummary(
+  sourceLocale: string | null,
+  targetLocales: string[],
+  intl?: ProjectFormIntl,
+) {
   if (!sourceLocale && targetLocales.length === 0) {
-    return "No locales configured";
+    return resolveMessage(intl, projectFormMessages.noLocalesConfigured);
   }
 
   const source = sourceLocale ? (canonicalizeLocale(sourceLocale) ?? sourceLocale) : "—";
@@ -170,5 +192,5 @@ export function formatProjectLocaleSummary(sourceLocale: string | null, targetLo
       ? targetLocales.map((locale) => canonicalizeLocale(locale) ?? locale).join(", ")
       : "—";
 
-  return `${source} → ${targets}`;
+  return resolveMessage(intl, projectFormMessages.localeSummary, { source, targets });
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-list.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-list.messages.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const projectListMessages = defineMessages({
+  noDescription: {
+    defaultMessage: "No description",
+    id: "Onn6EwAIjq",
+    description: "Fallback when a project list row has no description",
+  },
+  noTranslationContext: {
+    defaultMessage: "No translation context",
+    id: "/9wc0MhkMd",
+    description: "Fallback when a project list row has no translation context",
+  },
+  createdUnavailable: {
+    defaultMessage: "Created date unavailable",
+    id: "iVNWaz9pgs",
+    description: "Fallback when a project created date cannot be formatted",
+  },
+  updatedUnavailable: {
+    defaultMessage: "Updated date unavailable",
+    id: "XuLNOM8/60",
+    description: "Fallback when a project updated date cannot be formatted",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-list.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-list.ts
@@ -1,4 +1,21 @@
+import type { IntlShape } from "@formatjs/intl";
+
 import { sanitizeExternalUrl } from "@/lib/security/safe-external-url";
+
+import { projectListMessages } from "./project-list.messages";
+
+export type ProjectListIntl = Pick<IntlShape, "formatMessage">;
+
+function resolveMessage(
+  intl: ProjectListIntl | undefined,
+  descriptor: (typeof projectListMessages)[keyof typeof projectListMessages],
+) {
+  if (intl) {
+    return intl.formatMessage(descriptor);
+  }
+
+  return typeof descriptor.defaultMessage === "string" ? descriptor.defaultMessage : "";
+}
 
 export type ApiProject = {
   id: string;
@@ -131,7 +148,7 @@ export function formatProjectLocaleRoute(
   return `${source} → ${preview}${suffix}`;
 }
 
-export function mapProjectToListRow(project: ApiProject): ProjectListRow {
+export function mapProjectToListRow(project: ApiProject, intl?: ProjectListIntl): ProjectListRow {
   const descriptionValue = project.description?.trim() ?? "";
   const translationContextValue = project.translationContext?.trim() ?? "";
   const lastActivityAt =
@@ -141,12 +158,19 @@ export function mapProjectToListRow(project: ApiProject): ProjectListRow {
     id: project.id,
     name: project.name,
     key: createProjectKey(project),
-    description: descriptionValue || "No description",
+    description: descriptionValue || resolveMessage(intl, projectListMessages.noDescription),
     descriptionValue,
-    translationContext: translationContextValue || "No translation context",
+    translationContext:
+      translationContextValue || resolveMessage(intl, projectListMessages.noTranslationContext),
     translationContextValue,
-    created: formatTimestamp(project.createdAt, "Created date unavailable"),
-    updated: formatTimestamp(project.updatedAt, "Updated date unavailable"),
+    created: formatTimestamp(
+      project.createdAt,
+      resolveMessage(intl, projectListMessages.createdUnavailable),
+    ),
+    updated: formatTimestamp(
+      project.updatedAt,
+      resolveMessage(intl, projectListMessages.updatedUnavailable),
+    ),
     source: project.source ?? "native",
     externalProviderKind: project.externalProviderKind ?? null,
     externalProjectId: project.externalProjectId ?? null,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-locale-picker.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-locale-picker.messages.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const projectLocalePickerMessages = defineMessages({
+  sourceLocaleLabel: {
+    defaultMessage: "Source locale",
+    id: "UZWbgJ+bye",
+    description: "Label for the project source locale picker",
+  },
+  selectLocalePlaceholder: {
+    defaultMessage: "Select locale",
+    id: "v9kMcegF3r",
+    description: "Placeholder for the source locale select",
+  },
+  targetLocalesLabel: {
+    defaultMessage: "Target locales",
+    id: "vv8/iiR38E",
+    description: "Label for the project target locales picker",
+  },
+  invalidCustomLocale: {
+    defaultMessage: "Enter a valid BCP-47 locale (e.g. fr-FR, zh-Hant-TW).",
+    id: "hElFzW5+gy",
+    description: "Validation error for an invalid custom target locale",
+  },
+  targetMatchesSource: {
+    defaultMessage: "Target locale cannot match the source locale.",
+    id: "e2GH/61cB8",
+    description: "Validation error when a target locale matches the source locale",
+  },
+  otherTargetLocalePlaceholder: {
+    defaultMessage: "Other target locale",
+    id: "bgBgMVkDdH",
+    description: "Placeholder for adding a custom target locale",
+  },
+  add: {
+    defaultMessage: "Add",
+    id: "vytBTgUTFc",
+    description: "Button to add a custom target locale",
+  },
+  addOtherTargetLocale: {
+    defaultMessage: "Add other target locale",
+    id: "xePdJUPla7",
+    description: "Accessible label for the button that reveals the custom locale input",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-locale-picker.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-locale-picker.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useId, useMemo, useState } from "react";
 import { Add01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -20,6 +20,8 @@ import {
   formatLocaleOptionLabel,
 } from "@/lib/i18n/locale-display-names.messages";
 import { canonicalizeLocale, COMMON_LOCALES, isValidLocaleInput } from "@/lib/i18n/locales";
+
+import { projectLocalePickerMessages } from "./project-locale-picker.messages";
 
 function sortLocaleCodes(locales: string[]) {
   return [...locales].toSorted((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
@@ -60,7 +62,9 @@ export function ProjectSourceLocalePicker({
 
   return (
     <Field className="gap-1">
-      <FieldLabel htmlFor={fieldId}>Source locale</FieldLabel>
+      <FieldLabel htmlFor={fieldId}>
+        <FormattedMessage {...projectLocalePickerMessages.sourceLocaleLabel} />
+      </FieldLabel>
       <Select
         value={value || undefined}
         onValueChange={(next) => {
@@ -71,7 +75,9 @@ export function ProjectSourceLocalePicker({
         disabled={disabled}
       >
         <SelectTrigger id={fieldId} className="w-full border-border bg-muted text-foreground">
-          <SelectValue placeholder="Select locale" />
+          <SelectValue
+            placeholder={intl.formatMessage(projectLocalePickerMessages.selectLocalePlaceholder)}
+          />
         </SelectTrigger>
         <SelectContent
           align="start"
@@ -80,8 +86,7 @@ export function ProjectSourceLocalePicker({
         >
           {options.map((locale) => (
             <SelectItem key={locale} value={locale} label={formatLocaleOptionLabel(intl, locale)}>
-              <span className="truncate">{formatLocaleDisplayName(intl, locale)}</span>
-              <span className="text-muted-foreground">({locale})</span>
+              <span className="truncate">{formatLocaleOptionLabel(intl, locale)}</span>
             </SelectItem>
           ))}
         </SelectContent>
@@ -167,13 +172,13 @@ export function ProjectTargetLocalesPicker({
 
   function applyCustomLocale() {
     if (!isValidLocaleInput(customLocale)) {
-      setCustomError("Enter a valid BCP-47 locale (e.g. fr-FR, zh-Hant-TW).");
+      setCustomError(intl.formatMessage(projectLocalePickerMessages.invalidCustomLocale));
       return;
     }
 
     const canonical = canonicalizeLocale(customLocale) as string;
     if (canonical.toLowerCase() === sourceKey) {
-      setCustomError("Target locale cannot match the source locale.");
+      setCustomError(intl.formatMessage(projectLocalePickerMessages.targetMatchesSource));
       return;
     }
 
@@ -185,7 +190,9 @@ export function ProjectTargetLocalesPicker({
 
   return (
     <Field className="gap-1.5">
-      <FieldLabel id={fieldId}>Target locales</FieldLabel>
+      <FieldLabel id={fieldId}>
+        <FormattedMessage {...projectLocalePickerMessages.targetLocalesLabel} />
+      </FieldLabel>
       <div className="flex flex-wrap gap-1.5" role="group" aria-labelledby={fieldId}>
         {commonLocales.map((locale) => {
           const isSelected = selected.has(locale.toLowerCase());
@@ -245,7 +252,9 @@ export function ProjectTargetLocalesPicker({
               }
             }}
             disabled={disabled}
-            placeholder="Other target locale"
+            placeholder={intl.formatMessage(
+              projectLocalePickerMessages.otherTargetLocalePlaceholder,
+            )}
             className="min-w-0 flex-1 border-border bg-muted text-foreground placeholder:text-muted-foreground"
           />
           <Button
@@ -256,7 +265,7 @@ export function ProjectTargetLocalesPicker({
             disabled={disabled}
             onClick={applyCustomLocale}
           >
-            Add
+            <FormattedMessage {...projectLocalePickerMessages.add} />
           </Button>
         </div>
       ) : (
@@ -266,7 +275,7 @@ export function ProjectTargetLocalesPicker({
           size="sm"
           className="h-7 w-7 shrink-0 px-0"
           disabled={disabled}
-          aria-label="Add other target locale"
+          aria-label={intl.formatMessage(projectLocalePickerMessages.addOtherTargetLocale)}
           onClick={() => setShowCustomInput(true)}
         >
           <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.messages.ts
@@ -1,0 +1,164 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const projectsPageContentMessages = defineMessages({
+  recentlyOpened: {
+    defaultMessage: "Recently opened",
+    id: "ra0EyftjV0",
+    description: "Heading above the recently opened projects strip",
+  },
+  loadProjectsFailed: {
+    defaultMessage: "Failed to load projects",
+    id: "ItrnRpF69X",
+    description: "Fallback error when native projects fail to load",
+  },
+  createProjectFailed: {
+    defaultMessage: "Unable to create project",
+    id: "PqqKKd0E77",
+    description: "Fallback error when creating a project fails",
+  },
+  updateProjectFailed: {
+    defaultMessage: "Unable to update project",
+    id: "8cCnIQ+Lhz",
+    description: "Fallback error when updating a project fails",
+  },
+  deleteProjectFailed: {
+    defaultMessage: "Unable to delete project",
+    id: "GOImV2QS+V",
+    description: "Fallback error when deleting a project fails",
+  },
+  projectCreated: {
+    defaultMessage: "Project created",
+    id: "rzRd9sk8q6",
+    description: "Toast after a project is created successfully",
+  },
+  projectUpdated: {
+    defaultMessage: "Project updated",
+    id: "cgByBDP5Dl",
+    description: "Toast after a project is updated successfully",
+  },
+  projectDeleted: {
+    defaultMessage: "Project deleted",
+    id: "2lMmWOEFYn",
+    description: "Toast after a project is deleted successfully",
+  },
+  editProjectTitle: {
+    defaultMessage: "Edit project",
+    id: "lySN7MFYwz",
+    description: "Title of the edit project dialog",
+  },
+  createProjectTitle: {
+    defaultMessage: "Create project",
+    id: "DFNppqOCak",
+    description: "Title of the create project dialog",
+  },
+  editProjectDescription: {
+    defaultMessage: "Update the metadata stored with this project.",
+    id: "GeD3IIa8Fg",
+    description: "Description of the edit project dialog",
+  },
+  createProjectDescription: {
+    defaultMessage: "Add a project to track localization work and shared translation guidance.",
+    id: "5nqOLfQ5J8",
+    description: "Description of the create project dialog",
+  },
+  tmsFallbackName: {
+    defaultMessage: "TMS",
+    id: "aKIe8yWjB3",
+    description: "Fallback label when no TMS provider name is available",
+  },
+  pageDescriptionWithTms: {
+    defaultMessage:
+      "Browse live {providerName} projects and manage Hyperlocalise workspace projects.",
+    id: "MOJri1ONT9",
+    description: "Projects page description when a TMS provider is connected",
+  },
+  pageDescriptionWithoutTms: {
+    defaultMessage:
+      "Browse Hyperlocalise projects. Connect a TMS provider to view live provider projects alongside them.",
+    id: "HrQO2GGbYJ",
+    description: "Projects page description when no TMS provider is connected",
+  },
+  createNativeProject: {
+    defaultMessage: "Create native project",
+    id: "zKYGdX/fFA",
+    description: "Secondary button to create a Hyperlocalise-native project",
+  },
+  createProject: {
+    defaultMessage: "Create project",
+    id: "mjXFArSK6C",
+    description: "Primary button to create a project",
+  },
+  tmsProjectsTitle: {
+    defaultMessage: "{providerName} projects",
+    id: "c3ROZAXotz",
+    description: "Section title for live TMS provider projects",
+  },
+  tmsProjectsDescription: {
+    defaultMessage:
+      "Live projects fetched from your connected TMS provider, ordered by recent activity.",
+    id: "prJEYrujJH",
+    description: "Section description for live TMS provider projects",
+  },
+  hyperlocaliseProjectsTitle: {
+    defaultMessage: "Hyperlocalise projects",
+    id: "JRvnN6Kkq8",
+    description: "Section title for native Hyperlocalise projects",
+  },
+  hyperlocaliseProjectsDescription: {
+    defaultMessage: "Projects created and managed in this workspace.",
+    id: "BHCGhKF/Fb",
+    description: "Section description for native Hyperlocalise projects",
+  },
+  connectTmsTitle: {
+    defaultMessage: "TMS projects",
+    id: "jNNp9OLKEA",
+    description: "Section title prompting the user to connect a TMS provider",
+  },
+  connectTmsDescription: {
+    defaultMessage: "Connect a TMS provider to browse live provider projects here.",
+    id: "oU0PK0wDMT",
+    description: "Section description prompting the user to connect a TMS provider",
+  },
+  connectProvider: {
+    defaultMessage: "Connect a provider",
+    id: "hfzLE9ZrP4",
+    description: "Button linking to integrations to connect a TMS provider",
+  },
+  pageLabel: {
+    defaultMessage: "Workspace",
+    id: "Pgxv//ij4N",
+    description: "Projects page header eyebrow label",
+  },
+  pageTitle: {
+    defaultMessage: "Projects",
+    id: "WE7a6RlfNZ",
+    description: "Projects page heading",
+  },
+  searchLabel: {
+    defaultMessage: "Search",
+    id: "M09MwVsnwY",
+    description: "Label for the projects search field",
+  },
+  searchPlaceholder: {
+    defaultMessage: "Search by name...",
+    id: "nSqpG2XwMB",
+    description: "Placeholder for the projects search field",
+  },
+  filterAll: {
+    defaultMessage: "All",
+    id: "F25y8G/ydQ",
+    description: "Tab to show all project sources",
+  },
+  filterHyperlocalise: {
+    defaultMessage: "Hyperlocalise",
+    id: "b/Vd04dNDW",
+    description: "Tab to show only Hyperlocalise-native projects",
+  },
+  noSearchResults: {
+    defaultMessage: "No projects match your search. <clear>Clear search</clear>",
+    id: "2/tGcgvmb8",
+    description: "Empty state when the project search returns no results, with clear action",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Add01Icon, FolderKanbanIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -32,6 +33,7 @@ import {
 import { ProjectDialog } from "./project-dialog";
 import { mapProjectToListRow, type ProjectListRow } from "./project-list";
 import { PROJECTS_PAGE_SIZE, ProjectsTable } from "./projects-table";
+import { projectsPageContentMessages } from "./projects-page-content.messages";
 import { recordRecentProjectVisit, resolveRecentProjects } from "./recent-projects";
 
 const nativeProjectsQueryKey = (organizationSlug: string) =>
@@ -85,7 +87,7 @@ function RecentProjectsStrip({
   return (
     <section className="space-y-3">
       <TypographyP className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">
-        Recently opened
+        <FormattedMessage {...projectsPageContentMessages.recentlyOpened} />
       </TypographyP>
       <div className="flex flex-wrap gap-2">
         {projects.map((project) => (
@@ -111,6 +113,7 @@ function RecentProjectsStrip({
 }
 
 export function ProjectsPageContent({ organizationSlug }: { organizationSlug: string }) {
+  const intl = useIntl();
   const queryClient = useQueryClient();
   const [projectDialogMode, setProjectDialogMode] = useState<"create" | "edit" | null>(null);
   const [editingProject, setEditingProject] = useState<ProjectListRow | null>(null);
@@ -128,11 +131,14 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
       });
 
       if (response.status !== 200) {
-        throw await readApiResponseError(response, "Failed to load projects");
+        throw await readApiResponseError(
+          response,
+          intl.formatMessage(projectsPageContentMessages.loadProjectsFailed),
+        );
       }
 
       const body = await response.json();
-      return body.projects.map(mapProjectToListRow);
+      return body.projects.map((project) => mapProjectToListRow(project, intl));
     },
   });
   const activeTmsProviderQuery = useActiveTmsProvider(organizationSlug);
@@ -141,7 +147,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
     queryKey: tmsLiveProjectsQueryKey(organizationSlug),
     enabled: hasTmsConnection,
     queryFn: () => fetchTmsLiveProjects(organizationSlug),
-    select: (projects) => projects.map(mapProjectToListRow),
+    select: (projects) => projects.map((project) => mapProjectToListRow(project, intl)),
   });
   const createProject = useMutation({
     mutationFn: async (values: ProjectFormValues) => {
@@ -151,7 +157,10 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
       });
 
       if (!response.ok) {
-        throw await readApiResponseError(response, "Unable to create project");
+        throw await readApiResponseError(
+          response,
+          intl.formatMessage(projectsPageContentMessages.createProjectFailed),
+        );
       }
 
       return response.json();
@@ -159,7 +168,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: nativeProjectsQueryKey(organizationSlug) });
       setProjectDialogMode(null);
-      toast.success("Project created");
+      toast.success(intl.formatMessage(projectsPageContentMessages.projectCreated));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -176,7 +185,10 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
       });
 
       if (!response.ok) {
-        throw await readApiResponseError(response, "Unable to update project");
+        throw await readApiResponseError(
+          response,
+          intl.formatMessage(projectsPageContentMessages.updateProjectFailed),
+        );
       }
 
       return response.json();
@@ -185,7 +197,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
       await queryClient.invalidateQueries({ queryKey: nativeProjectsQueryKey(organizationSlug) });
       setProjectDialogMode(null);
       setEditingProject(null);
-      toast.success("Project updated");
+      toast.success(intl.formatMessage(projectsPageContentMessages.projectUpdated));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -200,13 +212,16 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
       );
 
       if (!response.ok) {
-        throw await readApiResponseError(response, "Unable to delete project");
+        throw await readApiResponseError(
+          response,
+          intl.formatMessage(projectsPageContentMessages.deleteProjectFailed),
+        );
       }
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: nativeProjectsQueryKey(organizationSlug) });
       setDeleteProject(null);
-      toast.success("Project deleted");
+      toast.success(intl.formatMessage(projectsPageContentMessages.projectDeleted));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -266,11 +281,14 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
   }, [allProjects, organizationSlug]);
 
   const isSavingProject = createProject.isPending || updateProject.isPending;
-  const projectDialogTitle = projectDialogMode === "edit" ? "Edit project" : "Create project";
+  const projectDialogTitle =
+    projectDialogMode === "edit"
+      ? intl.formatMessage(projectsPageContentMessages.editProjectTitle)
+      : intl.formatMessage(projectsPageContentMessages.createProjectTitle);
   const projectDialogDescription =
     projectDialogMode === "edit"
-      ? "Update the metadata stored with this project."
-      : "Add a project to track localization work and shared translation guidance.";
+      ? intl.formatMessage(projectsPageContentMessages.editProjectDescription)
+      : intl.formatMessage(projectsPageContentMessages.createProjectDescription);
   const initialProjectValues = useMemo(
     () =>
       projectDialogMode === "edit" && editingProject
@@ -290,7 +308,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
     (showTmsSection && visibleTmsProjects.length > 0);
   const tmsProviderName = activeTmsProviderQuery.data
     ? getTmsProviderBranding(activeTmsProviderQuery.data.providerKind).name
-    : "TMS";
+    : intl.formatMessage(projectsPageContentMessages.tmsFallbackName);
   const hasTmsPrimaryWorkflow = hasTmsConnection && tmsProjects.length > 0;
   const compactNativeEmpty = hasTmsPrimaryWorkflow && nativeProjects.length === 0;
 
@@ -323,8 +341,10 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
   }
 
   const pageDescription = hasTmsConnection
-    ? `Browse live ${tmsProviderName} projects and manage Hyperlocalise workspace projects.`
-    : "Browse Hyperlocalise projects. Connect a TMS provider to view live provider projects alongside them.";
+    ? intl.formatMessage(projectsPageContentMessages.pageDescriptionWithTms, {
+        providerName: tmsProviderName,
+      })
+    : intl.formatMessage(projectsPageContentMessages.pageDescriptionWithoutTms);
 
   const createProjectAction =
     hasTmsPrimaryWorkflow && nativeProjects.length === 0 ? (
@@ -336,7 +356,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
         disabled={isSavingProject}
       >
         <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
-        Create native project
+        <FormattedMessage {...projectsPageContentMessages.createNativeProject} />
       </Button>
     ) : (
       <Button
@@ -346,15 +366,17 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
         disabled={isSavingProject}
       >
         <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
-        Create project
+        <FormattedMessage {...projectsPageContentMessages.createProject} />
       </Button>
     );
 
   const tmsSection = showTmsSection ? (
     <section className="space-y-4">
       <ProjectsSectionHeader
-        title={`${tmsProviderName} projects`}
-        description="Live projects fetched from your connected TMS provider, ordered by recent activity."
+        title={intl.formatMessage(projectsPageContentMessages.tmsProjectsTitle, {
+          providerName: tmsProviderName,
+        })}
+        description={intl.formatMessage(projectsPageContentMessages.tmsProjectsDescription)}
       />
       <ProjectsTable
         projects={visibleTmsProjects}
@@ -373,8 +395,10 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
   const nativeSection = showNativeSection ? (
     <section className="space-y-4">
       <ProjectsSectionHeader
-        title="Hyperlocalise projects"
-        description="Projects created and managed in this workspace."
+        title={intl.formatMessage(projectsPageContentMessages.hyperlocaliseProjectsTitle)}
+        description={intl.formatMessage(
+          projectsPageContentMessages.hyperlocaliseProjectsDescription,
+        )}
       />
       <ProjectsTable
         projects={visibleNativeProjects}
@@ -398,8 +422,8 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
     !hasTmsConnection && !isTmsProjectsLoading && activeTmsProviderQuery.isSuccess ? (
       <section className="space-y-4">
         <ProjectsSectionHeader
-          title="TMS projects"
-          description="Connect a TMS provider to browse live provider projects here."
+          title={intl.formatMessage(projectsPageContentMessages.connectTmsTitle)}
+          description={intl.formatMessage(projectsPageContentMessages.connectTmsDescription)}
         />
         <div className="max-w-xl py-4">
           <Button
@@ -408,7 +432,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
             variant="outline"
             size="sm"
           >
-            Connect a provider
+            <FormattedMessage {...projectsPageContentMessages.connectProvider} />
           </Button>
         </div>
       </section>
@@ -418,17 +442,20 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
     <WorkspacePageShell>
       <PageHeader
         icon={FolderKanbanIcon}
-        label="Workspace"
-        title="Projects"
+        label={intl.formatMessage(projectsPageContentMessages.pageLabel)}
+        title={intl.formatMessage(projectsPageContentMessages.pageTitle)}
         description={pageDescription}
         actions={createProjectAction}
       />
 
       {hasAnyProjects ? (
         <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-          <WorkspaceFilterField label="Search" className="w-full sm:max-w-xs">
+          <WorkspaceFilterField
+            label={intl.formatMessage(projectsPageContentMessages.searchLabel)}
+            className="w-full sm:max-w-xs"
+          >
             <Input
-              placeholder="Search by name..."
+              placeholder={intl.formatMessage(projectsPageContentMessages.searchPlaceholder)}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               className="w-full"
@@ -440,9 +467,13 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
               onValueChange={(value) => setSourceFilter(value as ProjectSourceFilter)}
             >
               <TabsList>
-                <TabsTrigger value="all">All</TabsTrigger>
+                <TabsTrigger value="all">
+                  <FormattedMessage {...projectsPageContentMessages.filterAll} />
+                </TabsTrigger>
                 <TabsTrigger value="tms">{tmsProviderName}</TabsTrigger>
-                <TabsTrigger value="native">Hyperlocalise</TabsTrigger>
+                <TabsTrigger value="native">
+                  <FormattedMessage {...projectsPageContentMessages.filterHyperlocalise} />
+                </TabsTrigger>
               </TabsList>
             </Tabs>
           ) : null}
@@ -459,14 +490,20 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
 
       {hasAnyProjects && !hasFilteredResults ? (
         <div className="border-t border-border px-1 py-8 text-sm text-muted-foreground">
-          No projects match your search.{" "}
-          <button
-            type="button"
-            onClick={() => setSearchQuery("")}
-            className="text-subtle-foreground underline hover:text-foreground"
-          >
-            Clear search
-          </button>
+          <FormattedMessage
+            {...projectsPageContentMessages.noSearchResults}
+            values={{
+              clear: (chunks) => (
+                <button
+                  type="button"
+                  onClick={() => setSearchQuery("")}
+                  className="text-subtle-foreground underline hover:text-foreground"
+                >
+                  {chunks}
+                </button>
+              ),
+            }}
+          />
         </div>
       ) : null}
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.messages.ts
@@ -1,0 +1,129 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const projectsTableMessages = defineMessages({
+  nativeEmptyCompact: {
+    defaultMessage:
+      "No Hyperlocalise projects yet. <action>Create one</action> to add translation context and job tracking.",
+    id: "tFwg80J8SU",
+    description: "Compact empty state for Hyperlocalise projects with a create action link",
+  },
+  nativeEmptyTitle: {
+    defaultMessage: "Create your first localization project",
+    id: "eq+MOWqVs2",
+    description: "Title of the empty state when there are no Hyperlocalise projects",
+  },
+  nativeEmptyDescription: {
+    defaultMessage:
+      "Track source content, release ownership, and translation context before work moves into translation jobs.",
+    id: "0M4iVzJdHy",
+    description: "Description of the empty state when there are no Hyperlocalise projects",
+  },
+  hyperlocaliseProvider: {
+    defaultMessage: "Hyperlocalise",
+    id: "ESaaPFjV43",
+    description: "Provider label for native Hyperlocalise projects on project cards",
+  },
+  inactiveBadge: {
+    defaultMessage: "Inactive",
+    id: "6hZ0OrRvp2",
+    description: "Badge shown on inactive project cards",
+  },
+  noDescriptionYet: {
+    defaultMessage: "No description yet",
+    id: "RSCu8OSDph",
+    description: "Fallback text when a project card has no description",
+  },
+  openInProviderSrOnly: {
+    defaultMessage: "Open {projectName} in provider",
+    id: "h3qjecOeg8",
+    description: "Screen-reader label for opening a project in its external TMS provider",
+  },
+  openInProvider: {
+    defaultMessage: "Open in {providerName}",
+    id: "V0ZxKR31oY",
+    description: "Tooltip for opening a project in its external TMS provider",
+  },
+  actionsForProject: {
+    defaultMessage: "Actions for {projectName}",
+    id: "/0aHJPSP9g",
+    description: "Accessible label for the project card actions menu",
+  },
+  openProject: {
+    defaultMessage: "Open project",
+    id: "SUwoew7bqk",
+    description: "Menu item to open a project",
+  },
+  editProject: {
+    defaultMessage: "Edit project...",
+    id: "g7kCok/oT0",
+    description: "Menu item to edit a project",
+  },
+  deleteProject: {
+    defaultMessage: "Delete project...",
+    id: "eEy5UfpPzO",
+    description: "Menu item to delete a project",
+  },
+  localesLabel: {
+    defaultMessage: "Locales",
+    id: "LHjP+HTMcQ",
+    description: "Project card metadata label for locales",
+  },
+  openJobsLabel: {
+    defaultMessage: "Open jobs",
+    id: "1/Eg78Gi+a",
+    description: "Project card metadata label for open jobs",
+  },
+  openJobsCount: {
+    defaultMessage: "{count, plural, one {# job} other {# jobs}}",
+    id: "TKzoXsQ+7N",
+    description: "Count of open jobs on a project card",
+  },
+  noOpenJobs: {
+    defaultMessage: "None",
+    id: "TEhuWyiC97",
+    description: "Shown when a project has no open jobs",
+  },
+  updatedLabel: {
+    defaultMessage: "Updated",
+    id: "gzw597zx6d",
+    description: "Project card metadata label for last updated time",
+  },
+  updatedUnavailable: {
+    defaultMessage: "Updated date unavailable",
+    id: "dcbWLpn6f2",
+    description: "Fallback when a project has no usable updated timestamp",
+  },
+  emptyTmsTitle: {
+    defaultMessage: "No TMS projects found",
+    id: "LskMKNMd3j",
+    description: "Title when the TMS projects list is empty",
+  },
+  emptyTmsDescription: {
+    defaultMessage:
+      "Your provider connection is active, but no projects were returned from the live API.",
+    id: "DBBFqQ55km",
+    description: "Description when the TMS projects list is empty",
+  },
+  loadingProjects: {
+    defaultMessage: "Loading projects",
+    id: "vGGfZ3wAHV",
+    description: "Accessible label while project cards are loading",
+  },
+  loadFailedTitle: {
+    defaultMessage: "Projects failed to load.",
+    id: "4x93Ph/+pf",
+    description: "Error title when the projects list fails to load",
+  },
+  loadFailedFallback: {
+    defaultMessage: "Refresh the page to try again.",
+    id: "xy0kgWsXSb",
+    description: "Fallback error detail when projects fail to load without a message",
+  },
+  loadMore: {
+    defaultMessage: "Load more",
+    id: "C31IoV3z9k",
+    description: "Button to load more projects in the list",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.test.tsx
@@ -3,11 +3,21 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { UseQueryResult } from "@tanstack/react-query";
+import type { ReactElement } from "react";
+import { IntlProvider } from "react-intl";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import { DeleteProjectDialog } from "./delete-project-dialog";
 import type { ProjectListRow } from "./project-list";
 import { ProjectsTable } from "./projects-table";
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <IntlProvider locale="en" messages={{}}>
+      {ui}
+    </IntlProvider>,
+  );
+}
 
 function createProject(overrides: Partial<ProjectListRow> = {}): ProjectListRow {
   return {
@@ -47,7 +57,7 @@ function successQuery(): UseQueryResult<ProjectListRow[], Error> {
 
 describe("ProjectsTable", () => {
   it("shows source-to-target locales for native and external project cards", () => {
-    render(
+    renderWithIntl(
       <>
         <ProjectsTable
           projects={[createProject()]}
@@ -90,7 +100,7 @@ describe("ProjectsTable", () => {
     const onDeleteProject = vi.fn();
     const project = createProject();
 
-    render(
+    renderWithIntl(
       <ProjectsTable
         projects={[project]}
         projectsQuery={successQuery()}
@@ -120,7 +130,7 @@ describe("DeleteProjectDialog", () => {
     const onDelete = vi.fn();
     const project = createProject();
 
-    render(
+    renderWithIntl(
       <DeleteProjectDialog
         project={project}
         isDeleting={false}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 import {
   ArrowRight01Icon,
@@ -8,6 +10,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { UseQueryResult } from "@tanstack/react-query";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { TmsUserConnectionErrorPanel } from "@/components/app-shell/tms-user-connection-prompt";
 import { Badge } from "@/components/ui/badge";
@@ -30,6 +33,7 @@ import { isTmsUserConnectionRequiredError } from "@/lib/providers/credentials/tm
 import { formatRelativeTimestamp } from "../../_components/workspace-files-shared";
 import { ProjectAvatar } from "./project-avatar";
 import { formatProjectLocaleRoute, type ProjectListRow } from "./project-list";
+import { projectsTableMessages } from "./projects-table.messages";
 
 export const PROJECTS_PAGE_SIZE = 12;
 
@@ -63,19 +67,23 @@ function NativeEmptyState({
   if (compact) {
     return (
       <TypographyP className="text-sm leading-6 text-muted-foreground">
-        No Hyperlocalise projects yet.{" "}
-        {onCreateProject ? (
-          <button
-            type="button"
-            onClick={onCreateProject}
-            className="text-subtle-foreground underline hover:text-foreground"
-          >
-            Create one
-          </button>
-        ) : (
-          "Create one"
-        )}{" "}
-        to add translation context and job tracking.
+        <FormattedMessage
+          {...projectsTableMessages.nativeEmptyCompact}
+          values={{
+            action: (chunks) =>
+              onCreateProject ? (
+                <button
+                  type="button"
+                  onClick={onCreateProject}
+                  className="text-subtle-foreground underline hover:text-foreground"
+                >
+                  {chunks}
+                </button>
+              ) : (
+                chunks
+              ),
+          }}
+        />
       </TypographyP>
     );
   }
@@ -83,11 +91,10 @@ function NativeEmptyState({
   return (
     <div className="max-w-xl space-y-3 py-6">
       <TypographyP className="text-sm font-medium text-foreground">
-        Create your first localization project
+        <FormattedMessage {...projectsTableMessages.nativeEmptyTitle} />
       </TypographyP>
       <TypographyP className="text-sm leading-6 text-muted-foreground">
-        Track source content, release ownership, and translation context before work moves into
-        translation jobs.
+        <FormattedMessage {...projectsTableMessages.nativeEmptyDescription} />
       </TypographyP>
     </div>
   );
@@ -110,14 +117,15 @@ function ProjectCard({
   onDeleteProject?: (project: ProjectListRow) => void;
   onOpenProject?: (projectId: string) => void;
 }) {
+  const intl = useIntl();
   const providerName =
     project.source === "external_tms"
       ? getTmsProviderBranding(project.externalProviderKind).name
-      : "Hyperlocalise";
+      : intl.formatMessage(projectsTableMessages.hyperlocaliseProvider);
   const localeRoute = formatProjectLocaleRoute(project.sourceLocale, project.targetLocales);
   const activityLabel = project.lastActivityAt
     ? formatRelativeTimestamp(project.lastActivityAt)
-    : project.updated;
+    : project.updated || intl.formatMessage(projectsTableMessages.updatedUnavailable);
   const isNativeProject = project.source === "native";
   const projectHref = `/org/${organizationSlug}/projects/${project.id}`;
 
@@ -137,7 +145,7 @@ function ProjectCard({
               </TypographyH3>
               {!project.isActive ? (
                 <Badge variant="outline" className="text-[10px]">
-                  Inactive
+                  <FormattedMessage {...projectsTableMessages.inactiveBadge} />
                 </Badge>
               ) : null}
             </div>
@@ -145,7 +153,8 @@ function ProjectCard({
               {providerName}
             </TypographyP>
             <TypographyP className="mt-1 line-clamp-2 text-xs text-muted-foreground">
-              {project.descriptionValue || "No description yet"}
+              {project.descriptionValue ||
+                intl.formatMessage(projectsTableMessages.noDescriptionYet)}
             </TypographyP>
           </div>
         </Link>
@@ -169,12 +178,18 @@ function ProjectCard({
                     className="text-muted-foreground hover:text-foreground"
                   >
                     <HugeiconsIcon icon={ArrowUpRight01Icon} strokeWidth={1.8} />
-                    <span className="sr-only">Open {project.name} in provider</span>
+                    <span className="sr-only">
+                      {intl.formatMessage(projectsTableMessages.openInProviderSrOnly, {
+                        projectName: project.name,
+                      })}
+                    </span>
                   </Button>
                 }
               />
               <TooltipContent side="bottom" align="center">
-                Open in {providerName}
+                {intl.formatMessage(projectsTableMessages.openInProvider, {
+                  providerName,
+                })}
               </TooltipContent>
             </Tooltip>
           ) : null}
@@ -186,7 +201,9 @@ function ProjectCard({
                     type="button"
                     size="icon-sm"
                     variant="ghost"
-                    aria-label={`Actions for ${project.name}`}
+                    aria-label={intl.formatMessage(projectsTableMessages.actionsForProject, {
+                      projectName: project.name,
+                    })}
                     disabled={isDeletingProject || isSavingProject}
                     className="text-muted-foreground hover:text-foreground"
                   />
@@ -197,14 +214,14 @@ function ProjectCard({
               <DropdownMenuContent align="end" className="min-w-48">
                 <DropdownMenuGroup>
                   <DropdownMenuItem render={<Link href={projectHref} />}>
-                    Open project
+                    <FormattedMessage {...projectsTableMessages.openProject} />
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onClick={() => onEditProject(project)}
                     disabled={isSavingProject}
                   >
                     <HugeiconsIcon icon={Edit02Icon} strokeWidth={1.8} />
-                    Edit project...
+                    <FormattedMessage {...projectsTableMessages.editProject} />
                   </DropdownMenuItem>
                 </DropdownMenuGroup>
                 <DropdownMenuSeparator />
@@ -215,7 +232,7 @@ function ProjectCard({
                     disabled={isDeletingProject || isSavingProject}
                   >
                     <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
-                    Delete project...
+                    <FormattedMessage {...projectsTableMessages.deleteProject} />
                   </DropdownMenuItem>
                 </DropdownMenuGroup>
               </DropdownMenuContent>
@@ -231,26 +248,36 @@ function ProjectCard({
 
       <dl className="mt-5 grid gap-3 border-t border-border pt-4 sm:grid-cols-3">
         <div className="min-w-0">
-          <dt className="text-xs font-medium text-muted-foreground uppercase">Locales</dt>
+          <dt className="text-xs font-medium text-muted-foreground uppercase">
+            <FormattedMessage {...projectsTableMessages.localesLabel} />
+          </dt>
           <dd className="mt-1 truncate text-sm text-muted-foreground">{localeRoute}</dd>
         </div>
         <div className="min-w-0">
-          <dt className="text-xs font-medium text-muted-foreground uppercase">Open jobs</dt>
+          <dt className="text-xs font-medium text-muted-foreground uppercase">
+            <FormattedMessage {...projectsTableMessages.openJobsLabel} />
+          </dt>
           <dd className="mt-1 truncate text-sm text-muted-foreground">
             {project.openJobCount > 0 ? (
               <Link
                 href={`/org/${organizationSlug}/projects/${project.id}/jobs`}
                 className="text-subtle-foreground hover:text-foreground hover:underline"
               >
-                {project.openJobCount} {project.openJobCount === 1 ? "job" : "jobs"}
+                {intl.formatMessage(projectsTableMessages.openJobsCount, {
+                  count: project.openJobCount,
+                })}
               </Link>
             ) : (
-              <span>None</span>
+              <span>
+                <FormattedMessage {...projectsTableMessages.noOpenJobs} />
+              </span>
             )}
           </dd>
         </div>
         <div className="min-w-0">
-          <dt className="text-xs font-medium text-muted-foreground uppercase">Updated</dt>
+          <dt className="text-xs font-medium text-muted-foreground uppercase">
+            <FormattedMessage {...projectsTableMessages.updatedLabel} />
+          </dt>
           <dd className="mt-1 truncate text-sm text-muted-foreground">{activityLabel}</dd>
         </div>
       </dl>
@@ -287,9 +314,7 @@ export function ProjectsTable({
   onCreateProject?: () => void;
   onOpenProject?: (projectId: string) => void;
 }) {
-  const emptyTmsTitle = "No TMS projects found";
-  const emptyTmsDescription =
-    "Your provider connection is active, but no projects were returned from the live API.";
+  const intl = useIntl();
 
   return (
     <section>
@@ -297,7 +322,7 @@ export function ProjectsTable({
         <div
           className="grid gap-3 py-4 lg:grid-cols-2"
           aria-busy="true"
-          aria-label="Loading projects"
+          aria-label={intl.formatMessage(projectsTableMessages.loadingProjects)}
         >
           {Array.from({ length: 4 }).map((_, index) => (
             <ProjectCardSkeleton key={index} />
@@ -315,12 +340,12 @@ export function ProjectsTable({
           ) : (
             <>
               <TypographyP className="text-sm font-medium text-flame-100">
-                Projects failed to load.
+                <FormattedMessage {...projectsTableMessages.loadFailedTitle} />
               </TypographyP>
               <TypographyP className="mt-1 text-xs text-muted-foreground">
                 {projectsQuery.error instanceof Error
                   ? projectsQuery.error.message
-                  : "Refresh the page to try again."}
+                  : intl.formatMessage(projectsTableMessages.loadFailedFallback)}
               </TypographyP>
             </>
           )}
@@ -332,10 +357,10 @@ export function ProjectsTable({
         ) : (
           <div className="max-w-xl space-y-3 py-4">
             <TypographyP className="text-sm font-medium text-foreground">
-              {emptyTmsTitle}
+              <FormattedMessage {...projectsTableMessages.emptyTmsTitle} />
             </TypographyP>
             <TypographyP className="text-sm leading-6 text-muted-foreground">
-              {emptyTmsDescription}
+              <FormattedMessage {...projectsTableMessages.emptyTmsDescription} />
             </TypographyP>
           </div>
         )
@@ -378,7 +403,7 @@ export function ProjectsTable({
       {hasMore && projectsQuery.isSuccess && projects.length > 0 && onLoadMore ? (
         <div className={cn("flex justify-center", variant === "tms" ? "pt-4" : "pt-6")}>
           <Button type="button" variant="outline" onClick={onLoadMore} className="rounded-full">
-            Load more
+            <FormattedMessage {...projectsTableMessages.loadMore} />
           </Button>
         </div>
       ) : null}

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.messages.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const appShellFooterMessages = defineMessages({
+  emailSupportAriaLabel: {
+    defaultMessage: "Email support",
+    id: "ecG+jsddyC",
+    description: "Accessible label for the support email button in the app shell footer",
+  },
+  supportTooltip: {
+    defaultMessage: "Support",
+    id: "UkpQmLO4C5",
+    description: "Tooltip label for the support email button in the app shell footer",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
@@ -2,6 +2,7 @@
 
 import { CustomerSupportIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import type { InboxCurrentUser } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-types";
 import {
@@ -15,6 +16,8 @@ import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { SUPPORT_EMAIL } from "@/lib/support-contact";
 
+import { appShellFooterMessages } from "./app-shell-footer.messages";
+
 export function AppShellFooter({
   organizationSlug,
   showPlan,
@@ -24,6 +27,7 @@ export function AppShellFooter({
   showPlan: boolean;
   currentUser?: InboxCurrentUser;
 }) {
+  const intl = useIntl();
   const showChatDock = Boolean(organizationSlug && currentUser);
 
   return (
@@ -35,7 +39,7 @@ export function AppShellFooter({
         </ChatDockErrorBoundary>
       ) : null}
 
-      <div className="flex h-[var(--app-shell-plan-footer-height)] shrink-0 items-stretch px-2">
+      <div className="flex h-(--app-shell-plan-footer-height) shrink-0 items-stretch px-2">
         <div className="flex h-10 w-full items-center gap-2">
           {showPlan ? <PlanUsageFooterControl organizationSlug={organizationSlug} /> : null}
           <div className="ms-auto flex min-w-0 items-center gap-2">
@@ -47,14 +51,14 @@ export function AppShellFooter({
                     variant="ghost"
                     size="icon-xs"
                     render={<a href={`mailto:${SUPPORT_EMAIL}`} />}
-                    aria-label="Email support"
+                    aria-label={intl.formatMessage(appShellFooterMessages.emailSupportAriaLabel)}
                   >
                     <HugeiconsIcon icon={CustomerSupportIcon} strokeWidth={2} />
                   </Button>
                 }
               />
               <TooltipContent side="top" align="end">
-                Support
+                <FormattedMessage {...appShellFooterMessages.supportTooltip} />
               </TooltipContent>
             </Tooltip>
           </div>

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.messages.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const catWorkspaceViewMessages = defineMessages({
+  segmentPosition: {
+    defaultMessage: "{position} / {total}",
+    id: "8UnBVLcjgq",
+    description: "Current segment index and total count in the compact CAT workspace header",
+  },
+  segmentPositionOpenEnded: {
+    defaultMessage: "{position}+",
+    id: "0x11s5ha3b",
+    description: "Current segment index when more queue pages may exist and total count is unknown",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
@@ -17,6 +17,7 @@ import { catWorkspaceMessages } from "@/components/cat/shared/cat.messages";
 
 import { CatPanelErrorBoundary } from "./cat-panel-error-boundary";
 import { useCatWorkspace } from "./cat-workspace-context";
+import { catWorkspaceViewMessages } from "./cat-workspace.messages";
 import { resolveSegmentIntelligenceForDisplay } from "./store/cat-workspace-store-utils";
 
 const COMPACT_WORKSPACE_QUERY = "(max-width: 1023px)";
@@ -532,8 +533,22 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
           <div className="shrink-0 border-b border-border px-4 py-3">
             <div className="min-w-0 space-y-1">
               <p className="font-mono text-xs text-muted-foreground tabular-nums">
-                {String(segmentPosition).padStart(2, "0")}
-                {totalSegments != null ? ` / ${String(totalSegments).padStart(2, "0")}` : "+"}
+                {totalSegments != null ? (
+                  <FormattedMessage
+                    {...catWorkspaceViewMessages.segmentPosition}
+                    values={{
+                      position: String(segmentPosition).padStart(2, "0"),
+                      total: String(totalSegments).padStart(2, "0"),
+                    }}
+                  />
+                ) : (
+                  <FormattedMessage
+                    {...catWorkspaceViewMessages.segmentPositionOpenEnded}
+                    values={{
+                      position: String(segmentPosition).padStart(2, "0"),
+                    }}
+                  />
+                )}
               </p>
               <CatSegmentKeyMeta
                 segmentKey={editorSegment.key}


### PR DESCRIPTION
## What changed

Localize hardcoded user-facing copy in authenticated jobs/projects UI, the job CAT page, CAT workspace segment position, and the app shell footer using colocated react-intl (`defineMessages` + `FormattedMessage` / `useIntl`).

## How to test

- [ ] Open Jobs page: filters, empty states, kanban actions, create-job dialog, Crowdin detail rows render localized English defaults
- [ ] Open Projects page: table, create/edit/delete dialogs, locale picker copy looks correct
- [ ] Open a job CAT workspace: loading/error states and compact segment position (`01 / 12`, `01+`) render correctly
- [ ] Confirm app shell footer links/labels still look correct
- [ ] From `apps/hyperlocalise-web`: `vp check` and `vp test` on touched paths (projects-table / job-cat-page-content tests)

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)