### PR TITLE
fix(sandbox): install Chromium system deps for screenshot capture

### DIFF
--- a/apps/hyperlocalise-web/AGENTS.md
+++ b/apps/hyperlocalise-web/AGENTS.md
@@ -51,7 +51,7 @@ Fixture-auth infrastructure and baseline Playwright specs live under [`src/e2e/`
 
 - **Fixture auth**: set `E2E_AUTH_MODE=fixture` and a 32+ character `E2E_AUTH_SECRET` in `.env` (see [`.env.e2e.example`](.env.e2e.example)). Programmatic login: `POST /api/e2e/auth/session` with `X-E2E-Setup-Token`. Browser helpers in [`src/e2e/fixtures/browser.ts`](src/e2e/fixtures/browser.ts) use that API route. Disabled when `NODE_ENV=production` or `VERCEL_ENV=production`.
 - **Baseline specs**: [`src/e2e/flows/*.e2e.ts`](src/e2e/flows/) use Playwright from Node. Flows include fixture auth login, dashboard overview, project creation, and onboarding workspace creation. To run them manually, start Postgres, migrate, build, and serve the app with fixture auth, then invoke Vitest against those files directly if needed.
-- **Commands**: run `vp run e2e:install` once to install Chromium, then run `vp run test:e2e` while the fixture-auth app is available. Set `E2E_BASE_URL` when the app is not running at `http://localhost:3000`.
+- **Commands**: run `vp run e2e:install` once to install Chromium and OS libraries (`playwright install --with-deps chromium`), then run `vp run test:e2e` while the fixture-auth app is available. Set `E2E_BASE_URL` when the app is not running at `http://localhost:3000`.
 - Vitest Browser Mode is not used for route-level e2e (it cannot `page.goto` external origins).
 
 <!-- END:hono-agent-rules -->

--- a/apps/hyperlocalise-web/package.json
+++ b/apps/hyperlocalise-web/package.json
@@ -11,7 +11,7 @@
     "db:migrate": "bun scripts/check-drizzle-migration-collisions.ts && drizzle-kit migrate",
     "db:studio": "drizzle-kit studio",
     "dev": "next dev",
-    "e2e:install": "playwright install chromium",
+    "e2e:install": "playwright install --with-deps chromium",
     "start": "next start",
     "storybook": "storybook dev -p 6006",
     "test:e2e": "vp test run --config vite.e2e.config.ts",

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
@@ -394,6 +394,14 @@ describe("createCaptureScreenshotTool", () => {
       args: ["-lc", expect.stringContaining("install --with-deps chromium")],
     });
     expect(exec).toHaveBeenCalledWith("bash", {
+      args: [
+        "-lc",
+        expect.stringContaining(
+          "sudo env PLAYWRIGHT_BROWSERS_PATH='/tmp/hyperlocalise-browser-runtime/ms-playwright'",
+        ),
+      ],
+    });
+    expect(exec).toHaveBeenCalledWith("bash", {
       args: ["-lc", expect.stringContaining("'pnpm' 'run' 'storybook'")],
     });
     expect(createStoredFile).toHaveBeenCalledWith(

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
@@ -304,6 +304,16 @@ describe("classifyScreenshotCaptureFailure", () => {
         "chromium failed\nHYPERLOCALISE_SCREENSHOT_ERROR_CODE=browser_binary_unavailable",
       ),
     ).toBe("browser_binary_unavailable");
+    expect(
+      classifyScreenshotCaptureFailure(
+        "deps failed\nHYPERLOCALISE_SCREENSHOT_ERROR_CODE=browser_system_deps_unavailable",
+      ),
+    ).toBe("browser_system_deps_unavailable");
+    expect(
+      classifyScreenshotCaptureFailure(
+        "error while loading shared libraries: libnspr4.so: cannot open shared object file",
+      ),
+    ).toBe("browser_system_deps_unavailable");
     expect(classifyScreenshotCaptureFailure("storybook failed")).toBe("screenshot_capture_failed");
   });
 });
@@ -379,6 +389,9 @@ describe("createCaptureScreenshotTool", () => {
           "export PLAYWRIGHT_BROWSERS_PATH='/tmp/hyperlocalise-browser-runtime/ms-playwright'",
         ),
       ],
