### PR TITLE
feat(issues): add route-aware issue detail drawer

### DIFF
--- a/apps/hyperlocalise-web/.gitignore
+++ b/apps/hyperlocalise-web/.gitignore
@@ -44,3 +44,4 @@ next-env.d.ts
 
 *storybook.log
 storybook-static
+/.swc

--- a/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
@@ -190,6 +190,7 @@ async function inviteOrganizationMember(input: {
       isNewUser: false,
       member: toMemberSummary(
         {
+          userId: existingMembership.localUserId,
           workosUserId: existingMembership.workosUserId,
           email: existingMembership.email,
           firstName: existingMembership.firstName,
@@ -262,6 +263,7 @@ async function inviteOrganizationMember(input: {
     isNewUser,
     member: toMemberSummary(
       {
+        userId: user.id,
         workosUserId: user.workosUserId,
         email: user.email,
         firstName: user.firstName,
@@ -438,6 +440,7 @@ export function createMemberRoutes() {
 
       const rows = await db
         .select({
+          userId: schema.users.id,
           workosUserId: schema.users.workosUserId,
           email: schema.users.email,
           firstName: schema.users.firstName,
@@ -784,6 +787,7 @@ export function createMemberRoutes() {
         {
           member: toMemberSummary(
             {
+              userId: member.localUserId,
               workosUserId: member.workosUserId,
               email: member.email,
               firstName: member.firstName,

--- a/apps/hyperlocalise-web/src/api/routes/member/member.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.shared.ts
@@ -156,6 +156,7 @@ export async function getOrganizationMember(organizationId: string, workosUserId
 
 export function toMemberSummary(
   row: {
+    userId: string;
     workosUserId: string;
     email: string;
     firstName: string | null;
@@ -168,6 +169,7 @@ export function toMemberSummary(
   currentWorkosUserId: string,
   actorRole?: OrganizationMembershipRole,
 ): {
+  userId: string;
   workosUserId: string;
   email: string;
   firstName: string | null;
@@ -192,6 +194,7 @@ export function toMemberSummary(
         });
 
   return {
+    userId: row.userId,
     workosUserId: row.workosUserId,
     email: row.email,
     firstName: row.firstName,

--- a/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.test.ts
@@ -164,6 +164,22 @@ describe("Issue Sheet routes", () => {
     expect(viewWithStatusBody.issues).toHaveLength(0);
 
     const issueId = createdBody.issue.id;
+
+    const getIssueResponse = await requestJson(
+      issueSheetUrl(organizationSlug, project.id, `/${issueId}`),
+      { headers },
+    );
+    expect(getIssueResponse.status).toBe(200);
+    const getIssueBody = (await getIssueResponse.json()) as IssueResponse;
+    expect(getIssueBody.issue.id).toBe(issueId);
+    expect(getIssueBody.issue.title).toBe("Source string needs context");
+
+    const missingIssueResponse = await requestJson(
+      issueSheetUrl(organizationSlug, project.id, "/00000000-0000-4000-8000-000000000000"),
+      { headers },
+    );
+    expect(missingIssueResponse.status).toBe(404);
+
     const updateResponse = await requestJson(
       issueSheetUrl(organizationSlug, project.id, `/${issueId}`),
       {

--- a/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.ts
@@ -6,7 +6,7 @@ import {
   isProjectMutationAllowed,
   isWriteBackTranslationAllowed,
 } from "@/api/auth/capability-guards";
-import { badRequestResponse, conflictResponse } from "@/api/response.schema";
+import { badRequestResponse, conflictResponse, notFoundResponse } from "@/api/response.schema";
 import { createWorkspaceFeatureFlagMiddleware } from "@/api/middleware/workspace-feature-flag";
 import { workspaceIssuesFlag } from "@/lib/flags/workspace-flags";
 import { IssueSheetService } from "@/lib/projects/issue-sheet/issue-sheet-service";
@@ -106,6 +106,24 @@ export function createIssueSheetRoutes() {
         query: c.req.valid("query"),
       });
       return c.json(result, 200);
+    })
+    .get("/:issueId", validateIssueSheetIssueParams, async (c) => {
+      const params = c.req.valid("param");
+      const project = await requireProject(c, params.projectId);
+      if (!project) {
+        return projectNotFoundResponse(c);
+      }
+
+      const issue = await service.getIssue({
+        organizationId: c.var.auth.organization.localOrganizationId,
+        projectId: project.id,
+        issueId: params.issueId,
+        actorUserId: c.var.auth.user.localUserId,
+      });
+      if (!issue) {
+        return notFoundResponse(c, "issue_not_found", "Issue not found");
+      }
+      return c.json({ issue }, 200);
     })
     .post("/", validateIssueSheetParams, validateCreateIssueBody, async (c) => {
       if (!isWriteBackTranslationAllowed(c.var.auth.membership.role)) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-drawer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-drawer.tsx
@@ -68,13 +68,15 @@ export function IssueDetailDrawer({
       <SheetContent
         side="right"
         className={cn(
-          "w-full overflow-y-auto",
-          isMobile ? "max-w-none sm:max-w-none" : "sm:max-w-xl md:max-w-2xl",
+          "w-full overflow-y-auto p-0",
+          isMobile
+            ? "max-w-none data-[side=right]:sm:max-w-none"
+            : "data-[side=right]:sm:max-w-3xl data-[side=right]:md:max-w-4xl",
         )}
       >
-        <div ref={contentRef}>
-          <SheetHeader>
-            <SheetTitle>
+        <div ref={contentRef} className="flex min-h-full flex-col">
+          <SheetHeader className="border-b border-border px-6 py-4 pe-14">
+            <SheetTitle className="text-sm font-medium text-muted-foreground">
               <FormattedMessage {...messages.sheetTitle} />
             </SheetTitle>
             <SheetDescription className="sr-only">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-drawer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-drawer.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useRef, type RefObject } from "react";
+import { FormattedMessage } from "react-intl";
+
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { cn } from "@/lib/primitives/cn";
+
+import { issueDetailPanelMessages as messages } from "./issue-detail-panel.messages";
+import { IssueDetailPanel } from "./issue-detail-panel";
+
+export function IssueDetailDrawer({
+  organizationSlug,
+  projectId,
+  issueId,
+  isOpen,
+  onOpenChange,
+  returnFocusRef,
+}: {
+  organizationSlug: string;
+  projectId: string | undefined;
+  issueId: string | undefined;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  returnFocusRef?: RefObject<HTMLElement | null>;
+}) {
+  const isMobile = useIsMobile();
+  const contentRef = useRef<HTMLDivElement>(null);
+  const wasOpenRef = useRef(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      wasOpenRef.current = true;
+      const frame = window.requestAnimationFrame(() => {
+        const closeButton = contentRef.current?.querySelector<HTMLElement>(
+          '[data-slot="sheet-close"]',
+        );
+        closeButton?.focus();
+      });
+      return () => window.cancelAnimationFrame(frame);
+    }
+
+    if (wasOpenRef.current) {
+      wasOpenRef.current = false;
+      returnFocusRef?.current?.focus();
+    }
+  }, [isOpen, returnFocusRef]);
+
+  const resolvedProjectId = projectId;
+  const resolvedIssueId = issueId;
+
+  return (
+    <Sheet
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onOpenChange(false);
+        }
+      }}
+    >
+      <SheetContent
+        side="right"
+        className={cn(
+          "w-full overflow-y-auto",
+          isMobile ? "max-w-none sm:max-w-none" : "sm:max-w-xl md:max-w-2xl",
+        )}
+      >
+        <div ref={contentRef}>
+          <SheetHeader>
+            <SheetTitle>
+              <FormattedMessage {...messages.sheetTitle} />
+            </SheetTitle>
+            <SheetDescription className="sr-only">
+              <FormattedMessage {...messages.sheetTitle} />
+            </SheetDescription>
+          </SheetHeader>
+          {isOpen && resolvedProjectId && resolvedIssueId ? (
+            <IssueDetailPanel
+              organizationSlug={organizationSlug}
+              projectId={resolvedProjectId}
+              issueId={resolvedIssueId}
+            />
+          ) : null}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.messages.ts
@@ -1,0 +1,141 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const issueDetailPanelMessages = defineMessages({
+  sheetTitle: {
+    defaultMessage: "Issue details",
+    id: "l2pq2plLde",
+    description: "Title for the issue detail drawer",
+  },
+  loading: {
+    defaultMessage: "Loading issue…",
+    id: "87YejAyMlf",
+    description: "Loading state while fetching a single issue",
+  },
+  loadError: {
+    defaultMessage: "Could not load this issue.",
+    id: "NfnpZsFAE9",
+    description: "Error state when single issue fetch fails",
+  },
+  notFound: {
+    defaultMessage: "This issue could not be found.",
+    id: "TpepILtGKC",
+    description: "Error when issue detail returns not found",
+  },
+  saved: {
+    defaultMessage: "Saved",
+    id: "EVE7+QSKr9",
+    description: "Brief success label after saving an issue field",
+  },
+  fieldTitle: {
+    defaultMessage: "Title",
+    id: "4RE0bnosRR",
+    description: "Label for issue title field",
+  },
+  fieldDescription: {
+    defaultMessage: "Description",
+    id: "Mubi5jvzbc",
+    description: "Label for issue description field",
+  },
+  fieldStatus: {
+    defaultMessage: "Status",
+    id: "UirP0XHash",
+    description: "Label for issue status field",
+  },
+  fieldType: {
+    defaultMessage: "Type",
+    id: "Cow2splN/1",
+    description: "Label for issue type field",
+  },
+  fieldPriority: {
+    defaultMessage: "Priority",
+    id: "MwxM6cb/1r",
+    description: "Label for issue priority field",
+  },
+  fieldAssignee: {
+    defaultMessage: "Assignee",
+    id: "e1ZCr/FmBQ",
+    description: "Label for issue assignee field",
+  },
+  assigneeUnassigned: {
+    defaultMessage: "Unassigned",
+    id: "UfX+B2NG5i",
+    description: "Option for clearing issue assignee",
+  },
+  fieldReporter: {
+    defaultMessage: "Reporter",
+    id: "Cp3xy0MA7p",
+    description: "Label for issue reporter field",
+  },
+  fieldLocale: {
+    defaultMessage: "Locale",
+    id: "nLGLyaeThi",
+    description: "Label for issue target locale field",
+  },
+  fieldSourcePath: {
+    defaultMessage: "Source path",
+    id: "lEtyUUSw7r",
+    description: "Label for issue source path field",
+  },
+  fieldCreatedAt: {
+    defaultMessage: "Created",
+    id: "8roD8NwsMT",
+    description: "Label for issue created timestamp",
+  },
+  fieldUpdatedAt: {
+    defaultMessage: "Updated",
+    id: "7bzkQaXdN3",
+    description: "Label for issue updated timestamp",
+  },
+  fieldResolvedAt: {
+    defaultMessage: "Resolved",
+    id: "HmDnokfJEK",
+    description: "Label for issue resolved timestamp",
+  },
+  linkedContext: {
+    defaultMessage: "Linked context",
+    id: "W3V5ERIIW9",
+    description: "Section heading for linked issue context",
+  },
+  fieldKey: {
+    defaultMessage: "Key",
+    id: "awnc3dv3Xw",
+    description: "Label for translation key on an issue",
+  },
+  fieldSourceText: {
+    defaultMessage: "Source text",
+    id: "syMBsg2OBf",
+    description: "Label for source text on an issue",
+  },
+  fieldSegmentId: {
+    defaultMessage: "Segment",
+    id: "dQccrvPeHu",
+    description: "Label for CAT segment id on an issue",
+  },
+  fieldLink: {
+    defaultMessage: "Link",
+    id: "nsS+omXI6F",
+    description: "Label for external or custom issue link",
+  },
+  openInCat: {
+    defaultMessage: "Open in CAT",
+    id: "HDO9bAX2qb",
+    description: "Button to open the linked CAT segment",
+  },
+  openInCatUnavailable: {
+    defaultMessage: "Add a source path and locale to open this issue in CAT.",
+    id: "cd7UpbIU0k",
+    description: "Helper when Open in CAT is unavailable",
+  },
+  openLink: {
+    defaultMessage: "Open link",
+    id: "0AIuIWXaN7",
+    description: "Button to open a custom issue link",
+  },
+  updateFailed: {
+    defaultMessage: "Could not save changes.",
+    id: "fhtliL5Eg6",
+    description: "Toast when issue detail update fails",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
@@ -1,12 +1,25 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  Calendar03Icon,
+  CheckmarkCircle02Icon,
+  Clock01Icon,
+  File01Icon,
+  Flag01Icon,
+  LanguageCircleIcon,
+  LinkSquare02Icon,
+  Tag01Icon,
+  TranslateIcon,
+  User02Icon,
+  UserCircleIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useQuery } from "@tanstack/react-query";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Field, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -43,43 +56,75 @@ type WorkspaceMember = {
   status: "active" | "invited";
 };
 
-function DetailField({
+type PropertyIcon = Parameters<typeof HugeiconsIcon>[0]["icon"];
+
+function PropertyRow({
+  icon,
   label,
   children,
-  className,
 }: {
-  label: React.ReactNode;
-  children: React.ReactNode;
-  className?: string;
+  icon: PropertyIcon;
+  label: ReactNode;
+  children: ReactNode;
 }) {
   return (
-    <Field className={cn("gap-1.5", className)}>
-      <FieldLabel className="text-xs text-muted-foreground">{label}</FieldLabel>
-      {children}
-    </Field>
+    <div className="flex items-center justify-between gap-3 py-1.5">
+      <dt className="flex min-w-0 shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
+        <HugeiconsIcon icon={icon} strokeWidth={1.8} className="size-3.5 shrink-0" />
+        <span className="truncate">{label}</span>
+      </dt>
+      <dd className="flex min-w-0 max-w-[55%] justify-end text-end">{children}</dd>
+    </div>
   );
 }
 
-function ReadOnlyValue({ value, empty }: { value: string | null; empty: string }) {
+function ReadOnlyValue({
+  value,
+  empty,
+  className,
+}: {
+  value: string | null;
+  empty: string;
+  className?: string;
+}) {
   return (
-    <TypographyP className="text-sm text-foreground">{value?.trim() ? value : empty}</TypographyP>
+    <TypographyP className={cn("text-sm leading-5 text-foreground", className)}>
+      {value?.trim() ? value : empty}
+    </TypographyP>
+  );
+}
+
+function LinkedContextRow({ label, children }: { label: ReactNode; children: ReactNode }) {
+  return (
+    <div className="grid gap-1">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <div className="text-sm text-foreground">{children}</div>
+    </div>
   );
 }
 
 function IssueDetailSkeleton() {
   return (
-    <div className="flex flex-col gap-4 px-6 pb-6">
-      <Skeleton className="h-8 w-3/4" />
-      <Skeleton className="h-24 w-full" />
-      <div className="grid gap-4 sm:grid-cols-2">
-        <Skeleton className="h-10 w-full" />
-        <Skeleton className="h-10 w-full" />
-        <Skeleton className="h-10 w-full" />
-        <Skeleton className="h-10 w-full" />
+    <div className="grid flex-1 md:grid-cols-[minmax(0,1fr)_18rem]">
+      <div className="flex flex-col gap-4 px-6 py-5">
+        <Skeleton className="h-8 w-2/3" />
+        <Skeleton className="h-40 w-full" />
+        <Skeleton className="h-24 w-full" />
       </div>
+      <aside className="flex flex-col gap-3 border-t border-border bg-muted/20 px-4 py-5 md:border-t-0 md:border-s">
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="ml-auto h-7 w-24" />
+        <Skeleton className="ml-auto h-7 w-20" />
+        <Skeleton className="ml-auto h-7 w-28" />
+        <Skeleton className="ml-auto h-7 w-16" />
+        <Skeleton className="mt-2 ml-auto h-7 w-24" />
+      </aside>
     </div>
   );
 }
+
+const ghostSelectTriggerClassName =
+  "h-8 max-w-full justify-end border-transparent bg-transparent px-1.5 shadow-none hover:bg-muted/60 focus-visible:border-ring";
 
 export function IssueDetailPanel({
   organizationSlug,
@@ -172,7 +217,7 @@ export function IssueDetailPanel({
 
   if (issueQuery.isLoading) {
     return (
-      <div aria-busy="true" aria-live="polite">
+      <div aria-busy="true" aria-live="polite" className="flex flex-1 flex-col">
         <TypographyP className="sr-only">
           <FormattedMessage {...messages.loading} />
         </TypographyP>
@@ -183,7 +228,7 @@ export function IssueDetailPanel({
 
   if (issueQuery.isError) {
     return (
-      <div className="px-6 pb-6">
+      <div className="px-6 py-5">
         <TypographyP className="text-sm text-destructive">
           <FormattedMessage {...messages.loadError} />
         </TypographyP>
@@ -193,7 +238,7 @@ export function IssueDetailPanel({
 
   if (!issue) {
     return (
-      <div className="px-6 pb-6">
+      <div className="px-6 py-5">
         <TypographyP className="text-sm text-muted-foreground">
           <FormattedMessage {...messages.notFound} />
         </TypographyP>
@@ -203,6 +248,9 @@ export function IssueDetailPanel({
 
   const catHref = buildIssueCatHref(organizationSlug, projectId, issue);
   const priority = typeof issue.values.priority === "string" ? issue.values.priority : "";
+  const hasLinkedContext = Boolean(
+    issue.key || issue.sourceText || issue.segmentId || issue.linkKind,
+  );
 
   const saveTitle = () => {
     const next = titleDraft.trim();
@@ -220,224 +268,268 @@ export function IssueDetailPanel({
   };
 
   return (
-    <div className="flex flex-col gap-6 px-6 pb-6" aria-busy={isSaving}>
-      {showSaved ? (
-        <TypographyP className="text-xs text-muted-foreground" aria-live="polite">
-          <FormattedMessage {...messages.saved} />
-        </TypographyP>
-      ) : null}
-
-      <div className="flex flex-wrap items-center gap-2">
-        {catHref ? (
-          <Button variant="default" size="sm" render={<a href={catHref} />}>
-            <FormattedMessage {...messages.openInCat} />
-          </Button>
-        ) : (
-          <TypographyP className="text-xs text-muted-foreground">
-            <FormattedMessage {...messages.openInCatUnavailable} />
+    <div className="grid flex-1 md:grid-cols-[minmax(0,1fr)_18rem]" aria-busy={isSaving}>
+      <div className="flex min-w-0 flex-col gap-3 px-6 py-5">
+        {showSaved ? (
+          <TypographyP className="text-xs text-muted-foreground" aria-live="polite">
+            <FormattedMessage {...messages.saved} />
           </TypographyP>
-        )}
-        {issue.linkUrl && issue.linkUrl !== catHref ? (
-          <Button
-            variant="outline"
-            size="sm"
-            render={
-              <a
-                href={issue.linkUrl}
-                {...(isExternalHttpUrl(issue.linkUrl)
-                  ? { target: "_blank", rel: "noopener noreferrer" }
-                  : {})}
-              />
-            }
-          >
-            {issue.linkLabel || intl.formatMessage(messages.openLink)}
-          </Button>
         ) : null}
-      </div>
 
-      <DetailField label={<FormattedMessage {...messages.fieldTitle} />}>
         <Input
           value={titleDraft}
           onChange={(event) => setTitleDraft(event.currentTarget.value)}
           onBlur={saveTitle}
           disabled={isSaving}
+          aria-label={intl.formatMessage(messages.fieldTitle)}
+          className={cn(
+            "h-auto rounded-none border-transparent bg-transparent px-0 py-1 text-lg font-semibold shadow-none md:text-xl",
+            "focus-visible:border-transparent focus-visible:ring-0",
+          )}
         />
-      </DetailField>
 
-      <DetailField label={<FormattedMessage {...messages.fieldDescription} />}>
         <Textarea
           value={descriptionDraft}
           onChange={(event) => setDescriptionDraft(event.currentTarget.value)}
           onBlur={saveDescription}
           disabled={isSaving}
-          className="min-h-28"
+          aria-label={intl.formatMessage(messages.fieldDescription)}
+          placeholder={intl.formatMessage(messages.fieldDescription)}
+          className={cn(
+            "min-h-32 rounded-none border-transparent bg-transparent px-0 py-1 text-sm shadow-none md:text-sm",
+            "focus-visible:border-transparent focus-visible:ring-0",
+          )}
         />
-      </DetailField>
 
-      <div className="grid gap-4 sm:grid-cols-2">
-        <DetailField label={<FormattedMessage {...messages.fieldStatus} />}>
-          <Select
-            value={issue.status}
-            items={statusItems}
-            onValueChange={(value) => {
-              if (value) {
-                updateIssue.mutate({ status: value });
-              }
-            }}
-            disabled={isSaving}
-          >
-            <SelectTrigger className="w-full">
-              <Badge variant={issueStatusVariant(issue.status)}>
-                {issueStatusLabel(intl, issue.status)}
-              </Badge>
-            </SelectTrigger>
-            <SelectContent>
-              {statusItems.map((status) => (
-                <SelectItem key={status.value} value={status.value} label={status.label}>
-                  {status.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </DetailField>
-
-        <DetailField label={<FormattedMessage {...messages.fieldType} />}>
-          <Select
-            value={issue.issueType}
-            items={issueTypeItems}
-            onValueChange={(value) => {
-              if (value) {
-                updateIssue.mutate({ issueType: value });
-              }
-            }}
-            disabled={isSaving}
-          >
-            <SelectTrigger className="w-full">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {issueTypeItems.map((type) => (
-                <SelectItem key={type.value} value={type.value} label={type.label}>
-                  {type.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </DetailField>
-
-        <DetailField label={<FormattedMessage {...messages.fieldPriority} />}>
-          <Select
-            value={priority || undefined}
-            items={priorityItems}
-            onValueChange={(value) => {
-              if (value) {
-                setValue.mutate({ columnKey: "priority", value });
-              }
-            }}
-            disabled={isSaving}
-          >
-            <SelectTrigger className="w-full">
-              <SelectValue placeholder={emptyValue} />
-            </SelectTrigger>
-            <SelectContent>
-              {priorityItems.map((item) => (
-                <SelectItem key={item.value} value={item.value} label={item.label}>
-                  {item.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </DetailField>
-
-        <DetailField label={<FormattedMessage {...messages.fieldAssignee} />}>
-          <Select
-            value={issue.assigneeUserId ?? "unassigned"}
-            items={assigneeItems}
-            onValueChange={(value) => {
-              if (!value) {
-                return;
-              }
-              updateIssue.mutate({
-                assigneeUserId: value === "unassigned" ? null : value,
-              });
-            }}
-            disabled={isSaving || membersQuery.isLoading}
-          >
-            <SelectTrigger className="w-full">
-              <SelectValue placeholder={emptyValue} />
-            </SelectTrigger>
-            <SelectContent>
-              {assigneeItems.map((item) => (
-                <SelectItem key={item.value} value={item.value} label={item.label}>
-                  {item.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </DetailField>
-      </div>
-
-      <div className="grid gap-4 sm:grid-cols-2">
-        <DetailField label={<FormattedMessage {...messages.fieldReporter} />}>
-          <ReadOnlyValue value={issue.reporter} empty={emptyValue} />
-        </DetailField>
-        <DetailField label={<FormattedMessage {...messages.fieldLocale} />}>
-          <ReadOnlyValue value={issue.targetLocale} empty={emptyValue} />
-        </DetailField>
-        <DetailField
-          label={<FormattedMessage {...messages.fieldSourcePath} />}
-          className="sm:col-span-2"
-        >
-          <ReadOnlyValue value={issue.sourcePath} empty={emptyValue} />
-        </DetailField>
-      </div>
-
-      <div className="grid gap-4 sm:grid-cols-2">
-        <DetailField label={<FormattedMessage {...messages.fieldCreatedAt} />}>
-          <ReadOnlyValue value={formatRelativeTimestamp(issue.createdAt)} empty={emptyValue} />
-        </DetailField>
-        <DetailField label={<FormattedMessage {...messages.fieldUpdatedAt} />}>
-          <ReadOnlyValue value={formatRelativeTimestamp(issue.updatedAt)} empty={emptyValue} />
-        </DetailField>
-        {issue.resolvedAt ? (
-          <DetailField label={<FormattedMessage {...messages.fieldResolvedAt} />}>
-            <ReadOnlyValue value={formatRelativeTimestamp(issue.resolvedAt)} empty={emptyValue} />
-          </DetailField>
+        {hasLinkedContext ? (
+          <section className="mt-2 grid gap-3 border-t border-border pt-4">
+            <TypographyP className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground">
+              <HugeiconsIcon
+                icon={LinkSquare02Icon}
+                strokeWidth={1.8}
+                className="size-3.5 text-muted-foreground"
+              />
+              <FormattedMessage {...messages.linkedContext} />
+            </TypographyP>
+            <div className="grid gap-3">
+              {issue.key ? (
+                <LinkedContextRow label={<FormattedMessage {...messages.fieldKey} />}>
+                  <ReadOnlyValue value={issue.key} empty={emptyValue} />
+                </LinkedContextRow>
+              ) : null}
+              {issue.segmentId ? (
+                <LinkedContextRow label={<FormattedMessage {...messages.fieldSegmentId} />}>
+                  <ReadOnlyValue value={issue.segmentId} empty={emptyValue} />
+                </LinkedContextRow>
+              ) : null}
+              {issue.sourceText ? (
+                <LinkedContextRow label={<FormattedMessage {...messages.fieldSourceText} />}>
+                  <ReadOnlyValue value={issue.sourceText} empty={emptyValue} />
+                </LinkedContextRow>
+              ) : null}
+              {issue.linkKind ? (
+                <LinkedContextRow label={<FormattedMessage {...messages.fieldLink} />}>
+                  <ReadOnlyValue value={issue.linkKind} empty={emptyValue} />
+                </LinkedContextRow>
+              ) : null}
+            </div>
+          </section>
         ) : null}
       </div>
 
-      {(issue.key || issue.sourceText || issue.segmentId || issue.linkKind) && (
-        <div className="rounded-xl border bg-muted/30 p-4">
-          <TypographyP className="text-sm font-medium text-foreground">
-            <FormattedMessage {...messages.linkedContext} />
-          </TypographyP>
-          <div className="mt-3 grid gap-3 sm:grid-cols-2">
-            {issue.key ? (
-              <DetailField label={<FormattedMessage {...messages.fieldKey} />}>
-                <ReadOnlyValue value={issue.key} empty={emptyValue} />
-              </DetailField>
-            ) : null}
-            {issue.segmentId ? (
-              <DetailField label={<FormattedMessage {...messages.fieldSegmentId} />}>
-                <ReadOnlyValue value={issue.segmentId} empty={emptyValue} />
-              </DetailField>
-            ) : null}
-            {issue.sourceText ? (
-              <DetailField
-                label={<FormattedMessage {...messages.fieldSourceText} />}
-                className="sm:col-span-2"
-              >
-                <ReadOnlyValue value={issue.sourceText} empty={emptyValue} />
-              </DetailField>
-            ) : null}
-            {issue.linkKind ? (
-              <DetailField label={<FormattedMessage {...messages.fieldLink} />}>
-                <ReadOnlyValue value={issue.linkKind} empty={emptyValue} />
-              </DetailField>
-            ) : null}
-          </div>
+      <aside className="flex flex-col gap-1 border-t border-border bg-muted/20 px-4 py-5 md:border-t-0 md:border-s">
+        <div className="mb-3 flex flex-col gap-2">
+          {catHref ? (
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full justify-start"
+              render={<a href={catHref} />}
+            >
+              <HugeiconsIcon icon={TranslateIcon} strokeWidth={1.8} data-icon="inline-start" />
+              <FormattedMessage {...messages.openInCat} />
+            </Button>
+          ) : (
+            <TypographyP className="text-xs text-muted-foreground">
+              <FormattedMessage {...messages.openInCatUnavailable} />
+            </TypographyP>
+          )}
+          {issue.linkUrl && issue.linkUrl !== catHref ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full justify-start"
+              render={
+                <a
+                  href={issue.linkUrl}
+                  {...(isExternalHttpUrl(issue.linkUrl)
+                    ? { target: "_blank", rel: "noopener noreferrer" }
+                    : {})}
+                />
+              }
+            >
+              <HugeiconsIcon icon={LinkSquare02Icon} strokeWidth={1.8} data-icon="inline-start" />
+              {issue.linkLabel || intl.formatMessage(messages.openLink)}
+            </Button>
+          ) : null}
         </div>
-      )}
+
+        <dl className="flex flex-col">
+          <PropertyRow icon={User02Icon} label={<FormattedMessage {...messages.fieldAssignee} />}>
+            <Select
+              value={issue.assigneeUserId ?? "unassigned"}
+              items={assigneeItems}
+              onValueChange={(value) => {
+                if (!value) {
+                  return;
+                }
+                updateIssue.mutate({
+                  assigneeUserId: value === "unassigned" ? null : value,
+                });
+              }}
+              disabled={isSaving || membersQuery.isLoading}
+            >
+              <SelectTrigger className={ghostSelectTriggerClassName}>
+                <SelectValue placeholder={emptyValue} />
+              </SelectTrigger>
+              <SelectContent>
+                {assigneeItems.map((item) => (
+                  <SelectItem key={item.value} value={item.value} label={item.label}>
+                    {item.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </PropertyRow>
+
+          <PropertyRow
+            icon={CheckmarkCircle02Icon}
+            label={<FormattedMessage {...messages.fieldStatus} />}
+          >
+            <Select
+              value={issue.status}
+              items={statusItems}
+              onValueChange={(value) => {
+                if (value) {
+                  updateIssue.mutate({ status: value });
+                }
+              }}
+              disabled={isSaving}
+            >
+              <SelectTrigger className={ghostSelectTriggerClassName}>
+                <Badge variant={issueStatusVariant(issue.status)}>
+                  {issueStatusLabel(intl, issue.status)}
+                </Badge>
+              </SelectTrigger>
+              <SelectContent>
+                {statusItems.map((status) => (
+                  <SelectItem key={status.value} value={status.value} label={status.label}>
+                    {status.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </PropertyRow>
+
+          <PropertyRow icon={Tag01Icon} label={<FormattedMessage {...messages.fieldType} />}>
+            <Select
+              value={issue.issueType}
+              items={issueTypeItems}
+              onValueChange={(value) => {
+                if (value) {
+                  updateIssue.mutate({ issueType: value });
+                }
+              }}
+              disabled={isSaving}
+            >
+              <SelectTrigger className={ghostSelectTriggerClassName}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {issueTypeItems.map((type) => (
+                  <SelectItem key={type.value} value={type.value} label={type.label}>
+                    {type.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </PropertyRow>
+
+          <PropertyRow icon={Flag01Icon} label={<FormattedMessage {...messages.fieldPriority} />}>
+            <Select
+              value={priority || undefined}
+              items={priorityItems}
+              onValueChange={(value) => {
+                if (value) {
+                  setValue.mutate({ columnKey: "priority", value });
+                }
+              }}
+              disabled={isSaving}
+            >
+              <SelectTrigger className={ghostSelectTriggerClassName}>
+                <SelectValue placeholder={emptyValue} />
+              </SelectTrigger>
+              <SelectContent>
+                {priorityItems.map((item) => (
+                  <SelectItem key={item.value} value={item.value} label={item.label}>
+                    {item.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </PropertyRow>
+
+          <PropertyRow
+            icon={UserCircleIcon}
+            label={<FormattedMessage {...messages.fieldReporter} />}
+          >
+            <ReadOnlyValue value={issue.reporter} empty={emptyValue} className="truncate" />
+          </PropertyRow>
+
+          <PropertyRow
+            icon={LanguageCircleIcon}
+            label={<FormattedMessage {...messages.fieldLocale} />}
+          >
+            <ReadOnlyValue value={issue.targetLocale} empty={emptyValue} className="truncate" />
+          </PropertyRow>
+
+          <PropertyRow icon={File01Icon} label={<FormattedMessage {...messages.fieldSourcePath} />}>
+            <ReadOnlyValue value={issue.sourcePath} empty={emptyValue} className="truncate" />
+          </PropertyRow>
+
+          <PropertyRow
+            icon={Calendar03Icon}
+            label={<FormattedMessage {...messages.fieldCreatedAt} />}
+          >
+            <ReadOnlyValue
+              value={formatRelativeTimestamp(issue.createdAt)}
+              empty={emptyValue}
+              className="truncate"
+            />
+          </PropertyRow>
+
+          <PropertyRow icon={Clock01Icon} label={<FormattedMessage {...messages.fieldUpdatedAt} />}>
+            <ReadOnlyValue
+              value={formatRelativeTimestamp(issue.updatedAt)}
+              empty={emptyValue}
+              className="truncate"
+            />
+          </PropertyRow>
+
+          {issue.resolvedAt ? (
+            <PropertyRow
+              icon={CheckmarkCircle02Icon}
+              label={<FormattedMessage {...messages.fieldResolvedAt} />}
+            >
+              <ReadOnlyValue
+                value={formatRelativeTimestamp(issue.resolvedAt)}
+                empty={emptyValue}
+                className="truncate"
+              />
+            </PropertyRow>
+          ) : null}
+        </dl>
+      </aside>
     </div>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
@@ -139,10 +139,12 @@ export function IssueDetailPanel({
   const intl = useIntl();
   const emptyValue = intl.formatMessage(sharedMessages.emptyValue);
   const issueQuery = useIssueDetailQuery({ organizationSlug, projectId, issueId });
+  const [showSaved, setShowSaved] = useState(false);
   const { updateIssue, setValue } = useIssueDetailMutations({
     organizationSlug,
     projectId,
     issueId,
+    onSaved: () => setShowSaved(true),
   });
 
   const membersQuery = useQuery({
@@ -164,7 +166,7 @@ export function IssueDetailPanel({
   const issue = issueQuery.data;
   const [titleDraft, setTitleDraft] = useState("");
   const [descriptionDraft, setDescriptionDraft] = useState("");
-  const [showSaved, setShowSaved] = useState(false);
+  const isSaving = updateIssue.isPending || setValue.isPending;
 
   useEffect(() => {
     if (!issue) {
@@ -175,13 +177,16 @@ export function IssueDetailPanel({
   }, [issue?.id, issue?.title, issue?.description]);
 
   useEffect(() => {
-    if (!updateIssue.isSuccess && !setValue.isSuccess) {
+    if (isSaving) {
+      setShowSaved(false);
       return;
     }
-    setShowSaved(true);
+    if (!showSaved) {
+      return;
+    }
     const timeout = window.setTimeout(() => setShowSaved(false), 2000);
     return () => window.clearTimeout(timeout);
-  }, [setValue.isSuccess, updateIssue.isSuccess]);
+  }, [isSaving, showSaved]);
 
   const statusItems = useMemo(
     () =>
@@ -213,8 +218,6 @@ export function IssueDetailPanel({
       ...members.map((member) => ({ value: member.userId, label: member.displayName })),
     ];
   }, [intl, membersQuery.data]);
-
-  const isSaving = updateIssue.isPending || setValue.isPending;
 
   if (issueQuery.isLoading) {
     return (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
@@ -355,9 +355,7 @@ export function IssueDetailPanel({
               <FormattedMessage {...messages.openInCatUnavailable} />
             </TypographyP>
           )}
-          {issue.linkUrl &&
-          issue.linkUrl !== catHref &&
-          isHttpOrHttpsUrl(issue.linkUrl) ? (
+          {issue.linkUrl && issue.linkUrl !== catHref && isHttpOrHttpsUrl(issue.linkUrl) ? (
             <Button
               variant="ghost"
               size="sm"

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
@@ -1,0 +1,443 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+import { useQuery } from "@tanstack/react-query";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Field, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import { TypographyP } from "@/components/ui/typography";
+import { apiClient } from "@/lib/api-client-instance";
+import { cn } from "@/lib/primitives/cn";
+
+import { formatRelativeTimestamp } from "../workspace-files-shared";
+import { issueSheetSharedMessages as sharedMessages } from "../../projects/[projectId]/issue-sheet/_components/issue-sheet-shared.messages";
+import { issueDetailPanelMessages as messages } from "./issue-detail-panel.messages";
+import {
+  buildIssueCatHref,
+  isExternalHttpUrl,
+  issuePriorityValues,
+  issueStatusLabel,
+  issueStatusValues,
+  issueStatusVariant,
+  issueTypeLabel,
+  issueTypeValues,
+} from "./issue-detail-utils";
+import { useIssueDetailMutations } from "./use-issue-detail-mutations";
+import { useIssueDetailQuery } from "./use-issue-detail-query";
+
+type WorkspaceMember = {
+  userId: string;
+  displayName: string;
+  status: "active" | "invited";
+};
+
+function DetailField({
+  label,
+  children,
+  className,
+}: {
+  label: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <Field className={cn("gap-1.5", className)}>
+      <FieldLabel className="text-xs text-muted-foreground">{label}</FieldLabel>
+      {children}
+    </Field>
+  );
+}
+
+function ReadOnlyValue({ value, empty }: { value: string | null; empty: string }) {
+  return (
+    <TypographyP className="text-sm text-foreground">{value?.trim() ? value : empty}</TypographyP>
+  );
+}
+
+function IssueDetailSkeleton() {
+  return (
+    <div className="flex flex-col gap-4 px-6 pb-6">
+      <Skeleton className="h-8 w-3/4" />
+      <Skeleton className="h-24 w-full" />
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    </div>
+  );
+}
+
+export function IssueDetailPanel({
+  organizationSlug,
+  projectId,
+  issueId,
+}: {
+  organizationSlug: string;
+  projectId: string;
+  issueId: string;
+}) {
+  const intl = useIntl();
+  const emptyValue = intl.formatMessage(sharedMessages.emptyValue);
+  const issueQuery = useIssueDetailQuery({ organizationSlug, projectId, issueId });
+  const { updateIssue, setValue } = useIssueDetailMutations({
+    organizationSlug,
+    projectId,
+    issueId,
+  });
+
+  const membersQuery = useQuery({
+    queryKey: ["workspace-members", organizationSlug],
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].members.$get({
+        param: { organizationSlug },
+      });
+      if (!response.ok) {
+        throw new Error("Failed to load members");
+      }
+      const body = (await response.json()) as {
+        members: WorkspaceMember[];
+      };
+      return body.members.filter((member) => member.status === "active");
+    },
+  });
+
+  const issue = issueQuery.data;
+  const [titleDraft, setTitleDraft] = useState("");
+  const [descriptionDraft, setDescriptionDraft] = useState("");
+  const [showSaved, setShowSaved] = useState(false);
+
+  useEffect(() => {
+    if (!issue) {
+      return;
+    }
+    setTitleDraft(issue.title);
+    setDescriptionDraft(issue.description);
+  }, [issue]);
+
+  useEffect(() => {
+    if (!updateIssue.isSuccess && !setValue.isSuccess) {
+      return;
+    }
+    setShowSaved(true);
+    const timeout = window.setTimeout(() => setShowSaved(false), 2000);
+    return () => window.clearTimeout(timeout);
+  }, [setValue.isSuccess, updateIssue.isSuccess]);
+
+  const statusItems = useMemo(
+    () =>
+      issueStatusValues.map((value) => ({
+        value,
+        label: issueStatusLabel(intl, value),
+      })),
+    [intl],
+  );
+
+  const issueTypeItems = useMemo(
+    () =>
+      issueTypeValues.map((value) => ({
+        value,
+        label: issueTypeLabel(intl, value),
+      })),
+    [intl],
+  );
+
+  const priorityItems = useMemo(
+    () => issuePriorityValues.map((value) => ({ value, label: value })),
+    [],
+  );
+
+  const assigneeItems = useMemo(() => {
+    const members = membersQuery.data ?? [];
+    return [
+      { value: "unassigned", label: intl.formatMessage(messages.assigneeUnassigned) },
+      ...members.map((member) => ({ value: member.userId, label: member.displayName })),
+    ];
+  }, [intl, membersQuery.data]);
+
+  const isSaving = updateIssue.isPending || setValue.isPending;
+
+  if (issueQuery.isLoading) {
+    return (
+      <div aria-busy="true" aria-live="polite">
+        <TypographyP className="sr-only">
+          <FormattedMessage {...messages.loading} />
+        </TypographyP>
+        <IssueDetailSkeleton />
+      </div>
+    );
+  }
+
+  if (issueQuery.isError) {
+    return (
+      <div className="px-6 pb-6">
+        <TypographyP className="text-sm text-destructive">
+          <FormattedMessage {...messages.loadError} />
+        </TypographyP>
+      </div>
+    );
+  }
+
+  if (!issue) {
+    return (
+      <div className="px-6 pb-6">
+        <TypographyP className="text-sm text-muted-foreground">
+          <FormattedMessage {...messages.notFound} />
+        </TypographyP>
+      </div>
+    );
+  }
+
+  const catHref = buildIssueCatHref(organizationSlug, projectId, issue);
+  const priority = typeof issue.values.priority === "string" ? issue.values.priority : "";
+
+  const saveTitle = () => {
+    const next = titleDraft.trim();
+    if (!next || next === issue.title) {
+      return;
+    }
+    updateIssue.mutate({ title: next });
+  };
+
+  const saveDescription = () => {
+    if (descriptionDraft === issue.description) {
+      return;
+    }
+    updateIssue.mutate({ description: descriptionDraft });
+  };
+
+  return (
+    <div className="flex flex-col gap-6 px-6 pb-6" aria-busy={isSaving}>
+      {showSaved ? (
+        <TypographyP className="text-xs text-muted-foreground" aria-live="polite">
+          <FormattedMessage {...messages.saved} />
+        </TypographyP>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-2">
+        {catHref ? (
+          <Button variant="default" size="sm" render={<a href={catHref} />}>
+            <FormattedMessage {...messages.openInCat} />
+          </Button>
+        ) : (
+          <TypographyP className="text-xs text-muted-foreground">
+            <FormattedMessage {...messages.openInCatUnavailable} />
+          </TypographyP>
+        )}
+        {issue.linkUrl && issue.linkUrl !== catHref ? (
+          <Button
+            variant="outline"
+            size="sm"
+            render={
+              <a
+                href={issue.linkUrl}
+                {...(isExternalHttpUrl(issue.linkUrl)
+                  ? { target: "_blank", rel: "noopener noreferrer" }
+                  : {})}
+              />
+            }
+          >
+            {issue.linkLabel || intl.formatMessage(messages.openLink)}
+          </Button>
+        ) : null}
+      </div>
+
+      <DetailField label={<FormattedMessage {...messages.fieldTitle} />}>
+        <Input
+          value={titleDraft}
+          onChange={(event) => setTitleDraft(event.currentTarget.value)}
+          onBlur={saveTitle}
+          disabled={isSaving}
+        />
+      </DetailField>
+
+      <DetailField label={<FormattedMessage {...messages.fieldDescription} />}>
+        <Textarea
+          value={descriptionDraft}
+          onChange={(event) => setDescriptionDraft(event.currentTarget.value)}
+          onBlur={saveDescription}
+          disabled={isSaving}
+          className="min-h-28"
+        />
+      </DetailField>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <DetailField label={<FormattedMessage {...messages.fieldStatus} />}>
+          <Select
+            value={issue.status}
+            items={statusItems}
+            onValueChange={(value) => {
+              if (value) {
+                updateIssue.mutate({ status: value });
+              }
+            }}
+            disabled={isSaving}
+          >
+            <SelectTrigger className="w-full">
+              <Badge variant={issueStatusVariant(issue.status)}>
+                {issueStatusLabel(intl, issue.status)}
+              </Badge>
+            </SelectTrigger>
+            <SelectContent>
+              {statusItems.map((status) => (
+                <SelectItem key={status.value} value={status.value} label={status.label}>
+                  {status.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </DetailField>
+
+        <DetailField label={<FormattedMessage {...messages.fieldType} />}>
+          <Select
+            value={issue.issueType}
+            items={issueTypeItems}
+            onValueChange={(value) => {
+              if (value) {
+                updateIssue.mutate({ issueType: value });
+              }
+            }}
+            disabled={isSaving}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {issueTypeItems.map((type) => (
+                <SelectItem key={type.value} value={type.value} label={type.label}>
+                  {type.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </DetailField>
+
+        <DetailField label={<FormattedMessage {...messages.fieldPriority} />}>
+          <Select
+            value={priority || undefined}
+            items={priorityItems}
+            onValueChange={(value) => {
+              if (value) {
+                setValue.mutate({ columnKey: "priority", value });
+              }
+            }}
+            disabled={isSaving}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder={emptyValue} />
+            </SelectTrigger>
+            <SelectContent>
+              {priorityItems.map((item) => (
+                <SelectItem key={item.value} value={item.value} label={item.label}>
+                  {item.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </DetailField>
+
+        <DetailField label={<FormattedMessage {...messages.fieldAssignee} />}>
+          <Select
+            value={issue.assigneeUserId ?? "unassigned"}
+            items={assigneeItems}
+            onValueChange={(value) => {
+              if (!value) {
+                return;
+              }
+              updateIssue.mutate({
+                assigneeUserId: value === "unassigned" ? null : value,
+              });
+            }}
+            disabled={isSaving || membersQuery.isLoading}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder={emptyValue} />
+            </SelectTrigger>
+            <SelectContent>
+              {assigneeItems.map((item) => (
+                <SelectItem key={item.value} value={item.value} label={item.label}>
+                  {item.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </DetailField>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <DetailField label={<FormattedMessage {...messages.fieldReporter} />}>
+          <ReadOnlyValue value={issue.reporter} empty={emptyValue} />
+        </DetailField>
+        <DetailField label={<FormattedMessage {...messages.fieldLocale} />}>
+          <ReadOnlyValue value={issue.targetLocale} empty={emptyValue} />
+        </DetailField>
+        <DetailField
+          label={<FormattedMessage {...messages.fieldSourcePath} />}
+          className="sm:col-span-2"
+        >
+          <ReadOnlyValue value={issue.sourcePath} empty={emptyValue} />
+        </DetailField>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <DetailField label={<FormattedMessage {...messages.fieldCreatedAt} />}>
+          <ReadOnlyValue value={formatRelativeTimestamp(issue.createdAt)} empty={emptyValue} />
+        </DetailField>
+        <DetailField label={<FormattedMessage {...messages.fieldUpdatedAt} />}>
+          <ReadOnlyValue value={formatRelativeTimestamp(issue.updatedAt)} empty={emptyValue} />
+        </DetailField>
+        {issue.resolvedAt ? (
+          <DetailField label={<FormattedMessage {...messages.fieldResolvedAt} />}>
+            <ReadOnlyValue value={formatRelativeTimestamp(issue.resolvedAt)} empty={emptyValue} />
+          </DetailField>
+        ) : null}
+      </div>
+
+      {(issue.key || issue.sourceText || issue.segmentId || issue.linkKind) && (
+        <div className="rounded-xl border bg-muted/30 p-4">
+          <TypographyP className="text-sm font-medium text-foreground">
+            <FormattedMessage {...messages.linkedContext} />
+          </TypographyP>
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            {issue.key ? (
+              <DetailField label={<FormattedMessage {...messages.fieldKey} />}>
+                <ReadOnlyValue value={issue.key} empty={emptyValue} />
+              </DetailField>
+            ) : null}
+            {issue.segmentId ? (
+              <DetailField label={<FormattedMessage {...messages.fieldSegmentId} />}>
+                <ReadOnlyValue value={issue.segmentId} empty={emptyValue} />
+              </DetailField>
+            ) : null}
+            {issue.sourceText ? (
+              <DetailField
+                label={<FormattedMessage {...messages.fieldSourceText} />}
+                className="sm:col-span-2"
+              >
+                <ReadOnlyValue value={issue.sourceText} empty={emptyValue} />
+              </DetailField>
+            ) : null}
+            {issue.linkKind ? (
+              <DetailField label={<FormattedMessage {...messages.fieldLink} />}>
+                <ReadOnlyValue value={issue.linkKind} empty={emptyValue} />
+              </DetailField>
+            ) : null}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
@@ -40,6 +40,7 @@ import { issueDetailPanelMessages as messages } from "./issue-detail-panel.messa
 import {
   buildIssueCatHref,
   isExternalHttpUrl,
+  isHttpOrHttpsUrl,
   issuePriorityValues,
   issueStatusLabel,
   issueStatusValues,
@@ -354,7 +355,9 @@ export function IssueDetailPanel({
               <FormattedMessage {...messages.openInCatUnavailable} />
             </TypographyP>
           )}
-          {issue.linkUrl && issue.linkUrl !== catHref ? (
+          {issue.linkUrl &&
+          issue.linkUrl !== catHref &&
+          isHttpOrHttpsUrl(issue.linkUrl) ? (
             <Button
               variant="ghost"
               size="sm"

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
@@ -172,7 +172,7 @@ export function IssueDetailPanel({
     }
     setTitleDraft(issue.title);
     setDescriptionDraft(issue.description);
-  }, [issue]);
+  }, [issue?.id, issue?.title, issue?.description]);
 
   useEffect(() => {
     if (!updateIssue.isSuccess && !setValue.isSuccess) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-utils.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-utils.ts
@@ -1,0 +1,122 @@
+import type { IntlShape } from "react-intl";
+
+import { issueSheetSharedMessages as sharedMessages } from "../../projects/[projectId]/issue-sheet/_components/issue-sheet-shared.messages";
+import {
+  issueTypeValues,
+  type IssueTypeValue,
+} from "../../projects/[projectId]/issue-sheet/_components/issue-sheet-constants";
+
+export const issueStatusValues = ["open", "in_progress", "resolved", "wont_fix"] as const;
+export type IssueStatusValue = (typeof issueStatusValues)[number];
+
+export const issuePriorityValues = ["P0", "P1", "P2"] as const;
+
+export type IssueDetailIssue = {
+  id: string;
+  title: string;
+  description: string;
+  issueType: string;
+  status: string;
+  targetLocale: string | null;
+  sourcePath: string | null;
+  segmentId: string | null;
+  translationKeyId: string | null;
+  linkedCommentId: string | null;
+  linkedAgentRunId: string | null;
+  linkKind: string | null;
+  linkLabel: string | null;
+  linkUrl: string | null;
+  assigneeUserId: string | null;
+  reporter: string | null;
+  assignee: string | null;
+  key: string | null;
+  sourceText: string | null;
+  createdAt: string;
+  updatedAt: string;
+  resolvedAt: string | null;
+  values: Record<string, unknown>;
+};
+
+function formatUnknownLabel(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+export function issueStatusLabel(intl: IntlShape, status: string) {
+  switch (status as IssueStatusValue) {
+    case "open":
+      return intl.formatMessage(sharedMessages.statusOpen);
+    case "in_progress":
+      return intl.formatMessage(sharedMessages.statusInProgress);
+    case "resolved":
+      return intl.formatMessage(sharedMessages.statusResolved);
+    case "wont_fix":
+      return intl.formatMessage(sharedMessages.statusWontFix);
+    default:
+      return formatUnknownLabel(status);
+  }
+}
+
+export function issueTypeLabel(intl: IntlShape, value: string) {
+  switch (value as IssueTypeValue) {
+    case "general_question":
+      return intl.formatMessage(sharedMessages.issueTypeGeneralQuestion);
+    case "translation_mistake":
+      return intl.formatMessage(sharedMessages.issueTypeTranslationMistake);
+    case "context_request":
+      return intl.formatMessage(sharedMessages.issueTypeContextRequest);
+    case "source_mistake":
+      return intl.formatMessage(sharedMessages.issueTypeSourceMistake);
+    case "glossary_violation":
+      return intl.formatMessage(sharedMessages.issueTypeGlossaryViolation);
+    case "qa_failure":
+      return intl.formatMessage(sharedMessages.issueTypeQaFailure);
+    default:
+      return formatUnknownLabel(value);
+  }
+}
+
+export function issueStatusVariant(status: string) {
+  if (status === "resolved") return "success" as const;
+  if (status === "wont_fix") return "outline" as const;
+  if (status === "in_progress") return "warning" as const;
+  return "secondary" as const;
+}
+
+export function buildIssueCatHref(
+  organizationSlug: string,
+  projectId: string,
+  issue: Pick<IssueDetailIssue, "sourcePath" | "targetLocale" | "segmentId">,
+) {
+  if (!issue.sourcePath || !issue.targetLocale) {
+    return null;
+  }
+  const params = new URLSearchParams({
+    sourcePath: issue.sourcePath,
+    locale: issue.targetLocale,
+  });
+  if (issue.segmentId) {
+    params.set("segment", issue.segmentId);
+  }
+  return `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/files/cat?${params.toString()}`;
+}
+
+export function isExternalHttpUrl(url: string) {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  try {
+    const parsed = new URL(url);
+    return (
+      (parsed.protocol === "http:" || parsed.protocol === "https:") &&
+      parsed.origin !== window.location.origin
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function issueSheetApiPath(organizationSlug: string, projectId: string) {
+  return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/issue-sheet`;
+}
+
+export { issueTypeValues };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-utils.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-utils.ts
@@ -100,16 +100,22 @@ export function buildIssueCatHref(
   return `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/files/cat?${params.toString()}`;
 }
 
+export function isHttpOrHttpsUrl(url: string) {
+  try {
+    const protocol = new URL(url).protocol;
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 export function isExternalHttpUrl(url: string) {
   if (typeof window === "undefined") {
     return false;
   }
   try {
     const parsed = new URL(url);
-    return (
-      (parsed.protocol === "http:" || parsed.protocol === "https:") &&
-      parsed.origin !== window.location.origin
-    );
+    return isHttpOrHttpsUrl(url) && parsed.origin !== window.location.origin;
   } catch {
     return false;
   }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-detail-mutations.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-detail-mutations.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useIntl } from "react-intl";
+import { toast } from "sonner";
+
+import { readApiResponseError } from "@/lib/api-error";
+
+import { issueDetailPanelMessages as messages } from "./issue-detail-panel.messages";
+import { issueSheetApiPath, type IssueDetailIssue } from "./issue-detail-utils";
+import { issueDetailQueryKey } from "./use-issue-detail-query";
+
+async function readJsonOrThrow<T>(response: Response, fallbackMessage: string): Promise<T> {
+  if (!response.ok) {
+    const error = await readApiResponseError(response, fallbackMessage);
+    throw new Error(error.message || fallbackMessage);
+  }
+  return (await response.json()) as T;
+}
+
+export function useIssueDetailMutations({
+  organizationSlug,
+  projectId,
+  issueId,
+  onSaved,
+}: {
+  organizationSlug: string;
+  projectId: string;
+  issueId: string;
+  onSaved?: () => void;
+}) {
+  const intl = useIntl();
+  const queryClient = useQueryClient();
+  const requestFailed = intl.formatMessage(messages.updateFailed);
+
+  const invalidate = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: issueDetailQueryKey(organizationSlug, projectId, issueId),
+      }),
+      queryClient.invalidateQueries({ queryKey: ["issue-sheet", organizationSlug, projectId] }),
+      queryClient.invalidateQueries({ queryKey: ["organization-issues", organizationSlug] }),
+    ]);
+    onSaved?.();
+  };
+
+  const updateIssue = useMutation({
+    mutationFn: async (body: Record<string, unknown>) => {
+      const response = await fetch(`${issueSheetApiPath(organizationSlug, projectId)}/${issueId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      return readJsonOrThrow<{ issue: IssueDetailIssue }>(response, requestFailed);
+    },
+    onSuccess: async (result) => {
+      queryClient.setQueryData(
+        issueDetailQueryKey(organizationSlug, projectId, issueId),
+        result.issue,
+      );
+      await invalidate();
+    },
+    onError: (error) => toast.error(error instanceof Error ? error.message : requestFailed),
+  });
+
+  const setValue = useMutation({
+    mutationFn: async ({ columnKey, value }: { columnKey: string; value: unknown }) => {
+      const response = await fetch(
+        `${issueSheetApiPath(organizationSlug, projectId)}/${issueId}/values`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ columnKey, value }),
+        },
+      );
+      return readJsonOrThrow<{ value: unknown }>(response, requestFailed);
+    },
+    onSuccess: invalidate,
+    onError: (error) => toast.error(error instanceof Error ? error.message : requestFailed),
+  });
+
+  return { updateIssue, setValue };
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-detail-query.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-detail-query.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { readApiResponseError } from "@/lib/api-error";
+
+import { issueSheetApiPath, type IssueDetailIssue } from "./issue-detail-utils";
+
+export function issueDetailQueryKey(organizationSlug: string, projectId: string, issueId: string) {
+  return ["issue-detail", organizationSlug, projectId, issueId] as const;
+}
+
+export function useIssueDetailQuery({
+  organizationSlug,
+  projectId,
+  issueId,
+  enabled = true,
+}: {
+  organizationSlug: string;
+  projectId: string | undefined;
+  issueId: string | undefined;
+  enabled?: boolean;
+}) {
+  return useQuery({
+    queryKey: issueDetailQueryKey(organizationSlug, projectId ?? "", issueId ?? ""),
+    enabled: enabled && Boolean(projectId && issueId),
+    queryFn: async () => {
+      const response = await fetch(`${issueSheetApiPath(organizationSlug, projectId!)}/${issueId}`);
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to load issue");
+      }
+      const body = (await response.json()) as { issue: IssueDetailIssue };
+      return body.issue;
+    },
+  });
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-list-url-state.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-list-url-state.test.ts
@@ -4,120 +4,61 @@ import {
   buildIssueListHref,
   buildIssueListSearchParams,
   clearIssueListFilters,
-  getActiveIssueFilterChips,
-  issueListStateToApiQuery,
   parseIssueListSearchParams,
+  stripIssueDetailFromState,
 } from "./issue-list-url-state";
 
-describe("issue list URL state", () => {
-  it("parses supported filters, sort, and defaults", () => {
-    const state = parseIssueListSearchParams(
-      new URLSearchParams(
-        "view=qa_triage&status=open&issueType=qa_failure&priority=P0&locale=de-DE&assignee=unassigned&projectId=proj_1&search=hero&sort=priority&sortDir=asc",
-      ),
-      { includeProject: true },
-    );
-
-    expect(state).toEqual({
-      view: "qa_triage",
+describe("issue-list-url-state", () => {
+  it("parses and builds issue detail search params", () => {
+    const params = new URLSearchParams({
+      view: "my_work",
+      issue: "11111111-1111-4111-8111-111111111111",
+      issueProject: "project_website",
       status: "open",
-      issueType: "qa_failure",
-      priority: "P0",
-      locale: "de-DE",
-      assignee: "unassigned",
-      projectId: "proj_1",
-      search: "hero",
-      sort: "priority",
-      sortDir: "asc",
     });
+
+    const state = parseIssueListSearchParams(params, { includeProject: true });
+    expect(state.issue).toBe("11111111-1111-4111-8111-111111111111");
+    expect(state.issueProject).toBe("project_website");
+    expect(state.status).toBe("open");
+
+    const rebuilt = buildIssueListSearchParams(state, { includeProject: true });
+    expect(rebuilt.get("issue")).toBe("11111111-1111-4111-8111-111111111111");
+    expect(rebuilt.get("issueProject")).toBe("project_website");
+    expect(rebuilt.get("status")).toBe("open");
   });
 
-  it("omits default view and sort from the URL", () => {
-    const params = buildIssueListSearchParams({
+  it("preserves open issue when clearing filters", () => {
+    const state = clearIssueListFilters({
+      view: "qa_triage",
+      status: "open",
+      search: "checkout",
+      sort: "updated_at",
+      sortDir: "desc",
+      issue: "11111111-1111-4111-8111-111111111111",
+      issueProject: "project_website",
+    });
+
+    expect(state.search).toBe("");
+    expect(state.status).toBeUndefined();
+    expect(state.issue).toBe("11111111-1111-4111-8111-111111111111");
+    expect(state.issueProject).toBe("project_website");
+  });
+
+  it("strips issue detail params for close navigation", () => {
+    const state = stripIssueDetailFromState({
       view: "all_open",
       search: "",
       sort: "updated_at",
       sortDir: "desc",
-      status: "in_progress",
+      issue: "11111111-1111-4111-8111-111111111111",
+      issueProject: "project_website",
     });
 
-    expect(params.toString()).toBe("status=in_progress");
-    expect(
-      buildIssueListHref("/org/acme/issues", {
-        view: "all_open",
-        search: "",
-        sort: "updated_at",
-        sortDir: "desc",
-      }),
-    ).toBe("/org/acme/issues");
-  });
-
-  it("clears filters while preserving the selected preset and sort", () => {
-    const cleared = clearIssueListFilters({
-      view: "my_work",
-      status: "open",
-      issueType: "qa_failure",
-      priority: "P1",
-      locale: "fr-FR",
-      assignee: "me",
-      projectId: "proj_1",
-      search: "cta",
-      sort: "created_at",
-      sortDir: "asc",
-    });
-
-    expect(cleared).toEqual({
-      view: "my_work",
-      search: "",
-      sort: "created_at",
-      sortDir: "asc",
-    });
-  });
-
-  it("exposes active filter chips without opening a menu", () => {
-    const chips = getActiveIssueFilterChips(
-      {
-        view: "all_open",
-        status: "open",
-        assignee: "unassigned",
-        projectId: "proj_1",
-        search: "hero",
-        sort: "updated_at",
-        sortDir: "desc",
-      },
-      {
-        includeProject: true,
-        projectNameById: { proj_1: "Website" },
-      },
+    expect(state.issue).toBeUndefined();
+    expect(state.issueProject).toBeUndefined();
+    expect(buildIssueListHref("/org/acme/issues", state, { includeProject: true })).toBe(
+      "/org/acme/issues",
     );
-
-    expect(chips).toEqual([
-      { key: "status", value: "open" },
-      { key: "assignee", value: "unassigned" },
-      { key: "projectId", value: "proj_1", projectName: "Website" },
-      { key: "search", value: "hero" },
-    ]);
-  });
-
-  it("maps URL state into API query params used by built-in views", () => {
-    expect(
-      issueListStateToApiQuery(
-        {
-          view: "source_context",
-          issueType: "context_request",
-          search: "",
-          sort: "status",
-          sortDir: "asc",
-        },
-        { limit: 25, offset: 50 },
-      ),
-    ).toEqual({
-      view: "source_context",
-      issueType: "context_request",
-      sort: "status",
-      sortDir: "asc",
-      limit: "25",
-      offset: "50",
-    });
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-list-url-state.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-list-url-state.ts
@@ -34,6 +34,8 @@ export type IssueListUrlState = {
   locale?: string;
   assignee?: IssueAssigneeFilter;
   projectId?: string;
+  issue?: string;
+  issueProject?: string;
   search: string;
   sort: IssueListSortField;
   sortDir: IssueListSortDirection;
@@ -75,6 +77,8 @@ export function parseIssueListSearchParams(
   const projectId = options?.includeProject
     ? searchParams.get("projectId")?.trim() || undefined
     : undefined;
+  const issue = searchParams.get("issue")?.trim() || undefined;
+  const issueProject = searchParams.get("issueProject")?.trim() || undefined;
 
   return {
     view,
@@ -84,6 +88,8 @@ export function parseIssueListSearchParams(
     locale,
     assignee,
     projectId,
+    issue,
+    issueProject,
     search,
     sort,
     sortDir,
@@ -116,6 +122,12 @@ export function buildIssueListSearchParams(
   if (options?.includeProject && state.projectId) {
     params.set("projectId", state.projectId);
   }
+  if (state.issue) {
+    params.set("issue", state.issue);
+  }
+  if (state.issueProject) {
+    params.set("issueProject", state.issueProject);
+  }
   if (state.search.trim()) {
     params.set("search", state.search.trim());
   }
@@ -144,6 +156,16 @@ export function clearIssueListFilters(state: IssueListUrlState): IssueListUrlSta
     search: "",
     sort: state.sort,
     sortDir: state.sortDir,
+    issue: state.issue,
+    issueProject: state.issueProject,
+  };
+}
+
+export function stripIssueDetailFromState(state: IssueListUrlState): IssueListUrlState {
+  return {
+    ...state,
+    issue: undefined,
+    issueProject: undefined,
   };
 }
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/use-issue-detail-url.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/use-issue-detail-url.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { usePathname, useRouter } from "next/navigation";
+
+import {
+  buildIssueListHref,
+  stripIssueDetailFromState,
+  type IssueListUrlState,
+} from "./issue-list-url-state";
+
+export function useIssueDetailUrl(options: {
+  includeProject?: boolean;
+  state: IssueListUrlState;
+  updateState: (patch: Partial<IssueListUrlState>) => void;
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const includeProject = options.includeProject ?? false;
+  const openedViaPushRef = useRef(false);
+
+  const issueId = options.state.issue;
+  const issueProjectId = options.state.issueProject;
+  const isOpen = Boolean(issueId);
+
+  useEffect(() => {
+    if (!issueId) {
+      openedViaPushRef.current = false;
+    }
+  }, [issueId]);
+
+  const openIssueDetail = useCallback(
+    ({ issueId: nextIssueId, projectId }: { issueId: string; projectId?: string }) => {
+      openedViaPushRef.current = true;
+      const next: IssueListUrlState = {
+        ...options.state,
+        issue: nextIssueId,
+        ...(projectId ? { issueProject: projectId } : {}),
+      };
+      const href = buildIssueListHref(pathname, next, { includeProject });
+      router.push(href, { scroll: false });
+    },
+    [includeProject, options.state, pathname, router],
+  );
+
+  const closeIssueDetail = useCallback(() => {
+    if (openedViaPushRef.current) {
+      openedViaPushRef.current = false;
+      router.back();
+      return;
+    }
+
+    const next = stripIssueDetailFromState(options.state);
+    const href = buildIssueListHref(pathname, next, { includeProject });
+    router.replace(href, { scroll: false });
+    options.updateState({ issue: undefined, issueProject: undefined });
+  }, [includeProject, options, pathname, router]);
+
+  return {
+    issueId,
+    issueProjectId,
+    isOpen,
+    openIssueDetail,
+    closeIssueDetail,
+  };
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-content.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useRef, type KeyboardEvent } from "react";
 import { useInfiniteQuery, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { readApiResponseError } from "@/lib/api-error";
 
+import { IssueDetailDrawer } from "../../_components/issue-detail/issue-detail-drawer";
 import { IssueListFiltersBar } from "../../_components/issue-list-filters-bar";
 import { issueListStateToApiQuery } from "../../_components/issue-list-url-state";
+import { useIssueDetailUrl } from "../../_components/use-issue-detail-url";
 import { useIssueListUrlState } from "../../_components/use-issue-list-url-state";
 import { IssuesActions } from "./issues-actions";
 import { ISSUES_PAGE_SIZE, IssuesPageView, type OrganizationIssue } from "./issues-page-view";
@@ -37,6 +39,17 @@ export function IssuesPageContent({ organizationSlug }: { organizationSlug: stri
   const { state, searchDraft, setSearchDraft, updateState, clearFilters } = useIssueListUrlState({
     includeProject: true,
   });
+  const {
+    isOpen: isDetailOpen,
+    openIssueDetail,
+    closeIssueDetail,
+    issueProjectId,
+  } = useIssueDetailUrl({
+    includeProject: true,
+    state,
+    updateState,
+  });
+  const lastFocusedRowRef = useRef<HTMLTableRowElement | null>(null);
   const apiQuery = issueListStateToApiQuery(state, {
     includeProject: true,
     limit: ISSUES_PAGE_SIZE,
@@ -97,32 +110,71 @@ export function IssuesPageContent({ organizationSlug }: { organizationSlug: stri
     });
   };
 
+  const openIssueRow = (issue: OrganizationIssue, row: HTMLTableRowElement) => {
+    lastFocusedRowRef.current = row;
+    openIssueDetail({ issueId: issue.id, projectId: issue.projectId });
+  };
+
+  const handleIssueRowKeyDown = (
+    event: KeyboardEvent<HTMLTableRowElement>,
+    issue: OrganizationIssue,
+  ) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      openIssueRow(issue, event.currentTarget);
+    }
+  };
+
+  const stopRowActivation = (event: { stopPropagation: () => void }) => {
+    event.stopPropagation();
+  };
+
+  const detailProjectId = issueProjectId ?? state.issueProject;
+
   return (
-    <IssuesPageView
-      organizationSlug={organizationSlug}
-      issues={issues}
-      summary={summary}
-      isLoading={issuesQuery.isLoading}
-      isError={issuesQuery.isError}
-      isFetchingMore={issuesQuery.isFetchingNextPage}
-      hasMore={hasMore}
-      filterBar={
-        <IssueListFiltersBar
-          state={state}
-          searchDraft={searchDraft}
-          onSearchDraftChange={setSearchDraft}
-          onStateChange={updateState}
-          onClearFilters={clearFilters}
-          projects={projectsQuery.data ?? []}
-          searchPlaceholder="Search title, description, project, or source path"
-        />
-      }
-      actions={
-        <IssuesActions organizationSlug={organizationSlug} onIssuesChanged={refreshIssues} />
-      }
-      onLoadMore={() => {
-        void issuesQuery.fetchNextPage();
-      }}
-    />
+    <>
+      <IssuesPageView
+        organizationSlug={organizationSlug}
+        issues={issues}
+        summary={summary}
+        isLoading={issuesQuery.isLoading}
+        isError={issuesQuery.isError}
+        isFetchingMore={issuesQuery.isFetchingNextPage}
+        hasMore={hasMore}
+        selectedIssueId={state.issue}
+        onIssueRowClick={openIssueRow}
+        onIssueRowKeyDown={handleIssueRowKeyDown}
+        onStopRowActivation={stopRowActivation}
+        filterBar={
+          <IssueListFiltersBar
+            state={state}
+            searchDraft={searchDraft}
+            onSearchDraftChange={setSearchDraft}
+            onStateChange={updateState}
+            onClearFilters={clearFilters}
+            projects={projectsQuery.data ?? []}
+            searchPlaceholder="Search title, description, project, or source path"
+          />
+        }
+        actions={
+          <IssuesActions organizationSlug={organizationSlug} onIssuesChanged={refreshIssues} />
+        }
+        onLoadMore={() => {
+          void issuesQuery.fetchNextPage();
+        }}
+      />
+      <IssueDetailDrawer
+        organizationSlug={organizationSlug}
+        projectId={detailProjectId}
+        issueId={state.issue}
+        isOpen={isDetailOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            closeIssueDetail();
+          }
+        }}
+        returnFocusRef={lastFocusedRowRef}
+      />
+    </>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-content.tsx
@@ -129,8 +129,6 @@ export function IssuesPageContent({ organizationSlug }: { organizationSlug: stri
     event.stopPropagation();
   };
 
-  const detailProjectId = issueProjectId ?? state.issueProject;
-
   return (
     <>
       <IssuesPageView
@@ -165,7 +163,7 @@ export function IssuesPageContent({ organizationSlug }: { organizationSlug: stri
       />
       <IssueDetailDrawer
         organizationSlug={organizationSlug}
-        projectId={detailProjectId}
+        projectId={issueProjectId}
         issueId={state.issue}
         isOpen={isDetailOpen}
         onOpenChange={(open) => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.stories.tsx
@@ -25,6 +25,9 @@ const meta = {
     hasMore: false,
     filterBar: <div data-testid="issue-filters">Filters</div>,
     onLoadMore: fn(),
+    onIssueRowClick: fn(),
+    onIssueRowKeyDown: fn(),
+    onStopRowActivation: fn(),
   },
 } satisfies Meta<typeof IssuesPageView>;
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.tsx
@@ -209,8 +209,7 @@ export function IssuesPageView({
                 <tr
                   key={`${issue.projectId}:${issue.id}`}
                   tabIndex={0}
-                  role="button"
-                  aria-selected={selectedIssueId === issue.id}
+                  aria-current={selectedIssueId === issue.id ? "true" : undefined}
                   className={cn(
                     "align-top cursor-pointer hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                     selectedIssueId === issue.id && "bg-muted/40",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import type { KeyboardEvent, ReactNode } from "react";
 import Link from "next/link";
 import { ClipboardListIcon } from "@hugeicons/core-free-icons";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -8,6 +8,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/primitives/cn";
 
 import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
 import { formatRelativeTimestamp } from "../../_components/workspace-files-shared";
@@ -85,6 +86,10 @@ export function IssuesPageView({
   actions,
   filterBar,
   onLoadMore,
+  selectedIssueId,
+  onIssueRowClick,
+  onIssueRowKeyDown,
+  onStopRowActivation,
 }: {
   organizationSlug: string;
   issues: OrganizationIssue[];
@@ -102,6 +107,10 @@ export function IssuesPageView({
   actions?: ReactNode;
   filterBar: ReactNode;
   onLoadMore: () => void;
+  selectedIssueId?: string;
+  onIssueRowClick: (issue: OrganizationIssue, row: HTMLTableRowElement) => void;
+  onIssueRowKeyDown: (event: KeyboardEvent<HTMLTableRowElement>, issue: OrganizationIssue) => void;
+  onStopRowActivation: (event: { stopPropagation: () => void }) => void;
 }) {
   const intl = useIntl();
 
@@ -197,14 +206,20 @@ export function IssuesPageView({
               </tr>
             ) : (
               issues.map((issue) => (
-                <tr key={`${issue.projectId}:${issue.id}`} className="align-top">
+                <tr
+                  key={`${issue.projectId}:${issue.id}`}
+                  tabIndex={0}
+                  role="button"
+                  aria-selected={selectedIssueId === issue.id}
+                  className={cn(
+                    "align-top cursor-pointer hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                    selectedIssueId === issue.id && "bg-muted/40",
+                  )}
+                  onClick={(event) => onIssueRowClick(issue, event.currentTarget)}
+                  onKeyDown={(event) => onIssueRowKeyDown(event, issue)}
+                >
                   <td className="max-w-80 px-4 py-3">
-                    <Link
-                      href={`/org/${organizationSlug}/projects/${encodeURIComponent(issue.projectId)}/issue-sheet`}
-                      className="font-medium text-foreground hover:underline"
-                    >
-                      {issue.title}
-                    </Link>
+                    <span className="font-medium text-foreground">{issue.title}</span>
                     <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">
                       {issue.description ||
                         issue.sourcePath ||
@@ -222,7 +237,11 @@ export function IssuesPageView({
                   <td className="px-4 py-3 text-muted-foreground">
                     {formatLabel(issue.issueType)}
                   </td>
-                  <td className="px-4 py-3">
+                  <td
+                    className="px-4 py-3"
+                    onClick={onStopRowActivation}
+                    onKeyDown={onStopRowActivation}
+                  >
                     <Link
                       href={`/org/${organizationSlug}/projects/${encodeURIComponent(issue.projectId)}`}
                       className="text-foreground hover:underline"

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-msw-handlers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-msw-handlers.ts
@@ -13,6 +13,13 @@ export const issueSheetMswHandlers = [
     HttpResponse.json({ project: issueSheetProjectFixture }),
   ),
   http.get(issueSheetBasePath, () => HttpResponse.json(issueSheetResponseFixture)),
+  http.get(`${issueSheetBasePath}/:issueId`, ({ params }) => {
+    const issue = issueSheetIssuesFixture.find((row) => row.id === params.issueId);
+    if (!issue) {
+      return HttpResponse.json({ error: "issue_not_found" }, { status: 404 });
+    }
+    return HttpResponse.json({ issue });
+  }),
   http.patch(`${issueSheetBasePath}/:issueId`, async ({ params, request }) => {
     const body = (await request.json()) as Record<string, unknown>;
     const issue = issueSheetIssuesFixture.find((row) => row.id === params.issueId);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, type FormEvent } from "react";
+import { useMemo, useRef, useState, type FormEvent, type KeyboardEvent } from "react";
 import { ClipboardListIcon, PlusSignIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -28,10 +28,13 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { TypographyP } from "@/components/ui/typography";
 import { readApiResponseError } from "@/lib/api-error";
+import { cn } from "@/lib/primitives/cn";
 
+import { IssueDetailDrawer } from "../../../../_components/issue-detail/issue-detail-drawer";
 import { IssueListFiltersBar } from "../../../../_components/issue-list-filters-bar";
 import { issueListStateToApiQuery } from "../../../../_components/issue-list-url-state";
 import { useIssueListUrlState } from "../../../../_components/use-issue-list-url-state";
+import { useIssueDetailUrl } from "../../../../_components/use-issue-detail-url";
 import { issueTypeValues, type IssueTypeValue } from "./issue-sheet-constants";
 import { issueSheetPageContentMessages as messages } from "./issue-sheet-page-content.messages";
 import { issueSheetSharedMessages as sharedMessages } from "./issue-sheet-shared.messages";
@@ -218,6 +221,15 @@ export function IssueSheetPageContent({
   const intl = useIntl();
   const queryClient = useQueryClient();
   const { state, searchDraft, setSearchDraft, updateState, clearFilters } = useIssueListUrlState();
+  const {
+    isOpen: isDetailOpen,
+    openIssueDetail,
+    closeIssueDetail,
+  } = useIssueDetailUrl({
+    state,
+    updateState,
+  });
+  const lastFocusedRowRef = useRef<HTMLTableRowElement | null>(null);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [columnDialogOpen, setColumnDialogOpen] = useState(false);
   const [importDialogOpen, setImportDialogOpen] = useState(false);
@@ -298,6 +310,22 @@ export function IssueSheetPageContent({
     () => (data?.columns ?? []).filter((column) => column.layer !== "system"),
     [data?.columns],
   );
+
+  const openIssueRow = (issueId: string, row: HTMLTableRowElement) => {
+    lastFocusedRowRef.current = row;
+    openIssueDetail({ issueId });
+  };
+
+  const handleIssueRowKeyDown = (event: KeyboardEvent<HTMLTableRowElement>, issueId: string) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      openIssueRow(issueId, event.currentTarget);
+    }
+  };
+
+  const stopRowActivation = (event: { stopPropagation: () => void }) => {
+    event.stopPropagation();
+  };
 
   return (
     <ProjectPageShell>
@@ -404,7 +432,18 @@ export function IssueSheetPageContent({
                 </tr>
               ) : data?.issues.length ? (
                 data.issues.map((issue) => (
-                  <tr key={issue.id} className="align-top">
+                  <tr
+                    key={issue.id}
+                    tabIndex={0}
+                    role="button"
+                    aria-selected={state.issue === issue.id}
+                    className={cn(
+                      "align-top cursor-pointer hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                      state.issue === issue.id && "bg-muted/40",
+                    )}
+                    onClick={(event) => openIssueRow(issue.id, event.currentTarget)}
+                    onKeyDown={(event) => handleIssueRowKeyDown(event, issue.id)}
+                  >
                     <td className="max-w-80 px-4 py-3">
                       <div className="font-medium text-foreground">{issue.title}</div>
                       <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">
@@ -419,7 +458,11 @@ export function IssueSheetPageContent({
                         </div>
                       ) : null}
                     </td>
-                    <td className="px-4 py-3">
+                    <td
+                      className="px-4 py-3"
+                      onClick={stopRowActivation}
+                      onKeyDown={stopRowActivation}
+                    >
                       <Select
                         value={issue.status}
                         items={statusItems}
@@ -445,7 +488,11 @@ export function IssueSheetPageContent({
                         </SelectContent>
                       </Select>
                     </td>
-                    <td className="px-4 py-3">
+                    <td
+                      className="px-4 py-3"
+                      onClick={stopRowActivation}
+                      onKeyDown={stopRowActivation}
+                    >
                       <Select
                         value={issue.issueType}
                         items={issueTypeItems}
@@ -468,7 +515,11 @@ export function IssueSheetPageContent({
                     <td className="px-4 py-3 text-muted-foreground">
                       {issue.targetLocale ?? emptyValue}
                     </td>
-                    <td className="px-4 py-3">
+                    <td
+                      className="px-4 py-3"
+                      onClick={stopRowActivation}
+                      onKeyDown={stopRowActivation}
+                    >
                       <IssueLink
                         organizationSlug={organizationSlug}
                         projectId={projectId}
@@ -477,7 +528,12 @@ export function IssueSheetPageContent({
                       />
                     </td>
                     {editableColumns.map((column) => (
-                      <td key={column.id} className="px-4 py-3">
+                      <td
+                        key={column.id}
+                        className="px-4 py-3"
+                        onClick={stopRowActivation}
+                        onKeyDown={stopRowActivation}
+                      >
                         <CustomCell
                           column={column}
                           value={issue.values[column.key]}
@@ -528,6 +584,18 @@ export function IssueSheetPageContent({
         projectId={projectId}
         columns={data?.columns ?? []}
         onImported={refresh}
+      />
+      <IssueDetailDrawer
+        organizationSlug={organizationSlug}
+        projectId={projectId}
+        issueId={state.issue}
+        isOpen={isDetailOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            closeIssueDetail();
+          }
+        }}
+        returnFocusRef={lastFocusedRowRef}
       />
     </ProjectPageShell>
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
@@ -435,8 +435,7 @@ export function IssueSheetPageContent({
                   <tr
                     key={issue.id}
                     tabIndex={0}
-                    role="button"
-                    aria-selected={state.issue === issue.id}
+                    aria-current={state.issue === issue.id ? "true" : undefined}
                     className={cn(
                       "align-top cursor-pointer hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                       state.issue === issue.id && "bg-muted/40",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
@@ -31,6 +31,10 @@ import { readApiResponseError } from "@/lib/api-error";
 import { cn } from "@/lib/primitives/cn";
 
 import { IssueDetailDrawer } from "../../../../_components/issue-detail/issue-detail-drawer";
+import {
+  isExternalHttpUrl,
+  isHttpOrHttpsUrl,
+} from "../../../../_components/issue-detail/issue-detail-utils";
 import { IssueListFiltersBar } from "../../../../_components/issue-list-filters-bar";
 import { issueListStateToApiQuery } from "../../../../_components/issue-list-url-state";
 import { useIssueListUrlState } from "../../../../_components/use-issue-list-url-state";
@@ -196,18 +200,6 @@ function buildCatHref(organizationSlug: string, projectId: string, issue: IssueS
     params.set("segment", issue.segmentId);
   }
   return `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/files/cat?${params.toString()}`;
-}
-
-function isExternalHttpUrl(url: string) {
-  try {
-    const parsed = new URL(url);
-    return (
-      (parsed.protocol === "http:" || parsed.protocol === "https:") &&
-      parsed.origin !== window.location.origin
-    );
-  } catch {
-    return false;
-  }
 }
 
 export function IssueSheetPageContent({
@@ -613,11 +605,13 @@ function IssueLink({
 }) {
   const intl = useIntl();
   const catHref = buildCatHref(organizationSlug, projectId, issue);
-  const href = issue.linkUrl || catHref;
+  const safeLinkUrl =
+    issue.linkUrl != null && isHttpOrHttpsUrl(issue.linkUrl) ? issue.linkUrl : null;
+  const href = safeLinkUrl || catHref;
   if (!href) {
     return <span className="text-muted-foreground">{emptyValue}</span>;
   }
-  const openExternalLinkInNewTab = issue.linkUrl != null && isExternalHttpUrl(issue.linkUrl);
+  const openExternalLinkInNewTab = safeLinkUrl != null && isExternalHttpUrl(safeLinkUrl);
   return (
     <Button
       variant="link"

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
@@ -598,6 +598,15 @@ export class IssueSheetService {
     });
   }
 
+  async getIssue(input: {
+    organizationId: string;
+    projectId: string;
+    issueId: string;
+    actorUserId: string;
+  }): Promise<IssueSheetIssue | null> {
+    return this.getIssueById(input);
+  }
+
   private async getIssueById(input: {
     organizationId: string;
     projectId: string;


### PR DESCRIPTION
## Summary
- Add a URL-driven issue detail drawer on the project Issue Sheet and org Issues pages so users can inspect and edit an issue without leaving the list
- Expose `GET /issue-sheet/:issueId`, extend members API with local `userId` for assignee picking, and sync open/close via `issue` / `issueProject` search params (browser back closes the drawer; refresh restores it)
- Support editable title, description, status, type, priority, and assignee, plus Open in CAT, mobile full-screen layout, and focus return to the selected row

## Test plan
- [ ] On project Issue Sheet, click a row → drawer opens and URL includes `?issue=...`
- [ ] Browser back closes the drawer without leaving the sheet; list filters/scroll remain
- [ ] Refresh with `?issue=...` restores the drawer with loaded data
- [ ] Edit title, description, status, type, priority, assignee → changes persist after refresh
- [ ] Open in CAT navigates to the linked segment when source path + locale exist
- [ ] On org Issues, row click opens the same drawer with `issue` + `issueProject` in the URL
- [ ] Mobile viewport uses full-screen detail; keyboard focus enters drawer and returns to the row on close
- [ ] Inline table selects/inputs still edit without opening the drawer


Made with [Cursor](https://cursor.com)