### PR TITLE
fix(web): handle proxied conversation upload requests

### DIFF
--- a/apps/hyperlocalise-web/AGENTS.md
+++ b/apps/hyperlocalise-web/AGENTS.md
@@ -174,8 +174,7 @@ For predictable error handling, prefer the Go-like `Result<T, E>` pattern for ex
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 
 type ProviderCredentialError =
-  | { code: "unsupported_provider_model" }
-  | { code: "provider_validation_failed"; message: string };
+  { code: "unsupported_provider_model" } | { code: "provider_validation_failed"; message: string };
 
 async function validateCredential(
   input: CredentialInput,

--- a/apps/hyperlocalise-web/AGENTS.md
+++ b/apps/hyperlocalise-web/AGENTS.md
@@ -174,7 +174,8 @@ For predictable error handling, prefer the Go-like `Result<T, E>` pattern for ex
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 
 type ProviderCredentialError =
-  { code: "unsupported_provider_model" } | { code: "provider_validation_failed"; message: string };
+  | { code: "unsupported_provider_model" }
+  | { code: "provider_validation_failed"; message: string };
 
 async function validateCredential(
   input: CredentialInput,

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.test.ts
@@ -104,6 +104,37 @@ afterEach(async () => {
 });
 
 describe("conversation creation", () => {
+  it("accepts a proxied multipart request without content length", async () => {
+    const identity = createWorkosIdentity();
+    const headers = await authHeadersFor(identity);
+    const formData = new FormData();
+    formData.set("text", "Translate this to fr-FR");
+    const request = new Request(
+      `http://localhost/api/orgs/${identity.organization.slug}/conversations`,
+      {
+        method: "POST",
+        headers,
+        body: formData,
+      },
+    );
+    const proxiedRequest = new Proxy(request, {
+      get(target, property) {
+        const value = Reflect.get(target, property, target);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+
+    const response = await app.fetch(proxiedRequest);
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      message: {
+        text: "Translate this to fr-FR",
+        senderType: "user",
+      },
+    });
+  });
+
   it("creates a chat UI conversation with the initial user message", async () => {
     const identity = createWorkosIdentity();
     const projectResponse = await createProjectViaApi(identity);

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
@@ -58,9 +58,12 @@ const messageUploadBodyLimit = createMiddleware(async (c, next) => {
   const hasTransferEncoding = rawRequest.headers.has("transfer-encoding");
   const contentLength = rawRequest.headers.get("content-length");
   if (contentLength && !hasTransferEncoding) {
-    return Number.parseInt(contentLength, 10) > maxMessageUploadBytes
-      ? c.json({ error: "upload_too_large" }, 413)
-      : next();
+    const parsedLength = Number.parseInt(contentLength, 10);
+    if (!Number.isNaN(parsedLength)) {
+      return parsedLength > maxMessageUploadBytes
+        ? c.json({ error: "upload_too_large" }, 413)
+        : next();
+    }
   }
 
   let size = 0;
@@ -75,6 +78,8 @@ const messageUploadBodyLimit = createMiddleware(async (c, next) => {
 
     size += value.byteLength;
     if (size > maxMessageUploadBytes) {
+      await reader.cancel().catch(() => undefined);
+      reader.releaseLock();
       return c.json({ error: "upload_too_large" }, 413);
     }
     chunks.push(value);

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
@@ -12,7 +12,7 @@
  */
 import { and, asc, desc, eq, inArray, lt } from "drizzle-orm";
 import { Hono } from "hono";
-import { bodyLimit } from "hono/body-limit";
+import { createMiddleware } from "hono/factory";
 import { validator } from "hono/validator";
 
 import { buildAccessibleInteractionsWhere, canAccessInteraction } from "@/api/auth/team-access";
@@ -48,6 +48,55 @@ import {
 
 const maxMessageUploadBytes = 25 * 1024 * 1024;
 const maxMessageUploadFiles = 5;
+
+const messageUploadBodyLimit = createMiddleware(async (c, next) => {
+  const rawRequest = c.req.raw;
+  if (!rawRequest.body) {
+    return next();
+  }
+
+  const hasTransferEncoding = rawRequest.headers.has("transfer-encoding");
+  const contentLength = rawRequest.headers.get("content-length");
+  if (contentLength && !hasTransferEncoding) {
+    return Number.parseInt(contentLength, 10) > maxMessageUploadBytes
+      ? c.json({ error: "upload_too_large" }, 413)
+      : next();
+  }
+
+  let size = 0;
+  const chunks: Uint8Array[] = [];
+  const reader = rawRequest.body.getReader();
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    size += value.byteLength;
+    if (size > maxMessageUploadBytes) {
+      return c.json({ error: "upload_too_large" }, 413);
+    }
+    chunks.push(value);
+  }
+
+  c.req.raw = new Request(rawRequest.url, {
+    method: rawRequest.method,
+    headers: rawRequest.headers,
+    body: new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(chunk);
+        }
+        controller.close();
+      },
+    }),
+    signal: rawRequest.signal,
+    duplex: "half",
+  });
+
+  return next();
+});
 
 function notFoundResponse(c: { json(body: { error: string }, status: 404): Response }) {
   return c.json({ error: "not_found" }, 404);
@@ -289,10 +338,7 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
     })
     .post(
       "/",
-      bodyLimit({
-        maxSize: maxMessageUploadBytes,
-        onError: (c) => c.json({ error: "upload_too_large" }, 413),
-      }),
+      messageUploadBodyLimit,
       async (c) => {
         const body = await c.req.parseBody({ all: true });
         const parsed = createConversationRequestSchema.safeParse({

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
@@ -336,170 +336,164 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
         200,
       );
     })
-    .post(
-      "/",
-      messageUploadBodyLimit,
-      async (c) => {
-        const body = await c.req.parseBody({ all: true });
-        const parsed = createConversationRequestSchema.safeParse({
-          text: asString(body.text),
-          projectId: asString(body.projectId),
-          repositoryFullName: asString(body.repositoryFullName),
-        });
+    .post("/", messageUploadBodyLimit, async (c) => {
+      const body = await c.req.parseBody({ all: true });
+      const parsed = createConversationRequestSchema.safeParse({
+        text: asString(body.text),
+        projectId: asString(body.projectId),
+        repositoryFullName: asString(body.repositoryFullName),
+      });
 
-        if (!parsed.success) {
-          return badRequestResponse(c, "invalid_conversation_payload");
+      if (!parsed.success) {
+        return badRequestResponse(c, "invalid_conversation_payload");
+      }
+
+      const files = asFiles(body.files);
+      if (!parsed.data.text && files.length === 0) {
+        return badRequestResponse(c, "invalid_conversation_payload");
+      }
+      const messageText = parsed.data.text || "Please translate the attached source file.";
+
+      if (files.length > maxMessageUploadFiles) {
+        return tooManyFilesResponse(c);
+      }
+
+      for (const file of files) {
+        if (!inferSupportedSourceUploadFormat(file.name)) {
+          return badRequestResponse(c, "unsupported_translation_source_file", undefined, {
+            filename: file.name,
+          });
         }
+      }
 
-        const files = asFiles(body.files);
-        if (!parsed.data.text && files.length === 0) {
-          return badRequestResponse(c, "invalid_conversation_payload");
+      const embedSession = c.var.crowdinEmbedSession;
+      const requestedProjectId = parsed.data.projectId
+        ? normalizeProjectId(parsed.data.projectId)
+        : undefined;
+      const projectId = embedSession?.hlProjectId ?? requestedProjectId;
+
+      if (embedSession && requestedProjectId && requestedProjectId !== embedSession.hlProjectId) {
+        return badRequestResponse(c, "project_scope_mismatch");
+      }
+
+      if (projectId) {
+        const project = await getOwnedProject(c.var.auth, projectId);
+        if (!project) {
+          return c.json({ error: "project_not_found" }, 400);
         }
-        const messageText = parsed.data.text || "Please translate the attached source file.";
+      }
 
-        if (files.length > maxMessageUploadFiles) {
-          return tooManyFilesResponse(c);
-        }
+      if (embedSession && !projectId) {
+        return badRequestResponse(c, "project_required");
+      }
 
-        for (const file of files) {
-          if (!inferSupportedSourceUploadFormat(file.name)) {
-            return badRequestResponse(c, "unsupported_translation_source_file", undefined, {
-              filename: file.name,
-            });
-          }
-        }
-
-        const embedSession = c.var.crowdinEmbedSession;
-        const requestedProjectId = parsed.data.projectId
-          ? normalizeProjectId(parsed.data.projectId)
-          : undefined;
-        const projectId = embedSession?.hlProjectId ?? requestedProjectId;
-
-        if (embedSession && requestedProjectId && requestedProjectId !== embedSession.hlProjectId) {
-          return badRequestResponse(c, "project_scope_mismatch");
-        }
-
-        if (projectId) {
-          const project = await getOwnedProject(c.var.auth, projectId);
-          if (!project) {
-            return c.json({ error: "project_not_found" }, 400);
-          }
-        }
-
-        if (embedSession && !projectId) {
-          return badRequestResponse(c, "project_required");
-        }
-
-        const orgId = c.var.auth.activeOrganization.localOrganizationId;
-        const repositoryGitHubContext = await resolveSelectedRepositoryGitHubContext({
-          organizationId: orgId,
-          repositoryFullName: parsed.data.repositoryFullName,
-        });
-        if (parsed.data.repositoryFullName && !repositoryGitHubContext) {
-          return badRequestResponse(
-            c,
-            "github_repository_not_available",
-            "Selected GitHub repository is not enabled for this workspace.",
-          );
-        }
-
-        const adapter = options.fileStorageAdapter ?? getFileStorageAdapter();
-        const organizationSlug = c.var.auth.activeOrganization.slug ?? "";
-
-        const uploadResults = await Promise.allSettled(
-          files.map(async (file) =>
-            createStoredFile({
-              organizationId: orgId,
-              projectId,
-              createdByUserId: c.var.auth.user.localUserId,
-              role: "source",
-              sourceKind: "chat_upload",
-              filename: file.name,
-              contentType: file.type || "application/octet-stream",
-              content: await file.arrayBuffer(),
-              metadata: {
-                uploadSurface: "chat",
-                translationSource: true,
-              },
-              adapter,
-            }),
-          ),
+      const orgId = c.var.auth.activeOrganization.localOrganizationId;
+      const repositoryGitHubContext = await resolveSelectedRepositoryGitHubContext({
+        organizationId: orgId,
+        repositoryFullName: parsed.data.repositoryFullName,
+      });
+      if (parsed.data.repositoryFullName && !repositoryGitHubContext) {
+        return badRequestResponse(
+          c,
+          "github_repository_not_available",
+          "Selected GitHub repository is not enabled for this workspace.",
         );
-        const storedFiles = uploadResults
-          .filter((result) => result.status === "fulfilled")
-          .map((result) => result.value);
-        const failedUpload = uploadResults.find((result) => result.status === "rejected");
+      }
 
-        if (failedUpload) {
-          await cleanupStoredFiles(storedFiles, adapter);
-          throw failedUpload.reason instanceof Error
-            ? failedUpload.reason
-            : new Error("failed to store uploaded file");
-        }
+      const adapter = options.fileStorageAdapter ?? getFileStorageAdapter();
+      const organizationSlug = c.var.auth.activeOrganization.slug ?? "";
 
-        let conversation: Awaited<ReturnType<typeof createInteraction>> | undefined;
-        let responseFiles = storedFiles;
-        let message;
-        try {
-          const createdConversation = await createInteraction({
+      const uploadResults = await Promise.allSettled(
+        files.map(async (file) =>
+          createStoredFile({
             organizationId: orgId,
-            source: "chat_ui",
-            title: messageText.slice(0, 120),
             projectId,
-          });
-          conversation = createdConversation;
+            createdByUserId: c.var.auth.user.localUserId,
+            role: "source",
+            sourceKind: "chat_upload",
+            filename: file.name,
+            contentType: file.type || "application/octet-stream",
+            content: await file.arrayBuffer(),
+            metadata: {
+              uploadSurface: "chat",
+              translationSource: true,
+            },
+            adapter,
+          }),
+        ),
+      );
+      const storedFiles = uploadResults
+        .filter((result) => result.status === "fulfilled")
+        .map((result) => result.value);
+      const failedUpload = uploadResults.find((result) => result.status === "rejected");
 
-          if (repositoryGitHubContext) {
-            seedConversationRepositorySession(createdConversation.id, repositoryGitHubContext);
-          }
+      if (failedUpload) {
+        await cleanupStoredFiles(storedFiles, adapter);
+        throw failedUpload.reason instanceof Error
+          ? failedUpload.reason
+          : new Error("failed to store uploaded file");
+      }
 
-          if (storedFiles.length > 0) {
-            await db
-              .update(schema.storedFiles)
-              .set({ sourceInteractionId: createdConversation.id })
-              .where(
-                inArray(
-                  schema.storedFiles.id,
-                  storedFiles.map((file) => file.id),
-                ),
-              );
-            responseFiles = storedFiles.map((file) => ({
-              ...file,
-              sourceInteractionId: createdConversation.id,
-            }));
-          }
+      let conversation: Awaited<ReturnType<typeof createInteraction>> | undefined;
+      let responseFiles = storedFiles;
+      let message;
+      try {
+        const createdConversation = await createInteraction({
+          organizationId: orgId,
+          source: "chat_ui",
+          title: messageText.slice(0, 120),
+          projectId,
+        });
+        conversation = createdConversation;
 
-          message = await addInteractionMessage({
-            interactionId: createdConversation.id,
-            senderType: "user",
-            senderEmail: c.var.auth.user.email,
-            text: messageText,
-            attachments: storedFiles.map((file) => ({
-              id: file.id,
-              filename: file.filename,
-              contentType: file.contentType,
-              url: organizationSlug
-                ? buildOrganizationFileUrl(organizationSlug, file.id)
-                : (file.downloadUrl ?? file.storageUrl),
-            })),
-          });
-        } catch (error) {
-          try {
-            await cleanupStoredFiles(storedFiles, adapter);
-            if (conversation) {
-              await db
-                .delete(schema.interactions)
-                .where(eq(schema.interactions.id, conversation.id));
-            }
-          } catch {
-            // Best-effort cleanup; do not mask the original error.
-          }
-          throw error;
+        if (repositoryGitHubContext) {
+          seedConversationRepositorySession(createdConversation.id, repositoryGitHubContext);
         }
 
-        return c.json({ conversation, message, files: responseFiles }, 201);
-      },
-    )
+        if (storedFiles.length > 0) {
+          await db
+            .update(schema.storedFiles)
+            .set({ sourceInteractionId: createdConversation.id })
+            .where(
+              inArray(
+                schema.storedFiles.id,
+                storedFiles.map((file) => file.id),
+              ),
+            );
+          responseFiles = storedFiles.map((file) => ({
+            ...file,
+            sourceInteractionId: createdConversation.id,
+          }));
+        }
+
+        message = await addInteractionMessage({
+          interactionId: createdConversation.id,
+          senderType: "user",
+          senderEmail: c.var.auth.user.email,
+          text: messageText,
+          attachments: storedFiles.map((file) => ({
+            id: file.id,
+            filename: file.filename,
+            contentType: file.contentType,
+            url: organizationSlug
+              ? buildOrganizationFileUrl(organizationSlug, file.id)
+              : (file.downloadUrl ?? file.storageUrl),
+          })),
+        });
+      } catch (error) {
+        try {
+          await cleanupStoredFiles(storedFiles, adapter);
+          if (conversation) {
+            await db.delete(schema.interactions).where(eq(schema.interactions.id, conversation.id));
+          }
+        } catch {
+          // Best-effort cleanup; do not mask the original error.
+        }
+        throw error;
+      }
+
+      return c.json({ conversation, message, files: responseFiles }, 201);
+    })
     .get("/:conversationId", validateConversationParams, async (c) => {
       const { conversationId } = c.req.valid("param");
 

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
@@ -80,7 +80,7 @@ const messageUploadBodyLimit = createMiddleware(async (c, next) => {
     chunks.push(value);
   }
 
-  c.req.raw = new Request(rawRequest.url, {
+  const replayRequestInit: RequestInit & { duplex: "half" } = {
     method: rawRequest.method,
     headers: rawRequest.headers,
     body: new ReadableStream({
@@ -93,7 +93,8 @@ const messageUploadBodyLimit = createMiddleware(async (c, next) => {
     }),
     signal: rawRequest.signal,
     duplex: "half",
-  });
+  };
+  c.req.raw = new Request(rawRequest.url, replayRequestInit);
 
   return next();
 });
@@ -538,10 +539,7 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
     .post(
       "/:conversationId/messages",
       validateConversationParams,
-      bodyLimit({
-        maxSize: maxMessageUploadBytes,
-        onError: (c) => c.json({ error: "upload_too_large" }, 413),
-      }),
+      messageUploadBodyLimit,
       async (c) => {
         const { conversationId } = c.req.valid("param");
         const orgId = c.var.auth.activeOrganization.localOrganizationId;

--- a/docs/adr/2026-07-24-proxied-request-body-limit-design.md
+++ b/docs/adr/2026-07-24-proxied-request-body-limit-design.md
@@ -1,0 +1,28 @@
+# Proxied request body limit
+
+## Context
+
+The conversation creation route accepts multipart uploads and limits request bodies to 25 MB.
+Hono's `bodyLimit` middleware buffers requests without a trustworthy `Content-Length` header,
+then rebuilds them with `new Request(c.req.raw, init)`.
+
+Next.js can pass a proxy around Node's Undici `Request` in production. Undici cannot read its
+private state through that proxy, so rebuilding the request throws before the route handler runs.
+
+## Design
+
+Replace Hono's middleware on this route with a local middleware that keeps the same limit and
+response contract. Trust `Content-Length` only when `Transfer-Encoding` is absent. Otherwise,
+read the stream, reject it once it exceeds 25 MB, and replay accepted bytes in a new request.
+
+Build the replay request from the original URL and explicit request fields. Do not pass the
+proxied request to the `Request` constructor.
+
+Keep the change route-local. Other endpoints do not need this compatibility layer until they
+accept streamed bodies through the same middleware.
+
+## Verification
+
+Add a regression test that passes a proxied multipart request without `Content-Length` through
+the production app. Assert that conversation creation succeeds and preserves the initial message.
+Keep the existing oversized-upload behavior covered by the route test suite.


### PR DESCRIPTION


## What changed

- Replace Hono’s conversation upload body-limit middleware with a route-local implementation compatible with proxied Next.js requests.
- Preserve the 25 MB upload limit, including streamed requests without a trustworthy `Content-Length`.
- Rebuild accepted requests from explicit fields instead of passing the proxy to Undici’s `Request` constructor.
- Add regression coverage for proxied multipart requests and document the design.

## How to test

- `vp test src/api/routes/conversation/conversation.route.test.ts`
  - Blocked before test collection because the local installation was missing `@ai-sdk/mcp`.
- `make bootstrap`
  - Started restoring dependencies but was interrupted before completion.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review