### PR TITLE
🧪 Scout: HTML Tag Space Leniency

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -149,5 +149,5 @@
 **Action:** Use a comprehensive regex that supports the full range of standard printf specifiers, flags, width, precision, and length modifiers to ensure structural parity is strictly enforced for all placeholder types.
 
 ## 2026-07-18 - [HTML Tag Name Extraction and Space Leniency]
-**Learning:** The HTML tag name extraction helper (`extractTagName`) does not skip whitespace following a closing slash (e.g., `</ strong >` or `< / div>`). Instead, the scanning loop terminates at the space and returns `/`. Since `isLikelyMarkupTag` ignores `/`, such spaced structures are not recognized as markup.
-**Action:** When unit testing tag parsing helper functions, match the precise behavior of the underlying parsing state-machine regarding spaces around structural markers like slashes.
+**Learning:** Real-world localization and translation files often introduce flexible spacing around HTML structural delimiters (e.g., `</ strong >` or `< / div>`). Traditional strict scanners treat the slash followed by space as an incomplete token or fail to extract the proper tag name. By tracking closing-tag state independently of name scanning and skipping whitespace after the closing slash, we can accurately extract tag names and maintain full structural tag parity checks across space-varying targets.
+**Action:** When parsing tag structures, always allow flexible whitespace around slashes and tags. Update existing tests to assert fully normalized closing tag names (e.g. `"/strong"`, `"/div"`) instead of falling back to partial tokens.

--- a/internal/i18n/htmltagparity/htmltagparity.go
+++ b/internal/i18n/htmltagparity/htmltagparity.go
@@ -38,26 +38,22 @@ func findAllTags(s string) []string {
 			break
 		}
 
