### PR TITLE
feat(web): add localisation health audit

### DIFF
--- a/apps/hyperlocalise-web/drizzle/0069_organic_krista_starr.sql
+++ b/apps/hyperlocalise-web/drizzle/0069_organic_krista_starr.sql
@@ -1,0 +1,127 @@
+CREATE TYPE "public"."localisation_audit_category" AS ENUM('technical', 'linguistic', 'market');--> statement-breakpoint
+CREATE TYPE "public"."localisation_audit_event_type" AS ENUM('submitted', 'prepared', 'confirmed', 'completed', 'viewed', 'unlocked', 'shared', 'booked', 'workspace_converted', 'email_delivery_failed');--> statement-breakpoint
+CREATE TYPE "public"."localisation_audit_evidence_kind" AS ENUM('observed', 'judgement');--> statement-breakpoint
+CREATE TYPE "public"."localisation_audit_indexing_state" AS ENUM('noindex', 'eligible', 'indexed', 'removed');--> statement-breakpoint
+CREATE TYPE "public"."localisation_audit_page_status" AS ENUM('extracted', 'blocked', 'failed');--> statement-breakpoint
+CREATE TYPE "public"."localisation_audit_report_visibility" AS ENUM('private', 'public');--> statement-breakpoint
+CREATE TYPE "public"."localisation_audit_severity" AS ENUM('info', 'low', 'medium', 'high', 'critical');--> statement-breakpoint
+CREATE TYPE "public"."localisation_audit_status" AS ENUM('preparing', 'awaiting_confirmation', 'running', 'completed', 'partial', 'failed');--> statement-breakpoint
+CREATE TABLE "localisation_audit_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"audit_id" uuid NOT NULL,
+	"lead_id" uuid,
+	"event_type" "localisation_audit_event_type" NOT NULL,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"occurred_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "localisation_audit_findings" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"audit_id" uuid NOT NULL,
+	"page_id" uuid,
+	"rule_code" text NOT NULL,
+	"category" "localisation_audit_category" NOT NULL,
+	"severity" "localisation_audit_severity" NOT NULL,
+	"confidence" double precision NOT NULL,
+	"evidence_kind" "localisation_audit_evidence_kind" NOT NULL,
+	"title" text NOT NULL,
+	"evidence" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"impact" text NOT NULL,
+	"recommendation" text NOT NULL,
+	"available_points" integer NOT NULL,
+	"earned_points" integer NOT NULL,
+	"public_preview_eligible" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "localisation_audit_findings_confidence_check" CHECK ("localisation_audit_findings"."confidence" >= 0 and "localisation_audit_findings"."confidence" <= 1),
+	CONSTRAINT "localisation_audit_findings_points_check" CHECK ("localisation_audit_findings"."available_points" >= 0 and "localisation_audit_findings"."earned_points" >= 0 and "localisation_audit_findings"."earned_points" <= "localisation_audit_findings"."available_points")
+);
+--> statement-breakpoint
+CREATE TABLE "localisation_audit_leads" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"audit_id" uuid NOT NULL,
+	"email" text NOT NULL,
+	"name" text,
+	"email_delivery_status" text DEFAULT 'pending' NOT NULL,
+	"unlocked_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "localisation_audit_leads_delivery_status_check" CHECK ("localisation_audit_leads"."email_delivery_status" in ('pending', 'sent', 'skipped', 'failed'))
+);
+--> statement-breakpoint
+CREATE TABLE "localisation_audit_pages" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"audit_id" uuid NOT NULL,
+	"normalized_url" text NOT NULL,
+	"locale" text,
+	"is_primary" boolean DEFAULT false NOT NULL,
+	"status" "localisation_audit_page_status" NOT NULL,
+	"http_status" integer,
+	"content_fingerprint" text,
+	"extraction" jsonb,
+	"failure_code" text,
+	"fetched_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "localisation_audit_pages_http_status_check" CHECK ("localisation_audit_pages"."http_status" is null or ("localisation_audit_pages"."http_status" >= 100 and "localisation_audit_pages"."http_status" <= 599))
+);
+--> statement-breakpoint
+CREATE TABLE "localisation_audit_reports" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"audit_id" uuid NOT NULL,
+	"public_slug" text NOT NULL,
+	"visibility" "localisation_audit_report_visibility" DEFAULT 'public' NOT NULL,
+	"indexing_state" "localisation_audit_indexing_state" DEFAULT 'noindex' NOT NULL,
+	"score_version" text NOT NULL,
+	"report_version" text NOT NULL,
+	"public_report" jsonb NOT NULL,
+	"private_report" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "localisation_audit_reports_public_slug_check" CHECK (char_length("localisation_audit_reports"."public_slug") >= 16 and char_length("localisation_audit_reports"."public_slug") <= 64)
+);
+--> statement-breakpoint
+CREATE TABLE "localisation_audits" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"status" "localisation_audit_status" DEFAULT 'preparing' NOT NULL,
+	"submitted_url" text NOT NULL,
+	"normalized_url" text NOT NULL,
+	"domain" text NOT NULL,
+	"domain_hash" text NOT NULL,
+	"ip_hash" text NOT NULL,
+	"detected_locale" text,
+	"target_locale" text,
+	"target_market" text,
+	"alternatives" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"score_version" text NOT NULL,
+	"report_version" text NOT NULL,
+	"failure_code" text,
+	"confirmed_at" timestamp with time zone,
+	"completed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "localisation_audits_domain_hash_check" CHECK (char_length("localisation_audits"."domain_hash") = 64),
+	CONSTRAINT "localisation_audits_ip_hash_check" CHECK (char_length("localisation_audits"."ip_hash") = 64),
+	CONSTRAINT "localisation_audits_score_version_check" CHECK (char_length("localisation_audits"."score_version") > 0),
+	CONSTRAINT "localisation_audits_report_version_check" CHECK (char_length("localisation_audits"."report_version") > 0)
+);
+--> statement-breakpoint
+ALTER TABLE "localisation_audit_events" ADD CONSTRAINT "localisation_audit_events_audit_id_localisation_audits_id_fk" FOREIGN KEY ("audit_id") REFERENCES "public"."localisation_audits"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "localisation_audit_events" ADD CONSTRAINT "localisation_audit_events_lead_id_localisation_audit_leads_id_fk" FOREIGN KEY ("lead_id") REFERENCES "public"."localisation_audit_leads"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "localisation_audit_findings" ADD CONSTRAINT "localisation_audit_findings_audit_id_localisation_audits_id_fk" FOREIGN KEY ("audit_id") REFERENCES "public"."localisation_audits"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "localisation_audit_findings" ADD CONSTRAINT "localisation_audit_findings_page_id_localisation_audit_pages_id_fk" FOREIGN KEY ("page_id") REFERENCES "public"."localisation_audit_pages"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "localisation_audit_leads" ADD CONSTRAINT "localisation_audit_leads_audit_id_localisation_audits_id_fk" FOREIGN KEY ("audit_id") REFERENCES "public"."localisation_audits"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "localisation_audit_pages" ADD CONSTRAINT "localisation_audit_pages_audit_id_localisation_audits_id_fk" FOREIGN KEY ("audit_id") REFERENCES "public"."localisation_audits"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "localisation_audit_reports" ADD CONSTRAINT "localisation_audit_reports_audit_id_localisation_audits_id_fk" FOREIGN KEY ("audit_id") REFERENCES "public"."localisation_audits"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_localisation_audit_events_audit_time" ON "localisation_audit_events" USING btree ("audit_id","occurred_at");--> statement-breakpoint
+CREATE INDEX "idx_localisation_audit_events_type_time" ON "localisation_audit_events" USING btree ("event_type","occurred_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_localisation_audit_findings_rule_page" ON "localisation_audit_findings" USING btree ("audit_id","rule_code","page_id");--> statement-breakpoint
+CREATE INDEX "idx_localisation_audit_findings_audit_category" ON "localisation_audit_findings" USING btree ("audit_id","category");--> statement-breakpoint
+CREATE INDEX "idx_localisation_audit_leads_audit" ON "localisation_audit_leads" USING btree ("audit_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_localisation_audit_pages_audit_url" ON "localisation_audit_pages" USING btree ("audit_id","normalized_url");--> statement-breakpoint
+CREATE INDEX "idx_localisation_audit_pages_audit" ON "localisation_audit_pages" USING btree ("audit_id");--> statement-breakpoint
+CREATE INDEX "idx_localisation_audit_pages_fingerprint" ON "localisation_audit_pages" USING btree ("content_fingerprint");--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_localisation_audit_reports_audit" ON "localisation_audit_reports" USING btree ("audit_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_localisation_audit_reports_public_slug" ON "localisation_audit_reports" USING btree ("public_slug");--> statement-breakpoint
+CREATE INDEX "idx_localisation_audit_reports_visibility" ON "localisation_audit_reports" USING btree ("visibility","indexing_state");--> statement-breakpoint
+CREATE INDEX "idx_localisation_audits_ip_budget" ON "localisation_audits" USING btree ("ip_hash","created_at");--> statement-breakpoint
+CREATE INDEX "idx_localisation_audits_domain_budget" ON "localisation_audits" USING btree ("domain_hash","created_at");--> statement-breakpoint
+CREATE INDEX "idx_localisation_audits_status_created" ON "localisation_audits" USING btree ("status","created_at");

--- a/apps/hyperlocalise-web/drizzle/meta/0069_snapshot.json
+++ b/apps/hyperlocalise-web/drizzle/meta/0069_snapshot.json
@@ -1,0 +1,17580 @@
+{
+  "id": "650b015a-13ae-4ed9-b706-06de4157e2e2",
+  "prevId": "83dd22d3-f7ab-4b46-9e45-f7e80be3a1e8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.organization_memberships": {
+      "name": "organization_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workos_membership_id": {
+          "name": "workos_membership_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "organization_membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_memberships_org_user_key": {
+          "name": "organization_memberships_org_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_memberships_workos_membership_id_key": {
+          "name": "organization_memberships_workos_membership_id_key",
+          "columns": [
+            {
+              "expression": "workos_membership_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_memberships_user_id": {
+          "name": "idx_organization_memberships_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_memberships_organization_id_organizations_id_fk": {
+          "name": "organization_memberships_organization_id_organizations_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_user_id_users_id_fk": {
+          "name": "organization_memberships_user_id_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workos_organization_id": {
+          "name": "workos_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "organization_lifecycle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organizations_workos_organization_id_key": {
+          "name": "organizations_workos_organization_id_key",
+          "columns": [
+            {
+              "expression": "workos_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organizations_slug_key": {
+          "name": "organizations_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organizations_created_at": {
+          "name": "idx_organizations_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_memberships": {
+      "name": "team_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "team_membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_memberships_team_user_key": {
+          "name": "team_memberships_team_user_key",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_team_memberships_user_id": {
+          "name": "idx_team_memberships_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_memberships_team_id_teams_id_fk": {
+          "name": "team_memberships_team_id_teams_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_memberships_user_id_users_id_fk": {
+          "name": "team_memberships_user_id_users_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teams_org_slug_key": {
+          "name": "teams_org_slug_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_teams_org_created_at": {
+          "name": "idx_teams_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_organization_id_organizations_id_fk": {
+          "name": "teams_organization_id_organizations_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workos_user_id": {
+          "name": "workos_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workos_memberships_reconciled_at": {
+          "name": "workos_memberships_reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_workos_user_id_key": {
+          "name": "users_workos_user_id_key",
+          "columns": [
+            {
+              "expression": "workos_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_key": {
+          "name": "users_email_key",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_created_at": {
+          "name": "idx_users_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crowdin_oauth_states": {
+      "name": "crowdin_oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_secret_encryption_algorithm": {
+          "name": "oauth_client_secret_encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_secret_ciphertext": {
+          "name": "oauth_client_secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_secret_iv": {
+          "name": "oauth_client_secret_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_secret_auth_tag": {
+          "name": "oauth_client_secret_auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_secret_key_version": {
+          "name": "oauth_client_secret_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crowdin_oauth_states_nonce_key": {
+          "name": "crowdin_oauth_states_nonce_key",
+          "columns": [
+            {
+              "expression": "nonce",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crowdin_oauth_states_org_user": {
+          "name": "idx_crowdin_oauth_states_org_user",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crowdin_oauth_states_expires_at": {
+          "name": "idx_crowdin_oauth_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crowdin_oauth_states_organization_id_organizations_id_fk": {
+          "name": "crowdin_oauth_states_organization_id_organizations_id_fk",
+          "tableFrom": "crowdin_oauth_states",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crowdin_oauth_states_user_id_users_id_fk": {
+          "name": "crowdin_oauth_states_user_id_users_id_fk",
+          "tableFrom": "crowdin_oauth_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crowdin_user_connections": {
+      "name": "crowdin_user_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_credential_id": {
+          "name": "provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crowdin_user_id": {
+          "name": "crowdin_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'oauth'"
+        },
+        "oauth_expires_at": {
+          "name": "oauth_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryption_algorithm": {
+          "name": "encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crowdin_user_connections_org_user_key": {
+          "name": "crowdin_user_connections_org_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crowdin_user_connections_org_crowdin_user_key": {
+          "name": "crowdin_user_connections_org_crowdin_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "crowdin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crowdin_user_connections_provider_credential": {
+          "name": "idx_crowdin_user_connections_provider_credential",
+          "columns": [
+            {
+              "expression": "provider_credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crowdin_user_connections_organization_id_organizations_id_fk": {
+          "name": "crowdin_user_connections_organization_id_organizations_id_fk",
+          "tableFrom": "crowdin_user_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crowdin_user_connections_user_id_users_id_fk": {
+          "name": "crowdin_user_connections_user_id_users_id_fk",
+          "tableFrom": "crowdin_user_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crowdin_user_connections_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "crowdin_user_connections_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "crowdin_user_connections",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crowdin_user_oauth_states": {
+      "name": "crowdin_user_oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_credential_id": {
+          "name": "provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crowdin_user_oauth_states_nonce_key": {
+          "name": "crowdin_user_oauth_states_nonce_key",
+          "columns": [
+            {
+              "expression": "nonce",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crowdin_user_oauth_states_org_user": {
+          "name": "idx_crowdin_user_oauth_states_org_user",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crowdin_user_oauth_states_expires_at": {
+          "name": "idx_crowdin_user_oauth_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crowdin_user_oauth_states_organization_id_organizations_id_fk": {
+          "name": "crowdin_user_oauth_states_organization_id_organizations_id_fk",
+          "tableFrom": "crowdin_user_oauth_states",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crowdin_user_oauth_states_user_id_users_id_fk": {
+          "name": "crowdin_user_oauth_states_user_id_users_id_fk",
+          "tableFrom": "crowdin_user_oauth_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crowdin_user_oauth_states_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "crowdin_user_oauth_states_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "crowdin_user_oauth_states",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lokalise_user_connections": {
+      "name": "lokalise_user_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_credential_id": {
+          "name": "provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lokalise_user_id": {
+          "name": "lokalise_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_expires_at": {
+          "name": "oauth_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryption_algorithm": {
+          "name": "encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lokalise_user_connections_org_user_key": {
+          "name": "lokalise_user_connections_org_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lokalise_user_connections_org_lokalise_user_key": {
+          "name": "lokalise_user_connections_org_lokalise_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lokalise_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_lokalise_user_connections_provider_credential": {
+          "name": "idx_lokalise_user_connections_provider_credential",
+          "columns": [
+            {
+              "expression": "provider_credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lokalise_user_connections_organization_id_organizations_id_fk": {
+          "name": "lokalise_user_connections_organization_id_organizations_id_fk",
+          "tableFrom": "lokalise_user_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lokalise_user_connections_user_id_users_id_fk": {
+          "name": "lokalise_user_connections_user_id_users_id_fk",
+          "tableFrom": "lokalise_user_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lokalise_user_connections_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "lokalise_user_connections_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "lokalise_user_connections",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lokalise_user_oauth_states": {
+      "name": "lokalise_user_oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_credential_id": {
+          "name": "provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lokalise_user_oauth_states_nonce_key": {
+          "name": "lokalise_user_oauth_states_nonce_key",
+          "columns": [
+            {
+              "expression": "nonce",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_lokalise_user_oauth_states_org_user": {
+          "name": "idx_lokalise_user_oauth_states_org_user",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_lokalise_user_oauth_states_expires_at": {
+          "name": "idx_lokalise_user_oauth_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lokalise_user_oauth_states_organization_id_organizations_id_fk": {
+          "name": "lokalise_user_oauth_states_organization_id_organizations_id_fk",
+          "tableFrom": "lokalise_user_oauth_states",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lokalise_user_oauth_states_user_id_users_id_fk": {
+          "name": "lokalise_user_oauth_states_user_id_users_id_fk",
+          "tableFrom": "lokalise_user_oauth_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lokalise_user_oauth_states_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "lokalise_user_oauth_states_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "lokalise_user_oauth_states",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_external_tms_provider_credentials": {
+      "name": "organization_external_tms_provider_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "external_tms_provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'api_token'"
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_organization_id": {
+          "name": "external_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_expires_at": {
+          "name": "oauth_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unvalidated'"
+        },
+        "validation_message": {
+          "name": "validation_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryption_algorithm": {
+          "name": "encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "masked_secret_suffix": {
+          "name": "masked_secret_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_external_tms_provider_credentials_org_provider_kind_key": {
+          "name": "organization_external_tms_provider_credentials_org_provider_kind_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_external_tms_provider_credentials_updated_at": {
+          "name": "idx_organization_external_tms_provider_credentials_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_external_tms_provider_credentials_provider_ext_org_key": {
+          "name": "organization_external_tms_provider_credentials_provider_ext_org_key",
+          "columns": [
+            {
+              "expression": "provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"organization_external_tms_provider_credentials\".\"external_organization_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_external_tms_provider_credentials_organization_id_organizations_id_fk": {
+          "name": "organization_external_tms_provider_credentials_organization_id_organizations_id_fk",
+          "tableFrom": "organization_external_tms_provider_credentials",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_external_tms_provider_credentials_created_by_user_id_users_id_fk": {
+          "name": "organization_external_tms_provider_credentials_created_by_user_id_users_id_fk",
+          "tableFrom": "organization_external_tms_provider_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "organization_external_tms_provider_credentials_updated_by_user_id_users_id_fk": {
+          "name": "organization_external_tms_provider_credentials_updated_by_user_id_users_id_fk",
+          "tableFrom": "organization_external_tms_provider_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_llm_provider_credentials": {
+      "name": "organization_llm_provider_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "llm_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "masked_api_key_suffix": {
+          "name": "masked_api_key_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryption_algorithm": {
+          "name": "encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_llm_provider_credentials_org_provider_key": {
+          "name": "organization_llm_provider_credentials_org_provider_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_llm_provider_credentials_updated_at": {
+          "name": "idx_organization_llm_provider_credentials_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_llm_provider_credentials_organization_id_organizations_id_fk": {
+          "name": "organization_llm_provider_credentials_organization_id_organizations_id_fk",
+          "tableFrom": "organization_llm_provider_credentials",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_llm_provider_credentials_created_by_user_id_users_id_fk": {
+          "name": "organization_llm_provider_credentials_created_by_user_id_users_id_fk",
+          "tableFrom": "organization_llm_provider_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "organization_llm_provider_credentials_updated_by_user_id_users_id_fk": {
+          "name": "organization_llm_provider_credentials_updated_by_user_id_users_id_fk",
+          "tableFrom": "organization_llm_provider_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.phrase_user_connections": {
+      "name": "phrase_user_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_credential_id": {
+          "name": "provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phrase_user_uid": {
+          "name": "phrase_user_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_expires_at": {
+          "name": "oauth_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryption_algorithm": {
+          "name": "encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "phrase_user_connections_org_user_key": {
+          "name": "phrase_user_connections_org_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phrase_user_connections_org_phrase_user_key": {
+          "name": "phrase_user_connections_org_phrase_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "phrase_user_uid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_phrase_user_connections_provider_credential": {
+          "name": "idx_phrase_user_connections_provider_credential",
+          "columns": [
+            {
+              "expression": "provider_credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phrase_user_connections_organization_id_organizations_id_fk": {
+          "name": "phrase_user_connections_organization_id_organizations_id_fk",
+          "tableFrom": "phrase_user_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phrase_user_connections_user_id_users_id_fk": {
+          "name": "phrase_user_connections_user_id_users_id_fk",
+          "tableFrom": "phrase_user_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phrase_user_connections_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "phrase_user_connections_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "phrase_user_connections",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.phrase_user_oauth_states": {
+      "name": "phrase_user_oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_credential_id": {
+          "name": "provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "phrase_user_oauth_states_nonce_key": {
+          "name": "phrase_user_oauth_states_nonce_key",
+          "columns": [
+            {
+              "expression": "nonce",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_phrase_user_oauth_states_org_user": {
+          "name": "idx_phrase_user_oauth_states_org_user",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_phrase_user_oauth_states_expires_at": {
+          "name": "idx_phrase_user_oauth_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phrase_user_oauth_states_organization_id_organizations_id_fk": {
+          "name": "phrase_user_oauth_states_organization_id_organizations_id_fk",
+          "tableFrom": "phrase_user_oauth_states",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phrase_user_oauth_states_user_id_users_id_fk": {
+          "name": "phrase_user_oauth_states_user_id_users_id_fk",
+          "tableFrom": "phrase_user_oauth_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phrase_user_oauth_states_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "phrase_user_oauth_states_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "phrase_user_oauth_states",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_sync_intents": {
+      "name": "provider_sync_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_credential_id": {
+          "name": "provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "external_tms_provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_kind": {
+          "name": "sync_kind",
+          "type": "provider_sync_run_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_ids": {
+          "name": "resource_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "cause": {
+          "name": "cause",
+          "type": "provider_sync_intent_cause",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_references": {
+          "name": "event_references",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "provider_sync_intent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "lease_key": {
+          "name": "lease_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leased_until": {
+          "name": "leased_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leased_by": {
+          "name": "leased_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_sync_run_id": {
+          "name": "provider_sync_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_provider_sync_intents_org_created": {
+          "name": "idx_provider_sync_intents_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_sync_intents_status_next_attempt": {
+          "name": "idx_provider_sync_intents_status_next_attempt",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_sync_intents_lease_key": {
+          "name": "idx_provider_sync_intents_lease_key",
+          "columns": [
+            {
+              "expression": "lease_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_sync_intents_lease_key_active_key": {
+          "name": "provider_sync_intents_lease_key_active_key",
+          "columns": [
+            {
+              "expression": "lease_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"provider_sync_intents\".\"status\" in ('pending', 'running', 'retryable')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_sync_intents_organization_id_organizations_id_fk": {
+          "name": "provider_sync_intents_organization_id_organizations_id_fk",
+          "tableFrom": "provider_sync_intents",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provider_sync_intents_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "provider_sync_intents_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "provider_sync_intents",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "provider_sync_intents_project_id_projects_id_fk": {
+          "name": "provider_sync_intents_project_id_projects_id_fk",
+          "tableFrom": "provider_sync_intents",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "provider_sync_intents_provider_sync_run_id_provider_sync_runs_id_fk": {
+          "name": "provider_sync_intents_provider_sync_run_id_provider_sync_runs_id_fk",
+          "tableFrom": "provider_sync_intents",
+          "tableTo": "provider_sync_runs",
+          "columnsFrom": [
+            "provider_sync_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_sync_runs": {
+      "name": "provider_sync_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_credential_id": {
+          "name": "provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "external_tms_provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "provider_sync_run_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "provider_sync_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_project_id": {
+          "name": "external_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_resource_id": {
+          "name": "external_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "counts": {
+          "name": "counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_sync_runs_org_started": {
+          "name": "idx_provider_sync_runs_org_started",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_sync_runs_org_provider_started": {
+          "name": "idx_provider_sync_runs_org_provider_started",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_sync_runs_org_kind_started": {
+          "name": "idx_provider_sync_runs_org_kind_started",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_sync_runs_org_project_started": {
+          "name": "idx_provider_sync_runs_org_project_started",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_sync_runs_org_resource_started": {
+          "name": "idx_provider_sync_runs_org_resource_started",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_sync_runs_status": {
+          "name": "idx_provider_sync_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_sync_runs_organization_id_organizations_id_fk": {
+          "name": "provider_sync_runs_organization_id_organizations_id_fk",
+          "tableFrom": "provider_sync_runs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provider_sync_runs_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "provider_sync_runs_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "provider_sync_runs",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "provider_sync_runs_project_id_projects_id_fk": {
+          "name": "provider_sync_runs_project_id_projects_id_fk",
+          "tableFrom": "provider_sync_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_webhook_events": {
+      "name": "provider_webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "external_tms_provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_resource_id": {
+          "name": "external_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redacted_payload": {
+          "name": "redacted_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "processing_status": {
+          "name": "processing_status",
+          "type": "provider_webhook_event_processing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_sync_intent_id": {
+          "name": "provider_sync_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_sync_run_id": {
+          "name": "provider_sync_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_webhook_events_subscription_provider_event_key": {
+          "name": "provider_webhook_events_subscription_provider_event_key",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_webhook_events_subscription_dedupe_key": {
+          "name": "provider_webhook_events_subscription_dedupe_key",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_webhook_events_org_received": {
+          "name": "idx_provider_webhook_events_org_received",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_webhook_events_subscription_received": {
+          "name": "idx_provider_webhook_events_subscription_received",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_webhook_events_pending_retry": {
+          "name": "idx_provider_webhook_events_pending_retry",
+          "columns": [
+            {
+              "expression": "processing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_webhook_events_sync_run": {
+          "name": "idx_provider_webhook_events_sync_run",
+          "columns": [
+            {
+              "expression": "provider_sync_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_webhook_events_organization_id_organizations_id_fk": {
+          "name": "provider_webhook_events_organization_id_organizations_id_fk",
+          "tableFrom": "provider_webhook_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provider_webhook_events_subscription_id_provider_webhook_subscriptions_id_fk": {
+          "name": "provider_webhook_events_subscription_id_provider_webhook_subscriptions_id_fk",
+          "tableFrom": "provider_webhook_events",
+          "tableTo": "provider_webhook_subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provider_webhook_events_project_id_projects_id_fk": {
+          "name": "provider_webhook_events_project_id_projects_id_fk",
+          "tableFrom": "provider_webhook_events",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "provider_webhook_events_provider_sync_run_id_provider_sync_runs_id_fk": {
+          "name": "provider_webhook_events_provider_sync_run_id_provider_sync_runs_id_fk",
+          "tableFrom": "provider_webhook_events",
+          "tableTo": "provider_sync_runs",
+          "columnsFrom": [
+            "provider_sync_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_webhook_subscriptions": {
+      "name": "provider_webhook_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_credential_id": {
+          "name": "provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "external_tms_provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_webhook_id": {
+          "name": "provider_webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint_url": {
+          "name": "endpoint_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_metadata": {
+          "name": "secret_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "webhook_secret_ciphertext": {
+          "name": "webhook_secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret_iv": {
+          "name": "webhook_secret_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret_auth_tag": {
+          "name": "webhook_secret_auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret_key_version": {
+          "name": "webhook_secret_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribed_events": {
+          "name": "subscribed_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "provider_webhook_subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "manual_fallback": {
+          "name": "manual_fallback",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_audited_at": {
+          "name": "last_audited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_webhook_subscriptions_credential_webhook_key": {
+          "name": "provider_webhook_subscriptions_credential_webhook_key",
+          "columns": [
+            {
+              "expression": "provider_credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_webhook_subscriptions_org": {
+          "name": "idx_provider_webhook_subscriptions_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_webhook_subscriptions_credential": {
+          "name": "idx_provider_webhook_subscriptions_credential",
+          "columns": [
+            {
+              "expression": "provider_credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_webhook_subscriptions_credential_project": {
+          "name": "idx_provider_webhook_subscriptions_credential_project",
+          "columns": [
+            {
+              "expression": "provider_credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_webhook_subscriptions_credential_project_key": {
+          "name": "provider_webhook_subscriptions_credential_project_key",
+          "columns": [
+            {
+              "expression": "provider_credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_webhook_subscriptions_org_status": {
+          "name": "idx_provider_webhook_subscriptions_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_webhook_subscriptions_organization_id_organizations_id_fk": {
+          "name": "provider_webhook_subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "provider_webhook_subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provider_webhook_subscriptions_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "provider_webhook_subscriptions_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "provider_webhook_subscriptions",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provider_webhook_subscriptions_project_id_projects_id_fk": {
+          "name": "provider_webhook_subscriptions_project_id_projects_id_fk",
+          "tableFrom": "provider_webhook_subscriptions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tms_agent_automation_settings": {
+      "name": "tms_agent_automation_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "tms_agent_automation_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_credential_id": {
+          "name": "provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tms_agent_automation_settings_org": {
+          "name": "idx_tms_agent_automation_settings_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tms_agent_automation_settings_organization_id_organizations_id_fk": {
+          "name": "tms_agent_automation_settings_organization_id_organizations_id_fk",
+          "tableFrom": "tms_agent_automation_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tms_agent_automation_settings_project_id_projects_id_fk": {
+          "name": "tms_agent_automation_settings_project_id_projects_id_fk",
+          "tableFrom": "tms_agent_automation_settings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tms_agent_automation_settings_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "tms_agent_automation_settings_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "tms_agent_automation_settings",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tms_agent_automation_settings_org_scope_key": {
+          "name": "tms_agent_automation_settings_org_scope_key",
+          "nullsNotDistinct": true,
+          "columns": [
+            "organization_id",
+            "scope",
+            "project_id",
+            "provider_credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tms_agent_automation_settings_scope_shape": {
+          "name": "tms_agent_automation_settings_scope_shape",
+          "value": "(\n        (\"tms_agent_automation_settings\".\"scope\" = 'organization' AND \"tms_agent_automation_settings\".\"project_id\" IS NULL AND \"tms_agent_automation_settings\".\"provider_credential_id\" IS NULL)\n        OR (\"tms_agent_automation_settings\".\"scope\" = 'project' AND \"tms_agent_automation_settings\".\"project_id\" IS NOT NULL AND \"tms_agent_automation_settings\".\"provider_credential_id\" IS NULL)\n        OR (\"tms_agent_automation_settings\".\"scope\" = 'provider' AND \"tms_agent_automation_settings\".\"project_id\" IS NULL AND \"tms_agent_automation_settings\".\"provider_credential_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "translation_context": {
+          "name": "translation_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "project_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "external_provider_kind": {
+          "name": "external_provider_kind",
+          "type": "external_tms_provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_provider_credential_id": {
+          "name": "external_provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_project_id": {
+          "name": "external_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_locales": {
+          "name": "target_locales",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "external_project_url": {
+          "name": "external_project_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error_at": {
+          "name": "last_sync_error_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error_message": {
+          "name": "last_sync_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_id_organization_id_key": {
+          "name": "projects_id_organization_id_key",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_org_provider_external_project_key": {
+          "name": "projects_org_provider_external_project_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_org_created_at": {
+          "name": "idx_projects_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_team_id": {
+          "name": "idx_projects_team_id",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_created_by_user_id": {
+          "name": "idx_projects_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organizations_id_fk": {
+          "name": "projects_organization_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_team_id_teams_id_fk": {
+          "name": "projects_team_id_teams_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "projects_created_by_user_id_users_id_fk": {
+          "name": "projects_created_by_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "projects_updated_by_user_id_users_id_fk": {
+          "name": "projects_updated_by_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "projects_external_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "projects_external_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "external_provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossaries": {
+      "name": "glossaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_locale": {
+          "name": "target_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "asset_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source": {
+          "name": "source",
+          "type": "project_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "external_provider_kind": {
+          "name": "external_provider_kind",
+          "type": "external_tms_provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_provider_credential_id": {
+          "name": "external_provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_project_id": {
+          "name": "external_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_resource_type": {
+          "name": "external_resource_type",
+          "type": "external_tms_terminology_resource_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_glossary_id": {
+          "name": "external_glossary_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale_coverage": {
+          "name": "locale_coverage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "term_count": {
+          "name": "term_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_state": {
+          "name": "sync_state",
+          "type": "glossary_sync_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "term_capabilities": {
+          "name": "term_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error_at": {
+          "name": "last_sync_error_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error_message": {
+          "name": "last_sync_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "glossaries_id_organization_id_key": {
+          "name": "glossaries_id_organization_id_key",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "glossaries_org_provider_external_resource_key": {
+          "name": "glossaries_org_provider_external_resource_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_glossary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossaries_org_created_at": {
+          "name": "idx_glossaries_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossaries_org_locale_pair": {
+          "name": "idx_glossaries_org_locale_pair",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossaries_created_by_user_id": {
+          "name": "idx_glossaries_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossaries_sync_state": {
+          "name": "idx_glossaries_sync_state",
+          "columns": [
+            {
+              "expression": "sync_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossaries_external_provider": {
+          "name": "idx_glossaries_external_provider",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "glossaries_organization_id_organizations_id_fk": {
+          "name": "glossaries_organization_id_organizations_id_fk",
+          "tableFrom": "glossaries",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "glossaries_created_by_user_id_users_id_fk": {
+          "name": "glossaries_created_by_user_id_users_id_fk",
+          "tableFrom": "glossaries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "glossaries_external_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "glossaries_external_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "glossaries",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "external_provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary_terms": {
+      "name": "glossary_terms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "glossary_id": {
+          "name": "glossary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_term": {
+          "name": "source_term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_term": {
+          "name": "target_term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "part_of_speech": {
+          "name": "part_of_speech",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "case_sensitive": {
+          "name": "case_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forbidden": {
+          "name": "forbidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "glossary_term_provenance",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "review_status": {
+          "name": "review_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'approved'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "\n      setweight(to_tsvector('simple', coalesce(source_term, '')), 'A') ||\n      setweight(to_tsvector('simple', coalesce(target_term, '')), 'B') ||\n      setweight(to_tsvector('simple', coalesce(description, '')), 'C')\n    ",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "glossary_terms_glossary_source_term_key": {
+          "name": "glossary_terms_glossary_source_term_key",
+          "columns": [
+            {
+              "expression": "glossary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_term",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "glossary_terms_glossary_source_term_ci_key": {
+          "name": "glossary_terms_glossary_source_term_ci_key",
+          "columns": [
+            {
+              "expression": "glossary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"source_term\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"glossary_terms\".\"case_sensitive\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "glossary_terms_glossary_external_key": {
+          "name": "glossary_terms_glossary_external_key",
+          "columns": [
+            {
+              "expression": "glossary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossary_terms_glossary_created_at": {
+          "name": "idx_glossary_terms_glossary_created_at",
+          "columns": [
+            {
+              "expression": "glossary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossary_terms_external_key": {
+          "name": "idx_glossary_terms_external_key",
+          "columns": [
+            {
+              "expression": "external_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossary_terms_search_vector": {
+          "name": "idx_glossary_terms_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "glossary_terms_glossary_id_glossaries_id_fk": {
+          "name": "glossary_terms_glossary_id_glossaries_id_fk",
+          "tableFrom": "glossary_terms",
+          "tableTo": "glossaries",
+          "columnsFrom": [
+            "glossary_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memories": {
+      "name": "memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "asset_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source": {
+          "name": "source",
+          "type": "project_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "external_provider_kind": {
+          "name": "external_provider_kind",
+          "type": "external_tms_provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_provider_credential_id": {
+          "name": "external_provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_project_id": {
+          "name": "external_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_memory_id": {
+          "name": "external_memory_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale_coverage": {
+          "name": "locale_coverage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "segment_count": {
+          "name": "segment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_state": {
+          "name": "sync_state",
+          "type": "glossary_sync_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability_mode": {
+          "name": "capability_mode",
+          "type": "external_tms_memory_capability_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "segment_capabilities": {
+          "name": "segment_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error_at": {
+          "name": "last_sync_error_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error_message": {
+          "name": "last_sync_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memories_id_organization_id_key": {
+          "name": "memories_id_organization_id_key",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memories_org_provider_external_memory_key": {
+          "name": "memories_org_provider_external_memory_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memories_org_created_at": {
+          "name": "idx_memories_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memories_created_by_user_id": {
+          "name": "idx_memories_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memories_sync_state": {
+          "name": "idx_memories_sync_state",
+          "columns": [
+            {
+              "expression": "sync_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memories_external_provider": {
+          "name": "idx_memories_external_provider",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memories_organization_id_organizations_id_fk": {
+          "name": "memories_organization_id_organizations_id_fk",
+          "tableFrom": "memories",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memories_created_by_user_id_users_id_fk": {
+          "name": "memories_created_by_user_id_users_id_fk",
+          "tableFrom": "memories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "memories_external_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "memories_external_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "memories",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "external_provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_entries": {
+      "name": "memory_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_locale": {
+          "name": "target_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_source_text": {
+          "name": "normalized_source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_text": {
+          "name": "target_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_score": {
+          "name": "match_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_status": {
+          "name": "review_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'approved'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "\n      setweight(to_tsvector('simple', coalesce(source_text, '')), 'A') ||\n      setweight(to_tsvector('simple', coalesce(target_text, '')), 'B')\n    ",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memory_entries_memory_locale_source_key": {
+          "name": "memory_entries_memory_locale_source_key",
+          "columns": [
+            {
+              "expression": "memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_source_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memory_entries_memory_external_key": {
+          "name": "memory_entries_memory_external_key",
+          "columns": [
+            {
+              "expression": "memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_entries_memory_locale_pair": {
+          "name": "idx_memory_entries_memory_locale_pair",
+          "columns": [
+            {
+              "expression": "memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_entries_external_key": {
+          "name": "idx_memory_entries_external_key",
+          "columns": [
+            {
+              "expression": "external_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_entries_search_vector": {
+          "name": "idx_memory_entries_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_entries_memory_id_memories_id_fk": {
+          "name": "memory_entries_memory_id_memories_id_fk",
+          "tableFrom": "memory_entries",
+          "tableTo": "memories",
+          "columnsFrom": [
+            "memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "memory_entries_match_score_check": {
+          "name": "memory_entries_match_score_check",
+          "value": "\"memory_entries\".\"match_score\" >= 0 AND \"memory_entries\".\"match_score\" <= 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_glossaries": {
+      "name": "project_glossaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "glossary_id": {
+          "name": "glossary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_glossaries_project_glossary_key": {
+          "name": "project_glossaries_project_glossary_key",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "glossary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_glossaries_org": {
+          "name": "idx_project_glossaries_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_glossaries_project_priority": {
+          "name": "idx_project_glossaries_project_priority",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_glossaries_organization_id_organizations_id_fk": {
+          "name": "project_glossaries_organization_id_organizations_id_fk",
+          "tableFrom": "project_glossaries",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_glossaries_project_id_projects_id_fk": {
+          "name": "project_glossaries_project_id_projects_id_fk",
+          "tableFrom": "project_glossaries",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_memories": {
+      "name": "project_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_memories_project_memory_key": {
+          "name": "project_memories_project_memory_key",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_memories_org": {
+          "name": "idx_project_memories_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_memories_project_priority": {
+          "name": "idx_project_memories_project_priority",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_memories_organization_id_organizations_id_fk": {
+          "name": "project_memories_organization_id_organizations_id_fk",
+          "tableFrom": "project_memories",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_memories_project_id_projects_id_fk": {
+          "name": "project_memories_project_id_projects_id_fk",
+          "tableFrom": "project_memories",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_agent_requests": {
+      "name": "github_agent_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_kind": {
+          "name": "request_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claimed'"
+        },
+        "workflow_run_ids": {
+          "name": "workflow_run_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_agent_requests_idempotency_key": {
+          "name": "github_agent_requests_idempotency_key",
+          "columns": [
+            {
+              "expression": "request_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pull_request_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_agent_requests_installation_repo": {
+          "name": "idx_github_agent_requests_installation_repo",
+          "columns": [
+            {
+              "expression": "github_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_agent_requests_created_at": {
+          "name": "idx_github_agent_requests_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_i18n_setup_runs": {
+      "name": "github_i18n_setup_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detected_locale_count": {
+          "name": "detected_locale_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_i18n_setup_runs_org_repo": {
+          "name": "idx_github_i18n_setup_runs_org_repo",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_i18n_setup_runs_status": {
+          "name": "idx_github_i18n_setup_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_i18n_setup_runs_created_at": {
+          "name": "idx_github_i18n_setup_runs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_i18n_setup_runs_organization_id_organizations_id_fk": {
+          "name": "github_i18n_setup_runs_organization_id_organizations_id_fk",
+          "tableFrom": "github_i18n_setup_runs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_i18n_setup_runs_actor_user_id_users_id_fk": {
+          "name": "github_i18n_setup_runs_actor_user_id_users_id_fk",
+          "tableFrom": "github_i18n_setup_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installation_repositories": {
+      "name": "github_installation_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installation_repositories_github_repository_id_key": {
+          "name": "github_installation_repositories_github_repository_id_key",
+          "columns": [
+            {
+              "expression": "github_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_installation_repositories_org": {
+          "name": "idx_github_installation_repositories_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_installation_repositories_installation": {
+          "name": "idx_github_installation_repositories_installation",
+          "columns": [
+            {
+              "expression": "github_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_installation_repositories_org_enabled": {
+          "name": "idx_github_installation_repositories_org_enabled",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installation_repositories_organization_id_organizations_id_fk": {
+          "name": "github_installation_repositories_organization_id_organizations_id_fk",
+          "tableFrom": "github_installation_repositories",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installation_states": {
+      "name": "github_installation_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installation_states_nonce_key": {
+          "name": "github_installation_states_nonce_key",
+          "columns": [
+            {
+              "expression": "nonce",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_installation_states_org_user": {
+          "name": "idx_github_installation_states_org_user",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_installation_states_expires_at": {
+          "name": "idx_github_installation_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installation_states_organization_id_organizations_id_fk": {
+          "name": "github_installation_states_organization_id_organizations_id_fk",
+          "tableFrom": "github_installation_states",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_installation_states_user_id_users_id_fk": {
+          "name": "github_installation_states_user_id_users_id_fk",
+          "tableFrom": "github_installation_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_app_id": {
+          "name": "github_app_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_organization_id_key": {
+          "name": "github_installations_organization_id_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_github_installation_id_key": {
+          "name": "github_installations_github_installation_id_key",
+          "columns": [
+            {
+              "expression": "github_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_installations_created_at": {
+          "name": "idx_github_installations_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_organization_id_organizations_id_fk": {
+          "name": "github_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_automation_commit_results": {
+      "name": "github_repository_automation_commit_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_commit_sha": {
+          "name": "parent_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "github_repository_automation_commit_result_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_paths": {
+          "name": "changed_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "hl_check_report": {
+          "name": "hl_check_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_summary": {
+          "name": "agent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_fixes": {
+          "name": "suggested_fixes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_url": {
+          "name": "log_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_repository_automation_commit_results_job_commit": {
+          "name": "github_repository_automation_commit_results_job_commit",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_repository_automation_commit_results_job": {
+          "name": "idx_github_repository_automation_commit_results_job",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_automation_commit_results_job_id_github_repository_automation_jobs_id_fk": {
+          "name": "github_repository_automation_commit_results_job_id_github_repository_automation_jobs_id_fk",
+          "tableFrom": "github_repository_automation_commit_results",
+          "tableTo": "github_repository_automation_jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_automation_jobs": {
+      "name": "github_repository_automation_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_installation_repository_id": {
+          "name": "github_installation_repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_version": {
+          "name": "config_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_mode": {
+          "name": "trigger_mode",
+          "type": "github_repository_automation_job_trigger_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "github_repository_automation_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_branch": {
+          "name": "trigger_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_before": {
+          "name": "commit_before",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_after": {
+          "name": "commit_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflows": {
+          "name": "workflows",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"pushSource\":false,\"pullTranslations\":false,\"validation\":false}'::jsonb"
+        },
+        "result_summary": {
+          "name": "result_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_delivery_id": {
+          "name": "github_delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_run_at": {
+          "name": "scheduled_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_check_run_id": {
+          "name": "github_check_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_repository_automation_jobs_idempotency_key": {
+          "name": "github_repository_automation_jobs_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_repository_automation_jobs_org_created": {
+          "name": "idx_github_repository_automation_jobs_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_repository_automation_jobs_repo_created": {
+          "name": "idx_github_repository_automation_jobs_repo_created",
+          "columns": [
+            {
+              "expression": "github_installation_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_repository_automation_jobs_status": {
+          "name": "idx_github_repository_automation_jobs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_automation_jobs_organization_id_organizations_id_fk": {
+          "name": "github_repository_automation_jobs_organization_id_organizations_id_fk",
+          "tableFrom": "github_repository_automation_jobs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_repository_automation_jobs_github_installation_repository_id_github_installation_repositories_id_fk": {
+          "name": "github_repository_automation_jobs_github_installation_repository_id_github_installation_repositories_id_fk",
+          "tableFrom": "github_repository_automation_jobs",
+          "tableTo": "github_installation_repositories",
+          "columnsFrom": [
+            "github_installation_repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_automation_settings": {
+      "name": "github_repository_automation_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_installation_repository_id": {
+          "name": "github_installation_repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "config_version": {
+          "name": "config_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_repository_automation_settings_repo_key": {
+          "name": "github_repository_automation_settings_repo_key",
+          "columns": [
+            {
+              "expression": "github_installation_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_repository_automation_settings_org": {
+          "name": "idx_github_repository_automation_settings_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_repository_automation_settings_next_run": {
+          "name": "idx_github_repository_automation_settings_next_run",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_automation_settings_organization_id_organizations_id_fk": {
+          "name": "github_repository_automation_settings_organization_id_organizations_id_fk",
+          "tableFrom": "github_repository_automation_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_repository_automation_settings_github_installation_repository_id_github_installation_repositories_id_fk": {
+          "name": "github_repository_automation_settings_github_installation_repository_id_github_installation_repositories_id_fk",
+          "tableFrom": "github_repository_automation_settings",
+          "tableTo": "github_installation_repositories",
+          "columnsFrom": [
+            "github_installation_repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_installation_states": {
+      "name": "slack_installation_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_installation_states_nonce_key": {
+          "name": "slack_installation_states_nonce_key",
+          "columns": [
+            {
+              "expression": "nonce",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_installation_states_org_user": {
+          "name": "idx_slack_installation_states_org_user",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_installation_states_expires_at": {
+          "name": "idx_slack_installation_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_installation_states_organization_id_organizations_id_fk": {
+          "name": "slack_installation_states_organization_id_organizations_id_fk",
+          "tableFrom": "slack_installation_states",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_installation_states_user_id_users_id_fk": {
+          "name": "slack_installation_states_user_id_users_id_fk",
+          "tableFrom": "slack_installation_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connectors_org_kind_key": {
+          "name": "connectors_org_kind_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_org": {
+          "name": "idx_connectors_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_slack_team_id": {
+          "name": "idx_connectors_slack_team_id",
+          "columns": [
+            {
+              "expression": "(config->>'teamId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connectors\".\"kind\" = 'slack'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connectors_organization_id_organizations_id_fk": {
+          "name": "connectors_organization_id_organizations_id_fk",
+          "tableFrom": "connectors",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_clients": {
+      "name": "mcp_oauth_clients",
+      "schema": "",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"authorization_code\",\"refresh_token\"]'::jsonb"
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"code\"]'::jsonb"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mcp'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mcp_oauth_clients_created_at": {
+          "name": "idx_mcp_oauth_clients_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_sessions": {
+      "name": "mcp_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mcp'"
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workos_access_token_encrypted": {
+          "name": "workos_access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workos_refresh_token_encrypted": {
+          "name": "workos_refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_sessions_access_token_hash_key": {
+          "name": "mcp_sessions_access_token_hash_key",
+          "columns": [
+            {
+              "expression": "access_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_sessions_refresh_token_hash_key": {
+          "name": "mcp_sessions_refresh_token_hash_key",
+          "columns": [
+            {
+              "expression": "refresh_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_sessions_user_id": {
+          "name": "idx_mcp_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_sessions_organization_id": {
+          "name": "idx_mcp_sessions_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_sessions_expires_at": {
+          "name": "idx_mcp_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_sessions_user_id_users_id_fk": {
+          "name": "mcp_sessions_user_id_users_id_fk",
+          "tableFrom": "mcp_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_sessions_organization_id_organizations_id_fk": {
+          "name": "mcp_sessions_organization_id_organizations_id_fk",
+          "tableFrom": "mcp_sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_api_keys": {
+      "name": "organization_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"jobs:read\", \"jobs:write\", \"files:read\", \"files:write\"]'::jsonb"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_api_keys_key_hash_key": {
+          "name": "organization_api_keys_key_hash_key",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_api_keys_org": {
+          "name": "idx_organization_api_keys_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_api_keys_created_at": {
+          "name": "idx_organization_api_keys_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_api_keys_organization_id_organizations_id_fk": {
+          "name": "organization_api_keys_organization_id_organizations_id_fk",
+          "tableFrom": "organization_api_keys",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_api_keys_created_by_user_id_users_id_fk": {
+          "name": "organization_api_keys_created_by_user_id_users_id_fk",
+          "tableFrom": "organization_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tms_links": {
+      "name": "tms_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_project_id": {
+          "name": "external_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tms_links_org": {
+          "name": "idx_tms_links_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tms_links_org_provider": {
+          "name": "idx_tms_links_org_provider",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tms_links_organization_id_organizations_id_fk": {
+          "name": "tms_links_organization_id_organizations_id_fk",
+          "tableFrom": "tms_links",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tms_links_project_id_projects_id_fk": {
+          "name": "tms_links_project_id_projects_id_fk",
+          "tableFrom": "tms_links",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.used_authorization_codes": {
+      "name": "used_authorization_codes",
+      "schema": "",
+      "columns": {
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_used_authorization_codes_expires_at": {
+          "name": "idx_used_authorization_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contentful_connections": {
+      "name": "contentful_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'master'"
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_locales": {
+          "name": "target_locales",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "content_type_ids": {
+          "name": "content_type_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "field_config": {
+          "name": "field_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unvalidated'"
+        },
+        "validation_message": {
+          "name": "validation_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryption_algorithm": {
+          "name": "encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "masked_token_suffix": {
+          "name": "masked_token_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contentful_connections_org_space_env_key": {
+          "name": "contentful_connections_org_space_env_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_connections_org": {
+          "name": "idx_contentful_connections_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_connections_project": {
+          "name": "idx_contentful_connections_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contentful_connections_organization_id_organizations_id_fk": {
+          "name": "contentful_connections_organization_id_organizations_id_fk",
+          "tableFrom": "contentful_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contentful_connections_project_id_projects_id_fk": {
+          "name": "contentful_connections_project_id_projects_id_fk",
+          "tableFrom": "contentful_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contentful_connections_created_by_user_id_users_id_fk": {
+          "name": "contentful_connections_created_by_user_id_users_id_fk",
+          "tableFrom": "contentful_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contentful_connections_updated_by_user_id_users_id_fk": {
+          "name": "contentful_connections_updated_by_user_id_users_id_fk",
+          "tableFrom": "contentful_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contentful_translation_run_items": {
+      "name": "contentful_translation_run_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_preview": {
+          "name": "source_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "translation_preview": {
+          "name": "translation_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qa_findings": {
+          "name": "qa_findings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_contentful_translation_run_items_run": {
+          "name": "idx_contentful_translation_run_items_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_translation_run_items_status": {
+          "name": "idx_contentful_translation_run_items_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contentful_translation_run_items_run_id_contentful_translation_runs_id_fk": {
+          "name": "contentful_translation_run_items_run_id_contentful_translation_runs_id_fk",
+          "tableFrom": "contentful_translation_run_items",
+          "tableTo": "contentful_translation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contentful_translation_runs": {
+      "name": "contentful_translation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_automation_run_id": {
+          "name": "workspace_automation_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_event_id": {
+          "name": "webhook_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type_id": {
+          "name": "content_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_locales": {
+          "name": "target_locales",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "run_qa": {
+          "name": "run_qa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "write_drafts": {
+          "name": "write_drafts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "overwrite_draft_locales": {
+          "name": "overwrite_draft_locales",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "detected_fields": {
+          "name": "detected_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "qa_summary": {
+          "name": "qa_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "writeback_summary": {
+          "name": "writeback_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_contentful_translation_runs_org_created": {
+          "name": "idx_contentful_translation_runs_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_translation_runs_connection": {
+          "name": "idx_contentful_translation_runs_connection",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_translation_runs_project": {
+          "name": "idx_contentful_translation_runs_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_translation_runs_status": {
+          "name": "idx_contentful_translation_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_translation_runs_automation_run": {
+          "name": "idx_contentful_translation_runs_automation_run",
+          "columns": [
+            {
+              "expression": "workspace_automation_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_translation_runs_webhook_event_org": {
+          "name": "idx_contentful_translation_runs_webhook_event_org",
+          "columns": [
+            {
+              "expression": "webhook_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contentful_translation_runs_organization_id_organizations_id_fk": {
+          "name": "contentful_translation_runs_organization_id_organizations_id_fk",
+          "tableFrom": "contentful_translation_runs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contentful_translation_runs_connection_id_contentful_connections_id_fk": {
+          "name": "contentful_translation_runs_connection_id_contentful_connections_id_fk",
+          "tableFrom": "contentful_translation_runs",
+          "tableTo": "contentful_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contentful_translation_runs_project_id_projects_id_fk": {
+          "name": "contentful_translation_runs_project_id_projects_id_fk",
+          "tableFrom": "contentful_translation_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contentful_translation_runs_workspace_automation_run_id_workspace_automation_runs_id_fk": {
+          "name": "contentful_translation_runs_workspace_automation_run_id_workspace_automation_runs_id_fk",
+          "tableFrom": "contentful_translation_runs",
+          "tableTo": "workspace_automation_runs",
+          "columnsFrom": [
+            "workspace_automation_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contentful_translation_runs_webhook_event_id_contentful_webhook_events_id_fk": {
+          "name": "contentful_translation_runs_webhook_event_id_contentful_webhook_events_id_fk",
+          "tableFrom": "contentful_translation_runs",
+          "tableTo": "contentful_webhook_events",
+          "columnsFrom": [
+            "webhook_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contentful_webhook_events": {
+      "name": "contentful_webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type_id": {
+          "name": "content_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_status": {
+          "name": "processing_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "redacted_payload": {
+          "name": "redacted_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contentful_webhook_events_dedupe_key": {
+          "name": "contentful_webhook_events_dedupe_key",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_webhook_events_org_created": {
+          "name": "idx_contentful_webhook_events_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_webhook_events_status": {
+          "name": "idx_contentful_webhook_events_status",
+          "columns": [
+            {
+              "expression": "processing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contentful_webhook_events_organization_id_organizations_id_fk": {
+          "name": "contentful_webhook_events_organization_id_organizations_id_fk",
+          "tableFrom": "contentful_webhook_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contentful_webhook_events_connection_id_contentful_connections_id_fk": {
+          "name": "contentful_webhook_events_connection_id_contentful_connections_id_fk",
+          "tableFrom": "contentful_webhook_events",
+          "tableTo": "contentful_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contentful_webhook_events_subscription_id_contentful_webhook_subscriptions_id_fk": {
+          "name": "contentful_webhook_events_subscription_id_contentful_webhook_subscriptions_id_fk",
+          "tableFrom": "contentful_webhook_events",
+          "tableTo": "contentful_webhook_subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contentful_webhook_subscriptions": {
+      "name": "contentful_webhook_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_webhook_id": {
+          "name": "provider_webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_delivery_id": {
+          "name": "last_delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_delivered_at": {
+          "name": "last_delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contentful_webhook_subscriptions_connection_key": {
+          "name": "contentful_webhook_subscriptions_connection_key",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_webhook_subscriptions_org": {
+          "name": "idx_contentful_webhook_subscriptions_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contentful_webhook_subscriptions_provider_webhook": {
+          "name": "idx_contentful_webhook_subscriptions_provider_webhook",
+          "columns": [
+            {
+              "expression": "provider_webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contentful_webhook_subscriptions_organization_id_organizations_id_fk": {
+          "name": "contentful_webhook_subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "contentful_webhook_subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contentful_webhook_subscriptions_connection_id_contentful_connections_id_fk": {
+          "name": "contentful_webhook_subscriptions_connection_id_contentful_connections_id_fk",
+          "tableFrom": "contentful_webhook_subscriptions",
+          "tableTo": "contentful_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_server_connections": {
+      "name": "mcp_server_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'http'"
+        },
+        "auth_kind": {
+          "name": "auth_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unvalidated'"
+        },
+        "validation_message": {
+          "name": "validation_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryption_algorithm": {
+          "name": "encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "masked_token_suffix": {
+          "name": "masked_token_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_server_connections_org_url_key": {
+          "name": "mcp_server_connections_org_url_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "server_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_server_connections_org": {
+          "name": "idx_mcp_server_connections_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_server_connections_organization_id_organizations_id_fk": {
+          "name": "mcp_server_connections_organization_id_organizations_id_fk",
+          "tableFrom": "mcp_server_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_server_connections_created_by_user_id_users_id_fk": {
+          "name": "mcp_server_connections_created_by_user_id_users_id_fk",
+          "tableFrom": "mcp_server_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mcp_server_connections_updated_by_user_id_users_id_fk": {
+          "name": "mcp_server_connections_updated_by_user_id_users_id_fk",
+          "tableFrom": "mcp_server_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.semrush_connections": {
+      "name": "semrush_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unvalidated'"
+        },
+        "validation_message": {
+          "name": "validation_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryption_algorithm": {
+          "name": "encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "masked_api_key_suffix": {
+          "name": "masked_api_key_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_semrush_connections_org": {
+          "name": "idx_semrush_connections_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "semrush_connections_organization_id_organizations_id_fk": {
+          "name": "semrush_connections_organization_id_organizations_id_fk",
+          "tableFrom": "semrush_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "semrush_connections_created_by_user_id_users_id_fk": {
+          "name": "semrush_connections_created_by_user_id_users_id_fk",
+          "tableFrom": "semrush_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "semrush_connections_updated_by_user_id_users_id_fk": {
+          "name": "semrush_connections_updated_by_user_id_users_id_fk",
+          "tableFrom": "semrush_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ahrefs_connections": {
+      "name": "ahrefs_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unvalidated'"
+        },
+        "validation_message": {
+          "name": "validation_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryption_algorithm": {
+          "name": "encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "masked_api_key_suffix": {
+          "name": "masked_api_key_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ahrefs_connections_org": {
+          "name": "idx_ahrefs_connections_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ahrefs_connections_organization_id_organizations_id_fk": {
+          "name": "ahrefs_connections_organization_id_organizations_id_fk",
+          "tableFrom": "ahrefs_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ahrefs_connections_created_by_user_id_users_id_fk": {
+          "name": "ahrefs_connections_created_by_user_id_users_id_fk",
+          "tableFrom": "ahrefs_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ahrefs_connections_updated_by_user_id_users_id_fk": {
+          "name": "ahrefs_connections_updated_by_user_id_users_id_fk",
+          "tableFrom": "ahrefs_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canva_connections": {
+      "name": "canva_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "target_locales": {
+          "name": "target_locales",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"es\",\"fr\",\"de\"]'::jsonb"
+        },
+        "canva_brand_id": {
+          "name": "canva_brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_token_hash": {
+          "name": "connection_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_token_prefix": {
+          "name": "connection_token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "canva_connections_token_hash_key": {
+          "name": "canva_connections_token_hash_key",
+          "columns": [
+            {
+              "expression": "connection_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "canva_connections_org_brand_key": {
+          "name": "canva_connections_org_brand_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "canva_brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"canva_connections\".\"canva_brand_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_canva_connections_org": {
+          "name": "idx_canva_connections_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_canva_connections_api_key": {
+          "name": "idx_canva_connections_api_key",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_canva_connections_project": {
+          "name": "idx_canva_connections_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "canva_connections_organization_id_organizations_id_fk": {
+          "name": "canva_connections_organization_id_organizations_id_fk",
+          "tableFrom": "canva_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "canva_connections_api_key_id_organization_api_keys_id_fk": {
+          "name": "canva_connections_api_key_id_organization_api_keys_id_fk",
+          "tableFrom": "canva_connections",
+          "tableTo": "organization_api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "canva_connections_project_id_projects_id_fk": {
+          "name": "canva_connections_project_id_projects_id_fk",
+          "tableFrom": "canva_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "canva_connections_created_by_user_id_users_id_fk": {
+          "name": "canva_connections_created_by_user_id_users_id_fk",
+          "tableFrom": "canva_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "canva_connections_updated_by_user_id_users_id_fk": {
+          "name": "canva_connections_updated_by_user_id_users_id_fk",
+          "tableFrom": "canva_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crowdin_app_installations": {
+      "name": "crowdin_app_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "crowdin_organization_id": {
+          "name": "crowdin_organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crowdin_domain": {
+          "name": "crowdin_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crowdin_base_url": {
+          "name": "crowdin_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crowdin_user_id": {
+          "name": "crowdin_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_secret_encryption_algorithm": {
+          "name": "app_secret_encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_secret_ciphertext": {
+          "name": "app_secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_secret_iv": {
+          "name": "app_secret_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_secret_auth_tag": {
+          "name": "app_secret_auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_secret_key_version": {
+          "name": "app_secret_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crowdin_app_installations_crowdin_org_key": {
+          "name": "crowdin_app_installations_crowdin_org_key",
+          "columns": [
+            {
+              "expression": "crowdin_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crowdin_app_installations_organization": {
+          "name": "idx_crowdin_app_installations_organization",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crowdin_app_installations_organization_id_organizations_id_fk": {
+          "name": "crowdin_app_installations_organization_id_organizations_id_fk",
+          "tableFrom": "crowdin_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_management_job_details": {
+      "name": "asset_management_job_details",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asset_management_job_details_job_id_jobs_id_fk": {
+          "name": "asset_management_job_details_job_id_jobs_id_fk",
+          "tableFrom": "asset_management_job_details",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_job_details": {
+      "name": "external_job_details",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "external_tms_provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_job_id": {
+          "name": "external_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_task_id": {
+          "name": "external_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_status": {
+          "name": "external_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_locales": {
+          "name": "target_locales",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "assigned_users": {
+          "name": "assigned_users",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_state": {
+          "name": "sync_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "provider_payload": {
+          "name": "provider_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "linked_job_id": {
+          "name": "linked_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_external_job_details_provider_kind": {
+          "name": "idx_external_job_details_provider_kind",
+          "columns": [
+            {
+              "expression": "provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_job_details_external_job_id": {
+          "name": "idx_external_job_details_external_job_id",
+          "columns": [
+            {
+              "expression": "external_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_job_details_external_task_id": {
+          "name": "idx_external_job_details_external_task_id",
+          "columns": [
+            {
+              "expression": "external_task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_job_details_sync_state": {
+          "name": "idx_external_job_details_sync_state",
+          "columns": [
+            {
+              "expression": "sync_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_job_details_linked_job": {
+          "name": "idx_external_job_details_linked_job",
+          "columns": [
+            {
+              "expression": "linked_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_job_details_provider_job_unique": {
+          "name": "idx_external_job_details_provider_job_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_job_details_job_id_jobs_id_fk": {
+          "name": "external_job_details_job_id_jobs_id_fk",
+          "tableFrom": "external_job_details",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_job_details_organization_id_organizations_id_fk": {
+          "name": "external_job_details_organization_id_organizations_id_fk",
+          "tableFrom": "external_job_details",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_job_details_linked_job_id_jobs_id_fk": {
+          "name": "external_job_details_linked_job_id_jobs_id_fk",
+          "tableFrom": "external_job_details",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "linked_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "job_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "input_payload": {
+          "name": "input_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_payload": {
+          "name": "outcome_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interaction_id": {
+          "name": "interaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_snapshot": {
+          "name": "context_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_jobs_org_created_at": {
+          "name": "idx_jobs_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_project_created_at": {
+          "name": "idx_jobs_project_created_at",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_created_by_user_id": {
+          "name": "idx_jobs_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_owner_user_id": {
+          "name": "idx_jobs_owner_user_id",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_kind_status": {
+          "name": "idx_jobs_kind_status",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_workflow_run_id": {
+          "name": "idx_jobs_workflow_run_id",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_status": {
+          "name": "idx_jobs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_interaction": {
+          "name": "idx_jobs_interaction",
+          "columns": [
+            {
+              "expression": "interaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_api_key_id": {
+          "name": "idx_jobs_api_key_id",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "jobs_organization_id_organizations_id_fk": {
+          "name": "jobs_organization_id_organizations_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "jobs_project_id_projects_id_fk": {
+          "name": "jobs_project_id_projects_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "jobs_created_by_user_id_users_id_fk": {
+          "name": "jobs_created_by_user_id_users_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "jobs_owner_user_id_users_id_fk": {
+          "name": "jobs_owner_user_id_users_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "jobs_api_key_id_organization_api_keys_id_fk": {
+          "name": "jobs_api_key_id_organization_api_keys_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "organization_api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "jobs_interaction_id_interactions_id_fk": {
+          "name": "jobs_interaction_id_interactions_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "interactions",
+          "columnsFrom": [
+            "interaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_job_details": {
+      "name": "review_job_details",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "criteria": {
+          "name": "criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "target_locale": {
+          "name": "target_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "review_job_details_job_id_jobs_id_fk": {
+          "name": "review_job_details_job_id_jobs_id_fk",
+          "tableFrom": "review_job_details",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_job_details": {
+      "name": "sync_job_details",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connector_kind": {
+          "name": "connector_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_identifiers": {
+          "name": "external_identifiers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sync_job_details_job_id_jobs_id_fk": {
+          "name": "sync_job_details_job_id_jobs_id_fk",
+          "tableFrom": "sync_job_details",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_job_details": {
+      "name": "translation_job_details",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "translation_job_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_file_version_id": {
+          "name": "source_file_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome_kind": {
+          "name": "outcome_kind",
+          "type": "translation_job_outcome_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_translation_job_details_type": {
+          "name": "idx_translation_job_details_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_job_details_source_file_version": {
+          "name": "idx_translation_job_details_source_file_version",
+          "columns": [
+            {
+              "expression": "source_file_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_job_details_outcome_kind": {
+          "name": "idx_translation_job_details_outcome_kind",
+          "columns": [
+            {
+              "expression": "outcome_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translation_job_details_job_id_jobs_id_fk": {
+          "name": "translation_job_details_job_id_jobs_id_fk",
+          "tableFrom": "translation_job_details",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translation_job_details_source_file_version_id_repository_source_file_versions_id_fk": {
+          "name": "translation_job_details_source_file_version_id_repository_source_file_versions_id_fk",
+          "tableFrom": "translation_job_details",
+          "tableTo": "repository_source_file_versions",
+          "columnsFrom": [
+            "source_file_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_events": {
+      "name": "usage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "usage_feature_id",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "usage_event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "operation_key": {
+          "name": "operation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interaction_id": {
+          "name": "interaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autumn_tracked_at": {
+          "name": "autumn_tracked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autumn_track_error": {
+          "name": "autumn_track_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "usage_events_operation_key_key": {
+          "name": "usage_events_operation_key_key",
+          "columns": [
+            {
+              "expression": "operation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_events_org_created_at": {
+          "name": "idx_usage_events_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_events_feature_status": {
+          "name": "idx_usage_events_feature_status",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_events_job_id": {
+          "name": "idx_usage_events_job_id",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_events_organization_id_organizations_id_fk": {
+          "name": "usage_events_organization_id_organizations_id_fk",
+          "tableFrom": "usage_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_events_actor_user_id_users_id_fk": {
+          "name": "usage_events_actor_user_id_users_id_fk",
+          "tableFrom": "usage_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "usage_events_api_key_id_organization_api_keys_id_fk": {
+          "name": "usage_events_api_key_id_organization_api_keys_id_fk",
+          "tableFrom": "usage_events",
+          "tableTo": "organization_api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "usage_events_job_id_jobs_id_fk": {
+          "name": "usage_events_job_id_jobs_id_fk",
+          "tableFrom": "usage_events",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "usage_events_interaction_id_interactions_id_fk": {
+          "name": "usage_events_interaction_id_interactions_id_fk",
+          "tableFrom": "usage_events",
+          "tableTo": "interactions",
+          "columnsFrom": [
+            "interaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "external_tms_provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_job_id": {
+          "name": "external_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_task_id": {
+          "name": "external_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "agent_run_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_snapshot": {
+          "name": "input_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output_summary": {
+          "name": "output_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "changed_items": {
+          "name": "changed_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "hyperlocalise_job_id": {
+          "name": "hyperlocalise_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_runs_org_created": {
+          "name": "idx_agent_runs_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org_provider_job": {
+          "name": "idx_agent_runs_org_provider_job",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org_provider_task": {
+          "name": "idx_agent_runs_org_provider_task",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org_status": {
+          "name": "idx_agent_runs_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_hyperlocalise_job": {
+          "name": "idx_agent_runs_hyperlocalise_job",
+          "columns": [
+            {
+              "expression": "hyperlocalise_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org_actor": {
+          "name": "idx_agent_runs_org_actor",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_organization_id_organizations_id_fk": {
+          "name": "agent_runs_organization_id_organizations_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_runs_actor_user_id_users_id_fk": {
+          "name": "agent_runs_actor_user_id_users_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_runs_hyperlocalise_job_id_jobs_id_fk": {
+          "name": "agent_runs_hyperlocalise_job_id_jobs_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "hyperlocalise_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbox_items": {
+      "name": "inbox_items",
+      "schema": "",
+      "columns": {
+        "interaction_id": {
+          "name": "interaction_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "inbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_inbox_items_org_status": {
+          "name": "idx_inbox_items_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbox_items_org_updated": {
+          "name": "idx_inbox_items_org_updated",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbox_items_interaction_id_interactions_id_fk": {
+          "name": "inbox_items_interaction_id_interactions_id_fk",
+          "tableFrom": "inbox_items",
+          "tableTo": "interactions",
+          "columnsFrom": [
+            "interaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbox_items_organization_id_organizations_id_fk": {
+          "name": "inbox_items_organization_id_organizations_id_fk",
+          "tableFrom": "inbox_items",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interaction_messages": {
+      "name": "interaction_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "interaction_id": {
+          "name": "interaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_type": {
+          "name": "sender_type",
+          "type": "message_sender_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_email": {
+          "name": "sender_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_interaction_messages_interaction_created": {
+          "name": "idx_interaction_messages_interaction_created",
+          "columns": [
+            {
+              "expression": "interaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interaction_messages_interaction_id_interactions_id_fk": {
+          "name": "interaction_messages_interaction_id_interactions_id_fk",
+          "tableFrom": "interaction_messages",
+          "tableTo": "interactions",
+          "columnsFrom": [
+            "interaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interactions": {
+      "name": "interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "interaction_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "interactions_id_organization_id_key": {
+          "name": "interactions_id_organization_id_key",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interactions_org_source_thread_id_key": {
+          "name": "interactions_org_source_thread_id_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"interactions\".\"source_thread_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_interactions_org_last_message": {
+          "name": "idx_interactions_org_last_message",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interactions_organization_id_organizations_id_fk": {
+          "name": "interactions_organization_id_organizations_id_fk",
+          "tableFrom": "interactions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_automation_runs": {
+      "name": "workspace_automation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "workspace_automation_run_trigger_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workspace_automation_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_snapshot": {
+          "name": "input_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output_summary": {
+          "name": "output_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repository_automation_job_id": {
+          "name": "github_repository_automation_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_automation_runs_automation_created": {
+          "name": "idx_workspace_automation_runs_automation_created",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_automation_runs_org_status": {
+          "name": "idx_workspace_automation_runs_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_automation_runs_idempotency_key": {
+          "name": "idx_workspace_automation_runs_idempotency_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_automation_runs\".\"idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_automation_runs_github_job": {
+          "name": "idx_workspace_automation_runs_github_job",
+          "columns": [
+            {
+              "expression": "github_repository_automation_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_automation_runs\".\"github_repository_automation_job_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_automation_runs_automation_id_workspace_automations_id_fk": {
+          "name": "workspace_automation_runs_automation_id_workspace_automations_id_fk",
+          "tableFrom": "workspace_automation_runs",
+          "tableTo": "workspace_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_automation_runs_organization_id_organizations_id_fk": {
+          "name": "workspace_automation_runs_organization_id_organizations_id_fk",
+          "tableFrom": "workspace_automation_runs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_automation_runs_github_repository_automation_job_id_github_repository_automation_jobs_id_fk": {
+          "name": "workspace_automation_runs_github_repository_automation_job_id_github_repository_automation_jobs_id_fk",
+          "tableFrom": "workspace_automation_runs",
+          "tableTo": "github_repository_automation_jobs",
+          "columnsFrom": [
+            "github_repository_automation_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_automations": {
+      "name": "workspace_automations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workspace_automation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "github_installation_repository_id": {
+          "name": "github_installation_repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_target": {
+          "name": "repository_target",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "tool_config": {
+          "name": "tool_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "config_version": {
+          "name": "config_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_automations_org_status": {
+          "name": "idx_workspace_automations_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_automations_org_next_run": {
+          "name": "idx_workspace_automations_org_next_run",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_automations_github_repo": {
+          "name": "idx_workspace_automations_github_repo",
+          "columns": [
+            {
+              "expression": "github_installation_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_automations_organization_id_organizations_id_fk": {
+          "name": "workspace_automations_organization_id_organizations_id_fk",
+          "tableFrom": "workspace_automations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_automations_author_user_id_users_id_fk": {
+          "name": "workspace_automations_author_user_id_users_id_fk",
+          "tableFrom": "workspace_automations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_automations_github_installation_repository_id_github_installation_repositories_id_fk": {
+          "name": "workspace_automations_github_installation_repository_id_github_installation_repositories_id_fk",
+          "tableFrom": "workspace_automations",
+          "tableTo": "github_installation_repositories",
+          "columnsFrom": [
+            "github_installation_repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_tms_file_versions": {
+      "name": "external_tms_file_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_tms_file_id": {
+          "name": "external_tms_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_file_id": {
+          "name": "stored_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_external_tms_file_versions_file_captured": {
+          "name": "idx_external_tms_file_versions_file_captured",
+          "columns": [
+            {
+              "expression": "external_tms_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_tms_file_versions_org_project_path": {
+          "name": "idx_external_tms_file_versions_org_project_path",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_tms_file_versions_organization_id_organizations_id_fk": {
+          "name": "external_tms_file_versions_organization_id_organizations_id_fk",
+          "tableFrom": "external_tms_file_versions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_tms_file_versions_project_id_projects_id_fk": {
+          "name": "external_tms_file_versions_project_id_projects_id_fk",
+          "tableFrom": "external_tms_file_versions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_tms_file_versions_external_tms_file_id_external_tms_files_id_fk": {
+          "name": "external_tms_file_versions_external_tms_file_id_external_tms_files_id_fk",
+          "tableFrom": "external_tms_file_versions",
+          "tableTo": "external_tms_files",
+          "columnsFrom": [
+            "external_tms_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_tms_file_versions_stored_file_id_stored_files_id_fk": {
+          "name": "external_tms_file_versions_stored_file_id_stored_files_id_fk",
+          "tableFrom": "external_tms_file_versions",
+          "tableTo": "stored_files",
+          "columnsFrom": [
+            "stored_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_tms_files": {
+      "name": "external_tms_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_credential_id": {
+          "name": "provider_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "external_tms_provider_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_project_id": {
+          "name": "external_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "external_tms_resource_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_resource_id": {
+          "name": "external_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_locales": {
+          "name": "target_locales",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_file_id": {
+          "name": "stored_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_state": {
+          "name": "sync_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "locale_readiness": {
+          "name": "locale_readiness",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "provider_payload": {
+          "name": "provider_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_tms_files_provider_resource_key": {
+          "name": "external_tms_files_provider_resource_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_tms_files_org_project_path": {
+          "name": "idx_external_tms_files_org_project_path",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_tms_files_provider_project": {
+          "name": "idx_external_tms_files_provider_project",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_tms_files_stored_file": {
+          "name": "idx_external_tms_files_stored_file",
+          "columns": [
+            {
+              "expression": "stored_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_tms_files_sync_state": {
+          "name": "idx_external_tms_files_sync_state",
+          "columns": [
+            {
+              "expression": "sync_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_tms_files_organization_id_organizations_id_fk": {
+          "name": "external_tms_files_organization_id_organizations_id_fk",
+          "tableFrom": "external_tms_files",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_tms_files_project_id_projects_id_fk": {
+          "name": "external_tms_files_project_id_projects_id_fk",
+          "tableFrom": "external_tms_files",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_tms_files_provider_credential_id_organization_external_tms_provider_credentials_id_fk": {
+          "name": "external_tms_files_provider_credential_id_organization_external_tms_provider_credentials_id_fk",
+          "tableFrom": "external_tms_files",
+          "tableTo": "organization_external_tms_provider_credentials",
+          "columnsFrom": [
+            "provider_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "external_tms_files_stored_file_id_stored_files_id_fk": {
+          "name": "external_tms_files_stored_file_id_stored_files_id_fk",
+          "tableFrom": "external_tms_files",
+          "tableTo": "stored_files",
+          "columnsFrom": [
+            "stored_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repository_source_file_versions": {
+      "name": "repository_source_file_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "repository_source_file_id": {
+          "name": "repository_source_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stored_file_id": {
+          "name": "stored_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by_user_id": {
+          "name": "uploaded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by_api_key_id": {
+          "name": "uploaded_by_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_surface": {
+          "name": "upload_surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_state": {
+          "name": "ingest_state",
+          "type": "repository_source_file_ingest_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "ingest_error": {
+          "name": "ingest_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_workflow_run_id": {
+          "name": "ingest_workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repository_source_file_versions_stored_file_key": {
+          "name": "repository_source_file_versions_stored_file_key",
+          "columns": [
+            {
+              "expression": "stored_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repository_source_file_versions_file_created": {
+          "name": "idx_repository_source_file_versions_file_created",
+          "columns": [
+            {
+              "expression": "repository_source_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repository_source_file_versions_project_path_created": {
+          "name": "idx_repository_source_file_versions_project_path_created",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repository_source_file_versions_workflow_run": {
+          "name": "idx_repository_source_file_versions_workflow_run",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repository_source_file_versions_api_key": {
+          "name": "idx_repository_source_file_versions_api_key",
+          "columns": [
+            {
+              "expression": "uploaded_by_api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repository_source_file_versions_ingest_state": {
+          "name": "idx_repository_source_file_versions_ingest_state",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ingest_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repository_source_file_versions_repository_source_file_id_repository_source_files_id_fk": {
+          "name": "repository_source_file_versions_repository_source_file_id_repository_source_files_id_fk",
+          "tableFrom": "repository_source_file_versions",
+          "tableTo": "repository_source_files",
+          "columnsFrom": [
+            "repository_source_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repository_source_file_versions_organization_id_organizations_id_fk": {
+          "name": "repository_source_file_versions_organization_id_organizations_id_fk",
+          "tableFrom": "repository_source_file_versions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repository_source_file_versions_project_id_projects_id_fk": {
+          "name": "repository_source_file_versions_project_id_projects_id_fk",
+          "tableFrom": "repository_source_file_versions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repository_source_file_versions_stored_file_id_stored_files_id_fk": {
+          "name": "repository_source_file_versions_stored_file_id_stored_files_id_fk",
+          "tableFrom": "repository_source_file_versions",
+          "tableTo": "stored_files",
+          "columnsFrom": [
+            "stored_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repository_source_file_versions_uploaded_by_user_id_users_id_fk": {
+          "name": "repository_source_file_versions_uploaded_by_user_id_users_id_fk",
+          "tableFrom": "repository_source_file_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "repository_source_file_versions_uploaded_by_api_key_id_organization_api_keys_id_fk": {
+          "name": "repository_source_file_versions_uploaded_by_api_key_id_organization_api_keys_id_fk",
+          "tableFrom": "repository_source_file_versions",
+          "tableTo": "organization_api_keys",
+          "columnsFrom": [
+            "uploaded_by_api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repository_source_files": {
+      "name": "repository_source_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repository_source_files_project_path_key": {
+          "name": "repository_source_files_project_path_key",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repository_source_files_org_project": {
+          "name": "idx_repository_source_files_org_project",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repository_source_files_organization_id_organizations_id_fk": {
+          "name": "repository_source_files_organization_id_organizations_id_fk",
+          "tableFrom": "repository_source_files",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repository_source_files_project_id_projects_id_fk": {
+          "name": "repository_source_files_project_id_projects_id_fk",
+          "tableFrom": "repository_source_files",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stored_files": {
+      "name": "stored_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "stored_file_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "stored_file_source_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_interaction_id": {
+          "name": "source_interaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_job_id": {
+          "name": "source_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_url": {
+          "name": "storage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "download_url": {
+          "name": "download_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stored_files_storage_provider_key": {
+          "name": "stored_files_storage_provider_key",
+          "columns": [
+            {
+              "expression": "storage_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "storage_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stored_files_org_created_at": {
+          "name": "idx_stored_files_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stored_files_project_created_at": {
+          "name": "idx_stored_files_project_created_at",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stored_files_created_by_user_id": {
+          "name": "idx_stored_files_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stored_files_source_interaction": {
+          "name": "idx_stored_files_source_interaction",
+          "columns": [
+            {
+              "expression": "source_interaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stored_files_source_job": {
+          "name": "idx_stored_files_source_job",
+          "columns": [
+            {
+              "expression": "source_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stored_files_org_role": {
+          "name": "idx_stored_files_org_role",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stored_files_organization_id_organizations_id_fk": {
+          "name": "stored_files_organization_id_organizations_id_fk",
+          "tableFrom": "stored_files",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stored_files_project_id_projects_id_fk": {
+          "name": "stored_files_project_id_projects_id_fk",
+          "tableFrom": "stored_files",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stored_files_created_by_user_id_users_id_fk": {
+          "name": "stored_files_created_by_user_id_users_id_fk",
+          "tableFrom": "stored_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stored_files_source_interaction_id_interactions_id_fk": {
+          "name": "stored_files_source_interaction_id_interactions_id_fk",
+          "tableFrom": "stored_files",
+          "tableTo": "interactions",
+          "columnsFrom": [
+            "source_interaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stored_files_source_job_id_jobs_id_fk": {
+          "name": "stored_files_source_job_id_jobs_id_fk",
+          "tableFrom": "stored_files",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "source_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_translation_comments": {
+      "name": "project_translation_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation_key_id": {
+          "name": "translation_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_locale": {
+          "name": "target_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "project_translation_comment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'comment'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_translation_comments_org_project": {
+          "name": "idx_project_translation_comments_org_project",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_translation_comments_key_locale": {
+          "name": "idx_project_translation_comments_key_locale",
+          "columns": [
+            {
+              "expression": "translation_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_translation_comments_organization_id_organizations_id_fk": {
+          "name": "project_translation_comments_organization_id_organizations_id_fk",
+          "tableFrom": "project_translation_comments",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_translation_comments_project_id_projects_id_fk": {
+          "name": "project_translation_comments_project_id_projects_id_fk",
+          "tableFrom": "project_translation_comments",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_translation_comments_translation_key_id_project_translation_keys_id_fk": {
+          "name": "project_translation_comments_translation_key_id_project_translation_keys_id_fk",
+          "tableFrom": "project_translation_comments",
+          "tableTo": "project_translation_keys",
+          "columnsFrom": [
+            "translation_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_translation_comments_author_user_id_users_id_fk": {
+          "name": "project_translation_comments_author_user_id_users_id_fk",
+          "tableFrom": "project_translation_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_translation_keys": {
+      "name": "project_translation_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_source_file_id": {
+          "name": "repository_source_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_source_text": {
+          "name": "normalized_source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_length": {
+          "name": "max_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source_file_version_id": {
+          "name": "source_file_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_translation_keys_project_file_key": {
+          "name": "project_translation_keys_project_file_key",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_source_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_translation_keys_org_project": {
+          "name": "idx_project_translation_keys_org_project",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_translation_keys_file": {
+          "name": "idx_project_translation_keys_file",
+          "columns": [
+            {
+              "expression": "repository_source_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_translation_keys_organization_id_organizations_id_fk": {
+          "name": "project_translation_keys_organization_id_organizations_id_fk",
+          "tableFrom": "project_translation_keys",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_translation_keys_project_id_projects_id_fk": {
+          "name": "project_translation_keys_project_id_projects_id_fk",
+          "tableFrom": "project_translation_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_translation_keys_repository_source_file_id_repository_source_files_id_fk": {
+          "name": "project_translation_keys_repository_source_file_id_repository_source_files_id_fk",
+          "tableFrom": "project_translation_keys",
+          "tableTo": "repository_source_files",
+          "columnsFrom": [
+            "repository_source_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_translation_keys_source_file_version_id_repository_source_file_versions_id_fk": {
+          "name": "project_translation_keys_source_file_version_id_repository_source_file_versions_id_fk",
+          "tableFrom": "project_translation_keys",
+          "tableTo": "repository_source_file_versions",
+          "columnsFrom": [
+            "source_file_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_translations": {
+      "name": "project_translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation_key_id": {
+          "name": "translation_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_locale": {
+          "name": "target_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "project_translation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "project_translation_provenance",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "source_job_id": {
+          "name": "source_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_user_id": {
+          "name": "reviewed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_translations_key_locale": {
+          "name": "project_translations_key_locale",
+          "columns": [
+            {
+              "expression": "translation_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_translations_org_project": {
+          "name": "idx_project_translations_org_project",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_translations_status": {
+          "name": "idx_project_translations_status",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_translations_organization_id_organizations_id_fk": {
+          "name": "project_translations_organization_id_organizations_id_fk",
+          "tableFrom": "project_translations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_translations_project_id_projects_id_fk": {
+          "name": "project_translations_project_id_projects_id_fk",
+          "tableFrom": "project_translations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_translations_translation_key_id_project_translation_keys_id_fk": {
+          "name": "project_translations_translation_key_id_project_translation_keys_id_fk",
+          "tableFrom": "project_translations",
+          "tableTo": "project_translation_keys",
+          "columnsFrom": [
+            "translation_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_translations_source_job_id_jobs_id_fk": {
+          "name": "project_translations_source_job_id_jobs_id_fk",
+          "tableFrom": "project_translations",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "source_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_translations_reviewed_by_user_id_users_id_fk": {
+          "name": "project_translations_reviewed_by_user_id_users_id_fk",
+          "tableFrom": "project_translations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_image_variants": {
+      "name": "project_image_variants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_source_file_id": {
+          "name": "repository_source_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_tms_file_id": {
+          "name": "external_tms_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_locale": {
+          "name": "target_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stored_file_id": {
+          "name": "stored_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "project_translation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "project_translation_provenance",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "source_job_id": {
+          "name": "source_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_user_id": {
+          "name": "reviewed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_image_variants_project_path_locale": {
+          "name": "project_image_variants_project_path_locale",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_image_variants_org_project": {
+          "name": "idx_project_image_variants_org_project",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_image_variants_repo_file": {
+          "name": "idx_project_image_variants_repo_file",
+          "columns": [
+            {
+              "expression": "repository_source_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_image_variants_external_file": {
+          "name": "idx_project_image_variants_external_file",
+          "columns": [
+            {
+              "expression": "external_tms_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_image_variants_status": {
+          "name": "idx_project_image_variants_status",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_image_variants_organization_id_organizations_id_fk": {
+          "name": "project_image_variants_organization_id_organizations_id_fk",
+          "tableFrom": "project_image_variants",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_image_variants_project_id_projects_id_fk": {
+          "name": "project_image_variants_project_id_projects_id_fk",
+          "tableFrom": "project_image_variants",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_image_variants_repository_source_file_id_repository_source_files_id_fk": {
+          "name": "project_image_variants_repository_source_file_id_repository_source_files_id_fk",
+          "tableFrom": "project_image_variants",
+          "tableTo": "repository_source_files",
+          "columnsFrom": [
+            "repository_source_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_image_variants_external_tms_file_id_external_tms_files_id_fk": {
+          "name": "project_image_variants_external_tms_file_id_external_tms_files_id_fk",
+          "tableFrom": "project_image_variants",
+          "tableTo": "external_tms_files",
+          "columnsFrom": [
+            "external_tms_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_image_variants_stored_file_id_stored_files_id_fk": {
+          "name": "project_image_variants_stored_file_id_stored_files_id_fk",
+          "tableFrom": "project_image_variants",
+          "tableTo": "stored_files",
+          "columnsFrom": [
+            "stored_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_image_variants_source_job_id_jobs_id_fk": {
+          "name": "project_image_variants_source_job_id_jobs_id_fk",
+          "tableFrom": "project_image_variants",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "source_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_image_variants_reviewed_by_user_id_users_id_fk": {
+          "name": "project_image_variants_reviewed_by_user_id_users_id_fk",
+          "tableFrom": "project_image_variants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_sheet_columns": {
+      "name": "issue_sheet_columns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layer": {
+          "name": "layer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_sheet_columns_project_key": {
+          "name": "issue_sheet_columns_project_key",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_sheet_columns_org_project": {
+          "name": "idx_issue_sheet_columns_org_project",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_sheet_columns_organization_id_organizations_id_fk": {
+          "name": "issue_sheet_columns_organization_id_organizations_id_fk",
+          "tableFrom": "issue_sheet_columns",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_columns_project_id_projects_id_fk": {
+          "name": "issue_sheet_columns_project_id_projects_id_fk",
+          "tableFrom": "issue_sheet_columns",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_columns_created_by_user_id_users_id_fk": {
+          "name": "issue_sheet_columns_created_by_user_id_users_id_fk",
+          "tableFrom": "issue_sheet_columns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_sheet_issues": {
+      "name": "issue_sheet_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general_question'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "target_locale": {
+          "name": "target_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "segment_id": {
+          "name": "segment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "translation_key_id": {
+          "name": "translation_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_comment_id": {
+          "name": "linked_comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_agent_run_id": {
+          "name": "linked_agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_kind": {
+          "name": "link_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ref": {
+          "name": "external_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "reporter_user_id": {
+          "name": "reporter_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_user_id": {
+          "name": "assignee_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_issue_sheet_issues_org_project_status": {
+          "name": "idx_issue_sheet_issues_org_project_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_sheet_issues_project_locale": {
+          "name": "idx_issue_sheet_issues_project_locale",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_sheet_issues_linked_comment": {
+          "name": "idx_issue_sheet_issues_linked_comment",
+          "columns": [
+            {
+              "expression": "linked_comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_sheet_issues_project_external_ref_key": {
+          "name": "issue_sheet_issues_project_external_ref_key",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"issue_sheet_issues\".\"external_ref\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_sheet_issues_organization_id_organizations_id_fk": {
+          "name": "issue_sheet_issues_organization_id_organizations_id_fk",
+          "tableFrom": "issue_sheet_issues",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_issues_project_id_projects_id_fk": {
+          "name": "issue_sheet_issues_project_id_projects_id_fk",
+          "tableFrom": "issue_sheet_issues",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_issues_translation_key_id_project_translation_keys_id_fk": {
+          "name": "issue_sheet_issues_translation_key_id_project_translation_keys_id_fk",
+          "tableFrom": "issue_sheet_issues",
+          "tableTo": "project_translation_keys",
+          "columnsFrom": [
+            "translation_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_issues_linked_comment_id_project_translation_comments_id_fk": {
+          "name": "issue_sheet_issues_linked_comment_id_project_translation_comments_id_fk",
+          "tableFrom": "issue_sheet_issues",
+          "tableTo": "project_translation_comments",
+          "columnsFrom": [
+            "linked_comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_issues_linked_agent_run_id_agent_runs_id_fk": {
+          "name": "issue_sheet_issues_linked_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "issue_sheet_issues",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "linked_agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_issues_reporter_user_id_users_id_fk": {
+          "name": "issue_sheet_issues_reporter_user_id_users_id_fk",
+          "tableFrom": "issue_sheet_issues",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_issues_assignee_user_id_users_id_fk": {
+          "name": "issue_sheet_issues_assignee_user_id_users_id_fk",
+          "tableFrom": "issue_sheet_issues",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_sheet_row_values": {
+      "name": "issue_sheet_row_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_by_agent_run_id": {
+          "name": "computed_by_agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_sheet_row_values_issue_column": {
+          "name": "issue_sheet_row_values_issue_column",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_sheet_row_values_org_project": {
+          "name": "idx_issue_sheet_row_values_org_project",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_sheet_row_values_column": {
+          "name": "idx_issue_sheet_row_values_column",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_sheet_row_values_organization_id_organizations_id_fk": {
+          "name": "issue_sheet_row_values_organization_id_organizations_id_fk",
+          "tableFrom": "issue_sheet_row_values",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_row_values_project_id_projects_id_fk": {
+          "name": "issue_sheet_row_values_project_id_projects_id_fk",
+          "tableFrom": "issue_sheet_row_values",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_row_values_issue_id_issue_sheet_issues_id_fk": {
+          "name": "issue_sheet_row_values_issue_id_issue_sheet_issues_id_fk",
+          "tableFrom": "issue_sheet_row_values",
+          "tableTo": "issue_sheet_issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_row_values_column_id_issue_sheet_columns_id_fk": {
+          "name": "issue_sheet_row_values_column_id_issue_sheet_columns_id_fk",
+          "tableFrom": "issue_sheet_row_values",
+          "tableTo": "issue_sheet_columns",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_sheet_row_values_computed_by_agent_run_id_agent_runs_id_fk": {
+          "name": "issue_sheet_row_values_computed_by_agent_run_id_agent_runs_id_fk",
+          "tableFrom": "issue_sheet_row_values",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "computed_by_agent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repo_tms_mutation_logs": {
+      "name": "repo_tms_mutation_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "repo_tms_mutation_log_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "repo_tms_mutation_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_repo_tms_mutation_logs_org": {
+          "name": "idx_repo_tms_mutation_logs_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repo_tms_mutation_logs_task": {
+          "name": "idx_repo_tms_mutation_logs_task",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repo_tms_mutation_logs_workflow_run": {
+          "name": "idx_repo_tms_mutation_logs_workflow_run",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_repo_tms_mutation_logs_created_at": {
+          "name": "idx_repo_tms_mutation_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repo_tms_mutation_logs_organization_id_organizations_id_fk": {
+          "name": "repo_tms_mutation_logs_organization_id_organizations_id_fk",
+          "tableFrom": "repo_tms_mutation_logs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repo_tms_mutation_logs_project_id_projects_id_fk": {
+          "name": "repo_tms_mutation_logs_project_id_projects_id_fk",
+          "tableFrom": "repo_tms_mutation_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_memories": {
+      "name": "knowledge_memories",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "revision_id": {
+          "name": "revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Initial version'"
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_memories_revision_id_key": {
+          "name": "knowledge_memories_revision_id_key",
+          "columns": [
+            {
+              "expression": "revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "knowledge_memories_organization_id_organizations_id_fk": {
+          "name": "knowledge_memories_organization_id_organizations_id_fk",
+          "tableFrom": "knowledge_memories",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_memories_updated_by_user_id_users_id_fk": {
+          "name": "knowledge_memories_updated_by_user_id_users_id_fk",
+          "tableFrom": "knowledge_memories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "knowledge_memories_content_length_check": {
+          "name": "knowledge_memories_content_length_check",
+          "value": "char_length(\"knowledge_memories\".\"content\") <= 50000"
+        },
+        "knowledge_memories_summary_length_check": {
+          "name": "knowledge_memories_summary_length_check",
+          "value": "char_length(\"knowledge_memories\".\"summary\") <= 160"
+        },
+        "knowledge_memories_version_check": {
+          "name": "knowledge_memories_version_check",
+          "value": "\"knowledge_memories\".\"version\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.knowledge_memory_revisions": {
+      "name": "knowledge_memory_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "knowledge_memory_revisions_org_version_key": {
+          "name": "knowledge_memory_revisions_org_version_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "knowledge_memory_revisions_organization_id_organizations_id_fk": {
+          "name": "knowledge_memory_revisions_organization_id_organizations_id_fk",
+          "tableFrom": "knowledge_memory_revisions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_memory_revisions_created_by_user_id_users_id_fk": {
+          "name": "knowledge_memory_revisions_created_by_user_id_users_id_fk",
+          "tableFrom": "knowledge_memory_revisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "knowledge_memory_revisions_content_length_check": {
+          "name": "knowledge_memory_revisions_content_length_check",
+          "value": "char_length(\"knowledge_memory_revisions\".\"content\") <= 50000"
+        },
+        "knowledge_memory_revisions_summary_length_check": {
+          "name": "knowledge_memory_revisions_summary_length_check",
+          "value": "char_length(\"knowledge_memory_revisions\".\"summary\") <= 160"
+        },
+        "knowledge_memory_revisions_version_check": {
+          "name": "knowledge_memory_revisions_version_check",
+          "value": "\"knowledge_memory_revisions\".\"version\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_file_string_repository_contexts": {
+      "name": "project_file_string_repository_contexts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "string_key": {
+          "name": "string_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_text_hash": {
+          "name": "source_text_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_file_string_repository_contexts_lookup": {
+          "name": "project_file_string_repository_contexts_lookup",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "string_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_file_string_repository_contexts_file": {
+          "name": "idx_project_file_string_repository_contexts_file",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_file_string_repository_contexts_organization_id_organizations_id_fk": {
+          "name": "project_file_string_repository_contexts_organization_id_organizations_id_fk",
+          "tableFrom": "project_file_string_repository_contexts",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_file_string_repository_contexts_created_by_user_id_users_id_fk": {
+          "name": "project_file_string_repository_contexts_created_by_user_id_users_id_fk",
+          "tableFrom": "project_file_string_repository_contexts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_file_string_repository_contexts_summary_length_check": {
+          "name": "project_file_string_repository_contexts_summary_length_check",
+          "value": "char_length(\"project_file_string_repository_contexts\".\"summary\") <= 16384"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_cat_string_overlays": {
+      "name": "project_cat_string_overlays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_resource_id": {
+          "name": "external_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_string_id": {
+          "name": "external_string_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_cat_string_overlays_lookup": {
+          "name": "project_cat_string_overlays_lookup",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_string_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_cat_string_overlays_file": {
+          "name": "idx_project_cat_string_overlays_file",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_cat_string_overlays_organization_id_organizations_id_fk": {
+          "name": "project_cat_string_overlays_organization_id_organizations_id_fk",
+          "tableFrom": "project_cat_string_overlays",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_cat_string_overlays_updated_by_user_id_users_id_fk": {
+          "name": "project_cat_string_overlays_updated_by_user_id_users_id_fk",
+          "tableFrom": "project_cat_string_overlays",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_resource_usage_sync_states": {
+      "name": "workspace_resource_usage_sync_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_usage": {
+          "name": "synced_usage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sync_sequence": {
+          "name": "sync_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_resource_usage_sync_states_org_feature_key": {
+          "name": "workspace_resource_usage_sync_states_org_feature_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_resource_usage_sync_states_org": {
+          "name": "idx_workspace_resource_usage_sync_states_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_resource_usage_sync_states_organization_id_organizations_id_fk": {
+          "name": "workspace_resource_usage_sync_states_organization_id_organizations_id_fk",
+          "tableFrom": "workspace_resource_usage_sync_states",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.localisation_audit_events": {
+      "name": "localisation_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "localisation_audit_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_localisation_audit_events_audit_time": {
+          "name": "idx_localisation_audit_events_audit_time",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_localisation_audit_events_type_time": {
+          "name": "idx_localisation_audit_events_type_time",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "localisation_audit_events_audit_id_localisation_audits_id_fk": {
+          "name": "localisation_audit_events_audit_id_localisation_audits_id_fk",
+          "tableFrom": "localisation_audit_events",
+          "tableTo": "localisation_audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "localisation_audit_events_lead_id_localisation_audit_leads_id_fk": {
+          "name": "localisation_audit_events_lead_id_localisation_audit_leads_id_fk",
+          "tableFrom": "localisation_audit_events",
+          "tableTo": "localisation_audit_leads",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.localisation_audit_findings": {
+      "name": "localisation_audit_findings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_code": {
+          "name": "rule_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "localisation_audit_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "localisation_audit_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_kind": {
+          "name": "evidence_kind",
+          "type": "localisation_audit_evidence_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "impact": {
+          "name": "impact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendation": {
+          "name": "recommendation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_points": {
+          "name": "available_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_points": {
+          "name": "earned_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_preview_eligible": {
+          "name": "public_preview_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_localisation_audit_findings_rule_page": {
+          "name": "uq_localisation_audit_findings_rule_page",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rule_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_localisation_audit_findings_audit_category": {
+          "name": "idx_localisation_audit_findings_audit_category",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "localisation_audit_findings_audit_id_localisation_audits_id_fk": {
+          "name": "localisation_audit_findings_audit_id_localisation_audits_id_fk",
+          "tableFrom": "localisation_audit_findings",
+          "tableTo": "localisation_audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "localisation_audit_findings_page_id_localisation_audit_pages_id_fk": {
+          "name": "localisation_audit_findings_page_id_localisation_audit_pages_id_fk",
+          "tableFrom": "localisation_audit_findings",
+          "tableTo": "localisation_audit_pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "localisation_audit_findings_confidence_check": {
+          "name": "localisation_audit_findings_confidence_check",
+          "value": "\"localisation_audit_findings\".\"confidence\" >= 0 and \"localisation_audit_findings\".\"confidence\" <= 1"
+        },
+        "localisation_audit_findings_points_check": {
+          "name": "localisation_audit_findings_points_check",
+          "value": "\"localisation_audit_findings\".\"available_points\" >= 0 and \"localisation_audit_findings\".\"earned_points\" >= 0 and \"localisation_audit_findings\".\"earned_points\" <= \"localisation_audit_findings\".\"available_points\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.localisation_audit_leads": {
+      "name": "localisation_audit_leads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_delivery_status": {
+          "name": "email_delivery_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "unlocked_at": {
+          "name": "unlocked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_localisation_audit_leads_audit": {
+          "name": "idx_localisation_audit_leads_audit",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "localisation_audit_leads_audit_id_localisation_audits_id_fk": {
+          "name": "localisation_audit_leads_audit_id_localisation_audits_id_fk",
+          "tableFrom": "localisation_audit_leads",
+          "tableTo": "localisation_audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "localisation_audit_leads_delivery_status_check": {
+          "name": "localisation_audit_leads_delivery_status_check",
+          "value": "\"localisation_audit_leads\".\"email_delivery_status\" in ('pending', 'sent', 'skipped', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.localisation_audit_pages": {
+      "name": "localisation_audit_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_url": {
+          "name": "normalized_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "localisation_audit_page_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_fingerprint": {
+          "name": "content_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction": {
+          "name": "extraction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_localisation_audit_pages_audit_url": {
+          "name": "uq_localisation_audit_pages_audit_url",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_localisation_audit_pages_audit": {
+          "name": "idx_localisation_audit_pages_audit",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_localisation_audit_pages_fingerprint": {
+          "name": "idx_localisation_audit_pages_fingerprint",
+          "columns": [
+            {
+              "expression": "content_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "localisation_audit_pages_audit_id_localisation_audits_id_fk": {
+          "name": "localisation_audit_pages_audit_id_localisation_audits_id_fk",
+          "tableFrom": "localisation_audit_pages",
+          "tableTo": "localisation_audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "localisation_audit_pages_http_status_check": {
+          "name": "localisation_audit_pages_http_status_check",
+          "value": "\"localisation_audit_pages\".\"http_status\" is null or (\"localisation_audit_pages\".\"http_status\" >= 100 and \"localisation_audit_pages\".\"http_status\" <= 599)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.localisation_audit_reports": {
+      "name": "localisation_audit_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_slug": {
+          "name": "public_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "localisation_audit_report_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "indexing_state": {
+          "name": "indexing_state",
+          "type": "localisation_audit_indexing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'noindex'"
+        },
+        "score_version": {
+          "name": "score_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_version": {
+          "name": "report_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_report": {
+          "name": "public_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_report": {
+          "name": "private_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_localisation_audit_reports_audit": {
+          "name": "uq_localisation_audit_reports_audit",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_localisation_audit_reports_public_slug": {
+          "name": "uq_localisation_audit_reports_public_slug",
+          "columns": [
+            {
+              "expression": "public_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_localisation_audit_reports_visibility": {
+          "name": "idx_localisation_audit_reports_visibility",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "indexing_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "localisation_audit_reports_audit_id_localisation_audits_id_fk": {
+          "name": "localisation_audit_reports_audit_id_localisation_audits_id_fk",
+          "tableFrom": "localisation_audit_reports",
+          "tableTo": "localisation_audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "localisation_audit_reports_public_slug_check": {
+          "name": "localisation_audit_reports_public_slug_check",
+          "value": "char_length(\"localisation_audit_reports\".\"public_slug\") >= 16 and char_length(\"localisation_audit_reports\".\"public_slug\") <= 64"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.localisation_audits": {
+      "name": "localisation_audits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "status": {
+          "name": "status",
+          "type": "localisation_audit_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preparing'"
+        },
+        "submitted_url": {
+          "name": "submitted_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_url": {
+          "name": "normalized_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_hash": {
+          "name": "domain_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_locale": {
+          "name": "detected_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_locale": {
+          "name": "target_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_market": {
+          "name": "target_market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alternatives": {
+          "name": "alternatives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "score_version": {
+          "name": "score_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_version": {
+          "name": "report_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_localisation_audits_ip_budget": {
+          "name": "idx_localisation_audits_ip_budget",
+          "columns": [
+            {
+              "expression": "ip_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_localisation_audits_domain_budget": {
+          "name": "idx_localisation_audits_domain_budget",
+          "columns": [
+            {
+              "expression": "domain_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_localisation_audits_status_created": {
+          "name": "idx_localisation_audits_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "localisation_audits_domain_hash_check": {
+          "name": "localisation_audits_domain_hash_check",
+          "value": "char_length(\"localisation_audits\".\"domain_hash\") = 64"
+        },
+        "localisation_audits_ip_hash_check": {
+          "name": "localisation_audits_ip_hash_check",
+          "value": "char_length(\"localisation_audits\".\"ip_hash\") = 64"
+        },
+        "localisation_audits_score_version_check": {
+          "name": "localisation_audits_score_version_check",
+          "value": "char_length(\"localisation_audits\".\"score_version\") > 0"
+        },
+        "localisation_audits_report_version_check": {
+          "name": "localisation_audits_report_version_check",
+          "value": "char_length(\"localisation_audits\".\"report_version\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_run_kind": {
+      "name": "agent_run_kind",
+      "schema": "public",
+      "values": [
+        "translate",
+        "review",
+        "qa_fix",
+        "glossary_suggestion",
+        "comment_only"
+      ]
+    },
+    "public.agent_run_status": {
+      "name": "agent_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.asset_status": {
+      "name": "asset_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "archived"
+      ]
+    },
+    "public.external_tms_memory_capability_mode": {
+      "name": "external_tms_memory_capability_mode",
+      "schema": "public",
+      "values": [
+        "live_search",
+        "synced_import",
+        "reference_only"
+      ]
+    },
+    "public.external_tms_provider_kind": {
+      "name": "external_tms_provider_kind",
+      "schema": "public",
+      "values": [
+        "crowdin",
+        "smartling",
+        "phrase",
+        "lokalise"
+      ]
+    },
+    "public.external_tms_resource_type": {
+      "name": "external_tms_resource_type",
+      "schema": "public",
+      "values": [
+        "file",
+        "key"
+      ]
+    },
+    "public.external_tms_terminology_resource_type": {
+      "name": "external_tms_terminology_resource_type",
+      "schema": "public",
+      "values": [
+        "glossary",
+        "term_base"
+      ]
+    },
+    "public.glossary_sync_state": {
+      "name": "glossary_sync_state",
+      "schema": "public",
+      "values": [
+        "synced",
+        "stale",
+        "syncing",
+        "error"
+      ]
+    },
+    "public.glossary_term_provenance": {
+      "name": "glossary_term_provenance",
+      "schema": "public",
+      "values": [
+        "manual",
+        "sync"
+      ]
+    },
+    "public.inbox_status": {
+      "name": "inbox_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived"
+      ]
+    },
+    "public.interaction_source": {
+      "name": "interaction_source",
+      "schema": "public",
+      "values": [
+        "chat_ui",
+        "email_agent",
+        "github_agent",
+        "slack_agent"
+      ]
+    },
+    "public.job_kind": {
+      "name": "job_kind",
+      "schema": "public",
+      "values": [
+        "translation",
+        "research",
+        "review",
+        "proofread",
+        "sync",
+        "asset_management"
+      ]
+    },
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed",
+        "waiting_for_review",
+        "cancelled"
+      ]
+    },
+    "public.llm_provider": {
+      "name": "llm_provider",
+      "schema": "public",
+      "values": [
+        "openai",
+        "anthropic",
+        "gemini",
+        "groq",
+        "mistral"
+      ]
+    },
+    "public.localisation_audit_category": {
+      "name": "localisation_audit_category",
+      "schema": "public",
+      "values": [
+        "technical",
+        "linguistic",
+        "market"
+      ]
+    },
+    "public.localisation_audit_event_type": {
+      "name": "localisation_audit_event_type",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "prepared",
+        "confirmed",
+        "completed",
+        "viewed",
+        "unlocked",
+        "shared",
+        "booked",
+        "workspace_converted",
+        "email_delivery_failed"
+      ]
+    },
+    "public.localisation_audit_evidence_kind": {
+      "name": "localisation_audit_evidence_kind",
+      "schema": "public",
+      "values": [
+        "observed",
+        "judgement"
+      ]
+    },
+    "public.localisation_audit_indexing_state": {
+      "name": "localisation_audit_indexing_state",
+      "schema": "public",
+      "values": [
+        "noindex",
+        "eligible",
+        "indexed",
+        "removed"
+      ]
+    },
+    "public.localisation_audit_page_status": {
+      "name": "localisation_audit_page_status",
+      "schema": "public",
+      "values": [
+        "extracted",
+        "blocked",
+        "failed"
+      ]
+    },
+    "public.localisation_audit_report_visibility": {
+      "name": "localisation_audit_report_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "public"
+      ]
+    },
+    "public.localisation_audit_severity": {
+      "name": "localisation_audit_severity",
+      "schema": "public",
+      "values": [
+        "info",
+        "low",
+        "medium",
+        "high",
+        "critical"
+      ]
+    },
+    "public.localisation_audit_status": {
+      "name": "localisation_audit_status",
+      "schema": "public",
+      "values": [
+        "preparing",
+        "awaiting_confirmation",
+        "running",
+        "completed",
+        "partial",
+        "failed"
+      ]
+    },
+    "public.message_sender_type": {
+      "name": "message_sender_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "agent"
+      ]
+    },
+    "public.organization_lifecycle_status": {
+      "name": "organization_lifecycle_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived",
+        "deprecated"
+      ]
+    },
+    "public.organization_membership_role": {
+      "name": "organization_membership_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "localization_manager",
+        "developer",
+        "reviewer",
+        "translator",
+        "member"
+      ]
+    },
+    "public.project_source": {
+      "name": "project_source",
+      "schema": "public",
+      "values": [
+        "native",
+        "external_tms"
+      ]
+    },
+    "public.project_translation_comment_type": {
+      "name": "project_translation_comment_type",
+      "schema": "public",
+      "values": [
+        "comment",
+        "issue"
+      ]
+    },
+    "public.project_translation_provenance": {
+      "name": "project_translation_provenance",
+      "schema": "public",
+      "values": [
+        "manual",
+        "translation_job",
+        "import",
+        "agent"
+      ]
+    },
+    "public.project_translation_status": {
+      "name": "project_translation_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "needs_review",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.provider_sync_intent_cause": {
+      "name": "provider_sync_intent_cause",
+      "schema": "public",
+      "values": [
+        "webhook",
+        "manual",
+        "scheduled"
+      ]
+    },
+    "public.provider_sync_intent_status": {
+      "name": "provider_sync_intent_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "retryable",
+        "succeeded",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.provider_sync_run_kind": {
+      "name": "provider_sync_run_kind",
+      "schema": "public",
+      "values": [
+        "project_scan",
+        "file_key_scan",
+        "job_task_scan",
+        "context_scan",
+        "tm_scan",
+        "glossary_scan",
+        "pull_content",
+        "push_translations",
+        "webhook",
+        "health_check"
+      ]
+    },
+    "public.provider_sync_run_status": {
+      "name": "provider_sync_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "succeeded",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.provider_webhook_event_processing_status": {
+      "name": "provider_webhook_event_processing_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "succeeded",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.provider_webhook_subscription_status": {
+      "name": "provider_webhook_subscription_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "permission_error",
+        "provider_error",
+        "disabled",
+        "manual_required"
+      ]
+    },
+    "public.repository_source_file_ingest_state": {
+      "name": "repository_source_file_ingest_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "ingesting",
+        "ingested",
+        "skipped",
+        "failed"
+      ]
+    },
+    "public.stored_file_role": {
+      "name": "stored_file_role",
+      "schema": "public",
+      "values": [
+        "source",
+        "output",
+        "reference",
+        "asset"
+      ]
+    },
+    "public.stored_file_source_kind": {
+      "name": "stored_file_source_kind",
+      "schema": "public",
+      "values": [
+        "chat_upload",
+        "email_attachment",
+        "job_output",
+        "repository_file",
+        "tms_file"
+      ]
+    },
+    "public.team_membership_role": {
+      "name": "team_membership_role",
+      "schema": "public",
+      "values": [
+        "manager",
+        "member"
+      ]
+    },
+    "public.tms_agent_automation_scope": {
+      "name": "tms_agent_automation_scope",
+      "schema": "public",
+      "values": [
+        "organization",
+        "project",
+        "provider"
+      ]
+    },
+    "public.translation_job_outcome_kind": {
+      "name": "translation_job_outcome_kind",
+      "schema": "public",
+      "values": [
+        "string_result",
+        "file_result",
+        "error"
+      ]
+    },
+    "public.translation_job_type": {
+      "name": "translation_job_type",
+      "schema": "public",
+      "values": [
+        "string",
+        "file"
+      ]
+    },
+    "public.usage_event_status": {
+      "name": "usage_event_status",
+      "schema": "public",
+      "values": [
+        "reserved",
+        "succeeded",
+        "rejected",
+        "tracking_pending",
+        "tracking_succeeded",
+        "tracking_failed"
+      ]
+    },
+    "public.usage_feature_id": {
+      "name": "usage_feature_id",
+      "schema": "public",
+      "values": [
+        "translation_jobs",
+        "translation_units",
+        "source_characters",
+        "ai_tokens",
+        "api_requests",
+        "agent_runs"
+      ]
+    },
+    "public.workspace_automation_run_status": {
+      "name": "workspace_automation_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed",
+        "cancelled",
+        "skipped"
+      ]
+    },
+    "public.workspace_automation_run_trigger_source": {
+      "name": "workspace_automation_run_trigger_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "scheduled",
+        "github",
+        "contentful",
+        "source_upload"
+      ]
+    },
+    "public.workspace_automation_status": {
+      "name": "workspace_automation_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "paused",
+        "archived"
+      ]
+    },
+    "public.github_repository_automation_commit_result_status": {
+      "name": "github_repository_automation_commit_result_status",
+      "schema": "public",
+      "values": [
+        "skipped",
+        "passed",
+        "warning",
+        "failed",
+        "error"
+      ]
+    },
+    "public.github_repository_automation_job_status": {
+      "name": "github_repository_automation_job_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.github_repository_automation_job_trigger_mode": {
+      "name": "github_repository_automation_job_trigger_mode",
+      "schema": "public",
+      "values": [
+        "push",
+        "scheduled"
+      ]
+    },
+    "public.repo_tms_mutation_log_action": {
+      "name": "repo_tms_mutation_log_action",
+      "schema": "public",
+      "values": [
+        "upload_sources",
+        "apply_fixes",
+        "commit_changes",
+        "push_to_branch",
+        "tms_mutate"
+      ]
+    },
+    "public.repo_tms_mutation_log_status": {
+      "name": "repo_tms_mutation_log_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied",
+        "completed",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hyperlocalise-web/drizzle/meta/_journal.json
+++ b/apps/hyperlocalise-web/drizzle/meta/_journal.json
@@ -484,6 +484,13 @@
       "when": 1784860379091,
       "tag": "0068_dark_leper_queen",
       "breakpoints": true
+    },
+    {
+      "idx": 69,
+      "version": "7",
+      "when": 1784927980385,
+      "tag": "0069_organic_krista_starr",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -19,6 +19,7 @@ import type { LocalisationAuditService } from "@/lib/localisation-audit/service"
 import type {
   EmailAgentTaskQueue,
   JobQueue,
+  LocalisationAuditQueue,
   ProviderAgentCommentQueue,
   ProviderAgentQaQueue,
   ProviderAgentTranslationQueue,
@@ -97,6 +98,7 @@ type CreateAppOptions = {
   providerAgentWritebackQueue?: ProviderAgentWritebackQueue;
   fileStorageAdapter?: FileStorageAdapter;
   localisationAuditService?: LocalisationAuditService;
+  localisationAuditQueue?: LocalisationAuditQueue;
   translationFileImportQueue?: TranslationFileImportQueue;
 };
 
@@ -122,7 +124,10 @@ export function createApp(options: CreateAppOptions = {}) {
     .route("/blog", createBlogOgImageRoutes())
     .route(
       "/localisation-audit",
-      createLocalisationAuditRoutes({ service: options.localisationAuditService }),
+      createLocalisationAuditRoutes({
+        service: options.localisationAuditService,
+        localisationAuditQueue: options.localisationAuditQueue,
+      }),
     )
     .route(
       "/orgs/:organizationSlug",

--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -15,6 +15,7 @@ import { evlog, type EvlogVariables } from "evlog/hono";
 import { secureHeaders } from "hono/secure-headers";
 
 import type { FileStorageAdapter } from "@/lib/file-storage";
+import type { LocalisationAuditService } from "@/lib/localisation-audit/service";
 import type {
   EmailAgentTaskQueue,
   JobQueue,
@@ -43,6 +44,7 @@ import { createAhrefsConnectionRoutes } from "./routes/ahrefs-connection/ahrefs-
 import { createSemrushConnectionRoutes } from "./routes/semrush-connection/semrush-connection.route";
 import { createGlossaryRoutes } from "./routes/glossary/glossary.route";
 import { createKnowledgeMemoryRoutes } from "./routes/knowledge-memory/knowledge-memory.route";
+import { createLocalisationAuditRoutes } from "./routes/localisation-audit/localisation-audit.route";
 import { createMemoryRoutes } from "./routes/memory/memory.route";
 import { createOrganizationIssueSheetRoutes } from "./routes/issues/organization-issue-sheet.route";
 import { createOrganizationIssuesRoutes } from "./routes/issues/issues.route";
@@ -94,6 +96,7 @@ type CreateAppOptions = {
   providerAgentCommentQueue?: ProviderAgentCommentQueue;
   providerAgentWritebackQueue?: ProviderAgentWritebackQueue;
   fileStorageAdapter?: FileStorageAdapter;
+  localisationAuditService?: LocalisationAuditService;
   translationFileImportQueue?: TranslationFileImportQueue;
 };
 
@@ -117,6 +120,10 @@ export function createApp(options: CreateAppOptions = {}) {
     .route("/auth", createAuthRoutes())
     .route("/autumn", createAutumnRoutes())
     .route("/blog", createBlogOgImageRoutes())
+    .route(
+      "/localisation-audit",
+      createLocalisationAuditRoutes({ service: options.localisationAuditService }),
+    )
     .route(
       "/orgs/:organizationSlug",
       createOrgScopedAppRoutes({

--- a/apps/hyperlocalise-web/src/api/routes/localisation-audit/localisation-audit.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/localisation-audit/localisation-audit.route.test.ts
@@ -81,19 +81,19 @@ function createMockService() {
   const prepareAudit = vi.fn(async () =>
     ok<SafeAudit, LocalisationAuditError>({
       id: AUDIT_ID,
-      status: "awaiting_confirmation",
-      detectedLocale: "en-US",
+      status: "preparing",
+      detectedLocale: null,
       alternatives: [],
     }),
   );
   const confirmAudit = vi.fn(async () =>
     ok<SafeAudit, LocalisationAuditError>({
       id: AUDIT_ID,
-      status: "completed",
+      status: "running",
       detectedLocale: "en-US",
       alternatives: [],
-      publicSlug: "opaque-public-slug-1234",
-      summary: publicReport(),
+      targetLocale: "en-GB",
+      targetMarket: "GB",
     }),
   );
   const service: LocalisationAuditService = {
@@ -141,8 +141,8 @@ describe("localisation audit routes", () => {
     await expect(response.json()).resolves.toEqual({
       audit: {
         id: AUDIT_ID,
-        status: "awaiting_confirmation",
-        detectedLocale: "en-US",
+        status: "preparing",
+        detectedLocale: null,
         alternatives: [],
       },
     });

--- a/apps/hyperlocalise-web/src/api/routes/localisation-audit/localisation-audit.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/localisation-audit/localisation-audit.route.test.ts
@@ -73,6 +73,16 @@ function createMockService() {
       alternatives: [],
     }),
   );
+  const confirmAudit = vi.fn(async () =>
+    ok<SafeAudit, LocalisationAuditError>({
+      id: AUDIT_ID,
+      status: "completed",
+      detectedLocale: "en-US",
+      alternatives: [],
+      publicSlug: "opaque-public-slug-1234",
+      summary: publicReport(),
+    }),
+  );
   const service: LocalisationAuditService = {
     prepareAudit,
     getAudit: vi.fn(async () =>
@@ -83,16 +93,7 @@ function createMockService() {
         alternatives: [],
       }),
     ),
-    confirmAudit: vi.fn(async () =>
-      ok<SafeAudit, LocalisationAuditError>({
-        id: AUDIT_ID,
-        status: "completed",
-        detectedLocale: "en-US",
-        alternatives: [],
-        publicSlug: "opaque-public-slug-1234",
-        summary: publicReport(),
-      }),
-    ),
+    confirmAudit,
     unlockAudit: vi.fn(async () =>
       ok<{ accessUrl: string }, LocalisationAuditError>({
         accessUrl: "https://app.example.test/localisation-audit/report?access=signed-token",
@@ -102,11 +103,11 @@ function createMockService() {
       ok<PublicAuditReport, LocalisationAuditError>(publicReport()),
     ),
   };
-  return { prepareAudit, service };
+  return { confirmAudit, prepareAudit, service };
 }
 
 describe("localisation audit routes", () => {
-  const { prepareAudit, service } = createMockService();
+  const { confirmAudit, prepareAudit, service } = createMockService();
   const client = testClient(createApp({ localisationAuditService: service }));
 
   beforeEach(() => {
@@ -163,6 +164,30 @@ describe("localisation audit routes", () => {
       error: "audit_rate_limited",
       message: "Try again later.",
     });
+  });
+
+  it("accepts ISO country codes when confirming the target market", async () => {
+    const response = await client.api["localisation-audit"].audits[":auditId"].confirm.$patch({
+      param: { auditId: AUDIT_ID },
+      json: { targetLocale: "en-GB", targetMarket: "gb" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(confirmAudit).toHaveBeenCalledWith({
+      auditId: AUDIT_ID,
+      targetLocale: "en-GB",
+      targetMarket: "GB",
+    });
+  });
+
+  it("rejects country names when confirming the target market", async () => {
+    const response = await client.api["localisation-audit"].audits[":auditId"].confirm.$patch({
+      param: { auditId: AUDIT_ID },
+      json: { targetLocale: "en-GB", targetMarket: "United Kingdom" },
+    });
+
+    expect(response.status).toBe(400);
+    expect(confirmAudit).not.toHaveBeenCalled();
   });
 
   it("returns only an access URL when a report is unlocked", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/localisation-audit/localisation-audit.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/localisation-audit/localisation-audit.route.test.ts
@@ -15,6 +15,18 @@ import "dotenv/config";
 import { testClient } from "hono/testing";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
+const { getHyperlocaliseAgentModelMock } = vi.hoisted(() => ({
+  getHyperlocaliseAgentModelMock: vi.fn(() => ({ provider: "test" })),
+}));
+
+vi.mock("@/lib/agent-runtime/loops/model", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/agent-runtime/loops/model")>();
+  return {
+    ...actual,
+    getHyperlocaliseAgentModel: getHyperlocaliseAgentModelMock,
+  };
+});
+
 import { createApp } from "@/api/app";
 import type { LocalisationAuditService } from "@/lib/localisation-audit/service";
 import type {
@@ -25,6 +37,7 @@ import type {
 import { err, ok } from "@/lib/primitives/result/results";
 
 const AUDIT_ID = "11111111-1111-4111-8111-111111111111";
+const agentModelInitializationsDuringApiImport = getHyperlocaliseAgentModelMock.mock.calls.length;
 
 function publicReport(): PublicAuditReport {
   return {
@@ -112,6 +125,10 @@ describe("localisation audit routes", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("does not initialize authenticated agent models while loading the public audit API", () => {
+    expect(agentModelInitializationsDuringApiImport).toBe(0);
   });
 
   it("prepares an audit through the real API app and forwards the client IP", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/localisation-audit/localisation-audit.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/localisation-audit/localisation-audit.route.test.ts
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import "dotenv/config";
+
+import { testClient } from "hono/testing";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { createApp } from "@/api/app";
+import type { LocalisationAuditService } from "@/lib/localisation-audit/service";
+import type {
+  LocalisationAuditError,
+  PublicAuditReport,
+  SafeAudit,
+} from "@/lib/localisation-audit/types";
+import { err, ok } from "@/lib/primitives/result/results";
+
+const AUDIT_ID = "11111111-1111-4111-8111-111111111111";
+
+function publicReport(): PublicAuditReport {
+  return {
+    reportVersion: "1",
+    scoreVersion: "2026-07-24.1",
+    domain: "example.com",
+    auditedAt: "2026-07-24T12:00:00.000Z",
+    status: "completed",
+    overallStatus: "insufficient_evidence",
+    overallScore: null,
+    categoryScores: {
+      technical: {
+        status: "scored",
+        score: 100,
+        earnedPoints: 20,
+        applicablePoints: 20,
+        evaluatedRuleCount: 2,
+      },
+      linguistic: {
+        status: "insufficient_evidence",
+        score: null,
+        earnedPoints: 0,
+        applicablePoints: 0,
+        evaluatedRuleCount: 0,
+      },
+      market: {
+        status: "insufficient_evidence",
+        score: null,
+        earnedPoints: 0,
+        applicablePoints: 0,
+        evaluatedRuleCount: 0,
+      },
+    },
+    findings: [],
+    lockedFindingCount: 0,
+    limitations: [],
+  };
+}
+
+function createMockService() {
+  const prepareAudit = vi.fn(async () =>
+    ok<SafeAudit, LocalisationAuditError>({
+      id: AUDIT_ID,
+      status: "awaiting_confirmation",
+      detectedLocale: "en-US",
+      alternatives: [],
+    }),
+  );
+  const service: LocalisationAuditService = {
+    prepareAudit,
+    getAudit: vi.fn(async () =>
+      ok<SafeAudit, LocalisationAuditError>({
+        id: AUDIT_ID,
+        status: "awaiting_confirmation",
+        detectedLocale: "en-US",
+        alternatives: [],
+      }),
+    ),
+    confirmAudit: vi.fn(async () =>
+      ok<SafeAudit, LocalisationAuditError>({
+        id: AUDIT_ID,
+        status: "completed",
+        detectedLocale: "en-US",
+        alternatives: [],
+        publicSlug: "opaque-public-slug-1234",
+        summary: publicReport(),
+      }),
+    ),
+    unlockAudit: vi.fn(async () =>
+      ok<{ accessUrl: string }, LocalisationAuditError>({
+        accessUrl: "https://app.example.test/localisation-audit/report?access=signed-token",
+      }),
+    ),
+    getPublicReport: vi.fn(async () =>
+      ok<PublicAuditReport, LocalisationAuditError>(publicReport()),
+    ),
+  };
+  return { prepareAudit, service };
+}
+
+describe("localisation audit routes", () => {
+  const { prepareAudit, service } = createMockService();
+  const client = testClient(createApp({ localisationAuditService: service }));
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("prepares an audit through the real API app and forwards the client IP", async () => {
+    const response = await client.api["localisation-audit"].audits.$post(
+      { json: { url: "https://example.com/en" } },
+      { headers: { "cf-connecting-ip": "203.0.113.42" } },
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      audit: {
+        id: AUDIT_ID,
+        status: "awaiting_confirmation",
+        detectedLocale: "en-US",
+        alternatives: [],
+      },
+    });
+    expect(prepareAudit).toHaveBeenCalledWith({
+      url: "https://example.com/en",
+      ipAddress: "203.0.113.42",
+    });
+  });
+
+  it("rejects malformed payloads before invoking the service", async () => {
+    const response = await client.api["localisation-audit"].audits.$post({
+      json: { url: "" },
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "invalid_audit_payload",
+    });
+    expect(prepareAudit).not.toHaveBeenCalled();
+  });
+
+  it("maps stable rate-limit errors to a standard JSON error envelope", async () => {
+    prepareAudit.mockResolvedValueOnce(
+      err<SafeAudit, LocalisationAuditError>({
+        code: "audit_rate_limited",
+        message: "Try again later.",
+      }),
+    );
+
+    const response = await client.api["localisation-audit"].audits.$post({
+      json: { url: "https://example.com" },
+    });
+
+    expect(response.status).toBe(429);
+    await expect(response.json()).resolves.toEqual({
+      error: "audit_rate_limited",
+      message: "Try again later.",
+    });
+  });
+
+  it("returns only an access URL when a report is unlocked", async () => {
+    const response = await client.api["localisation-audit"].audits[":auditId"].unlock.$post({
+      param: { auditId: AUDIT_ID },
+      json: { email: "lead@example.com", name: "Lead" },
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({
+      report: {
+        accessUrl: "https://app.example.test/localisation-audit/report?access=signed-token",
+      },
+    });
+    expect(JSON.stringify(body)).not.toContain("lead@example.com");
+  });
+
+  it("serves only the public report projection by slug", async () => {
+    const response = await client.api["localisation-audit"].reports[":slug"].$get({
+      param: { slug: "opaque-public-slug-1234" },
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({ report: publicReport() });
+    if (!("report" in body)) {
+      throw new Error("Expected a public report response.");
+    }
+    expect(body.report).not.toHaveProperty("pages");
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/localisation-audit/localisation-audit.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/localisation-audit/localisation-audit.route.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { Hono } from "hono";
+import { validator } from "hono/validator";
+
+import {
+  badRequestResponse,
+  conflictResponse,
+  notFoundResponse,
+  serviceUnavailableResponse,
+  tooManyRequestsResponse,
+  unauthorizedResponse,
+} from "@/api/response.schema";
+import { env } from "@/lib/env";
+import { isErr } from "@/lib/primitives/result/results";
+import {
+  localisationAuditService,
+  type LocalisationAuditService,
+} from "@/lib/localisation-audit/service";
+import type { LocalisationAuditError } from "@/lib/localisation-audit/types";
+
+import {
+  confirmLocalisationAuditBodySchema,
+  createLocalisationAuditBodySchema,
+  localisationAuditIdParamSchema,
+  localisationAuditReportSlugParamSchema,
+  unlockLocalisationAuditBodySchema,
+} from "./localisation-audit.schema";
+
+function validationMiddleware<TSchema extends { safeParse(value: unknown): unknown }>(
+  schema: TSchema,
+  code: string,
+) {
+  return validator("json", (value, c) => {
+    const parsed = schema.safeParse(value) as
+      | { success: true; data: unknown }
+      | { success: false; error: { flatten(): unknown } };
+    if (!parsed.success) {
+      return badRequestResponse(c, code, "The request payload is invalid.", parsed.error.flatten());
+    }
+    return parsed.data;
+  });
+}
+
+const validateAuditId = validator("param", (value, c) => {
+  const parsed = localisationAuditIdParamSchema.safeParse(value);
+  if (!parsed.success) {
+    return badRequestResponse(c, "invalid_audit_id", "The audit ID is invalid.");
+  }
+  return parsed.data;
+});
+
+const validateReportSlug = validator("param", (value, c) => {
+  const parsed = localisationAuditReportSlugParamSchema.safeParse(value);
+  if (!parsed.success) {
+    return badRequestResponse(c, "invalid_report_slug", "The report slug is invalid.");
+  }
+  return parsed.data;
+});
+
+const validateCreateBody = validationMiddleware(
+  createLocalisationAuditBodySchema,
+  "invalid_audit_payload",
+);
+const validateConfirmBody = validationMiddleware(
+  confirmLocalisationAuditBodySchema,
+  "invalid_audit_confirmation",
+);
+const validateUnlockBody = validationMiddleware(
+  unlockLocalisationAuditBodySchema,
+  "invalid_audit_unlock_payload",
+);
+
+function mapAuditError(c: Parameters<typeof badRequestResponse>[0], error: LocalisationAuditError) {
+  switch (error.code) {
+    case "audit_not_found":
+    case "report_not_found":
+      return notFoundResponse(c, error.code, error.message);
+    case "audit_rate_limited":
+      return tooManyRequestsResponse(c, error.code, error.message);
+    case "audit_not_awaiting_confirmation":
+    case "audit_not_complete":
+      return conflictResponse(c, error.code, error.message);
+    case "audit_access_not_configured":
+    case "audit_email_delivery_failed":
+      return serviceUnavailableResponse(c, error.code, error.message);
+    case "invalid_report_access_token":
+      return unauthorizedResponse(c, error.code, error.message);
+    default:
+      return badRequestResponse(c, error.code, error.message);
+  }
+}
+
+function requestIpAddress(headers: Headers): string {
+  const connectingIp = headers.get("cf-connecting-ip")?.trim();
+  if (connectingIp) {
+    return connectingIp;
+  }
+  return headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
+}
+
+export function createLocalisationAuditRoutes(
+  options: { service?: LocalisationAuditService } = {},
+) {
+  const service = options.service ?? localisationAuditService;
+
+  return new Hono()
+    .post("/audits", validateCreateBody, async (c) => {
+      const body = c.req.valid("json") as { url: string };
+      const result = await service.prepareAudit({
+        url: body.url,
+        ipAddress: requestIpAddress(c.req.raw.headers),
+      });
+      if (isErr(result)) {
+        return mapAuditError(c, result.error);
+      }
+      return c.json({ audit: result.value }, 201);
+    })
+    .get("/audits/:auditId", validateAuditId, async (c) => {
+      const { auditId } = c.req.valid("param");
+      const result = await service.getAudit(auditId);
+      if (isErr(result)) {
+        return mapAuditError(c, result.error);
+      }
+      return c.json({ audit: result.value }, 200);
+    })
+    .patch("/audits/:auditId/confirm", validateAuditId, validateConfirmBody, async (c) => {
+      const { auditId } = c.req.valid("param");
+      const body = c.req.valid("json") as {
+        targetLocale: string;
+        targetMarket: string;
+      };
+      const result = await service.confirmAudit({
+        auditId,
+        targetLocale: body.targetLocale,
+        targetMarket: body.targetMarket,
+      });
+      if (isErr(result)) {
+        return mapAuditError(c, result.error);
+      }
+      return c.json({ audit: result.value }, 200);
+    })
+    .post("/audits/:auditId/unlock", validateAuditId, validateUnlockBody, async (c) => {
+      const { auditId } = c.req.valid("param");
+      const body = c.req.valid("json") as { email: string; name?: string };
+      const result = await service.unlockAudit({
+        auditId,
+        email: body.email,
+        name: body.name,
+        origin: env.HYPERLOCALISE_PUBLIC_APP_URL ?? new URL(c.req.url).origin,
+      });
+      if (isErr(result)) {
+        return mapAuditError(c, result.error);
+      }
+      return c.json({ report: { accessUrl: result.value.accessUrl } }, 200);
+    })
+    .get("/reports/:slug", validateReportSlug, async (c) => {
+      const { slug } = c.req.valid("param");
+      const result = await service.getPublicReport(slug);
+      if (isErr(result)) {
+        return mapAuditError(c, result.error);
+      }
+      return c.json({ report: result.value }, 200);
+    });
+}

--- a/apps/hyperlocalise-web/src/api/routes/localisation-audit/localisation-audit.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/localisation-audit/localisation-audit.route.ts
@@ -24,10 +24,12 @@ import {
 import { env } from "@/lib/env";
 import { isErr } from "@/lib/primitives/result/results";
 import {
+  createLocalisationAuditService,
   localisationAuditService,
   type LocalisationAuditService,
 } from "@/lib/localisation-audit/service";
 import type { LocalisationAuditError } from "@/lib/localisation-audit/types";
+import type { LocalisationAuditQueue } from "@/lib/workflow/types";
 
 import {
   confirmLocalisationAuditBodySchema,
@@ -110,9 +112,16 @@ function requestIpAddress(headers: Headers): string {
 }
 
 export function createLocalisationAuditRoutes(
-  options: { service?: LocalisationAuditService } = {},
+  options: {
+    service?: LocalisationAuditService;
+    localisationAuditQueue?: LocalisationAuditQueue;
+  } = {},
 ) {
-  const service = options.service ?? localisationAuditService;
+  const service =
+    options.service ??
+    (options.localisationAuditQueue
+      ? createLocalisationAuditService({ queue: options.localisationAuditQueue })
+      : localisationAuditService);
 
   return new Hono()
     .post("/audits", validateCreateBody, async (c) => {

--- a/apps/hyperlocalise-web/src/api/routes/localisation-audit/localisation-audit.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/localisation-audit/localisation-audit.schema.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { z } from "zod";
+
+export const localisationAuditIdParamSchema = z.object({
+  auditId: z.uuid(),
+});
+
+export const localisationAuditReportSlugParamSchema = z.object({
+  slug: z
+    .string()
+    .min(16)
+    .max(64)
+    .regex(/^[A-Za-z0-9_-]+$/),
+});
+
+export const createLocalisationAuditBodySchema = z.object({
+  url: z.string().trim().min(1).max(2_048),
+});
+
+export const confirmLocalisationAuditBodySchema = z.object({
+  targetLocale: z
+    .string()
+    .trim()
+    .min(2)
+    .max(35)
+    .refine((value) => {
+      try {
+        return Intl.getCanonicalLocales(value).length === 1;
+      } catch {
+        return false;
+      }
+    }, "Target locale must be a valid BCP 47 locale."),
+  targetMarket: z
+    .string()
+    .trim()
+    .length(2)
+    .regex(/^[A-Za-z]{2}$/)
+    .transform((value) => value.toUpperCase()),
+});
+
+export const unlockLocalisationAuditBodySchema = z.object({
+  email: z.email().max(320),
+  name: z.string().trim().min(1).max(100).optional(),
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/[slug]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/[slug]/page.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { getPublicAuditReportBySlug } from "@/lib/localisation-audit/service";
+
+import { AuditReportView } from "../_components/audit-report-view";
+import { toAuditReportProjection } from "../_components/localisation-audit-types";
+
+export const metadata: Metadata = {
+  title: "Shared Localisation Health Report | Hyperlocalise",
+  description:
+    "A shareable summary of a website's technical localisation readiness, linguistic quality, and market experience.",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+type PublicAuditReportPageProps = {
+  params: Promise<{ lang: string; slug: string }>;
+};
+
+export default async function PublicAuditReportPage({ params }: PublicAuditReportPageProps) {
+  const { slug } = await params;
+  const serviceReport = await getPublicAuditReportBySlug(slug);
+  if (!serviceReport) {
+    notFound();
+  }
+
+  const report = toAuditReportProjection(serviceReport);
+  return <AuditReportView report={report} mode="public" showFooter />;
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/audit-report-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/audit-report-view.tsx
@@ -1,0 +1,381 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import {
+  ArrowRight01Icon,
+  Calendar03Icon,
+  CheckmarkCircle02Icon,
+  LockIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useIntl } from "react-intl";
+
+import { MarketingFooter } from "@/components/marketing/marketing-footer";
+import { footerColumns } from "@/components/marketing/marketing-page-content";
+import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@/components/ui/empty";
+import { Progress, ProgressLabel, ProgressValue } from "@/components/ui/progress";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/primitives/cn";
+
+import type {
+  AuditFinding,
+  AuditReportProjection,
+  AuditSummary,
+  ScoreResult,
+} from "./localisation-audit-types";
+import { localisationAuditMessages as messages } from "./localisation-audit.messages";
+
+type AuditReportViewProps = {
+  report: AuditSummary | AuditReportProjection;
+  mode: "preview" | "public" | "private";
+  showFooter?: boolean;
+  children?: React.ReactNode;
+};
+
+function humanize(value: string): string {
+  return value.replaceAll("_", " ").replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function ScoreCard({
+  label,
+  score,
+  featured = false,
+}: {
+  label: string;
+  score: ScoreResult;
+  featured?: boolean;
+}) {
+  const intl = useIntl();
+
+  return (
+    <Card className={featured ? "bg-primary text-primary-foreground ring-primary" : undefined}>
+      <CardHeader>
+        <CardTitle className={featured ? "text-primary-foreground" : undefined}>{label}</CardTitle>
+        <CardAction>
+          {score.state === "scored" ? (
+            <span className="text-3xl font-semibold tabular-nums">{score.score}</span>
+          ) : (
+            <Badge
+              variant="outline"
+              className={featured ? "border-primary-foreground/30" : undefined}
+            >
+              {intl.formatMessage(messages.insufficientEvidence)}
+            </Badge>
+          )}
+        </CardAction>
+        <CardDescription className={featured ? "text-primary-foreground/75" : undefined}>
+          {intl.formatMessage(messages.evaluatedRules, {
+            count: score.evaluatedRules,
+          })}
+        </CardDescription>
+      </CardHeader>
+      {score.state === "scored" ? (
+        <CardContent>
+          <Progress
+            value={score.score}
+            aria-label={`${label}: ${score.score} out of 100`}
+            className={
+              featured
+                ? "[&_[data-slot=progress-indicator]]:bg-primary-foreground [&_[data-slot=progress-track]]:bg-primary-foreground/20"
+                : undefined
+            }
+          >
+            <ProgressLabel className="sr-only">{label}</ProgressLabel>
+            <ProgressValue className="sr-only" />
+          </Progress>
+        </CardContent>
+      ) : null}
+    </Card>
+  );
+}
+
+function FindingCard({ finding, index }: { finding: AuditFinding; index: number }) {
+  const intl = useIntl();
+  const hasEvidence = finding.evidence.trim().length > 0;
+  const confidence =
+    typeof finding.confidence === "number"
+      ? finding.confidence <= 1
+        ? intl.formatNumber(finding.confidence, { style: "percent" })
+        : intl.formatNumber(finding.confidence)
+      : humanize(finding.confidence);
+
+  return (
+    <Card size="sm">
+      <CardHeader className="border-b">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm font-medium tabular-nums text-muted-foreground">
+            {String(index + 1).padStart(2, "0")}
+          </span>
+          <Badge variant="outline">{humanize(finding.category)}</Badge>
+          <Badge
+            variant={finding.severity.toLowerCase() === "critical" ? "destructive" : "secondary"}
+          >
+            {humanize(finding.severity)}
+          </Badge>
+          {confidence ? (
+            <Badge variant="ghost">
+              {intl.formatMessage(messages.confidence, { value: confidence })}
+            </Badge>
+          ) : null}
+        </div>
+        <CardTitle className="mt-2 text-lg">{finding.title}</CardTitle>
+      </CardHeader>
+      <CardContent className={cn("grid gap-5", hasEvidence ? "md:grid-cols-3" : "md:grid-cols-2")}>
+        {hasEvidence ? (
+          <div className="flex flex-col gap-1.5">
+            <h3 className="text-sm font-semibold text-balance">
+              {intl.formatMessage(messages.evidence)}
+            </h3>
+            <p className="text-sm leading-6 text-pretty text-muted-foreground">
+              {finding.evidence}
+            </p>
+          </div>
+        ) : null}
+        <div className="flex flex-col gap-1.5">
+          <h3 className="text-sm font-semibold text-balance">
+            {intl.formatMessage(messages.businessImpact)}
+          </h3>
+          <p className="text-sm leading-6 text-pretty text-muted-foreground">
+            {finding.businessImpact}
+          </p>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <h3 className="text-sm font-semibold text-balance">
+            {intl.formatMessage(messages.recommendation)}
+          </h3>
+          <p className="text-sm leading-6 text-pretty text-muted-foreground">
+            {finding.recommendation}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ConversionCta() {
+  const intl = useIntl();
+
+  return (
+    <section className="border-t border-border px-5 py-16 sm:px-8 lg:px-10 lg:py-20">
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+        <div className="flex max-w-2xl flex-col gap-3">
+          <h2 className="font-heading text-3xl font-semibold text-balance">
+            {intl.formatMessage(messages.strategyTitle)}
+          </h2>
+          <p className="text-base leading-7 text-pretty text-muted-foreground">
+            {intl.formatMessage(messages.strategyDescription)}
+          </p>
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <Button
+            size="lg"
+            nativeButton={false}
+            render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
+          >
+            {intl.formatMessage(messages.bookCall)}
+            <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={2} data-icon="inline-end" />
+          </Button>
+          <Button
+            size="lg"
+            variant="outline"
+            nativeButton={false}
+            render={<a href="/auth/sign-in?returnTo=%2Fauth%2Fonboarding" />}
+          >
+            {intl.formatMessage(messages.createWorkspace)}
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function AuditReportView({
+  report,
+  mode,
+  showFooter = false,
+  children,
+}: AuditReportViewProps) {
+  const intl = useIntl();
+  const availableFindings =
+    mode === "private" && "findings" in report ? report.findings : report.previewFindings;
+  const findings = mode === "private" ? availableFindings : availableFindings.slice(0, 3);
+  const parsedDate = new Date(report.auditedAt);
+  const auditDate = Number.isNaN(parsedDate.valueOf())
+    ? report.auditedAt
+    : intl.formatDate(parsedDate, { dateStyle: "long" });
+
+  return (
+    <div className="bg-background text-foreground">
+      <div className="mx-auto max-w-7xl">
+        <section className="grid gap-10 px-5 pb-14 pt-12 sm:px-8 lg:grid-cols-[minmax(0,1fr)_auto] lg:px-10 lg:pb-18 lg:pt-16">
+          <div className="flex max-w-3xl flex-col gap-5">
+            <Badge variant="outline">{intl.formatMessage(messages.reportEyebrow)}</Badge>
+            <div className="flex flex-col gap-3">
+              <h1 className="font-heading text-4xl font-semibold text-balance sm:text-5xl">
+                {report.domain || intl.formatMessage(messages.reportTitle)}
+              </h1>
+              <p className="flex items-center gap-2 text-sm text-pretty text-muted-foreground">
+                <HugeiconsIcon
+                  icon={Calendar03Icon}
+                  strokeWidth={1.8}
+                  className="size-4"
+                  aria-hidden="true"
+                />
+                {intl.formatMessage(messages.auditedOn, { date: auditDate })}
+              </p>
+            </div>
+          </div>
+          <div className="hidden size-20 items-center justify-center rounded-full border border-border bg-muted/40 lg:flex">
+            <HugeiconsIcon
+              icon={CheckmarkCircle02Icon}
+              strokeWidth={1.5}
+              className="size-9 text-primary"
+              aria-hidden="true"
+            />
+          </div>
+        </section>
+
+        <section className="border-t border-border px-5 py-14 sm:px-8 lg:px-10 lg:py-18">
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+            <ScoreCard
+              label={intl.formatMessage(messages.overallScore)}
+              score={report.overallScore}
+              featured
+            />
+            <ScoreCard
+              label={intl.formatMessage(messages.technical)}
+              score={report.categories.technical}
+            />
+            <ScoreCard
+              label={intl.formatMessage(messages.linguistic)}
+              score={report.categories.linguistic}
+            />
+            <ScoreCard
+              label={intl.formatMessage(messages.market)}
+              score={report.categories.market}
+            />
+          </div>
+        </section>
+
+        <section className="border-t border-border px-5 py-14 sm:px-8 lg:px-10 lg:py-18">
+          <div className="mb-8 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-sm font-medium text-primary">
+                {mode === "private"
+                  ? intl.formatMessage(messages.reportTitle)
+                  : intl.formatMessage(messages.reportEyebrow)}
+              </p>
+              <h2 className="font-heading mt-2 text-3xl font-semibold text-balance">
+                {intl.formatMessage(
+                  mode === "private" ? messages.allFindings : messages.previewFindings,
+                )}
+              </h2>
+            </div>
+            {mode !== "private" && report.lockedFindingCount > 0 ? (
+              <div className="flex items-center gap-2 text-sm text-pretty text-muted-foreground">
+                <HugeiconsIcon
+                  icon={LockIcon}
+                  strokeWidth={1.8}
+                  className="size-4"
+                  aria-hidden="true"
+                />
+                {intl.formatMessage(messages.lockedFindings, {
+                  count: report.lockedFindingCount,
+                })}
+              </div>
+            ) : null}
+          </div>
+
+          {findings.length > 0 ? (
+            <div className="grid gap-4">
+              {findings.map((finding, index) => (
+                <FindingCard key={finding.id} finding={finding} index={index} />
+              ))}
+            </div>
+          ) : (
+            <Empty className="border">
+              <EmptyHeader>
+                <EmptyTitle>{intl.formatMessage(messages.previewFindings)}</EmptyTitle>
+                <EmptyDescription>
+                  {intl.formatMessage(messages.reportUnavailable)}
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          )}
+
+          {children ? (
+            <>
+              <Separator className="my-10" />
+              {children}
+            </>
+          ) : null}
+        </section>
+
+        {mode === "private" && report.limitations.length > 0 ? (
+          <section className="border-t border-border px-5 py-14 sm:px-8 lg:px-10 lg:py-18">
+            <Card>
+              <CardHeader>
+                <CardTitle>{intl.formatMessage(messages.limitations)}</CardTitle>
+                <CardDescription className="text-pretty">
+                  {intl.formatMessage(messages.limitationsDescription)}
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ul className="grid gap-3">
+                  {report.limitations.map((limitation) => (
+                    <li
+                      key={limitation}
+                      className="flex gap-3 text-sm leading-6 text-pretty text-muted-foreground"
+                    >
+                      <span
+                        className="mt-2 size-1.5 shrink-0 rounded-full bg-primary"
+                        aria-hidden="true"
+                      />
+                      {limitation}
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+              <CardFooter className="border-t text-xs text-muted-foreground">
+                {intl.formatMessage(messages.missingEvidenceNote)}
+              </CardFooter>
+            </Card>
+          </section>
+        ) : null}
+
+        <ConversionCta />
+
+        {showFooter ? (
+          <section className="border-t border-border">
+            <div className="px-5 pt-16 sm:px-8 lg:px-10">
+              <MarketingFooter columns={footerColumns} />
+            </div>
+          </section>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit-flow.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit-flow.test.tsx
@@ -40,9 +40,26 @@ const findings = Array.from({ length: 4 }, (_, index) => ({
   confidence: "high",
 }));
 
-function jsonResponse(body: unknown): Response {
+const completedSummary = {
+  domain: "example.com",
+  auditedAt: "2026-07-24T12:00:00.000Z",
+  overallScore: scored,
+  categories: {
+    technical: scored,
+    linguistic: {
+      state: "insufficient_evidence",
+      evaluatedRules: 2,
+    },
+    market: scored,
+  },
+  previewFindings: findings,
+  lockedFindingCount: 6,
+  limitations: [],
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
-    status: 200,
+    status,
     headers: { "Content-Type": "application/json" },
   });
 }
@@ -52,10 +69,20 @@ afterEach(() => {
 });
 
 describe("LocalisationAuditFlow", () => {
-  it("completes discovery, confirmation, preview, and report unlock", async () => {
+  it("polls durable prepare/run workflows through discovery, confirmation, preview, and unlock", async () => {
     const user = userEvent.setup();
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        jsonResponse({
+          audit: {
+            id: "audit-1",
+            status: "preparing",
+            detectedLocale: null,
+            alternatives: [],
+          },
+        }),
+      )
       .mockResolvedValueOnce(
         jsonResponse({
           audit: {
@@ -75,24 +102,19 @@ describe("LocalisationAuditFlow", () => {
         jsonResponse({
           audit: {
             id: "audit-1",
+            status: "running",
+            detectedLocale: "fr-FR",
+            alternatives: [],
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          audit: {
+            id: "audit-1",
             status: "completed",
             publicSlug: "shared-1",
-            summary: {
-              domain: "example.com",
-              auditedAt: "2026-07-24T12:00:00.000Z",
-              overallScore: scored,
-              categories: {
-                technical: scored,
-                linguistic: {
-                  state: "insufficient_evidence",
-                  evaluatedRules: 2,
-                },
-                market: scored,
-              },
-              previewFindings: findings,
-              lockedFindingCount: 6,
-              limitations: [],
-            },
+            summary: completedSummary,
           },
         }),
       )
@@ -156,8 +178,9 @@ describe("LocalisationAuditFlow", () => {
         body: JSON.stringify({ url: "https://example.com/fr" }),
       }),
     );
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "/api/localisation-audit/audits/audit-1");
     expect(fetchMock).toHaveBeenNthCalledWith(
-      2,
+      3,
       "/api/localisation-audit/audits/audit-1/confirm",
       expect.objectContaining({
         method: "PATCH",
@@ -167,8 +190,9 @@ describe("LocalisationAuditFlow", () => {
         }),
       }),
     );
+    expect(fetchMock).toHaveBeenNthCalledWith(4, "/api/localisation-audit/audits/audit-1");
     expect(fetchMock).toHaveBeenNthCalledWith(
-      3,
+      5,
       "/api/localisation-audit/audits/audit-1/unlock",
       expect.objectContaining({
         method: "POST",

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit-flow.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit-flow.test.tsx
@@ -120,7 +120,9 @@ describe("LocalisationAuditFlow", () => {
     const targetMarketInput = screen.getByRole("textbox", {
       name: "Target market country code",
     });
-    expect(screen.getByText("Use a two-letter ISO country code such as FR, DE, or GB.")).toBeVisible();
+    expect(
+      screen.getByText("Use a two-letter ISO country code such as FR, DE, or GB."),
+    ).toBeVisible();
     await user.type(targetMarketInput, "gb");
     expect(targetMarketInput).toHaveValue("GB");
     await user.click(screen.getByRole("button", { name: "Run the full health check" }));

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit-flow.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit-flow.test.tsx
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IntlProvider } from "react-intl";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { LocalisationAuditFlow } from "./localisation-audit-flow";
+
+vi.mock("@/components/marketing/marketing-footer", () => ({
+  MarketingFooter: () => <footer data-testid="marketing-footer" />,
+}));
+
+const scored = {
+  state: "scored" as const,
+  score: 82,
+  evaluatedRules: 8,
+};
+
+const findings = Array.from({ length: 4 }, (_, index) => ({
+  id: `finding-${index + 1}`,
+  category: index === 0 ? "technical" : "linguistic",
+  severity: index === 0 ? "high" : "medium",
+  title: `Finding ${index + 1}`,
+  evidence: `Evidence ${index + 1}`,
+  businessImpact: `Impact ${index + 1}`,
+  recommendation: `Recommendation ${index + 1}`,
+  confidence: "high",
+}));
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("LocalisationAuditFlow", () => {
+  it("completes discovery, confirmation, preview, and report unlock", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        jsonResponse({
+          audit: {
+            id: "audit-1",
+            status: "awaiting_confirmation",
+            detectedLocale: "fr-FR",
+            alternatives: [
+              {
+                locale: "en-GB",
+                url: "https://example.com/en",
+              },
+            ],
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          audit: {
+            id: "audit-1",
+            status: "completed",
+            publicSlug: "shared-1",
+            summary: {
+              domain: "example.com",
+              auditedAt: "2026-07-24T12:00:00.000Z",
+              overallScore: scored,
+              categories: {
+                technical: scored,
+                linguistic: {
+                  state: "insufficient_evidence",
+                  evaluatedRules: 2,
+                },
+                market: scored,
+              },
+              previewFindings: findings,
+              lockedFindingCount: 6,
+              limitations: [],
+            },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          report: {
+            accessUrl: "/en/localisation-audit/report/private-token",
+          },
+        }),
+      );
+
+    render(
+      <IntlProvider locale="en" messages={{}}>
+        <LocalisationAuditFlow />
+      </IntlProvider>,
+    );
+
+    await user.type(screen.getByRole("textbox", { name: "Website URL" }), "https://example.com/fr");
+    await user.click(screen.getByRole("button", { name: "Check my website" }));
+
+    expect(await screen.findByText("We found your localisation footprint")).toBeVisible();
+    expect(screen.getByText("fr-FR")).toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: "en-GB" }));
+    await user.type(screen.getByRole("textbox", { name: "Target market" }), "United Kingdom");
+    await user.click(screen.getByRole("button", { name: "Run the full health check" }));
+
+    expect(await screen.findByRole("heading", { name: "example.com" })).toBeVisible();
+    expect(screen.getByText("Insufficient evidence")).toBeVisible();
+    expect(screen.getByText("6 additional findings are in the full report")).toBeVisible();
+
+    expect(screen.getByText("Finding 1")).toBeVisible();
+    expect(screen.getByText("Finding 2")).toBeVisible();
+    expect(screen.getByText("Finding 3")).toBeVisible();
+    expect(screen.queryByText("Finding 4")).not.toBeInTheDocument();
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Work email" }),
+      "localisation@example.com",
+    );
+    await user.click(screen.getByRole("button", { name: "Email me the full report" }));
+
+    const reportLinkLabel = await screen.findByText("Open the complete report");
+    expect(reportLinkLabel.closest("a")).toHaveAttribute(
+      "href",
+      "/en/localisation-audit/report/private-token",
+    );
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/api/localisation-audit/audits",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ url: "https://example.com/fr" }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/localisation-audit/audits/audit-1/confirm",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({
+          targetLocale: "en-GB",
+          targetMarket: "United Kingdom",
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "/api/localisation-audit/audits/audit-1/unlock",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          email: "localisation@example.com",
+        }),
+      }),
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit-flow.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit-flow.test.tsx
@@ -117,7 +117,12 @@ describe("LocalisationAuditFlow", () => {
     expect(screen.getByText("fr-FR")).toBeVisible();
 
     await user.click(screen.getByRole("button", { name: "en-GB" }));
-    await user.type(screen.getByRole("textbox", { name: "Target market" }), "United Kingdom");
+    const targetMarketInput = screen.getByRole("textbox", {
+      name: "Target market country code",
+    });
+    expect(screen.getByText("Use a two-letter ISO country code such as FR, DE, or GB.")).toBeVisible();
+    await user.type(targetMarketInput, "gb");
+    expect(targetMarketInput).toHaveValue("GB");
     await user.click(screen.getByRole("button", { name: "Run the full health check" }));
 
     expect(await screen.findByRole("heading", { name: "example.com" })).toBeVisible();
@@ -156,7 +161,7 @@ describe("LocalisationAuditFlow", () => {
         method: "PATCH",
         body: JSON.stringify({
           targetLocale: "en-GB",
-          targetMarket: "United Kingdom",
+          targetMarket: "GB",
         }),
       }),
     );

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit-flow.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit-flow.tsx
@@ -550,10 +550,18 @@ export function LocalisationAuditFlow() {
                         <Input
                           id="target-market"
                           value={targetMarket}
-                          onChange={(event) => setTargetMarket(event.currentTarget.value)}
+                          onChange={(event) =>
+                            setTargetMarket(event.currentTarget.value.toUpperCase())
+                          }
                           placeholder={intl.formatMessage(messages.targetMarketPlaceholder)}
+                          autoCapitalize="characters"
+                          maxLength={2}
+                          pattern="[A-Za-z]{2}"
                           required
                         />
+                        <FieldDescription>
+                          {intl.formatMessage(messages.targetMarketDescription)}
+                        </FieldDescription>
                       </Field>
                       {error && failedAction === "confirm" ? (
                         <FormError

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit-flow.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit-flow.tsx
@@ -45,6 +45,7 @@ import { Progress, ProgressLabel, ProgressValue } from "@/components/ui/progress
 
 import { AuditReportView } from "./audit-report-view";
 import type {
+  AuditStatus,
   ConfirmAuditResponse,
   CreateAuditResponse,
   UnlockAuditResponse,
@@ -54,6 +55,15 @@ import { localisationAuditMessages as messages } from "./localisation-audit.mess
 
 type FlowStage = "input" | "discovering" | "confirm" | "auditing" | "result";
 type FailedAction = "create" | "confirm" | "unlock" | null;
+type CompletedAuditView = {
+  id: string;
+  status: "completed" | "partial";
+  publicSlug?: string;
+  summary: ReturnType<typeof toAuditReportProjection>;
+};
+
+const AUDIT_POLL_INTERVAL_MS = 1_000;
+const AUDIT_POLL_TIMEOUT_MS = 90_000;
 
 async function readErrorMessage(response: Response, fallback: string): Promise<string> {
   try {
@@ -67,6 +77,32 @@ async function readErrorMessage(response: Response, fallback: string): Promise<s
 function getFormString(formData: FormData, key: string): string {
   const value = formData.get(key);
   return typeof value === "string" ? value : "";
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
+async function pollAuditUntil(
+  auditId: string,
+  isTerminal: (status: AuditStatus) => boolean,
+  fallbackError: string,
+): Promise<ConfirmAuditResponse["audit"]> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < AUDIT_POLL_TIMEOUT_MS) {
+    const response = await fetch(`/api/localisation-audit/audits/${encodeURIComponent(auditId)}`);
+    if (!response.ok) {
+      throw new Error(await readErrorMessage(response, fallbackError));
+    }
+    const body = (await response.json()) as ConfirmAuditResponse;
+    if (isTerminal(body.audit.status)) {
+      return body.audit;
+    }
+    await sleep(AUDIT_POLL_INTERVAL_MS);
+  }
+  throw new Error(fallbackError);
 }
 
 function LoadingStage({
@@ -157,7 +193,7 @@ export function LocalisationAuditFlow() {
   const [stage, setStage] = useState<FlowStage>("input");
   const [submittedUrl, setSubmittedUrl] = useState("");
   const [createdAudit, setCreatedAudit] = useState<CreateAuditResponse["audit"] | null>(null);
-  const [completedAudit, setCompletedAudit] = useState<ConfirmAuditResponse["audit"] | null>(null);
+  const [completedAudit, setCompletedAudit] = useState<CompletedAuditView | null>(null);
   const [targetLocale, setTargetLocale] = useState("");
   const [targetMarket, setTargetMarket] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -185,8 +221,24 @@ export function LocalisationAuditFlow() {
       }
 
       const body = (await response.json()) as CreateAuditResponse;
-      setCreatedAudit(body.audit);
-      setTargetLocale(body.audit.detectedLocale ?? body.audit.alternatives[0]?.locale ?? "");
+      const prepared =
+        body.audit.status === "awaiting_confirmation" || body.audit.status === "failed"
+          ? body.audit
+          : await pollAuditUntil(
+              body.audit.id,
+              (status) => status === "awaiting_confirmation" || status === "failed",
+              fallbackError,
+            );
+      if (prepared.status === "failed") {
+        throw new Error(fallbackError);
+      }
+      setCreatedAudit({
+        id: prepared.id,
+        status: prepared.status,
+        detectedLocale: prepared.detectedLocale ?? null,
+        alternatives: prepared.alternatives ?? [],
+      });
+      setTargetLocale(prepared.detectedLocale ?? prepared.alternatives?.[0]?.locale ?? "");
       setStage("confirm");
     } catch (requestError) {
       setStage("input");
@@ -221,9 +273,27 @@ export function LocalisationAuditFlow() {
       }
 
       const body = (await response.json()) as ConfirmAuditResponse;
+      const completed =
+        body.audit.status === "completed" ||
+        body.audit.status === "partial" ||
+        body.audit.status === "failed"
+          ? body.audit
+          : await pollAuditUntil(
+              createdAudit.id,
+              (status) => status === "completed" || status === "partial" || status === "failed",
+              fallbackError,
+            );
+      if (
+        (completed.status !== "completed" && completed.status !== "partial") ||
+        !completed.summary
+      ) {
+        throw new Error(fallbackError);
+      }
       setCompletedAudit({
-        ...body.audit,
-        summary: toAuditReportProjection(body.audit.summary),
+        id: completed.id,
+        status: completed.status,
+        publicSlug: completed.publicSlug,
+        summary: toAuditReportProjection(completed.summary),
       });
       setStage("result");
     } catch (requestError) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit-flow.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit-flow.tsx
@@ -1,0 +1,599 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import {
+  ArrowRight01Icon,
+  CheckmarkCircle02Icon,
+  Globe02Icon,
+  InformationCircleIcon,
+  LinkSquare02Icon,
+  Mail01Icon,
+  Search01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useState } from "react";
+import { useIntl } from "react-intl";
+
+import { MarketingFooter } from "@/components/marketing/marketing-footer";
+import { footerColumns } from "@/components/marketing/marketing-page-content";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/input-group";
+import { Progress, ProgressLabel, ProgressValue } from "@/components/ui/progress";
+
+import { AuditReportView } from "./audit-report-view";
+import type {
+  ConfirmAuditResponse,
+  CreateAuditResponse,
+  UnlockAuditResponse,
+} from "./localisation-audit-types";
+import { toAuditReportProjection } from "./localisation-audit-types";
+import { localisationAuditMessages as messages } from "./localisation-audit.messages";
+
+type FlowStage = "input" | "discovering" | "confirm" | "auditing" | "result";
+type FailedAction = "create" | "confirm" | "unlock" | null;
+
+async function readErrorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const body = (await response.json()) as { message?: unknown };
+    return typeof body.message === "string" && body.message ? body.message : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function getFormString(formData: FormData, key: string): string {
+  const value = formData.get(key);
+  return typeof value === "string" ? value : "";
+}
+
+function LoadingStage({
+  title,
+  description,
+  value,
+  auditRunning,
+}: {
+  title: string;
+  description: string;
+  value: number;
+  auditRunning: boolean;
+}) {
+  const intl = useIntl();
+
+  return (
+    <Card aria-live="polite" aria-busy="true">
+      <CardHeader>
+        <CardTitle className="text-2xl">{title}</CardTitle>
+        <CardDescription className="max-w-2xl text-base leading-7 text-pretty">
+          {description}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-7">
+        <Progress value={value}>
+          <ProgressLabel>{intl.formatMessage(messages.progressLabel)}</ProgressLabel>
+          <ProgressValue />
+        </Progress>
+        <ol className="grid gap-3 text-sm sm:grid-cols-3">
+          <li className="flex items-center gap-2 text-foreground">
+            <HugeiconsIcon
+              icon={CheckmarkCircle02Icon}
+              strokeWidth={1.8}
+              className="size-4 text-primary"
+              aria-hidden="true"
+            />
+            {intl.formatMessage(messages.progressDiscover)}
+          </li>
+          <li className="flex items-center gap-2 text-muted-foreground">
+            <span className="size-2 rounded-full bg-primary" aria-hidden="true" />
+            {auditRunning
+              ? intl.formatMessage(messages.progressTechnical)
+              : intl.formatMessage(messages.discoveryTitle)}
+          </li>
+          <li className="flex items-center gap-2 text-muted-foreground">
+            <span className="size-2 rounded-full bg-muted-foreground/40" aria-hidden="true" />
+            {intl.formatMessage(messages.progressLanguage)}
+          </li>
+        </ol>
+      </CardContent>
+    </Card>
+  );
+}
+
+function FormError({
+  message,
+  onRetry,
+  retrying,
+}: {
+  message: string;
+  onRetry: () => void;
+  retrying: boolean;
+}) {
+  const intl = useIntl();
+
+  return (
+    <Alert variant="destructive">
+      <HugeiconsIcon icon={InformationCircleIcon} strokeWidth={1.8} aria-hidden="true" />
+      <AlertTitle>{message}</AlertTitle>
+      <AlertDescription>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="mt-3"
+          onClick={onRetry}
+          disabled={retrying}
+        >
+          {intl.formatMessage(messages.retry)}
+        </Button>
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+export function LocalisationAuditFlow() {
+  const intl = useIntl();
+  const [stage, setStage] = useState<FlowStage>("input");
+  const [submittedUrl, setSubmittedUrl] = useState("");
+  const [createdAudit, setCreatedAudit] = useState<CreateAuditResponse["audit"] | null>(null);
+  const [completedAudit, setCompletedAudit] = useState<ConfirmAuditResponse["audit"] | null>(null);
+  const [targetLocale, setTargetLocale] = useState("");
+  const [targetMarket, setTargetMarket] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [failedAction, setFailedAction] = useState<FailedAction>(null);
+  const [reportAccessUrl, setReportAccessUrl] = useState<string | null>(null);
+  const [isUnlocking, setIsUnlocking] = useState(false);
+
+  const fallbackError = intl.formatMessage(messages.requestFailed);
+  const isPending = stage === "discovering" || stage === "auditing";
+
+  async function createAudit(url: string) {
+    setError(null);
+    setFailedAction(null);
+    setSubmittedUrl(url);
+    setStage("discovering");
+
+    try {
+      const response = await fetch("/api/localisation-audit/audits", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url }),
+      });
+      if (!response.ok) {
+        throw new Error(await readErrorMessage(response, fallbackError));
+      }
+
+      const body = (await response.json()) as CreateAuditResponse;
+      setCreatedAudit(body.audit);
+      setTargetLocale(body.audit.detectedLocale ?? body.audit.alternatives[0]?.locale ?? "");
+      setStage("confirm");
+    } catch (requestError) {
+      setStage("input");
+      setFailedAction("create");
+      setError(requestError instanceof Error ? requestError.message : fallbackError);
+    }
+  }
+
+  async function confirmAudit(locale: string, market: string) {
+    if (!createdAudit) {
+      return;
+    }
+
+    setError(null);
+    setFailedAction(null);
+    setStage("auditing");
+
+    try {
+      const response = await fetch(
+        `/api/localisation-audit/audits/${encodeURIComponent(createdAudit.id)}/confirm`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            targetLocale: locale,
+            targetMarket: market,
+          }),
+        },
+      );
+      if (!response.ok) {
+        throw new Error(await readErrorMessage(response, fallbackError));
+      }
+
+      const body = (await response.json()) as ConfirmAuditResponse;
+      setCompletedAudit({
+        ...body.audit,
+        summary: toAuditReportProjection(body.audit.summary),
+      });
+      setStage("result");
+    } catch (requestError) {
+      setStage("confirm");
+      setFailedAction("confirm");
+      setError(requestError instanceof Error ? requestError.message : fallbackError);
+    }
+  }
+
+  async function unlockReport(workEmail: string, name: string) {
+    if (!completedAudit) {
+      return;
+    }
+
+    setError(null);
+    setFailedAction(null);
+    setIsUnlocking(true);
+
+    try {
+      const response = await fetch(
+        `/api/localisation-audit/audits/${encodeURIComponent(completedAudit.id)}/unlock`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email: workEmail,
+            ...(name ? { name } : {}),
+          }),
+        },
+      );
+      if (!response.ok) {
+        throw new Error(await readErrorMessage(response, fallbackError));
+      }
+
+      const body = (await response.json()) as UnlockAuditResponse;
+      setReportAccessUrl(body.report.accessUrl);
+    } catch (requestError) {
+      setFailedAction("unlock");
+      setError(requestError instanceof Error ? requestError.message : fallbackError);
+    } finally {
+      setIsUnlocking(false);
+    }
+  }
+
+  function retryFailedAction() {
+    if (failedAction === "create") {
+      void createAudit(submittedUrl);
+      return;
+    }
+    if (failedAction === "confirm") {
+      void confirmAudit(targetLocale, targetMarket);
+    }
+  }
+
+  if (stage === "result" && completedAudit) {
+    return (
+      <AuditReportView report={completedAudit.summary} mode="preview" showFooter>
+        <Card className="mx-auto max-w-3xl bg-muted/20">
+          <CardHeader>
+            <CardTitle className="text-2xl">
+              {reportAccessUrl
+                ? intl.formatMessage(messages.unlockedTitle)
+                : intl.formatMessage(messages.unlockTitle)}
+            </CardTitle>
+            <CardDescription className="text-base leading-7 text-pretty">
+              {intl.formatMessage(messages.unlockDescription)}
+            </CardDescription>
+          </CardHeader>
+          {reportAccessUrl ? (
+            <CardFooter>
+              <Button nativeButton={false} render={<a href={reportAccessUrl} />}>
+                {intl.formatMessage(messages.openReport)}
+                <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={2} data-icon="inline-end" />
+              </Button>
+            </CardFooter>
+          ) : (
+            <form
+              onSubmit={(event) => {
+                event.preventDefault();
+                const formData = new FormData(event.currentTarget);
+                void unlockReport(
+                  getFormString(formData, "workEmail"),
+                  getFormString(formData, "name").trim(),
+                );
+              }}
+            >
+              <CardContent>
+                <FieldGroup>
+                  <Field>
+                    <FieldLabel htmlFor="audit-work-email">
+                      {intl.formatMessage(messages.workEmailLabel)}
+                    </FieldLabel>
+                    <Input
+                      id="audit-work-email"
+                      name="workEmail"
+                      type="email"
+                      autoComplete="email"
+                      required
+                      aria-invalid={failedAction === "unlock" || undefined}
+                    />
+                  </Field>
+                  <Field>
+                    <FieldLabel htmlFor="audit-name">
+                      {intl.formatMessage(messages.nameLabel)}
+                    </FieldLabel>
+                    <Input id="audit-name" name="name" autoComplete="name" />
+                  </Field>
+                  {error && failedAction === "unlock" ? <FieldError>{error}</FieldError> : null}
+                  {isUnlocking ? (
+                    <Progress value={90} aria-label={intl.formatMessage(messages.preparingReport)}>
+                      <ProgressLabel>{intl.formatMessage(messages.preparingReport)}</ProgressLabel>
+                      <ProgressValue className="sr-only" />
+                    </Progress>
+                  ) : null}
+                </FieldGroup>
+              </CardContent>
+              <CardFooter className="border-t">
+                <Button type="submit" size="lg" disabled={isUnlocking}>
+                  <HugeiconsIcon icon={Mail01Icon} strokeWidth={1.8} data-icon="inline-start" />
+                  {intl.formatMessage(messages.unlockButton)}
+                </Button>
+              </CardFooter>
+            </form>
+          )}
+        </Card>
+      </AuditReportView>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto max-w-7xl">
+        <section className="grid gap-10 px-5 pb-16 pt-12 sm:px-8 lg:grid-cols-[minmax(0,0.9fr)_minmax(380px,0.7fr)] lg:px-10 lg:pb-24 lg:pt-20">
+          <div className="flex max-w-3xl flex-col gap-6">
+            <Badge variant="outline">{intl.formatMessage(messages.eyebrow)}</Badge>
+            <div className="flex flex-col gap-5">
+              <h1 className="font-heading text-4xl font-semibold leading-tight text-balance sm:text-5xl lg:text-6xl">
+                {intl.formatMessage(messages.title)}
+              </h1>
+              <p className="max-w-2xl text-lg leading-8 text-pretty text-muted-foreground">
+                {intl.formatMessage(messages.lead)}
+              </p>
+            </div>
+            <div className="grid max-w-2xl gap-3 text-sm text-muted-foreground sm:grid-cols-3">
+              <div className="flex items-center gap-2">
+                <HugeiconsIcon
+                  icon={Globe02Icon}
+                  strokeWidth={1.8}
+                  className="size-4 text-primary"
+                  aria-hidden="true"
+                />
+                {intl.formatMessage(messages.technicalReadinessShort)}
+              </div>
+              <div className="flex items-center gap-2">
+                <HugeiconsIcon
+                  icon={Search01Icon}
+                  strokeWidth={1.8}
+                  className="size-4 text-primary"
+                  aria-hidden="true"
+                />
+                {intl.formatMessage(messages.languageQualityShort)}
+              </div>
+              <div className="flex items-center gap-2">
+                <HugeiconsIcon
+                  icon={LinkSquare02Icon}
+                  strokeWidth={1.8}
+                  className="size-4 text-primary"
+                  aria-hidden="true"
+                />
+                {intl.formatMessage(messages.marketFitShort)}
+              </div>
+            </div>
+          </div>
+
+          <div className="self-start">
+            {stage === "input" ? (
+              <Card>
+                <form
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    const formData = new FormData(event.currentTarget);
+                    void createAudit(getFormString(formData, "url"));
+                  }}
+                >
+                  <CardHeader>
+                    <CardTitle>{intl.formatMessage(messages.urlLabel)}</CardTitle>
+                    <CardDescription className="text-pretty">
+                      {intl.formatMessage(messages.urlDescription)}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <FieldGroup>
+                      <Field>
+                        <FieldLabel className="sr-only" htmlFor="audit-url">
+                          {intl.formatMessage(messages.urlLabel)}
+                        </FieldLabel>
+                        <InputGroup className="h-12">
+                          <InputGroupInput
+                            id="audit-url"
+                            name="url"
+                            type="url"
+                            inputMode="url"
+                            autoComplete="url"
+                            placeholder={intl.formatMessage(messages.urlPlaceholder)}
+                            defaultValue={submittedUrl}
+                            required
+                            aria-invalid={failedAction === "create" || undefined}
+                          />
+                          <InputGroupAddon align="inline-start">
+                            <HugeiconsIcon
+                              icon={Globe02Icon}
+                              strokeWidth={1.8}
+                              aria-hidden="true"
+                            />
+                          </InputGroupAddon>
+                        </InputGroup>
+                        {error && failedAction === "create" ? (
+                          <FieldError>{error}</FieldError>
+                        ) : null}
+                      </Field>
+                    </FieldGroup>
+                  </CardContent>
+                  <CardFooter className="border-t">
+                    <Button type="submit" size="lg" className="w-full">
+                      {intl.formatMessage(messages.startAudit)}
+                      <HugeiconsIcon
+                        icon={ArrowRight01Icon}
+                        strokeWidth={2}
+                        data-icon="inline-end"
+                      />
+                    </Button>
+                  </CardFooter>
+                </form>
+              </Card>
+            ) : null}
+
+            {stage === "discovering" ? (
+              <LoadingStage
+                title={intl.formatMessage(messages.discoveryTitle)}
+                description={intl.formatMessage(messages.discoveryDescription)}
+                value={34}
+                auditRunning={false}
+              />
+            ) : null}
+
+            {stage === "auditing" ? (
+              <LoadingStage
+                title={intl.formatMessage(messages.auditProgressTitle)}
+                description={intl.formatMessage(messages.auditProgressDescription)}
+                value={72}
+                auditRunning
+              />
+            ) : null}
+
+            {stage === "confirm" && createdAudit ? (
+              <Card>
+                <form
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    void confirmAudit(targetLocale.trim(), targetMarket.trim());
+                  }}
+                >
+                  <CardHeader>
+                    <Badge variant="secondary">{intl.formatMessage(messages.confirmEyebrow)}</Badge>
+                    <CardTitle className="text-2xl">
+                      {intl.formatMessage(messages.confirmTitle)}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="mb-7 grid gap-4 rounded-lg border border-border bg-muted/20 p-4">
+                      <div>
+                        <p className="text-xs font-medium text-muted-foreground">
+                          {intl.formatMessage(messages.detectedLocale)}
+                        </p>
+                        <p className="mt-1 font-medium">
+                          {createdAudit.detectedLocale ?? intl.formatMessage(messages.notDetected)}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-xs font-medium text-muted-foreground">
+                          {intl.formatMessage(messages.alternatives)}
+                        </p>
+                        {createdAudit.alternatives.length > 0 ? (
+                          <div className="mt-2 flex flex-wrap gap-2">
+                            {createdAudit.alternatives.map((alternative) => (
+                              <Button
+                                key={`${alternative.locale}-${alternative.url}`}
+                                type="button"
+                                size="sm"
+                                variant="outline"
+                                onClick={() => setTargetLocale(alternative.locale)}
+                              >
+                                {alternative.locale}
+                              </Button>
+                            ))}
+                          </div>
+                        ) : (
+                          <p className="mt-1 text-sm text-pretty text-muted-foreground">
+                            {intl.formatMessage(messages.noAlternatives)}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+
+                    <FieldGroup>
+                      <Field>
+                        <FieldLabel htmlFor="target-locale">
+                          {intl.formatMessage(messages.targetLocaleLabel)}
+                        </FieldLabel>
+                        <Input
+                          id="target-locale"
+                          value={targetLocale}
+                          onChange={(event) => setTargetLocale(event.currentTarget.value)}
+                          required
+                        />
+                        <FieldDescription>
+                          {intl.formatMessage(messages.targetLocaleDescription)}
+                        </FieldDescription>
+                      </Field>
+                      <Field>
+                        <FieldLabel htmlFor="target-market">
+                          {intl.formatMessage(messages.targetMarketLabel)}
+                        </FieldLabel>
+                        <Input
+                          id="target-market"
+                          value={targetMarket}
+                          onChange={(event) => setTargetMarket(event.currentTarget.value)}
+                          placeholder={intl.formatMessage(messages.targetMarketPlaceholder)}
+                          required
+                        />
+                      </Field>
+                      {error && failedAction === "confirm" ? (
+                        <FormError
+                          message={error}
+                          onRetry={retryFailedAction}
+                          retrying={isPending}
+                        />
+                      ) : null}
+                    </FieldGroup>
+                  </CardContent>
+                  <CardFooter className="flex-col gap-2 border-t sm:flex-row">
+                    <Button type="submit" size="lg" className="w-full sm:w-auto">
+                      {intl.formatMessage(messages.runAudit)}
+                    </Button>
+                    <Button
+                      type="button"
+                      size="lg"
+                      variant="ghost"
+                      className="w-full sm:w-auto"
+                      onClick={() => {
+                        setError(null);
+                        setFailedAction(null);
+                        setStage("input");
+                      }}
+                    >
+                      {intl.formatMessage(messages.changeUrl)}
+                    </Button>
+                  </CardFooter>
+                </form>
+              </Card>
+            ) : null}
+          </div>
+        </section>
+
+        <section className="border-t border-border">
+          <div className="px-5 pt-16 sm:px-8 lg:px-10">
+            <MarketingFooter columns={footerColumns} />
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit-types.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit-types.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { toAuditReportProjection } from "./localisation-audit-types";
+
+describe("toAuditReportProjection", () => {
+  it("normalizes the persisted report projection for the shared report UI", () => {
+    const report = toAuditReportProjection({
+      domain: "example.com",
+      auditedAt: "2026-07-24T12:00:00.000Z",
+      overallStatus: "scored",
+      overallScore: 75,
+      categoryScores: {
+        technical: {
+          status: "scored",
+          score: 90,
+          evaluatedRuleCount: 8,
+        },
+        linguistic: {
+          status: "insufficient_evidence",
+          score: null,
+          evaluatedRuleCount: 2,
+        },
+        market: {
+          status: "scored",
+          score: 61,
+          evaluatedRuleCount: 4,
+        },
+      },
+      findings: [
+        {
+          code: "html_lang_missing",
+          category: "technical",
+          severity: "high",
+          title: "Document language is missing",
+          evidence: {
+            expectedValue: "A valid BCP 47 language tag",
+          },
+          impact: "Assistive technology may use the wrong language.",
+          recommendation: "Add a valid lang attribute.",
+        },
+      ],
+      lockedFindingCount: 3,
+      limitations: ["One locale was blocked."],
+    });
+
+    expect(report.overallScore).toEqual({
+      state: "scored",
+      score: 75,
+      evaluatedRules: 0,
+    });
+    expect(report.categories.linguistic).toEqual({
+      state: "insufficient_evidence",
+      evaluatedRules: 2,
+    });
+    expect(report.findings[0]).toMatchObject({
+      id: "html_lang_missing",
+      businessImpact: "Assistive technology may use the wrong language.",
+      evidence: "A valid BCP 47 language tag",
+    });
+    expect(report.previewFindings).toHaveLength(1);
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit-types.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit-types.ts
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+export type ScoreResult =
+  | {
+      state: "scored";
+      score: number;
+      evaluatedRules: number;
+    }
+  | {
+      state: "insufficient_evidence";
+      evaluatedRules: number;
+    };
+
+export type AuditFinding = {
+  id: string;
+  category: string;
+  severity: string;
+  title: string;
+  evidence: string;
+  businessImpact: string;
+  recommendation: string;
+  confidence: string | number;
+};
+
+export type AuditSummary = {
+  domain: string;
+  auditedAt: string;
+  overallScore: ScoreResult;
+  categories: {
+    technical: ScoreResult;
+    linguistic: ScoreResult;
+    market: ScoreResult;
+  };
+  previewFindings: AuditFinding[];
+  lockedFindingCount: number;
+  limitations: string[];
+};
+
+export type DiscoveredAlternative = {
+  locale: string;
+  url: string;
+};
+
+export type CreateAuditResponse = {
+  audit: {
+    id: string;
+    status: "awaiting_confirmation";
+    detectedLocale: string | null;
+    alternatives: DiscoveredAlternative[];
+  };
+};
+
+export type ConfirmAuditResponse = {
+  audit: {
+    id: string;
+    status: "completed" | "partial";
+    publicSlug: string;
+    summary: AuditSummary;
+  };
+};
+
+export type UnlockAuditResponse = {
+  report: {
+    accessUrl: string;
+  };
+};
+
+export type AuditReportProjection = AuditSummary & {
+  findings: AuditFinding[];
+};
+
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null;
+}
+
+function stringValue(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function numberValue(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function parseScore(value: unknown, status?: unknown): ScoreResult {
+  if (typeof value === "number" && status === "scored") {
+    return { state: "scored", score: value, evaluatedRules: 0 };
+  }
+
+  if (!isRecord(value)) {
+    return { state: "insufficient_evidence", evaluatedRules: 0 };
+  }
+
+  const evaluatedRules = numberValue(value.evaluatedRules ?? value.evaluatedRuleCount);
+  if (value.state === "scored" || value.status === "scored") {
+    return {
+      state: "scored",
+      score: numberValue(value.score),
+      evaluatedRules,
+    };
+  }
+
+  return { state: "insufficient_evidence", evaluatedRules };
+}
+
+function parseFinding(value: unknown, index: number): AuditFinding | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const title = stringValue(value.title);
+  if (!title) {
+    return null;
+  }
+
+  const evidenceValue = isRecord(value.evidence)
+    ? [
+        stringValue(value.evidence.excerpt),
+        stringValue(value.evidence.observedValue),
+        stringValue(value.evidence.expectedValue),
+      ]
+        .filter(Boolean)
+        .join(" — ")
+    : stringValue(value.evidence);
+
+  return {
+    id: stringValue(value.id ?? value.code, `finding-${index}`),
+    category: stringValue(value.category, "technical"),
+    severity: stringValue(value.severity, "medium"),
+    title,
+    evidence: evidenceValue,
+    businessImpact: stringValue(value.businessImpact ?? value.impact),
+    recommendation: stringValue(value.recommendation),
+    confidence:
+      typeof value.confidence === "number" ? value.confidence : stringValue(value.confidence),
+  };
+}
+
+function parseFindings(value: unknown): AuditFinding[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((finding, index) => {
+    const parsed = parseFinding(finding, index);
+    return parsed ? [parsed] : [];
+  });
+}
+
+/**
+ * Keeps report pages tolerant of the service returning either a report
+ * projection directly or a `{ report: { summary, findings } }` envelope.
+ */
+export function toAuditReportProjection(value: unknown): AuditReportProjection {
+  const envelope = isRecord(value) && isRecord(value.report) ? value.report : value;
+  const report = isRecord(envelope) ? envelope : {};
+  const summary = isRecord(report.summary) ? report.summary : report;
+  const categoryValue = isRecord(summary.categories)
+    ? summary.categories
+    : isRecord(summary.categoryScores)
+      ? summary.categoryScores
+      : {};
+  const findings = parseFindings(report.findings ?? summary.findings ?? summary.previewFindings);
+  const limitations = Array.isArray(summary.limitations)
+    ? summary.limitations.filter((item): item is string => typeof item === "string")
+    : [];
+
+  return {
+    domain: stringValue(summary.domain),
+    auditedAt: stringValue(summary.auditedAt),
+    overallScore: parseScore(summary.overallScore, summary.overallStatus),
+    categories: {
+      technical: parseScore(categoryValue.technical),
+      linguistic: parseScore(categoryValue.linguistic),
+      market: parseScore(categoryValue.market),
+    },
+    previewFindings: findings.slice(0, 3),
+    findings,
+    lockedFindingCount: numberValue(summary.lockedFindingCount),
+    limitations,
+  };
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit-types.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit-types.ts
@@ -52,10 +52,18 @@ export type DiscoveredAlternative = {
   url: string;
 };
 
+export type AuditStatus =
+  | "preparing"
+  | "awaiting_confirmation"
+  | "running"
+  | "completed"
+  | "partial"
+  | "failed";
+
 export type CreateAuditResponse = {
   audit: {
     id: string;
-    status: "awaiting_confirmation";
+    status: AuditStatus;
     detectedLocale: string | null;
     alternatives: DiscoveredAlternative[];
   };
@@ -64,9 +72,11 @@ export type CreateAuditResponse = {
 export type ConfirmAuditResponse = {
   audit: {
     id: string;
-    status: "completed" | "partial";
-    publicSlug: string;
-    summary: AuditSummary;
+    status: AuditStatus;
+    publicSlug?: string;
+    summary?: AuditSummary;
+    detectedLocale?: string | null;
+    alternatives?: DiscoveredAlternative[];
   };
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit.messages.ts
@@ -207,7 +207,7 @@ export const localisationAuditMessages = defineMessages({
   },
   preparingReport: {
     defaultMessage: "Preparing your private report",
-    id: 'bDKd8Zqp+d',
+    id: "bDKd8Zqp+d",
     description: "Progress label shown while the private report is unlocked",
   },
   unlockedTitle: {
@@ -292,7 +292,7 @@ export const localisationAuditMessages = defineMessages({
   },
   confidence: {
     defaultMessage: "Confidence: {value}",
-    id: 'mmf3D9G6N+',
+    id: "mmf3D9G6N+",
     description: "Confidence level shown on an audit finding",
   },
   lockedFindings: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit.messages.ts
@@ -100,17 +100,17 @@ export const localisationAuditMessages = defineMessages({
   },
   targetMarketLabel: {
     defaultMessage: "Target market country code",
-    id: "yprulwCnhD",
+    id: "msClVR0B/h",
     description: "Label for the target market field",
   },
   targetMarketPlaceholder: {
     defaultMessage: "FR",
-    id: "CoXn5VFRR1",
+    id: "eCVyo25b2J",
     description: "Placeholder for the target market field",
   },
   targetMarketDescription: {
     defaultMessage: "Use a two-letter ISO country code such as FR, DE, or GB.",
-    id: "sEAQ4SkKdC",
+    id: "Gn6sPMvpDX",
     description: "Help text for the target market field",
   },
   runAudit: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit.messages.ts
@@ -99,14 +99,19 @@ export const localisationAuditMessages = defineMessages({
     description: "Help text for the target locale field",
   },
   targetMarketLabel: {
-    defaultMessage: "Target market",
+    defaultMessage: "Target market country code",
     id: "yprulwCnhD",
     description: "Label for the target market field",
   },
   targetMarketPlaceholder: {
-    defaultMessage: "France",
+    defaultMessage: "FR",
     id: "CoXn5VFRR1",
     description: "Placeholder for the target market field",
+  },
+  targetMarketDescription: {
+    defaultMessage: "Use a two-letter ISO country code such as FR, DE, or GB.",
+    id: "sEAQ4SkKdC",
+    description: "Help text for the target market field",
   },
   runAudit: {
     defaultMessage: "Run the full health check",

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/_components/localisation-audit.messages.ts
@@ -1,0 +1,345 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const localisationAuditMessages = defineMessages({
+  eyebrow: {
+    defaultMessage: "Free localisation health audit",
+    id: "QiRgMV5D5m",
+    description: "Eyebrow above the localisation audit landing page heading",
+  },
+  title: {
+    defaultMessage: "How ready is your website for global customers?",
+    id: "eNlgAWtuHj",
+    description: "Main heading on the localisation audit landing page",
+  },
+  lead: {
+    defaultMessage:
+      "Get an evidence-led health check covering technical setup, translation quality, and market fit. See your first findings before sharing any contact details.",
+    id: "TD37NN4wcF",
+    description: "Introductory paragraph on the localisation audit landing page",
+  },
+  urlLabel: {
+    defaultMessage: "Website URL",
+    id: "HGNA8Jzft3",
+    description: "Label for the website URL field",
+  },
+  urlPlaceholder: {
+    defaultMessage: "https://example.com/fr",
+    id: "H6WGqCgI47",
+    description: "Placeholder for the website URL field",
+  },
+  urlDescription: {
+    defaultMessage:
+      "Use a public page from the locale you want to assess. We only inspect that page and explicit locale alternatives.",
+    id: "d/iklzyWkL",
+    description: "Help text below the website URL field",
+  },
+  startAudit: {
+    defaultMessage: "Check my website",
+    id: "dXT/a0dKYC",
+    description: "Button that starts a localisation audit",
+  },
+  discoveryTitle: {
+    defaultMessage: "Discovering your locale setup",
+    id: "IclkH2nRam",
+    description: "Heading shown while locale alternatives are discovered",
+  },
+  discoveryDescription: {
+    defaultMessage:
+      "We are checking the submitted page, document language, hreflang links, and locale navigation.",
+    id: "ThfNx+zDbl",
+    description: "Description shown while locale alternatives are discovered",
+  },
+  confirmEyebrow: {
+    defaultMessage: "Confirm the audit context",
+    id: "Ehhlog/nK7",
+    description: "Eyebrow above locale and market confirmation",
+  },
+  confirmTitle: {
+    defaultMessage: "We found your localisation footprint",
+    id: "LilQ/7MatW",
+    description: "Heading above locale and market confirmation",
+  },
+  detectedLocale: {
+    defaultMessage: "Detected locale",
+    id: "dZaWoBfTmV",
+    description: "Label for the automatically detected locale",
+  },
+  alternatives: {
+    defaultMessage: "Discovered alternatives",
+    id: "pJdtVbInId",
+    description: "Label for discovered locale alternatives",
+  },
+  noAlternatives: {
+    defaultMessage: "No explicit locale alternatives were found on this page.",
+    id: "xPpUL07RES",
+    description: "Empty state when no locale alternatives are found",
+  },
+  targetLocaleLabel: {
+    defaultMessage: "Target locale",
+    id: "9zoBMpc6Se",
+    description: "Label for the target locale field",
+  },
+  targetLocaleDescription: {
+    defaultMessage: "Use a BCP 47 locale such as fr-FR, de-DE, or en-GB.",
+    id: "bVlzg8F+ca",
+    description: "Help text for the target locale field",
+  },
+  targetMarketLabel: {
+    defaultMessage: "Target market",
+    id: "yprulwCnhD",
+    description: "Label for the target market field",
+  },
+  targetMarketPlaceholder: {
+    defaultMessage: "France",
+    id: "CoXn5VFRR1",
+    description: "Placeholder for the target market field",
+  },
+  runAudit: {
+    defaultMessage: "Run the full health check",
+    id: "+YlTkw0Ix2",
+    description: "Button that confirms locale and market and runs the audit",
+  },
+  changeUrl: {
+    defaultMessage: "Use a different URL",
+    id: "Qu/Jwr9p3E",
+    description: "Button that returns to the website URL step",
+  },
+  auditProgressTitle: {
+    defaultMessage: "Building your evidence-led audit",
+    id: "eC0BjCOLKg",
+    description: "Heading shown while the audit runs",
+  },
+  auditProgressDescription: {
+    defaultMessage:
+      "We are checking technical readiness, reviewing customer-facing language, and evaluating the target-market experience.",
+    id: "fLRLdWOPMG",
+    description: "Description shown while the audit runs",
+  },
+  progressDiscover: {
+    defaultMessage: "Locale discovery complete",
+    id: "vpW8rC5/ef",
+    description: "Completed audit progress step for locale discovery",
+  },
+  progressTechnical: {
+    defaultMessage: "Checking technical localisation signals",
+    id: "FK3silV7Zf",
+    description: "Audit progress step for technical checks",
+  },
+  progressLanguage: {
+    defaultMessage: "Reviewing language and market evidence",
+    id: "/dg1YuoOmY",
+    description: "Audit progress step for language and market checks",
+  },
+  progressLabel: {
+    defaultMessage: "Audit progress",
+    id: "uALKQ/bcAx",
+    description: "Accessible label for audit progress",
+  },
+  technicalReadinessShort: {
+    defaultMessage: "Technical readiness",
+    id: "yAjmSKLE/o",
+    description: "Short benefit label for technical localisation readiness",
+  },
+  languageQualityShort: {
+    defaultMessage: "Language quality",
+    id: "DxoQlK1C3S",
+    description: "Short benefit label for language quality",
+  },
+  marketFitShort: {
+    defaultMessage: "Market fit",
+    id: "wE62n9OzMb",
+    description: "Short benefit label for market fit",
+  },
+  notDetected: {
+    defaultMessage: "Not detected",
+    id: "voLjxXNTIH",
+    description: "Fallback when the submitted page locale cannot be detected",
+  },
+  requestFailed: {
+    defaultMessage: "We couldn't complete that request. Please try again.",
+    id: "bA1sXATwWq",
+    description: "Fallback error shown when an audit API request fails",
+  },
+  retry: {
+    defaultMessage: "Try again",
+    id: "xCk/UtnXH/",
+    description: "Button that retries a failed audit action",
+  },
+  unlockTitle: {
+    defaultMessage: "Unlock the complete report",
+    id: "oJ6y2R4an4",
+    description: "Heading above the work email report unlock form",
+  },
+  unlockDescription: {
+    defaultMessage:
+      "Get every finding, its evidence, business impact, and a practical recommendation. We will also email a private access link.",
+    id: "z5B4sRmCaQ",
+    description: "Description of what the visitor receives after unlocking",
+  },
+  workEmailLabel: {
+    defaultMessage: "Work email",
+    id: "kl7OHQHi3d",
+    description: "Label for the required work email field",
+  },
+  nameLabel: {
+    defaultMessage: "Name (optional)",
+    id: "BMYClNiBi9",
+    description: "Label for the optional name field",
+  },
+  unlockButton: {
+    defaultMessage: "Email me the full report",
+    id: "wfSk0ebnkG",
+    description: "Button that unlocks the private audit report",
+  },
+  preparingReport: {
+    defaultMessage: "Preparing your private report",
+    id: 'bDKd8Zqp+d',
+    description: "Progress label shown while the private report is unlocked",
+  },
+  unlockedTitle: {
+    defaultMessage: "Your complete report is ready",
+    id: "4i+4Te/1Wj",
+    description: "Heading shown when the private report link is ready",
+  },
+  openReport: {
+    defaultMessage: "Open the complete report",
+    id: "5pKaWvWB+S",
+    description: "Link that opens the private audit report",
+  },
+  reportEyebrow: {
+    defaultMessage: "Localisation health",
+    id: "/69VfAUag5",
+    description: "Eyebrow above an audit report heading",
+  },
+  reportTitle: {
+    defaultMessage: "Localisation health report",
+    id: "IYGIANb1Va",
+    description: "Heading for public and private localisation audit reports",
+  },
+  auditedOn: {
+    defaultMessage: "Audited {date}",
+    id: "PUhGAWoLRR",
+    description: "Audit date shown on a report",
+  },
+  overallScore: {
+    defaultMessage: "Overall score",
+    id: "dXoPyfF4EG",
+    description: "Label for the overall audit score",
+  },
+  technical: {
+    defaultMessage: "Technical readiness",
+    id: "FqUUKybaOd",
+    description: "Label for the technical readiness score",
+  },
+  linguistic: {
+    defaultMessage: "Linguistic quality",
+    id: "bdvoCvx2Yj",
+    description: "Label for the linguistic quality score",
+  },
+  market: {
+    defaultMessage: "Market experience",
+    id: "Dl193MrSIu",
+    description: "Label for the market experience score",
+  },
+  insufficientEvidence: {
+    defaultMessage: "Insufficient evidence",
+    id: "E8h14FdS5F",
+    description: "State shown when a category cannot be scored reliably",
+  },
+  evaluatedRules: {
+    defaultMessage: "{count, plural, one {# rule evaluated} other {# rules evaluated}}",
+    id: "vndU973UWB",
+    description: "Number of rules evaluated for an audit score",
+  },
+  previewFindings: {
+    defaultMessage: "Highest-impact findings",
+    id: "Mh/xcC5aRt",
+    description: "Heading above the preview findings list",
+  },
+  allFindings: {
+    defaultMessage: "All findings",
+    id: "IelLd3kVog",
+    description: "Heading above the complete findings list",
+  },
+  evidence: {
+    defaultMessage: "Evidence",
+    id: "6SfJ0+UaZc",
+    description: "Label for evidence supporting an audit finding",
+  },
+  businessImpact: {
+    defaultMessage: "Business impact",
+    id: "+4AARGw4TH",
+    description: "Label for the business impact of an audit finding",
+  },
+  recommendation: {
+    defaultMessage: "Recommended action",
+    id: "RTDH8WfqoF",
+    description: "Label for an audit finding recommendation",
+  },
+  confidence: {
+    defaultMessage: "Confidence: {value}",
+    id: 'mmf3D9G6N+',
+    description: "Confidence level shown on an audit finding",
+  },
+  lockedFindings: {
+    defaultMessage:
+      "{count, plural, one {# additional finding is in the full report} other {# additional findings are in the full report}}",
+    id: "BnN4qVzr8S",
+    description: "Count of findings hidden behind the email unlock",
+  },
+  limitations: {
+    defaultMessage: "Report limitations",
+    id: "Zw9mUkXMO5",
+    description: "Heading above audit report limitations",
+  },
+  limitationsDescription: {
+    defaultMessage: "These notes identify evidence the audit could not reliably evaluate.",
+    id: "swiSUSAhMW",
+    description: "Explanation shown above audit report limitations",
+  },
+  missingEvidenceNote: {
+    defaultMessage: "Missing evidence does not reduce a score.",
+    id: "o43UuFVBLP",
+    description: "Scoring note shown below report limitations",
+  },
+  strategyTitle: {
+    defaultMessage: "Turn these findings into a localisation plan",
+    id: "17og2/qE30",
+    description: "Heading above report calls to action",
+  },
+  strategyDescription: {
+    defaultMessage:
+      "Book a localisation strategy call to prioritise the highest-impact fixes, or create a workspace to bring review into your delivery workflow.",
+    id: "7jR4RVKU2P",
+    description: "Description above report calls to action",
+  },
+  bookCall: {
+    defaultMessage: "Book a strategy call",
+    id: "uL/Q9PYRdF",
+    description: "Primary button for booking a localisation strategy call",
+  },
+  createWorkspace: {
+    defaultMessage: "Create a workspace or sign in",
+    id: "2qORT9DJ/g",
+    description: "Secondary link for creating a workspace or signing in",
+  },
+  reportUnavailable: {
+    defaultMessage: "No report findings are available yet.",
+    id: "aPc3GIB/QJ",
+    description: "Empty state when a report has no available findings",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/page.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/page.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { SITE_URL } from "@/lib/seo/site-url";
+
+import { generateMetadata } from "./page";
+
+describe("localisation audit metadata", () => {
+  it("is indexable and includes localized canonical and language alternatives", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ lang: "de-DE" }),
+    });
+
+    expect(metadata.robots).toEqual({
+      index: true,
+      follow: true,
+    });
+    expect(metadata.alternates?.canonical).toBe(`${SITE_URL}/de-DE/localisation-audit`);
+    expect(metadata.alternates?.languages).toMatchObject({
+      en: `${SITE_URL}/en/localisation-audit`,
+      "de-DE": `${SITE_URL}/de-DE/localisation-audit`,
+      "x-default": `${SITE_URL}/en/localisation-audit`,
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/page.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Metadata } from "next";
+
+import { getIntlShape } from "@/lib/app-i18n/intl";
+import { DEFAULT_APP_LOCALE, normalizeAppLocale } from "@/lib/app-i18n/locales";
+import { getLocalizedAlternates } from "@/lib/seo/localized-alternates";
+
+import { LocalisationAuditFlow } from "./_components/localisation-audit-flow";
+
+type LocalisationAuditPageProps = {
+  params: Promise<{ lang: string }>;
+};
+
+export async function generateMetadata({ params }: LocalisationAuditPageProps): Promise<Metadata> {
+  const { lang } = await params;
+  const locale = normalizeAppLocale(lang) ?? DEFAULT_APP_LOCALE;
+  const intl = getIntlShape(locale);
+  const title = intl.formatMessage({
+    defaultMessage: "Free Localisation Health Audit | Hyperlocalise",
+    id: "kyr6Q2HSYP",
+    description: "Page title for the free localisation health audit",
+  });
+  const description = intl.formatMessage({
+    defaultMessage:
+      "Check your website's technical localisation setup, translation quality, and market fit. See an evidence-led summary before sharing your work email.",
+    id: "rqddtYvPV9",
+    description: "Meta description for the free localisation health audit",
+  });
+
+  return {
+    title,
+    description,
+    alternates: getLocalizedAlternates({
+      locale,
+      path: "/localisation-audit",
+    }),
+    robots: {
+      index: true,
+      follow: true,
+    },
+    openGraph: {
+      title,
+      description,
+      type: "website",
+    },
+  };
+}
+
+export default function LocalisationAuditPage() {
+  return <LocalisationAuditFlow />;
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/report/[token]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/report/[token]/page.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { getPrivateAuditReportByToken } from "@/lib/localisation-audit/service";
+
+import { AuditReportView } from "../../_components/audit-report-view";
+import { toAuditReportProjection } from "../../_components/localisation-audit-types";
+
+export const metadata: Metadata = {
+  title: "Private Localisation Health Report | Hyperlocalise",
+  description: "Your complete Hyperlocalise website localisation health report.",
+  robots: {
+    index: false,
+    follow: false,
+    noarchive: true,
+    nosnippet: true,
+  },
+};
+
+type PrivateAuditReportPageProps = {
+  params: Promise<{ lang: string; token: string }>;
+};
+
+export default async function PrivateAuditReportPage({ params }: PrivateAuditReportPageProps) {
+  const { token } = await params;
+  const serviceReport = await getPrivateAuditReportByToken(token);
+  if (!serviceReport) {
+    notFound();
+  }
+
+  const report = toAuditReportProjection(serviceReport);
+  return <AuditReportView report={report} mode="private" showFooter />;
+}

--- a/apps/hyperlocalise-web/src/app/sitemap.test.ts
+++ b/apps/hyperlocalise-web/src/app/sitemap.test.ts
@@ -45,4 +45,16 @@ describe("sitemap", () => {
     expect(install).toBeDefined();
     expect(install?.alternates).toBeUndefined();
   });
+
+  it("includes only the indexable localisation audit landing pages", () => {
+    const entries = sitemap();
+
+    for (const locale of SUPPORTED_APP_LOCALES) {
+      expect(
+        entries.find((entry) => entry.url === `${SITE_URL}/${locale}/localisation-audit`),
+      ).toBeDefined();
+    }
+
+    expect(entries.some((entry) => entry.url.includes("/localisation-audit/report/"))).toBe(false);
+  });
 });

--- a/apps/hyperlocalise-web/src/app/sitemap.ts
+++ b/apps/hyperlocalise-web/src/app/sitemap.ts
@@ -53,6 +53,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const now = new Date();
   const localizedStaticPaths = [
     { path: "/", changeFrequency: "weekly" as const, priority: 1 },
+    {
+      path: "/localisation-audit",
+      changeFrequency: "monthly" as const,
+      priority: 0.8,
+    },
     { path: "/terms", changeFrequency: "monthly" as const, priority: 0.5 },
     { path: "/privacy", changeFrequency: "monthly" as const, priority: 0.5 },
     { path: "/trust-center", changeFrequency: "monthly" as const, priority: 0.5 },

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/definitions.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/definitions.ts
@@ -12,8 +12,6 @@
  */
 import type { HyperlocaliseAgentRuntimeContext } from "@/lib/agent-runtime/context";
 
-import { repositorySubagent } from "./repository";
-import { translationSubagent } from "./translation";
 import {
   SUBAGENT_TYPES,
   type HyperlocaliseSubagentType,
@@ -26,7 +24,6 @@ export const SUBAGENT_REGISTRY = {
   translation: {
     shortDescription:
       "Translate uploaded localization files, queue translation jobs, run Crowdin TMS tools, and translate inline strings when a project is attached",
-    agent: translationSubagent,
     isAvailable: (runtime: HyperlocaliseAgentRuntimeContext) =>
       runtime.hasFileAttachments || Boolean(runtime.toolContext.projectId),
     unavailableMessage: (_runtime) =>
@@ -35,7 +32,6 @@ export const SUBAGENT_REGISTRY = {
   repository: {
     shortDescription:
       "Explore a connected GitHub repository for localization context around source strings, messages, or keys (read-only)",
-    agent: repositorySubagent,
     isAvailable: (runtime: HyperlocaliseAgentRuntimeContext) =>
       Boolean(runtime.toolContext.sandboxId),
     unavailableMessage: (_runtime) =>

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/run-subagent.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/run-subagent.ts
@@ -11,23 +11,22 @@
  * Version 2.0 or later.
  */
 import type { SubagentCallOptions, HyperlocaliseSubagentType } from "./types";
-import { repositorySubagent } from "./repository";
-import { translationSubagent } from "./translation";
 
 type SubagentGenerate = {
   generate(input: { prompt: string; options: SubagentCallOptions }): Promise<{ text: string }>;
 };
 
-const subagents: Record<HyperlocaliseSubagentType, SubagentGenerate> = {
-  translation: translationSubagent as SubagentGenerate,
-  repository: repositorySubagent as SubagentGenerate,
+const loadSubagent: Record<HyperlocaliseSubagentType, () => Promise<SubagentGenerate>> = {
+  translation: async () => (await import("./translation")).translationSubagent as SubagentGenerate,
+  repository: async () => (await import("./repository")).repositorySubagent as SubagentGenerate,
 };
 
 export async function runSubagent(
   subagentType: HyperlocaliseSubagentType,
   options: SubagentCallOptions,
 ): Promise<{ text: string }> {
-  return subagents[subagentType].generate({
+  const subagent = await loadSubagent[subagentType]();
+  return subagent.generate({
     prompt: "Complete the task and return a concise summary for the end user.",
     options,
   });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/types.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/types.ts
@@ -13,9 +13,6 @@
 import type { HyperlocaliseAgentRuntimeContext } from "@/lib/agent-runtime/context";
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 
-import type { repositorySubagent } from "./repository";
-import type { translationSubagent } from "./translation";
-
 export const SUBAGENT_TYPES = ["translation", "repository"] as const;
 
 export type HyperlocaliseSubagentType = (typeof SUBAGENT_TYPES)[number];
@@ -26,11 +23,8 @@ export type SubagentCallOptions = {
   instructions: string;
 };
 
-export type HyperlocaliseSubagent = typeof translationSubagent | typeof repositorySubagent;
-
 export type SubagentRegistryEntry = {
   shortDescription: string;
-  agent: HyperlocaliseSubagent;
   isAvailable: (runtime: HyperlocaliseAgentRuntimeContext) => boolean;
   unavailableMessage: (runtime: HyperlocaliseAgentRuntimeContext) => string;
 };

--- a/apps/hyperlocalise-web/src/lib/database/schema/enums.ts
+++ b/apps/hyperlocalise-web/src/lib/database/schema/enums.ts
@@ -333,3 +333,70 @@ export const repositorySourceFileIngestStateEnum = pgEnum("repository_source_fil
   "skipped",
   "failed",
 ]);
+
+/** Tracks the public localisation audit lifecycle. */
+export const localisationAuditStatusEnum = pgEnum("localisation_audit_status", [
+  "preparing",
+  "awaiting_confirmation",
+  "running",
+  "completed",
+  "partial",
+  "failed",
+]);
+
+/** Tracks whether an audit page was extracted or unavailable. */
+export const localisationAuditPageStatusEnum = pgEnum("localisation_audit_page_status", [
+  "extracted",
+  "blocked",
+  "failed",
+]);
+
+/** Identifies the score category associated with an audit rule or finding. */
+export const localisationAuditCategoryEnum = pgEnum("localisation_audit_category", [
+  "technical",
+  "linguistic",
+  "market",
+]);
+
+/** Orders audit findings by likely business impact. */
+export const localisationAuditSeverityEnum = pgEnum("localisation_audit_severity", [
+  "info",
+  "low",
+  "medium",
+  "high",
+  "critical",
+]);
+
+/** Distinguishes directly observed evidence from conservative rule judgements. */
+export const localisationAuditEvidenceKindEnum = pgEnum("localisation_audit_evidence_kind", [
+  "observed",
+  "judgement",
+]);
+
+/** Controls whether a report summary can be resolved through its public slug. */
+export const localisationAuditReportVisibilityEnum = pgEnum(
+  "localisation_audit_report_visibility",
+  ["private", "public"],
+);
+
+/** Records the independent eligibility state for search indexing. */
+export const localisationAuditIndexingStateEnum = pgEnum("localisation_audit_indexing_state", [
+  "noindex",
+  "eligible",
+  "indexed",
+  "removed",
+]);
+
+/** Classifies first-party audit funnel events without storing customer text. */
+export const localisationAuditEventTypeEnum = pgEnum("localisation_audit_event_type", [
+  "submitted",
+  "prepared",
+  "confirmed",
+  "completed",
+  "viewed",
+  "unlocked",
+  "shared",
+  "booked",
+  "workspace_converted",
+  "email_delivery_failed",
+]);

--- a/apps/hyperlocalise-web/src/lib/database/schema/index.ts
+++ b/apps/hyperlocalise-web/src/lib/database/schema/index.ts
@@ -35,3 +35,4 @@ export * from "./knowledge-memory";
 export * from "./project-file-string-contexts";
 export * from "./project-cat-string-overlays";
 export * from "./billing";
+export * from "./localisation-audit";

--- a/apps/hyperlocalise-web/src/lib/database/schema/localisation-audit.ts
+++ b/apps/hyperlocalise-web/src/lib/database/schema/localisation-audit.ts
@@ -99,10 +99,12 @@ export type LocalisationAuditPrivateReportData = LocalisationAuditReportData & {
 };
 
 export type LocalisationAuditEventMetadata = {
-  source?: "api" | "email" | "report";
+  source?: "api" | "email" | "report" | "workflow";
   findingCount?: number;
   localeCount?: number;
   deliveryStatus?: "sent" | "skipped" | "failed";
+  workflowRunId?: string;
+  phase?: "prepare" | "run" | "deliver";
 };
 
 export const localisationAudits = pgTable(

--- a/apps/hyperlocalise-web/src/lib/database/schema/localisation-audit.ts
+++ b/apps/hyperlocalise-web/src/lib/database/schema/localisation-audit.ts
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { sql } from "drizzle-orm";
+import {
+  boolean,
+  check,
+  doublePrecision,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+
+import {
+  localisationAuditCategoryEnum,
+  localisationAuditEventTypeEnum,
+  localisationAuditEvidenceKindEnum,
+  localisationAuditIndexingStateEnum,
+  localisationAuditPageStatusEnum,
+  localisationAuditReportVisibilityEnum,
+  localisationAuditSeverityEnum,
+  localisationAuditStatusEnum,
+} from "./enums";
+
+export type LocalisationAuditAlternativeData = {
+  locale: string;
+  url: string;
+  source: "hreflang" | "language_link";
+};
+
+export type LocalisationAuditPageExtractionData = {
+  htmlLang: string | null;
+  title: string | null;
+  description: string | null;
+  canonicalUrl: string | null;
+  alternateLinks: LocalisationAuditAlternativeData[];
+  headings: string[];
+  navigation: string[];
+  callsToAction: string[];
+  visibleTextSample: string;
+};
+
+export type LocalisationAuditFindingEvidenceData = {
+  excerpt?: string;
+  observedValue?: string;
+  expectedValue?: string;
+};
+
+export type LocalisationAuditScoreData = {
+  status: "scored" | "insufficient_evidence";
+  score: number | null;
+  earnedPoints: number;
+  applicablePoints: number;
+  evaluatedRuleCount: number;
+};
+
+export type LocalisationAuditReportData = {
+  reportVersion: string;
+  scoreVersion: string;
+  domain: string;
+  auditedAt: string;
+  status: "completed" | "partial";
+  overallScore: number | null;
+  overallStatus: "scored" | "insufficient_evidence";
+  categoryScores: Record<"technical" | "linguistic" | "market", LocalisationAuditScoreData>;
+  findings: Array<{
+    code: string;
+    category: "technical" | "linguistic" | "market";
+    severity: "info" | "low" | "medium" | "high" | "critical";
+    title: string;
+    impact: string;
+    recommendation: string;
+    evidence?: LocalisationAuditFindingEvidenceData;
+  }>;
+  lockedFindingCount: number;
+  limitations: string[];
+};
+
+export type LocalisationAuditPrivateReportData = LocalisationAuditReportData & {
+  pages: Array<{
+    url: string;
+    locale: string | null;
+    status: "extracted" | "blocked" | "failed";
+  }>;
+};
+
+export type LocalisationAuditEventMetadata = {
+  source?: "api" | "email" | "report";
+  findingCount?: number;
+  localeCount?: number;
+  deliveryStatus?: "sent" | "skipped" | "failed";
+};
+
+export const localisationAudits = pgTable(
+  "localisation_audits",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    status: localisationAuditStatusEnum("status").notNull().default("preparing"),
+    submittedUrl: text("submitted_url").notNull(),
+    normalizedUrl: text("normalized_url").notNull(),
+    domain: text("domain").notNull(),
+    domainHash: text("domain_hash").notNull(),
+    ipHash: text("ip_hash").notNull(),
+    detectedLocale: text("detected_locale"),
+    targetLocale: text("target_locale"),
+    targetMarket: text("target_market"),
+    alternatives: jsonb("alternatives")
+      .$type<LocalisationAuditAlternativeData[]>()
+      .notNull()
+      .default([]),
+    scoreVersion: text("score_version").notNull(),
+    reportVersion: text("report_version").notNull(),
+    failureCode: text("failure_code"),
+    confirmedAt: timestamp("confirmed_at", { withTimezone: true }),
+    completedAt: timestamp("completed_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdateFn(() => new Date()),
+  },
+  (table) => [
+    index("idx_localisation_audits_ip_budget").on(table.ipHash, table.createdAt),
+    index("idx_localisation_audits_domain_budget").on(table.domainHash, table.createdAt),
+    index("idx_localisation_audits_status_created").on(table.status, table.createdAt),
+    check("localisation_audits_domain_hash_check", sql`char_length(${table.domainHash}) = 64`),
+    check("localisation_audits_ip_hash_check", sql`char_length(${table.ipHash}) = 64`),
+    check("localisation_audits_score_version_check", sql`char_length(${table.scoreVersion}) > 0`),
+    check("localisation_audits_report_version_check", sql`char_length(${table.reportVersion}) > 0`),
+  ],
+);
+
+export const localisationAuditPages = pgTable(
+  "localisation_audit_pages",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    auditId: uuid("audit_id")
+      .notNull()
+      .references(() => localisationAudits.id, { onDelete: "cascade" }),
+    normalizedUrl: text("normalized_url").notNull(),
+    locale: text("locale"),
+    isPrimary: boolean("is_primary").notNull().default(false),
+    status: localisationAuditPageStatusEnum("status").notNull(),
+    httpStatus: integer("http_status"),
+    contentFingerprint: text("content_fingerprint"),
+    extraction: jsonb("extraction").$type<LocalisationAuditPageExtractionData>(),
+    failureCode: text("failure_code"),
+    fetchedAt: timestamp("fetched_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("uq_localisation_audit_pages_audit_url").on(table.auditId, table.normalizedUrl),
+    index("idx_localisation_audit_pages_audit").on(table.auditId),
+    index("idx_localisation_audit_pages_fingerprint").on(table.contentFingerprint),
+    check(
+      "localisation_audit_pages_http_status_check",
+      sql`${table.httpStatus} is null or (${table.httpStatus} >= 100 and ${table.httpStatus} <= 599)`,
+    ),
+  ],
+);
+
+export const localisationAuditFindings = pgTable(
+  "localisation_audit_findings",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    auditId: uuid("audit_id")
+      .notNull()
+      .references(() => localisationAudits.id, { onDelete: "cascade" }),
+    pageId: uuid("page_id").references(() => localisationAuditPages.id, { onDelete: "set null" }),
+    ruleCode: text("rule_code").notNull(),
+    category: localisationAuditCategoryEnum("category").notNull(),
+    severity: localisationAuditSeverityEnum("severity").notNull(),
+    confidence: doublePrecision("confidence").notNull(),
+    evidenceKind: localisationAuditEvidenceKindEnum("evidence_kind").notNull(),
+    title: text("title").notNull(),
+    evidence: jsonb("evidence").$type<LocalisationAuditFindingEvidenceData>().notNull().default({}),
+    impact: text("impact").notNull(),
+    recommendation: text("recommendation").notNull(),
+    availablePoints: integer("available_points").notNull(),
+    earnedPoints: integer("earned_points").notNull(),
+    publicPreviewEligible: boolean("public_preview_eligible").notNull().default(true),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("uq_localisation_audit_findings_rule_page").on(
+      table.auditId,
+      table.ruleCode,
+      table.pageId,
+    ),
+    index("idx_localisation_audit_findings_audit_category").on(table.auditId, table.category),
+    check(
+      "localisation_audit_findings_confidence_check",
+      sql`${table.confidence} >= 0 and ${table.confidence} <= 1`,
+    ),
+    check(
+      "localisation_audit_findings_points_check",
+      sql`${table.availablePoints} >= 0 and ${table.earnedPoints} >= 0 and ${table.earnedPoints} <= ${table.availablePoints}`,
+    ),
+  ],
+);
+
+export const localisationAuditReports = pgTable(
+  "localisation_audit_reports",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    auditId: uuid("audit_id")
+      .notNull()
+      .references(() => localisationAudits.id, { onDelete: "cascade" }),
+    publicSlug: text("public_slug").notNull(),
+    visibility: localisationAuditReportVisibilityEnum("visibility").notNull().default("public"),
+    indexingState: localisationAuditIndexingStateEnum("indexing_state")
+      .notNull()
+      .default("noindex"),
+    scoreVersion: text("score_version").notNull(),
+    reportVersion: text("report_version").notNull(),
+    publicReport: jsonb("public_report").$type<LocalisationAuditReportData>().notNull(),
+    privateReport: jsonb("private_report").$type<LocalisationAuditPrivateReportData>().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdateFn(() => new Date()),
+  },
+  (table) => [
+    uniqueIndex("uq_localisation_audit_reports_audit").on(table.auditId),
+    uniqueIndex("uq_localisation_audit_reports_public_slug").on(table.publicSlug),
+    index("idx_localisation_audit_reports_visibility").on(table.visibility, table.indexingState),
+    check(
+      "localisation_audit_reports_public_slug_check",
+      sql`char_length(${table.publicSlug}) >= 16 and char_length(${table.publicSlug}) <= 64`,
+    ),
+  ],
+);
+
+export const localisationAuditLeads = pgTable(
+  "localisation_audit_leads",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    auditId: uuid("audit_id")
+      .notNull()
+      .references(() => localisationAudits.id, { onDelete: "cascade" }),
+    email: text("email").notNull(),
+    name: text("name"),
+    emailDeliveryStatus: text("email_delivery_status").notNull().default("pending"),
+    unlockedAt: timestamp("unlocked_at", { withTimezone: true }).notNull().defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdateFn(() => new Date()),
+  },
+  (table) => [
+    index("idx_localisation_audit_leads_audit").on(table.auditId),
+    check(
+      "localisation_audit_leads_delivery_status_check",
+      sql`${table.emailDeliveryStatus} in ('pending', 'sent', 'skipped', 'failed')`,
+    ),
+  ],
+);
+
+export const localisationAuditEvents = pgTable(
+  "localisation_audit_events",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    auditId: uuid("audit_id")
+      .notNull()
+      .references(() => localisationAudits.id, { onDelete: "cascade" }),
+    leadId: uuid("lead_id").references(() => localisationAuditLeads.id, { onDelete: "set null" }),
+    eventType: localisationAuditEventTypeEnum("event_type").notNull(),
+    metadata: jsonb("metadata").$type<LocalisationAuditEventMetadata>().notNull().default({}),
+    occurredAt: timestamp("occurred_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_localisation_audit_events_audit_time").on(table.auditId, table.occurredAt),
+    index("idx_localisation_audit_events_type_time").on(table.eventType, table.occurredAt),
+  ],
+);

--- a/apps/hyperlocalise-web/src/lib/env.ts
+++ b/apps/hyperlocalise-web/src/lib/env.ts
@@ -77,6 +77,9 @@ export const env = createEnv({
     /** Resend API key for sending and receiving emails. Required for email bot integration. */
     RESEND_API_KEY: z.string().min(1).optional(),
 
+    /** Secret used to hash audit rate-limit keys and sign private report access tokens. */
+    LOCALISATION_AUDIT_ACCESS_SECRET: z.string().min(32).optional(),
+
     /** Resend webhook secret for verifying inbound email webhooks. Required for secure email handling. */
     RESEND_WEBHOOK_SECRET: z.string().min(1).optional(),
 
@@ -239,6 +242,9 @@ export const env = createEnv({
       process.env.FLAGS_SECRET ??
       (isTestEnv ? "test-flags-secret-at-least-32-characters-long" : undefined),
     RESEND_API_KEY: process.env.RESEND_API_KEY ?? (isTestEnv ? "test-resend-api-key" : undefined),
+    LOCALISATION_AUDIT_ACCESS_SECRET:
+      process.env.LOCALISATION_AUDIT_ACCESS_SECRET ??
+      (isTestEnv ? "test-localisation-audit-access-secret-32chars" : undefined),
     RESEND_WEBHOOK_SECRET:
       process.env.RESEND_WEBHOOK_SECRET ?? (isTestEnv ? "test-resend-webhook-secret" : undefined),
     RESEND_FROM_ADDRESS:

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/access-token.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/access-token.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { mintPrivateReportAccessToken, verifyPrivateReportAccessToken } from "./access-token";
+
+const SECRET = "test-secret-that-is-at-least-32-characters";
+const NOW = new Date("2026-07-24T12:00:00.000Z");
+
+describe("private localisation report access token", () => {
+  it("verifies an unexpired signed token", () => {
+    const token = mintPrivateReportAccessToken({
+      auditId: "audit-id",
+      reportId: "report-id",
+      secret: SECRET,
+      now: NOW,
+      lifetimeSeconds: 60,
+    });
+
+    const result = verifyPrivateReportAccessToken({
+      token,
+      secret: SECRET,
+      now: new Date("2026-07-24T12:00:30.000Z"),
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual({
+        auditId: "audit-id",
+        reportId: "report-id",
+        expiresAt: new Date("2026-07-24T12:01:00.000Z"),
+      });
+    }
+  });
+
+  it("rejects an expired token", () => {
+    const token = mintPrivateReportAccessToken({
+      auditId: "audit-id",
+      reportId: "report-id",
+      secret: SECRET,
+      now: NOW,
+      lifetimeSeconds: 60,
+    });
+
+    const result = verifyPrivateReportAccessToken({
+      token,
+      secret: SECRET,
+      now: new Date("2026-07-24T12:01:00.000Z"),
+    });
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: "invalid_report_access_token" },
+    });
+  });
+
+  it("rejects payload and signature tampering", () => {
+    const token = mintPrivateReportAccessToken({
+      auditId: "audit-id",
+      reportId: "report-id",
+      secret: SECRET,
+      now: NOW,
+    });
+    const [payload, signature] = token.split(".");
+
+    expect(
+      verifyPrivateReportAccessToken({
+        token: `${payload}x.${signature}`,
+        secret: SECRET,
+        now: NOW,
+      }),
+    ).toMatchObject({ ok: false });
+    expect(
+      verifyPrivateReportAccessToken({
+        token: `${payload}.${signature}x`,
+        secret: SECRET,
+        now: NOW,
+      }),
+    ).toMatchObject({ ok: false });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/access-token.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/access-token.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+import { err, ok, type Result } from "@/lib/primitives/result/results";
+
+import type { LocalisationAuditError } from "./types";
+
+const TOKEN_VERSION = 1;
+const DEFAULT_TOKEN_LIFETIME_SECONDS = 24 * 60 * 60;
+
+export type PrivateReportAccessClaims = {
+  auditId: string;
+  reportId: string;
+  expiresAt: Date;
+};
+
+type TokenPayload = {
+  v: number;
+  auditId: string;
+  reportId: string;
+  exp: number;
+};
+
+function signatureFor(encodedPayload: string, secret: string): Buffer {
+  return createHmac("sha256", secret).update(encodedPayload).digest();
+}
+
+export function mintPrivateReportAccessToken(input: {
+  auditId: string;
+  reportId: string;
+  secret: string;
+  now?: Date;
+  lifetimeSeconds?: number;
+}): string {
+  const now = input.now ?? new Date();
+  const payload: TokenPayload = {
+    v: TOKEN_VERSION,
+    auditId: input.auditId,
+    reportId: input.reportId,
+    exp:
+      Math.floor(now.getTime() / 1000) + (input.lifetimeSeconds ?? DEFAULT_TOKEN_LIFETIME_SECONDS),
+  };
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signature = signatureFor(encodedPayload, input.secret).toString("base64url");
+  return `${encodedPayload}.${signature}`;
+}
+
+export function verifyPrivateReportAccessToken(input: {
+  token: string;
+  secret: string;
+  now?: Date;
+}): Result<PrivateReportAccessClaims, LocalisationAuditError> {
+  const [encodedPayload, encodedSignature, extra] = input.token.split(".");
+  if (!encodedPayload || !encodedSignature || extra) {
+    return err({
+      code: "invalid_report_access_token",
+      message: "The report access token is invalid.",
+    });
+  }
+
+  let suppliedSignature: Buffer;
+  let payload: TokenPayload;
+  try {
+    suppliedSignature = Buffer.from(encodedSignature, "base64url");
+    payload = JSON.parse(Buffer.from(encodedPayload, "base64url").toString("utf8")) as TokenPayload;
+  } catch {
+    return err({
+      code: "invalid_report_access_token",
+      message: "The report access token is invalid.",
+    });
+  }
+
+  const expectedSignature = signatureFor(encodedPayload, input.secret);
+  if (
+    suppliedSignature.length !== expectedSignature.length ||
+    !timingSafeEqual(suppliedSignature, expectedSignature)
+  ) {
+    return err({
+      code: "invalid_report_access_token",
+      message: "The report access token is invalid.",
+    });
+  }
+
+  const nowSeconds = Math.floor((input.now ?? new Date()).getTime() / 1000);
+  if (
+    payload.v !== TOKEN_VERSION ||
+    typeof payload.auditId !== "string" ||
+    typeof payload.reportId !== "string" ||
+    !Number.isSafeInteger(payload.exp) ||
+    payload.exp <= nowSeconds
+  ) {
+    return err({
+      code: "invalid_report_access_token",
+      message: "The report access token is invalid or expired.",
+    });
+  }
+
+  return ok({
+    auditId: payload.auditId,
+    reportId: payload.reportId,
+    expiresAt: new Date(payload.exp * 1000),
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/dedupe-pages.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/dedupe-pages.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { dedupeAuditedPages } from "./dedupe-pages";
+import type { AuditedPage } from "./types";
+
+function failedPage(url: string, locale: string, isPrimary = false): AuditedPage {
+  return {
+    url,
+    locale,
+    isPrimary,
+    status: "failed",
+    failureCode: "audit_fetch_failed",
+  };
+}
+
+describe("dedupeAuditedPages", () => {
+  it("keeps the primary page when an alternative redirects to its final URL", () => {
+    const primary = failedPage("https://example.com/fr/", "fr-FR", true);
+    const redirectedAlternative = failedPage("https://example.com/fr/", "fr-CA");
+
+    expect(dedupeAuditedPages([primary, redirectedAlternative])).toEqual([primary]);
+  });
+
+  it("keeps only the first alternative for each final URL", () => {
+    const primary = failedPage("https://example.com/", "en-US", true);
+    const french = failedPage("https://example.com/fr/", "fr-FR");
+    const duplicateFrench = failedPage("https://example.com/fr/", "fr-CA");
+
+    expect(dedupeAuditedPages([primary, french, duplicateFrench])).toEqual([primary, french]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/dedupe-pages.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/dedupe-pages.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { AuditedPage } from "./types";
+
+export function dedupeAuditedPages(pages: AuditedPage[]): AuditedPage[] {
+  const seenUrls = new Set<string>();
+
+  return pages.filter((page) => {
+    if (seenUrls.has(page.url)) {
+      return false;
+    }
+    seenUrls.add(page.url);
+    return true;
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/deliver-audit-report-work.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/deliver-audit-report-work.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { eq } from "drizzle-orm";
+import { Resend } from "resend";
+
+import { db, schema } from "@/lib/database";
+import { env } from "@/lib/env";
+import { err, ok, type Result } from "@/lib/primitives/result/results";
+
+import type { LocalisationAuditError } from "./types";
+
+export type DeliverAuditReportInput = {
+  leadId: string;
+  accessUrl: string;
+};
+
+export type DeliverAuditReportResult = {
+  leadId: string;
+  deliveryStatus: "sent" | "skipped" | "failed";
+};
+
+async function sendReportEmailBestEffort(input: {
+  email: string;
+  accessUrl: string;
+}): Promise<"sent" | "skipped" | "failed"> {
+  const apiKey = process.env.RESEND_API_KEY;
+  const fromAddress = process.env.RESEND_FROM_ADDRESS;
+  if (!apiKey || !fromAddress) {
+    return "skipped";
+  }
+
+  try {
+    const resend = new Resend(apiKey);
+    const response = await resend.emails.send({
+      from: `${env.RESEND_FROM_NAME ?? "Hyperlocalise"} <${fromAddress}>`,
+      to: input.email,
+      subject: "Your localisation health audit",
+      text: `Your private localisation audit is ready: ${input.accessUrl}`,
+    });
+    return response.error ? "failed" : "sent";
+  } catch {
+    return "failed";
+  }
+}
+
+export async function deliverAuditReportWork(
+  input: DeliverAuditReportInput,
+): Promise<Result<DeliverAuditReportResult, LocalisationAuditError>> {
+  const [lead] = await db
+    .select({
+      id: schema.localisationAuditLeads.id,
+      auditId: schema.localisationAuditLeads.auditId,
+      email: schema.localisationAuditLeads.email,
+      emailDeliveryStatus: schema.localisationAuditLeads.emailDeliveryStatus,
+    })
+    .from(schema.localisationAuditLeads)
+    .where(eq(schema.localisationAuditLeads.id, input.leadId))
+    .limit(1);
+  if (!lead) {
+    return err({ code: "report_not_found", message: "The report lead was not found." });
+  }
+  if (lead.emailDeliveryStatus === "sent" || lead.emailDeliveryStatus === "skipped") {
+    return ok({
+      leadId: lead.id,
+      deliveryStatus: lead.emailDeliveryStatus,
+    });
+  }
+
+  const deliveryStatus = await sendReportEmailBestEffort({
+    email: lead.email,
+    accessUrl: input.accessUrl,
+  });
+  await db
+    .update(schema.localisationAuditLeads)
+    .set({ emailDeliveryStatus: deliveryStatus })
+    .where(eq(schema.localisationAuditLeads.id, lead.id));
+
+  if (deliveryStatus === "failed") {
+    await db.insert(schema.localisationAuditEvents).values({
+      auditId: lead.auditId,
+      leadId: lead.id,
+      eventType: "email_delivery_failed",
+      metadata: { deliveryStatus },
+    });
+    return err({
+      code: "audit_email_delivery_failed",
+      message: "The report email could not be delivered. Try again.",
+    });
+  }
+
+  return ok({ leadId: lead.id, deliveryStatus });
+}

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/fetch-page.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/fetch-page.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
+import {
+  assertResolvablePublicHttpUrl,
+  readBoundedResponseBody,
+  withPublicHttpFetch,
+} from "@/lib/security/public-http-fetch";
+
+import { extractLocalisationPage, normalizeAuditUrl } from "./parser";
+import type { AuditedPage, LocalisationAuditError } from "./types";
+
+const MAX_AUDIT_PAGE_BYTES = 1_000_000;
+const MAX_REDIRECTS = 3;
+const FETCH_TIMEOUT_MS = 10_000;
+
+type RawFetchResult =
+  | { kind: "redirect"; location: string; status: number }
+  | { kind: "response"; status: number; contentType: string; body: Uint8Array };
+
+function mapFetchFailure(error: unknown): LocalisationAuditError {
+  const message = error instanceof Error ? error.message : "";
+  if (message.includes("too large")) {
+    return {
+      code: "audit_response_too_large",
+      message: "The page exceeds the audit response size limit.",
+    };
+  }
+  return { code: "audit_fetch_failed", message: "The page could not be fetched." };
+}
+
+export async function fetchAuditPage(
+  value: string,
+  options: { locale?: string | null; isPrimary?: boolean; signal?: AbortSignal } = {},
+): Promise<Result<AuditedPage, LocalisationAuditError>> {
+  let currentUrl = normalizeAuditUrl(value);
+  if (!currentUrl) {
+    return err({ code: "invalid_audit_url", message: "Enter a valid HTTP(S) URL." });
+  }
+
+  for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount += 1) {
+    const validation = await assertResolvablePublicHttpUrl(currentUrl);
+    if (isErr(validation)) {
+      return err({
+        code: "audit_url_not_public",
+        message: "The URL must resolve to a public internet address.",
+      });
+    }
+
+    const timeoutSignal = AbortSignal.timeout(FETCH_TIMEOUT_MS);
+    const signal = options.signal
+      ? AbortSignal.any([options.signal, timeoutSignal])
+      : timeoutSignal;
+
+    let fetched: RawFetchResult;
+    try {
+      fetched = await withPublicHttpFetch(
+        currentUrl,
+        {
+          headers: {
+            accept: "text/html,application/xhtml+xml",
+            "user-agent": "Hyperlocalise-Localisation-Audit/1.0",
+          },
+          redirect: "manual",
+          signal,
+        },
+        async (response) => {
+          if (response.status >= 300 && response.status < 400) {
+            return {
+              kind: "redirect" as const,
+              location: response.headers.get("location") ?? "",
+              status: response.status,
+            };
+          }
+          return {
+            kind: "response" as const,
+            status: response.status,
+            contentType: response.headers.get("content-type") ?? "",
+            body: await readBoundedResponseBody(response, MAX_AUDIT_PAGE_BYTES),
+          };
+        },
+      );
+    } catch (error) {
+      return err(mapFetchFailure(error));
+    }
+
+    if (fetched.kind === "redirect") {
+      if (!fetched.location || redirectCount === MAX_REDIRECTS) {
+        return err({
+          code: "audit_fetch_failed",
+          message: "The page redirected too many times.",
+        });
+      }
+      const redirectUrl = normalizeAuditUrl(fetched.location, currentUrl);
+      if (!redirectUrl) {
+        return err({
+          code: "audit_fetch_failed",
+          message: "The page redirected to an invalid URL.",
+        });
+      }
+      currentUrl = redirectUrl;
+      continue;
+    }
+
+    if (fetched.status < 200 || fetched.status >= 300) {
+      return ok({
+        url: currentUrl,
+        locale: options.locale ?? null,
+        isPrimary: options.isPrimary ?? false,
+        status: fetched.status === 401 || fetched.status === 403 ? "blocked" : "failed",
+        failureCode: `http_${fetched.status}`,
+        httpStatus: fetched.status,
+      });
+    }
+
+    if (
+      !fetched.contentType.toLowerCase().includes("text/html") &&
+      !fetched.contentType.toLowerCase().includes("application/xhtml+xml")
+    ) {
+      return err({
+        code: "audit_response_not_html",
+        message: "The URL did not return an HTML document.",
+      });
+    }
+
+    const html = new TextDecoder("utf-8", { fatal: false }).decode(fetched.body);
+    return ok({
+      url: currentUrl,
+      locale: options.locale ?? null,
+      isPrimary: options.isPrimary ?? false,
+      status: "extracted",
+      httpStatus: fetched.status,
+      extracted: extractLocalisationPage(html, currentUrl),
+    });
+  }
+
+  return err({ code: "audit_fetch_failed", message: "The page could not be fetched." });
+}

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/findings.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/findings.test.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { evaluateLocalisationAudit } from "./findings";
+import type { AuditedPage, ExtractedPage } from "./types";
+
+function extractedPage(overrides: Partial<ExtractedPage> = {}): ExtractedPage {
+  return {
+    url: "https://example.com/en",
+    htmlLang: "en-US",
+    title: "Product",
+    description: "Product description",
+    canonicalUrl: "https://example.com/en",
+    alternateLinks: [
+      {
+        locale: "fr-FR",
+        url: "https://example.com/fr",
+        source: "hreflang",
+      },
+      {
+        locale: "x-default",
+        url: "https://example.com",
+        source: "hreflang",
+      },
+    ],
+    headings: ["Product"],
+    navigation: ["Home"],
+    callsToAction: ["Buy now"],
+    visibleText:
+      "Product for international customers. Buy now for EUR 20. Lorem ipsum placeholder copy that should be replaced before launch.",
+    contentFingerprint: "a".repeat(64),
+    ...overrides,
+  };
+}
+
+describe("deterministic localisation audit findings", () => {
+  it("returns stable evidence-led findings for the same extracted pages", () => {
+    const primary: AuditedPage = {
+      url: "https://example.com/en",
+      locale: "en-US",
+      isPrimary: true,
+      status: "extracted",
+      httpStatus: 200,
+      extracted: extractedPage(),
+    };
+    const alternative: AuditedPage = {
+      url: "https://example.com/fr",
+      locale: "fr-FR",
+      isPrimary: false,
+      status: "extracted",
+      httpStatus: 200,
+      extracted: extractedPage({
+        url: "https://example.com/fr",
+        htmlLang: "fr-FR",
+        canonicalUrl: "https://example.com/fr",
+        alternateLinks: [
+          {
+            locale: "en-US",
+            url: "https://example.com/en",
+            source: "hreflang",
+          },
+        ],
+      }),
+    };
+
+    const first = evaluateLocalisationAudit({
+      pages: [primary, alternative],
+      targetLocale: "en-US",
+      targetMarket: "US",
+    });
+    const second = evaluateLocalisationAudit({
+      pages: [primary, alternative],
+      targetLocale: "en-US",
+      targetMarket: "US",
+    });
+
+    expect(first).toEqual(second);
+    expect(first.findings.map((finding) => finding.code)).toEqual(
+      expect.arrayContaining([
+        "cross_locale_copy",
+        "placeholder_copy",
+        "cross_locale_cta_copy",
+        "market_currency",
+      ]),
+    );
+    expect(first.findings.find((finding) => finding.code === "placeholder_copy")?.evidence).toEqual(
+      { excerpt: "Lorem ipsum" },
+    );
+  });
+
+  it("records inaccessible alternatives as limitations rather than negative findings", () => {
+    const primary: AuditedPage = {
+      url: "https://example.com/en",
+      locale: "en-US",
+      isPrimary: true,
+      status: "extracted",
+      httpStatus: 200,
+      extracted: extractedPage(),
+    };
+    const blocked: AuditedPage = {
+      url: "https://example.com/fr",
+      locale: "fr-FR",
+      isPrimary: false,
+      status: "blocked",
+      failureCode: "http_403",
+      httpStatus: 403,
+    };
+
+    const result = evaluateLocalisationAudit({
+      pages: [primary, blocked],
+      targetLocale: "en-US",
+      targetMarket: "US",
+    });
+
+    expect(result.limitations).toEqual([
+      "1 explicit locale alternative(s) could not be extracted; comparison checks exclude them.",
+    ]);
+    expect(result.findings).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "alternative_unavailable" })]),
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/findings.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/findings.ts
@@ -1,0 +1,563 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { sanitizeAuditExcerpt } from "./parser";
+import type {
+  AuditCategory,
+  AuditEvaluation,
+  AuditFinding,
+  AuditedPage,
+  ExtractedPage,
+  RuleEvaluation,
+} from "./types";
+
+const PLACEHOLDER_PATTERN =
+  /\b(lorem ipsum|todo\b|translation missing|replace me|sample text)\b|{{[^}]+}}|\[\[[^\]]+\]\]/i;
+const CURRENCY_CODE_PATTERN =
+  /\b(USD|EUR|GBP|AUD|CAD|JPY|CNY|RMB|KRW|INR|BRL|MXN|CHF|SEK|NOK|DKK|NZD)\b/g;
+
+const MARKET_CURRENCY: Record<string, string> = {
+  US: "USD",
+  GB: "GBP",
+  AU: "AUD",
+  CA: "CAD",
+  JP: "JPY",
+  CN: "CNY",
+  KR: "KRW",
+  IN: "INR",
+  BR: "BRL",
+  MX: "MXN",
+  CH: "CHF",
+  SE: "SEK",
+  NO: "NOK",
+  DK: "DKK",
+  NZ: "NZD",
+  DE: "EUR",
+  FR: "EUR",
+  ES: "EUR",
+  IT: "EUR",
+  NL: "EUR",
+  IE: "EUR",
+  AT: "EUR",
+  BE: "EUR",
+  FI: "EUR",
+  PT: "EUR",
+};
+
+function localeLanguage(locale: string | null | undefined): string | null {
+  if (!locale || locale === "x-default") {
+    return null;
+  }
+  try {
+    return new Intl.Locale(locale).language.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function localeRegion(locale: string | null | undefined): string | null {
+  if (!locale || locale === "x-default") {
+    return null;
+  }
+  try {
+    return new Intl.Locale(locale).region?.toUpperCase() ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function evaluation(
+  code: string,
+  category: AuditCategory,
+  availablePoints: number,
+  earnedPoints: number,
+  applicable = true,
+): RuleEvaluation {
+  return { code, category, availablePoints, earnedPoints, applicable };
+}
+
+function finding(
+  input: Omit<AuditFinding, "confidence" | "evidenceKind" | "publicPreviewEligible"> &
+    Partial<Pick<AuditFinding, "confidence" | "evidenceKind" | "publicPreviewEligible">>,
+): AuditFinding {
+  return {
+    confidence: 1,
+    evidenceKind: "observed",
+    publicPreviewEligible: true,
+    ...input,
+    evidence: {
+      ...input.evidence,
+      ...(input.evidence.excerpt ? { excerpt: sanitizeAuditExcerpt(input.evidence.excerpt) } : {}),
+      ...(input.evidence.observedValue
+        ? { observedValue: sanitizeAuditExcerpt(input.evidence.observedValue) }
+        : {}),
+      ...(input.evidence.expectedValue
+        ? { expectedValue: sanitizeAuditExcerpt(input.evidence.expectedValue) }
+        : {}),
+    },
+  };
+}
+
+function addTechnicalRules(
+  primary: ExtractedPage,
+  pages: AuditedPage[],
+  targetLocale: string,
+  rules: RuleEvaluation[],
+  findings: AuditFinding[],
+) {
+  const pageUrl = primary.url;
+  const validLanguage = localeLanguage(primary.htmlLang);
+  rules.push(evaluation("document_language", "technical", 12, validLanguage ? 12 : 0));
+  if (!validLanguage) {
+    findings.push(
+      finding({
+        code: "document_language",
+        category: "technical",
+        severity: "high",
+        title: "Document language is missing or invalid",
+        evidence: { observedValue: primary.htmlLang ?? "missing" },
+        impact: "Browsers and assistive technology cannot reliably identify the page language.",
+        recommendation: "Set a valid BCP 47 language tag on the html element.",
+        availablePoints: 12,
+        earnedPoints: 0,
+        pageUrl,
+      }),
+    );
+  }
+
+  rules.push(evaluation("canonical_url", "technical", 8, primary.canonicalUrl ? 8 : 0));
+  if (!primary.canonicalUrl) {
+    findings.push(
+      finding({
+        code: "canonical_url",
+        category: "technical",
+        severity: "medium",
+        title: "Canonical URL is missing",
+        evidence: {},
+        impact: "Search engines have less guidance about the preferred localized page URL.",
+        recommendation: "Add a self-referencing canonical link to each locale page.",
+        availablePoints: 8,
+        earnedPoints: 0,
+        pageUrl,
+      }),
+    );
+  }
+
+  const metadataPoints = (primary.title ? 4 : 0) + (primary.description ? 4 : 0);
+  rules.push(evaluation("localized_metadata", "technical", 8, metadataPoints));
+  if (metadataPoints < 8) {
+    findings.push(
+      finding({
+        code: "localized_metadata",
+        category: "technical",
+        severity: "medium",
+        title: "Search metadata is incomplete",
+        evidence: {
+          observedValue: [
+            primary.title ? null : "title missing",
+            primary.description ? null : "description missing",
+          ]
+            .filter(Boolean)
+            .join(", "),
+        },
+        impact: "Incomplete metadata weakens localized search results and click-through context.",
+        recommendation: "Provide a localized title and meta description.",
+        availablePoints: 8,
+        earnedPoints: metadataPoints,
+        pageUrl,
+      }),
+    );
+  }
+
+  const alternatives = primary.alternateLinks.filter((item) => item.locale !== "x-default");
+  rules.push(evaluation("locale_alternatives", "technical", 8, alternatives.length > 0 ? 8 : 0));
+  if (alternatives.length === 0) {
+    findings.push(
+      finding({
+        code: "locale_alternatives",
+        category: "technical",
+        severity: "high",
+        title: "No explicit locale alternatives were found",
+        evidence: {},
+        impact: "Visitors and search engines cannot reliably discover equivalent locale pages.",
+        recommendation: "Add alternate hreflang links or an explicit language switcher.",
+        availablePoints: 8,
+        earnedPoints: 0,
+        pageUrl,
+      }),
+    );
+  }
+
+  const hasXDefault = primary.alternateLinks.some((item) => item.locale === "x-default");
+  rules.push(
+    evaluation("hreflang_x_default", "technical", 4, hasXDefault ? 4 : 0, alternatives.length > 0),
+  );
+  if (alternatives.length > 0 && !hasXDefault) {
+    findings.push(
+      finding({
+        code: "hreflang_x_default",
+        category: "technical",
+        severity: "low",
+        title: "No x-default locale fallback was found",
+        evidence: {},
+        impact: "Users without a matching locale have no declared default experience.",
+        recommendation: "Add an x-default hreflang link to the appropriate fallback page.",
+        availablePoints: 4,
+        earnedPoints: 0,
+        pageUrl,
+      }),
+    );
+  }
+
+  const alternativePages = pages.filter((page) => !page.isPrimary);
+  const extractedAlternatives = alternativePages.filter(
+    (page): page is Extract<AuditedPage, { status: "extracted" }> => page.status === "extracted",
+  );
+  const reciprocalCount = extractedAlternatives.filter((page) =>
+    page.extracted.alternateLinks.some((link) => link.url === primary.url),
+  ).length;
+  const reciprocalPoints =
+    extractedAlternatives.length === 0
+      ? 0
+      : Math.round((10 * reciprocalCount) / extractedAlternatives.length);
+  rules.push(
+    evaluation(
+      "reciprocal_hreflang",
+      "technical",
+      10,
+      reciprocalPoints,
+      extractedAlternatives.length > 0,
+    ),
+  );
+  if (extractedAlternatives.length > 0 && reciprocalCount < extractedAlternatives.length) {
+    findings.push(
+      finding({
+        code: "reciprocal_hreflang",
+        category: "technical",
+        severity: "high",
+        title: "Some locale alternatives are not reciprocal",
+        evidence: {
+          observedValue: `${reciprocalCount} of ${extractedAlternatives.length} checked alternatives link back`,
+        },
+        impact: "Incomplete hreflang clusters can be ignored or interpreted incorrectly.",
+        recommendation:
+          "Ensure every locale page references all equivalent pages, including itself.",
+        availablePoints: 10,
+        earnedPoints: reciprocalPoints,
+        pageUrl,
+      }),
+    );
+  }
+
+  const targetLanguage = localeLanguage(targetLocale);
+  const languageMatches = Boolean(
+    validLanguage && targetLanguage && validLanguage === targetLanguage,
+  );
+  rules.push(
+    evaluation(
+      "target_language_alignment",
+      "technical",
+      8,
+      languageMatches ? 8 : 0,
+      Boolean(validLanguage && targetLanguage),
+    ),
+  );
+  if (validLanguage && targetLanguage && !languageMatches) {
+    findings.push(
+      finding({
+        code: "target_language_alignment",
+        category: "technical",
+        severity: "high",
+        title: "Document language does not match the confirmed target locale",
+        evidence: {
+          observedValue: primary.htmlLang ?? undefined,
+          expectedValue: targetLocale,
+        },
+        impact: "Language-dependent browser, accessibility, and search behavior may be incorrect.",
+        recommendation: "Align the html language tag with the language of the rendered page.",
+        availablePoints: 8,
+        earnedPoints: 0,
+        pageUrl,
+      }),
+    );
+  }
+}
+
+function addLinguisticRules(
+  primary: ExtractedPage,
+  pages: AuditedPage[],
+  rules: RuleEvaluation[],
+  findings: AuditFinding[],
+) {
+  const hasEnoughCopy = primary.visibleText.length >= 120;
+  const placeholderMatch = hasEnoughCopy ? primary.visibleText.match(PLACEHOLDER_PATTERN) : null;
+  rules.push(
+    evaluation("placeholder_copy", "linguistic", 10, placeholderMatch ? 0 : 10, hasEnoughCopy),
+  );
+  if (placeholderMatch) {
+    findings.push(
+      finding({
+        code: "placeholder_copy",
+        category: "linguistic",
+        severity: "high",
+        title: "Placeholder or unresolved copy is visible",
+        evidence: { excerpt: placeholderMatch[0] },
+        impact: "Unfinished copy reduces trust and can expose localization implementation details.",
+        recommendation: "Replace the placeholder and verify the affected locale resource.",
+        availablePoints: 10,
+        earnedPoints: 0,
+        pageUrl: primary.url,
+      }),
+    );
+  }
+
+  const comparisonPages = pages.filter(
+    (page): page is Extract<AuditedPage, { status: "extracted" }> =>
+      !page.isPrimary &&
+      page.status === "extracted" &&
+      localeLanguage(page.locale) !== localeLanguage(primary.htmlLang),
+  );
+  const duplicatePages = comparisonPages.filter(
+    (page) => page.extracted.contentFingerprint === primary.contentFingerprint,
+  );
+  rules.push(
+    evaluation(
+      "cross_locale_copy",
+      "linguistic",
+      20,
+      duplicatePages.length === 0 ? 20 : 0,
+      comparisonPages.length > 0,
+    ),
+  );
+  if (duplicatePages.length > 0) {
+    findings.push(
+      finding({
+        code: "cross_locale_copy",
+        category: "linguistic",
+        severity: "critical",
+        title: "A different-locale page has identical customer-facing content",
+        evidence: { observedValue: `${duplicatePages.length} identical locale page(s)` },
+        impact: "Visitors may be receiving untranslated content despite selecting another locale.",
+        recommendation:
+          "Publish localized copy and verify locale routing before exposing the alternative.",
+        availablePoints: 20,
+        earnedPoints: 0,
+        pageUrl: primary.url,
+      }),
+    );
+  }
+
+  const comparableCtas = comparisonPages.filter(
+    (page) => page.extracted.callsToAction.length > 0 && primary.callsToAction.length > 0,
+  );
+  const primaryCtas = new Set(primary.callsToAction.map((value) => value.toLocaleLowerCase()));
+  const repeatedCtas = comparableCtas.flatMap((page) =>
+    page.extracted.callsToAction.filter((value) => primaryCtas.has(value.toLocaleLowerCase())),
+  );
+  rules.push(
+    evaluation(
+      "cross_locale_cta_copy",
+      "linguistic",
+      10,
+      repeatedCtas.length === 0 ? 10 : 0,
+      comparableCtas.length > 0,
+    ),
+  );
+  if (repeatedCtas.length > 0) {
+    findings.push(
+      finding({
+        code: "cross_locale_cta_copy",
+        category: "linguistic",
+        severity: "medium",
+        confidence: 0.9,
+        evidenceKind: "judgement",
+        title: "Calls to action repeat across different languages",
+        evidence: { excerpt: repeatedCtas[0] },
+        impact: "A conversion-critical action may not have been localized.",
+        recommendation: "Review calls to action in context with a native-language reviewer.",
+        availablePoints: 10,
+        earnedPoints: 0,
+        pageUrl: primary.url,
+      }),
+    );
+  }
+}
+
+function addMarketRules(
+  primary: ExtractedPage,
+  pages: AuditedPage[],
+  targetLocale: string,
+  targetMarket: string,
+  rules: RuleEvaluation[],
+  findings: AuditFinding[],
+) {
+  const normalizedMarket = targetMarket.toUpperCase();
+  const expectedCurrency = MARKET_CURRENCY[normalizedMarket];
+  const currencyCodes = Array.from(new Set(primary.visibleText.match(CURRENCY_CODE_PATTERN) ?? []));
+  const currencyMatches = Boolean(
+    expectedCurrency && currencyCodes.length > 0 && currencyCodes.includes(expectedCurrency),
+  );
+  rules.push(
+    evaluation(
+      "market_currency",
+      "market",
+      12,
+      currencyMatches ? 12 : 0,
+      Boolean(expectedCurrency && currencyCodes.length > 0),
+    ),
+  );
+  if (expectedCurrency && currencyCodes.length > 0 && !currencyMatches) {
+    findings.push(
+      finding({
+        code: "market_currency",
+        category: "market",
+        severity: "high",
+        confidence: 0.95,
+        evidenceKind: "judgement",
+        title: "Displayed currency does not match the confirmed market",
+        evidence: {
+          observedValue: currencyCodes.join(", "),
+          expectedValue: expectedCurrency,
+        },
+        impact: "Unexpected pricing currency can create friction and reduce purchase confidence.",
+        recommendation: "Confirm pricing and currency presentation for the selected market.",
+        availablePoints: 12,
+        earnedPoints: 0,
+        pageUrl: primary.url,
+      }),
+    );
+  }
+
+  const targetRegion = localeRegion(targetLocale);
+  const regionMatches = Boolean(targetRegion && targetRegion === normalizedMarket);
+  rules.push(
+    evaluation(
+      "locale_market_alignment",
+      "market",
+      8,
+      regionMatches ? 8 : 0,
+      Boolean(targetRegion),
+    ),
+  );
+  if (targetRegion && !regionMatches) {
+    findings.push(
+      finding({
+        code: "locale_market_alignment",
+        category: "market",
+        severity: "medium",
+        title: "Locale region and target market differ",
+        evidence: {
+          observedValue: targetLocale,
+          expectedValue: normalizedMarket,
+        },
+        impact:
+          "Regional spelling, formats, legal copy, and offers may not fit the intended market.",
+        recommendation: "Confirm that the selected locale variant is intentional for this market.",
+        availablePoints: 8,
+        earnedPoints: 0,
+        pageUrl: primary.url,
+      }),
+    );
+  }
+
+  const comparisonPages = pages.filter(
+    (page): page is Extract<AuditedPage, { status: "extracted" }> =>
+      !page.isPrimary && page.status === "extracted",
+  );
+  const comparableMetadata = comparisonPages.filter((page) =>
+    Boolean(primary.title && page.extracted.title),
+  );
+  const duplicateMetadata = comparableMetadata.filter(
+    (page) =>
+      page.extracted.title?.toLocaleLowerCase() === primary.title?.toLocaleLowerCase() &&
+      page.locale !== primary.htmlLang,
+  );
+  rules.push(
+    evaluation(
+      "localized_search_metadata",
+      "market",
+      10,
+      duplicateMetadata.length === 0 ? 10 : 0,
+      comparableMetadata.length > 0,
+    ),
+  );
+  if (duplicateMetadata.length > 0) {
+    findings.push(
+      finding({
+        code: "localized_search_metadata",
+        category: "market",
+        severity: "medium",
+        confidence: 0.9,
+        evidenceKind: "judgement",
+        title: "Page titles repeat across locale pages",
+        evidence: { excerpt: primary.title ?? undefined },
+        impact: "Repeated titles may not reflect local search language or intent.",
+        recommendation: "Research and localize the title for each target market.",
+        availablePoints: 10,
+        earnedPoints: 0,
+        pageUrl: primary.url,
+      }),
+    );
+  }
+}
+
+export function evaluateLocalisationAudit(input: {
+  pages: AuditedPage[];
+  targetLocale: string;
+  targetMarket: string;
+}): AuditEvaluation {
+  const primaryPage = input.pages.find(
+    (page): page is Extract<AuditedPage, { status: "extracted" }> =>
+      page.isPrimary && page.status === "extracted",
+  );
+  if (!primaryPage) {
+    return {
+      findings: [],
+      rules: [],
+      limitations: ["The submitted page could not be extracted."],
+    };
+  }
+
+  const findings: AuditFinding[] = [];
+  const rules: RuleEvaluation[] = [];
+  addTechnicalRules(primaryPage.extracted, input.pages, input.targetLocale, rules, findings);
+  addLinguisticRules(primaryPage.extracted, input.pages, rules, findings);
+  addMarketRules(
+    primaryPage.extracted,
+    input.pages,
+    input.targetLocale,
+    input.targetMarket,
+    rules,
+    findings,
+  );
+
+  const failedAlternatives = input.pages.filter(
+    (page) => !page.isPrimary && page.status !== "extracted",
+  );
+  const limitations =
+    failedAlternatives.length > 0
+      ? [
+          `${failedAlternatives.length} explicit locale alternative(s) could not be extracted; comparison checks exclude them.`,
+        ]
+      : [];
+
+  return {
+    findings: findings.toSorted(
+      (left, right) =>
+        ["info", "low", "medium", "high", "critical"].indexOf(right.severity) -
+          ["info", "low", "medium", "high", "critical"].indexOf(left.severity) ||
+        left.code.localeCompare(right.code),
+    ),
+    rules,
+    limitations,
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/operations.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/operations.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { createHmac } from "node:crypto";
+
+import { eq } from "drizzle-orm";
+
+import { type DatabaseClient, schema } from "@/lib/database";
+import type {
+  LocalisationAuditPageExtractionData,
+  LocalisationAuditReportData,
+} from "@/lib/database/schema/localisation-audit";
+
+import { sanitizeAuditExcerpt } from "./parser";
+import type { ExtractedPage, PrivateAuditReport, SafeAudit } from "./types";
+
+export const MAX_PERSISTED_VISIBLE_TEXT = 2_000;
+
+export type AuditRecord = typeof schema.localisationAudits.$inferSelect;
+
+export function hashBudgetKey(value: string, secret: string): string {
+  return createHmac("sha256", secret).update(value).digest("hex");
+}
+
+export function toPersistedExtraction(
+  extracted: ExtractedPage,
+): LocalisationAuditPageExtractionData {
+  return {
+    htmlLang: extracted.htmlLang,
+    title: extracted.title,
+    description: extracted.description,
+    canonicalUrl: extracted.canonicalUrl,
+    alternateLinks: extracted.alternateLinks,
+    headings: extracted.headings,
+    navigation: extracted.navigation,
+    callsToAction: extracted.callsToAction,
+    visibleTextSample: sanitizeAuditExcerpt(extracted.visibleText, MAX_PERSISTED_VISIBLE_TEXT),
+  };
+}
+
+export function fromPersistedExtraction(
+  url: string,
+  fingerprint: string,
+  extraction: LocalisationAuditPageExtractionData,
+): ExtractedPage {
+  return {
+    url,
+    htmlLang: extraction.htmlLang,
+    title: extraction.title,
+    description: extraction.description,
+    canonicalUrl: extraction.canonicalUrl,
+    alternateLinks: extraction.alternateLinks,
+    headings: extraction.headings,
+    navigation: extraction.navigation,
+    callsToAction: extraction.callsToAction,
+    visibleText: extraction.visibleTextSample,
+    contentFingerprint: fingerprint,
+  };
+}
+
+export function safeAuditFromRecord(
+  audit: AuditRecord,
+  report?: {
+    publicSlug: string;
+    publicReport: LocalisationAuditReportData;
+  } | null,
+): SafeAudit {
+  return {
+    id: audit.id,
+    status: audit.status,
+    detectedLocale: audit.detectedLocale,
+    alternatives: audit.alternatives,
+    targetLocale: audit.targetLocale,
+    targetMarket: audit.targetMarket,
+    ...(report
+      ? {
+          publicSlug: report.publicSlug,
+          summary: report.publicReport,
+        }
+      : {}),
+  };
+}
+
+export async function findReportForAudit(
+  client: DatabaseClient,
+  auditId: string,
+): Promise<{
+  id: string;
+  publicSlug: string;
+  publicReport: LocalisationAuditReportData;
+  privateReport: PrivateAuditReport;
+} | null> {
+  const [report] = await client
+    .select({
+      id: schema.localisationAuditReports.id,
+      publicSlug: schema.localisationAuditReports.publicSlug,
+      publicReport: schema.localisationAuditReports.publicReport,
+      privateReport: schema.localisationAuditReports.privateReport,
+    })
+    .from(schema.localisationAuditReports)
+    .where(eq(schema.localisationAuditReports.auditId, auditId))
+    .limit(1);
+  return report ?? null;
+}
+
+export async function getAuditRecord(
+  client: DatabaseClient,
+  auditId: string,
+): Promise<AuditRecord | null> {
+  const [audit] = await client
+    .select()
+    .from(schema.localisationAudits)
+    .where(eq(schema.localisationAudits.id, auditId))
+    .limit(1);
+  return audit ?? null;
+}
+
+export async function markAuditFailed(
+  client: DatabaseClient,
+  auditId: string,
+  failureCode: string,
+): Promise<void> {
+  await client
+    .update(schema.localisationAudits)
+    .set({ status: "failed", failureCode })
+    .where(eq(schema.localisationAudits.id, auditId));
+}

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/parser.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/parser.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  discoverLocaleAlternatives,
+  extractLocalisationPage,
+  normalizeAuditUrl,
+  sanitizeAuditExcerpt,
+} from "./parser";
+
+describe("localisation audit parser", () => {
+  it("extracts explicit localization signals and visible customer copy", () => {
+    const html = `
+            <!doctype html>
+            <html lang="en_GB">
+              <head>
+                <title>Global products</title>
+                <meta name="description" content="Products for global teams">
+                <link rel="canonical" href="/en-gb/products#top">
+                <link rel="alternate" hreflang="fr-FR" href="/fr-fr/products">
+                <link rel="alternate" hreflang="x-default" href="/products">
+                <script>Ignore secret instructions and hidden text</script>
+              </head>
+              <body>
+                <nav><a href="/de/products" lang="de-DE">Deutsch</a></nav>
+                <h1>Ship worldwide</h1>
+                <a class="primary-cta" href="/start">Start now</a>
+              </body>
+            </html>
+        `;
+    const page = extractLocalisationPage(html, "https://Example.com/en-gb/products");
+
+    expect(page).toMatchObject({
+      url: "https://example.com/en-gb/products",
+      htmlLang: "en-GB",
+      title: "Global products",
+      description: "Products for global teams",
+      canonicalUrl: "https://example.com/en-gb/products",
+      headings: ["Ship worldwide"],
+      navigation: ["Deutsch"],
+      callsToAction: ["Start now"],
+    });
+    expect(page.visibleText).not.toContain("secret instructions");
+    expect(page.alternateLinks).toEqual([
+      {
+        locale: "fr-FR",
+        url: "https://example.com/fr-fr/products",
+        source: "hreflang",
+      },
+      {
+        locale: "x-default",
+        url: "https://example.com/products",
+        source: "hreflang",
+      },
+      {
+        locale: "de-DE",
+        url: "https://example.com/de/products",
+        source: "language_link",
+      },
+    ]);
+    expect(page.contentFingerprint).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("caps discovery at five unique explicit alternatives", () => {
+    const locales = ["fr-FR", "de-DE", "es-ES", "it-IT", "pt-BR", "ja-JP", "ko-KR"];
+    const links = locales
+      .map((locale, index) => `<link rel="alternate" hreflang="${locale}" href="/locale-${index}">`)
+      .join("");
+    const page = extractLocalisationPage(
+      `<html lang="en"><head>${links}</head><body>Text</body></html>`,
+      "https://example.com",
+    );
+
+    expect(discoverLocaleAlternatives(page)).toHaveLength(5);
+  });
+
+  it("sanitizes control characters, markup delimiters, and long excerpts", () => {
+    expect(sanitizeAuditExcerpt("  <b>Hello\u0000   world</b>  ", 16)).toBe("bHello world/b");
+  });
+
+  it("produces stable fingerprints for equivalent input", () => {
+    const html = `<html lang="fr"><head><title>Bonjour</title></head><body><h1>Salut</h1></body></html>`;
+    const first = extractLocalisationPage(html, "https://example.com/fr");
+    const second = extractLocalisationPage(html, "https://example.com/fr");
+    expect(first.contentFingerprint).toBe(second.contentFingerprint);
+  });
+
+  it("rejects URLs containing embedded credentials", () => {
+    expect(normalizeAuditUrl("https://user:password@example.com/page")).toBeNull();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/parser.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/parser.ts
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { createHash } from "node:crypto";
+
+import { Parser } from "htmlparser2";
+
+import type { DiscoveredLocaleAlternative, ExtractedPage } from "./types";
+
+const EXCLUDED_TAGS = new Set(["script", "style", "noscript", "template", "svg"]);
+const HEADING_TAGS = new Set(["h1", "h2", "h3"]);
+const CTA_CLASS_PATTERN = /(?:^|[\s_-])(button|btn|cta)(?:$|[\s_-])/i;
+const MAX_VISIBLE_TEXT_LENGTH = 20_000;
+const MAX_SNIPPET_LENGTH = 240;
+
+type ElementFrame = {
+  tagName: string;
+  attributes: Record<string, string>;
+  text: string;
+};
+
+export function sanitizeAuditExcerpt(value: string, maxLength = MAX_SNIPPET_LENGTH): string {
+  const withoutControls = Array.from(value, (character) => {
+    const code = character.charCodeAt(0);
+    return (code >= 0 && code <= 8) ||
+      code === 11 ||
+      code === 12 ||
+      (code >= 14 && code <= 31) ||
+      code === 127
+      ? " "
+      : character;
+  }).join("");
+  const normalized = withoutControls.replace(/[<>]/g, "").replace(/\s+/g, " ").trim();
+
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
+}
+
+export function normalizeAuditUrl(value: string, baseUrl?: string): string | null {
+  try {
+    const url = baseUrl ? new URL(value, baseUrl) : new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return null;
+    }
+    if (url.username || url.password) {
+      return null;
+    }
+    url.hash = "";
+    url.hostname = url.hostname.toLowerCase();
+    if (
+      (url.protocol === "https:" && url.port === "443") ||
+      (url.protocol === "http:" && url.port === "80")
+    ) {
+      url.port = "";
+    }
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function normalizeLocale(value: string | undefined): string | null {
+  if (!value || value.toLowerCase() === "x-default") {
+    return value?.toLowerCase() === "x-default" ? "x-default" : null;
+  }
+
+  try {
+    return Intl.getCanonicalLocales(value.replace("_", "-"))[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function isCtaElement(tagName: string, attributes: Record<string, string>): boolean {
+  return (
+    tagName === "button" ||
+    attributes.role?.toLowerCase() === "button" ||
+    CTA_CLASS_PATTERN.test(attributes.class ?? "")
+  );
+}
+
+function createFingerprint(input: Omit<ExtractedPage, "contentFingerprint">): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        htmlLang: input.htmlLang,
+        title: input.title,
+        description: input.description,
+        headings: input.headings,
+        navigation: input.navigation,
+        callsToAction: input.callsToAction,
+        visibleText: input.visibleText,
+      }),
+    )
+    .digest("hex");
+}
+
+export function extractLocalisationPage(html: string, pageUrl: string): ExtractedPage {
+  const normalizedPageUrl = normalizeAuditUrl(pageUrl);
+  if (!normalizedPageUrl) {
+    throw new Error("A valid HTTP(S) page URL is required.");
+  }
+
+  let htmlLang: string | null = null;
+  let title: string | null = null;
+  let description: string | null = null;
+  let canonicalUrl: string | null = null;
+  let excludedDepth = 0;
+  let visibleText = "";
+  const stack: ElementFrame[] = [];
+  const headings: string[] = [];
+  const navigation: string[] = [];
+  const callsToAction: string[] = [];
+  const alternatives: DiscoveredLocaleAlternative[] = [];
+
+  const addAlternative = (
+    localeValue: string | undefined,
+    href: string | undefined,
+    source: DiscoveredLocaleAlternative["source"],
+  ) => {
+    const locale = normalizeLocale(localeValue);
+    const url = href ? normalizeAuditUrl(href, normalizedPageUrl) : null;
+    if (!locale || !url || url === normalizedPageUrl) {
+      return;
+    }
+    alternatives.push({ locale, url, source });
+  };
+
+  const parser = new Parser(
+    {
+      onopentag(tagName, rawAttributes) {
+        const attributes = Object.fromEntries(
+          Object.entries(rawAttributes).map(([key, value]) => [key.toLowerCase(), value]),
+        );
+        const normalizedTagName = tagName.toLowerCase();
+        stack.push({ tagName: normalizedTagName, attributes, text: "" });
+
+        if (EXCLUDED_TAGS.has(normalizedTagName)) {
+          excludedDepth += 1;
+        }
+        if (normalizedTagName === "html") {
+          htmlLang = normalizeLocale(attributes.lang);
+        }
+        if (normalizedTagName === "meta") {
+          const metaName = (attributes.name ?? attributes.property ?? "").toLowerCase();
+          if (metaName === "description" && attributes.content) {
+            description = sanitizeAuditExcerpt(attributes.content, 500);
+          }
+        }
+        if (normalizedTagName === "link") {
+          const rel = (attributes.rel ?? "").toLowerCase().split(/\s+/).filter(Boolean);
+          if (rel.includes("canonical") && attributes.href) {
+            canonicalUrl = normalizeAuditUrl(attributes.href, normalizedPageUrl);
+          }
+          if (rel.includes("alternate")) {
+            addAlternative(attributes.hreflang, attributes.href, "hreflang");
+          }
+        }
+        if (normalizedTagName === "a") {
+          const locale = attributes.hreflang ?? attributes["data-locale"] ?? attributes.lang;
+          addAlternative(locale, attributes.href, "language_link");
+        }
+      },
+      ontext(text) {
+        if (excludedDepth > 0) {
+          return;
+        }
+        visibleText += ` ${text}`;
+        for (const frame of stack) {
+          frame.text += ` ${text}`;
+        }
+      },
+      onclosetag(tagName) {
+        const normalizedTagName = tagName.toLowerCase();
+        const frame = stack.pop();
+        if (!frame) {
+          return;
+        }
+
+        if (EXCLUDED_TAGS.has(normalizedTagName)) {
+          excludedDepth = Math.max(0, excludedDepth - 1);
+          return;
+        }
+
+        const text = sanitizeAuditExcerpt(frame.text);
+        if (normalizedTagName === "title" && text) {
+          title = text;
+        }
+        if (HEADING_TAGS.has(normalizedTagName) && text) {
+          headings.push(text);
+        }
+        const isInsideNavigation = stack.some(
+          (ancestor) =>
+            ancestor.tagName === "nav" || ancestor.attributes.role?.toLowerCase() === "navigation",
+        );
+        if (
+          text &&
+          (normalizedTagName === "a" || normalizedTagName === "button") &&
+          isInsideNavigation
+        ) {
+          navigation.push(text);
+        }
+        if (text && isCtaElement(normalizedTagName, frame.attributes)) {
+          callsToAction.push(text);
+        }
+      },
+    },
+    { decodeEntities: true, lowerCaseAttributeNames: true, lowerCaseTags: true },
+  );
+
+  parser.write(html);
+  parser.end();
+
+  const uniqueAlternatives = Array.from(
+    new Map(
+      alternatives.map((alternative) => [`${alternative.locale}:${alternative.url}`, alternative]),
+    ).values(),
+  );
+  const extractedWithoutFingerprint = {
+    url: normalizedPageUrl,
+    htmlLang,
+    title,
+    description,
+    canonicalUrl,
+    alternateLinks: uniqueAlternatives,
+    headings: headings.slice(0, 20),
+    navigation: Array.from(new Set(navigation)).slice(0, 30),
+    callsToAction: Array.from(new Set(callsToAction)).slice(0, 20),
+    visibleText: sanitizeAuditExcerpt(visibleText, MAX_VISIBLE_TEXT_LENGTH),
+  };
+
+  return {
+    ...extractedWithoutFingerprint,
+    contentFingerprint: createFingerprint(extractedWithoutFingerprint),
+  };
+}
+
+export function discoverLocaleAlternatives(
+  page: ExtractedPage,
+  maxAlternatives = 5,
+): DiscoveredLocaleAlternative[] {
+  const byUrl = new Map<string, DiscoveredLocaleAlternative>();
+  for (const alternative of page.alternateLinks) {
+    if (!byUrl.has(alternative.url)) {
+      byUrl.set(alternative.url, alternative);
+    }
+    if (byUrl.size >= maxAlternatives) {
+      break;
+    }
+  }
+  return Array.from(byUrl.values());
+}

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/prepare-audit-work.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/prepare-audit-work.test.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { isFatalPrepareError } from "./prepare-audit-work";
+
+describe("isFatalPrepareError", () => {
+  it("treats private-network and invalid HTML failures as fatal", () => {
+    expect(isFatalPrepareError("audit_url_not_public")).toBe(true);
+    expect(isFatalPrepareError("audit_response_not_html")).toBe(true);
+    expect(isFatalPrepareError("audit_response_too_large")).toBe(true);
+    expect(isFatalPrepareError("invalid_audit_url")).toBe(true);
+  });
+
+  it("keeps generic fetch failures retryable", () => {
+    expect(isFatalPrepareError("audit_fetch_failed")).toBe(false);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/prepare-audit-work.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/prepare-audit-work.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
+
+import { fetchAuditPage } from "./fetch-page";
+import {
+  getAuditRecord,
+  markAuditFailed,
+  safeAuditFromRecord,
+  toPersistedExtraction,
+} from "./operations";
+import { discoverLocaleAlternatives } from "./parser";
+import type { LocalisationAuditError, SafeAudit } from "./types";
+
+const FATAL_PREPARE_CODES = new Set<LocalisationAuditError["code"]>([
+  "invalid_audit_url",
+  "audit_url_not_public",
+  "audit_response_not_html",
+  "audit_response_too_large",
+]);
+
+export function isFatalPrepareError(code: LocalisationAuditError["code"]): boolean {
+  return FATAL_PREPARE_CODES.has(code);
+}
+
+export async function prepareAuditWork(
+  auditId: string,
+): Promise<Result<SafeAudit, LocalisationAuditError>> {
+  const audit = await getAuditRecord(db, auditId);
+  if (!audit) {
+    return err({ code: "audit_not_found", message: "The audit was not found." });
+  }
+  if (audit.status !== "preparing") {
+    // Idempotent replays after success or terminal failure complete without re-fetching.
+    return ok(safeAuditFromRecord(audit));
+  }
+
+  const pageResult = await fetchAuditPage(audit.normalizedUrl, { isPrimary: true });
+  if (isErr(pageResult)) {
+    await markAuditFailed(db, audit.id, pageResult.error.code);
+    return pageResult;
+  }
+  if (pageResult.value.status !== "extracted") {
+    await markAuditFailed(db, audit.id, "audit_fetch_failed");
+    return err({
+      code: "audit_fetch_failed",
+      message: "The submitted page could not be extracted.",
+    });
+  }
+
+  const page = pageResult.value;
+  const alternatives = discoverLocaleAlternatives(page.extracted);
+  const preparedAudit = await db.transaction(async (tx) => {
+    const [updatedAudit] = await tx
+      .update(schema.localisationAudits)
+      .set({
+        status: "awaiting_confirmation",
+        detectedLocale: page.extracted.htmlLang,
+        alternatives,
+        failureCode: null,
+      })
+      .where(eq(schema.localisationAudits.id, audit.id))
+      .returning();
+    if (!updatedAudit) {
+      throw new Error("Failed to prepare localisation audit.");
+    }
+    await tx.insert(schema.localisationAuditPages).values({
+      auditId: audit.id,
+      normalizedUrl: page.url,
+      locale: page.extracted.htmlLang,
+      isPrimary: true,
+      status: "extracted",
+      httpStatus: page.httpStatus,
+      contentFingerprint: page.extracted.contentFingerprint,
+      extraction: toPersistedExtraction(page.extracted),
+      fetchedAt: new Date(),
+    });
+    await tx.insert(schema.localisationAuditEvents).values({
+      auditId: audit.id,
+      eventType: "prepared",
+      metadata: { localeCount: alternatives.length + 1 },
+    });
+    return updatedAudit;
+  });
+
+  return ok(safeAuditFromRecord(preparedAudit));
+}

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/report-loaders.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/report-loaders.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { and, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import { env } from "@/lib/env";
+import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
+
+import { verifyPrivateReportAccessToken } from "./access-token";
+import type { LocalisationAuditError, PrivateAuditReport, PublicAuditReport } from "./types";
+
+export async function loadPublicLocalisationAuditReportBySlug(
+  slug: string,
+): Promise<PublicAuditReport | null> {
+  const [report] = await db
+    .select({ publicReport: schema.localisationAuditReports.publicReport })
+    .from(schema.localisationAuditReports)
+    .where(
+      and(
+        eq(schema.localisationAuditReports.publicSlug, slug),
+        eq(schema.localisationAuditReports.visibility, "public"),
+      ),
+    )
+    .limit(1);
+  return report?.publicReport ?? null;
+}
+
+export async function loadPrivateLocalisationAuditReportByToken(
+  token: string,
+): Promise<Result<PrivateAuditReport, LocalisationAuditError>> {
+  const secret = env.LOCALISATION_AUDIT_ACCESS_SECRET;
+  if (!secret) {
+    return err({
+      code: "audit_access_not_configured",
+      message: "Private report access is not configured.",
+    });
+  }
+  const tokenResult = verifyPrivateReportAccessToken({ token, secret });
+  if (isErr(tokenResult)) {
+    return tokenResult;
+  }
+
+  const [report] = await db
+    .select({ privateReport: schema.localisationAuditReports.privateReport })
+    .from(schema.localisationAuditReports)
+    .where(
+      and(
+        eq(schema.localisationAuditReports.id, tokenResult.value.reportId),
+        eq(schema.localisationAuditReports.auditId, tokenResult.value.auditId),
+      ),
+    )
+    .limit(1);
+  if (!report) {
+    return err({ code: "report_not_found", message: "The report was not found." });
+  }
+  return ok(report.privateReport);
+}

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/report.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/report.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { createReportProjections } from "./report";
+import type { AuditEvaluation, AuditFinding, AuditScores, AuditedPage } from "./types";
+
+function finding(index: number): AuditFinding {
+  return {
+    code: `finding_${index}`,
+    category: "technical",
+    severity: "high",
+    confidence: 1,
+    evidenceKind: "observed",
+    title: `Finding ${index}`,
+    evidence: { excerpt: index === 1 ? "person@example.com private excerpt" : "evidence" },
+    impact: "Impact",
+    recommendation: "Recommendation",
+    availablePoints: 10,
+    earnedPoints: 0,
+    pageUrl: "https://example.com/private-path",
+    publicPreviewEligible: true,
+  };
+}
+
+describe("localisation audit report projections", () => {
+  it("keeps public summaries separate from private evidence and page details", () => {
+    const scores: AuditScores = {
+      scoreVersion: "2026-07-24.1",
+      overallStatus: "scored",
+      overallScore: 80,
+      categoryScores: {
+        technical: {
+          status: "scored",
+          score: 80,
+          earnedPoints: 8,
+          applicablePoints: 10,
+          evaluatedRuleCount: 1,
+        },
+        linguistic: {
+          status: "scored",
+          score: 80,
+          earnedPoints: 8,
+          applicablePoints: 10,
+          evaluatedRuleCount: 1,
+        },
+        market: {
+          status: "scored",
+          score: 80,
+          earnedPoints: 8,
+          applicablePoints: 10,
+          evaluatedRuleCount: 1,
+        },
+      },
+    };
+    const evaluation: AuditEvaluation = {
+      findings: [finding(1), finding(2), finding(3), finding(4)],
+      rules: [],
+      limitations: [],
+    };
+    const pages: AuditedPage[] = [
+      {
+        url: "https://example.com/private-path",
+        locale: "en-US",
+        isPrimary: true,
+        status: "failed",
+        failureCode: "test",
+      },
+    ];
+
+    const { publicReport, privateReport } = createReportProjections({
+      domain: "example.com",
+      auditedAt: new Date("2026-07-24T12:00:00.000Z"),
+      pages,
+      evaluation,
+      scores,
+    });
+
+    expect(publicReport.findings).toHaveLength(3);
+    expect(publicReport.lockedFindingCount).toBe(1);
+    expect(publicReport.status).toBe("partial");
+    expect(JSON.stringify(publicReport)).not.toContain("person@example.com");
+    expect(JSON.stringify(publicReport)).not.toContain("/private-path");
+    expect(publicReport.findings[0]).not.toHaveProperty("evidence");
+    expect(privateReport.findings).toHaveLength(4);
+    expect(privateReport.pages).toEqual([
+      {
+        url: "https://example.com/private-path",
+        locale: "en-US",
+        status: "failed",
+      },
+    ]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/report.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/report.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type {
+  AuditCompletionStatus,
+  AuditEvaluation,
+  AuditScores,
+  AuditedPage,
+  PrivateAuditReport,
+  PublicAuditReport,
+  PublicReportFinding,
+} from "./types";
+import { LOCALISATION_AUDIT_REPORT_VERSION } from "./types";
+
+function projectFinding(
+  finding: AuditEvaluation["findings"][number],
+  includeEvidence: boolean,
+): PublicReportFinding {
+  return {
+    code: finding.code,
+    category: finding.category,
+    severity: finding.severity,
+    title: finding.title,
+    impact: finding.impact,
+    recommendation: finding.recommendation,
+    ...(includeEvidence && Object.keys(finding.evidence).length > 0
+      ? { evidence: finding.evidence }
+      : {}),
+  };
+}
+
+export function createReportProjections(input: {
+  domain: string;
+  auditedAt: Date;
+  pages: AuditedPage[];
+  evaluation: AuditEvaluation;
+  scores: AuditScores;
+}): { publicReport: PublicAuditReport; privateReport: PrivateAuditReport } {
+  const status: AuditCompletionStatus = input.pages.some((page) => page.status !== "extracted")
+    ? "partial"
+    : "completed";
+  const publicFindings = input.evaluation.findings
+    .filter((finding) => finding.publicPreviewEligible)
+    .slice(0, 3)
+    .map((finding) => projectFinding(finding, false));
+  const reportBase = {
+    ...input.scores,
+    reportVersion: LOCALISATION_AUDIT_REPORT_VERSION,
+    domain: input.domain,
+    auditedAt: input.auditedAt.toISOString(),
+    status,
+    lockedFindingCount: Math.max(0, input.evaluation.findings.length - publicFindings.length),
+    limitations: input.evaluation.limitations,
+  };
+
+  return {
+    publicReport: {
+      ...reportBase,
+      findings: publicFindings,
+    },
+    privateReport: {
+      ...reportBase,
+      findings: input.evaluation.findings.map((finding) => projectFinding(finding, true)),
+      pages: input.pages.map((page) => ({
+        url: page.url,
+        locale: page.locale,
+        status: page.status,
+      })),
+    },
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/run-audit-work.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/run-audit-work.ts
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { and, eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+
+import { db, schema } from "@/lib/database";
+import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-with-concurrency";
+import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
+
+import { dedupeAuditedPages } from "./dedupe-pages";
+import { fetchAuditPage } from "./fetch-page";
+import { evaluateLocalisationAudit } from "./findings";
+import {
+  findReportForAudit,
+  fromPersistedExtraction,
+  getAuditRecord,
+  markAuditFailed,
+  safeAuditFromRecord,
+  toPersistedExtraction,
+} from "./operations";
+import { createReportProjections } from "./report";
+import { calculateLocalisationAuditScores } from "./scoring";
+import type { AuditedPage, LocalisationAuditError, SafeAudit } from "./types";
+import { LOCALISATION_AUDIT_REPORT_VERSION, LOCALISATION_AUDIT_SCORE_VERSION } from "./types";
+
+export async function runAuditWork(
+  auditId: string,
+): Promise<Result<SafeAudit, LocalisationAuditError>> {
+  const audit = await getAuditRecord(db, auditId);
+  if (!audit) {
+    return err({ code: "audit_not_found", message: "The audit was not found." });
+  }
+  if (audit.status === "completed" || audit.status === "partial") {
+    const report = await findReportForAudit(db, audit.id);
+    return ok(safeAuditFromRecord(audit, report));
+  }
+  if (audit.status === "failed") {
+    return ok(safeAuditFromRecord(audit));
+  }
+  if (audit.status !== "running") {
+    return err({
+      code: "audit_not_awaiting_confirmation",
+      message: "The audit cannot be run in its current state.",
+    });
+  }
+  if (!audit.targetLocale || !audit.targetMarket) {
+    await markAuditFailed(db, audit.id, "invalid_audit_confirmation");
+    return err({
+      code: "audit_fetch_failed",
+      message: "The audit is missing a confirmed locale or market.",
+    });
+  }
+
+  const [primaryRecord] = await db
+    .select()
+    .from(schema.localisationAuditPages)
+    .where(
+      and(
+        eq(schema.localisationAuditPages.auditId, audit.id),
+        eq(schema.localisationAuditPages.isPrimary, true),
+      ),
+    )
+    .limit(1);
+  if (
+    !primaryRecord?.extraction ||
+    !primaryRecord.contentFingerprint ||
+    primaryRecord.status !== "extracted"
+  ) {
+    await markAuditFailed(db, audit.id, "audit_fetch_failed");
+    return err({
+      code: "audit_fetch_failed",
+      message: "The submitted page extraction is unavailable.",
+    });
+  }
+
+  const primaryPage: AuditedPage = {
+    url: primaryRecord.normalizedUrl,
+    locale: primaryRecord.locale,
+    isPrimary: true,
+    status: "extracted",
+    httpStatus: primaryRecord.httpStatus ?? 200,
+    extracted: fromPersistedExtraction(
+      primaryRecord.normalizedUrl,
+      primaryRecord.contentFingerprint,
+      primaryRecord.extraction,
+    ),
+  };
+  const fetchedAlternativePages = await mapWithConcurrency(
+    audit.alternatives,
+    3,
+    async (alternative) => {
+      const result = await fetchAuditPage(alternative.url, {
+        locale: alternative.locale,
+        isPrimary: false,
+      });
+      if (isErr(result)) {
+        return {
+          url: alternative.url,
+          locale: alternative.locale,
+          isPrimary: false,
+          status:
+            result.error.code === "audit_url_not_public"
+              ? ("blocked" as const)
+              : ("failed" as const),
+          failureCode: result.error.code,
+        };
+      }
+      return result.value;
+    },
+  );
+  const pages = dedupeAuditedPages([primaryPage, ...fetchedAlternativePages]);
+  const alternativePages = pages.slice(1);
+  const evaluation = evaluateLocalisationAudit({
+    pages,
+    targetLocale: audit.targetLocale,
+    targetMarket: audit.targetMarket,
+  });
+  const scores = calculateLocalisationAuditScores(evaluation.rules);
+  const projections = createReportProjections({
+    domain: audit.domain,
+    auditedAt: new Date(),
+    pages,
+    evaluation,
+    scores,
+  });
+  const publicSlug = nanoid(24);
+
+  const completed = await db.transaction(async (tx) => {
+    const pageIdByUrl = new Map<string, string>([[primaryRecord.normalizedUrl, primaryRecord.id]]);
+    if (alternativePages.length > 0) {
+      const insertedPages = await tx
+        .insert(schema.localisationAuditPages)
+        .values(
+          alternativePages.map((page) => ({
+            auditId: audit.id,
+            normalizedUrl: page.url,
+            locale: page.locale,
+            isPrimary: false,
+            status: page.status,
+            httpStatus: page.httpStatus,
+            contentFingerprint:
+              page.status === "extracted" ? page.extracted.contentFingerprint : undefined,
+            extraction:
+              page.status === "extracted" ? toPersistedExtraction(page.extracted) : undefined,
+            failureCode: page.status === "extracted" ? undefined : page.failureCode,
+            fetchedAt: new Date(),
+          })),
+        )
+        .returning({
+          id: schema.localisationAuditPages.id,
+          normalizedUrl: schema.localisationAuditPages.normalizedUrl,
+        });
+      for (const page of insertedPages) {
+        pageIdByUrl.set(page.normalizedUrl, page.id);
+      }
+    }
+    if (evaluation.findings.length > 0) {
+      await tx.insert(schema.localisationAuditFindings).values(
+        evaluation.findings.map((auditFinding) => ({
+          auditId: audit.id,
+          pageId: pageIdByUrl.get(auditFinding.pageUrl),
+          ruleCode: auditFinding.code,
+          category: auditFinding.category,
+          severity: auditFinding.severity,
+          confidence: auditFinding.confidence,
+          evidenceKind: auditFinding.evidenceKind,
+          title: auditFinding.title,
+          evidence: auditFinding.evidence,
+          impact: auditFinding.impact,
+          recommendation: auditFinding.recommendation,
+          availablePoints: auditFinding.availablePoints,
+          earnedPoints: auditFinding.earnedPoints,
+          publicPreviewEligible: auditFinding.publicPreviewEligible,
+        })),
+      );
+    }
+    const [report] = await tx
+      .insert(schema.localisationAuditReports)
+      .values({
+        auditId: audit.id,
+        publicSlug,
+        scoreVersion: LOCALISATION_AUDIT_SCORE_VERSION,
+        reportVersion: LOCALISATION_AUDIT_REPORT_VERSION,
+        publicReport: projections.publicReport,
+        privateReport: projections.privateReport,
+      })
+      .returning({
+        publicSlug: schema.localisationAuditReports.publicSlug,
+        publicReport: schema.localisationAuditReports.publicReport,
+      });
+    if (!report) {
+      throw new Error("Failed to persist localisation audit report.");
+    }
+    const status = projections.publicReport.status;
+    const [updatedAudit] = await tx
+      .update(schema.localisationAudits)
+      .set({ status, completedAt: new Date() })
+      .where(eq(schema.localisationAudits.id, audit.id))
+      .returning();
+    if (!updatedAudit) {
+      throw new Error("Failed to complete localisation audit.");
+    }
+    await tx.insert(schema.localisationAuditEvents).values({
+      auditId: audit.id,
+      eventType: "completed",
+      metadata: {
+        findingCount: evaluation.findings.length,
+        localeCount: pages.length,
+      },
+    });
+    return safeAuditFromRecord(updatedAudit, report);
+  });
+
+  return ok(completed);
+}

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/scoring.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/scoring.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { calculateLocalisationAuditScores } from "./scoring";
+import type { RuleEvaluation } from "./types";
+
+describe("localisation audit scoring", () => {
+  it("returns insufficient evidence when no rules are applicable", () => {
+    const scores = calculateLocalisationAuditScores([]);
+
+    expect(scores.overallStatus).toBe("insufficient_evidence");
+    expect(scores.overallScore).toBeNull();
+    expect(scores.categoryScores).toEqual({
+      technical: {
+        status: "insufficient_evidence",
+        score: null,
+        earnedPoints: 0,
+        applicablePoints: 0,
+        evaluatedRuleCount: 0,
+      },
+      linguistic: {
+        status: "insufficient_evidence",
+        score: null,
+        earnedPoints: 0,
+        applicablePoints: 0,
+        evaluatedRuleCount: 0,
+      },
+      market: {
+        status: "insufficient_evidence",
+        score: null,
+        earnedPoints: 0,
+        applicablePoints: 0,
+        evaluatedRuleCount: 0,
+      },
+    });
+  });
+
+  it("calculates reproducible category scores and the 40/40/20 overall score", () => {
+    const rules: RuleEvaluation[] = [
+      {
+        code: "t1",
+        category: "technical",
+        applicable: true,
+        availablePoints: 20,
+        earnedPoints: 10,
+      },
+      {
+        code: "l1",
+        category: "linguistic",
+        applicable: true,
+        availablePoints: 10,
+        earnedPoints: 8,
+      },
+      {
+        code: "m1",
+        category: "market",
+        applicable: true,
+        availablePoints: 8,
+        earnedPoints: 2,
+      },
+    ];
+
+    const scores = calculateLocalisationAuditScores(rules);
+
+    expect(scores.categoryScores.technical.score).toBe(50);
+    expect(scores.categoryScores.linguistic.score).toBe(80);
+    expect(scores.categoryScores.market.score).toBe(25);
+    expect(scores.overallStatus).toBe("scored");
+    expect(scores.overallScore).toBe(57);
+    expect(scores.scoreVersion).toBe("2026-07-24.1");
+  });
+
+  it("does not reweight remaining categories when one lacks evidence", () => {
+    const scores = calculateLocalisationAuditScores([
+      {
+        code: "t1",
+        category: "technical",
+        applicable: true,
+        availablePoints: 20,
+        earnedPoints: 20,
+      },
+      {
+        code: "l1",
+        category: "linguistic",
+        applicable: true,
+        availablePoints: 10,
+        earnedPoints: 10,
+      },
+    ]);
+
+    expect(scores.categoryScores.technical.score).toBe(100);
+    expect(scores.categoryScores.market.status).toBe("insufficient_evidence");
+    expect(scores.overallScore).toBeNull();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/scoring.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/scoring.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { AuditCategory, AuditScores, CategoryScore, RuleEvaluation } from "./types";
+import { LOCALISATION_AUDIT_SCORE_VERSION } from "./types";
+
+const CATEGORY_CONFIG: Record<AuditCategory, { weight: number; minimumApplicablePoints: number }> =
+  {
+    technical: { weight: 0.4, minimumApplicablePoints: 20 },
+    linguistic: { weight: 0.4, minimumApplicablePoints: 10 },
+    market: { weight: 0.2, minimumApplicablePoints: 8 },
+  };
+
+function scoreCategory(category: AuditCategory, evaluations: RuleEvaluation[]): CategoryScore {
+  const applicable = evaluations.filter(
+    (evaluation) => evaluation.category === category && evaluation.applicable,
+  );
+  const applicablePoints = applicable.reduce(
+    (total, evaluation) => total + evaluation.availablePoints,
+    0,
+  );
+  const earnedPoints = applicable.reduce((total, evaluation) => total + evaluation.earnedPoints, 0);
+  if (applicablePoints < CATEGORY_CONFIG[category].minimumApplicablePoints) {
+    return {
+      status: "insufficient_evidence",
+      score: null,
+      earnedPoints,
+      applicablePoints,
+      evaluatedRuleCount: applicable.length,
+    };
+  }
+
+  return {
+    status: "scored",
+    score: Math.round((earnedPoints / applicablePoints) * 100),
+    earnedPoints,
+    applicablePoints,
+    evaluatedRuleCount: applicable.length,
+  };
+}
+
+export function calculateLocalisationAuditScores(evaluations: RuleEvaluation[]): AuditScores {
+  const categoryScores = {
+    technical: scoreCategory("technical", evaluations),
+    linguistic: scoreCategory("linguistic", evaluations),
+    market: scoreCategory("market", evaluations),
+  };
+  const allCategoriesScored = Object.values(categoryScores).every(
+    (category) => category.status === "scored",
+  );
+
+  return {
+    scoreVersion: LOCALISATION_AUDIT_SCORE_VERSION,
+    overallStatus: allCategoriesScored ? "scored" : "insufficient_evidence",
+    overallScore: allCategoriesScored
+      ? Math.round(
+          Object.entries(categoryScores).reduce(
+            (total, [category, score]) =>
+              total + (score.score ?? 0) * CATEGORY_CONFIG[category as AuditCategory].weight,
+            0,
+          ),
+        )
+      : null,
+    categoryScores,
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/service.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/service.ts
@@ -26,6 +26,7 @@ import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-wi
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 
 import { mintPrivateReportAccessToken } from "./access-token";
+import { dedupeAuditedPages } from "./dedupe-pages";
 import { fetchAuditPage } from "./fetch-page";
 import { evaluateLocalisationAudit } from "./findings";
 import { discoverLocaleAlternatives, normalizeAuditUrl, sanitizeAuditExcerpt } from "./parser";
@@ -237,11 +238,44 @@ async function prepareAudit(
     });
   }
 
+  const audit = await db.transaction(async (tx) => {
+    const [createdAudit] = await tx
+      .insert(schema.localisationAudits)
+      .values({
+        status: "preparing",
+        submittedUrl: normalizedUrl,
+        normalizedUrl,
+        domain,
+        domainHash,
+        ipHash,
+        scoreVersion: LOCALISATION_AUDIT_SCORE_VERSION,
+        reportVersion: LOCALISATION_AUDIT_REPORT_VERSION,
+      })
+      .returning();
+    if (!createdAudit) {
+      throw new Error("Failed to persist localisation audit.");
+    }
+    await tx.insert(schema.localisationAuditEvents).values({
+      auditId: createdAudit.id,
+      eventType: "submitted",
+      metadata: { source: "api" },
+    });
+    return createdAudit;
+  });
+
   const pageResult = await fetchAuditPage(normalizedUrl, { isPrimary: true });
   if (isErr(pageResult)) {
+    await db
+      .update(schema.localisationAudits)
+      .set({ status: "failed", failureCode: pageResult.error.code })
+      .where(eq(schema.localisationAudits.id, audit.id));
     return pageResult;
   }
   if (pageResult.value.status !== "extracted") {
+    await db
+      .update(schema.localisationAudits)
+      .set({ status: "failed", failureCode: "audit_fetch_failed" })
+      .where(eq(schema.localisationAudits.id, audit.id));
     return err({
       code: "audit_fetch_failed",
       message: "The submitted page could not be extracted.",
@@ -250,27 +284,22 @@ async function prepareAudit(
 
   const page = pageResult.value;
   const alternatives = discoverLocaleAlternatives(page.extracted);
-  const audit = await db.transaction(async (tx) => {
-    const [createdAudit] = await tx
-      .insert(schema.localisationAudits)
-      .values({
+  const preparedAudit = await db.transaction(async (tx) => {
+    const [updatedAudit] = await tx
+      .update(schema.localisationAudits)
+      .set({
         status: "awaiting_confirmation",
-        submittedUrl: normalizedUrl,
-        normalizedUrl,
-        domain,
-        domainHash,
-        ipHash,
         detectedLocale: page.extracted.htmlLang,
         alternatives,
-        scoreVersion: LOCALISATION_AUDIT_SCORE_VERSION,
-        reportVersion: LOCALISATION_AUDIT_REPORT_VERSION,
+        failureCode: null,
       })
+      .where(eq(schema.localisationAudits.id, audit.id))
       .returning();
-    if (!createdAudit) {
-      throw new Error("Failed to persist localisation audit.");
+    if (!updatedAudit) {
+      throw new Error("Failed to prepare localisation audit.");
     }
     await tx.insert(schema.localisationAuditPages).values({
-      auditId: createdAudit.id,
+      auditId: audit.id,
       normalizedUrl: page.url,
       locale: page.extracted.htmlLang,
       isPrimary: true,
@@ -280,18 +309,15 @@ async function prepareAudit(
       extraction: toPersistedExtraction(page.extracted),
       fetchedAt: new Date(),
     });
-    await tx.insert(schema.localisationAuditEvents).values([
-      { auditId: createdAudit.id, eventType: "submitted", metadata: { source: "api" } },
-      {
-        auditId: createdAudit.id,
-        eventType: "prepared",
-        metadata: { localeCount: alternatives.length + 1 },
-      },
-    ]);
-    return createdAudit;
+    await tx.insert(schema.localisationAuditEvents).values({
+      auditId: audit.id,
+      eventType: "prepared",
+      metadata: { localeCount: alternatives.length + 1 },
+    });
+    return updatedAudit;
   });
 
-  return ok(safeAuditFromRecord(audit));
+  return ok(safeAuditFromRecord(preparedAudit));
 }
 
 async function getAudit(auditId: string): Promise<Result<SafeAudit, LocalisationAuditError>> {
@@ -363,24 +389,31 @@ async function confirmAudit(
       primaryRecord.extraction,
     ),
   };
-  const alternativePages = await mapWithConcurrency(audit.alternatives, 3, async (alternative) => {
-    const result = await fetchAuditPage(alternative.url, {
-      locale: alternative.locale,
-      isPrimary: false,
-    });
-    if (isErr(result)) {
-      return {
-        url: alternative.url,
+  const fetchedAlternativePages = await mapWithConcurrency(
+    audit.alternatives,
+    3,
+    async (alternative) => {
+      const result = await fetchAuditPage(alternative.url, {
         locale: alternative.locale,
         isPrimary: false,
-        status:
-          result.error.code === "audit_url_not_public" ? ("blocked" as const) : ("failed" as const),
-        failureCode: result.error.code,
-      };
-    }
-    return result.value;
-  });
-  const pages = [primaryPage, ...alternativePages];
+      });
+      if (isErr(result)) {
+        return {
+          url: alternative.url,
+          locale: alternative.locale,
+          isPrimary: false,
+          status:
+            result.error.code === "audit_url_not_public"
+              ? ("blocked" as const)
+              : ("failed" as const),
+          failureCode: result.error.code,
+        };
+      }
+      return result.value;
+    },
+  );
+  const pages = dedupeAuditedPages([primaryPage, ...fetchedAlternativePages]);
+  const alternativePages = pages.slice(1);
   const evaluation = evaluateLocalisationAudit({
     pages,
     targetLocale: input.targetLocale,

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/service.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/service.ts
@@ -1,0 +1,600 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { createHmac } from "node:crypto";
+
+import { and, count, eq, gte } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { Resend } from "resend";
+
+import { db, schema, type DatabaseClient } from "@/lib/database";
+import type {
+  LocalisationAuditPageExtractionData,
+  LocalisationAuditReportData,
+} from "@/lib/database/schema/localisation-audit";
+import { env } from "@/lib/env";
+import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-with-concurrency";
+import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
+
+import { mintPrivateReportAccessToken } from "./access-token";
+import { fetchAuditPage } from "./fetch-page";
+import { evaluateLocalisationAudit } from "./findings";
+import { discoverLocaleAlternatives, normalizeAuditUrl, sanitizeAuditExcerpt } from "./parser";
+import { createReportProjections } from "./report";
+import {
+  loadPrivateLocalisationAuditReportByToken,
+  loadPublicLocalisationAuditReportBySlug,
+} from "./report-loaders";
+import { calculateLocalisationAuditScores } from "./scoring";
+import type {
+  AuditedPage,
+  ConfirmAuditInput,
+  ExtractedPage,
+  LocalisationAuditError,
+  PrepareAuditInput,
+  PrivateAuditReport,
+  PublicAuditReport,
+  SafeAudit,
+  UnlockAuditInput,
+} from "./types";
+import { LOCALISATION_AUDIT_REPORT_VERSION, LOCALISATION_AUDIT_SCORE_VERSION } from "./types";
+
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+const IP_RATE_LIMIT = 10;
+const DOMAIN_RATE_LIMIT = 5;
+const MAX_PERSISTED_VISIBLE_TEXT = 2_000;
+
+type AuditRecord = typeof schema.localisationAudits.$inferSelect;
+
+export type LocalisationAuditService = {
+  prepareAudit(input: PrepareAuditInput): Promise<Result<SafeAudit, LocalisationAuditError>>;
+  getAudit(auditId: string): Promise<Result<SafeAudit, LocalisationAuditError>>;
+  confirmAudit(input: ConfirmAuditInput): Promise<Result<SafeAudit, LocalisationAuditError>>;
+  unlockAudit(
+    input: UnlockAuditInput,
+  ): Promise<Result<{ accessUrl: string }, LocalisationAuditError>>;
+  getPublicReport(slug: string): Promise<Result<PublicAuditReport, LocalisationAuditError>>;
+};
+
+function hashBudgetKey(value: string, secret: string): string {
+  return createHmac("sha256", secret).update(value).digest("hex");
+}
+
+function toPersistedExtraction(extracted: ExtractedPage): LocalisationAuditPageExtractionData {
+  return {
+    htmlLang: extracted.htmlLang,
+    title: extracted.title,
+    description: extracted.description,
+    canonicalUrl: extracted.canonicalUrl,
+    alternateLinks: extracted.alternateLinks,
+    headings: extracted.headings,
+    navigation: extracted.navigation,
+    callsToAction: extracted.callsToAction,
+    visibleTextSample: sanitizeAuditExcerpt(extracted.visibleText, MAX_PERSISTED_VISIBLE_TEXT),
+  };
+}
+
+function fromPersistedExtraction(
+  url: string,
+  fingerprint: string,
+  extraction: LocalisationAuditPageExtractionData,
+): ExtractedPage {
+  return {
+    url,
+    htmlLang: extraction.htmlLang,
+    title: extraction.title,
+    description: extraction.description,
+    canonicalUrl: extraction.canonicalUrl,
+    alternateLinks: extraction.alternateLinks,
+    headings: extraction.headings,
+    navigation: extraction.navigation,
+    callsToAction: extraction.callsToAction,
+    visibleText: extraction.visibleTextSample,
+    contentFingerprint: fingerprint,
+  };
+}
+
+function safeAuditFromRecord(
+  audit: AuditRecord,
+  report?: {
+    publicSlug: string;
+    publicReport: LocalisationAuditReportData;
+  } | null,
+): SafeAudit {
+  return {
+    id: audit.id,
+    status: audit.status,
+    detectedLocale: audit.detectedLocale,
+    alternatives: audit.alternatives,
+    targetLocale: audit.targetLocale,
+    targetMarket: audit.targetMarket,
+    ...(report
+      ? {
+          publicSlug: report.publicSlug,
+          summary: report.publicReport,
+        }
+      : {}),
+  };
+}
+
+async function findReportForAudit(
+  client: DatabaseClient,
+  auditId: string,
+): Promise<{
+  id: string;
+  publicSlug: string;
+  publicReport: LocalisationAuditReportData;
+  privateReport: PrivateAuditReport;
+} | null> {
+  const [report] = await client
+    .select({
+      id: schema.localisationAuditReports.id,
+      publicSlug: schema.localisationAuditReports.publicSlug,
+      publicReport: schema.localisationAuditReports.publicReport,
+      privateReport: schema.localisationAuditReports.privateReport,
+    })
+    .from(schema.localisationAuditReports)
+    .where(eq(schema.localisationAuditReports.auditId, auditId))
+    .limit(1);
+  return report ?? null;
+}
+
+async function getAuditRecord(
+  client: DatabaseClient,
+  auditId: string,
+): Promise<AuditRecord | null> {
+  const [audit] = await client
+    .select()
+    .from(schema.localisationAudits)
+    .where(eq(schema.localisationAudits.id, auditId))
+    .limit(1);
+  return audit ?? null;
+}
+
+async function checkRateLimit(ipHash: string, domainHash: string): Promise<boolean> {
+  const windowStart = new Date(Date.now() - RATE_LIMIT_WINDOW_MS);
+  const [ipCountRows, domainCountRows] = await Promise.all([
+    db
+      .select({ value: count() })
+      .from(schema.localisationAudits)
+      .where(
+        and(
+          eq(schema.localisationAudits.ipHash, ipHash),
+          gte(schema.localisationAudits.createdAt, windowStart),
+        ),
+      ),
+    db
+      .select({ value: count() })
+      .from(schema.localisationAudits)
+      .where(
+        and(
+          eq(schema.localisationAudits.domainHash, domainHash),
+          gte(schema.localisationAudits.createdAt, windowStart),
+        ),
+      ),
+  ]);
+  return (
+    Number(ipCountRows[0]?.value ?? 0) < IP_RATE_LIMIT &&
+    Number(domainCountRows[0]?.value ?? 0) < DOMAIN_RATE_LIMIT
+  );
+}
+
+async function sendReportEmailBestEffort(input: {
+  email: string;
+  accessUrl: string;
+}): Promise<"sent" | "skipped" | "failed"> {
+  const apiKey = process.env.RESEND_API_KEY;
+  const fromAddress = process.env.RESEND_FROM_ADDRESS;
+  if (!apiKey || !fromAddress) {
+    return "skipped";
+  }
+
+  try {
+    const resend = new Resend(apiKey);
+    const response = await resend.emails.send({
+      from: `${env.RESEND_FROM_NAME ?? "Hyperlocalise"} <${fromAddress}>`,
+      to: input.email,
+      subject: "Your localisation health audit",
+      text: `Your private localisation audit is ready: ${input.accessUrl}`,
+    });
+    return response.error ? "failed" : "sent";
+  } catch {
+    return "failed";
+  }
+}
+
+async function prepareAudit(
+  input: PrepareAuditInput,
+): Promise<Result<SafeAudit, LocalisationAuditError>> {
+  const secret = env.LOCALISATION_AUDIT_ACCESS_SECRET;
+  if (!secret) {
+    return err({
+      code: "audit_access_not_configured",
+      message: "The localisation audit is not configured.",
+    });
+  }
+  const normalizedUrl = normalizeAuditUrl(input.url);
+  if (!normalizedUrl) {
+    return err({ code: "invalid_audit_url", message: "Enter a valid HTTP(S) URL." });
+  }
+  const url = new URL(normalizedUrl);
+  const domain = url.hostname.toLowerCase();
+  const domainHash = hashBudgetKey(domain, secret);
+  const ipHash = hashBudgetKey(input.ipAddress, secret);
+  if (!(await checkRateLimit(ipHash, domainHash))) {
+    return err({
+      code: "audit_rate_limited",
+      message: "The audit submission limit has been reached. Try again later.",
+    });
+  }
+
+  const pageResult = await fetchAuditPage(normalizedUrl, { isPrimary: true });
+  if (isErr(pageResult)) {
+    return pageResult;
+  }
+  if (pageResult.value.status !== "extracted") {
+    return err({
+      code: "audit_fetch_failed",
+      message: "The submitted page could not be extracted.",
+    });
+  }
+
+  const page = pageResult.value;
+  const alternatives = discoverLocaleAlternatives(page.extracted);
+  const audit = await db.transaction(async (tx) => {
+    const [createdAudit] = await tx
+      .insert(schema.localisationAudits)
+      .values({
+        status: "awaiting_confirmation",
+        submittedUrl: normalizedUrl,
+        normalizedUrl,
+        domain,
+        domainHash,
+        ipHash,
+        detectedLocale: page.extracted.htmlLang,
+        alternatives,
+        scoreVersion: LOCALISATION_AUDIT_SCORE_VERSION,
+        reportVersion: LOCALISATION_AUDIT_REPORT_VERSION,
+      })
+      .returning();
+    if (!createdAudit) {
+      throw new Error("Failed to persist localisation audit.");
+    }
+    await tx.insert(schema.localisationAuditPages).values({
+      auditId: createdAudit.id,
+      normalizedUrl: page.url,
+      locale: page.extracted.htmlLang,
+      isPrimary: true,
+      status: "extracted",
+      httpStatus: page.httpStatus,
+      contentFingerprint: page.extracted.contentFingerprint,
+      extraction: toPersistedExtraction(page.extracted),
+      fetchedAt: new Date(),
+    });
+    await tx.insert(schema.localisationAuditEvents).values([
+      { auditId: createdAudit.id, eventType: "submitted", metadata: { source: "api" } },
+      {
+        auditId: createdAudit.id,
+        eventType: "prepared",
+        metadata: { localeCount: alternatives.length + 1 },
+      },
+    ]);
+    return createdAudit;
+  });
+
+  return ok(safeAuditFromRecord(audit));
+}
+
+async function getAudit(auditId: string): Promise<Result<SafeAudit, LocalisationAuditError>> {
+  const audit = await getAuditRecord(db, auditId);
+  if (!audit) {
+    return err({ code: "audit_not_found", message: "The audit was not found." });
+  }
+  const report =
+    audit.status === "completed" || audit.status === "partial"
+      ? await findReportForAudit(db, audit.id)
+      : null;
+  return ok(safeAuditFromRecord(audit, report));
+}
+
+async function confirmAudit(
+  input: ConfirmAuditInput,
+): Promise<Result<SafeAudit, LocalisationAuditError>> {
+  const audit = await getAuditRecord(db, input.auditId);
+  if (!audit) {
+    return err({ code: "audit_not_found", message: "The audit was not found." });
+  }
+  if (audit.status !== "awaiting_confirmation") {
+    return err({
+      code: "audit_not_awaiting_confirmation",
+      message: "The audit cannot be confirmed in its current state.",
+    });
+  }
+
+  const [primaryRecord] = await db
+    .select()
+    .from(schema.localisationAuditPages)
+    .where(
+      and(
+        eq(schema.localisationAuditPages.auditId, audit.id),
+        eq(schema.localisationAuditPages.isPrimary, true),
+      ),
+    )
+    .limit(1);
+  if (
+    !primaryRecord?.extraction ||
+    !primaryRecord.contentFingerprint ||
+    primaryRecord.status !== "extracted"
+  ) {
+    return err({
+      code: "audit_fetch_failed",
+      message: "The submitted page extraction is unavailable.",
+    });
+  }
+
+  await db
+    .update(schema.localisationAudits)
+    .set({
+      status: "running",
+      targetLocale: input.targetLocale,
+      targetMarket: input.targetMarket.toUpperCase(),
+      confirmedAt: new Date(),
+    })
+    .where(eq(schema.localisationAudits.id, audit.id));
+
+  const primaryPage: AuditedPage = {
+    url: primaryRecord.normalizedUrl,
+    locale: primaryRecord.locale,
+    isPrimary: true,
+    status: "extracted",
+    httpStatus: primaryRecord.httpStatus ?? 200,
+    extracted: fromPersistedExtraction(
+      primaryRecord.normalizedUrl,
+      primaryRecord.contentFingerprint,
+      primaryRecord.extraction,
+    ),
+  };
+  const alternativePages = await mapWithConcurrency(audit.alternatives, 3, async (alternative) => {
+    const result = await fetchAuditPage(alternative.url, {
+      locale: alternative.locale,
+      isPrimary: false,
+    });
+    if (isErr(result)) {
+      return {
+        url: alternative.url,
+        locale: alternative.locale,
+        isPrimary: false,
+        status:
+          result.error.code === "audit_url_not_public" ? ("blocked" as const) : ("failed" as const),
+        failureCode: result.error.code,
+      };
+    }
+    return result.value;
+  });
+  const pages = [primaryPage, ...alternativePages];
+  const evaluation = evaluateLocalisationAudit({
+    pages,
+    targetLocale: input.targetLocale,
+    targetMarket: input.targetMarket,
+  });
+  const scores = calculateLocalisationAuditScores(evaluation.rules);
+  const projections = createReportProjections({
+    domain: audit.domain,
+    auditedAt: new Date(),
+    pages,
+    evaluation,
+    scores,
+  });
+  const publicSlug = nanoid(24);
+
+  const completed = await db.transaction(async (tx) => {
+    const pageIdByUrl = new Map<string, string>([[primaryRecord.normalizedUrl, primaryRecord.id]]);
+    if (alternativePages.length > 0) {
+      const insertedPages = await tx
+        .insert(schema.localisationAuditPages)
+        .values(
+          alternativePages.map((page) => ({
+            auditId: audit.id,
+            normalizedUrl: page.url,
+            locale: page.locale,
+            isPrimary: false,
+            status: page.status,
+            httpStatus: page.httpStatus,
+            contentFingerprint:
+              page.status === "extracted" ? page.extracted.contentFingerprint : undefined,
+            extraction:
+              page.status === "extracted" ? toPersistedExtraction(page.extracted) : undefined,
+            failureCode: page.status === "extracted" ? undefined : page.failureCode,
+            fetchedAt: new Date(),
+          })),
+        )
+        .returning({
+          id: schema.localisationAuditPages.id,
+          normalizedUrl: schema.localisationAuditPages.normalizedUrl,
+        });
+      for (const page of insertedPages) {
+        pageIdByUrl.set(page.normalizedUrl, page.id);
+      }
+    }
+    if (evaluation.findings.length > 0) {
+      await tx.insert(schema.localisationAuditFindings).values(
+        evaluation.findings.map((auditFinding) => ({
+          auditId: audit.id,
+          pageId: pageIdByUrl.get(auditFinding.pageUrl),
+          ruleCode: auditFinding.code,
+          category: auditFinding.category,
+          severity: auditFinding.severity,
+          confidence: auditFinding.confidence,
+          evidenceKind: auditFinding.evidenceKind,
+          title: auditFinding.title,
+          evidence: auditFinding.evidence,
+          impact: auditFinding.impact,
+          recommendation: auditFinding.recommendation,
+          availablePoints: auditFinding.availablePoints,
+          earnedPoints: auditFinding.earnedPoints,
+          publicPreviewEligible: auditFinding.publicPreviewEligible,
+        })),
+      );
+    }
+    const [report] = await tx
+      .insert(schema.localisationAuditReports)
+      .values({
+        auditId: audit.id,
+        publicSlug,
+        scoreVersion: LOCALISATION_AUDIT_SCORE_VERSION,
+        reportVersion: LOCALISATION_AUDIT_REPORT_VERSION,
+        publicReport: projections.publicReport,
+        privateReport: projections.privateReport,
+      })
+      .returning({
+        publicSlug: schema.localisationAuditReports.publicSlug,
+        publicReport: schema.localisationAuditReports.publicReport,
+      });
+    if (!report) {
+      throw new Error("Failed to persist localisation audit report.");
+    }
+    const status = projections.publicReport.status;
+    const [updatedAudit] = await tx
+      .update(schema.localisationAudits)
+      .set({ status, completedAt: new Date() })
+      .where(eq(schema.localisationAudits.id, audit.id))
+      .returning();
+    if (!updatedAudit) {
+      throw new Error("Failed to complete localisation audit.");
+    }
+    await tx.insert(schema.localisationAuditEvents).values([
+      { auditId: audit.id, eventType: "confirmed", metadata: { source: "api" } },
+      {
+        auditId: audit.id,
+        eventType: "completed",
+        metadata: {
+          findingCount: evaluation.findings.length,
+          localeCount: pages.length,
+        },
+      },
+    ]);
+    return safeAuditFromRecord(updatedAudit, report);
+  });
+
+  return ok(completed);
+}
+
+async function unlockAudit(
+  input: UnlockAuditInput,
+): Promise<Result<{ accessUrl: string }, LocalisationAuditError>> {
+  const secret = env.LOCALISATION_AUDIT_ACCESS_SECRET;
+  if (!secret) {
+    return err({
+      code: "audit_access_not_configured",
+      message: "Private report access is not configured.",
+    });
+  }
+  const audit = await getAuditRecord(db, input.auditId);
+  if (!audit) {
+    return err({ code: "audit_not_found", message: "The audit was not found." });
+  }
+  if (audit.status !== "completed" && audit.status !== "partial") {
+    return err({
+      code: "audit_not_complete",
+      message: "The audit report is not ready to unlock.",
+    });
+  }
+  const report = await findReportForAudit(db, audit.id);
+  if (!report) {
+    return err({ code: "report_not_found", message: "The report was not found." });
+  }
+
+  const token = mintPrivateReportAccessToken({
+    auditId: audit.id,
+    reportId: report.id,
+    secret,
+  });
+  const accessUrl = `${input.origin.replace(/\/+$/, "")}/en/localisation-audit/report/${encodeURIComponent(token)}`;
+  const [lead] = await db
+    .insert(schema.localisationAuditLeads)
+    .values({
+      auditId: audit.id,
+      email: input.email,
+      name: input.name,
+    })
+    .returning({ id: schema.localisationAuditLeads.id });
+  if (!lead) {
+    throw new Error("Failed to persist localisation audit lead.");
+  }
+  await db.insert(schema.localisationAuditEvents).values({
+    auditId: audit.id,
+    leadId: lead.id,
+    eventType: "unlocked",
+    metadata: { source: "api" },
+  });
+
+  const deliveryStatus = await sendReportEmailBestEffort({
+    email: input.email,
+    accessUrl,
+  });
+  await db
+    .update(schema.localisationAuditLeads)
+    .set({ emailDeliveryStatus: deliveryStatus })
+    .where(eq(schema.localisationAuditLeads.id, lead.id));
+  if (deliveryStatus === "failed") {
+    await db.insert(schema.localisationAuditEvents).values({
+      auditId: audit.id,
+      leadId: lead.id,
+      eventType: "email_delivery_failed",
+      metadata: { deliveryStatus },
+    });
+    return err({
+      code: "audit_email_delivery_failed",
+      message: "The report email could not be delivered. Try again.",
+    });
+  }
+
+  return ok({ accessUrl });
+}
+
+async function getPublicReport(
+  slug: string,
+): Promise<Result<PublicAuditReport, LocalisationAuditError>> {
+  const [report] = await db
+    .select({ publicReport: schema.localisationAuditReports.publicReport })
+    .from(schema.localisationAuditReports)
+    .where(
+      and(
+        eq(schema.localisationAuditReports.publicSlug, slug),
+        eq(schema.localisationAuditReports.visibility, "public"),
+      ),
+    )
+    .limit(1);
+  if (!report) {
+    return err({ code: "report_not_found", message: "The report was not found." });
+  }
+  return ok(report.publicReport);
+}
+
+export const localisationAuditService: LocalisationAuditService = {
+  prepareAudit,
+  getAudit,
+  confirmAudit,
+  unlockAudit,
+  getPublicReport,
+};
+
+export async function getPublicAuditReportBySlug(slug: string): Promise<PublicAuditReport | null> {
+  return loadPublicLocalisationAuditReportBySlug(slug);
+}
+
+export async function getPrivateAuditReportByToken(
+  token: string,
+): Promise<PrivateAuditReport | null> {
+  const result = await loadPrivateLocalisationAuditReportByToken(token);
+  return isErr(result) ? null : result.value;
+}

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/service.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/service.ts
@@ -10,36 +10,28 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { createHmac } from "node:crypto";
-
 import { and, count, eq, gte } from "drizzle-orm";
-import { nanoid } from "nanoid";
-import { Resend } from "resend";
 
-import { db, schema, type DatabaseClient } from "@/lib/database";
-import type {
-  LocalisationAuditPageExtractionData,
-  LocalisationAuditReportData,
-} from "@/lib/database/schema/localisation-audit";
+import { db, schema } from "@/lib/database";
 import { env } from "@/lib/env";
-import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-with-concurrency";
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
+import type { LocalisationAuditQueue } from "@/lib/workflow/types";
 
 import { mintPrivateReportAccessToken } from "./access-token";
-import { dedupeAuditedPages } from "./dedupe-pages";
-import { fetchAuditPage } from "./fetch-page";
-import { evaluateLocalisationAudit } from "./findings";
-import { discoverLocaleAlternatives, normalizeAuditUrl, sanitizeAuditExcerpt } from "./parser";
-import { createReportProjections } from "./report";
+import {
+  findReportForAudit,
+  getAuditRecord,
+  hashBudgetKey,
+  markAuditFailed,
+  safeAuditFromRecord,
+} from "./operations";
+import { normalizeAuditUrl } from "./parser";
 import {
   loadPrivateLocalisationAuditReportByToken,
   loadPublicLocalisationAuditReportBySlug,
 } from "./report-loaders";
-import { calculateLocalisationAuditScores } from "./scoring";
 import type {
-  AuditedPage,
   ConfirmAuditInput,
-  ExtractedPage,
   LocalisationAuditError,
   PrepareAuditInput,
   PrivateAuditReport,
@@ -52,9 +44,6 @@ import { LOCALISATION_AUDIT_REPORT_VERSION, LOCALISATION_AUDIT_SCORE_VERSION } f
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
 const IP_RATE_LIMIT = 10;
 const DOMAIN_RATE_LIMIT = 5;
-const MAX_PERSISTED_VISIBLE_TEXT = 2_000;
-
-type AuditRecord = typeof schema.localisationAudits.$inferSelect;
 
 export type LocalisationAuditService = {
   prepareAudit(input: PrepareAuditInput): Promise<Result<SafeAudit, LocalisationAuditError>>;
@@ -65,101 +54,6 @@ export type LocalisationAuditService = {
   ): Promise<Result<{ accessUrl: string }, LocalisationAuditError>>;
   getPublicReport(slug: string): Promise<Result<PublicAuditReport, LocalisationAuditError>>;
 };
-
-function hashBudgetKey(value: string, secret: string): string {
-  return createHmac("sha256", secret).update(value).digest("hex");
-}
-
-function toPersistedExtraction(extracted: ExtractedPage): LocalisationAuditPageExtractionData {
-  return {
-    htmlLang: extracted.htmlLang,
-    title: extracted.title,
-    description: extracted.description,
-    canonicalUrl: extracted.canonicalUrl,
-    alternateLinks: extracted.alternateLinks,
-    headings: extracted.headings,
-    navigation: extracted.navigation,
-    callsToAction: extracted.callsToAction,
-    visibleTextSample: sanitizeAuditExcerpt(extracted.visibleText, MAX_PERSISTED_VISIBLE_TEXT),
-  };
-}
-
-function fromPersistedExtraction(
-  url: string,
-  fingerprint: string,
-  extraction: LocalisationAuditPageExtractionData,
-): ExtractedPage {
-  return {
-    url,
-    htmlLang: extraction.htmlLang,
-    title: extraction.title,
-    description: extraction.description,
-    canonicalUrl: extraction.canonicalUrl,
-    alternateLinks: extraction.alternateLinks,
-    headings: extraction.headings,
-    navigation: extraction.navigation,
-    callsToAction: extraction.callsToAction,
-    visibleText: extraction.visibleTextSample,
-    contentFingerprint: fingerprint,
-  };
-}
-
-function safeAuditFromRecord(
-  audit: AuditRecord,
-  report?: {
-    publicSlug: string;
-    publicReport: LocalisationAuditReportData;
-  } | null,
-): SafeAudit {
-  return {
-    id: audit.id,
-    status: audit.status,
-    detectedLocale: audit.detectedLocale,
-    alternatives: audit.alternatives,
-    targetLocale: audit.targetLocale,
-    targetMarket: audit.targetMarket,
-    ...(report
-      ? {
-          publicSlug: report.publicSlug,
-          summary: report.publicReport,
-        }
-      : {}),
-  };
-}
-
-async function findReportForAudit(
-  client: DatabaseClient,
-  auditId: string,
-): Promise<{
-  id: string;
-  publicSlug: string;
-  publicReport: LocalisationAuditReportData;
-  privateReport: PrivateAuditReport;
-} | null> {
-  const [report] = await client
-    .select({
-      id: schema.localisationAuditReports.id,
-      publicSlug: schema.localisationAuditReports.publicSlug,
-      publicReport: schema.localisationAuditReports.publicReport,
-      privateReport: schema.localisationAuditReports.privateReport,
-    })
-    .from(schema.localisationAuditReports)
-    .where(eq(schema.localisationAuditReports.auditId, auditId))
-    .limit(1);
-  return report ?? null;
-}
-
-async function getAuditRecord(
-  client: DatabaseClient,
-  auditId: string,
-): Promise<AuditRecord | null> {
-  const [audit] = await client
-    .select()
-    .from(schema.localisationAudits)
-    .where(eq(schema.localisationAudits.id, auditId))
-    .limit(1);
-  return audit ?? null;
-}
 
 async function checkRateLimit(ipHash: string, domainHash: string): Promise<boolean> {
   const windowStart = new Date(Date.now() - RATE_LIMIT_WINDOW_MS);
@@ -189,437 +83,274 @@ async function checkRateLimit(ipHash: string, domainHash: string): Promise<boole
   );
 }
 
-async function sendReportEmailBestEffort(input: {
-  email: string;
-  accessUrl: string;
-}): Promise<"sent" | "skipped" | "failed"> {
-  const apiKey = process.env.RESEND_API_KEY;
-  const fromAddress = process.env.RESEND_FROM_ADDRESS;
-  if (!apiKey || !fromAddress) {
-    return "skipped";
-  }
+export function createLocalisationAuditService(options: {
+  queue: LocalisationAuditQueue;
+}): LocalisationAuditService {
+  const { queue } = options;
 
-  try {
-    const resend = new Resend(apiKey);
-    const response = await resend.emails.send({
-      from: `${env.RESEND_FROM_NAME ?? "Hyperlocalise"} <${fromAddress}>`,
-      to: input.email,
-      subject: "Your localisation health audit",
-      text: `Your private localisation audit is ready: ${input.accessUrl}`,
-    });
-    return response.error ? "failed" : "sent";
-  } catch {
-    return "failed";
-  }
-}
-
-async function prepareAudit(
-  input: PrepareAuditInput,
-): Promise<Result<SafeAudit, LocalisationAuditError>> {
-  const secret = env.LOCALISATION_AUDIT_ACCESS_SECRET;
-  if (!secret) {
-    return err({
-      code: "audit_access_not_configured",
-      message: "The localisation audit is not configured.",
-    });
-  }
-  const normalizedUrl = normalizeAuditUrl(input.url);
-  if (!normalizedUrl) {
-    return err({ code: "invalid_audit_url", message: "Enter a valid HTTP(S) URL." });
-  }
-  const url = new URL(normalizedUrl);
-  const domain = url.hostname.toLowerCase();
-  const domainHash = hashBudgetKey(domain, secret);
-  const ipHash = hashBudgetKey(input.ipAddress, secret);
-  if (!(await checkRateLimit(ipHash, domainHash))) {
-    return err({
-      code: "audit_rate_limited",
-      message: "The audit submission limit has been reached. Try again later.",
-    });
-  }
-
-  const audit = await db.transaction(async (tx) => {
-    const [createdAudit] = await tx
-      .insert(schema.localisationAudits)
-      .values({
-        status: "preparing",
-        submittedUrl: normalizedUrl,
-        normalizedUrl,
-        domain,
-        domainHash,
-        ipHash,
-        scoreVersion: LOCALISATION_AUDIT_SCORE_VERSION,
-        reportVersion: LOCALISATION_AUDIT_REPORT_VERSION,
-      })
-      .returning();
-    if (!createdAudit) {
-      throw new Error("Failed to persist localisation audit.");
+  async function prepareAudit(
+    input: PrepareAuditInput,
+  ): Promise<Result<SafeAudit, LocalisationAuditError>> {
+    const secret = env.LOCALISATION_AUDIT_ACCESS_SECRET;
+    if (!secret) {
+      return err({
+        code: "audit_access_not_configured",
+        message: "The localisation audit is not configured.",
+      });
     }
-    await tx.insert(schema.localisationAuditEvents).values({
-      auditId: createdAudit.id,
-      eventType: "submitted",
-      metadata: { source: "api" },
-    });
-    return createdAudit;
-  });
+    const normalizedUrl = normalizeAuditUrl(input.url);
+    if (!normalizedUrl) {
+      return err({ code: "invalid_audit_url", message: "Enter a valid HTTP(S) URL." });
+    }
+    const url = new URL(normalizedUrl);
+    const domain = url.hostname.toLowerCase();
+    const domainHash = hashBudgetKey(domain, secret);
+    const ipHash = hashBudgetKey(input.ipAddress, secret);
+    if (!(await checkRateLimit(ipHash, domainHash))) {
+      return err({
+        code: "audit_rate_limited",
+        message: "The audit submission limit has been reached. Try again later.",
+      });
+    }
 
-  const pageResult = await fetchAuditPage(normalizedUrl, { isPrimary: true });
-  if (isErr(pageResult)) {
-    await db
-      .update(schema.localisationAudits)
-      .set({ status: "failed", failureCode: pageResult.error.code })
-      .where(eq(schema.localisationAudits.id, audit.id));
-    return pageResult;
-  }
-  if (pageResult.value.status !== "extracted") {
-    await db
-      .update(schema.localisationAudits)
-      .set({ status: "failed", failureCode: "audit_fetch_failed" })
-      .where(eq(schema.localisationAudits.id, audit.id));
-    return err({
-      code: "audit_fetch_failed",
-      message: "The submitted page could not be extracted.",
+    const audit = await db.transaction(async (tx) => {
+      const [createdAudit] = await tx
+        .insert(schema.localisationAudits)
+        .values({
+          status: "preparing",
+          submittedUrl: normalizedUrl,
+          normalizedUrl,
+          domain,
+          domainHash,
+          ipHash,
+          scoreVersion: LOCALISATION_AUDIT_SCORE_VERSION,
+          reportVersion: LOCALISATION_AUDIT_REPORT_VERSION,
+        })
+        .returning();
+      if (!createdAudit) {
+        throw new Error("Failed to persist localisation audit.");
+      }
+      await tx.insert(schema.localisationAuditEvents).values({
+        auditId: createdAudit.id,
+        eventType: "submitted",
+        metadata: { source: "api" },
+      });
+      return createdAudit;
     });
+
+    try {
+      await queue.enqueuePrepare({ auditId: audit.id });
+    } catch {
+      await markAuditFailed(db, audit.id, "audit_queue_unavailable");
+      return err({
+        code: "audit_access_not_configured",
+        message: "The localisation audit workflow is unavailable.",
+      });
+    }
+
+    return ok(safeAuditFromRecord(audit));
   }
 
-  const page = pageResult.value;
-  const alternatives = discoverLocaleAlternatives(page.extracted);
-  const preparedAudit = await db.transaction(async (tx) => {
-    const [updatedAudit] = await tx
+  async function getAudit(auditId: string): Promise<Result<SafeAudit, LocalisationAuditError>> {
+    const audit = await getAuditRecord(db, auditId);
+    if (!audit) {
+      return err({ code: "audit_not_found", message: "The audit was not found." });
+    }
+    const report =
+      audit.status === "completed" || audit.status === "partial"
+        ? await findReportForAudit(db, audit.id)
+        : null;
+    return ok(safeAuditFromRecord(audit, report));
+  }
+
+  async function confirmAudit(
+    input: ConfirmAuditInput,
+  ): Promise<Result<SafeAudit, LocalisationAuditError>> {
+    const audit = await getAuditRecord(db, input.auditId);
+    if (!audit) {
+      return err({ code: "audit_not_found", message: "The audit was not found." });
+    }
+    if (audit.status !== "awaiting_confirmation") {
+      return err({
+        code: "audit_not_awaiting_confirmation",
+        message: "The audit cannot be confirmed in its current state.",
+      });
+    }
+
+    const [primaryRecord] = await db
+      .select({
+        id: schema.localisationAuditPages.id,
+        status: schema.localisationAuditPages.status,
+        extraction: schema.localisationAuditPages.extraction,
+        contentFingerprint: schema.localisationAuditPages.contentFingerprint,
+      })
+      .from(schema.localisationAuditPages)
+      .where(
+        and(
+          eq(schema.localisationAuditPages.auditId, audit.id),
+          eq(schema.localisationAuditPages.isPrimary, true),
+        ),
+      )
+      .limit(1);
+    if (
+      !primaryRecord?.extraction ||
+      !primaryRecord.contentFingerprint ||
+      primaryRecord.status !== "extracted"
+    ) {
+      return err({
+        code: "audit_fetch_failed",
+        message: "The submitted page extraction is unavailable.",
+      });
+    }
+
+    const [updatedAudit] = await db
       .update(schema.localisationAudits)
       .set({
-        status: "awaiting_confirmation",
-        detectedLocale: page.extracted.htmlLang,
-        alternatives,
-        failureCode: null,
+        status: "running",
+        targetLocale: input.targetLocale,
+        targetMarket: input.targetMarket.toUpperCase(),
+        confirmedAt: new Date(),
       })
       .where(eq(schema.localisationAudits.id, audit.id))
       .returning();
     if (!updatedAudit) {
-      throw new Error("Failed to prepare localisation audit.");
+      throw new Error("Failed to confirm localisation audit.");
     }
-    await tx.insert(schema.localisationAuditPages).values({
+    await db.insert(schema.localisationAuditEvents).values({
       auditId: audit.id,
-      normalizedUrl: page.url,
-      locale: page.extracted.htmlLang,
-      isPrimary: true,
-      status: "extracted",
-      httpStatus: page.httpStatus,
-      contentFingerprint: page.extracted.contentFingerprint,
-      extraction: toPersistedExtraction(page.extracted),
-      fetchedAt: new Date(),
+      eventType: "confirmed",
+      metadata: { source: "api" },
     });
-    await tx.insert(schema.localisationAuditEvents).values({
-      auditId: audit.id,
-      eventType: "prepared",
-      metadata: { localeCount: alternatives.length + 1 },
-    });
-    return updatedAudit;
-  });
 
-  return ok(safeAuditFromRecord(preparedAudit));
-}
-
-async function getAudit(auditId: string): Promise<Result<SafeAudit, LocalisationAuditError>> {
-  const audit = await getAuditRecord(db, auditId);
-  if (!audit) {
-    return err({ code: "audit_not_found", message: "The audit was not found." });
-  }
-  const report =
-    audit.status === "completed" || audit.status === "partial"
-      ? await findReportForAudit(db, audit.id)
-      : null;
-  return ok(safeAuditFromRecord(audit, report));
-}
-
-async function confirmAudit(
-  input: ConfirmAuditInput,
-): Promise<Result<SafeAudit, LocalisationAuditError>> {
-  const audit = await getAuditRecord(db, input.auditId);
-  if (!audit) {
-    return err({ code: "audit_not_found", message: "The audit was not found." });
-  }
-  if (audit.status !== "awaiting_confirmation") {
-    return err({
-      code: "audit_not_awaiting_confirmation",
-      message: "The audit cannot be confirmed in its current state.",
-    });
-  }
-
-  const [primaryRecord] = await db
-    .select()
-    .from(schema.localisationAuditPages)
-    .where(
-      and(
-        eq(schema.localisationAuditPages.auditId, audit.id),
-        eq(schema.localisationAuditPages.isPrimary, true),
-      ),
-    )
-    .limit(1);
-  if (
-    !primaryRecord?.extraction ||
-    !primaryRecord.contentFingerprint ||
-    primaryRecord.status !== "extracted"
-  ) {
-    return err({
-      code: "audit_fetch_failed",
-      message: "The submitted page extraction is unavailable.",
-    });
-  }
-
-  await db
-    .update(schema.localisationAudits)
-    .set({
-      status: "running",
-      targetLocale: input.targetLocale,
-      targetMarket: input.targetMarket.toUpperCase(),
-      confirmedAt: new Date(),
-    })
-    .where(eq(schema.localisationAudits.id, audit.id));
-
-  const primaryPage: AuditedPage = {
-    url: primaryRecord.normalizedUrl,
-    locale: primaryRecord.locale,
-    isPrimary: true,
-    status: "extracted",
-    httpStatus: primaryRecord.httpStatus ?? 200,
-    extracted: fromPersistedExtraction(
-      primaryRecord.normalizedUrl,
-      primaryRecord.contentFingerprint,
-      primaryRecord.extraction,
-    ),
-  };
-  const fetchedAlternativePages = await mapWithConcurrency(
-    audit.alternatives,
-    3,
-    async (alternative) => {
-      const result = await fetchAuditPage(alternative.url, {
-        locale: alternative.locale,
-        isPrimary: false,
+    try {
+      await queue.enqueueRun({ auditId: audit.id });
+    } catch {
+      await markAuditFailed(db, audit.id, "audit_queue_unavailable");
+      return err({
+        code: "audit_access_not_configured",
+        message: "The localisation audit workflow is unavailable.",
       });
-      if (isErr(result)) {
-        return {
-          url: alternative.url,
-          locale: alternative.locale,
-          isPrimary: false,
-          status:
-            result.error.code === "audit_url_not_public"
-              ? ("blocked" as const)
-              : ("failed" as const),
-          failureCode: result.error.code,
-        };
-      }
-      return result.value;
-    },
-  );
-  const pages = dedupeAuditedPages([primaryPage, ...fetchedAlternativePages]);
-  const alternativePages = pages.slice(1);
-  const evaluation = evaluateLocalisationAudit({
-    pages,
-    targetLocale: input.targetLocale,
-    targetMarket: input.targetMarket,
-  });
-  const scores = calculateLocalisationAuditScores(evaluation.rules);
-  const projections = createReportProjections({
-    domain: audit.domain,
-    auditedAt: new Date(),
-    pages,
-    evaluation,
-    scores,
-  });
-  const publicSlug = nanoid(24);
+    }
 
-  const completed = await db.transaction(async (tx) => {
-    const pageIdByUrl = new Map<string, string>([[primaryRecord.normalizedUrl, primaryRecord.id]]);
-    if (alternativePages.length > 0) {
-      const insertedPages = await tx
-        .insert(schema.localisationAuditPages)
-        .values(
-          alternativePages.map((page) => ({
-            auditId: audit.id,
-            normalizedUrl: page.url,
-            locale: page.locale,
-            isPrimary: false,
-            status: page.status,
-            httpStatus: page.httpStatus,
-            contentFingerprint:
-              page.status === "extracted" ? page.extracted.contentFingerprint : undefined,
-            extraction:
-              page.status === "extracted" ? toPersistedExtraction(page.extracted) : undefined,
-            failureCode: page.status === "extracted" ? undefined : page.failureCode,
-            fetchedAt: new Date(),
-          })),
-        )
-        .returning({
-          id: schema.localisationAuditPages.id,
-          normalizedUrl: schema.localisationAuditPages.normalizedUrl,
-        });
-      for (const page of insertedPages) {
-        pageIdByUrl.set(page.normalizedUrl, page.id);
-      }
+    return ok(safeAuditFromRecord(updatedAudit));
+  }
+
+  async function unlockAudit(
+    input: UnlockAuditInput,
+  ): Promise<Result<{ accessUrl: string }, LocalisationAuditError>> {
+    const secret = env.LOCALISATION_AUDIT_ACCESS_SECRET;
+    if (!secret) {
+      return err({
+        code: "audit_access_not_configured",
+        message: "Private report access is not configured.",
+      });
     }
-    if (evaluation.findings.length > 0) {
-      await tx.insert(schema.localisationAuditFindings).values(
-        evaluation.findings.map((auditFinding) => ({
-          auditId: audit.id,
-          pageId: pageIdByUrl.get(auditFinding.pageUrl),
-          ruleCode: auditFinding.code,
-          category: auditFinding.category,
-          severity: auditFinding.severity,
-          confidence: auditFinding.confidence,
-          evidenceKind: auditFinding.evidenceKind,
-          title: auditFinding.title,
-          evidence: auditFinding.evidence,
-          impact: auditFinding.impact,
-          recommendation: auditFinding.recommendation,
-          availablePoints: auditFinding.availablePoints,
-          earnedPoints: auditFinding.earnedPoints,
-          publicPreviewEligible: auditFinding.publicPreviewEligible,
-        })),
-      );
+    const audit = await getAuditRecord(db, input.auditId);
+    if (!audit) {
+      return err({ code: "audit_not_found", message: "The audit was not found." });
     }
-    const [report] = await tx
-      .insert(schema.localisationAuditReports)
+    if (audit.status !== "completed" && audit.status !== "partial") {
+      return err({
+        code: "audit_not_complete",
+        message: "The audit report is not ready to unlock.",
+      });
+    }
+    const report = await findReportForAudit(db, audit.id);
+    if (!report) {
+      return err({ code: "report_not_found", message: "The report was not found." });
+    }
+
+    const token = mintPrivateReportAccessToken({
+      auditId: audit.id,
+      reportId: report.id,
+      secret,
+    });
+    const accessUrl = `${input.origin.replace(/\/+$/, "")}/en/localisation-audit/report/${encodeURIComponent(token)}`;
+    const [lead] = await db
+      .insert(schema.localisationAuditLeads)
       .values({
         auditId: audit.id,
-        publicSlug,
-        scoreVersion: LOCALISATION_AUDIT_SCORE_VERSION,
-        reportVersion: LOCALISATION_AUDIT_REPORT_VERSION,
-        publicReport: projections.publicReport,
-        privateReport: projections.privateReport,
+        email: input.email,
+        name: input.name,
+        emailDeliveryStatus: "pending",
       })
-      .returning({
-        publicSlug: schema.localisationAuditReports.publicSlug,
-        publicReport: schema.localisationAuditReports.publicReport,
-      });
-    if (!report) {
-      throw new Error("Failed to persist localisation audit report.");
+      .returning({ id: schema.localisationAuditLeads.id });
+    if (!lead) {
+      throw new Error("Failed to persist localisation audit lead.");
     }
-    const status = projections.publicReport.status;
-    const [updatedAudit] = await tx
-      .update(schema.localisationAudits)
-      .set({ status, completedAt: new Date() })
-      .where(eq(schema.localisationAudits.id, audit.id))
-      .returning();
-    if (!updatedAudit) {
-      throw new Error("Failed to complete localisation audit.");
-    }
-    await tx.insert(schema.localisationAuditEvents).values([
-      { auditId: audit.id, eventType: "confirmed", metadata: { source: "api" } },
-      {
-        auditId: audit.id,
-        eventType: "completed",
-        metadata: {
-          findingCount: evaluation.findings.length,
-          localeCount: pages.length,
-        },
-      },
-    ]);
-    return safeAuditFromRecord(updatedAudit, report);
-  });
-
-  return ok(completed);
-}
-
-async function unlockAudit(
-  input: UnlockAuditInput,
-): Promise<Result<{ accessUrl: string }, LocalisationAuditError>> {
-  const secret = env.LOCALISATION_AUDIT_ACCESS_SECRET;
-  if (!secret) {
-    return err({
-      code: "audit_access_not_configured",
-      message: "Private report access is not configured.",
-    });
-  }
-  const audit = await getAuditRecord(db, input.auditId);
-  if (!audit) {
-    return err({ code: "audit_not_found", message: "The audit was not found." });
-  }
-  if (audit.status !== "completed" && audit.status !== "partial") {
-    return err({
-      code: "audit_not_complete",
-      message: "The audit report is not ready to unlock.",
-    });
-  }
-  const report = await findReportForAudit(db, audit.id);
-  if (!report) {
-    return err({ code: "report_not_found", message: "The report was not found." });
-  }
-
-  const token = mintPrivateReportAccessToken({
-    auditId: audit.id,
-    reportId: report.id,
-    secret,
-  });
-  const accessUrl = `${input.origin.replace(/\/+$/, "")}/en/localisation-audit/report/${encodeURIComponent(token)}`;
-  const [lead] = await db
-    .insert(schema.localisationAuditLeads)
-    .values({
-      auditId: audit.id,
-      email: input.email,
-      name: input.name,
-    })
-    .returning({ id: schema.localisationAuditLeads.id });
-  if (!lead) {
-    throw new Error("Failed to persist localisation audit lead.");
-  }
-  await db.insert(schema.localisationAuditEvents).values({
-    auditId: audit.id,
-    leadId: lead.id,
-    eventType: "unlocked",
-    metadata: { source: "api" },
-  });
-
-  const deliveryStatus = await sendReportEmailBestEffort({
-    email: input.email,
-    accessUrl,
-  });
-  await db
-    .update(schema.localisationAuditLeads)
-    .set({ emailDeliveryStatus: deliveryStatus })
-    .where(eq(schema.localisationAuditLeads.id, lead.id));
-  if (deliveryStatus === "failed") {
     await db.insert(schema.localisationAuditEvents).values({
       auditId: audit.id,
       leadId: lead.id,
-      eventType: "email_delivery_failed",
-      metadata: { deliveryStatus },
+      eventType: "unlocked",
+      metadata: { source: "api" },
     });
-    return err({
-      code: "audit_email_delivery_failed",
-      message: "The report email could not be delivered. Try again.",
-    });
+
+    try {
+      await queue.enqueueDeliver({
+        leadId: lead.id,
+        accessUrl,
+      });
+    } catch {
+      await db
+        .update(schema.localisationAuditLeads)
+        .set({ emailDeliveryStatus: "failed" })
+        .where(eq(schema.localisationAuditLeads.id, lead.id));
+      await db.insert(schema.localisationAuditEvents).values({
+        auditId: audit.id,
+        leadId: lead.id,
+        eventType: "email_delivery_failed",
+        metadata: { deliveryStatus: "failed" },
+      });
+      // Access URL remains usable even when email delivery enqueue fails.
+    }
+
+    return ok({ accessUrl });
   }
 
-  return ok({ accessUrl });
-}
-
-async function getPublicReport(
-  slug: string,
-): Promise<Result<PublicAuditReport, LocalisationAuditError>> {
-  const [report] = await db
-    .select({ publicReport: schema.localisationAuditReports.publicReport })
-    .from(schema.localisationAuditReports)
-    .where(
-      and(
-        eq(schema.localisationAuditReports.publicSlug, slug),
-        eq(schema.localisationAuditReports.visibility, "public"),
-      ),
-    )
-    .limit(1);
-  if (!report) {
-    return err({ code: "report_not_found", message: "The report was not found." });
+  async function getPublicReport(
+    slug: string,
+  ): Promise<Result<PublicAuditReport, LocalisationAuditError>> {
+    const [report] = await db
+      .select({ publicReport: schema.localisationAuditReports.publicReport })
+      .from(schema.localisationAuditReports)
+      .where(
+        and(
+          eq(schema.localisationAuditReports.publicSlug, slug),
+          eq(schema.localisationAuditReports.visibility, "public"),
+        ),
+      )
+      .limit(1);
+    if (!report) {
+      return err({ code: "report_not_found", message: "The report was not found." });
+    }
+    return ok(report.publicReport);
   }
-  return ok(report.publicReport);
+
+  return {
+    prepareAudit,
+    getAudit,
+    confirmAudit,
+    unlockAudit,
+    getPublicReport,
+  };
 }
 
-export const localisationAuditService: LocalisationAuditService = {
-  prepareAudit,
-  getAudit,
-  confirmAudit,
-  unlockAudit,
-  getPublicReport,
-};
+export const localisationAuditService = createLocalisationAuditService({
+  queue: {
+    async enqueuePrepare(event) {
+      const { createLocalisationAuditQueue } = await import("@/workflows/adapters");
+      return createLocalisationAuditQueue().enqueuePrepare(event);
+    },
+    async enqueueRun(event) {
+      const { createLocalisationAuditQueue } = await import("@/workflows/adapters");
+      return createLocalisationAuditQueue().enqueueRun(event);
+    },
+    async enqueueDeliver(event) {
+      const { createLocalisationAuditQueue } = await import("@/workflows/adapters");
+      return createLocalisationAuditQueue().enqueueDeliver(event);
+    },
+  },
+});
 
 export async function getPublicAuditReportBySlug(slug: string): Promise<PublicAuditReport | null> {
   return loadPublicLocalisationAuditReportBySlug(slug);

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/types.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/types.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+export const LOCALISATION_AUDIT_SCORE_VERSION = "2026-07-24.1";
+export const LOCALISATION_AUDIT_REPORT_VERSION = "1";
+
+export type AuditCategory = "technical" | "linguistic" | "market";
+export type AuditSeverity = "info" | "low" | "medium" | "high" | "critical";
+export type AuditEvidenceKind = "observed" | "judgement";
+export type AuditCompletionStatus = "completed" | "partial";
+
+export type DiscoveredLocaleAlternative = {
+  locale: string;
+  url: string;
+  source: "hreflang" | "language_link";
+};
+
+export type ExtractedPage = {
+  url: string;
+  htmlLang: string | null;
+  title: string | null;
+  description: string | null;
+  canonicalUrl: string | null;
+  alternateLinks: DiscoveredLocaleAlternative[];
+  headings: string[];
+  navigation: string[];
+  callsToAction: string[];
+  visibleText: string;
+  contentFingerprint: string;
+};
+
+export type AuditedPage =
+  | {
+      url: string;
+      locale: string | null;
+      isPrimary: boolean;
+      status: "extracted";
+      httpStatus: number;
+      extracted: ExtractedPage;
+    }
+  | {
+      url: string;
+      locale: string | null;
+      isPrimary: boolean;
+      status: "blocked" | "failed";
+      failureCode: string;
+      httpStatus?: number;
+    };
+
+export type FindingEvidence = {
+  excerpt?: string;
+  observedValue?: string;
+  expectedValue?: string;
+};
+
+export type AuditFinding = {
+  code: string;
+  category: AuditCategory;
+  severity: AuditSeverity;
+  confidence: number;
+  evidenceKind: AuditEvidenceKind;
+  title: string;
+  evidence: FindingEvidence;
+  impact: string;
+  recommendation: string;
+  availablePoints: number;
+  earnedPoints: number;
+  pageUrl: string;
+  publicPreviewEligible: boolean;
+};
+
+export type RuleEvaluation = {
+  code: string;
+  category: AuditCategory;
+  applicable: boolean;
+  availablePoints: number;
+  earnedPoints: number;
+};
+
+export type AuditEvaluation = {
+  findings: AuditFinding[];
+  rules: RuleEvaluation[];
+  limitations: string[];
+};
+
+export type CategoryScore = {
+  status: "scored" | "insufficient_evidence";
+  score: number | null;
+  earnedPoints: number;
+  applicablePoints: number;
+  evaluatedRuleCount: number;
+};
+
+export type AuditScores = {
+  scoreVersion: string;
+  overallStatus: "scored" | "insufficient_evidence";
+  overallScore: number | null;
+  categoryScores: Record<AuditCategory, CategoryScore>;
+};
+
+export type PublicReportFinding = Pick<
+  AuditFinding,
+  "code" | "category" | "severity" | "title" | "impact" | "recommendation"
+> & {
+  evidence?: FindingEvidence;
+};
+
+export type PublicAuditReport = AuditScores & {
+  reportVersion: string;
+  domain: string;
+  auditedAt: string;
+  status: AuditCompletionStatus;
+  findings: PublicReportFinding[];
+  lockedFindingCount: number;
+  limitations: string[];
+};
+
+export type PrivateAuditReport = PublicAuditReport & {
+  findings: PublicReportFinding[];
+  pages: Array<{
+    url: string;
+    locale: string | null;
+    status: "extracted" | "blocked" | "failed";
+  }>;
+};
+
+export type SafeAudit = {
+  id: string;
+  status: "preparing" | "awaiting_confirmation" | "running" | "completed" | "partial" | "failed";
+  detectedLocale: string | null;
+  alternatives: DiscoveredLocaleAlternative[];
+  targetLocale?: string | null;
+  targetMarket?: string | null;
+  publicSlug?: string;
+  summary?: PublicAuditReport;
+};
+
+export type LocalisationAuditError =
+  | { code: "invalid_audit_url"; message: string }
+  | { code: "audit_url_not_public"; message: string }
+  | { code: "audit_fetch_failed"; message: string }
+  | { code: "audit_response_not_html"; message: string }
+  | { code: "audit_response_too_large"; message: string }
+  | { code: "audit_rate_limited"; message: string }
+  | { code: "audit_not_found"; message: string }
+  | { code: "audit_not_awaiting_confirmation"; message: string }
+  | { code: "audit_not_complete"; message: string }
+  | { code: "report_not_found"; message: string }
+  | { code: "audit_access_not_configured"; message: string }
+  | { code: "audit_email_delivery_failed"; message: string }
+  | { code: "invalid_report_access_token"; message: string };
+
+export type PrepareAuditInput = {
+  url: string;
+  ipAddress: string;
+};
+
+export type ConfirmAuditInput = {
+  auditId: string;
+  targetLocale: string;
+  targetMarket: string;
+};
+
+export type UnlockAuditInput = {
+  auditId: string;
+  email: string;
+  name?: string;
+  origin: string;
+};

--- a/apps/hyperlocalise-web/src/lib/security/public-http-fetch.test.ts
+++ b/apps/hyperlocalise-web/src/lib/security/public-http-fetch.test.ts
@@ -98,6 +98,23 @@ describe("public-http-fetch", () => {
       });
     });
     expect(pinned).toEqual({ address: "93.184.216.34", family: 4 });
+
+    const pinnedAll = await new Promise<Array<{ address: string; family: number }>>(
+      (resolve, reject) => {
+        lookup?.(
+          "api.example.com",
+          { all: true },
+          (error: Error | null, addresses: Array<{ address: string; family: number }>) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+            resolve(addresses);
+          },
+        );
+      },
+    );
+    expect(pinnedAll).toEqual([{ address: "93.184.216.34", family: 4 }]);
     expect(undiciMock.close).toHaveBeenCalled();
   });
 

--- a/apps/hyperlocalise-web/src/lib/security/public-http-fetch.ts
+++ b/apps/hyperlocalise-web/src/lib/security/public-http-fetch.ts
@@ -60,7 +60,11 @@ export async function withPublicHttpFetch<T>(
   const { address, family } = hostResult.value;
   const dispatcher = new Agent({
     connect: {
-      lookup(_hostname, _options, callback) {
+      lookup(_hostname, options, callback) {
+        if (options.all) {
+          callback(null, [{ address, family }]);
+          return;
+        }
         callback(null, address, family);
       },
     },

--- a/apps/hyperlocalise-web/src/lib/workflow/types.ts
+++ b/apps/hyperlocalise-web/src/lib/workflow/types.ts
@@ -143,3 +143,22 @@ export type TranslationFileImportEventData = {
 };
 
 export type TranslationFileImportQueue = JobQueue<TranslationFileImportEventData>;
+
+export type LocalisationAuditPrepareEventData = {
+  auditId: string;
+};
+
+export type LocalisationAuditRunEventData = {
+  auditId: string;
+};
+
+export type LocalisationAuditDeliverEventData = {
+  leadId: string;
+  accessUrl: string;
+};
+
+export type LocalisationAuditQueue = {
+  enqueuePrepare(event: LocalisationAuditPrepareEventData): Promise<{ ids: string[] }>;
+  enqueueRun(event: LocalisationAuditRunEventData): Promise<{ ids: string[] }>;
+  enqueueDeliver(event: LocalisationAuditDeliverEventData): Promise<{ ids: string[] }>;
+};

--- a/apps/hyperlocalise-web/src/proxy.test.ts
+++ b/apps/hyperlocalise-web/src/proxy.test.ts
@@ -60,6 +60,8 @@ describe("isUnsupportedLocalePath", () => {
     expect(isUnsupportedLocalePath("/product/agents-automation")).toBe(false);
     expect(isUnsupportedLocalePath("/use-cases/saas")).toBe(false);
     expect(isUnsupportedLocalePath("/blog")).toBe(false);
+    expect(isUnsupportedLocalePath("/localisation-audit")).toBe(false);
+    expect(isUnsupportedLocalePath("/localisation-audit/report/private-token")).toBe(false);
     expect(isUnsupportedLocalePath("/privacy")).toBe(false);
   });
 
@@ -134,6 +136,18 @@ describe("proxy", () => {
 
     expect(response?.status).toBe(307);
     expect(response?.headers.get("location")).toBe("https://www.hyperlocalise.com/en/blog");
+    expect(authkitProxyMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects localisation audit paths without a locale prefix", async () => {
+    authkitProxyMock.mockReset();
+
+    const response = await proxy(createRequest("/localisation-audit"), {} as never);
+
+    expect(response?.status).toBe(307);
+    expect(response?.headers.get("location")).toBe(
+      "https://www.hyperlocalise.com/en/localisation-audit",
+    );
     expect(authkitProxyMock).not.toHaveBeenCalled();
   });
 

--- a/apps/hyperlocalise-web/src/proxy.ts
+++ b/apps/hyperlocalise-web/src/proxy.ts
@@ -131,7 +131,7 @@ async function maybeWorkosProxy(request: NextRequest, event: NextFetchEvent) {
   return nextResponse;
 }
 
-const PUBLIC_LOCALIZED_PREFIXES = ["/product", "/use-cases", "/blog"];
+const PUBLIC_LOCALIZED_PREFIXES = ["/product", "/use-cases", "/blog", "/localisation-audit"];
 const PUBLIC_LOCALIZED_PATHS = new Set(["/", "/privacy", "/terms", "/trust-center"]);
 const PROTECTED_LOCALIZED_PREFIXES = ["/dashboard", "/org"];
 const NON_LOCALE_ROOT_PREFIXES = ["/auth", "/install", "/api", "/crowdin-app"];

--- a/apps/hyperlocalise-web/src/workflows/adapters.ts
+++ b/apps/hyperlocalise-web/src/workflows/adapters.ts
@@ -24,6 +24,7 @@ import { repositoryAgentWorkflow } from "./repository-agent";
 import type {
   EmailAgentTaskQueue,
   JobQueue,
+  LocalisationAuditQueue,
   ProviderAgentCommentQueue,
   ProviderAgentQaQueue,
   ProviderAgentTranslationQueue,
@@ -138,6 +139,28 @@ export function createTranslationFileImportQueue(): TranslationFileImportQueue {
     async enqueue(event) {
       const { translationFileImportWorkflow } = await import("@/workflows/translation-file-import");
       const run = await start(translationFileImportWorkflow, [event]);
+      return { ids: [run.runId] };
+    },
+  };
+}
+
+export function createLocalisationAuditQueue(): LocalisationAuditQueue {
+  return {
+    async enqueuePrepare(event) {
+      const { localisationAuditPrepareWorkflow } =
+        await import("@/workflows/localisation-audit-prepare");
+      const run = await start(localisationAuditPrepareWorkflow, [event]);
+      return { ids: [run.runId] };
+    },
+    async enqueueRun(event) {
+      const { localisationAuditRunWorkflow } = await import("@/workflows/localisation-audit-run");
+      const run = await start(localisationAuditRunWorkflow, [event]);
+      return { ids: [run.runId] };
+    },
+    async enqueueDeliver(event) {
+      const { localisationAuditDeliverWorkflow } =
+        await import("@/workflows/localisation-audit-deliver");
+      const run = await start(localisationAuditDeliverWorkflow, [event]);
       return { ids: [run.runId] };
     },
   };

--- a/apps/hyperlocalise-web/src/workflows/localisation-audit-deliver.ts
+++ b/apps/hyperlocalise-web/src/workflows/localisation-audit-deliver.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { FatalError, getWorkflowMetadata } from "workflow";
+
+import type { LocalisationAuditDeliverEventData } from "@/lib/workflow/types";
+
+import { deliverLocalisationAuditReportStep } from "./steps/localisation-audit";
+
+export async function localisationAuditDeliverWorkflow(event: LocalisationAuditDeliverEventData) {
+  "use workflow";
+
+  getWorkflowMetadata();
+  const result = await deliverLocalisationAuditReportStep(event);
+  if (result.ok) {
+    return result.delivery;
+  }
+  if (result.fatal) {
+    throw new FatalError(result.message);
+  }
+  throw new Error(result.message);
+}

--- a/apps/hyperlocalise-web/src/workflows/localisation-audit-prepare.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/localisation-audit-prepare.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { getWorkflowMetadataMock, prepareLocalisationAuditStepMock, FatalErrorMock } = vi.hoisted(
+  () => {
+    class FatalError extends Error {
+      fatal = true;
+    }
+    return {
+      getWorkflowMetadataMock: vi.fn(() => ({ workflowRunId: "run_1" })),
+      prepareLocalisationAuditStepMock: vi.fn(),
+      FatalErrorMock: FatalError,
+    };
+  },
+);
+
+vi.mock("workflow", () => ({
+  getWorkflowMetadata: getWorkflowMetadataMock,
+  FatalError: FatalErrorMock,
+}));
+
+vi.mock("./steps/localisation-audit", () => ({
+  prepareLocalisationAuditStep: prepareLocalisationAuditStepMock,
+}));
+
+import { localisationAuditPrepareWorkflow } from "./localisation-audit-prepare";
+
+describe("localisationAuditPrepareWorkflow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the prepared audit when the prepare step succeeds", async () => {
+    prepareLocalisationAuditStepMock.mockResolvedValueOnce({
+      ok: true,
+      audit: {
+        id: "audit-1",
+        status: "awaiting_confirmation",
+        detectedLocale: "en-US",
+        alternatives: [],
+      },
+    });
+
+    await expect(localisationAuditPrepareWorkflow({ auditId: "audit-1" })).resolves.toMatchObject({
+      id: "audit-1",
+      status: "awaiting_confirmation",
+    });
+  });
+
+  it("throws a fatal error for non-retryable prepare failures", async () => {
+    prepareLocalisationAuditStepMock.mockResolvedValueOnce({
+      ok: false,
+      code: "audit_url_not_public",
+      message: "Private network rejected.",
+      fatal: true,
+    });
+
+    await expect(localisationAuditPrepareWorkflow({ auditId: "audit-1" })).rejects.toBeInstanceOf(
+      FatalErrorMock,
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/workflows/localisation-audit-prepare.ts
+++ b/apps/hyperlocalise-web/src/workflows/localisation-audit-prepare.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { FatalError, getWorkflowMetadata } from "workflow";
+
+import type { LocalisationAuditPrepareEventData } from "@/lib/workflow/types";
+
+import { prepareLocalisationAuditStep } from "./steps/localisation-audit";
+
+export async function localisationAuditPrepareWorkflow(event: LocalisationAuditPrepareEventData) {
+  "use workflow";
+
+  getWorkflowMetadata();
+  const result = await prepareLocalisationAuditStep(event);
+  if (result.ok) {
+    return result.audit;
+  }
+  if (result.fatal) {
+    throw new FatalError(result.message);
+  }
+  throw new Error(result.message);
+}

--- a/apps/hyperlocalise-web/src/workflows/localisation-audit-run.ts
+++ b/apps/hyperlocalise-web/src/workflows/localisation-audit-run.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { FatalError, getWorkflowMetadata } from "workflow";
+
+import type { LocalisationAuditRunEventData } from "@/lib/workflow/types";
+
+import { runLocalisationAuditStep } from "./steps/localisation-audit";
+
+export async function localisationAuditRunWorkflow(event: LocalisationAuditRunEventData) {
+  "use workflow";
+
+  getWorkflowMetadata();
+  const result = await runLocalisationAuditStep(event);
+  if (result.ok) {
+    return result.audit;
+  }
+  if (result.fatal) {
+    throw new FatalError(result.message);
+  }
+  throw new Error(result.message);
+}

--- a/apps/hyperlocalise-web/src/workflows/steps/localisation-audit.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/localisation-audit.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type {
+  LocalisationAuditDeliverEventData,
+  LocalisationAuditPrepareEventData,
+  LocalisationAuditRunEventData,
+} from "@/lib/workflow/types";
+
+export async function prepareLocalisationAuditStep(event: LocalisationAuditPrepareEventData) {
+  "use step";
+  const { isErr } = await import("@/lib/primitives/result/results");
+  const { isFatalPrepareError, prepareAuditWork } =
+    await import("@/lib/localisation-audit/prepare-audit-work");
+  const result = await prepareAuditWork(event.auditId);
+  if (!isErr(result)) {
+    return { ok: true as const, audit: result.value };
+  }
+  return {
+    ok: false as const,
+    code: result.error.code,
+    message: result.error.message,
+    fatal: isFatalPrepareError(result.error.code),
+  };
+}
+
+export async function runLocalisationAuditStep(event: LocalisationAuditRunEventData) {
+  "use step";
+  const { isErr } = await import("@/lib/primitives/result/results");
+  const { runAuditWork } = await import("@/lib/localisation-audit/run-audit-work");
+  const result = await runAuditWork(event.auditId);
+  if (!isErr(result)) {
+    return { ok: true as const, audit: result.value };
+  }
+  const { markAuditFailed } = await import("@/lib/localisation-audit/operations");
+  const { db } = await import("@/lib/database");
+  await markAuditFailed(db, event.auditId, result.error.code);
+  return {
+    ok: false as const,
+    code: result.error.code,
+    message: result.error.message,
+    fatal: true,
+  };
+}
+
+export async function deliverLocalisationAuditReportStep(event: LocalisationAuditDeliverEventData) {
+  "use step";
+  const { isErr } = await import("@/lib/primitives/result/results");
+  const { deliverAuditReportWork } =
+    await import("@/lib/localisation-audit/deliver-audit-report-work");
+  const result = await deliverAuditReportWork(event);
+  if (!isErr(result)) {
+    return { ok: true as const, delivery: result.value };
+  }
+  return {
+    ok: false as const,
+    code: result.error.code,
+    message: result.error.message,
+    fatal: result.error.code !== "audit_email_delivery_failed",
+  };
+}

--- a/docs/plans/2026-07-24-localisation-health-audit-agent-design.md
+++ b/docs/plans/2026-07-24-localisation-health-audit-agent-design.md
@@ -25,8 +25,9 @@ without exposing personal or sensitive information.
 3. The visitor confirms or corrects the detected language and target market.
 4. The audit shows progress while it discovers locales, checks technical
    setup, reviews customer-facing language, and compares market experiences.
-5. The free result shows the overall score, three category scores, three
-   high-impact findings, and the number of locked findings.
+5. The free result shows the available overall and category scores, an
+   **Insufficient evidence** state for withheld scores, three high-impact
+   findings, and the number of locked findings.
 6. The visitor enters a work email to unlock the full web report and receive an
    emailed copy.
 7. The primary call to action invites the lead to book a localisation strategy

--- a/docs/plans/2026-07-24-localisation-health-audit-agent-design.md
+++ b/docs/plans/2026-07-24-localisation-health-audit-agent-design.md
@@ -1,0 +1,255 @@
+# Localisation health audit agent
+
+## Goal
+
+Create a public lead-generation tool that audits a submitted website URL for
+technical localisation readiness, linguistic quality, and market fit. The
+initial audience is localisation managers at established global companies,
+followed by product and engineering teams beginning international expansion.
+
+The page will promise:
+
+> How ready is your website for global customers? Get a free localisation
+> health check covering technical setup, translation quality, and market fit.
+
+The tool must demonstrate value before collecting contact details. It should
+also turn useful audit data into shareable reports and aggregate SEO content
+without exposing personal or sensitive information.
+
+## User journey
+
+1. A visitor submits one public URL.
+2. The agent discovers explicit locale alternatives from `hreflang`, language
+   switchers, canonical links, and URL patterns.
+3. The visitor confirms or corrects the detected language and target market.
+4. The audit shows progress while it discovers locales, checks technical
+   setup, reviews customer-facing language, and compares market experiences.
+5. The free result shows the overall score, three category scores, three
+   high-impact findings, and the number of locked findings.
+6. The visitor enters a work email to unlock the full web report and receive an
+   emailed copy.
+7. The primary call to action invites the lead to book a localisation strategy
+   call.
+8. A secondary call to action lets product and engineering visitors create a
+   Hyperlocalise workspace and save the audit.
+
+The flow will not require an account, phone number, or company questionnaire
+before showing the summary.
+
+## Audit model
+
+### Technical readiness: 40%
+
+- Valid document language
+- Complete and reciprocal `hreflang`
+- Correct `x-default`, canonical, and locale URLs
+- Discoverable locale switcher with valid destinations
+- Mixed-language or untranslated content
+- Localised metadata, structured data, images, and accessibility labels
+- Encoding, layout overflow, and text expansion
+- Locale-appropriate dates, numbers, currencies, and units
+
+### Linguistic quality: 40%
+
+- Fluency, grammar, and clarity
+- Literal or machine-translated phrasing
+- Terminology consistency
+- Tone consistency
+- Untranslated fragments
+- Calls to action and navigation language
+- Locale-specific usage, such as `en-US` compared with `en-GB`
+
+### Market experience: 20%
+
+- Currency, units, dates, addresses, and legal expectations
+- Local relevance of claims, examples, social proof, and imagery
+- Search intent alignment in headings and metadata
+- Market-appropriate conversion language
+
+Every finding will include its affected URL, severity, confidence, evidence,
+business impact, and a suggested fix. The report must distinguish observed
+facts from model judgements. It must not claim translation accuracy when it
+cannot identify a reliable source page for comparison. Missing evidence does
+not reduce a score.
+
+## Agent workflow
+
+1. **Validate:** Normalise the URL, block private networks, enforce rate limits,
+   and confirm public access.
+2. **Discover:** Fetch the submitted page and identify explicit locale
+   alternatives. Do not run an unrestricted crawl.
+3. **Confirm:** Ask the visitor to confirm the detected language and target
+   market.
+4. **Extract:** Capture visible copy, metadata, links, locale controls,
+   structured data, formatting, and screenshots.
+5. **Compare:** Match equivalent sections across locale pages only when the
+   match meets a confidence threshold.
+6. **Evaluate:** Run deterministic technical checks first. Send only relevant
+   extracted content to the linguistic evaluator.
+7. **Synthesize:** Deduplicate findings, rank them by business impact,
+   calculate versioned category scores, and generate the report.
+8. **Convert:** Reveal the summary immediately. Store and email the full report
+   after lead capture.
+
+The workflow will use bounded concurrency and page and content limits. It will
+return partial results when an alternative page is unavailable. It will state
+blocked pages, unsupported claims, and low-confidence locale matches as report
+limitations rather than findings.
+
+## Persistence and public reports
+
+Store every completed or partial audit as versioned records:
+
+| Record | Purpose |
+|---|---|
+| `audit` | Submitted URL, status, target locale and market, timestamps, and score version |
+| `audit_page` | Discovered URL, locale, extraction status, and content fingerprint |
+| `audit_finding` | Category, severity, confidence, evidence, impact, and recommendation |
+| `audit_report` | Stable public slug, summary, visibility, indexing consent, and report version |
+| `audit_lead` | Contact data and conversion state, separate from public report data |
+| `audit_event` | Report viewed, unlocked, shared, booked, or converted to a workspace |
+
+Content fingerprints may reuse a recent extraction. A changed fingerprint,
+target market, or scoring version starts a new audit version rather than
+overwriting prior evidence.
+
+The public route will use a stable slug such as
+`/localisation-audit/example-com-a1b2`. It will show the domain, audit date,
+scores, three high-level findings, sanitised recommendations, and Hyperlocalise
+calls to action. It will not expose email addresses, detailed
+vulnerability-like findings, raw model output, raw extracted content, or
+sensitive evidence.
+
+Reports will be shareable but `noindex` by default. A report becomes eligible
+for indexing only when:
+
+1. The submitter explicitly opts into public indexing.
+2. The report passes completeness and uniqueness thresholds.
+3. Automated checks find no sensitive content.
+4. The report receives editorial approval when required.
+
+Domain ownership cannot be inferred from URL submission. Domain owners must
+have a removal path. Aggregate, anonymised findings can support indexable
+benchmark pages such as localisation health benchmarks for SaaS websites. This
+creates stronger SEO content than automatically indexing thin reports.
+
+## Lead generation
+
+The unlock form will collect a work email and name. The visitor may optionally
+provide a role and primary target market. Company inference from an email
+domain is advisory because free, agency, and shared domains make it unreliable.
+
+Attach the following audit context to the lead:
+
+- Domain and discovered locale count
+- Overall and category scores
+- Critical finding count
+- Apparent localisation maturity
+- Relevant technology signals
+- Report views, shares, and revisits
+- Strategy-call and workspace conversion events
+
+Lead priority will combine product fit and intent. A multi-locale site with
+recurring defects and repeat report visits is a stronger lead than a
+single-language brochure site with a low score. Follow-up should cite specific
+findings instead of sending generic nurture copy. Localisation leaders should
+see the strategy-call path first; product and engineering visitors should also
+see the workspace and GitHub path.
+
+## System boundaries
+
+The first version includes:
+
+- Public URL submission
+- Explicit locale-alternative discovery
+- Language and target-market confirmation
+- Deterministic technical checks
+- Model-assisted linguistic and market review
+- Overall and category scoring
+- Three-finding preview and email-gated full report
+- Persistent audit records
+- Shareable, `noindex` summary pages
+- Strategy-call and workspace calls to action
+- Submission, unlock, sharing, and conversion analytics
+
+The first version excludes:
+
+- Full-domain crawling
+- Scheduled monitoring
+- GitHub or TMS root-cause diagnosis
+- Custom glossaries and brand voice
+- PDF generation
+- Ahrefs or Semrush enrichment
+- Automatically indexed domain reports
+- Competitive comparisons
+
+## Components
+
+- Public audit form and progress interface
+- URL discovery and extraction service
+- Deterministic rules engine
+- Linguistic evaluation agent
+- Scoring and report generator
+- Lead-capture service
+- Public report renderer
+- Background audit workflow
+
+Expected integration failures should use typed result codes. URL fetching must
+reuse the application's SSRF protections. Logs may contain opaque audit IDs,
+statuses, timings, and counts, but not URLs, emails, page content, company
+names, or model prompts.
+
+## Failure handling
+
+- Retry transient network and model failures within fixed limits.
+- Return a partial report when one or more alternatives are inaccessible.
+- Explain blocked, redirected, JavaScript-only, or authenticated pages.
+- Never convert missing evidence into a negative finding or score.
+- Rate-limit submissions by IP and domain.
+- Cap locale alternatives, extracted content, screenshots, and model tokens.
+- Treat page content as untrusted input and isolate it from agent instructions.
+- Provide a removal process for public reports.
+
+## Success measures
+
+- Audit completion rate
+- Summary-to-email conversion rate
+- Report share and revisit rate
+- Qualified strategy-call bookings
+- Workspace creation rate
+- Cost and latency per completed audit
+- False-positive rate in human-reviewed samples
+
+## Validation
+
+- Unit-test every deterministic rule and scoring boundary.
+- Integration-test redirects, malformed HTML, conflicting locale signals,
+  JavaScript-only pages, and partial failures.
+- Benchmark linguistic findings against human-reviewed multilingual samples.
+- Test SSRF controls, prompt injection, abuse limits, and public-data
+  redaction.
+- Run end-to-end tests from URL submission through email unlock and the shared
+  report.
+- Review early reports manually and measure false positives before publishing
+  indexed benchmark content.
+
+## Alternatives considered
+
+### Conversational audit agent
+
+An agent could ask about target markets, brand voice, and localisation
+processes before auditing. This would collect richer qualification data but
+would delay the first useful result and add friction to the lead funnel.
+
+### Website localisation grader
+
+An instant score would be simple and shareable, but a score without evidence
+could resemble a generic SEO checker. The chosen design uses the score as the
+hook and supports it with evidence-led findings.
+
+### Single-page snapshot
+
+Auditing only the submitted page would cost less, but it would miss the
+cross-locale defects that matter most to localisation managers. The chosen
+design audits the submitted page and its explicit locale alternatives without
+introducing a general crawler.

--- a/docs/plans/2026-07-24-localisation-health-audit-agent-design.md
+++ b/docs/plans/2026-07-24-localisation-health-audit-agent-design.md
@@ -81,6 +81,11 @@ Apply the 40/40/20 category weights only after calculating each category.
 Publish the score version and evaluated-rule count with the report so a result
 can be reproduced.
 
+If a category has no applicable points or does not meet its score version's
+minimum evidence threshold, show **Insufficient evidence** instead of a numeric
+category score. Withhold the overall score unless all three categories meet
+their minimum thresholds; do not reweight the remaining categories.
+
 ## Agent workflow
 
 1. **Validate:** Normalise the URL, block private networks, enforce rate limits,
@@ -113,7 +118,7 @@ Store every completed or partial audit as versioned records:
 |---|---|
 | `audit` | Submitted URL, status, target locale and market, timestamps, and score version |
 | `audit_page` | Discovered URL, locale, extraction status, and content fingerprint |
-| `audit_finding` | Category, severity, confidence, evidence, impact, and recommendation |
+| `audit_finding` | Category, severity, confidence, sanitised evidence, impact, and recommendation |
 | `audit_report` | Public summary, private full-report reference, visibility, indexing state, and report version |
 | `audit_lead` | Contact data and conversion state, separate from public report data |
 | `audit_event` | Report viewed, unlocked, shared, booked, or converted to a workspace |
@@ -122,8 +127,8 @@ Content fingerprints may reuse a recent extraction. A changed fingerprint,
 target market, or scoring version starts a new audit version rather than
 overwriting prior evidence.
 
-The public summary will use a stable slug such as
-`/localisation-audit/example-com-a1b2`. It will show the domain, audit date,
+The public summary will use an opaque stable slug such as
+`/localisation-audit/a1b2c3d4`. It will show the domain, audit date,
 scores, three high-level findings, sanitised recommendations, and Hyperlocalise
 calls to action. It will not expose email addresses, detailed
 vulnerability-like findings, raw model output, raw extracted content, or
@@ -152,10 +157,12 @@ content than automatically indexing thin reports.
 Raw extracted content and screenshots will be encrypted, restricted to the
 audit service and authorised support staff, and deleted within 30 days. Private
 reports and findings will be retained for 12 months unless the lead requests
-earlier deletion. Lead records follow the product's consent, suppression, and
-legal retention policies. A deletion request must cover raw artifacts, private
-reports, public summaries, and lead links while retaining only records required
-for suppression or legal compliance.
+earlier deletion. Retained findings may contain only short, sanitised evidence
+excerpts; links to raw artifacts must expire when those artifacts are deleted.
+Lead records follow the product's consent, suppression, and legal retention
+policies. A deletion request must cover raw artifacts, private reports, public
+summaries, and lead links while retaining only records required for suppression
+or legal compliance.
 
 ## Lead generation
 

--- a/docs/plans/2026-07-24-localisation-health-audit-agent-design.md
+++ b/docs/plans/2026-07-24-localisation-health-audit-agent-design.md
@@ -19,8 +19,9 @@ without exposing personal or sensitive information.
 ## User journey
 
 1. A visitor submits one public URL.
-2. The agent discovers explicit locale alternatives from `hreflang`, language
-   switchers, canonical links, and URL patterns.
+2. The agent discovers explicit locale alternatives from `hreflang` and
+   language switchers. Canonical links and URL patterns supply candidates that
+   require an explicit signal or user confirmation.
 3. The visitor confirms or corrects the detected language and target market.
 4. The audit shows progress while it discovers locales, checks technical
    setup, reviews customer-facing language, and compares market experiences.
@@ -72,6 +73,14 @@ facts from model judgements. It must not claim translation accuracy when it
 cannot identify a reliable source page for comparison. Missing evidence does
 not reduce a score.
 
+Each score version will define the points available for every rule, the
+severity thresholds, and the minimum confidence required to score a
+model-assisted rule. Calculate a category score from earned points divided by
+applicable points; exclude rules without enough evidence from both values.
+Apply the 40/40/20 category weights only after calculating each category.
+Publish the score version and evaluated-rule count with the report so a result
+can be reproduced.
+
 ## Agent workflow
 
 1. **Validate:** Normalise the URL, block private networks, enforce rate limits,
@@ -105,7 +114,7 @@ Store every completed or partial audit as versioned records:
 | `audit` | Submitted URL, status, target locale and market, timestamps, and score version |
 | `audit_page` | Discovered URL, locale, extraction status, and content fingerprint |
 | `audit_finding` | Category, severity, confidence, evidence, impact, and recommendation |
-| `audit_report` | Stable public slug, summary, visibility, indexing consent, and report version |
+| `audit_report` | Public summary, private full-report reference, visibility, indexing state, and report version |
 | `audit_lead` | Contact data and conversion state, separate from public report data |
 | `audit_event` | Report viewed, unlocked, shared, booked, or converted to a workspace |
 
@@ -113,31 +122,46 @@ Content fingerprints may reuse a recent extraction. A changed fingerprint,
 target market, or scoring version starts a new audit version rather than
 overwriting prior evidence.
 
-The public route will use a stable slug such as
+The public summary will use a stable slug such as
 `/localisation-audit/example-com-a1b2`. It will show the domain, audit date,
 scores, three high-level findings, sanitised recommendations, and Hyperlocalise
 calls to action. It will not expose email addresses, detailed
 vulnerability-like findings, raw model output, raw extracted content, or
 sensitive evidence.
 
-Reports will be shareable but `noindex` by default. A report becomes eligible
-for indexing only when:
+The full report is a separate private projection. The unlock flow will bind it
+to the visitor's browser session and send an expiring, signed access link by
+email. The public slug must never resolve to the private projection, even after
+the visitor unlocks it.
+
+Public summaries will be shareable but `noindex` by default. A summary becomes
+eligible for indexing only when:
 
 1. The submitter explicitly opts into public indexing.
 2. The report passes completeness and uniqueness thresholds.
 3. Automated checks find no sensitive content.
-4. The report receives editorial approval when required.
+4. The submitter verifies control of the domain, or Hyperlocalise independently
+   reviews and approves the report as editorial content.
 
-Domain ownership cannot be inferred from URL submission. Domain owners must
-have a removal path. Aggregate, anonymised findings can support indexable
-benchmark pages such as localisation health benchmarks for SaaS websites. This
-creates stronger SEO content than automatically indexing thin reports.
+Domain ownership cannot be inferred from URL submission, and opt-in alone
+cannot index a third-party domain. Domain owners must have a removal path.
+Aggregate, anonymised findings can support indexable benchmark pages such as
+localisation health benchmarks for SaaS websites. This creates stronger SEO
+content than automatically indexing thin reports.
+
+Raw extracted content and screenshots will be encrypted, restricted to the
+audit service and authorised support staff, and deleted within 30 days. Private
+reports and findings will be retained for 12 months unless the lead requests
+earlier deletion. Lead records follow the product's consent, suppression, and
+legal retention policies. A deletion request must cover raw artifacts, private
+reports, public summaries, and lead links while retaining only records required
+for suppression or legal compliance.
 
 ## Lead generation
 
-The unlock form will collect a work email and name. The visitor may optionally
-provide a role and primary target market. Company inference from an email
-domain is advisory because free, agency, and shared domains make it unreliable.
+The unlock form will require a work email. Name, role, and primary target
+market are optional. Company inference from an email domain is advisory because
+free, agency, and shared domains make it unreliable.
 
 Attach the following audit context to the lead:
 
@@ -154,7 +178,14 @@ recurring defects and repeat report visits is a stronger lead than a
 single-language brochure site with a low score. Follow-up should cite specific
 findings instead of sending generic nurture copy. Localisation leaders should
 see the strategy-call path first; product and engineering visitors should also
-see the workspace and GitHub path.
+see the workspace path. GitHub connection remains a post-workspace option
+outside this audit's first version.
+
+Collect product events through first-party analytics with an opaque `audit_id`;
+do not send URLs, emails, extracted copy, or findings as event properties.
+Carry a signed audit reference through strategy-call and workspace links so
+server-side conversion events can connect to the audit. Apply regional consent
+requirements and retain event-level analytics for no more than 13 months.
 
 ## System boundaries
 
@@ -208,7 +239,8 @@ names, or model prompts.
 - Rate-limit submissions by IP and domain.
 - Cap locale alternatives, extracted content, screenshots, and model tokens.
 - Treat page content as untrusted input and isolate it from agent instructions.
-- Provide a removal process for public reports.
+- Apply the documented retention and deletion policy to raw artifacts, reports,
+  leads, and public summaries.
 
 ## Success measures
 
@@ -228,8 +260,14 @@ names, or model prompts.
 - Benchmark linguistic findings against human-reviewed multilingual samples.
 - Test SSRF controls, prompt injection, abuse limits, and public-data
   redaction.
-- Run end-to-end tests from URL submission through email unlock and the shared
-  report.
+- Run end-to-end tests from URL submission through the three-finding preview,
+  email unlock, private-link access, and shared public summary.
+- Assert that failed email delivery preserves a retry path without exposing the
+  full report.
+- Assert that public summaries remain redacted and `noindex` until indexing
+  consent, quality, ownership or editorial review, and sensitivity checks pass.
+- Assert first-party analytics, both calls to action, signed conversion
+  attribution, partial reports, retention, deletion, and domain-owner removal.
 - Review early reports manually and measure false positives before publishing
   indexed benchmark content.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

- add the approved URL-based localisation health audit design and implementation
- persist audits, pages, findings, reports, leads, and first-party events with versioned scoring
- perform SSRF-safe page discovery and evidence-based technical, linguistic, and market checks
- add public audit APIs, DB-backed rate limits, opaque share links, and signed private report access
- add the localized marketing flow, score preview, email gate, public summary, and private full report pages
- count failed fetch attempts against submission budgets, dedupe redirected locale pages, and align target-market input with ISO country codes
- run prepare, audit scoring, and report email delivery through durable Vercel Workflows; API creates/confirms/unlocks jobs and the UI polls status

## How to test

- `vp test`
- `vp check --fix`
- submit a public URL, confirm locale/market, review the summary, unlock the report, and open both public/private report routes

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9460-2e70-75f4-b99a-00dfb74057cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9460-2e70-75f4-b99a-00dfb74057cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

