### PR TITLE
fix(agent): explain screenshot failures and retry when recoverable

### DIFF
--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/agent.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/agent.ts
@@ -14,6 +14,11 @@ import { composeInstructions } from "@/agents/_runtime/compose-instructions";
 
 export type HyperlocaliseAgentSurface = "web" | "slack" | "github";
 
+/**
+ * Visual-mock and repository inspection turns need room for inspect → scaffold →
+ * capture → fix → retry → final text. Reserve the last step for a text-only reply
+ * via `prepareConversationSkillStep`.
+ */
 export const hyperlocaliseAgentStepLimit = 16;
 export const hyperlocaliseAgentMaxOutputTokens = 4_000;
 

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/agent.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/agent.ts
@@ -14,7 +14,7 @@ import { composeInstructions } from "@/agents/_runtime/compose-instructions";
 
 export type HyperlocaliseAgentSurface = "web" | "slack" | "github";
 
-export const hyperlocaliseAgentStepLimit = 10;
+export const hyperlocaliseAgentStepLimit = 16;
 export const hyperlocaliseAgentMaxOutputTokens = 4_000;
 
 export function buildHyperlocaliseDynamicSections(input: {

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/conversation.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/conversation.md
@@ -27,4 +27,6 @@ Use the capability skills and tools available for this turn. Match the user's re
 
 When multiple capability skills are active, gather repository context before creating translation jobs when both apply.
 
+When a tool fails, always leave a short user-facing explanation of what failed and what you tried next (or why you stopped). Do not end a turn after tool calls with no text reply.
+
 Be concise, scannable, and professional.

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/visual-mock.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/visual-mock.md
@@ -33,6 +33,7 @@ This is an agent workflow skill, not a screenshot product tool. Compose lower-le
 - Do not commit changes, push branches, open pull requests, or publish repository changes. Visual mocks may mutate only the sandbox workspace.
 - When a browser or screenshot primitive is available, render the preview and capture an image. Record the viewport, route or preview file / story id, and any assumptions.
 - Use `captureScreenshot` for Storybook stories. Provide the Storybook story id, viewport, and `waitForText` with the copy that should be visible before capture; do not ask for package-manager-specific commands. The tool discovers Storybook in the repo root or nested app packages and waits until those strings appear in the story DOM.
+- If `captureScreenshot` fails, read the tool `errorCode`, `recoveryHint`, and error excerpt. Fix recoverable issues in the sandbox (Storybook story syntax/index errors, wrong `storyId`, missing mock props) and call `captureScreenshot` again once. Do not retry blindly when the failure is environmental (`browser_*`, `package_manager_unavailable`, `write_not_allowed`).
 - When durable file attachment primitives are available, attach the screenshot as an agent artifact with metadata identifying it as `visual-mock`.
 - If write, render, screenshot, or attachment primitives are unavailable, do not claim a screenshot was created. Return a concise mock plan with the target component, data state, viewport, and exact next primitive needed.
 
@@ -52,4 +53,4 @@ When a screenshot is created, respond with:
 - viewport
 - assumptions or missing fidelity
 
-When a screenshot cannot be created, respond with the mock plan and the missing capability. If Storybook is missing from the repo, explicitly recommend adding Storybook for visual regression testing so future visual-context requests can capture component screenshots.
+When a screenshot cannot be created, always reply with what failed (include the Storybook/path error when present), the mock plan, and the missing capability or next fix. Never finish silently after a failed capture. If Storybook is missing from the repo, explicitly recommend adding Storybook for visual regression testing so future visual-context requests can capture component screenshots.

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.test.ts
@@ -93,13 +93,17 @@ describe("conversation skill agent", () => {
     const settings = toolLoopAgentMock.mock.calls.at(-1)?.[0] as {
       instructions: string;
       activeTools: string[];
-      prepareStep?: unknown;
+      prepareStep?: (input: { stepNumber: number }) => unknown;
     };
 
     expect(settings.instructions).toContain("Translation tools");
     expect(settings.instructions).not.toContain("TMS tools");
     expect(settings.activeTools).not.toContain("check_crowdin_progress");
-    expect(settings.prepareStep).toBeUndefined();
+    expect(settings.prepareStep).toEqual(expect.any(Function));
+    expect(settings.prepareStep?.({ stepNumber: 0 })).toBeUndefined();
+    expect(settings.prepareStep?.({ stepNumber: hyperlocaliseAgentStepLimit - 1 })).toEqual({
+      toolChoice: "none",
+    });
   });
 
   it("adds TMS tools when integration is available", () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.ts
@@ -23,6 +23,7 @@ import { DEFAULT_AGENT_TIMEOUT } from "@/lib/agent-runtime/subagents/constants";
 import {
   hyperlocaliseAgentMaxOutputTokens,
   hyperlocaliseAgentStepLimit,
+  prepareConversationSkillStep,
 } from "@/lib/agent-runtime/loops/hyperlocalise-agent";
 
 import { getHyperlocaliseAgentModel } from "./model";
@@ -56,6 +57,7 @@ export function createConversationSkillAgent(
     maxOutputTokens: hyperlocaliseAgentMaxOutputTokens,
     timeout: DEFAULT_AGENT_TIMEOUT,
     stopWhen: stepCountIs(hyperlocaliseAgentStepLimit),
+    prepareStep: prepareConversationSkillStep,
     onFinish,
   });
 }

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/hyperlocalise-agent.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/hyperlocalise-agent.test.ts
@@ -65,6 +65,7 @@ import {
   createHyperlocaliseAgent,
   hyperlocaliseAgentModelId,
   hyperlocaliseAgentStepLimit,
+  prepareConversationSkillStep,
   replaceLastUserMessage,
   toModelMessages,
 } from "./hyperlocalise-agent";
@@ -135,6 +136,14 @@ describe("hyperlocalise agent core", () => {
         stopWhen: { stepLimit: hyperlocaliseAgentStepLimit },
       }),
     );
