### PR TITLE
fix(web): right-align end chat dock messages

### DIFF
--- a/apps/hyperlocalise-web/src/components/ui/message.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/message.tsx
@@ -16,7 +16,7 @@ export function Message({
       data-align={align}
       data-slot="message"
       className={cn(
-        "group/message relative flex w-full min-w-0 gap-2 text-sm data-[align=end]:flex-row-reverse",
+        "group/message relative flex w-full min-w-0 gap-2 text-sm data-[align=end]:ms-auto data-[align=end]:flex-row-reverse",
         className,
       )}
       {...props}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

User messages in the chat dock (and inbox) looked left-anchored with a blank gap on the right. They already used `align="end"` and `max-w-[85%]`, but the shared `Message` row never got `ms-auto`, so the capped-width block stayed on the leading edge.

Added `data-[align=end]:ms-auto` to the `Message` UI primitive so end-aligned messages sit on the trailing edge, matching the marketing chat mock and `ai-elements` layout.

## How to test

- Open the chat dock and send a short user message
- Confirm the user bubble sits on the right (with avatar), not left with a blank gap
- Confirm assistant messages remain full-width / left-aligned
- Spot-check the inbox conversation view for the same alignment
- `vp check --fix` and related message tests passed

## Checklist
- [x] I ran relevant checks locally (`vp check --fix`, `vp test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a9828ee-147c-4bc4-a7cb-c33313168501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a9828ee-147c-4bc4-a7cb-c33313168501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

