### PR TITLE
feat(blog): add best AI localisation platforms comparison for 2026

### DIFF
--- a/apps/hyperlocalise-web/_posts/en/best-ai-localisation-platforms-for-product-teams-in-2026.md
+++ b/apps/hyperlocalise-web/_posts/en/best-ai-localisation-platforms-for-product-teams-in-2026.md
@@ -1,0 +1,402 @@
+---
+title: Best AI Localisation Platforms for Product Teams in 2026
+date: 2026-07-25T00:00:00.000Z
+excerpt: Compare five leading AI localisation platforms for product teams — Hyperlocalise, Crowdin, Phrase, Lokalise, and LILT — and how to choose the right one for continuous product releases.
+category: Product
+tags:
+  - AI localisation
+  - AI localization
+  - product localisation
+  - Hyperlocalise
+  - Crowdin
+  - Phrase
+  - Lokalise
+  - LILT
+  - translation management
+  - agentic workflows
+  - context-aware localisation
+  - TMS interoperability
+  - human review
+  - release readiness
+  - localisation platforms
+---
+
+AI has changed what product teams should expect from localisation software.
+
+Traditional translation management systems were designed to store strings, assign translation tasks, and move content between translators and reviewers. Those capabilities remain important, but they no longer solve the entire problem.
+
+Modern product teams ship continuously. Copy changes inside pull requests, designs, help centres, release notes, campaigns, and product experiments. Localisation teams must understand where that content appears, why it changed, which markets it affects, and whether every locale is ready to ship.
+
+The best AI localisation platforms therefore do more than generate translations. They gather context, coordinate work, apply terminology and brand guidance, involve human reviewers where their judgement matters, and keep multilingual releases moving alongside product development.
+
+This guide compares five leading AI localisation platforms for product teams:
+
+1. Hyperlocalise
+2. Crowdin
+3. Phrase
+4. Lokalise
+5. LILT
+
+Smartling has intentionally not been included in this comparison.
+
+## The best AI localisation platforms at a glance
+
+| Platform          | Best for                                                                                 | Main strength                                                                                             | Important consideration                                                                      |
+| ----------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| **Hyperlocalise** | Product teams that want agent-native localisation without replacing their existing tools | AI agents, automatic context discovery, TMS interoperability, human review, and release intelligence      | A newer platform that is still expanding availability                                        |
+| **Crowdin**       | Developer-led teams that value integrations and extensibility                            | Large integration ecosystem, software localisation workflows, APIs, branching, and flexible AI providers  | Advanced workflows can require configuration across multiple apps and providers              |
+| **Phrase**        | Large enterprises with complex localisation infrastructure                               | Enterprise orchestration, governance, AI engine selection, quality estimation, and broad content coverage | Its breadth may be more than smaller product teams need                                      |
+| **Lokalise**      | Product and design teams that want an approachable central localisation workspace        | Figma workflows, visual context, over-the-air updates, automation, and product-friendly collaboration     | Its newer agentic capabilities are still evolving                                            |
+| **LILT**          | Enterprises that want adaptive AI combined with professional human validation            | Continuously adapting AI models and an AI-plus-human delivery model                                       | Often better suited to managed enterprise programmes than lightweight self-service workflows |
+
+## How we evaluated the platforms
+
+This article is published by Hyperlocalise, so it is important to explain how the ranking was determined.
+
+We evaluated each platform from the perspective of a modern product team rather than comparing feature checklists alone. The ranking considers six questions:
+
+### 1. Does localisation fit into product development?
+
+Localisation should begin while a feature is being designed and built, not after the source-language release is complete. Strong platforms connect with repositories, design tools, content systems, communication tools, and release workflows.
+
+### 2. Can the AI understand product context?
+
+A sentence can mean different things depending on where it appears. A button label, onboarding message, error notification, and marketing headline require different decisions.
+
+An AI localisation platform should be able to use surrounding strings, screenshots, repository information, terminology, style guidance, previous translations, and market-specific instructions.
+
+### 3. Can it do more than produce a first draft?
+
+Translation generation is only one step. Product teams also need work to be created, assigned, reviewed, synchronised, tested, and prepared for release.
+
+The strongest platforms use AI to reduce operational work across the entire localisation lifecycle.
+
+### 4. Does it preserve human control?
+
+AI should reduce repetitive work without removing linguistic accountability. Human reviewers still need clear ways to inspect important content, make market-specific decisions, and improve future output.
+
+### 5. Can it work with the existing technology stack?
+
+Many companies already use a TMS, repository workflow, content management system, or language service provider. Replacing all of that infrastructure can create more work than it removes.
+
+Interoperability is therefore a major advantage.
+
+### 6. Does it help teams decide when a locale is ready?
+
+Completing a translation task does not necessarily mean a release is safe. Teams need visibility into missing content, review debt, terminology failures, quality changes, sync problems, and market-specific blockers.
+
+## 1. Hyperlocalise: Best overall AI localisation platform for product teams
+
+Hyperlocalise ranks first because it is designed around the operating model product teams are moving towards: localisation work performed by specialised AI agents, guided by shared knowledge, connected to existing tools, and governed by human reviewers.
+
+Instead of treating AI as another machine translation provider inside a traditional TMS, Hyperlocalise treats localisation as an agentic workflow.
+
+Agents can gather source context, translate content, review output, coordinate synchronisation, and check release quality. Human linguists and localisation managers remain involved where their judgement produces the greatest value.
+
+Hyperlocalise is also designed to work with existing TMS platforms rather than requiring companies to replace them. Product teams can introduce agent workflows, context discovery, and localisation intelligence while continuing to use systems such as Crowdin, Phrase, or Lokalise for established translation and review processes.
+
+### Why Hyperlocalise is different
+
+Most localisation platforms begin with a central database of strings. Hyperlocalise begins with the work happening around those strings.
+
+A pull request contains information about what changed. A Slack request contains urgency and launch timing. A design explains where the text appears. A repository contains related components and product terminology. A previous release contains evidence about which translations were accepted or corrected.
+
+Hyperlocalise agents are designed to collect that information and attach it to the localisation workflow automatically.
+
+This reduces one of the most persistent causes of poor localisation: translators receiving isolated strings with little explanation of what they mean.
+
+### Built for product release velocity
+
+Hyperlocalise connects localisation work with product changes rather than treating it as a separate downstream process.
+
+Its product direction includes:
+
+* Agent-native translation, review, and synchronisation workflows
+* Automatic discovery of context from repositories and connected tools
+* A next-generation CAT environment with human review
+* Support for different AI model providers
+* Compatibility with existing TMS platforms
+* Translation evaluations and regression checks
+* Locale readiness information for release decisions
+* Shared localisation knowledge that improves over time
+
+The objective is not simply to translate more words. It is to help localisation teams keep pace with continuous product development while maintaining market quality.
+
+### Best suited to
+
+Hyperlocalise is particularly well suited to:
+
+* Software companies releasing frequently across multiple markets
+* Product teams whose localisation managers are overwhelmed by coordination work
+* Companies already using a TMS but wanting more capable AI automation
+* Teams that struggle to provide translators with screenshots and product context
+* Organisations that want to use multiple AI models without becoming dependent on one provider
+* Teams that need better visibility into whether each locale is genuinely ready
+
+### Important consideration
+
+Hyperlocalise is newer than the established TMS vendors in this comparison, and parts of the platform are still being introduced through early access and pilot programmes. Companies that require a long-established procurement footprint may prefer Phrase, Crowdin, Lokalise, or LILT.
+
+For teams willing to adopt an agent-native operating model, however, Hyperlocalise offers the clearest vision of localisation as an intelligent product workflow rather than a translation queue.
+
+## 2. Crowdin: Best for developer integrations and extensibility
+
+Crowdin is one of the strongest options for developer-led localisation.
+
+Its core platform supports Git-based workflows, branching, APIs, command-line tools, translation memory, glossaries, quality checks, in-context previews, and support for more than 100 file formats. Its marketplace includes hundreds of applications and integrations across repositories, design systems, content platforms, documentation tools, and automation services.
+
+That ecosystem makes Crowdin especially attractive to teams that want to assemble a localisation workflow around their existing engineering stack.
+
+### Crowdin’s approach to AI
+
+Crowdin allows teams to use machine translation and large language model providers including OpenAI, Anthropic, Azure AI, DeepL, and Google. Teams can provide glossaries, translation memories, style instructions, and additional context to improve generated translations.
+
+Its Context Harvester is intended to collect product context, while AI-assisted proofreading and quality checks support the review process. Crowdin has also introduced Crowdin Copilot, an AI assistant embedded inside the platform with access to project and organisational operations. At the time of writing, Crowdin describes Copilot as an early-stage product whose behaviour may continue to change.
+
+### Where Crowdin performs well
+
+Crowdin is particularly strong when product localisation is closely connected to software delivery.
+
+Developers can synchronise content from repositories, organise translations around branches, automate imports and exports, and return completed translations to the codebase. Teams can also extend the platform through its marketplace instead of waiting for every workflow to become a native product feature.
+
+This makes Crowdin a practical choice for:
+
+* Developer-led product companies
+* Open-source projects
+* Teams with complex integration requirements
+* Companies that want control over their AI providers
+* Organisations managing software, documentation, websites, and community translation together
+
+### Where Hyperlocalise has an advantage
+
+Crowdin provides a highly capable localisation platform and a broad collection of AI tools. Hyperlocalise places greater emphasis on agents coordinating work across systems, discovering context from the source environment, and evaluating release readiness across an existing localisation stack.
+
+For teams that want a central and extensible TMS, Crowdin remains a strong choice. For teams that want an intelligent layer working across their TMS, repository, product context, reviewers, and release process, Hyperlocalise offers a more agent-native approach.
+
+## 3. Phrase: Best for complex enterprise localisation programmes
+
+Phrase offers one of the broadest localisation technology portfolios in the market.
+
+Phrase Strings is designed for software, application, and website localisation, while Phrase TMS supports enterprise translation management, vendor workflows, linguistic assets, and high-volume content operations. These capabilities now sit within what Phrase describes as a Language Intelligence Platform.
+
+For large organisations, the combination can support product interfaces, documentation, marketing content, multimedia, and enterprise translation operations within one ecosystem.
+
+### Phrase’s approach to AI
+
+Phrase focuses heavily on AI orchestration.
+
+Its platform can select from multiple machine translation engines and language models based on content type, cost, and quality requirements. Teams can also connect their own engines. Translation memories, terminology, style guides, and other linguistic resources can be supplied as context, while quality estimation helps determine which content requires additional attention.
+
+Phrase has also invested in APIs, software development kits, command-line workflows, webhooks, branching, MCP connectivity, and agent-to-agent interaction. This makes the platform increasingly relevant to engineering and AI teams as well as traditional localisation departments.
+
+### Where Phrase performs well
+
+Phrase is a strong option for organisations that need:
+
+* Enterprise governance and permissions
+* A combined software localisation and TMS ecosystem
+* Vendor and linguist management
+* AI engine selection and orchestration
+* Quality estimation and reporting
+* APIs and custom integrations
+* Support for many content types and business departments
+* A large partner and services ecosystem
+
+Its breadth can be valuable when localisation spans multiple divisions, vendors, systems, and content formats.
+
+### Important consideration
+
+That breadth can also introduce complexity.
+
+A product team primarily trying to localise an application may not need the complete enterprise environment. Phrase is generally most compelling when the company has a mature localisation function, substantial content volume, formal governance requirements, or several departments sharing localisation infrastructure.
+
+Hyperlocalise takes a more focused approach. It is intended to add intelligent agents, context, evaluation, and release coordination around product localisation without requiring teams to consolidate every localisation function into one large platform.
+
+## 4. Lokalise: Best for collaborative product and design workflows
+
+Lokalise has built a strong position among software companies by making localisation accessible to developers, designers, product managers, and translators.
+
+Its product workflows include repository integrations, APIs, command-line tools, webhooks, mobile SDKs, over-the-air updates, automation, task management, dashboards, and visual review. Its design capabilities include a native Figma integration, screenshots, previews, character limits, and pseudo-localisation for identifying interface problems before release.
+
+These features make Lokalise especially useful when product and design teams want to participate directly in localisation rather than handing everything to a separate department.
+
+### Lokalise’s approach to AI
+
+Lokalise provides AI translation using project context such as glossaries, style guides, instructions, and previous translations. It also offers AI-generated suggestions, automated quality evaluation, and workflows that can route content for human review.
+
+The company is expanding into agentic workflows through an MCP server and AI agents capable of performing administrative actions such as creating projects, assigning roles, and coordinating tasks. Some of these capabilities were still described as beta or early-access features in Lokalise’s 2026 product updates.
+
+### Where Lokalise performs well
+
+Lokalise is a strong choice for:
+
+* Product-led SaaS companies
+* Mobile application teams
+* Design-heavy product organisations
+* Teams that want localisation to begin in Figma
+* Companies that value an approachable central workspace
+* Teams that need over-the-air translation updates
+* Organisations bringing developers, designers, translators, and product managers into one process
+
+### Where Hyperlocalise has an advantage
+
+Lokalise is primarily the system in which localisation projects and strings are managed. Hyperlocalise is designed to act as an intelligence and agent layer across the systems where product and localisation work already happens.
+
+This distinction matters for teams that already have a TMS or do not want another migration.
+
+Rather than asking every participant to move into a new central workflow, Hyperlocalise aims to gather knowledge from repositories, requests, AI assistants, and localisation systems, then coordinate the necessary work while preserving human review.
+
+## 5. LILT: Best for adaptive AI with human validation
+
+LILT is a strong option for enterprise organisations that want AI translation combined with professional linguistic services and human validation.
+
+Its adaptive AI models learn from brand terminology, domain data, and human corrections. LILT states that feedback from human verification can be applied continuously so that models adapt as work progresses. The platform can also match different models to different tasks and fine-tune models using customer data.
+
+This approach is valuable for organisations with large volumes of specialised content where model adaptation and professional linguistic oversight are central requirements.
+
+### LILT’s approach to product localisation
+
+LILT positions its platform as supporting end-to-end global launches, including interface strings, advertising, documentation, packaging, and support content. It combines AI-generated translation with expert review and connects with content, design, marketing, and product systems.
+
+LILT Assist extends this model with an enterprise AI agent that can support translation requests, operational tasks, reporting, and localisation management across departments. Product and engineering teams can use it to incorporate localisation into development workflows.
+
+### Where LILT performs well
+
+LILT is particularly suitable for:
+
+* Large enterprises with substantial translation volume
+* Regulated or specialised content
+* Organisations that want AI technology and linguistic services together
+* Teams that value continuously adapting models
+* Companies requiring human validation across major launches
+* Enterprise localisation programmes that prefer a managed engagement
+
+### Important consideration
+
+LILT’s model may be less appropriate for a small product team seeking a lightweight, self-service software localisation environment.
+
+Its strongest proposition combines enterprise AI, workflow technology, linguistic expertise, and service delivery. Teams primarily looking for repository-first localisation management may find Crowdin or Lokalise more immediately familiar. Teams seeking an agent layer across their existing stack may prefer Hyperlocalise.
+
+## Why AI translation alone is not enough
+
+Many platforms now offer access to capable language models. That does not make every platform equally effective for product localisation.
+
+A model can generate a fluent translation and still make the wrong product decision.
+
+It may misunderstand whether “Save” is a verb or noun. It may translate a feature name that should remain in English. It may use terminology approved for marketing but prohibited inside the product. It may produce text that overflows a mobile interface or contradicts an earlier onboarding step.
+
+The challenge is not merely generating language. It is giving the AI enough knowledge to make the correct decision, then verifying that decision within the broader product experience.
+
+Product teams should therefore evaluate how a platform handles:
+
+* Repository and interface context
+* Screenshots and visual references
+* Terminology and style guidance
+* Previous translations
+* Market-specific rules
+* Human feedback
+* Automated quality checks
+* Translation regressions
+* Synchronisation with source systems
+* Release blockers and locale readiness
+
+The model is only one component. The surrounding context, workflow, knowledge, and quality system determine whether AI localisation is reliable at scale.
+
+## How to choose the right AI localisation platform
+
+The right platform depends on the operating model you want to build.
+
+### Choose Hyperlocalise when you want an agentic layer across your stack
+
+Hyperlocalise is the strongest fit when your main problem is not storing translations, but coordinating context, AI work, human review, existing TMS platforms, and multilingual releases.
+
+It is particularly relevant when you want to improve your localisation capability without immediately replacing your current infrastructure.
+
+### Choose Crowdin when developer extensibility is the priority
+
+Crowdin is a strong choice when engineers want extensive integrations, branching, APIs, a marketplace, and flexibility over how the localisation system is assembled.
+
+### Choose Phrase when you need enterprise breadth and governance
+
+Phrase is best considered when localisation spans multiple departments, vendors, content types, and governance requirements. It provides a broad enterprise environment, although smaller teams should determine whether they need its full scope.
+
+### Choose Lokalise when product and design collaboration is the priority
+
+Lokalise is compelling when designers, developers, product managers, and translators need to work inside one approachable system, especially when Figma and mobile application workflows are important.
+
+### Choose LILT when you want adaptive AI and managed human expertise
+
+LILT is well suited to enterprises that want custom AI models, continuous learning, expert validation, and service delivery as part of the same localisation programme.
+
+## Questions to ask during an AI localisation platform evaluation
+
+Before selecting a platform, test it against real content from an upcoming release.
+
+Ask each vendor:
+
+1. How does the platform discover what a string means?
+2. Can it use repository, screenshot, design, and product context?
+3. Can we use our preferred models or bring our own model provider?
+4. Can it work with our current TMS?
+5. How does human feedback improve future translations?
+6. How are high-risk translations routed for review?
+7. Can the platform identify regressions between releases?
+8. Can developers trigger localisation from CI/CD workflows?
+9. Can product managers see what is blocking each locale?
+10. How does the platform measure quality beyond translation completion?
+11. Can we trace why the AI made a particular decision?
+12. What happens when terminology or product context changes?
+
+A polished demonstration is useful, but a pilot using real product content will reveal much more about context quality, integration effort, reviewer experience, and release reliability.
+
+## The future of product localisation is agentic
+
+The localisation platform category is changing.
+
+Translation management systems will continue to provide important infrastructure, including linguistic assets, permissions, workflows, translation editors, and content storage. AI models will continue to improve the speed and fluency of first drafts.
+
+The next major shift is the layer connecting those capabilities.
+
+AI agents can gather context before translation begins, create and coordinate work, identify content that requires human judgement, synchronise changes between systems, and monitor whether every market is prepared for release.
+
+That changes localisation from a downstream service into a continuous product capability.
+
+For product teams that want to adopt this model while keeping human expertise and existing localisation infrastructure, Hyperlocalise is our number-one AI localisation platform for 2026.
+
+It is not simply using AI to translate faster. It is building an AI workforce that helps localisation teams understand more, coordinate less, and launch products in every market with greater confidence.
+
+## Frequently asked questions
+
+### What is an AI localisation platform?
+
+An AI localisation platform helps teams adapt products and content for different languages and markets using artificial intelligence.
+
+Depending on the platform, this can include translation generation, terminology application, quality evaluation, workflow automation, context collection, task assignment, human review, synchronisation, and reporting.
+
+### What is the best AI localisation platform for product teams?
+
+Hyperlocalise is our top choice for product teams that want agent-native workflows, automatic context discovery, human review, TMS interoperability, and release-focused quality intelligence.
+
+Crowdin, Phrase, Lokalise, and LILT remain strong choices for teams with different requirements.
+
+### Can AI replace a localisation team?
+
+AI can automate large amounts of translation and operational work, but it should not eliminate human ownership.
+
+Localisation professionals provide market judgement, cultural knowledge, brand interpretation, risk assessment, and strategic direction. The most effective platforms use AI to increase the capacity of localisation teams rather than treating human expertise as unnecessary.
+
+### Do we need to replace our existing TMS to use AI localisation?
+
+Not necessarily.
+
+Some organisations will benefit from moving to a platform with more capable native AI. Others can introduce an intelligence and agent layer that works with their current TMS.
+
+Hyperlocalise is specifically designed around the second approach, allowing teams to introduce agentic localisation workflows without rebuilding their entire operating model.
+
+### What is the difference between AI translation and AI localisation?
+
+AI translation focuses on converting text from one language into another.
+
+AI localisation considers the broader product and market context, including terminology, intent, user experience, interface constraints, tone, cultural expectations, workflows, quality checks, and release requirements.
+
+Translation is one task inside localisation. A complete AI localisation platform must support the decisions and operations surrounding it.

