### PR TITLE
🧪 Scout: Add Strategy custom parser registration unit tests

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -155,3 +155,7 @@
 ## 2026-08-25 - [Testing Uncleaned and Relative Paths for Containment]
 **Learning:** Testing path containment/directory traversal logic with pre-cleaned paths (e.g., using `filepath.Join` inside the test assertions) can mask issues. To properly verify containment defenses, test inputs must include raw uncleaned relative traversal strings (such as `path/../outside`) and relative paths (like `.` or `../`) to ensure the system handles dynamic resolving and absolute normalization correctly.
 **Action:** When testing path guards or canonicalization logic, avoid pre-cleaning test candidates, and explicitly test both absolute and relative inputs across existence and non-existence boundaries.
+
+## 2026-08-30 - [Strategy Parser Extension Resolution]
+**Learning:** `Strategy.Parse` relies on Go's `filepath.Ext` to resolve custom registered extensions. Therefore, dynamically registered parser test cases must pass input filenames containing a dot (e.g. `file.custom` or `file.CUSTOM`) to ensure extension detection succeeds, rather than naked extensions like `custom`.
+**Action:** Always construct realistic, dot-prefixed filenames (e.g. `"file." + strings.TrimPrefix(ext, ".")`) when verifying registered parser resolution in strategy-level unit tests.

--- a/internal/i18n/translationfileparser/strategy_scout_test.go
+++ b/internal/i18n/translationfileparser/strategy_scout_test.go
@@ -1,0 +1,104 @@
+package translationfileparser
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+type mockCustomParser struct{}
+
+func (m mockCustomParser) Parse(content []byte) (map[string]string, error) {
+	if string(content) == "invalid" {
+		return nil, errors.New("invalid content")
+	}
+	return map[string]string{"custom_key": string(content)}, nil
+}
+
+func TestStrategyRegisterAndNormalization(t *testing.T) {
+	tests := []struct {
+		name      string
+		ext       string
+		parsedExt string
+	}{
+		{
+			name:      "already normalized",
+			ext:       ".custom",
+			parsedExt: ".custom",
+		},
+		{
+			name:      "missing leading dot",
+			ext:       "custom",
+			parsedExt: ".custom",
+		},
+		{
+			name:      "uppercase with missing dot",
+			ext:       "CUSTOM",
+			parsedExt: ".custom",
+		},
+		{
+			name:      "whitespace in extension with dot",
+			ext:       "  .CUSTOM  ",
+			parsedExt: ".custom",
+		},
+		{
+			name:      "whitespace in extension without dot",
+			ext:       "  CUSTOM  ",
+			parsedExt: ".custom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Strategy{} // starts with nil parsersByExt
+			s.Register(tt.ext, mockCustomParser{})
+
+			// Check normalization inside strategy map
+			parser, ok := s.parsersByExt[tt.parsedExt]
+			if !ok {
+				t.Fatalf("expected parser to be registered under normalized extension %q", tt.parsedExt)
+			}
+
+			if _, ok := parser.(mockCustomParser); !ok {
+				t.Fatalf("expected mockCustomParser, got %T", parser)
+			}
+
+			// Construct a valid filename that ends with a dot followed by the extension
+			cleanExt := strings.TrimPrefix(strings.TrimSpace(tt.ext), ".")
+			filename := "file." + cleanExt
+
+			// Verify it resolves and parses correctly through Strategy.Parse
+			got, err := s.Parse(filename, []byte("hello-scout"))
+			if err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+			if got["custom_key"] != "hello-scout" {
+				t.Fatalf("expected custom_key = %q, got %q", "hello-scout", got["custom_key"])
+			}
+		})
+	}
+}
+
+func TestStrategyRegisterIgnoresEmptyExtension(t *testing.T) {
+	s := &Strategy{}
+	s.Register("  ", mockCustomParser{})
+	s.Register("", mockCustomParser{})
+
+	if len(s.parsersByExt) != 0 {
+		t.Fatalf("expected parsersByExt to remain empty, got length %d", len(s.parsersByExt))
+	}
+}
+
+func TestStrategyRegisterOverwritesDefaultParser(t *testing.T) {
+	s := NewDefaultStrategy()
+	// Default .json parser is JSONParser. Overwrite it.
+	s.Register("json", mockCustomParser{})
+
+	got, err := s.Parse("file.json", []byte("hello-scout"))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if got["custom_key"] != "hello-scout" {
+		t.Fatalf("expected custom_key = %q, got %q", "hello-scout", got["custom_key"])
+	}
+}


### PR DESCRIPTION
- 💡 What: Added comprehensive behavior-driven unit tests for Strategy custom parser registration and extension normalization in `internal/i18n/translationfileparser/strategy_scout_test.go`.
- 🎯 Why: To safeguard the `Strategy.Register` behavior (whitespace trimming, lowercase normalization, missing leading dot addition, nil-map initialization, and parser overriding) which is critical for supporting customized translation formats.
- 🧩 Scope: `internal/i18n/translationfileparser/strategy_scout_test.go`, `.jules/scout.md`
- ✅ Verification: Ran `go test -v ./internal/i18n/translationfileparser/...` and verified all tests pass successfully.
- 🛡️ Confidence: Extremely high. The tests are fully deterministic, run instantly, and protect critical parser extension mapping against regression.

---
*PR created automatically by Jules for task [10613604114490275958](https://jules.google.com/task/10613604114490275958) started by @cungminh2710*