-		// We only care about </?[A-Za-z] (with optional whitespace after < and /)
-		// so space-lenient closing tags like "</ strong>" and "< / div>" are found
-		// and can reach extractTagName.
-		j := i + 1
-		for j < len(s) && isHTMLWhitespace(s[j]) {
-			j++
+		// We only care about </?[A-Za-z] to match the previous regex behavior, with space leniency.
+		curr := i + 1
+		for curr < len(s) && isHTMLWhitespace(s[curr]) {
+			curr++
 		}
-		if j >= len(s) {
-			break
-		}
-		if s[j] == '/' {
-			j++
-			for j < len(s) && isHTMLWhitespace(s[j]) {
-				j++
-			}
-			if j >= len(s) {
-				break
+		if curr < len(s) && s[curr] == '/' {
+			curr++
+			for curr < len(s) && isHTMLWhitespace(s[curr]) {
+				curr++
 			}
 		}
-		next := s[j]
+		if curr >= len(s) {
+			i++
+			continue
+		}
+		next := s[curr]
 		if (next < 'a' || next > 'z') && (next < 'A' || next > 'Z') {
 			i++
 			continue

--- a/internal/i18n/htmltagparity/htmltagparity.go
+++ b/internal/i18n/htmltagparity/htmltagparity.go
@@ -38,14 +38,26 @@ func findAllTags(s string) []string {
 			break
 		}
 
-		// We only care about </?[A-Za-z] to match the previous regex behavior.
-		next := s[i+1]
-		if next == '/' {
-			if i+2 >= len(s) {
+		// We only care about </?[A-Za-z] (with optional whitespace after < and /)
+		// so space-lenient closing tags like "</ strong>" and "< / div>" are found
+		// and can reach extractTagName.
+		j := i + 1
+		for j < len(s) && isHTMLWhitespace(s[j]) {
+			j++
+		}
+		if j >= len(s) {
+			break
+		}
+		if s[j] == '/' {
+			j++
+			for j < len(s) && isHTMLWhitespace(s[j]) {
+				j++
+			}
+			if j >= len(s) {
 				break
 			}
-			next = s[i+2]
 		}
+		next := s[j]
 		if (next < 'a' || next > 'z') && (next < 'A' || next > 'Z') {
 			i++
 			continue

--- a/internal/i18n/htmltagparity/htmltagparity.go
+++ b/internal/i18n/htmltagparity/htmltagparity.go
@@ -117,12 +117,16 @@ func extractTagName(tag string) string {
 		i++
 	}
 
-	start := i
-	// Handle closing tag prefix
+	isClosing := false
 	if i < len(tag) && tag[i] == '/' {
+		isClosing = true
 		i++
+		for i < len(tag) && isHTMLWhitespace(tag[i]) {
+			i++
+		}
 	}
 
+	start := i
 	// Scan name characters
 	for i < len(tag) {
 		ch := tag[i]
@@ -136,7 +140,11 @@ func extractTagName(tag string) string {
 		return ""
 	}
 
-	return strings.ToLower(tag[start:i])
+	name := strings.ToLower(tag[start:i])
+	if isClosing {
+		return "/" + name
+	}
+	return name
 }
 
 func normalizedMarkupTagNames(tags []string) []string {

--- a/internal/i18n/htmltagparity/htmltagparity_scout_test.go
+++ b/internal/i18n/htmltagparity/htmltagparity_scout_test.go
@@ -81,16 +81,6 @@ func TestFindAllTags_Direct(t *testing.T) {
 			in:   `<br / >`,
 			want: []string{`<br / >`},
 		},
-		{
-			name: "closing tag with space after slash",
-			in:   "Hello <strong>world</ strong >",
-			want: []string{"<strong>", "</ strong >"},
-		},
-		{
-			name: "closing tag with space before slash",
-			in:   "Hello <div>world< / div>",
-			want: []string{"<div>", "< / div>"},
-		},
 	}
 
 	for _, tt := range tests {
@@ -98,48 +88,6 @@ func TestFindAllTags_Direct(t *testing.T) {
 			got := findAllTags(tt.in)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("findAllTags(%q) = %q, want %q", tt.in, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestMismatch_SpacedClosingTags(t *testing.T) {
-	tests := []struct {
-		name string
-		src  string
-		tgt  string
-		want bool
-	}{
-		{
-			name: "space after slash in closing tag matches tight closing tag",
-			src:  "Hello <strong>world</ strong >",
-			tgt:  "Bonjour <strong>monde</strong>",
-			want: false,
-		},
-		{
-			name: "space before slash in closing tag matches tight closing tag",
-			src:  "Hello <div>world< / div>",
-			tgt:  "Bonjour <div>monde</div>",
-			want: false,
-		},
-		{
-			name: "both sides use spaced closing tags and match",
-			src:  "Hello <strong>world</ strong>",
-			tgt:  "Bonjour <strong>monde< / strong >",
-			want: false,
-		},
-		{
-			name: "spaced closing tag still detects real mismatch",
-			src:  "Hello <strong>world</ strong >",
-			tgt:  "Bonjour <em>monde</em>",
-			want: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := Mismatch(tt.src, tt.tgt); got != tt.want {
-				t.Errorf("Mismatch(%q, %q) = %v, want %v", tt.src, tt.tgt, got, tt.want)
 			}
 		})
 	}

--- a/internal/i18n/htmltagparity/htmltagparity_scout_test.go
+++ b/internal/i18n/htmltagparity/htmltagparity_scout_test.go
@@ -81,6 +81,16 @@ func TestFindAllTags_Direct(t *testing.T) {
 			in:   `<br / >`,
 			want: []string{`<br / >`},
 		},
+		{
+			name: "closing tag with space after slash",
+			in:   "Hello <strong>world</ strong >",
+			want: []string{"<strong>", "</ strong >"},
+		},
+		{
+			name: "closing tag with space before slash",
+			in:   "Hello <div>world< / div>",
+			want: []string{"<div>", "< / div>"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -88,6 +98,48 @@ func TestFindAllTags_Direct(t *testing.T) {
 			got := findAllTags(tt.in)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("findAllTags(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMismatch_SpacedClosingTags(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		tgt  string
+		want bool
+	}{
+		{
+			name: "space after slash in closing tag matches tight closing tag",
+			src:  "Hello <strong>world</ strong >",
+			tgt:  "Bonjour <strong>monde</strong>",
+			want: false,
+		},
+		{
+			name: "space before slash in closing tag matches tight closing tag",
+			src:  "Hello <div>world< / div>",
+			tgt:  "Bonjour <div>monde</div>",
+			want: false,
+		},
+		{
+			name: "both sides use spaced closing tags and match",
+			src:  "Hello <strong>world</ strong>",
+			tgt:  "Bonjour <strong>monde< / strong >",
+			want: false,
+		},
+		{
+			name: "spaced closing tag still detects real mismatch",
+			src:  "Hello <strong>world</ strong >",
+			tgt:  "Bonjour <em>monde</em>",
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Mismatch(tt.src, tt.tgt); got != tt.want {
+				t.Errorf("Mismatch(%q, %q) = %v, want %v", tt.src, tt.tgt, got, tt.want)
 			}
 		})
 	}

--- a/internal/i18n/htmltagparity/htmltagparity_scout_test.go
+++ b/internal/i18n/htmltagparity/htmltagparity_scout_test.go
@@ -124,14 +124,14 @@ func TestExtractTagName_Direct(t *testing.T) {
 			want: "div",
 		},
 		{
-			name: "closing tag with space inside parses as slash only",
+			name: "closing tag with space inside parses correctly",
 			tag:  "</ strong >",
-			want: "/",
+			want: "/strong",
 		},
 		{
-			name: "closing tag with space before slash parses as slash only",
+			name: "closing tag with space before slash parses correctly",
 			tag:  "< / div>",
-			want: "/",
+			want: "/div",
 		},
 		{
 			name: "self-closing tag",
@@ -154,9 +154,9 @@ func TestExtractTagName_Direct(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "just closing brace parses as slash only",
+			name: "just closing brace parses as empty",
 			tag:  "</>",
-			want: "/",
+			want: "",
 		},
 	}
 

--- a/internal/i18n/htmltagparity/htmltagparity_test.go
+++ b/internal/i18n/htmltagparity/htmltagparity_test.go
@@ -120,6 +120,24 @@ func TestMismatchFormattingAndKnownTags(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "space-separated closing tags (whitespace inside closing tag)",
+			src:  "Hello <strong>world</ strong>",
+			tgt:  "Bonjour <strong>monde</strong>",
+			want: false,
+		},
+		{
+			name: "space-separated closing tags (whitespace before closing slash)",
+			src:  "Hello <div>world< / div>",
+			tgt:  "Bonjour <div>monde</div>",
+			want: false,
+		},
+		{
+			name: "space-separated closing tags in both source and target",
+			src:  "Hello <div>world< / div> and <strong>text</ strong>",
+			tgt:  "Bonjour <div>monde< / div> and <strong>texte</ strong>",
+			want: false,
+		},
+		{
 			name: "custom tags are treated as markup",
 			src:  "Hello <not-a-tag>world</not-a-tag>",
 			tgt:  "Bonjour world",


### PR DESCRIPTION
💡 What: Improved `extractTagName` in `internal/i18n/htmltagparity/htmltagparity.go` to support space-lenient HTML closing tags (e.g., `</ strong >`, `< / div>`) and updated related unit tests.

🎯 Why: To ensure HTML tag parity checks correctly normalize and recognize spaced closing tags as structural markup, avoiding false-positive mismatches when translation files vary in whitespace formatting.

🧩 Scope: `internal/i18n/htmltagparity/htmltagparity.go`, `internal/i18n/htmltagparity/htmltagparity_scout_test.go`, and `.jules/scout.md`.

✅ Verification: Verified by running `go test ./...` and `go test -v ./internal/i18n/htmltagparity/...`, which both pass perfectly.

🛡️ Confidence: Extremely high. The fix is robustly covered by updated and existing test suites, with clear and correct tag extraction asserted.

---
*PR created automatically by Jules for task [10920751065258200651](https://jules.google.com/task/10920751065258200651) started by @cungminh2710*