### PR TITLE
fix(sandbox): install Chromium deps with dnf on Amazon Linux

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
@@ -391,15 +391,13 @@ describe("createCaptureScreenshotTool", () => {
       ],
     });
     expect(exec).toHaveBeenCalledWith("bash", {
-      args: ["-lc", expect.stringContaining("install --with-deps chromium")],
+      args: ["-lc", expect.stringContaining("install chromium")],
     });
     expect(exec).toHaveBeenCalledWith("bash", {
-      args: [
-        "-lc",
-        expect.stringContaining(
-          "sudo env PLAYWRIGHT_BROWSERS_PATH='/tmp/hyperlocalise-browser-runtime/ms-playwright'",
-        ),
-      ],
+      args: ["-lc", expect.stringContaining("install_chromium_system_dependencies")],
+    });
+    expect(exec).toHaveBeenCalledWith("bash", {
+      args: ["-lc", expect.stringContaining("run_as_root dnf install -y")],
     });
     expect(exec).toHaveBeenCalledWith("bash", {
       args: ["-lc", expect.stringContaining("'pnpm' 'run' 'storybook'")],

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -4,6 +4,10 @@ import { z } from "zod";
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 import { assertRepositoryWriteAllowed } from "@/lib/agent-runtime/tools/policy";
 import { createStoredFile } from "@/lib/file-storage/records";
+import {
+  installChromiumSystemDependenciesFunction,
+  sandboxPlaywrightVersion,
+} from "@/lib/vercel-sandbox-config";
 
 import { normalizeWorkspacePath } from "./path";
 import { DEFAULT_MAX_OUTPUT_BYTES, redact, truncate } from "./redact";
@@ -15,8 +19,7 @@ const MAX_VIEWPORT_SIZE = 3840;
 const DEFAULT_WAIT_FOR_MS = 500;
 const MAX_WAIT_FOR_MS = 5000;
 const STORYBOOK_PORT = 6006;
-/** Keep in sync with `sandboxPlaywrightVersion` in vercel-sandbox-config.ts. */
-const MANAGED_PLAYWRIGHT_VERSION = "1.61.1";
+const MANAGED_PLAYWRIGHT_VERSION = sandboxPlaywrightVersion;
 const MANAGED_BROWSER_RUNTIME_DIR = "/tmp/hyperlocalise-browser-runtime";
 const MANAGED_PLAYWRIGHT_MODULE = `${MANAGED_BROWSER_RUNTIME_DIR}/node_modules/playwright`;
 const ERROR_CODE_PREFIX = "HYPERLOCALISE_SCREENSHOT_ERROR_CODE=";
@@ -485,28 +488,21 @@ function managedBrowserRuntimeCommand() {
     "  fi",
     "fi",
     // Prefer OS deps from sandbox bootstrap; retry here when Linux libs are missing.
+    // On Amazon Linux (Vercel Sandbox), Playwright install-deps cannot use apt-get.
+    installChromiumSystemDependenciesFunction,
     "if command -v ldconfig >/dev/null 2>&1 && ! ldconfig -p 2>/dev/null | grep -q 'libnspr4\\.so'; then",
-    "  DEPS_RC=1",
-    "  if command -v sudo >/dev/null 2>&1; then",
-    `    sudo env PLAYWRIGHT_BROWSERS_PATH=${browsersPath} ${playwrightBin} install-deps chromium >/tmp/hyperlocalise-chromium-deps.log 2>&1 && DEPS_RC=0`,
-    "  fi",
-    '  if [ "$DEPS_RC" -ne 0 ]; then',
-    `    PLAYWRIGHT_BROWSERS_PATH=${browsersPath} ${playwrightBin} install-deps chromium >/tmp/hyperlocalise-chromium-deps.log 2>&1 && DEPS_RC=0`,
-    "  fi",
-    '  if [ "$DEPS_RC" -ne 0 ]; then',
+    "  if ! install_chromium_system_dependencies >/tmp/hyperlocalise-chromium-deps.log 2>&1; then",
     "    cat /tmp/hyperlocalise-chromium-deps.log >&2 || true",
     `    echo "${ERROR_CODE_PREFIX}browser_system_deps_unavailable" >&2`,
     "    exit 89",
     "  fi",
     "fi",
-    `if ! PLAYWRIGHT_BROWSERS_PATH=${browsersPath} ${playwrightBin} install --with-deps chromium >/tmp/hyperlocalise-chromium-install.log 2>&1; then`,
-    // `--with-deps` may fail without root even when the browser binary itself installs; retry binary-only.
-    // Append so the original `--with-deps` failure reason is preserved for debugging.
-    `  if ! PLAYWRIGHT_BROWSERS_PATH=${browsersPath} ${playwrightBin} install chromium >>/tmp/hyperlocalise-chromium-install.log 2>&1; then`,
-    `    cat /tmp/hyperlocalise-chromium-install.log >&2 || true`,
-    `    echo "${ERROR_CODE_PREFIX}browser_binary_unavailable" >&2`,
-    "    exit 88",
-    "  fi",
+    // Install the browser binary only. System libs are handled above (dnf/apt);
+    // `--with-deps` fails on Amazon Linux because Playwright shells out to apt-get.
+    `if ! PLAYWRIGHT_BROWSERS_PATH=${browsersPath} ${playwrightBin} install chromium >/tmp/hyperlocalise-chromium-install.log 2>&1; then`,
+    `  cat /tmp/hyperlocalise-chromium-install.log >&2 || true`,
+    `  echo "${ERROR_CODE_PREFIX}browser_binary_unavailable" >&2`,
+    "  exit 88",
     "fi",
   ].join("\n");
 }

--- a/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.test.ts
+++ b/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   installRequiredSandboxToolsCommand,
+  sandboxChromiumDnfPackages,
   sandboxHyperlocaliseReleaseVersion,
   sandboxPlaywrightVersion,
   sandboxRipgrepReleaseVersion,
@@ -19,16 +20,25 @@ describe("installRequiredSandboxToolsCommand", () => {
       "install_chromium_system_dependencies || true",
     );
     expect(installRequiredSandboxToolsCommand).toContain(
+      `run_as_root dnf install -y ${sandboxChromiumDnfPackages.join(" ")}`,
+    );
+    expect(installRequiredSandboxToolsCommand).toContain(
       `PW_VERSION="${sandboxPlaywrightVersion}"`,
     );
     expect(installRequiredSandboxToolsCommand).toContain(
-      'npx --yes "playwright@${PW_VERSION}" install-deps chromium',
+      'run_as_root npx --yes "playwright@${PW_VERSION}" install-deps chromium',
     );
     expect(installRequiredSandboxToolsCommand).toContain(
-      "apt-get update && apt-get install -y libnspr4 libnss3",
+      "run_as_root apt-get update && run_as_root apt-get install -y libnspr4 libnss3",
     );
     expect(installRequiredSandboxToolsCommand).toContain(
       "if command -v ldconfig >/dev/null 2>&1 && ! ldconfig -p 2>/dev/null | grep -q 'libnspr4\\.so'; then",
+    );
+    // dnf must be preferred: Vercel Sandbox is Amazon Linux and has npm, but no apt-get.
+    expect(installRequiredSandboxToolsCommand.indexOf("run_as_root dnf install -y")).toBeLessThan(
+      installRequiredSandboxToolsCommand.indexOf(
+        'run_as_root npx --yes "playwright@${PW_VERSION}" install-deps chromium',
+      ),
     );
   });
 

