### PR TITLE
feat(web): native TMS create + assign-translate automation tools

### DIFF
--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/build-workspace-orchestrator-tools.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/build-workspace-orchestrator-tools.ts
@@ -2,11 +2,12 @@ import type { ToolSet } from "ai";
 
 import type { WorkspaceOrchestratorSession } from "./context";
 import type { WorkspaceOrchestratorToolName } from "./plan";
+import { createAssignTranslateWithAgentTool } from "./tools/assign_translate_with_agent";
+import { createNativeTmsJobTool } from "./tools/create_native_tms_job";
 import { createNotifyEmailTool } from "./tools/notify_email";
 import { createNotifySlackTool } from "./tools/notify_slack";
 import { createRunContentfulTranslationTool } from "./tools/run_contentful_translation";
 import { createRunGithubWorkflowsTool } from "./tools/run_github_workflows";
-import { createTranslationJobsTool } from "./tools/create_translation_jobs";
 import { createUseGithubRepositoryTool } from "./tools/use_github_repository";
 
 const TOOL_BUILDERS: Record<
@@ -16,7 +17,8 @@ const TOOL_BUILDERS: Record<
   use_github_repository: createUseGithubRepositoryTool,
   run_github_workflows: createRunGithubWorkflowsTool,
   run_contentful_translation: createRunContentfulTranslationTool,
-  create_translation_jobs: createTranslationJobsTool,
+  create_native_tms_job: createNativeTmsJobTool,
+  assign_translate_with_agent: createAssignTranslateWithAgentTool,
   notify_slack: createNotifySlackTool,
   notify_email: createNotifyEmailTool,
 };

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.test.ts
@@ -99,4 +99,3 @@ describe("buildWorkspaceOrchestratorPlan", () => {
     expect(plan.tools).toEqual(["create_native_tms_job", "assign_translate_with_agent"]);
   });
 });
-

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.test.ts
@@ -80,4 +80,23 @@ describe("buildWorkspaceOrchestratorPlan", () => {
     const plan = buildWorkspaceOrchestratorPlan(automation());
     expect(plan.tools).toEqual([]);
   });
+
+  it("plans native TMS create then assign when translation workflow is enabled", () => {
+    const plan = buildWorkspaceOrchestratorPlan(
+      automation({
+        triggerConfig: { mode: "source_upload" },
+        toolConfig: {
+          translation: {
+            enabled: true,
+            projectId: "project-1",
+            useProjectTargetLocales: true,
+            targetLocales: [],
+          },
+        },
+      }),
+    );
+
+    expect(plan.tools).toEqual(["create_native_tms_job", "assign_translate_with_agent"]);
+  });
 });
+

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.ts
@@ -15,7 +15,8 @@ export const WORKSPACE_ORCHESTRATOR_TOOL_NAMES = [
   "use_github_repository",
   "run_github_workflows",
   "run_contentful_translation",
-  "create_translation_jobs",
+  "create_native_tms_job",
+  "assign_translate_with_agent",
   "notify_slack",
   "notify_email",
 ] as const;
@@ -34,7 +35,8 @@ const WORKFLOW_TOOLS: WorkspaceOrchestratorToolName[] = [
   "use_github_repository",
   "run_github_workflows",
   "run_contentful_translation",
-  "create_translation_jobs",
+  "create_native_tms_job",
+  "assign_translate_with_agent",
 ];
 
 const NOTIFICATION_TOOLS: WorkspaceOrchestratorToolName[] = ["notify_slack", "notify_email"];
