### PR TITLE
fix(web): keep screenshot artifacts and stream images to the model

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
@@ -18,6 +18,7 @@ import { MessageResponse } from "@/components/ai-elements/message";
 import { Reasoning, ReasoningContent, ReasoningTrigger } from "@/components/ai-elements/reasoning";
 import { Source, Sources, SourcesContent, SourcesTrigger } from "@/components/ai-elements/sources";
 import {
+  getImageToolOutput,
   serializeToolJson,
   Tool,
   ToolContent,
@@ -450,9 +451,10 @@ function AssistantToolPart({ part }: { part: ToolPart }) {
         type: part.type,
         state: part.state,
       };
+  const hasImageOutput = Boolean(getImageToolOutput(part.output));
 
   return (
-    <Tool>
+    <Tool defaultOpen={hasImageOutput}>
       <ToolHeader {...headerProps} input={part.input} />
       <ToolContent>
         <ToolInput input={part.input} />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
@@ -9,7 +9,7 @@ import type {
   UIMessage,
 } from "ai";
 import { DownloadIcon, FileTextIcon } from "lucide-react";
-import { memo, type ReactNode } from "react";
+import { memo, useState, type ReactNode } from "react";
 import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
 
 import { ConversationEmptyState } from "@/components/ai-elements/conversation";
@@ -452,9 +452,12 @@ function AssistantToolPart({ part }: { part: ToolPart }) {
         state: part.state,
       };
   const hasImageOutput = Boolean(getImageToolOutput(part.output));
+  // null = follow hasImageOutput; once the user toggles, keep their choice.
+  const [userOpen, setUserOpen] = useState<boolean | null>(null);
+  const open = userOpen ?? hasImageOutput;
 
   return (
-    <Tool defaultOpen={hasImageOutput}>
+    <Tool open={open} onOpenChange={setUserOpen}>
       <ToolHeader {...headerProps} input={part.input} />
       <ToolContent>
         <ToolInput input={part.input} />

--- a/apps/hyperlocalise-web/src/components/ai-elements/tool-stream-safety.test.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/tool-stream-safety.test.ts
@@ -29,6 +29,13 @@ describe("getImageToolOutput", () => {
       }),
     ).toBeNull();
     expect(getImageToolOutput({ success: false, error: "failed" })).toBeNull();
+    expect(
+      getImageToolOutput({
+        url: "https://download.example/legacy.png",
+        contentType: "image/png",
+        filename: "legacy.png",
+      }),
+    ).toBeNull();
   });
 });
 

