### PR TITLE
fix(agent): route visual context to mock and support nested Storybook

### DIFF
--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/conversation.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/conversation.md
@@ -21,8 +21,8 @@ Use the capability skills and tools available for this turn. Match the user's re
 
 - **"Recent translations" / "what's new" / "what changed last week" (list only)** → use **repo-tools** and `gitHistory`. Return a scannable changelog of **currently present** added/updated source keys/strings (ignore deletions unless asked). Do **not** treat this as a TMS progress question.
 - **"Recent translations" + context** ("last week… give me context", "new strings and what they mean", "context for everything that changed") → use **find-context**'s recent-change + context procedure: discover present keys with `gitHistory`, then run find-context for each discovered key/source string that still exists.
-- **Visual context / mock / screenshot** ("visual context for …", "show me the UI", "create a visual mock", "screenshot of this screen") → use **visual-mock** when it is enabled. Prefer a Storybook/`captureScreenshot` image over a text-only placement description. If visual-mock is not enabled for this workspace, say so briefly and fall back to **find-context**.
-- **Specific string or key context** ("what does X mean", "where is this copy used") → **find-context**. Prefer **visual-mock** instead when the user also asks for a screenshot, mock, or visual context image.
+- **Visual context / mock / screenshot** ("visual context for …", "show me the UI", "create a visual mock", "screenshot of this screen", or meaning/context plus any of those) → use **visual-mock** when it is enabled. Prefer a Storybook/`captureScreenshot` image over a text-only placement description. If visual-mock is not enabled for this workspace, say so briefly and fall back to **find-context**.
+- **Specific string or key context** ("what does X mean", "where is this copy used") → **find-context** for text-only context without an image request.
 - **Linked TMS completion/status** ("Crowdin progress", "how many strings left") → **tms-tools** only when a TMS is integrated. Do not pivot to TMS because repository source discovery was empty.
 
 When multiple capability skills are active, gather repository context before creating translation jobs when both apply.

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/conversation.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/conversation.md
@@ -21,7 +21,8 @@ Use the capability skills and tools available for this turn. Match the user's re
 
 - **"Recent translations" / "what's new" / "what changed last week" (list only)** → use **repo-tools** and `gitHistory`. Return a scannable changelog of **currently present** added/updated source keys/strings (ignore deletions unless asked). Do **not** treat this as a TMS progress question.
 - **"Recent translations" + context** ("last week… give me context", "new strings and what they mean", "context for everything that changed") → use **find-context**'s recent-change + context procedure: discover present keys with `gitHistory`, then run find-context for each discovered key/source string that still exists.
-- **Specific string or key context** ("what does X mean", "where is this copy used") → **find-context**.
+- **Visual context / mock / screenshot** ("visual context for …", "show me the UI", "create a visual mock", "screenshot of this screen") → use **visual-mock** when it is enabled. Prefer a Storybook/`captureScreenshot` image over a text-only placement description. If visual-mock is not enabled for this workspace, say so briefly and fall back to **find-context**.
+- **Specific string or key context** ("what does X mean", "where is this copy used") → **find-context**. Prefer **visual-mock** instead when the user also asks for a screenshot, mock, or visual context image.
 - **Linked TMS completion/status** ("Crowdin progress", "how many strings left") → **tms-tools** only when a TMS is integrated. Do not pivot to TMS because repository source discovery was empty.
 
 When multiple capability skills are active, gather repository context before creating translation jobs when both apply.

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/find-context.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/find-context.md
@@ -7,6 +7,8 @@ requiresSandbox: true
 
 This skill applies when the user or product asks for translation context for source text, messages, localization keys, UI labels, or uploaded-file segments — either for one string/key or for every recently changed source entry in a time window.
 
+Do **not** use this skill as the primary path when the user asks for visual context, a UI screenshot, or a visual mock. Those requests belong to `visual-mock` when that skill is enabled. Use this skill only as a text fallback if visual-mock is unavailable, or when the user explicitly wants textual placement guidance without an image.
+
 Use the `repo-tools` skill to search and inspect the repository. This skill adds the localization-specific search priorities and final answer contract.
 
 In multi-turn conversations, treat the latest user message as the active lookup target. Previous source strings, keys, and labels are history only; do not include them in the answer unless the latest user message explicitly asks to compare, include both, revisit a previous string, or explain a relationship between strings.

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/visual-mock.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/visual-mock.md
@@ -7,9 +7,9 @@ tools: grep,fuzzySearch,read,glob,todoWrite,write,applyPatch,captureScreenshot,f
 
 ## Visual mock
 
