### PR TITLE
feat(mac-app): native Mac MVP with WorkOS login and chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,13 @@ go.work.sum
 # macOS
 .DS_Store
 
+# Xcode / Mac app
+apps/mac-app/Hyperlocalise.xcodeproj/
+apps/mac-app/DerivedData/
+apps/mac-app/*.xcworkspace/
+xcuserdata/
+*.xcuserstate
+
 # Editor/IDE
 .idea/
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ completions
 bazel-*
 
 .hyperlocalise
+
+# Sparkle private keys (mac-app)
+apps/mac-app/.sparkle-keys/

--- a/LICENSE
+++ b/LICENSE
@@ -1,10 +1,10 @@
 Repository License Notice
 
 This MIT License applies to this repository except for directories that include
-their own license file. The web application in apps/hyperlocalise-web/ is
-licensed separately under the Business Source License 1.1. The Canva app in
-apps/canva-app/ is also licensed separately under the Business Source License
-1.1. See each directory's LICENSE file for the applicable terms.
+their own license file. The web application in apps/hyperlocalise-web/, the
+Canva app in apps/canva-app/, and the Mac app in apps/mac-app/ are licensed
+separately under the Business Source License 1.1. See each directory's LICENSE
+file for the applicable terms.
 
 MIT License
 

--- a/README.md
+++ b/README.md
@@ -223,9 +223,9 @@ The web application in [`apps/hyperlocalise-web/`](apps/hyperlocalise-web/) is
 licensed separately under the Business Source License 1.1. See
 [`apps/hyperlocalise-web/LICENSE`](apps/hyperlocalise-web/LICENSE).
 
-The Canva app in [`apps/canva-app/`](apps/canva-app/) is also licensed
-separately under the Business Source License 1.1. See
-[`apps/canva-app/LICENSE`](apps/canva-app/LICENSE).
+The Canva app in [`apps/canva-app/`](apps/canva-app/) and the Mac app in
+[`apps/mac-app/`](apps/mac-app/) are also licensed separately under the
+Business Source License 1.1. See each directory's `LICENSE` file.
 
 ## Contributing
 

--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -19,6 +19,7 @@ import { createAgentEmailRoutes } from "./routes/agent-email/agent-email.route";
 import { createAgentSlackRoutes } from "./routes/agent-slack/agent-slack.route";
 import { createApiKeyRoutes } from "./routes/api-key/api-key.route";
 import { authRoutes } from "./routes/auth/auth.route";
+import { createNativeAuthRoutes } from "./routes/auth/native-auth.route";
 import { createConversationRoutes } from "./routes/conversation/conversation.route";
 import { createCanvaConnectionRoutes } from "./routes/canva-connection/canva-connection.route";
 import { createCanvaIntegrationRoutes } from "./routes/canva-integration/canva-integration.route";
@@ -137,7 +138,10 @@ function createInternalRoutes() {
 }
 
 function createAuthRoutes() {
-  return new Hono().route("/", authRoutes).route("/slack", createSlackOAuthRoutes());
+  return new Hono()
+    .route("/native", createNativeAuthRoutes())
+    .route("/", authRoutes)
+    .route("/slack", createSlackOAuthRoutes());
 }
 
 function createOrgScopedAppRoutes(

--- a/apps/hyperlocalise-web/src/api/auth/AUTH_INVARIANTS.md
+++ b/apps/hyperlocalise-web/src/api/auth/AUTH_INVARIANTS.md
@@ -49,6 +49,10 @@ full WorkOS identity model.
    still loads WorkOS-authoritative membership and capabilities for that
    user/org. Crowdin JWTs and Crowdin user OAuth tokens must never be accepted
    as org API auth by themselves.
+   9b. **Native Mac clients use the same WorkOS sealed session.** The Mac app
+   obtains a sealed `wos-session` via `/api/auth/native/*` (AuthKit PKCE) and
+   presents it as a `Cookie` header. Do not mint a separate native identity
+   channel that bypasses WorkOS session verification.
 10. **Org slug must match an active membership.** Requested
     `organizationSlug` must resolve to a membership returned after the access
     gate; otherwise return `organization_access_denied` or picker/unresolvable

--- a/apps/hyperlocalise-web/src/api/routes/auth/native-auth.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/auth/native-auth.route.test.ts
@@ -1,0 +1,192 @@
+import "dotenv/config";
+
+import { Hono } from "hono";
+import { evlog } from "evlog/hono";
+import { testClient } from "hono/testing";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+const {
+  getAuthorizationUrlMock,
+  authenticateWithCodeMock,
+  getWorkosServerClientMock,
+  getWorkosAuthKitConfigMock,
+} = vi.hoisted(() => ({
+  getAuthorizationUrlMock: vi.fn(),
+  authenticateWithCodeMock: vi.fn(),
+  getWorkosServerClientMock: vi.fn(),
+  getWorkosAuthKitConfigMock: vi.fn(),
+}));
+
+vi.mock("@/lib/workos/server-client", () => ({
+  getWorkosServerClient: getWorkosServerClientMock,
+}));
+
+vi.mock("@/lib/workos/config", () => ({
+  getWorkosAuthKitConfig: getWorkosAuthKitConfigMock,
+}));
+
+import { createNativeAuthRoutes } from "./native-auth.route";
+
+const VALID_CHALLENGE = "a".repeat(43);
+const VALID_VERIFIER = "b".repeat(43);
+
+function createClient() {
+  return testClient(new Hono().use("*", evlog()).route("/", createNativeAuthRoutes()));
+}
+
+describe("nativeAuthRoutes", () => {
+  afterEach(() => {
+    getAuthorizationUrlMock.mockReset();
+    authenticateWithCodeMock.mockReset();
+    getWorkosServerClientMock.mockReset();
+    getWorkosAuthKitConfigMock.mockReset();
+  });
+
+  it("rejects disallowed redirect URIs on authorize", async () => {
+    getWorkosAuthKitConfigMock.mockReturnValue({
+      clientId: "client_test",
+      apiKey: "sk_test",
+      redirectUri: "http://localhost:3000/auth/callback",
+      cookiePassword: "test-workos-cookie-password-at-least-32-chars",
+    });
+    getWorkosServerClientMock.mockReturnValue({
+      userManagement: { getAuthorizationUrl: getAuthorizationUrlMock },
+    });
+
+    const client = createClient();
+    const response = await client.authorize.$get({
+      query: {
+        codeChallenge: VALID_CHALLENGE,
+        codeChallengeMethod: "S256",
+        redirectUri: "https://evil.example/callback",
+      },
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: "redirect_uri_not_allowed" });
+    expect(getAuthorizationUrlMock).not.toHaveBeenCalled();
+  });
+
+  it("returns an AuthKit authorization URL for the Mac redirect", async () => {
+    getWorkosAuthKitConfigMock.mockReturnValue({
+      clientId: "client_test",
+      apiKey: "sk_test",
+      redirectUri: "http://localhost:3000/auth/callback",
+      cookiePassword: "test-workos-cookie-password-at-least-32-chars",
+    });
+    getAuthorizationUrlMock.mockReturnValue("https://api.workos.com/user_management/authorize?x=1");
+    getWorkosServerClientMock.mockReturnValue({
+      userManagement: { getAuthorizationUrl: getAuthorizationUrlMock },
+    });
+
+    const client = createClient();
+    const response = await client.authorize.$get({
+      query: {
+        codeChallenge: VALID_CHALLENGE,
+        codeChallengeMethod: "S256",
+        redirectUri: "hyperlocalise://auth/callback",
+        state: "state-value-12",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      authorization: {
+        url: "https://api.workos.com/user_management/authorize?x=1",
+        redirectUri: "hyperlocalise://auth/callback",
+      },
+    });
+    expect(getAuthorizationUrlMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "authkit",
+        redirectUri: "hyperlocalise://auth/callback",
+        codeChallenge: VALID_CHALLENGE,
+        codeChallengeMethod: "S256",
+      }),
+    );
+  });
+
+  it("exchanges a code for a sealed session", async () => {
+    getWorkosAuthKitConfigMock.mockReturnValue({
+      clientId: "client_test",
+      apiKey: "sk_test",
+      redirectUri: "http://localhost:3000/auth/callback",
+      cookiePassword: "test-workos-cookie-password-at-least-32-chars",
+    });
+    authenticateWithCodeMock.mockResolvedValue({
+      sealedSession: "sealed.session.value",
+      user: {
+        id: "user_123",
+        email: "dev@example.com",
+        firstName: "Dev",
+        lastName: "User",
+        profilePictureUrl: null,
+      },
+      organizationId: "org_123",
+    });
+    getWorkosServerClientMock.mockReturnValue({
+      userManagement: { authenticateWithCode: authenticateWithCodeMock },
+    });
+
+    const client = createClient();
+    const response = await client.token.$post({
+      json: {
+        code: "auth_code",
+        codeVerifier: VALID_VERIFIER,
+        redirectUri: "hyperlocalise://auth/callback",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      session: {
+        sealedSession: "sealed.session.value",
+        cookieName: "wos-session",
+      },
+      user: {
+        workosUserId: "user_123",
+        email: "dev@example.com",
+        firstName: "Dev",
+        lastName: "User",
+      },
+      organizationId: "org_123",
+    });
+    expect(authenticateWithCodeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: "auth_code",
+        codeVerifier: VALID_VERIFIER,
+        session: {
+          sealSession: true,
+          cookiePassword: "test-workos-cookie-password-at-least-32-chars",
+        },
+      }),
+    );
+  });
+
+  it("returns 401 when WorkOS token exchange fails", async () => {
+    getWorkosAuthKitConfigMock.mockReturnValue({
+      clientId: "client_test",
+      apiKey: "sk_test",
+      redirectUri: "http://localhost:3000/auth/callback",
+      cookiePassword: "test-workos-cookie-password-at-least-32-chars",
+    });
+    authenticateWithCodeMock.mockRejectedValue(new Error("invalid_grant"));
+    getWorkosServerClientMock.mockReturnValue({
+      userManagement: { authenticateWithCode: authenticateWithCodeMock },
+    });
+
+    const client = createClient();
+    const response = await client.token.$post({
+      json: {
+        code: "bad_code",
+        codeVerifier: VALID_VERIFIER,
+        redirectUri: "hyperlocalise://auth/callback",
+      },
+    });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "native_token_exchange_failed",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/auth/native-auth.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/auth/native-auth.route.test.ts
@@ -1,7 +1,5 @@
 import "dotenv/config";
 
-import { Hono } from "hono";
-import { evlog } from "evlog/hono";
 import { testClient } from "hono/testing";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
@@ -25,14 +23,12 @@ vi.mock("@/lib/workos/config", () => ({
   getWorkosAuthKitConfig: getWorkosAuthKitConfigMock,
 }));
 
-import { createNativeAuthRoutes } from "./native-auth.route";
+import { createApp } from "@/api/app";
 
 const VALID_CHALLENGE = "a".repeat(43);
 const VALID_VERIFIER = "b".repeat(43);
 
-function createClient() {
-  return testClient(new Hono().use("*", evlog()).route("/", createNativeAuthRoutes()));
-}
+const client = testClient(createApp());
 
 describe("nativeAuthRoutes", () => {
   afterEach(() => {
@@ -53,8 +49,7 @@ describe("nativeAuthRoutes", () => {
       userManagement: { getAuthorizationUrl: getAuthorizationUrlMock },
     });
 
-    const client = createClient();
-    const response = await client.authorize.$get({
+    const response = await client.api.auth.native.authorize.$get({
       query: {
         codeChallenge: VALID_CHALLENGE,
         codeChallengeMethod: "S256",
@@ -79,8 +74,7 @@ describe("nativeAuthRoutes", () => {
       userManagement: { getAuthorizationUrl: getAuthorizationUrlMock },
     });
 
-    const client = createClient();
-    const response = await client.authorize.$get({
+    const response = await client.api.auth.native.authorize.$get({
       query: {
         codeChallenge: VALID_CHALLENGE,
         codeChallengeMethod: "S256",
@@ -128,8 +122,7 @@ describe("nativeAuthRoutes", () => {
       userManagement: { authenticateWithCode: authenticateWithCodeMock },
     });
 
-    const client = createClient();
-    const response = await client.token.$post({
+    const response = await client.api.auth.native.token.$post({
       json: {
         code: "auth_code",
         codeVerifier: VALID_VERIFIER,
@@ -175,8 +168,7 @@ describe("nativeAuthRoutes", () => {
       userManagement: { authenticateWithCode: authenticateWithCodeMock },
     });
 
-    const client = createClient();
-    const response = await client.token.$post({
+    const response = await client.api.auth.native.token.$post({
       json: {
         code: "bad_code",
         codeVerifier: VALID_VERIFIER,

--- a/apps/hyperlocalise-web/src/api/routes/auth/native-auth.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/auth/native-auth.route.ts
@@ -1,0 +1,128 @@
+import { Hono } from "hono";
+import { validator } from "hono/validator";
+
+import { badRequestResponse, unauthorizedResponse } from "@/api/response.schema";
+import { getWorkosAuthKitConfig } from "@/lib/workos/config";
+import { isAllowedNativeRedirectUri } from "@/lib/workos/native-redirect";
+import { getWorkosServerClient } from "@/lib/workos/server-client";
+
+import { nativeAuthorizeQuerySchema, nativeTokenBodySchema } from "./native-auth.schema";
+
+/**
+ * Native AuthKit PKCE bridge for apps/mac-app.
+ *
+ * Authorize builds a WorkOS AuthKit URL for a client-generated PKCE challenge.
+ * Token exchanges the authorization code for a sealed WorkOS session that the
+ * Mac app stores in Keychain and sends as `Cookie: wos-session=…` — the same
+ * channel used by the web app (see AUTH_INVARIANTS §9).
+ */
+export function createNativeAuthRoutes() {
+  return new Hono()
+    .get(
+      "/authorize",
+      validator("query", (value, c) => {
+        const parsed = nativeAuthorizeQuerySchema.safeParse(value);
+        if (!parsed.success) {
+          return badRequestResponse(c, "invalid_native_authorize_query");
+        }
+        return parsed.data;
+      }),
+      async (c) => {
+        const query = c.req.valid("query");
+        if (!isAllowedNativeRedirectUri(query.redirectUri)) {
+          return badRequestResponse(c, "redirect_uri_not_allowed");
+        }
+
+        const config = getWorkosAuthKitConfig();
+        const workos = getWorkosServerClient();
+        if (!config || !workos) {
+          return c.json({ error: "workos_not_configured" }, 503);
+        }
+
+        const authorizationUrl = workos.userManagement.getAuthorizationUrl({
+          provider: "authkit",
+          clientId: config.clientId,
+          redirectUri: query.redirectUri,
+          codeChallenge: query.codeChallenge,
+          codeChallengeMethod: query.codeChallengeMethod,
+          state: query.state,
+          screenHint: query.screenHint,
+        });
+
+        return c.json(
+          {
+            authorization: {
+              url: authorizationUrl,
+              redirectUri: query.redirectUri,
+            },
+          },
+          200,
+        );
+      },
+    )
+    .post(
+      "/token",
+      validator("json", (value, c) => {
+        const parsed = nativeTokenBodySchema.safeParse(value);
+        if (!parsed.success) {
+          return badRequestResponse(c, "invalid_native_token_payload");
+        }
+        return parsed.data;
+      }),
+      async (c) => {
+        const body = c.req.valid("json");
+        if (!isAllowedNativeRedirectUri(body.redirectUri)) {
+          return badRequestResponse(c, "redirect_uri_not_allowed");
+        }
+
+        const config = getWorkosAuthKitConfig();
+        const workos = getWorkosServerClient();
+        if (!config || !workos) {
+          return c.json({ error: "workos_not_configured" }, 503);
+        }
+
+        try {
+          const authResponse = await workos.userManagement.authenticateWithCode({
+            clientId: config.clientId,
+            code: body.code,
+            codeVerifier: body.codeVerifier,
+            session: {
+              sealSession: true,
+              cookiePassword: config.cookiePassword,
+            },
+          });
+
+          const sealedSession = authResponse.sealedSession;
+          if (!sealedSession) {
+            return c.json({ error: "session_seal_failed" }, 502);
+          }
+
+          return c.json(
+            {
+              session: {
+                sealedSession,
+                cookieName: "wos-session",
+              },
+              user: {
+                workosUserId: authResponse.user.id,
+                email: authResponse.user.email,
+                ...(authResponse.user.firstName ? { firstName: authResponse.user.firstName } : {}),
+                ...(authResponse.user.lastName ? { lastName: authResponse.user.lastName } : {}),
+                ...(authResponse.user.profilePictureUrl
+                  ? { avatarUrl: authResponse.user.profilePictureUrl }
+                  : {}),
+              },
+              ...(authResponse.organizationId
+                ? { organizationId: authResponse.organizationId }
+                : {}),
+            },
+            200,
+          );
+        } catch {
+          return unauthorizedResponse(c, "native_token_exchange_failed");
+        }
+      },
+    );
+}
+
+export const nativeAuthRoutes = createNativeAuthRoutes();

