### PR TITLE
feat(web): add hreflang and canonical alternates for marketing SEO

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/legal-page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/legal-page.tsx
@@ -2,6 +2,8 @@ import type { ReactNode } from "react";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { TypographyH1, TypographyH2, TypographyP } from "@/components/ui/typography";
+import type { AppLocale } from "@/lib/app-i18n/locales";
+import { getLocalizedAlternates } from "@/lib/seo/localized-alternates";
 
 type LegalPageProps = {
   eyebrow: string;
@@ -13,13 +15,18 @@ type LegalPageProps = {
 export function createLegalMetadata({
   title,
   description,
+  locale,
+  path,
 }: {
   title: string;
   description: string;
+  locale: AppLocale;
+  path: "/terms" | "/privacy";
 }): Metadata {
   return {
     title,
     description,
+    alternates: getLocalizedAlternates({ locale, path }),
   };
 }
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/blog/[slug]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/blog/[slug]/page.tsx
@@ -4,13 +4,22 @@ import { notFound } from "next/navigation";
 
 import { BlogPostPage } from "@/components/marketing/blog/blog-post-page";
 import { JsonLd } from "@/components/seo/json-ld";
-import { SUPPORTED_APP_LOCALES } from "@/lib/app-i18n/locales";
+import {
+  DEFAULT_APP_LOCALE,
+  normalizeAppLocale,
+  SUPPORTED_APP_LOCALES,
+  type AppLocale,
+} from "@/lib/app-i18n/locales";
 import { getPostBySlug, getPostSlugs, getRelevantPosts } from "@/lib/blog/blog-post";
 import { getBlogPostPath } from "@/lib/blog/blog-post-path";
 import { getBlogPostCoverAbsoluteUrl } from "@/lib/blog/get-blog-post-cover-url";
 import { markdownToHtml } from "@/lib/blog/markdown-to-html";
+import { getLocalizedAlternates } from "@/lib/seo/localized-alternates";
+import { SITE_URL } from "@/lib/seo/site-url";
 
-const BASE_URL = "https://www.hyperlocalise.com";
+function getLocalesWithBlogPost(slug: string): AppLocale[] {
+  return SUPPORTED_APP_LOCALES.filter((locale) => getPostBySlug(slug, locale) != null);
+}
 
 type BlogPostRouteParams = {
   lang: string;
@@ -29,17 +38,24 @@ export function generateStaticParams() {
 
 export async function generateMetadata({ params }: BlogPostRouteProps): Promise<Metadata> {
   const { lang, slug } = await params;
-  const post = getPostBySlug(slug, lang);
+  const locale = normalizeAppLocale(lang) ?? DEFAULT_APP_LOCALE;
+  const post = getPostBySlug(slug, locale);
 
   if (!post) {
     return {};
   }
 
-  const imageUrl = getBlogPostCoverAbsoluteUrl(post, lang, BASE_URL);
+  const imageUrl = getBlogPostCoverAbsoluteUrl(post, locale, SITE_URL);
+  const availableLocales = getLocalesWithBlogPost(slug);
 
   return {
     title: `${post.title} | Hyperlocalise`,
     description: post.excerpt,
+    alternates: getLocalizedAlternates({
+      locale,
+      path: `/blog/${post.slug}`,
+      locales: availableLocales,
+    }),
     openGraph: {
       title: post.title,
       description: post.excerpt,
@@ -58,8 +74,8 @@ export async function generateMetadata({ params }: BlogPostRouteProps): Promise<
 
 function buildArticleJsonLd(post: NonNullable<ReturnType<typeof getPostBySlug>>, lang: string) {
   const postPath = getBlogPostPath(lang, post.slug);
-  const canonicalUrl = postPath ? `${BASE_URL}${postPath}` : `${BASE_URL}/${lang}/blog`;
-  const imageUrl = getBlogPostCoverAbsoluteUrl(post, lang, BASE_URL);
+  const canonicalUrl = postPath ? `${SITE_URL}${postPath}` : `${SITE_URL}/${lang}/blog`;
+  const imageUrl = getBlogPostCoverAbsoluteUrl(post, lang, SITE_URL);
 
   const articleSchema: WithContext<Article> = {
     "@context": "https://schema.org",
@@ -77,14 +93,14 @@ function buildArticleJsonLd(post: NonNullable<ReturnType<typeof getPostBySlug>>,
     author: {
       "@type": "Organization",
       name: "Hyperlocalise",
-      url: BASE_URL,
+      url: SITE_URL,
     },
     publisher: {
       "@type": "Organization",
       name: "Hyperlocalise",
       logo: {
         "@type": "ImageObject",
-        url: `${BASE_URL}/images/logo.png`,
+        url: `${SITE_URL}/images/logo.png`,
       },
     },
   };

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/blog/[slug]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/blog/[slug]/page.tsx
@@ -72,10 +72,13 @@ export async function generateMetadata({ params }: BlogPostRouteProps): Promise<
   };
 }
 
-function buildArticleJsonLd(post: NonNullable<ReturnType<typeof getPostBySlug>>, lang: string) {
-  const postPath = getBlogPostPath(lang, post.slug);
-  const canonicalUrl = postPath ? `${SITE_URL}${postPath}` : `${SITE_URL}/${lang}/blog`;
-  const imageUrl = getBlogPostCoverAbsoluteUrl(post, lang, SITE_URL);
+function buildArticleJsonLd(
+  post: NonNullable<ReturnType<typeof getPostBySlug>>,
+  locale: AppLocale,
+) {
+  const postPath = getBlogPostPath(locale, post.slug);
+  const canonicalUrl = postPath ? `${SITE_URL}${postPath}` : `${SITE_URL}/${locale}/blog`;
+  const imageUrl = getBlogPostCoverAbsoluteUrl(post, locale, SITE_URL);
 
   const articleSchema: WithContext<Article> = {
     "@context": "https://schema.org",
@@ -110,20 +113,26 @@ function buildArticleJsonLd(post: NonNullable<ReturnType<typeof getPostBySlug>>,
 
 export default async function BlogPostRoute({ params }: BlogPostRouteProps) {
   const { lang, slug } = await params;
-  const post = getPostBySlug(slug, lang);
+  const locale = normalizeAppLocale(lang) ?? DEFAULT_APP_LOCALE;
+  const post = getPostBySlug(slug, locale);
 
   if (!post) {
     notFound();
   }
 
   const htmlContent = await markdownToHtml(post.content);
-  const jsonLd = buildArticleJsonLd(post, lang);
-  const relatedPosts = getRelevantPosts(slug, lang);
+  const jsonLd = buildArticleJsonLd(post, locale);
+  const relatedPosts = getRelevantPosts(slug, locale);
 
   return (
     <>
       <JsonLd data={jsonLd} />
-      <BlogPostPage htmlContent={htmlContent} lang={lang} post={post} relatedPosts={relatedPosts} />
+      <BlogPostPage
+        htmlContent={htmlContent}
+        lang={locale}
+        post={post}
+        relatedPosts={relatedPosts}
+      />
     </>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/blog/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/blog/page.tsx
@@ -3,6 +3,8 @@ import type { Metadata } from "next";
 import { BlogIndexPage } from "@/components/marketing/blog/blog-index-page";
 import { getAllPosts } from "@/lib/blog/blog-post";
 import { getIntlShape } from "@/lib/app-i18n/intl";
+import { DEFAULT_APP_LOCALE, normalizeAppLocale } from "@/lib/app-i18n/locales";
+import { getLocalizedAlternates } from "@/lib/seo/localized-alternates";
 
 import { getBlogRouteMetadata } from "./blog-route-metadata";
 
@@ -12,12 +14,14 @@ type BlogIndexRouteProps = {
 
 export async function generateMetadata({ params }: BlogIndexRouteProps): Promise<Metadata> {
   const { lang } = await params;
-  const intl = getIntlShape(lang);
+  const locale = normalizeAppLocale(lang) ?? DEFAULT_APP_LOCALE;
+  const intl = getIntlShape(locale);
   const metadata = getBlogRouteMetadata(intl);
 
   return {
     title: metadata.title,
     description: metadata.description,
+    alternates: getLocalizedAlternates({ locale, path: "/blog" }),
     openGraph: {
       title: metadata.title,
       description: metadata.description,

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/page.tsx
@@ -12,7 +12,9 @@ import {
   RecentBlogPostsSection,
 } from "@/components/marketing";
 import { getIntlShape } from "@/lib/app-i18n/intl";
+import { DEFAULT_APP_LOCALE, normalizeAppLocale } from "@/lib/app-i18n/locales";
 import { getAllPosts } from "@/lib/blog/blog-post";
+import { getLocalizedAlternates } from "@/lib/seo/localized-alternates";
 
 const metadataKeywords = [
   "localisation",
@@ -30,7 +32,8 @@ type HomePageProps = {
 
 export async function generateMetadata({ params }: HomePageProps): Promise<Metadata> {
   const { lang } = await params;
-  const intl = getIntlShape(lang);
+  const locale = normalizeAppLocale(lang) ?? DEFAULT_APP_LOCALE;
+  const intl = getIntlShape(locale);
 
   const title = intl.formatMessage({
     defaultMessage: "Hyperlocalise | Localisation Platform for the Agentic Era",
@@ -55,6 +58,7 @@ export async function generateMetadata({ params }: HomePageProps): Promise<Metad
     title,
     description,
     keywords: [...metadataKeywords],
+    alternates: getLocalizedAlternates({ locale, path: "/" }),
     openGraph: {
       title,
       description: openGraphDescription,

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/privacy/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/privacy/page.tsx
@@ -1,10 +1,25 @@
-import { createLegalMetadata, LegalList, LegalPage, LegalSection } from "../_components/legal-page";
+import type { Metadata } from "next";
+
+import { DEFAULT_APP_LOCALE, normalizeAppLocale } from "@/lib/app-i18n/locales";
 import { TypographyP } from "@/components/ui/typography";
 
-export const metadata = createLegalMetadata({
-  title: "Privacy policy",
-  description: "How Hyperlocalise handles account, usage, and provider-related data.",
-});
+import { createLegalMetadata, LegalList, LegalPage, LegalSection } from "../_components/legal-page";
+
+type PrivacyPageProps = {
+  params: Promise<{ lang: string }>;
+};
+
+export async function generateMetadata({ params }: PrivacyPageProps): Promise<Metadata> {
+  const { lang } = await params;
+  const locale = normalizeAppLocale(lang) ?? DEFAULT_APP_LOCALE;
+
+  return createLegalMetadata({
+    title: "Privacy policy",
+    description: "How Hyperlocalise handles account, usage, and provider-related data.",
+    locale,
+    path: "/privacy",
+  });
+}
 
 export default function PrivacyPage() {
   return (

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/product/[slug]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/product/[slug]/page.tsx
@@ -3,7 +3,12 @@ import { notFound } from "next/navigation";
 
 import { ProductPage, productPagesBySlug, productSlugs } from "@/components/marketing/product";
 import { getIntlShape } from "@/lib/app-i18n/intl";
-import { SUPPORTED_APP_LOCALES } from "@/lib/app-i18n/locales";
+import {
+  DEFAULT_APP_LOCALE,
+  normalizeAppLocale,
+  SUPPORTED_APP_LOCALES,
+} from "@/lib/app-i18n/locales";
+import { getLocalizedAlternates } from "@/lib/seo/localized-alternates";
 
 import { getProductRouteMetadata } from "./product-route-metadata";
 
@@ -28,7 +33,8 @@ export async function generateMetadata({ params }: ProductRouteProps): Promise<M
     return {};
   }
 
-  const intl = getIntlShape(lang);
+  const locale = normalizeAppLocale(lang) ?? DEFAULT_APP_LOCALE;
+  const intl = getIntlShape(locale);
   const metadata = getProductRouteMetadata(slug, intl);
 
   if (!metadata) {
@@ -41,6 +47,7 @@ export async function generateMetadata({ params }: ProductRouteProps): Promise<M
     title,
     description,
     keywords: content.metadata.keywords,
+    alternates: getLocalizedAlternates({ locale, path: `/product/${slug}` }),
     openGraph: {
       title,
       description,

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/terms/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/terms/page.tsx
@@ -1,10 +1,26 @@
-import { createLegalMetadata, LegalList, LegalPage, LegalSection } from "../_components/legal-page";
+import type { Metadata } from "next";
+
+import { DEFAULT_APP_LOCALE, normalizeAppLocale } from "@/lib/app-i18n/locales";
 import { TypographyP } from "@/components/ui/typography";
 
-export const metadata = createLegalMetadata({
-  title: "Terms of service",
-  description: "The baseline terms that govern use of Hyperlocalise websites, docs, and services.",
-});
+import { createLegalMetadata, LegalList, LegalPage, LegalSection } from "../_components/legal-page";
+
+type TermsPageProps = {
+  params: Promise<{ lang: string }>;
+};
+
+export async function generateMetadata({ params }: TermsPageProps): Promise<Metadata> {
+  const { lang } = await params;
+  const locale = normalizeAppLocale(lang) ?? DEFAULT_APP_LOCALE;
+
+  return createLegalMetadata({
+    title: "Terms of service",
+    description:
+      "The baseline terms that govern use of Hyperlocalise websites, docs, and services.",
+    locale,
+    path: "/terms",
+  });
+}
 
 export default function TermsPage() {
   return (

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/trust-center/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/trust-center/page.tsx
@@ -4,18 +4,30 @@ import { MarketingFooter } from "@/components/marketing/marketing-footer";
 import { footerColumns } from "@/components/marketing/marketing-page-content";
 import { Button } from "@/components/ui/button";
 import { TypographyH1, TypographyH2, TypographyH3, TypographyP } from "@/components/ui/typography";
+import { DEFAULT_APP_LOCALE, normalizeAppLocale } from "@/lib/app-i18n/locales";
+import { getLocalizedAlternates } from "@/lib/seo/localized-alternates";
 
-export const metadata: Metadata = {
-  title: "Trust Center",
-  description:
-    "Security, subprocessor, privacy, and certification status information for Hyperlocalise.",
-  openGraph: {
-    title: "Hyperlocalise Trust Center",
-    description:
-      "Security, subprocessor, privacy, and certification status information for Hyperlocalise.",
-    type: "website",
-  },
+type TrustCenterPageProps = {
+  params: Promise<{ lang: string }>;
 };
+
+export async function generateMetadata({ params }: TrustCenterPageProps): Promise<Metadata> {
+  const { lang } = await params;
+  const locale = normalizeAppLocale(lang) ?? DEFAULT_APP_LOCALE;
+  const description =
+    "Security, subprocessor, privacy, and certification status information for Hyperlocalise.";
+
+  return {
+    title: "Trust Center",
+    description,
+    alternates: getLocalizedAlternates({ locale, path: "/trust-center" }),
+    openGraph: {
+      title: "Hyperlocalise Trust Center",
+      description,
+      type: "website",
+    },
+  };
+}
 
 const securityPractices = [
   {

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/use-cases/[slug]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/use-cases/[slug]/page.tsx
@@ -3,7 +3,12 @@ import { notFound } from "next/navigation";
 
 import { UseCasePage, useCasePagesBySlug, useCaseSlugs } from "@/components/marketing/use-case";
 import { getIntlShape } from "@/lib/app-i18n/intl";
-import { SUPPORTED_APP_LOCALES } from "@/lib/app-i18n/locales";
+import {
+  DEFAULT_APP_LOCALE,
+  normalizeAppLocale,
+  SUPPORTED_APP_LOCALES,
+} from "@/lib/app-i18n/locales";
+import { getLocalizedAlternates } from "@/lib/seo/localized-alternates";
 
 import { getUseCaseRouteMetadata } from "./use-case-route-metadata";
 
@@ -28,7 +33,8 @@ export async function generateMetadata({ params }: UseCaseRouteProps): Promise<M
     return {};
   }
 
-  const intl = getIntlShape(lang);
+  const locale = normalizeAppLocale(lang) ?? DEFAULT_APP_LOCALE;
+  const intl = getIntlShape(locale);
   const metadata = getUseCaseRouteMetadata(slug, intl);
 
   if (!metadata) {
@@ -41,6 +47,7 @@ export async function generateMetadata({ params }: UseCaseRouteProps): Promise<M
     title,
     description,
     keywords: content.metadata.keywords,
+    alternates: getLocalizedAlternates({ locale, path: `/use-cases/${slug}` }),
     openGraph: {
       title,
       description,

--- a/apps/hyperlocalise-web/src/app/layout.tsx
+++ b/apps/hyperlocalise-web/src/app/layout.tsx
@@ -10,6 +10,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { getAppLocale } from "@/lib/app-i18n/server-locale";
 import type { AppLocale } from "@/lib/app-i18n/locales";
+import { SITE_URL } from "@/lib/seo/site-url";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { cn } from "@/lib/primitives/cn";
 import "./globals.css";
@@ -55,6 +56,7 @@ function headingFontForLocale(locale: AppLocale) {
 }
 
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: "Hyperlocalise | Localisation for the Agentic Era",
   description:
     "Localisation for the Agentic Era. Hyperlocalise helps teams review multilingual product copy for quality, nuance, and release safety before it ships.",

--- a/apps/hyperlocalise-web/src/app/robots.ts
+++ b/apps/hyperlocalise-web/src/app/robots.ts
@@ -1,8 +1,7 @@
 import { MetadataRoute } from "next";
 
 import { SUPPORTED_APP_LOCALES } from "@/lib/app-i18n/locales";
-
-const BASE_URL = "https://www.hyperlocalise.com";
+import { SITE_URL } from "@/lib/seo/site-url";
 
 export default function robots(): MetadataRoute.Robots {
   const protectedLocalizedDisallows = SUPPORTED_APP_LOCALES.flatMap((locale) => [
@@ -16,6 +15,6 @@ export default function robots(): MetadataRoute.Robots {
       allow: "/",
       disallow: ["/auth/", "/api/", "/mcp", ...protectedLocalizedDisallows],
     },
-    sitemap: `${BASE_URL}/sitemap.xml`,
+    sitemap: `${SITE_URL}/sitemap.xml`,
   };
 }

--- a/apps/hyperlocalise-web/src/app/sitemap.test.ts
+++ b/apps/hyperlocalise-web/src/app/sitemap.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { SUPPORTED_APP_LOCALES } from "@/lib/app-i18n/locales";
+import { SITE_URL } from "@/lib/seo/site-url";
+
+import sitemap from "./sitemap";
+
+describe("sitemap", () => {
+  it("includes hreflang language alternates for localized marketing URLs", () => {
+    const entries = sitemap();
+    const homeEn = entries.find((entry) => entry.url === `${SITE_URL}/en`);
+
+    expect(homeEn?.alternates?.languages).toEqual({
+      en: `${SITE_URL}/en`,
+      "zh-CN": `${SITE_URL}/zh-CN`,
+      "vi-VN": `${SITE_URL}/vi-VN`,
+      "de-DE": `${SITE_URL}/de-DE`,
+      "fr-FR": `${SITE_URL}/fr-FR`,
+      "x-default": `${SITE_URL}/en`,
+    });
+
+    for (const locale of SUPPORTED_APP_LOCALES) {
+      const blogIndex = entries.find((entry) => entry.url === `${SITE_URL}/${locale}/blog`);
+      expect(blogIndex?.alternates?.languages?.["x-default"]).toBe(`${SITE_URL}/en/blog`);
+      expect(blogIndex?.alternates?.languages?.[locale]).toBe(`${SITE_URL}/${locale}/blog`);
+    }
+  });
+
+  it("keeps the non-localized install URL without language alternates", () => {
+    const entries = sitemap();
+    const install = entries.find((entry) => entry.url === `${SITE_URL}/install`);
+
+    expect(install).toBeDefined();
+    expect(install?.alternates).toBeUndefined();
+  });
+});

--- a/apps/hyperlocalise-web/src/app/sitemap.ts
+++ b/apps/hyperlocalise-web/src/app/sitemap.ts
@@ -2,56 +2,89 @@ import { MetadataRoute } from "next";
 
 import { productSlugs } from "@/components/marketing/product";
 import { useCaseSlugs } from "@/components/marketing/use-case";
-import { SUPPORTED_APP_LOCALES } from "@/lib/app-i18n/locales";
-import { getAllPosts, parseBlogPostDate } from "@/lib/blog/blog-post";
+import { SUPPORTED_APP_LOCALES, type AppLocale } from "@/lib/app-i18n/locales";
+import { getAllPosts, getPostBySlug, parseBlogPostDate } from "@/lib/blog/blog-post";
 import { getBlogPostPath } from "@/lib/blog/blog-post-path";
+import {
+  getLocalizedAbsoluteUrl,
+  getSitemapLanguageAlternates,
+} from "@/lib/seo/localized-alternates";
+import { SITE_URL } from "@/lib/seo/site-url";
 
-const BASE_URL = "https://www.hyperlocalise.com";
-
-function localizedPath(locale: string, path = "/") {
-  return path === "/" ? `/${locale}` : `/${locale}${path}`;
-}
-
-function localizedUrl(locale: string, path = "/") {
-  return `${BASE_URL}${localizedPath(locale, path)}`;
+function localizedSitemapEntry({
+  locale,
+  path,
+  lastModified,
+  changeFrequency,
+  priority,
+  locales = SUPPORTED_APP_LOCALES,
+}: {
+  locale: AppLocale;
+  path: string;
+  lastModified: Date;
+  changeFrequency: NonNullable<MetadataRoute.Sitemap[number]["changeFrequency"]>;
+  priority: number;
+  locales?: readonly AppLocale[];
+}): MetadataRoute.Sitemap[number] {
+  return {
+    url: getLocalizedAbsoluteUrl(locale, path),
+    lastModified,
+    changeFrequency,
+    priority,
+    alternates: {
+      languages: getSitemapLanguageAlternates(path, locales),
+    },
+  };
 }
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const now = new Date();
-  const localizedStaticPaths = ["/", "/terms", "/privacy", "/trust-center"];
+  const localizedStaticPaths = [
+    { path: "/", changeFrequency: "weekly" as const, priority: 1 },
+    { path: "/terms", changeFrequency: "monthly" as const, priority: 0.5 },
+    { path: "/privacy", changeFrequency: "monthly" as const, priority: 0.5 },
+    { path: "/trust-center", changeFrequency: "monthly" as const, priority: 0.5 },
+  ];
+
   const localizedStaticEntries: MetadataRoute.Sitemap = SUPPORTED_APP_LOCALES.flatMap((locale) =>
-    localizedStaticPaths.map((path) => ({
-      url: localizedUrl(locale, path),
-      lastModified: now,
-      changeFrequency: path === "/" ? "weekly" : "monthly",
-      priority: path === "/" ? 1 : 0.5,
-    })),
+    localizedStaticPaths.map(({ path, changeFrequency, priority }) =>
+      localizedSitemapEntry({ locale, path, lastModified: now, changeFrequency, priority }),
+    ),
   );
 
   const productEntries: MetadataRoute.Sitemap = SUPPORTED_APP_LOCALES.flatMap((locale) =>
-    productSlugs.map((slug) => ({
-      url: localizedUrl(locale, `/product/${slug}`),
-      lastModified: now,
-      changeFrequency: "monthly",
-      priority: 0.8,
-    })),
+    productSlugs.map((slug) =>
+      localizedSitemapEntry({
+        locale,
+        path: `/product/${slug}`,
+        lastModified: now,
+        changeFrequency: "monthly",
+        priority: 0.8,
+      }),
+    ),
   );
 
   const useCaseEntries: MetadataRoute.Sitemap = SUPPORTED_APP_LOCALES.flatMap((locale) =>
-    useCaseSlugs.map((slug) => ({
-      url: localizedUrl(locale, `/use-cases/${slug}`),
-      lastModified: now,
-      changeFrequency: "monthly",
-      priority: 0.8,
-    })),
+    useCaseSlugs.map((slug) =>
+      localizedSitemapEntry({
+        locale,
+        path: `/use-cases/${slug}`,
+        lastModified: now,
+        changeFrequency: "monthly",
+        priority: 0.8,
+      }),
+    ),
   );
 
-  const blogIndexEntries: MetadataRoute.Sitemap = SUPPORTED_APP_LOCALES.map((locale) => ({
-    url: localizedUrl(locale, "/blog"),
-    lastModified: now,
-    changeFrequency: "weekly",
-    priority: 0.7,
-  }));
+  const blogIndexEntries: MetadataRoute.Sitemap = SUPPORTED_APP_LOCALES.map((locale) =>
+    localizedSitemapEntry({
+      locale,
+      path: "/blog",
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 0.7,
+    }),
+  );
 
   const blogPostEntries: MetadataRoute.Sitemap = SUPPORTED_APP_LOCALES.flatMap((locale) =>
     getAllPosts(locale).flatMap((post) => {
@@ -65,13 +98,19 @@ export default function sitemap(): MetadataRoute.Sitemap {
         return [];
       }
 
+      const availableLocales = SUPPORTED_APP_LOCALES.filter(
+        (candidateLocale) => getPostBySlug(post.slug, candidateLocale) != null,
+      );
+
       return [
-        {
-          url: `${BASE_URL}${postPath}`,
+        localizedSitemapEntry({
+          locale,
+          path: `/blog/${post.slug}`,
           lastModified,
-          changeFrequency: "monthly" as const,
+          changeFrequency: "monthly",
           priority: 0.7,
-        },
+          locales: availableLocales,
+        }),
       ];
     }),
   );
@@ -79,7 +118,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   return [
     ...localizedStaticEntries,
     {
-      url: `${BASE_URL}/install`,
+      url: `${SITE_URL}/install`,
       lastModified: now,
       changeFrequency: "weekly",
       priority: 0.8,

--- a/apps/hyperlocalise-web/src/lib/seo/localized-alternates.test.ts
+++ b/apps/hyperlocalise-web/src/lib/seo/localized-alternates.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { DEFAULT_APP_LOCALE, SUPPORTED_APP_LOCALES } from "@/lib/app-i18n/locales";
+
+import {
+  getLocalizedAbsoluteUrl,
+  getLocalizedAlternates,
+  getSitemapLanguageAlternates,
+} from "./localized-alternates";
+import { SITE_URL } from "./site-url";
+
+describe("getLocalizedAbsoluteUrl", () => {
+  it("builds home and nested paths with the locale prefix", () => {
+    expect(getLocalizedAbsoluteUrl("en")).toBe(`${SITE_URL}/en`);
+    expect(getLocalizedAbsoluteUrl("zh-CN", "/")).toBe(`${SITE_URL}/zh-CN`);
+    expect(getLocalizedAbsoluteUrl("fr-FR", "/blog")).toBe(`${SITE_URL}/fr-FR/blog`);
+    expect(getLocalizedAbsoluteUrl("de-DE", "/blog/hello-world")).toBe(
+      `${SITE_URL}/de-DE/blog/hello-world`,
+    );
+  });
+
+  it("normalizes missing leading slash and trailing slash", () => {
+    expect(getLocalizedAbsoluteUrl("en", "terms")).toBe(`${SITE_URL}/en/terms`);
+    expect(getLocalizedAbsoluteUrl("en", "/terms/")).toBe(`${SITE_URL}/en/terms`);
+  });
+});
+
+describe("getLocalizedAlternates", () => {
+  it("sets canonical for the current locale and hreflang for every supported locale", () => {
+    const alternates = getLocalizedAlternates({ locale: "vi-VN", path: "/product/agents" });
+
+    expect(alternates.canonical).toBe(`${SITE_URL}/vi-VN/product/agents`);
+    expect(alternates.languages).toEqual({
+      en: `${SITE_URL}/en/product/agents`,
+      "zh-CN": `${SITE_URL}/zh-CN/product/agents`,
+      "vi-VN": `${SITE_URL}/vi-VN/product/agents`,
+      "de-DE": `${SITE_URL}/de-DE/product/agents`,
+      "fr-FR": `${SITE_URL}/fr-FR/product/agents`,
+      "x-default": `${SITE_URL}/en/product/agents`,
+    });
+    expect(Object.keys(alternates.languages ?? {}).filter((key) => key !== "x-default")).toEqual(
+      expect.arrayContaining([...SUPPORTED_APP_LOCALES]),
+    );
+  });
+
+  it("limits hreflang to the locales that actually have the page", () => {
+    const alternates = getLocalizedAlternates({
+      locale: "en",
+      path: "/blog/partial-post",
+      locales: ["en", "de-DE"],
+    });
+
+    expect(alternates.languages).toEqual({
+      en: `${SITE_URL}/en/blog/partial-post`,
+      "de-DE": `${SITE_URL}/de-DE/blog/partial-post`,
+      "x-default": `${SITE_URL}/en/blog/partial-post`,
+    });
+  });
+
+  it("omits x-default when the default locale is not among available locales", () => {
+    const alternates = getLocalizedAlternates({
+      locale: "fr-FR",
+      path: "/blog/fr-only",
+      locales: ["fr-FR", "de-DE"],
+    });
+
+    expect(alternates.languages).toEqual({
+      "fr-FR": `${SITE_URL}/fr-FR/blog/fr-only`,
+      "de-DE": `${SITE_URL}/de-DE/blog/fr-only`,
+    });
+    expect(alternates.languages).not.toHaveProperty("x-default");
+    expect(DEFAULT_APP_LOCALE).toBe("en");
+  });
+});
+
+describe("getSitemapLanguageAlternates", () => {
+  it("returns the same language map used for metadata hreflang", () => {
+    expect(getSitemapLanguageAlternates("/trust-center")).toEqual(
+      getLocalizedAlternates({ locale: "en", path: "/trust-center" }).languages,
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/seo/localized-alternates.ts
+++ b/apps/hyperlocalise-web/src/lib/seo/localized-alternates.ts
@@ -35,39 +35,7 @@ export type LocalizedAlternatesOptions = {
   locales?: readonly AppLocale[];
 };
 
-/**
- * Builds Next.js `metadata.alternates` with a canonical URL and hreflang language map,
- * including `x-default` pointing at the default app locale (English).
- */
-export function getLocalizedAlternates({
-  locale,
-  path,
-  locales = SUPPORTED_APP_LOCALES,
-}: LocalizedAlternatesOptions): NonNullable<Metadata["alternates"]> {
-  const languages: Record<string, string> = {};
-
-  for (const appLocale of locales) {
-    languages[appLocale] = getLocalizedAbsoluteUrl(appLocale, path);
-  }
-
-  if (locales.includes(DEFAULT_APP_LOCALE)) {
-    languages["x-default"] = getLocalizedAbsoluteUrl(DEFAULT_APP_LOCALE, path);
-  }
-
-  return {
-    canonical: getLocalizedAbsoluteUrl(locale, path),
-    languages,
-  };
-}
-
-/**
- * Language alternate map for a sitemap entry (`alternates.languages`).
- * Same shape as metadata hreflang, including `x-default`.
- */
-export function getSitemapLanguageAlternates(
-  path: string,
-  locales: readonly AppLocale[] = SUPPORTED_APP_LOCALES,
-): NonNullable<NonNullable<MetadataRoute.Sitemap[number]["alternates"]>["languages"]> {
+function buildLanguageMap(path: string, locales: readonly AppLocale[]): Record<string, string> {
   const languages: Record<string, string> = {};
 
   for (const appLocale of locales) {
@@ -79,4 +47,30 @@ export function getSitemapLanguageAlternates(
   }
 
   return languages;
+}
+
+/**
+ * Builds Next.js `metadata.alternates` with a canonical URL and hreflang language map,
+ * including `x-default` pointing at the default app locale (English).
+ */
+export function getLocalizedAlternates({
+  locale,
+  path,
+  locales = SUPPORTED_APP_LOCALES,
+}: LocalizedAlternatesOptions): NonNullable<Metadata["alternates"]> {
+  return {
+    canonical: getLocalizedAbsoluteUrl(locale, path),
+    languages: buildLanguageMap(path, locales),
+  };
+}
+
+/**
+ * Language alternate map for a sitemap entry (`alternates.languages`).
+ * Same shape as metadata hreflang, including `x-default`.
+ */
+export function getSitemapLanguageAlternates(
+  path: string,
+  locales: readonly AppLocale[] = SUPPORTED_APP_LOCALES,
+): NonNullable<NonNullable<MetadataRoute.Sitemap[number]["alternates"]>["languages"]> {
+  return buildLanguageMap(path, locales);
 }

--- a/apps/hyperlocalise-web/src/lib/seo/localized-alternates.ts
+++ b/apps/hyperlocalise-web/src/lib/seo/localized-alternates.ts
@@ -1,0 +1,82 @@
+import type { Metadata } from "next";
+import type { MetadataRoute } from "next";
+
+import { DEFAULT_APP_LOCALE, SUPPORTED_APP_LOCALES, type AppLocale } from "@/lib/app-i18n/locales";
+
+import { SITE_URL } from "./site-url";
+
+function normalizeLocalizedPath(path: string): string {
+  if (!path || path === "/") {
+    return "/";
+  }
+
+  const withLeadingSlash = path.startsWith("/") ? path : `/${path}`;
+  return withLeadingSlash.length > 1 && withLeadingSlash.endsWith("/")
+    ? withLeadingSlash.slice(0, -1)
+    : withLeadingSlash;
+}
+
+/** Absolute URL for a locale + locale-free path. */
+export function getLocalizedAbsoluteUrl(locale: AppLocale, path: string = "/"): string {
+  const normalizedPath = normalizeLocalizedPath(path);
+  const pathname = normalizedPath === "/" ? `/${locale}` : `/${locale}${normalizedPath}`;
+  return `${SITE_URL}${pathname}`;
+}
+
+export type LocalizedAlternatesOptions = {
+  /** Current page locale (used for `canonical`). */
+  locale: AppLocale;
+  /** Locale-free path, e.g. `/blog/my-post`. */
+  path: string;
+  /**
+   * Locales that have an equivalent page. Defaults to all supported app locales.
+   * Pass a subset for content that is not available in every locale (e.g. a blog post).
+   */
+  locales?: readonly AppLocale[];
+};
+
+/**
+ * Builds Next.js `metadata.alternates` with a canonical URL and hreflang language map,
+ * including `x-default` pointing at the default app locale (English).
+ */
+export function getLocalizedAlternates({
+  locale,
+  path,
+  locales = SUPPORTED_APP_LOCALES,
+}: LocalizedAlternatesOptions): NonNullable<Metadata["alternates"]> {
+  const languages: Record<string, string> = {};
+
+  for (const appLocale of locales) {
+    languages[appLocale] = getLocalizedAbsoluteUrl(appLocale, path);
+  }
+
+  if (locales.includes(DEFAULT_APP_LOCALE)) {
+    languages["x-default"] = getLocalizedAbsoluteUrl(DEFAULT_APP_LOCALE, path);
+  }
+
+  return {
+    canonical: getLocalizedAbsoluteUrl(locale, path),
+    languages,
+  };
+}
+
+/**
+ * Language alternate map for a sitemap entry (`alternates.languages`).
+ * Same shape as metadata hreflang, including `x-default`.
+ */
+export function getSitemapLanguageAlternates(
+  path: string,
+  locales: readonly AppLocale[] = SUPPORTED_APP_LOCALES,
+): NonNullable<NonNullable<MetadataRoute.Sitemap[number]["alternates"]>["languages"]> {
+  const languages: Record<string, string> = {};
+
+  for (const appLocale of locales) {
+    languages[appLocale] = getLocalizedAbsoluteUrl(appLocale, path);
+  }
+
+  if (locales.includes(DEFAULT_APP_LOCALE)) {
+    languages["x-default"] = getLocalizedAbsoluteUrl(DEFAULT_APP_LOCALE, path);
+  }
+
+  return languages;
+}

--- a/apps/hyperlocalise-web/src/lib/seo/site-url.ts
+++ b/apps/hyperlocalise-web/src/lib/seo/site-url.ts
@@ -1,0 +1,2 @@
+/** Canonical public origin for marketing SEO (canonical, hreflang, sitemap, robots). */
+export const SITE_URL = "https://www.hyperlocalise.com";


### PR DESCRIPTION
## What changed

Adds hreflang + canonical locale alternates for localized marketing pages so search engines can relate language variants (`en`, `zh-CN`, `vi-VN`, `de-DE`, `fr-FR`, plus `x-default` → English).

- Shared helpers in `src/lib/seo/` for absolute localized URLs and Next.js `metadata.alternates`
- Wired into home, blog index/posts, product, use-cases, terms, privacy, and trust center
- Sitemap entries now include matching `alternates.languages`
- Blog posts only emit hreflang for locales that actually have the post
- Sets root `metadataBase` and centralizes `SITE_URL`

## How to test

- [ ] `cd apps/hyperlocalise-web && vp test src/lib/seo/localized-alternates.test.ts src/app/sitemap.test.ts src/app/robots.test.ts`
- [ ] `cd apps/hyperlocalise-web && vp check --fix`
- [ ] View source on a marketing page (e.g. `/en/blog`) and confirm `rel="canonical"` plus `rel="alternate" hreflang="…"` links for each locale and `x-default`
- [ ] Confirm `/sitemap.xml` includes language alternates on localized URLs

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review