+  });
+
+  it("forces a text-only reply on the final conversation skill step", () => {
+    expect(prepareConversationSkillStep({ stepNumber: 0 })).toBeUndefined();
+    expect(prepareConversationSkillStep({ stepNumber: hyperlocaliseAgentStepLimit - 2 })).toBeUndefined();
+    expect(prepareConversationSkillStep({ stepNumber: hyperlocaliseAgentStepLimit - 1 })).toEqual({
+      toolChoice: "none",
+    });
   });
 
   it("creates a skill-based conversation agent from runtime context", () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/hyperlocalise-agent.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/hyperlocalise-agent.test.ts
@@ -140,7 +140,9 @@ describe("hyperlocalise agent core", () => {
 
   it("forces a text-only reply on the final conversation skill step", () => {
     expect(prepareConversationSkillStep({ stepNumber: 0 })).toBeUndefined();
-    expect(prepareConversationSkillStep({ stepNumber: hyperlocaliseAgentStepLimit - 2 })).toBeUndefined();
+    expect(
+      prepareConversationSkillStep({ stepNumber: hyperlocaliseAgentStepLimit - 2 }),
+    ).toBeUndefined();
     expect(prepareConversationSkillStep({ stepNumber: hyperlocaliseAgentStepLimit - 1 })).toEqual({
       toolChoice: "none",
     });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/hyperlocalise-agent.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/hyperlocalise-agent.ts
@@ -30,6 +30,8 @@ import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 import { DEFAULT_AGENT_TIMEOUT } from "@/lib/agent-runtime/subagents/constants";
 import {
   buildHyperlocaliseBaseInstructions,
+  hyperlocaliseAgentMaxOutputTokens,
+  hyperlocaliseAgentStepLimit,
   type HyperlocaliseAgentSurface,
 } from "@/agents/hyperlocalise/agent/agent";
 import {
@@ -38,14 +40,7 @@ import {
 } from "./conversation-skill-agent";
 
 export type { HyperlocaliseAgentSurface };
-
-/**
- * Visual-mock and repository inspection turns need room for inspect → scaffold →
- * capture → fix → retry → final text. Reserve the last step for a text-only reply
- * via `prepareConversationSkillStep`.
- */
-export const hyperlocaliseAgentStepLimit = 16;
-export const hyperlocaliseAgentMaxOutputTokens = 4_000;
+export { hyperlocaliseAgentMaxOutputTokens, hyperlocaliseAgentStepLimit };
 
 /** Force a text-only final step so tool failures are explained to the user. */
 export function prepareConversationSkillStep({ stepNumber }: { stepNumber: number }) {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/hyperlocalise-agent.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/hyperlocalise-agent.ts
@@ -39,8 +39,22 @@ import {
 
 export type { HyperlocaliseAgentSurface };
 
-export const hyperlocaliseAgentStepLimit = 10;
+/**
+ * Visual-mock and repository inspection turns need room for inspect → scaffold →
+ * capture → fix → retry → final text. Reserve the last step for a text-only reply
+ * via `prepareConversationSkillStep`.
+ */
+export const hyperlocaliseAgentStepLimit = 16;
 export const hyperlocaliseAgentMaxOutputTokens = 4_000;
+
+/** Force a text-only final step so tool failures are explained to the user. */
+export function prepareConversationSkillStep({ stepNumber }: { stepNumber: number }) {
+  if (stepNumber >= hyperlocaliseAgentStepLimit - 1) {
+    return { toolChoice: "none" as const };
+  }
+
+  return undefined;
+}
 
 type InteractionHistoryRow = {
   senderType: "user" | "agent";

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
@@ -201,9 +201,15 @@ describe("conversation skill registry", () => {
     expect(visualMockSkill).toContain(
       "Call `captureScreenshot` with that `storyId` and `waitForText`",
     );
+    expect(visualMockSkill).toContain("If `captureScreenshot` fails");
+    expect(visualMockSkill).toContain("call `captureScreenshot` again once");
+    expect(visualMockSkill).toContain("Never finish silently after a failed capture");
     expect(visualMockSkill).toContain("do not invent a Storybook setup");
     expect(visualMockSkill).toContain(
       "implement visual regression testing with it so component screenshots can be captured",
+    );
+    expect(conversationSkill).toContain(
+      "When a tool fails, always leave a short user-facing explanation",
     );
   });
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
@@ -766,6 +766,9 @@ describe("createCaptureScreenshotTool", () => {
       attempts: 1,
     });
     expect(exec.mock.calls.filter(([command]) => command === "bash")).toHaveLength(1);
+    if (!result || typeof result !== "object" || !("success" in result) || result.success) {
+      throw new Error("expected failed screenshot capture");
+    }
 
     const modelOutput = await captureScreenshot.toModelOutput!({
       toolCallId: "test-tool-call",

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
@@ -427,6 +427,15 @@ describe("classifyScreenshotCaptureFailure", () => {
       }),
     ).toBe(true);
   });
+
+  it("extracts story paths with a linear scan that tolerates prefix noise", () => {
+    expect(extractStorybookStoryPathFromFailure("no stories here")).toBeNull();
+    expect(
+      extractStorybookStoryPathFromFailure(
+        "prefix!/!/!/noise ./apps/web/src/button.stories.tsx trailing",
+      ),
+    ).toBe("apps/web/src/button.stories.tsx");
+  });
 });
 
 describe("createCaptureScreenshotTool", () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
@@ -23,10 +23,13 @@ import {
   detectPackageManager,
   detectStorybookMajorVersion,
   detectStorybookScreenshotCommand,
+  extractStorybookStoryPathFromFailure,
+  isTransientScreenshotCaptureFailure,
   parseDependencyMajorVersion,
   parsePackageJsonCandidatePaths,
   resolveStorybookPackage,
   shouldOmitPackageScriptArgSeparator,
+  summarizeScreenshotCaptureFailure,
 } from "./capture-screenshot";
 import type { RepoToolContext } from "./types";
 
@@ -71,6 +74,7 @@ function createRepoContext(input: {
   lockfiles?: readonly string[];
   findStdout?: string;
   execResult?: { exitCode: number; stdout: string; stderr: string };
+  execResults?: Array<{ exitCode: number; stdout: string; stderr: string }>;
 }) {
   const packageJsonByPath: Record<string, Record<string, unknown>> = {
     ...(input.packageJson ? { "package.json": input.packageJson } : {}),
@@ -78,6 +82,7 @@ function createRepoContext(input: {
   };
   const lockfiles = new Set(input.lockfiles ?? []);
   const writtenFiles = new Map<string, string | Buffer>();
+  const queuedExecResults = [...(input.execResults ?? [])];
   const exec = vi.fn(async (command: string) => {
     if (command === "find") {
       return {
@@ -88,10 +93,11 @@ function createRepoContext(input: {
       };
     }
 
+    const nextResult = queuedExecResults.shift() ?? input.execResult;
     return {
-      exitCode: input.execResult?.exitCode ?? 0,
-      stdout: input.execResult?.stdout ?? Buffer.from("png-bytes").toString("base64"),
-      stderr: input.execResult?.stderr ?? "",
+      exitCode: nextResult?.exitCode ?? 0,
+      stdout: nextResult?.stdout ?? Buffer.from("png-bytes").toString("base64"),
+      stderr: nextResult?.stderr ?? "",
       env: {},
     };
   });
@@ -378,6 +384,49 @@ describe("classifyScreenshotCaptureFailure", () => {
     ).toBe("browser_system_deps_unavailable");
     expect(classifyScreenshotCaptureFailure("storybook failed")).toBe("screenshot_capture_failed");
   });
+
+  it("maps Storybook index/syntax failures to storybook_index_failed", () => {
+    const output = [
+      "curl: (7) Failed to connect to 127.0.0.1 port 6006",
+      "Storybook did not become ready on the expected port.",
+      "▲  🚨 Unable to index",
+      "│  ./src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.stories.tsx:",
+      "│  SyntaxError: Unexpected token (115:0)",
+      "■  Error: Unable to index",
+      "Broken build, fix the error above.",
+    ].join("\n");
+
+    expect(classifyScreenshotCaptureFailure(output)).toBe("storybook_index_failed");
+    expect(extractStorybookStoryPathFromFailure(output)).toBe(
+      "src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.stories.tsx",
+    );
+    expect(
+      summarizeScreenshotCaptureFailure({
+        errorCode: "storybook_index_failed",
+        error: output,
+      }),
+    ).toMatchObject({
+      summary: expect.stringContaining("project-overview-page-content.stories.tsx"),
+      recoveryHint: expect.stringContaining("call captureScreenshot again"),
+    });
+    expect(
+      isTransientScreenshotCaptureFailure({
+        errorCode: "storybook_index_failed",
+        error: output,
+      }),
+    ).toBe(false);
+  });
+
+  it("treats connection-only readiness flakes as transient", () => {
+    const output =
+      "curl: (7) Failed to connect to 127.0.0.1 port 6006 after 0 ms: Could not connect to server\nStorybook did not become ready on the expected port.";
+    expect(
+      isTransientScreenshotCaptureFailure({
+        errorCode: "screenshot_capture_failed",
+        error: output,
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("createCaptureScreenshotTool", () => {
@@ -618,6 +667,121 @@ describe("createCaptureScreenshotTool", () => {
     expect(result).toMatchObject({
       success: false,
       errorCode: "browser_binary_unavailable",
+      recoveryHint: expect.stringContaining("environment failure"),
+      attempts: 1,
+    });
+  });
+
+  it("retries once for transient Storybook readiness failures", async () => {
+    const reportToolProgress = vi.fn();
+    const { exec, repo } = createRepoContext({
+      packageJson: {
+        scripts: { storybook: "storybook dev" },
+      },
+      execResults: [
+        {
+          exitCode: 1,
+          stdout: "",
+          stderr:
+            "curl: (7) Failed to connect to 127.0.0.1 port 6006 after 0 ms: Could not connect to server\nStorybook did not become ready on the expected port.",
+        },
+        {
+          exitCode: 0,
+          stdout: Buffer.from("png-bytes").toString("base64"),
+          stderr: "",
+        },
+      ],
+    });
+    vi.mocked(createStoredFile).mockResolvedValueOnce({
+      id: "file_retry",
+      organizationId: "org_1",
+      projectId: "project_1",
+      createdByUserId: "user_1",
+      role: "reference",
+      sourceKind: "repository_file",
+      sourceInteractionId: "conv_1",
+      sourceJobId: null,
+      storageProvider: "vercel_blob",
+      storageKey: "organizations/org_1/files/file_retry/storybook.png",
+      storageUrl: "https://blob.example/storybook-retry.png",
+      downloadUrl: "https://download.example/storybook-retry.png",
+      filename: "storybook-components-button--primary.png",
+      contentType: "image/png",
+      byteSize: 9,
+      sha256: "hash",
+      etag: null,
+      metadata: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const captureScreenshot = createCaptureScreenshotTool(
+      createToolContext({ reportToolProgress }),
+      repo,
+    );
+
+    const result = await captureScreenshot.execute!(
+      { target: { type: "storybook", storyId: "components-button--primary" } },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({ success: true, fileId: "file_retry" });
+    expect(exec.mock.calls.filter(([command]) => command === "bash")).toHaveLength(2);
+    expect(reportToolProgress).toHaveBeenCalledWith({
+      toolCallId: "test-tool-call",
+      message: "Retrying screenshot capture…",
+    });
+  });
+
+  it("does not retry Storybook index failures and returns a recovery hint", async () => {
+    const storybookLog = [
+      "curl: (7) Failed to connect to 127.0.0.1 port 6006",
+      "Storybook did not become ready on the expected port.",
+      "Unable to index",
+      "./src/app/[lang]/(authenticated)/org/acme/projects/p1/_components/project-overview-page-content.stories.tsx:",
+      "SyntaxError: Unexpected token (115:0)",
+      "Broken build, fix the error above.",
+    ].join("\n");
+    const { exec, repo } = createRepoContext({
+      packageJson: {
+        scripts: { storybook: "storybook dev" },
+      },
+      execResult: {
+        exitCode: 1,
+        stdout: "",
+        stderr: storybookLog,
+      },
+    });
+    const captureScreenshot = createCaptureScreenshotTool(createToolContext(), repo);
+
+    const result = await captureScreenshot.execute!(
+      { target: { type: "storybook", storyId: "app-project-overview-page--default" } },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      errorCode: "storybook_index_failed",
+      summary: expect.stringContaining("project-overview-page-content.stories.tsx"),
+      recoveryHint: expect.stringContaining("call captureScreenshot again"),
+      attempts: 1,
+    });
+    expect(exec.mock.calls.filter(([command]) => command === "bash")).toHaveLength(1);
+
+    const modelOutput = await captureScreenshot.toModelOutput!({
+      toolCallId: "test-tool-call",
+      input: { target: { type: "storybook", storyId: "app-project-overview-page--default" } },
+      output: result,
+    });
+    expect(modelOutput).toEqual({
+      type: "content",
+      value: [
+        {
+          type: "text",
+          text: expect.stringMatching(
+            /errorCode: storybook_index_failed[\s\S]*recoveryHint:[\s\S]*SyntaxError/,
+          ),
+        },
+      ],
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -694,14 +694,21 @@ export function isTransientScreenshotCaptureFailure(input: {
     return false;
   }
 
-  if (/Unable to index|Broken build|SyntaxError:|ELIFECYCLE|story missing|Storybook story failed/i.test(input.error)) {
+  if (
+    /Unable to index|Broken build|SyntaxError:|ELIFECYCLE|story missing|Storybook story failed/i.test(
+      input.error,
+    )
+  ) {
     return false;
   }
 
   return (
     /Could not connect to server|Connection refused|ECONNREFUSED|Storybook did not become ready/i.test(
       input.error,
-    ) || /Playwright screenshot capture failed[\s\S]*(Timeout|net::ERR_|Target closed)/i.test(input.error)
+    ) ||
+    /Playwright screenshot capture failed[\s\S]*(Timeout|net::ERR_|Target closed)/i.test(
+      input.error,
+    )
   );
 }
 
@@ -1089,9 +1096,7 @@ It does not commit, push, open pull requests, or publish repository changes.`,
         ctx.reportToolProgress?.({
           toolCallId,
           message:
-            attempt === 1
-              ? "Preparing browser and loading story…"
-              : "Retrying screenshot capture…",
+            attempt === 1 ? "Preparing browser and loading story…" : "Retrying screenshot capture…",
         });
         captureResult = await repo.bash.exec("bash", {
           args: ["-lc", captureCommand],

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -640,14 +640,28 @@ export function classifyScreenshotCaptureFailure(output: string): ScreenshotCapt
   return "screenshot_capture_failed";
 }
 
+const STORYBOOK_STORIES_SUFFIX_PATTERN = /\.stories\.(tsx?|jsx?|mdx)\b/i;
+/** Conservative path charset, including Next.js `[param]` / `(group)` segments. */
+const STORYBOOK_PATH_CHAR_PATTERN = /[\w@[\]()./-]/;
+
+/**
+ * Extract a `.stories.*` path from Storybook failure output.
+ * Uses a linear scan (no nested quantifiers) to avoid ReDoS.
+ */
 export function extractStorybookStoryPathFromFailure(output: string): string | null {
-  // Paths may include Next.js route groups / dynamic segments such as `[lang]` or `(authenticated)`.
-  const match = output.match(/((?:\.\/)?(?:[^\s:'"]+\/)*[^\s:'"/]+\.stories\.(?:tsx?|jsx?|mdx))/i);
-  if (!match?.[1]) {
+  const suffixMatch = STORYBOOK_STORIES_SUFFIX_PATTERN.exec(output);
+  if (!suffixMatch || suffixMatch.index === undefined) {
     return null;
   }
 
-  return match[1].replace(/^\.\//, "");
+  const end = suffixMatch.index + suffixMatch[0].length;
+  let start = suffixMatch.index;
+  while (start > 0 && STORYBOOK_PATH_CHAR_PATTERN.test(output.charAt(start - 1))) {
+    start -= 1;
+  }
+
+  const path = output.slice(start, end).replace(/^\.\//, "");
+  return path.length > 0 ? path : null;
 }
 
 export function buildScreenshotCaptureRecoveryHint(input: {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -1149,26 +1149,9 @@ It does not commit, push, open pull requests, or publish repository changes.`,
         }
       }
 
+      // Failures return inside the loop; reaching here means a successful capture.
       if (!captureResult || captureResult.exitCode !== 0) {
-        const output = truncate(
-          redact([captureResult?.stdout ?? "", captureResult?.stderr ?? ""].join("\n")),
-          DEFAULT_MAX_OUTPUT_BYTES,
-        );
-        const errorCode = classifyScreenshotCaptureFailure(output.text);
-        const summarized = summarizeScreenshotCaptureFailure({
-          errorCode,
-          error: output.text || "Screenshot capture failed.",
-          truncated: output.truncated,
-        });
-        return {
-          success: false as const,
-          errorCode,
-          error: summarized.errorExcerpt || "Screenshot capture failed.",
-          summary: summarized.summary,
-          recoveryHint: summarized.recoveryHint,
-          truncated: summarized.truncated,
-          attempts,
-        };
+        throw new Error("Invariant violated: screenshot capture loop exited without success");
       }
 
       const content = Buffer.from(captureResult.stdout.trim(), "base64");

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -40,6 +40,10 @@ const STORYBOOK_PORT = 6006;
 const STORYBOOK_READY_TIMEOUT_MS = 30_000;
 /** Server cold-start (deps + bundling) is slower than story render; keep a longer poll. */
 const STORYBOOK_SERVER_READY_SECONDS = 120;
+/** One automatic re-run for transient Storybook/Playwright readiness flakes. */
+const MAX_TRANSIENT_CAPTURE_ATTEMPTS = 2;
+/** Keep failure excerpts short enough for the model to act on. */
+const FAILURE_ERROR_EXCERPT_BYTES = 8_000;
 const MANAGED_PLAYWRIGHT_VERSION = sandboxPlaywrightVersion;
 const MANAGED_BROWSER_RUNTIME_DIR = "/tmp/hyperlocalise-browser-runtime";
 const MANAGED_PLAYWRIGHT_MODULE = `${MANAGED_BROWSER_RUNTIME_DIR}/node_modules/playwright`;
@@ -605,12 +609,20 @@ const waitForText = ${JSON.stringify(input.waitForText)};
 `.trimStart();
 }
 
-export function classifyScreenshotCaptureFailure(output: string) {
+export type ScreenshotCaptureErrorCode =
+  | "package_manager_unavailable"
+  | "browser_runtime_install_failed"
+  | "browser_binary_unavailable"
+  | "browser_system_deps_unavailable"
+  | "storybook_index_failed"
+  | "screenshot_capture_failed";
+
+export function classifyScreenshotCaptureFailure(output: string): ScreenshotCaptureErrorCode {
   const match = output.match(
     /HYPERLOCALISE_SCREENSHOT_ERROR_CODE=(package_manager_unavailable|browser_runtime_install_failed|browser_binary_unavailable|browser_system_deps_unavailable)\b/,
   );
   if (match?.[1]) {
-    return match[1];
+    return match[1] as ScreenshotCaptureErrorCode;
   }
   // Chromium linked against libnspr4/libnss3; surface a structured code when the OS libs are missing.
   if (
@@ -619,7 +631,110 @@ export function classifyScreenshotCaptureFailure(output: string) {
   ) {
     return "browser_system_deps_unavailable";
   }
+  if (
+    /Unable to index|Broken build, fix the error above|SyntaxError:/i.test(output) &&
+    /\.stories\.(tsx?|jsx?|mdx)/i.test(output)
+  ) {
+    return "storybook_index_failed";
+  }
   return "screenshot_capture_failed";
+}
+
+export function extractStorybookStoryPathFromFailure(output: string): string | null {
+  // Paths may include Next.js route groups / dynamic segments such as `[lang]` or `(authenticated)`.
+  const match = output.match(/((?:\.\/)?(?:[^\s:'"]+\/)*[^\s:'"/]+\.stories\.(?:tsx?|jsx?|mdx))/i);
+  if (!match?.[1]) {
+    return null;
+  }
+
+  return match[1].replace(/^\.\//, "");
+}
+
+export function buildScreenshotCaptureRecoveryHint(input: {
+  errorCode: string;
+  error: string;
+}): string | undefined {
+  switch (input.errorCode) {
+    case "storybook_index_failed": {
+      const storyPath = extractStorybookStoryPathFromFailure(input.error);
+      return storyPath
+        ? `Fix the Storybook syntax/index error in ${storyPath}, then call captureScreenshot again with the same storyId.`
+        : "Fix the Storybook story syntax/index error shown in the log, then call captureScreenshot again with the same storyId.";
+    }
+    case "screenshot_capture_failed":
+      if (/story missing|storyErrored|Storybook story failed/i.test(input.error)) {
+        return "Verify the storyId and that the temporary story renders without runtime errors, then call captureScreenshot again.";
+      }
+      if (/waitForText|Timeout/i.test(input.error)) {
+        return "Confirm waitForText matches visible copy in the story, adjust mock props if needed, then call captureScreenshot again.";
+      }
+      return "Inspect the Storybook/Playwright error excerpt, fix the preview in the sandbox if possible, then call captureScreenshot once more.";
+    case "browser_runtime_install_failed":
+    case "browser_binary_unavailable":
+    case "browser_system_deps_unavailable":
+    case "package_manager_unavailable":
+      return "This is an environment failure. Explain it to the user; do not keep retrying captureScreenshot.";
+    case "write_not_allowed":
+    case "workspace_write_unavailable":
+      return "Screenshot capture requires write access to the sandbox. Explain the limitation to the user.";
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Transient readiness flakes can clear on a second launch. Fatal Storybook index /
+ * syntax / dependency failures should not be retried by the tool itself.
+ */
+export function isTransientScreenshotCaptureFailure(input: {
+  errorCode: string;
+  error: string;
+}): boolean {
+  if (input.errorCode !== "screenshot_capture_failed") {
+    return false;
+  }
+
+  if (/Unable to index|Broken build|SyntaxError:|ELIFECYCLE|story missing|Storybook story failed/i.test(input.error)) {
+    return false;
+  }
+
+  return (
+    /Could not connect to server|Connection refused|ECONNREFUSED|Storybook did not become ready/i.test(
+      input.error,
+    ) || /Playwright screenshot capture failed[\s\S]*(Timeout|net::ERR_|Target closed)/i.test(input.error)
+  );
+}
+
+export function summarizeScreenshotCaptureFailure(input: {
+  errorCode: string;
+  error: string;
+  truncated?: boolean;
+}): {
+  errorCode: string;
+  summary: string;
+  recoveryHint?: string;
+  errorExcerpt: string;
+  truncated?: boolean;
+} {
+  const recoveryHint = buildScreenshotCaptureRecoveryHint(input);
+  const excerpt = truncate(input.error, FAILURE_ERROR_EXCERPT_BYTES);
+  const storyPath = extractStorybookStoryPathFromFailure(input.error);
+  const summary =
+    input.errorCode === "storybook_index_failed"
+      ? storyPath
+        ? `Storybook failed to index ${storyPath}.`
+        : "Storybook failed to index a stories file."
+      : input.errorCode === "screenshot_capture_failed"
+        ? "Storybook screenshot capture failed."
+        : `Screenshot capture failed (${input.errorCode}).`;
+
+  return {
+    errorCode: input.errorCode,
+    summary,
+    recoveryHint,
+    errorExcerpt: excerpt.text,
+    truncated: input.truncated || excerpt.truncated || undefined,
+  };
 }
 
 function managedBrowserRuntimeCommand() {
@@ -725,8 +840,11 @@ type CaptureScreenshotFailure = {
   success: false;
   errorCode: string;
   error: string;
+  summary?: string;
+  recoveryHint?: string;
   checkedFiles?: string[];
   truncated?: boolean;
+  attempts?: number;
 };
 
 export type CaptureScreenshotResult = CaptureScreenshotSuccess | CaptureScreenshotFailure;
@@ -793,7 +911,35 @@ It does not commit, push, open pull requests, or publish repository changes.`,
     inputSchema: captureScreenshotInputSchema,
     toModelOutput: async ({ output }) => {
       if (!isCaptureScreenshotSuccess(output)) {
-        return { type: "json", value: output as CaptureScreenshotFailure };
+        const failure = output as CaptureScreenshotFailure;
+        const summarized = summarizeScreenshotCaptureFailure({
+          errorCode: failure.errorCode,
+          error: failure.error,
+          truncated: failure.truncated,
+        });
+        const recoveryHint = failure.recoveryHint ?? summarized.recoveryHint;
+        return {
+          type: "content",
+          value: [
+            {
+              type: "text",
+              text: [
+                "Screenshot capture failed.",
+                `errorCode: ${summarized.errorCode}`,
+                `summary: ${failure.summary ?? summarized.summary}`,
+                recoveryHint ? `recoveryHint: ${recoveryHint}` : null,
+                failure.attempts && failure.attempts > 1 ? `attempts: ${failure.attempts}` : null,
+                failure.checkedFiles?.length
+                  ? `checkedFiles: ${failure.checkedFiles.join(", ")}`
+                  : null,
+                "errorExcerpt:",
+                summarized.errorExcerpt,
+              ]
+                .filter((line): line is string => Boolean(line))
+                .join("\n"),
+            },
+          ],
+        };
       }
 
       try {
@@ -851,13 +997,24 @@ It does not commit, push, open pull requests, or publish repository changes.`,
           success: false as const,
           errorCode: "write_not_allowed" as const,
           error: gate.reason,
+          summary: "Screenshot capture is not allowed for this actor.",
+          recoveryHint: buildScreenshotCaptureRecoveryHint({
+            errorCode: "write_not_allowed",
+            error: gate.reason,
+          }),
         };
       }
       if (!repo.bash.writeWorkspaceFile) {
+        const error = "Workspace write support is required to create screenshot scripts.";
         return {
           success: false as const,
           errorCode: "workspace_write_unavailable" as const,
-          error: "Workspace write support is required to create screenshot scripts.",
+          error,
+          summary: "Workspace write support is unavailable.",
+          recoveryHint: buildScreenshotCaptureRecoveryHint({
+            errorCode: "workspace_write_unavailable",
+            error,
+          }),
         };
       }
 
@@ -871,6 +1028,7 @@ It does not commit, push, open pull requests, or publish repository changes.`,
           success: false as const,
           errorCode: resolvedPackage.errorCode,
           error: resolvedPackage.error,
+          summary: resolvedPackage.error,
           checkedFiles: resolvedPackage.checkedFiles,
         };
       }
@@ -915,34 +1073,82 @@ It does not commit, push, open pull requests, or publish repository changes.`,
         }),
       );
 
-      ctx.reportToolProgress?.({
-        toolCallId,
-        message: "Preparing browser and loading story…",
-      });
-      const captureResult = await repo.bash.exec("bash", {
-        args: [
-          "-lc",
-          buildCaptureCommand({
-            storybookCommand,
-            baseDir,
-            scriptPath,
-            screenshotPath,
-            port: STORYBOOK_PORT,
-          }),
-        ],
+      const captureCommand = buildCaptureCommand({
+        storybookCommand,
+        baseDir,
+        scriptPath,
+        screenshotPath,
+        port: STORYBOOK_PORT,
       });
 
-      if (captureResult.exitCode !== 0) {
-        const output = truncate(
+      let captureResult: Awaited<ReturnType<RepoToolContext["bash"]["exec"]>> | null = null;
+      let attempts = 0;
+
+      for (let attempt = 1; attempt <= MAX_TRANSIENT_CAPTURE_ATTEMPTS; attempt += 1) {
+        attempts = attempt;
+        ctx.reportToolProgress?.({
+          toolCallId,
+          message:
+            attempt === 1
+              ? "Preparing browser and loading story…"
+              : "Retrying screenshot capture…",
+        });
+        captureResult = await repo.bash.exec("bash", {
+          args: ["-lc", captureCommand],
+        });
+
+        if (captureResult.exitCode === 0) {
+          break;
+        }
+
+        const failedOutput = truncate(
           redact([captureResult.stdout, captureResult.stderr].join("\n")),
           DEFAULT_MAX_OUTPUT_BYTES,
         );
+        const errorCode = classifyScreenshotCaptureFailure(failedOutput.text);
+        const canRetry =
+          attempt < MAX_TRANSIENT_CAPTURE_ATTEMPTS &&
+          isTransientScreenshotCaptureFailure({
+            errorCode,
+            error: failedOutput.text,
+          });
+        if (!canRetry) {
+          const summarized = summarizeScreenshotCaptureFailure({
+            errorCode,
+            error: failedOutput.text || "Screenshot capture failed.",
+            truncated: failedOutput.truncated,
+          });
+          return {
+            success: false as const,
+            errorCode,
+            error: summarized.errorExcerpt || "Screenshot capture failed.",
+            summary: summarized.summary,
+            recoveryHint: summarized.recoveryHint,
+            truncated: summarized.truncated,
+            attempts,
+          };
+        }
+      }
+
+      if (!captureResult || captureResult.exitCode !== 0) {
+        const output = truncate(
+          redact([captureResult?.stdout ?? "", captureResult?.stderr ?? ""].join("\n")),
+          DEFAULT_MAX_OUTPUT_BYTES,
+        );
         const errorCode = classifyScreenshotCaptureFailure(output.text);
-        return {
-          success: false as const,
+        const summarized = summarizeScreenshotCaptureFailure({
           errorCode,
           error: output.text || "Screenshot capture failed.",
           truncated: output.truncated,
+        });
+        return {
+          success: false as const,
+          errorCode,
+          error: summarized.errorExcerpt || "Screenshot capture failed.",
+          summary: summarized.summary,
+          recoveryHint: summarized.recoveryHint,
+          truncated: summarized.truncated,
+          attempts,
         };
       }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When `captureScreenshot` failed (e.g. Storybook `Unable to index` / `SyntaxError`), the conversation agent often burned its step budget on tool calls and ended with no user-facing text. Users saw tool activity stop with no explanation.

## Changes

- Force a text-only final step (`toolChoice: "none"`) so the agent must explain failures before stopping
- Raise the conversation step limit from 10 → 16 so visual-mock can inspect → scaffold → capture → fix → retry → reply
- Classify Storybook story index/syntax failures as `storybook_index_failed` with a concrete `recoveryHint`
- Return concise failure content (not opaque JSON) from `toModelOutput`
- Retry once inside `captureScreenshot` for transient readiness/connection flakes; do not auto-retry fatal index/syntax errors
- Update `visual-mock` / `conversation` skill instructions to fix+retry once and never finish silently after a failed capture
- Avoid ReDoS in story-path extraction via a linear scan
- Address review: remove unreachable capture fallback; dedupe `hyperlocaliseAgentStepLimit` to `agent.ts`

## Notes

The Storybook syntax error in the attached log was sandbox-side corruption of a temporary stories file during an earlier agent edit; `main` currently has a valid `project-overview-page-content.stories.tsx`. This PR makes the agent recover/report that class of failure instead of going silent.

## Verification

- `vp test` on capture-screenshot, conversation-skill-agent, hyperlocalise-agent, and conversation-skill-registry suites
- `vp check --fix` passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7440dfc8-f621-4c00-a9af-2d490a62d781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7440dfc8-f621-4c00-a9af-2d490a62d781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

