### PR TITLE
feat(web): add chat dock mock to marketing home

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/page.tsx
@@ -6,6 +6,7 @@ import { chapters, footerColumns } from "@/components/marketing/marketing-page-c
 import { JsonLd } from "@/components/seo/json-ld";
 import {
   ChapterSection,
+  ChatDockMockSection,
   FinalCtaSection,
   HeroSection,
   PrinciplesSection,
@@ -107,6 +108,10 @@ export default async function Home({ params }: HomePageProps) {
         <main className="mx-auto max-w-7xl">
           <section className=" px-5 pb-14 pt-8 sm:px-8 lg:px-10 lg:pt-10">
             <HeroSection />
+          </section>
+
+          <section className="px-5 py-16 sm:px-8 lg:px-10">
+            <ChatDockMockSection />
           </section>
 
           <section className="px-5 py-16 sm:px-8 lg:px-10">

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/page.tsx
@@ -4,9 +4,9 @@ import { WebApplication } from "schema-dts";
 import { MarketingFooter } from "@/components/marketing/marketing-footer";
 import { chapters, footerColumns } from "@/components/marketing/marketing-page-content";
 import { JsonLd } from "@/components/seo/json-ld";
+import { ChatDockMockSection } from "@/components/marketing/chat-dock-mock";
 import {
   ChapterSection,
-  ChatDockMockSection,
   FinalCtaSection,
   HeroSection,
   PrinciplesSection,

--- a/apps/hyperlocalise-web/src/components/marketing/chapter-section.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/chapter-section.tsx
@@ -47,7 +47,7 @@ export function ChapterSection({ chapter }: { chapter: MarketingChapter }) {
     <section>
       <div className="max-w-2xl space-y-1.5">
         <div className="mt-6 text-sm text-muted-foreground">
-          {chapter.id} <FormattedMessage {...marketingPageMessages[chapter.labelKey]} />
+          <FormattedMessage {...marketingPageMessages[chapter.labelKey]} />
         </div>
         <TypographyH2 className="text-4xl sm:text-5xl">
           <FormattedMessage {...marketingPageMessages[chapter.titleKey]} />
@@ -74,9 +74,9 @@ export function ChapterSection({ chapter }: { chapter: MarketingChapter }) {
       </div>
 
       <div className="mt-8 grid gap-4 text-sm text-muted-foreground sm:grid-cols-2 lg:grid-cols-4">
-        {chapter.linkKeys.map((linkKey, index) => (
+        {chapter.linkKeys.map((linkKey) => (
           <div key={linkKey}>
-            {chapter.id}.{index + 1} <FormattedMessage {...marketingPageMessages[linkKey]} />
+            <FormattedMessage {...marketingPageMessages[linkKey]} />
           </div>
         ))}
       </div>

--- a/apps/hyperlocalise-web/src/components/marketing/chat-dock-mock.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/chat-dock-mock.messages.ts
@@ -1,0 +1,107 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const chatDockMockMessages = defineMessages({
+  sectionEyebrow: {
+    defaultMessage: "Inbox",
+    id: "k8mN2pQxR1",
+    description: "Eyebrow label above the marketing chat dock mock section",
+  },
+  sectionTitle: {
+    defaultMessage: "Ask any string. Get repo-backed context.",
+    id: "v3Lw9sHtY2",
+    description: "Title for the marketing chat dock mock section",
+  },
+  sectionBody: {
+    defaultMessage:
+      "Open the chat dock from review, ask what a string means, and watch agents search the repository before they answer.",
+    id: "b7Fq4nUcE5",
+    description: "Supporting copy for the marketing chat dock mock section",
+  },
+  featuresLabel: {
+    defaultMessage: "Features",
+    id: "p2Rd6aKmZ8",
+    description: "Label above the feature list beside the chat dock mock",
+  },
+  featureContextDiscovery: {
+    defaultMessage: "Context auto-discovery",
+    id: "w5Hj1cVoL3",
+    description: "Feature label next to the chat dock mock",
+  },
+  featureRepositorySearch: {
+    defaultMessage: "Repository search",
+    id: "n9Xs7eBpQ4",
+    description: "Feature label next to the chat dock mock",
+  },
+  featureTranslationGuidance: {
+    defaultMessage: "Translation guidance",
+    id: "t4Yu8gCfM6",
+    description: "Feature label next to the chat dock mock",
+  },
+  featureHumanReview: {
+    defaultMessage: "Human review first-class",
+    id: "m1Za3iDkN7",
+    description: "Feature label next to the chat dock mock",
+  },
+  dockTitle: {
+    defaultMessage: "New AI chat",
+    id: "c6Eb2oPrS9",
+    description: "Title shown in the marketing chat dock mock window header",
+  },
+  emptyTitle: {
+    defaultMessage: "How can I help you today?",
+    id: "h0Jl5qWtU2",
+    description: "Empty-state heading inside the marketing chat dock mock",
+  },
+  emptySubtitle: {
+    defaultMessage: "Ask about strings, context, progress, or translations",
+    id: "r8Kn6fXyV1",
+    description: "Empty-state subtitle inside the marketing chat dock mock",
+  },
+  contextPill: {
+    defaultMessage: "Save",
+    id: "d3Po9sAzW4",
+    description: "Context pill label for the Save string in the chat dock mock",
+  },
+  composerPlaceholder: {
+    defaultMessage: "Ask, search, or make anything…",
+    id: "f7Qi4bGxY5",
+    description: "Placeholder shown in the marketing chat dock mock composer",
+  },
+  sendLabel: {
+    defaultMessage: "Send",
+    id: "g2Rw8cHvZ6",
+    description: "Accessible label for the send button in the chat dock mock",
+  },
+  replayLabel: {
+    defaultMessage: "Replay",
+    id: "j5Tx1dKuA7",
+    description: "Button label to replay the chat dock mock interaction",
+  },
+  collapseLabel: {
+    defaultMessage: "Collapse panel",
+    id: "l9Uy3eJvB8",
+    description: "Decorative collapse control label in the chat dock mock",
+  },
+  closeLabel: {
+    defaultMessage: "Close",
+    id: "o4Vz6fIwC9",
+    description: "Decorative close control label in the chat dock mock",
+  },
+  backgroundDocTitle: {
+    defaultMessage: "account.settings.save",
+    id: "q8Wa7gJxD1",
+    description: "Key shown on the background document peek behind the chat dock",
+  },
+  backgroundDocSource: {
+    defaultMessage: "Save",
+    id: "s1Xb9hKyE2",
+    description: "Source string shown on the background document peek",
+  },
+  backgroundDocMeta: {
+    defaultMessage: "Settings · Primary action",
+    id: "u5Yc2iLzF3",
+    description: "Meta line on the background document peek behind the chat dock",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/marketing/chat-dock-mock.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/chat-dock-mock.messages.ts
@@ -5,103 +5,103 @@ import { defineMessages } from "react-intl";
 export const chatDockMockMessages = defineMessages({
   sectionEyebrow: {
     defaultMessage: "Inbox",
-    id: "k8mN2pQxR1",
+    id: "LKzEjgHAIl",
     description: "Eyebrow label above the marketing chat dock mock section",
   },
   sectionTitle: {
     defaultMessage: "Ask any string. Get repo-backed context.",
-    id: "v3Lw9sHtY2",
+    id: "DZx5zjElsr",
     description: "Title for the marketing chat dock mock section",
   },
   sectionBody: {
     defaultMessage:
       "Open the chat dock from review, ask what a string means, and watch agents search the repository before they answer.",
-    id: "b7Fq4nUcE5",
+    id: "wwAfUYqWC+",
     description: "Supporting copy for the marketing chat dock mock section",
   },
   featuresLabel: {
     defaultMessage: "Features",
-    id: "p2Rd6aKmZ8",
+    id: "ojxwGqk22y",
     description: "Label above the feature list beside the chat dock mock",
   },
   featureContextDiscovery: {
     defaultMessage: "Context auto-discovery",
-    id: "w5Hj1cVoL3",
+    id: "4UqkRDJW9u",
     description: "Feature label next to the chat dock mock",
   },
   featureRepositorySearch: {
     defaultMessage: "Repository search",
-    id: "n9Xs7eBpQ4",
+    id: "Uey+g5GKxu",
     description: "Feature label next to the chat dock mock",
   },
   featureTranslationGuidance: {
     defaultMessage: "Translation guidance",
-    id: "t4Yu8gCfM6",
+    id: "9aQ4/u+Ejv",
     description: "Feature label next to the chat dock mock",
   },
   featureHumanReview: {
     defaultMessage: "Human review first-class",
-    id: "m1Za3iDkN7",
+    id: "qfnq4xZIyD",
     description: "Feature label next to the chat dock mock",
   },
   dockTitle: {
     defaultMessage: "New AI chat",
-    id: "c6Eb2oPrS9",
+    id: "xm2niAeH2y",
     description: "Title shown in the marketing chat dock mock window header",
   },
   emptyTitle: {
     defaultMessage: "How can I help you today?",
-    id: "h0Jl5qWtU2",
+    id: "X7qkN/IoEW",
     description: "Empty-state heading inside the marketing chat dock mock",
   },
   emptySubtitle: {
     defaultMessage: "Ask about strings, context, progress, or translations",
-    id: "r8Kn6fXyV1",
+    id: "qHxiBnE/J7",
     description: "Empty-state subtitle inside the marketing chat dock mock",
   },
   contextPill: {
     defaultMessage: "Save",
-    id: "d3Po9sAzW4",
+    id: "t92moi3waZ",
     description: "Context pill label for the Save string in the chat dock mock",
   },
   composerPlaceholder: {
     defaultMessage: "Ask, search, or make anything…",
-    id: "f7Qi4bGxY5",
+    id: "qlu/Ts2pCg",
     description: "Placeholder shown in the marketing chat dock mock composer",
   },
   sendLabel: {
     defaultMessage: "Send",
-    id: "g2Rw8cHvZ6",
+    id: "pSCJIupsz5",
     description: "Accessible label for the send button in the chat dock mock",
   },
   replayLabel: {
     defaultMessage: "Replay",
-    id: "j5Tx1dKuA7",
+    id: "Uga+NfEpia",
     description: "Button label to replay the chat dock mock interaction",
   },
   collapseLabel: {
     defaultMessage: "Collapse panel",
-    id: "l9Uy3eJvB8",
+    id: "M2ZOmyFhbv",
     description: "Decorative collapse control label in the chat dock mock",
   },
   closeLabel: {
     defaultMessage: "Close",
-    id: "o4Vz6fIwC9",
+    id: "UCzEXfoNQa",
     description: "Decorative close control label in the chat dock mock",
   },
   backgroundDocTitle: {
     defaultMessage: "account.settings.save",
-    id: "q8Wa7gJxD1",
+    id: "ojvX7Bmfi7",
     description: "Key shown on the background document peek behind the chat dock",
   },
   backgroundDocSource: {
     defaultMessage: "Save",
-    id: "s1Xb9hKyE2",
+    id: "1ij8kHzcbw",
     description: "Source string shown on the background document peek",
   },
   backgroundDocMeta: {
     defaultMessage: "Settings · Primary action",
-    id: "u5Yc2iLzF3",
+    id: "0s28QK0gJ3",
     description: "Meta line on the background document peek behind the chat dock",
   },
 });

--- a/apps/hyperlocalise-web/src/components/marketing/chat-dock-mock.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/chat-dock-mock.messages.ts
@@ -59,6 +59,11 @@ export const chatDockMockMessages = defineMessages({
     id: "qHxiBnE/J7",
     description: "Empty-state subtitle inside the marketing chat dock mock",
   },
+  prefilledPrompt: {
+    defaultMessage: 'What\'s the context of "Save"?',
+    id: "kpb8SkGVO8",
+    description: "Prefilled prompt shown in the marketing chat dock mock composer and transcript",
+  },
   contextPill: {
     defaultMessage: "Save",
     id: "t92moi3waZ",

--- a/apps/hyperlocalise-web/src/components/marketing/chat-dock-mock.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/chat-dock-mock.tsx
@@ -1,0 +1,408 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  ArrowUp01Icon,
+  Cancel01Icon,
+  Chat01Icon,
+  File01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { Tool, ToolHeader } from "@/components/ai-elements/tool";
+import { Button } from "@/components/ui/button";
+import { TypographyH2, TypographyMuted, TypographyP } from "@/components/ui/typography";
+import { cn } from "@/lib/primitives/cn";
+
+import { chatDockMockMessages } from "./chat-dock-mock.messages";
+
+const PREFILLED_PROMPT = `What's the context of "Save"?`;
+const STEP_MS = 720;
+const TOOL_RESOLVE_MS = 520;
+const EASE_OUT = [0.19, 1, 0.22, 1] as const;
+
+type ToolStep = {
+  kind: "tool";
+  id: string;
+  toolName: string;
+  detail: string;
+  input: Record<string, string>;
+  resultLines: string[];
+};
+
+type AnswerStep = {
+  kind: "answer";
+  id: string;
+  sections: Array<{ label: string; body: string }>;
+};
+
+type DemoStep = ToolStep | AnswerStep;
+
+const DEMO_STEPS: DemoStep[] = [
+  {
+    kind: "tool",
+    id: "grep-save",
+    toolName: "grep",
+    detail: "Save",
+    input: {
+      pattern: "Save",
+      path: "apps/web/src",
+    },
+    resultLines: [
+      "apps/web/src/components/settings/account-form.tsx:84",
+      '  <Button type="submit">{t("account.settings.save")}</Button>',
+      "apps/web/src/messages/en-US.json:128",
+      '  "account.settings.save": "Save"',
+    ],
+  },
+  {
+    kind: "tool",
+    id: "read-form",
+    toolName: "read",
+    detail: "account-form.tsx",
+    input: {
+      path: "apps/web/src/components/settings/account-form.tsx",
+    },
+    resultLines: [
+      "82  <div className=\"flex justify-end gap-2\">",
+      "83    <Button variant=\"ghost\">Cancel</Button>",
+      '84    <Button type="submit">{t("account.settings.save")}</Button>',
+      "85  </div>",
+    ],
+  },
+  {
+    kind: "answer",
+    id: "final-answer",
+    sections: [
+      {
+        label: "What it is",
+        body: "Primary submit label for the account settings form. It commits profile edits the user already made on the page.",
+      },
+      {
+        label: "Where/how it shows",
+        body: "Bottom-right of Settings → Account, beside Cancel. Evidence: account-form.tsx:84 and account.settings.save.",
+      },
+      {
+        label: "Translation guidance",
+        body: "Keep it a short verb, not “Save changes.” Match Cancel’s brevity so the pair stays balanced in tight toolbars.",
+      },
+    ],
+  },
+];
+
+const FEATURE_KEYS = [
+  "featureContextDiscovery",
+  "featureRepositorySearch",
+  "featureTranslationGuidance",
+  "featureHumanReview",
+] as const;
+
+type PlaybackPhase = "idle" | "playing" | "done";
+
+type VisibleTool = {
+  step: ToolStep;
+  state: "input-available" | "output-available";
+};
+
+export function ChatDockMockSection() {
+  const intl = useIntl();
+  const shouldReduceMotion = useReducedMotion();
+  const [phase, setPhase] = useState<PlaybackPhase>("idle");
+  const [visibleToolCount, setVisibleToolCount] = useState(0);
+  const [toolStates, setToolStates] = useState<Record<string, VisibleTool["state"]>>({});
+  const [showAnswer, setShowAnswer] = useState(false);
+  const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const transcriptRef = useRef<HTMLDivElement>(null);
+
+  const clearTimers = () => {
+    for (const timer of timersRef.current) {
+      clearTimeout(timer);
+    }
+    timersRef.current = [];
+  };
+
+  const resetPlayback = () => {
+    clearTimers();
+    setPhase("idle");
+    setVisibleToolCount(0);
+    setToolStates({});
+    setShowAnswer(false);
+  };
+
+  const schedule = (fn: () => void, delay: number) => {
+    const timer = setTimeout(fn, delay);
+    timersRef.current.push(timer);
+  };
+
+  const startPlayback = () => {
+    if (phase === "playing") {
+      return;
+    }
+
+    clearTimers();
+    setPhase("playing");
+    setVisibleToolCount(0);
+    setToolStates({});
+    setShowAnswer(false);
+
+    const toolSteps = DEMO_STEPS.filter((step): step is ToolStep => step.kind === "tool");
+    let elapsed = shouldReduceMotion ? 0 : 180;
+
+    toolSteps.forEach((step, index) => {
+      schedule(() => {
+        setVisibleToolCount(index + 1);
+        setToolStates((current) => ({ ...current, [step.id]: "input-available" }));
+      }, elapsed);
+
+      elapsed += shouldReduceMotion ? 0 : TOOL_RESOLVE_MS;
+
+      schedule(() => {
+        setToolStates((current) => ({ ...current, [step.id]: "output-available" }));
+      }, elapsed);
+
+      elapsed += shouldReduceMotion ? 0 : STEP_MS;
+    });
+
+    schedule(() => {
+      setShowAnswer(true);
+      setPhase("done");
+    }, elapsed + (shouldReduceMotion ? 0 : 120));
+  };
+
+  useEffect(() => () => clearTimers(), []);
+
+  useEffect(() => {
+    if (!transcriptRef.current) {
+      return;
+    }
+    transcriptRef.current.scrollTop = transcriptRef.current.scrollHeight;
+  }, [visibleToolCount, toolStates, showAnswer]);
+
+  const toolSteps = DEMO_STEPS.filter((step): step is ToolStep => step.kind === "tool");
+  const answerStep = DEMO_STEPS.find((step): step is AnswerStep => step.kind === "answer");
+  const isBusy = phase === "playing";
+
+  return (
+    <section className="relative overflow-hidden rounded-[1.5rem] border border-border bg-background shadow-[0_20px_48px_rgba(0,0,0,0.14)] sm:rounded-[2rem]">
+      <div className="grid lg:grid-cols-[minmax(0,1.35fr)_minmax(16rem,0.75fr)]">
+        <div className="relative min-h-112 overflow-hidden border-b border-border px-4 py-8 sm:px-6 sm:py-10 lg:min-h-128 lg:border-b-0 lg:border-r lg:px-8 lg:py-12">
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_18%_12%,rgba(96,116,9,0.14),transparent_42%),radial-gradient(circle_at_88%_78%,rgba(9,108,229,0.1),transparent_46%)]"
+          />
+
+          <motion.div
+            aria-hidden
+            className="absolute left-3 top-8 w-[min(18rem,70%)] rounded-xl border border-border bg-card/90 p-4 shadow-lg backdrop-blur-sm sm:left-6 sm:top-12"
+            initial={shouldReduceMotion ? false : { opacity: 0, y: 18, rotate: -2 }}
+            animate={{ opacity: 1, y: 0, rotate: -2 }}
+            transition={{ duration: shouldReduceMotion ? 0 : 0.8, ease: EASE_OUT }}
+          >
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <HugeiconsIcon icon={File01Icon} strokeWidth={1.8} className="size-3.5" />
+              <span className="font-mono tracking-tight">
+                <FormattedMessage {...chatDockMockMessages.backgroundDocTitle} />
+              </span>
+            </div>
+            <p className="mt-3 text-2xl font-medium tracking-[-0.04em] text-foreground">
+              <FormattedMessage {...chatDockMockMessages.backgroundDocSource} />
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              <FormattedMessage {...chatDockMockMessages.backgroundDocMeta} />
+            </p>
+          </motion.div>
+
+          <motion.div
+            className="relative mx-auto mt-16 w-full max-w-[30rem] sm:mt-10"
+            initial={shouldReduceMotion ? false : { opacity: 0, y: 28, scale: 0.97 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            transition={{
+              duration: shouldReduceMotion ? 0 : 0.9,
+              delay: shouldReduceMotion ? 0 : 0.12,
+              ease: EASE_OUT,
+            }}
+          >
+            <div
+              className="flex h-[min(36rem,70svh)] flex-col overflow-hidden rounded-xl border border-border bg-background shadow-2xl shadow-black/15"
+              role="region"
+              aria-label={intl.formatMessage(chatDockMockMessages.dockTitle)}
+            >
+              <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-3">
+                <p className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+                  <FormattedMessage {...chatDockMockMessages.dockTitle} />
+                </p>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  tabIndex={-1}
+                  aria-label={intl.formatMessage(chatDockMockMessages.collapseLabel)}
+                >
+                  <span aria-hidden className="text-base leading-none">
+                    −
+                  </span>
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  tabIndex={-1}
+                  aria-label={intl.formatMessage(chatDockMockMessages.closeLabel)}
+                >
+                  <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} className="size-3.5" />
+                </Button>
+              </header>
+
+              <div ref={transcriptRef} className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+                {phase === "idle" ? (
+                  <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-5 px-5 py-8 text-center">
+                    <div className="flex size-10 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                      <HugeiconsIcon icon={Chat01Icon} strokeWidth={1.8} className="size-5" />
+                    </div>
+                    <div className="max-w-sm space-y-1">
+                      <h3 className="text-balance text-sm font-semibold text-foreground">
+                        <FormattedMessage {...chatDockMockMessages.emptyTitle} />
+                      </h3>
+                      <p className="text-pretty text-sm text-muted-foreground">
+                        <FormattedMessage {...chatDockMockMessages.emptySubtitle} />
+                      </p>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="flex flex-col gap-4 px-4 py-5">
+                    <div className="ms-auto max-w-[90%] rounded-2xl bg-muted px-3.5 py-2.5 text-sm leading-6 text-foreground">
+                      {PREFILLED_PROMPT}
+                    </div>
+
+                    <div className="space-y-3">
+                      <AnimatePresence initial={false}>
+                        {toolSteps.slice(0, visibleToolCount).map((step) => {
+                          const state = toolStates[step.id] ?? "input-available";
+                          return (
+                            <motion.div
+                              key={step.id}
+                              initial={shouldReduceMotion ? false : { opacity: 0, y: 10 }}
+                              animate={{ opacity: 1, y: 0 }}
+                              transition={{ duration: shouldReduceMotion ? 0 : 0.28, ease: EASE_OUT }}
+                              className="rounded-lg border border-border/70 bg-muted/20 px-3 py-2"
+                            >
+                              <Tool defaultOpen={state === "output-available"}>
+                                <ToolHeader
+                                  type="dynamic-tool"
+                                  toolName={step.toolName}
+                                  state={state}
+                                  input={step.input}
+                                />
+                              </Tool>
+                              {state === "output-available" ? (
+                                <pre className="mt-2 overflow-x-auto rounded-md bg-muted/50 px-2.5 py-2 font-mono text-[0.72rem] leading-5 text-muted-foreground">
+                                  {step.resultLines.join("\n")}
+                                </pre>
+                              ) : null}
+                            </motion.div>
+                          );
+                        })}
+                      </AnimatePresence>
+
+                      {showAnswer && answerStep ? (
+                        <motion.div
+                          initial={shouldReduceMotion ? false : { opacity: 0, y: 12 }}
+                          animate={{ opacity: 1, y: 0 }}
+                          transition={{ duration: shouldReduceMotion ? 0 : 0.35, ease: EASE_OUT }}
+                          className="space-y-4 text-sm leading-6 text-foreground"
+                        >
+                          {answerStep.sections.map((section) => (
+                            <div key={section.label} className="space-y-1">
+                              <p className="font-medium text-foreground">{section.label}</p>
+                              <p className="text-muted-foreground">{section.body}</p>
+                            </div>
+                          ))}
+                        </motion.div>
+                      ) : null}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className="shrink-0 border-t border-border bg-background p-3">
+                <div className="overflow-hidden rounded-xl border border-border bg-muted/30 shadow-sm">
+                  <div className="flex flex-wrap gap-1.5 px-3 pt-3">
+                    <span className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-2 py-0.5 text-[0.7rem] text-muted-foreground">
+                      @
+                    </span>
+                    <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-background px-2 py-0.5 text-[0.7rem] text-foreground">
+                      <HugeiconsIcon icon={File01Icon} strokeWidth={1.8} className="size-3" />
+                      <FormattedMessage {...chatDockMockMessages.contextPill} />
+                    </span>
+                  </div>
+                  <div className="flex items-end gap-2 px-3 py-3">
+                    <p className="min-w-0 flex-1 text-sm leading-5 text-foreground">
+                      {phase === "idle" ? (
+                        PREFILLED_PROMPT
+                      ) : (
+                        <span className="text-muted-foreground">
+                          <FormattedMessage {...chatDockMockMessages.composerPlaceholder} />
+                        </span>
+                      )}
+                    </p>
+                    {phase === "done" ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="secondary"
+                        className="h-8 rounded-full px-3"
+                        onClick={resetPlayback}
+                      >
+                        <FormattedMessage {...chatDockMockMessages.replayLabel} />
+                      </Button>
+                    ) : (
+                      <Button
+                        type="button"
+                        size="icon-sm"
+                        className="size-8 rounded-full"
+                        disabled={isBusy}
+                        aria-label={intl.formatMessage(chatDockMockMessages.sendLabel)}
+                        onClick={startPlayback}
+                      >
+                        <HugeiconsIcon icon={ArrowUp01Icon} strokeWidth={2} className="size-4" />
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </motion.div>
+        </div>
+
+        <aside className="flex flex-col justify-between gap-10 px-6 py-8 sm:px-8 sm:py-10 lg:py-12">
+          <div className="space-y-4">
+            <TypographyMuted className="text-[0.72rem] font-medium tracking-[0.18em] uppercase">
+              <FormattedMessage {...chatDockMockMessages.sectionEyebrow} />
+            </TypographyMuted>
+            <TypographyH2 className="pb-0 text-3xl leading-[1.04] tracking-[-0.045em] sm:text-4xl">
+              <FormattedMessage {...chatDockMockMessages.sectionTitle} />
+            </TypographyH2>
+            <TypographyP className="max-w-sm text-muted-foreground">
+              <FormattedMessage {...chatDockMockMessages.sectionBody} />
+            </TypographyP>
+          </div>
+
+          <div className="space-y-4">
+            <TypographyMuted className="text-[0.72rem] font-medium tracking-[0.18em] uppercase">
+              <FormattedMessage {...chatDockMockMessages.featuresLabel} />
+            </TypographyMuted>
+            <ul className="space-y-3 font-mono text-[0.78rem] tracking-[0.08em] text-muted-foreground uppercase">
+              {FEATURE_KEYS.map((key) => (
+                <li key={key} className={cn("leading-5")}>
+                  <FormattedMessage {...chatDockMockMessages[key]} />
+                </li>
+              ))}
+            </ul>
+          </div>
+        </aside>
+      </div>
+    </section>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/marketing/chat-dock-mock.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/chat-dock-mock.tsx
@@ -13,7 +13,6 @@ import { cn } from "@/lib/primitives/cn";
 
 import { chatDockMockMessages } from "./chat-dock-mock.messages";
 
-const PREFILLED_PROMPT = `What's the context of "Save"?`;
 const STEP_MS = 720;
 const TOOL_RESOLVE_MS = 520;
 const EASE_OUT = [0.19, 1, 0.22, 1] as const;
@@ -110,6 +109,7 @@ export function ChatDockMockSection() {
   const [showAnswer, setShowAnswer] = useState(false);
   const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
   const transcriptRef = useRef<HTMLDivElement>(null);
+  const prefilledPrompt = intl.formatMessage(chatDockMockMessages.prefilledPrompt);
 
   const clearTimers = () => {
     for (const timer of timersRef.current) {
@@ -271,7 +271,7 @@ export function ChatDockMockSection() {
                 ) : (
                   <div className="flex flex-col gap-4 px-4 py-5">
                     <div className="ms-auto max-w-[90%] rounded-2xl bg-muted px-3.5 py-2.5 text-sm leading-6 text-foreground">
-                      {PREFILLED_PROMPT}
+                      {prefilledPrompt}
                     </div>
 
                     <div className="space-y-3">
@@ -294,6 +294,7 @@ export function ChatDockMockSection() {
                                   type="dynamic-tool"
                                   toolName={step.toolName}
                                   state={state}
+                                  detail={step.detail}
                                   input={step.input}
                                 />
                               </Tool>
@@ -341,7 +342,7 @@ export function ChatDockMockSection() {
                   <div className="flex items-end gap-2 px-3 py-3">
                     <p className="min-w-0 flex-1 text-sm leading-5 text-foreground">
                       {phase === "idle" ? (
-                        PREFILLED_PROMPT
+                        prefilledPrompt
                       ) : (
                         <span className="text-muted-foreground">
                           <FormattedMessage {...chatDockMockMessages.composerPlaceholder} />

--- a/apps/hyperlocalise-web/src/components/marketing/chat-dock-mock.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/chat-dock-mock.tsx
@@ -1,12 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import {
-  ArrowUp01Icon,
-  Cancel01Icon,
-  Chat01Icon,
-  File01Icon,
-} from "@hugeicons/core-free-icons";
+import { ArrowUp01Icon, Cancel01Icon, Chat01Icon, File01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -66,8 +61,8 @@ const DEMO_STEPS: DemoStep[] = [
       path: "apps/web/src/components/settings/account-form.tsx",
     },
     resultLines: [
-      "82  <div className=\"flex justify-end gap-2\">",
-      "83    <Button variant=\"ghost\">Cancel</Button>",
+      '82  <div className="flex justify-end gap-2">',
+      '83    <Button variant="ghost">Cancel</Button>',
       '84    <Button type="submit">{t("account.settings.save")}</Button>',
       "85  </div>",
     ],
@@ -165,10 +160,13 @@ export function ChatDockMockSection() {
       elapsed += shouldReduceMotion ? 0 : STEP_MS;
     });
 
-    schedule(() => {
-      setShowAnswer(true);
-      setPhase("done");
-    }, elapsed + (shouldReduceMotion ? 0 : 120));
+    schedule(
+      () => {
+        setShowAnswer(true);
+        setPhase("done");
+      },
+      elapsed + (shouldReduceMotion ? 0 : 120),
+    );
   };
 
   useEffect(() => () => clearTimers(), []);
@@ -285,7 +283,10 @@ export function ChatDockMockSection() {
                               key={step.id}
                               initial={shouldReduceMotion ? false : { opacity: 0, y: 10 }}
                               animate={{ opacity: 1, y: 0 }}
-                              transition={{ duration: shouldReduceMotion ? 0 : 0.28, ease: EASE_OUT }}
+                              transition={{
+                                duration: shouldReduceMotion ? 0 : 0.28,
+                                ease: EASE_OUT,
+                              }}
                               className="rounded-lg border border-border/70 bg-muted/20 px-3 py-2"
                             >
                               <Tool defaultOpen={state === "output-available"}>

--- a/apps/hyperlocalise-web/src/components/marketing/index.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/index.ts
@@ -1,4 +1,5 @@
 export { ChapterSection } from "./chapter-section";
+export { ChatDockMockSection } from "./chat-dock-mock";
 export { RecentBlogPostsSection } from "./recent-blog-posts-section";
 export { FinalCtaSection } from "./final-cta-section";
 export { HeroSection } from "./hero-section";

--- a/apps/hyperlocalise-web/src/components/marketing/index.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/index.ts
@@ -1,5 +1,4 @@
 export { ChapterSection } from "./chapter-section";
-export { ChatDockMockSection } from "./chat-dock-mock";
 export { RecentBlogPostsSection } from "./recent-blog-posts-section";
 export { FinalCtaSection } from "./final-cta-section";
 export { HeroSection } from "./hero-section";

--- a/apps/hyperlocalise-web/src/components/marketing/principles-section.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/principles-section.tsx
@@ -27,7 +27,6 @@ export function PrinciplesSection() {
       <div className="mt-10 overflow-hidden rounded-[1.5rem] border border-border bg-background shadow-[0_20px_48px_rgba(0,0,0,0.22)] sm:mt-12 sm:rounded-[2rem] sm:shadow-[0_32px_80px_rgba(0,0,0,0.28)]">
         <div className="grid divide-y divide-border lg:grid-cols-3 lg:divide-x lg:divide-y-0">
           {principles.map((item, index) => {
-            const chapterNumber = `0${index + 1}.0`;
             const anchorIds = ["translate-task", "providers", "evaluations"] as const;
             const href = `#${anchorIds[index]}`;
 
@@ -37,10 +36,6 @@ export function PrinciplesSection() {
                 className="flex flex-col gap-8 px-6 py-7 text-foreground sm:px-7 sm:py-8 lg:min-h-112 lg:justify-between lg:gap-16 lg:px-8 lg:py-9"
               >
                 <div className="space-y-8 sm:space-y-12 lg:space-y-16">
-                  <TypographyP className="text-[0.95rem] tracking-[-0.02em] text-muted-foreground">
-                    {chapterNumber}
-                  </TypographyP>
-
                   <div className="max-w-none space-y-4 sm:max-w-[21ch]">
                     <TypographyH3 className="max-w-none text-balance text-[1.55rem] font-medium leading-[0.98] tracking-[-0.045em] text-foreground sm:max-w-[11ch] sm:text-[2.05rem] sm:tracking-[-0.05em] md:text-[2.05rem] lg:max-w-[10ch] lg:text-[2.15rem] lg:leading-[1.02]">
                       <FormattedMessage {...marketingPageMessages[item.titleKey]} />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an interactive chat inbox dock mock to the marketing homepage, inspired by product-demo hero compositions with a floating dock window and a side feature list.

- Prefills `What's the context of "Save"?`
- On send, plays through `grep` → `read` tool calls and a final translator-style answer in sequence
- Includes Replay after the demo finishes
- Removes order numbers from homepage principles and workflow chapter sections for a simpler layout

## Review fixes

- Import `ChatDockMockSection` from `@/components/marketing/chat-dock-mock` (no new barrel export)
- Internationalize the prefilled prompt via `chatDockMockMessages`
- Pass `ToolStep.detail` through to `ToolHeader`

## Test plan

- [x] `vp check --fix` in `apps/hyperlocalise-web`
- [ ] Open the marketing homepage and confirm the new Inbox section appears between hero and principles
- [ ] Click send on the prefilled prompt and verify tool calls appear one after another, then the answer
- [ ] Click Replay and confirm the demo resets cleanly
- [ ] Confirm principles cards and chapter link rows no longer show `01.0` / `01.1` style numbers
- [ ] `vp test` in `apps/hyperlocalise-web`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5177940f-c75a-492a-b575-760ce873cd37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5177940f-c75a-492a-b575-760ce873cd37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

