### PR TITLE
fix(web): defer TMS project access to live provider API

### DIFF
--- a/apps/hyperlocalise-web/src/api/auth/team-access.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/team-access.test.ts
@@ -1,14 +1,30 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import type { ApiAuthContext } from "@/api/auth/workos";
+import { encodeProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 
 const dbSelectMock = vi.fn();
+const getTmsProviderLiveProjectMock = vi.fn();
 
 vi.mock("@/lib/database", () => ({
   db: {
     select: dbSelectMock,
   },
   schema: {
+    projects: {
+      id: "id",
+      organizationId: "organization_id",
+      teamId: "team_id",
+      source: "source",
+    },
+    teams: {
+      id: "id",
+      organizationId: "organization_id",
+    },
+    teamMemberships: {
+      teamId: "team_id",
+      userId: "user_id",
+    },
     glossaries: {
       id: "id",
       organizationId: "organization_id",
@@ -24,7 +40,20 @@ vi.mock("@/lib/teams/default-workspace-team", () => ({
   backfillOrganizationProjectTeams: vi.fn(),
 }));
 
-function createAuthContext(): ApiAuthContext {
+vi.mock("@/lib/providers/jobs/tms-provider-live", () => ({
+  getTmsProviderLiveProject: (...args: unknown[]) => getTmsProviderLiveProjectMock(...args),
+}));
+
+vi.mock("@/api/auth/policy", () => ({
+  hasCapability: (role: string, capability: string) => {
+    if (capability === "teams:write") {
+      return role === "admin" || role === "localization_manager";
+    }
+    return true;
+  },
+}));
+
+function createAuthContext(role: "admin" | "member" = "admin"): ApiAuthContext {
   const organization = {
     workosOrganizationId: "workos_org_1",
     localOrganizationId: "org_1",
@@ -32,7 +61,7 @@ function createAuthContext(): ApiAuthContext {
     slug: null,
     membership: {
       workosMembershipId: null,
-      role: "admin",
+      role,
       accessSource: "direct",
     },
   };
@@ -50,6 +79,37 @@ function createAuthContext(): ApiAuthContext {
     activeTeam: null,
     capabilities: [],
   } as ApiAuthContext;
+}
+
+/**
+ * Chainable select mock that supports both:
+ * - `.from().where().limit()` (project / backfill lookups)
+ * - `.from().innerJoin().where()` (team membership lookups)
+ */
+function mockEmptyTeamScopedLookups() {
+  dbSelectMock.mockImplementation(() => {
+    const createThenable = (value: unknown[] = []) => {
+      const thenable: {
+        limit: ReturnType<typeof vi.fn>;
+        then: Promise<unknown[]>["then"];
+        innerJoin: ReturnType<typeof vi.fn>;
+        where: ReturnType<typeof vi.fn>;
+        from: ReturnType<typeof vi.fn>;
+      } = {
+        limit: vi.fn(async () => value),
+        then: (onFulfilled, onRejected) => Promise.resolve(value).then(onFulfilled, onRejected),
+        innerJoin: vi.fn(),
+        where: vi.fn(),
+        from: vi.fn(),
+      };
+      thenable.innerJoin.mockReturnValue(thenable);
+      thenable.where.mockReturnValue(thenable);
+      thenable.from.mockReturnValue(thenable);
+      return thenable;
+    };
+
+    return createThenable([]);
+  });
 }
 
 describe("canAccessGlossary", () => {
@@ -79,5 +139,67 @@ describe("canAccessMemory", () => {
 
     expect(result).toBeNull();
     expect(dbSelectMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("canAccessProject", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mockEmptyTeamScopedLookups();
+  });
+
+  it("allows live-only external TMS projects when no local projects row exists", async () => {
+    const projectId = encodeProviderProjectId({
+      providerKind: "crowdin",
+      externalProjectId: "902807",
+    });
+
+    getTmsProviderLiveProjectMock.mockResolvedValueOnce({
+      id: projectId,
+      name: "HL-Test",
+    });
+
+    const { canAccessProject } = await import("./team-access");
+    const result = await canAccessProject(createAuthContext("member"), projectId);
+
+    expect(getTmsProviderLiveProjectMock).toHaveBeenCalledWith("org_1", "902807", {
+      actorUserId: "user_1",
+    });
+    expect(result).toEqual({ id: projectId });
+  });
+
+  it("allows live external TMS projects even when materialized outside the member's teams", async () => {
+    const projectId = encodeProviderProjectId({
+      providerKind: "crowdin",
+      externalProjectId: "902807",
+    });
+
+    getTmsProviderLiveProjectMock.mockResolvedValueOnce({
+      id: projectId,
+      name: "HL-Test",
+    });
+
+    const { canAccessProject } = await import("./team-access");
+    const result = await canAccessProject(createAuthContext("member"), projectId);
+
+    expect(getTmsProviderLiveProjectMock).toHaveBeenCalledWith("org_1", "902807", {
+      actorUserId: "user_1",
+    });
+    expect(result).toEqual({ id: projectId });
+  });
+
+  it("denies external TMS projects the live provider does not return", async () => {
+    const projectId = encodeProviderProjectId({
+      providerKind: "crowdin",
+      externalProjectId: "902807",
+    });
+
+    getTmsProviderLiveProjectMock.mockResolvedValueOnce(null);
+
+    const { canAccessProject } = await import("./team-access");
+    const result = await canAccessProject(createAuthContext("member"), projectId);
+
+    expect(result).toBeNull();
   });
 });

--- a/apps/hyperlocalise-web/src/api/auth/team-access.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/team-access.test.ts
@@ -85,11 +85,15 @@ function createAuthContext(role: "admin" | "member" = "admin"): ApiAuthContext {
  * Chainable select mock that supports both:
  * - `.from().where().limit()` (project / backfill lookups)
  * - `.from().innerJoin().where()` (team membership lookups)
+ *
+ * Each `db.select()` consumes the next queued row set so tests can simulate
+ * backfill → visible teams → team-scoped project lookup sequences.
  */
-function mockEmptyTeamScopedLookups() {
+function mockSelectQueue(rowSets: unknown[][]) {
+  let callIndex = 0;
   dbSelectMock.mockImplementation(() => {
-    const emptyRows: unknown[] = [];
-    const builder = Promise.resolve(emptyRows) as Promise<unknown[]> & {
+    const rows = rowSets[callIndex++] ?? [];
+    const builder = Promise.resolve(rows) as Promise<unknown[]> & {
       from: ReturnType<typeof vi.fn>;
       innerJoin: ReturnType<typeof vi.fn>;
       where: ReturnType<typeof vi.fn>;
@@ -98,7 +102,7 @@ function mockEmptyTeamScopedLookups() {
     builder.from = vi.fn(() => builder);
     builder.innerJoin = vi.fn(() => builder);
     builder.where = vi.fn(() => builder);
-    builder.limit = vi.fn(async () => emptyRows);
+    builder.limit = vi.fn(async () => rows);
     return builder;
   });
 }
@@ -137,7 +141,6 @@ describe("canAccessProject", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
-    mockEmptyTeamScopedLookups();
   });
 
   it("allows live-only external TMS projects when no local projects row exists", async () => {
@@ -146,6 +149,8 @@ describe("canAccessProject", () => {
       externalProjectId: "902807",
     });
 
+    // backfill check → no visible teams → team-scoped project miss
+    mockSelectQueue([[], [], []]);
     getTmsProviderLiveProjectMock.mockResolvedValueOnce({
       id: projectId,
       name: "HL-Test",
@@ -166,6 +171,13 @@ describe("canAccessProject", () => {
       externalProjectId: "902807",
     });
 
+    // Member belongs to a team, but the team-scoped project query still misses
+    // (materialized row lives on another team). Live TMS must authorize instead.
+    mockSelectQueue([
+      [], // backfill: no null-team projects
+      [{ id: "team_alpha" }], // visible teams for the member
+      [], // team-scoped ownedProjectWhere filters the project out
+    ]);
     getTmsProviderLiveProjectMock.mockResolvedValueOnce({
       id: projectId,
       name: "HL-Test",
@@ -174,6 +186,7 @@ describe("canAccessProject", () => {
     const { canAccessProject } = await import("./team-access");
     const result = await canAccessProject(createAuthContext("member"), projectId);
 
+    expect(dbSelectMock).toHaveBeenCalledTimes(3);
     expect(getTmsProviderLiveProjectMock).toHaveBeenCalledWith("org_1", "902807", {
       actorUserId: "user_1",
     });
@@ -186,6 +199,7 @@ describe("canAccessProject", () => {
       externalProjectId: "902807",
     });
 
+    mockSelectQueue([[], [], []]);
     getTmsProviderLiveProjectMock.mockResolvedValueOnce(null);
 
     const { canAccessProject } = await import("./team-access");

--- a/apps/hyperlocalise-web/src/api/auth/team-access.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/team-access.test.ts
@@ -88,27 +88,18 @@ function createAuthContext(role: "admin" | "member" = "admin"): ApiAuthContext {
  */
 function mockEmptyTeamScopedLookups() {
   dbSelectMock.mockImplementation(() => {
-    const createThenable = (value: unknown[] = []) => {
-      const thenable: {
-        limit: ReturnType<typeof vi.fn>;
-        then: Promise<unknown[]>["then"];
-        innerJoin: ReturnType<typeof vi.fn>;
-        where: ReturnType<typeof vi.fn>;
-        from: ReturnType<typeof vi.fn>;
-      } = {
-        limit: vi.fn(async () => value),
-        then: (onFulfilled, onRejected) => Promise.resolve(value).then(onFulfilled, onRejected),
-        innerJoin: vi.fn(),
-        where: vi.fn(),
-        from: vi.fn(),
-      };
-      thenable.innerJoin.mockReturnValue(thenable);
-      thenable.where.mockReturnValue(thenable);
-      thenable.from.mockReturnValue(thenable);
-      return thenable;
+    const emptyRows: unknown[] = [];
+    const builder = Promise.resolve(emptyRows) as Promise<unknown[]> & {
+      from: ReturnType<typeof vi.fn>;
+      innerJoin: ReturnType<typeof vi.fn>;
+      where: ReturnType<typeof vi.fn>;
+      limit: ReturnType<typeof vi.fn>;
     };
-
-    return createThenable([]);
+    builder.from = vi.fn(() => builder);
+    builder.innerJoin = vi.fn(() => builder);
+    builder.where = vi.fn(() => builder);
+    builder.limit = vi.fn(async () => emptyRows);
+    return builder;
   });
 }
 

--- a/apps/hyperlocalise-web/src/api/auth/team-access.ts
+++ b/apps/hyperlocalise-web/src/api/auth/team-access.ts
@@ -4,10 +4,13 @@ import { hasCapability } from "@/api/auth/policy";
 import type { ApiAuthContext } from "@/api/auth/workos";
 import { db, schema } from "@/lib/database";
 import { providerAssignedUsersMatch } from "@/lib/providers/jobs/tms-provider-assignee-match";
+import { getTmsProviderLiveProject } from "@/lib/providers/jobs/tms-provider-live";
 import {
   isLiveProviderGlossaryId,
   isLiveProviderMemoryId,
+  parseProviderProjectId,
 } from "@/lib/providers/jobs/tms-provider-resource-id";
+import { normalizeProjectId } from "@/lib/projects/identity/project-id";
 import { backfillOrganizationProjectTeams } from "@/lib/teams/default-workspace-team";
 
 export function hasOrganizationWideProjectAccess(auth: ApiAuthContext) {
@@ -74,6 +77,51 @@ export async function buildAccessibleProjectsWhere(auth: ApiAuthContext): Promis
 
 export async function ownedProjectWhere(auth: ApiAuthContext, projectId: string) {
   return and(eq(schema.projects.id, projectId), await buildAccessibleProjectsWhere(auth))!;
+}
+
+/**
+ * Resolve whether the caller may use a project id.
+ *
+ * Native projects stay team-scoped. External TMS project ids (`ext:…`) defer to
+ * the connected provider's live API with the caller's credentials — Crowdin and
+ * other TMS systems already enforce project membership, so Hyperlocalise must
+ * not re-apply team gates after a project is materialized locally.
+ */
+export async function canAccessProject(
+  auth: ApiAuthContext,
+  projectId: string,
+): Promise<{ id: string } | null> {
+  const normalizedProjectId = normalizeProjectId(projectId);
+  if (typeof normalizedProjectId !== "string" || normalizedProjectId.length === 0) {
+    return null;
+  }
+
+  const [project] = await db
+    .select({ id: schema.projects.id })
+    .from(schema.projects)
+    .where(await ownedProjectWhere(auth, normalizedProjectId))
+    .limit(1);
+
+  if (project) {
+    return project;
+  }
+
+  const encodedProject = parseProviderProjectId(normalizedProjectId);
+  if (!encodedProject) {
+    return null;
+  }
+
+  const liveProject = await getTmsProviderLiveProject(
+    auth.organization.localOrganizationId,
+    encodedProject.externalProjectId,
+    { actorUserId: auth.user.localUserId },
+  ).catch(() => null);
+
+  if (!liveProject || liveProject.id !== normalizedProjectId) {
+    return null;
+  }
+
+  return { id: liveProject.id };
 }
 
 export async function getAccessibleProjectIds(auth: ApiAuthContext) {
@@ -310,12 +358,7 @@ export async function canAccessStoredFile(
   }
 
   if (input.projectId) {
-    const [project] = await db
-      .select({ id: schema.projects.id })
-      .from(schema.projects)
-      .where(await ownedProjectWhere(auth, input.projectId))
-      .limit(1);
-
+    const project = await canAccessProject(auth, input.projectId);
     return Boolean(project);
   }
 

--- a/apps/hyperlocalise-web/src/api/routes/project/project.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.shared.ts
@@ -1,5 +1,6 @@
 import {
   buildAccessibleProjectsWhere,
+  canAccessProject,
   getVisibleTeamIds,
   hasOrganizationWideProjectAccess,
   ownedProjectWhere as teamOwnedProjectWhere,
@@ -227,21 +228,27 @@ export async function ownedProjectWhere(auth: ApiAuthContext, projectId: string)
 }
 
 export async function getOwnedProject(auth: ApiAuthContext, projectId: string) {
-  const [project] = await db
-    .select({ id: schema.projects.id })
-    .from(schema.projects)
-    .where(await ownedProjectWhere(auth, projectId))
-    .limit(1);
-
-  return project ?? null;
+  return canAccessProject(auth, projectId);
 }
 
 export async function getOwnedProjectRecord(auth: ApiAuthContext, projectId: string) {
-  const [project] = await db
+  const accessibleProject = await canAccessProject(auth, projectId);
+  if (!accessibleProject) {
+    return null;
+  }
+
+  // Access was already authorized (team scope for native, live TMS for
+  // provider ids). Load the org-scoped row without re-applying team filters.
+  const [organizationProject] = await db
     .select()
     .from(schema.projects)
-    .where(await ownedProjectWhere(auth, projectId))
+    .where(
+      and(
+        eq(schema.projects.organizationId, auth.organization.localOrganizationId),
+        eq(schema.projects.id, accessibleProject.id),
+      ),
+    )
     .limit(1);
 
-  return project ?? null;
+  return organizationProject ?? null;
 }

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
@@ -1,3 +1,4 @@
+import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { validator } from "hono/validator";
 import { z } from "zod";
@@ -8,7 +9,7 @@ import {
   isJobProviderActionAllowed,
 } from "@/api/auth/capability-guards";
 import { hasCapability } from "@/api/auth/policy";
-import { ownedProjectWhere } from "@/api/auth/team-access";
+import { canAccessProject } from "@/api/auth/team-access";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
 import {
   badRequestResponse,
@@ -506,6 +507,11 @@ export function createTmsProviderRoutes(options: CreateTmsProviderRoutesOptions 
         return badRequestResponse(c, "invalid_encoded_job_id", "Job id is not a provider job id");
       }
 
+      const accessibleProject = await canAccessProject(c.var.auth, payload.projectId);
+      if (!accessibleProject) {
+        return notFoundResponse(c, "project_not_found", "Project not found");
+      }
+
       const [project] = await db
         .select({
           id: schema.projects.id,
@@ -513,7 +519,12 @@ export function createTmsProviderRoutes(options: CreateTmsProviderRoutesOptions 
           externalProviderKind: schema.projects.externalProviderKind,
         })
         .from(schema.projects)
-        .where(await ownedProjectWhere(c.var.auth, payload.projectId))
+        .where(
+          and(
+            eq(schema.projects.organizationId, organizationId),
+            eq(schema.projects.id, accessibleProject.id),
+          ),
+        )
         .limit(1);
 
       if (!project) {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/tool-access.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/tool-access.test.ts
@@ -2,11 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { encodeProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 
-const ownedProjectWhereMock = vi.fn(async () => ({}));
-const getTmsProviderLiveProjectMock = vi.fn();
+const canAccessProjectMock = vi.fn();
 
 vi.mock("@/api/auth/team-access", () => ({
-  ownedProjectWhere: ownedProjectWhereMock,
+  canAccessProject: canAccessProjectMock,
+  ownedProjectWhere: vi.fn(),
   buildAccessibleProjectsWhere: vi.fn(),
   buildAccessibleJobsWhere: vi.fn(),
   buildProjectLinkedGlossaryWhere: vi.fn(),
@@ -14,10 +14,6 @@ vi.mock("@/api/auth/team-access", () => ({
   canAccessGlossary: vi.fn(),
   canAccessMemory: vi.fn(),
   canAccessStoredFile: vi.fn(),
-}));
-
-vi.mock("@/lib/providers/jobs/tms-provider-live", () => ({
-  getTmsProviderLiveProject: getTmsProviderLiveProjectMock,
 }));
 
 vi.mock("@/lib/database", () => ({
@@ -31,36 +27,19 @@ vi.mock("@/lib/database", () => ({
   },
 }));
 
-function createDbSelectMock(results: Array<Array<{ id: string }>>) {
-  let callIndex = 0;
-
-  return {
-    select: vi.fn(() => ({
-      from: vi.fn(() => ({
-        where: vi.fn(() => ({
-          limit: vi.fn(async () => results[callIndex++] ?? []),
-        })),
-      })),
-    })),
-  };
-}
-
 describe("toolCanAccessProject", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
   });
 
-  it("allows live-only external TMS projects when no local projects row exists", async () => {
+  it("delegates project access to canAccessProject, including live TMS fallback", async () => {
     const projectId = encodeProviderProjectId({
       providerKind: "crowdin",
       externalProjectId: "902807",
     });
 
-    getTmsProviderLiveProjectMock.mockResolvedValueOnce({
-      id: projectId,
-      name: "HL-Test",
-    });
+    canAccessProjectMock.mockResolvedValueOnce({ id: projectId });
 
     const { toolCanAccessProject } = await import("./tool-access");
     const result = await toolCanAccessProject(
@@ -70,38 +49,20 @@ describe("toolCanAccessProject", () => {
         localUserId: "user_1",
         membershipRole: "member",
         projectId: null,
-        db: createDbSelectMock([[], []]),
+        db: {},
       } as never,
       projectId,
     );
 
-    expect(getTmsProviderLiveProjectMock).toHaveBeenCalledWith("org_1", "902807", {
-      actorUserId: "user_1",
-    });
+    expect(canAccessProjectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user: expect.objectContaining({ localUserId: "user_1" }),
+        organization: expect.objectContaining({ localOrganizationId: "org_1" }),
+        membership: expect.objectContaining({ role: "member" }),
+      }),
+      projectId,
+    );
     expect(result).toEqual({ id: projectId });
-  });
-
-  it("denies live external TMS projects that are materialized outside the member's teams", async () => {
-    const projectId = encodeProviderProjectId({
-      providerKind: "crowdin",
-      externalProjectId: "902807",
-    });
-
-    const { toolCanAccessProject } = await import("./tool-access");
-    const result = await toolCanAccessProject(
-      {
-        conversationId: "conv_1",
-        organizationId: "org_1",
-        localUserId: "user_1",
-        membershipRole: "member",
-        projectId: null,
-        db: createDbSelectMock([[], [{ id: projectId }]]),
-      } as never,
-      projectId,
-    );
-
-    expect(getTmsProviderLiveProjectMock).not.toHaveBeenCalled();
-    expect(result).toBeNull();
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/tool-access.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/tool-access.ts
@@ -7,19 +7,16 @@ import {
   buildProjectLinkedMemoryWhere,
   canAccessGlossary,
   canAccessMemory,
+  canAccessProject,
   canAccessStoredFile,
-  ownedProjectWhere,
 } from "@/api/auth/team-access";
 import type { ApiAuthContext } from "@/api/auth/workos";
 import { schema } from "@/lib/database";
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
-import { getTmsProviderLiveProject } from "@/lib/providers/jobs/tms-provider-live";
 import {
   isLiveProviderGlossaryId,
   isLiveProviderMemoryId,
-  parseProviderProjectId,
 } from "@/lib/providers/jobs/tms-provider-resource-id";
-import { normalizeProjectId } from "@/lib/projects/identity/project-id";
 import { resolveOrganizationMembershipAccessSource } from "@/lib/workos/membership-access";
 
 function organizationRecord(ctx: ToolContext) {
@@ -72,54 +69,7 @@ export function toolProjectLinkedMemoryWhere(ctx: ToolContext) {
 }
 
 export async function toolCanAccessProject(ctx: ToolContext, projectId: string) {
-  const normalizedProjectId = normalizeProjectId(projectId);
-  if (typeof normalizedProjectId !== "string" || normalizedProjectId.length === 0) {
-    return null;
-  }
-
-  const auth = apiAuthContextFromToolContext(ctx);
-
-  const [project] = await ctx.db
-    .select({ id: schema.projects.id })
-    .from(schema.projects)
-    .where(await ownedProjectWhere(auth, normalizedProjectId))
-    .limit(1);
-
-  if (project) {
-    return project;
-  }
-
-  const encodedProject = parseProviderProjectId(normalizedProjectId);
-  if (!encodedProject) {
-    return null;
-  }
-
-  const [organizationProject] = await ctx.db
-    .select({ id: schema.projects.id })
-    .from(schema.projects)
-    .where(
-      and(
-        eq(schema.projects.organizationId, ctx.organizationId),
-        eq(schema.projects.id, normalizedProjectId),
-      ),
-    )
-    .limit(1);
-
-  if (organizationProject) {
-    return null;
-  }
-
-  const liveProject = await getTmsProviderLiveProject(
-    ctx.organizationId,
-    encodedProject.externalProjectId,
-    { actorUserId: ctx.localUserId },
-  ).catch(() => null);
-
-  if (!liveProject || liveProject.id !== normalizedProjectId) {
-    return null;
-  }
-
-  return { id: liveProject.id };
+  return canAccessProject(apiAuthContextFromToolContext(ctx), projectId);
 }
 
 export function toolCanAccessGlossary(ctx: ToolContext, glossaryId: string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

External TMS projects use the connected provider's live API (Crowdin, Phrase, Lokalise, Smartling). Those providers already enforce project membership via the caller's credentials, so Hyperlocalise should not re-apply team membership gates after a project is materialized locally.

Previously, `toolCanAccessProject` and SQL `ownedProjectWhere` paths denied access when a materialized `ext:…` project sat on a team the member did not belong to — even when the live TMS API would authorize them.

## Changes

- Add `canAccessProject` that keeps native projects team-scoped, then falls back to `getTmsProviderLiveProject` for provider ids
- Route `getOwnedProject`, `getOwnedProjectRecord`, agent tool access, stored-file project checks, and TMS agent-run project lookup through that helper
- Update tests to require live-provider authorization instead of denying materialized-outside-team TMS projects

## Test plan

- [x] `vp test src/api/auth/team-access.test.ts src/lib/agent-runtime/tools/tool-access.test.ts`
- [x] `vp test` for project/TMS related suites (46 passed)
- [x] `vp check --fix`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f723a-74d8-7e59-82af-3175948ea2d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f723a-74d8-7e59-82af-3175948ea2d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

