### PR TITLE
chore(ci): switch Blacksmith runners to 2vcpu Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   action-self-test:
     name: Action Self Test
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
 
     steps:
       - name: Checkout
@@ -61,7 +61,7 @@ jobs:
 
   web-sync-cli-smoke-test:
     name: Web Sync CLI Smoke Test
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     defaults:
       run:
         working-directory: apps/hyperlocalise-web
@@ -89,7 +89,7 @@ jobs:
 
   bazel-build-test:
     name: Bazel Build/Test
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     env:
       BUILDBUDDY_ENDPOINT: grpcs://remote.buildbuddy.io
       BUILDBUDDY_RESULTS_URL: https://app.buildbuddy.io/invocation/
@@ -130,7 +130,7 @@ jobs:
 
   go-quality:
     name: Go Quality
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   action-self-test:
     name: Action Self Test
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
       - name: Checkout
@@ -61,7 +61,7 @@ jobs:
 
   web-sync-cli-smoke-test:
     name: Web Sync CLI Smoke Test
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     defaults:
       run:
         working-directory: apps/hyperlocalise-web
@@ -89,7 +89,7 @@ jobs:
 
   bazel-build-test:
     name: Bazel Build/Test
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     env:
       BUILDBUDDY_ENDPOINT: grpcs://remote.buildbuddy.io
       BUILDBUDDY_RESULTS_URL: https://app.buildbuddy.io/invocation/
@@ -130,7 +130,7 @@ jobs:
 
   go-quality:
     name: Go Quality
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
       - name: Checkout

--- a/.github/workflows/hyperlocalise-web-localize.yml
+++ b/.github/workflows/hyperlocalise-web-localize.yml
@@ -34,7 +34,7 @@ jobs:
         (github.event_name == 'workflow_dispatch' && github.event.inputs.job == 'upload') ||
         (github.event_name == 'schedule' && github.event.schedule == '0 2 * * *')
       }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     environment: hyperlocalise-web-localize
     defaults:
       run:
@@ -72,7 +72,7 @@ jobs:
         (github.event_name == 'workflow_dispatch' && github.event.inputs.job == 'download') ||
         (github.event_name == 'schedule' && github.event.schedule == '0 10 * * *')
       }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     environment: hyperlocalise-web-localize
     permissions:
       contents: write

--- a/.github/workflows/hyperlocalise-web-localize.yml
+++ b/.github/workflows/hyperlocalise-web-localize.yml
@@ -34,7 +34,7 @@ jobs:
         (github.event_name == 'workflow_dispatch' && github.event.inputs.job == 'upload') ||
         (github.event_name == 'schedule' && github.event.schedule == '0 2 * * *')
       }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     environment: hyperlocalise-web-localize
     defaults:
       run:
@@ -72,7 +72,7 @@ jobs:
         (github.event_name == 'workflow_dispatch' && github.event.inputs.job == 'download') ||
         (github.event_name == 'schedule' && github.event.schedule == '0 10 * * *')
       }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     environment: hyperlocalise-web-localize
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   goreleaser:
     name: GoReleaser
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   goreleaser:
     name: GoReleaser
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
       - name: Checkout

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   hyperlocalise-web-build:
     name: Hyperlocalise Web Build
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     services:
       postgres:
         image: postgres:18
@@ -39,7 +39,7 @@ jobs:
           --health-retries 12
     env:
       CI: "true"
-      NODE_OPTIONS: --max-old-space-size=8192
+      NODE_OPTIONS: --max-old-space-size=4096
       DATABASE_URL: postgres://hyperlocalise:hyperlocalise@127.0.0.1:5432/hyperlocalise?sslmode=disable
       OPENAI_API_KEY: test-openai-api-key
       NEXT_PUBLIC_WAITLIST_URL: https://example.com/waitlist

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   hyperlocalise-web-build:
     name: Hyperlocalise Web Build
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     services:
       postgres:
         image: postgres:18
@@ -39,7 +39,7 @@ jobs:
           --health-retries 12
     env:
       CI: "true"
-      NODE_OPTIONS: --max-old-space-size=4096
+      NODE_OPTIONS: --max-old-space-size=8192
       DATABASE_URL: postgres://hyperlocalise:hyperlocalise@127.0.0.1:5432/hyperlocalise?sslmode=disable
       OPENAI_API_KEY: test-openai-api-key
       NEXT_PUBLIC_WAITLIST_URL: https://example.com/waitlist


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace all `blacksmith-4vcpu-ubuntu-2404` runners with `blacksmith-2vcpu-ubuntu-2404` across CI, Web CI, Release, and Localize workflows.

## Test plan
- [ ] Confirm CI workflow jobs pick up `blacksmith-2vcpu-ubuntu-2404`
- [ ] Confirm Web CI completes on the smaller runner (build/test/check)
- [ ] Spot-check Release and Localize workflows still schedule correctly on the new label

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c4f0915-1253-4e67-a204-ce133b33ca8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c4f0915-1253-4e67-a204-ce133b33ca8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

