### PR TITLE
fix(web): preserve UTF-8 when capturing hl entries from sandbox

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-write-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-write-tools.test.ts
@@ -46,6 +46,14 @@ vi.mock("@/lib/file-storage/records", async (importOriginal) => {
   };
 });
 
+const { readTranslatedFileMock } = vi.hoisted(() => ({
+  readTranslatedFileMock: vi.fn(),
+}));
+
+vi.mock("@/lib/translation/sandbox", () => ({
+  readTranslatedFile: readTranslatedFileMock,
+}));
+
 import {
   createApplyHyperlocaliseFixesTool,
   createCommitChangesTool,
@@ -422,13 +430,12 @@ describe("createUploadSourcesTool", () => {
   });
 
   it("uploads files and returns success", async () => {
-    const runCommandMock = vi.fn(async () => ({
-      exitCode: 0,
-      output: vi.fn(async () => '{"hello":"Hello"}'),
-    }));
-    sandboxGetMock.mockResolvedValue({
-      runCommand: runCommandMock,
-    } as never);
+    readTranslatedFileMock.mockImplementation(async (_sandboxId: string, path: string) => {
+      if (path.endsWith("en.json")) {
+        return Buffer.from('{"hello":"Hello"}');
+      }
+      return Buffer.from('{"hello":"Bonjour"}');
+    });
 
     const tool = createUploadSourcesTool(createBaseCtx());
     const result = (await tool.execute!(
@@ -452,6 +459,7 @@ describe("createUploadSourcesTool", () => {
         sourceFileVersionId: "version_file_fr.json",
       },
     ]);
+    expect(readTranslatedFileMock).toHaveBeenCalledWith("sbx_1", "src/i18n/en.json");
     expect(createStoredFileMock).toHaveBeenCalledWith(
       expect.objectContaining({
         organizationId: "org_1",
@@ -478,14 +486,9 @@ describe("createUploadSourcesTool", () => {
   });
 
   it("returns error when a file cannot be read", async () => {
-    const runCommandMock = vi
-      .fn()
-      .mockResolvedValueOnce({ exitCode: 0, output: vi.fn(async () => '{"hello":"Hello"}') })
-      .mockResolvedValueOnce({ exitCode: 1, output: vi.fn(async () => "No such file") });
-
-    sandboxGetMock.mockResolvedValue({
-      runCommand: runCommandMock,
-    } as never);
+    readTranslatedFileMock
+      .mockResolvedValueOnce(Buffer.from('{"hello":"Hello"}'))
+      .mockRejectedValueOnce(new Error("Failed to read src/i18n/missing.json"));
 
     const tool = createUploadSourcesTool(createBaseCtx());
     const result = (await tool.execute!(

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-write-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-write-tools.ts
@@ -12,6 +12,7 @@ import {
   normalizeSourcePath,
 } from "@/lib/file-storage/records";
 import { inferSupportedSourceUploadFormat } from "@/lib/translation/file-formats";
+import { readTranslatedFile } from "@/lib/translation/sandbox";
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 import type { WriteAction } from "@/lib/agent-contracts/write-gate";
 import { canPushToGitHubBranch } from "@/lib/agents/repository-write-gate";
@@ -394,14 +395,18 @@ export function createUploadSourcesTool(ctx: ToolContext) {
             };
           }
 
-          const result = await runSandboxCommand(ctx.sandboxId, "cat", [path], "stdout");
-          if (result.exitCode !== 0) {
+          let fileContent: Buffer;
+          try {
+            // Binary read avoids sandbox stdout UTF-8 corruption (multi-byte → �).
+            fileContent = await readTranslatedFile(ctx.sandboxId, path);
+          } catch (error) {
+            const message = error instanceof Error ? error.message : `Failed to read ${path}`;
             await logMutation(ctx, {
               action: "upload_sources",
               status: "failed",
-              details: { error: `Failed to read ${path}: ${result.output}` },
+              details: { error: message },
             });
-            return { success: false, error: `Failed to read ${path}: ${result.output}` };
+            return { success: false, error: message };
           }
 
           let uploadedFile: typeof schema.storedFiles.$inferSelect | null = null;
@@ -415,7 +420,7 @@ export function createUploadSourcesTool(ctx: ToolContext) {
                 sourceKind: "repository_file",
                 filename: sourceFilename(normalizedPath),
                 contentType: sourceContentType(normalizedPath),
-                content: Buffer.from(result.output),
+                content: fileContent,
                 metadata: {
                   sourcePath: normalizedPath,
                   commitSha: ctx.githubContext?.commitSha,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/vercel-sandbox-runtime.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/vercel-sandbox-runtime.test.ts
@@ -75,7 +75,8 @@ describe("VercelSandboxRuntime", () => {
 
   it("reads files via binary buffer so Vietnamese UTF-8 is preserved", async () => {
     const vietnamese = "Tìm hiểu thêm về{0}";
-    const output = vi.fn().mockResolvedValue("");
+    const resolvedPath = "/vercel/sandbox/lang/vi-VN.json";
+    const output = vi.fn().mockResolvedValue(resolvedPath);
     const readFileToBuffer = vi.fn().mockResolvedValue(Buffer.from(vietnamese, "utf8"));
     sandboxMocks.runCommand.mockResolvedValueOnce({
       exitCode: 0,
@@ -92,10 +93,10 @@ describe("VercelSandboxRuntime", () => {
     const runtime = new VercelSandboxRuntime("sbx_123");
     await expect(runtime.readFile("lang/vi-VN.json")).resolves.toBe(vietnamese);
 
-    expect(readFileToBuffer).toHaveBeenCalledWith({ path: "lang/vi-VN.json" });
+    expect(readFileToBuffer).toHaveBeenCalledWith({ path: resolvedPath });
     expect(sandboxMocks.runCommand).toHaveBeenCalledWith(
       "bash",
-      expect.arrayContaining(["-lc", expect.stringContaining("readlink -f")]),
+      expect.arrayContaining(["-lc", expect.stringContaining(`printf '%s' "$resolved"`)]),
     );
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/vercel-sandbox-runtime.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/vercel-sandbox-runtime.test.ts
@@ -72,4 +72,30 @@ describe("VercelSandboxRuntime", () => {
       });
     }
   });
+
+  it("reads files via binary buffer so Vietnamese UTF-8 is preserved", async () => {
+    const vietnamese = "Tìm hiểu thêm về{0}";
+    const output = vi.fn().mockResolvedValue("");
+    const readFileToBuffer = vi.fn().mockResolvedValue(Buffer.from(vietnamese, "utf8"));
+    sandboxMocks.runCommand.mockResolvedValueOnce({
+      exitCode: 0,
+      output,
+    });
+    sandboxMocks.get
+      .mockResolvedValueOnce({
+        runCommand: sandboxMocks.runCommand,
+      })
+      .mockResolvedValueOnce({
+        readFileToBuffer,
+      });
+
+    const runtime = new VercelSandboxRuntime("sbx_123");
+    await expect(runtime.readFile("lang/vi-VN.json")).resolves.toBe(vietnamese);
+
+    expect(readFileToBuffer).toHaveBeenCalledWith({ path: "lang/vi-VN.json" });
+    expect(sandboxMocks.runCommand).toHaveBeenCalledWith(
+      "bash",
+      expect.arrayContaining(["-lc", expect.stringContaining("readlink -f")]),
+    );
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/vercel-sandbox-runtime.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/vercel-sandbox-runtime.ts
@@ -156,7 +156,7 @@ export class VercelSandboxRuntime implements WorkspaceRuntime {
       "bash",
       [
         "-lc",
-        `set -euo pipefail; target=${shellQuote(path)}; if [ -L "$target" ]; then exit 42; fi; resolved=$(readlink -f "$target" 2>/dev/null || true); if [ -z "$resolved" ] || [ ! -f "$resolved" ]; then exit 43; fi; case "$resolved" in /etc/*|/proc/*|/sys/*|/var/*|/root/*|/home/*/.ssh/*) exit 44;; esac; cat "$resolved"`,
+        `set -euo pipefail; target=${shellQuote(path)}; if [ -L "$target" ]; then exit 42; fi; resolved=$(readlink -f "$target" 2>/dev/null || true); if [ -z "$resolved" ] || [ ! -f "$resolved" ]; then exit 43; fi; case "$resolved" in /etc/*|/proc/*|/sys/*|/var/*|/root/*|/home/*/.ssh/*) exit 44;; esac`,
       ],
       { output: "stdout" },
     );
@@ -174,7 +174,13 @@ export class VercelSandboxRuntime implements WorkspaceRuntime {
       throw new Error(guard.output || `Failed to read ${path}`);
     }
 
-    return guard.output;
+    // Binary read avoids sandbox stdout UTF-8 corruption (multi-byte → �).
+    const sandbox = await Sandbox.get({ name: this.id });
+    const content = await sandbox.readFileToBuffer({ path });
+    if (!content) {
+      throw new Error(`Failed to read ${path}`);
+    }
+    return Buffer.from(content).toString("utf8");
   }
 
   async writeFile(path: string, content: string | Buffer): Promise<void> {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/vercel-sandbox-runtime.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/vercel-sandbox-runtime.ts
@@ -156,7 +156,7 @@ export class VercelSandboxRuntime implements WorkspaceRuntime {
       "bash",
       [
         "-lc",
-        `set -euo pipefail; target=${shellQuote(path)}; if [ -L "$target" ]; then exit 42; fi; resolved=$(readlink -f "$target" 2>/dev/null || true); if [ -z "$resolved" ] || [ ! -f "$resolved" ]; then exit 43; fi; case "$resolved" in /etc/*|/proc/*|/sys/*|/var/*|/root/*|/home/*/.ssh/*) exit 44;; esac`,
+        `set -euo pipefail; target=${shellQuote(path)}; if [ -L "$target" ]; then exit 42; fi; resolved=$(readlink -f "$target" 2>/dev/null || true); if [ -z "$resolved" ] || [ ! -f "$resolved" ]; then exit 43; fi; case "$resolved" in /etc/*|/proc/*|/sys/*|/var/*|/root/*|/home/*/.ssh/*) exit 44;; esac; printf '%s' "$resolved"`,
       ],
       { output: "stdout" },
     );
@@ -174,9 +174,15 @@ export class VercelSandboxRuntime implements WorkspaceRuntime {
       throw new Error(guard.output || `Failed to read ${path}`);
     }
 
+    const resolvedPath = guard.output.trim();
+    if (!resolvedPath) {
+      throw new Error(`Failed to read ${path}`);
+    }
+
     // Binary read avoids sandbox stdout UTF-8 corruption (multi-byte → �).
+    // Use the guard-resolved absolute path so the bytes match what was validated.
     const sandbox = await Sandbox.get({ name: this.id });
-    const content = await sandbox.readFileToBuffer({ path });
+    const content = await sandbox.readFileToBuffer({ path: resolvedPath });
     if (!content) {
       throw new Error(`Failed to read ${path}`);
     }

--- a/apps/hyperlocalise-web/src/lib/file-storage/upload-repository-source-files.ts
+++ b/apps/hyperlocalise-web/src/lib/file-storage/upload-repository-source-files.ts
@@ -10,7 +10,7 @@ import {
   sha256Hex,
 } from "@/lib/file-storage/records";
 import { sourceContentType, sourceFilename } from "@/lib/file-storage/source-file-metadata";
-import { runSandboxCommand } from "@/lib/translation/sandbox";
+import { readTranslatedFile } from "@/lib/translation/sandbox";
 import { inferSupportedSourceUploadFormat } from "@/lib/translation/file-formats";
 
 const logger = createLogger("upload-repository-source-files");
@@ -57,10 +57,11 @@ export async function uploadRepositorySourceFilesFromSandbox(input: {
       continue;
     }
 
-    const readResult = await runSandboxCommand(input.sandboxId, "cat", [normalizedPath], {
-      output: "stdout",
-    });
-    if (readResult.exitCode !== 0) {
+    let content: Buffer;
+    try {
+      // Binary read avoids sandbox stdout UTF-8 corruption (multi-byte → �).
+      content = await readTranslatedFile(input.sandboxId, normalizedPath);
+    } catch {
       results.push({
         path: normalizedPath,
         outcome: "failed",
@@ -69,7 +70,6 @@ export async function uploadRepositorySourceFilesFromSandbox(input: {
       continue;
     }
 
-    const content = Buffer.from(readResult.output);
     const sourceHash = await sha256Hex(content);
 
     if (input.commitSha) {

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
@@ -217,13 +217,15 @@ async function runFileTranslationInSandbox(input: {
 
   const translatedContent = await readTranslatedFile(input.sandboxId, outputFilename);
   const translatedEntries = await extractSandboxEntries(input.sandboxId, outputFilename);
-  if (!translatedEntries) {
-    throw new Error(`failed to extract translated entries: ${outputFilename}`);
+  if (!translatedEntries.ok) {
+    throw new Error(
+      `failed to extract translated entries: ${outputFilename}: exitCode=${translatedEntries.exitCode}`,
+    );
   }
 
   return {
     translatedText: translatedContent.toString("utf8"),
-    translatedEntries,
+    translatedEntries: translatedEntries.entries,
   };
 }
 
@@ -458,7 +460,14 @@ export async function translateProviderJobFiles(input: {
       );
 
       try {
-        sourceEntries = await extractSandboxEntries(sandboxId, inputFilename);
+        const extracted = await extractSandboxEntries(sandboxId, inputFilename);
+        if (extracted.ok) {
+          sourceEntries = extracted.entries;
+        } else {
+          warnings.push(
+            `Could not extract entries for ${sourceFile.displayName ?? sourceFile.id}: exitCode=${extracted.exitCode}`,
+          );
+        }
       } catch (error) {
         warnings.push(
           `Could not extract entries for ${sourceFile.displayName ?? sourceFile.id}: ${
@@ -525,7 +534,8 @@ export async function translateProviderJobFiles(input: {
             mergeApproved: true,
           });
           if (downloadResult.ok) {
-            crowdinPrefilled = (await extractSandboxEntries(sandboxId, outputFilename)) ?? {};
+            const crowdinEntries = await extractSandboxEntries(sandboxId, outputFilename);
+            crowdinPrefilled = crowdinEntries.ok ? crowdinEntries.entries : {};
           }
         }
 

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
@@ -337,20 +337,33 @@ describe("sandbox command runner", () => {
       exitCode: 0,
       output: sandboxMocks.output,
     });
-    const readFileToBuffer = vi.fn().mockResolvedValue(Buffer.from(entriesJson, "utf8"));
-    sandboxMocks.output.mockResolvedValueOnce("");
-    sandboxMocks.runCommand.mockResolvedValueOnce({
-      cmdId: "cmd_entries",
-      wait,
+    const cleanupWait = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      output: sandboxMocks.output,
     });
+    const readFileToBuffer = vi.fn().mockResolvedValue(Buffer.from(entriesJson, "utf8"));
+    sandboxMocks.output.mockResolvedValue("");
+    sandboxMocks.runCommand
+      .mockResolvedValueOnce({
+        cmdId: "cmd_entries",
+        wait,
+      })
+      .mockResolvedValueOnce({
+        cmdId: "cmd_cleanup",
+        wait: cleanupWait,
+      });
     sandboxMocks.get
       .mockResolvedValueOnce({
         runCommand: sandboxMocks.runCommand,
       })
-      .mockResolvedValueOnce({ readFileToBuffer });
+      .mockResolvedValueOnce({ readFileToBuffer })
+      .mockResolvedValueOnce({
+        runCommand: sandboxMocks.runCommand,
+      });
 
     await expect(extractSandboxEntries("sandbox_123", "lang/vi-VN.json")).resolves.toEqual({
-      i02F07: vietnamese,
+      ok: true,
+      entries: { i02F07: vietnamese },
     });
 
     expect(sandboxMocks.runCommand).toHaveBeenCalledWith({
@@ -366,6 +379,46 @@ describe("sandbox command runner", () => {
     });
     expect(readFileToBuffer).toHaveBeenCalledWith({
       path: expect.stringMatching(/^\/tmp\/hl-entries-[0-9a-f-]+\.json$/),
+    });
+    expect(sandboxMocks.runCommand).toHaveBeenCalledWith({
+      cmd: "rm",
+      args: ["-f", expect.stringMatching(/^\/tmp\/hl-entries-[0-9a-f-]+\.json$/)],
+      env: undefined,
+      detached: true,
+    });
+  });
+
+  it("returns exitCode and output when hl entries fails", async () => {
+    const wait = vi.fn().mockResolvedValue({
+      exitCode: 1,
+      output: sandboxMocks.output,
+    });
+    const cleanupWait = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      output: sandboxMocks.output,
+    });
+    sandboxMocks.output.mockResolvedValue("markdown AST parity mismatch");
+    sandboxMocks.runCommand
+      .mockResolvedValueOnce({
+        cmdId: "cmd_entries",
+        wait,
+      })
+      .mockResolvedValueOnce({
+        cmdId: "cmd_cleanup",
+        wait: cleanupWait,
+      });
+    sandboxMocks.get
+      .mockResolvedValueOnce({
+        runCommand: sandboxMocks.runCommand,
+      })
+      .mockResolvedValueOnce({
+        runCommand: sandboxMocks.runCommand,
+      });
+
+    await expect(extractSandboxEntries("sandbox_123", "lang/vi-VN.json")).resolves.toEqual({
+      ok: false,
+      exitCode: 1,
+      output: "markdown AST parity mismatch",
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
@@ -40,6 +40,7 @@ import {
   buildMultiLocaleTempConfig,
   buildTempConfig,
   createTranslationSandbox,
+  extractSandboxEntries,
   getOutputFilenamePattern,
   isSandboxDisconnectError,
   isSandboxStreamClosedError,
@@ -327,6 +328,59 @@ describe("sandbox command runner", () => {
     expect(sandboxMocks.get).not.toHaveBeenCalledWith(
       expect.objectContaining({ resume: expect.anything() }),
     );
+  });
+
+  it("extracts hl entries via file redirect so Vietnamese UTF-8 is preserved", async () => {
+    const vietnamese = "Tìm hiểu thêm về{0}";
+    const entriesJson = `${JSON.stringify({ i02F07: vietnamese }, null, 2)}\n`;
+    const wait = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      output: sandboxMocks.output,
+    });
+    const readFileToBuffer = vi.fn().mockResolvedValue(Buffer.from(entriesJson, "utf8"));
+    sandboxMocks.output.mockResolvedValueOnce("");
+    sandboxMocks.runCommand.mockResolvedValueOnce({
+      cmdId: "cmd_entries",
+      wait,
+    });
+    sandboxMocks.get
+      .mockResolvedValueOnce({
+        runCommand: sandboxMocks.runCommand,
+      })
+      .mockResolvedValueOnce({ readFileToBuffer });
+
+    await expect(extractSandboxEntries("sandbox_123", "lang/vi-VN.json")).resolves.toEqual({
+      i02F07: vietnamese,
+    });
+
+    expect(sandboxMocks.runCommand).toHaveBeenCalledWith({
+      cmd: "bash",
+      args: [
+        "-lc",
+        expect.stringMatching(
+          /^hl entries 'lang\/vi-VN\.json' > '\/tmp\/hl-entries-[0-9a-f-]+\.json'$/,
+        ),
+      ],
+      env: { OPENAI_API_KEY: "test-openai-api-key" },
+      detached: true,
+    });
+    expect(readFileToBuffer).toHaveBeenCalledWith({
+      path: expect.stringMatching(/^\/tmp\/hl-entries-[0-9a-f-]+\.json$/),
+    });
+  });
+
+  it("documents that splitting UTF-8 bytes across chunks yields U+FFFD", () => {
+    // Sandbox NDJSON log capture can deliver multi-byte UTF-8 across chunk
+    // boundaries. Decoding each chunk independently replaces orphaned bytes
+    // with U+FFFD — the CAT symptom for "về" → "v���".
+    const eWithCircumflexGrave = Buffer.from("ề", "utf8"); // E1 BB 81
+    expect(eWithCircumflexGrave).toEqual(Buffer.from([0xe1, 0xbb, 0x81]));
+
+    const decoder = new TextDecoder("utf-8");
+    const corrupted =
+      decoder.decode(eWithCircumflexGrave.subarray(0, 1)) +
+      decoder.decode(eWithCircumflexGrave.subarray(1));
+    expect(corrupted).toBe("\uFFFD\uFFFD\uFFFD");
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
@@ -22,6 +22,10 @@ export const sandboxFileBucketName = "file";
 
 export type { SandboxTranslationContext };
 
+export type ExtractSandboxEntriesResult =
+  | { ok: true; entries: Record<string, string> }
+  | { ok: false; exitCode: number; output: string };
+
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
@@ -700,7 +704,7 @@ export class HyperlocaliseCliRunner {
     sandboxId: string,
     path: string,
     options?: { locale?: string; sourcePath?: string },
-  ): Promise<Record<string, string> | null> {
+  ): Promise<ExtractSandboxEntriesResult> {
     const locale = options?.locale?.trim();
     const localeFlag = locale ? ` --locale ${shellQuote(locale)}` : "";
     const sourcePath = options?.sourcePath?.trim();
@@ -710,24 +714,39 @@ export class HyperlocaliseCliRunner {
     // chunks, each orphaned byte becomes U+FFFD (�). Write entries to a file and
     // read bytes instead so CAT / pull persist valid Unicode.
     const outputPath = `/tmp/hl-entries-${randomUUID()}.json`;
-    const result = await this.lifecycle.runCommand(
-      sandboxId,
-      "bash",
-      [
-        "-lc",
-        `hl entries ${shellQuote(path)}${localeFlag}${sourceFlag} > ${shellQuote(outputPath)}`,
-      ],
-      { env: getSandboxTranslationEnv() },
-    );
-    if (result.exitCode !== 0) {
-      return null;
-    }
-
     try {
-      const content = await this.lifecycle.readFile(sandboxId, outputPath);
-      return JSON.parse(content.toString("utf8")) as Record<string, string>;
-    } catch {
-      return null;
+      const result = await this.lifecycle.runCommand(
+        sandboxId,
+        "bash",
+        [
+          "-lc",
+          `hl entries ${shellQuote(path)}${localeFlag}${sourceFlag} > ${shellQuote(outputPath)}`,
+        ],
+        { env: getSandboxTranslationEnv() },
+      );
+      if (result.exitCode !== 0) {
+        return { ok: false, exitCode: result.exitCode, output: result.output };
+      }
+
+      try {
+        const content = await this.lifecycle.readFile(sandboxId, outputPath);
+        return {
+          ok: true,
+          entries: JSON.parse(content.toString("utf8")) as Record<string, string>,
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          exitCode: 0,
+          output: error instanceof Error ? error.message : "failed to read or parse entries JSON",
+        };
+      }
+    } finally {
+      try {
+        await this.lifecycle.runCommand(sandboxId, "rm", ["-f", outputPath]);
+      } catch {
+        // Best-effort cleanup; sandboxes are ephemeral.
+      }
     }
   }
 }
@@ -913,7 +932,7 @@ export async function extractSandboxEntries(
   sandboxId: string,
   path: string,
   options?: { locale?: string; sourcePath?: string },
-) {
+): Promise<ExtractSandboxEntriesResult> {
   return defaultRunner.extractEntries(sandboxId, path, options);
 }
 

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import { Sandbox, StreamError } from "@vercel/sandbox";
 
 import { hyperlocaliseAgentModelId } from "@/lib/agent-runtime/loops/model-id";
@@ -703,17 +705,30 @@ export class HyperlocaliseCliRunner {
     const localeFlag = locale ? ` --locale ${shellQuote(locale)}` : "";
     const sourcePath = options?.sourcePath?.trim();
     const sourceFlag = sourcePath ? ` --source ${shellQuote(sourcePath)}` : "";
+    // Sandbox command.output() concatenates NDJSON log chunks as JS strings. When a
+    // UTF-8 multi-byte character (e.g. Vietnamese ề = E1 BB 81) is split across
+    // chunks, each orphaned byte becomes U+FFFD (�). Write entries to a file and
+    // read bytes instead so CAT / pull persist valid Unicode.
+    const outputPath = `/tmp/hl-entries-${randomUUID()}.json`;
     const result = await this.lifecycle.runCommand(
       sandboxId,
       "bash",
-      ["-lc", `hl entries ${shellQuote(path)}${localeFlag}${sourceFlag}`],
-      { env: getSandboxTranslationEnv(), output: "stdout" },
+      [
+        "-lc",
+        `hl entries ${shellQuote(path)}${localeFlag}${sourceFlag} > ${shellQuote(outputPath)}`,
+      ],
+      { env: getSandboxTranslationEnv() },
     );
     if (result.exitCode !== 0) {
       return null;
     }
 
-    return JSON.parse(result.output) as Record<string, string>;
+    try {
+      const content = await this.lifecycle.readFile(sandboxId, outputPath);
+      return JSON.parse(content.toString("utf8")) as Record<string, string>;
+    } catch {
+      return null;
+    }
   }
 }
 

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -380,21 +380,16 @@ async function extractEntriesStep(
   options?: { sourcePath?: string },
 ) {
   "use step";
-  const { getSandboxTranslationEnv, runSandboxCommand } = await import("@/lib/translation/sandbox");
-  const sourcePath = options?.sourcePath?.trim();
-  const sourceFlag = sourcePath ? ` --source '${shellSingleQuote(sourcePath)}'` : "";
-  const result = await runSandboxCommand(
-    sandboxId,
-    "bash",
-    ["-lc", `hl entries '${shellSingleQuote(path)}'${sourceFlag}`],
-    { env: getSandboxTranslationEnv(), output: "stdout" },
-  );
-  if (result.exitCode !== 0) {
-    throw new Error(
-      `failed to extract entries: exitCode=${result.exitCode} kind=${classifyCliFailureKind(result.output)}`,
-    );
+  // Use extractSandboxEntries so UTF-8 entries are read via binary file IO,
+  // not sandbox stdout string capture (which can turn multi-byte chars into �).
+  const { extractSandboxEntries } = await import("@/lib/translation/sandbox");
+  const entries = await extractSandboxEntries(sandboxId, path, {
+    sourcePath: options?.sourcePath,
+  });
+  if (!entries) {
+    throw new Error(`failed to extract entries for ${path}`);
   }
-  return JSON.parse(result.output) as Record<string, string>;
+  return entries;
 }
 async function readOutputStep(sandboxId: string, outputFile: string, _attempt: 1 | 2) {
   "use step";

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -383,13 +383,15 @@ async function extractEntriesStep(
   // Use extractSandboxEntries so UTF-8 entries are read via binary file IO,
   // not sandbox stdout string capture (which can turn multi-byte chars into �).
   const { extractSandboxEntries } = await import("@/lib/translation/sandbox");
-  const entries = await extractSandboxEntries(sandboxId, path, {
+  const result = await extractSandboxEntries(sandboxId, path, {
     sourcePath: options?.sourcePath,
   });
-  if (!entries) {
-    throw new Error(`failed to extract entries for ${path}`);
+  if (!result.ok) {
+    throw new Error(
+      `failed to extract entries: exitCode=${result.exitCode} kind=${classifyCliFailureKind(result.output)}`,
+    );
   }
-  return entries;
+  return result.entries;
 }
 async function readOutputStep(sandboxId: string, outputFile: string, _attempt: 1 | 2) {
   "use step";

--- a/apps/hyperlocalise-web/src/workflows/steps/source-file-ingest.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/source-file-ingest.ts
@@ -58,11 +58,11 @@ export async function writeSourceIngestFileStep(
 export async function extractSourceIngestEntriesStep(sandboxId: string, filePath: string) {
   "use step";
   const { extractSandboxEntries } = await import("@/lib/translation/sandbox");
-  const entries = await extractSandboxEntries(sandboxId, filePath);
-  if (!entries) {
-    throw new Error(`failed to extract entries for ${filePath}`);
+  const result = await extractSandboxEntries(sandboxId, filePath);
+  if (!result.ok) {
+    throw new Error(`failed to extract entries for ${filePath}: exitCode=${result.exitCode}`);
   }
-  return entries;
+  return result.entries;
 }
 
 export async function parseHlEntriesStep(

--- a/apps/hyperlocalise-web/src/workflows/steps/translation-file-import.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/translation-file-import.ts
@@ -5,13 +5,13 @@ export async function extractTranslationImportEntriesStep(input: {
 }) {
   "use step";
   const { extractSandboxEntries } = await import("@/lib/translation/sandbox");
-  const entries = await extractSandboxEntries(input.sandboxId, input.filePath, {
+  const result = await extractSandboxEntries(input.sandboxId, input.filePath, {
     locale: input.targetLocale,
   });
-  if (!entries) {
-    throw new Error(`failed to extract entries for ${input.filePath}`);
+  if (!result.ok) {
+    throw new Error(`failed to extract entries for ${input.filePath}: exitCode=${result.exitCode}`);
   }
-  return entries;
+  return result.entries;
 }
 
 export async function importTranslationsFromEntriesStep(input: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Vietnamese translations showed as `�` (U+FFFD) in CAT and after `hl pull` — e.g. `về` became `v���`.

**Root cause:** Workflows run `hl entries` in a Vercel sandbox and parse **stdout**. The sandbox SDK builds stdout from NDJSON log chunks as JS strings. When a 3-byte UTF-8 character is split across chunks, each orphaned byte becomes U+FFFD. That corrupted map was written to the DB, so CAT and pull both showed diamond question marks.

`hl entries` and the Go JSON parsers were fine; corruption happened at sandbox stdout capture.

**Fix:**
- Redirect `hl entries` to a temp file and read with `readFileToBuffer`
- Route the file-translation job through the same helper
- Stop using `cat` + `Buffer.from(stdout)` for source uploads / agent file reads

## How to test

- `vp test src/lib/translation/sandbox-translation.test.ts src/lib/agent-runtime/workspaces/vercel-sandbox-runtime.test.ts`
- `vp check --fix`
- Re-run a vi-VN file translation job and confirm CAT shows `về` correctly, then `hl pull`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8b8de92-f915-4e80-b7f9-365df474ff4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8b8de92-f915-4e80-b7f9-365df474ff4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