-Use this skill when the user asks the Hyperlocalise agent to create or reason from a mock UI screenshot, mocked visual context, generated UI state, wireframe, or screenshot-like preview for a connected repository.
+Use this skill when the user asks for visual context, a mock UI screenshot, mocked visual context, generated UI state, wireframe, or screenshot-like preview for a connected repository — including phrasing like "visual context for …", "show me the UI for …", or "screenshot of …".
 
-This is an agent workflow skill, not a screenshot product tool. Compose lower-level repository, coding, browser, and storage primitives when they are available.
+This is an agent workflow skill, not a screenshot product tool. Compose lower-level repository, coding, browser, and storage primitives when they are available. Do not answer visual-context requests with find-context's text-only "Where/how it shows" contract when this skill and `captureScreenshot` are available.
 
 ## Workflow
 
@@ -19,7 +19,7 @@ This is an agent workflow skill, not a screenshot product tool. Compose lower-le
 - When coding write primitives such as `write` or `apply_patch` are available, use them only for temporary preview scaffolding or narrowly scoped mock fixtures unless the user also asks for a production code change.
 - Do not commit changes, push branches, open pull requests, or publish repository changes. Visual mocks may mutate only the sandbox workspace.
 - When a browser or screenshot primitive is available, render the preview and capture an image. Record the viewport, route or preview file, and any assumptions.
-- Use `captureScreenshot` for Storybook stories. Provide the Storybook story id and viewport; do not ask for package-manager-specific commands.
+- Use `captureScreenshot` for Storybook stories. Provide the Storybook story id and viewport; do not ask for package-manager-specific commands. The tool discovers Storybook in the repo root or nested app packages.
 - When durable file attachment primitives are available, attach the screenshot as an agent artifact with metadata identifying it as `visual-mock`.
 - If write, render, screenshot, or attachment primitives are unavailable, do not claim a screenshot was created. Return a concise mock plan with the target component, data state, viewport, and exact next primitive needed.
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
@@ -178,6 +178,10 @@ describe("conversation skill registry", () => {
 
     expect(conversationSkill).toContain("Visual context / mock / screenshot");
     expect(conversationSkill).toContain("use **visual-mock** when it is enabled");
+    expect(conversationSkill).toContain("for text-only context without an image request");
+    expect(conversationSkill).not.toContain(
+      "Prefer **visual-mock** instead when the user also asks",
+    );
     expect(visualMockSkill).toContain("visual context for …");
     expect(visualMockSkill).toContain("Do not answer visual-context requests with find-context");
   });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
@@ -176,12 +176,10 @@ describe("conversation skill registry", () => {
       skillId: "visual-mock",
     });
 
-    expect(conversationSkill.body).toContain("Visual context / mock / screenshot");
-    expect(conversationSkill.body).toContain("use **visual-mock** when it is enabled");
-    expect(visualMockSkill.body).toContain("visual context for …");
-    expect(visualMockSkill.body).toContain(
-      "Do not answer visual-context requests with find-context",
-    );
+    expect(conversationSkill).toContain("Visual context / mock / screenshot");
+    expect(conversationSkill).toContain("use **visual-mock** when it is enabled");
+    expect(visualMockSkill).toContain("visual context for …");
+    expect(visualMockSkill).toContain("Do not answer visual-context requests with find-context");
   });
 
   it("activates visual-mock when a sandbox is available and the flag is enabled", () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vite-plus/test";
 
-import { clearAgentManifestCache } from "@/agents/_runtime/loader";
+import { clearAgentManifestCache, loadAgentSkill } from "@/agents/_runtime/loader";
 import {
   buildConversationSkillPlan,
   filterAvailableConversationToolNames,
@@ -164,6 +164,24 @@ describe("conversation skill registry", () => {
         }),
       ),
     ).toBe(true);
