### PR TITLE
feat(issue-detail): polish issue details sheet layout and close flow

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-drawer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-drawer.tsx
@@ -25,6 +25,15 @@ import { cn } from "@/lib/primitives/cn";
 import { issueDetailPanelMessages as messages } from "./issue-detail-panel.messages";
 import { IssueDetailPanel, type IssueDetailPanelHandle } from "./issue-detail-panel";
 
+function isSheetCloseTarget(target: EventTarget | null) {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+  return Boolean(
+    target.closest('[data-slot="sheet-close"]') || target.closest('[data-slot="sheet-overlay"]'),
+  );
+}
+
 export function IssueDetailDrawer({
   organizationSlug,
   projectId,
@@ -43,12 +52,14 @@ export function IssueDetailDrawer({
   const contentRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<IssueDetailPanelHandle>(null);
   const wasOpenRef = useRef(false);
+  const closingSheetRef = useRef(false);
   const [confirmCloseOpen, setConfirmCloseOpen] = useState(false);
   const [isSavingClose, setIsSavingClose] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
       wasOpenRef.current = true;
+      closingSheetRef.current = false;
       const frame = window.requestAnimationFrame(() => {
         const closeButton = contentRef.current?.querySelector<HTMLElement>(
           '[data-slot="sheet-close"]',
@@ -67,11 +78,45 @@ export function IssueDetailDrawer({
     }
   }, [isOpen, returnFocusRef]);
 
+  // Suppress blur autosave before focus leaves the field when the user starts closing.
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const suppressBeforeCloseInteraction = (event: Event) => {
+      if (isSheetCloseTarget(event.target)) {
+        panelRef.current?.beginCloseConfirm();
+      }
+    };
+
+    const suppressBeforeEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        panelRef.current?.beginCloseConfirm();
+      }
+    };
+
+    document.addEventListener("pointerdown", suppressBeforeCloseInteraction, true);
+    document.addEventListener("keydown", suppressBeforeEscape, true);
+    return () => {
+      document.removeEventListener("pointerdown", suppressBeforeCloseInteraction, true);
+      document.removeEventListener("keydown", suppressBeforeEscape, true);
+    };
+  }, [isOpen]);
+
   const resolvedProjectId = projectId;
   const resolvedIssueId = issueId;
 
-  const closeSheet = () => {
+  const keepEditing = () => {
+    closingSheetRef.current = false;
+    setConfirmCloseOpen(false);
+    setIsSavingClose(false);
     panelRef.current?.endCloseConfirm();
+  };
+
+  const closeSheetWithoutReenablingAutosave = () => {
+    closingSheetRef.current = true;
+    panelRef.current?.beginCloseConfirm();
     setConfirmCloseOpen(false);
     setIsSavingClose(false);
     onOpenChange(false);
@@ -80,7 +125,8 @@ export function IssueDetailDrawer({
   const requestClose = () => {
     const panel = panelRef.current;
     if (!panel) {
-      closeSheet();
+      closingSheetRef.current = true;
+      onOpenChange(false);
       return;
     }
     panel.beginCloseConfirm();
@@ -88,20 +134,19 @@ export function IssueDetailDrawer({
       setConfirmCloseOpen(true);
       return;
     }
-    panel.endCloseConfirm();
-    closeSheet();
+    closeSheetWithoutReenablingAutosave();
   };
 
   const handleDiscard = () => {
     panelRef.current?.discardPending();
-    closeSheet();
+    closeSheetWithoutReenablingAutosave();
   };
 
   const handleSaveAndClose = async () => {
     setIsSavingClose(true);
     try {
       await panelRef.current?.savePending();
-      closeSheet();
+      closeSheetWithoutReenablingAutosave();
     } catch {
       setIsSavingClose(false);
     }
@@ -152,10 +197,15 @@ export function IssueDetailDrawer({
           if (isSavingClose) {
             return;
           }
-          setConfirmCloseOpen(open);
           if (!open) {
-            panelRef.current?.endCloseConfirm();
+            if (closingSheetRef.current) {
+              setConfirmCloseOpen(false);
+              return;
+            }
+            keepEditing();
+            return;
           }
+          setConfirmCloseOpen(true);
         }}
       >
         <AlertDialogContent>
@@ -168,13 +218,22 @@ export function IssueDetailDrawer({
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={isSavingClose}>
+            <AlertDialogCancel disabled={isSavingClose} onClick={keepEditing}>
               <FormattedMessage {...messages.unsavedChangesKeepEditing} />
             </AlertDialogCancel>
-            <Button variant="outline" disabled={isSavingClose} onClick={handleDiscard}>
+            <Button
+              variant="outline"
+              disabled={isSavingClose}
+              onPointerDown={() => panelRef.current?.beginCloseConfirm()}
+              onClick={handleDiscard}
+            >
               <FormattedMessage {...messages.unsavedChangesDiscard} />
             </Button>
-            <Button disabled={isSavingClose} onClick={() => void handleSaveAndClose()}>
+            <Button
+              disabled={isSavingClose}
+              onPointerDown={() => panelRef.current?.beginCloseConfirm()}
+              onClick={() => void handleSaveAndClose()}
+            >
               <FormattedMessage {...messages.unsavedChangesSave} />
             </Button>
           </AlertDialogFooter>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-drawer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-drawer.tsx
@@ -1,8 +1,18 @@
 "use client";
 
-import { useEffect, useRef, type RefObject } from "react";
+import { useEffect, useRef, useState, type RefObject } from "react";
 import { FormattedMessage } from "react-intl";
 
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 import {
   Sheet,
   SheetContent,
@@ -10,11 +20,10 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
-import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/primitives/cn";
 
 import { issueDetailPanelMessages as messages } from "./issue-detail-panel.messages";
-import { IssueDetailPanel } from "./issue-detail-panel";
+import { IssueDetailPanel, type IssueDetailPanelHandle } from "./issue-detail-panel";
 
 export function IssueDetailDrawer({
   organizationSlug,
@@ -31,9 +40,11 @@ export function IssueDetailDrawer({
   onOpenChange: (open: boolean) => void;
   returnFocusRef?: RefObject<HTMLElement | null>;
 }) {
-  const isMobile = useIsMobile();
   const contentRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<IssueDetailPanelHandle>(null);
   const wasOpenRef = useRef(false);
+  const [confirmCloseOpen, setConfirmCloseOpen] = useState(false);
+  const [isSavingClose, setIsSavingClose] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
@@ -47,6 +58,9 @@ export function IssueDetailDrawer({
       return () => window.cancelAnimationFrame(frame);
     }
 
+    setConfirmCloseOpen(false);
+    setIsSavingClose(false);
+
     if (wasOpenRef.current) {
       wasOpenRef.current = false;
       returnFocusRef?.current?.focus();
@@ -56,42 +70,116 @@ export function IssueDetailDrawer({
   const resolvedProjectId = projectId;
   const resolvedIssueId = issueId;
 
+  const closeSheet = () => {
+    panelRef.current?.endCloseConfirm();
+    setConfirmCloseOpen(false);
+    setIsSavingClose(false);
+    onOpenChange(false);
+  };
+
+  const requestClose = () => {
+    const panel = panelRef.current;
+    if (!panel) {
+      closeSheet();
+      return;
+    }
+    panel.beginCloseConfirm();
+    if (panel.isDirty()) {
+      setConfirmCloseOpen(true);
+      return;
+    }
+    panel.endCloseConfirm();
+    closeSheet();
+  };
+
+  const handleDiscard = () => {
+    closeSheet();
+  };
+
+  const handleSaveAndClose = async () => {
+    setIsSavingClose(true);
+    try {
+      await panelRef.current?.savePending();
+      closeSheet();
+    } catch {
+      setIsSavingClose(false);
+      panelRef.current?.endCloseConfirm();
+    }
+  };
+
   return (
-    <Sheet
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          onOpenChange(false);
-        }
-      }}
-    >
-      <SheetContent
-        side="right"
-        className={cn(
-          "w-full overflow-y-auto p-0",
-          isMobile
-            ? "max-w-none data-[side=right]:sm:max-w-none"
-            : "data-[side=right]:sm:max-w-3xl data-[side=right]:md:max-w-4xl",
-        )}
+    <>
+      <Sheet
+        open={isOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            requestClose();
+          }
+        }}
       >
-        <div ref={contentRef} className="flex min-h-full flex-col">
-          <SheetHeader className="border-b border-border px-6 py-4 pe-14">
-            <SheetTitle className="text-sm font-medium text-muted-foreground">
-              <FormattedMessage {...messages.sheetTitle} />
-            </SheetTitle>
-            <SheetDescription className="sr-only">
-              <FormattedMessage {...messages.sheetTitle} />
-            </SheetDescription>
-          </SheetHeader>
-          {isOpen && resolvedProjectId && resolvedIssueId ? (
-            <IssueDetailPanel
-              organizationSlug={organizationSlug}
-              projectId={resolvedProjectId}
-              issueId={resolvedIssueId}
-            />
-          ) : null}
-        </div>
-      </SheetContent>
-    </Sheet>
+        <SheetContent
+          side="right"
+          className={cn(
+            "overflow-hidden p-0",
+            "data-[side=right]:w-full data-[side=right]:max-w-none",
+            "data-[side=right]:sm:max-w-4xl data-[side=right]:md:max-w-5xl",
+          )}
+        >
+          <div ref={contentRef} className="flex h-full min-h-0 flex-col">
+            <SheetHeader className="shrink-0 border-b border-border px-6 py-4 pe-14">
+              <SheetTitle className="text-sm font-medium text-muted-foreground">
+                <FormattedMessage {...messages.sheetTitle} />
+              </SheetTitle>
+              <SheetDescription className="sr-only">
+                <FormattedMessage {...messages.sheetTitle} />
+              </SheetDescription>
+            </SheetHeader>
+            {isOpen && resolvedProjectId && resolvedIssueId ? (
+              <IssueDetailPanel
+                ref={panelRef}
+                organizationSlug={organizationSlug}
+                projectId={resolvedProjectId}
+                issueId={resolvedIssueId}
+              />
+            ) : null}
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      <AlertDialog
+        open={confirmCloseOpen}
+        onOpenChange={(open) => {
+          if (isSavingClose) {
+            return;
+          }
+          setConfirmCloseOpen(open);
+          if (!open) {
+            panelRef.current?.endCloseConfirm();
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              <FormattedMessage {...messages.unsavedChangesTitle} />
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              <FormattedMessage {...messages.unsavedChangesDescription} />
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isSavingClose}>
+              <FormattedMessage {...messages.unsavedChangesKeepEditing} />
+            </AlertDialogCancel>
+            <Button variant="outline" disabled={isSavingClose} onClick={handleDiscard}>
+              <FormattedMessage {...messages.unsavedChangesDiscard} />
+            </Button>
+            <Button disabled={isSavingClose} onClick={() => void handleSaveAndClose()}>
+              <FormattedMessage {...messages.unsavedChangesSave} />
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-drawer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-drawer.tsx
@@ -93,6 +93,7 @@ export function IssueDetailDrawer({
   };
 
   const handleDiscard = () => {
+    panelRef.current?.discardPending();
     closeSheet();
   };
 
@@ -103,7 +104,6 @@ export function IssueDetailDrawer({
       closeSheet();
     } catch {
       setIsSavingClose(false);
-      panelRef.current?.endCloseConfirm();
     }
   };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.messages.ts
@@ -148,6 +148,11 @@ export const issueDetailPanelMessages = defineMessages({
     id: "fhtliL5Eg6",
     description: "Toast when issue detail update fails",
   },
+  titleRequired: {
+    defaultMessage: "Title cannot be empty.",
+    id: "kx356lhAw5",
+    description: "Toast when saving issue details with an empty title",
+  },
   unsavedChangesTitle: {
     defaultMessage: "Unsaved changes",
     id: "f5viDmb9eZ",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.messages.ts
@@ -114,9 +114,19 @@ export const issueDetailPanelMessages = defineMessages({
     description: "Label for CAT segment id on an issue",
   },
   fieldLink: {
-    defaultMessage: "Link",
-    id: "nsS+omXI6F",
-    description: "Label for external or custom issue link",
+    defaultMessage: "Link kind",
+    id: "RBrBoi9ilw",
+    description: "Label for issue link kind",
+  },
+  fieldOwnerNote: {
+    defaultMessage: "Owner note",
+    id: "Nw/qZUdZvV",
+    description: "Label for issue owner note field",
+  },
+  fieldOwnerNotePlaceholder: {
+    defaultMessage: "Add a note for the issue owner…",
+    id: "ImR4b9kD2P",
+    description: "Placeholder for the owner note textarea",
   },
   openInCat: {
     defaultMessage: "Open in CAT",
@@ -137,5 +147,31 @@ export const issueDetailPanelMessages = defineMessages({
     defaultMessage: "Could not save changes.",
     id: "fhtliL5Eg6",
     description: "Toast when issue detail update fails",
+  },
+  unsavedChangesTitle: {
+    defaultMessage: "Unsaved changes",
+    id: "f5viDmb9eZ",
+    description: "Title for unsaved changes confirmation when closing issue details",
+  },
+  unsavedChangesDescription: {
+    defaultMessage:
+      "You have unsaved edits on this issue. Save them before closing, or discard them.",
+    id: "xy1S5rhKQr",
+    description: "Description for unsaved changes confirmation when closing issue details",
+  },
+  unsavedChangesSave: {
+    defaultMessage: "Save",
+    id: "xEznmg3kZB",
+    description: "Save and close button on unsaved changes dialog",
+  },
+  unsavedChangesDiscard: {
+    defaultMessage: "Discard",
+    id: "xa11NKAkvz",
+    description: "Discard changes and close button on unsaved changes dialog",
+  },
+  unsavedChangesKeepEditing: {
+    defaultMessage: "Keep editing",
+    id: "uNxjflTYdv",
+    description: "Cancel close and keep editing button on unsaved changes dialog",
   },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.messages.ts
@@ -25,8 +25,8 @@ export const issueDetailPanelMessages = defineMessages({
   },
   saved: {
     defaultMessage: "Saved",
-    id: "EVE7+QSKr9",
-    description: "Brief success label after saving an issue field",
+    id: "iGoxhCxQNO",
+    description: "Toast after saving an issue field",
   },
   fieldTitle: {
     defaultMessage: "Title",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
@@ -176,12 +176,11 @@ export const IssueDetailPanel = forwardRef<
   const intl = useIntl();
   const emptyValue = intl.formatMessage(sharedMessages.emptyValue);
   const issueQuery = useIssueDetailQuery({ organizationSlug, projectId, issueId });
-  const [showSaved, setShowSaved] = useState(false);
   const { updateIssue, setValue, cancelPending } = useIssueDetailMutations({
     organizationSlug,
     projectId,
     issueId,
-    onSaved: () => setShowSaved(true),
+    onSaved: () => toast.success(intl.formatMessage(messages.saved)),
   });
 
   const membersQuery = useQuery({
@@ -307,18 +306,6 @@ export const IssueDetailPanel = forwardRef<
     },
   }));
 
-  useEffect(() => {
-    if (isSaving) {
-      setShowSaved(false);
-      return;
-    }
-    if (!showSaved) {
-      return;
-    }
-    const timeout = window.setTimeout(() => setShowSaved(false), 2000);
-    return () => window.clearTimeout(timeout);
-  }, [isSaving, showSaved]);
-
   const statusItems = useMemo(
     () =>
       issueStatusValues.map((value) => ({
@@ -425,12 +412,6 @@ export const IssueDetailPanel = forwardRef<
       aria-busy={isSaving}
     >
       <div className="flex min-w-0 flex-col gap-3 px-6 py-5 md:min-h-0 md:overflow-y-auto">
-        {showSaved ? (
-          <TypographyP className="text-xs text-muted-foreground" aria-live="polite">
-            <FormattedMessage {...messages.saved} />
-          </TypographyP>
-        ) : null}
-
         <Textarea
           value={titleDraft}
           onChange={(event) => setTitleDraft(event.currentTarget.value)}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
@@ -25,6 +25,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -74,6 +75,7 @@ export type IssueDetailPanelHandle = {
   savePending: () => Promise<void>;
   beginCloseConfirm: () => void;
   endCloseConfirm: () => void;
+  discardPending: () => void;
 };
 
 function ownerNoteFromIssue(issue: IssueDetailIssue) {
@@ -86,9 +88,8 @@ function isIssueDraftDirty(
   descriptionDraft: string,
   ownerNoteDraft: string,
 ) {
-  const nextTitle = titleDraft.trim();
   return (
-    (nextTitle !== "" && nextTitle !== issue.title) ||
+    titleDraft.trim() !== issue.title ||
     descriptionDraft !== issue.description ||
     ownerNoteDraft !== ownerNoteFromIssue(issue)
   );
@@ -176,7 +177,7 @@ export const IssueDetailPanel = forwardRef<
   const emptyValue = intl.formatMessage(sharedMessages.emptyValue);
   const issueQuery = useIssueDetailQuery({ organizationSlug, projectId, issueId });
   const [showSaved, setShowSaved] = useState(false);
-  const { updateIssue, setValue } = useIssueDetailMutations({
+  const { updateIssue, setValue, cancelPending } = useIssueDetailMutations({
     organizationSlug,
     projectId,
     issueId,
@@ -210,6 +211,12 @@ export const IssueDetailPanel = forwardRef<
   const ownerNoteDraftRef = useRef(ownerNoteDraft);
   const issueRef = useRef(issue);
   const suppressAutoSaveRef = useRef(false);
+  const draftBaselineRef = useRef<{
+    issueId: string;
+    title: string;
+    description: string;
+    ownerNote: string;
+  } | null>(null);
   titleDraftRef.current = titleDraft;
   descriptionDraftRef.current = descriptionDraft;
   ownerNoteDraftRef.current = ownerNoteDraft;
@@ -219,10 +226,33 @@ export const IssueDetailPanel = forwardRef<
     if (!issue) {
       return;
     }
-    setTitleDraft(issue.title);
-    setDescriptionDraft(issue.description);
-    setOwnerNoteDraft(ownerNoteFromIssue(issue));
-  }, [issue?.id, issue?.title, issue?.description, issue?.values.owner_note]);
+
+    const ownerNote = ownerNoteFromIssue(issue);
+    const baseline = draftBaselineRef.current;
+
+    if (!baseline || baseline.issueId !== issue.id) {
+      draftBaselineRef.current = {
+        issueId: issue.id,
+        title: issue.title,
+        description: issue.description,
+        ownerNote,
+      };
+      setTitleDraft(issue.title);
+      setDescriptionDraft(issue.description);
+      setOwnerNoteDraft(ownerNote);
+      return;
+    }
+
+    setTitleDraft((draft) => (draft === baseline.title ? issue.title : draft));
+    setDescriptionDraft((draft) => (draft === baseline.description ? issue.description : draft));
+    setOwnerNoteDraft((draft) => (draft === baseline.ownerNote ? ownerNote : draft));
+    draftBaselineRef.current = {
+      issueId: issue.id,
+      title: issue.title,
+      description: issue.description,
+      ownerNote,
+    };
+  }, [issue]);
 
   useImperativeHandle(ref, () => ({
     isDirty: () => {
@@ -243,6 +273,10 @@ export const IssueDetailPanel = forwardRef<
     endCloseConfirm: () => {
       suppressAutoSaveRef.current = false;
     },
+    discardPending: () => {
+      suppressAutoSaveRef.current = true;
+      cancelPending();
+    },
     savePending: async () => {
       const current = issueRef.current;
       if (!current) {
@@ -250,8 +284,13 @@ export const IssueDetailPanel = forwardRef<
       }
 
       const nextTitle = titleDraftRef.current.trim();
+      if (nextTitle === "") {
+        toast.error(intl.formatMessage(messages.titleRequired));
+        throw new Error("title_required");
+      }
+
       const issueUpdates: Record<string, unknown> = {};
-      if (nextTitle && nextTitle !== current.title) {
+      if (nextTitle !== current.title) {
         issueUpdates.title = nextTitle;
       }
       if (descriptionDraftRef.current !== current.description) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import {
   Calendar03Icon,
   CheckmarkCircle02Icon,
@@ -20,7 +28,6 @@ import { useQuery } from "@tanstack/react-query";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -42,11 +49,14 @@ import {
   isExternalHttpUrl,
   isHttpOrHttpsUrl,
   issuePriorityValues,
+  issuePriorityVariant,
   issueStatusLabel,
   issueStatusValues,
   issueStatusVariant,
   issueTypeLabel,
   issueTypeValues,
+  linkKindLabel,
+  type IssueDetailIssue,
 } from "./issue-detail-utils";
 import { useIssueDetailMutations } from "./use-issue-detail-mutations";
 import { useIssueDetailQuery } from "./use-issue-detail-query";
@@ -59,6 +69,31 @@ type WorkspaceMember = {
 
 type PropertyIcon = Parameters<typeof HugeiconsIcon>[0]["icon"];
 
+export type IssueDetailPanelHandle = {
+  isDirty: () => boolean;
+  savePending: () => Promise<void>;
+  beginCloseConfirm: () => void;
+  endCloseConfirm: () => void;
+};
+
+function ownerNoteFromIssue(issue: IssueDetailIssue) {
+  return typeof issue.values.owner_note === "string" ? issue.values.owner_note : "";
+}
+
+function isIssueDraftDirty(
+  issue: IssueDetailIssue,
+  titleDraft: string,
+  descriptionDraft: string,
+  ownerNoteDraft: string,
+) {
+  const nextTitle = titleDraft.trim();
+  return (
+    (nextTitle !== "" && nextTitle !== issue.title) ||
+    descriptionDraft !== issue.description ||
+    ownerNoteDraft !== ownerNoteFromIssue(issue)
+  );
+}
+
 function PropertyRow({
   icon,
   label,
@@ -69,12 +104,14 @@ function PropertyRow({
   children: ReactNode;
 }) {
   return (
-    <div className="flex items-center justify-between gap-3 py-1.5">
+    <div className="flex min-h-8 items-center justify-between gap-3 py-1.5">
       <dt className="flex min-w-0 shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
         <HugeiconsIcon icon={icon} strokeWidth={1.8} className="size-3.5 shrink-0" />
         <span className="truncate">{label}</span>
       </dt>
-      <dd className="flex min-w-0 max-w-[55%] justify-end text-end">{children}</dd>
+      <dd className="flex min-h-8 min-w-0 max-w-[55%] items-center justify-end text-end">
+        {children}
+      </dd>
     </div>
   );
 }
@@ -106,13 +143,13 @@ function LinkedContextRow({ label, children }: { label: ReactNode; children: Rea
 
 function IssueDetailSkeleton() {
   return (
-    <div className="grid flex-1 md:grid-cols-[minmax(0,1fr)_18rem]">
-      <div className="flex flex-col gap-4 px-6 py-5">
+    <div className="grid min-h-0 flex-1 overflow-y-auto md:grid-cols-[minmax(0,1fr)_22rem] md:overflow-hidden">
+      <div className="flex flex-col gap-4 px-6 py-5 md:min-h-0 md:overflow-y-auto">
         <Skeleton className="h-8 w-2/3" />
         <Skeleton className="h-40 w-full" />
         <Skeleton className="h-24 w-full" />
       </div>
-      <aside className="flex flex-col gap-3 border-t border-border bg-muted/20 px-4 py-5 md:border-t-0 md:border-s">
+      <aside className="flex flex-col gap-3 border-t border-border bg-muted/20 px-4 py-5 md:min-h-0 md:overflow-y-auto md:border-t-0 md:border-s">
         <Skeleton className="h-8 w-full" />
         <Skeleton className="ml-auto h-7 w-24" />
         <Skeleton className="ml-auto h-7 w-20" />
@@ -127,15 +164,14 @@ function IssueDetailSkeleton() {
 const ghostSelectTriggerClassName =
   "h-8 max-w-full justify-end border-transparent bg-transparent px-1.5 shadow-none hover:bg-muted/60 focus-visible:border-ring";
 
-export function IssueDetailPanel({
-  organizationSlug,
-  projectId,
-  issueId,
-}: {
-  organizationSlug: string;
-  projectId: string;
-  issueId: string;
-}) {
+export const IssueDetailPanel = forwardRef<
+  IssueDetailPanelHandle,
+  {
+    organizationSlug: string;
+    projectId: string;
+    issueId: string;
+  }
+>(function IssueDetailPanel({ organizationSlug, projectId, issueId }, ref) {
   const intl = useIntl();
   const emptyValue = intl.formatMessage(sharedMessages.emptyValue);
   const issueQuery = useIssueDetailQuery({ organizationSlug, projectId, issueId });
@@ -166,7 +202,18 @@ export function IssueDetailPanel({
   const issue = issueQuery.data;
   const [titleDraft, setTitleDraft] = useState("");
   const [descriptionDraft, setDescriptionDraft] = useState("");
+  const [ownerNoteDraft, setOwnerNoteDraft] = useState("");
   const isSaving = updateIssue.isPending || setValue.isPending;
+
+  const titleDraftRef = useRef(titleDraft);
+  const descriptionDraftRef = useRef(descriptionDraft);
+  const ownerNoteDraftRef = useRef(ownerNoteDraft);
+  const issueRef = useRef(issue);
+  const suppressAutoSaveRef = useRef(false);
+  titleDraftRef.current = titleDraft;
+  descriptionDraftRef.current = descriptionDraft;
+  ownerNoteDraftRef.current = ownerNoteDraft;
+  issueRef.current = issue;
 
   useEffect(() => {
     if (!issue) {
@@ -174,7 +221,52 @@ export function IssueDetailPanel({
     }
     setTitleDraft(issue.title);
     setDescriptionDraft(issue.description);
-  }, [issue?.id, issue?.title, issue?.description]);
+    setOwnerNoteDraft(ownerNoteFromIssue(issue));
+  }, [issue?.id, issue?.title, issue?.description, issue?.values.owner_note]);
+
+  useImperativeHandle(ref, () => ({
+    isDirty: () => {
+      const current = issueRef.current;
+      if (!current) {
+        return false;
+      }
+      return isIssueDraftDirty(
+        current,
+        titleDraftRef.current,
+        descriptionDraftRef.current,
+        ownerNoteDraftRef.current,
+      );
+    },
+    beginCloseConfirm: () => {
+      suppressAutoSaveRef.current = true;
+    },
+    endCloseConfirm: () => {
+      suppressAutoSaveRef.current = false;
+    },
+    savePending: async () => {
+      const current = issueRef.current;
+      if (!current) {
+        return;
+      }
+
+      const nextTitle = titleDraftRef.current.trim();
+      const issueUpdates: Record<string, unknown> = {};
+      if (nextTitle && nextTitle !== current.title) {
+        issueUpdates.title = nextTitle;
+      }
+      if (descriptionDraftRef.current !== current.description) {
+        issueUpdates.description = descriptionDraftRef.current;
+      }
+      if (Object.keys(issueUpdates).length > 0) {
+        await updateIssue.mutateAsync(issueUpdates);
+      }
+
+      const nextOwnerNote = ownerNoteDraftRef.current;
+      if (nextOwnerNote !== ownerNoteFromIssue(current)) {
+        await setValue.mutateAsync({ columnKey: "owner_note", value: nextOwnerNote });
+      }
+    },
+  }));
 
   useEffect(() => {
     if (isSaving) {
@@ -221,7 +313,7 @@ export function IssueDetailPanel({
 
   if (issueQuery.isLoading) {
     return (
-      <div aria-busy="true" aria-live="polite" className="flex flex-1 flex-col">
+      <div aria-busy="true" aria-live="polite" className="flex min-h-0 flex-1 flex-col">
         <TypographyP className="sr-only">
           <FormattedMessage {...messages.loading} />
         </TypographyP>
@@ -257,6 +349,9 @@ export function IssueDetailPanel({
   );
 
   const saveTitle = () => {
+    if (suppressAutoSaveRef.current) {
+      return;
+    }
     const next = titleDraft.trim();
     if (!next || next === issue.title) {
       return;
@@ -265,29 +360,47 @@ export function IssueDetailPanel({
   };
 
   const saveDescription = () => {
+    if (suppressAutoSaveRef.current) {
+      return;
+    }
     if (descriptionDraft === issue.description) {
       return;
     }
     updateIssue.mutate({ description: descriptionDraft });
   };
 
+  const saveOwnerNote = () => {
+    if (suppressAutoSaveRef.current) {
+      return;
+    }
+    const current = ownerNoteFromIssue(issue);
+    if (ownerNoteDraft === current) {
+      return;
+    }
+    setValue.mutate({ columnKey: "owner_note", value: ownerNoteDraft });
+  };
+
   return (
-    <div className="grid flex-1 md:grid-cols-[minmax(0,1fr)_18rem]" aria-busy={isSaving}>
-      <div className="flex min-w-0 flex-col gap-3 px-6 py-5">
+    <div
+      className="grid min-h-0 flex-1 overflow-y-auto md:grid-cols-[minmax(0,1fr)_22rem] md:overflow-hidden"
+      aria-busy={isSaving}
+    >
+      <div className="flex min-w-0 flex-col gap-3 px-6 py-5 md:min-h-0 md:overflow-y-auto">
         {showSaved ? (
           <TypographyP className="text-xs text-muted-foreground" aria-live="polite">
             <FormattedMessage {...messages.saved} />
           </TypographyP>
         ) : null}
 
-        <Input
+        <Textarea
           value={titleDraft}
           onChange={(event) => setTitleDraft(event.currentTarget.value)}
           onBlur={saveTitle}
           disabled={isSaving}
           aria-label={intl.formatMessage(messages.fieldTitle)}
+          rows={1}
           className={cn(
-            "h-auto rounded-none border-transparent bg-transparent px-0 py-1 text-lg font-semibold shadow-none md:text-xl",
+            "min-h-10 shrink-0 overflow-hidden rounded-none border-transparent bg-transparent px-0 py-1 text-lg font-semibold shadow-none md:min-h-10 md:text-xl",
             "focus-visible:border-transparent focus-visible:ring-0",
           )}
         />
@@ -300,10 +413,28 @@ export function IssueDetailPanel({
           aria-label={intl.formatMessage(messages.fieldDescription)}
           placeholder={intl.formatMessage(messages.fieldDescription)}
           className={cn(
-            "min-h-32 rounded-none border-transparent bg-transparent px-0 py-1 text-sm shadow-none md:text-sm",
+            "min-h-32 shrink-0 overflow-hidden rounded-none border-transparent bg-transparent px-0 py-1 text-sm shadow-none md:text-sm",
             "focus-visible:border-transparent focus-visible:ring-0",
           )}
         />
+
+        <section className="mt-2 grid gap-2 border-t border-border pt-4">
+          <TypographyP className="text-sm font-medium text-foreground">
+            <FormattedMessage {...messages.fieldOwnerNote} />
+          </TypographyP>
+          <Textarea
+            value={ownerNoteDraft}
+            onChange={(event) => setOwnerNoteDraft(event.currentTarget.value)}
+            onBlur={saveOwnerNote}
+            disabled={isSaving}
+            aria-label={intl.formatMessage(messages.fieldOwnerNote)}
+            placeholder={intl.formatMessage(messages.fieldOwnerNotePlaceholder)}
+            className={cn(
+              "min-h-20 shrink-0 overflow-hidden rounded-none border-transparent bg-transparent px-0 py-1 text-sm shadow-none md:text-sm",
+              "focus-visible:border-transparent focus-visible:ring-0",
+            )}
+          />
+        </section>
 
         {hasLinkedContext ? (
           <section className="mt-2 grid gap-3 border-t border-border pt-4">
@@ -333,7 +464,7 @@ export function IssueDetailPanel({
               ) : null}
               {issue.linkKind ? (
                 <LinkedContextRow label={<FormattedMessage {...messages.fieldLink} />}>
-                  <ReadOnlyValue value={issue.linkKind} empty={emptyValue} />
+                  <ReadOnlyValue value={linkKindLabel(intl, issue.linkKind)} empty={emptyValue} />
                 </LinkedContextRow>
               ) : null}
             </div>
@@ -341,7 +472,7 @@ export function IssueDetailPanel({
         ) : null}
       </div>
 
-      <aside className="flex flex-col gap-1 border-t border-border bg-muted/20 px-4 py-5 md:border-t-0 md:border-s">
+      <aside className="flex flex-col gap-1 border-t border-border bg-muted/20 px-4 py-5 md:min-h-0 md:overflow-y-auto md:border-t-0 md:border-s">
         <div className="mb-3 flex flex-col gap-2">
           {catHref ? (
             <Button
@@ -428,7 +559,7 @@ export function IssueDetailPanel({
               <SelectContent>
                 {statusItems.map((status) => (
                   <SelectItem key={status.value} value={status.value} label={status.label}>
-                    {status.label}
+                    <Badge variant={issueStatusVariant(status.value)}>{status.label}</Badge>
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -471,12 +602,16 @@ export function IssueDetailPanel({
               disabled={isSaving}
             >
               <SelectTrigger className={ghostSelectTriggerClassName}>
-                <SelectValue placeholder={emptyValue} />
+                {priority ? (
+                  <Badge variant={issuePriorityVariant(priority)}>{priority}</Badge>
+                ) : (
+                  <SelectValue placeholder={emptyValue} />
+                )}
               </SelectTrigger>
               <SelectContent>
                 {priorityItems.map((item) => (
                   <SelectItem key={item.value} value={item.value} label={item.label}>
-                    {item.label}
+                    <Badge variant={issuePriorityVariant(item.value)}>{item.label}</Badge>
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -536,4 +671,4 @@ export function IssueDetailPanel({
       </aside>
     </div>
   );
-}
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-utils.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-utils.ts
@@ -10,6 +10,17 @@ export const issueStatusValues = ["open", "in_progress", "resolved", "wont_fix"]
 export type IssueStatusValue = (typeof issueStatusValues)[number];
 
 export const issuePriorityValues = ["P0", "P1", "P2"] as const;
+export type IssuePriorityValue = (typeof issuePriorityValues)[number];
+
+export const issueLinkKindValues = [
+  "cat_segment",
+  "native_issue",
+  "provider_issue",
+  "agent_run",
+  "url",
+  "manual",
+] as const;
+export type IssueLinkKindValue = (typeof issueLinkKindValues)[number];
 
 export type IssueDetailIssue = {
   id: string;
@@ -80,6 +91,38 @@ export function issueStatusVariant(status: string) {
   if (status === "wont_fix") return "outline" as const;
   if (status === "in_progress") return "warning" as const;
   return "secondary" as const;
+}
+
+export function issuePriorityVariant(priority: string) {
+  switch (priority as IssuePriorityValue) {
+    case "P0":
+      return "destructive" as const;
+    case "P1":
+      return "warning" as const;
+    case "P2":
+      return "secondary" as const;
+    default:
+      return "outline" as const;
+  }
+}
+
+export function linkKindLabel(intl: IntlShape, value: string) {
+  switch (value as IssueLinkKindValue) {
+    case "cat_segment":
+      return intl.formatMessage(sharedMessages.linkKindCatSegment);
+    case "native_issue":
+      return intl.formatMessage(sharedMessages.linkKindNativeIssue);
+    case "provider_issue":
+      return intl.formatMessage(sharedMessages.linkKindProviderIssue);
+    case "agent_run":
+      return intl.formatMessage(sharedMessages.linkKindAgentRun);
+    case "url":
+      return intl.formatMessage(sharedMessages.linkKindUrl);
+    case "manual":
+      return intl.formatMessage(sharedMessages.linkKindManual);
+    default:
+      return formatUnknownLabel(value);
+  }
 }
 
 export function buildIssueCatHref(

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-detail-mutations.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-detail-mutations.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRef } from "react";
 import { useIntl } from "react-intl";
 import { toast } from "sonner";
 
@@ -18,6 +19,12 @@ async function readJsonOrThrow<T>(response: Response, fallbackMessage: string): 
   return (await response.json()) as T;
 }
 
+function isAbortError(error: unknown) {
+  return error instanceof DOMException
+    ? error.name === "AbortError"
+    : error instanceof Error && error.name === "AbortError";
+}
+
 export function useIssueDetailMutations({
   organizationSlug,
   projectId,
@@ -32,6 +39,8 @@ export function useIssueDetailMutations({
   const intl = useIntl();
   const queryClient = useQueryClient();
   const requestFailed = intl.formatMessage(messages.updateFailed);
+  const updateAbortRef = useRef<AbortController | null>(null);
+  const setValueAbortRef = useRef<AbortController | null>(null);
 
   const invalidate = async () => {
     await Promise.all([
@@ -46,10 +55,14 @@ export function useIssueDetailMutations({
 
   const updateIssue = useMutation({
     mutationFn: async (body: Record<string, unknown>) => {
+      updateAbortRef.current?.abort();
+      const controller = new AbortController();
+      updateAbortRef.current = controller;
       const response = await fetch(`${issueSheetApiPath(organizationSlug, projectId)}/${issueId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
+        signal: controller.signal,
       });
       return readJsonOrThrow<{ issue: IssueDetailIssue }>(response, requestFailed);
     },
@@ -60,24 +73,47 @@ export function useIssueDetailMutations({
       );
       await invalidate();
     },
-    onError: (error) => toast.error(error instanceof Error ? error.message : requestFailed),
+    onError: (error) => {
+      if (isAbortError(error)) {
+        return;
+      }
+      toast.error(error instanceof Error ? error.message : requestFailed);
+    },
   });
 
   const setValue = useMutation({
     mutationFn: async ({ columnKey, value }: { columnKey: string; value: unknown }) => {
+      setValueAbortRef.current?.abort();
+      const controller = new AbortController();
+      setValueAbortRef.current = controller;
       const response = await fetch(
         `${issueSheetApiPath(organizationSlug, projectId)}/${issueId}/values`,
         {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ columnKey, value }),
+          signal: controller.signal,
         },
       );
       return readJsonOrThrow<{ value: unknown }>(response, requestFailed);
     },
     onSuccess: invalidate,
-    onError: (error) => toast.error(error instanceof Error ? error.message : requestFailed),
+    onError: (error) => {
+      if (isAbortError(error)) {
+        return;
+      }
+      toast.error(error instanceof Error ? error.message : requestFailed);
+    },
   });
 
-  return { updateIssue, setValue };
+  const cancelPending = () => {
+    updateAbortRef.current?.abort();
+    setValueAbortRef.current?.abort();
+    updateAbortRef.current = null;
+    setValueAbortRef.current = null;
+    updateIssue.reset();
+    setValue.reset();
+  };
+
+  return { updateIssue, setValue, cancelPending };
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/_components/issues-page-view.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/primitives/cn";
 
+import { issueStatusVariant } from "../../_components/issue-detail/issue-detail-utils";
 import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
 import { formatRelativeTimestamp } from "../../_components/workspace-files-shared";
 import { issuesPageViewMessages } from "./issues-page-view.messages";
@@ -40,13 +41,6 @@ function formatLabel(value: string) {
     .split("_")
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ");
-}
-
-function statusVariant(status: string) {
-  if (status === "resolved") return "success" as const;
-  if (status === "wont_fix") return "outline" as const;
-  if (status === "in_progress") return "warning" as const;
-  return "secondary" as const;
 }
 
 function IssueRowSkeleton() {
@@ -227,7 +221,7 @@ export function IssuesPageView({
                   </td>
                   <td className="px-4 py-3">
                     <Badge
-                      variant={statusVariant(issue.status)}
+                      variant={issueStatusVariant(issue.status)}
                       className="rounded-full capitalize"
                     >
                       {formatLabel(issue.status)}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.tsx
@@ -34,6 +34,7 @@ import { IssueDetailDrawer } from "../../../../_components/issue-detail/issue-de
 import {
   isExternalHttpUrl,
   isHttpOrHttpsUrl,
+  issueStatusVariant,
 } from "../../../../_components/issue-detail/issue-detail-utils";
 import { IssueListFiltersBar } from "../../../../_components/issue-list-filters-bar";
 import { issueListStateToApiQuery } from "../../../../_components/issue-list-url-state";
@@ -179,13 +180,6 @@ function columnTypeLabel(intl: IntlShape, value: ColumnTypeValue) {
     case "user":
       return intl.formatMessage(sharedMessages.columnTypeUserId);
   }
-}
-
-function statusVariant(status: string) {
-  if (status === "resolved") return "success";
-  if (status === "wont_fix") return "outline";
-  if (status === "in_progress") return "warning";
-  return "secondary";
 }
 
 function buildCatHref(organizationSlug: string, projectId: string, issue: IssueSheetIssue) {
@@ -462,7 +456,7 @@ export function IssueSheetPageContent({
                         }
                       >
                         <SelectTrigger className="w-36">
-                          <Badge variant={statusVariant(issue.status)}>
+                          <Badge variant={issueStatusVariant(issue.status)}>
                             {statusLabel(intl, issue.status)}
                           </Badge>
                         </SelectTrigger>
@@ -473,7 +467,9 @@ export function IssueSheetPageContent({
                               value={status.value}
                               label={status.label}
                             >
-                              {status.label}
+                              <Badge variant={issueStatusVariant(status.value)}>
+                                {status.label}
+                              </Badge>
                             </SelectItem>
                           ))}
                         </SelectContent>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-shared.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-shared.messages.ts
@@ -73,6 +73,36 @@ export const issueSheetSharedMessages = defineMessages({
     id: "G0DAu7HpBC",
     description: "Issue Sheet status option when an issue will not be fixed",
   },
+  linkKindCatSegment: {
+    defaultMessage: "CAT segment",
+    id: "v+JpRsdgw2",
+    description: "Issue Sheet link kind for a CAT segment",
+  },
+  linkKindNativeIssue: {
+    defaultMessage: "Native issue",
+    id: "QVweQ7BzMt",
+    description: "Issue Sheet link kind for a native issue",
+  },
+  linkKindProviderIssue: {
+    defaultMessage: "Provider issue",
+    id: "ienF5sVVz0",
+    description: "Issue Sheet link kind for a provider issue",
+  },
+  linkKindAgentRun: {
+    defaultMessage: "Agent run",
+    id: "te38CqnzSy",
+    description: "Issue Sheet link kind for an agent run",
+  },
+  linkKindUrl: {
+    defaultMessage: "URL",
+    id: "q4WpE1QriH",
+    description: "Issue Sheet link kind for an external URL",
+  },
+  linkKindManual: {
+    defaultMessage: "Manual",
+    id: "WUFTI428rT",
+    description: "Issue Sheet link kind for a manually created issue",
+  },
   emptyValue: {
     defaultMessage: "—",
     id: "wy44X4k96P",


### PR DESCRIPTION
## Summary
- Widen the issue detail drawer (full width on mobile; larger desktop max widths) with a fixed sidebar and independently scrolling main content
- Improve detail editing UX: wrapping title, labeled link kinds, owner note section, colorized status/priority badges shared with the issue table
- Prompt save, discard, or keep editing when closing with unsaved title/description/owner note edits

## Test plan
- [ ] Open an issue detail sheet on desktop — confirm wider layout, sidebar stays put while main content scrolls
- [ ] Open on a narrow/mobile viewport — sheet is full width
- [ ] Edit a long title — wraps instead of scrolling horizontally
- [ ] Confirm owner note shows under a clear “Owner note” heading and saves on blur
- [ ] Confirm link kind shows human-readable labels (e.g. CAT segment)
- [ ] Confirm status and priority badges match issue table colors (including dropdown options)
- [ ] Edit fields, then close the sheet — dialog offers Save / Discard / Keep editing
- [ ] Save and Discard both leave the sheet closed with the expected persistence


Made with [Cursor](https://cursor.com)