### PR TITLE
fix(cat): show Approve for clean needs-review segments

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.test.tsx
@@ -101,8 +101,22 @@ describe("CatSideBySideRow", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("hides approve actions when the focused row is clean", () => {
+  it("shows approve actions when the focused row has a target and is clean", () => {
     renderRow({ isDirty: false });
+
+    expect(screen.getByRole("button", { name: /Approve/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Save as draft/i })).toBeInTheDocument();
+  });
+
+  it("hides approve actions when the focused row has no target text", () => {
+    const state = createCatWorkspaceState({ selectedSegmentId: "seg-02" });
+    const segment = {
+      ...state.segments!.find((item) => item.id === "seg-02")!,
+      status: "pending" as const,
+      targetText: "",
+    };
+
+    renderRow({ segment, isDirty: false });
 
     expect(screen.queryByRole("button", { name: /Approve/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Save as draft/i })).not.toBeInTheDocument();
@@ -160,16 +174,16 @@ describe("CatSideBySideRow", () => {
     expect(screen.queryByRole("button", { name: /Save as draft/i })).not.toBeInTheDocument();
   });
 
-  it("disables approve when the target is empty", () => {
+  it("hides approve when the target is empty even if the row is dirty", () => {
     const state = createCatWorkspaceState({ selectedSegmentId: "seg-02" });
     const segment = {
       ...state.segments!.find((item) => item.id === "seg-02")!,
       targetText: "",
     };
 
-    renderRow({ segment });
+    renderRow({ segment, isDirty: true });
 
-    expect(screen.getByRole("button", { name: /Approve/i })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: /Approve/i })).not.toBeInTheDocument();
   });
 
   it("shows copy source and clear for focused text rows", async () => {
@@ -408,7 +422,7 @@ describe("CatSideBySideRow", () => {
 
     renderRow({ isDirty: false, onAddToIssueSheet });
 
-    expect(screen.queryByRole("button", { name: /Approve/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Approve/i })).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /Add to issue sheet/i }));
     expect(onAddToIssueSheet).toHaveBeenCalledTimes(1);
   });
@@ -432,7 +446,7 @@ describe("CatSideBySideRow", () => {
     });
 
     expect(screen.getByText(/Upload/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Approve/i })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: /Approve/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Save as draft/i })).not.toBeInTheDocument();
   });
 

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.tsx
@@ -139,10 +139,8 @@ export function CatSideBySideRow({
     isImageBusy;
   // Show Approve whenever the focused row has a target to approve — including clean
   // "Needs review" drafts (AI/job-written) that the reviewer has not edited yet.
-  const canTriggerApprove =
-    Boolean(onApprove) && canEdit && hasApprovingTarget && !isActionBlocked;
-  const showReviewActions =
-    isFocused && canEdit && Boolean(onApprove) && hasApprovingTarget;
+  const canTriggerApprove = Boolean(onApprove) && canEdit && hasApprovingTarget && !isActionBlocked;
+  const showReviewActions = isFocused && canEdit && Boolean(onApprove) && hasApprovingTarget;
   const showIssueSheetAction =
     isFocused && canEdit && !isImageSegment && Boolean(onAddToIssueSheet);
   const canEditTarget = canEdit && !isImageBusy;

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.tsx
@@ -137,15 +137,12 @@ export function CatSideBySideRow({
     isFormatChecksLoading ||
     isTargetLoading ||
     isImageBusy;
-  // Image uploads update assets without a text dirty flag; show Approve whenever focused.
+  // Show Approve whenever the focused row has a target to approve — including clean
+  // "Needs review" drafts (AI/job-written) that the reviewer has not edited yet.
   const canTriggerApprove =
-    Boolean(onApprove) &&
-    canEdit &&
-    hasApprovingTarget &&
-    !isActionBlocked &&
-    (isImageSegment || isDirty);
+    Boolean(onApprove) && canEdit && hasApprovingTarget && !isActionBlocked;
   const showReviewActions =
-    isFocused && canEdit && Boolean(onApprove) && (isImageSegment || isDirty);
+    isFocused && canEdit && Boolean(onApprove) && hasApprovingTarget;
   const showIssueSheetAction =
     isFocused && canEdit && !isImageSegment && Boolean(onAddToIssueSheet);
   const canEditTarget = canEdit && !isImageBusy;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Side-by-side CAT rows only showed **Approve** when the segment was dirty (or an image). Clean “Needs review” drafts — including AI/job-written translations that already match the suggestion — had Use/Regenerate but no way to approve without editing first.

## Changes

- Show Approve (and Save as draft) whenever a focused, editable row has a target to approve, matching the detail editor panel.
- Hide Approve when there is no target text / image asset (instead of showing a disabled button).
- Update unit tests for the new visibility rules.

## How to test

- Focus a clean “Needs review” segment in side-by-side and confirm Approve appears
- Approve without editing and confirm status becomes Approved
- Confirm empty/untranslated focused rows still hide Approve
- Confirm ⌘/Ctrl+Enter still approves when a target is present

## Checklist

- [x] `vp check --fix`
- [x] `vp test` (2999 passed)
- [x] Updated unit tests for Approve visibility
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b3345a4-6762-4f46-8873-abc113a27318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b3345a4-6762-4f46-8873-abc113a27318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

