### PR TITLE
feat(web): localize workspace teams UI with react-intl

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/add-team-member-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/add-team-member-dialog.messages.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const addTeamMemberDialogMessages = defineMessages({
+  title: {
+    defaultMessage: "Add team member",
+    id: "Rnm9kBTKL/",
+    description: "Title of the add team member dialog",
+  },
+  description: {
+    defaultMessage:
+      "Assign an existing workspace member to this team. People must already belong to the workspace before they can join a team.",
+    id: "RWjNPOBQ+S",
+    description: "Description of the add team member dialog",
+  },
+  everyoneAlreadyOnTeam: {
+    defaultMessage: "Everyone in this workspace is already on the team.",
+    id: "PXpU01XAii",
+    description: "Empty state when no assignable members remain",
+  },
+  memberLabel: {
+    defaultMessage: "Member",
+    id: "3tBZU7JUcu",
+    description: "Label for the member select in the add team member dialog",
+  },
+  selectMemberPlaceholder: {
+    defaultMessage: "Select a member",
+    id: "oeVZ6ETPjK",
+    description: "Placeholder for the member select",
+  },
+  roleLabel: {
+    defaultMessage: "Role",
+    id: "VaaPQXovs9",
+    description: "Label for the team role select",
+  },
+  cancel: {
+    defaultMessage: "Cancel",
+    id: "j6Jw8eFz2s",
+    description: "Cancel button in the add team member dialog footer",
+  },
+  adding: {
+    defaultMessage: "Adding...",
+    id: "S+mzU53tQz",
+    description: "Submit button label while a member is being added",
+  },
+  addMember: {
+    defaultMessage: "Add member",
+    id: "hiEPeRn6WE",
+    description: "Submit button to add a member to the team",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/add-team-member-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/add-team-member-dialog.tsx
@@ -3,6 +3,7 @@
 import { type FormEvent, useEffect, useId, useState } from "react";
 import { Add01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import type { TeamRole } from "@/api/routes/team/team.schema";
 import { Button } from "@/components/ui/button";
@@ -24,6 +25,7 @@ import {
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 
+import { addTeamMemberDialogMessages } from "./add-team-member-dialog.messages";
 import type { OrganizationMemberDirectoryEntry } from "./teams-api";
 import { getTeamRoleDescription, getTeamRoleLabel } from "./teams-settings-view-model";
 
@@ -42,6 +44,7 @@ export function AddTeamMemberDialog({
   onOpenChange: (open: boolean) => void;
   onSubmit: (input: { workosUserId: string; role: TeamRole }) => void;
 }) {
+  const intl = useIntl();
   const [workosUserId, setWorkosUserId] = useState("");
   const [role, setRole] = useState<TeamRole>("member");
   const memberId = useId();
@@ -79,21 +82,24 @@ export function AddTeamMemberDialog({
       <DialogContent className="border-border bg-background text-foreground sm:max-w-md">
         <form onSubmit={handleSubmit} className="grid gap-4">
           <DialogHeader>
-            <DialogTitle>Add team member</DialogTitle>
+            <DialogTitle>
+              <FormattedMessage {...addTeamMemberDialogMessages.title} />
+            </DialogTitle>
             <DialogDescription>
-              Assign an existing workspace member to this team. People must already belong to the
-              workspace before they can join a team.
+              <FormattedMessage {...addTeamMemberDialogMessages.description} />
             </DialogDescription>
           </DialogHeader>
 
           {assignableMembers.length === 0 ? (
             <p className="text-sm text-muted-foreground">
-              Everyone in this workspace is already on the team.
+              <FormattedMessage {...addTeamMemberDialogMessages.everyoneAlreadyOnTeam} />
             </p>
           ) : (
             <>
               <Field>
-                <FieldLabel htmlFor={memberId}>Member</FieldLabel>
+                <FieldLabel htmlFor={memberId}>
+                  <FormattedMessage {...addTeamMemberDialogMessages.memberLabel} />
+                </FieldLabel>
                 <Select
                   value={workosUserId}
                   onValueChange={(value) => {
@@ -104,7 +110,13 @@ export function AddTeamMemberDialog({
                   disabled={isSaving}
                 >
                   <SelectTrigger id={memberId} className="border-border bg-muted">
-                    <SelectValue placeholder="Select a member">{selectedMemberEmail}</SelectValue>
+                    <SelectValue
+                      placeholder={intl.formatMessage(
+                        addTeamMemberDialogMessages.selectMemberPlaceholder,
+                      )}
+                    >
+                      {selectedMemberEmail}
+                    </SelectValue>
                   </SelectTrigger>
                   <SelectContent>
                     {assignableMembers.map((member) => (
@@ -117,24 +129,26 @@ export function AddTeamMemberDialog({
               </Field>
 
               <Field>
-                <FieldLabel>Role</FieldLabel>
+                <FieldLabel>
+                  <FormattedMessage {...addTeamMemberDialogMessages.roleLabel} />
+                </FieldLabel>
                 <Select
                   value={role}
                   onValueChange={(value) => setRole(value as TeamRole)}
                   disabled={isSaving}
                 >
                   <SelectTrigger className="border-border bg-muted">
-                    <SelectValue>{getTeamRoleLabel(role)}</SelectValue>
+                    <SelectValue>{getTeamRoleLabel(role, intl)}</SelectValue>
                   </SelectTrigger>
                   <SelectContent>
                     {teamRoles.map((teamRole) => (
                       <SelectItem key={teamRole} value={teamRole}>
-                        {getTeamRoleLabel(teamRole)}
+                        {getTeamRoleLabel(teamRole, intl)}
                       </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
-                <FieldDescription>{getTeamRoleDescription(role)}</FieldDescription>
+                <FieldDescription>{getTeamRoleDescription(role, intl)}</FieldDescription>
               </Field>
             </>
           )}
@@ -146,11 +160,15 @@ export function AddTeamMemberDialog({
               disabled={isSaving}
               onClick={() => onOpenChange(false)}
             >
-              Cancel
+              <FormattedMessage {...addTeamMemberDialogMessages.cancel} />
             </Button>
             <Button type="submit" disabled={isSaving || assignableMembers.length === 0}>
               {isSaving ? <Spinner /> : <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />}
-              {isSaving ? "Adding..." : "Add member"}
+              {isSaving ? (
+                <FormattedMessage {...addTeamMemberDialogMessages.adding} />
+              ) : (
+                <FormattedMessage {...addTeamMemberDialogMessages.addMember} />
+              )}
             </Button>
           </DialogFooter>
         </form>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-content.messages.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const teamDetailPageContentMessages = defineMessages({
+  teamUpdated: {
+    defaultMessage: "Team updated",
+    id: "p/PBwViDjv",
+    description: "Toast after team details are updated from the detail page",
+  },
+  memberAdded: {
+    defaultMessage: "Member added to team",
+    id: "118lC+/u/6",
+    description: "Toast after a member is added to a team",
+  },
+  roleUpdated: {
+    defaultMessage: "Team role updated",
+    id: "HGHGAGahop",
+    description: "Toast after a team member’s role is updated",
+  },
+  memberRemoved: {
+    defaultMessage: "Member removed from team",
+    id: "jd3LwSKaUe",
+    description: "Toast after a member is removed from a team",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-content.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useIntl } from "react-intl";
 import { toast } from "sonner";
 
 import type { TeamRole } from "@/api/routes/team/team.schema";
@@ -10,6 +11,7 @@ import { apiClient } from "@/lib/api-client-instance";
 import { createTeamsApi, type TeamMemberRow } from "./teams-api";
 import { toUpdateTeamPayload } from "./team-form";
 import { TeamDetailPageView } from "./team-detail-page-view";
+import { teamDetailPageContentMessages } from "./team-detail-page-content.messages";
 
 const teamsApi = createTeamsApi(apiClient);
 
@@ -34,6 +36,7 @@ export function TeamDetailPageContent({
   currentUserWorkosId: string;
   teamsApi?: typeof teamsApi;
 }) {
+  const intl = useIntl();
   const queryClient = useQueryClient();
   const [isAddMemberOpen, setIsAddMemberOpen] = useState(false);
   const [isEditOpen, setIsEditOpen] = useState(false);
@@ -63,7 +66,7 @@ export function TeamDetailPageContent({
     onSuccess: async () => {
       setIsEditOpen(false);
       await invalidateTeam();
-      toast.success("Team updated");
+      toast.success(intl.formatMessage(teamDetailPageContentMessages.teamUpdated));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -76,7 +79,7 @@ export function TeamDetailPageContent({
     onSuccess: async () => {
       setIsAddMemberOpen(false);
       await invalidateTeam();
-      toast.success("Member added to team");
+      toast.success(intl.formatMessage(teamDetailPageContentMessages.memberAdded));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -88,7 +91,7 @@ export function TeamDetailPageContent({
       injectedTeamsApi.addTeamMember(organizationSlug, teamId, input),
     onSuccess: async () => {
       await invalidateTeam();
-      toast.success("Team role updated");
+      toast.success(intl.formatMessage(teamDetailPageContentMessages.roleUpdated));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -101,7 +104,7 @@ export function TeamDetailPageContent({
     onSuccess: async () => {
       setRemovingMember(null);
       await invalidateTeam();
-      toast.success("Member removed from team");
+      toast.success(intl.formatMessage(teamDetailPageContentMessages.memberRemoved));
     },
     onError: (error) => {
       toast.error(error.message);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.messages.ts
@@ -1,0 +1,142 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const teamDetailPageViewMessages = defineMessages({
+  columnMember: {
+    defaultMessage: "Member",
+    id: "b7wwLWokOY",
+    description: "Team members table column header for member email",
+  },
+  columnRole: {
+    defaultMessage: "Role",
+    id: "1XoRKevTzz",
+    description: "Team members table column header for role",
+  },
+  columnActions: {
+    defaultMessage: "Actions",
+    id: "GRWKZQ9lbF",
+    description: "Screen-reader label for the members table actions column",
+  },
+  actionsForMember: {
+    defaultMessage: "Actions for {email}",
+    id: "jletyEWDwl",
+    description: "Accessible label for a team member row actions menu",
+  },
+  removeFromTeam: {
+    defaultMessage: "Remove from team...",
+    id: "BkNjvJSOTT",
+    description: "Menu item to remove a member from the team",
+  },
+  backToTeams: {
+    defaultMessage: "Back to teams",
+    id: "wtUAi5KCmb",
+    description: "Link back to the workspace teams list",
+  },
+  pageLabel: {
+    defaultMessage: "Team",
+    id: "SFMLZ4RNJi",
+    description: "Eyebrow label above the team detail page title",
+  },
+  pageTitleFallback: {
+    defaultMessage: "Team",
+    id: "gI8N/Ms4so",
+    description: "Fallback team detail page title while the team is loading",
+  },
+  pageDescriptionWithSlug: {
+    defaultMessage: "Manage membership and roles for the {slug} team.",
+    id: "vrxnOkVw+Z",
+    description: "Team detail page description when the team slug is known",
+  },
+  pageDescriptionLoading: {
+    defaultMessage: "Load team membership and roles.",
+    id: "NTnOgDMsrG",
+    description: "Team detail page description while the team is loading",
+  },
+  editTeam: {
+    defaultMessage: "Edit team",
+    id: "cAGL69hzyh",
+    description: "Button to open the edit team dialog on the detail page",
+  },
+  sectionLabel: {
+    defaultMessage: "Team members",
+    id: "3iZn32bnuU",
+    description: "Accessible label for the team members section",
+  },
+  membersHeading: {
+    defaultMessage: "Members",
+    id: "ke25Z8UYMw",
+    description: "Heading above the team members list",
+  },
+  membersDescription: {
+    defaultMessage:
+      "People assigned to this team can access its projects and jobs. Need someone new in the workspace? <invite>Invite a member</invite>.",
+    id: "eKYKN2COzf",
+    description: "Description under the members heading with an invite link",
+  },
+  addMember: {
+    defaultMessage: "Add member",
+    id: "+ImwzEWoEE",
+    description: "Button to open the add team member dialog",
+  },
+  loading: {
+    defaultMessage: "Loading team...",
+    id: "JS3/JRN7Fy",
+    description: "Loading state for the team detail page",
+  },
+  loadFailed: {
+    defaultMessage: "Team failed to load.",
+    id: "dWHXPEdP65",
+    description: "Error heading when a team fails to load",
+  },
+  loadFailedFallback: {
+    defaultMessage: "Refresh the page to try again.",
+    id: "Hemunr1kUc",
+    description: "Fallback error when a team fails to load without a message",
+  },
+  emptyTitle: {
+    defaultMessage: "No members on this team",
+    id: "CS4n4RFeFk",
+    description: "Empty state title when a team has no members",
+  },
+  emptyDescription: {
+    defaultMessage: "Add workspace members to start scoping projects and jobs to this team.",
+    id: "KQDlfibJWf",
+    description: "Empty state description when a team has no members",
+  },
+  youBadge: {
+    defaultMessage: "You",
+    id: "+RWDHuTqY1",
+    description: "Badge marking the current user in the members list",
+  },
+  editTeamTitle: {
+    defaultMessage: "Edit team",
+    id: "McBaOEOgmY",
+    description: "Title of the edit team dialog on the detail page",
+  },
+  editTeamDescription: {
+    defaultMessage: "Update the team name or slug used for project scoping.",
+    id: "9YjuTKjSna",
+    description: "Description of the edit team dialog on the detail page",
+  },
+  removeMemberTitle: {
+    defaultMessage: "Remove team member",
+    id: "UqeBgW87bt",
+    description: "Title of the remove team member confirmation dialog",
+  },
+  removeMemberDescription: {
+    defaultMessage: "{email} will lose access to projects scoped to this team.",
+    id: "Z6vGjRVdyz",
+    description: "Remove member confirmation when the member email is known",
+  },
+  cancel: {
+    defaultMessage: "Cancel",
+    id: "Nx+ZrjUtj2",
+    description: "Cancel button in the remove member dialog",
+  },
+  removeMemberConfirm: {
+    defaultMessage: "Remove member",
+    id: "N/k3pDV14E",
+    description: "Confirm button to remove a team member",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.tsx
@@ -8,6 +8,7 @@ import {
   UserGroupIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import type { TeamRole } from "@/api/routes/team/team.schema";
 import { Badge } from "@/components/ui/badge";
@@ -53,6 +54,7 @@ import {
   listAssignableMembers,
   resolveTeamDetailPageState,
 } from "./teams-settings-view-model";
+import { teamDetailPageViewMessages } from "./team-detail-page-view.messages";
 
 function MembersTableHeader({ showActions }: { showActions: boolean }) {
   return (
@@ -65,11 +67,17 @@ function MembersTableHeader({ showActions }: { showActions: boolean }) {
           : "md:grid-cols-[minmax(0,1.5fr)_12rem]",
       )}
     >
-      <div role="columnheader">Member</div>
-      <div role="columnheader">Role</div>
+      <div role="columnheader">
+        <FormattedMessage {...teamDetailPageViewMessages.columnMember} />
+      </div>
+      <div role="columnheader">
+        <FormattedMessage {...teamDetailPageViewMessages.columnRole} />
+      </div>
       {showActions ? (
         <div role="columnheader" className="text-right">
-          <span className="sr-only">Actions</span>
+          <span className="sr-only">
+            <FormattedMessage {...teamDetailPageViewMessages.columnActions} />
+          </span>
         </div>
       ) : null}
     </div>
@@ -87,6 +95,8 @@ function MemberRowActions({
   isRemovingMember: boolean;
   onRemoveMember: (member: TeamMemberRow) => void;
 }) {
+  const intl = useIntl();
+
   if (!canRemove) {
     return null;
   }
@@ -104,7 +114,9 @@ function MemberRowActions({
               "opacity-100 transition-opacity md:opacity-0 md:group-hover/row:opacity-100 md:group-focus-within/row:opacity-100",
               "data-popup-open:opacity-100 aria-expanded:opacity-100",
             )}
-            aria-label={`Actions for ${member.email}`}
+            aria-label={intl.formatMessage(teamDetailPageViewMessages.actionsForMember, {
+              email: member.email,
+            })}
             disabled={isRemovingMember}
           />
         }
@@ -118,7 +130,7 @@ function MemberRowActions({
             onClick={() => onRemoveMember(member)}
             disabled={isRemovingMember}
           >
-            Remove from team...
+            <FormattedMessage {...teamDetailPageViewMessages.removeFromTeam} />
           </DropdownMenuItem>
         </DropdownMenuGroup>
       </DropdownMenuContent>
@@ -171,6 +183,7 @@ export function TeamDetailPageView({
   onRemoveMember: (workosUserId: string) => void;
   onRemovingMemberChange: (member: TeamMemberRow | null) => void;
 }) {
+  const intl = useIntl();
   const pageState = resolveTeamDetailPageState({
     team,
     canManageTeams,
@@ -194,17 +207,19 @@ export function TeamDetailPageView({
           className="w-fit px-2 text-muted-foreground hover:text-foreground"
         >
           <HugeiconsIcon icon={ArrowLeft01Icon} strokeWidth={1.8} />
-          Back to teams
+          <FormattedMessage {...teamDetailPageViewMessages.backToTeams} />
         </Button>
 
         <PageHeader
           icon={UserGroupIcon}
-          label="Team"
-          title={team?.name ?? "Team"}
+          label={intl.formatMessage(teamDetailPageViewMessages.pageLabel)}
+          title={team?.name ?? intl.formatMessage(teamDetailPageViewMessages.pageTitleFallback)}
           description={
             team
-              ? `Manage membership and roles for the ${team.slug} team.`
-              : "Load team membership and roles."
+              ? intl.formatMessage(teamDetailPageViewMessages.pageDescriptionWithSlug, {
+                  slug: team.slug,
+                })
+              : intl.formatMessage(teamDetailPageViewMessages.pageDescriptionLoading)
           }
           actions={
             pageState.canManageTeams && team ? (
@@ -215,27 +230,36 @@ export function TeamDetailPageView({
                 onClick={() => onEditOpenChange(true)}
                 disabled={isSavingTeam}
               >
-                Edit team
+                <FormattedMessage {...teamDetailPageViewMessages.editTeam} />
               </Button>
             ) : null
           }
         />
       </div>
 
-      <section aria-label="Team members" className="min-w-0">
+      <section
+        aria-label={intl.formatMessage(teamDetailPageViewMessages.sectionLabel)}
+        className="min-w-0"
+      >
         <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <TypographyP className="text-sm font-medium text-foreground">Members</TypographyP>
+            <TypographyP className="text-sm font-medium text-foreground">
+              <FormattedMessage {...teamDetailPageViewMessages.membersHeading} />
+            </TypographyP>
             <TypographyP className="mt-1 text-sm text-muted-foreground">
-              People assigned to this team can access its projects and jobs. Need someone new in the
-              workspace?{" "}
-              <Link
-                href={`/org/${organizationSlug}/members`}
-                className="font-medium text-subtle-foreground underline-offset-4 hover:text-foreground hover:underline"
-              >
-                Invite a member
-              </Link>
-              .
+              <FormattedMessage
+                {...teamDetailPageViewMessages.membersDescription}
+                values={{
+                  invite: (chunks) => (
+                    <Link
+                      href={`/org/${organizationSlug}/members`}
+                      className="font-medium text-subtle-foreground underline-offset-4 hover:text-foreground hover:underline"
+                    >
+                      {chunks}
+                    </Link>
+                  ),
+                }}
+              />
             </TypographyP>
           </div>
           {pageState.canManageMembers ? (
@@ -246,29 +270,33 @@ export function TeamDetailPageView({
               disabled={isAddingMember}
             >
               <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
-              Add member
+              <FormattedMessage {...teamDetailPageViewMessages.addMember} />
             </Button>
           ) : null}
         </div>
 
         {isLoading ? (
-          <TypographyP className="py-8 text-sm text-muted-foreground">Loading team...</TypographyP>
+          <TypographyP className="py-8 text-sm text-muted-foreground">
+            <FormattedMessage {...teamDetailPageViewMessages.loading} />
+          </TypographyP>
         ) : error ? (
           <div className="py-8">
             <TypographyP className="text-sm font-medium text-flame-100">
-              Team failed to load.
+              <FormattedMessage {...teamDetailPageViewMessages.loadFailed} />
             </TypographyP>
             <TypographyP className="mt-1 text-xs text-muted-foreground">
-              {error instanceof Error ? error.message : "Refresh the page to try again."}
+              {error instanceof Error
+                ? error.message
+                : intl.formatMessage(teamDetailPageViewMessages.loadFailedFallback)}
             </TypographyP>
           </div>
         ) : pageState.members.length === 0 ? (
           <div className="py-10">
             <TypographyP className="text-sm font-medium text-foreground">
-              No members on this team
+              <FormattedMessage {...teamDetailPageViewMessages.emptyTitle} />
             </TypographyP>
             <TypographyP className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
-              Add workspace members to start scoping projects and jobs to this team.
+              <FormattedMessage {...teamDetailPageViewMessages.emptyDescription} />
             </TypographyP>
           </div>
         ) : (
@@ -305,7 +333,7 @@ export function TeamDetailPageView({
                       </TypographyP>
                       {isCurrentUser ? (
                         <span className="rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                          You
+                          <FormattedMessage {...teamDetailPageViewMessages.youBadge} />
                         </span>
                       ) : null}
                     </div>
@@ -314,7 +342,7 @@ export function TeamDetailPageView({
                   <div role="cell" className="min-w-0">
                     <div className="flex items-center justify-between gap-3 md:block">
                       <span className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase md:hidden">
-                        Role
+                        <FormattedMessage {...teamDetailPageViewMessages.columnRole} />
                       </span>
                       {canUpdateRole ? (
                         <Select
@@ -332,11 +360,15 @@ export function TeamDetailPageView({
                           disabled={updatingMemberRoleId === member.workosUserId}
                         >
                           <SelectTrigger className="h-9 w-[12rem] max-w-full border-border bg-background/60 text-subtle-foreground hover:bg-muted">
-                            <SelectValue>{getTeamRoleLabel(member.role)}</SelectValue>
+                            <SelectValue>{getTeamRoleLabel(member.role, intl)}</SelectValue>
                           </SelectTrigger>
                           <SelectContent>
-                            <SelectItem value="manager">{getTeamRoleLabel("manager")}</SelectItem>
-                            <SelectItem value="member">{getTeamRoleLabel("member")}</SelectItem>
+                            <SelectItem value="manager">
+                              {getTeamRoleLabel("manager", intl)}
+                            </SelectItem>
+                            <SelectItem value="member">
+                              {getTeamRoleLabel("member", intl)}
+                            </SelectItem>
                           </SelectContent>
                         </Select>
                       ) : (
@@ -350,12 +382,12 @@ export function TeamDetailPageView({
                                   "border-border bg-muted text-subtle-foreground",
                                 )}
                               >
-                                {getTeamRoleLabel(member.role)}
+                                {getTeamRoleLabel(member.role, intl)}
                               </Badge>
                             }
                           />
                           <TooltipContent side="bottom" align="start" className="max-w-xs">
-                            {getTeamRoleDescription(member.role)}
+                            {getTeamRoleDescription(member.role, intl)}
                           </TooltipContent>
                         </Tooltip>
                       )}
@@ -383,8 +415,8 @@ export function TeamDetailPageView({
         <TeamDialog
           open={isEditOpen}
           mode="edit"
-          title="Edit team"
-          description="Update the team name or slug used for project scoping."
+          title={intl.formatMessage(teamDetailPageViewMessages.editTeamTitle)}
+          description={intl.formatMessage(teamDetailPageViewMessages.editTeamDescription)}
           initialValues={createTeamFormFromSummary(team)}
           isSaving={isSavingTeam}
           onOpenChange={onEditOpenChange}
@@ -406,16 +438,20 @@ export function TeamDetailPageView({
       >
         <DialogContent className="border-border bg-background text-foreground sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>Remove team member</DialogTitle>
+            <DialogTitle>
+              <FormattedMessage {...teamDetailPageViewMessages.removeMemberTitle} />
+            </DialogTitle>
             <DialogDescription>
               {removingMember
-                ? `${removingMember.email} will lose access to projects scoped to this team.`
+                ? intl.formatMessage(teamDetailPageViewMessages.removeMemberDescription, {
+                    email: removingMember.email,
+                  })
                 : ""}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => onRemovingMemberChange(null)}>
-              Cancel
+              <FormattedMessage {...teamDetailPageViewMessages.cancel} />
             </Button>
             <Button
               type="button"
@@ -427,7 +463,7 @@ export function TeamDetailPageView({
                 }
               }}
             >
-              Remove member
+              <FormattedMessage {...teamDetailPageViewMessages.removeMemberConfirm} />
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-dialog.messages.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const teamDialogMessages = defineMessages({
+  nameLabel: {
+    defaultMessage: "Name",
+    id: "a74JhYiAwS",
+    description: "Label for the team name field",
+  },
+  namePlaceholder: {
+    defaultMessage: "Localization",
+    id: "jwBq0AHFrW",
+    description: "Placeholder for the team name field",
+  },
+  slugLabel: {
+    defaultMessage: "Slug",
+    id: "V9wej2JTKV",
+    description: "Label for the team slug field",
+  },
+  slugPlaceholder: {
+    defaultMessage: "localization",
+    id: "KHmNU2OTMW",
+    description: "Placeholder for the team slug field",
+  },
+  slugDescription: {
+    defaultMessage:
+      "Used in URLs and project scoping. Lowercase letters, numbers, and hyphens only.",
+    id: "zg0fvgxUv4",
+    description: "Helper text under the team slug field",
+  },
+  cancel: {
+    defaultMessage: "Cancel",
+    id: "kA73rJ1hM2",
+    description: "Cancel button in the team dialog footer",
+  },
+  saving: {
+    defaultMessage: "Saving...",
+    id: "U+Ll/sGDKs",
+    description: "Submit button label while a team is being saved",
+  },
+  createTeam: {
+    defaultMessage: "Create team",
+    id: "NkvwsDHwcu",
+    description: "Submit button to create a team",
+  },
+  saveChanges: {
+    defaultMessage: "Save changes",
+    id: "+HZaUMLm0i",
+    description: "Submit button to save team edits",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-dialog.tsx
@@ -3,6 +3,7 @@
 import { type FormEvent, useEffect, useId, useState } from "react";
 import { SaveIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -17,6 +18,7 @@ import { Field, FieldDescription, FieldError, FieldLabel } from "@/components/ui
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 
+import { teamDialogMessages } from "./team-dialog.messages";
 import {
   createEmptyTeamForm,
   suggestTeamSlug,
@@ -45,6 +47,7 @@ export function TeamDialog({
   onOpenChange: (open: boolean) => void;
   onSubmit: (values: TeamFormValues) => void;
 }) {
+  const intl = useIntl();
   const [values, setValues] = useState<TeamFormValues>(initialValues ?? createEmptyTeamForm());
   const [errors, setErrors] = useState<TeamFormErrors>({});
   const [slugTouched, setSlugTouched] = useState(false);
@@ -62,7 +65,7 @@ export function TeamDialog({
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
-    const nextErrors = validateTeamForm(values, mode);
+    const nextErrors = validateTeamForm(values, mode, { intl });
     setErrors(nextErrors);
 
     if (teamFormHasErrors(nextErrors)) {
@@ -91,7 +94,9 @@ export function TeamDialog({
           </DialogHeader>
 
           <Field>
-            <FieldLabel htmlFor={nameId}>Name</FieldLabel>
+            <FieldLabel htmlFor={nameId}>
+              <FormattedMessage {...teamDialogMessages.nameLabel} />
+            </FieldLabel>
             <Input
               id={nameId}
               value={values.name}
@@ -104,14 +109,16 @@ export function TeamDialog({
               }}
               aria-invalid={Boolean(errors.name)}
               disabled={isSaving}
-              placeholder="Localization"
+              placeholder={intl.formatMessage(teamDialogMessages.namePlaceholder)}
               className="border-border bg-muted"
             />
             <FieldError errors={errors.name ? [{ message: errors.name }] : undefined} />
           </Field>
 
           <Field>
-            <FieldLabel htmlFor={slugId}>Slug</FieldLabel>
+            <FieldLabel htmlFor={slugId}>
+              <FormattedMessage {...teamDialogMessages.slugLabel} />
+            </FieldLabel>
             <Input
               id={slugId}
               value={values.slug}
@@ -121,11 +128,11 @@ export function TeamDialog({
               }}
               aria-invalid={Boolean(errors.slug)}
               disabled={isSaving}
-              placeholder="localization"
+              placeholder={intl.formatMessage(teamDialogMessages.slugPlaceholder)}
               className="border-border bg-muted"
             />
             <FieldDescription>
-              Used in URLs and project scoping. Lowercase letters, numbers, and hyphens only.
+              <FormattedMessage {...teamDialogMessages.slugDescription} />
             </FieldDescription>
             <FieldError errors={errors.slug ? [{ message: errors.slug }] : undefined} />
           </Field>
@@ -137,11 +144,17 @@ export function TeamDialog({
               disabled={isSaving}
               onClick={() => onOpenChange(false)}
             >
-              Cancel
+              <FormattedMessage {...teamDialogMessages.cancel} />
             </Button>
             <Button type="submit" disabled={isSaving}>
               {isSaving ? <Spinner /> : <HugeiconsIcon icon={SaveIcon} strokeWidth={1.8} />}
-              {isSaving ? "Saving..." : mode === "create" ? "Create team" : "Save changes"}
+              {isSaving ? (
+                <FormattedMessage {...teamDialogMessages.saving} />
+              ) : mode === "create" ? (
+                <FormattedMessage {...teamDialogMessages.createTeam} />
+              ) : (
+                <FormattedMessage {...teamDialogMessages.saveChanges} />
+              )}
             </Button>
           </DialogFooter>
         </form>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-form.messages.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const teamFormMessages = defineMessages({
+  nameRequired: {
+    defaultMessage: "Team name is required.",
+    id: "TKbQtKFrh9",
+    description: "Validation error when the team name is empty",
+  },
+  nameTooLong: {
+    defaultMessage: "Team name must be 120 characters or fewer.",
+    id: "R/pK1EOhod",
+    description: "Validation error when the team name exceeds 120 characters",
+  },
+  slugRequired: {
+    defaultMessage: "Team slug is required.",
+    id: "x9bd7qMA5t",
+    description: "Validation error when the team slug is empty",
+  },
+  slugInvalid: {
+    defaultMessage: "Use lowercase letters, numbers, and hyphens only.",
+    id: "mZxMVREyg5",
+    description: "Validation error when the team slug has invalid characters",
+  },
+  slugTooLong: {
+    defaultMessage: "Team slug must be 120 characters or fewer.",
+    id: "XVkuBQ3TjB",
+    description: "Validation error when the team slug exceeds 120 characters",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-form.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-form.ts
@@ -1,7 +1,10 @@
+import type { IntlShape } from "@formatjs/intl";
+
 import { slugifyTeamName } from "@/api/routes/team/team-slug";
 import type { CreateTeamBody, UpdateTeamBody } from "@/api/routes/team/team.schema";
 
 import type { TeamSummaryRow } from "./teams-api";
+import { teamFormMessages } from "./team-form.messages";
 
 export type TeamFormValues = {
   name: string;
@@ -10,7 +13,20 @@ export type TeamFormValues = {
 
 export type TeamFormErrors = Partial<Record<keyof TeamFormValues, string>>;
 
+export type TeamFormIntl = Pick<IntlShape, "formatMessage">;
+
 const slugPattern = /^[a-z0-9-]+$/;
+
+function resolveMessage(
+  intl: TeamFormIntl | undefined,
+  descriptor: (typeof teamFormMessages)[keyof typeof teamFormMessages],
+) {
+  if (intl) {
+    return intl.formatMessage(descriptor);
+  }
+
+  return typeof descriptor.defaultMessage === "string" ? descriptor.defaultMessage : "";
+}
 
 export function createEmptyTeamForm(): TeamFormValues {
   return {
@@ -28,24 +44,29 @@ export function createTeamFormFromSummary(
   };
 }
 
-export function validateTeamForm(values: TeamFormValues, mode: "create" | "edit"): TeamFormErrors {
+export function validateTeamForm(
+  values: TeamFormValues,
+  mode: "create" | "edit",
+  options?: { intl?: TeamFormIntl },
+): TeamFormErrors {
   const errors: TeamFormErrors = {};
   const name = values.name.trim();
   const slug = values.slug.trim();
+  const intl = options?.intl;
 
   if (!name) {
-    errors.name = "Team name is required.";
+    errors.name = resolveMessage(intl, teamFormMessages.nameRequired);
   } else if (name.length > 120) {
-    errors.name = "Team name must be 120 characters or fewer.";
+    errors.name = resolveMessage(intl, teamFormMessages.nameTooLong);
   }
 
   if (mode === "edit" || slug.length > 0) {
     if (!slug) {
-      errors.slug = "Team slug is required.";
+      errors.slug = resolveMessage(intl, teamFormMessages.slugRequired);
     } else if (!slugPattern.test(slug)) {
-      errors.slug = "Use lowercase letters, numbers, and hyphens only.";
+      errors.slug = resolveMessage(intl, teamFormMessages.slugInvalid);
     } else if (slug.length > 120) {
-      errors.slug = "Team slug must be 120 characters or fewer.";
+      errors.slug = resolveMessage(intl, teamFormMessages.slugTooLong);
     }
   }
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-form.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-form.ts
@@ -1,7 +1,10 @@
+"use client";
+
 import type { IntlShape } from "@formatjs/intl";
 
 import { slugifyTeamName } from "@/api/routes/team/team-slug";
 import type { CreateTeamBody, UpdateTeamBody } from "@/api/routes/team/team.schema";
+import { resolveMessage } from "@/lib/app-i18n/resolve-message";
 
 import type { TeamSummaryRow } from "./teams-api";
 import { teamFormMessages } from "./team-form.messages";
@@ -16,17 +19,6 @@ export type TeamFormErrors = Partial<Record<keyof TeamFormValues, string>>;
 export type TeamFormIntl = Pick<IntlShape, "formatMessage">;
 
 const slugPattern = /^[a-z0-9-]+$/;
-
-function resolveMessage(
-  intl: TeamFormIntl | undefined,
-  descriptor: (typeof teamFormMessages)[keyof typeof teamFormMessages],
-) {
-  if (intl) {
-    return intl.formatMessage(descriptor);
-  }
-
-  return typeof descriptor.defaultMessage === "string" ? descriptor.defaultMessage : "";
-}
 
 export function createEmptyTeamForm(): TeamFormValues {
   return {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-page-content.messages.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const teamsPageContentMessages = defineMessages({
+  teamCreated: {
+    defaultMessage: "Team created",
+    id: "FgWgulEUlJ",
+    description: "Toast after a team is created successfully",
+  },
+  teamUpdated: {
+    defaultMessage: "Team updated",
+    id: "BxEHMhUBpO",
+    description: "Toast after a team is updated successfully",
+  },
+  teamDeleted: {
+    defaultMessage: "Team deleted",
+    id: "QZh18oy2Qs",
+    description: "Toast after a team is deleted successfully",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-page-content.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useIntl } from "react-intl";
 import { toast } from "sonner";
 
 import { apiClient } from "@/lib/api-client-instance";
@@ -10,6 +11,7 @@ import { apiClient } from "@/lib/api-client-instance";
 import { createTeamsApi, type TeamSummaryRow } from "./teams-api";
 import { toCreateTeamPayload, toUpdateTeamPayload } from "./team-form";
 import { TeamsPageView } from "./teams-page-view";
+import { teamsPageContentMessages } from "./teams-page-content.messages";
 
 const teamsApi = createTeamsApi(apiClient);
 
@@ -26,6 +28,7 @@ export function TeamsPageContent({
   canManageTeams: boolean;
   teamsApi?: typeof teamsApi;
 }) {
+  const intl = useIntl();
   const router = useRouter();
   const queryClient = useQueryClient();
   const [isCreateOpen, setIsCreateOpen] = useState(false);
@@ -47,7 +50,7 @@ export function TeamsPageContent({
     onSuccess: async (team) => {
       setIsCreateOpen(false);
       await invalidateTeams();
-      toast.success("Team created");
+      toast.success(intl.formatMessage(teamsPageContentMessages.teamCreated));
       router.push(`/org/${organizationSlug}/teams/${team.id}`);
     },
     onError: (error) => {
@@ -70,7 +73,7 @@ export function TeamsPageContent({
     onSuccess: async () => {
       setEditingTeam(null);
       await invalidateTeams();
-      toast.success("Team updated");
+      toast.success(intl.formatMessage(teamsPageContentMessages.teamUpdated));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -88,7 +91,7 @@ export function TeamsPageContent({
     onSuccess: async () => {
       setDeletingTeam(null);
       await invalidateTeams();
-      toast.success("Team deleted");
+      toast.success(intl.formatMessage(teamsPageContentMessages.teamDeleted));
     },
     onError: (error) => {
       toast.error(error.message);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-page-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-page-view.messages.ts
@@ -1,0 +1,153 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const teamsPageViewMessages = defineMessages({
+  columnTeam: {
+    defaultMessage: "Team",
+    id: "h11M7dgCU3",
+    description: "Teams table column header for team name",
+  },
+  columnSlug: {
+    defaultMessage: "Slug",
+    id: "JBzesbmAoL",
+    description: "Teams table column header for team slug",
+  },
+  columnYourRole: {
+    defaultMessage: "Your role",
+    id: "bpqqgx/kva",
+    description: "Teams table column header for the current user’s role",
+  },
+  columnMembers: {
+    defaultMessage: "Members",
+    id: "zZs7tzKcIn",
+    description: "Teams table column header for member count",
+  },
+  columnActions: {
+    defaultMessage: "Actions",
+    id: "3rELHi7DJJ",
+    description: "Screen-reader label for the teams table actions column",
+  },
+  actionsForTeam: {
+    defaultMessage: "Actions for {teamName}",
+    id: "vLcCxwUDbQ",
+    description: "Accessible label for a team row actions menu",
+  },
+  openTeam: {
+    defaultMessage: "Open team",
+    id: "LqefsWsyri",
+    description: "Menu item to open a team detail page",
+  },
+  editTeam: {
+    defaultMessage: "Edit team...",
+    id: "jNzAYm1gdg",
+    description: "Menu item to open the edit team dialog",
+  },
+  manageMembers: {
+    defaultMessage: "Manage members...",
+    id: "waagTqlJ5r",
+    description: "Menu item to manage team members",
+  },
+  deleteTeamMenu: {
+    defaultMessage: "Delete team...",
+    id: "inv55FPnya",
+    description: "Menu item to open the delete team confirmation",
+  },
+  pageLabel: {
+    defaultMessage: "Workspace",
+    id: "9Sp/POP1Pn",
+    description: "Eyebrow label above the teams page title",
+  },
+  pageTitle: {
+    defaultMessage: "Teams",
+    id: "sGkYArMEbA",
+    description: "Teams page title",
+  },
+  pageDescription: {
+    defaultMessage: "Group people into teams to scope projects, jobs, and localization ownership.",
+    id: "zDFrDsXQnc",
+    description: "Teams page description",
+  },
+  createTeam: {
+    defaultMessage: "Create team",
+    id: "kf0aB8NC11",
+    description: "Button to open the create team dialog",
+  },
+  sectionLabel: {
+    defaultMessage: "Workspace teams",
+    id: "9n4esczT5X",
+    description: "Accessible label for the teams list section",
+  },
+  loading: {
+    defaultMessage: "Loading teams...",
+    id: "fpXSPN+8qa",
+    description: "Loading state for the teams list",
+  },
+  loadFailed: {
+    defaultMessage: "Teams failed to load.",
+    id: "uAwYoMQSJA",
+    description: "Error heading when teams fail to load",
+  },
+  loadFailedFallback: {
+    defaultMessage: "Refresh the page to try again.",
+    id: "QHSMConoTh",
+    description: "Fallback error when teams fail to load without a message",
+  },
+  emptyTitle: {
+    defaultMessage: "No teams yet",
+    id: "XzH5GON6Rv",
+    description: "Empty state title when the workspace has no teams",
+  },
+  emptyDescription: {
+    defaultMessage:
+      "Create a team to group workspace members and scope project access. Invite people on the <members>Members</members> page first if your workspace is still empty.",
+    id: "vUbrtmWuOu",
+    description: "Empty state description with a link to the members page",
+  },
+  noRole: {
+    defaultMessage: "—",
+    id: "F7mBujjsRG",
+    description: "Placeholder when the current user has no role on a team",
+  },
+  createTeamTitle: {
+    defaultMessage: "Create team",
+    id: "41LGUaV8nc",
+    description: "Title of the create team dialog",
+  },
+  createTeamDescription: {
+    defaultMessage: "Teams group workspace members and scope which projects they can access.",
+    id: "gesmb9XaV+",
+    description: "Description of the create team dialog",
+  },
+  editTeamTitle: {
+    defaultMessage: "Edit team",
+    id: "YeNii+JHGo",
+    description: "Title of the edit team dialog on the teams list page",
+  },
+  editTeamDescription: {
+    defaultMessage: "Update the team name or slug used across the workspace.",
+    id: "n+YVQESgnK",
+    description: "Description of the edit team dialog on the teams list page",
+  },
+  deleteTeamTitle: {
+    defaultMessage: "Delete team",
+    id: "BavpDSRiE2",
+    description: "Title of the delete team confirmation dialog",
+  },
+  deleteTeamDescription: {
+    defaultMessage:
+      "{teamName} will be removed and members will lose team-scoped access tied to it.",
+    id: "Q2OuXlhfDS",
+    description: "Delete team confirmation when the team name is known",
+  },
+  cancel: {
+    defaultMessage: "Cancel",
+    id: "g1PbE9rfHL",
+    description: "Cancel button in the delete team dialog",
+  },
+  deleteTeamConfirm: {
+    defaultMessage: "Delete team",
+    id: "Yy3NR/q4ik",
+    description: "Confirm button to delete a team",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-page-view.tsx
@@ -9,6 +9,7 @@ import {
   UserGroupIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -38,6 +39,7 @@ import { TeamDialog } from "./team-dialog";
 import type { TeamSummaryRow } from "./teams-api";
 import { createEmptyTeamForm, createTeamFormFromSummary } from "./team-form";
 import { getTeamRoleLabel, resolveTeamsListPageState } from "./teams-settings-view-model";
+import { teamsPageViewMessages } from "./teams-page-view.messages";
 
 export type TeamsLinkRenderer = (props: {
   href: string;
@@ -76,15 +78,23 @@ function TeamsTableHeader({ showActions }: { showActions: boolean }) {
         teamsTableColumns,
       )}
     >
-      <div role="columnheader">Team</div>
-      <div role="columnheader">Slug</div>
-      <div role="columnheader">Your role</div>
+      <div role="columnheader">
+        <FormattedMessage {...teamsPageViewMessages.columnTeam} />
+      </div>
+      <div role="columnheader">
+        <FormattedMessage {...teamsPageViewMessages.columnSlug} />
+      </div>
+      <div role="columnheader">
+        <FormattedMessage {...teamsPageViewMessages.columnYourRole} />
+      </div>
       <div role="columnheader" className="text-right">
-        Members
+        <FormattedMessage {...teamsPageViewMessages.columnMembers} />
       </div>
       {showActions ? (
         <div role="columnheader" className="text-right">
-          <span className="sr-only">Actions</span>
+          <span className="sr-only">
+            <FormattedMessage {...teamsPageViewMessages.columnActions} />
+          </span>
         </div>
       ) : null}
     </div>
@@ -106,6 +116,7 @@ function TeamRowActions({
   onEditTeam: (team: TeamSummaryRow) => void;
   onDeleteTeam: (team: TeamSummaryRow) => void;
 }) {
+  const intl = useIntl();
   const teamHref = `/org/${organizationSlug}/teams/${team.id}`;
 
   return (
@@ -121,7 +132,9 @@ function TeamRowActions({
               "opacity-100 transition-opacity md:opacity-0 md:group-hover/row:opacity-100 md:group-focus-within/row:opacity-100",
               "data-popup-open:opacity-100 aria-expanded:opacity-100",
             )}
-            aria-label={`Actions for ${team.name}`}
+            aria-label={intl.formatMessage(teamsPageViewMessages.actionsForTeam, {
+              teamName: team.name,
+            })}
             disabled={isDeletingTeam}
           />
         }
@@ -130,11 +143,17 @@ function TeamRowActions({
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-48">
         <DropdownMenuGroup>
-          <DropdownMenuItem render={<Link href={teamHref} />}>Open team</DropdownMenuItem>
+          <DropdownMenuItem render={<Link href={teamHref} />}>
+            <FormattedMessage {...teamsPageViewMessages.openTeam} />
+          </DropdownMenuItem>
           {canManageTeams ? (
-            <DropdownMenuItem onClick={() => onEditTeam(team)}>Edit team...</DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onEditTeam(team)}>
+              <FormattedMessage {...teamsPageViewMessages.editTeam} />
+            </DropdownMenuItem>
           ) : null}
-          <DropdownMenuItem render={<Link href={teamHref} />}>Manage members...</DropdownMenuItem>
+          <DropdownMenuItem render={<Link href={teamHref} />}>
+            <FormattedMessage {...teamsPageViewMessages.manageMembers} />
+          </DropdownMenuItem>
         </DropdownMenuGroup>
         {canManageTeams ? (
           <>
@@ -145,7 +164,7 @@ function TeamRowActions({
                 onClick={() => onDeleteTeam(team)}
                 disabled={isDeletingTeam}
               >
-                Delete team...
+                <FormattedMessage {...teamsPageViewMessages.deleteTeamMenu} />
               </DropdownMenuItem>
             </DropdownMenuGroup>
           </>
@@ -194,6 +213,7 @@ export function TeamsPageView({
   onDeleteTeam: () => void;
   renderTeamLink?: TeamsLinkRenderer;
 }) {
+  const intl = useIntl();
   const pageState = resolveTeamsListPageState({ teams, canManageTeams });
 
   return (
@@ -202,9 +222,9 @@ export function TeamsPageView({
 
       <PageHeader
         icon={UserGroupIcon}
-        label="Workspace"
-        title="Teams"
-        description="Group people into teams to scope projects, jobs, and localization ownership."
+        label={intl.formatMessage(teamsPageViewMessages.pageLabel)}
+        title={intl.formatMessage(teamsPageViewMessages.pageTitle)}
+        description={intl.formatMessage(teamsPageViewMessages.pageDescription)}
         actions={
           pageState.canCreateTeam ? (
             <Button
@@ -214,37 +234,50 @@ export function TeamsPageView({
               disabled={isCreating}
             >
               <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
-              Create team
+              <FormattedMessage {...teamsPageViewMessages.createTeam} />
             </Button>
           ) : null
         }
       />
 
-      <section aria-label="Workspace teams" className="min-w-0">
+      <section
+        aria-label={intl.formatMessage(teamsPageViewMessages.sectionLabel)}
+        className="min-w-0"
+      >
         {isLoading ? (
-          <TypographyP className="py-8 text-sm text-muted-foreground">Loading teams...</TypographyP>
+          <TypographyP className="py-8 text-sm text-muted-foreground">
+            <FormattedMessage {...teamsPageViewMessages.loading} />
+          </TypographyP>
         ) : error ? (
           <div className="py-8">
             <TypographyP className="text-sm font-medium text-flame-100">
-              Teams failed to load.
+              <FormattedMessage {...teamsPageViewMessages.loadFailed} />
             </TypographyP>
             <TypographyP className="mt-1 text-xs text-muted-foreground">
-              {error instanceof Error ? error.message : "Refresh the page to try again."}
+              {error instanceof Error
+                ? error.message
+                : intl.formatMessage(teamsPageViewMessages.loadFailedFallback)}
             </TypographyP>
           </div>
         ) : pageState.teams.length === 0 ? (
           <div className="py-10">
-            <TypographyP className="text-sm font-medium text-foreground">No teams yet</TypographyP>
+            <TypographyP className="text-sm font-medium text-foreground">
+              <FormattedMessage {...teamsPageViewMessages.emptyTitle} />
+            </TypographyP>
             <TypographyP className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
-              Create a team to group workspace members and scope project access. Invite people on
-              the{" "}
-              <Link
-                href={`/org/${organizationSlug}/members`}
-                className="font-medium text-subtle-foreground underline-offset-4 hover:text-foreground hover:underline"
-              >
-                Members
-              </Link>{" "}
-              page first if your workspace is still empty.
+              <FormattedMessage
+                {...teamsPageViewMessages.emptyDescription}
+                values={{
+                  members: (chunks) => (
+                    <Link
+                      href={`/org/${organizationSlug}/members`}
+                      className="font-medium text-subtle-foreground underline-offset-4 hover:text-foreground hover:underline"
+                    >
+                      {chunks}
+                    </Link>
+                  ),
+                }}
+              />
             </TypographyP>
           </div>
         ) : (
@@ -291,24 +324,26 @@ export function TeamsPageView({
                 <div role="cell" className="min-w-0">
                   <div className="flex items-center justify-between gap-3 md:block">
                     <span className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase md:hidden">
-                      Your role
+                      <FormattedMessage {...teamsPageViewMessages.columnYourRole} />
                     </span>
                     {team.currentUserRole ? (
                       <Badge
                         variant="outline"
                         className="w-fit rounded-full border-border bg-muted px-2.5 py-0.5 text-xs font-medium text-subtle-foreground"
                       >
-                        {getTeamRoleLabel(team.currentUserRole)}
+                        {getTeamRoleLabel(team.currentUserRole, intl)}
                       </Badge>
                     ) : (
-                      <span className="text-sm text-muted-foreground">—</span>
+                      <span className="text-sm text-muted-foreground">
+                        <FormattedMessage {...teamsPageViewMessages.noRole} />
+                      </span>
                     )}
                   </div>
                 </div>
 
                 <div role="cell" className="flex items-center justify-between gap-3 md:justify-end">
                   <span className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase md:hidden">
-                    Members
+                    <FormattedMessage {...teamsPageViewMessages.columnMembers} />
                   </span>
                   <span
                     className={cn(
@@ -339,8 +374,8 @@ export function TeamsPageView({
       <TeamDialog
         open={isCreateOpen}
         mode="create"
-        title="Create team"
-        description="Teams group workspace members and scope which projects they can access."
+        title={intl.formatMessage(teamsPageViewMessages.createTeamTitle)}
+        description={intl.formatMessage(teamsPageViewMessages.createTeamDescription)}
         initialValues={createEmptyTeamForm()}
         isSaving={isCreating}
         onOpenChange={onCreateOpenChange}
@@ -350,8 +385,8 @@ export function TeamsPageView({
       <TeamDialog
         open={editingTeam !== null}
         mode="edit"
-        title="Edit team"
-        description="Update the team name or slug used across the workspace."
+        title={intl.formatMessage(teamsPageViewMessages.editTeamTitle)}
+        description={intl.formatMessage(teamsPageViewMessages.editTeamDescription)}
         initialValues={editingTeam ? createTeamFormFromSummary(editingTeam) : createEmptyTeamForm()}
         isSaving={isUpdatingTeam}
         onOpenChange={(open) => !open && onEditingTeamChange(null)}
@@ -364,16 +399,20 @@ export function TeamsPageView({
       >
         <DialogContent className="border-border bg-background text-foreground sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>Delete team</DialogTitle>
+            <DialogTitle>
+              <FormattedMessage {...teamsPageViewMessages.deleteTeamTitle} />
+            </DialogTitle>
             <DialogDescription>
               {deletingTeam
-                ? `${deletingTeam.name} will be removed and members will lose team-scoped access tied to it.`
+                ? intl.formatMessage(teamsPageViewMessages.deleteTeamDescription, {
+                    teamName: deletingTeam.name,
+                  })
                 : ""}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => onDeletingTeamChange(null)}>
-              Cancel
+              <FormattedMessage {...teamsPageViewMessages.cancel} />
             </Button>
             <Button
               type="button"
@@ -382,7 +421,7 @@ export function TeamsPageView({
               onClick={onDeleteTeam}
             >
               <HugeiconsIcon icon={Delete01Icon} strokeWidth={1.8} />
-              Delete team
+              <FormattedMessage {...teamsPageViewMessages.deleteTeamConfirm} />
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-settings-view-model.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-settings-view-model.messages.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const teamsSettingsViewModelMessages = defineMessages({
+  roleManager: {
+    defaultMessage: "Manager",
+    id: "KgPZ5Uqgat",
+    description: "Team role label for managers",
+  },
+  roleMember: {
+    defaultMessage: "Member",
+    id: "OZfnTzJi03",
+    description: "Team role label for members",
+  },
+  roleManagerDescription: {
+    defaultMessage: "Can add or remove people and update team membership roles.",
+    id: "AHcGbeiVhJ",
+    description: "Tooltip describing the team manager role",
+  },
+  roleMemberDescription: {
+    defaultMessage: "Can access projects and work assigned to this team.",
+    id: "Z91mmC1MhD",
+    description: "Tooltip describing the team member role",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-settings-view-model.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-settings-view-model.ts
@@ -1,6 +1,9 @@
+"use client";
+
 import type { IntlShape } from "@formatjs/intl";
 
 import type { TeamRole } from "@/api/routes/team/team.schema";
+import { resolveMessage } from "@/lib/app-i18n/resolve-message";
 
 import type {
   OrganizationMemberDirectoryEntry,
@@ -11,17 +14,6 @@ import type {
 import { teamsSettingsViewModelMessages } from "./teams-settings-view-model.messages";
 
 export type TeamsSettingsIntl = Pick<IntlShape, "formatMessage">;
-
-function resolveMessage(
-  intl: TeamsSettingsIntl | undefined,
-  descriptor: (typeof teamsSettingsViewModelMessages)[keyof typeof teamsSettingsViewModelMessages],
-) {
-  if (intl) {
-    return intl.formatMessage(descriptor);
-  }
-
-  return typeof descriptor.defaultMessage === "string" ? descriptor.defaultMessage : "";
-}
 
 const teamRoleLabelMessages = {
   manager: teamsSettingsViewModelMessages.roleManager,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-settings-view-model.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-settings-view-model.ts
@@ -1,3 +1,5 @@
+import type { IntlShape } from "@formatjs/intl";
+
 import type { TeamRole } from "@/api/routes/team/team.schema";
 
 import type {
@@ -6,23 +8,37 @@ import type {
   TeamMemberRow,
   TeamSummaryRow,
 } from "./teams-api";
+import { teamsSettingsViewModelMessages } from "./teams-settings-view-model.messages";
 
-const teamRoleLabels: Record<TeamRole, string> = {
-  manager: "Manager",
-  member: "Member",
-};
+export type TeamsSettingsIntl = Pick<IntlShape, "formatMessage">;
 
-const teamRoleDescriptions: Record<TeamRole, string> = {
-  manager: "Can add or remove people and update team membership roles.",
-  member: "Can access projects and work assigned to this team.",
-};
+function resolveMessage(
+  intl: TeamsSettingsIntl | undefined,
+  descriptor: (typeof teamsSettingsViewModelMessages)[keyof typeof teamsSettingsViewModelMessages],
+) {
+  if (intl) {
+    return intl.formatMessage(descriptor);
+  }
 
-export function getTeamRoleLabel(role: TeamRole) {
-  return teamRoleLabels[role];
+  return typeof descriptor.defaultMessage === "string" ? descriptor.defaultMessage : "";
 }
 
-export function getTeamRoleDescription(role: TeamRole) {
-  return teamRoleDescriptions[role];
+const teamRoleLabelMessages = {
+  manager: teamsSettingsViewModelMessages.roleManager,
+  member: teamsSettingsViewModelMessages.roleMember,
+} as const;
+
+const teamRoleDescriptionMessages = {
+  manager: teamsSettingsViewModelMessages.roleManagerDescription,
+  member: teamsSettingsViewModelMessages.roleMemberDescription,
+} as const;
+
+export function getTeamRoleLabel(role: TeamRole, intl?: TeamsSettingsIntl) {
+  return resolveMessage(intl, teamRoleLabelMessages[role]);
+}
+
+export function getTeamRoleDescription(role: TeamRole, intl?: TeamsSettingsIntl) {
+  return resolveMessage(intl, teamRoleDescriptionMessages[role]);
 }
 
 export function resolveTeamsListPageState(input: {

--- a/apps/hyperlocalise-web/src/lib/app-i18n/resolve-message.ts
+++ b/apps/hyperlocalise-web/src/lib/app-i18n/resolve-message.ts
@@ -1,0 +1,17 @@
+import type { IntlShape } from "@formatjs/intl";
+import type { MessageDescriptor } from "react-intl";
+
+export type ResolveMessageIntl = Pick<IntlShape, "formatMessage">;
+
+/** Formats with intl when available; otherwise returns string `defaultMessage`. */
+export function resolveMessage(
+  intl: ResolveMessageIntl | undefined,
+  descriptor: MessageDescriptor,
+  values?: Record<string, string>,
+): string {
+  if (intl) {
+    return intl.formatMessage(descriptor, values);
+  }
+
+  return typeof descriptor.defaultMessage === "string" ? descriptor.defaultMessage : "";
+}


### PR DESCRIPTION
## What changed

Localize hardcoded user-facing copy in the workspace teams `_components` folder with react-intl (ICU):

- Colocated `*.messages.ts` modules for list/detail pages, dialogs, form validation, role labels, and toasts
- Client components use `<FormattedMessage>` / `useIntl().formatMessage`
- `team-form` and role helpers accept optional `intl` (same pattern as projects)
- Rich-text messages for Members / invite links

## How to test

- [ ] Open `/org/{slug}/teams` — headers, empty/loading/error states, create/edit/delete dialogs, toasts
- [ ] Open a team detail page — members table, add/remove member, role labels, edit team
- [ ] `cd apps/hyperlocalise-web && vp lint -- src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components`
- [ ] `cd apps/hyperlocalise-web && vp test -- src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components`

## Checklist

- [x] I ran relevant checks locally (`vp lint`, `vp test` on teams `_components`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review