### PR TITLE
🧪 Scout: relative and uncleaned path containment tests

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -151,3 +151,7 @@
 ## 2026-07-18 - [HTML Tag Name Extraction and Space Leniency]
 **Learning:** The HTML tag name extraction helper (`extractTagName`) does not skip whitespace following a closing slash (e.g., `</ strong >` or `< / div>`). Instead, the scanning loop terminates at the space and returns `/`. Since `isLikelyMarkupTag` ignores `/`, such spaced structures are not recognized as markup.
 **Action:** When unit testing tag parsing helper functions, match the precise behavior of the underlying parsing state-machine regarding spaces around structural markers like slashes.
+
+## 2026-08-25 - [Testing Uncleaned and Relative Paths for Containment]
+**Learning:** Testing path containment/directory traversal logic with pre-cleaned paths (e.g., using `filepath.Join` inside the test assertions) can mask issues. To properly verify containment defenses, test inputs must include raw uncleaned relative traversal strings (such as `path/../outside`) and relative paths (like `.` or `../`) to ensure the system handles dynamic resolving and absolute normalization correctly.
+**Action:** When testing path guards or canonicalization logic, avoid pre-cleaning test candidates, and explicitly test both absolute and relative inputs across existence and non-existence boundaries.

--- a/internal/pathguard/pathguard_test.go
+++ b/internal/pathguard/pathguard_test.go
@@ -245,3 +245,105 @@ func TestCanonicalForContainment_Symlinks(t *testing.T) {
 		t.Errorf("expected %q, got %q", expectedMissing, canonical)
 	}
 }
+
+func TestEnsureUnderRoot_RelativeAndEdgeCases(t *testing.T) {
+	tmp, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		tmp = t.TempDir()
+	}
+
+	// Setup dir structure
+	root := filepath.Join(tmp, "root")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("failed to create root: %v", err)
+	}
+
+	subdir := filepath.Join(root, "subdir")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatalf("failed to create subdir: %v", err)
+	}
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get wd: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(originalWD)
+	})
+
+	// Change directory to root to test relative paths
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		root      string
+		candidate string
+		wantErr   bool
+	}{
+		{
+			name:      "relative dot root and relative child",
+			root:      ".",
+			candidate: "subdir/file.txt",
+			wantErr:   false,
+		},
+		{
+			name:      "relative dot root and relative escapes",
+			root:      ".",
+			candidate: "../outside.txt",
+			wantErr:   true,
+		},
+		{
+			name:      "absolute root and relative child",
+			root:      root,
+			candidate: "subdir/file.txt",
+			wantErr:   false,
+		},
+		{
+			name:      "absolute root and relative escapes",
+			root:      root,
+			candidate: "../outside.txt",
+			wantErr:   true,
+		},
+		{
+			name:      "relative child containing uncleaned dots stays inside",
+			root:      root,
+			candidate: root + "/subdir/../file.txt",
+			wantErr:   false,
+		},
+		{
+			name:      "relative escapes containing uncleaned dots goes outside",
+			root:      root,
+			candidate: root + "/subdir/../../outside.txt",
+			wantErr:   true,
+		},
+		{
+			name:      "non-existent candidate containing dots stays inside",
+			root:      root,
+			candidate: root + "/missing/../other_missing.txt",
+			wantErr:   false,
+		},
+		{
+			name:      "non-existent candidate containing dots goes outside",
+			root:      root,
+			candidate: root + "/missing/../../outside_missing.txt",
+			wantErr:   true,
+		},
+		{
+			name:      "empty path behaves as current working directory",
+			root:      "",
+			candidate: "",
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := EnsureUnderRoot(tt.root, tt.candidate)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("EnsureUnderRoot(%q, %q) error = %v, wantErr %v", tt.root, tt.candidate, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
💡 What: Added a new comprehensive test suite `TestEnsureUnderRoot_RelativeAndEdgeCases` in `internal/pathguard/pathguard_test.go` and documented findings in `.jules/scout.md`.

🎯 Why: Protects critical path containment/directory traversal logic against uncleaned path traversal segments and relative/empty paths.

🧩 Scope: `internal/pathguard/pathguard_test.go` and `.jules/scout.md`.

✅ Verification: Ran `go test -v ./internal/pathguard`, `make lint` and `go test ./...`. All passed successfully.

🛡️ Confidence: Prevents security regressions where uncleaned traversals or relative directories might bypass root folder containment safety checks.

---
*PR created automatically by Jules for task [11107885231456575565](https://jules.google.com/task/11107885231456575565) started by @cungminh2710*