+  });
+
+  it("routes visual context requests to visual-mock in conversation skill instructions", () => {
+    const conversationSkill = loadAgentSkill({
+      agentId: "hyperlocalise",
+      skillId: "conversation",
+    });
+    const visualMockSkill = loadAgentSkill({
+      agentId: "hyperlocalise",
+      skillId: "visual-mock",
+    });
+
+    expect(conversationSkill.body).toContain("Visual context / mock / screenshot");
+    expect(conversationSkill.body).toContain("use **visual-mock** when it is enabled");
+    expect(visualMockSkill.body).toContain("visual context for …");
+    expect(visualMockSkill.body).toContain(
+      "Do not answer visual-context requests with find-context",
+    );
   });
 
   it("activates visual-mock when a sandbox is available and the flag is enabled", () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/find-context-instructions.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/find-context-instructions.test.ts
@@ -36,4 +36,11 @@ describe("buildFindContextSkillInstructions", () => {
     expect(instructions).toContain("one find-context section block per discovered entry");
     expect(instructions).toContain('mode: "changedFiles"');
   });
+
+  it("defers visual context and screenshot requests to visual-mock", () => {
+    const instructions = buildFindContextSkillInstructions({});
+
+    expect(instructions).toContain("visual context");
+    expect(instructions).toContain("visual-mock");
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
@@ -8,6 +8,8 @@ import {
   createCaptureScreenshotTool,
   detectPackageManager,
   detectStorybookScreenshotCommand,
+  parsePackageJsonCandidatePaths,
+  resolveStorybookPackage,
 } from "./capture-screenshot";
 import type { RepoToolContext } from "./types";
 
@@ -34,21 +36,38 @@ function createToolContext(overrides: Partial<ToolContext> = {}): ToolContext {
 }
 
 function createRepoContext(input: {
-  packageJson: Record<string, unknown>;
+  packageJsonByPath?: Record<string, Record<string, unknown>>;
+  packageJson?: Record<string, unknown>;
   lockfiles?: readonly string[];
+  findStdout?: string;
   execResult?: { exitCode: number; stdout: string; stderr: string };
 }) {
+  const packageJsonByPath = {
+    ...(input.packageJson ? { "package.json": input.packageJson } : {}),
+    ...(input.packageJsonByPath ?? {}),
+  };
   const lockfiles = new Set(input.lockfiles ?? []);
   const writtenFiles = new Map<string, string | Buffer>();
-  const exec = vi.fn(async () => ({
-    exitCode: input.execResult?.exitCode ?? 0,
-    stdout: input.execResult?.stdout ?? Buffer.from("png-bytes").toString("base64"),
-    stderr: input.execResult?.stderr ?? "",
-    env: {},
-  }));
+  const exec = vi.fn(async (command: string) => {
+    if (command === "find") {
+      return {
+        exitCode: 0,
+        stdout: input.findStdout ?? Object.keys(packageJsonByPath).join("\n"),
+        stderr: "",
+        env: {},
+      };
+    }
+
+    return {
+      exitCode: input.execResult?.exitCode ?? 0,
+      stdout: input.execResult?.stdout ?? Buffer.from("png-bytes").toString("base64"),
+      stderr: input.execResult?.stderr ?? "",
+      env: {},
+    };
+  });
   const readFile = vi.fn(async (path: string) => {
-    if (path === "package.json") {
-      return JSON.stringify(input.packageJson);
+    if (path in packageJsonByPath) {
+      return JSON.stringify(packageJsonByPath[path]);
     }
     if (lockfiles.has(path)) {
       return "";
@@ -79,8 +98,14 @@ describe("detectPackageManager", () => {
     ).toBe("pnpm");
   });
 
-  it("falls back to lockfiles", () => {
+  it("falls back to lockfiles, including nested lockfile paths", () => {
     expect(detectPackageManager({ packageJson: {}, lockfiles: ["yarn.lock"] })).toBe("yarn");
+    expect(
+      detectPackageManager({
+        packageJson: {},
+        lockfiles: ["apps/hyperlocalise-web/pnpm-lock.yaml"],
+      }),
+    ).toBe("pnpm");
   });
 });
 
@@ -93,12 +118,14 @@ describe("detectStorybookScreenshotCommand", () => {
           scripts: { storybook: "storybook dev" },
         },
         port: 6123,
+        packageDir: "apps/web",
       }),
     ).toMatchObject({
       packageManager: "pnpm",
       scriptName: "storybook",
       command: "pnpm",
       args: ["run", "storybook", "--", "--port", "6123", "--host", "127.0.0.1", "--ci"],
+      packageDir: "apps/web",
     });
   });
 
@@ -106,6 +133,66 @@ describe("detectStorybookScreenshotCommand", () => {
     expect(detectStorybookScreenshotCommand({ packageJson: { scripts: { dev: "vite" } } })).toEqual(
       { errorCode: "storybook_script_not_found" },
     );
+  });
+});
+
+describe("parsePackageJsonCandidatePaths", () => {
+  it("normalizes and prefers shallower package manifests", () => {
+    expect(
+      parsePackageJsonCandidatePaths(`
+./apps/hyperlocalise-web/package.json
+./package.json
+./docs/package.json
+`),
+    ).toEqual(["package.json", "docs/package.json", "apps/hyperlocalise-web/package.json"]);
+  });
+});
+
+describe("resolveStorybookPackage", () => {
+  it("uses a nested package when the repository root has no package.json", async () => {
+    const { repo } = createRepoContext({
+      packageJsonByPath: {
+        "apps/hyperlocalise-web/package.json": {
+          packageManager: "pnpm@11.12.0",
+          scripts: { storybook: "storybook dev -p 6006" },
+        },
+      },
+      lockfiles: ["apps/hyperlocalise-web/pnpm-lock.yaml"],
+      findStdout: "apps/hyperlocalise-web/package.json\n",
+    });
+
+    await expect(resolveStorybookPackage(repo)).resolves.toMatchObject({
+      packageDir: "apps/hyperlocalise-web",
+      packageJsonPath: "apps/hyperlocalise-web/package.json",
+      lockfiles: ["apps/hyperlocalise-web/pnpm-lock.yaml"],
+    });
+  });
+
+  it("skips nested packages without Storybook scripts", async () => {
+    const { repo } = createRepoContext({
+      packageJsonByPath: {
+        "docs/package.json": { scripts: { build: "vitepress build" } },
+        "apps/hyperlocalise-web/package.json": {
+          scripts: { storybook: "storybook dev" },
+        },
+      },
+      findStdout: "docs/package.json\napps/hyperlocalise-web/package.json\n",
+    });
+
+    await expect(resolveStorybookPackage(repo)).resolves.toMatchObject({
+      packageDir: "apps/hyperlocalise-web",
+      packageJsonPath: "apps/hyperlocalise-web/package.json",
+    });
+  });
+
+  it("returns package_json_unavailable when no manifests exist", async () => {
+    const { repo } = createRepoContext({
+      findStdout: "",
+    });
+
+    await expect(resolveStorybookPackage(repo)).resolves.toMatchObject({
+      errorCode: "package_json_unavailable",
+    });
   });
 });
 
@@ -203,6 +290,70 @@ describe("createCaptureScreenshotTool", () => {
           kind: "visual-mock",
           targetType: "storybook",
           storyId: "components-button--primary",
+          packageDir: ".",
+          packageJsonPath: "package.json",
+        }),
+      }),
+    );
+  });
+
+  it("captures from a nested Storybook package when root package.json is missing", async () => {
+    vi.mocked(createStoredFile).mockResolvedValueOnce({
+      id: "file_nested",
+      organizationId: "org_1",
+      projectId: "project_1",
+      createdByUserId: "user_1",
+      role: "reference",
+      sourceKind: "repository_file",
+      sourceInteractionId: "conv_1",
+      sourceJobId: null,
+      storageProvider: "vercel_blob",
+      storageKey: "organizations/org_1/files/file_nested/storybook.png",
+      storageUrl: "https://blob.example/storybook-nested.png",
+      downloadUrl: "https://download.example/storybook-nested.png",
+      filename: "storybook-app-project-overview-page--default.png",
+      contentType: "image/png",
+      byteSize: 9,
+      sha256: "hash",
+      etag: null,
+      metadata: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const { exec, repo } = createRepoContext({
+      packageJsonByPath: {
+        "apps/hyperlocalise-web/package.json": {
+          packageManager: "pnpm@11.12.0",
+          scripts: { storybook: "storybook dev -p 6006" },
+        },
+      },
+      lockfiles: ["apps/hyperlocalise-web/pnpm-lock.yaml"],
+      findStdout: "apps/hyperlocalise-web/package.json\n",
+    });
+    const captureScreenshot = createCaptureScreenshotTool(createToolContext(), repo);
+
+    const result = await captureScreenshot.execute!(
+      { target: { type: "storybook", storyId: "app-project-overview-page--default" } },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      fileId: "file_nested",
+    });
+    expect(exec).toHaveBeenCalledWith("bash", {
+      args: [
+        "-lc",
+        expect.stringContaining(
+          "(cd 'apps/hyperlocalise-web' && 'pnpm' 'run' 'storybook' '--' '--port' '6006' '--host' '127.0.0.1' '--ci')",
+        ),
+      ],
+    });
+    expect(createStoredFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          packageDir: "apps/hyperlocalise-web",
+          packageJsonPath: "apps/hyperlocalise-web/package.json",
         }),
       }),
     );

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
@@ -42,9 +42,9 @@ function createRepoContext(input: {
   findStdout?: string;
   execResult?: { exitCode: number; stdout: string; stderr: string };
 }) {
-  const packageJsonByPath = {
+  const packageJsonByPath: Record<string, Record<string, unknown>> = {
     ...(input.packageJson ? { "package.json": input.packageJson } : {}),
-    ...(input.packageJsonByPath ?? {}),
+    ...input.packageJsonByPath,
   };
   const lockfiles = new Set(input.lockfiles ?? []);
   const writtenFiles = new Map<string, string | Buffer>();

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -464,22 +464,17 @@ It does not commit, push, open pull requests, or publish repository changes.`,
         };
       }
 
-      const storybookCommand = detectStorybookScreenshotCommand({
+      const detectedCommand = detectStorybookScreenshotCommand({
         packageJson: resolvedPackage.packageJson,
         lockfiles: resolvedPackage.lockfiles,
         port: STORYBOOK_PORT,
         packageDir: resolvedPackage.packageDir,
       });
-
-      if ("errorCode" in storybookCommand) {
-        return {
-          success: false as const,
-          errorCode: storybookCommand.errorCode,
-          error:
-            "No supported Storybook script was found in package.json at the repository root or nested packages.",
-          checkedFiles: [resolvedPackage.packageJsonPath, ...resolvedPackage.lockfiles],
-        };
+      // Invariant: resolveStorybookPackage only returns packages with a Storybook script.
+      if ("errorCode" in detectedCommand) {
+        throw new Error("Invariant violated: Storybook script missing after package resolution");
       }
+      const storybookCommand = detectedCommand;
 
       const captureId = crypto.randomUUID();
       const baseDir = normalizeWorkspacePath(`.hyperlocalise-agent/screenshots/${captureId}`);

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -48,7 +48,31 @@ export type StorybookScreenshotCommand = {
   scriptName: string;
   command: string;
   args: string[];
+  /** Workspace-relative directory that contains the Storybook package.json. Empty string = repo root. */
+  packageDir: string;
 };
+
+export type StorybookPackageResolution =
+  | {
+      packageDir: string;
+      packageJsonPath: string;
+      packageJson: PackageJson;
+      lockfiles: string[];
+    }
+  | {
+      errorCode: "package_json_unavailable" | "storybook_script_not_found";
+      error: string;
+      checkedFiles: string[];
+    };
+
+const STORYBOOK_SCRIPT_NAMES = new Set(["storybook", "dev:storybook", "storybook:dev"]);
+const LOCKFILE_NAMES = [
+  "pnpm-lock.yaml",
+  "yarn.lock",
+  "bun.lockb",
+  "bun.lock",
+  "package-lock.json",
+] as const;
 
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -77,6 +101,15 @@ function packageManagerFromPackageJson(packageJson: PackageJson): PackageManager
   return null;
 }
 
+function lockfileBasenames(lockfiles: readonly string[] | undefined): Set<string> {
+  return new Set(
+    (lockfiles ?? []).map((lockfile) => {
+      const segments = lockfile.replace(/\\/g, "/").split("/");
+      return segments[segments.length - 1] ?? lockfile;
+    }),
+  );
+}
+
 export function detectPackageManager(input: {
   packageJson: PackageJson;
   lockfiles?: readonly string[];
@@ -86,7 +119,7 @@ export function detectPackageManager(input: {
     return declared;
   }
 
-  const lockfiles = new Set(input.lockfiles ?? []);
+  const lockfiles = lockfileBasenames(input.lockfiles);
   if (lockfiles.has("pnpm-lock.yaml")) {
     return "pnpm";
   }
@@ -117,16 +150,18 @@ function buildRunArgs(packageManager: PackageManager, scriptName: string, port: 
   }
 }
 
+export function hasStorybookScript(packageJson: PackageJson): string | null {
+  const scripts = asRecord(packageJson.scripts);
+  return Object.keys(scripts).find((name) => STORYBOOK_SCRIPT_NAMES.has(name)) ?? null;
+}
+
 export function detectStorybookScreenshotCommand(input: {
   packageJson: PackageJson;
   lockfiles?: readonly string[];
   port?: number;
+  packageDir?: string;
 }): StorybookScreenshotCommand | { errorCode: "storybook_script_not_found" } {
-  const scripts = asRecord(input.packageJson.scripts);
-  const scriptName = Object.keys(scripts).find(
-    (name) => name === "storybook" || name === "dev:storybook" || name === "storybook:dev",
-  );
-
+  const scriptName = hasStorybookScript(input.packageJson);
   if (!scriptName) {
     return { errorCode: "storybook_script_not_found" };
   }
@@ -137,28 +172,163 @@ export function detectStorybookScreenshotCommand(input: {
     scriptName,
     command: packageManager,
     args: buildRunArgs(packageManager, scriptName, input.port ?? STORYBOOK_PORT),
+    packageDir: input.packageDir ?? "",
   };
 }
 
-async function readPackageJson(repo: RepoToolContext) {
-  const raw = await repo.bash.readFile("package.json");
+function sortPackageJsonCandidates(paths: readonly string[]) {
+  return [...paths].sort((left, right) => {
+    const leftDepth = left === "package.json" ? 0 : left.split("/").length;
+    const rightDepth = right === "package.json" ? 0 : right.split("/").length;
+    if (leftDepth !== rightDepth) {
+      return leftDepth - rightDepth;
+    }
+    return left.localeCompare(right);
+  });
+}
+
+export function parsePackageJsonCandidatePaths(stdout: string): string[] {
+  const candidates = stdout
+    .split("\n")
+    .map((line) => line.trim().replace(/^\.\//, ""))
+    .filter((line) => line.endsWith("package.json"))
+    .map((line) => normalizeWorkspacePath(line))
+    .filter((line): line is string => Boolean(line));
+
+  return sortPackageJsonCandidates([...new Set(candidates)]);
+}
+
+async function readPackageJsonAt(repo: RepoToolContext, packageJsonPath: string) {
+  const raw = await repo.bash.readFile(packageJsonPath);
   return JSON.parse(raw) as PackageJson;
 }
 
-async function detectLockfiles(repo: RepoToolContext) {
-  const lockfiles = ["pnpm-lock.yaml", "yarn.lock", "bun.lockb", "bun.lock", "package-lock.json"];
-  const existing: string[] = [];
+async function fileExists(repo: RepoToolContext, path: string) {
+  try {
+    await repo.bash.readFile(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
-  for (const lockfile of lockfiles) {
-    try {
-      await repo.bash.readFile(lockfile);
-      existing.push(lockfile);
-    } catch {
-      // Missing lockfiles are expected in generic repositories.
+async function detectLockfiles(repo: RepoToolContext, packageDir: string) {
+  const dirsToSearch = new Set<string>();
+  dirsToSearch.add(packageDir);
+
+  if (packageDir) {
+    const segments = packageDir.split("/");
+    for (let index = segments.length - 1; index >= 0; index -= 1) {
+      dirsToSearch.add(segments.slice(0, index).join("/"));
+    }
+  }
+
+  const existing: string[] = [];
+  for (const dir of dirsToSearch) {
+    for (const lockfile of LOCKFILE_NAMES) {
+      const path = dir ? `${dir}/${lockfile}` : lockfile;
+      if (await fileExists(repo, path)) {
+        existing.push(path);
+      }
     }
   }
 
   return existing;
+}
+
+async function listPackageJsonCandidates(repo: RepoToolContext): Promise<string[]> {
+  const result = await repo.bash.exec("find", {
+    args: [
+      ".",
+      "-name",
+      "package.json",
+      "-not",
+      "-path",
+      "*/node_modules/*",
+      "-not",
+      "-path",
+      "*/.git/*",
+      "-not",
+      "-path",
+      "*/.hyperlocalise-agent/*",
+      "-not",
+      "-path",
+      "*/dist/*",
+      "-not",
+      "-path",
+      "*/build/*",
+      "-not",
+      "-path",
+      "*/.next/*",
+      "-not",
+      "-path",
+      "*/coverage/*",
+    ],
+  });
+
+  if (result.exitCode !== 0) {
+    return [];
+  }
+
+  return parsePackageJsonCandidatePaths(result.stdout);
+}
+
+export async function resolveStorybookPackage(
+  repo: RepoToolContext,
+): Promise<StorybookPackageResolution> {
+  const checkedFiles: string[] = [];
+  const candidatePaths = new Set<string>(["package.json"]);
+
+  for (const path of await listPackageJsonCandidates(repo)) {
+    candidatePaths.add(path);
+  }
+
+  const orderedCandidates = sortPackageJsonCandidates([...candidatePaths]);
+  let sawAnyPackageJson = false;
+
+  for (const packageJsonPath of orderedCandidates) {
+    checkedFiles.push(packageJsonPath);
+    let packageJson: PackageJson;
+    try {
+      packageJson = await readPackageJsonAt(repo, packageJsonPath);
+      sawAnyPackageJson = true;
+    } catch {
+      continue;
+    }
+
+    if (!hasStorybookScript(packageJson)) {
+      continue;
+    }
+
+    const packageDir =
+      packageJsonPath === "package.json"
+        ? ""
+        : packageJsonPath.slice(0, -"/package.json".length);
+    const lockfiles = await detectLockfiles(repo, packageDir);
+
+    return {
+      packageDir,
+      packageJsonPath,
+      packageJson,
+      lockfiles,
+    };
+  }
+
+  if (!sawAnyPackageJson) {
+    return {
+      errorCode: "package_json_unavailable",
+      error:
+        "No package.json was found at the repository root or in nested application packages.",
+      checkedFiles,
+    };
+  }
+
+  return {
+    errorCode: "storybook_script_not_found",
+    error:
+      "No supported Storybook script (storybook, dev:storybook, or storybook:dev) was found in package.json.",
+    checkedFiles,
+  };
 }
 
 function shellQuote(value: string) {
@@ -236,11 +406,15 @@ function buildCaptureCommand(input: {
   const storybookCommand = [input.storybookCommand.command, ...input.storybookCommand.args]
     .map(shellQuote)
     .join(" ");
+  const packageDir = input.storybookCommand.packageDir;
+  const storybookLaunch = packageDir
+    ? `(cd ${shellQuote(packageDir)} && ${storybookCommand})`
+    : storybookCommand;
 
   return [
     "set -euo pipefail",
     managedBrowserRuntimeCommand(),
-    `${storybookCommand} >/tmp/hyperlocalise-storybook.log 2>&1 &`,
+    `${storybookLaunch} >/tmp/hyperlocalise-storybook.log 2>&1 &`,
     "SERVER_PID=$!",
     'cleanup() { kill "$SERVER_PID" >/dev/null 2>&1 || true; }',
     "trap cleanup EXIT",
@@ -262,7 +436,7 @@ export function createCaptureScreenshotTool(ctx: ToolContext, repo: RepoToolCont
 Currently supported target:
 - Storybook stories by story id
 
-The tool detects the repository package manager and Storybook script, uses a Hyperlocalise-managed Playwright/Chromium runtime in the sandbox, captures a PNG, and stores it as a Hyperlocalise file artifact.
+The tool finds package.json at the repository root or in nested app packages, detects the package manager and Storybook script, runs Storybook from that package directory, uses a Hyperlocalise-managed Playwright/Chromium runtime in the sandbox, captures a PNG, and stores it as a Hyperlocalise file artifact.
 
 It does not commit, push, open pull requests, or publish repository changes.`,
     inputSchema: captureScreenshotInputSchema,
@@ -283,30 +457,30 @@ It does not commit, push, open pull requests, or publish repository changes.`,
         };
       }
 
-      let packageJson: PackageJson;
-      try {
-        packageJson = await readPackageJson(repo);
-      } catch (error) {
+      const resolvedPackage = await resolveStorybookPackage(repo);
+      if ("errorCode" in resolvedPackage) {
         return {
           success: false as const,
-          errorCode: "package_json_unavailable" as const,
-          error: redact(error instanceof Error ? error.message : String(error)),
+          errorCode: resolvedPackage.errorCode,
+          error: resolvedPackage.error,
+          checkedFiles: resolvedPackage.checkedFiles,
         };
       }
 
-      const lockfiles = await detectLockfiles(repo);
       const storybookCommand = detectStorybookScreenshotCommand({
-        packageJson,
-        lockfiles,
+        packageJson: resolvedPackage.packageJson,
+        lockfiles: resolvedPackage.lockfiles,
         port: STORYBOOK_PORT,
+        packageDir: resolvedPackage.packageDir,
       });
 
       if ("errorCode" in storybookCommand) {
         return {
           success: false as const,
           errorCode: storybookCommand.errorCode,
-          error: "No supported Storybook script was found in package.json.",
-          checkedFiles: ["package.json", ...lockfiles],
+          error:
+            "No supported Storybook script was found in package.json at the repository root or nested packages.",
+          checkedFiles: [resolvedPackage.packageJsonPath, ...resolvedPackage.lockfiles],
         };
       }
 
@@ -383,6 +557,8 @@ It does not commit, push, open pull requests, or publish repository changes.`,
           waitForMs,
           packageManager: storybookCommand.packageManager,
           scriptName: storybookCommand.scriptName,
+          packageDir: storybookCommand.packageDir || ".",
+          packageJsonPath: resolvedPackage.packageJsonPath,
         },
         db: ctx.db,
       });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -301,9 +301,7 @@ export async function resolveStorybookPackage(
     }
 
     const packageDir =
