### PR TITLE
🧪 Scout: add parser and tag parity tests for self-closing tags with attributes

### DIFF
--- a/internal/i18n/htmltagparity/htmltagparity_test.go
+++ b/internal/i18n/htmltagparity/htmltagparity_test.go
@@ -221,6 +221,24 @@ func TestMismatchFormattingAndKnownTags(t *testing.T) {
 			tgt:  "Bonjour",
 			want: true,
 		},
+		{
+			name: "custom tag with dot and attributes in self-closing syntax is protected",
+			src:  `<tag.name attr="val" />`,
+			tgt:  "Bonjour",
+			want: true,
+		},
+		{
+			name: "custom tag with underscore and attributes in flexible self-closing syntax is protected",
+			src:  `<tag_name attr="val" / >`,
+			tgt:  "Bonjour",
+			want: true,
+		},
+		{
+			name: "custom tag with digit and attributes in flexible self-closing syntax is protected",
+			src:  `<tag1 attr="val"  /  >`,
+			tgt:  "Bonjour",
+			want: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/i18n/icuparser/parse_test.go
+++ b/internal/i18n/icuparser/parse_test.go
@@ -93,6 +93,62 @@ func TestParseASTPluralNegativeSelector(t *testing.T) {
 	}
 }
 
+func TestParseSelfClosingTagsWithAttributes(t *testing.T) {
+	tests := []struct {
+		name        string
+		msg         string
+		expectedTag string
+	}{
+		{
+			name:        "simple self-closing with double quotes attribute",
+			msg:         `Hello<img src="foo.png"/>world`,
+			expectedTag: "img",
+		},
+		{
+			name:        "space before slash and single quotes attribute",
+			msg:         `Hello<img src='foo.png' />world`,
+			expectedTag: "img",
+		},
+		{
+			name:        "space after slash and multiple attributes",
+			msg:         `Hello<img class="img-fluid" src="foo.png" / >world`,
+			expectedTag: "img",
+		},
+		{
+			name:        "boolean attribute, spaces around slash",
+			msg:         `Hello<input disabled   /   >world`,
+			expectedTag: "input",
+		},
+		{
+			name:        "namespaced tag with mixed attributes",
+			msg:         `Hello<ui:image path='btn' disabled / >world`,
+			expectedTag: "ui:image",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			elems, err := Parse(tt.msg, nil)
+			if err != nil {
+				t.Fatalf("Parse(%q) failed: %v", tt.msg, err)
+			}
+			if len(elems) != 3 {
+				t.Fatalf("expected 3 elements, got %d: %+v", len(elems), elems)
+			}
+			tag, ok := elems[1].(TagElement)
+			if !ok {
+				t.Fatalf("expected tag element, got %T", elems[1])
+			}
+			if tag.Value != tt.expectedTag {
+				t.Errorf("expected tag name %q, got %q", tt.expectedTag, tag.Value)
+			}
+			if !tag.SelfClosing {
+				t.Errorf("expected tag to be self-closing")
+			}
+		})
+	}
+}
+
 func TestParseSelfClosingTagsWithWhitespace(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
💡 What: Added comprehensive unit tests for self-closing tags containing attributes and variable whitespaces in both the ICU parser and the HTML tag parity checker.
🎯 Why: To ensure that complex, namespaced, or custom self-closing markup with attributes (such as `<img src="foo.png" / >` or `<tag.name attr="val" />`) is parsed correctly and treated as structural markup during HTML tag parity checks.
🧩 Scope: `internal/i18n/icuparser/parse_test.go` and `internal/i18n/htmltagparity/htmltagparity_test.go`
✅ Verification: Ran unit tests via `go test ./internal/i18n/icuparser/...` and `go test ./internal/i18n/htmltagparity/...`, as well as global workspace test and quality checks (`make fmt`, `make lint`).
🛡️ Confidence: Protects the localization pipeline from misidentifying translation markup as placeholders or failing to parse tags with attributes, preventing false-positive mismatch errors or unclosed-tag parsing failures.

---
*PR created automatically by Jules for task [17559849841265478892](https://jules.google.com/task/17559849841265478892) started by @cungminh2710*