### PR TITLE
fix(agent): export Playwright browsers path for screenshot capture

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
@@ -373,6 +373,14 @@ describe("createCaptureScreenshotTool", () => {
       ],
     });
     expect(exec).toHaveBeenCalledWith("bash", {
+      args: [
+        "-lc",
+        expect.stringContaining(
+          "export PLAYWRIGHT_BROWSERS_PATH='/tmp/hyperlocalise-browser-runtime/ms-playwright'",
+        ),
+      ],
+    });
+    expect(exec).toHaveBeenCalledWith("bash", {
       args: ["-lc", expect.stringContaining("'pnpm' 'run' 'storybook'")],
     });
     expect(createStoredFile).toHaveBeenCalledWith(

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -495,10 +495,13 @@ function buildCaptureCommand(input: {
   const storybookLaunch = packageDir
     ? `(cd ${shellQuote(packageDir)} && ${storybookCommand})`
     : storybookCommand;
+  const browsersPath = shellQuote(`${MANAGED_BROWSER_RUNTIME_DIR}/ms-playwright`);
 
   return [
     "set -euo pipefail",
     managedBrowserRuntimeCommand(),
+    // Must match the install path above; otherwise chromium.launch looks in the default cache.
+    `export PLAYWRIGHT_BROWSERS_PATH=${browsersPath}`,
     `${storybookLaunch} >/tmp/hyperlocalise-storybook.log 2>&1 &`,
     "SERVER_PID=$!",
     'cleanup() { kill "$SERVER_PID" >/dev/null 2>&1 || true; }',


### PR DESCRIPTION
## What changed

`captureScreenshot` installs Chromium into `/tmp/hyperlocalise-browser-runtime/ms-playwright` via `PLAYWRIGHT_BROWSERS_PATH`, but the Node launch step did not export that same path. Playwright then looked in the default cache and reported the executable unavailable even though Storybook had started.

Export `PLAYWRIGHT_BROWSERS_PATH` for the capture process so launch uses the managed install location.

## How to test

- [x] `vp test src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts` in `apps/hyperlocalise-web`
- [ ] Retry a visual-mock / `captureScreenshot` flow in a sandbox and confirm the PNG artifact is stored

## Checklist

- [x] I ran relevant checks locally (`vp test` for the capture-screenshot suite)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review