### PR TITLE
fix(web): remove misleading Sync labels from live TMS UI

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/tms-provider-credential-panel.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/tms-provider-credential-panel.messages.ts
@@ -196,8 +196,8 @@ export const tmsProviderCredentialPanelMessages = defineMessages({
   },
   saveCredentialsIntro: {
     defaultMessage:
-      "Save credentials to connect {providerName}. The secret is encrypted at rest and used to sync projects, files, and jobs into the workspace.",
-    id: "YOCao9EtJ4",
+      "Save credentials to connect {providerName}. The secret is encrypted at rest and used for live API calls to projects, files, and jobs.",
+    id: "bR6xM3pQeL",
     description: "Intro text before saving API token credentials for a TMS provider",
   },
   displayNameLabel: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/tms-provider-credential-panel.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/tms-provider-credential-panel.messages.ts
@@ -197,7 +197,7 @@ export const tmsProviderCredentialPanelMessages = defineMessages({
   saveCredentialsIntro: {
     defaultMessage:
       "Save credentials to connect {providerName}. The secret is encrypted at rest and used for live API calls to projects, files, and jobs.",
-    id: "bR6xM3pQeL",
+    id: "Sc1cRdhWAf",
     description: "Intro text before saving API token credentials for a TMS provider",
   },
   displayNameLabel: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-kanban-board.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-kanban-board.messages.ts
@@ -22,10 +22,10 @@ export const jobsKanbanBoardMessages = defineMessages({
     id: "mYcDqMLO3I",
     description: "Fallback project badge when a kanban job has no project name",
   },
-  dueSyncedMeta: {
-    defaultMessage: "Due {due} · Synced {synced}",
-    id: "WL/j4jcqMB",
-    description: "Relative due date and last sync time on a kanban job card",
+  dueMeta: {
+    defaultMessage: "Due {due}",
+    id: "wN7cF5yKpA",
+    description: "Relative due date on a kanban job card",
   },
   noJobs: {
     defaultMessage: "No jobs",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-kanban-board.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-kanban-board.messages.ts
@@ -24,7 +24,7 @@ export const jobsKanbanBoardMessages = defineMessages({
   },
   dueMeta: {
     defaultMessage: "Due {due}",
-    id: "wN7cF5yKpA",
+    id: "kPJq84MgiE",
     description: "Relative due date on a kanban job card",
   },
   noJobs: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-kanban-board.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-kanban-board.tsx
@@ -145,10 +145,9 @@ function JobKanbanCard({
       </TypographyP>
       <TypographyP className="mt-1 text-[11px] text-muted-foreground">
         <FormattedMessage
-          {...jobsKanbanBoardMessages.dueSyncedMeta}
+          {...jobsKanbanBoardMessages.dueMeta}
           values={{
             due: formatRelativeTime(job.externalDueDate, now),
-            synced: formatRelativeTime(job.updatedAt, now),
           }}
         />
       </TypographyP>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.messages.ts
@@ -93,10 +93,10 @@ export const jobsPageViewMessages = defineMessages({
     id: "3n0F65flH2",
     description: "Fallback label when a job has no project name",
   },
-  dueSyncedMeta: {
-    defaultMessage: "Due {due} · Synced {synced}",
-    id: "7M3ajU1pAe",
-    description: "Relative due date and last sync time under job task details",
+  dueMeta: {
+    defaultMessage: "Due {due}",
+    id: "kP9mR2wLxN",
+    description: "Relative due date under job task details",
   },
   viewModeAriaLabel: {
     defaultMessage: "Jobs view mode",
@@ -219,8 +219,8 @@ export const jobsPageViewMessages = defineMessages({
     description: "Project page section label for the jobs view",
   },
   projectSectionDescription: {
-    defaultMessage: "Translation, review, QA, and sync work from Hyperlocalise and your TMS.",
-    id: "v0xJPzewtL",
+    defaultMessage: "Translation, review, and QA work from Hyperlocalise and your TMS.",
+    id: "hT4nQ8vBcR",
     description: "Project page section description for the jobs view",
   },
   workspaceLabel: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.messages.ts
@@ -95,7 +95,7 @@ export const jobsPageViewMessages = defineMessages({
   },
   dueMeta: {
     defaultMessage: "Due {due}",
-    id: "kP9mR2wLxN",
+    id: "GvcjcKm7Sc",
     description: "Relative due date under job task details",
   },
   viewModeAriaLabel: {
@@ -220,7 +220,7 @@ export const jobsPageViewMessages = defineMessages({
   },
   projectSectionDescription: {
     defaultMessage: "Translation, review, and QA work from Hyperlocalise and your TMS.",
-    id: "hT4nQ8vBcR",
+    id: "zjUiRNln1O",
     description: "Project page section description for the jobs view",
   },
   workspaceLabel: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
@@ -494,10 +494,9 @@ function JobsList({
                   </TypographyP>
                   <TypographyP className="mt-1 truncate text-xs text-muted-foreground">
                     <FormattedMessage
-                      {...jobsPageViewMessages.dueSyncedMeta}
+                      {...jobsPageViewMessages.dueMeta}
                       values={{
                         due: formatRelativeTime(job.externalDueDate, now),
-                        synced: formatRelativeTime(job.updatedAt, now),
                       }}
                     />
                   </TypographyP>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section-view.tsx
@@ -167,7 +167,6 @@ export function JobProviderDetailSectionView({
           <dl className="mt-3 divide-y divide-border">
             <DetailRow label="Provider title" value={job.externalTitle} />
             <DetailRow label="Provider status" value={job.externalStatus} />
-            <DetailRow label="Sync state" value={job.externalSyncState} />
             {job.externalProviderKind === "crowdin" ? (
               <>
                 <DetailRow

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/synced-job-source-files-section.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/synced-job-source-files-section.tsx
@@ -44,7 +44,7 @@ export function SyncedJobSourceFilesSection({
       projectId={projectId}
       encodedJobId={encodedJobId}
       files={files}
-      emptyMessage="No synced source files linked to this job."
+      emptyMessage="No source files linked to this job."
       highlightLocale={highlightLocale ?? null}
       queueFilter={queueFilter}
     />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Live TMS jobs set `updatedAt` to “now” on every API fetch, so the jobs list/kanban showed **Synced now** even though nothing was synced. TMS data is live API, not a background sync.

- Jobs list and kanban: show `Due {due}` only (drop `Synced {synced}`)
- Provider details: remove the Sync state row
- TMS credential intro: describe live API calls instead of syncing into the workspace
- Job source-files empty state and project jobs section copy: drop sync wording

## How to test

1. Connect a TMS provider and open Jobs (workspace or project scope).
2. Confirm job rows/cards show due date only — no “Synced now”.
3. Open a live TMS job’s Provider Details and confirm Sync state is gone.
4. Open Integrations → manage a TMS credential and confirm the intro mentions live API calls.

```
cd apps/hyperlocalise-web && vp test 'src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs' && vp check --fix
```

## Checklist

- [x] I ran relevant checks locally (`vp test` on jobs paths, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fac879b-71be-4752-af5d-7a3e65d0f2d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fac879b-71be-4752-af5d-7a3e65d0f2d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