@@ -50,7 +52,8 @@ function workflowToolEnabled(
       return hasWorkspaceAutomationGithubWorkflow(toolConfig);
     case "run_contentful_translation":
       return hasWorkspaceAutomationContentfulWorkflow(toolConfig);
-    case "create_translation_jobs":
+    case "create_native_tms_job":
+    case "assign_translate_with_agent":
       return hasWorkspaceAutomationTranslationWorkflow(toolConfig);
     default:
       return false;
@@ -93,6 +96,8 @@ function orderWorkflowTools(input: {
       ...enabled.filter((tool) => tool === "run_contentful_translation"),
       ...enabled.filter((tool) => tool === "run_github_workflows"),
       ...enabled.filter((tool) => tool === "use_github_repository"),
+      ...enabled.filter((tool) => tool === "create_native_tms_job"),
+      ...enabled.filter((tool) => tool === "assign_translate_with_agent"),
     ];
   }
 
@@ -100,6 +105,8 @@ function orderWorkflowTools(input: {
     ...enabled.filter((tool) => tool === "use_github_repository"),
     ...enabled.filter((tool) => tool === "run_github_workflows"),
     ...enabled.filter((tool) => tool === "run_contentful_translation"),
+    ...enabled.filter((tool) => tool === "create_native_tms_job"),
+    ...enabled.filter((tool) => tool === "assign_translate_with_agent"),
   ];
 }
 

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/assign_translate_with_agent.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/assign_translate_with_agent.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import type {
+  WorkspaceAutomationRecord,
+  WorkspaceAutomationRunRecord,
+} from "@/lib/agents/workspace-automations";
+
+import type { WorkspaceOrchestratorSession } from "../context";
+import { createAssignTranslateWithAgentTool } from "./assign_translate_with_agent";
+
+const mocks = vi.hoisted(() => ({
+  enqueueExistingFileTranslationJob: vi.fn(),
+  updateWorkspaceAutomationRun: vi.fn(),
+  createTranslationJobEventQueue: vi.fn(() => ({ enqueue: vi.fn() })),
+}));
+
+vi.mock("@/lib/projects/jobs/enqueue-file-translation-job", () => ({
+  enqueueExistingFileTranslationJob: (...args: unknown[]) =>
+    mocks.enqueueExistingFileTranslationJob(...args),
+}));
+
+vi.mock("@/lib/agents/workspace-automations", () => ({
+  updateWorkspaceAutomationRun: (...args: unknown[]) => mocks.updateWorkspaceAutomationRun(...args),
+}));
+
+vi.mock("@/lib/workflow/queues", () => ({
+  createTranslationJobEventQueue: () => mocks.createTranslationJobEventQueue(),
+}));
+
+function session(overrides: {
+  outputSummary?: Record<string, unknown>;
+  stepResults?: WorkspaceOrchestratorSession["stepResults"];
+} = {}): WorkspaceOrchestratorSession {
+  const automation = {
+    id: "automation-1",
+    organizationId: "org-1",
+    authorUserId: null,
+    status: "active",
+    name: "Translate on source upload",
+    instructions: "",
+    triggerConfig: { mode: "source_upload" },
+    repositoryTarget: { kind: "none" },
+    toolConfig: {
+      translation: {
+        enabled: true,
+        projectId: "project-1",
+        useProjectTargetLocales: true,
+        targetLocales: [],
+      },
+    },
+    configVersion: 1,
+    nextRunAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  } satisfies WorkspaceAutomationRecord;
+
+  const run = {
+    id: "run-1",
+    automationId: automation.id,
+    organizationId: automation.organizationId,
+    triggerSource: "source_upload",
+    status: "running",
+    inputSnapshot: {
+      projectId: "project-1",
+      sourceFileId: "file-1",
+      sourceFileVersionId: "version-1",
+    },
+    outputSummary: overrides.outputSummary ?? {
+      createNativeTmsJob: {
+        jobId: "job_1",
+        projectId: "project-1",
+      },
+    },
+    error: null,
+    githubRepositoryAutomationJobId: null,
+    idempotencyKey: null,
+    startedAt: null,
+    completedAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  } satisfies WorkspaceAutomationRunRecord;
+
+  return {
+    organizationId: automation.organizationId,
+    automation,
+    run,
+    plan: { tools: ["create_native_tms_job", "assign_translate_with_agent"] },
+    repository: null,
+    composedInstructions: "",
+    stepResults: overrides.stepResults ?? {},
+    terminalStatus: null,
+    terminalError: null,
+  };
+}
+
+describe("createAssignTranslateWithAgentTool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.enqueueExistingFileTranslationJob.mockResolvedValue({
+      ok: true,
+      jobId: "job_1",
+      projectId: "project-1",
+    });
+    mocks.updateWorkspaceAutomationRun.mockResolvedValue(undefined);
+  });
+
+  it("enqueues the created native job for translation", async () => {
+    const currentSession = session();
+    const tool = createAssignTranslateWithAgentTool(currentSession);
+
+    const result = await tool.execute!({}, { toolCallId: "call-1", messages: [] });
+
+    expect(result).toMatchObject({
+      jobId: "job_1",
+      projectId: "project-1",
+      action: "translate_with_agent",
+      enqueued: true,
+    });
+    expect(mocks.enqueueExistingFileTranslationJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: "org-1",
+        jobId: "job_1",
+      }),
+    );
+    expect(currentSession.stepResults.assign_translate_with_agent).toMatchObject({
+      jobId: "job_1",
+      enqueued: true,
+    });
+  });
+
+  it("returns the existing assign output for idempotent retries", async () => {
+    const existing = {
+      jobId: "job_1",
+      projectId: "project-1",
+      action: "translate_with_agent",
+      enqueued: true,
+    };
+    const currentSession = session({
+      outputSummary: {
+        createNativeTmsJob: { jobId: "job_1", projectId: "project-1" },
+        assignTranslateWithAgent: existing,
+      },
+    });
+    const tool = createAssignTranslateWithAgentTool(currentSession);
+
+    const result = await tool.execute!({}, { toolCallId: "call-1", messages: [] });
+
+    expect(result).toEqual(existing);
+    expect(mocks.enqueueExistingFileTranslationJob).not.toHaveBeenCalled();
+  });
+
+  it("fails when no native job is available", async () => {
+    const currentSession = session({ outputSummary: {} });
+    const tool = createAssignTranslateWithAgentTool(currentSession);
+
+    await expect(tool.execute!({}, { toolCallId: "call-1", messages: [] })).rejects.toThrow(
+      "native_tms_job_missing",
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/assign_translate_with_agent.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/assign_translate_with_agent.test.ts
@@ -27,10 +27,12 @@ vi.mock("@/lib/workflow/queues", () => ({
   createTranslationJobEventQueue: () => mocks.createTranslationJobEventQueue(),
 }));
 
-function session(overrides: {
-  outputSummary?: Record<string, unknown>;
-  stepResults?: WorkspaceOrchestratorSession["stepResults"];
-} = {}): WorkspaceOrchestratorSession {
+function session(
+  overrides: {
+    outputSummary?: Record<string, unknown>;
+    stepResults?: WorkspaceOrchestratorSession["stepResults"];
+  } = {},
+): WorkspaceOrchestratorSession {
   const automation = {
     id: "automation-1",
     organizationId: "org-1",

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/assign_translate_with_agent.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/assign_translate_with_agent.ts
@@ -47,9 +47,7 @@ export function createAssignTranslateWithAgentTool(session: WorkspaceOrchestrato
 
       const createdJob = readCreateNativeTmsJob(session.run.outputSummary, session.stepResults);
       const resolvedJobId =
-        jobId?.trim() ||
-        (typeof createdJob?.jobId === "string" ? createdJob.jobId : null) ||
-        null;
+        jobId?.trim() || (typeof createdJob?.jobId === "string" ? createdJob.jobId : null) || null;
 
       if (!resolvedJobId) {
         throw new Error("native_tms_job_missing");

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/assign_translate_with_agent.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/assign_translate_with_agent.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+
+import { defineAgentTool } from "@/agents/_runtime/define-agent-tool";
+import { updateWorkspaceAutomationRun } from "@/lib/agents/workspace-automations";
+import { enqueueExistingFileTranslationJob } from "@/lib/projects/jobs/enqueue-file-translation-job";
+import { createTranslationJobEventQueue } from "@/lib/workflow/queues";
+
+import type { WorkspaceOrchestratorSession } from "../context";
+import {
+  mergeToolOutputSummaryIntoSessionRun,
+  readAssignTranslateWithAgent,
+  readCreateNativeTmsJob,
+} from "../workspace-orchestrator-output-summary";
+
+const jobQueue = createTranslationJobEventQueue();
+
+export function createAssignTranslateWithAgentTool(session: WorkspaceOrchestratorSession) {
+  return defineAgentTool({
+    description:
+      "Assign a native TMS file translation job to the Hyperlocalise translation agent and start translation.",
+    inputSchema: z.object({
+      jobId: z
+        .string()
+        .optional()
+        .describe(
+          "Native job ID to translate. Defaults to the job created earlier in this automation run.",
+        ),
+      summary: z
+        .string()
+        .optional()
+        .describe("Optional operator note to include in the run record."),
+    }),
+    execute: async ({ jobId, summary }) => {
+      const translationConfig = session.automation.toolConfig.translation;
+      if (!translationConfig?.enabled || !translationConfig.projectId) {
+        throw new Error("translation_workflow_not_configured");
+      }
+
+      const existingOutput = readAssignTranslateWithAgent(
+        session.run.outputSummary,
+        session.stepResults,
+      );
+      if (existingOutput) {
+        session.stepResults.assign_translate_with_agent = existingOutput;
+        return existingOutput;
+      }
+
+      const createdJob = readCreateNativeTmsJob(session.run.outputSummary, session.stepResults);
+      const resolvedJobId =
+        jobId?.trim() ||
+        (typeof createdJob?.jobId === "string" ? createdJob.jobId : null) ||
+        null;
+
+      if (!resolvedJobId) {
+        throw new Error("native_tms_job_missing");
+      }
+
+      const result = await enqueueExistingFileTranslationJob({
+        organizationId: session.organizationId,
+        jobId: resolvedJobId,
+        jobQueue,
+      });
+
+      if (!result.ok) {
+        throw new Error(result.code);
+      }
+
+      const output = {
+        jobId: result.jobId,
+        projectId: result.projectId,
+        action: "translate_with_agent",
+        enqueued: true,
+        summary: summary?.trim() || undefined,
+      };
+
+      session.stepResults.assign_translate_with_agent = output;
+
+      await updateWorkspaceAutomationRun({
+        runId: session.run.id,
+        organizationId: session.organizationId,
+        outputSummary: {
+          ...session.run.outputSummary,
+          assignTranslateWithAgent: output,
+        },
+      });
+      mergeToolOutputSummaryIntoSessionRun(session, { assignTranslateWithAgent: output });
+
+      return output;
+    },
+  });
+}

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_native_tms_job.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_native_tms_job.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import type {
+  WorkspaceAutomationRecord,
+  WorkspaceAutomationRunRecord,
+} from "@/lib/agents/workspace-automations";
+
+import type { WorkspaceOrchestratorSession } from "../context";
+import { createNativeTmsJobTool } from "./create_native_tms_job";
+
+const mocks = vi.hoisted(() => ({
+  createFileTranslationJob: vi.fn(),
+  updateWorkspaceAutomationRun: vi.fn(),
+  selectLimit: vi.fn(),
+}));
+
+vi.mock("@/lib/projects/jobs/enqueue-file-translation-job", () => ({
+  createFileTranslationJob: (...args: unknown[]) => mocks.createFileTranslationJob(...args),
+}));
+
+vi.mock("@/lib/agents/workspace-automations", () => ({
+  updateWorkspaceAutomationRun: (...args: unknown[]) => mocks.updateWorkspaceAutomationRun(...args),
+}));
+
+vi.mock("@/lib/database", () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: mocks.selectLimit,
+        })),
+      })),
+    })),
+  },
+  schema: {
+    projects: {
+      id: "id",
+      sourceLocale: "sourceLocale",
+      targetLocales: "targetLocales",
+    },
+  },
+}));
+
+function session(overrides: {
+  outputSummary?: Record<string, unknown>;
+  stepResults?: WorkspaceOrchestratorSession["stepResults"];
+  inputSnapshot?: Record<string, unknown>;
+} = {}): WorkspaceOrchestratorSession {
+  const automation = {
+    id: "automation-1",
+    organizationId: "org-1",
+    authorUserId: null,
+    status: "active",
+    name: "Translate on source upload",
+    instructions: "",
+    triggerConfig: { mode: "source_upload" },
+    repositoryTarget: { kind: "none" },
+    toolConfig: {
+      translation: {
+        enabled: true,
+        projectId: "project-1",
+        useProjectTargetLocales: true,
+        targetLocales: [],
+      },
+    },
+    configVersion: 1,
+    nextRunAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  } satisfies WorkspaceAutomationRecord;
+
+  const run = {
+    id: "run-1",
+    automationId: automation.id,
+    organizationId: automation.organizationId,
+    triggerSource: "source_upload",
+    status: "running",
+    inputSnapshot: overrides.inputSnapshot ?? {
+      projectId: "project-1",
+      sourceFileId: "file-1",
+      sourceFileVersionId: "version-1",
+      sourcePath: "locales/en.json",
+    },
+    outputSummary: overrides.outputSummary ?? {},
+    error: null,
+    githubRepositoryAutomationJobId: null,
+    idempotencyKey: null,
+    startedAt: null,
+    completedAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  } satisfies WorkspaceAutomationRunRecord;
+
+  return {
+    organizationId: automation.organizationId,
+    automation,
+    run,
+    plan: { tools: ["create_native_tms_job", "assign_translate_with_agent"] },
+    repository: null,
+    composedInstructions: "",
+    stepResults: overrides.stepResults ?? {},
+    terminalStatus: null,
+    terminalError: null,
+  };
+}
+
+describe("createNativeTmsJobTool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.selectLimit.mockResolvedValue([
+      {
+        sourceLocale: "en",
+        targetLocales: ["fr-FR", "de-DE"],
+      },
+    ]);
+    mocks.createFileTranslationJob.mockResolvedValue({
+      ok: true,
+      jobId: "job_1",
+      projectId: "project-1",
+      sourceFileVersionId: "version-1",
+    });
+    mocks.updateWorkspaceAutomationRun.mockResolvedValue(undefined);
+  });
+
+  it("creates a native file translation job without enqueueing", async () => {
+    const currentSession = session();
+    const tool = createNativeTmsJobTool(currentSession);
+
+    const result = await tool.execute!({ summary: "from upload" }, {
+      toolCallId: "call-1",
+      messages: [],
+    });
+
+    expect(result).toMatchObject({
+      jobId: "job_1",
+      projectId: "project-1",
+      sourceFileId: "file-1",
+      targetLocales: ["fr-FR", "de-DE"],
+      summary: "from upload",
+    });
+    expect(mocks.createFileTranslationJob).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      projectId: "project-1",
+      sourceFileId: "file-1",
+      sourceLocale: "en",
+      targetLocales: ["fr-FR", "de-DE"],
+    });
+    expect(currentSession.stepResults.create_native_tms_job).toMatchObject({ jobId: "job_1" });
+  });
+
+  it("returns the existing create output for idempotent retries", async () => {
+    const existing = {
+      jobId: "job_existing",
+      projectId: "project-1",
+      sourceFileId: "file-1",
+      sourceFileVersionId: "version-1",
+      targetLocales: ["fr-FR"],
+    };
+    const currentSession = session({ outputSummary: { createNativeTmsJob: existing } });
+    const tool = createNativeTmsJobTool(currentSession);
+
+    const result = await tool.execute!({}, { toolCallId: "call-1", messages: [] });
+
+    expect(result).toEqual(existing);
+    expect(mocks.createFileTranslationJob).not.toHaveBeenCalled();
+  });
+});

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_native_tms_job.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_native_tms_job.test.ts
@@ -41,11 +41,13 @@ vi.mock("@/lib/database", () => ({
   },
 }));
 
