### PR TITLE
feat(slack): attach visual-mock screenshots to replies

### DIFF
--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/slack.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/slack.ts
@@ -493,11 +493,12 @@ async function processSlackMessage(
     await removeEyesReaction(thread, message);
     wrapThreadPost(thread, interactionId);
     const replyText = result.text.trim();
-    if (replyText || screenshotFiles.length > 0) {
-      await thread.post({
-        ...(replyText ? { markdown: replyText } : {}),
-        ...(screenshotFiles.length > 0 ? { files: screenshotFiles } : {}),
-      });
+    if (replyText && screenshotFiles.length > 0) {
+      await thread.post({ markdown: replyText, files: screenshotFiles });
+    } else if (replyText) {
+      await thread.post({ markdown: replyText });
+    } else if (screenshotFiles.length > 0) {
+      await thread.post({ markdown: "", files: screenshotFiles });
     }
   } catch (error) {
     log.error({ err: serializeErrorForLog(error) }, "slack agent message processing failed");

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/slack.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/slack.ts
@@ -53,6 +53,10 @@ import {
 } from "@/lib/agents/slack/image-attachments";
 import { threadHasStoredSlackImages } from "@/lib/agents/slack/image-session";
 import { type SlackBotThreadState } from "@/lib/agents/slack/repository-session";
+import {
+  buildSlackScreenshotFileUploads,
+  extractSuccessfulCaptureScreenshots,
+} from "@/lib/agents/slack/screenshot-attachments";
 
 type SlackBotState = SlackBotThreadState;
 
@@ -470,9 +474,18 @@ async function processSlackMessage(
       operationKey: usageOperationKey,
       dimensions: usageDimensions,
     });
+
+    const screenshots = extractSuccessfulCaptureScreenshots(result);
+    const screenshotFiles = await buildSlackScreenshotFileUploads({
+      screenshots,
+      organizationId,
+      projectId,
+    });
     log.info(
       {
         hasReplyText: result.text.trim().length > 0,
+        screenshotCount: screenshots.length,
+        screenshotUploadCount: screenshotFiles.length,
       },
       "slack conversation agent completed",
     );
@@ -480,8 +493,11 @@ async function processSlackMessage(
     await removeEyesReaction(thread, message);
     wrapThreadPost(thread, interactionId);
     const replyText = result.text.trim();
-    if (replyText) {
-      await thread.post({ markdown: replyText });
+    if (replyText || screenshotFiles.length > 0) {
+      await thread.post({
+        ...(replyText ? { markdown: replyText } : {}),
+        ...(screenshotFiles.length > 0 ? { files: screenshotFiles } : {}),
+      });
     }
   } catch (error) {
     log.error({ err: serializeErrorForLog(error) }, "slack agent message processing failed");

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -695,7 +695,7 @@ function buildCaptureCommand(input: {
   ].join("\n");
 }
 
-type CaptureScreenshotSuccess = {
+export type CaptureScreenshotSuccess = {
   success: true;
   fileId: string;
   url: string;
@@ -719,7 +719,7 @@ type CaptureScreenshotFailure = {
 
 export type CaptureScreenshotResult = CaptureScreenshotSuccess | CaptureScreenshotFailure;
 
-function isCaptureScreenshotSuccess(output: unknown): output is CaptureScreenshotSuccess {
+export function isCaptureScreenshotSuccess(output: unknown): output is CaptureScreenshotSuccess {
   return (
     Boolean(output) &&
     typeof output === "object" &&

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
@@ -521,6 +521,189 @@ describe("handleNewConversation", () => {
     );
   });
 
+  it("attaches all successful captureScreenshot artifacts to the Slack reply", async () => {
+    const { thread, posts } = createThread();
+    const message = createMessage({ text: "Show the button story" });
+
+    vi.mocked(findSlackConnector).mockResolvedValue({
+      id: "connector-123",
+      organizationId: "org-123",
+      enabled: true,
+    } as never);
+    vi.mocked(lookupMembership).mockResolvedValue({
+      role: "admin",
+      localUserId: "user-123",
+    } as never);
+    vi.mocked(findInteractionBySourceThreadId).mockResolvedValue(null as never);
+    vi.mocked(createInteraction).mockResolvedValue({
+      id: "interaction-123",
+      title: "Show the button story",
+      projectId: "project-123",
+    } as never);
+    vi.mocked(addInteractionMessage).mockResolvedValue({ id: "msg-123" } as never);
+    vi.mocked(getStoredFileContent)
+      .mockResolvedValueOnce({
+        file: { id: "file_shot_a" },
+        content: Buffer.from("shot-a"),
+      } as never)
+      .mockResolvedValueOnce({
+        file: { id: "file_shot_b" },
+        content: Buffer.from("shot-b"),
+      } as never);
+
+    agentGenerateMock.mockResolvedValue({
+      text: "Here are the screenshots.",
+      steps: [
+        {
+          toolResults: [
+            {
+              toolName: "captureScreenshot",
+              output: {
+                success: true,
+                fileId: "file_shot_a",
+                url: "https://app.example/files/file_shot_a",
+                filename: "button-primary.png",
+                contentType: "image/png",
+                byteSize: 6,
+                workspacePath: "/tmp",
+                screenshotPath: "/tmp/a.png",
+                target: { type: "storybook", storyId: "button--primary" },
+                viewport: { width: 1280, height: 720 },
+                storybookUrl: "http://localhost:6006",
+              },
+            },
+          ],
+        },
+        {
+          toolResults: [
+            {
+              toolName: "captureScreenshot",
+              output: {
+                success: false,
+                errorCode: "story_not_found",
+                error: "missing",
+              },
+            },
+            {
+              toolName: "captureScreenshot",
+              output: {
+                success: true,
+                fileId: "file_shot_b",
+                url: "https://app.example/files/file_shot_b",
+                filename: "button-secondary.png",
+                contentType: "image/png",
+                byteSize: 6,
+                workspacePath: "/tmp",
+                screenshotPath: "/tmp/b.png",
+                target: { type: "storybook", storyId: "button--secondary" },
+                viewport: { width: 1280, height: 720 },
+                storybookUrl: "http://localhost:6006",
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    await handleNewConversation(thread, message);
+
+    expect(getStoredFileContent).toHaveBeenCalledWith({
+      fileId: "file_shot_a",
+      organizationId: "org-123",
+      projectId: "project-123",
+    });
+    expect(getStoredFileContent).toHaveBeenCalledWith({
+      fileId: "file_shot_b",
+      organizationId: "org-123",
+      projectId: "project-123",
+    });
+    expect(posts).toEqual([
+      SLACK_PROCESSING_ACK_POST,
+      {
+        markdown: "Here are the screenshots.",
+        files: [
+          {
+            data: Buffer.from("shot-a"),
+            filename: "button-primary.png",
+            mimeType: "image/png",
+          },
+          {
+            data: Buffer.from("shot-b"),
+            filename: "button-secondary.png",
+            mimeType: "image/png",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("posts screenshot files when the agent reply text is empty", async () => {
+    const { thread, posts } = createThread();
+    const message = createMessage({ text: "Screenshot the story" });
+
+    vi.mocked(findSlackConnector).mockResolvedValue({
+      id: "connector-123",
+      organizationId: "org-123",
+      enabled: true,
+    } as never);
+    vi.mocked(lookupMembership).mockResolvedValue({
+      role: "admin",
+      localUserId: "user-123",
+    } as never);
+    vi.mocked(findInteractionBySourceThreadId).mockResolvedValue(null as never);
+    vi.mocked(createInteraction).mockResolvedValue({
+      id: "interaction-123",
+      title: "Screenshot the story",
+      projectId: null,
+    } as never);
+    vi.mocked(addInteractionMessage).mockResolvedValue({ id: "msg-123" } as never);
+    vi.mocked(getStoredFileContent).mockResolvedValueOnce({
+      file: { id: "file_shot_only" },
+      content: Buffer.from("shot-only"),
+    } as never);
+
+    agentGenerateMock.mockResolvedValue({
+      text: "   ",
+      steps: [
+        {
+          toolResults: [
+            {
+              toolName: "captureScreenshot",
+              output: {
+                success: true,
+                fileId: "file_shot_only",
+                url: "https://app.example/files/file_shot_only",
+                filename: "story.png",
+                contentType: "image/png",
+                byteSize: 9,
+                workspacePath: "/tmp",
+                screenshotPath: "/tmp/story.png",
+                target: { type: "storybook", storyId: "story--default" },
+                viewport: { width: 1280, height: 720 },
+                storybookUrl: "http://localhost:6006",
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    await handleNewConversation(thread, message);
+
+    expect(posts).toEqual([
+      SLACK_PROCESSING_ACK_POST,
+      {
+        files: [
+          {
+            data: Buffer.from("shot-only"),
+            filename: "story.png",
+            mimeType: "image/png",
+          },
+        ],
+      },
+    ]);
+  });
+
   it("skips GitHub context discovery for ordinary chat without attachments", async () => {
     const { thread } = createThread();
     const message = createMessage({ text: "Translate this to French" });

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
@@ -693,6 +693,7 @@ describe("handleNewConversation", () => {
     expect(posts).toEqual([
       SLACK_PROCESSING_ACK_POST,
       {
+        markdown: "",
         files: [
           {
             data: Buffer.from("shot-only"),

--- a/apps/hyperlocalise-web/src/lib/agents/slack/screenshot-attachments.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/screenshot-attachments.test.ts
@@ -11,6 +11,14 @@ vi.mock("@/lib/file-storage/records", () => ({
   getStoredFileContent: vi.fn(),
 }));
 
+vi.mock("@/lib/agent-runtime/tools/workspace/capture-screenshot", () => ({
+  isCaptureScreenshotSuccess: (output: unknown) =>
+    Boolean(output) &&
+    typeof output === "object" &&
+    (output as { success?: boolean }).success === true &&
+    typeof (output as { fileId?: unknown }).fileId === "string",
+}));
+
 vi.mock("@/lib/log", () => ({
   createLogger: vi.fn(() => ({
     warn: vi.fn(),

--- a/apps/hyperlocalise-web/src/lib/agents/slack/screenshot-attachments.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/screenshot-attachments.test.ts
@@ -102,7 +102,7 @@ describe("extractSuccessfulCaptureScreenshots", () => {
     expect(screenshots.map((screenshot) => screenshot.fileId)).toEqual(["file_a", "file_b"]);
   });
 
-  it("falls back to top-level toolResults when steps are empty", () => {
+  it("falls back to top-level toolResults only when steps are omitted", () => {
     const screenshot = successfulScreenshot({ fileId: "file_top" });
 
     const screenshots = extractSuccessfulCaptureScreenshots({
@@ -119,6 +119,20 @@ describe("extractSuccessfulCaptureScreenshots", () => {
     });
 
     expect(screenshots).toEqual([screenshot]);
+  });
+
+  it("does not fall back to toolResults when steps are present but empty of tools", () => {
+    const screenshots = extractSuccessfulCaptureScreenshots({
+      steps: [{ toolResults: [] }, {}],
+      toolResults: [
+        {
+          toolName: "captureScreenshot",
+          output: successfulScreenshot({ fileId: "file_should_ignore" }),
+        },
+      ],
+    });
+
+    expect(screenshots).toEqual([]);
   });
 
   it("returns an empty list when no captureScreenshot tools ran", () => {

--- a/apps/hyperlocalise-web/src/lib/agents/slack/screenshot-attachments.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/screenshot-attachments.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { getStoredFileContent } from "@/lib/file-storage/records";
+
+import {
+  buildSlackScreenshotFileUploads,
+  extractSuccessfulCaptureScreenshots,
+} from "./screenshot-attachments";
+
+vi.mock("@/lib/file-storage/records", () => ({
+  getStoredFileContent: vi.fn(),
+}));
+
+vi.mock("@/lib/log", () => ({
+  createLogger: vi.fn(() => ({
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(),
+  })),
+  serializeErrorForLog: vi.fn((error: unknown) => ({ error })),
+}));
+
+function successfulScreenshot(overrides: {
+  fileId: string;
+  filename?: string;
+  contentType?: string;
+}) {
+  return {
+    success: true as const,
+    fileId: overrides.fileId,
+    url: `https://app.example/files/${overrides.fileId}`,
+    filename: overrides.filename ?? `${overrides.fileId}.png`,
+    contentType: overrides.contentType ?? "image/png",
+    byteSize: 12,
+    workspacePath: "/tmp/workspace",
+    screenshotPath: "/tmp/workspace/screenshot.png",
+    target: { type: "storybook" as const, storyId: "button--primary" },
+    viewport: { width: 1280, height: 720 },
+    storybookUrl: "http://localhost:6006",
+  };
+}
+
+describe("extractSuccessfulCaptureScreenshots", () => {
+  it("collects successful screenshots from all steps in order", () => {
+    const first = successfulScreenshot({ fileId: "file_a" });
+    const second = successfulScreenshot({ fileId: "file_b" });
+
+    const screenshots = extractSuccessfulCaptureScreenshots({
+      steps: [
+        {
+          toolResults: [
+            {
+              toolName: "captureScreenshot",
+              output: first,
+            },
+          ],
+        },
+        {
+          toolResults: [
+            {
+              toolName: "captureScreenshot",
+              output: {
+                success: false,
+                errorCode: "story_not_found",
+                error: "missing",
+              },
+            },
+          ],
+        },
+        {
+          toolResults: [
+            {
+              toolName: "captureScreenshot",
+              output: second,
+            },
+            {
+              toolName: "captureScreenshot",
+              preliminary: true,
+              output: successfulScreenshot({ fileId: "file_preliminary" }),
+            },
+          ],
+        },
+      ],
+      toolResults: [
+        {
+          toolName: "captureScreenshot",
+          output: successfulScreenshot({ fileId: "file_last_step_only" }),
+        },
+      ],
+    });
+
+    expect(screenshots.map((screenshot) => screenshot.fileId)).toEqual(["file_a", "file_b"]);
+  });
+
+  it("falls back to top-level toolResults when steps are empty", () => {
+    const screenshot = successfulScreenshot({ fileId: "file_top" });
+
+    const screenshots = extractSuccessfulCaptureScreenshots({
+      toolResults: [
+        {
+          toolName: "captureScreenshot",
+          output: screenshot,
+        },
+        {
+          toolName: "otherTool",
+          output: { ok: true },
+        },
+      ],
+    });
+
+    expect(screenshots).toEqual([screenshot]);
+  });
+
+  it("returns an empty list when no captureScreenshot tools ran", () => {
+    expect(extractSuccessfulCaptureScreenshots({ text: "hello" } as never)).toEqual([]);
+    expect(extractSuccessfulCaptureScreenshots({ steps: [] })).toEqual([]);
+  });
+});
+
+describe("buildSlackScreenshotFileUploads", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads stored bytes for each screenshot", async () => {
+    vi.mocked(getStoredFileContent)
+      .mockResolvedValueOnce({
+        file: { id: "file_a" },
+        content: Buffer.from("a"),
+      } as never)
+      .mockResolvedValueOnce({
+        file: { id: "file_b" },
+        content: Buffer.from("b"),
+      } as never);
+
+    const uploads = await buildSlackScreenshotFileUploads({
+      screenshots: [
+        successfulScreenshot({ fileId: "file_a", filename: "a.png" }),
+        successfulScreenshot({
+          fileId: "file_b",
+          filename: "b.png",
+          contentType: "image/jpeg",
+        }),
+      ],
+      organizationId: "org-123",
+      projectId: "project-123",
+    });
+
+    expect(getStoredFileContent).toHaveBeenNthCalledWith(1, {
+      fileId: "file_a",
+      organizationId: "org-123",
+      projectId: "project-123",
+    });
+    expect(getStoredFileContent).toHaveBeenNthCalledWith(2, {
+      fileId: "file_b",
+      organizationId: "org-123",
+      projectId: "project-123",
+    });
+    expect(uploads).toEqual([
+      {
+        data: Buffer.from("a"),
+        filename: "a.png",
+        mimeType: "image/png",
+      },
+      {
+        data: Buffer.from("b"),
+        filename: "b.png",
+        mimeType: "image/jpeg",
+      },
+    ]);
+  });
+
+  it("skips screenshots that fail to load", async () => {
+    vi.mocked(getStoredFileContent)
+      .mockRejectedValueOnce(new Error("missing"))
+      .mockResolvedValueOnce({
+        file: { id: "file_b" },
+        content: Buffer.from("b"),
+      } as never);
+
+    const uploads = await buildSlackScreenshotFileUploads({
+      screenshots: [
+        successfulScreenshot({ fileId: "file_a" }),
+        successfulScreenshot({ fileId: "file_b", filename: "b.png" }),
+      ],
+      organizationId: "org-123",
+      projectId: null,
+    });
+
+    expect(uploads).toEqual([
+      {
+        data: Buffer.from("b"),
+        filename: "b.png",
+        mimeType: "image/png",
+      },
+    ]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/slack/screenshot-attachments.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/screenshot-attachments.ts
@@ -29,9 +29,10 @@ export type SlackScreenshotFileUpload = {
 };
 
 function collectToolResults(result: GenerateResultWithToolSteps): ToolResultLike[] {
-  const fromSteps = (result.steps ?? []).flatMap((step) => step.toolResults ?? []);
-  if (fromSteps.length > 0) {
-    return fromSteps;
+  // Prefer steps whenever present (including empty / text-only steps). Fall back
+  // to top-level toolResults only for callers/mocks that omit steps entirely.
+  if (result.steps !== undefined) {
+    return result.steps.flatMap((step) => step.toolResults ?? []);
   }
   return result.toolResults ?? [];
 }
@@ -54,31 +55,38 @@ export async function buildSlackScreenshotFileUploads(input: {
   organizationId: string;
   projectId: string | null;
 }): Promise<SlackScreenshotFileUpload[]> {
-  const uploads: SlackScreenshotFileUpload[] = [];
-
-  for (const screenshot of input.screenshots) {
-    try {
-      const { content } = await getStoredFileContent({
+  const results = await Promise.allSettled(
+    input.screenshots.map((screenshot) =>
+      getStoredFileContent({
         fileId: screenshot.fileId,
         organizationId: input.organizationId,
         projectId: input.projectId,
-      });
-      uploads.push({
+      }).then(({ content }) => ({
         data: content,
         filename: screenshot.filename,
         mimeType: screenshot.contentType || "image/png",
-      });
-    } catch (error) {
-      log.warn(
-        {
-          err: serializeErrorForLog(error),
-          fileId: screenshot.fileId,
-          organizationId: input.organizationId,
-          projectId: input.projectId,
-        },
-        "failed to load captureScreenshot artifact for Slack upload",
-      );
+      })),
+    ),
+  );
+
+  const uploads: SlackScreenshotFileUpload[] = [];
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    if (result.status === "fulfilled") {
+      uploads.push(result.value);
+      continue;
     }
+
+    const screenshot = input.screenshots[i];
+    log.warn(
+      {
+        err: serializeErrorForLog(result.reason),
+        fileId: screenshot?.fileId,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      },
+      "failed to load captureScreenshot artifact for Slack upload",
+    );
   }
 
   return uploads;

--- a/apps/hyperlocalise-web/src/lib/agents/slack/screenshot-attachments.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/screenshot-attachments.ts
@@ -1,0 +1,85 @@
+import { getStoredFileContent } from "@/lib/file-storage/records";
+import {
+  isCaptureScreenshotSuccess,
+  type CaptureScreenshotSuccess,
+} from "@/lib/agent-runtime/tools/workspace/capture-screenshot";
+import { createLogger, serializeErrorForLog } from "@/lib/log";
+
+const log = createLogger("slack-screenshot-attachments");
+
+type ToolResultLike = {
+  toolName?: string;
+  output?: unknown;
+  preliminary?: boolean;
+};
+
+type StepLike = {
+  toolResults?: ToolResultLike[];
+};
+
+export type GenerateResultWithToolSteps = {
+  steps?: StepLike[];
+  toolResults?: ToolResultLike[];
+};
+
+export type SlackScreenshotFileUpload = {
+  data: Buffer;
+  filename: string;
+  mimeType: string;
+};
+
+function collectToolResults(result: GenerateResultWithToolSteps): ToolResultLike[] {
+  const fromSteps = (result.steps ?? []).flatMap((step) => step.toolResults ?? []);
+  if (fromSteps.length > 0) {
+    return fromSteps;
+  }
+  return result.toolResults ?? [];
+}
+
+export function extractSuccessfulCaptureScreenshots(
+  result: GenerateResultWithToolSteps,
+): CaptureScreenshotSuccess[] {
+  return collectToolResults(result)
+    .filter(
+      (toolResult) =>
+        toolResult.toolName === "captureScreenshot" &&
+        !toolResult.preliminary &&
+        isCaptureScreenshotSuccess(toolResult.output),
+    )
+    .map((toolResult) => toolResult.output as CaptureScreenshotSuccess);
+}
+
+export async function buildSlackScreenshotFileUploads(input: {
+  screenshots: CaptureScreenshotSuccess[];
+  organizationId: string;
+  projectId: string | null;
+}): Promise<SlackScreenshotFileUpload[]> {
+  const uploads: SlackScreenshotFileUpload[] = [];
+
+  for (const screenshot of input.screenshots) {
+    try {
+      const { content } = await getStoredFileContent({
+        fileId: screenshot.fileId,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      });
+      uploads.push({
+        data: content,
+        filename: screenshot.filename,
+        mimeType: screenshot.contentType || "image/png",
+      });
+    } catch (error) {
+      log.warn(
+        {
+          err: serializeErrorForLog(error),
+          fileId: screenshot.fileId,
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+        },
+        "failed to load captureScreenshot artifact for Slack upload",
+      );
+    }
+  }
+
+  return uploads;
+}

--- a/docs/plans/2026-07-18-slack-screenshot-attachments-design.md
+++ b/docs/plans/2026-07-18-slack-screenshot-attachments-design.md
@@ -1,0 +1,31 @@
+# Slack screenshot attachments
+
+## Problem
+
+Slack conversation turns can run `captureScreenshot` when the visual-mock skill is active, but the reply path only posts `result.text`. Screenshots stay in tool outputs and never reach the Slack thread.
+
+## Decision
+
+After `agent.generate()`, collect every successful `captureScreenshot` from `result.steps`, load stored bytes by `fileId`, and post one Slack message with markdown plus all screenshot files.
+
+## Behavior
+
+1. Scan `result.steps[].toolResults` for `toolName === "captureScreenshot"`.
+2. Keep non-preliminary successes (`success: true` with `fileId`).
+3. Load each file with `getStoredFileContent` (not the auth proxy URL).
+4. Post once: `{ markdown?, files? }` with all uploads in step order.
+5. Skip files that fail to load; still post text and remaining images.
+6. Post files even when reply text is empty.
+
+## Out of scope
+
+- Streaming Slack replies
+- Attaching non-screenshot tool artifacts
+- Changing visual-mock flags, skills, or write gates
+
+## Files
+
+- `lib/agents/slack/screenshot-attachments.ts` — extract + load helpers
+- `agents/hyperlocalise/agent/channels/slack.ts` — wire into reply post
+- `lib/agent-runtime/tools/workspace/capture-screenshot.ts` — export success guard
+- Tests for extractor and Slack reply attach


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Slack conversation replies now attach every successful `captureScreenshot` artifact from the agent turn.

- Extract successes from `result.steps` (all screenshots, step order)
- Load stored bytes by `fileId` and post with `thread.post({ markdown, files })`
- Still post files when reply text is empty; skip files that fail to load

Design: `docs/plans/2026-07-18-slack-screenshot-attachments-design.md`

## How to test

- `vp test src/lib/agents/slack/screenshot-attachments.test.ts src/lib/agents/slack/bot.test.ts`
- `vp check --fix`
- Manual: with visual-mock enabled, ask Slack for a Storybook screenshot and confirm the PNG is attached on the reply

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f777d-b2c1-79b3-bf43-0bd8a65dc469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f777d-b2c1-79b3-bf43-0bd8a65dc469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

