### PR TITLE
fix(agent): expose todoWrite to conversation skill tools

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.test.ts
@@ -157,4 +157,40 @@ describe("conversation skill agent", () => {
     expect(settings.instructions).toContain("Recent changes with full context");
     expect(settings.instructions).toContain("exist in the current source files now");
   });
+
+  it("exposes todoWrite in both tools and activeTools for repo skills", () => {
+    createConversationSkillAgent({
+      surface: "web",
+      hasFileAttachments: false,
+      hasTmsIntegration: false,
+      hasVisualMockSkill: true,
+      toolContext: {
+        ...baseToolContext,
+        sandboxId: "sbx_123",
+        workMode: "write",
+        repositorySource: "chat_ui",
+        actor: { sourceUserId: "user_123", role: "admin" },
+        membershipRole: "admin",
+      },
+    });
+
+    expect(toolLoopAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activeTools: expect.arrayContaining(["todoWrite", "grep", "captureScreenshot"]),
+        tools: expect.objectContaining({
+          todoWrite: expect.any(Object),
+          grep: expect.any(Object),
+          captureScreenshot: expect.any(Object),
+        }),
+      }),
+    );
+
+    const settings = toolLoopAgentMock.mock.calls.at(-1)?.[0] as {
+      activeTools: string[];
+      tools: Record<string, unknown>;
+    };
+    for (const toolName of settings.activeTools) {
+      expect(settings.tools[toolName]).toBeDefined();
+    }
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.ts
@@ -17,7 +17,6 @@ import { buildConversationSkillInstructions } from "@/lib/agent-runtime/skills/c
 import {
   buildConversationSkillPlan,
   buildConversationSkillTools,
-  filterAvailableConversationToolNames,
 } from "@/lib/agent-runtime/skills/conversation-skill-registry";
 import { DEFAULT_AGENT_TIMEOUT } from "@/lib/agent-runtime/subagents/constants";
 import {
@@ -35,11 +34,9 @@ export function createConversationSkillAgent(
   onFinish?: ConversationSkillAgentOnFinish,
 ) {
   const skillPlan = buildConversationSkillPlan(runtime);
-  const toolNames = filterAvailableConversationToolNames(skillPlan.toolNames, runtime);
-  const tools = buildConversationSkillTools(runtime, toolNames);
-  // Only advertise tools that were actually built (session tools like todoWrite
-  // must not appear in activeTools when missing from the ToolSet).
-  const activeTools = toolNames.filter((toolName) => toolName in tools);
+  // Filtering lives in buildConversationSkillTools; activeTools mirrors what was built.
+  const tools = buildConversationSkillTools(runtime, skillPlan.toolNames);
+  const activeTools = Object.keys(tools);
 
   return new ToolLoopAgent<never, ToolSet>({
     model: getHyperlocaliseAgentModel(),

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.ts
@@ -37,6 +37,9 @@ export function createConversationSkillAgent(
   const skillPlan = buildConversationSkillPlan(runtime);
   const toolNames = filterAvailableConversationToolNames(skillPlan.toolNames, runtime);
   const tools = buildConversationSkillTools(runtime, toolNames);
+  // Only advertise tools that were actually built (session tools like todoWrite
+  // must not appear in activeTools when missing from the ToolSet).
+  const activeTools = toolNames.filter((toolName) => toolName in tools);
 
   return new ToolLoopAgent<never, ToolSet>({
     model: getHyperlocaliseAgentModel(),
@@ -47,7 +50,7 @@ export function createConversationSkillAgent(
       additionalInstructions: runtime.additionalInstructions,
     }),
     tools,
-    activeTools: toolNames,
+    activeTools,
     providerOptions: {
       openai: {
         reasoningSummary: "auto",

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
@@ -15,6 +15,7 @@ import { beforeEach, describe, expect, it } from "vite-plus/test";
 import { clearAgentManifestCache, loadAgentSkill } from "@/agents/_runtime/loader";
 import {
   buildConversationSkillPlan,
+  buildConversationSkillTools,
   filterAvailableConversationToolNames,
   isConversationSkillActivated,
   listConversationSkills,
@@ -329,6 +330,63 @@ describe("conversation skill registry", () => {
     );
 
     expect(toolNames).toEqual(["translate_string", "list_projects"]);
+  });
+
+  it("keeps todoWrite available without a sandbox", () => {
+    const toolNames = filterAvailableConversationToolNames(["todoWrite", "grep"], {
+      hasFileAttachments: false,
+      toolContext: {
+        conversationId: "conv_1",
+        organizationId: "org_1",
+        localUserId: "user_1",
+        membershipRole: "member",
+        projectId: null,
+        db: {} as never,
+      },
+    });
+
+    expect(toolNames).toEqual(["todoWrite"]);
+  });
+
+  it("builds todoWrite as a session tool for conversation skills", () => {
+    const tools = buildConversationSkillTools(
+      {
+        hasFileAttachments: false,
+        toolContext: {
+          conversationId: "conv_1",
+          organizationId: "org_1",
+          localUserId: "user_1",
+          membershipRole: "member",
+          projectId: null,
+          db: {} as never,
+          sandboxId: "sbx_1",
+        },
+      },
+      ["todoWrite", "grep"],
+    );
+
+    expect(tools.todoWrite).toBeDefined();
+    expect(tools.grep).toBeDefined();
+  });
+
+  it("builds todoWrite even when no sandbox workspace tools are available", () => {
+    const tools = buildConversationSkillTools(
+      {
+        hasFileAttachments: false,
+        toolContext: {
+          conversationId: "conv_1",
+          organizationId: "org_1",
+          localUserId: "user_1",
+          membershipRole: "member",
+          projectId: null,
+          db: {} as never,
+        },
+      },
+      ["todoWrite"],
+    );
+
+    expect(tools.todoWrite).toBeDefined();
+    expect(Object.keys(tools)).toEqual(["todoWrite"]);
   });
 
   it("gates repository write tools from read-only conversation runtimes", () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.ts
@@ -20,9 +20,8 @@ import type { HyperlocaliseAgentRuntimeContext } from "@/lib/agent-runtime/conte
 import { repositoryWorkspaceToolNames } from "@/lib/agent-contracts/repository-workspace-tools";
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 import { assertRepositoryWriteAllowed } from "@/lib/agent-runtime/tools/policy";
-import { createTranslationJobTool } from "@/lib/agent-runtime/tools/translation-tools";
 import { createSandboxRepoBash } from "@/lib/agent-runtime/workspaces/sandbox-repo-bash";
-import { buildWorkspaceTools } from "@/lib/agent-runtime/tools/registry";
+import { buildWorkspaceTools, createTranslationJobTool } from "@/lib/agent-runtime/tools/registry";
 import {
   createFetchTool,
   createTodoWriteTool,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.ts
@@ -20,9 +20,14 @@ import type { HyperlocaliseAgentRuntimeContext } from "@/lib/agent-runtime/conte
 import { repositoryWorkspaceToolNames } from "@/lib/agent-contracts/repository-workspace-tools";
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 import { assertRepositoryWriteAllowed } from "@/lib/agent-runtime/tools/policy";
+import { createTranslationJobTool } from "@/lib/agent-runtime/tools/translation-tools";
 import { createSandboxRepoBash } from "@/lib/agent-runtime/workspaces/sandbox-repo-bash";
-import { buildTools, buildWorkspaceTools } from "@/lib/agent-runtime/tools/registry";
-import { workspaceSessionToolNames } from "@/lib/agent-runtime/tools/workspace";
+import { buildWorkspaceTools } from "@/lib/agent-runtime/tools/registry";
+import {
+  createFetchTool,
+  createTodoWriteTool,
+  workspaceSessionToolNames,
+} from "@/lib/agent-runtime/tools/workspace";
 import {
   createGetProjectContextTool,
   createListProjectsTool,
@@ -247,14 +252,9 @@ export function buildConversationSkillTools(
       ? buildWorkspaceTools(ctx, { bash: createSandboxRepoBash(ctx.sandboxId) as Bash })
       : null;
 
-  const builtTools = buildTools(ctx);
-
   for (const toolName of availableToolNames) {
-    if (SESSION_TOOL_NAMES.has(toolName)) {
-      const sessionTool = builtTools[toolName];
-      if (sessionTool) {
-        tools[toolName] = sessionTool;
-      }
+    if (toolName === "todoWrite") {
+      tools[toolName] = createTodoWriteTool(() => ctx);
       continue;
     }
 
@@ -266,16 +266,13 @@ export function buildConversationSkillTools(
       continue;
     }
 
-    if (toolName === "createTranslationJob" && builtTools.createTranslationJob) {
-      tools[toolName] = builtTools.createTranslationJob;
+    if (toolName === "createTranslationJob") {
+      tools[toolName] = createTranslationJobTool(ctx);
       continue;
     }
 
     if (WEB_TOOL_NAMES.has(toolName)) {
-      const webTool = builtTools[toolName];
-      if (webTool) {
-        tools[toolName] = webTool;
-      }
+      tools[toolName] = createFetchTool();
       continue;
     }
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.ts
@@ -22,6 +22,7 @@ import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 import { assertRepositoryWriteAllowed } from "@/lib/agent-runtime/tools/policy";
 import { createSandboxRepoBash } from "@/lib/agent-runtime/workspaces/sandbox-repo-bash";
 import { buildTools, buildWorkspaceTools } from "@/lib/agent-runtime/tools/registry";
+import { workspaceSessionToolNames } from "@/lib/agent-runtime/tools/workspace";
 import {
   createGetProjectContextTool,
   createListProjectsTool,
@@ -30,7 +31,13 @@ import {
 
 const CONVERSATION_AGENT_ID = "hyperlocalise";
 
-const REPO_TOOL_NAMES = new Set<string>([...repositoryWorkspaceToolNames, "captureScreenshot"]);
+/** Session tools live on the agent session, not the sandbox workspace. */
+const SESSION_TOOL_NAMES = new Set<string>(workspaceSessionToolNames);
+const REPO_TOOL_NAMES = new Set<string>(
+  [...repositoryWorkspaceToolNames, "captureScreenshot"].filter(
+    (toolName) => !SESSION_TOOL_NAMES.has(toolName),
+  ),
+);
 const WEB_TOOL_NAMES = new Set(["fetch"]);
 const FILE_JOB_GATED_TOOL_NAMES = new Set(["createTranslationJob"]);
 const REPO_WRITE_TOOL_NAMES = new Set(["write", "applyPatch", "captureScreenshot"]);
@@ -243,6 +250,14 @@ export function buildConversationSkillTools(
   const builtTools = buildTools(ctx);
 
   for (const toolName of availableToolNames) {
+    if (SESSION_TOOL_NAMES.has(toolName)) {
+      const sessionTool = builtTools[toolName];
+      if (sessionTool) {
+        tools[toolName] = sessionTool;
+      }
+      continue;
+    }
+
     if (REPO_TOOL_NAMES.has(toolName)) {
       const repoTool = repoTools?.[toolName];
       if (repoTool) {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/registry.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/registry.ts
@@ -39,6 +39,9 @@ import {
   type RepoToolContext,
 } from "./workspace";
 
+/** Re-export for callers that must stay behind the registry mock boundary in tests. */
+export { createTranslationJobTool };
+
 function createWorkspaceTools(ctx: ToolContext, repoBash: RepoToolContext): ToolSet {
   const policy = resolveToolPolicy({
     organizationId: ctx.organizationId,

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
@@ -143,6 +143,8 @@ vi.mock("ai", async () => {
 
 vi.mock("@/lib/agent-runtime/tools/registry", () => ({
   buildTools: vi.fn(() => ({})),
+  buildWorkspaceTools: vi.fn(() => ({})),
+  createTranslationJobTool: vi.fn(() => ({})),
 }));
 
 vi.mock("@/lib/agents/image-generation", () => ({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

We already had `todoWrite` for visual-mock / repo workflow progress, but conversation skill agents could not call it. Skills listed it while the ToolSet silently dropped it.

**Root cause:** `buildConversationSkillTools` treated `todoWrite` as a repository workspace tool and looked it up in `buildWorkspaceTools`, which never creates session tools.

**Fix:**
- Build `todoWrite` via `createTodoWriteTool` as a session tool (no sandbox required)
- Assemble conversation tools from specific factories instead of `buildTools`, so repo skill turns do not open a second unused sandbox bash connection
- Keep availability filtering inside `buildConversationSkillTools` and derive `activeTools` from the built ToolSet
- Import `createTranslationJobTool` through the registry re-export so slack `bot.test` mocks keep shielding incomplete database schema

## How to test

- `vp test` on conversation skill registry/agent + `src/lib/agents/slack/bot.test.ts`
- `vp check --fix` on changed files
- Web CI / Hyperlocalise Web Build

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1d7faf2-f060-4196-9b95-3908c616d616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1d7faf2-f060-4196-9b95-3908c616d616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

