### PR TITLE
fix(cli): extract formatMessage calls inside template literals

### DIFF
--- a/apps/cli/cmd/extract.go
+++ b/apps/cli/cmd/extract.go
@@ -456,9 +456,41 @@ func extractMessagesFromReactIntlSource(src, file string) ([]extractMessage, err
 }
 
 func extractReactIntlCallMessages(src, file string) ([]extractMessage, error) {
+	return extractReactIntlCallMessagesRange(src, file, 0, len(src))
+}
+
+func extractReactIntlCallMessagesRange(src, file string, start, end int) ([]extractMessage, error) {
+	if start < 0 {
+		start = 0
+	}
+	if end > len(src) {
+		end = len(src)
+	}
+
 	messages := make([]extractMessage, 0)
-	for i := 0; i < len(src); {
+	for i := start; i < end; {
+		if src[i] == '`' {
+			next, expressions, ok := scanTemplateLiteral(src, i)
+			if !ok {
+				return nil, fmt.Errorf("unterminated template literal at line %d", sourceLine(src, i))
+			}
+			for _, expression := range expressions {
+				extracted, err := extractReactIntlCallMessagesRange(src, file, expression.start, expression.end)
+				if err != nil {
+					return nil, err
+				}
+				messages = append(messages, extracted...)
+			}
+			if next > end {
+				break
+			}
+			i = next
+			continue
+		}
 		if next, ok := skipIgnoredToken(src, i); ok {
+			if next > end {
+				break
+			}
 			i = next
 			continue
 		}
@@ -468,19 +500,19 @@ func extractReactIntlCallMessages(src, file string) ([]extractMessage, error) {
 		}
 
 		name, next := readIdentifier(src, i)
-		if !isReactIntlCallName(name) {
+		if next > end || !isReactIntlCallName(name) {
 			i = next
 			continue
 		}
 
 		callOpen := findCallOpenAfterIdentifier(src, next)
-		if callOpen < 0 {
+		if callOpen < 0 || callOpen >= end {
 			i = next
 			continue
 		}
 
 		objectStart := firstObjectArgument(src, callOpen)
-		if objectStart < 0 {
+		if objectStart < 0 || objectStart >= end {
 			i = callOpen + 1
 			continue
 		}
@@ -728,19 +760,51 @@ func skipValueExpression(src string, index, end int) int {
 }
 
 func extractReactIntlJSXMessages(src, file string) ([]extractMessage, error) {
+	return extractReactIntlJSXMessagesRange(src, file, 0, len(src))
+}
+
+func extractReactIntlJSXMessagesRange(src, file string, start, end int) ([]extractMessage, error) {
+	if start < 0 {
+		start = 0
+	}
+	if end > len(src) {
+		end = len(src)
+	}
+
 	messages := make([]extractMessage, 0)
-	for i := 0; i < len(src); {
-		if next, ok := skipIgnoredToken(src, i); ok {
+	for i := start; i < end; {
+		if src[i] == '`' {
+			next, expressions, ok := scanTemplateLiteral(src, i)
+			if !ok {
+				return nil, fmt.Errorf("unterminated template literal at line %d", sourceLine(src, i))
+			}
+			for _, expression := range expressions {
+				extracted, err := extractReactIntlJSXMessagesRange(src, file, expression.start, expression.end)
+				if err != nil {
+					return nil, err
+				}
+				messages = append(messages, extracted...)
+			}
+			if next > end {
+				break
+			}
 			i = next
 			continue
 		}
-		if src[i] != '<' || i+1 >= len(src) || src[i+1] == '/' {
+		if next, ok := skipIgnoredToken(src, i); ok {
+			if next > end {
+				break
+			}
+			i = next
+			continue
+		}
+		if src[i] != '<' || i+1 >= end || src[i+1] == '/' {
 			i++
 			continue
 		}
 
 		name, nameEnd, ok := readJSXElementName(src, i+1)
-		if !ok || !isReactIntlJSXName(name) {
+		if !ok || nameEnd > end || !isReactIntlJSXName(name) {
 			i++
 			continue
 		}
@@ -1129,6 +1193,11 @@ func findTypeArgumentEnd(src string, open int) (int, bool) {
 	return 0, false
 }
 
+type extractSourceRange struct {
+	start int
+	end   int
+}
+
 func skipIgnoredToken(src string, index int) (int, bool) {
 	if index >= len(src) {
 		return index, false
@@ -1145,6 +1214,17 @@ func skipIgnoredToken(src string, index int) (int, bool) {
 }
 
 func skipStringLiteral(src string, index int) int {
+	if index >= len(src) {
+		return index
+	}
+	if src[index] == '`' {
+		end, _, ok := scanTemplateLiteral(src, index)
+		if !ok {
+			return len(src)
+		}
+		return end
+	}
+
 	quote := src[index]
 	for i := index + 1; i < len(src); i++ {
 		if src[i] == '\\' {
@@ -1157,6 +1237,46 @@ func skipStringLiteral(src string, index int) int {
 	}
 
 	return len(src)
+}
+
+// scanTemplateLiteral walks a template literal starting at a backtick.
+// It returns the index after the closing backtick and the body ranges of
+// each top-level ${...} interpolation so callers can extract from them.
+func scanTemplateLiteral(src string, start int) (int, []extractSourceRange, bool) {
+	if start >= len(src) || src[start] != '`' {
+		return start, nil, false
+	}
+
+	expressions := make([]extractSourceRange, 0)
+	for i := start + 1; i < len(src); {
+		switch src[i] {
+		case '\\':
+			if i+1 >= len(src) {
+				return len(src), nil, false
+			}
+			i += 2
+		case '`':
+			return i + 1, expressions, true
+		case '$':
+			if i+1 < len(src) && src[i+1] == '{' {
+				closeIdx, ok := findMatchingDelimiter(src, i+1, '{', '}')
+				if !ok {
+					return len(src), nil, false
+				}
+				expressions = append(expressions, extractSourceRange{
+					start: i + 2,
+					end:   closeIdx,
+				})
+				i = closeIdx + 1
+				continue
+			}
+			i++
+		default:
+			i++
+		}
+	}
+
+	return len(src), nil, false
 }
 
 func skipComment(src string, index int) (int, bool) {

--- a/apps/cli/cmd/extract_test.go
+++ b/apps/cli/cmd/extract_test.go
@@ -487,6 +487,274 @@ export const message = defineMessage({
 	}
 }
 
+func TestExtractCommandExtractsFormatMessageInsideTemplateLiterals(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	writeExtractTestFile(t, filepath.Join(dir, "src", "Greeting.tsx"), `
+import { defineMessage, defineMessages, FormattedMessage, useIntl } from "react-intl";
+
+export function Greeting(name: string) {
+  const intl = useIntl();
+  const outside = intl.formatMessage({
+    id: "greeting.outside",
+    defaultMessage: "Outside template",
+  });
+
+  const nested = defineMessages({
+    title: {
+      id: "greeting.nested-define",
+      defaultMessage: "Nested defineMessages",
+    },
+  });
+
+  return [
+    `+"`"+`Hello ${intl.formatMessage({
+      id: "greeting.hello",
+      defaultMessage: "World",
+      description: "Greeting inside template literal",
+    })}`+"`"+`,
+    `+"`"+`Status: ${formatMessage({
+      id: "greeting.status",
+      defaultMessage: "Active",
+    })} and ${intl.formatMessage({
+      id: "greeting.again",
+      defaultMessage: "Again",
+    })}`+"`"+`,
+    `+"`"+`Escaped \${intl.formatMessage({
+      id: "greeting.escaped",
+      defaultMessage: "Should not extract",
+    })}`+"`"+`,
+    `+"`"+`Plain formatMessage text without a call`+"`"+`,
+    `+"`"+`Outer ${`+"`"+`Inner ${intl.formatMessage({
+      id: "greeting.nested-template",
+      defaultMessage: "Nested template call",
+    })}`+"`"+`}`+"`"+`,
+    `+"`"+`Define ${defineMessage({
+      id: "greeting.define-in-template",
+      defaultMessage: "Defined in template",
+    })}`+"`"+`,
+    `+"`"+`JSX ${(<FormattedMessage id="greeting.jsx-in-template" defaultMessage="JSX in template" />)}`+"`"+`,
+    `+"`"+`Typed ${intl.formatMessage<{ name: string }>({
+      id: "greeting.typed",
+      defaultMessage: "Typed call",
+    })}`+"`"+`,
+    outside,
+    nested.title,
+  ];
+}
+`)
+
+	cmd := newExtractCmd()
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"src"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute extract command: %v", err)
+	}
+
+	got := decodeExtractTestCatalog(t, out.Bytes())
+	want := map[string]extractCatalogMessage{
+		"greeting.outside": {
+			DefaultMessage: "Outside template",
+		},
+		"greeting.nested-define": {
+			DefaultMessage: "Nested defineMessages",
+		},
+		"greeting.hello": {
+			DefaultMessage: "World",
+			Description:    "Greeting inside template literal",
+		},
+		"greeting.status": {
+			DefaultMessage: "Active",
+		},
+		"greeting.again": {
+			DefaultMessage: "Again",
+		},
+		"greeting.nested-template": {
+			DefaultMessage: "Nested template call",
+		},
+		"greeting.define-in-template": {
+			DefaultMessage: "Defined in template",
+		},
+		"greeting.jsx-in-template": {
+			DefaultMessage: "JSX in template",
+		},
+		"greeting.typed": {
+			DefaultMessage: "Typed call",
+		},
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("message count = %d, want %d; output=%s", len(got), len(want), out.String())
+	}
+	for id, wantMessage := range want {
+		gotMessage, ok := got[id]
+		if !ok {
+			t.Fatalf("missing message %q in output=%s", id, out.String())
+		}
+		if gotMessage.DefaultMessage != wantMessage.DefaultMessage ||
+			gotMessage.Description != wantMessage.Description {
+			t.Fatalf("message %q = %#v, want %#v", id, gotMessage, wantMessage)
+		}
+	}
+	if _, ok := got["greeting.escaped"]; ok {
+		t.Fatalf("escaped template interpolation should not extract: %s", out.String())
+	}
+}
+
+func TestExtractCommandExtractsFormatMessageInsideNestedTemplateExpressions(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	writeExtractTestFile(t, filepath.Join(dir, "src", "Nested.tsx"), `
+import { useIntl } from "react-intl";
+
+export function Nested(count: number) {
+  const intl = useIntl();
+  return `+"`"+`Items: ${count > 0 ? `+"`"+`${intl.formatMessage({
+    id: "nested.positive",
+    defaultMessage: "Has items",
+  })}`+"`"+` : intl.formatMessage({
+    id: "nested.empty",
+    defaultMessage: "No items",
+    description: "Empty state inside ternary in template",
+  })}`+"`"+`;
+}
+`)
+
+	cmd := newExtractCmd()
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"src"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute extract command: %v", err)
+	}
+
+	got := decodeExtractTestCatalog(t, out.Bytes())
+	want := map[string]extractCatalogMessage{
+		"nested.positive": {
+			DefaultMessage: "Has items",
+		},
+		"nested.empty": {
+			DefaultMessage: "No items",
+			Description:    "Empty state inside ternary in template",
+		},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("message count = %d, want %d; output=%s", len(got), len(want), out.String())
+	}
+	for id, wantMessage := range want {
+		gotMessage, ok := got[id]
+		if !ok {
+			t.Fatalf("missing message %q in output=%s", id, out.String())
+		}
+		if gotMessage != wantMessage {
+			t.Fatalf("message %q = %#v, want %#v", id, gotMessage, wantMessage)
+		}
+	}
+}
+
+func TestExtractCommandExtractsFormatMessageWithGeneratedIDInsideTemplateLiteral(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	writeExtractTestFile(t, filepath.Join(dir, "src", "Generated.tsx"), `
+import { useIntl } from "react-intl";
+
+export function Generated() {
+  const intl = useIntl();
+  return `+"`"+`Label: ${intl.formatMessage({
+    defaultMessage: "Generated inside template",
+    description: "Template literal generated id",
+  })}`+"`"+`;
+}
+`)
+
+	cmd := newExtractCmd()
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"src"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute extract command: %v", err)
+	}
+
+	catalog := decodeExtractTestCatalog(t, out.Bytes())
+	id := generatedFormatJSMessageID("Generated inside template", "Template literal generated id")
+	got, ok := catalog[id]
+	if !ok {
+		t.Fatalf("missing generated id %q in output=%s", id, out.String())
+	}
+	if got.DefaultMessage != "Generated inside template" {
+		t.Fatalf("defaultMessage = %q", got.DefaultMessage)
+	}
+	if got.Description != "Template literal generated id" {
+		t.Fatalf("description = %q", got.Description)
+	}
+}
+
+func TestScanTemplateLiteralFindsInterpolationRangesAndNestedTemplates(t *testing.T) {
+	src := "`a ${one} b ${`inner ${two}`} c`"
+	end, expressions, ok := scanTemplateLiteral(src, 0)
+	if !ok {
+		t.Fatalf("expected template literal to scan successfully")
+	}
+	if end != len(src) {
+		t.Fatalf("end = %d, want %d", end, len(src))
+	}
+	if got, want := len(expressions), 2; got != want {
+		t.Fatalf("expression count = %d, want %d", got, want)
+	}
+	if got, want := src[expressions[0].start:expressions[0].end], "one"; got != want {
+		t.Fatalf("first expression = %q, want %q", got, want)
+	}
+	if got, want := src[expressions[1].start:expressions[1].end], "`inner ${two}`"; got != want {
+		t.Fatalf("second expression = %q, want %q", got, want)
+	}
+
+	nestedEnd, nestedExpressions, ok := scanTemplateLiteral(src, expressions[1].start)
+	if !ok {
+		t.Fatalf("expected nested template literal to scan successfully")
+	}
+	if nestedEnd != expressions[1].end {
+		t.Fatalf("nested end = %d, want %d", nestedEnd, expressions[1].end)
+	}
+	if got, want := len(nestedExpressions), 1; got != want {
+		t.Fatalf("nested expression count = %d, want %d", got, want)
+	}
+	if got, want := src[nestedExpressions[0].start:nestedExpressions[0].end], "two"; got != want {
+		t.Fatalf("nested expression = %q, want %q", got, want)
+	}
+}
+
+func TestScanTemplateLiteralIgnoresEscapedInterpolations(t *testing.T) {
+	src := "`literal \\${not.an.interpolation} and ${real}`" // one backslash before ${
+	end, expressions, ok := scanTemplateLiteral(src, 0)
+	if !ok {
+		t.Fatalf("expected template literal to scan successfully")
+	}
+	if end != len(src) {
+		t.Fatalf("end = %d, want %d", end, len(src))
+	}
+	if got, want := len(expressions), 1; got != want {
+		t.Fatalf("expression count = %d, want %d; exprs=%v", got, want, expressions)
+	}
+	if got, want := src[expressions[0].start:expressions[0].end], "real"; got != want {
+		t.Fatalf("expression = %q, want %q", got, want)
+	}
+}
+
+func TestSkipStringLiteralHandlesNestedTemplateLiterals(t *testing.T) {
+	src := "`outer ${`inner`} tail` ;"
+	got := skipStringLiteral(src, 0)
+	if got != len("`outer ${`inner`} tail`") {
+		t.Fatalf("skipStringLiteral end = %d, want %d (src=%q)", got, len("`outer ${`inner`} tail`"), src[:got])
+	}
+}
+
 func TestUnescapeJavaScriptStringSupportsHighByteHexEscapes(t *testing.T) {
 	got := []byte(unescapeJavaScriptString(`\x7F\x80\xA0\xFF`))
 	want := []byte{0x7f, 0x80, 0xa0, 0xff}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The `extract` CLI skipped entire template literals while scanning for react-intl calls, so messages in `${formatMessage(...)}` / `${intl.formatMessage(...)}` interpolations were missed.

This change:
- Adds `scanTemplateLiteral` to correctly walk nested templates and collect `${...}` expression ranges
- Recurses into those ranges for both call extraction (`formatMessage`, `defineMessage`, `defineMessages`) and JSX extraction (`FormattedMessage`)
- Fixes `skipStringLiteral` so nested template literals no longer truncate at the inner backtick

## How to test

```bash
go test ./apps/cli/cmd/ -run 'Template|ScanTemplate|SkipStringLiteral' -count=1
make fmt
make lint
go test ./...
```

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `go test ./...`; `make test` hits the known missing `covdata` tool warning)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7dbf101c-cd2a-483a-bc29-0217f927eb1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7dbf101c-cd2a-483a-bc29-0217f927eb1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

