### PR TITLE
feat(web): add homepage FAQ structured data

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/page.tsx
@@ -13,6 +13,11 @@
 import type { Metadata } from "next";
 import type { WithContext } from "schema-dts";
 import { WebApplication } from "schema-dts";
+import {
+  buildHomepageFaqJsonLd,
+  getHomepageFaqItems,
+} from "@/components/marketing/homepage-faq-content";
+import { HomepageFaqSection } from "@/components/marketing/homepage-faq-section";
 import { MarketingFooter } from "@/components/marketing/marketing-footer";
 import { footerColumns } from "@/components/marketing/marketing-page-content";
 import { JsonLd } from "@/components/seo/json-ld";
@@ -109,6 +114,8 @@ function buildJsonLd(locale: string): WithContext<WebApplication> & object {
 export default async function Home({ params }: HomePageProps) {
   const { lang } = await params;
   const jsonLd = buildJsonLd(lang);
+  const faqItems = getHomepageFaqItems(lang);
+  const faqJsonLd = buildHomepageFaqJsonLd(faqItems);
   const recentPosts = getAllPosts(lang)
     .slice(0, 4)
     .map(({ content: _content, ...rest }) => rest);
@@ -116,6 +123,7 @@ export default async function Home({ params }: HomePageProps) {
   return (
     <>
       <JsonLd data={jsonLd} />
+      <JsonLd data={faqJsonLd} />
       <div className="min-h-screen bg-background text-foreground">
         <HeroSection />
 
@@ -133,6 +141,12 @@ export default async function Home({ params }: HomePageProps) {
           <section className="border-t border-border scroll-mt-24">
             <div className="px-5 py-24 sm:px-8 sm:py-28 lg:px-10">
               <FeatureMeshCardsSection />
+            </div>
+          </section>
+
+          <section className="border-t border-border scroll-mt-24">
+            <div className="px-5 py-24 sm:px-8 sm:py-28 lg:px-10">
+              <HomepageFaqSection items={faqItems} />
             </div>
           </section>
 

--- a/apps/hyperlocalise-web/src/components/marketing/homepage-faq-content.test.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/homepage-faq-content.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildHomepageFaqJsonLd, getHomepageFaqItems } from "./homepage-faq-content";
+
+describe("homepage FAQ content", () => {
+  it("builds matching visible content and FAQPage structured data", () => {
+    const items = getHomepageFaqItems("en");
+    const jsonLd = buildHomepageFaqJsonLd(items);
+
+    expect(items).toHaveLength(12);
+    expect(jsonLd).toMatchObject({
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+    });
+    expect(jsonLd.mainEntity).toEqual(
+      items.map((item) => ({
+        "@type": "Question",
+        name: item.question,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: item.answer,
+        },
+      })),
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/components/marketing/homepage-faq-content.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/homepage-faq-content.ts
@@ -26,165 +26,163 @@ export function getHomepageFaqItems(locale: string): HomepageFaqItem[] {
     {
       question: intl.formatMessage({
         defaultMessage: "Do I need to replace my TMS?",
-        id: "NEp4sVqR2K",
+        id: "Fm4Rzqmp2/",
         description: "Homepage FAQ question about replacing an existing TMS",
       }),
       answer: intl.formatMessage({
         defaultMessage:
           "No. Hyperlocalise works alongside your existing TMS. Keep using Phrase, Lokalise, Crowdin or Smartling while Hyperlocalise orchestrates AI agents, review workflows, context discovery and quality checks.",
-        id: "dFA6uX1JmP",
+        id: "YIX0kOlYt0",
         description: "Homepage FAQ answer about working with an existing TMS",
       }),
     },
     {
       question: intl.formatMessage({
         defaultMessage: "How is Hyperlocalise different from AI translation?",
-        id: "Vh3zQ8nL5C",
+        id: "uMB4LineFP",
         description: "Homepage FAQ question comparing Hyperlocalise with AI translation",
       }),
       answer: intl.formatMessage({
         defaultMessage:
           "AI translation generates text. Hyperlocalise manages the entire localisation workflow—from discovering context and assigning AI agents to coordinating human review, syncing with your TMS and preventing regressions before release.",
-        id: "mT7kB2wY9A",
+        id: "YjvgVDe80A",
         description: "Homepage FAQ answer comparing Hyperlocalise with AI translation",
       }),
     },
     {
       question: intl.formatMessage({
         defaultMessage: "What is Translation Intelligence?",
-        id: "Pq5cN8sD1H",
+        id: "DNjUZTzqsq",
         description: "Homepage FAQ question about Translation Intelligence",
       }),
       answer: intl.formatMessage({
         defaultMessage:
           "Translation Intelligence is Hyperlocalise’s approach to giving AI and reviewers the context they need to make better localisation decisions. Instead of translating isolated strings, Hyperlocalise automatically surfaces repository context, terminology, previous decisions and product knowledge.",
-        id: "rL4xG7vK2E",
+        id: "F6jUO01B6K",
         description: "Homepage FAQ answer defining Translation Intelligence",
       }),
     },
     {
       question: intl.formatMessage({
         defaultMessage: "Can I use my preferred AI models?",
-        id: "Jw8bM3fT6Q",
+        id: "YNuOCyPMCd",
         description: "Homepage FAQ question about supported AI models",
       }),
       answer: intl.formatMessage({
         defaultMessage:
           "Yes. Hyperlocalise is LLM-agnostic. Use OpenAI, Anthropic, Gemini or your preferred provider, and switch models without changing your workflow.",
-        id: "cY2pH9nR5V",
+        id: "NwyqQCxTLG",
         description: "Homepage FAQ answer about supported AI models",
       }),
     },
     {
       question: intl.formatMessage({
         defaultMessage: "Does Hyperlocalise work with GitHub?",
-        id: "Af6kS1dX8M",
+        id: "2o5nZo9c+I",
         description: "Homepage FAQ question about GitHub integration",
       }),
       answer: intl.formatMessage({
         defaultMessage:
           "Yes. Repository changes, pull requests and release workflows can automatically become localisation tasks. Hyperlocalise also adds localisation checks to your CI/CD pipeline before code reaches production.",
-        id: "uQ3eL7zB4N",
+        id: "G5X9k5HMha",
         description: "Homepage FAQ answer about GitHub integration",
       }),
     },
     {
       question: intl.formatMessage({
         defaultMessage: "How does Hyperlocalise find context automatically?",
-        id: "Kx9rC2mW5F",
+        id: "3067sEMny+",
         description: "Homepage FAQ question about automatic context discovery",
       }),
       answer: intl.formatMessage({
         defaultMessage:
           "Our AI agents search your repository, documentation, translation memory and terminology to attach relevant context before translation begins. Translators and reviewers spend less time asking questions and more time shipping.",
-        id: "gD4vP8sJ1T",
+        id: "YrE1KC753H",
         description: "Homepage FAQ answer about automatic context discovery",
       }),
     },
     {
       question: intl.formatMessage({
         defaultMessage: "Can translators chat with AI inside Hyperlocalise?",
-        id: "Rb7nY3hL6C",
+        id: "iPIf89d9nW",
         description: "Homepage FAQ question about chatting with AI",
       }),
       answer: intl.formatMessage({
         defaultMessage:
           "Yes. Simply ask about a string, feature or translation, and Hyperlocalise searches your repository and available context before answering.",
-        id: "eM2qV9kA5X",
+        id: "AfLb8PFRl0",
         description: "Homepage FAQ answer about chatting with AI",
       }),
     },
     {
       question: intl.formatMessage({
         defaultMessage: "How do you ensure AI translation quality?",
-        id: "Tz5fB1wN8Q",
+        id: "7jGjjgImqC",
         description: "Homepage FAQ question about AI translation quality",
       }),
       answer: intl.formatMessage({
         defaultMessage:
           "Hyperlocalise combines AI with human review, regression evaluations, terminology checks and release gates so localisation quality doesn’t silently drift over time.",
-        id: "pH7cK3rD6J",
+        id: "/powsKQ55L",
         description: "Homepage FAQ answer about AI translation quality",
       }),
     },
     {
       question: intl.formatMessage({
         defaultMessage: "Who is Hyperlocalise built for?",
-        id: "Wm4sL8xG2V",
+        id: "kU9ZZlDF/l",
         description: "Homepage FAQ question about the target audience",
       }),
       answer: intl.formatMessage({
         defaultMessage:
           "Software companies and localisation teams that want to launch globally faster without replacing their existing tools or sacrificing translation quality.",
-        id: "nC9qF5bY1R",
+        id: "5UK41gXo2F",
         description: "Homepage FAQ answer about the target audience",
       }),
     },
     {
       question: intl.formatMessage({
         defaultMessage: "How quickly can we get started?",
-        id: "Dk6vP2tM9A",
+        id: "UWwGwAtcmr",
         description: "Homepage FAQ question about getting started",
       }),
       answer: intl.formatMessage({
         defaultMessage:
           "Most teams can connect their repositories, AI providers and existing TMS without changing how they currently manage localisation.",
-        id: "sJ3hX7wQ4E",
+        id: "LhmocGd1bG",
         description: "Homepage FAQ answer about getting started",
       }),
     },
     {
       question: intl.formatMessage({
         defaultMessage: "Why do companies launch in quarters instead of days?",
-        id: "Yq8nB4fK1L",
+        id: "xDlcmJ2xzu",
         description: "Homepage FAQ question about slow global launches",
       }),
       answer: intl.formatMessage({
         defaultMessage:
           "Because localisation isn’t slowed by translation anymore. Teams lose time gathering context, coordinating reviewers, switching between tools and fixing issues after release. Hyperlocalise automates these workflows so teams can move continuously.",
-        id: "aV5rM9cT2P",
+        id: "sSszzKe0NY",
         description: "Homepage FAQ answer about slow global launches",
       }),
     },
     {
       question: intl.formatMessage({
         defaultMessage: "Do I need to migrate my existing translations?",
-        id: "Fh2xR6dW8N",
+        id: "HcFGSr9o03",
         description: "Homepage FAQ question about migrating existing translations",
       }),
       answer: intl.formatMessage({
         defaultMessage:
           "No. Hyperlocalise works with your existing repositories, translation memory and TMS, so you can adopt it incrementally instead of starting from scratch.",
-        id: "kQ7pC3zL5G",
+        id: "k+dQ8UYqvJ",
         description: "Homepage FAQ answer about migrating existing translations",
       }),
     },
   ];
 }
 
-export function buildHomepageFaqJsonLd(
-  items: readonly HomepageFaqItem[],
-): WithContext<FAQPage> {
+export function buildHomepageFaqJsonLd(items: readonly HomepageFaqItem[]): WithContext<FAQPage> {
   return {
     "@context": "https://schema.org",
     "@type": "FAQPage",

--- a/apps/hyperlocalise-web/src/components/marketing/homepage-faq-content.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/homepage-faq-content.ts
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { FAQPage, WithContext } from "schema-dts";
+
+import { getIntlShape } from "@/lib/app-i18n/intl";
+
+export type HomepageFaqItem = {
+  question: string;
+  answer: string;
+};
+
+export function getHomepageFaqItems(locale: string): HomepageFaqItem[] {
+  const intl = getIntlShape(locale);
+
+  return [
+    {
+      question: intl.formatMessage({
+        defaultMessage: "Do I need to replace my TMS?",
+        id: "NEp4sVqR2K",
+        description: "Homepage FAQ question about replacing an existing TMS",
+      }),
+      answer: intl.formatMessage({
+        defaultMessage:
+          "No. Hyperlocalise works alongside your existing TMS. Keep using Phrase, Lokalise, Crowdin or Smartling while Hyperlocalise orchestrates AI agents, review workflows, context discovery and quality checks.",
+        id: "dFA6uX1JmP",
+        description: "Homepage FAQ answer about working with an existing TMS",
+      }),
+    },
+    {
+      question: intl.formatMessage({
+        defaultMessage: "How is Hyperlocalise different from AI translation?",
+        id: "Vh3zQ8nL5C",
+        description: "Homepage FAQ question comparing Hyperlocalise with AI translation",
+      }),
+      answer: intl.formatMessage({
+        defaultMessage:
+          "AI translation generates text. Hyperlocalise manages the entire localisation workflow—from discovering context and assigning AI agents to coordinating human review, syncing with your TMS and preventing regressions before release.",
+        id: "mT7kB2wY9A",
+        description: "Homepage FAQ answer comparing Hyperlocalise with AI translation",
+      }),
+    },
+    {
+      question: intl.formatMessage({
+        defaultMessage: "What is Translation Intelligence?",
+        id: "Pq5cN8sD1H",
+        description: "Homepage FAQ question about Translation Intelligence",
+      }),
+      answer: intl.formatMessage({
+        defaultMessage:
+          "Translation Intelligence is Hyperlocalise’s approach to giving AI and reviewers the context they need to make better localisation decisions. Instead of translating isolated strings, Hyperlocalise automatically surfaces repository context, terminology, previous decisions and product knowledge.",
+        id: "rL4xG7vK2E",
+        description: "Homepage FAQ answer defining Translation Intelligence",
+      }),
+    },
+    {
+      question: intl.formatMessage({
+        defaultMessage: "Can I use my preferred AI models?",
+        id: "Jw8bM3fT6Q",
+        description: "Homepage FAQ question about supported AI models",
+      }),
+      answer: intl.formatMessage({
+        defaultMessage:
+          "Yes. Hyperlocalise is LLM-agnostic. Use OpenAI, Anthropic, Gemini or your preferred provider, and switch models without changing your workflow.",
+        id: "cY2pH9nR5V",
+        description: "Homepage FAQ answer about supported AI models",
+      }),
+    },
+    {
+      question: intl.formatMessage({
+        defaultMessage: "Does Hyperlocalise work with GitHub?",
+        id: "Af6kS1dX8M",
+        description: "Homepage FAQ question about GitHub integration",
+      }),
+      answer: intl.formatMessage({
+        defaultMessage:
+          "Yes. Repository changes, pull requests and release workflows can automatically become localisation tasks. Hyperlocalise also adds localisation checks to your CI/CD pipeline before code reaches production.",
+        id: "uQ3eL7zB4N",
+        description: "Homepage FAQ answer about GitHub integration",
+      }),
+    },
+    {
+      question: intl.formatMessage({
+        defaultMessage: "How does Hyperlocalise find context automatically?",
+        id: "Kx9rC2mW5F",
+        description: "Homepage FAQ question about automatic context discovery",
+      }),
+      answer: intl.formatMessage({
+        defaultMessage:
+          "Our AI agents search your repository, documentation, translation memory and terminology to attach relevant context before translation begins. Translators and reviewers spend less time asking questions and more time shipping.",
+        id: "gD4vP8sJ1T",
+        description: "Homepage FAQ answer about automatic context discovery",
+      }),
+    },
+    {
+      question: intl.formatMessage({
+        defaultMessage: "Can translators chat with AI inside Hyperlocalise?",
+        id: "Rb7nY3hL6C",
+        description: "Homepage FAQ question about chatting with AI",
+      }),
+      answer: intl.formatMessage({
+        defaultMessage:
+          "Yes. Simply ask about a string, feature or translation, and Hyperlocalise searches your repository and available context before answering.",
+        id: "eM2qV9kA5X",
+        description: "Homepage FAQ answer about chatting with AI",
+      }),
+    },
+    {
+      question: intl.formatMessage({
+        defaultMessage: "How do you ensure AI translation quality?",
+        id: "Tz5fB1wN8Q",
+        description: "Homepage FAQ question about AI translation quality",
+      }),
+      answer: intl.formatMessage({
+        defaultMessage:
+          "Hyperlocalise combines AI with human review, regression evaluations, terminology checks and release gates so localisation quality doesn’t silently drift over time.",
+        id: "pH7cK3rD6J",
+        description: "Homepage FAQ answer about AI translation quality",
+      }),
+    },
+    {
+      question: intl.formatMessage({
+        defaultMessage: "Who is Hyperlocalise built for?",
+        id: "Wm4sL8xG2V",
+        description: "Homepage FAQ question about the target audience",
+      }),
+      answer: intl.formatMessage({
+        defaultMessage:
+          "Software companies and localisation teams that want to launch globally faster without replacing their existing tools or sacrificing translation quality.",
+        id: "nC9qF5bY1R",
+        description: "Homepage FAQ answer about the target audience",
+      }),
+    },
+    {
+      question: intl.formatMessage({
+        defaultMessage: "How quickly can we get started?",
+        id: "Dk6vP2tM9A",
+        description: "Homepage FAQ question about getting started",
+      }),
+      answer: intl.formatMessage({
+        defaultMessage:
+          "Most teams can connect their repositories, AI providers and existing TMS without changing how they currently manage localisation.",
+        id: "sJ3hX7wQ4E",
+        description: "Homepage FAQ answer about getting started",
+      }),
+    },
+    {
+      question: intl.formatMessage({
+        defaultMessage: "Why do companies launch in quarters instead of days?",
+        id: "Yq8nB4fK1L",
+        description: "Homepage FAQ question about slow global launches",
+      }),
+      answer: intl.formatMessage({
+        defaultMessage:
+          "Because localisation isn’t slowed by translation anymore. Teams lose time gathering context, coordinating reviewers, switching between tools and fixing issues after release. Hyperlocalise automates these workflows so teams can move continuously.",
+        id: "aV5rM9cT2P",
+        description: "Homepage FAQ answer about slow global launches",
+      }),
+    },
+    {
+      question: intl.formatMessage({
+        defaultMessage: "Do I need to migrate my existing translations?",
+        id: "Fh2xR6dW8N",
+        description: "Homepage FAQ question about migrating existing translations",
+      }),
+      answer: intl.formatMessage({
+        defaultMessage:
+          "No. Hyperlocalise works with your existing repositories, translation memory and TMS, so you can adopt it incrementally instead of starting from scratch.",
+        id: "kQ7pC3zL5G",
+        description: "Homepage FAQ answer about migrating existing translations",
+      }),
+    },
+  ];
+}
+
+export function buildHomepageFaqJsonLd(
+  items: readonly HomepageFaqItem[],
+): WithContext<FAQPage> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: items.map((item) => ({
+      "@type": "Question",
+      name: item.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.answer,
+      },
+    })),
+  };
+}

--- a/apps/hyperlocalise-web/src/components/marketing/homepage-faq-section.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/homepage-faq-section.messages.ts
@@ -1,0 +1,34 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const homepageFaqSectionMessages = defineMessages({
+  eyebrow: {
+    defaultMessage: "FAQ",
+    id: "Zr4mH8qC2V",
+    description: "Eyebrow label for the marketing homepage FAQ section",
+  },
+  heading: {
+    defaultMessage: "Questions, answered.",
+    id: "bN7xK3pT5D",
+    description: "Heading for the marketing homepage FAQ section",
+  },
+  description: {
+    defaultMessage:
+      "How Hyperlocalise fits your stack, connects your context and keeps localisation quality on track.",
+    id: "jL2wF9sQ6A",
+    description: "Description for the marketing homepage FAQ section",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/marketing/homepage-faq-section.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/homepage-faq-section.messages.ts
@@ -17,18 +17,18 @@ import { defineMessages } from "react-intl";
 export const homepageFaqSectionMessages = defineMessages({
   eyebrow: {
     defaultMessage: "FAQ",
-    id: "Zr4mH8qC2V",
+    id: "rWBGfmxnmS",
     description: "Eyebrow label for the marketing homepage FAQ section",
   },
   heading: {
     defaultMessage: "Questions, answered.",
-    id: "bN7xK3pT5D",
+    id: "gOqcpFET9Z",
     description: "Heading for the marketing homepage FAQ section",
   },
   description: {
     defaultMessage:
       "How Hyperlocalise fits your stack, connects your context and keeps localisation quality on track.",
-    id: "jL2wF9sQ6A",
+    id: "YzbXflQN6b",
     description: "Description for the marketing homepage FAQ section",
   },
 });

--- a/apps/hyperlocalise-web/src/components/marketing/homepage-faq-section.test.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/homepage-faq-section.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IntlProvider } from "react-intl";
+import { describe, expect, it } from "vite-plus/test";
+
+import { HomepageFaqSection } from "./homepage-faq-section";
+
+const items = [
+  {
+    question: "Do I need to replace my TMS?",
+    answer: "No. Hyperlocalise works alongside your existing TMS.",
+  },
+  {
+    question: "Can I use my preferred AI models?",
+    answer: "Yes. Hyperlocalise is LLM-agnostic.",
+  },
+] as const;
+
+describe("HomepageFaqSection", () => {
+  it("starts collapsed and reveals an answer when its question is selected", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <IntlProvider locale="en" messages={{}}>
+        <HomepageFaqSection items={items} />
+      </IntlProvider>,
+    );
+
+    const firstQuestion = screen.getByRole("button", { name: items[0].question });
+    const secondQuestion = screen.getByRole("button", { name: items[1].question });
+
+    expect(firstQuestion).toHaveAttribute("aria-expanded", "false");
+    expect(secondQuestion).toHaveAttribute("aria-expanded", "false");
+
+    await user.click(firstQuestion);
+
+    expect(firstQuestion).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText(items[0].answer)).toBeVisible();
+  });
+});

--- a/apps/hyperlocalise-web/src/components/marketing/homepage-faq-section.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/homepage-faq-section.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { FormattedMessage } from "react-intl";
+
+import type { HomepageFaqItem } from "@/components/marketing/homepage-faq-content";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { TypographyH2, TypographyP } from "@/components/ui/typography";
+
+import { homepageFaqSectionMessages } from "./homepage-faq-section.messages";
+
+type HomepageFaqSectionProps = {
+  items: readonly HomepageFaqItem[];
+};
+
+export function HomepageFaqSection({ items }: HomepageFaqSectionProps) {
+  return (
+    <section
+      id="faq"
+      aria-labelledby="homepage-faq-heading"
+      className="grid gap-12 lg:grid-cols-[minmax(0,0.72fr)_minmax(0,1.28fr)] lg:gap-20"
+    >
+      <div className="max-w-xl lg:pt-5">
+        <TypographyP className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+          <FormattedMessage {...homepageFaqSectionMessages.eyebrow} />
+        </TypographyP>
+        <TypographyH2
+          id="homepage-faq-heading"
+          className="pt-3 pb-0 text-balance text-4xl font-semibold tracking-[-0.04em] normal-case text-foreground sm:text-5xl"
+        >
+          <FormattedMessage {...homepageFaqSectionMessages.heading} />
+        </TypographyH2>
+        <TypographyP className="mt-5 max-w-md text-pretty text-sm leading-6 text-muted-foreground sm:text-[0.95rem]">
+          <FormattedMessage {...homepageFaqSectionMessages.description} />
+        </TypographyP>
+      </div>
+
+      <Accordion className="rounded-none border-x-0 bg-transparent">
+        {items.map((item, index) => (
+          <AccordionItem
+            key={item.question}
+            value={`faq-${index + 1}`}
+            className="data-open:bg-transparent"
+          >
+            <AccordionTrigger className="px-0 py-6 text-base leading-6 font-medium hover:no-underline sm:py-7 sm:text-lg">
+              {item.question}
+            </AccordionTrigger>
+            <AccordionContent className="max-w-2xl px-0 pb-6 text-pretty text-sm leading-6 text-muted-foreground sm:pb-7 sm:text-[0.95rem]">
+              <p>{item.answer}</p>
+            </AccordionContent>
+          </AccordionItem>
+        ))}
+      </Accordion>
+    </section>
+  );
+}

--- a/docs/adr/2026-07-24-homepage-faq-seo-design.md
+++ b/docs/adr/2026-07-24-homepage-faq-seo-design.md
@@ -1,0 +1,26 @@
+# Homepage FAQ and structured data
+
+## Goal
+
+Answer common product-evaluation questions on the homepage and expose the same answers as Schema.org `FAQPage` structured data.
+
+## Design
+
+Add a restrained FAQ section between the feature overview and final call to action. The section uses the existing accessible accordion primitive, starts with every item collapsed, and follows the homepage's established typography, borders, spacing, light theme, and dark theme.
+
+Keep the twelve approved question-and-answer pairs in one typed message collection. The client-rendered accordion formats those messages for the active locale. The homepage Server Component formats the same descriptors to build localized `Question` and `Answer` entities for JSON-LD. This keeps visible content and structured data aligned without duplicating English copy.
+
+## Accessibility and SEO
+
+- Use the existing Base UI accordion for keyboard and focus behavior.
+- Associate the section heading with the section through `aria-labelledby`.
+- Render every answer in the server response even when visually collapsed.
+- Emit one `FAQPage` JSON-LD script beside the existing `WebApplication` script.
+- Escape structured data through the shared `JsonLd` component.
+
+## Verification
+
+- Run `vp check --fix` and `vp test`.
+- Open the localized homepage in a browser at desktop and mobile widths.
+- Confirm all questions start collapsed, expand from keyboard and pointer input, and remain readable in light and dark themes.
+- Inspect the rendered JSON-LD and verify all visible questions and answers match the `FAQPage` entities.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

- Add a collapsed, accessible FAQ section to the marketing homepage.
- Localize the approved question-and-answer content.
- Generate matching Schema.org `FAQPage` JSON-LD from the visible content.
- Cover accordion behavior and structured-data mapping with tests.
- Apply formatter fixes for the FAQ content files that failed CI.

## How to test

- `vp check --fix`
- `vp test`
- Open `/en/`, scroll to the FAQ, and expand questions with pointer and keyboard input.
- Inspect the page's `application/ld+json` scripts for the `FAQPage` entry.

## Checklist

- [x] I ran relevant checks locally (`vp check`, targeted FAQ tests)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f93bb-c5ab-7313-a12f-10d85a430aa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f93bb-c5ab-7313-a12f-10d85a430aa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

