### PR TITLE
ci(bazel): switch to Blacksmith Bazel build caching

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,11 +9,11 @@ test --test_output=errors
 test --test_summary=detailed
 
 build:ci --keep_going
+# Upload local results so Blacksmith's injected remote cache stays warm.
 build:ci --remote_upload_local_results=true
 build:ci --color=yes
 build:ci --curses=no
 build:ci --show_result=20
-build:ci --bes_upload_mode=wait_for_upload_complete
 
 test:ci --test_output=errors
 test:ci --test_summary=detailed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,9 +90,6 @@ jobs:
   bazel-build-test:
     name: Bazel Build/Test
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    env:
-      BUILDBUDDY_ENDPOINT: grpcs://remote.buildbuddy.io
-      BUILDBUDDY_RESULTS_URL: https://app.buildbuddy.io/invocation/
 
     steps:
       - name: Checkout
@@ -101,32 +98,13 @@ jobs:
       - name: Setup Bazelisk
         uses: bazelbuild/setup-bazelisk@b39c379c82683a5f25d34f0d062761f62693e0b2 # v3
 
-      - name: Configure BuildBuddy
-        id: buildbuddy
-        shell: bash
-        env:
-          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
-        run: |
-          rc_path="$RUNNER_TEMP/buildbuddy.bazelrc"
-          if [[ -n "${BUILDBUDDY_API_KEY}" ]]; then
-            printf '%s\n' \
-              "common --bes_backend=${BUILDBUDDY_ENDPOINT}" \
-              "common --bes_results_url=${BUILDBUDDY_RESULTS_URL}" \
-              "common --remote_cache=${BUILDBUDDY_ENDPOINT}" \
-              "common --remote_timeout=10m" \
-              "common --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" \
-              >"${rc_path}"
-            echo "extra_bazelrc=--bazelrc=${rc_path}" >>"${GITHUB_OUTPUT}"
-          else
-            echo "extra_bazelrc=" >>"${GITHUB_OUTPUT}"
-            echo "BuildBuddy secret unavailable; continuing with local-only Bazel execution."
-          fi
-
+      # Blacksmith injects --remote_cache when Bazel Build Caching is enabled.
+      # Do not set an explicit --remote_cache here; it would take precedence.
       - name: Bazel build
-        run: bazel ${{ steps.buildbuddy.outputs.extra_bazelrc }} build --config=ci //:cli
+        run: bazel build --config=ci //:cli
 
       - name: Bazel test
-        run: bazel ${{ steps.buildbuddy.outputs.extra_bazelrc }} test --config=ci //apps/cli/cmd:cmd_test
+        run: bazel test --config=ci //apps/cli/cmd:cmd_test
 
   go-quality:
     name: Go Quality


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Remove the BuildBuddy `--remote_cache` / BES workflow setup from the Bazel CI job so Blacksmith's transparent Bazel remote cache can take effect ([docs](https://docs.blacksmith.sh/blacksmith-caching/bazel-build-caching)).
- Drop BuildBuddy-only `--bes_upload_mode` from `.bazelrc`, keep `--remote_upload_local_results=true` so local action results still warm the injected cache.

## Follow-up (dashboard)

An org admin still needs to enable **Bazel Build Caching** under Settings → Features → Caching in the Blacksmith dashboard. No further workflow or `.bazelrc` remote-cache config is required after that.

## Test plan

- [ ] Confirm CI `Bazel Build/Test` passes on Blacksmith runners
- [ ] After enabling the feature, confirm Bazel process summary shows `remote cache hit` on a second run
- [ ] Check Blacksmith Cache page → Bazel tab for hit rate / storage usage

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e74a0f6-ccc1-44e7-8d03-0a1768ee0c83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e74a0f6-ccc1-44e7-8d03-0a1768ee0c83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