--- a/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
+++ b/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
@@ -7,11 +7,40 @@ export const sandboxRipgrepReleaseVersion = "14.1.1";
 export const sandboxHyperlocaliseReleaseVersion = "1.8.24";
 
 /**
- * Pinned Playwright release used to install Chromium OS libraries
- * (e.g. libnspr4.so) via `playwright install-deps`. Keep in sync with
- * `MANAGED_PLAYWRIGHT_VERSION` in capture-screenshot.ts.
+ * Pinned Playwright release used for Debian/Ubuntu `install-deps` fallback.
+ * Keep in sync with `MANAGED_PLAYWRIGHT_VERSION` in capture-screenshot.ts.
  */
 export const sandboxPlaywrightVersion = "1.61.1";
+
+/**
+ * Amazon Linux 2023 packages required to run Playwright's Ubuntu Chromium
+ * build. Vercel Sandbox is AL2023 (`dnf`); Playwright's `install-deps` assumes
+ * `apt-get` and fails there.
+ */
+export const sandboxChromiumDnfPackages = [
+  "nspr",
+  "nss",
+  "atk",
+  "at-spi2-atk",
+  "at-spi2-core",
+  "cups-libs",
+  "libdrm",
+  "libxkbcommon",
+  "libgbm",
+  "libX11",
+  "libXcomposite",
+  "libXcursor",
+  "libXdamage",
+  "libXext",
+  "libXi",
+  "libXrandr",
+  "libXScrnSaver",
+  "libXtst",
+  "gtk3",
+  "pango",
+  "alsa-lib",
+  "xorg-x11-server-Xvfb",
+] as const;
 
 type VercelSandboxCreateOptions = Parameters<typeof Sandbox.create>[0];
 