--- a/apps/hyperlocalise-web/_posts/en/best-ai-localisation-platforms-for-product-teams-in-2026.md
+++ b/apps/hyperlocalise-web/_posts/en/best-ai-localisation-platforms-for-product-teams-in-2026.md
@@ -111,14 +111,14 @@ Hyperlocalise connects localisation work with product changes rather than treati
 
 Its product direction includes:
 
-* Agent-native translation, review, and synchronisation workflows
-* Automatic discovery of context from repositories and connected tools
-* A next-generation CAT environment with human review
-* Support for different AI model providers
-* Compatibility with existing TMS platforms
-* Translation evaluations and regression checks
-* Locale readiness information for release decisions
-* Shared localisation knowledge that improves over time
+- Agent-native translation, review, and synchronisation workflows
+- Automatic discovery of context from repositories and connected tools
+- A next-generation CAT environment with human review
+- Support for different AI model providers
+- Compatibility with existing TMS platforms
+- Translation evaluations and regression checks
+- Locale readiness information for release decisions
+- Shared localisation knowledge that improves over time
 
 The objective is not simply to translate more words. It is to help localisation teams keep pace with continuous product development while maintaining market quality.
 
@@ -126,12 +126,12 @@ The objective is not simply to translate more words. It is to help localisation 
 
 Hyperlocalise is particularly well suited to:
 