--- a/apps/hyperlocalise-web/src/components/ai-elements/tool-stream-safety.test.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/tool-stream-safety.test.ts
@@ -1,7 +1,36 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import { normalizeCodeBlockSource } from "./code-block";
-import { extractToolInputDetail, serializeToolJson } from "./tool";
+import { extractToolInputDetail, getImageToolOutput, serializeToolJson } from "./tool";
+
+describe("getImageToolOutput", () => {
+  it("extracts image urls from successful screenshot tool output", () => {
+    expect(
+      getImageToolOutput({
+        success: true,
+        url: "https://download.example/story.png",
+        contentType: "image/png",
+        filename: "story.png",
+      }),
+    ).toEqual({
+      url: "https://download.example/story.png",
+      contentType: "image/png",
+      filename: "story.png",
+    });
+  });
+
+  it("ignores non-image tool output", () => {
+    expect(
+      getImageToolOutput({
+        success: true,
+        url: "https://example.com/notes.txt",
+        contentType: "text/plain",
+        filename: "notes.txt",
+      }),
+    ).toBeNull();
+    expect(getImageToolOutput({ success: false, error: "failed" })).toBeNull();
+  });
+});
 
 describe("serializeToolJson", () => {
   it("returns {} when input is undefined (streaming tool args)", () => {

--- a/apps/hyperlocalise-web/src/components/ai-elements/tool.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/tool.tsx
@@ -259,7 +259,7 @@ export function getImageToolOutput(output: unknown): ImageToolOutput | null {
   }
 
   const record = output as Record<string, unknown>;
-  if (record.success === false || typeof record.url !== "string" || !record.url) {
+  if (record.success !== true || typeof record.url !== "string" || !record.url) {
     return null;
   }
 

--- a/apps/hyperlocalise-web/src/components/ai-elements/tool.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/tool.tsx
@@ -247,11 +247,45 @@ export type ToolOutputProps = ComponentProps<"div"> & {
   errorText: ToolPart["errorText"];
 };
 
+type ImageToolOutput = {
+  url: string;
+  filename?: string;
+  contentType?: string;
+};
+
+export function getImageToolOutput(output: unknown): ImageToolOutput | null {
+  if (!output || typeof output !== "object" || isValidElement(output)) {
+    return null;
+  }
+
+  const record = output as Record<string, unknown>;
+  if (record.success === false || typeof record.url !== "string" || !record.url) {
+    return null;
+  }
+
+  const contentType = typeof record.contentType === "string" ? record.contentType : "";
+  const filename = typeof record.filename === "string" ? record.filename : undefined;
+  const looksLikeImage =
+    contentType.toLowerCase().startsWith("image/") ||
+    Boolean(filename && /\.(png|jpe?g|gif|webp|avif|svg)$/i.test(filename));
+
+  if (!looksLikeImage) {
+    return null;
+  }
+
+  return {
+    url: record.url,
+    filename,
+    contentType: contentType || undefined,
+  };
+}
+
 export const ToolOutput = ({ className, output, errorText, ...props }: ToolOutputProps) => {
   if (!(output || errorText)) {
     return null;
   }
 
+  const imageOutput = getImageToolOutput(output);
   let Output = <div>{output as ReactNode}</div>;
 
   if (typeof output === "object" && !isValidElement(output)) {
@@ -278,6 +312,20 @@ export const ToolOutput = ({ className, output, errorText, ...props }: ToolOutpu
           <FormattedMessage {...toolMessages.result} />
         )}
       </TypographyH4>
+      {imageOutput ? (
+        <a
+          href={imageOutput.url}
+          target="_blank"
+          rel="noreferrer"
+          className="block overflow-hidden rounded-md border border-border bg-background"
+        >
+          <img
+            src={imageOutput.url}
+            alt={imageOutput.filename || "Tool result image"}
+            className="max-h-96 w-full object-contain"
+          />
+        </a>
+      ) : null}
       <div
         className={cn(
           "overflow-x-auto rounded-md text-xs [&_table]:w-full",

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
-import { createStoredFile } from "@/lib/file-storage/records";
+import { createStoredFile, getStoredFileContent } from "@/lib/file-storage/records";
 
 import {
   classifyScreenshotCaptureFailure,
@@ -18,6 +18,7 @@ import type { RepoToolContext } from "./types";
 
 vi.mock("@/lib/file-storage/records", () => ({
   createStoredFile: vi.fn(),
+  getStoredFileContent: vi.fn(),
 }));
 
 const toolCallInfo = { toolCallId: "test-tool-call", messages: [] };
@@ -365,6 +366,10 @@ describe("createCaptureScreenshotTool", () => {
       url: "https://download.example/storybook.png",
       target: { type: "storybook", storyId: "components-button--primary" },
       viewport: { width: 1280, height: 720 },
+      workspacePath: expect.stringMatching(/^\.hyperlocalise-agent\/screenshots\//),
+      screenshotPath: expect.stringMatching(
+        /^\.hyperlocalise-agent\/screenshots\/.+\/screenshot\.png$/,
+      ),
     });
     expect(writeWorkspaceFile).toHaveBeenCalledWith(
       expect.stringMatching(/^\.hyperlocalise-agent\/screenshots\/.+\/capture\.cjs$/),
@@ -372,6 +377,12 @@ describe("createCaptureScreenshotTool", () => {
         'require("/tmp/hyperlocalise-browser-runtime/node_modules/playwright")',
       ),
     );
+    expect(exec).toHaveBeenCalledWith("bash", {
+      args: ["-lc", expect.stringContaining("base64 -w 0")],
+    });
+    expect(exec).toHaveBeenCalledWith("bash", {
+      args: ["-lc", expect.not.stringMatching(/rm -rf ['"]?\.hyperlocalise-agent\/screenshots\//)],
+    });
     const captureScript = String(writeWorkspaceFile.mock.calls[0]?.[1] ?? "");
     expect(captureScript).toContain('waitUntil: "load"');
     expect(captureScript).not.toMatch(/waitUntil:\s*"networkidle"/);
@@ -507,6 +518,82 @@ describe("createCaptureScreenshotTool", () => {
     expect(result).toMatchObject({
       success: false,
       errorCode: "browser_binary_unavailable",
+    });
+  });
+
+  it("maps stored screenshot bytes to multimodal model output", async () => {
+    vi.mocked(createStoredFile).mockResolvedValueOnce({
+      id: "file_vision",
+      organizationId: "org_1",
+      projectId: "project_1",
+      createdByUserId: "user_1",
+      role: "reference",
+      sourceKind: "repository_file",
+      sourceInteractionId: "conv_1",
+      sourceJobId: null,
+      storageProvider: "vercel_blob",
+      storageKey: "organizations/org_1/files/file_vision/storybook.png",
+      storageUrl: "https://blob.example/storybook-vision.png",
+      downloadUrl: "https://download.example/storybook-vision.png",
+      filename: "storybook-components-button--primary.png",
+      contentType: "image/png",
+      byteSize: 9,
+      sha256: "hash",
+      etag: null,
+      metadata: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    vi.mocked(getStoredFileContent).mockResolvedValueOnce({
+      file: {
+        id: "file_vision",
+        contentType: "image/png",
+      } as never,
+      content: Buffer.from("png-bytes"),
+    });
+    const { repo } = createRepoContext({
+      packageJson: {
+        packageManager: "pnpm@11.9.0",
+        scripts: { storybook: "storybook dev" },
+      },
+      lockfiles: ["pnpm-lock.yaml"],
+    });
+    const captureScreenshot = createCaptureScreenshotTool(createToolContext(), repo);
+    const result = await captureScreenshot.execute!(
+      { target: { type: "storybook", storyId: "components-button--primary" } },
+      toolCallInfo,
+    );
+    expect(result).toMatchObject({ success: true, fileId: "file_vision" });
+    if (!result || typeof result !== "object" || !("success" in result) || !result.success) {
+      throw new Error("expected successful screenshot capture");
+    }
+
+    const modelOutput = await captureScreenshot.toModelOutput!({
+      toolCallId: "test-tool-call",
+      input: { target: { type: "storybook", storyId: "components-button--primary" } },
+      output: result,
+    });
+
+    expect(getStoredFileContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileId: "file_vision",
+        organizationId: "org_1",
+        projectId: "project_1",
+      }),
+    );
+    expect(modelOutput).toEqual({
+      type: "content",
+      value: [
+        {
+          type: "text",
+          text: expect.stringContaining("components-button--primary"),
+        },
+        {
+          type: "image-data",
+          data: Buffer.from("png-bytes").toString("base64"),
+          mediaType: "image/png",
+        },
+      ],
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
@@ -5,6 +5,7 @@ import { createStoredFile, getStoredFileContent } from "@/lib/file-storage/recor
 
 import {
   classifyScreenshotCaptureFailure,
+  clearScreenshotBase64CacheForTests,
   createCaptureScreenshotTool,
   detectPackageManager,
   detectStorybookMajorVersion,
@@ -522,6 +523,7 @@ describe("createCaptureScreenshotTool", () => {
   });
 
   it("maps stored screenshot bytes to multimodal model output", async () => {
+    clearScreenshotBase64CacheForTests();
     vi.mocked(createStoredFile).mockResolvedValueOnce({
       id: "file_vision",
       organizationId: "org_1",
@@ -574,6 +576,7 @@ describe("createCaptureScreenshotTool", () => {
       output: result,
     });
 
+    expect(getStoredFileContent).toHaveBeenCalledTimes(1);
     expect(getStoredFileContent).toHaveBeenCalledWith(
       expect.objectContaining({
         fileId: "file_vision",
@@ -595,6 +598,13 @@ describe("createCaptureScreenshotTool", () => {
         },
       ],
     });
+
+    await captureScreenshot.toModelOutput!({
+      toolCallId: "test-tool-call-replay",
+      input: { target: { type: "storybook", storyId: "components-button--primary" } },
+      output: result,
+    });
+    expect(getStoredFileContent).toHaveBeenCalledTimes(1);
   });
 
   it("denies capture when the repository write gate rejects the actor", async () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 import { assertRepositoryWriteAllowed } from "@/lib/agent-runtime/tools/policy";
-import { createStoredFile } from "@/lib/file-storage/records";
+import { createStoredFile, getStoredFileContent } from "@/lib/file-storage/records";
 import {
   installChromiumSystemDependenciesFunction,
   sandboxPlaywrightVersion,
@@ -545,10 +545,44 @@ function buildCaptureCommand(input: {
     "  tail -n 40 /tmp/hyperlocalise-storybook.log >&2 || true",
     "  exit 1",
     "fi",
+    // Keep the workspace screenshot directory for sandbox debugging. The durable
+    // artifact is stored via createStoredFile; this folder is disposable scaffolding.
     `SCREENSHOT_B64=$(base64 -w 0 ${shellQuote(input.screenshotPath)})`,
-    `rm -rf ${shellQuote(input.baseDir)}`,
     'printf "%s" "$SCREENSHOT_B64"',
   ].join("\n");
+}
+
+type CaptureScreenshotSuccess = {
+  success: true;
+  fileId: string;
+  url: string;
+  filename: string;
+  contentType: string;
+  byteSize: number;
+  workspacePath: string;
+  screenshotPath: string;
+  target: { type: "storybook"; storyId: string };
+  viewport: { width: number; height: number };
+  storybookUrl: string;
+};
+
+type CaptureScreenshotFailure = {
+  success: false;
+  errorCode: string;
+  error: string;
+  checkedFiles?: string[];
+  truncated?: boolean;
+};
+
+export type CaptureScreenshotResult = CaptureScreenshotSuccess | CaptureScreenshotFailure;
+
+function isCaptureScreenshotSuccess(output: unknown): output is CaptureScreenshotSuccess {
+  return (
+    Boolean(output) &&
+    typeof output === "object" &&
+    (output as CaptureScreenshotSuccess).success === true &&
+    typeof (output as CaptureScreenshotSuccess).fileId === "string"
+  );
 }
 
 export function createCaptureScreenshotTool(ctx: ToolContext, repo: RepoToolContext) {
@@ -562,7 +596,61 @@ The tool finds package.json at the repository root or in nested app packages, de
 
 It does not commit, push, open pull requests, or publish repository changes.`,
     inputSchema: captureScreenshotInputSchema,
-    execute: async ({ target, viewport = DEFAULT_VIEWPORT, waitForMs = DEFAULT_WAIT_FOR_MS }) => {
+    toModelOutput: async ({ output }) => {
+      if (!isCaptureScreenshotSuccess(output)) {
+        return { type: "json", value: output as CaptureScreenshotFailure };
+      }
+
+      try {
+        const { content } = await getStoredFileContent({
+          fileId: output.fileId,
+          organizationId: ctx.organizationId,
+          projectId: ctx.projectId,
+          db: ctx.db,
+        });
+
+        return {
+          type: "content",
+          value: [
+            {
+              type: "text",
+              text: [
+                `Screenshot captured for Storybook story ${output.target.storyId}.`,
+                `Stored file: ${output.filename} (${output.fileId}).`,
+                `URL: ${output.url}`,
+                `Workspace path (sandbox debug): ${output.screenshotPath}`,
+                `Viewport: ${output.viewport.width}×${output.viewport.height}`,
+              ].join("\n"),
+            },
+            {
+              type: "image-data",
+              data: content.toString("base64"),
+              mediaType: output.contentType || "image/png",
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          type: "content",
+          value: [
+            {
+              type: "text",
+              text: [
+                `Screenshot metadata for ${output.target.storyId}: file ${output.fileId} at ${output.url}.`,
+                `Failed to load image bytes for the model: ${
+                  error instanceof Error ? error.message : String(error)
+                }`,
+              ].join("\n"),
+            },
+          ],
+        };
+      }
+    },
+    execute: async ({
+      target,
+      viewport = DEFAULT_VIEWPORT,
+      waitForMs = DEFAULT_WAIT_FOR_MS,
+    }): Promise<CaptureScreenshotResult> => {
       const gate = assertRepositoryWriteAllowed(ctx, "apply_fixes");
       if (!gate.allowed) {
         return {
@@ -687,6 +775,8 @@ It does not commit, push, open pull requests, or publish repository changes.`,
         filename: storedFile.filename,
         contentType: storedFile.contentType,
         byteSize: storedFile.byteSize,
+        workspacePath: baseDir,
+        screenshotPath,
         target,
         viewport,
         storybookUrl: storyUrl,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -585,6 +585,44 @@ function isCaptureScreenshotSuccess(output: unknown): output is CaptureScreensho
   );
 }
 
+/** Process-local cache so multi-turn toModelOutput replays avoid re-fetching storage. */
+const screenshotBase64Cache = new Map<string, string>();
+const SCREENSHOT_BASE64_CACHE_LIMIT = 32;
+
+async function loadScreenshotBase64ForModel(input: {
+  fileId: string;
+  organizationId: string;
+  projectId: string | null;
+  db: ToolContext["db"];
+}) {
+  const cached = screenshotBase64Cache.get(input.fileId);
+  if (cached) {
+    return cached;
+  }
+
+  const { content } = await getStoredFileContent({
+    fileId: input.fileId,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    db: input.db,
+  });
+  const base64 = content.toString("base64");
+
+  if (screenshotBase64Cache.size >= SCREENSHOT_BASE64_CACHE_LIMIT) {
+    const oldestKey = screenshotBase64Cache.keys().next().value;
+    if (oldestKey) {
+      screenshotBase64Cache.delete(oldestKey);
+    }
+  }
+  screenshotBase64Cache.set(input.fileId, base64);
+  return base64;
+}
+
+/** Test helper: clear the in-process screenshot base64 cache. */
+export function clearScreenshotBase64CacheForTests() {
+  screenshotBase64Cache.clear();
+}
+
 export function createCaptureScreenshotTool(ctx: ToolContext, repo: RepoToolContext) {
   return tool({
     description: `Capture a screenshot from the connected repository workspace.
@@ -602,7 +640,7 @@ It does not commit, push, open pull requests, or publish repository changes.`,
       }
 
       try {
-        const { content } = await getStoredFileContent({
+        const base64 = await loadScreenshotBase64ForModel({
           fileId: output.fileId,
           organizationId: ctx.organizationId,
           projectId: ctx.projectId,
@@ -624,7 +662,7 @@ It does not commit, push, open pull requests, or publish repository changes.`,
             },
             {
               type: "image-data",
-              data: content.toString("base64"),
+              data: base64,
               mediaType: output.contentType || "image/png",
             },
           ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Stop deleting `.hyperlocalise-agent/screenshots/<id>/` after capture so sandbox debugging can inspect `screenshot.png`.
- Add `toModelOutput` on `captureScreenshot` so the AI SDK sends image bytes (`image-data`) back to the model instead of JSON metadata only.
- Render successful image tool outputs (URL + `image/*`) inline in inbox/chat dock tool results.

## Review follow-ups
- Control the tool accordion with `open`/`onOpenChange` so streaming image results expand when output arrives (not only on historical remount).
- Require `success === true` before treating tool output as an image.
- Cache screenshot base64 by `fileId` so multi-turn `toModelOutput` replays skip object-storage re-reads (kept `image-data` for provider compatibility).

## Test plan
- [x] `vp test src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts src/components/ai-elements/tool-stream-safety.test.ts`
- [x] `vp check --fix`
- [ ] Manually: enable visual-mock, ask for a Storybook screenshot in chat dock, confirm the tool panel auto-opens with the PNG during the live stream.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1cc2671-4ccb-4f8f-a941-76d4c507b4af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1cc2671-4ccb-4f8f-a941-76d4c507b4af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

