### PR TITLE
fix(agent): avoid Storybook screenshot networkidle timeouts

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
@@ -362,6 +362,10 @@ describe("createCaptureScreenshotTool", () => {
         'require("/tmp/hyperlocalise-browser-runtime/node_modules/playwright")',
       ),
     );
+    const captureScript = String(writeWorkspaceFile.mock.calls[0]?.[1] ?? "");
+    expect(captureScript).toContain('waitUntil: "load"');
+    expect(captureScript).not.toMatch(/waitUntil:\s*"networkidle"/);
+    expect(captureScript).toContain('waitForSelector("#storybook-root, #root"');
     expect(exec).toHaveBeenCalledWith("bash", {
       args: [
         "-lc",

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -433,7 +433,9 @@ const { chromium } = require(${JSON.stringify(input.playwrightModulePath)});
   const page = await browser.newPage({
     viewport: ${JSON.stringify(input.viewport)}
   });
-  await page.goto(${JSON.stringify(input.url)}, { waitUntil: "networkidle", timeout: 60000 });
+  // Storybook keeps HMR/WebSocket traffic open, so "networkidle" often never settles.
+  await page.goto(${JSON.stringify(input.url)}, { waitUntil: "load", timeout: 60000 });
+  await page.waitForSelector("#storybook-root, #root", { state: "attached", timeout: 30000 });
   await page.waitForTimeout(${input.waitForMs});
   await page.screenshot({ path: ${JSON.stringify(input.outputPath)}, fullPage: true });
   await browser.close();
@@ -504,8 +506,16 @@ function buildCaptureCommand(input: {
     `for i in $(seq 1 60); do if curl -fsS ${shellQuote(
       `http://127.0.0.1:${input.port}/iframe.html`,
     )} >/dev/null 2>&1; then break; fi; sleep 1; done`,
-    `curl -fsS ${shellQuote(`http://127.0.0.1:${input.port}/iframe.html`)} >/dev/null`,
-    `node ${shellQuote(input.scriptPath)}`,
+    `if ! curl -fsS ${shellQuote(`http://127.0.0.1:${input.port}/iframe.html`)} >/dev/null; then`,
+    '  echo "Storybook did not become ready on the expected port." >&2',
+    "  tail -n 80 /tmp/hyperlocalise-storybook.log >&2 || true",
+    "  exit 1",
+    "fi",
+    `if ! node ${shellQuote(input.scriptPath)}; then`,
+    '  echo "Playwright screenshot capture failed." >&2',
+    "  tail -n 40 /tmp/hyperlocalise-storybook.log >&2 || true",
+    "  exit 1",
+    "fi",
     `SCREENSHOT_B64=$(base64 -w 0 ${shellQuote(input.screenshotPath)})`,
     `rm -rf ${shellQuote(input.baseDir)}`,
     'printf "%s" "$SCREENSHOT_B64"',


### PR DESCRIPTION
## What changed

Storybook screenshot capture was failing with exit code 1 after ~60s because Playwright waited for `networkidle`, which rarely settles while Storybook keeps HMR/WebSocket traffic open.

Wait for `load` and the story root (`#storybook-root` / `#root`) instead, and dump the Storybook log when readiness or capture fails so the next failure is easier to diagnose.

## How to test

- [x] `vp test src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts`
- [x] `vp check --fix -- src/lib/agent-runtime/tools/workspace/capture-screenshot.ts src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts`
- [ ] Capture a Storybook screenshot via the agent and confirm it completes without a ~60s Playwright timeout

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)