### PR TITLE
fix(crowdin): improve Group model parity for ParentID root filtering

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -229,3 +229,9 @@
 **Learning:** Crowdin API v2 supports branch-level webhooks (`branch.translated`, `branch.approved`) which were missing from the SDK's `Event` type. Additionally, the service documentation was missing many modern events like file lifecycle, tasks, and groups, which can lead to confusion about supported capabilities.
 
 **Action:** Added `BranchTranslated` and `BranchApproved` constants to the `Event` model in `model/webhooks.go`. Comprehensively updated the docstrings for `WebhooksService` and `OrganizationWebhooksService` to list all supported events confirmed by documentation. Verified correct serialization of the new branch events with `TestWebhooksService_Add_BranchEvents`.
+
+## 2026-12-12 - Improve Group model parity for ParentID root filtering
+
+**Learning:** In Crowdin API v2, `parentId` is an optional field when listing groups. Specifically, querying root-level groups requires setting `parentId=0`. However, the Go SDK typed `ParentID` as an `int` and had a condition `o.ParentID > 0` before appending it to query parameters, making root group filtering impossible.
+
+**Action:** Changed `ParentID` type to `*int` in `GroupsListOptions` and updated `Values()` serialization logic to append the parameter as long as `ParentID != nil`. Updated unit tests in both `model/groups_test.go` and `groups_test.go` to explicitly verify `parentId=0` query parameter construction.

--- a/third_party/crowdin-api-client-go/crowdin/groups_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/groups_test.go
@@ -122,7 +122,7 @@ func TestGroupService_ListWithQueryParams(t *testing.T) {
 
 	groups, _, err := client.Groups.List(
 		context.Background(),
-		&model.GroupsListOptions{ParentID: 1, ListOptions: model.ListOptions{Limit: 100, Offset: 1}},
+		&model.GroupsListOptions{ParentID: ToPtr(1), ListOptions: model.ListOptions{Limit: 100, Offset: 1}},
 	)
 	if err != nil {
 		t.Errorf("Groups.List returned error: %v", err)
@@ -134,6 +134,66 @@ func TestGroupService_ListWithQueryParams(t *testing.T) {
 			Name:           "KB materials",
 			Description:    "KB localization materials",
 			ParentID:       2,
+			OrganizationID: 200000299,
+			UserID:         6,
+			SubgroupsCount: 0,
+			ProjectsCount:  1,
+			WebURL:         "https://example.crowdin.com/u/groups/123",
+			CreatedAt:      "2023-09-20T11:11:05+00:00",
+			UpdatedAt:      "2023-09-20T12:22:20+00:00",
+		},
+	}
+	if !reflect.DeepEqual(groups, want) {
+		t.Errorf("Groups.List returned %+v, want %+v", groups, want)
+	}
+}
+
+func TestGroupService_ListWithRootQueryParam(t *testing.T) {
+	client, mux, teardown := setupClient()
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/groups", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		testURL(t, r, "/api/v2/groups?parentId=0")
+		fmt.Fprint(w, `{
+			"data": [
+				{
+					"data": {
+						"id": 1,
+						"name": "Root materials",
+						"description": "Root KB localization materials",
+						"parentId": 0,
+						"organizationId": 200000299,
+						"userId": 6,
+						"subgroupsCount": 0,
+						"projectsCount": 1,
+						"webUrl": "https://example.crowdin.com/u/groups/123",
+						"createdAt": "2023-09-20T11:11:05+00:00",
+						"updatedAt": "2023-09-20T12:22:20+00:00"
+					}
+				}
+			],
+			"pagination": {
+				"offset": 0,
+				"limit": 25
+			}
+		}`)
+	})
+
+	groups, _, err := client.Groups.List(
+		context.Background(),
+		&model.GroupsListOptions{ParentID: ToPtr(0)},
+	)
+	if err != nil {
+		t.Errorf("Groups.List returned error: %v", err)
+	}
+
+	want := []*model.Group{
+		{
+			ID:             1,
+			Name:           "Root materials",
+			Description:    "Root KB localization materials",
+			ParentID:       0,
 			OrganizationID: 200000299,
 			UserID:         6,
 			SubgroupsCount: 0,

--- a/third_party/crowdin-api-client-go/crowdin/model/groups.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/groups.go
@@ -25,7 +25,7 @@ type Group struct {
 type GroupsListOptions struct {
 	ListOptions
 
-	ParentID int `json:"parentId,omitempty"`
+	ParentID *int `json:"parentId,omitempty"`
 }
 
 // Values returns the url.Values representation of the GroupsListOptions.
@@ -36,8 +36,8 @@ func (o *GroupsListOptions) Values() (url.Values, bool) {
 	}
 
 	v, _ := o.ListOptions.Values()
-	if o.ParentID > 0 {
-		v.Add("parentId", strconv.Itoa(o.ParentID))
+	if o.ParentID != nil {
+		v.Add("parentId", strconv.Itoa(*o.ParentID))
 	}
 
 	return v, len(v) > 0

--- a/third_party/crowdin-api-client-go/crowdin/model/groups_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/groups_test.go
@@ -21,8 +21,13 @@ func TestGroupsListOptionsValues(t *testing.T) {
 			opts: &GroupsListOptions{},
 		},
 		{
-			name: "with parent ID",
-			opts: &GroupsListOptions{ParentID: 123},
+			name: "with parent ID = 0",
+			opts: &GroupsListOptions{ParentID: toPtr(0)},
+			out:  "parentId=0",
+		},
+		{
+			name: "with parent ID = 123",
+			opts: &GroupsListOptions{ParentID: toPtr(123)},
 			out:  "parentId=123",
 		},
 		{


### PR DESCRIPTION
- What: Updated `GroupsListOptions`' `ParentID` to `*int` to support filtering by root groups (`parentId=0`).
- Why: In Crowdin API v2, listing groups allows an optional `parentId`. The official API contract specifies that to retrieve root-level groups only, callers must specify `parentId=0`. The SDK incorrectly used a plain `int` with a `ParentID > 0` condition, omitting the parameter when set to `0`.
- Docs: https://developer.crowdin.com/enterprise/api/v2/#operation/api.groups.getMany
- Scope: `third_party/crowdin-api-client-go/crowdin/model/groups.go`, `third_party/crowdin-api-client-go/crowdin/model/groups_test.go`, and `third_party/crowdin-api-client-go/crowdin/groups_test.go`.
- Tests: Ran `go test -v ./third_party/crowdin-api-client-go/crowdin/...` and `make lint`.
- Confidence: Ensures full contract parity with Crowdin API v2 and prevents clients from being unable to filter root groups.

---
*PR created automatically by Jules for task [1219828315781833939](https://jules.google.com/task/1219828315781833939) started by @cungminh2710*