### PR TITLE
feat(web): force comfortable view on homepage CAT mock

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.test.tsx
@@ -56,6 +56,29 @@ describe("CatWorkspaceContainer UI", () => {
     ).toBeInTheDocument();
   });
 
+  it("starts in comfortable view when initialViewMode is comfortable", async () => {
+    window.localStorage.setItem("cat-workspace-view-mode:v1", "side-by-side");
+
+    try {
+      renderCatWorkspace(
+        <CatWorkspaceContainer
+          initialState={createUiCatWorkspaceState()}
+          initialViewMode="comfortable"
+          services={{ validateFormat: mockValidateFormat }}
+        />,
+      );
+
+      const viewModeButton = await waitFor(() =>
+        screen.getByRole("button", { name: "CAT view mode" }),
+      );
+      expect(viewModeButton).toHaveTextContent("Comfortable");
+      expect(screen.getByText("Translation Intelligence")).toBeInTheDocument();
+      expect(screen.queryByText("Source")).not.toBeInTheDocument();
+    } finally {
+      window.localStorage.removeItem("cat-workspace-view-mode:v1");
+    }
+  });
+
   it("shows an empty queue state when there are no segments", () => {
     renderCatWorkspace(
       <CatWorkspaceContainer

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
@@ -33,11 +33,14 @@ import { CatWorkspaceView } from "./cat-workspace";
 import { CatWorkspaceProvider, useCatWorkspace } from "./cat-workspace-context";
 import type { CatWorkspaceOrchestrator } from "./cat-workspace-orchestrator";
 import type { CatPageNavigationGuardRef } from "./cat-page-navigation-guard";
+import type { CatWorkspaceViewMode } from "./cat-workspace-view-mode";
 import { CatWorkspaceViewModeSync } from "./cat-workspace-view-mode-sync";
 import { useCatWorkspaceRuntime } from "./use-cat-workspace-runtime";
 
 export interface CatWorkspaceContainerProps {
   initialState: CatWorkspaceState;
+  /** Overrides persisted view-mode preference for this workspace instance. */
+  initialViewMode?: CatWorkspaceViewMode;
   queueSnapshot?: CatWorkspaceState | null;
   lazySegment?: {
     organizationSlug: string;
@@ -229,13 +232,19 @@ const CatWorkspaceContainerObserver = observer(function CatWorkspaceContainerObs
 export function CatWorkspaceContainer({
   initialState,
   initialSegmentKeyOrId,
+  initialViewMode,
   ...props
 }: CatWorkspaceContainerProps) {
   return (
-    <CatWorkspaceProvider initialState={initialState} initialSegmentKeyOrId={initialSegmentKeyOrId}>
+    <CatWorkspaceProvider
+      initialState={initialState}
+      initialSegmentKeyOrId={initialSegmentKeyOrId}
+      initialViewMode={initialViewMode}
+    >
       <CatWorkspaceContainerInner
         initialState={initialState}
         initialSegmentKeyOrId={initialSegmentKeyOrId}
+        initialViewMode={initialViewMode}
         {...props}
       />
     </CatWorkspaceProvider>

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-context.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-context.tsx
@@ -4,21 +4,33 @@ import { createContext, useContext, useMemo, type ReactNode } from "react";
 
 import type { CatWorkspaceState } from "@/components/cat/shared/types";
 
-import { CatWorkspaceOrchestrator, createCatWorkspace } from "./cat-workspace-orchestrator";
+import {
+  CatWorkspaceOrchestrator,
+  createCatWorkspace,
+  type CreateCatWorkspaceOptions,
+} from "./cat-workspace-orchestrator";
+import type { CatWorkspaceViewMode } from "./cat-workspace-view-mode";
 
 const CatWorkspaceContext = createContext<CatWorkspaceOrchestrator | null>(null);
 
 export function CatWorkspaceProvider({
   initialState,
   initialSegmentKeyOrId,
+  initialViewMode,
   children,
 }: {
   initialState: CatWorkspaceState;
   initialSegmentKeyOrId?: string | null;
+  initialViewMode?: CatWorkspaceViewMode;
   children: ReactNode;
 }) {
   const store = useMemo(
-    () => createCatWorkspace(initialState, initialSegmentKeyOrId),
+    () => {
+      const options: CreateCatWorkspaceOptions | undefined = initialViewMode
+        ? { initialViewMode }
+        : undefined;
+      return createCatWorkspace(initialState, initialSegmentKeyOrId, options);
+    },
     // Store is scoped to workspace mount; parent key handles remounts.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
@@ -28,6 +28,7 @@ import {
   mapSegmentComments,
 } from "@/components/cat/project-file/project-file-cat-mapper";
 
+import type { CatWorkspaceViewMode } from "./cat-workspace-view-mode";
 import { CatIntelligenceStore } from "./store/cat-intelligence-store";
 import { CatQueueStore } from "./store/cat-queue-store";
 import { CatSegmentDraft } from "./store/cat-segment-draft";
@@ -39,6 +40,10 @@ import {
   hasSaveFailureCheck,
   mergeSegmentIntelligenceOnHydrate,
 } from "./store/cat-workspace-store-utils";
+
+export type CreateCatWorkspaceOptions = {
+  initialViewMode?: CatWorkspaceViewMode;
+};
 
 type UnsavedNavigationPrompt = {
   proceed: () => void;
@@ -152,7 +157,7 @@ export class CatWorkspaceOrchestrator {
   readonly queue = new CatQueueStore();
   readonly segments = new CatSegmentStore();
   readonly intelligenceState = new CatIntelligenceStore();
-  readonly ui = new CatWorkspaceUiStore();
+  readonly ui: CatWorkspaceUiStore;
 
   jobTitle?: string;
   breadcrumbs?: string[];
@@ -188,7 +193,8 @@ export class CatWorkspaceOrchestrator {
   private dirtyStateDisposer?: IReactionDisposer;
   private beforeUnloadHandler?: (event: BeforeUnloadEvent) => void;
 
-  constructor() {
+  constructor(options?: CreateCatWorkspaceOptions) {
+    this.ui = new CatWorkspaceUiStore(options?.initialViewMode);
     makeAutoObservable(
       this,
       {
@@ -1122,8 +1128,9 @@ export class CatWorkspaceOrchestrator {
 export function createCatWorkspace(
   initialState: CatWorkspaceState,
   initialSegmentKeyOrId?: string | null,
+  options?: CreateCatWorkspaceOptions,
 ) {
-  const workspace = new CatWorkspaceOrchestrator();
+  const workspace = new CatWorkspaceOrchestrator(options);
   workspace.reset(initialState, initialSegmentKeyOrId);
   return workspace;
 }

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-domain-stores.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-domain-stores.test.ts
@@ -274,6 +274,21 @@ describe("CatWorkspaceUiStore", () => {
     }
   });
 
+  it("does not persist view mode changes when initialViewMode was set", () => {
+    const setItem = vi.fn();
+    vi.stubGlobal("localStorage", { getItem: vi.fn(), setItem });
+
+    try {
+      const ui = new CatWorkspaceUiStore("comfortable");
+      ui.setViewMode("side-by-side");
+
+      expect(ui.viewMode).toBe("side-by-side");
+      expect(setItem).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("tracks hovered segment and preview loading state", () => {
     const ui = new CatWorkspaceUiStore();
 

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-domain-stores.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-domain-stores.test.ts
@@ -1,5 +1,5 @@
 import { autorun } from "mobx";
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it, vi } from "vite-plus/test";
 
 import { CatIntelligenceStore } from "./cat-intelligence-store";
 import { CatQueueStore } from "./cat-queue-store";
@@ -257,6 +257,21 @@ describe("CatWorkspaceUiStore", () => {
     expect(ui.viewMode).toBe("side-by-side");
     expect(ui.pageLimit).toBe(20);
     expect(ui.isSideBySideView).toBe(true);
+  });
+
+  it("honors an explicit initial view mode without reading storage", () => {
+    const getItem = vi.fn().mockReturnValue("side-by-side");
+    vi.stubGlobal("localStorage", { getItem, setItem: vi.fn() });
+
+    try {
+      const ui = new CatWorkspaceUiStore("comfortable");
+
+      expect(ui.viewMode).toBe("comfortable");
+      expect(ui.isSideBySideView).toBe(false);
+      expect(getItem).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("tracks hovered segment and preview loading state", () => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-workspace-ui-store.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-workspace-ui-store.ts
@@ -14,9 +14,13 @@ export class CatWorkspaceUiStore {
   previewTargetLoading = false;
   previewCommentsLoading = false;
   visibleSideBySideSegmentIds: string[] = [];
+  // Explicit initial modes (e.g. marketing demos) must not overwrite the
+  // visitor's real CAT workspace preference.
+  #persistViewMode: boolean;
 
   constructor(initialViewMode?: CatWorkspaceViewMode) {
     this.viewMode = initialViewMode ?? readCatWorkspaceViewMode();
+    this.#persistViewMode = initialViewMode === undefined;
     makeAutoObservable(this, {}, { autoBind: true });
   }
 
@@ -30,7 +34,9 @@ export class CatWorkspaceUiStore {
 
   setViewMode(mode: CatWorkspaceViewMode) {
     this.viewMode = mode;
-    writeCatWorkspaceViewMode(mode);
+    if (this.#persistViewMode) {
+      writeCatWorkspaceViewMode(mode);
+    }
   }
 
   setHoveredSegment(segmentId: string | null) {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-workspace-ui-store.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-workspace-ui-store.ts
@@ -8,14 +8,15 @@ import {
 } from "@/components/cat/workspace/cat-workspace-view-mode";
 
 export class CatWorkspaceUiStore {
-  viewMode: CatWorkspaceViewMode = readCatWorkspaceViewMode();
+  viewMode: CatWorkspaceViewMode;
   hoveredSegmentId: string | null = null;
   previewLoadingSegmentId: string | null = null;
   previewTargetLoading = false;
   previewCommentsLoading = false;
   visibleSideBySideSegmentIds: string[] = [];
 
-  constructor() {
+  constructor(initialViewMode?: CatWorkspaceViewMode) {
+    this.viewMode = initialViewMode ?? readCatWorkspaceViewMode();
     makeAutoObservable(this, {}, { autoBind: true });
   }
 

--- a/apps/hyperlocalise-web/src/components/marketing/hero-frame.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/hero-frame.tsx
@@ -624,7 +624,11 @@ export function HeroFrame() {
         }}
       >
         <div className="flex h-[min(42rem,78svh)] min-h-136 flex-col lg:h-176 xl:h-184">
-          <CatWorkspaceContainer initialState={heroDemoState} services={services} />
+          <CatWorkspaceContainer
+            initialState={heroDemoState}
+            initialViewMode="comfortable"
+            services={services}
+          />
         </div>
       </motion.div>
     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add an `initialViewMode` option on the CAT workspace container/store so demos can opt out of the persisted preference.
- Pass `initialViewMode="comfortable"` from the homepage hero CAT mock so it always opens in comfortable layout, even when localStorage has side-by-side saved.
- When `initialViewMode` is set, in-session view toggles no longer write to localStorage, so the demo cannot overwrite the visitor's real CAT preference.

## Test plan
- [x] `vp test src/components/cat/workspace/store/cat-domain-stores.test.ts src/components/cat/workspace/cat-workspace-container.test.tsx`
- [x] `vp check --fix`
- [ ] Confirm the homepage hero CAT mock opens in Comfortable view after previously selecting Side by side in the real CAT workspace
- [ ] Toggle view mode in the hero demo and confirm the real CAT workspace preference is unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7de2-7843-73ed-9110-3530f0eef976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7de2-7843-73ed-9110-3530f0eef976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

