### PR TITLE
feat(sandbox): delete sandboxes older than 7 days via cron

### DIFF
--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -61,6 +61,7 @@ import { createAutumnRoutes } from "./routes/autumn/autumn.route";
 import { createBillingRoutes } from "./routes/billing/billing.route";
 import { createBlogOgImageRoutes } from "./routes/blog-og-image/blog-og-image.route";
 import { createGithubRepositoryAutomationDispatchRoutes } from "./routes/cron/github-repository-automation-dispatch.route";
+import { createSandboxCleanupRoutes } from "./routes/cron/sandbox-cleanup.route";
 import { createE2eAuthRoutes } from "./routes/e2e/e2e-auth.route";
 import {
   createProviderAgentCommentQueue,
@@ -134,7 +135,8 @@ function createInternalRoutes() {
     .route(
       "/cron/github-repository-automation-dispatch",
       createGithubRepositoryAutomationDispatchRoutes(),
-    );
+    )
+    .route("/cron/sandbox-cleanup", createSandboxCleanupRoutes());
 }
 
 function createAuthRoutes() {

--- a/apps/hyperlocalise-web/src/api/routes/cron/sandbox-cleanup.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/cron/sandbox-cleanup.route.test.ts
@@ -1,0 +1,89 @@
+import { testClient } from "hono/testing";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+const runSandboxCleanupMock = vi.fn(async () => ({
+  scanned: 3,
+  expired: 2,
+  deleted: 2,
+  failed: 0,
+  skippedYoung: 1,
+}));
+
+async function createClient(input?: { cronSecret?: string | null }) {
+  const cronSecret = input?.cronSecret === null ? undefined : (input?.cronSecret ?? "cron-secret");
+
+  vi.resetModules();
+  vi.doMock("@/lib/agent-runtime/workspaces/sandbox-cleanup", () => ({
+    runSandboxCleanup: runSandboxCleanupMock,
+  }));
+  vi.doMock("@/lib/env", () => ({
+    env: {
+      CRON_SECRET: cronSecret,
+      SANDBOX_CLEANUP_MAX_PER_TICK: 50,
+    },
+  }));
+
+  const { createSandboxCleanupRoutes } = await import("./sandbox-cleanup.route");
+
+  return testClient(createSandboxCleanupRoutes());
+}
+
+describe("sandbox cleanup cron route", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("@/lib/agent-runtime/workspaces/sandbox-cleanup");
+    vi.doUnmock("@/lib/env");
+    runSandboxCleanupMock.mockClear();
+  });
+
+  it("rejects requests without the cron secret", async () => {
+    const client = await createClient();
+
+    const response = await client.index.$get();
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "unauthorized" });
+  });
+
+  it("rejects requests when CRON_SECRET is not configured", async () => {
+    const client = await createClient({ cronSecret: null });
+
+    const response = await client.index.$get(
+      {},
+      {
+        headers: {
+          authorization: "Bearer cron-secret",
+        },
+      },
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({ error: "sandbox_cleanup_misconfigured" });
+  });
+
+  it("runs sandbox cleanup when authorized", async () => {
+    const client = await createClient();
+
+    const response = await client.index.$get(
+      {},
+      {
+        headers: {
+          authorization: "Bearer cron-secret",
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      results: {
+        scanned: 3,
+        expired: 2,
+        deleted: 2,
+        failed: 0,
+        skippedYoung: 1,
+      },
+    });
+    expect(runSandboxCleanupMock).toHaveBeenCalledTimes(1);
+    expect(runSandboxCleanupMock).toHaveBeenCalledWith({ limit: 50 });
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/cron/sandbox-cleanup.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/cron/sandbox-cleanup.route.ts
@@ -1,0 +1,40 @@
+import { Hono } from "hono";
+
+import { verifyCronRequest } from "@/api/routes/cron/cron-auth";
+import { env } from "@/lib/env";
+import { createLogger } from "@/lib/log";
+import { runSandboxCleanup } from "@/lib/agent-runtime/workspaces/sandbox-cleanup";
+
+const logger = createLogger("cron-sandbox-cleanup");
+
+export function createSandboxCleanupRoutes() {
+  return new Hono().get("/", async (c) => {
+    logger.info("cron tick received");
+
+    const auth = verifyCronRequest(c.req.raw);
+    if (!auth.ok) {
+      if (auth.reason === "misconfigured") {
+        logger.warn({ reason: "misconfigured" }, "cron tick rejected; CRON_SECRET is not set");
+        return c.json({ error: "sandbox_cleanup_misconfigured" }, 503);
+      }
+
+      logger.warn(
+        {
+          reason: "unauthorized",
+          hasAuthorizationHeader: auth.hasAuthorizationHeader,
+          hasCronSecretHeader: auth.hasCronSecretHeader,
+        },
+        "cron tick rejected; missing or invalid cron secret",
+      );
+      return c.json({ error: "unauthorized" }, 401);
+    }
+
+    const results = await runSandboxCleanup({
+      limit: env.SANDBOX_CLEANUP_MAX_PER_TICK,
+    });
+
+    logger.info(results, "cron tick completed");
+
+    return c.json({ results }, 200);
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/sandbox-cleanup.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/sandbox-cleanup.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  runSandboxCleanup,
+  SANDBOX_CLEANUP_MAX_AGE_MS,
+} from "./sandbox-cleanup";
+
+describe("runSandboxCleanup", () => {
+  const now = new Date("2026-07-18T12:00:00.000Z");
+
+  it("deletes sandboxes older than seven days and stops at the first young sandbox", async () => {
+    const eightDaysAgo = now.getTime() - 8 * 24 * 60 * 60 * 1000;
+    const nineDaysAgo = now.getTime() - 9 * 24 * 60 * 60 * 1000;
+    const oneDayAgo = now.getTime() - 1 * 24 * 60 * 60 * 1000;
+
+    const deleteSandbox = vi.fn(async () => undefined);
+    const listed = [
+      { name: "old-a", createdAt: nineDaysAgo, status: "stopped" },
+      { name: "old-b", createdAt: eightDaysAgo, status: "stopped" },
+      { name: "young-c", createdAt: oneDayAgo, status: "stopped" },
+      { name: "young-d", createdAt: oneDayAgo, status: "running" },
+    ];
+
+    const result = await runSandboxCleanup({
+      deps: {
+        now,
+        listSandboxes: async () => listed,
+        deleteSandbox,
+      },
+    });
+
+    expect(result).toEqual({
+      scanned: 3,
+      expired: 2,
+      deleted: 2,
+      failed: 0,
+      skippedYoung: 1,
+    });
+    expect(deleteSandbox).toHaveBeenCalledTimes(2);
+    expect(deleteSandbox).toHaveBeenCalledWith("old-a", undefined);
+    expect(deleteSandbox).toHaveBeenCalledWith("old-b", undefined);
+  });
+
+  it("respects the per-tick delete limit", async () => {
+    const old = now.getTime() - SANDBOX_CLEANUP_MAX_AGE_MS - 1;
+    const listed = Array.from({ length: 5 }, (_, index) => ({
+      name: `old-${index}`,
+      createdAt: old - index,
+      status: "stopped",
+    }));
+    const deleteSandbox = vi.fn(async () => undefined);
+
+    const result = await runSandboxCleanup({
+      limit: 2,
+      deps: {
+        now,
+        listSandboxes: async () => listed,
+        deleteSandbox,
+      },
+    });
+
+    expect(result.expired).toBe(2);
+    expect(result.deleted).toBe(2);
+    expect(deleteSandbox).toHaveBeenCalledTimes(2);
+  });
+
+  it("counts delete failures without aborting the rest", async () => {
+    const old = now.getTime() - SANDBOX_CLEANUP_MAX_AGE_MS - 1;
+    const listed = [
+      { name: "old-a", createdAt: old, status: "stopped" },
+      { name: "old-b", createdAt: old, status: "stopped" },
+    ];
+    const deleteSandbox = vi.fn(async (name: string) => {
+      if (name === "old-a") {
+        throw new Error("delete failed");
+      }
+    });
+
+    const result = await runSandboxCleanup({
+      deps: {
+        now,
+        listSandboxes: async () => listed,
+        deleteSandbox,
+      },
+    });
+
+    expect(result).toMatchObject({
+      expired: 2,
+      deleted: 1,
+      failed: 1,
+    });
+  });
+
+  it("returns empty counts when nothing is expired", async () => {
+    const listed = [
+      {
+        name: "young",
+        createdAt: now.getTime() - 60_000,
+        status: "stopped",
+      },
+    ];
+
+    const result = await runSandboxCleanup({
+      deps: {
+        now,
+        listSandboxes: async () => listed,
+        deleteSandbox: vi.fn(async () => undefined),
+      },
+    });
+
+    expect(result).toEqual({
+      scanned: 1,
+      expired: 0,
+      deleted: 0,
+      failed: 0,
+      skippedYoung: 1,
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/sandbox-cleanup.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/sandbox-cleanup.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 
-import {
-  runSandboxCleanup,
-  SANDBOX_CLEANUP_MAX_AGE_MS,
-} from "./sandbox-cleanup";
+import { runSandboxCleanup, SANDBOX_CLEANUP_MAX_AGE_MS } from "./sandbox-cleanup";
 
 describe("runSandboxCleanup", () => {
   const now = new Date("2026-07-18T12:00:00.000Z");

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/sandbox-cleanup.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/sandbox-cleanup.ts
@@ -1,0 +1,178 @@
+import { Sandbox } from "@vercel/sandbox";
+
+import { createLogger } from "@/lib/log";
+
+const logger = createLogger("sandbox-cleanup");
+
+/** Sandboxes older than this are eligible for permanent deletion. */
+export const SANDBOX_CLEANUP_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Default max deletes per cron tick to stay within serverless time limits. */
+export const SANDBOX_CLEANUP_DEFAULT_LIMIT = 100;
+
+/** Bounded concurrency when calling the Vercel Sandbox delete API. */
+const SANDBOX_DELETE_CONCURRENCY = 5;
+
+export type SandboxCleanupResult = {
+  scanned: number;
+  expired: number;
+  deleted: number;
+  failed: number;
+  skippedYoung: number;
+};
+
+type ListedSandbox = {
+  name: string;
+  createdAt: number;
+  status: string;
+};
+
+type SandboxCleanupDeps = {
+  listSandboxes?: (params: {
+    sortBy: "createdAt";
+    sortOrder: "asc";
+    limit: number;
+    signal?: AbortSignal;
+  }) => Promise<AsyncIterable<ListedSandbox>>;
+  deleteSandbox?: (name: string, signal?: AbortSignal) => Promise<void>;
+  now?: Date;
+};
+
+async function defaultListSandboxes(params: {
+  sortBy: "createdAt";
+  sortOrder: "asc";
+  limit: number;
+  signal?: AbortSignal;
+}): Promise<AsyncIterable<ListedSandbox>> {
+  return Sandbox.list({
+    sortBy: params.sortBy,
+    sortOrder: params.sortOrder,
+    limit: params.limit,
+    signal: params.signal,
+  });
+}
+
+async function defaultDeleteSandbox(name: string, signal?: AbortSignal): Promise<void> {
+  const sandbox = await Sandbox.get({ name, resume: false, signal });
+  await sandbox.delete({ signal });
+}
+
+function isExpired(createdAtMs: number, nowMs: number, maxAgeMs: number) {
+  return nowMs - createdAtMs >= maxAgeMs;
+}
+
+async function deleteWithBoundedConcurrency(
+  names: string[],
+  concurrency: number,
+  deleteSandbox: (name: string, signal?: AbortSignal) => Promise<void>,
+  signal?: AbortSignal,
+): Promise<{ deleted: number; failed: number }> {
+  let deleted = 0;
+  let failed = 0;
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < names.length) {
+      if (signal?.aborted) {
+        return;
+      }
+
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      const name = names[currentIndex];
+      if (!name) {
+        return;
+      }
+
+      try {
+        await deleteSandbox(name, signal);
+        deleted += 1;
+      } catch (error) {
+        failed += 1;
+        logger.warn(
+          {
+            sandboxId: name,
+            error: error instanceof Error ? error.message : "unknown",
+          },
+          "failed to delete expired sandbox",
+        );
+      }
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(concurrency, names.length) }, () => worker());
+  await Promise.all(workers);
+  return { deleted, failed };
+}
+
+/**
+ * Lists Vercel sandboxes oldest-first and permanently deletes those older than
+ * {@link SANDBOX_CLEANUP_MAX_AGE_MS}. Stops once a young sandbox is seen (list is
+ * sorted by createdAt ascending) or the per-tick limit is reached.
+ */
+export async function runSandboxCleanup(input?: {
+  limit?: number;
+  maxAgeMs?: number;
+  signal?: AbortSignal;
+  deps?: SandboxCleanupDeps;
+}): Promise<SandboxCleanupResult> {
+  const limit = input?.limit ?? SANDBOX_CLEANUP_DEFAULT_LIMIT;
+  const maxAgeMs = input?.maxAgeMs ?? SANDBOX_CLEANUP_MAX_AGE_MS;
+  const nowMs = (input?.deps?.now ?? new Date()).getTime();
+  const listSandboxes = input?.deps?.listSandboxes ?? defaultListSandboxes;
+  const deleteSandbox = input?.deps?.deleteSandbox ?? defaultDeleteSandbox;
+
+  const result: SandboxCleanupResult = {
+    scanned: 0,
+    expired: 0,
+    deleted: 0,
+    failed: 0,
+    skippedYoung: 0,
+  };
+
+  const expiredNames: string[] = [];
+  const listed = await listSandboxes({
+    sortBy: "createdAt",
+    sortOrder: "asc",
+    limit,
+    signal: input?.signal,
+  });
+
+  for await (const sandbox of listed) {
+    if (input?.signal?.aborted) {
+      break;
+    }
+
+    result.scanned += 1;
+
+    if (!isExpired(sandbox.createdAt, nowMs, maxAgeMs)) {
+      result.skippedYoung += 1;
+      // Remaining pages are newer when sorted by createdAt ascending.
+      break;
+    }
+
+    result.expired += 1;
+    expiredNames.push(sandbox.name);
+
+    if (expiredNames.length >= limit) {
+      break;
+    }
+  }
+
+  if (expiredNames.length === 0) {
+    logger.info(result, "sandbox cleanup completed; nothing to delete");
+    return result;
+  }
+
+  const deleteResult = await deleteWithBoundedConcurrency(
+    expiredNames,
+    SANDBOX_DELETE_CONCURRENCY,
+    deleteSandbox,
+    input?.signal,
+  );
+  result.deleted = deleteResult.deleted;
+  result.failed = deleteResult.failed;
+
+  logger.info(result, "sandbox cleanup completed");
+  return result;
+}

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/sandbox-cleanup.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/sandbox-cleanup.ts
@@ -27,13 +27,15 @@ type ListedSandbox = {
   status: string;
 };
 
+type ListedSandboxIterable = AsyncIterable<ListedSandbox> | Iterable<ListedSandbox>;
+
 type SandboxCleanupDeps = {
   listSandboxes?: (params: {
     sortBy: "createdAt";
     sortOrder: "asc";
     limit: number;
     signal?: AbortSignal;
-  }) => Promise<AsyncIterable<ListedSandbox>>;
+  }) => Promise<ListedSandboxIterable>;
   deleteSandbox?: (name: string, signal?: AbortSignal) => Promise<void>;
   now?: Date;
 };
@@ -43,7 +45,7 @@ async function defaultListSandboxes(params: {
   sortOrder: "asc";
   limit: number;
   signal?: AbortSignal;
-}): Promise<AsyncIterable<ListedSandbox>> {
+}): Promise<ListedSandboxIterable> {
   return Sandbox.list({
     sortBy: params.sortBy,
     sortOrder: params.sortOrder,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/sandbox-cleanup.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/sandbox-cleanup.ts
@@ -10,6 +10,13 @@ export const SANDBOX_CLEANUP_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 /** Default max deletes per cron tick to stay within serverless time limits. */
 export const SANDBOX_CLEANUP_DEFAULT_LIMIT = 100;
 
+/**
+ * Page size for `Sandbox.list`. Kept separate from the delete cap and clamped to
+ * the Vercel `/v2/sandboxes` max (`limit` max 50). `sortBy`/`limit` are part of
+ * `@vercel/sandbox` `listSandboxes` and are forwarded in the SDK client query.
+ */
+const SANDBOX_LIST_PAGE_SIZE = 50;
+
 /** Bounded concurrency when calling the Vercel Sandbox delete API. */
 const SANDBOX_DELETE_CONCURRENCY = 5;
 
@@ -31,9 +38,8 @@ type ListedSandboxIterable = AsyncIterable<ListedSandbox> | Iterable<ListedSandb
 
 type SandboxCleanupDeps = {
   listSandboxes?: (params: {
-    sortBy: "createdAt";
     sortOrder: "asc";
-    limit: number;
+    pageSize: number;
     signal?: AbortSignal;
   }) => Promise<ListedSandboxIterable>;
   deleteSandbox?: (name: string, signal?: AbortSignal) => Promise<void>;
@@ -41,15 +47,14 @@ type SandboxCleanupDeps = {
 };
 
 async function defaultListSandboxes(params: {
-  sortBy: "createdAt";
   sortOrder: "asc";
-  limit: number;
+  pageSize: number;
   signal?: AbortSignal;
 }): Promise<ListedSandboxIterable> {
   return Sandbox.list({
-    sortBy: params.sortBy,
+    sortBy: "createdAt",
     sortOrder: params.sortOrder,
-    limit: params.limit,
+    limit: params.pageSize,
     signal: params.signal,
   });
 }
@@ -134,9 +139,8 @@ export async function runSandboxCleanup(input?: {
 
   const expiredNames: string[] = [];
   const listed = await listSandboxes({
-    sortBy: "createdAt",
     sortOrder: "asc",
-    limit,
+    pageSize: Math.min(limit, SANDBOX_LIST_PAGE_SIZE),
     signal: input?.signal,
   });
 

--- a/apps/hyperlocalise-web/src/lib/env.ts
+++ b/apps/hyperlocalise-web/src/lib/env.ts
@@ -141,6 +141,9 @@ export const env = createEnv({
       .positive()
       .default(100),
 
+    /** Maximum sandboxes deleted per sandbox cleanup cron tick. */
+    SANDBOX_CLEANUP_MAX_PER_TICK: z.coerce.number().int().positive().default(100),
+
     /** Canva app ID used to verify Canva JWTs for the integration API. */
     CANVA_APP_ID: z.string().min(1).optional(),
 
@@ -259,6 +262,7 @@ export const env = createEnv({
     CRON_SECRET: process.env.CRON_SECRET ?? (isTestEnv ? "test-cron-secret" : undefined),
     GITHUB_REPOSITORY_AUTOMATION_DISPATCH_MAX_REPOS_PER_TICK:
       process.env.GITHUB_REPOSITORY_AUTOMATION_DISPATCH_MAX_REPOS_PER_TICK,
+    SANDBOX_CLEANUP_MAX_PER_TICK: process.env.SANDBOX_CLEANUP_MAX_PER_TICK,
     CANVA_APP_ID: process.env.CANVA_APP_ID ?? (isTestEnv ? "test-canva-app-id" : undefined),
     CANVA_CORS_ORIGINS: process.env.CANVA_CORS_ORIGINS,
     CANVA_APP_ORIGIN: process.env.CANVA_APP_ORIGIN,

--- a/apps/hyperlocalise-web/vercel.json
+++ b/apps/hyperlocalise-web/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/github-repository-automation-dispatch",
       "schedule": "*/15 * * * *"
+    },
+    {
+      "path": "/api/cron/sandbox-cleanup",
+      "schedule": "0 3 * * *"
     }
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Persistent Vercel sandboxes were only stopped, so stopped resources could accumulate indefinitely. This adds a cleanup path that permanently deletes sandboxes older than 7 days.

- `runSandboxCleanup` lists sandboxes oldest-first via `Sandbox.list`, then calls `sandbox.delete()` for entries past 7 days
- `GET /api/cron/sandbox-cleanup` (protected by `CRON_SECRET`, same auth as the existing GitHub automation cron)
- Daily cron at 03:00 UTC in `vercel.json`
- Per-tick delete cap via `SANDBOX_CLEANUP_MAX_PER_TICK` (default 100)

## How to test

- `vp test src/lib/agent-runtime/workspaces/sandbox-cleanup.test.ts src/api/routes/cron/sandbox-cleanup.route.test.ts`
- `vp check --fix`
- Manual: `curl -H "Authorization: Bearer $CRON_SECRET" https://<host>/api/cron/sandbox-cleanup`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29f3bb61-6b97-4d36-80d8-1b8265670e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29f3bb61-6b97-4d36-80d8-1b8265670e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