-* Software companies releasing frequently across multiple markets
-* Product teams whose localisation managers are overwhelmed by coordination work
-* Companies already using a TMS but wanting more capable AI automation
-* Teams that struggle to provide translators with screenshots and product context
-* Organisations that want to use multiple AI models without becoming dependent on one provider
-* Teams that need better visibility into whether each locale is genuinely ready
+- Software companies releasing frequently across multiple markets
+- Product teams whose localisation managers are overwhelmed by coordination work
+- Companies already using a TMS but wanting more capable AI automation
+- Teams that struggle to provide translators with screenshots and product context
+- Organisations that want to use multiple AI models without becoming dependent on one provider
+- Teams that need better visibility into whether each locale is genuinely ready
 
 ### Important consideration
 
@@ -161,11 +161,11 @@ Developers can synchronise content from repositories, organise translations arou
 
 This makes Crowdin a practical choice for:
 
-* Developer-led product companies
-* Open-source projects
-* Teams with complex integration requirements
-* Companies that want control over their AI providers
-* Organisations managing software, documentation, websites, and community translation together
+- Developer-led product companies
+- Open-source projects
+- Teams with complex integration requirements
+- Companies that want control over their AI providers
+- Organisations managing software, documentation, websites, and community translation together
 
 ### Where Hyperlocalise has an advantage
 
