### PR TITLE
⚡ Bolt: Add fast-path to whitespace profile parity validation

### DIFF
--- a/internal/i18n/segmentvalidate/profile.go
+++ b/internal/i18n/segmentvalidate/profile.go
@@ -34,6 +34,11 @@ func validateWhitespaceProfile(source, translated string) error {
 	sourceNorm := normalizeProfileText(source)
 	targetNorm := normalizeProfileText(translated)
 
+	// BOLT OPTIMIZATION: If the normalized strings are identical, their whitespace profiles are guaranteed to be identical.
+	if sourceNorm == targetNorm {
+		return nil
+	}
+
 	sourceLeading, sourceTrailing := profileEdgeWhitespace(sourceNorm)
 	targetLeading, targetTrailing := profileEdgeWhitespace(targetNorm)
 


### PR DESCRIPTION
💡 What: Added a fast-path to validateWhitespaceProfile in internal/i18n/segmentvalidate/profile.go to immediately return nil if the normalized source and target strings are identical.
🎯 Why: In high-volume translation validation tasks, a significant percentage of segments are translated identically or contain zero formatting differences. Short-circuiting identical cases avoids two calls to profileEdgeWhitespace (which scans leading and trailing unicode runes) and subsequent NBSP counting.
📊 Impact: Eliminates edge whitespace scans and allocation overhead for identical segment inputs.
🔬 Measurement: Verified with existing go test suites.

---
*PR created automatically by Jules for task [6246875391423702252](https://jules.google.com/task/6246875391423702252) started by @cungminh2710*