+    });
+    expect(exec).toHaveBeenCalledWith("bash", {
+      args: ["-lc", expect.stringContaining("install --with-deps chromium")],
     });
     expect(exec).toHaveBeenCalledWith("bash", {
       args: ["-lc", expect.stringContaining("'pnpm' 'run' 'storybook'")],

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -9,12 +9,13 @@ import { normalizeWorkspacePath } from "./path";
 import { DEFAULT_MAX_OUTPUT_BYTES, redact, truncate } from "./redact";
 import type { RepoToolContext } from "./types";
 
-const DEFAULT_VIEWPORT = { width: 1440, height: 900 };
+const DEFAULT_VIEWPORT = { width: 1440, height: 1000 };
 const MIN_VIEWPORT_SIZE = 320;
 const MAX_VIEWPORT_SIZE = 3840;
 const DEFAULT_WAIT_FOR_MS = 500;
 const MAX_WAIT_FOR_MS = 5000;
 const STORYBOOK_PORT = 6006;
+/** Keep in sync with `sandboxPlaywrightVersion` in vercel-sandbox-config.ts. */
 const MANAGED_PLAYWRIGHT_VERSION = "1.61.1";
 const MANAGED_BROWSER_RUNTIME_DIR = "/tmp/hyperlocalise-browser-runtime";
 const MANAGED_PLAYWRIGHT_MODULE = `${MANAGED_BROWSER_RUNTIME_DIR}/node_modules/playwright`;
@@ -448,9 +449,19 @@ const { chromium } = require(${JSON.stringify(input.playwrightModulePath)});
 
 export function classifyScreenshotCaptureFailure(output: string) {
   const match = output.match(
-    /HYPERLOCALISE_SCREENSHOT_ERROR_CODE=(package_manager_unavailable|browser_runtime_install_failed|browser_binary_unavailable)\b/,
+    /HYPERLOCALISE_SCREENSHOT_ERROR_CODE=(package_manager_unavailable|browser_runtime_install_failed|browser_binary_unavailable|browser_system_deps_unavailable)\b/,
   );
-  return match?.[1] ?? "screenshot_capture_failed";
+  if (match?.[1]) {
+    return match[1];
+  }
+  // Chromium linked against libnspr4/libnss3; surface a structured code when the OS libs are missing.
+  if (
+    /libnspr4\.so|libnss3\.so|error while loading shared libraries/i.test(output) ||
+    /Host system is missing dependencies/i.test(output)
+  ) {
+    return "browser_system_deps_unavailable";
+  }
+  return "screenshot_capture_failed";
 }
 
 function managedBrowserRuntimeCommand() {
@@ -473,10 +484,28 @@ function managedBrowserRuntimeCommand() {
     "    exit 87",
     "  fi",
     "fi",
-    `if ! PLAYWRIGHT_BROWSERS_PATH=${browsersPath} ${playwrightBin} install chromium >/tmp/hyperlocalise-chromium-install.log 2>&1; then`,
-    `  cat /tmp/hyperlocalise-chromium-install.log >&2 || true`,
-    `  echo "${ERROR_CODE_PREFIX}browser_binary_unavailable" >&2`,
-    "  exit 88",
+    // Prefer OS deps from sandbox bootstrap; retry here when Linux libs are missing.
+    "if command -v ldconfig >/dev/null 2>&1 && ! ldconfig -p 2>/dev/null | grep -q 'libnspr4\\.so'; then",
+    "  DEPS_RC=1",
+    "  if command -v sudo >/dev/null 2>&1; then",
+    `    sudo PLAYWRIGHT_BROWSERS_PATH=${browsersPath} ${playwrightBin} install-deps chromium >/tmp/hyperlocalise-chromium-deps.log 2>&1 && DEPS_RC=0`,
+    "  fi",
+    '  if [ "$DEPS_RC" -ne 0 ]; then',
+    `    PLAYWRIGHT_BROWSERS_PATH=${browsersPath} ${playwrightBin} install-deps chromium >/tmp/hyperlocalise-chromium-deps.log 2>&1 && DEPS_RC=0`,
+    "  fi",
+    '  if [ "$DEPS_RC" -ne 0 ]; then',
+    "    cat /tmp/hyperlocalise-chromium-deps.log >&2 || true",
+    `    echo "${ERROR_CODE_PREFIX}browser_system_deps_unavailable" >&2`,
+    "    exit 89",
+    "  fi",
+    "fi",
+    `if ! PLAYWRIGHT_BROWSERS_PATH=${browsersPath} ${playwrightBin} install --with-deps chromium >/tmp/hyperlocalise-chromium-install.log 2>&1; then`,
+    // `--with-deps` may fail without root even when the browser binary itself installs; retry binary-only.
+    `  if ! PLAYWRIGHT_BROWSERS_PATH=${browsersPath} ${playwrightBin} install chromium >/tmp/hyperlocalise-chromium-install.log 2>&1; then`,
+    `    cat /tmp/hyperlocalise-chromium-install.log >&2 || true`,
+    `    echo "${ERROR_CODE_PREFIX}browser_binary_unavailable" >&2`,
+    "    exit 88",
+    "  fi",
     "fi",
   ].join("\n");
 }

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -501,7 +501,8 @@ function managedBrowserRuntimeCommand() {
     "fi",
     `if ! PLAYWRIGHT_BROWSERS_PATH=${browsersPath} ${playwrightBin} install --with-deps chromium >/tmp/hyperlocalise-chromium-install.log 2>&1; then`,
     // `--with-deps` may fail without root even when the browser binary itself installs; retry binary-only.
-    `  if ! PLAYWRIGHT_BROWSERS_PATH=${browsersPath} ${playwrightBin} install chromium >/tmp/hyperlocalise-chromium-install.log 2>&1; then`,
+    // Append so the original `--with-deps` failure reason is preserved for debugging.
+    `  if ! PLAYWRIGHT_BROWSERS_PATH=${browsersPath} ${playwrightBin} install chromium >>/tmp/hyperlocalise-chromium-install.log 2>&1; then`,
     `    cat /tmp/hyperlocalise-chromium-install.log >&2 || true`,
     `    echo "${ERROR_CODE_PREFIX}browser_binary_unavailable" >&2`,
     "    exit 88",

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -488,7 +488,7 @@ function managedBrowserRuntimeCommand() {
     "if command -v ldconfig >/dev/null 2>&1 && ! ldconfig -p 2>/dev/null | grep -q 'libnspr4\\.so'; then",
     "  DEPS_RC=1",
     "  if command -v sudo >/dev/null 2>&1; then",
-    `    sudo PLAYWRIGHT_BROWSERS_PATH=${browsersPath} ${playwrightBin} install-deps chromium >/tmp/hyperlocalise-chromium-deps.log 2>&1 && DEPS_RC=0`,
+    `    sudo env PLAYWRIGHT_BROWSERS_PATH=${browsersPath} ${playwrightBin} install-deps chromium >/tmp/hyperlocalise-chromium-deps.log 2>&1 && DEPS_RC=0`,
     "  fi",
     '  if [ "$DEPS_RC" -ne 0 ]; then',
     `    PLAYWRIGHT_BROWSERS_PATH=${browsersPath} ${playwrightBin} install-deps chromium >/tmp/hyperlocalise-chromium-deps.log 2>&1 && DEPS_RC=0`,

--- a/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.test.ts
+++ b/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.test.ts
@@ -15,7 +15,9 @@ describe("installRequiredSandboxToolsCommand", () => {
   });
 
   it("installs Chromium system libraries when libnspr4 is missing", () => {
-    expect(installRequiredSandboxToolsCommand).toContain("install_chromium_system_dependencies");
+    expect(installRequiredSandboxToolsCommand).toContain(
+      "install_chromium_system_dependencies || true",
+    );
     expect(installRequiredSandboxToolsCommand).toContain(
       `PW_VERSION="${sandboxPlaywrightVersion}"`,
     );

--- a/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.test.ts
+++ b/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   installRequiredSandboxToolsCommand,
   sandboxHyperlocaliseReleaseVersion,
+  sandboxPlaywrightVersion,
   sandboxRipgrepReleaseVersion,
 } from "@/lib/vercel-sandbox-config";
 
@@ -10,6 +11,22 @@ describe("installRequiredSandboxToolsCommand", () => {
   it("installs ripgrep via apt on Debian-based sandboxes", () => {
     expect(installRequiredSandboxToolsCommand).toContain(
       "apt-get update && apt-get install -y ripgrep",
+    );
+  });
+
+  it("installs Chromium system libraries when libnspr4 is missing", () => {
+    expect(installRequiredSandboxToolsCommand).toContain("install_chromium_system_dependencies");
+    expect(installRequiredSandboxToolsCommand).toContain(
+      `PW_VERSION="${sandboxPlaywrightVersion}"`,
+    );
+    expect(installRequiredSandboxToolsCommand).toContain(
+      'npx --yes "playwright@${PW_VERSION}" install-deps chromium',
+    );
+    expect(installRequiredSandboxToolsCommand).toContain(
+      "apt-get update && apt-get install -y libnspr4 libnss3",
+    );
+    expect(installRequiredSandboxToolsCommand).toContain(
+      "if command -v ldconfig >/dev/null 2>&1 && ! ldconfig -p 2>/dev/null | grep -q 'libnspr4\\.so'; then",
     );
   });
 

--- a/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
+++ b/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
@@ -6,6 +6,13 @@ export const sandboxRipgrepReleaseVersion = "14.1.1";
 /** Pinned hyperlocalise CLI release installed into every sandbox. */
 export const sandboxHyperlocaliseReleaseVersion = "1.8.24";
 
+/**
+ * Pinned Playwright release used to install Chromium OS libraries
+ * (e.g. libnspr4.so) via `playwright install-deps`. Keep in sync with
+ * `MANAGED_PLAYWRIGHT_VERSION` in capture-screenshot.ts.
+ */
+export const sandboxPlaywrightVersion = "1.61.1";
+
 type VercelSandboxCreateOptions = Parameters<typeof Sandbox.create>[0];
 
 export const defaultVercelSandboxRuntime = "node26";
@@ -59,9 +66,26 @@ const installHyperlocaliseFromGithubRelease = [
   "}",
 ].join("\n");
 
+const installChromiumSystemDependencies = [
+  "install_chromium_system_dependencies() {",
+  `  PW_VERSION="${sandboxPlaywrightVersion}"`,
+  "  if command -v npm >/dev/null 2>&1; then",
+  '    npx --yes "playwright@${PW_VERSION}" install-deps chromium',
+  "    return $?",
+  "  fi",
+  "  if command -v apt-get >/dev/null 2>&1; then",
+  "    apt-get update && apt-get install -y libnspr4 libnss3",
+  "    return $?",
+  "  fi",
+  '  echo "Unable to install Chromium system dependencies (npm/apt-get unavailable)." >&2',
+  "  return 1",
+  "}",
+].join("\n");
+
 export const installRequiredSandboxToolsCommand = [
   installRipgrepFromGithubRelease,
   installHyperlocaliseFromGithubRelease,
+  installChromiumSystemDependencies,
   "if ! command -v rg >/dev/null 2>&1; then",
   "  if command -v apt-get >/dev/null 2>&1; then",
   "    apt-get update && apt-get install -y ripgrep",
@@ -79,6 +103,11 @@ export const installRequiredSandboxToolsCommand = [
   "  install_hyperlocalise_from_github_release",
   "fi",
   "command -v hl >/dev/null 2>&1",
+  // Playwright Chromium needs OS libs such as libnspr4.so; install during bootstrap
+  // where sudo is available. Skip when already present (warm/reused images).
+  "if command -v ldconfig >/dev/null 2>&1 && ! ldconfig -p 2>/dev/null | grep -q 'libnspr4\\.so'; then",
+  "  install_chromium_system_dependencies",
+  "fi",
 ].join("\n");
 
 export async function createConfiguredVercelSandbox(

--- a/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
+++ b/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
@@ -105,8 +105,9 @@ export const installRequiredSandboxToolsCommand = [
   "command -v hl >/dev/null 2>&1",
   // Playwright Chromium needs OS libs such as libnspr4.so; install during bootstrap
   // where sudo is available. Skip when already present (warm/reused images).
+  // Best-effort: capture-time retry handles missing deps if this fails.
   "if command -v ldconfig >/dev/null 2>&1 && ! ldconfig -p 2>/dev/null | grep -q 'libnspr4\\.so'; then",
-  "  install_chromium_system_dependencies",
+  "  install_chromium_system_dependencies || true",
   "fi",
 ].join("\n");
 


### PR DESCRIPTION
## What changed

Sandbox Playwright Chromium failed to launch with a missing `libnspr4.so`. This change installs Chromium OS dependencies during sandbox bootstrap (`playwright install-deps`, with an apt fallback), retries deps during `captureScreenshot` via `--with-deps`, and maps missing shared libraries to `browser_system_deps_unavailable`. Also updates local `e2e:install` and the default Storybook screenshot viewport to 1440×1000.

## How to test

- [x] `vp test src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts src/lib/vercel-sandbox-config.test.ts src/lib/translation/sandbox-translation.test.ts src/workflows/repository-agent.test.ts` in `apps/hyperlocalise-web`
- [x] `vp check --fix` in `apps/hyperlocalise-web`
- [ ] Create a new sandbox and retry a Storybook `captureScreenshot` (e.g. App/Project/Files/Page — RepositoryFiles) and confirm the PNG artifact is stored

## Checklist

- [x] I ran relevant checks locally (`vp test` for the affected suites, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)