### PR TITLE
feat(automations): add built-in knowledge memories tool

### DIFF
--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/compose-workspace-instructions.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/compose-workspace-instructions.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { composeWorkspaceAutomationInstructions } from "./compose-workspace-instructions";
+
+describe("composeWorkspaceAutomationInstructions", () => {
+  it("includes selected knowledge when memories are enabled", () => {
+    const instructions = composeWorkspaceAutomationInstructions({
+      triggerMode: "manual",
+      plan: { tools: ["notify_slack"] },
+      userOverride: "Notify the team.",
+      knowledgeEnabled: true,
+      knowledgeMemory: "Use sentence case for feature names.",
+    });
+
+    expect(instructions).toContain("Workspace knowledge memories are enabled");
+    expect(instructions).toContain("## Workspace knowledge");
+    expect(instructions).toContain("Use sentence case for feature names.");
+  });
+});

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/compose-workspace-instructions.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/compose-workspace-instructions.test.ts
@@ -16,4 +16,17 @@ describe("composeWorkspaceAutomationInstructions", () => {
     expect(instructions).toContain("## Workspace knowledge");
     expect(instructions).toContain("Use sentence case for feature names.");
   });
+
+  it("omits knowledge context copy when memories are enabled but empty", () => {
+    const instructions = composeWorkspaceAutomationInstructions({
+      triggerMode: "manual",
+      plan: { tools: ["notify_slack"] },
+      userOverride: "Notify the team.",
+      knowledgeEnabled: true,
+      knowledgeMemory: null,
+    });
+
+    expect(instructions).not.toContain("applied as context below");
+    expect(instructions).not.toContain("## Workspace knowledge");
+  });
 });

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/compose-workspace-instructions.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/compose-workspace-instructions.ts
@@ -8,20 +8,32 @@ export function composeWorkspaceAutomationInstructions(input: {
   userOverride?: string | null;
   triggerMode: WorkspaceAutomationTriggerConfig["mode"];
   plan: WorkspaceOrchestratorPlan;
+  knowledgeMemory?: string | null;
+  knowledgeEnabled?: boolean;
 }) {
   const enabledToolsSection = [
     "## Enabled tools",
     `Trigger mode: ${input.triggerMode}.`,
     `Execution plan: ${input.plan.tools.map((tool) => `\`${tool}\``).join(" → ") || "none"}.`,
+    input.knowledgeEnabled
+      ? "Workspace knowledge memories are enabled and applied as context below."
+      : null,
     "Call each planned tool in order. Use customer instructions when invoking workflow tools.",
-  ].join("\n");
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join("\n");
+
+  const dynamicSections = [enabledToolsSection];
+  if (input.knowledgeMemory?.trim()) {
+    dynamicSections.push(`## Workspace knowledge\n${input.knowledgeMemory.trim()}`);
+  }
 
   const skills = input.templateSkillId ? [input.templateSkillId] : [];
 
   return composeInstructions({
     automationId: "workspace",
     skills,
-    dynamicSections: [enabledToolsSection],
+    dynamicSections,
     userOverride: input.userOverride,
   });
 }

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/compose-workspace-instructions.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/compose-workspace-instructions.ts
@@ -15,7 +15,7 @@ export function composeWorkspaceAutomationInstructions(input: {
     "## Enabled tools",
     `Trigger mode: ${input.triggerMode}.`,
     `Execution plan: ${input.plan.tools.map((tool) => `\`${tool}\``).join(" → ") || "none"}.`,
-    input.knowledgeEnabled
+    input.knowledgeEnabled && input.knowledgeMemory?.trim()
       ? "Workspace knowledge memories are enabled and applied as context below."
       : null,
     "Call each planned tool in order. Use customer instructions when invoking workflow tools.",

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/resolve-workspace-automation-knowledge.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/resolve-workspace-automation-knowledge.test.ts
@@ -1,9 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-import type { WorkspaceAutomationRecord } from "@/lib/agents/workspace-automations";
-
-const getKnowledgeMemoryForOrganizationMock = vi.hoisted(() => vi.fn());
+const getKnowledgeMemoryForOrganizationMock = vi.hoisted(() => {
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/hyperlocalise_test";
+  process.env.PROVIDER_CREDENTIALS_MASTER_KEY ??= "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=";
+  return vi.fn();
+});
 const selectKnowledgeMemoryContextMock = vi.hoisted(() => vi.fn());
+
+import type { WorkspaceAutomationRecord } from "@/lib/agents/workspace-automations";
 
 vi.mock("@/lib/knowledge-memory/knowledge-memory", () => ({
   getKnowledgeMemoryForOrganization: getKnowledgeMemoryForOrganizationMock,
@@ -15,7 +19,9 @@ vi.mock("@/lib/knowledge-memory/knowledge-memory-selection", () => ({
 
 import { resolveWorkspaceAutomationKnowledgeContext } from "./resolve-workspace-automation-knowledge";
 
-function automation(toolConfig: WorkspaceAutomationRecord["toolConfig"]): WorkspaceAutomationRecord {
+function automation(
+  toolConfig: WorkspaceAutomationRecord["toolConfig"],
+): WorkspaceAutomationRecord {
   return {
     id: "automation-1",
     organizationId: "org-1",

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/resolve-workspace-automation-knowledge.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/resolve-workspace-automation-knowledge.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import type { WorkspaceAutomationRecord } from "@/lib/agents/workspace-automations";
+
+const getKnowledgeMemoryForOrganizationMock = vi.hoisted(() => vi.fn());
+const selectKnowledgeMemoryContextMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/knowledge-memory/knowledge-memory", () => ({
+  getKnowledgeMemoryForOrganization: getKnowledgeMemoryForOrganizationMock,
+}));
+
+vi.mock("@/lib/knowledge-memory/knowledge-memory-selection", () => ({
+  selectKnowledgeMemoryContext: selectKnowledgeMemoryContextMock,
+}));
+
+import { resolveWorkspaceAutomationKnowledgeContext } from "./resolve-workspace-automation-knowledge";
+
+function automation(toolConfig: WorkspaceAutomationRecord["toolConfig"]): WorkspaceAutomationRecord {
+  return {
+    id: "automation-1",
+    organizationId: "org-1",
+    authorUserId: null,
+    status: "active",
+    name: "Nightly sync",
+    instructions: "Keep product names consistent.",
+    triggerConfig: { mode: "manual" },
+    repositoryTarget: { kind: "none" },
+    toolConfig,
+    configVersion: 1,
+    nextRunAt: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+describe("resolveWorkspaceAutomationKnowledgeContext", () => {
+  beforeEach(() => {
+    getKnowledgeMemoryForOrganizationMock.mockReset();
+    selectKnowledgeMemoryContextMock.mockReset();
+  });
+
+  it("returns null when knowledge tool is disabled", async () => {
+    await expect(
+      resolveWorkspaceAutomationKnowledgeContext({
+        organizationId: "org-1",
+        automation: automation({}),
+      }),
+    ).resolves.toBeNull();
+    expect(getKnowledgeMemoryForOrganizationMock).not.toHaveBeenCalled();
+  });
+
+  it("returns selected knowledge when the tool is enabled", async () => {
+    getKnowledgeMemoryForOrganizationMock.mockResolvedValue({
+      content: "# Style\nUse sentence case.",
+      updatedAt: null,
+      updatedByUserId: null,
+    });
+    selectKnowledgeMemoryContextMock.mockReturnValue({
+      compactText: "Use sentence case.",
+      segments: [],
+      metrics: {
+        selectedMemoryCount: 1,
+        selectedMemoryChars: 18,
+        wholeMemoryChars: 24,
+        reductionPercent: 25,
+        matchedHeadingPaths: [],
+        fallbackMode: "selective",
+      },
+    });
+
+    await expect(
+      resolveWorkspaceAutomationKnowledgeContext({
+        organizationId: "org-1",
+        automation: automation({ knowledge: { enabled: true } }),
+      }),
+    ).resolves.toBe("Use sentence case.");
+
+    expect(selectKnowledgeMemoryContextMock).toHaveBeenCalledWith({
+      content: "# Style\nUse sentence case.",
+      sourceText: "Keep product names consistent.",
+      context: "Nightly sync",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/resolve-workspace-automation-knowledge.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/resolve-workspace-automation-knowledge.ts
@@ -1,0 +1,29 @@
+import {
+  hasWorkspaceAutomationKnowledgeTool,
+  type WorkspaceAutomationRecord,
+} from "@/lib/agents/workspace-automations";
+import { getKnowledgeMemoryForOrganization } from "@/lib/knowledge-memory/knowledge-memory";
+import { selectKnowledgeMemoryContext } from "@/lib/knowledge-memory/knowledge-memory-selection";
+
+export async function resolveWorkspaceAutomationKnowledgeContext(input: {
+  organizationId: string;
+  automation: WorkspaceAutomationRecord;
+}): Promise<string | null> {
+  if (!hasWorkspaceAutomationKnowledgeTool(input.automation.toolConfig)) {
+    return null;
+  }
+
+  const memory = await getKnowledgeMemoryForOrganization(input.organizationId);
+  if (!memory.content.trim()) {
+    return null;
+  }
+
+  const selected = selectKnowledgeMemoryContext({
+    content: memory.content,
+    sourceText: input.automation.instructions,
+    context: input.automation.name,
+  });
+
+  const compactText = selected.compactText.trim();
+  return compactText.length > 0 ? compactText : null;
+}

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/resolve-workspace-automation-knowledge.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/resolve-workspace-automation-knowledge.ts
@@ -1,7 +1,4 @@
-import {
-  hasWorkspaceAutomationKnowledgeTool,
-  type WorkspaceAutomationRecord,
-} from "@/lib/agents/workspace-automations";
+import type { WorkspaceAutomationRecord } from "@/lib/agents/workspace-automations";
 import { getKnowledgeMemoryForOrganization } from "@/lib/knowledge-memory/knowledge-memory";
 import { selectKnowledgeMemoryContext } from "@/lib/knowledge-memory/knowledge-memory-selection";
 
@@ -9,7 +6,7 @@ export async function resolveWorkspaceAutomationKnowledgeContext(input: {
   organizationId: string;
   automation: WorkspaceAutomationRecord;
 }): Promise<string | null> {
-  if (!hasWorkspaceAutomationKnowledgeTool(input.automation.toolConfig)) {
+  if (!input.automation.toolConfig.knowledge?.enabled) {
     return null;
   }
 

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/run-workspace-orchestrator.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/run-workspace-orchestrator.ts
@@ -19,6 +19,7 @@ import { createWorkspaceOrchestratorAgent } from "./agent";
 import { composeWorkspaceAutomationInstructions } from "./compose-workspace-instructions";
 import { createWorkspaceOrchestratorSession, type WorkspaceOrchestratorSession } from "./context";
 import { buildWorkspaceOrchestratorPlan } from "./plan";
+import { resolveWorkspaceAutomationKnowledgeContext } from "./resolve-workspace-automation-knowledge";
 import { buildWorkspaceOrchestratorOutputSummary } from "./workspace-orchestrator-output-summary";
 
 const logger = createLogger("workspace-orchestrator");
@@ -147,11 +148,17 @@ export async function runWorkspaceOrchestrator(input: {
 
   const templateSkillId = resolveTemplateSkillId(run.inputSnapshot);
   const plan = buildWorkspaceOrchestratorPlan(automation, { templateSkillId });
+  const knowledgeMemory = await resolveWorkspaceAutomationKnowledgeContext({
+    organizationId: input.organizationId,
+    automation,
+  });
   const composedInstructions = composeWorkspaceAutomationInstructions({
     templateSkillId,
     userOverride: automation.instructions,
     triggerMode: automation.triggerConfig.mode,
     plan,
+    knowledgeEnabled: Boolean(automation.toolConfig.knowledge?.enabled),
+    knowledgeMemory,
   });
 
   let repository: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/[automationId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/[automationId]/page.tsx
@@ -1,6 +1,11 @@
 import { Suspense } from "react";
 
-import { requireWorkspaceFeatureFlag, workspaceAutomationsFlag } from "@/lib/flags/workspace-flags";
+import { hasCapability } from "@/api/auth/policy";
+import {
+  evaluateWorkspaceFeatureFlags,
+  requireWorkspaceFeatureFlag,
+  workspaceAutomationsFlag,
+} from "@/lib/flags/workspace-flags";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { AutomationDetailPageContent } from "../_components/automation-detail-page-content";
@@ -13,12 +18,15 @@ export default async function AutomationDetailPage({
   const { organizationSlug, automationId } = await params;
   const auth = await requireAppAuthContext({ organizationSlug });
   await requireWorkspaceFeatureFlag(workspaceAutomationsFlag, auth);
+  const flags = await evaluateWorkspaceFeatureFlags(auth);
 
   return (
     <Suspense fallback={null}>
       <AutomationDetailPageContent
         organizationSlug={organizationSlug}
         automationId={automationId}
+        knowledgeAvailable={flags.knowledge}
+        canUpdateKnowledgeMemory={hasCapability(auth.membership.role, "workspace:update")}
       />
     </Suspense>
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.tsx
@@ -21,9 +21,13 @@ import { WorkspaceAutomationEditor } from "./workspace-automation-form";
 export function AutomationDetailPageContent({
   organizationSlug,
   automationId,
+  knowledgeAvailable = false,
+  canUpdateKnowledgeMemory = false,
 }: {
   organizationSlug: string;
   automationId: string;
+  knowledgeAvailable?: boolean;
+  canUpdateKnowledgeMemory?: boolean;
 }) {
   const intl = useIntl();
   const queryClient = useQueryClient();
@@ -148,6 +152,8 @@ export function AutomationDetailPageContent({
         organizationSlug={organizationSlug}
         form={form}
         errors={errors}
+        knowledgeAvailable={knowledgeAvailable}
+        canUpdateKnowledgeMemory={canUpdateKnowledgeMemory}
         onChange={setForm}
         runHistory={recentRuns}
         actions={

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-editor.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-editor.fixture.ts
@@ -128,3 +128,8 @@ export const createContentfulAutomationFormFixture = () => {
 
 export const createDetailAutomationFormFixture = () =>
   createWorkspaceAutomationFormStateFromRecord(createAutomationSummary());
+
+export const createMemoriesAutomationFormFixture = () => ({
+  ...createGithubAutomationFormFixture(),
+  knowledgeEnabled: true,
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-msw-handlers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-msw-handlers.ts
@@ -44,6 +44,25 @@ export const automationEditorMswHandlers = [
   http.get("/api/orgs/:organizationSlug/contentful-connections", () =>
     HttpResponse.json({ contentfulConnections: automationEditorContentfulConnectionsFixture }),
   ),
+  http.get("/api/orgs/:organizationSlug/knowledge-memory", () =>
+    HttpResponse.json({
+      knowledgeMemory: {
+        content: "# Brand\nUse sentence case for feature names.",
+        updatedAt: "2026-07-01T12:00:00.000Z",
+        updatedByUserId: "user_001",
+      },
+    }),
+  ),
+  http.put("/api/orgs/:organizationSlug/knowledge-memory", async ({ request }) => {
+    const body = (await request.json()) as { content?: string };
+    return HttpResponse.json({
+      knowledgeMemory: {
+        content: body.content ?? "",
+        updatedAt: "2026-07-17T12:00:00.000Z",
+        updatedByUserId: "user_001",
+      },
+    });
+  }),
 ];
 
 export const automationEditorDisconnectedMswHandlers = [

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-new-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-new-page-content.tsx
@@ -23,9 +23,13 @@ import { WorkspaceAutomationEditor } from "./workspace-automation-form";
 export function AutomationsNewPageContent({
   organizationSlug,
   initialForm = createDefaultWorkspaceAutomationFormState(),
+  knowledgeAvailable = false,
+  canUpdateKnowledgeMemory = false,
 }: {
   organizationSlug: string;
   initialForm?: WorkspaceAutomationFormState;
+  knowledgeAvailable?: boolean;
+  canUpdateKnowledgeMemory?: boolean;
 }) {
   const intl = useIntl();
   const router = useRouter();
@@ -80,6 +84,8 @@ export function AutomationsNewPageContent({
         organizationSlug={organizationSlug}
         form={form}
         errors={errors}
+        knowledgeAvailable={knowledgeAvailable}
+        canUpdateKnowledgeMemory={canUpdateKnowledgeMemory}
         onChange={setForm}
         actions={
           <>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-editor.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-editor.stories.tsx
@@ -12,23 +12,28 @@ import {
   createDetailAutomationFormFixture,
   createEmptyAutomationFormFixture,
   createGithubAutomationFormFixture,
+  createMemoriesAutomationFormFixture,
 } from "./automation-editor.fixture";
 import { automationEditorMswHandlers } from "./automation-msw-handlers";
 import { WorkspaceAutomationEditor } from "./workspace-automation-form";
 
 function WorkspaceAutomationEditorStory({
   actions,
+  canUpdateKnowledgeMemory = true,
   disabled,
   errors: initialErrors = {},
   form: initialForm,
+  knowledgeAvailable = true,
   mode,
   organizationSlug = "acme",
   runHistory,
 }: {
   actions?: ReactNode;
+  canUpdateKnowledgeMemory?: boolean;
   disabled?: boolean;
   errors?: Record<string, string | undefined>;
   form: WorkspaceAutomationFormState;
+  knowledgeAvailable?: boolean;
   mode: "create" | "detail";
   organizationSlug?: string;
   runHistory?: typeof automationRunsFixture;
@@ -40,9 +45,11 @@ function WorkspaceAutomationEditorStory({
     <WorkspacePageShell className="max-w-5xl">
       <WorkspaceAutomationEditor
         actions={actions}
+        canUpdateKnowledgeMemory={canUpdateKnowledgeMemory}
         disabled={disabled}
         errors={errors}
         form={form}
+        knowledgeAvailable={knowledgeAvailable}
         mode={mode}
         onChange={(next) => {
           setForm(next);
@@ -115,6 +122,17 @@ export const CreateFromContentfulTemplate: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByDisplayValue("Translate Contentful article")).toBeInTheDocument();
     await expect(canvas.getByText("Contentful")).toBeInTheDocument();
+  },
+};
+
+export const CreateWithMemories: Story = {
+  args: {
+    form: createMemoriesAutomationFormFixture(),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Memories")).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Manage" })).toBeInTheDocument();
+    await expect(canvas.getByText("3 tools")).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -260,7 +260,7 @@ export const workspaceAutomationFormMessages = defineMessages({
   },
   builtInTools: {
     defaultMessage: "Built-in",
-    id: "kMemBuiltIn1",
+    id: "8Ktyj8rNhr",
     description: "Dropdown section label for built-in automation tools",
   },
   supportedTools: {
@@ -270,43 +270,43 @@ export const workspaceAutomationFormMessages = defineMessages({
   },
   memories: {
     defaultMessage: "Memories",
-    id: "kMemTitle01",
+    id: "mLI55faX8v",
     description: "Menu item and tool title for workspace knowledge memories",
   },
   memoriesDescription: {
     defaultMessage: "Use organization knowledge memory as guidance for this automation.",
-    id: "kMemDesc001",
+    id: "rcdU5+Pv4r",
     description: "Description for the knowledge memories automation tool",
   },
   memoriesUnavailableDescription: {
     defaultMessage:
       "Enable workspace knowledge for this organization before using memories in automations.",
-    id: "kMemUnavail1",
+    id: "yl7Dzt+xE3",
     description: "Description when knowledge memories cannot be used yet",
   },
   manageMemories: {
     defaultMessage: "Manage",
-    id: "kMemManage1",
+    id: "WNUkfqHAtJ",
     description: "Button to open the knowledge memories editor from an automation",
   },
   manageMemoriesTitle: {
     defaultMessage: "Knowledge memories",
-    id: "kMemSheetT1",
+    id: "W9S7Ht69kS",
     description: "Title for the knowledge memories management sheet",
   },
   manageMemoriesDescription: {
     defaultMessage: "Edit the shared organization knowledge used by this automation.",
-    id: "kMemSheetD1",
+    id: "WBqbSdV/u8",
     description: "Description for the knowledge memories management sheet",
   },
   removeMemoriesTool: {
     defaultMessage: "Remove memories tool",
-    id: "kMemRemove1",
+    id: "axtydiBtML",
     description: "Accessible label to remove the knowledge memories tool",
   },
   enableKnowledgeFirstShortcut: {
     defaultMessage: "Enable first",
-    id: "kMemEnable1",
+    id: "a51/Gtv+h4",
     description: "Shortcut shown when workspace knowledge is not enabled for the organization",
   },
   useGithubRepo: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -258,10 +258,56 @@ export const workspaceAutomationFormMessages = defineMessages({
     id: "FCdijMuIQ9",
     description: "Button to open the add-tool menu",
   },
+  builtInTools: {
+    defaultMessage: "Built-in",
+    id: "kMemBuiltIn1",
+    description: "Dropdown section label for built-in automation tools",
+  },
   supportedTools: {
     defaultMessage: "Supported tools",
     id: "WsiwWcs52J",
     description: "Dropdown section label for available automation tools",
+  },
+  memories: {
+    defaultMessage: "Memories",
+    id: "kMemTitle01",
+    description: "Menu item and tool title for workspace knowledge memories",
+  },
+  memoriesDescription: {
+    defaultMessage: "Use organization knowledge memory as guidance for this automation.",
+    id: "kMemDesc001",
+    description: "Description for the knowledge memories automation tool",
+  },
+  memoriesUnavailableDescription: {
+    defaultMessage:
+      "Enable workspace knowledge for this organization before using memories in automations.",
+    id: "kMemUnavail1",
+    description: "Description when knowledge memories cannot be used yet",
+  },
+  manageMemories: {
+    defaultMessage: "Manage",
+    id: "kMemManage1",
+    description: "Button to open the knowledge memories editor from an automation",
+  },
+  manageMemoriesTitle: {
+    defaultMessage: "Knowledge memories",
+    id: "kMemSheetT1",
+    description: "Title for the knowledge memories management sheet",
+  },
+  manageMemoriesDescription: {
+    defaultMessage: "Edit the shared organization knowledge used by this automation.",
+    id: "kMemSheetD1",
+    description: "Description for the knowledge memories management sheet",
+  },
+  removeMemoriesTool: {
+    defaultMessage: "Remove memories tool",
+    id: "kMemRemove1",
+    description: "Accessible label to remove the knowledge memories tool",
+  },
+  enableKnowledgeFirstShortcut: {
+    defaultMessage: "Enable first",
+    id: "kMemEnable1",
+    description: "Shortcut shown when workspace knowledge is not enabled for the organization",
   },
   useGithubRepo: {
     defaultMessage: "Use GitHub repo",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -1991,10 +1991,7 @@ function ToolsSettings({
       </EditorPanel>
 
       <Sheet open={memoriesOpen} onOpenChange={setMemoriesOpen}>
-        <SheetContent
-          side="right"
-          className="w-full overflow-y-auto sm:max-w-xl md:max-w-2xl"
-        >
+        <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-xl md:max-w-2xl">
           <SheetHeader>
             <SheetTitle>
               <FormattedMessage {...workspaceAutomationFormMessages.manageMemoriesTitle} />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState, type ReactNode } from "react";
 import {
   Add01Icon,
   ArrowDown01Icon,
+  BrainCircuitIcon,
   FolderLibraryIcon,
   GitBranchIcon,
   SlackIcon,
@@ -25,6 +26,7 @@ import {
 } from "simple-icons";
 
 import { SimpleBrandIcon } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/simple-brand-icon";
+import { KnowledgeMemoryEditor } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/knowledge/_components/knowledge-memory-editor";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -50,6 +52,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -293,7 +302,8 @@ function toolCount(form: WorkspaceAutomationFormState) {
     Number(form.slackEnabled) +
     Number(form.emailEnabled) +
     Number(form.contentfulEnabled) +
-    Number(form.translationEnabled)
+    Number(form.translationEnabled) +
+    Number(form.knowledgeEnabled)
   );
 }
 
@@ -1042,6 +1052,7 @@ function AddToolMenu({
   emailConnected,
   form,
   githubConnected,
+  knowledgeAvailable,
   onChange,
   repositories,
   slackConnected,
@@ -1051,6 +1062,7 @@ function AddToolMenu({
   emailConnected: boolean;
   form: WorkspaceAutomationFormState;
   githubConnected: boolean;
+  knowledgeAvailable: boolean;
   onChange: (next: WorkspaceAutomationFormState) => void;
   repositories: GithubRepositoryOption[];
   slackConnected: boolean;
@@ -1077,6 +1089,30 @@ function AddToolMenu({
           align="start"
           sideOffset={2}
         >
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>
+              <FormattedMessage {...workspaceAutomationFormMessages.builtInTools} />
+            </DropdownMenuLabel>
+            <DropdownMenuItem
+              disabled={form.knowledgeEnabled || !knowledgeAvailable}
+              onClick={() => onChange({ ...form, knowledgeEnabled: true })}
+            >
+              <HugeiconsIcon icon={BrainCircuitIcon} strokeWidth={1.8} className="size-4" />
+              <FormattedMessage {...workspaceAutomationFormMessages.memories} />
+              {form.knowledgeEnabled ? (
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                </DropdownMenuShortcut>
+              ) : !knowledgeAvailable ? (
+                <DropdownMenuShortcut>
+                  <FormattedMessage
+                    {...workspaceAutomationFormMessages.enableKnowledgeFirstShortcut}
+                  />
+                </DropdownMenuShortcut>
+              ) : null}
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
           <DropdownMenuGroup>
             <DropdownMenuLabel>
               <FormattedMessage {...workspaceAutomationFormMessages.supportedTools} />
@@ -1322,12 +1358,14 @@ function ContentfulTargetLocalesPicker({
 }
 
 function ToolsSettings({
+  canUpdateKnowledgeMemory,
   contentfulConnections,
   disabled,
   emailConnected,
   errors,
   form,
   githubConnected,
+  knowledgeAvailable,
   onChange,
   organizationSlug,
   projects,
@@ -1336,12 +1374,14 @@ function ToolsSettings({
   slackChannelsLoading,
   slackConnected,
 }: {
+  canUpdateKnowledgeMemory: boolean;
   contentfulConnections: ContentfulConnectionOption[];
   disabled?: boolean;
   emailConnected: boolean;
   errors: Record<string, string | undefined>;
   form: WorkspaceAutomationFormState;
   githubConnected: boolean;
+  knowledgeAvailable: boolean;
   onChange: (next: WorkspaceAutomationFormState) => void;
   organizationSlug: string;
   projects: ProjectOption[];
@@ -1363,10 +1403,42 @@ function ToolsSettings({
   const translationAvailableTargetLocales = selectedTranslationProject?.targetLocales ?? [];
   const translationTargetLocalesFieldId = "translation-target-locales";
   const intl = useIntl();
+  const [memoriesOpen, setMemoriesOpen] = useState(false);
 
   return (
     <EditorSection title={intl.formatMessage(workspaceAutomationFormMessages.toolsSection)}>
       <EditorPanel>
+        {form.knowledgeEnabled ? (
+          <EditorRow
+            icon={<HugeiconsIcon icon={BrainCircuitIcon} strokeWidth={1.8} className="size-4" />}
+            title={<FormattedMessage {...workspaceAutomationFormMessages.memories} />}
+            description={
+              knowledgeAvailable
+                ? intl.formatMessage(workspaceAutomationFormMessages.memoriesDescription)
+                : intl.formatMessage(workspaceAutomationFormMessages.memoriesUnavailableDescription)
+            }
+            action={
+              <>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  disabled={disabled || !knowledgeAvailable}
+                  className="h-8 rounded-full px-3"
+                  onClick={() => setMemoriesOpen(true)}
+                >
+                  <FormattedMessage {...workspaceAutomationFormMessages.manageMemories} />
+                </Button>
+                <DeleteToolButton
+                  disabled={disabled}
+                  label={intl.formatMessage(workspaceAutomationFormMessages.removeMemoriesTool)}
+                  onClick={() => onChange({ ...form, knowledgeEnabled: false })}
+                />
+              </>
+            }
+          />
+        ) : null}
+
         {form.githubEnabled && form.githubMode === "agent" ? (
           <EditorRow
             icon={<HugeiconsIcon icon={GitBranchIcon} strokeWidth={1.8} className="size-4" />}
@@ -1911,11 +1983,34 @@ function ToolsSettings({
           emailConnected={emailConnected}
           form={form}
           githubConnected={githubConnected}
+          knowledgeAvailable={knowledgeAvailable}
           onChange={onChange}
           repositories={repositories}
           slackConnected={slackConnected}
         />
       </EditorPanel>
+
+      <Sheet open={memoriesOpen} onOpenChange={setMemoriesOpen}>
+        <SheetContent
+          side="right"
+          className="w-full overflow-y-auto sm:max-w-xl md:max-w-2xl"
+        >
+          <SheetHeader>
+            <SheetTitle>
+              <FormattedMessage {...workspaceAutomationFormMessages.manageMemoriesTitle} />
+            </SheetTitle>
+            <SheetDescription>
+              <FormattedMessage {...workspaceAutomationFormMessages.manageMemoriesDescription} />
+            </SheetDescription>
+          </SheetHeader>
+          <div className="px-6 pb-6">
+            <KnowledgeMemoryEditor
+              organizationSlug={organizationSlug}
+              canUpdateKnowledgeMemory={canUpdateKnowledgeMemory}
+            />
+          </div>
+        </SheetContent>
+      </Sheet>
     </EditorSection>
   );
 }
@@ -2001,18 +2096,22 @@ function RunHistoryTable({ runs }: { runs: WorkspaceAutomationRunRecord[] }) {
 
 export function WorkspaceAutomationEditor({
   actions,
+  canUpdateKnowledgeMemory = false,
   disabled,
   errors,
   form,
+  knowledgeAvailable = false,
   mode,
   onChange,
   organizationSlug,
   runHistory,
 }: {
   actions?: ReactNode;
+  canUpdateKnowledgeMemory?: boolean;
   disabled?: boolean;
   errors: Record<string, string | undefined>;
   form: WorkspaceAutomationFormState;
+  knowledgeAvailable?: boolean;
   mode: "create" | "detail";
   onChange: (next: WorkspaceAutomationFormState) => void;
   organizationSlug: string;
@@ -2267,12 +2366,14 @@ export function WorkspaceAutomationEditor({
           </EditorSection>
 
           <ToolsSettings
+            canUpdateKnowledgeMemory={canUpdateKnowledgeMemory}
             contentfulConnections={contentfulConnections}
             disabled={disabled}
             emailConnected={emailConnected}
             errors={errors}
             form={form}
             githubConnected={githubConnected}
+            knowledgeAvailable={knowledgeAvailable}
             onChange={onChange}
             organizationSlug={organizationSlug}
             projects={projectsQuery.data ?? []}
@@ -2298,6 +2399,8 @@ export function WorkspaceAutomationForm(props: {
   form: WorkspaceAutomationFormState;
   errors: Record<string, string | undefined>;
   disabled?: boolean;
+  knowledgeAvailable?: boolean;
+  canUpdateKnowledgeMemory?: boolean;
   onChange: (next: WorkspaceAutomationFormState) => void;
 }) {
   return <WorkspaceAutomationEditor mode="create" {...props} />;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/new/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/new/page.tsx
@@ -1,11 +1,16 @@
 import { Suspense } from "react";
 
+import { hasCapability } from "@/api/auth/policy";
 import {
   createDefaultWorkspaceAutomationFormState,
   createWorkspaceAutomationFormStateFromTemplate,
 } from "@/lib/agents/workspace-automation-view-model";
 import { getMergedWorkspaceAutomationTemplates } from "@/lib/agents/workspace-automation-templates.server";
-import { requireWorkspaceFeatureFlag, workspaceAutomationsFlag } from "@/lib/flags/workspace-flags";
+import {
+  evaluateWorkspaceFeatureFlags,
+  requireWorkspaceFeatureFlag,
+  workspaceAutomationsFlag,
+} from "@/lib/flags/workspace-flags";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { AutomationsNewPageContent } from "../_components/automations-new-page-content";
@@ -21,6 +26,7 @@ export default async function NewAutomationPage({
   const { template } = await searchParams;
   const auth = await requireAppAuthContext({ organizationSlug });
   await requireWorkspaceFeatureFlag(workspaceAutomationsFlag, auth);
+  const flags = await evaluateWorkspaceFeatureFlags(auth);
   const templates = getMergedWorkspaceAutomationTemplates();
   const initialForm = template
     ? (createWorkspaceAutomationFormStateFromTemplate(template, templates) ??
@@ -29,7 +35,12 @@ export default async function NewAutomationPage({
 
   return (
     <Suspense fallback={null}>
-      <AutomationsNewPageContent organizationSlug={organizationSlug} initialForm={initialForm} />
+      <AutomationsNewPageContent
+        organizationSlug={organizationSlug}
+        initialForm={initialForm}
+        knowledgeAvailable={flags.knowledge}
+        canUpdateKnowledgeMemory={hasCapability(auth.membership.role, "workspace:update")}
+      />
     </Suspense>
   );
 }

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
@@ -88,6 +88,22 @@ describe("workspace automation view model", () => {
     });
   });
 
+  it("maps knowledge memories tool into the API payload", () => {
+    const form = {
+      ...createDefaultWorkspaceAutomationFormState(),
+      name: "Knowledge-aware sync",
+      instructions: "Follow brand guidance.",
+      githubEnabled: true,
+      githubMode: "agent" as const,
+      githubInstallationRepositoryId: "11111111-1111-4111-8111-111111111111",
+      knowledgeEnabled: true,
+    };
+
+    expect(formStateToWorkspaceAutomationPayload(form).toolConfig.knowledge).toEqual({
+      enabled: true,
+    });
+  });
+
   it("prefills the Contentful translation template", () => {
     const form = createWorkspaceAutomationFormStateFromTemplate(
       "translate-contentful-article",

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
@@ -54,6 +54,7 @@ export type WorkspaceAutomationFormState = {
   translationProjectId: string;
   translationUseProjectTargetLocales: boolean;
   translationTargetLocales: string[];
+  knowledgeEnabled: boolean;
 };
 
 export type WorkspaceAutomationFieldErrors = Partial<
@@ -140,6 +141,7 @@ export function createDefaultWorkspaceAutomationFormState(): WorkspaceAutomation
     translationProjectId: "",
     translationUseProjectTargetLocales: true,
     translationTargetLocales: [],
+    knowledgeEnabled: false,
   };
 }
 
@@ -151,6 +153,7 @@ export function createWorkspaceAutomationFormStateFromRecord(
   const email = automation.toolConfig.email;
   const contentful = automation.toolConfig.contentful;
   const translation = automation.toolConfig.translation;
+  const knowledge = automation.toolConfig.knowledge;
 
   return {
     name: automation.name,
@@ -205,6 +208,7 @@ export function createWorkspaceAutomationFormStateFromRecord(
     translationProjectId: translation?.projectId ?? "",
     translationUseProjectTargetLocales: translation?.useProjectTargetLocales ?? true,
     translationTargetLocales: translation?.targetLocales ? [...translation.targetLocales] : [],
+    knowledgeEnabled: Boolean(knowledge?.enabled),
   };
 }
 
@@ -335,6 +339,13 @@ export function formStateToWorkspaceAutomationPayload(form: WorkspaceAutomationF
             targetLocales: form.translationUseProjectTargetLocales
               ? []
               : form.translationTargetLocales,
+          },
+        }
+      : {}),
+    ...(form.knowledgeEnabled
+      ? {
+          knowledge: {
+            enabled: true,
           },
         }
       : {}),

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -126,6 +126,12 @@ const translationToolConfigSchema = z
   })
   .default({ enabled: false, useProjectTargetLocales: true, targetLocales: [] });
 
+const knowledgeToolConfigSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+  })
+  .default({ enabled: false });
+
 const toolConfigSchema = z
   .object({
     github: githubToolConfigSchema.optional(),
@@ -133,6 +139,7 @@ const toolConfigSchema = z
     email: emailToolConfigSchema.optional(),
     contentful: contentfulToolConfigSchema.optional(),
     translation: translationToolConfigSchema.optional(),
+    knowledge: knowledgeToolConfigSchema.optional(),
   })
   .default({});
 
@@ -152,6 +159,7 @@ export type WorkspaceAutomationRepositoryTarget = z.infer<typeof repositoryTarge
 export type WorkspaceAutomationSlackToolConfig = z.infer<typeof slackToolConfigSchema>;
 export type WorkspaceAutomationEmailToolConfig = z.infer<typeof emailToolConfigSchema>;
 export type WorkspaceAutomationContentfulToolConfig = z.infer<typeof contentfulToolConfigSchema>;
+export type WorkspaceAutomationKnowledgeToolConfig = z.infer<typeof knowledgeToolConfigSchema>;
 export type WorkspaceAutomationToolConfig = z.infer<typeof toolConfigSchema>;
 
 export type WorkspaceAutomationConfigValidationError =
@@ -234,6 +242,10 @@ export function hasWorkspaceAutomationTranslationWorkflow(
   toolConfig: WorkspaceAutomationToolConfig,
 ) {
   return Boolean(toolConfig.translation?.enabled);
+}
+
+export function hasWorkspaceAutomationKnowledgeTool(toolConfig: WorkspaceAutomationToolConfig) {
+  return Boolean(toolConfig.knowledge?.enabled);
 }
 
 export type WorkspaceAutomationRecord = {

--- a/docs/plans/2026-07-17-automation-knowledge-memories-design.md
+++ b/docs/plans/2026-07-17-automation-knowledge-memories-design.md
@@ -1,0 +1,37 @@
+# Automation knowledge memories
+
+## Problem
+
+Workspace automations can use GitHub, Contentful, translation, Slack, and email
+tools, but they cannot opt into the organization knowledge base. Teams already
+edit that guidance under **Knowledge**; automations should reuse it as a
+built-in tool with manage/edit in the automation UI.
+
+## Decision
+
+Treat organization knowledge memory as a built-in automation tool named
+**Memories**.
+
+- Store opt-in in `toolConfig.knowledge: { enabled: boolean }`.
+- Show **Memories** under a **Built-in** group in Add Tool.
+- When enabled, show a Tools row with **Manage** and remove.
+- **Manage** opens a sheet that reuses `KnowledgeMemoryEditor`.
+- Gate adding Memories on the `workspace-knowledge` flag and
+  `workspace:update` for edits (same as the Knowledge page).
+- At run time, when enabled, select relevant knowledge and append it to
+  composed orchestrator instructions. Do not add a forced orchestrator tool
+  call; knowledge guides other planned tools.
+- Memories alone does not count as an activatable workflow tool.
+
+## Behavior
+
+1. User adds **Memories** from Add Tool → Built-in.
+2. Tools list shows Memories with **Manage** and delete.
+3. **Manage** edits the shared org knowledge markdown memory.
+4. On run, if `toolConfig.knowledge.enabled`, load memory, select context from
+   automation name/instructions, and inject under `## Workspace knowledge`.
+
+## Out of scope
+
+Per-automation private memories, translation-memory (TM) tools, outbound MCP
+servers, and forcing a `consult_knowledge_memory` tool step.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **Memories** as a built-in workspace automation tool backed by organization knowledge memory.

- Add Tool → **Built-in** → Memories (gated by `workspace-knowledge`)
- Tools row with **Manage** + remove; Manage opens a sheet reusing `KnowledgeMemoryEditor`
- Persist opt-in as `toolConfig.knowledge: { enabled: true }`
- On run, select relevant knowledge and inject it into orchestrator instructions

## Test plan

- [x] Targeted unit tests for knowledge resolve, compose instructions, and view-model mapping
- [x] `vp check --fix` in `apps/hyperlocalise-web`
- [x] Automation agent/view-model/workspace-automations tests against local Postgres
- [ ] Manual: with workspace knowledge enabled, confirm Memories under Built-in, Manage edits knowledge, and saved automations include `toolConfig.knowledge`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3219cb85-f332-477f-952f-b4149a8bc2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3219cb85-f332-477f-952f-b4149a8bc2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

