### PR TITLE
fix(agent): adapt Storybook screenshot CLI for pnpm and SB10

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
@@ -126,6 +126,11 @@ describe("parseDependencyMajorVersion", () => {
     expect(parseDependencyMajorVersion("latest")).toBeNull();
     expect(parseDependencyMajorVersion(undefined)).toBeNull();
   });
+
+  it("ignores digits that are not a semver major", () => {
+    expect(parseDependencyMajorVersion("file:../storybook-v10")).toBeNull();
+    expect(parseDependencyMajorVersion("catalog:storybook@10.0.0")).toBe(10);
+  });
 });
 
 describe("detectStorybookMajorVersion", () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
@@ -158,12 +158,12 @@ describe("shouldOmitPackageScriptArgSeparator", () => {
   });
 
   it("keeps the separator for older Storybook on pnpm and for npm", () => {
-    expect(
-      shouldOmitPackageScriptArgSeparator({ packageManager: "pnpm", storybookMajor: 8 }),
-    ).toBe(false);
-    expect(
-      shouldOmitPackageScriptArgSeparator({ packageManager: "npm", storybookMajor: 10 }),
-    ).toBe(false);
+    expect(shouldOmitPackageScriptArgSeparator({ packageManager: "pnpm", storybookMajor: 8 })).toBe(
+      false,
+    );
+    expect(shouldOmitPackageScriptArgSeparator({ packageManager: "npm", storybookMajor: 10 })).toBe(
+      false,
+    );
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
@@ -7,9 +7,12 @@ import {
   classifyScreenshotCaptureFailure,
   createCaptureScreenshotTool,
   detectPackageManager,
+  detectStorybookMajorVersion,
   detectStorybookScreenshotCommand,
+  parseDependencyMajorVersion,
   parsePackageJsonCandidatePaths,
   resolveStorybookPackage,
+  shouldOmitPackageScriptArgSeparator,
 } from "./capture-screenshot";
 import type { RepoToolContext } from "./types";
 
@@ -109,13 +112,69 @@ describe("detectPackageManager", () => {
   });
 });
 
+describe("parseDependencyMajorVersion", () => {
+  it("parses common semver ranges", () => {
+    expect(parseDependencyMajorVersion("10.4.6")).toBe(10);
+    expect(parseDependencyMajorVersion("^10.4.6")).toBe(10);
+    expect(parseDependencyMajorVersion("~8.0.0")).toBe(8);
+    expect(parseDependencyMajorVersion(">=9.1.0")).toBe(9);
+  });
+
+  it("returns null for unparseable versions", () => {
+    expect(parseDependencyMajorVersion("workspace:*")).toBeNull();
+    expect(parseDependencyMajorVersion("catalog:")).toBeNull();
+    expect(parseDependencyMajorVersion("latest")).toBeNull();
+    expect(parseDependencyMajorVersion(undefined)).toBeNull();
+  });
+});
+
+describe("detectStorybookMajorVersion", () => {
+  it("prefers the storybook package version", () => {
+    expect(
+      detectStorybookMajorVersion({
+        dependencies: { "@storybook/react": "^8.6.0" },
+        devDependencies: { storybook: "^10.4.6" },
+      }),
+    ).toBe(10);
+  });
+
+  it("falls back to an @storybook/* package", () => {
+    expect(
+      detectStorybookMajorVersion({
+        devDependencies: { "@storybook/nextjs": "^8.2.0" },
+      }),
+    ).toBe(8);
+  });
+});
+
+describe("shouldOmitPackageScriptArgSeparator", () => {
+  it("omits the separator for pnpm on Storybook 10+ or unknown", () => {
+    expect(
+      shouldOmitPackageScriptArgSeparator({ packageManager: "pnpm", storybookMajor: 10 }),
+    ).toBe(true);
+    expect(
+      shouldOmitPackageScriptArgSeparator({ packageManager: "pnpm", storybookMajor: null }),
+    ).toBe(true);
+  });
+
+  it("keeps the separator for older Storybook on pnpm and for npm", () => {
+    expect(
+      shouldOmitPackageScriptArgSeparator({ packageManager: "pnpm", storybookMajor: 8 }),
+    ).toBe(false);
+    expect(
+      shouldOmitPackageScriptArgSeparator({ packageManager: "npm", storybookMajor: 10 }),
+    ).toBe(false);
+  });
+});
+
 describe("detectStorybookScreenshotCommand", () => {
-  it("builds a generic Storybook command from package metadata", () => {
+  it("builds a Storybook 10 pnpm command without a script arg separator", () => {
     expect(
       detectStorybookScreenshotCommand({
         packageJson: {
           packageManager: "pnpm@11.9.0",
           scripts: { storybook: "storybook dev" },
+          devDependencies: { storybook: "^10.4.6" },
         },
         port: 6123,
         packageDir: "apps/web",
@@ -124,8 +183,40 @@ describe("detectStorybookScreenshotCommand", () => {
       packageManager: "pnpm",
       scriptName: "storybook",
       command: "pnpm",
-      args: ["run", "storybook", "--", "--port", "6123", "--host", "127.0.0.1", "--ci"],
+      args: ["run", "storybook", "--port", "6123", "--host", "127.0.0.1", "--ci"],
       packageDir: "apps/web",
+    });
+  });
+
+  it("keeps the pnpm script arg separator for Storybook 8", () => {
+    expect(
+      detectStorybookScreenshotCommand({
+        packageJson: {
+          packageManager: "pnpm@11.9.0",
+          scripts: { storybook: "storybook dev" },
+          devDependencies: { storybook: "^8.6.14" },
+        },
+        port: 6123,
+      }),
+    ).toMatchObject({
+      packageManager: "pnpm",
+      args: ["run", "storybook", "--", "--port", "6123", "--host", "127.0.0.1", "--ci"],
+    });
+  });
+
+  it("keeps npm `--` separator so flags are not consumed by npm", () => {
+    expect(
+      detectStorybookScreenshotCommand({
+        packageJson: {
+          packageManager: "npm@10.9.0",
+          scripts: { storybook: "storybook dev" },
+          devDependencies: { storybook: "^10.4.6" },
+        },
+        port: 6123,
+      }),
+    ).toMatchObject({
+      packageManager: "npm",
+      args: ["run", "storybook", "--", "--port", "6123", "--host", "127.0.0.1", "--ci"],
     });
   });
 
@@ -345,7 +436,7 @@ describe("createCaptureScreenshotTool", () => {
       args: [
         "-lc",
         expect.stringContaining(
-          "(cd 'apps/hyperlocalise-web' && 'pnpm' 'run' 'storybook' '--' '--port' '6006' '--host' '127.0.0.1' '--ci')",
+          "(cd 'apps/hyperlocalise-web' && 'pnpm' 'run' 'storybook' '--port' '6006' '--host' '127.0.0.1' '--ci')",
         ),
       ],
     });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -143,15 +143,16 @@ function storybookArgs(port: number) {
 
 /**
  * Parse a major version from a package.json dependency range.
- * Handles forms like `10.4.6`, `^10.4.6`, `~8.0.0`, `>=9.1.0`.
- * Returns null for unparseable values (`workspace:*`, `catalog:`, `latest`, …).
+ * Matches a semver-like major (`digits` + `.`), with an optional `~^>=` prefix —
+ * e.g. `10.4.6`, `^10.4.6`, `~8.0.0`, `>=9.1.0`, `catalog:storybook@10.0.0`.
+ * Returns null when no such major is present (`workspace:*`, `latest`, `file:../storybook-v10`, …).
  */
 export function parseDependencyMajorVersion(version: unknown): number | null {
   if (typeof version !== "string") {
     return null;
   }
 
-  const match = version.trim().match(/(\d+)/);
+  const match = version.trim().match(/[~^>=]*(\d+)\./);
   if (!match) {
     return null;
   }

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -39,6 +39,7 @@ type PackageJson = {
   scripts?: unknown;
   dependencies?: unknown;
   devDependencies?: unknown;
+  optionalDependencies?: unknown;
 };
 
 type PackageManager = "pnpm" | "yarn" | "bun" | "npm";
@@ -133,20 +134,98 @@ export function detectPackageManager(input: {
   return "npm";
 }
 
+/** Storybook 10+ uses a strict CLI that rejects unexpected positional args after `--`. */
+const STORYBOOK_STRICT_CLI_MAJOR = 10;
+
 function storybookArgs(port: number) {
   return ["--port", String(port), "--host", "127.0.0.1", "--ci"];
 }
 
-function buildRunArgs(packageManager: PackageManager, scriptName: string, port: number) {
-  const args = storybookArgs(port);
+/**
+ * Parse a major version from a package.json dependency range.
+ * Handles forms like `10.4.6`, `^10.4.6`, `~8.0.0`, `>=9.1.0`.
+ * Returns null for unparseable values (`workspace:*`, `catalog:`, `latest`, …).
+ */
+export function parseDependencyMajorVersion(version: unknown): number | null {
+  if (typeof version !== "string") {
+    return null;
+  }
 
-  switch (packageManager) {
+  const match = version.trim().match(/(\d+)/);
+  if (!match) {
+    return null;
+  }
+
+  const major = Number.parseInt(match[1]!, 10);
+  return Number.isFinite(major) ? major : null;
+}
+
+export function detectStorybookMajorVersion(packageJson: PackageJson): number | null {
+  const dependencyBlocks = [
+    asRecord(packageJson.dependencies),
+    asRecord(packageJson.devDependencies),
+    asRecord(packageJson.optionalDependencies),
+  ];
+
+  for (const block of dependencyBlocks) {
+    const direct = parseDependencyMajorVersion(block.storybook);
+    if (direct !== null) {
+      return direct;
+    }
+  }
+
+  for (const block of dependencyBlocks) {
+    for (const [name, version] of Object.entries(block)) {
+      if (!name.startsWith("@storybook/")) {
+        continue;
+      }
+      const major = parseDependencyMajorVersion(version);
+      if (major !== null) {
+        return major;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * pnpm forwards a literal `--` into the script argv. Storybook 10+ treats those
+ * tokens as unexpected positional args for `dev` and exits.
+ * When the major version is unknown, prefer the modern (no-separator) form.
+ */
+export function shouldOmitPackageScriptArgSeparator(input: {
+  packageManager: PackageManager;
+  storybookMajor: number | null;
+}): boolean {
+  if (input.packageManager !== "pnpm") {
+    return false;
+  }
+
+  return input.storybookMajor === null || input.storybookMajor >= STORYBOOK_STRICT_CLI_MAJOR;
+}
+
+function buildRunArgs(input: {
+  packageManager: PackageManager;
+  scriptName: string;
+  port: number;
+  storybookMajor: number | null;
+}) {
+  const args = storybookArgs(input.port);
+
+  switch (input.packageManager) {
     case "pnpm":
+      if (shouldOmitPackageScriptArgSeparator(input)) {
+        return ["run", input.scriptName, ...args];
+      }
+      return ["run", input.scriptName, "--", ...args];
     case "npm":
+      // npm requires `--` so flags like `--port` are not consumed by npm itself.
+      return ["run", input.scriptName, "--", ...args];
     case "bun":
-      return ["run", scriptName, "--", ...args];
+      return ["run", input.scriptName, "--", ...args];
     case "yarn":
-      return [scriptName, ...args];
+      return [input.scriptName, ...args];
   }
 }
 
@@ -167,11 +246,17 @@ export function detectStorybookScreenshotCommand(input: {
   }
 
   const packageManager = detectPackageManager(input);
+  const storybookMajor = detectStorybookMajorVersion(input.packageJson);
   return {
     packageManager,
     scriptName,
     command: packageManager,
-    args: buildRunArgs(packageManager, scriptName, input.port ?? STORYBOOK_PORT),
+    args: buildRunArgs({
+      packageManager,
+      scriptName,
+      port: input.port ?? STORYBOOK_PORT,
+      storybookMajor,
+    }),
     packageDir: input.packageDir ?? "",
   };
 }


### PR DESCRIPTION
## What changed

Storybook screenshot capture failed on pnpm + Storybook 10 because `pnpm run storybook -- --port …` forwards a literal `--`, and Storybook 10's strict CLI rejects those tokens as unexpected positional args for `dev`.

Detect the Storybook major from `package.json` and omit the script arg separator for pnpm on Storybook 10+ (or when the version is unknown). Keep the separator for older Storybook on pnpm, and keep npm's `--` so npm does not consume `--port` itself.

## How to test

- [ ] `vp test src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts`
- [ ] Capture a Storybook screenshot in a pnpm + Storybook 10 workspace and confirm Storybook starts (no `too many arguments for 'dev'`)
- [ ] Confirm npm workspaces still receive `--port` / `--host` / `--ci` via `npm run storybook -- …`

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)