--- a/apps/hyperlocalise-web/src/api/routes/auth/native-auth.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/auth/native-auth.schema.ts
@@ -18,7 +18,7 @@ export const nativeAuthorizeQuerySchema = z.object({
 });
 
 export const nativeTokenBodySchema = z.object({
-  code: z.string().min(1),
+  code: z.string().min(1).max(512),
   codeVerifier: z.string().min(43).max(128),
   redirectUri: nativeRedirectUriSchema,
 });

--- a/apps/hyperlocalise-web/src/api/routes/auth/native-auth.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/auth/native-auth.schema.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+/** AuthKit redirect for native clients: custom scheme or http(s) loopback. */
+const nativeRedirectUriSchema = z
+  .string()
+  .min(1)
+  .max(512)
+  .refine((value) => value.startsWith("hyperlocalise://") || /^https?:\/\//i.test(value), {
+    message: "invalid_native_redirect_uri",
+  });
+
+export const nativeAuthorizeQuerySchema = z.object({
+  codeChallenge: z.string().min(43).max(128),
+  codeChallengeMethod: z.literal("S256").default("S256"),
+  redirectUri: nativeRedirectUriSchema,
+  state: z.string().min(8).max(256).optional(),
+  screenHint: z.enum(["sign-in", "sign-up"]).optional(),
+});
+
+export const nativeTokenBodySchema = z.object({
+  code: z.string().min(1),
+  codeVerifier: z.string().min(43).max(128),
+  redirectUri: nativeRedirectUriSchema,
+});
+
+export type NativeAuthorizeQuery = z.infer<typeof nativeAuthorizeQuerySchema>;
+export type NativeTokenBody = z.infer<typeof nativeTokenBodySchema>;