@@ -66,18 +95,34 @@ const installHyperlocaliseFromGithubRelease = [
   "}",
 ].join("\n");
 
-const installChromiumSystemDependencies = [
+/** Shell function used by sandbox bootstrap and screenshot capture-time retry. */
+export const installChromiumSystemDependenciesFunction = [
   "install_chromium_system_dependencies() {",
+  "  run_as_root() {",
+  '    if [ "$(id -u)" -eq 0 ]; then',
+  '      "$@"',
+  "    elif command -v sudo >/dev/null 2>&1; then",
+  '      sudo "$@"',
+  "    else",
+  '      "$@"',
+  "    fi",
+  "  }",
+  // Prefer dnf: Vercel Sandbox is Amazon Linux 2023. Playwright install-deps
+  // falls back to ubuntu packages and shells out to apt-get (missing here).
+  "  if command -v dnf >/dev/null 2>&1; then",
+  `    run_as_root dnf install -y ${sandboxChromiumDnfPackages.join(" ")}`,
+  "    return $?",
+  "  fi",
   `  PW_VERSION="${sandboxPlaywrightVersion}"`,
   "  if command -v npm >/dev/null 2>&1; then",
-  '    npx --yes "playwright@${PW_VERSION}" install-deps chromium',
+  '    run_as_root npx --yes "playwright@${PW_VERSION}" install-deps chromium',
   "    return $?",
   "  fi",
   "  if command -v apt-get >/dev/null 2>&1; then",
-  "    apt-get update && apt-get install -y libnspr4 libnss3",
+  "    run_as_root apt-get update && run_as_root apt-get install -y libnspr4 libnss3",
   "    return $?",
   "  fi",
-  '  echo "Unable to install Chromium system dependencies (npm/apt-get unavailable)." >&2',
+  '  echo "Unable to install Chromium system dependencies (dnf/npm/apt-get unavailable)." >&2',
   "  return 1",
   "}",
 ].join("\n");
@@ -85,7 +130,7 @@ const installChromiumSystemDependencies = [
 export const installRequiredSandboxToolsCommand = [
   installRipgrepFromGithubRelease,
   installHyperlocaliseFromGithubRelease,
-  installChromiumSystemDependencies,
+  installChromiumSystemDependenciesFunction,
   "if ! command -v rg >/dev/null 2>&1; then",
   "  if command -v apt-get >/dev/null 2>&1; then",
   "    apt-get update && apt-get install -y ripgrep",

--- a/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
+++ b/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
@@ -8,7 +8,7 @@ export const sandboxHyperlocaliseReleaseVersion = "1.8.24";
 
 /**
  * Pinned Playwright release used for Debian/Ubuntu `install-deps` fallback.
- * Keep in sync with `MANAGED_PLAYWRIGHT_VERSION` in capture-screenshot.ts.
+ * Also used as `MANAGED_PLAYWRIGHT_VERSION` in capture-screenshot.ts.
  */
 export const sandboxPlaywrightVersion = "1.61.1";
 
@@ -26,7 +26,7 @@ export const sandboxChromiumDnfPackages = [
   "cups-libs",
   "libdrm",
   "libxkbcommon",
-  "libgbm",
+  "mesa-libgbm",
   "libX11",
   "libXcomposite",
   "libXcursor",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Vercel Sandbox is Amazon Linux 2023 (`dnf`). Bootstrap was calling `playwright install-deps`, which falls back to Ubuntu packages and runs `apt-get` — missing on AL2023 — producing:

```
BEWARE: your OS is not officially supported by Playwright; installing dependencies for ubuntu24.04-x64 as a fallback.
Switching to root user to install dependencies...
sh: line 1: apt-get: command not found
```

This change installs Chromium system libraries with `dnf` first (`nspr`, `nss`, and related X11/GTK packages), keeps Playwright `install-deps` / `apt-get` for Debian/Ubuntu, and reuses the same helper for screenshot capture-time retry. Browser binary install no longer uses `--with-deps`.

## How to test

- `vp test src/lib/vercel-sandbox-config.test.ts src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts`
- `vp check --fix`
- On a fresh Vercel Sandbox: confirm bootstrap installs `libnspr4.so` and screenshot capture can launch Chromium

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2cce295-c8a5-4a5c-b2ef-fedce0814066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2cce295-c8a5-4a5c-b2ef-fedce0814066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

