### PR TITLE
fix(translation): clarify prompts so descriptions are not used as values

### DIFF
--- a/apps/cli/internal/i18n/runsvc/retry.go
+++ b/apps/cli/internal/i18n/runsvc/retry.go
@@ -150,7 +150,7 @@ func buildTranslationRuntimeContext(entryKey, sourceContext, sharedMemory string
 		parts = append(parts, "Entry key: "+key)
 	}
 	if sanitizedContext := sanitizePromptContext(sourceContext, maxSourceContextLen); sanitizedContext != "" {
-		parts = append(parts, "Source context:\n"+sanitizedContext)
+		parts = append(parts, "String description (guidance only; do not translate or use as the translation):\n"+sanitizedContext)
 	}
 	if memory := strings.TrimSpace(sharedMemory); memory != "" {
 		parts = append(parts, "Shared memory:\n"+memory)

--- a/apps/cli/internal/i18n/runsvc/retry_test.go
+++ b/apps/cli/internal/i18n/runsvc/retry_test.go
@@ -88,7 +88,7 @@ func TestTranslateWithRetryBuildsRequestWithSourceContext(t *testing.T) {
 		t.Fatalf("translateWithRetry returned error: %v", err)
 	}
 
-	wantRuntime := "Entry key: checkout.title\n\nSource context:\nCheckout submit button"
+	wantRuntime := "Entry key: checkout.title\n\nString description (guidance only; do not translate or use as the translation):\nCheckout submit button"
 	if got.RuntimeContext != wantRuntime {
 		t.Fatalf("request runtime context = %q, want %q", got.RuntimeContext, wantRuntime)
 	}
@@ -115,7 +115,7 @@ func TestTranslateWithRetryBuildsRequestWithContextMemory(t *testing.T) {
 		t.Fatalf("translateWithRetry returned error: %v", err)
 	}
 
-	wantRuntime := "Entry key: checkout.title\n\nSource context:\nCheckout submit button\n\nShared memory:\nShared context"
+	wantRuntime := "Entry key: checkout.title\n\nString description (guidance only; do not translate or use as the translation):\nCheckout submit button\n\nShared memory:\nShared context"
 	if got.SystemPrompt != "" {
 		t.Fatalf("request system prompt = %q, want empty string", got.SystemPrompt)
 	}

--- a/apps/hyperlocalise-web/src/lib/translation/generation.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/generation.ts
@@ -114,22 +114,22 @@ export class TranslationPromptPolicy {
           ]
         : input.mode === "sandbox"
           ? [
-              "You are a translation assistant. Translate the user-provided source text into the requested target language.",
+              "You are a translation assistant. Translate only the user-provided source text into the requested target language.",
               "Preserve meaning, placeholders, variables, formatting, HTML/Markdown structure, and ICU message syntax.",
               "Do not translate programmatic identifiers inside placeholders or ICU selectors.",
-              "Follow project context, job context, and glossary rules as binding translation guidance.",
-              "If constraints conflict, preserve placeholders and markup first, then glossary rules, then project and job context.",
-              "Return only the translated text with no explanations, labels, markdown fences, or quotes unless the translated content itself requires them.",
+              "Project context, string description, and glossary rules are guidance only. Never translate them, never repeat them, and never use them as the translation value.",
+              "If constraints conflict, preserve placeholders and markup first, then glossary rules, then project context and string description.",
+              "Return only the translated source text with no explanations, labels, markdown fences, or quotes unless the translated content itself requires them.",
             ]
           : [
               "You are an expert software localization engine.",
-              "Translate the provided source text into every requested target locale.",
+              "Translate only the provided source text into every requested target locale.",
               "Preserve meaning, tone, placeholders, HTML, Markdown, punctuation, whitespace, and line breaks.",
-              "Follow the project translation context and job context as binding style and usage guidance.",
+              "Project translation context and string description are developer guidance for meaning and tone. Never translate them, never repeat them, and never use them as the translation value.",
               "Follow workspace knowledge memory when present.",
               "Use glossary terms exactly for their target locale. Do not use forbidden glossary terms.",
               "Use approved translation memory matches as consistency references when they apply.",
-              "If constraints conflict, prioritize placeholder and markup preservation first, then glossary rules, then project context, job context, workspace knowledge memory, then translation memory examples.",
+              "If constraints conflict, prioritize placeholder and markup preservation first, then glossary rules, then project context, string description, workspace knowledge memory, then translation memory examples.",
               "Do not explain your work.",
               "Return one translation for each requested locale.",
             ];
@@ -159,7 +159,7 @@ export class TranslationPromptPolicy {
       sections.push(
         input.projectName ? `Project: ${input.projectName}` : "",
         `Project translation context: ${input.projectTranslationContext?.trim() || "(none)"}`,
-        `Job context: ${input.jobContext?.trim() || "(none)"}`,
+        `String description (guidance only; do not translate or use as the translation): ${input.jobContext?.trim() || "(none)"}`,
         `Workspace knowledge memory: ${knowledgeMemory || "(none)"}`,
         input.userInstructions?.trim()
           ? `User style instructions: ${input.userInstructions.trim()}`

--- a/apps/hyperlocalise-web/src/lib/translation/generation.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/generation.ts
@@ -101,9 +101,9 @@ export class TranslationPromptPolicy {
       input.mode === "cat-suggest"
         ? [
             "You are an expert software localization assistant helping a human reviewer in a CAT tool.",
-            "Recommend the best target-locale translation for the provided source string.",
+            "Recommend the best target-locale translation for the provided source string only.",
             "Preserve meaning, tone, placeholders, HTML, Markdown, punctuation, whitespace, and line breaks.",
-            "Follow project translation context, file context, and repository context as binding style and usage guidance.",
+            "Project translation context, file context, and repository context are guidance only. Never translate them, never repeat them, and never use them as the translation value.",
             "Follow workspace knowledge memory when present.",
             "Use glossary terms exactly for the target locale. Do not use forbidden glossary terms.",
             "Use approved translation memory matches as consistency references when they apply.",
@@ -194,10 +194,14 @@ export class TranslationPromptPolicy {
 
     if (input.mode === "cat-suggest") {
       if (input.fileContext?.trim()) {
-        sections.push(`File context: ${input.fileContext.trim()}`);
+        sections.push(
+          `File context (guidance only; do not translate or use as the translation): ${input.fileContext.trim()}`,
+        );
       }
       if (input.repositoryContext?.trim()) {
-        sections.push(`Repository context: ${input.repositoryContext.trim()}`);
+        sections.push(
+          `Repository context (guidance only; do not translate or use as the translation): ${input.repositoryContext.trim()}`,
+        );
       }
     }
 

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
@@ -475,7 +475,12 @@ describe("sandbox translation temporary config", () => {
     expect(config).toContain("  file:");
     expect(config).toContain("Project: Marketing Site");
     expect(config).toContain("Project translation context: Use concise product-marketing copy.");
-    expect(config).toContain("Job context: Homepage launch banner.");
+    expect(config).toContain(
+      "String description (guidance only; do not translate or use as the translation): Homepage launch banner.",
+    );
+    expect(config).toContain(
+      "Never translate them, never repeat them, and never use them as the translation value.",
+    );
     expect(config).toContain("User style instructions: Keep it formal.");
     expect(config).toContain("workspace -> espace de travail (fr-FR)");
     expect(config).toContain("Approved product term.");

--- a/apps/hyperlocalise-web/src/lib/translation/string-job-executor.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/string-job-executor.test.ts
@@ -60,7 +60,7 @@ function createInput(overrides: Partial<StringTranslationGeneratorInput> = {}) {
 }
 
 describe("createStringTranslationGenerator", () => {
-  it("puts binding context and terminology in the system prompt", async () => {
+  it("puts string description guidance and terminology in the system prompt", async () => {
     const doGenerate = vi.fn(async () => ({
       content: [
         {

--- a/apps/hyperlocalise-web/src/lib/translation/string-job-executor.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/string-job-executor.test.ts
@@ -125,6 +125,12 @@ describe("createStringTranslationGenerator", () => {
     const systemMessage = generateOptions.prompt?.find((message) => message.role === "system");
     const systemContent = JSON.stringify(systemMessage?.content);
     expect(systemContent).toContain("Use concise product-marketing language.");
+    expect(systemContent).toContain(
+      "String description (guidance only; do not translate or use as the translation): Homepage hero title",
+    );
+    expect(systemContent).toContain(
+      "Never translate them, never repeat them, and never use them as the translation value.",
+    );
     expect(systemContent).toContain("workspace");
     expect(systemContent).toContain("espace de travail");
     expect(systemContent).toContain("Hello workspace");

--- a/internal/i18n/translator/prompts.go
+++ b/internal/i18n/translator/prompts.go
@@ -6,7 +6,7 @@ func buildSystemPrompt(req Request) string {
 	base := strings.TrimSpace(req.SystemPrompt)
 	if base == "" {
 		b := strings.Builder{}
-		b.WriteString("You are a translation assistant. Translate the user-provided source text into the requested target language. Preserve meaning, placeholders, variables, and formatting. Do not translate programmatic identifiers inside placeholders or ICU message syntax. Keep ICU keywords and selectors such as plural, select, selectordinal, zero, one, two, few, many, other, explicit selectors like =0, and # unchanged. Return only the translated text with no explanations, labels, markdown, or quotes unless the translated content itself requires them.")
+		b.WriteString("You are a translation assistant. Translate only the user-provided source text into the requested target language. Preserve meaning, placeholders, variables, and formatting. Do not translate programmatic identifiers inside placeholders or ICU message syntax. Keep ICU keywords and selectors such as plural, select, selectordinal, zero, one, two, few, many, other, explicit selectors like =0, and # unchanged. Runtime context such as entry keys, string descriptions, and shared memory is guidance only: never translate it, never repeat it, and never use it as the translation value. Return only the translated source text with no explanations, labels, markdown, or quotes unless the translated content itself requires them.")
 
 		target := strings.TrimSpace(req.TargetLanguage)
 		if target != "" {
@@ -26,7 +26,7 @@ func buildUserPrompt(req Request) string {
 	}
 
 	b := strings.Builder{}
-	b.WriteString("Translate the following source text into the requested target language. Preserve placeholders, variables, and formatting. Do not translate ICU keywords, selectors, or placeholder names.\n\n")
+	b.WriteString("Translate only the following source text into the requested target language. Preserve placeholders, variables, and formatting. Do not translate ICU keywords, selectors, or placeholder names. Do not use string descriptions or other runtime context as the translation.\n\n")
 	b.WriteString("Target language: ")
 	b.WriteString(strings.TrimSpace(req.TargetLanguage))
 	b.WriteString("\n")
@@ -43,7 +43,7 @@ func appendRuntimeContextToSystemPrompt(baseSystemPrompt, runtimeContext string)
 		return base
 	}
 
-	const header = "Runtime translation context (do not translate or repeat):"
+	const header = "Runtime translation context (guidance only; never translate, repeat, or use as the translation value):"
 	if base == "" {
 		return header + "\n" + contextBlock
 	}

--- a/internal/i18n/translator/prompts_test.go
+++ b/internal/i18n/translator/prompts_test.go
@@ -21,10 +21,10 @@ func TestBuildSystemPromptUsesDefaultPolicyWhenNoPromptProvided(t *testing.T) {
 	t.Parallel()
 
 	got := buildSystemPrompt(Request{TargetLanguage: "vi-VN"})
-	if !strings.Contains(got, "Return only the translated text") {
+	if !strings.Contains(got, "Return only the translated source text") {
 		t.Fatalf("expected default policy suffix, got %q", got)
 	}
-	if !strings.Contains(got, "Translate the user-provided source text") {
+	if !strings.Contains(got, "Translate only the user-provided source text") {
 		t.Fatalf("expected default translation instruction, got %q", got)
 	}
 	if !strings.Contains(got, "Do not translate programmatic identifiers inside placeholders or ICU message syntax") {
@@ -42,7 +42,7 @@ func TestBuildSystemPromptUsesDefaultPolicyWhenSystemPromptIsWhitespace(t *testi
 	t.Parallel()
 
 	got := buildSystemPrompt(Request{SystemPrompt: "   \n\t  "})
-	if !strings.Contains(got, "Return only the translated text") {
+	if !strings.Contains(got, "Return only the translated source text") {
 		t.Fatalf("expected default policy suffix for whitespace prompt, got %q", got)
 	}
 }
@@ -82,8 +82,11 @@ func TestBuildSystemPromptAppendsRuntimeContextWithDefaultPrompt(t *testing.T) {
 	if !strings.Contains(got, "Target language: fr") {
 		t.Fatalf("expected target language in default system prompt, got %q", got)
 	}
-	if !strings.Contains(got, "Runtime translation context (do not translate or repeat):\nEntry key: common.hello") {
+	if !strings.Contains(got, "Runtime translation context (guidance only; never translate, repeat, or use as the translation value):\nEntry key: common.hello") {
 		t.Fatalf("expected runtime context block in system prompt, got %q", got)
+	}
+	if !strings.Contains(got, "never use it as the translation value") {
+		t.Fatalf("expected default system prompt to forbid using runtime context as the translation, got %q", got)
 	}
 }
 
@@ -94,7 +97,7 @@ func TestBuildSystemPromptAppendsRuntimeContextWithCustomSystemPrompt(t *testing
 		SystemPrompt:   "custom system",
 		RuntimeContext: "Entry key: common.hello",
 	})
-	if !strings.HasPrefix(got, "custom system\n\nRuntime translation context (do not translate or repeat):") {
+	if !strings.HasPrefix(got, "custom system\n\nRuntime translation context (guidance only; never translate, repeat, or use as the translation value):") {
 		t.Fatalf("expected runtime context appended to custom system prompt, got %q", got)
 	}
 }

--- a/internal/i18n/translator/translator_test.go
+++ b/internal/i18n/translator/translator_test.go
@@ -320,7 +320,7 @@ func TestTranslateComposesPromptsBeforeProviderCall(t *testing.T) {
 	if got.SystemPrompt == "" || !strings.Contains(got.SystemPrompt, "Target language: fr") {
 		t.Fatalf("expected composed system prompt, got %q", got.SystemPrompt)
 	}
-	if !strings.Contains(got.SystemPrompt, "Runtime translation context (do not translate or repeat):\nEntry key: common.hello") {
+	if !strings.Contains(got.SystemPrompt, "Runtime translation context (guidance only; never translate, repeat, or use as the translation value):\nEntry key: common.hello") {
 		t.Fatalf("expected runtime context in provider system prompt, got %q", got.SystemPrompt)
 	}
 	if !strings.Contains(got.UserPrompt, "Source text:\nhello") {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After **Translate with agent**, we sometimes see string **description** text used as the translation value.

Descriptions (FormatJS `description`, Phrase/Lokalise key description, etc.) are injected into prompts as context. The wording made that easy to misread:

- Web string/sandbox prompts called them **Job context** and **binding** guidance
- CLI labeled them **Source context** next to the actual source text
- Neither path clearly said “do not use this as the translation”

When the source string is short (`OK`, `Save`) and the description is a longer sentence, models can return the description (or a translation of it) instead of the source.

## Fix

Tighten prompt wording in both paths:

1. **Web agent / sandbox / cat-suggest** (`generation.ts`): translate *only* the source text; treat project/file/repository/string description context as guidance that must never be translated, repeated, or used as the output
2. **CLI translator** (`prompts.go` + `retry.go`): same rule for runtime context / string descriptions

Also renamed the string-job executor test so it no longer refers to removed “binding” language.

## Tests

- Updated prompt assertion coverage in web + Go packages
- `go test ./internal/i18n/translator/ ./apps/cli/internal/i18n/runsvc/`
- `vp test` for the affected translation prompt tests
- `vp check --fix`

## Note

There is a separate structural issue where mixed/nested FormatJS catalogs can flatten `description` into parseable string entries via `hl entries`. This PR addresses the prompt confusion path; parser hardening can follow if needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7b0d06c-83e0-4aa0-b780-f3c9851896a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7b0d06c-83e0-4aa0-b780-f3c9851896a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