-function session(overrides: {
-  outputSummary?: Record<string, unknown>;
-  stepResults?: WorkspaceOrchestratorSession["stepResults"];
-  inputSnapshot?: Record<string, unknown>;
-} = {}): WorkspaceOrchestratorSession {
+function session(
+  overrides: {
+    outputSummary?: Record<string, unknown>;
+    stepResults?: WorkspaceOrchestratorSession["stepResults"];
+    inputSnapshot?: Record<string, unknown>;
+  } = {},
+): WorkspaceOrchestratorSession {
   const automation = {
     id: "automation-1",
     organizationId: "org-1",
@@ -126,10 +128,13 @@ describe("createNativeTmsJobTool", () => {
     const currentSession = session();
     const tool = createNativeTmsJobTool(currentSession);
 
-    const result = await tool.execute!({ summary: "from upload" }, {
-      toolCallId: "call-1",
-      messages: [],
-    });
+    const result = await tool.execute!(
+      { summary: "from upload" },
+      {
+        toolCallId: "call-1",
+        messages: [],
+      },
+    );
 
     expect(result).toMatchObject({
       jobId: "job_1",

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_native_tms_job.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_native_tms_job.ts
@@ -4,21 +4,18 @@ import { z } from "zod";
 import { defineAgentTool } from "@/agents/_runtime/define-agent-tool";
 import { db, schema } from "@/lib/database";
 import { updateWorkspaceAutomationRun } from "@/lib/agents/workspace-automations";
-import { enqueueFileTranslationJob } from "@/lib/projects/jobs/enqueue-file-translation-job";
-import { createTranslationJobEventQueue } from "@/lib/workflow/queues";
+import { createFileTranslationJob } from "@/lib/projects/jobs/enqueue-file-translation-job";
 
 import type { WorkspaceOrchestratorSession } from "../context";
 import {
   mergeToolOutputSummaryIntoSessionRun,
-  readCreateTranslationJobs,
+  readCreateNativeTmsJob,
 } from "../workspace-orchestrator-output-summary";
 
-const jobQueue = createTranslationJobEventQueue();
-
-export function createTranslationJobsTool(session: WorkspaceOrchestratorSession) {
+export function createNativeTmsJobTool(session: WorkspaceOrchestratorSession) {
   return defineAgentTool({
     description:
-      "Create file translation jobs for uploaded source files when this automation is triggered by a source upload.",
+      "Create a Hyperlocalise native TMS file translation job for an uploaded source file. Does not start translation.",
     inputSchema: z.object({
       summary: z
         .string()
@@ -31,12 +28,12 @@ export function createTranslationJobsTool(session: WorkspaceOrchestratorSession)
         throw new Error("translation_workflow_not_configured");
       }
 
-      const existingOutput = readCreateTranslationJobs(
+      const existingOutput = readCreateNativeTmsJob(
         session.run.outputSummary,
         session.stepResults,
       );
       if (existingOutput) {
-        session.stepResults.create_translation_jobs = existingOutput;
+        session.stepResults.create_native_tms_job = existingOutput;
         return existingOutput;
       }
 
@@ -75,13 +72,12 @@ export function createTranslationJobsTool(session: WorkspaceOrchestratorSession)
       }
 
       const sourceLocale = project.sourceLocale?.trim() || "en";
-      const result = await enqueueFileTranslationJob({
+      const result = await createFileTranslationJob({
         organizationId: session.organizationId,
         projectId,
         sourceFileId,
         sourceLocale,
         targetLocales: configuredLocales,
-        jobQueue,
       });
 
       if (!result.ok) {
@@ -90,24 +86,24 @@ export function createTranslationJobsTool(session: WorkspaceOrchestratorSession)
 
       const output = {
         jobId: result.jobId,
-        projectId,
+        projectId: result.projectId,
         sourceFileId,
-        sourceFileVersionId,
+        sourceFileVersionId: result.sourceFileVersionId ?? sourceFileVersionId,
         targetLocales: configuredLocales,
         summary: summary?.trim() || undefined,
       };
 
-      session.stepResults.create_translation_jobs = output;
+      session.stepResults.create_native_tms_job = output;
 
       await updateWorkspaceAutomationRun({
         runId: session.run.id,
         organizationId: session.organizationId,
         outputSummary: {
           ...session.run.outputSummary,
-          createTranslationJobs: output,
+          createNativeTmsJob: output,
         },
       });
-      mergeToolOutputSummaryIntoSessionRun(session, { createTranslationJobs: output });
+      mergeToolOutputSummaryIntoSessionRun(session, { createNativeTmsJob: output });
 
       return output;
     },

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_native_tms_job.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_native_tms_job.ts
@@ -28,10 +28,7 @@ export function createNativeTmsJobTool(session: WorkspaceOrchestratorSession) {
         throw new Error("translation_workflow_not_configured");
       }
 
-      const existingOutput = readCreateNativeTmsJob(
-        session.run.outputSummary,
-        session.stepResults,
-      );
+      const existingOutput = readCreateNativeTmsJob(session.run.outputSummary, session.stepResults);
       if (existingOutput) {
         session.stepResults.create_native_tms_job = existingOutput;
         return existingOutput;

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-orchestrator-output-summary.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-orchestrator-output-summary.test.ts
@@ -26,21 +26,33 @@ describe("buildWorkspaceOrchestratorOutputSummary", () => {
     });
   });
 
-  it("preserves createTranslationJobs from current step results", () => {
+  it("preserves createNativeTmsJob and assignTranslateWithAgent from current step results", () => {
     const outputSummary = buildWorkspaceOrchestratorOutputSummary(
       { orchestratorEnqueuedAt: "2026-06-24T00:00:00.000Z" },
       {
-        create_translation_jobs: {
+        create_native_tms_job: {
           jobId: "job_123",
           projectId: "project_123",
+        },
+        assign_translate_with_agent: {
+          jobId: "job_123",
+          projectId: "project_123",
+          action: "translate_with_agent",
+          enqueued: true,
         },
       },
     );
 
     expect(outputSummary).toMatchObject({
-      createTranslationJobs: {
+      createNativeTmsJob: {
         jobId: "job_123",
         projectId: "project_123",
+      },
+      assignTranslateWithAgent: {
+        jobId: "job_123",
+        projectId: "project_123",
+        action: "translate_with_agent",
+        enqueued: true,
       },
     });
   });

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-orchestrator-output-summary.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-orchestrator-output-summary.ts
@@ -39,16 +39,16 @@ function readContentfulTranslationRunId(
   );
 }
 
-export function readCreateTranslationJobs(
+export function readCreateNativeTmsJob(
   outputSummary: Record<string, unknown>,
   stepResults: Partial<Record<WorkspaceOrchestratorToolName, Record<string, unknown>>>,
 ): Record<string, unknown> | null {
-  const fromCurrentStep = stepResults.create_translation_jobs;
+  const fromCurrentStep = stepResults.create_native_tms_job;
   if (fromCurrentStep && readString(fromCurrentStep.jobId)) {
     return fromCurrentStep;
   }
 
-  const fromOutput = outputSummary.createTranslationJobs;
+  const fromOutput = outputSummary.createNativeTmsJob;
   if (fromOutput && typeof fromOutput === "object" && !Array.isArray(fromOutput)) {
     const record = fromOutput as Record<string, unknown>;
     if (readString(record.jobId)) {
@@ -58,9 +58,37 @@ export function readCreateTranslationJobs(
 
   const fromPriorStep = readStepResult(
     outputSummary.orchestratorStepResults,
-    "create_translation_jobs",
+    "create_native_tms_job",
   );
   if (fromPriorStep && readString(fromPriorStep.jobId)) {
+    return fromPriorStep;
+  }
+
+  return null;
+}
+
+export function readAssignTranslateWithAgent(
+  outputSummary: Record<string, unknown>,
+  stepResults: Partial<Record<WorkspaceOrchestratorToolName, Record<string, unknown>>>,
+): Record<string, unknown> | null {
+  const fromCurrentStep = stepResults.assign_translate_with_agent;
+  if (fromCurrentStep && readString(fromCurrentStep.jobId) && fromCurrentStep.enqueued === true) {
+    return fromCurrentStep;
+  }
+
+  const fromOutput = outputSummary.assignTranslateWithAgent;
+  if (fromOutput && typeof fromOutput === "object" && !Array.isArray(fromOutput)) {
+    const record = fromOutput as Record<string, unknown>;
+    if (readString(record.jobId) && record.enqueued === true) {
+      return record;
+    }
+  }
+
+  const fromPriorStep = readStepResult(
+    outputSummary.orchestratorStepResults,
+    "assign_translate_with_agent",
+  );
+  if (fromPriorStep && readString(fromPriorStep.jobId) && fromPriorStep.enqueued === true) {
     return fromPriorStep;
   }
 
@@ -75,12 +103,14 @@ export function buildWorkspaceOrchestratorOutputSummary(
   },
 ): Record<string, unknown> {
   const contentfulTranslationRunId = readContentfulTranslationRunId(base, stepResults);
-  const createTranslationJobs = readCreateTranslationJobs(base, stepResults);
+  const createNativeTmsJob = readCreateNativeTmsJob(base, stepResults);
+  const assignTranslateWithAgent = readAssignTranslateWithAgent(base, stepResults);
 
   return {
     ...base,
     ...(contentfulTranslationRunId ? { contentfulTranslationRunId } : {}),
-    ...(createTranslationJobs ? { createTranslationJobs } : {}),
+    ...(createNativeTmsJob ? { createNativeTmsJob } : {}),
+    ...(assignTranslateWithAgent ? { assignTranslateWithAgent } : {}),
     orchestratorStepResults: stepResults,
     ...(options?.notificationWarnings && options.notificationWarnings.length > 0
       ? { notificationWarnings: options.notificationWarnings }

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/enqueue-file-translation-job.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/enqueue-file-translation-job.test.ts
@@ -78,8 +78,18 @@ vi.mock("@/lib/database", () => ({
     jobs: {
       id: "id",
       projectId: "projectId",
+      organizationId: "organizationId",
+      kind: "kind",
+      status: "status",
     },
-    translationJobDetails: {},
+    translationJobDetails: {
+      jobId: "jobId",
+      type: "type",
+    },
+    externalJobDetails: {
+      jobId: "jobId",
+      providerKind: "providerKind",
+    },
   },
 }));
 

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/enqueue-file-translation-job.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/enqueue-file-translation-job.test.ts
@@ -51,49 +51,58 @@ vi.mock("@/lib/billing/usage-control", () => ({
   usageFeatureIds: { translationJobs: "translation_jobs" },
 }));
 
-vi.mock("@/lib/database", () => ({
-  db: {
-    select: vi.fn(() => ({
-      from: vi.fn(() => ({
-        where: vi.fn(() => ({
-          limit: selectLimitMock,
+vi.mock("@/lib/database", () => {
+  const createSelectBuilder = () => {
+    const builder = {
+      from: vi.fn(() => builder),
+      leftJoin: vi.fn(() => builder),
+      where: vi.fn(() => builder),
+      limit: selectLimitMock,
+    };
+    return builder;
+  };
+
+  return {
+    db: {
+      select: vi.fn(() => createSelectBuilder()),
+      transaction: (...args: unknown[]) => transactionMock(...args),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn(),
         })),
       })),
-    })),
-    transaction: (...args: unknown[]) => transactionMock(...args),
-    update: vi.fn(() => ({
-      set: vi.fn(() => ({
-        where: vi.fn(),
-      })),
-    })),
-  },
-  schema: {
-    projects: {
-      id: "id",
-      organizationId: "organizationId",
-      source: "source",
-      sourceLocale: "sourceLocale",
-      targetLocales: "targetLocales",
     },
-    jobs: {
-      id: "id",
-      projectId: "projectId",
-      organizationId: "organizationId",
-      kind: "kind",
-      status: "status",
+    schema: {
+      projects: {
+        id: "id",
+        organizationId: "organizationId",
+        source: "source",
+        sourceLocale: "sourceLocale",
+        targetLocales: "targetLocales",
+      },
+      jobs: {
+        id: "id",
+        projectId: "projectId",
+        organizationId: "organizationId",
+        kind: "kind",
+        status: "status",
+      },
+      translationJobDetails: {
+        jobId: "jobId",
+        type: "type",
+      },
+      externalJobDetails: {
+        jobId: "jobId",
+        providerKind: "providerKind",
+      },
     },
-    translationJobDetails: {
-      jobId: "jobId",
-      type: "type",
-    },
-    externalJobDetails: {
-      jobId: "jobId",
-      providerKind: "providerKind",
-    },
-  },
-}));
+  };
+});
 
-import { enqueueFileTranslationJob } from "./enqueue-file-translation-job";
+import {
+  enqueueExistingFileTranslationJob,
+  enqueueFileTranslationJob,
+} from "./enqueue-file-translation-job";
 
 describe("enqueueFileTranslationJob", () => {
   beforeEach(() => {
@@ -185,5 +194,70 @@ describe("enqueueFileTranslationJob", () => {
       message: "Unsupported source file format.",
     });
     expect(jobQueueEnqueueMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("enqueueExistingFileTranslationJob", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    jobQueueEnqueueMock.mockResolvedValue(undefined);
+  });
+
+  it("rejects non-queued terminal job statuses", async () => {
+    selectLimitMock.mockResolvedValue([
+      {
+        id: "job_failed",
+        projectId: "project_1",
+        kind: "translation",
+        status: "failed",
+        type: "file",
+        externalProviderKind: null,
+      },
+    ]);
+
+    const result = await enqueueExistingFileTranslationJob({
+      organizationId: "org_1",
+      jobId: "job_failed",
+      jobQueue: { enqueue: jobQueueEnqueueMock } as never,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      code: "job_not_enqueueable",
+      message: 'Job status "failed" cannot be assigned to the translation agent.',
+    });
+    expect(jobQueueEnqueueMock).not.toHaveBeenCalled();
+  });
+
+  it("enqueues queued native file translation jobs", async () => {
+    selectLimitMock.mockResolvedValue([
+      {
+        id: "job_queued",
+        projectId: "project_1",
+        kind: "translation",
+        status: "queued",
+        type: "file",
+        externalProviderKind: null,
+      },
+    ]);
+
+    const result = await enqueueExistingFileTranslationJob({
+      organizationId: "org_1",
+      jobId: "job_queued",
+      jobQueue: { enqueue: jobQueueEnqueueMock } as never,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      jobId: "job_queued",
+      projectId: "project_1",
+    });
+    expect(jobQueueEnqueueMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "translation",
+        type: "file",
+        jobId: "job_queued",
+      }),
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/enqueue-file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/enqueue-file-translation-job.ts
@@ -24,16 +24,29 @@ import {
 } from "@/lib/translation/file-formats";
 import type { JobQueue, TranslationJobEventData } from "@/lib/workflow/types";
 
-export type EnqueueFileTranslationJobInput = {
+export type CreateFileTranslationJobInput = {
   organizationId: string;
   projectId: string;
   createdByUserId?: string | null;
   apiKeyId?: string | null;
+  ownerUserId?: string | null;
   sourceFileId: string;
   sourceLocale: string;
   targetLocales: string[];
   fileFormat?: SupportedTranslationFileFormat;
   metadata?: Record<string, string>;
+};
+
+export type CreateFileTranslationJobResult =
+  | {
+      ok: true;
+      jobId: string;
+      projectId: string;
+      sourceFileVersionId: string | null;
+    }
+  | { ok: false; code: string; message: string };
+
+export type EnqueueFileTranslationJobInput = CreateFileTranslationJobInput & {
   jobQueue: JobQueue<TranslationJobEventData>;
 };
 
@@ -41,9 +54,76 @@ export type EnqueueFileTranslationJobResult =
   | { ok: true; jobId: string }
   | { ok: false; code: string; message: string };
 
-export async function enqueueFileTranslationJob(
-  input: EnqueueFileTranslationJobInput,
-): Promise<EnqueueFileTranslationJobResult> {
+export type EnqueueExistingFileTranslationJobInput = {
+  organizationId: string;
+  jobId: string;
+  jobQueue: JobQueue<TranslationJobEventData>;
+};
+
+export type EnqueueExistingFileTranslationJobResult =
+  | { ok: true; jobId: string; projectId: string }
+  | { ok: false; code: string; message: string };
+
+async function markFileTranslationJobEnqueueFailed(input: {
+  organizationId: string;
+  jobId: string;
+  projectId?: string | null;
+  error: unknown;
+}) {
+  try {
+    await db
+      .update(schema.jobs)
+      .set({
+        status: "failed",
+        lastError:
+          input.error instanceof Error ? input.error.message : "translation job queue unavailable",
+      })
+      .where(
+        and(
+          eq(schema.jobs.organizationId, input.organizationId),
+          eq(schema.jobs.id, input.jobId),
+          ...(input.projectId ? [eq(schema.jobs.projectId, input.projectId)] : []),
+        ),
+      );
+  } catch {
+    // Best-effort cleanup; preserve the original enqueue failure response.
+  }
+}
+
+async function enqueueFileTranslationJobEvent(input: {
+  organizationId: string;
+  jobId: string;
+  projectId: string;
+  jobQueue: JobQueue<TranslationJobEventData>;
+}): Promise<EnqueueFileTranslationJobResult> {
+  try {
+    await input.jobQueue.enqueue({
+      kind: "translation",
+      jobId: input.jobId,
+      projectId: input.projectId,
+      type: "file",
+    });
+
+    return { ok: true, jobId: input.jobId };
+  } catch (error) {
+    await markFileTranslationJobEnqueueFailed({
+      organizationId: input.organizationId,
+      jobId: input.jobId,
+      projectId: input.projectId,
+      error,
+    });
+
+    return {
+      ok: false,
+      code: "translation_job_enqueue_failed",
+      message: error instanceof Error ? error.message : "Unable to enqueue translation job.",
+    };
+  }
+}
+
+export async function createFileTranslationJob(
+  input: CreateFileTranslationJobInput,
+): Promise<CreateFileTranslationJobResult> {
   const [project] = await db
     .select({
       id: schema.projects.id,
@@ -115,7 +195,7 @@ export async function enqueueFileTranslationJob(
   const jobId = `job_${randomUUID()}`;
 
   try {
-    const job = await db.transaction(async (tx) => {
+    const created = await db.transaction(async (tx) => {
       const jobBudget = await assertOrganizationCanEnqueueTranslationJobInTransaction(
         tx,
         input.organizationId,
@@ -139,11 +219,15 @@ export async function enqueueFileTranslationJob(
           projectId: input.projectId,
           createdByUserId: input.createdByUserId ?? null,
           apiKeyId: input.apiKeyId ?? null,
+          ownerUserId: input.ownerUserId ?? null,
           kind: "translation",
           status: "queued",
           inputPayload,
         })
-        .returning();
+        .returning({
+          id: schema.jobs.id,
+          projectId: schema.jobs.projectId,
+        });
 
       await tx.insert(schema.translationJobDetails).values({
         jobId,
@@ -164,17 +248,14 @@ export async function enqueueFileTranslationJob(
         throw new Error(formatUsageControlError(usageEventResult.error));
       }
 
-      return createdJob;
+      return {
+        jobId: createdJob.id,
+        projectId: createdJob.projectId ?? input.projectId,
+        sourceFileVersionId: sourceFileVersion?.id ?? null,
+      };
     });
 
-    await input.jobQueue.enqueue({
-      kind: "translation",
-      jobId: job.id,
-      projectId: job.projectId ?? input.projectId,
-      type: "file",
-    });
-
-    return { ok: true, jobId: job.id };
+    return { ok: true, ...created };
   } catch (error) {
     if (error instanceof OrganizationJobBudgetExceededError) {
       return {
@@ -184,22 +265,87 @@ export async function enqueueFileTranslationJob(
       };
     }
 
-    try {
-      await db
-        .update(schema.jobs)
-        .set({
-          status: "failed",
-          lastError: error instanceof Error ? error.message : "translation job queue unavailable",
-        })
-        .where(and(eq(schema.jobs.projectId, input.projectId), eq(schema.jobs.id, jobId)));
-    } catch {
-      // Best-effort cleanup; preserve the original enqueue failure response.
-    }
-
     return {
       ok: false,
-      code: "translation_job_enqueue_failed",
-      message: error instanceof Error ? error.message : "Unable to enqueue translation job.",
+      code: "translation_job_create_failed",
+      message: error instanceof Error ? error.message : "Unable to create translation job.",
     };
   }
+}
+
+export async function enqueueExistingFileTranslationJob(
+  input: EnqueueExistingFileTranslationJobInput,
+): Promise<EnqueueExistingFileTranslationJobResult> {
+  const [job] = await db
+    .select({
+      id: schema.jobs.id,
+      projectId: schema.jobs.projectId,
+      kind: schema.jobs.kind,
+      status: schema.jobs.status,
+      type: schema.translationJobDetails.type,
+      externalProviderKind: schema.externalJobDetails.providerKind,
+    })
+    .from(schema.jobs)
+    .leftJoin(schema.translationJobDetails, eq(schema.translationJobDetails.jobId, schema.jobs.id))
+    .leftJoin(schema.externalJobDetails, eq(schema.externalJobDetails.jobId, schema.jobs.id))
+    .where(
+      and(eq(schema.jobs.id, input.jobId), eq(schema.jobs.organizationId, input.organizationId)),
+    )
+    .limit(1);
+
+  if (!job) {
+    return { ok: false, code: "job_not_found", message: "Job not found." };
+  }
+
+  if (job.externalProviderKind) {
+    return {
+      ok: false,
+      code: "native_job_required",
+      message: "Only native file translation jobs can be assigned to the translation agent.",
+    };
+  }
+
+  if (job.kind !== "translation" || job.type !== "file" || !job.projectId) {
+    return {
+      ok: false,
+      code: "file_translation_job_required",
+      message: "Only native file translation jobs can be assigned to the translation agent.",
+    };
+  }
+
+  if (job.status === "running") {
+    return {
+      ok: false,
+      code: "job_already_running",
+      message: "Job is already running.",
+    };
+  }
+
+  const enqueued = await enqueueFileTranslationJobEvent({
+    organizationId: input.organizationId,
+    jobId: job.id,
+    projectId: job.projectId,
+    jobQueue: input.jobQueue,
+  });
+  if (!enqueued.ok) {
+    return enqueued;
+  }
+
+  return { ok: true, jobId: job.id, projectId: job.projectId };
+}
+
+export async function enqueueFileTranslationJob(
+  input: EnqueueFileTranslationJobInput,
+): Promise<EnqueueFileTranslationJobResult> {
+  const created = await createFileTranslationJob(input);
+  if (!created.ok) {
+    return created;
+  }
+
+  return enqueueFileTranslationJobEvent({
+    organizationId: input.organizationId,
+    jobId: created.jobId,
+    projectId: created.projectId,
+    jobQueue: input.jobQueue,
+  });
 }

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/enqueue-file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/enqueue-file-translation-job.ts
@@ -321,6 +321,14 @@ export async function enqueueExistingFileTranslationJob(
     };
   }
 
+  if (job.status !== "queued") {
+    return {
+      ok: false,
+      code: "job_not_enqueueable",
+      message: `Job status "${job.status}" cannot be assigned to the translation agent.`,
+    };
+  }
+
   const enqueued = await enqueueFileTranslationJobEvent({
     organizationId: input.organizationId,
     jobId: job.id,

--- a/docs/plans/2026-07-17-native-tms-automation-tools-design.md
+++ b/docs/plans/2026-07-17-native-tms-automation-tools-design.md
@@ -1,0 +1,49 @@
+# Native TMS automation tools
+
+## Problem
+
+Source-upload automations need to work with Hyperlocalise native TMS in two
+clear steps: create a job, then start agent translation. Today
+`create_translation_jobs` creates and enqueues in one tool, which hides that
+orchestration.
+
+## Decision
+
+Replace `create_translation_jobs` with two workspace orchestrator tools:
+
+1. `create_native_tms_job` — create a native file translation job from the
+   source-upload snapshot and automation translation config. Persist only.
+2. `assign_translate_with_agent` — enqueue that job on the existing translation
+   job queue (same path as native `run-agent`).
+
+## Scope
+
+- Workspace automation orchestrator only
+- Reuse the native file-translation workflow queue
+- Keep `toolConfig.translation` as the enablement gate
+
+## Out of scope
+
+- Conversational Hyperlocalise agent tools
+- Provider TMS `translate_with_agent` agent-run path for native jobs
+- New job status values for “created but not started”
+
+## Data flow
+
+```
+source upload
+  → workspace automation (mode: source_upload)
+  → create_native_tms_job (DB job + details)
+  → assign_translate_with_agent (enqueue translation job event)
+  → file translation workflow
+```
+
+## Shared helpers
+
+Split `enqueueFileTranslationJob` into create + enqueue helpers. The combined
+helper remains for API and other callers.
+
+## Idempotency
+
+Both tools read prior step results / run `outputSummary` and return the same
+payload when already completed for the run.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Replaces workspace orchestrator `create_translation_jobs` with two native TMS tools for source-upload automations:

1. **`create_native_tms_job`** — create a Hyperlocalise native file translation job from the upload snapshot (persist only)
2. **`assign_translate_with_agent`** — enqueue that job on the existing translation job queue (same path as native `run-agent`)

Also splits `enqueueFileTranslationJob` into create + enqueue helpers, updates plan/tool registry/output summary, and adds unit coverage.

Design: `docs/plans/2026-07-17-native-tms-automation-tools-design.md`

## How to test

```bash
cd apps/hyperlocalise-web
vp test src/agents/automations/workspace/agent/plan.test.ts \
  src/agents/automations/workspace/agent/workspace-orchestrator-output-summary.test.ts \
  src/agents/automations/workspace/agent/tools/create_native_tms_job.test.ts \
  src/agents/automations/workspace/agent/tools/assign_translate_with_agent.test.ts \
  src/lib/projects/jobs/enqueue-file-translation-job.test.ts
vp check --fix
```

Example automation: enable translation tools + `source_upload` trigger → create native job → assign/enqueue translation.

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f724b-2c0b-7751-ae1e-6a47101ee887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f724b-2c0b-7751-ae1e-6a47101ee887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