--- a/apps/hyperlocalise-web/src/lib/env.ts
+++ b/apps/hyperlocalise-web/src/lib/env.ts
@@ -49,6 +49,13 @@ export const env = createEnv({
     /** Password for encrypting WorkOS session cookies. Must be at least 32 characters. */
     WORKOS_COOKIE_PASSWORD: z.string().min(32).optional(),
 
+    /**
+     * Comma-separated AuthKit redirect URIs allowed for native clients (Mac app).
+     * Always merged with the default `hyperlocalise://auth/callback` scheme.
+     * Example: `http://127.0.0.1:53682/callback`
+     */
+    WORKOS_NATIVE_REDIRECT_URIS: z.string().min(1).optional(),
+
     /** Secret used by WorkOS to sign webhook payloads. Required for secure WorkOS webhook handling. */
     WORKOS_WEBHOOK_SECRET: z.string().min(1).optional(),
 
@@ -210,6 +217,7 @@ export const env = createEnv({
     WORKOS_COOKIE_PASSWORD:
       process.env.WORKOS_COOKIE_PASSWORD ??
       (isTestEnv ? "test-workos-cookie-password-at-least-32-chars" : undefined),
+    WORKOS_NATIVE_REDIRECT_URIS: process.env.WORKOS_NATIVE_REDIRECT_URIS,
     WORKOS_WEBHOOK_SECRET:
       process.env.WORKOS_WEBHOOK_SECRET ?? (isTestEnv ? "test-workos-webhook-secret" : undefined),
     FLAGS_SECRET:

--- a/apps/hyperlocalise-web/src/lib/workos/native-redirect.test.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/native-redirect.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  DEFAULT_NATIVE_REDIRECT_URI,
+  getAllowedNativeRedirectUris,
+  isAllowedNativeRedirectUri,
+} from "./native-redirect";
+
+describe("native-redirect", () => {
+  it("always allows the default custom scheme", () => {
+    expect(DEFAULT_NATIVE_REDIRECT_URI).toBe("hyperlocalise://auth/callback");
+    expect(getAllowedNativeRedirectUris()).toContain("hyperlocalise://auth/callback");
+    expect(isAllowedNativeRedirectUri("hyperlocalise://auth/callback")).toBe(true);
+    expect(isAllowedNativeRedirectUri("https://evil.example/callback")).toBe(false);
+    expect(isAllowedNativeRedirectUri("")).toBe(false);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/workos/native-redirect.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/native-redirect.ts
@@ -1,0 +1,25 @@
+import { env } from "@/lib/env";
+
+/** Default custom URL scheme used by apps/mac-app ASWebAuthenticationSession. */
+export const DEFAULT_NATIVE_REDIRECT_URI = "hyperlocalise://auth/callback";
+
+/**
+ * Redirect URIs the Mac (and future native) clients may use for AuthKit PKCE.
+ * Always includes the default custom scheme; env may add loopback URIs for local builds.
+ */
+export function getAllowedNativeRedirectUris(): string[] {
+  const fromEnv = env.WORKOS_NATIVE_REDIRECT_URIS?.split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  const uris = new Set<string>([DEFAULT_NATIVE_REDIRECT_URI, ...(fromEnv ?? [])]);
+  return [...uris];
+}
+
+export function isAllowedNativeRedirectUri(redirectUri: string): boolean {
+  const normalized = redirectUri.trim();
+  if (!normalized) {
+    return false;
+  }
+  return getAllowedNativeRedirectUris().includes(normalized);
+}

--- a/apps/mac-app/AGENTS.md
+++ b/apps/mac-app/AGENTS.md
@@ -1,0 +1,23 @@
+# Mac App Agent Instructions
+
+Native SwiftUI macOS app. Licensed BSL 1.1 (`LICENSE`).
+
+## Tooling
+
+- Generate the Xcode project with `./Scripts/generate-project.sh` (requires `xcodegen`).
+- Do not commit `Hyperlocalise.xcodeproj` unless the team decides to vend it.
+- Prefer editing sources under `Hyperlocalise/` and `HyperlocaliseTests/`.
+- Keep auth on the WorkOS sealed session cookie channel — do not invent a parallel Bearer identity for org APIs.
+
+## Before Finalizing
+
+On macOS with Xcode installed:
+
+```bash
+./Scripts/generate-project.sh
+xcodebuild -scheme Hyperlocalise -destination 'platform=macOS' build
+xcodebuild test -scheme Hyperlocalise -destination 'platform=macOS'
+```
+
+When changing the native auth bridge in `apps/hyperlocalise-web`, also run
+`vp test` and `vp check --fix` there.

--- a/apps/mac-app/AGENTS.md
+++ b/apps/mac-app/AGENTS.md
@@ -8,6 +8,8 @@ Native SwiftUI macOS app. Licensed BSL 1.1 (`LICENSE`).
 - Do not commit `Hyperlocalise.xcodeproj` unless the team decides to vend it.
 - Prefer editing sources under `Hyperlocalise/` and `HyperlocaliseTests/`.
 - Keep auth on the WorkOS sealed session cookie channel — do not invent a parallel Bearer identity for org APIs.
+- Sparkle 2 is an SPM dependency in `project.yml`. Set `SU_PUBLIC_ED_KEY` after
+  `./Scripts/generate-sparkle-keys.sh`; never commit `.sparkle-keys/`.
 
 ## Before Finalizing
 

--- a/apps/mac-app/Config/Debug.xcconfig
+++ b/apps/mac-app/Config/Debug.xcconfig
@@ -1,3 +1,7 @@
 // Local / staging defaults. Override in the Xcode scheme if needed.
 HYPERLOCALISE_API_BASE_URL = http:/$()/localhost:3000
 SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG
+
+// Sparkle: leave the public key unset for local builds (updater stays idle).
+SU_FEED_URL = https:/$()/updates.hyperlocalise.com/mac/appcast.xml
+SU_PUBLIC_ED_KEY = REPLACE_WITH_SPARKLE_PUBLIC_ED_KEY

--- a/apps/mac-app/Config/Debug.xcconfig
+++ b/apps/mac-app/Config/Debug.xcconfig
@@ -1,0 +1,3 @@
+// Local / staging defaults. Override in the Xcode scheme if needed.
+HYPERLOCALISE_API_BASE_URL = http:/$()/localhost:3000
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG

--- a/apps/mac-app/Config/Release.xcconfig
+++ b/apps/mac-app/Config/Release.xcconfig
@@ -1,0 +1,1 @@
+HYPERLOCALISE_API_BASE_URL = https:/$()/app.hyperlocalise.com

--- a/apps/mac-app/Config/Release.xcconfig
+++ b/apps/mac-app/Config/Release.xcconfig
@@ -1,1 +1,1 @@
-HYPERLOCALISE_API_BASE_URL = https:/$()/app.hyperlocalise.com
+HYPERLOCALISE_API_BASE_URL = https:/$()/hyperlocalise.com

--- a/apps/mac-app/Config/Release.xcconfig
+++ b/apps/mac-app/Config/Release.xcconfig
@@ -1,1 +1,5 @@
 HYPERLOCALISE_API_BASE_URL = https:/$()/hyperlocalise.com
+
+// Sparkle appcast + EdDSA public key (replace after ./Scripts/generate-sparkle-keys.sh).
+SU_FEED_URL = https:/$()/updates.hyperlocalise.com/mac/appcast.xml
+SU_PUBLIC_ED_KEY = REPLACE_WITH_SPARKLE_PUBLIC_ED_KEY

--- a/apps/mac-app/Hyperlocalise/API/APIClient.swift
+++ b/apps/mac-app/Hyperlocalise/API/APIClient.swift
@@ -1,0 +1,239 @@
+import Foundation
+
+enum APIClientError: Error, LocalizedError {
+    case unauthorized
+    case http(status: Int, body: String)
+    case decoding(Error)
+    case invalidResponse
+
+    var errorDescription: String? {
+        switch self {
+        case .unauthorized:
+            return "Your session expired. Sign in again."
+        case .http(let status, let body):
+            return "Request failed (\(status)): \(body)"
+        case .decoding(let error):
+            return "Could not read server response: \(error.localizedDescription)"
+        case .invalidResponse:
+            return "Invalid server response."
+        }
+    }
+}
+
+actor APIClient {
+    private let baseURL: URL
+    private let session: URLSession
+    private var sealedSession: String?
+
+    init(baseURL: URL, sealedSession: String? = nil, session: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.sealedSession = sealedSession
+        self.session = session
+    }
+
+    func setSealedSession(_ value: String?) {
+        sealedSession = value
+    }
+
+    func fetchAuthContext() async throws -> AuthContext {
+        let data = try await requestData(path: "/api/auth/context", method: "GET")
+        return try decode(AuthContextResponse.self, from: data).auth
+    }
+
+    func listConversations(organizationSlug: String) async throws -> [ConversationSummary] {
+        let data = try await requestData(
+            path: "/api/orgs/\(organizationSlug)/conversations",
+            method: "GET"
+        )
+        return try decode(ConversationsResponse.self, from: data).conversations
+    }
+
+    func fetchConversation(
+        organizationSlug: String,
+        conversationId: String
+    ) async throws -> (ConversationSummary, [ConversationMessage]) {
+        let data = try await requestData(
+            path: "/api/orgs/\(organizationSlug)/conversations/\(conversationId)",
+            method: "GET"
+        )
+        // Detail endpoints may nest messages at top-level or omit them; also try /messages.
+        if let detail = try? decode(ConversationDetailResponse.self, from: data),
+           let messages = detail.messages
+        {
+            return (detail.conversation, messages)
+        }
+
+        let messagesData = try await requestData(
+            path: "/api/orgs/\(organizationSlug)/conversations/\(conversationId)/messages",
+            method: "GET"
+        )
+        struct MessagesEnvelope: Decodable { let messages: [ConversationMessage] }
+        let conversation: ConversationSummary
+        if let detail = try? decode(ConversationDetailResponse.self, from: data) {
+            conversation = detail.conversation
+        } else {
+            conversation = ConversationSummary(
+                id: conversationId,
+                title: nil,
+                lastMessage: nil,
+                lastMessageAt: nil,
+                createdAt: nil
+            )
+        }
+        let messages = try decode(MessagesEnvelope.self, from: messagesData).messages
+        return (conversation, messages)
+    }
+
+    func createConversation(
+        organizationSlug: String,
+        text: String,
+        repositoryFullName: String? = nil
+    ) async throws -> CreateConversationResponse {
+        let boundary = "Boundary-\(UUID().uuidString)"
+        var body = Data()
+        func appendField(_ name: String, _ value: String) {
+            body.append("--\(boundary)\r\n".data(using: .utf8)!)
+            body.append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n".data(using: .utf8)!)
+            body.append("\(value)\r\n".data(using: .utf8)!)
+        }
+        appendField("text", text)
+        if let repositoryFullName, !repositoryFullName.isEmpty {
+            appendField("repositoryFullName", repositoryFullName)
+        }
+        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+
+        let data = try await requestData(
+            path: "/api/orgs/\(organizationSlug)/conversations",
+            method: "POST",
+            headers: ["Content-Type": "multipart/form-data; boundary=\(boundary)"],
+            body: body
+        )
+        return try decode(CreateConversationResponse.self, from: data)
+    }
+
+    func sendMessage(
+        organizationSlug: String,
+        conversationId: String,
+        text: String
+    ) async throws -> ConversationMessage {
+        let boundary = "Boundary-\(UUID().uuidString)"
+        var body = Data()
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"text\"\r\n\r\n".data(using: .utf8)!)
+        body.append("\(text)\r\n".data(using: .utf8)!)
+        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+
+        let data = try await requestData(
+            path: "/api/orgs/\(organizationSlug)/conversations/\(conversationId)/messages",
+            method: "POST",
+            headers: ["Content-Type": "multipart/form-data; boundary=\(boundary)"],
+            body: body
+        )
+        return try decode(CreateMessageResponse.self, from: data).message
+    }
+
+    func streamChat(
+        organizationSlug: String,
+        conversationId: String,
+        userMessageId: String,
+        userText: String,
+        onEvent: @Sendable (String) -> Void
+    ) async throws {
+        let url = baseURL.appending(
+            path: "/api/orgs/\(organizationSlug)/conversations/\(conversationId)/chat"
+        )
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applySessionCookie(to: &request)
+
+        let payload: [String: Any] = [
+            "id": conversationId,
+            "trigger": "submit-message",
+            "messages": [
+                [
+                    "id": userMessageId,
+                    "role": "user",
+                    "parts": [["type": "text", "text": userText]],
+                ],
+            ],
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+
+        let (bytes, response) = try await session.bytes(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw APIClientError.invalidResponse
+        }
+        if http.statusCode == 401 {
+            throw APIClientError.unauthorized
+        }
+        guard (200 ..< 300).contains(http.statusCode) else {
+            var errorBody = ""
+            for try await line in bytes.lines {
+                errorBody += line
+                if errorBody.count > 2_000 { break }
+            }
+            throw APIClientError.http(status: http.statusCode, body: errorBody)
+        }
+
+        var dataBuffer = ""
+        for try await line in bytes.lines {
+            if line.hasPrefix("data:") {
+                let payload = line.dropFirst(5).trimmingCharacters(in: .whitespaces)
+                if payload == "[DONE]" { break }
+                dataBuffer += payload
+                continue
+            }
+            if line.isEmpty, !dataBuffer.isEmpty {
+                onEvent(dataBuffer)
+                dataBuffer = ""
+            }
+        }
+        if !dataBuffer.isEmpty {
+            onEvent(dataBuffer)
+        }
+    }
+
+    private func requestData(
+        path: String,
+        method: String,
+        headers: [String: String] = [:],
+        body: Data? = nil
+    ) async throws -> Data {
+        let url = baseURL.appending(path: path)
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.httpBody = body
+        for (key, value) in headers {
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+        applySessionCookie(to: &request)
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw APIClientError.invalidResponse
+        }
+        if http.statusCode == 401 {
+            throw APIClientError.unauthorized
+        }
+        guard (200 ..< 300).contains(http.statusCode) else {
+            let bodyText = String(data: data, encoding: .utf8) ?? ""
+            throw APIClientError.http(status: http.statusCode, body: bodyText)
+        }
+        return data
+    }
+
+    private func applySessionCookie(to request: inout URLRequest) {
+        if let sealedSession {
+            request.setValue("wos-session=\(sealedSession)", forHTTPHeaderField: "Cookie")
+        }
+    }
+
+    private func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        do {
+            return try JSONDecoder().decode(type, from: data)
+        } catch {
+            throw APIClientError.decoding(error)
+        }
+    }
+}

--- a/apps/mac-app/Hyperlocalise/API/APIClient.swift
+++ b/apps/mac-app/Hyperlocalise/API/APIClient.swift
@@ -181,6 +181,7 @@ actor APIClient {
             if line.hasPrefix("data:") {
                 let payload = line.dropFirst(5).trimmingCharacters(in: .whitespaces)
                 if payload == "[DONE]" { break }
+                if !dataBuffer.isEmpty { dataBuffer += "\n" }
                 dataBuffer += payload
                 continue
             }

--- a/apps/mac-app/Hyperlocalise/API/AppConfig.swift
+++ b/apps/mac-app/Hyperlocalise/API/AppConfig.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+enum AppConfig {
+    static var apiBaseURL: URL {
+        if let env = ProcessInfo.processInfo.environment["HYPERLOCALISE_API_BASE_URL"],
+           let url = URL(string: env),
+           !env.isEmpty
+        {
+            return url
+        }
+        if let plist = Bundle.main.object(forInfoDictionaryKey: "HYPERLOCALISE_API_BASE_URL") as? String,
+           let url = URL(string: plist),
+           !plist.isEmpty
+        {
+            return url
+        }
+        return URL(string: "http://localhost:3000")!
+    }
+}

--- a/apps/mac-app/Hyperlocalise/API/ChatStreamParser.swift
+++ b/apps/mac-app/Hyperlocalise/API/ChatStreamParser.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// Extracts assistant-visible text from AI SDK UIMessage SSE JSON payloads.
+enum ChatStreamParser {
+    static func extractAssistantText(from jsonPayload: String) -> String? {
+        guard let data = jsonPayload.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data)
+        else {
+            return nil
+        }
+        return extractText(from: object)
+    }
+
+    static func extractText(from value: Any) -> String? {
+        if let dict = value as? [String: Any] {
+            if let type = dict["type"] as? String {
+                // UI message stream chunks
+                if type == "text-delta" || type == "text" {
+                    if let delta = dict["delta"] as? String { return delta }
+                    if let text = dict["text"] as? String { return text }
+                }
+            }
+
+            // Full UIMessage snapshot
+            if let role = dict["role"] as? String, role == "assistant",
+               let parts = dict["parts"] as? [[String: Any]]
+            {
+                let text = parts.compactMap { part -> String? in
+                    guard let type = part["type"] as? String else { return nil }
+                    if type == "text" { return part["text"] as? String }
+                    return nil
+                }.joined()
+                return text.isEmpty ? nil : text
+            }
+
+            // Nested message object
+            if let message = dict["message"] {
+                return extractText(from: message)
+            }
+        }
+
+        if let array = value as? [Any] {
+            let joined = array.compactMap { extractText(from: $0) }.joined()
+            return joined.isEmpty ? nil : joined
+        }
+
+        return nil
+    }
+
+    /// Merges stream deltas into a running assistant transcript.
+    static func apply(eventJSON: String, to current: inout String) -> Bool {
+        guard let data = eventJSON.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return false
+        }
+
+        if let type = object["type"] as? String {
+            if type == "text-delta", let delta = object["delta"] as? String {
+                current += delta
+                return true
+            }
+            if type == "text", let text = object["text"] as? String {
+                current = text
+                return true
+            }
+        }
+
+        if let snapshot = extractText(from: object) {
+            // Prefer longer snapshot (full message replace) when it grows.
+            if snapshot.count >= current.count {
+                current = snapshot
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/apps/mac-app/Hyperlocalise/API/Models.swift
+++ b/apps/mac-app/Hyperlocalise/API/Models.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+struct AuthContextResponse: Decodable, Sendable {
+    let auth: AuthContext
+}
+
+struct AuthContext: Decodable, Sendable {
+    let user: AuthUser
+    let organizations: [AuthOrganization]
+    let organization: AuthOrganization
+}
+
+struct AuthUser: Decodable, Hashable, Sendable {
+    let workosUserId: String
+    let localUserId: String
+    let email: String
+}
+
+struct AuthOrganization: Decodable, Hashable, Identifiable, Sendable {
+    var id: String { localOrganizationId }
+    let workosOrganizationId: String
+    let localOrganizationId: String
+    let name: String
+    let slug: String?
+}
+
+struct ConversationLastMessage: Decodable, Hashable, Sendable {
+    let text: String?
+}
+
+struct ConversationSummary: Decodable, Hashable, Identifiable, Sendable {
+    let id: String
+    let title: String?
+    let lastMessage: ConversationLastMessage?
+    let lastMessageAt: FlexibleDateString?
+    let createdAt: FlexibleDateString?
+
+    var lastMessagePreview: String? { lastMessage?.text }
+}
+
+/// Accepts ISO-8601 strings from JSON date serialization.
+struct FlexibleDateString: Decodable, Hashable, Sendable {
+    let raw: String
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let string = try? container.decode(String.self) {
+            raw = string
+            return
+        }
+        if let double = try? container.decode(Double.self) {
+            raw = String(double)
+            return
+        }
+        raw = ""
+    }
+}
+
+struct ConversationsResponse: Decodable, Sendable {
+    let conversations: [ConversationSummary]
+}
+
+struct ConversationMessage: Decodable, Hashable, Identifiable, Sendable {
+    let id: String
+    let senderType: String
+    let text: String?
+    let createdAt: String?
+    let parts: [MessagePart]?
+}
+
+struct MessagePart: Decodable, Hashable, Sendable {
+    let type: String?
+    let text: String?
+}
+
+struct ConversationDetailResponse: Decodable, Sendable {
+    let conversation: ConversationSummary
+    let messages: [ConversationMessage]?
+}
+
+struct CreateConversationResponse: Decodable, Sendable {
+    let conversation: ConversationSummary
+    let message: ConversationMessage
+}
+
+struct CreateMessageResponse: Decodable, Sendable {
+    let message: ConversationMessage
+}
+
+enum ChatRole: String, Hashable, Sendable {
+    case user
+    case assistant
+    case system
+}
+
+struct ChatDisplayMessage: Identifiable, Hashable, Sendable {
+    let id: String
+    let role: ChatRole
+    var text: String
+    var isStreaming: Bool
+}

--- a/apps/mac-app/Hyperlocalise/App/AppModel.swift
+++ b/apps/mac-app/Hyperlocalise/App/AppModel.swift
@@ -1,0 +1,268 @@
+import AppKit
+import Observation
+import SwiftUI
+
+@MainActor
+@Observable
+final class AppModel {
+    private(set) var isBootstrapping = true
+    private(set) var isAuthenticated = false
+    private(set) var authContext: AuthContext?
+    private(set) var selectedOrganization: AuthOrganization?
+    private(set) var conversations: [ConversationSummary] = []
+    private(set) var selectedConversationID: String?
+    private(set) var messages: [ChatDisplayMessage] = []
+    private(set) var isStreaming = false
+    private(set) var statusMessage: String?
+    var draft = ""
+    var repositoryFullName = ""
+    var errorMessage: String?
+
+    private let authService: AuthService
+    private let apiClient: APIClient
+
+    init(
+        authService: AuthService? = nil,
+        apiClient: APIClient? = nil
+    ) {
+        let baseURL = AppConfig.apiBaseURL
+        self.authService = authService ?? AuthService(apiBaseURL: baseURL)
+        self.apiClient = apiClient ?? APIClient(baseURL: baseURL)
+        Task { await bootstrap() }
+    }
+
+    var userEmail: String? {
+        authContext?.user.email
+    }
+
+    func bootstrap() async {
+        isBootstrapping = true
+        defer { isBootstrapping = false }
+
+        guard let sealed = authService.restoreSealedSession() else {
+            isAuthenticated = false
+            return
+        }
+
+        await apiClient.setSealedSession(sealed)
+        do {
+            try await refreshAuthContext()
+            isAuthenticated = true
+            try await refreshConversations()
+        } catch {
+            authService.signOut()
+            await apiClient.setSealedSession(nil)
+            isAuthenticated = false
+            authContext = nil
+        }
+    }
+
+    func signIn(from window: NSWindow?) async {
+        errorMessage = nil
+        statusMessage = "Opening WorkOS…"
+        do {
+            let anchor = window ?? NSApp.keyWindow ?? ASPresentationFallback.anchor
+            _ = try await authService.signIn(from: anchor)
+            if let sealed = authService.restoreSealedSession() {
+                await apiClient.setSealedSession(sealed)
+            }
+            try await refreshAuthContext()
+            isAuthenticated = true
+            try await refreshConversations()
+            statusMessage = nil
+        } catch AuthServiceError.authorizationCancelled {
+            statusMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+            statusMessage = nil
+        }
+    }
+
+    func signOut() {
+        authService.signOut()
+        Task {
+            await apiClient.setSealedSession(nil)
+        }
+        isAuthenticated = false
+        authContext = nil
+        selectedOrganization = nil
+        conversations = []
+        selectedConversationID = nil
+        messages = []
+        draft = ""
+    }
+
+    func selectOrganization(_ organization: AuthOrganization) async {
+        selectedOrganization = organization
+        selectedConversationID = nil
+        messages = []
+        do {
+            try await refreshConversations()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func selectConversation(_ conversation: ConversationSummary) async {
+        selectedConversationID = conversation.id
+        do {
+            try await loadMessages(for: conversation.id)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func startNewConversation() async {
+        selectedConversationID = nil
+        messages = []
+        draft = ""
+    }
+
+    func sendDraft() async {
+        let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty, let organization = selectedOrganization, let slug = organization.slug
+        else {
+            errorMessage = "Select an organization with a slug before chatting."
+            return
+        }
+        guard !isStreaming else { return }
+
+        errorMessage = nil
+        draft = ""
+        isStreaming = true
+        defer { isStreaming = false }
+
+        do {
+            let userMessageId: String
+            let conversationId: String
+
+            if let existingID = selectedConversationID {
+                let created = try await apiClient.sendMessage(
+                    organizationSlug: slug,
+                    conversationId: existingID,
+                    text: text
+                )
+                conversationId = existingID
+                userMessageId = created.id
+                messages.append(
+                    ChatDisplayMessage(id: created.id, role: .user, text: text, isStreaming: false)
+                )
+            } else {
+                let created = try await apiClient.createConversation(
+                    organizationSlug: slug,
+                    text: text,
+                    repositoryFullName: repositoryFullName.trimmingCharacters(in: .whitespacesAndNewlines)
+                )
+                conversationId = created.conversation.id
+                userMessageId = created.message.id
+                selectedConversationID = conversationId
+                messages = [
+                    ChatDisplayMessage(
+                        id: created.message.id,
+                        role: .user,
+                        text: text,
+                        isStreaming: false
+                    ),
+                ]
+                try await refreshConversations()
+            }
+
+            let assistantID = "stream-\(userMessageId)"
+            messages.append(
+                ChatDisplayMessage(id: assistantID, role: .assistant, text: "", isStreaming: true)
+            )
+            var assistantText = ""
+
+            try await apiClient.streamChat(
+                organizationSlug: slug,
+                conversationId: conversationId,
+                userMessageId: userMessageId,
+                userText: text
+            ) { [weak self] event in
+                Task { @MainActor in
+                    guard let self else { return }
+                    if ChatStreamParser.apply(eventJSON: event, to: &assistantText) {
+                        if let index = self.messages.firstIndex(where: { $0.id == assistantID }) {
+                            self.messages[index].text = assistantText
+                        }
+                    }
+                }
+            }
+
+            if let index = messages.firstIndex(where: { $0.id == assistantID }) {
+                messages[index].isStreaming = false
+                if messages[index].text.isEmpty {
+                    messages[index].text = "…"
+                }
+            }
+            try await refreshConversations()
+        } catch APIClientError.unauthorized {
+            errorMessage = APIClientError.unauthorized.localizedDescription
+            signOut()
+        } catch {
+            errorMessage = error.localizedDescription
+            if let index = messages.firstIndex(where: { $0.isStreaming }) {
+                messages[index].isStreaming = false
+                if messages[index].text.isEmpty {
+                    messages[index].text = "Sorry — the agent could not finish that turn."
+                }
+            }
+        }
+    }
+
+    private func refreshAuthContext() async throws {
+        let context = try await apiClient.fetchAuthContext()
+        authContext = context
+        if let selected = selectedOrganization,
+           context.organizations.contains(where: { $0.localOrganizationId == selected.localOrganizationId })
+        {
+            // keep selection
+        } else {
+            selectedOrganization = context.organizations.first(where: { $0.slug != nil })
+                ?? context.organization
+        }
+    }
+
+    private func refreshConversations() async throws {
+        guard let slug = selectedOrganization?.slug else {
+            conversations = []
+            return
+        }
+        conversations = try await apiClient.listConversations(organizationSlug: slug)
+    }
+
+    private func loadMessages(for conversationId: String) async throws {
+        guard let slug = selectedOrganization?.slug else { return }
+        let (_, remote) = try await apiClient.fetchConversation(
+            organizationSlug: slug,
+            conversationId: conversationId
+        )
+        messages = remote.map { message in
+            let role: ChatRole =
+                message.senderType == "user" ? .user :
+                message.senderType == "system" ? .system :
+                .assistant // includes agent
+            let textFromParts = message.parts?
+                .compactMap(\.text)
+                .joined(separator: "\n")
+            return ChatDisplayMessage(
+                id: message.id,
+                role: role,
+                text: textFromParts?.isEmpty == false ? textFromParts! : (message.text ?? ""),
+                isStreaming: false
+            )
+        }
+    }
+}
+
+private enum ASPresentationFallback {
+    @MainActor
+    static var anchor: NSWindow {
+        NSApp.windows.first ?? NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 100, height: 100),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+    }
+}

--- a/apps/mac-app/Hyperlocalise/App/AppModel.swift
+++ b/apps/mac-app/Hyperlocalise/App/AppModel.swift
@@ -128,7 +128,6 @@ final class AppModel {
         guard !isStreaming else { return }
 
         errorMessage = nil
-        draft = ""
         isStreaming = true
         defer { isStreaming = false }
 
@@ -144,6 +143,7 @@ final class AppModel {
                 )
                 conversationId = existingID
                 userMessageId = created.id
+                draft = ""
                 messages.append(
                     ChatDisplayMessage(id: created.id, role: .user, text: text, isStreaming: false)
                 )
@@ -155,6 +155,7 @@ final class AppModel {
                 )
                 conversationId = created.conversation.id
                 userMessageId = created.message.id
+                draft = ""
                 selectedConversationID = conversationId
                 messages = [
                     ChatDisplayMessage(

--- a/apps/mac-app/Hyperlocalise/App/RootView.swift
+++ b/apps/mac-app/Hyperlocalise/App/RootView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct RootView: View {
+    @Environment(AppModel.self) private var appModel
+
+    var body: some View {
+        Group {
+            if appModel.isBootstrapping {
+                ZStack {
+                    AtmosphereBackground()
+                    ProgressView("Restoring session…")
+                        .controlSize(.large)
+                }
+            } else if appModel.isAuthenticated {
+                ChatShellView()
+            } else {
+                LoginView()
+            }
+        }
+        .animation(.easeInOut(duration: 0.25), value: appModel.isAuthenticated)
+        .animation(.easeInOut(duration: 0.2), value: appModel.isBootstrapping)
+    }
+}

--- a/apps/mac-app/Hyperlocalise/App/SparkleUpdater.swift
+++ b/apps/mac-app/Hyperlocalise/App/SparkleUpdater.swift
@@ -1,0 +1,61 @@
+import Combine
+import Sparkle
+import SwiftUI
+
+/// Owns the Sparkle 2 updater for the app lifecycle.
+@MainActor
+final class SparkleUpdater {
+    let controller: SPUStandardUpdaterController
+
+    var updater: SPUUpdater { controller.updater }
+
+    init(startingUpdater: Bool = true) {
+        controller = SPUStandardUpdaterController(
+            startingUpdater: startingUpdater,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+    }
+
+    /// Starts background checks only when feed URL and public key are configured.
+    static func makeForCurrentBundle() -> SparkleUpdater {
+        let feed = Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") as? String
+        let publicKey = Bundle.main.object(forInfoDictionaryKey: "SUPublicEDKey") as? String
+        let configured =
+            !(feed?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+            && !(publicKey?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+            && publicKey != "REPLACE_WITH_SPARKLE_PUBLIC_ED_KEY"
+        return SparkleUpdater(startingUpdater: configured)
+    }
+}
+
+/// Tracks whether Sparkle can run a manual check (disables the menu item while busy).
+final class CheckForUpdatesViewModel: ObservableObject {
+    @Published var canCheckForUpdates = false
+    private var cancellable: AnyCancellable?
+
+    init(updater: SPUUpdater) {
+        cancellable = updater.publisher(for: \.canCheckForUpdates)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] value in
+                self?.canCheckForUpdates = value
+            }
+    }
+}
+
+struct CheckForUpdatesView: View {
+    @ObservedObject private var viewModel: CheckForUpdatesViewModel
+    private let updater: SPUUpdater
+
+    init(updater: SPUUpdater) {
+        self.updater = updater
+        viewModel = CheckForUpdatesViewModel(updater: updater)
+    }
+
+    var body: some View {
+        Button("Check for Updates…") {
+            updater.checkForUpdates()
+        }
+        .disabled(!viewModel.canCheckForUpdates)
+    }
+}

--- a/apps/mac-app/Hyperlocalise/Auth/AuthService.swift
+++ b/apps/mac-app/Hyperlocalise/Auth/AuthService.swift
@@ -33,6 +33,7 @@ enum AuthServiceError: Error, LocalizedError {
     case invalidAPIBaseURL
     case authorizationCancelled
     case missingAuthorizationCode
+    case invalidOAuthState
     case invalidAuthorizationURL
     case server(String)
 
@@ -44,6 +45,8 @@ enum AuthServiceError: Error, LocalizedError {
             return "Sign-in was cancelled."
         case .missingAuthorizationCode:
             return "WorkOS did not return an authorization code."
+        case .invalidOAuthState:
+            return "Sign-in callback failed state validation."
         case .invalidAuthorizationURL:
             return "WorkOS returned an invalid authorization URL."
         case .server(let message):
@@ -82,7 +85,7 @@ final class AuthService: NSObject {
         )
 
         let callbackURL = try await startWebAuthentication(url: authorizeURL)
-        let code = try extractCode(from: callbackURL)
+        let code = try extractCode(from: callbackURL, expectedState: state)
         let token = try await exchangeToken(
             code: code,
             codeVerifier: pkce.verifier
@@ -173,8 +176,12 @@ final class AuthService: NSObject {
         }
     }
 
-    private func extractCode(from url: URL) throws -> String {
+    private func extractCode(from url: URL, expectedState: String) throws -> String {
         let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems
+        let returnedState = items?.first(where: { $0.name == "state" })?.value
+        guard let returnedState, returnedState == expectedState else {
+            throw AuthServiceError.invalidOAuthState
+        }
         if let code = items?.first(where: { $0.name == "code" })?.value, !code.isEmpty {
             return code
         }

--- a/apps/mac-app/Hyperlocalise/Auth/AuthService.swift
+++ b/apps/mac-app/Hyperlocalise/Auth/AuthService.swift
@@ -60,6 +60,9 @@ final class AuthService: NSObject {
     private let apiBaseURL: URL
     private let session: URLSession
     private var presentationAnchor: ASPresentationAnchor?
+    /// Retained for the lifetime of the browser flow; Apple requires a strong
+    /// reference so the session is not deallocated before the callback fires.
+    private var webAuthSession: ASWebAuthenticationSession?
 
     init(apiBaseURL: URL, session: URLSession = .shared) {
         self.apiBaseURL = apiBaseURL
@@ -147,10 +150,11 @@ final class AuthService: NSObject {
 
     private func startWebAuthentication(url: URL) async throws -> URL {
         try await withCheckedThrowingContinuation { continuation in
-            let session = ASWebAuthenticationSession(
+            let authSession = ASWebAuthenticationSession(
                 url: url,
                 callbackURLScheme: "hyperlocalise"
-            ) { callbackURL, error in
+            ) { [weak self] callbackURL, error in
+                self?.webAuthSession = nil
                 if let error {
                     let nsError = error as NSError
                     if nsError.domain == ASWebAuthenticationSessionError.errorDomain,
@@ -168,9 +172,11 @@ final class AuthService: NSObject {
                 }
                 continuation.resume(returning: callbackURL)
             }
-            session.presentationContextProvider = self
-            session.prefersEphemeralWebBrowserSession = false
-            if !session.start() {
+            authSession.presentationContextProvider = self
+            authSession.prefersEphemeralWebBrowserSession = false
+            webAuthSession = authSession
+            if !authSession.start() {
+                webAuthSession = nil
                 continuation.resume(throwing: AuthServiceError.server("Unable to start sign-in session."))
             }
         }

--- a/apps/mac-app/Hyperlocalise/Auth/AuthService.swift
+++ b/apps/mac-app/Hyperlocalise/Auth/AuthService.swift
@@ -1,0 +1,197 @@
+import AuthenticationServices
+import Foundation
+
+struct NativeSessionResponse: Decodable, Sendable {
+    struct Session: Decodable, Sendable {
+        let sealedSession: String
+        let cookieName: String
+    }
+
+    struct User: Decodable, Sendable {
+        let workosUserId: String
+        let email: String
+        let firstName: String?
+        let lastName: String?
+        let avatarUrl: String?
+    }
+
+    let session: Session
+    let user: User
+    let organizationId: String?
+}
+
+struct NativeAuthorizeResponse: Decodable, Sendable {
+    struct Authorization: Decodable, Sendable {
+        let url: String
+        let redirectUri: String
+    }
+
+    let authorization: Authorization
+}
+
+enum AuthServiceError: Error, LocalizedError {
+    case invalidAPIBaseURL
+    case authorizationCancelled
+    case missingAuthorizationCode
+    case invalidAuthorizationURL
+    case server(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidAPIBaseURL:
+            return "API base URL is not configured."
+        case .authorizationCancelled:
+            return "Sign-in was cancelled."
+        case .missingAuthorizationCode:
+            return "WorkOS did not return an authorization code."
+        case .invalidAuthorizationURL:
+            return "WorkOS returned an invalid authorization URL."
+        case .server(let message):
+            return message
+        }
+    }
+}
+
+@MainActor
+final class AuthService: NSObject {
+    private let apiBaseURL: URL
+    private let session: URLSession
+    private var presentationAnchor: ASPresentationAnchor?
+
+    init(apiBaseURL: URL, session: URLSession = .shared) {
+        self.apiBaseURL = apiBaseURL
+        self.session = session
+    }
+
+    func restoreSealedSession() -> String? {
+        KeychainStore.loadSession()
+    }
+
+    func signOut() {
+        KeychainStore.deleteSession()
+    }
+
+    func signIn(from anchor: ASPresentationAnchor) async throws -> NativeSessionResponse {
+        presentationAnchor = anchor
+        let pkce = PKCE.generatePair()
+        let state = PKCE.generatePair(byteCount: 16).verifier
+
+        let authorizeURL = try await fetchAuthorizationURL(
+            codeChallenge: pkce.challenge,
+            state: state
+        )
+
+        let callbackURL = try await startWebAuthentication(url: authorizeURL)
+        let code = try extractCode(from: callbackURL)
+        let token = try await exchangeToken(
+            code: code,
+            codeVerifier: pkce.verifier
+        )
+        try KeychainStore.saveSession(token.session.sealedSession)
+        return token
+    }
+
+    private func fetchAuthorizationURL(codeChallenge: String, state: String) async throws -> URL {
+        var components = URLComponents(
+            url: apiBaseURL.appending(path: "/api/auth/native/authorize"),
+            resolvingAgainstBaseURL: false
+        )
+        components?.queryItems = [
+            URLQueryItem(name: "codeChallenge", value: codeChallenge),
+            URLQueryItem(name: "codeChallengeMethod", value: "S256"),
+            URLQueryItem(name: "redirectUri", value: PKCE.redirectURI),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "screenHint", value: "sign-in"),
+        ]
+        guard let url = components?.url else {
+            throw AuthServiceError.invalidAPIBaseURL
+        }
+
+        let (data, response) = try await session.data(from: url)
+        guard let http = response as? HTTPURLResponse else {
+            throw AuthServiceError.server("Unexpected authorize response.")
+        }
+        guard http.statusCode == 200 else {
+            throw AuthServiceError.server(Self.errorMessage(from: data, fallback: "Authorize failed."))
+        }
+        let decoded = try JSONDecoder().decode(NativeAuthorizeResponse.self, from: data)
+        guard let authorizationURL = URL(string: decoded.authorization.url) else {
+            throw AuthServiceError.invalidAuthorizationURL
+        }
+        return authorizationURL
+    }
+
+    private func exchangeToken(code: String, codeVerifier: String) async throws -> NativeSessionResponse {
+        let url = apiBaseURL.appending(path: "/api/auth/native/token")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "code": code,
+            "codeVerifier": codeVerifier,
+            "redirectUri": PKCE.redirectURI,
+        ])
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw AuthServiceError.server("Unexpected token response.")
+        }
+        guard http.statusCode == 200 else {
+            throw AuthServiceError.server(Self.errorMessage(from: data, fallback: "Token exchange failed."))
+        }
+        return try JSONDecoder().decode(NativeSessionResponse.self, from: data)
+    }
+
+    private func startWebAuthentication(url: URL) async throws -> URL {
+        try await withCheckedThrowingContinuation { continuation in
+            let session = ASWebAuthenticationSession(
+                url: url,
+                callbackURLScheme: "hyperlocalise"
+            ) { callbackURL, error in
+                if let error {
+                    let nsError = error as NSError
+                    if nsError.domain == ASWebAuthenticationSessionError.errorDomain,
+                       nsError.code == ASWebAuthenticationSessionError.canceledLogin.rawValue
+                    {
+                        continuation.resume(throwing: AuthServiceError.authorizationCancelled)
+                    } else {
+                        continuation.resume(throwing: error)
+                    }
+                    return
+                }
+                guard let callbackURL else {
+                    continuation.resume(throwing: AuthServiceError.missingAuthorizationCode)
+                    return
+                }
+                continuation.resume(returning: callbackURL)
+            }
+            session.presentationContextProvider = self
+            session.prefersEphemeralWebBrowserSession = false
+            if !session.start() {
+                continuation.resume(throwing: AuthServiceError.server("Unable to start sign-in session."))
+            }
+        }
+    }
+
+    private func extractCode(from url: URL) throws -> String {
+        let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems
+        if let code = items?.first(where: { $0.name == "code" })?.value, !code.isEmpty {
+            return code
+        }
+        throw AuthServiceError.missingAuthorizationCode
+    }
+
+    private static func errorMessage(from data: Data, fallback: String) -> String {
+        struct Envelope: Decodable { let error: String?; let message: String? }
+        if let envelope = try? JSONDecoder().decode(Envelope.self, from: data) {
+            return envelope.message ?? envelope.error ?? fallback
+        }
+        return fallback
+    }
+}
+
+extension AuthService: ASWebAuthenticationPresentationContextProviding {
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        presentationAnchor ?? ASPresentationAnchor()
+    }
+}

--- a/apps/mac-app/Hyperlocalise/Auth/KeychainStore.swift
+++ b/apps/mac-app/Hyperlocalise/Auth/KeychainStore.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Security
+
+enum KeychainStore {
+    private static let service = "com.hyperlocalise.mac"
+    private static let sessionAccount = "wos-session"
+
+    static func saveSession(_ sealedSession: String) throws {
+        let data = Data(sealedSession.utf8)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: sessionAccount,
+        ]
+        SecItemDelete(query as CFDictionary)
+
+        var add = query
+        add[kSecValueData as String] = data
+        add[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+
+        let status = SecItemAdd(add as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw KeychainError.unhandled(status)
+        }
+    }
+
+    static func loadSession() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: sessionAccount,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess, let data = item as? Data else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func deleteSession() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: sessionAccount,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}
+
+enum KeychainError: Error, LocalizedError {
+    case unhandled(OSStatus)
+
+    var errorDescription: String? {
+        switch self {
+        case .unhandled(let status):
+            return "Keychain error (\(status))"
+        }
+    }
+}

--- a/apps/mac-app/Hyperlocalise/Auth/LoginView.swift
+++ b/apps/mac-app/Hyperlocalise/Auth/LoginView.swift
@@ -1,0 +1,78 @@
+import AppKit
+import SwiftUI
+
+struct LoginView: View {
+    @Environment(AppModel.self) private var appModel
+    @State private var appeared = false
+
+    var body: some View {
+        ZStack {
+            AtmosphereBackground()
+
+            VStack(spacing: 28) {
+                Spacer(minLength: 40)
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Hyperlocalise")
+                        .font(HLTheme.displayFont)
+                        .foregroundStyle(HLTheme.ink)
+                        .opacity(appeared ? 1 : 0)
+                        .offset(y: appeared ? 0 : 12)
+
+                    Text("Find context. Ship the work.")
+                        .font(HLTheme.titleFont)
+                        .foregroundStyle(HLTheme.ink.opacity(0.88))
+                        .opacity(appeared ? 1 : 0)
+                        .offset(y: appeared ? 0 : 10)
+
+                    Text("Sign in with WorkOS to chat with your localization agent from the menu bar of your Mac.")
+                        .font(HLTheme.bodyFont)
+                        .foregroundStyle(HLTheme.ink.opacity(0.7))
+                        .frame(maxWidth: 420, alignment: .leading)
+                        .opacity(appeared ? 1 : 0)
+                }
+                .frame(maxWidth: 520, alignment: .leading)
+
+                HStack(spacing: 12) {
+                    Button {
+                        Task {
+                            await appModel.signIn(from: NSApp.keyWindow)
+                        }
+                    } label: {
+                        Text("Sign in with WorkOS")
+                            .font(.headline)
+                            .padding(.horizontal, 18)
+                            .padding(.vertical, 10)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(HLTheme.moss)
+                    .disabled(appModel.statusMessage != nil)
+
+                    if let status = appModel.statusMessage {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text(status)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .opacity(appeared ? 1 : 0)
+
+                if let error = appModel.errorMessage {
+                    Text(error)
+                        .foregroundStyle(.red)
+                        .font(.callout)
+                        .frame(maxWidth: 480, alignment: .leading)
+                }
+
+                Spacer()
+            }
+            .padding(48)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
+        .onAppear {
+            withAnimation(.spring(response: 0.55, dampingFraction: 0.86)) {
+                appeared = true
+            }
+        }
+    }
+}

--- a/apps/mac-app/Hyperlocalise/Auth/PKCE.swift
+++ b/apps/mac-app/Hyperlocalise/Auth/PKCE.swift
@@ -1,0 +1,30 @@
+import CryptoKit
+import Foundation
+
+enum PKCE {
+    static let redirectURI = "hyperlocalise://auth/callback"
+
+    struct Pair: Equatable, Sendable {
+        let verifier: String
+        let challenge: String
+    }
+
+    /// RFC 7636 code_verifier: 43–128 URL-safe characters.
+    static func generatePair(byteCount: Int = 32) -> Pair {
+        var bytes = [UInt8](repeating: 0, count: byteCount)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        precondition(status == errSecSuccess, "SecRandomCopyBytes failed")
+        let verifier = Data(bytes).base64URLEncodedString()
+        let challenge = Data(SHA256.hash(data: Data(verifier.utf8))).base64URLEncodedString()
+        return Pair(verifier: verifier, challenge: challenge)
+    }
+}
+
+extension Data {
+    func base64URLEncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/apps/mac-app/Hyperlocalise/Chat/ChatShellView.swift
+++ b/apps/mac-app/Hyperlocalise/Chat/ChatShellView.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+
+struct ChatShellView: View {
+    @Environment(AppModel.self) private var appModel
+
+    var body: some View {
+        NavigationSplitView {
+            VStack(alignment: .leading, spacing: 0) {
+                organizationHeader
+                Divider()
+                conversationList
+                Divider()
+                footer
+            }
+            .navigationSplitViewColumnWidth(min: 220, ideal: 260, max: 320)
+        } detail: {
+            ChatView()
+        }
+        .alert("Something went wrong", isPresented: Binding(
+            get: { appModel.errorMessage != nil },
+            set: { if !$0 { appModel.errorMessage = nil } }
+        )) {
+            Button("OK", role: .cancel) { appModel.errorMessage = nil }
+        } message: {
+            Text(appModel.errorMessage ?? "")
+        }
+    }
+
+    @ViewBuilder
+    private var organizationHeader: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Hyperlocalise")
+                .font(.headline)
+                .foregroundStyle(HLTheme.moss)
+
+            if let orgs = appModel.authContext?.organizations, !orgs.isEmpty {
+                Picker("Organization", selection: Binding(
+                    get: { appModel.selectedOrganization },
+                    set: { org in
+                        guard let org else { return }
+                        Task { await appModel.selectOrganization(org) }
+                    }
+                )) {
+                    ForEach(orgs) { org in
+                        Text(org.name).tag(Optional(org))
+                    }
+                }
+                .labelsHidden()
+            }
+
+            Text(appModel.userEmail ?? "")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .padding(16)
+    }
+
+    private var conversationList: some View {
+        List(selection: Binding(
+            get: { appModel.selectedConversationID },
+            set: { id in
+                guard let id,
+                      let conversation = appModel.conversations.first(where: { $0.id == id })
+                else {
+                    Task { await appModel.startNewConversation() }
+                    return
+                }
+                Task { await appModel.selectConversation(conversation) }
+            }
+        )) {
+            Button {
+                Task { await appModel.startNewConversation() }
+            } label: {
+                Label("New chat", systemImage: "plus.message")
+            }
+            .buttonStyle(.plain)
+
+            Section("Recent") {
+                ForEach(appModel.conversations) { conversation in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(conversation.title?.isEmpty == false
+                            ? conversation.title!
+                            : "Untitled chat")
+                            .font(.body.weight(.medium))
+                            .lineLimit(1)
+                        if let preview = conversation.lastMessagePreview, !preview.isEmpty {
+                            Text(preview)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                        }
+                    }
+                    .tag(Optional(conversation.id))
+                    .padding(.vertical, 2)
+                }
+            }
+        }
+        .listStyle(.sidebar)
+    }
+
+    private var footer: some View {
+        HStack {
+            Button("Sign out") {
+                appModel.signOut()
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(12)
+    }
+}

--- a/apps/mac-app/Hyperlocalise/Chat/ChatView.swift
+++ b/apps/mac-app/Hyperlocalise/Chat/ChatView.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+
+struct ChatView: View {
+    @Environment(AppModel.self) private var appModel
+    @FocusState private var composerFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            messageList
+            Divider()
+            composer
+        }
+        .background(HLTheme.mist.opacity(0.35))
+        .onAppear { composerFocused = true }
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(appModel.selectedConversationID == nil ? "New conversation" : "Conversation")
+                    .font(HLTheme.titleFont)
+                Text("Ask the agent to find context and do the work.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            if appModel.isStreaming {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Working…")
+                        .foregroundStyle(.secondary)
+                }
+                .transition(.opacity)
+            }
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 16)
+        .animation(.easeInOut(duration: 0.2), value: appModel.isStreaming)
+    }
+
+    private var messageList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 14) {
+                    if appModel.messages.isEmpty {
+                        emptyState
+                    } else {
+                        ForEach(appModel.messages) { message in
+                            MessageBubble(message: message)
+                                .id(message.id)
+                        }
+                    }
+                }
+                .padding(24)
+            }
+            .onChange(of: appModel.messages.last?.text) { _, _ in
+                if let last = appModel.messages.last {
+                    withAnimation(.easeOut(duration: 0.2)) {
+                        proxy.scrollTo(last.id, anchor: .bottom)
+                    }
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Start with a localization question")
+                .font(.title3.weight(.semibold))
+            Text("Examples: “Find where checkout CTA copy lives”, “Translate the onboarding strings for de-DE”, “Open a PR for the glossary update”.")
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: 520, alignment: .leading)
+        }
+        .padding(.top, 40)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var composer: some View {
+        @Bindable var model = appModel
+
+        return VStack(alignment: .leading, spacing: 10) {
+            TextField(
+                "Optional repo (owner/name) for find-context",
+                text: $model.repositoryFullName
+            )
+            .textFieldStyle(.roundedBorder)
+            .font(HLTheme.monoFont)
+            .disabled(appModel.selectedConversationID != nil)
+
+            HStack(alignment: .bottom, spacing: 12) {
+                TextField("Message the agent…", text: $model.draft, axis: .vertical)
+                    .textFieldStyle(.plain)
+                    .lineLimit(1 ... 6)
+                    .focused($composerFocused)
+                    .padding(12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .fill(Color(nsColor: .textBackgroundColor))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .stroke(HLTheme.fog, lineWidth: 1)
+                    )
+                    .onSubmit {
+                        Task { await appModel.sendDraft() }
+                    }
+
+                Button {
+                    Task { await appModel.sendDraft() }
+                } label: {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.system(size: 28))
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(HLTheme.moss)
+                }
+                .buttonStyle(.plain)
+                .disabled(
+                    appModel.draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        || appModel.isStreaming
+                )
+                .keyboardShortcut(.return, modifiers: [.command])
+            }
+        }
+        .padding(16)
+        .background(.ultraThinMaterial)
+    }
+}

--- a/apps/mac-app/Hyperlocalise/Chat/MessageBubble.swift
+++ b/apps/mac-app/Hyperlocalise/Chat/MessageBubble.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct MessageBubble: View {
+    let message: ChatDisplayMessage
+
+    var body: some View {
+        HStack(alignment: .top) {
+            if message.role == .user { Spacer(minLength: 80) }
+
+            VStack(alignment: message.role == .user ? .trailing : .leading, spacing: 6) {
+                Text(roleLabel)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                Text(message.text.isEmpty && message.isStreaming ? "…" : message.text)
+                    .font(HLTheme.bodyFont)
+                    .textSelection(.enabled)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
+                    .background(background)
+                    .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                    .animation(.easeInOut(duration: 0.15), value: message.text)
+            }
+
+            if message.role != .user { Spacer(minLength: 80) }
+        }
+    }
+
+    private var roleLabel: String {
+        switch message.role {
+        case .user: "You"
+        case .assistant: "Agent"
+        case .system: "System"
+        }
+    }
+
+    private var background: some ShapeStyle {
+        switch message.role {
+        case .user:
+            HLTheme.moss.opacity(0.14)
+        case .assistant:
+            Color(nsColor: .textBackgroundColor)
+        case .system:
+            HLTheme.clay.opacity(0.12)
+        }
+    }
+}

--- a/apps/mac-app/Hyperlocalise/Design/Theme.swift
+++ b/apps/mac-app/Hyperlocalise/Design/Theme.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+enum HLTheme {
+    static let brand = Color("AccentColor")
+    static let ink = Color(red: 0.07, green: 0.09, blue: 0.11)
+    static let mist = Color(red: 0.93, green: 0.95, blue: 0.94)
+    static let moss = Color(red: 0.09, green: 0.42, blue: 0.29)
+    static let clay = Color(red: 0.72, green: 0.45, blue: 0.22)
+    static let fog = Color(red: 0.86, green: 0.89, blue: 0.88)
+
+    static let displayFont = Font.system(.largeTitle, design: .serif).weight(.semibold)
+    static let titleFont = Font.system(.title2, design: .default).weight(.semibold)
+    static let bodyFont = Font.system(.body, design: .default)
+    static let monoFont = Font.system(.body, design: .monospaced)
+}
+
+struct AtmosphereBackground: View {
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [
+                    Color(red: 0.94, green: 0.96, blue: 0.95),
+                    Color(red: 0.88, green: 0.92, blue: 0.90),
+                    Color(red: 0.82, green: 0.88, blue: 0.86),
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            RadialGradient(
+                colors: [
+                    HLTheme.moss.opacity(0.16),
+                    .clear,
+                ],
+                center: .topTrailing,
+                startRadius: 20,
+                endRadius: 420
+            )
+            RadialGradient(
+                colors: [
+                    HLTheme.clay.opacity(0.10),
+                    .clear,
+                ],
+                center: .bottomLeading,
+                startRadius: 10,
+                endRadius: 360
+            )
+        }
+        .ignoresSafeArea()
+    }
+}

--- a/apps/mac-app/Hyperlocalise/Hyperlocalise.entitlements
+++ b/apps/mac-app/Hyperlocalise/Hyperlocalise.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/apps/mac-app/Hyperlocalise/Hyperlocalise.entitlements
+++ b/apps/mac-app/Hyperlocalise/Hyperlocalise.entitlements
@@ -6,5 +6,10 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+	<array>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spki</string>
+	</array>
 </dict>
 </plist>

--- a/apps/mac-app/Hyperlocalise/HyperlocaliseApp.swift
+++ b/apps/mac-app/Hyperlocalise/HyperlocaliseApp.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+@main
+struct HyperlocaliseApp: App {
+    @State private var appModel = AppModel()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environment(appModel)
+                .frame(minWidth: 960, minHeight: 640)
+        }
+        .windowStyle(.automatic)
+        .defaultSize(width: 1180, height: 760)
+        .commands {
+            CommandGroup(replacing: .newItem) {
+                Button("New Conversation") {
+                    Task { await appModel.startNewConversation() }
+                }
+                .keyboardShortcut("n", modifiers: [.command])
+                .disabled(!appModel.isAuthenticated)
+            }
+        }
+    }
+}

--- a/apps/mac-app/Hyperlocalise/HyperlocaliseApp.swift
+++ b/apps/mac-app/Hyperlocalise/HyperlocaliseApp.swift
@@ -3,6 +3,7 @@ import SwiftUI
 @main
 struct HyperlocaliseApp: App {
     @State private var appModel = AppModel()
+    private let sparkleUpdater = SparkleUpdater.makeForCurrentBundle()
 
     var body: some Scene {
         WindowGroup {
@@ -13,6 +14,9 @@ struct HyperlocaliseApp: App {
         .windowStyle(.automatic)
         .defaultSize(width: 1180, height: 760)
         .commands {
+            CommandGroup(after: .appInfo) {
+                CheckForUpdatesView(updater: sparkleUpdater.updater)
+            }
             CommandGroup(replacing: .newItem) {
                 Button("New Conversation") {
                     Task { await appModel.startNewConversation() }

--- a/apps/mac-app/Hyperlocalise/Info.plist
+++ b/apps/mac-app/Hyperlocalise/Info.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Hyperlocalise</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Hyperlocalise</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.hyperlocalise.mac.auth</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>hyperlocalise</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>HYPERLOCALISE_API_BASE_URL</key>
+	<string>$(HYPERLOCALISE_API_BASE_URL)</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.developer-tools</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/apps/mac-app/Hyperlocalise/Info.plist
+++ b/apps/mac-app/Hyperlocalise/Info.plist
@@ -44,5 +44,13 @@
 	</dict>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUEnableInstallerLauncherService</key>
+	<true/>
+	<key>SUFeedURL</key>
+	<string>$(SU_FEED_URL)</string>
+	<key>SUPublicEDKey</key>
+	<string>$(SU_PUBLIC_ED_KEY)</string>
 </dict>
 </plist>

--- a/apps/mac-app/Hyperlocalise/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/apps/mac-app/Hyperlocalise/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.290",
+          "green" : "0.420",
+          "red" : "0.090"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apps/mac-app/Hyperlocalise/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/apps/mac-app/Hyperlocalise/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apps/mac-app/Hyperlocalise/Resources/Assets.xcassets/Contents.json
+++ b/apps/mac-app/Hyperlocalise/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apps/mac-app/HyperlocaliseTests/ChatStreamParserTests.swift
+++ b/apps/mac-app/HyperlocaliseTests/ChatStreamParserTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import Hyperlocalise
+
+final class ChatStreamParserTests: XCTestCase {
+    func testAppliesTextDeltaChunks() {
+        var text = ""
+        XCTAssertTrue(
+            ChatStreamParser.apply(
+                eventJSON: #"{"type":"text-delta","delta":"Hello"}"#,
+                to: &text
+            )
+        )
+        XCTAssertTrue(
+            ChatStreamParser.apply(
+                eventJSON: #"{"type":"text-delta","delta":" world"}"#,
+                to: &text
+            )
+        )
+        XCTAssertEqual(text, "Hello world")
+    }
+
+    func testExtractsAssistantSnapshotParts() {
+        let payload = """
+        {"role":"assistant","parts":[{"type":"text","text":"Found the CTA copy."}]}
+        """
+        XCTAssertEqual(
+            ChatStreamParser.extractAssistantText(from: payload),
+            "Found the CTA copy."
+        )
+    }
+}

--- a/apps/mac-app/HyperlocaliseTests/PKCETests.swift
+++ b/apps/mac-app/HyperlocaliseTests/PKCETests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import Hyperlocalise
+
+final class PKCETests: XCTestCase {
+    func testGeneratePairUsesURLSafeCharactersAndChallenge() {
+        let pair = PKCE.generatePair()
+
+        XCTAssertGreaterThanOrEqual(pair.verifier.count, 43)
+        XCTAssertLessThanOrEqual(pair.verifier.count, 128)
+        XCTAssertFalse(pair.verifier.contains("+"))
+        XCTAssertFalse(pair.verifier.contains("/"))
+        XCTAssertFalse(pair.verifier.contains("="))
+        XCTAssertFalse(pair.challenge.isEmpty)
+        XCTAssertNotEqual(pair.verifier, pair.challenge)
+    }
+
+    func testRedirectURIMatchesServerAllowlistDefault() {
+        XCTAssertEqual(PKCE.redirectURI, "hyperlocalise://auth/callback")
+    }
+}

--- a/apps/mac-app/LICENSE
+++ b/apps/mac-app/LICENSE
@@ -1,0 +1,95 @@
+Business Source License 1.1
+
+License text copyright © 2026 hyperlocalise, All Rights Reserved.
+"Business Source License" is a trademark of hyperlocalise.
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
+
+hyperlocalise hereby grants you permission to use this License's text to license
+your works, and to refer to it using the trademark "Business Source License",
+as long as you comply with the Covenants of Licensor below.
+
+Covenants of Licensor
+
+In consideration of the right to use this License's text and the "Business
+Source License" name and trademark, Licensor covenants to hyperlocalise, and to all
+other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where "compatible" means that software provided under the Change License can
+   be included in a program with software provided under GPL Version 2.0 or a
+   later version. Licensor may specify additional Change Licenses without
+   limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.
+
+Additional Use Grant
+
+None
+
+Change License
+
+GNU General Public License Version 2.0 or any later version
+
+Change Date
+
+April 21, 2030
+
+Notice
+
+The Business Source License (this document, or the "License") is not an Open Source
+license. However, the Licensed Work will eventually be made available under an
+Open Source License, as stated in this License.
+
+For more information on commercial licensing, please contact:
+https://hyperlocalise.com/contact
+
+The full License text is available at:
+https://github.com/hyperlocalise/hyperlocalise/blob/main/apps/mac-app/LICENSE

--- a/apps/mac-app/README.md
+++ b/apps/mac-app/README.md
@@ -11,6 +11,7 @@ Licensed under the Business Source License 1.1 — see [LICENSE](./LICENSE).
 - Sealed session stored in Keychain (`wos-session`, same channel as the web app)
 - Organization context bootstrap
 - Conversation list, create, reply, and AI SDK UIMessage streaming
+- Sparkle 2 in-app updates (**Hyperlocalise → Check for Updates…**)
 
 ## Requirements
 
@@ -62,17 +63,23 @@ Do not commit `Hyperlocalise.xcodeproj` or DerivedData; regenerate with
 | Debug (local) | `http://localhost:3000` |
 | Release | `https://hyperlocalise.com` |
 
+| Sparkle key | Default |
+|-------------|---------|
+| `SU_FEED_URL` | `https://updates.hyperlocalise.com/mac/appcast.xml` |
+| `SU_PUBLIC_ED_KEY` | `REPLACE_WITH_SPARKLE_PUBLIC_ED_KEY` until keys are generated |
+
 Override in the Xcode scheme environment if you point at a preview deployment.
 
 ## Architecture
 
 ```
 Hyperlocalise/
-  App/          # SwiftUI shell, app model
+  App/          # SwiftUI shell, app model, Sparkle updater
   Auth/         # PKCE, ASWebAuthenticationSession, Keychain
   API/          # HTTP client, conversation + chat stream parsers
   Chat/         # Chat UI + view model
   Design/       # Colors, typography tokens
+Updates/        # Example appcast for Sparkle releases
 ```
 
 Auth bridge (server):
@@ -88,47 +95,84 @@ Chat APIs (existing org routes, cookie session):
 
 Design notes: [`docs/plans/2026-07-18-mac-app-mvp-design.md`](../../docs/plans/2026-07-18-mac-app-mvp-design.md).
 
-## Delivery and auto-update
+## Delivery and auto-update (Sparkle)
 
-The intended distribution path is **outside the Mac App Store**: a Developer
-ID–signed, notarized DMG (or ZIP) from GitHub Releases or
-`https://hyperlocalise.com`, with in-app updates via
-[Sparkle](https://sparkle-project.org/).
+Distribution is **outside the Mac App Store**: Developer ID–signed, notarized
+DMG/ZIP, with in-app updates via [Sparkle 2](https://sparkle-project.org/).
+
+The app already embeds Sparkle (`project.yml` SPM dependency) and exposes
+**Hyperlocalise → Check for Updates…** through `SPUStandardUpdaterController`.
+Sandbox support uses `SUEnableInstallerLauncherService` plus the
+`mach-lookup` temporary exceptions in `Hyperlocalise.entitlements`.
+
+Until `SU_PUBLIC_ED_KEY` is a real EdDSA public key, the updater does **not**
+start automatic checks (see `SparkleUpdater.makeForCurrentBundle()`), so local
+Debug builds stay quiet.
+
+### One-time key setup
+
+On a Mac, download a Sparkle release that includes `bin/generate_keys`, then:
+
+```bash
+cd apps/mac-app
+GENERATE_KEYS=/path/to/Sparkle/bin/generate_keys ./Scripts/generate-sparkle-keys.sh
+```
+
+1. Paste the **public** key into `SU_PUBLIC_ED_KEY` in `Config/Debug.xcconfig`
+   and `Config/Release.xcconfig` (or Release-only if you prefer).
+2. Store the **private** key in CI secrets. Never commit
+   `apps/mac-app/.sparkle-keys/`.
+3. Keep `SU_FEED_URL` pointed at the hosted appcast (default
+   `https://updates.hyperlocalise.com/mac/appcast.xml`).
 
 ### How users get the app
 
 1. Download a notarized `Hyperlocalise.app` archive (DMG/ZIP).
 2. Open it under Gatekeeper (Developer ID + notarization).
-3. Optional later: Homebrew Cask (`brew install --cask …`) for engineer installs.
+3. Optional later: Homebrew Cask for engineer installs.
 
-Mac App Store is a separate path (Apple-hosted updates, sandbox/review tradeoffs)
-and is not the MVP delivery plan.
+### Release an update
 
-### How “Check for Updates” works (Sparkle)
+1. Bump `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` in `project.yml`.
+2. Archive, sign with **Developer ID Application**, notarize, and upload the
+   DMG/ZIP (GitHub Releases or `https://hyperlocalise.com`).
+3. Sign the archive with Sparkle:
 
-1. CI archives the app, signs with **Developer ID Application**, notarizes, and
-   uploads the DMG/ZIP to a release.
-2. CI publishes an **appcast** (XML) at a stable URL, for example
-   `https://updates.hyperlocalise.com/mac/appcast.xml`, with version, download
-   URL, and an **EdDSA signature** of the archive.
-3. The app embeds Sparkle. On launch or when the user chooses **Check for
-   Updates…**, Sparkle fetches the appcast, compares
-   `CFBundleShortVersionString` / build number, downloads the new archive,
-   verifies the EdDSA signature, replaces the app bundle, and relaunches.
+```bash
+/path/to/Sparkle/bin/sign_update Hyperlocalise-0.2.0.dmg
+```
 
-Trust model: Apple code signature + notarization for first install; Sparkle
-EdDSA so a tampered appcast cannot ship a fake binary.
+4. Publish `appcast.xml` from `Updates/appcast.example.xml`: set
+   `sparkle:version`, `sparkle:shortVersionString`, `enclosure url`,
+   `length`, and `sparkle:edSignature` from `sign_update`.
+5. Host the appcast at `SU_FEED_URL`.
+
+Users choose **Check for Updates…**, or Sparkle checks in the background
+(about once per day when configured). Sparkle compares versions, downloads the
+archive, verifies the EdDSA signature, replaces the app, and relaunches.
 
 ### What release automation needs
 
 - Apple Developer Program (Developer ID Application certificate)
 - Notarization credentials (App Store Connect API key)
-- Sparkle EdDSA keypair (private key in CI secrets; public key embedded in the app)
-- Stable appcast URL that stays fixed across versions
-- A Mac CI runner for `xcodebuild archive` → notarize → upload → sign appcast
+- Sparkle EdDSA keypair (private in CI; public in `SU_PUBLIC_ED_KEY`)
+- Stable appcast URL
+- A Mac CI runner for `xcodebuild archive` → notarize → upload → `sign_update`
 
-Sparkle is not wired into the MVP sources yet; add it when the first public
-binary ships.
+### Testing updates locally
+
+1. Set a real `SU_PUBLIC_ED_KEY` and point `SU_FEED_URL` at a local or staging
+   appcast (HTTPS, or temporarily allow the host under ATS if needed).
+2. Install an older build, then serve a newer signed build via the appcast.
+3. Clear the last check time if needed:
+
+```bash
+defaults delete com.hyperlocalise.mac SULastCheckTime
+```
+
+4. Run **Check for Updates…**. If Xcode cannot attach to Sparkle XPC services,
+   disable **Debug XPC services used by app** in the scheme, or test a
+   notarized build outside the debugger.
 
 ## Tests
 

--- a/apps/mac-app/README.md
+++ b/apps/mac-app/README.md
@@ -1,0 +1,77 @@
+# Hyperlocalise Mac App
+
+Native macOS client for Hyperlocalise. Sign in with WorkOS AuthKit, then chat
+with the agent to find repository context and run localization work.
+
+Licensed under the Business Source License 1.1 — see [LICENSE](./LICENSE).
+
+## MVP features
+
+- WorkOS AuthKit login via `ASWebAuthenticationSession` + PKCE
+- Sealed session stored in Keychain (`wos-session`, same channel as the web app)
+- Organization context bootstrap
+- Conversation list, create, reply, and AI SDK UIMessage streaming
+
+## Requirements
+
+- macOS 14+
+- Xcode 16+
+- [XcodeGen](https://github.com/yonaskolb/XcodeGen) (`brew install xcodegen`)
+- A Hyperlocalise web deployment with WorkOS configured
+- WorkOS redirect URI registered: `hyperlocalise://auth/callback`
+
+## Setup
+
+```bash
+cd apps/mac-app
+./Scripts/generate-project.sh
+open Hyperlocalise.xcodeproj
+```
+
+In Xcode scheme environment variables (or `Config/Debug.xcconfig`):
+
+```
+HYPERLOCALISE_API_BASE_URL = https://app.hyperlocalise.com
+```
+
+For local API development:
+
+```
+HYPERLOCALISE_API_BASE_URL = http://localhost:3000
+```
+
+Optional loopback redirects for debugging can be allowlisted on the server with
+`WORKOS_NATIVE_REDIRECT_URIS`.
+
+## Architecture
+
+```
+Hyperlocalise/
+  App/          # SwiftUI shell, app model
+  Auth/         # PKCE, ASWebAuthenticationSession, Keychain
+  API/          # HTTP client, conversation + chat stream parsers
+  Chat/         # Chat UI + view model
+  Design/       # Colors, typography tokens
+```
+
+Auth bridge (server):
+
+- `GET  /api/auth/native/authorize`
+- `POST /api/auth/native/token`
+
+Chat APIs (existing org routes, cookie session):
+
+- `GET  /api/auth/context`
+- `GET|POST /api/orgs/{slug}/conversations…`
+- `POST /api/orgs/{slug}/conversations/{id}/chat`
+
+Design notes: [`docs/plans/2026-07-18-mac-app-mvp-design.md`](../../docs/plans/2026-07-18-mac-app-mvp-design.md).
+
+## Tests
+
+```bash
+xcodebuild test -scheme Hyperlocalise -destination 'platform=macOS'
+```
+
+Linux CI does not build this target (requires Xcode). Server-side native auth
+tests live under `apps/hyperlocalise-web`.

--- a/apps/mac-app/README.md
+++ b/apps/mac-app/README.md
@@ -20,7 +20,11 @@ Licensed under the Business Source License 1.1 — see [LICENSE](./LICENSE).
 - A Hyperlocalise web deployment with WorkOS configured
 - WorkOS redirect URI registered: `hyperlocalise://auth/callback`
 
-## Setup
+## Development workflow
+
+1. Run the web API locally (see [`apps/hyperlocalise-web/AGENTS.md`](../hyperlocalise-web/AGENTS.md)) so auth and chat routes are available at `http://localhost:3000`.
+2. In the WorkOS dashboard, add the native redirect URI `hyperlocalise://auth/callback`.
+3. Generate and open the Xcode project:
 
 ```bash
 cd apps/mac-app
@@ -28,20 +32,37 @@ cd apps/mac-app
 open Hyperlocalise.xcodeproj
 ```
 
-In Xcode scheme environment variables (or `Config/Debug.xcconfig`):
-
-```
-HYPERLOCALISE_API_BASE_URL = https://app.hyperlocalise.com
-```
-
-For local API development:
+4. Confirm Debug uses the local API (default in `Config/Debug.xcconfig`):
 
 ```
 HYPERLOCALISE_API_BASE_URL = http://localhost:3000
 ```
 
+5. Build and run the **Hyperlocalise** scheme from Xcode (`⌘R`).
+6. Sign in with WorkOS, pick an organization, and send a chat message.
+7. After changing Swift sources or `project.yml`, regenerate if needed and re-run tests:
+
+```bash
+./Scripts/generate-project.sh
+xcodebuild test -scheme Hyperlocalise -destination 'platform=macOS'
+```
+
+Server-side native auth changes live under `apps/hyperlocalise-web` (`/api/auth/native/*`). Validate those with `vp test` and `vp check --fix` in that app.
+
 Optional loopback redirects for debugging can be allowlisted on the server with
 `WORKOS_NATIVE_REDIRECT_URIS`.
+
+Do not commit `Hyperlocalise.xcodeproj` or DerivedData; regenerate with
+`./Scripts/generate-project.sh`.
+
+## Configuration
+
+| Build | `HYPERLOCALISE_API_BASE_URL` |
+|-------|------------------------------|
+| Debug (local) | `http://localhost:3000` |
+| Release | `https://hyperlocalise.com` |
+
+Override in the Xcode scheme environment if you point at a preview deployment.
 
 ## Architecture
 
@@ -66,6 +87,48 @@ Chat APIs (existing org routes, cookie session):
 - `POST /api/orgs/{slug}/conversations/{id}/chat`
 
 Design notes: [`docs/plans/2026-07-18-mac-app-mvp-design.md`](../../docs/plans/2026-07-18-mac-app-mvp-design.md).
+
+## Delivery and auto-update
+
+The intended distribution path is **outside the Mac App Store**: a Developer
+ID–signed, notarized DMG (or ZIP) from GitHub Releases or
+`https://hyperlocalise.com`, with in-app updates via
+[Sparkle](https://sparkle-project.org/).
+
+### How users get the app
+
+1. Download a notarized `Hyperlocalise.app` archive (DMG/ZIP).
+2. Open it under Gatekeeper (Developer ID + notarization).
+3. Optional later: Homebrew Cask (`brew install --cask …`) for engineer installs.
+
+Mac App Store is a separate path (Apple-hosted updates, sandbox/review tradeoffs)
+and is not the MVP delivery plan.
+
+### How “Check for Updates” works (Sparkle)
+
+1. CI archives the app, signs with **Developer ID Application**, notarizes, and
+   uploads the DMG/ZIP to a release.
+2. CI publishes an **appcast** (XML) at a stable URL, for example
+   `https://updates.hyperlocalise.com/mac/appcast.xml`, with version, download
+   URL, and an **EdDSA signature** of the archive.
+3. The app embeds Sparkle. On launch or when the user chooses **Check for
+   Updates…**, Sparkle fetches the appcast, compares
+   `CFBundleShortVersionString` / build number, downloads the new archive,
+   verifies the EdDSA signature, replaces the app bundle, and relaunches.
+
+Trust model: Apple code signature + notarization for first install; Sparkle
+EdDSA so a tampered appcast cannot ship a fake binary.
+
+### What release automation needs
+
+- Apple Developer Program (Developer ID Application certificate)
+- Notarization credentials (App Store Connect API key)
+- Sparkle EdDSA keypair (private key in CI secrets; public key embedded in the app)
+- Stable appcast URL that stays fixed across versions
+- A Mac CI runner for `xcodebuild archive` → notarize → upload → sign appcast
+
+Sparkle is not wired into the MVP sources yet; add it when the first public
+binary ships.
 
 ## Tests
 

--- a/apps/mac-app/Scripts/generate-project.sh
+++ b/apps/mac-app/Scripts/generate-project.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if ! command -v xcodegen >/dev/null 2>&1; then
+  echo "xcodegen is required. Install with: brew install xcodegen" >&2
+  exit 1
+fi
+
+xcodegen generate --spec project.yml
+echo "Generated Hyperlocalise.xcodeproj"

--- a/apps/mac-app/Scripts/generate-sparkle-keys.sh
+++ b/apps/mac-app/Scripts/generate-sparkle-keys.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Generate a Sparkle EdDSA keypair for signing update archives.
+# Requires macOS and a Sparkle release that includes generate_keys.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT_DIR="${SPARKLE_KEYS_DIR:-$ROOT/.sparkle-keys}"
+mkdir -p "$OUT_DIR"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "Sparkle key generation requires macOS (generate_keys is a Mac binary)." >&2
+  exit 1
+fi
+
+GENERATE_KEYS="${GENERATE_KEYS:-}"
+if [[ -z "$GENERATE_KEYS" ]]; then
+  if command -v generate_keys >/dev/null 2>&1; then
+    GENERATE_KEYS="$(command -v generate_keys)"
+  else
+    echo "Set GENERATE_KEYS to Sparkle's generate_keys binary, e.g.:" >&2
+    echo "  GENERATE_KEYS=/path/to/Sparkle-2.x/bin/generate_keys $0" >&2
+    echo "Download Sparkle from https://github.com/sparkle-project/Sparkle/releases" >&2
+    exit 1
+  fi
+fi
+
+cd "$OUT_DIR"
+"$GENERATE_KEYS"
+
+echo
+echo "Keys written under $OUT_DIR (do not commit the private key)."
+echo "1. Copy the public key into Config/Debug.xcconfig and Config/Release.xcconfig as SU_PUBLIC_ED_KEY."
+echo "2. Store the private key in CI secrets for sign_update."
+echo "3. Keep SU_FEED_URL pointed at your hosted appcast."

--- a/apps/mac-app/Updates/README.md
+++ b/apps/mac-app/Updates/README.md
@@ -1,0 +1,7 @@
+# Sparkle appcast assets
+
+Host a real `appcast.xml` (based on `appcast.example.xml`) at the URL in
+`SU_FEED_URL` (`https://updates.hyperlocalise.com/mac/appcast.xml` by default).
+
+Do not commit private Sparkle keys. Sign each DMG/ZIP with `sign_update` and
+paste the EdDSA signature into the `sparkle:edSignature` attribute.

--- a/apps/mac-app/Updates/appcast.example.xml
+++ b/apps/mac-app/Updates/appcast.example.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Hyperlocalise Mac</title>
+    <link>https://updates.hyperlocalise.com/mac/appcast.xml</link>
+    <description>Hyperlocalise macOS app updates</description>
+    <language>en</language>
+    <item>
+      <title>Version 0.1.0</title>
+      <pubDate>Sat, 18 Jul 2026 00:00:00 +0000</pubDate>
+      <sparkle:version>1</sparkle:version>
+      <sparkle:shortVersionString>0.1.0</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://github.com/hyperlocalise/hyperlocalise/releases/download/mac-app-v0.1.0/Hyperlocalise-0.1.0.dmg"
+        sparkle:edSignature="REPLACE_WITH_sign_update_OUTPUT"
+        length="0"
+        type="application/octet-stream" />
+    </item>
+  </channel>
+</rss>

--- a/apps/mac-app/project.yml
+++ b/apps/mac-app/project.yml
@@ -5,6 +5,10 @@ options:
     macOS: "14.0"
   createIntermediateGroups: true
   groupSortPosition: top
+packages:
+  Sparkle:
+    url: https://github.com/sparkle-project/Sparkle
+    from: "2.7.0"
 settings:
   base:
     SWIFT_VERSION: "5.10"
@@ -23,6 +27,9 @@ targets:
     platform: macOS
     sources:
       - path: Hyperlocalise
+    dependencies:
+      - package: Sparkle
+        product: Sparkle
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.hyperlocalise.mac
@@ -56,6 +63,8 @@ targets:
               - hyperlocalise
         NSAppTransportSecurity:
           NSAllowsLocalNetworking: true
+        SUEnableAutomaticChecks: true
+        SUEnableInstallerLauncherService: true
     entitlements:
       path: Hyperlocalise/Hyperlocalise.entitlements
   HyperlocaliseTests:

--- a/apps/mac-app/project.yml
+++ b/apps/mac-app/project.yml
@@ -1,0 +1,82 @@
+name: Hyperlocalise
+options:
+  bundleIdPrefix: com.hyperlocalise
+  deploymentTarget:
+    macOS: "14.0"
+  createIntermediateGroups: true
+  groupSortPosition: top
+settings:
+  base:
+    SWIFT_VERSION: "5.10"
+    MACOSX_DEPLOYMENT_TARGET: "14.0"
+    ENABLE_USER_SCRIPT_SANDBOXING: true
+    STRING_CATALOG_GENERATE_SYMBOLS: true
+configs:
+  Debug: debug
+  Release: release
+configFiles:
+  Debug: Config/Debug.xcconfig
+  Release: Config/Release.xcconfig
+targets:
+  Hyperlocalise:
+    type: application
+    platform: macOS
+    sources:
+      - path: Hyperlocalise
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.hyperlocalise.mac
+        PRODUCT_NAME: Hyperlocalise
+        INFOPLIST_FILE: Hyperlocalise/Info.plist
+        CODE_SIGN_ENTITLEMENTS: Hyperlocalise/Hyperlocalise.entitlements
+        COMBINE_HIDPI_IMAGES: true
+        CURRENT_PROJECT_VERSION: 1
+        MARKETING_VERSION: 0.1.0
+        GENERATE_INFOPLIST_FILE: false
+        LD_RUNPATH_SEARCH_PATHS:
+          - "$(inherited)"
+          - "@executable_path/../Frameworks"
+        ENABLE_HARDENED_RUNTIME: true
+        SWIFT_STRICT_CONCURRENCY: complete
+        ENABLE_TESTABILITY: YES
+    info:
+      path: Hyperlocalise/Info.plist
+      properties:
+        CFBundleName: Hyperlocalise
+        CFBundleDisplayName: Hyperlocalise
+        CFBundleIdentifier: com.hyperlocalise.mac
+        CFBundleShortVersionString: "0.1.0"
+        CFBundleVersion: "1"
+        LSMinimumSystemVersion: "14.0"
+        LSApplicationCategoryType: public.app-category.developer-tools
+        NSPrincipalClass: NSApplication
+        CFBundleURLTypes:
+          - CFBundleURLName: com.hyperlocalise.mac.auth
+            CFBundleURLSchemes:
+              - hyperlocalise
+        NSAppTransportSecurity:
+          NSAllowsLocalNetworking: true
+    entitlements:
+      path: Hyperlocalise/Hyperlocalise.entitlements
+  HyperlocaliseTests:
+    type: bundle.unit-test
+    platform: macOS
+    sources:
+      - path: HyperlocaliseTests
+    dependencies:
+      - target: Hyperlocalise
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.hyperlocalise.mac.tests
+        GENERATE_INFOPLIST_FILE: true
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Hyperlocalise.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Hyperlocalise"
+        BUNDLE_LOADER: "$(TEST_HOST)"
+schemes:
+  Hyperlocalise:
+    build:
+      targets:
+        Hyperlocalise: all
+        HyperlocaliseTests: [test]
+    test:
+      targets:
+        - HyperlocaliseTests

--- a/docs/plans/2026-07-18-mac-app-mvp-design.md
+++ b/docs/plans/2026-07-18-mac-app-mvp-design.md
@@ -1,0 +1,98 @@
+# Mac app MVP design
+
+## Goal
+
+Ship a native macOS client under `apps/mac-app` (BSL 1.1) that lets a signed-in
+user chat with the Hyperlocalise agent to find context and do localization work.
+
+## Approaches considered
+
+1. **Electron / Tauri shell around the web chat dock** — fastest UI reuse, weak
+   native fit, larger runtime, still needs a native-friendly auth story.
+2. **SwiftUI client + new Bearer token channel (`hlmac_`)** — clean native API,
+   but invents a second org-auth channel beside WorkOS cookies and Crowdin
+   embed tokens.
+3. **SwiftUI client + WorkOS AuthKit PKCE → sealed `wos-session` (chosen)** —
+   Mac opens AuthKit via `ASWebAuthenticationSession`, exchanges the code
+   through a thin API bridge, stores the same sealed session the web app uses,
+   and calls existing conversation APIs with `Cookie: wos-session=…`.
+
+Option 3 keeps AUTH_INVARIANTS intact (WorkOS session remains the primary org
+API channel) and reuses chat, membership reconcile, and streaming unchanged.
+
+## Architecture
+
+```
+┌──────────────────────────── apps/mac-app ────────────────────────────┐
+│  SwiftUI                                                             │
+│  LoginView ──ASWebAuthenticationSession──► WorkOS AuthKit (PKCE)     │
+│       │                                                              │
+│       ▼                                                              │
+│  AuthService ──POST /api/auth/native/token──► sealedSession          │
+│       │                                      (Keychain)              │
+│       ▼                                                              │
+│  APIClient (Cookie: wos-session)                                     │
+│       ├── GET  /api/auth/context                                     │
+│       ├── GET/POST /api/orgs/{slug}/conversations[…]                 │
+│       └── POST /api/orgs/{slug}/conversations/{id}/chat (SSE)        │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Native auth bridge (`hyperlocalise-web`)
+
+| Route | Auth | Purpose |
+|-------|------|---------|
+| `GET /api/auth/native/authorize` | public | Build AuthKit authorize URL for a client PKCE challenge + allowlisted redirect |
+| `POST /api/auth/native/token` | public | Exchange `code` + `code_verifier` for sealed session + user profile |
+| `POST /api/auth/native/logout` | session cookie | Best-effort revoke / clear guidance |
+
+Redirect allowlist (MVP):
+
+- `hyperlocalise://auth/callback` (production custom URL scheme)
+- optional env override `WORKOS_NATIVE_REDIRECT_URIS` (comma-separated)
+
+The bridge calls `workos.userManagement.authenticateWithCode` with
+`session: { sealSession: true, cookiePassword }` so the Mac receives the same
+sealed payload AuthKit would write into the browser cookie.
+
+### Chat client
+
+Mirror the web chat dock pipeline:
+
+1. Bootstrap orgs via `GET /api/auth/context`.
+2. Create conversation: `POST …/conversations` (multipart `text`).
+3. Reply: `POST …/conversations/{id}/messages`.
+4. Stream: `POST …/conversations/{id}/chat` with AI SDK UIMessage JSON whose
+   last user message id matches the persisted row.
+5. Parse SSE for text parts; show tool/status lines when present.
+
+Optional `repositoryFullName` on create enables find-context / repo sandbox,
+matching the web dock.
+
+## Mac app layout
+
+- **Login**: brand + short promise + Sign in with WorkOS.
+- **Shell**: sidebar (org picker, conversation list, sign out) + chat column
+  (transcript + composer).
+- **MVP out of scope**: attachments UI, full tool-card parity, CAT workspace,
+  billing, inbox triage.
+
+## Licensing
+
+`apps/mac-app/LICENSE` uses Business Source License 1.1 with the same Change
+Date / Additional Use Grant as `apps/hyperlocalise-web` and `apps/canva-app`.
+Root `LICENSE` notice updated to list the Mac app.
+
+## Testing
+
+- Web: unit tests for authorize allowlist + token exchange happy/error paths.
+- Mac: XCTest for PKCE generation and UIMessage stream text extraction.
+- Full Xcode build requires macOS; Linux CI validates web bridge tests and
+  source layout.
+
+## Risks
+
+- WorkOS dashboard must register the custom scheme redirect URI.
+- Sealed sessions follow AuthKit cookie lifetime/refresh rules; Mac must treat
+  401 as sign-out and re-auth.
+- AI SDK stream schema may evolve; keep a thin parser that extracts text first.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds a BSL-licensed native macOS app at `apps/mac-app` and the server bridge it needs for MVP auth + chat:

- **SwiftUI Mac client** — WorkOS AuthKit sign-in via `ASWebAuthenticationSession` + PKCE, Keychain-backed sealed session, org picker, conversation list, composer, and AI SDK UIMessage stream parsing
- **Native auth bridge** — `GET /api/auth/native/authorize` and `POST /api/auth/native/token` exchange AuthKit codes for the same sealed `wos-session` the web app uses (no parallel Bearer identity channel)
- **Sparkle 2** — SPM dependency, **Check for Updates…** menu, sandboxed installer entitlements, example appcast, key-generation script; updater stays idle until `SU_PUBLIC_ED_KEY` is set
- **README** — development workflow, Sparkle key/release instructions; Release API base is `https://hyperlocalise.com`
- Design notes in `docs/plans/2026-07-18-mac-app-mvp-design.md`

Review follow-ups: native-auth tests go through `createApp()`, OAuth `state` is validated on callback, SSE multi-line `data:` joins use `\n`, token `code` is capped at 512 chars, `ASWebAuthenticationSession` is retained until the callback fires, and the composer draft is cleared only after create/send succeeds.

## How to test

**Server (Linux/CI):**
```bash
cd apps/hyperlocalise-web
vp test src/api/routes/auth/native-auth.route.test.ts src/lib/workos/native-redirect.test.ts
vp check --fix src/api/routes/auth/native-auth.route.ts src/api/routes/auth/native-auth.schema.ts src/lib/workos/native-redirect.ts src/lib/env.ts src/api/app.ts
```

**Mac (requires Xcode + xcodegen):**
1. Register WorkOS redirect URI `hyperlocalise://auth/callback`
2. `cd apps/mac-app && ./Scripts/generate-project.sh && open Hyperlocalise.xcodeproj`
3. Debug defaults to `http://localhost:3000`; Release uses `https://hyperlocalise.com`
4. Sign in, create a chat, confirm streaming reply
5. For updates: run `./Scripts/generate-sparkle-keys.sh`, set `SU_PUBLIC_ED_KEY`, host an appcast, then use **Hyperlocalise → Check for Updates…**

## Checklist

- [x] I ran relevant checks locally (`vp test` + `vp check --fix` for the web bridge)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Note: Full `xcodebuild` verification needs macOS; this environment is Linux-only for the Mac target.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72e3-cd9d-7821-9181-ede7bbbbeed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72e3-cd9d-7821-9181-ede7bbbbeed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

