### PR TITLE
fix(agent): serve private screenshots and wait for Storybook copy

### DIFF
--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/visual-mock.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/visual-mock.md
@@ -21,13 +21,13 @@ This is an agent workflow skill, not a screenshot product tool. Compose lower-le
   1. Use repository write tools (`write` / `applyPatch`) to create a temporary CSF story next to the component (or in the repo's usual stories location), following existing Storybook conventions in that package.
   2. Supply realistic mock props/args so the target string is visible in a representative state. Prefer fixtures and patterns from sibling stories or tests; invent only what is missing.
   3. Derive the Storybook `storyId` from the new story's `title` + export name (CSF id form, e.g. `components-button--primary`).
-  4. Call `captureScreenshot` with that `storyId`.
+  4. Call `captureScreenshot` with that `storyId` and `waitForText` set to the visible strings that must appear in the mock (the source/target copy under review, button labels, headings). Exact substrings from the rendered UI work best.
   5. Keep the generated story disposable sandbox scaffolding unless the user also asked for a production Storybook addition.
 - If Storybook is **not** present in the repo, do not invent a Storybook setup. Tell the user to add Storybook and implement visual regression testing with it so component screenshots can be captured for localization context. Include a short mock plan (target component, data state, viewport) and that Storybook is the missing capability. Do not claim a screenshot was created.
 - When coding write primitives such as `write` or `applyPatch` are available, use them only for temporary preview scaffolding, missing Storybook stories for capture, or narrowly scoped mock fixtures unless the user also asks for a production code change.
 - Do not commit changes, push branches, open pull requests, or publish repository changes. Visual mocks may mutate only the sandbox workspace.
 - When a browser or screenshot primitive is available, render the preview and capture an image. Record the viewport, route or preview file / story id, and any assumptions.
-- Use `captureScreenshot` for Storybook stories. Provide the Storybook story id and viewport; do not ask for package-manager-specific commands. The tool discovers Storybook in the repo root or nested app packages.
+- Use `captureScreenshot` for Storybook stories. Provide the Storybook story id, viewport, and `waitForText` with the copy that should be visible before capture; do not ask for package-manager-specific commands. The tool discovers Storybook in the repo root or nested app packages and waits until those strings appear in the story DOM.
 - When durable file attachment primitives are available, attach the screenshot as an agent artifact with metadata identifying it as `visual-mock`.
 - If write, render, screenshot, or attachment primitives are unavailable, do not claim a screenshot was created. Return a concise mock plan with the target component, data state, viewport, and exact next primitive needed.
 

--- a/apps/hyperlocalise-web/src/api/routes/file/file.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/file/file.route.ts
@@ -60,18 +60,20 @@ export function createFileRoutes(options: CreateFileRoutesOptions = {}) {
         return fileNotFoundResponse(c);
       }
 
-      c.header(
-        "Content-Type",
-        storedObject.contentType ?? file.contentType ?? "application/octet-stream",
-      );
+      const contentType =
+        storedObject.contentType ?? file.contentType ?? "application/octet-stream";
+      const isImage = contentType.toLowerCase().startsWith("image/");
+      c.header("Content-Type", contentType);
       c.header(
         "Content-Disposition",
-        `attachment; filename*=UTF-8''${encodeURIComponent(file.filename)}`,
+        `${isImage ? "inline" : "attachment"}; filename*=UTF-8''${encodeURIComponent(file.filename)}`,
       );
       c.header("Content-Security-Policy", "default-src 'none'; sandbox;");
       c.header("X-Content-Type-Options", "nosniff");
-      c.header("X-Download-Options", "noopen");
-      c.header("Cache-Control", "no-store");
+      if (!isImage) {
+        c.header("X-Download-Options", "noopen");
+      }
+      c.header("Cache-Control", isImage ? "private, max-age=60" : "no-store");
 
       return c.body(storedObject.body);
     });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
