### PR TITLE
feat(marketing): Send and Replay icons in chat dock mock

### DIFF
--- a/apps/hyperlocalise-web/src/components/marketing/chat-dock-mock.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/chat-dock-mock.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { ArrowUp01Icon, Cancel01Icon, Chat01Icon, File01Icon } from "@hugeicons/core-free-icons";
+import {
+  Cancel01Icon,
+  Chat01Icon,
+  File01Icon,
+  RefreshIcon,
+  SentIcon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -357,18 +363,30 @@ export function ChatDockMockSection() {
                         className="h-8 rounded-full px-3"
                         onClick={resetPlayback}
                       >
+                        <HugeiconsIcon
+                          data-icon="inline-start"
+                          icon={RefreshIcon}
+                          strokeWidth={2}
+                          className="size-3.5"
+                        />
                         <FormattedMessage {...chatDockMockMessages.replayLabel} />
                       </Button>
                     ) : (
                       <Button
                         type="button"
-                        size="icon-sm"
-                        className="size-8 rounded-full"
+                        size="sm"
+                        className="h-8 rounded-full px-3"
                         disabled={isBusy}
                         aria-label={intl.formatMessage(chatDockMockMessages.sendLabel)}
                         onClick={startPlayback}
                       >
-                        <HugeiconsIcon icon={ArrowUp01Icon} strokeWidth={2} className="size-4" />
+                        <HugeiconsIcon
+                          data-icon="inline-start"
+                          icon={SentIcon}
+                          strokeWidth={2}
+                          className="size-3.5"
+                        />
+                        <FormattedMessage {...chatDockMockMessages.sendLabel} />
                       </Button>
                     )}
                   </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

In the marketing inbox/chat dock mock composer:
- **Send** is now a labeled button with `SentIcon` (was icon-only arrow).
- **Replay** includes a `RefreshIcon` beside the label.

## How to test

- Open the marketing section with the chat dock mock
- Confirm the composer shows **Send** with a send icon before playback
- Run the mock to completion and confirm **Replay** shows with a refresh icon
- `vp check --fix` in `apps/hyperlocalise-web` (passed)

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e24bd2c9-3606-4295-ac26-a128dde94cea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e24bd2c9-3606-4295-ac26-a128dde94cea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