@@ -193,14 +193,14 @@ Phrase has also invested in APIs, software development kits, command-line workfl
 
 Phrase is a strong option for organisations that need:
 
-* Enterprise governance and permissions
-* A combined software localisation and TMS ecosystem
-* Vendor and linguist management
-* AI engine selection and orchestration
-* Quality estimation and reporting
-* APIs and custom integrations
-* Support for many content types and business departments
-* A large partner and services ecosystem
+- Enterprise governance and permissions
+- A combined software localisation and TMS ecosystem
+- Vendor and linguist management
+- AI engine selection and orchestration
+- Quality estimation and reporting
+- APIs and custom integrations
+- Support for many content types and business departments
+- A large partner and services ecosystem
 
 Its breadth can be valuable when localisation spans multiple divisions, vendors, systems, and content formats.
 
@@ -230,13 +230,13 @@ The company is expanding into agentic workflows through an MCP server and AI age
 
 Lokalise is a strong choice for:
 
-* Product-led SaaS companies
-* Mobile application teams
-* Design-heavy product organisations
-* Teams that want localisation to begin in Figma
-* Companies that value an approachable central workspace
-* Teams that need over-the-air translation updates
-* Organisations bringing developers, designers, translators, and product managers into one process
+- Product-led SaaS companies
+- Mobile application teams
+- Design-heavy product organisations
+- Teams that want localisation to begin in Figma
+- Companies that value an approachable central workspace
+- Teams that need over-the-air translation updates
+- Organisations bringing developers, designers, translators, and product managers into one process
 
 ### Where Hyperlocalise has an advantage
 