@@ -186,7 +186,9 @@ describe("conversation skill registry", () => {
     expect(visualMockSkill).toContain("Do not answer visual-context requests with find-context");
     expect(visualMockSkill).toContain("When the component has no Storybook story");
     expect(visualMockSkill).toContain("create a temporary CSF story");
-    expect(visualMockSkill).toContain("Call `captureScreenshot` with that `storyId`");
+    expect(visualMockSkill).toContain(
+      "Call `captureScreenshot` with that `storyId` and `waitForText`",
+    );
     expect(visualMockSkill).toContain("do not invent a Storybook setup");
     expect(visualMockSkill).toContain(
       "implement visual regression testing with it so component screenshots can be captured",

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
@@ -440,6 +440,8 @@ describe("createCaptureScreenshotTool", () => {
     expect(captureScript).toContain("addInitScript");
     expect(captureScript).toContain("__STORYBOOK_ADDONS_CHANNEL__");
     expect(captureScript).toContain("storyRendered");
+    expect(captureScript).toContain("storyMissing");
+    expect(captureScript).not.toContain("storyFinished");
     expect(captureScript).toContain("sb-show-preparing-story");
     expect(captureScript).toContain('const waitForText = ["Save changes","Discard"]');
     expect(captureScript).toContain("texts.every((text) => haystack.includes(text))");

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
@@ -4,6 +4,7 @@ import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 import { createStoredFile, getStoredFileContent } from "@/lib/file-storage/records";
 
 import {
+  buildScreenshotServeUrl,
   classifyScreenshotCaptureFailure,
   clearScreenshotBase64CacheForTests,
   createCaptureScreenshotTool,
@@ -24,6 +25,18 @@ vi.mock("@/lib/file-storage/records", () => ({
 
 const toolCallInfo = { toolCallId: "test-tool-call", messages: [] };
 
+function createMockDb(organizationSlug = "acme") {
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => [{ slug: organizationSlug }]),
+        })),
+      })),
+    })),
+  } as never;
+}
+
 function createToolContext(overrides: Partial<ToolContext> = {}): ToolContext {
   return {
     conversationId: "conv_1",
@@ -31,7 +44,7 @@ function createToolContext(overrides: Partial<ToolContext> = {}): ToolContext {
     localUserId: "user_1",
     membershipRole: "admin",
     projectId: "project_1",
-    db: {} as never,
+    db: createMockDb(),
     workMode: "write",
     repositorySource: "chat_ui",
     actor: { sourceUserId: "user_1", role: "admin" },
@@ -294,6 +307,41 @@ describe("resolveStorybookPackage", () => {
   });
 });
 
+describe("buildScreenshotServeUrl", () => {
+  it("prefers the auth'd project assets proxy for in-app <img> rendering", () => {
+    expect(
+      buildScreenshotServeUrl({
+        organizationSlug: "acme",
+        projectId: "project_1",
+        fileId: "file_1",
+        fallbackUrl: "https://blob.example/private.png",
+      }),
+    ).toBe("/api/orgs/acme/projects/project_1/assets/file_1");
+  });
+
+  it("falls back to the org files proxy when there is no project", () => {
+    expect(
+      buildScreenshotServeUrl({
+        organizationSlug: "acme",
+        projectId: null,
+        fileId: "file_1",
+        fallbackUrl: "https://blob.example/private.png",
+      }),
+    ).toBe("/api/orgs/acme/files/file_1");
+  });
+
+  it("keeps the storage URL when the organization slug is unavailable", () => {
+    expect(
+      buildScreenshotServeUrl({
+        organizationSlug: null,
+        projectId: "project_1",
+        fileId: "file_1",
+        fallbackUrl: "https://blob.example/private.png",
+      }),
+    ).toBe("https://blob.example/private.png");
+  });
+});
+
 describe("classifyScreenshotCaptureFailure", () => {
   it("maps managed browser runtime sentinels to structured error codes", () => {
     expect(
@@ -357,6 +405,7 @@ describe("createCaptureScreenshotTool", () => {
       {
         target: { type: "storybook", storyId: "components-button--primary" },
         viewport: { width: 1280, height: 720 },
+        waitForText: ["Save changes", "Discard"],
       },
       toolCallInfo,
     );
@@ -364,7 +413,7 @@ describe("createCaptureScreenshotTool", () => {
     expect(result).toMatchObject({
       success: true,
       fileId: "file_1",
-      url: "https://download.example/storybook.png",
+      url: "/api/orgs/acme/projects/project_1/assets/file_1",
       target: { type: "storybook", storyId: "components-button--primary" },
       viewport: { width: 1280, height: 720 },
       workspacePath: expect.stringMatching(/^\.hyperlocalise-agent\/screenshots\//),
@@ -388,6 +437,12 @@ describe("createCaptureScreenshotTool", () => {
     expect(captureScript).toContain('waitUntil: "load"');
     expect(captureScript).not.toMatch(/waitUntil:\s*"networkidle"/);
     expect(captureScript).toContain('waitForSelector("#storybook-root, #root"');
+    expect(captureScript).toContain("addInitScript");
+    expect(captureScript).toContain("__STORYBOOK_ADDONS_CHANNEL__");
+    expect(captureScript).toContain("storyRendered");
+    expect(captureScript).toContain("sb-show-preparing-story");
+    expect(captureScript).toContain('const waitForText = ["Save changes","Discard"]');
+    expect(captureScript).toContain("texts.every((text) => haystack.includes(text))");
     expect(exec).toHaveBeenCalledWith("bash", {
       args: [
         "-lc",
@@ -429,6 +484,7 @@ describe("createCaptureScreenshotTool", () => {
           kind: "visual-mock",
           targetType: "storybook",
           storyId: "components-button--primary",
+          waitForText: ["Save changes", "Discard"],
           packageDir: ".",
           packageJsonPath: "package.json",
         }),

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -504,7 +504,7 @@ const waitForText = ${JSON.stringify(input.waitForText)};
       }
       channel.__hyperlocaliseHooked = true;
       channel.on("storyRendered", markReady);
-      channel.on("storyFinished", markReady);
+      channel.on("storyMissing", markError);
       channel.on("storyErrored", markError);
       channel.on("storyThrewException", markError);
       return true;
@@ -538,7 +538,7 @@ const waitForText = ${JSON.stringify(input.waitForText)};
   await page.goto(${JSON.stringify(input.url)}, { waitUntil: "load", timeout: ${STORYBOOK_READY_TIMEOUT_MS} });
   await page.waitForSelector("#storybook-root, #root", { state: "attached", timeout: ${STORYBOOK_READY_TIMEOUT_MS} });
 
-  // Prefer Storybook's private channel events (storyRendered / storyFinished).
+  // Prefer Storybook channel events (storyRendered / storyMissing / errors).
   // Fall back to: preparing overlays gone + #storybook-root has painted content.
   await page.waitForFunction(() => {
     if (window.__HYPERLOCALISE_STORY_ERROR__ || window.__HYPERLOCALISE_STORY_READY__) {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -1,8 +1,10 @@
 import { tool } from "ai";
+import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 import { assertRepositoryWriteAllowed } from "@/lib/agent-runtime/tools/policy";
+import { schema } from "@/lib/database";
 import { createStoredFile, getStoredFileContent } from "@/lib/file-storage/records";
 import {
   installChromiumSystemDependenciesFunction,
@@ -16,9 +18,14 @@ import type { RepoToolContext } from "./types";
 const DEFAULT_VIEWPORT = { width: 1440, height: 1000 };
 const MIN_VIEWPORT_SIZE = 320;
 const MAX_VIEWPORT_SIZE = 3840;
-const DEFAULT_WAIT_FOR_MS = 500;
-const MAX_WAIT_FOR_MS = 5000;
+/** Extra settle time after Storybook reports the story is ready. */
+const DEFAULT_WAIT_FOR_MS = 250;
+const MAX_WAIT_FOR_MS = 15_000;
+const MAX_WAIT_FOR_TEXT_ITEMS = 12;
+const MAX_WAIT_FOR_TEXT_LENGTH = 200;
 const STORYBOOK_PORT = 6006;
+const STORYBOOK_READY_TIMEOUT_MS = 120_000;
+const STORYBOOK_SERVER_READY_SECONDS = 120;
 const MANAGED_PLAYWRIGHT_VERSION = sandboxPlaywrightVersion;
 const MANAGED_BROWSER_RUNTIME_DIR = "/tmp/hyperlocalise-browser-runtime";
 const MANAGED_PLAYWRIGHT_MODULE = `${MANAGED_BROWSER_RUNTIME_DIR}/node_modules/playwright`;
@@ -36,6 +43,14 @@ const captureScreenshotInputSchema = z.object({
   }),
   viewport: viewportSchema.optional(),
   waitForMs: z.number().int().min(0).max(MAX_WAIT_FOR_MS).optional(),
+  waitForText: z
+    .array(z.string().trim().min(1).max(MAX_WAIT_FOR_TEXT_LENGTH))
+    .min(1)
+    .max(MAX_WAIT_FOR_TEXT_ITEMS)
+    .optional()
+    .describe(
+      "Visible UI strings that must appear in the story before capture (e.g. the source/target copy under review). Prefer exact substrings from the rendered mock.",
+    ),
 });
 
 type PackageJson = {
@@ -422,25 +437,151 @@ function shellQuote(value: string) {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
+export function buildScreenshotServeUrl(input: {
+  organizationSlug: string | null | undefined;
+  projectId: string | null | undefined;
+  fileId: string;
+  fallbackUrl: string;
+}) {
+  const organizationSlug = input.organizationSlug?.trim();
+  if (!organizationSlug) {
+    return input.fallbackUrl;
+  }
+
+  if (input.projectId) {
+    return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(input.projectId)}/assets/${encodeURIComponent(input.fileId)}`;
+  }
+
+  return `/api/orgs/${encodeURIComponent(organizationSlug)}/files/${encodeURIComponent(input.fileId)}`;
+}
+
+async function resolveOrganizationSlug(input: { organizationId: string; db: ToolContext["db"] }) {
+  const [organization] = await input.db
+    .select({ slug: schema.organizations.slug })
+    .from(schema.organizations)
+    .where(eq(schema.organizations.id, input.organizationId))
+    .limit(1);
+
+  return organization?.slug ?? null;
+}
+
 function buildPlaywrightScript(input: {
   playwrightModulePath: string;
   url: string;
   outputPath: string;
   viewport: { width: number; height: number };
   waitForMs: number;
+  waitForText: string[];
 }) {
   return `
 const { chromium } = require(${JSON.stringify(input.playwrightModulePath)});
+const waitForText = ${JSON.stringify(input.waitForText)};
 
 (async () => {
   const browser = await chromium.launch({ headless: true });
   const page = await browser.newPage({
     viewport: ${JSON.stringify(input.viewport)}
   });
+
+  // Install Storybook channel hooks before navigation so we do not miss storyRendered.
+  await page.addInitScript(() => {
+    window.__HYPERLOCALISE_STORY_READY__ = false;
+    window.__HYPERLOCALISE_STORY_ERROR__ = null;
+
+    const markReady = () => {
+      window.__HYPERLOCALISE_STORY_READY__ = true;
+    };
+    const markError = (error) => {
+      window.__HYPERLOCALISE_STORY_ERROR__ =
+        error && typeof error === "object" && "message" in error
+          ? String(error.message)
+          : String(error ?? "Storybook story failed");
+    };
+
+    const hookChannel = (channel) => {
+      if (!channel || channel.__hyperlocaliseHooked) {
+        return Boolean(channel);
+      }
+      channel.__hyperlocaliseHooked = true;
+      channel.on("storyRendered", markReady);
+      channel.on("storyFinished", markReady);
+      channel.on("storyErrored", markError);
+      channel.on("storyThrewException", markError);
+      return true;
+    };
+
+    const tryHook = () => {
+      if (hookChannel(window.__STORYBOOK_ADDONS_CHANNEL__)) {
+        return;
+      }
+      const preview = window.__STORYBOOK_PREVIEW__;
+      const channelFromPreview =
+        preview && typeof preview.channel === "object" ? preview.channel : null;
+      hookChannel(channelFromPreview);
+    };
+
+    tryHook();
+    const intervalId = setInterval(() => {
+      tryHook();
+      if (
+        window.__STORYBOOK_ADDONS_CHANNEL__?.__hyperlocaliseHooked ||
+        window.__HYPERLOCALISE_STORY_READY__ ||
+        window.__HYPERLOCALISE_STORY_ERROR__
+      ) {
+        clearInterval(intervalId);
+      }
+    }, 50);
+    setTimeout(() => clearInterval(intervalId), ${STORYBOOK_READY_TIMEOUT_MS});
+  });
+
   // Storybook keeps HMR/WebSocket traffic open, so "networkidle" often never settles.
-  await page.goto(${JSON.stringify(input.url)}, { waitUntil: "load", timeout: 60000 });
-  await page.waitForSelector("#storybook-root, #root", { state: "attached", timeout: 30000 });
-  await page.waitForTimeout(${input.waitForMs});
+  await page.goto(${JSON.stringify(input.url)}, { waitUntil: "load", timeout: ${STORYBOOK_READY_TIMEOUT_MS} });
+  await page.waitForSelector("#storybook-root, #root", { state: "attached", timeout: ${STORYBOOK_READY_TIMEOUT_MS} });
+
+  // Prefer Storybook's private channel events (storyRendered / storyFinished).
+  // Fall back to: preparing overlays gone + #storybook-root has painted content.
+  await page.waitForFunction(() => {
+    if (window.__HYPERLOCALISE_STORY_ERROR__ || window.__HYPERLOCALISE_STORY_READY__) {
+      return true;
+    }
+
+    const preparing =
+      document.body.classList.contains("sb-show-preparing-story") ||
+      document.body.classList.contains("sb-show-preparing-docs") ||
+      Boolean(document.querySelector(".sb-preparing-story, .sb-preparing-docs, .sb-nopreview"));
+    if (preparing) {
+      return false;
+    }
+
+    const root = document.querySelector("#storybook-root, #root");
+    if (!root) {
+      return false;
+    }
+
+    return root.childElementCount > 0 || Boolean((root.textContent || "").trim());
+  }, { timeout: ${STORYBOOK_READY_TIMEOUT_MS} });
+
+  const storyError = await page.evaluate(() => window.__HYPERLOCALISE_STORY_ERROR__);
+  if (storyError) {
+    throw new Error("Storybook story failed: " + storyError);
+  }
+
+  // Strongest readiness signal for localization mocks: expected copy is in the DOM.
+  if (waitForText.length > 0) {
+    await page.waitForFunction(
+      (texts) => {
+        const root = document.querySelector("#storybook-root, #root") || document.body;
+        const haystack = root?.innerText || root?.textContent || "";
+        return texts.every((text) => haystack.includes(text));
+      },
+      waitForText,
+      { timeout: ${STORYBOOK_READY_TIMEOUT_MS} },
+    );
+  }
+
+  if (${input.waitForMs} > 0) {
+    await page.waitForTimeout(${input.waitForMs});
+  }
   await page.screenshot({ path: ${JSON.stringify(input.outputPath)}, fullPage: true });
   await browser.close();
 })().catch((error) => {
@@ -532,7 +673,7 @@ function buildCaptureCommand(input: {
     "SERVER_PID=$!",
     'cleanup() { kill "$SERVER_PID" >/dev/null 2>&1 || true; }',
     "trap cleanup EXIT",
-    `for i in $(seq 1 60); do if curl -fsS ${shellQuote(
+    `for i in $(seq 1 ${STORYBOOK_SERVER_READY_SECONDS}); do if curl -fsS ${shellQuote(
       `http://127.0.0.1:${input.port}/iframe.html`,
     )} >/dev/null 2>&1; then break; fi; sleep 1; done`,
     `if ! curl -fsS ${shellQuote(`http://127.0.0.1:${input.port}/iframe.html`)} >/dev/null; then`,
@@ -632,6 +773,8 @@ Currently supported target:
 
 The tool finds package.json at the repository root or in nested app packages, detects the package manager and Storybook script, runs Storybook from that package directory, uses a Hyperlocalise-managed Playwright/Chromium runtime in the sandbox, captures a PNG, and stores it as a Hyperlocalise file artifact.
 
+Pass waitForText with the visible strings that must appear before capture (source/target copy under review). The tool waits for those substrings in the story DOM after Storybook reports ready.
+
 It does not commit, push, open pull requests, or publish repository changes.`,
     inputSchema: captureScreenshotInputSchema,
     toModelOutput: async ({ output }) => {
@@ -688,6 +831,7 @@ It does not commit, push, open pull requests, or publish repository changes.`,
       target,
       viewport = DEFAULT_VIEWPORT,
       waitForMs = DEFAULT_WAIT_FOR_MS,
+      waitForText = [],
     }): Promise<CaptureScreenshotResult> => {
       const gate = assertRepositoryWriteAllowed(ctx, "apply_fixes");
       if (!gate.allowed) {
@@ -751,6 +895,7 @@ It does not commit, push, open pull requests, or publish repository changes.`,
           outputPath: screenshotPath,
           viewport,
           waitForMs,
+          waitForText,
         }),
       );
 
@@ -798,6 +943,7 @@ It does not commit, push, open pull requests, or publish repository changes.`,
           storyId: target.storyId,
           viewport,
           waitForMs,
+          waitForText,
           packageManager: storybookCommand.packageManager,
           scriptName: storybookCommand.scriptName,
           packageDir: storybookCommand.packageDir || ".",
@@ -806,10 +952,23 @@ It does not commit, push, open pull requests, or publish repository changes.`,
         db: ctx.db,
       });
 
+      // Private Vercel Blob URLs are not browser-readable. Serve via the auth'd
+      // app proxy (project assets prefer inline disposition for <img>).
+      const organizationSlug = await resolveOrganizationSlug({
+        organizationId: ctx.organizationId,
+        db: ctx.db,
+      });
+      const serveUrl = buildScreenshotServeUrl({
+        organizationSlug,
+        projectId: ctx.projectId,
+        fileId: storedFile.id,
+        fallbackUrl: storedFile.downloadUrl ?? storedFile.storageUrl,
+      });
+
       return {
         success: true as const,
         fileId: storedFile.id,
-        url: storedFile.downloadUrl ?? storedFile.storageUrl,
+        url: serveUrl,
         filename: storedFile.filename,
         contentType: storedFile.contentType,
         byteSize: storedFile.byteSize,


### PR DESCRIPTION
## What changed

`captureScreenshot` returned private Vercel Blob URLs that browsers cannot load, and often captured Storybook while it was still showing the preparing spinner.

- Return auth'd app proxy URLs (`/api/orgs/.../assets/...` or `/files/...`) instead of private blob URLs
- Serve org file images with `inline` disposition so `<img>` works
- Wait for Storybook `storyRendered` / preparing overlays to clear, then optional `waitForText` strings in the story DOM
- Raise Storybook readiness timeouts to 120s
- Update visual-mock skill to pass `waitForText`

## How to test

- [x] `vp test src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts src/lib/agent-runtime/skills/conversation-skill-registry.test.ts`
- [x] `vp check --fix` on changed files
- [ ] Capture a Storybook screenshot in chat and confirm the inbox `<img>` loads
- [ ] Confirm a slow story with `waitForText` waits for copy before capture

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)