### PR TITLE
fix(web): show only context suggestion in chat dock

### DIFF
--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-empty-state.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-empty-state.test.ts
@@ -23,7 +23,7 @@ describe("buildChatDockSuggestions", () => {
     expect(suggestions[0]?.prompt).toBe("What's the context of ");
   });
 
-  it("shows only the selected segment chip with page context", () => {
+  it("shows only the selected segment chip using the source string", () => {
     const pageContext: ChatDockPageContext = {
       kind: "cat-segment",
       segmentId: "seg-02",
@@ -34,22 +34,22 @@ describe("buildChatDockSuggestions", () => {
     const suggestions = buildChatDockSuggestions(pageContext, formatMessage);
 
     expect(suggestions.map((suggestion) => suggestion.id)).toEqual(["segment-context"]);
-    expect(suggestions[0]?.label).toBe("Context of checkout.submit");
-    expect(suggestions[0]?.prompt).toBe('What\'s the context of "checkout.submit"?');
+    expect(suggestions[0]?.label).toBe("Context of Submit order");
+    expect(suggestions[0]?.prompt).toBe('What\'s the context of "Submit order"?');
   });
 
-  it("truncates long keys in the pill label only", () => {
-    const longKey = "a".repeat(50);
+  it("truncates long source strings in the pill label only", () => {
+    const longSource = "a".repeat(50);
     const pageContext: ChatDockPageContext = {
       kind: "cat-segment",
       segmentId: "seg-02",
-      key: longKey,
-      sourceText: "Submit",
+      key: "checkout.submit",
+      sourceText: longSource,
     };
 
     const suggestions = buildChatDockSuggestions(pageContext, formatMessage);
 
     expect(suggestions[0]?.label).toBe(`Context of ${"a".repeat(35)}…`);
-    expect(suggestions[0]?.prompt).toBe(`What's the context of "${longKey}"?`);
+    expect(suggestions[0]?.prompt).toBe(`What's the context of "${longSource}"?`);
   });
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-empty-state.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-empty-state.test.ts
@@ -15,19 +15,15 @@ function formatMessage(descriptor: MessageDescriptor, values?: Record<string, st
 }
 
 describe("buildChatDockSuggestions", () => {
-  it("uses the generic find-context chip without page context", () => {
+  it("shows only the find-context chip without page context", () => {
     const suggestions = buildChatDockSuggestions(null, formatMessage);
 
-    expect(suggestions.map((suggestion) => suggestion.id)).toEqual([
-      "find-context",
-      "recent-changes",
-      "progress",
-      "translate",
-    ]);
-    expect(suggestions[0]?.prompt).toBe("What does this string mean, and where is it used?");
+    expect(suggestions.map((suggestion) => suggestion.id)).toEqual(["find-context"]);
+    expect(suggestions[0]?.label).toBe("What's the context of a string");
+    expect(suggestions[0]?.prompt).toBe("What's the context of ");
   });
 
-  it("replaces find-context with the selected segment chip", () => {
+  it("shows only the selected segment chip with page context", () => {
     const pageContext: ChatDockPageContext = {
       kind: "cat-segment",
       segmentId: "seg-02",
@@ -37,12 +33,7 @@ describe("buildChatDockSuggestions", () => {
 
     const suggestions = buildChatDockSuggestions(pageContext, formatMessage);
 
-    expect(suggestions.map((suggestion) => suggestion.id)).toEqual([
-      "segment-context",
-      "recent-changes",
-      "progress",
-      "translate",
-    ]);
+    expect(suggestions.map((suggestion) => suggestion.id)).toEqual(["segment-context"]);
     expect(suggestions[0]?.label).toBe("Context of checkout.submit");
     expect(suggestions[0]?.prompt).toBe('What\'s the context of "checkout.submit"?');
   });

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-empty-state.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-empty-state.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import type { ComponentProps } from "react";
-import {
-  AnalyticsUpIcon,
-  Chat01Icon,
-  Clock01Icon,
-  FileSearchIcon,
-  TranslateIcon,
-} from "@hugeicons/core-free-icons";
+import { Chat01Icon, FileSearchIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, type MessageDescriptor, useIntl } from "react-intl";
 
@@ -42,25 +36,6 @@ export function buildChatDockSuggestions(
   pageContext: ChatDockPageContext | null,
   formatMessage: FormatMessage,
 ): Suggestion[] {
-  const recentChanges: Suggestion = {
-    id: "recent-changes",
-    icon: Clock01Icon,
-    label: formatMessage(chatDockMessages.suggestionRecentChanges),
-    prompt: formatMessage(chatDockMessages.promptRecentChanges),
-  };
-  const progress: Suggestion = {
-    id: "progress",
-    icon: AnalyticsUpIcon,
-    label: formatMessage(chatDockMessages.suggestionProgress),
-    prompt: formatMessage(chatDockMessages.promptProgress),
-  };
-  const translate: Suggestion = {
-    id: "translate",
-    icon: TranslateIcon,
-    label: formatMessage(chatDockMessages.suggestionTranslate),
-    prompt: formatMessage(chatDockMessages.promptTranslate),
-  };
-
   if (pageContext?.kind === "cat-segment") {
     const keyLabel = truncateLabel(pageContext.key, KEY_LABEL_MAX_LENGTH);
     return [
@@ -70,9 +45,6 @@ export function buildChatDockSuggestions(
         label: formatMessage(chatDockMessages.suggestionSegmentContext, { key: keyLabel }),
         prompt: formatMessage(chatDockMessages.promptSegmentContext, { key: pageContext.key }),
       },
-      recentChanges,
-      progress,
-      translate,
     ];
   }
 
@@ -81,11 +53,9 @@ export function buildChatDockSuggestions(
       id: "find-context",
       icon: FileSearchIcon,
       label: formatMessage(chatDockMessages.suggestionFindContext),
-      prompt: formatMessage(chatDockMessages.promptFindContext),
+      // Trailing space lets the user finish typing the string key.
+      prompt: `${formatMessage(chatDockMessages.promptFindContext)} `,
     },
-    recentChanges,
-    progress,
-    translate,
   ];
 }
 

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-empty-state.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-empty-state.tsx
@@ -21,7 +21,7 @@ type Suggestion = {
 
 type FormatMessage = (descriptor: MessageDescriptor, values?: Record<string, string>) => string;
 
-const KEY_LABEL_MAX_LENGTH = 36;
+const SOURCE_LABEL_MAX_LENGTH = 36;
 
 function truncateLabel(value: string, maxLength: number) {
   const trimmed = value.trim();
@@ -37,13 +37,17 @@ export function buildChatDockSuggestions(
   formatMessage: FormatMessage,
 ): Suggestion[] {
   if (pageContext?.kind === "cat-segment") {
-    const keyLabel = truncateLabel(pageContext.key, KEY_LABEL_MAX_LENGTH);
+    const sourceLabel = truncateLabel(pageContext.sourceText, SOURCE_LABEL_MAX_LENGTH);
     return [
       {
         id: "segment-context",
         icon: FileSearchIcon,
-        label: formatMessage(chatDockMessages.suggestionSegmentContext, { key: keyLabel }),
-        prompt: formatMessage(chatDockMessages.promptSegmentContext, { key: pageContext.key }),
+        label: formatMessage(chatDockMessages.suggestionSegmentContext, {
+          source: sourceLabel,
+        }),
+        prompt: formatMessage(chatDockMessages.promptSegmentContext, {
+          source: pageContext.sourceText,
+        }),
       },
     ];
   }
@@ -53,7 +57,7 @@ export function buildChatDockSuggestions(
       id: "find-context",
       icon: FileSearchIcon,
       label: formatMessage(chatDockMessages.suggestionFindContext),
-      // Trailing space lets the user finish typing the string key.
+      // Trailing space lets the user finish typing the string.
       prompt: `${formatMessage(chatDockMessages.promptFindContext)} `,
     },
   ];

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.messages.ts
@@ -49,9 +49,9 @@ export const chatDockMessages = defineMessages({
     description: "Suggested prompt chip to find localisation context",
   },
   suggestionSegmentContext: {
-    id: "tToS3qyu6G",
-    defaultMessage: "Context of {key}",
-    description: "Suggested prompt chip for the currently selected CAT segment",
+    id: "01h5d0m29X",
+    defaultMessage: "Context of {source}",
+    description: "Suggested prompt chip for the currently selected CAT segment source string",
   },
   promptFindContext: {
     id: "FLl4UNTozx",
@@ -60,9 +60,10 @@ export const chatDockMessages = defineMessages({
       "Prefilled prompt stem when choosing the find-context chip without a selected string",
   },
   promptSegmentContext: {
-    id: "084ETvW6A4",
-    defaultMessage: 'What\'s the context of "{key}"?',
-    description: "Prefilled prompt when asking for context of the selected CAT segment",
+    id: "ERiH8D9Q+l",
+    defaultMessage: 'What\'s the context of "{source}"?',
+    description:
+      "Prefilled prompt when asking for context of the selected CAT segment source string",
   },
   streaming: {
     id: "pXpP8bdMfG",

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.messages.ts
@@ -39,8 +39,8 @@ export const chatDockMessages = defineMessages({
     description: "Empty state title for a new chat dock conversation",
   },
   emptySubtitle: {
-    id: "l2MbFKxoMr",
-    defaultMessage: "Ask about strings, context, progress, or translations",
+    id: "w2b0cdIV3S",
+    defaultMessage: "Ask about strings, context, or anything else",
     description: "Empty state subtitle describing chat capabilities",
   },
   suggestionFindContext: {

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.messages.ts
@@ -44,8 +44,8 @@ export const chatDockMessages = defineMessages({
     description: "Empty state subtitle describing chat capabilities",
   },
   suggestionFindContext: {
-    id: "vHurxfGj2i",
-    defaultMessage: "Find context for a string",
+    id: "pehDkakH9A",
+    defaultMessage: "What's the context of a string",
     description: "Suggested prompt chip to find localisation context",
   },
   suggestionSegmentContext: {
@@ -53,45 +53,16 @@ export const chatDockMessages = defineMessages({
     defaultMessage: "Context of {key}",
     description: "Suggested prompt chip for the currently selected CAT segment",
   },
-  suggestionRecentChanges: {
-    id: "EChSkkf+KW",
-    defaultMessage: "What changed recently",
-    description: "Suggested prompt chip for recent localisation changes",
-  },
-  suggestionProgress: {
-    id: "QpIX9JaUhS",
-    defaultMessage: "Check localisation progress",
-    description: "Suggested prompt chip for TMS localisation progress",
-  },
-  suggestionTranslate: {
-    id: "C1FbXuFTUH",
-    defaultMessage: "Start a translation",
-    description: "Suggested prompt chip to start a translation",
-  },
   promptFindContext: {
-    id: "VKjWHU/QDH",
-    defaultMessage: "What does this string mean, and where is it used?",
-    description: "Prefilled prompt when choosing the find-context chip",
+    id: "FLl4UNTozx",
+    defaultMessage: "What's the context of",
+    description:
+      "Prefilled prompt stem when choosing the find-context chip without a selected string",
   },
   promptSegmentContext: {
     id: "084ETvW6A4",
     defaultMessage: 'What\'s the context of "{key}"?',
     description: "Prefilled prompt when asking for context of the selected CAT segment",
-  },
-  promptRecentChanges: {
-    id: "N83FNjAdU2",
-    defaultMessage: "What localisation strings changed recently?",
-    description: "Prefilled prompt when choosing the recent-changes chip",
-  },
-  promptProgress: {
-    id: "W8paQ6RjZy",
-    defaultMessage: "How is localisation progress looking across linked TMS projects?",
-    description: "Prefilled prompt when choosing the progress chip",
-  },
-  promptTranslate: {
-    id: "homymlbTZo",
-    defaultMessage: "Translate the following text:",
-    description: "Prefilled prompt when choosing the translate chip",
   },
   streaming: {
     id: "pXpP8bdMfG",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Chat dock empty state now shows only the context suggestion pill (hides recent changes, progress, and translate).
- Without a selected CAT segment, the pill is labeled “What’s the context of a string” and prefills the composer with `What's the context of ` so the user can finish typing.
- With a selected CAT segment, only the segment-specific context pill remains, using the **source string value** (not the key) in both the pill label and the prefilled prompt.
- Empty-state subtitle updated to “Ask about strings, context, or anything else” so it no longer implies progress/translation pills.

## Test plan
- [x] `vp test src/components/app-shell/chat-dock/chat-dock-empty-state.test.ts`
- [x] `vp check --fix`
- [ ] Open chat dock with no CAT segment selected → only one pill → click → composer shows `What's the context of `
- [ ] Open chat dock with a CAT segment selected → pill shows truncated source text → click → `What's the context of "{source}"?`
- [ ] Confirm empty-state subtitle reads “Ask about strings, context, or anything else”
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7295-2197-73be-b4ee-73af246d6615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7295-2197-73be-b4ee-73af246d6615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