@@ -264,12 +264,12 @@ LILT Assist extends this model with an enterprise AI agent that can support tran
 
 LILT is particularly suitable for:
 
-* Large enterprises with substantial translation volume
-* Regulated or specialised content
-* Organisations that want AI technology and linguistic services together
-* Teams that value continuously adapting models
-* Companies requiring human validation across major launches
-* Enterprise localisation programmes that prefer a managed engagement
+- Large enterprises with substantial translation volume
+- Regulated or specialised content
+- Organisations that want AI technology and linguistic services together
+- Teams that value continuously adapting models
+- Companies requiring human validation across major launches
+- Enterprise localisation programmes that prefer a managed engagement
 
 ### Important consideration
 
@@ -289,16 +289,16 @@ The challenge is not merely generating language. It is giving the AI enough know
 
 Product teams should therefore evaluate how a platform handles:
 
-* Repository and interface context
-* Screenshots and visual references
-* Terminology and style guidance
-* Previous translations
-* Market-specific rules
-* Human feedback
-* Automated quality checks
-* Translation regressions
-* Synchronisation with source systems
-* Release blockers and locale readiness
+- Repository and interface context
+- Screenshots and visual references
+- Terminology and style guidance
+- Previous translations
+- Market-specific rules
+- Human feedback
+- Automated quality checks
+- Translation regressions
+- Synchronisation with source systems
+- Release blockers and locale readiness
 
 The model is only one component. The surrounding context, workflow, knowledge, and quality system determine whether AI localisation is reliable at scale.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds a new English Product blog post comparing five AI localisation platforms for product teams (Hyperlocalise, Crowdin, Phrase, Lokalise, and LILT), dated 25 July 2026.

- File: `apps/hyperlocalise-web/_posts/en/best-ai-localisation-platforms-for-product-teams-in-2026.md`
- Slug: `best-ai-localisation-platforms-for-product-teams-in-2026`
- Locale translations can follow the usual sync process
- Follow-up: ran `vp check --fix` so Oxfmt list style matches CI (`*` → `-`)

## How to test

- Confirm the post appears first on `/en/blog` with the 25 July 2026 date and excerpt
- Open `/en/blog/best-ai-localisation-platforms-for-product-teams-in-2026` and verify headings, comparison table, lists, and FAQ render correctly
- Spot-check mobile layout for the comparison table
- Local verification: `vp check --fix` (passed after formatter fix)

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61d5a9c2-f1a2-4345-a19d-b88b1666ace4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61d5a9c2-f1a2-4345-a19d-b88b1666ace4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