-      packageJsonPath === "package.json"
-        ? ""
-        : packageJsonPath.slice(0, -"/package.json".length);
+      packageJsonPath === "package.json" ? "" : packageJsonPath.slice(0, -"/package.json".length);
     const lockfiles = await detectLockfiles(repo, packageDir);
 
     return {
@@ -317,8 +315,7 @@ export async function resolveStorybookPackage(
   if (!sawAnyPackageJson) {
     return {
       errorCode: "package_json_unavailable",
-      error:
-        "No package.json was found at the repository root or in nested application packages.",
+      error: "No package.json was found at the repository root or in nested application packages.",
       checkedFiles,
     };
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Asking for “visual context” was routed to text-only **find-context**, so the agent never used **visual-mock** / `captureScreenshot` unless the user asked explicitly for a mock. Separately, `captureScreenshot` only read the repo-root `package.json`, so monorepos like this one (Storybook under `apps/hyperlocalise-web/`) failed before Storybook could start.

This PR:
- Routes visual context / screenshot / mock requests (including meaning + UI) to **visual-mock** when enabled; **find-context** stays text-only without an image request
- Discovers Storybook `package.json` in nested app packages, detects nested lockfiles, and runs Storybook from that package directory
- After review: removed the unreachable `storybook_script_not_found` return path in favor of an invariant assertion

## How to test

- `vp test src/lib/agent-runtime`
- `vp check --fix`
- With `workspace-visual-mock` enabled, ask the agent for “visual context for …” on a string that has a Storybook story in a nested package and confirm it calls `captureScreenshot` instead of returning only text placement guidance

## Checklist

- [x] I ran relevant checks locally (`vp test src/lib/agent-runtime`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e0f1a91-3a8c-4213-8a0a-126aa9a71b81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e0f1a91-3a8c-4213-8a0a-126aa9a71b81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

