### PR TITLE
feat(web): add Create job and View strings on project overview

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-action-card.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-action-card.messages.ts
@@ -1,0 +1,11 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const overviewActionCardMessages = defineMessages({
+  view: {
+    defaultMessage: "View",
+    id: "aFsemv4CDb",
+    description: "Button on an overview action card to open the related job or file",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-action-card.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-action-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { FormattedMessage } from "react-intl";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -9,6 +10,7 @@ import { TypographyP } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
 
 import { toneClass, type Tone } from "../workspace-resource-shared";
+import { overviewActionCardMessages } from "./overview-action-card.messages";
 
 export function OverviewActionCard({
   category,
@@ -58,7 +60,7 @@ export function OverviewActionCard({
           size="sm"
           className="w-fit rounded-full"
         >
-          View
+          <FormattedMessage {...overviewActionCardMessages.view} />
         </Button>
       </CardContent>
     </Card>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-hero-card.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-hero-card.messages.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const overviewHeroCardMessages = defineMessages({
+  allCaughtUp: {
+    defaultMessage: "All caught up",
+    id: "CDHpNJeAfK",
+    description: "Overview hero badge when there are no pending actions",
+  },
+  pendingActions: {
+    defaultMessage: "{count, plural, one {# pending action} other {# pending actions}}",
+    id: "CzEPtyNc5S",
+    description: "Overview hero badge showing how many pending actions remain",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-hero-card.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-hero-card.tsx
@@ -3,11 +3,14 @@
 import Link from "next/link";
 import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage } from "react-intl";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { TypographyP } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
+
+import { overviewHeroCardMessages } from "./overview-hero-card.messages";
 
 export function OverviewHeroCard({
   pendingCount,
@@ -41,9 +44,14 @@ export function OverviewHeroCard({
       <CardContent className="flex h-full flex-col justify-between gap-6 px-6 py-6">
         <div>
           <TypographyP className="text-sm font-medium text-subtle-foreground">
-            {isCaughtUp
-              ? "All caught up"
-              : `${pendingCount} pending ${pendingCount === 1 ? "action" : "actions"}`}
+            {isCaughtUp ? (
+              <FormattedMessage {...overviewHeroCardMessages.allCaughtUp} />
+            ) : (
+              <FormattedMessage
+                {...overviewHeroCardMessages.pendingActions}
+                values={{ count: pendingCount }}
+              />
+            )}
           </TypographyP>
           <TypographyP className="mt-2 font-heading text-2xl font-medium text-foreground">
             {title}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
@@ -6,6 +6,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
 
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+import { MarkdownDescriptionEditor } from "@/components/markdown-description-editor/markdown-description-editor";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -26,7 +27,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
-import { Textarea } from "@/components/ui/textarea";
 import { readApiResponseError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
 import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
@@ -510,7 +510,7 @@ export function CreateJobDialog({
           </div>
 
           {isProviderProject ? (
-            <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-5">
               <div className="space-y-2">
                 <Label>
                   <FormattedMessage {...createJobDialogMessages.taskTypeLabel} />
@@ -524,28 +524,38 @@ export function CreateJobDialog({
                   }}
                 >
                   <SelectTrigger className="w-full">
-                    <SelectValue />
+                    <SelectValue>
+                      {intl.formatMessage(
+                        kind === "proofread"
+                          ? createJobDialogMessages.taskTypeProofread
+                          : createJobDialogMessages.taskTypeTranslation,
+                      )}
+                    </SelectValue>
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="translation">
+                    <SelectItem
+                      value="translation"
+                      label={intl.formatMessage(createJobDialogMessages.taskTypeTranslation)}
+                    >
                       <FormattedMessage {...createJobDialogMessages.taskTypeTranslation} />
                     </SelectItem>
-                    <SelectItem value="proofread">
+                    <SelectItem
+                      value="proofread"
+                      label={intl.formatMessage(createJobDialogMessages.taskTypeProofread)}
+                    >
                       <FormattedMessage {...createJobDialogMessages.taskTypeProofread} />
                     </SelectItem>
                   </SelectContent>
                 </Select>
               </div>
               <div className="space-y-2">
-                <Label htmlFor="create-job-description">
+                <Label>
                   <FormattedMessage {...createJobDialogMessages.descriptionLabel} />
                 </Label>
-                <Textarea
-                  id="create-job-description"
+                <MarkdownDescriptionEditor
                   value={description}
-                  onChange={(event) => setDescription(event.target.value)}
-                  rows={2}
-                  maxLength={2048}
+                  onChange={setDescription}
+                  disabled={createJob.isPending}
                   placeholder={intl.formatMessage(createJobDialogMessages.descriptionPlaceholder)}
                 />
               </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.messages.ts
@@ -1,0 +1,215 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const projectOverviewPageContentMessages = defineMessages({
+  createJob: {
+    defaultMessage: "Create job",
+    id: "7WTIzTDLbF",
+    description: "Button on project overview to open the create job dialog",
+  },
+  viewStrings: {
+    defaultMessage: "View strings",
+    id: "EBgNz2ZSu6",
+    description: "Button on project overview linking to the project Strings page",
+  },
+  projectOverviewFallbackTitle: {
+    defaultMessage: "Project overview",
+    id: "mehTxJuesM",
+    description: "Fallback project overview heading when project details fail to load",
+  },
+  projectFallbackName: {
+    defaultMessage: "Project",
+    id: "NhoTfXzaHI",
+    description: "Fallback project name when the project title is missing",
+  },
+  loadProjectError: {
+    defaultMessage: "Unable to load project details. Refresh the page or try again in a moment.",
+    id: "KjJZbmRFki",
+    description: "Error message when project overview details fail to load",
+  },
+  defaultProjectDescription: {
+    defaultMessage: "Project hub for localization work.",
+    id: "fbtbMSQ/2I",
+    description: "Fallback project description on the project overview page",
+  },
+  caughtUpHeroTitle: {
+    defaultMessage: "You’re all caught up",
+    id: "esZVdLzFOW",
+    description: "Project overview hero title when there are no pending actions",
+  },
+  caughtUpHeroDescription: {
+    defaultMessage:
+      "No pending actions right now. Upload source files or review completed jobs when you’re ready to continue.",
+    id: "VZSf2k42GF",
+    description: "Project overview hero description when there are no pending actions",
+  },
+  browseFilesCta: {
+    defaultMessage: "Browse files",
+    id: "Q3hdQblIYe",
+    description: "Project overview hero call-to-action when the project is caught up",
+  },
+  attentionHeroTitle: {
+    defaultMessage: "A few things need your attention",
+    id: "3XNlGxtFuq",
+    description: "Project overview hero title when pending actions need review",
+  },
+  attentionHeroDescription: {
+    defaultMessage: "Pick up where you left off — {details}.",
+    id: "hx+ozGK2uu",
+    description: "Project overview hero description listing open jobs and files needing attention",
+  },
+  openJobsDetail: {
+    defaultMessage: "{count, plural, one {# open job} other {# open jobs}}",
+    id: "SyMDAHRe17",
+    description: "Fragment listing open job count in the project overview hero",
+  },
+  filesNeedingAttentionDetail: {
+    defaultMessage:
+      "{count, plural, one {# file needing attention} other {# files needing attention}}",
+    id: "e3B7xw2yS4",
+    description: "Fragment listing files needing attention in the project overview hero",
+  },
+  pickUpWhereYouLeftOffCta: {
+    defaultMessage: "Pick up where you left off",
+    id: "2P3llDCJQ9",
+    description: "Project overview hero call-to-action when work needs attention",
+  },
+  snapshotTitle: {
+    defaultMessage: "Project snapshot",
+    id: "tQnsj9c8zW",
+    description: "Title of the project snapshot card on project overview",
+  },
+  snapshotLocales: {
+    defaultMessage: "Locales",
+    id: "0pVEMuUCAh",
+    description: "Project snapshot row label for source and target locales",
+  },
+  snapshotSource: {
+    defaultMessage: "Source",
+    id: "R1inHgae6i",
+    description: "Project snapshot row label for project source type",
+  },
+  snapshotOpenJobs: {
+    defaultMessage: "Open jobs",
+    id: "qoKaksFa9x",
+    description: "Project snapshot row label for open job count",
+  },
+  nativeProjectSource: {
+    defaultMessage: "Native project",
+    id: "kpZpdwbYk2",
+    description: "Project snapshot source value for Hyperlocalise-native projects",
+  },
+  openJobsUnavailable: {
+    defaultMessage: "Unavailable",
+    id: "Z9kckxHp8S",
+    description: "Shown in project snapshot when open job count fails to load",
+  },
+  viewSettings: {
+    defaultMessage: "View settings",
+    id: "zIinCypcXs",
+    description: "Call-to-action on the project snapshot card linking to project settings",
+  },
+  ongoingSection: {
+    defaultMessage: "Ongoing",
+    id: "AUY6LRuqkn",
+    description: "Section heading for ongoing jobs and files on project overview",
+  },
+  categoryJob: {
+    defaultMessage: "Job",
+    id: "zliOrjr0oj",
+    description: "Category badge for a job card on project overview",
+  },
+  categoryFile: {
+    defaultMessage: "File",
+    id: "XlCqTK9P8L",
+    description: "Category badge for a file card on project overview",
+  },
+  jobStatusUpdated: {
+    defaultMessage: "{status} · updated {updated}",
+    id: "intwkVhq+i",
+    description: "Status line for an ongoing job card showing status and relative update time",
+  },
+  needsAttention: {
+    defaultMessage: "Needs attention",
+    id: "Jwoqn7hfPq",
+    description: "Fallback status line when a file needs attention but has no readiness summary",
+  },
+  jobsUnavailable: {
+    defaultMessage: "Jobs unavailable",
+    id: "M4sYVolrI+",
+    description: "Empty-state title when project jobs fail to load",
+  },
+  noActiveJobs: {
+    defaultMessage: "No active jobs",
+    id: "qsiC3fEv6E",
+    description: "Empty-state title when the project has no active jobs",
+  },
+  jobsUnavailableDescription: {
+    defaultMessage: "We could not load jobs for this project.",
+    id: "CvYNnC7KYY",
+    description: "Empty-state description when project jobs fail to load",
+  },
+  noActiveJobsDescription: {
+    defaultMessage: "Queued, running, and review jobs will appear here.",
+    id: "VreTPRoxTI",
+    description: "Empty-state description when the project has no active jobs",
+  },
+  viewJobs: {
+    defaultMessage: "View jobs",
+    id: "ah1fHcY0dZ",
+    description: "Button linking to the project jobs page from the empty jobs card",
+  },
+  filesUnavailable: {
+    defaultMessage: "Files unavailable",
+    id: "lnENdnqB3K",
+    description: "Empty-state title when project files fail to load",
+  },
+  noFilesNeedAttention: {
+    defaultMessage: "No files need attention",
+    id: "ng2kCyPWWf",
+    description: "Empty-state title when no project files need attention",
+  },
+  filesUnavailableDescription: {
+    defaultMessage: "We could not load project files.",
+    id: "MtSPbgepa5",
+    description: "Empty-state description when project files fail to load",
+  },
+  noFilesNeedAttentionDescription: {
+    defaultMessage: "Files with missing or changed translations will appear here.",
+    id: "Pu5h/suwW5",
+    description: "Empty-state description when no project files need attention",
+  },
+  viewFiles: {
+    defaultMessage: "View files",
+    id: "3KtrgP1VL6",
+    description: "Button linking to the project files page from the empty files card",
+  },
+  readyToPullTitle: {
+    defaultMessage: "Ready to pull",
+    id: "PMhWQU9+xq",
+    description: "Title of the ready-to-pull callout on project overview",
+  },
+  readyToPullDescription: {
+    defaultMessage:
+      "{count, plural, one {# file has} other {# files have}} completed translations you can download or sync with <code>sync pull</code>.",
+    id: "iczDvJ3VLc",
+    description:
+      "Description of files ready to pull, with the sync pull command highlighted in monospace",
+  },
+  openFiles: {
+    defaultMessage: "Open files",
+    id: "/L2n1hwt0/",
+    description: "Button linking to project files from the ready-to-pull callout",
+  },
+  loadProjectFilesFailed: {
+    defaultMessage: "Failed to load project files",
+    id: "fIXR+y8rly",
+    description: "Error when the project overview files query fails",
+  },
+  invalidProjectFilesResponse: {
+    defaultMessage: "Invalid project files response",
+    id: "kgAiiSB4O6",
+    description: "Error when the project overview files API returns an unexpected payload",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.stories.tsx
@@ -58,7 +58,7 @@ export const CaughtUp: Story = {
     files: [projectOverviewFilesFixture[1]!],
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText("You're all caught up")).toBeInTheDocument();
+    await expect(canvas.getByText("You’re all caught up")).toBeInTheDocument();
     await expect(canvas.getByText("Browse files")).toBeInTheDocument();
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.stories.tsx
@@ -39,6 +39,11 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("heading", { name: "Website localization" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Create job" })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "View strings" })).toHaveAttribute(
+      "href",
+      "/org/acme/projects/project_website/strings",
+    );
     await expect(canvas.getByText("A few things need your attention")).toBeInTheDocument();
     await expect(canvas.getByText("Ongoing")).toBeInTheDocument();
     await expect(canvas.getByText("home.json")).toBeInTheDocument();
@@ -68,6 +73,10 @@ export const Loading: Story = {
     openJobCount: 0,
     jobs: [],
     files: [],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.queryByRole("button", { name: "Create job" })).toBeNull();
+    await expect(canvas.queryByRole("link", { name: "View strings" })).toBeNull();
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { File01Icon } from "@hugeicons/core-free-icons";
+import { Add01Icon, File01Icon, LanguageCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
 import { buildProjectPath } from "@/components/app-shell/navigation-config";
@@ -12,6 +13,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { TypographyH1, TypographyP } from "@/components/ui/typography";
 import { parseApiJsonResponse, readApiResponseError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
+import { supportsCatAllFilesProvider } from "@/lib/projects/cat-all-files";
 import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 import {
   projectFilesResponseSchema,
@@ -38,6 +40,7 @@ import {
   resolveFileLocaleReadiness,
 } from "@/lib/projects/files/native-locale-readiness";
 import type { Tone } from "../../../_components/workspace-resource-shared";
+import { CreateJobDialog } from "../../../jobs/_components/create-job-dialog";
 import { getJobName, jobTone, type ApiJob } from "../../../jobs/_components/jobs-page-view";
 import type { ProjectListRow } from "../../_components/project-list";
 import { ProjectPageShell, useProjectPageQuery } from "./project-page-shell";
@@ -141,6 +144,7 @@ export type ProjectOverviewPageContentViewProps = {
   files: readonly ProjectFileRecord[];
   isFilesLoading: boolean;
   isFilesError: boolean;
+  onCreateJob?: () => void;
 };
 
 export function ProjectOverviewPageContentView({
@@ -158,6 +162,7 @@ export function ProjectOverviewPageContentView({
   files,
   isFilesLoading,
   isFilesError,
+  onCreateJob,
 }: ProjectOverviewPageContentViewProps) {
   const filesNeedingAttention = countFilesNeedingAttention(files);
   const pendingCount = project ? computeProjectPendingActionCount({ openJobCount }, files) : 0;
@@ -165,6 +170,9 @@ export function ProjectOverviewPageContentView({
   const attentionFiles = selectFilesNeedingAttention(files);
   const ongoingCount = ongoingJobs.length + attentionFiles.length;
   const readyToPullCount = project ? countReadyToPullFiles(files, project.targetLocales.length) : 0;
+  const showViewStrings = supportsCatAllFilesProvider(
+    parseProviderProjectId(projectId)?.providerKind,
+  );
 
   const heroCopy = project
     ? buildHeroCopy(filesNeedingAttention, pendingCount, openJobCount)
@@ -199,33 +207,57 @@ export function ProjectOverviewPageContentView({
       ]
     : [];
 
+  const showHeaderActions = Boolean(project) && !isProjectLoading && !isProjectError;
+
   return (
     <ProjectPageShell className="gap-8">
-      <header className="space-y-2">
-        {isProjectLoading ? (
-          <>
-            <Skeleton className="h-8 w-64" />
-            <Skeleton className="h-4 w-full max-w-xl" />
-          </>
-        ) : isProjectError ? (
-          <>
-            <TypographyH1 className="font-sans text-2xl font-medium text-foreground">
-              Project overview
-            </TypographyH1>
-            <TypographyP className="text-sm text-muted-foreground">
-              Unable to load project details. Refresh the page or try again in a moment.
-            </TypographyP>
-          </>
-        ) : (
-          <>
-            <TypographyH1 className="font-sans text-2xl font-medium text-foreground">
-              {project?.name ?? "Project"}
-            </TypographyH1>
-            <TypographyP className="max-w-2xl text-sm leading-6 text-muted-foreground">
-              {projectDescription}
-            </TypographyP>
-          </>
-        )}
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 space-y-2">
+          {isProjectLoading ? (
+            <>
+              <Skeleton className="h-8 w-64" />
+              <Skeleton className="h-4 w-full max-w-xl" />
+            </>
+          ) : isProjectError ? (
+            <>
+              <TypographyH1 className="font-sans text-2xl font-medium text-foreground">
+                Project overview
+              </TypographyH1>
+              <TypographyP className="text-sm text-muted-foreground">
+                Unable to load project details. Refresh the page or try again in a moment.
+              </TypographyP>
+            </>
+          ) : (
+            <>
+              <TypographyH1 className="font-sans text-2xl font-medium text-foreground">
+                {project?.name ?? "Project"}
+              </TypographyH1>
+              <TypographyP className="max-w-2xl text-sm leading-6 text-muted-foreground">
+                {projectDescription}
+              </TypographyP>
+            </>
+          )}
+        </div>
+
+        {showHeaderActions ? (
+          <div className="flex shrink-0 flex-wrap gap-2">
+            {showViewStrings ? (
+              <Button
+                nativeButton={false}
+                render={<Link href={buildProjectPath(organizationSlug, projectId, "strings")} />}
+                size="sm"
+                variant="outline"
+              >
+                <HugeiconsIcon icon={LanguageCircleIcon} strokeWidth={1.8} />
+                View strings
+              </Button>
+            ) : null}
+            <Button type="button" size="sm" onClick={onCreateJob}>
+              <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
+              Create job
+            </Button>
+          </div>
+        ) : null}
       </header>
 
       <section className="grid gap-4 lg:grid-cols-3">
@@ -382,6 +414,7 @@ export function ProjectOverviewPageContent({
   organizationSlug: string;
   projectId: string;
 }) {
+  const [createJobOpen, setCreateJobOpen] = useState(false);
   const projectQuery = useProjectPageQuery(organizationSlug, projectId);
   const isLiveTmsProject = Boolean(parseProviderProjectId(projectId));
   const openJobCountQuery = useProjectOpenJobCountQuery(organizationSlug, projectId, {
@@ -413,22 +446,39 @@ export function ProjectOverviewPageContent({
     },
   });
 
+  const sourceLocale = projectQuery.data?.sourceLocale?.trim() || "en";
+  const targetLocales = projectQuery.data?.targetLocales ?? [];
+
   return (
-    <ProjectOverviewPageContentView
-      organizationSlug={organizationSlug}
-      projectId={projectId}
-      project={projectQuery.data ?? null}
-      isProjectLoading={projectQuery.isLoading}
-      isProjectError={projectQuery.isError}
-      openJobCount={openJobCountQuery.data ?? 0}
-      isOpenJobCountLoading={openJobCountQuery.isLoading}
-      isOpenJobCountError={openJobCountQuery.isError}
-      jobs={jobsQuery.data ?? []}
-      isJobsLoading={jobsQuery.isLoading}
-      isJobsError={jobsQuery.isError}
-      files={filesQuery.data ?? []}
-      isFilesLoading={filesQuery.isLoading}
-      isFilesError={filesQuery.isError}
-    />
+    <>
+      <ProjectOverviewPageContentView
+        organizationSlug={organizationSlug}
+        projectId={projectId}
+        project={projectQuery.data ?? null}
+        isProjectLoading={projectQuery.isLoading}
+        isProjectError={projectQuery.isError}
+        openJobCount={openJobCountQuery.data ?? 0}
+        isOpenJobCountLoading={openJobCountQuery.isLoading}
+        isOpenJobCountError={openJobCountQuery.isError}
+        jobs={jobsQuery.data ?? []}
+        isJobsLoading={jobsQuery.isLoading}
+        isJobsError={jobsQuery.isError}
+        files={filesQuery.data ?? []}
+        isFilesLoading={filesQuery.isLoading}
+        isFilesError={filesQuery.isError}
+        onCreateJob={() => setCreateJobOpen(true)}
+      />
+      <CreateJobDialog
+        open={createJobOpen}
+        onOpenChange={setCreateJobOpen}
+        organizationSlug={organizationSlug}
+        projectId={projectId}
+        sourceLocale={sourceLocale}
+        targetLocales={targetLocales}
+        onCreated={async () => {
+          await Promise.all([jobsQuery.refetch(), openJobCountQuery.refetch()]);
+        }}
+      />
+    </>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Add01Icon, File01Icon, LanguageCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
 
 import { buildProjectPath } from "@/components/app-shell/navigation-config";
 import { Button } from "@/components/ui/button";
@@ -41,8 +42,10 @@ import {
 } from "@/lib/projects/files/native-locale-readiness";
 import type { Tone } from "../../../_components/workspace-resource-shared";
 import { CreateJobDialog } from "../../../jobs/_components/create-job-dialog";
+import { getJobStatusMessage } from "../../../jobs/_components/jobs-page-view.messages";
 import { getJobName, jobTone, type ApiJob } from "../../../jobs/_components/jobs-page-view";
 import type { ProjectListRow } from "../../_components/project-list";
+import { projectOverviewPageContentMessages as messages } from "./project-overview-page-content.messages";
 import { ProjectPageShell, useProjectPageQuery } from "./project-page-shell";
 import { useProjectOpenJobCountQuery } from "./use-project-open-job-count";
 import { useProjectOverviewJobsQuery } from "./use-project-overview-jobs";
@@ -68,43 +71,54 @@ function formatLocaleRoute(sourceLocale: string | null, targetLocales: readonly 
   return `${source} → ${preview}${suffix}`;
 }
 
-function buildHeroCopy(filesNeedingAttention: number, pendingCount: number, openJobCount: number) {
+function buildHeroCopy(
+  intl: IntlShape,
+  filesNeedingAttention: number,
+  pendingCount: number,
+  openJobCount: number,
+) {
   if (pendingCount === 0) {
     return {
-      title: "You're all caught up",
-      description:
-        "No pending actions right now. Upload source files or review completed jobs when you're ready to continue.",
-      ctaLabel: "Browse files",
+      title: intl.formatMessage(messages.caughtUpHeroTitle),
+      description: intl.formatMessage(messages.caughtUpHeroDescription),
+      ctaLabel: intl.formatMessage(messages.browseFilesCta),
       ctaHref: "files",
     };
   }
 
   const parts: string[] = [];
   if (openJobCount > 0) {
-    parts.push(`${openJobCount} open ${openJobCount === 1 ? "job" : "jobs"}`);
+    parts.push(intl.formatMessage(messages.openJobsDetail, { count: openJobCount }));
   }
   if (filesNeedingAttention > 0) {
     parts.push(
-      `${filesNeedingAttention} ${filesNeedingAttention === 1 ? "file" : "files"} needing attention`,
+      intl.formatMessage(messages.filesNeedingAttentionDetail, {
+        count: filesNeedingAttention,
+      }),
     );
   }
 
   return {
-    title: "A few things need your attention",
-    description: `Pick up where you left off — ${parts.join(", ")}.`,
-    ctaLabel: "Pick up where you left off",
+    title: intl.formatMessage(messages.attentionHeroTitle),
+    description: intl.formatMessage(messages.attentionHeroDescription, {
+      details: parts.join(", "),
+    }),
+    ctaLabel: intl.formatMessage(messages.pickUpWhereYouLeftOffCta),
     ctaHref: "jobs",
   };
 }
 
-function formatJobStatusLine(job: ApiJob) {
-  return `${job.status.replaceAll("_", " ")} · updated ${formatRelativeTimestamp(job.updatedAt)}`;
+function formatJobStatusLine(intl: IntlShape, job: ApiJob) {
+  return intl.formatMessage(messages.jobStatusUpdated, {
+    status: intl.formatMessage(getJobStatusMessage(job.status)),
+    updated: formatRelativeTimestamp(job.updatedAt),
+  });
 }
 
-function formatFileStatusLine(file: ProjectFileRecord) {
+function formatFileStatusLine(intl: IntlShape, file: ProjectFileRecord) {
   const readiness = resolveFileLocaleReadiness(file);
   const summary = summarizeLocaleReadiness(readiness);
-  return summary ?? "Needs attention";
+  return summary ?? intl.formatMessage(messages.needsAttention);
 }
 
 function fileStatusTone(file: ProjectFileRecord): Tone {
@@ -164,6 +178,7 @@ export function ProjectOverviewPageContentView({
   isFilesError,
   onCreateJob,
 }: ProjectOverviewPageContentViewProps) {
+  const intl = useIntl();
   const filesNeedingAttention = countFilesNeedingAttention(files);
   const pendingCount = project ? computeProjectPendingActionCount({ openJobCount }, files) : 0;
   const ongoingJobs = selectOngoingJobs(jobs);
@@ -175,33 +190,33 @@ export function ProjectOverviewPageContentView({
   );
 
   const heroCopy = project
-    ? buildHeroCopy(filesNeedingAttention, pendingCount, openJobCount)
+    ? buildHeroCopy(intl, filesNeedingAttention, pendingCount, openJobCount)
     : null;
 
   const projectDescription =
     project?.descriptionValue ||
     project?.translationContextValue ||
-    "Project hub for localization work.";
+    intl.formatMessage(messages.defaultProjectDescription);
 
   const snapshotRows = project
     ? [
         {
-          label: "Locales",
+          label: intl.formatMessage(messages.snapshotLocales),
           value: formatLocaleRoute(project.sourceLocale, project.targetLocales),
         },
         {
-          label: "Source",
+          label: intl.formatMessage(messages.snapshotSource),
           value:
             project.source === "external_tms" && project.externalProviderKind
               ? providerLabel(project.externalProviderKind)
-              : "Native project",
+              : intl.formatMessage(messages.nativeProjectSource),
         },
         {
-          label: "Open jobs",
+          label: intl.formatMessage(messages.snapshotOpenJobs),
           value: isOpenJobCountLoading
             ? "…"
             : isOpenJobCountError
-              ? "Unavailable"
+              ? intl.formatMessage(messages.openJobsUnavailable)
               : String(openJobCount),
         },
       ]
@@ -221,16 +236,16 @@ export function ProjectOverviewPageContentView({
           ) : isProjectError ? (
             <>
               <TypographyH1 className="font-sans text-2xl font-medium text-foreground">
-                Project overview
+                <FormattedMessage {...messages.projectOverviewFallbackTitle} />
               </TypographyH1>
               <TypographyP className="text-sm text-muted-foreground">
-                Unable to load project details. Refresh the page or try again in a moment.
+                <FormattedMessage {...messages.loadProjectError} />
               </TypographyP>
             </>
           ) : (
             <>
               <TypographyH1 className="font-sans text-2xl font-medium text-foreground">
-                {project?.name ?? "Project"}
+                {project?.name ?? intl.formatMessage(messages.projectFallbackName)}
               </TypographyH1>
               <TypographyP className="max-w-2xl text-sm leading-6 text-muted-foreground">
                 {projectDescription}
@@ -249,12 +264,12 @@ export function ProjectOverviewPageContentView({
                 variant="outline"
               >
                 <HugeiconsIcon icon={LanguageCircleIcon} strokeWidth={1.8} />
-                View strings
+                <FormattedMessage {...messages.viewStrings} />
               </Button>
             ) : null}
             <Button type="button" size="sm" onClick={onCreateJob}>
               <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
-              Create job
+              <FormattedMessage {...messages.createJob} />
             </Button>
           </div>
         ) : null}
@@ -277,9 +292,9 @@ export function ProjectOverviewPageContentView({
               ctaHref={buildProjectPath(organizationSlug, projectId, heroCopy.ctaHref)}
             />
             <OverviewSnapshotCard
-              title="Project snapshot"
+              title={intl.formatMessage(messages.snapshotTitle)}
               rows={snapshotRows}
-              ctaLabel="View settings"
+              ctaLabel={intl.formatMessage(messages.viewSettings)}
               ctaHref={buildProjectPath(organizationSlug, projectId, "settings")}
             />
           </>
@@ -287,7 +302,10 @@ export function ProjectOverviewPageContentView({
       </section>
 
       <section className="space-y-4">
-        <OverviewSectionHeader title="Ongoing" count={ongoingCount} />
+        <OverviewSectionHeader
+          title={intl.formatMessage(messages.ongoingSection)}
+          count={ongoingCount}
+        />
 
         <div className="grid gap-4 md:grid-cols-2">
           {isJobsLoading || isFilesLoading ? (
@@ -301,9 +319,9 @@ export function ProjectOverviewPageContentView({
                 ongoingJobs.map((job) => (
                   <OverviewActionCard
                     key={job.id}
-                    category="Job"
+                    category={intl.formatMessage(messages.categoryJob)}
                     title={getJobName(job)}
-                    statusLine={formatJobStatusLine(job)}
+                    statusLine={formatJobStatusLine(intl, job)}
                     statusTone={jobTone(job.status)}
                     viewHref={buildProjectJobHref(organizationSlug, projectId, job.id)}
                   />
@@ -313,12 +331,18 @@ export function ProjectOverviewPageContentView({
                   <CardContent className="flex h-full flex-col justify-between gap-4 px-5 py-5">
                     <div>
                       <TypographyP className="text-sm font-medium text-foreground">
-                        {isJobsError ? "Jobs unavailable" : "No active jobs"}
+                        {isJobsError ? (
+                          <FormattedMessage {...messages.jobsUnavailable} />
+                        ) : (
+                          <FormattedMessage {...messages.noActiveJobs} />
+                        )}
                       </TypographyP>
                       <TypographyP className="mt-1 text-sm text-muted-foreground">
-                        {isJobsError
-                          ? "We could not load jobs for this project."
-                          : "Queued, running, and review jobs will appear here."}
+                        {isJobsError ? (
+                          <FormattedMessage {...messages.jobsUnavailableDescription} />
+                        ) : (
+                          <FormattedMessage {...messages.noActiveJobsDescription} />
+                        )}
                       </TypographyP>
                     </div>
                     <Button
@@ -328,7 +352,7 @@ export function ProjectOverviewPageContentView({
                       size="sm"
                       className="w-fit rounded-full"
                     >
-                      View jobs
+                      <FormattedMessage {...messages.viewJobs} />
                     </Button>
                   </CardContent>
                 </Card>
@@ -338,9 +362,9 @@ export function ProjectOverviewPageContentView({
                 attentionFiles.map((file) => (
                   <OverviewActionCard
                     key={file.sourcePath}
-                    category="File"
+                    category={intl.formatMessage(messages.categoryFile)}
                     title={file.filename}
-                    statusLine={formatFileStatusLine(file)}
+                    statusLine={formatFileStatusLine(intl, file)}
                     statusTone={fileStatusTone(file)}
                     viewHref={buildProjectFileHref(organizationSlug, projectId, file.sourcePath)}
                   />
@@ -350,12 +374,18 @@ export function ProjectOverviewPageContentView({
                   <CardContent className="flex h-full flex-col justify-between gap-4 px-5 py-5">
                     <div>
                       <TypographyP className="text-sm font-medium text-foreground">
-                        {isFilesError ? "Files unavailable" : "No files need attention"}
+                        {isFilesError ? (
+                          <FormattedMessage {...messages.filesUnavailable} />
+                        ) : (
+                          <FormattedMessage {...messages.noFilesNeedAttention} />
+                        )}
                       </TypographyP>
                       <TypographyP className="mt-1 text-sm text-muted-foreground">
-                        {isFilesError
-                          ? "We could not load project files."
-                          : "Files with missing or changed translations will appear here."}
+                        {isFilesError ? (
+                          <FormattedMessage {...messages.filesUnavailableDescription} />
+                        ) : (
+                          <FormattedMessage {...messages.noFilesNeedAttentionDescription} />
+                        )}
                       </TypographyP>
                     </div>
                     <Button
@@ -367,7 +397,7 @@ export function ProjectOverviewPageContentView({
                       size="sm"
                       className="w-fit rounded-full"
                     >
-                      View files
+                      <FormattedMessage {...messages.viewFiles} />
                     </Button>
                   </CardContent>
                 </Card>
@@ -382,12 +412,18 @@ export function ProjectOverviewPageContentView({
           <CardContent className="flex flex-col gap-3 px-5 py-5 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <TypographyP className="text-sm font-medium text-foreground">
-                Ready to pull
+                <FormattedMessage {...messages.readyToPullTitle} />
               </TypographyP>
               <TypographyP className="mt-1 text-sm text-muted-foreground">
-                {readyToPullCount} {readyToPullCount === 1 ? "file has" : "files have"} completed
-                translations you can download or sync with{" "}
-                <span className="font-mono text-foreground">sync pull</span>.
+                <FormattedMessage
+                  {...messages.readyToPullDescription}
+                  values={{
+                    count: readyToPullCount,
+                    code: (chunks: ReactNode) => (
+                      <span className="font-mono text-foreground">{chunks}</span>
+                    ),
+                  }}
+                />
               </TypographyP>
             </div>
             <Button
@@ -398,7 +434,7 @@ export function ProjectOverviewPageContentView({
               className="w-fit rounded-full"
             >
               <HugeiconsIcon icon={File01Icon} strokeWidth={1.8} />
-              Open files
+              <FormattedMessage {...messages.openFiles} />
             </Button>
           </CardContent>
         </Card>
@@ -414,6 +450,7 @@ export function ProjectOverviewPageContent({
   organizationSlug: string;
   projectId: string;
 }) {
+  const intl = useIntl();
   const [createJobOpen, setCreateJobOpen] = useState(false);
   const projectQuery = useProjectPageQuery(organizationSlug, projectId);
   const isLiveTmsProject = Boolean(parseProviderProjectId(projectId));
@@ -435,12 +472,15 @@ export function ProjectOverviewPageContent({
         query: { limit: "10" },
       });
       if (!response.ok) {
-        throw await readApiResponseError(response, "Failed to load project files");
+        throw await readApiResponseError(
+          response,
+          intl.formatMessage(messages.loadProjectFilesFailed),
+        );
       }
       const { files } = await parseApiJsonResponse(
         response,
         projectFilesResponseSchema,
-        "Invalid project files response",
+        intl.formatMessage(messages.invalidProjectFilesResponse),
       );
       return files;
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Add **Create job** and **View strings** actions to the Project Overview header so users can start work without leaving the page.

- **Create job** opens the existing `CreateJobDialog` (same as Jobs page) and refreshes overview job data on success.
- **View strings** links to the project Strings page for native and Crowdin projects (same visibility gate as the sidebar Strings item).

Create job dialog polish:
- Task type select shows translated labels (`Translation` / `Proofread`) instead of raw values.
- Description uses the TipTap markdown editor shared with job detail.

Localization:
- Project Overview page copy moved to colocated `*.messages.ts` modules with ICU plurals.
- Shared overview hero/action card badges localized as well.

## How to test

- Open a native or Crowdin project Overview and confirm both buttons appear in the header.
- Click **Create job** and verify the dialog opens and creates a job successfully.
- For Crowdin projects, confirm Task type shows **Translation** / **Proofread** (not `translation` / `proofread`).
- Confirm Description has the TipTap toolbar and accepts markdown.
- Click **View strings** and verify it navigates to `/org/{slug}/projects/{id}/strings`.
- Confirm overview copy renders via react-intl (default English still looks correct).
- Ran `vp check --fix` in `apps/hyperlocalise-web` (pass).

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13d619db-4fc2-42fc-9819-d2c822921827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13d619db-4fc2-42fc-9819-d2c822921827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

