### PR TITLE
fix(cli): harden extract template scanning and skip bad files

### DIFF
--- a/apps/cli/cmd/extract.go
+++ b/apps/cli/cmd/extract.go
@@ -1207,10 +1207,105 @@ func skipIgnoredToken(src string, index int) (int, bool) {
 	case '\'', '"', '`':
 		return skipStringLiteral(src, index), true
 	case '/':
-		return skipComment(src, index)
+		if next, ok := skipComment(src, index); ok {
+			return next, true
+		}
+		return skipRegexLiteral(src, index)
 	default:
 		return index, false
 	}
+}
+
+// skipRegexLiteral skips a JavaScript regular expression literal starting at '/'.
+// It uses a lookbehind heuristic to distinguish regex literals from division.
+func skipRegexLiteral(src string, index int) (int, bool) {
+	if index >= len(src) || src[index] != '/' || !canStartRegexLiteral(src, index) {
+		return index, false
+	}
+
+	inClass := false
+	for i := index + 1; i < len(src); i++ {
+		switch src[i] {
+		case '\\':
+			if i+1 >= len(src) {
+				return index, false
+			}
+			i++
+		case '\n', '\r':
+			return index, false
+		case '[':
+			if !inClass {
+				inClass = true
+				if i+1 < len(src) && src[i+1] == '^' {
+					i++
+				}
+				// A ']' immediately after '[' or '[^' is a literal character.
+				if i+1 < len(src) && src[i+1] == ']' {
+					i++
+				}
+			}
+		case ']':
+			inClass = false
+		case '/':
+			if inClass {
+				continue
+			}
+			i++
+			for i < len(src) && isRegexFlag(src[i]) {
+				i++
+			}
+			return i, true
+		}
+	}
+
+	return index, false
+}
+
+func canStartRegexLiteral(src string, index int) bool {
+	i := index - 1
+	for i >= 0 && unicode.IsSpace(rune(src[i])) {
+		i--
+	}
+	if i < 0 {
+		return true
+	}
+
+	ch := src[i]
+	switch ch {
+	case ')', ']', '"', '\'', '`':
+		return false
+	case '+', '-':
+		if i > 0 && src[i-1] == ch {
+			return false
+		}
+		return true
+	}
+
+	if !isIdentifierPart(ch) {
+		return true
+	}
+
+	end := i + 1
+	for i >= 0 && isIdentifierPart(src[i]) {
+		i--
+	}
+
+	return isRegexPrefixKeyword(src[i+1 : end])
+}
+
+func isRegexPrefixKeyword(word string) bool {
+	switch word {
+	case "return", "throw", "case", "else", "typeof", "void", "delete",
+		"await", "yield", "new", "in", "of", "instanceof", "extends",
+		"do", "with":
+		return true
+	default:
+		return false
+	}
+}
+
+func isRegexFlag(ch byte) bool {
+	return ('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z')
 }
 
 func skipStringLiteral(src string, index int) int {

--- a/apps/cli/cmd/extract.go
+++ b/apps/cli/cmd/extract.go
@@ -59,7 +59,7 @@ func newExtractCmd() *cobra.Command {
 		Short:        "extract react-intl messages from TypeScript files",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			messages, err := runExtract(args, o, cmd.OutOrStdout())
+			messages, err := runExtract(args, o, cmd.ErrOrStderr())
 			if err != nil {
 				return err
 			}

--- a/apps/cli/cmd/extract.go
+++ b/apps/cli/cmd/extract.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -58,7 +59,7 @@ func newExtractCmd() *cobra.Command {
 		Short:        "extract react-intl messages from TypeScript files",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			messages, err := runExtract(args, o)
+			messages, err := runExtract(args, o, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}
@@ -119,7 +120,7 @@ func buildExtractCatalog(messages []extractMessage) map[string]extractCatalogMes
 	return catalog
 }
 
-func runExtract(paths []string, options extractOptions) ([]extractMessage, error) {
+func runExtract(paths []string, options extractOptions, errorOut io.Writer) ([]extractMessage, error) {
 	if len(paths) == 0 {
 		paths = []string{"."}
 	}
@@ -131,6 +132,9 @@ func runExtract(paths []string, options extractOptions) ([]extractMessage, error
 	if len(files) == 0 {
 		return nil, fmt.Errorf("no .ts or .tsx files matched")
 	}
+	if errorOut == nil {
+		errorOut = io.Discard
+	}
 
 	messages := make([]extractMessage, 0)
 	for _, file := range files {
@@ -141,7 +145,10 @@ func runExtract(paths []string, options extractOptions) ([]extractMessage, error
 
 		fileMessages, err := extractMessagesFromReactIntlSource(string(content), file)
 		if err != nil {
-			return nil, fmt.Errorf("extract %q: %w", file, err)
+			if _, writeErr := fmt.Fprintf(errorOut, "error: extract %q: %v\n", file, err); writeErr != nil {
+				return nil, fmt.Errorf("write extract error for %q: %w", file, writeErr)
+			}
+			continue
 		}
 		if options.prefixID {
 			prefix := normalizedExtractFilename(file)
@@ -151,7 +158,10 @@ func runExtract(paths []string, options extractOptions) ([]extractMessage, error
 		}
 		if options.flatten {
 			if err := flattenExtractMessages(fileMessages); err != nil {
-				return nil, fmt.Errorf("flatten %q: %w", file, err)
+				if _, writeErr := fmt.Fprintf(errorOut, "error: flatten %q: %v\n", file, err); writeErr != nil {
+					return nil, fmt.Errorf("write flatten error for %q: %w", file, writeErr)
+				}
+				continue
 			}
 		}
 

--- a/apps/cli/cmd/extract_test.go
+++ b/apps/cli/cmd/extract_test.go
@@ -845,19 +845,20 @@ formatMessage({
 			"});\n",
 	)
 
-	outFile := filepath.Join(dir, "messages.json")
 	cmd := newExtractCmd()
 	out := bytes.NewBuffer(nil)
+	errOut := bytes.NewBuffer(nil)
 	cmd.SetOut(out)
-	cmd.SetArgs([]string{".", "--out-file", outFile})
+	cmd.SetErr(errOut)
+	cmd.SetArgs([]string{"."})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("execute extract command: %v", err)
 	}
 
-	errorOutput := out.String()
+	errorOutput := errOut.String()
 	if !strings.Contains(errorOutput, `error: extract "`) || !strings.Contains(errorOutput, "bad.ts") {
-		t.Fatalf("expected extraction error for bad.ts on stdout, got %q", errorOutput)
+		t.Fatalf("expected extraction error for bad.ts on stderr, got %q", errorOutput)
 	}
 	if !strings.Contains(errorOutput, "unterminated template literal") {
 		t.Fatalf("expected unterminated template literal detail, got %q", errorOutput)
@@ -865,17 +866,16 @@ formatMessage({
 	if strings.Contains(errorOutput, "good.ts") {
 		t.Fatalf("did not expect error for good.ts, got %q", errorOutput)
 	}
-
-	content, err := os.ReadFile(outFile)
-	if err != nil {
-		t.Fatalf("read out-file: %v", err)
+	if strings.Contains(out.String(), "error:") {
+		t.Fatalf("stdout JSON must not include error lines, got %q", out.String())
 	}
-	catalog := decodeExtractTestCatalog(t, content)
+
+	catalog := decodeExtractTestCatalog(t, out.Bytes())
 	if _, ok := catalog["good.message"]; !ok {
-		t.Fatalf("missing good.message in catalog=%s", content)
+		t.Fatalf("missing good.message in catalog=%s", out.String())
 	}
 	if _, ok := catalog["bad.message"]; ok {
-		t.Fatalf("bad.message should be skipped, catalog=%s", content)
+		t.Fatalf("bad.message should be skipped, catalog=%s", out.String())
 	}
 }
 

--- a/apps/cli/cmd/extract_test.go
+++ b/apps/cli/cmd/extract_test.go
@@ -747,6 +747,68 @@ func TestScanTemplateLiteralIgnoresEscapedInterpolations(t *testing.T) {
 	}
 }
 
+func TestScanTemplateLiteralHandlesRegexWithQuotesInInterpolation(t *testing.T) {
+	// Mirrors escapeCsv-style helpers: a template literal whose interpolation
+	// contains a regex with a quote, plus a string with doubled quotes.
+	src := "`\"${str.replace(/\"/g, '\"\"')}\"`"
+	end, expressions, ok := scanTemplateLiteral(src, 0)
+	if !ok {
+		t.Fatalf("expected template literal with regex interpolation to scan successfully")
+	}
+	if end != len(src) {
+		t.Fatalf("end = %d, want %d", end, len(src))
+	}
+	if got, want := len(expressions), 1; got != want {
+		t.Fatalf("expression count = %d, want %d", got, want)
+	}
+	if got, want := src[expressions[0].start:expressions[0].end], "str.replace(/\"/g, '\"\"')"; got != want {
+		t.Fatalf("expression = %q, want %q", got, want)
+	}
+}
+
+func TestExtractMessagesFromSourceWithRegexInsideTemplateLiteral(t *testing.T) {
+	src := "\n" +
+		"function escapeCsv(field: string | number): string {\n" +
+		"  const str = String(field);\n" +
+		"  if (str.includes(\",\") || str.includes('\"') || str.includes(\"\\n\")) {\n" +
+		"    return `\"${str.replace(/\"/g, '\"\"')}\"`;\n" +
+		"  }\n" +
+		"  return str;\n" +
+		"}\n" +
+		"\n" +
+		"formatMessage({\n" +
+		"  id: \"csv.header\",\n" +
+		"  defaultMessage: \"Export\",\n" +
+		"  description: \"CSV header\",\n" +
+		"});\n"
+	messages, err := extractMessagesFromReactIntlSource(src, "escape-csv.ts")
+	if err != nil {
+		t.Fatalf("extractMessagesFromReactIntlSource: %v", err)
+	}
+	if got, want := len(messages), 1; got != want {
+		t.Fatalf("message count = %d, want %d", got, want)
+	}
+	if messages[0].ID != "csv.header" {
+		t.Fatalf("id = %q, want csv.header", messages[0].ID)
+	}
+}
+
+func TestSkipRegexLiteralDistinguishesDivision(t *testing.T) {
+	regexSrc := `replace(/"/g, '""')`
+	end, ok := skipRegexLiteral(regexSrc, strings.IndexByte(regexSrc, '/'))
+	if !ok {
+		t.Fatalf("expected regex literal to be skipped")
+	}
+	if got, want := regexSrc[:end], `replace(/"/g`; got != want {
+		t.Fatalf("skipped prefix = %q, want %q", got, want)
+	}
+
+	divisionSrc := "value / 2"
+	if _, ok := skipRegexLiteral(divisionSrc, strings.IndexByte(divisionSrc, '/')); ok {
+		t.Fatalf("expected division operator not to be treated as regex")
+	}
+}
+
 func TestSkipStringLiteralHandlesNestedTemplateLiterals(t *testing.T) {
 	src := "`outer ${`inner`} tail` ;"
 	got := skipStringLiteral(src, 0)

--- a/apps/cli/cmd/extract_test.go
+++ b/apps/cli/cmd/extract_test.go
@@ -825,6 +825,60 @@ func TestUnescapeJavaScriptStringSupportsHighByteHexEscapes(t *testing.T) {
 	}
 }
 
+func TestExtractCommandSkipsFilesWithExtractionErrors(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	writeExtractTestFile(t, filepath.Join(dir, "good.ts"), `
+formatMessage({
+  id: "good.message",
+  defaultMessage: "Hello",
+  description: "Greeting",
+});
+`)
+	writeExtractTestFile(
+		t, filepath.Join(dir, "bad.ts"),
+		"const broken = `unterminated template;\n"+
+			"formatMessage({\n"+
+			"  id: \"bad.message\",\n"+
+			"  defaultMessage: \"Should be skipped\",\n"+
+			"});\n",
+	)
+
+	outFile := filepath.Join(dir, "messages.json")
+	cmd := newExtractCmd()
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{".", "--out-file", outFile})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute extract command: %v", err)
+	}
+
+	errorOutput := out.String()
+	if !strings.Contains(errorOutput, `error: extract "`) || !strings.Contains(errorOutput, "bad.ts") {
+		t.Fatalf("expected extraction error for bad.ts on stdout, got %q", errorOutput)
+	}
+	if !strings.Contains(errorOutput, "unterminated template literal") {
+		t.Fatalf("expected unterminated template literal detail, got %q", errorOutput)
+	}
+	if strings.Contains(errorOutput, "good.ts") {
+		t.Fatalf("did not expect error for good.ts, got %q", errorOutput)
+	}
+
+	content, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("read out-file: %v", err)
+	}
+	catalog := decodeExtractTestCatalog(t, content)
+	if _, ok := catalog["good.message"]; !ok {
+		t.Fatalf("missing good.message in catalog=%s", content)
+	}
+	if _, ok := catalog["bad.message"]; ok {
+		t.Fatalf("bad.message should be skipped, catalog=%s", content)
+	}
+}
+
 func TestRootHelpIncludesExtractCommand(t *testing.T) {
 	cmd := newRootCmd("")
 	b := bytes.NewBufferString("")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Two related `extract` fixes:

1. **Regex literals inside template interpolations** — helpers like `escapeCsv` failed with `unterminated template literal` because quotes in `/"/g` were treated as string delimiters. The scanner now skips JavaScript regex literals (with a lookbehind heuristic so division stays division).

2. **Per-file extraction errors no longer abort the run** — if a file fails to parse, extract logs `error: extract "<file>": ...` to stderr, skips that file, and continues with the rest. JSON catalog output on stdout stays valid.

## How to test

- `go test ./apps/cli/cmd/ -run 'TestScanTemplateLiteral|TestSkipRegex|TestExtractMessagesFromSourceWithRegex|TestExtractCommandSkipsFilesWithExtractionErrors' -count=1`
- `make fmt && make lint`
- `go test ./apps/cli/cmd/ -count=1`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6be00661-9fb1-4271-b836-95a253dacaef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6be00661-9fb1-4271-b836-95a253dacaef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

