### PR TITLE
feat(blog): Should You Build Your Own Localisation Agent?

### DIFF
--- a/apps/hyperlocalise-web/_posts/en/should-you-build-your-own-localisation-agent.md
+++ b/apps/hyperlocalise-web/_posts/en/should-you-build-your-own-localisation-agent.md
@@ -29,7 +29,7 @@ The answer depends on what you are actually trying to build.
 
 A prototype that generates translated text is relatively straightforward. A dependable localisation agent that understands product context, follows market-specific guidance, protects variables, works across your existing systems and improves through human feedback is a much larger undertaking.
 
-The important question is not whether your team *can* build a localisation agent. It is whether owning and operating that system will create enough strategic value to justify the continuing investment.
+The important question is not whether your team _can_ build a localisation agent. It is whether owning and operating that system will create enough strategic value to justify the continuing investment.
 
 ## A localisation agent is more than an AI translator
 
@@ -39,15 +39,15 @@ OpenAI describes agents as systems that combine models with instructions, tools 
 
 Applied to localisation, that means an effective agent must do considerably more than call a translation model. It needs to:
 
-* retrieve relevant product, brand and market context;
-* apply terminology, style guides and previous translation decisions;
-* preserve placeholders, formatting, markup and technical constraints;
-* distinguish between content that requires translation, transcreation or no change;
-* coordinate reviews, approvals and revisions;
-* synchronise work with repositories, content systems and translation platforms;
-* explain why it made a decision;
-* escalate uncertainty to the right person; and
-* learn from reviewer feedback without repeating previous mistakes.
+- retrieve relevant product, brand and market context;
+- apply terminology, style guides and previous translation decisions;
+- preserve placeholders, formatting, markup and technical constraints;
+- distinguish between content that requires translation, transcreation or no change;
+- coordinate reviews, approvals and revisions;
+- synchronise work with repositories, content systems and translation platforms;
+- explain why it made a decision;
+- escalate uncertainty to the right person; and
+- learn from reviewer feedback without repeating previous mistakes.
 
 This distinction matters because a team can build the translation step and believe it has built the complete system. In reality, translation generation may be one of the easier components.
 
@@ -151,13 +151,13 @@ The build-versus-buy decision should therefore be based on strategic differentia
 
 Building internally may be the right decision when most of the following conditions are true:
 
-* Localisation intelligence is fundamental to your company’s core product or competitive advantage.
-* Your workflows are sufficiently specialised that existing platforms cannot support them through configuration or integration.
-* You have a dedicated, long-term engineering team responsible for the system.
-* You have access to localisation specialists who can design evaluations and guide product decisions.
-* Your security, deployment or data requirements cannot be met by external providers.
-* Your content volume and operational scale can justify the complete cost of ownership.
-* Your organisation is prepared to maintain integrations, evaluations and governance continuously.
+- Localisation intelligence is fundamental to your company’s core product or competitive advantage.
+- Your workflows are sufficiently specialised that existing platforms cannot support them through configuration or integration.
+- You have a dedicated, long-term engineering team responsible for the system.
+- You have access to localisation specialists who can design evaluations and guide product decisions.
+- Your security, deployment or data requirements cannot be met by external providers.
+- Your content volume and operational scale can justify the complete cost of ownership.
+- Your organisation is prepared to maintain integrations, evaluations and governance continuously.
 
 In that situation, the system should be treated as a strategic platform rather than an internal experiment.
 
@@ -183,24 +183,24 @@ Many companies should own their localisation knowledge while using a specialised
 
 Your organisation can own:
 
-* brand and market strategy;
-* terminology and style guidance;
-* product and customer context;
-* approval policies;
-* quality expectations;
-* human reviewer relationships; and
-* the final decision about what is released.
+- brand and market strategy;
+- terminology and style guidance;
+- product and customer context;
+- approval policies;
+- quality expectations;
+- human reviewer relationships; and
+- the final decision about what is released.
 
 A platform can provide:
 
-* model orchestration;
-* context retrieval;
-* integrations;
-* workflow automation;
-* evaluation infrastructure;
-* observability;
-* permissions and auditability; and
-* continuing adaptation as models and localisation practices evolve.
+- model orchestration;
+- context retrieval;
+- integrations;
+- workflow automation;
+- evaluation infrastructure;
+- observability;
+- permissions and auditability; and
+- continuing adaptation as models and localisation practices evolve.
 
 This allows the company to preserve the knowledge that creates differentiation without rebuilding the technical plumbing required to make that knowledge usable.
 

--- a/apps/hyperlocalise-web/_posts/en/should-you-build-your-own-localisation-agent.md
+++ b/apps/hyperlocalise-web/_posts/en/should-you-build-your-own-localisation-agent.md
@@ -1,0 +1,247 @@
+---
+title: Should You Build Your Own Localisation Agent?
+date: 2026-07-25T00:00:00.000Z
+excerpt: An impressive AI translation demo is easy to build. A dependable localisation agent that understands context, protects product integrity, and improves through human feedback is a much larger undertaking. Here is how to decide whether to build or buy.
+category: Product
+tags:
+  - localisation agent
+  - localization agent
+  - AI localisation
+  - AI localization
+  - build vs buy
+  - agentic workflows
+  - context-aware localisation
+  - translation intelligence
+  - product localisation
+  - human review
+  - TMS interoperability
+  - evaluation
+  - AI agents
+---
+
+It has never been easier to build an impressive AI translation demo.
+
+Connect a large language model to a repository, give it a glossary and ask it to translate a set of strings. Within days, a product team can have something that looks like a localisation agent. It may produce fluent translations, respond to instructions and even open pull requests automatically.
+
+That early progress can make the next decision seem obvious: why pay for a localisation platform when your engineering team can build an agent internally?
+
+The answer depends on what you are actually trying to build.
+
+A prototype that generates translated text is relatively straightforward. A dependable localisation agent that understands product context, follows market-specific guidance, protects variables, works across your existing systems and improves through human feedback is a much larger undertaking.
+
+The important question is not whether your team *can* build a localisation agent. It is whether owning and operating that system will create enough strategic value to justify the continuing investment.
+
+## A localisation agent is more than an AI translator
+
+An AI translator receives text and returns text in another language. A localisation agent operates across a workflow.
+
+OpenAI describes agents as systems that combine models with instructions, tools and guardrails so they can complete tasks on a user’s behalf. Anthropic similarly recommends beginning with simple, composable workflows rather than adding unnecessary agent complexity.
+
+Applied to localisation, that means an effective agent must do considerably more than call a translation model. It needs to:
+
+* retrieve relevant product, brand and market context;
+* apply terminology, style guides and previous translation decisions;
+* preserve placeholders, formatting, markup and technical constraints;
+* distinguish between content that requires translation, transcreation or no change;
+* coordinate reviews, approvals and revisions;
+* synchronise work with repositories, content systems and translation platforms;
+* explain why it made a decision;
+* escalate uncertainty to the right person; and
+* learn from reviewer feedback without repeating previous mistakes.
+
+This distinction matters because a team can build the translation step and believe it has built the complete system. In reality, translation generation may be one of the easier components.
+
+The harder problem is creating a reliable operating layer around it.
+
+## Why building your own agent is appealing
+
+There are legitimate reasons to consider an internal localisation agent.
+
+The most obvious is control. Your team can decide exactly which models to use, how prompts are structured, where data is processed and how the agent interacts with internal systems. You are not constrained by another company’s product roadmap or assumptions about how localisation should work.
+
+Building internally can also make sense when your workflow is genuinely unusual. A gaming company with narrative branching, a regulated medical platform or a business with a proprietary content architecture may have requirements that general-purpose tools cannot support cleanly.
+
+There is also a strategic argument. When localisation technology is central to your product rather than an operational function, the underlying intelligence may become valuable intellectual property. A language-learning company, multilingual search provider or AI communication product may reasonably decide that localisation capabilities belong inside its core platform.
+
+At sufficient scale, an internal system could also reduce certain vendor costs. However, this comparison is often made using model API expenses alone. The true cost includes the engineering, infrastructure and operational work required to keep the system dependable.
+
+Control is valuable, but control also means ownership.
+
+## The hidden scope of building a localisation agent
+
+The first internal version may only require a model, a prompt and access to source strings. Production use introduces a much larger set of responsibilities.
+
+### 1. Building the context layer
+
+Translation quality depends heavily on context. The agent may need to understand where a message appears, which user action triggered it, what surrounding interface elements say and whether the content belongs to onboarding, billing, support or marketing.
+
+That information is usually scattered across design files, repositories, product documentation, screenshots, analytics, tickets and conversations. Building an agent therefore requires more than prompt engineering. It requires a context retrieval system that can identify the right information for each translation task without overwhelming the model with irrelevant data.
+
+The context must also stay current. A screenshot from an earlier interface, an outdated glossary entry or an obsolete product description can produce a confident but incorrect translation.
+
+This becomes a data architecture problem: what information should be indexed, who owns it, how is it updated and which sources should the agent trust when they conflict?
+
+### 2. Supporting localisation-specific formats
+
+Product content is not always plain text.
+
+Localisation systems must handle placeholders, plurals, variables, tags, character limits and structured file formats without corrupting them. XLIFF, for example, exists to carry localisable content between different stages and tools in a localisation workflow. Unicode’s MessageFormat specification addresses dynamic messages involving variables, plural rules, grammatical matching, dates and numbers.
+
+A translation can sound perfectly natural while still breaking the product because the model moved a placeholder incorrectly, translated a variable, removed markup or misunderstood how a plural branch works.
+
+Your agent therefore needs deterministic validation alongside generative intelligence. Fluency alone is not enough.
+
+### 3. Creating a meaningful evaluation system
+
+Localisation quality cannot be measured with a single pass-or-fail test.
+
+A production evaluation framework may need to assess meaning preservation, terminology, tone, grammar, cultural suitability, formatting integrity, length restrictions and consistency with related content. Different content types also require different standards. A legal notice should not be evaluated in the same way as a campaign headline or a conversational interface message.
+
+Automated evaluations can detect many problems, but they must be calibrated against human judgement. Your team needs representative test sets, expected outcomes, language-specific reviewers and a method for measuring whether changes to prompts, models or context retrieval improve the system.
+
+Without this layer, a model upgrade can silently improve one language while reducing quality in another.
+
+### 4. Integrating the entire workflow
+
+An agent becomes useful when it can act inside the systems where localisation work already happens.
+
+That may include GitHub, design tools, content management systems, customer support platforms, product databases, translation management systems and internal approval workflows. Each integration needs authentication, permission handling, retry logic, error recovery, monitoring and maintenance.
+
+The workflow must also account for partial failures. What happens when the agent translates 900 strings successfully but cannot process the remaining 100? What happens when content changes during review? Can reviewers see which context influenced the result? Can an approved translation be traced to a particular model, instruction set and source version?
+
+These are product and infrastructure concerns, not merely AI concerns.
+
+### 5. Protecting sensitive data and systems
+
+A localisation agent may be given access to unreleased product features, customer communications, internal documentation and proprietary terminology. If it can take actions, it may also have permission to modify content or push changes into production workflows.
+
+OWASP identifies prompt injection and insecure output handling among the major risks facing applications built with large language models. A malicious or accidental instruction inside retrieved content can influence an agent, while unvalidated output can create downstream security problems.
+
+A production system needs strict permission boundaries, input and output validation, audit logs, data-retention controls and clear rules governing which actions can be automated. Higher-risk changes may require explicit human approval.
+
+NIST’s AI Risk Management Framework also emphasises that trustworthy AI requires continuing governance, measurement and risk management rather than a one-time technical review.
+
+### 6. Maintaining the agent after launch
+
+Models change. Prices change. APIs change. Product terminology evolves. New markets introduce new linguistic requirements. Integrations break, security expectations increase and users discover edge cases that were invisible during development.
+
+The agent therefore needs an ongoing owner.
+
+That owner is not simply maintaining code. They are managing the relationship between models, workflows, organisational knowledge and human reviewers. They must investigate failures, improve evaluations, update instructions and decide when new capabilities are safe enough to release.
+
+A localisation agent is not a project that ends when the first version ships. It becomes an internal product.
+
+## The real build-versus-buy calculation
+
+The cost of an internally built agent is not simply:
+
+> Model usage + a few weeks of engineering
+
+A more realistic calculation is:
+
+> Initial development + integrations + context infrastructure + evaluation systems + security + observability + ongoing maintenance + localisation expertise + opportunity cost
+
+Opportunity cost is especially important.
+
+Every engineer working on localisation infrastructure is not working on the company’s core product. That investment may be worthwhile when the localisation system creates a durable competitive advantage. It is harder to justify when the objective is simply to help the localisation team release content faster.
+
+The build-versus-buy decision should therefore be based on strategic differentiation, not whether a prototype appears inexpensive.
+
+## When building your own localisation agent makes sense
+
+Building internally may be the right decision when most of the following conditions are true:
+
+* Localisation intelligence is fundamental to your company’s core product or competitive advantage.
+* Your workflows are sufficiently specialised that existing platforms cannot support them through configuration or integration.
+* You have a dedicated, long-term engineering team responsible for the system.
+* You have access to localisation specialists who can design evaluations and guide product decisions.
+* Your security, deployment or data requirements cannot be met by external providers.
+* Your content volume and operational scale can justify the complete cost of ownership.
+* Your organisation is prepared to maintain integrations, evaluations and governance continuously.
+
+In that situation, the system should be treated as a strategic platform rather than an internal experiment.
+
+The team should define ownership, reliability targets, approval boundaries and evaluation criteria before expanding automation. It should also resist building a complex multi-agent architecture before simpler workflows have been proven.
+
+## When using a localisation agent platform makes more sense
+
+A platform is usually the stronger choice when localisation supports the business but is not itself the business.
+
+This is particularly true when the primary goal is to improve translation quality, shorten release cycles or reduce operational workload without creating a new internal infrastructure team.
+
+A specialised platform can provide the context layer, workflow orchestration, integrations, quality controls and review experience that would otherwise need to be developed internally. Your localisation team can focus on market decisions and quality rather than maintaining AI infrastructure.
+
+This does not require giving up control. The right platform should let you retain ownership of terminology, style, review policies, translation memory and approval decisions. It should also provide visibility into what the agent is doing, what information it used and where human judgement is required.
+
+It should work with your existing localisation stack rather than forcing an immediate migration. As we explored in [How to Add AI Translation Without Replacing Your TMS](/blog/how-to-add-ai-translation-without-replacing-tms), an agent can add intelligence across an existing workflow without requiring the organisation to discard the systems and processes it already relies on.
+
+## The hybrid approach is often the strongest
+
+The decision does not have to be completely binary.
+
+Many companies should own their localisation knowledge while using a specialised platform to operationalise it.
+
+Your organisation can own:
+
+* brand and market strategy;
+* terminology and style guidance;
+* product and customer context;
+* approval policies;
+* quality expectations;
+* human reviewer relationships; and
+* the final decision about what is released.
+
+A platform can provide:
+
+* model orchestration;
+* context retrieval;
+* integrations;
+* workflow automation;
+* evaluation infrastructure;
+* observability;
+* permissions and auditability; and
+* continuing adaptation as models and localisation practices evolve.
+
+This allows the company to preserve the knowledge that creates differentiation without rebuilding the technical plumbing required to make that knowledge usable.
+
+In other words, own your localisation intelligence. Be deliberate about whether you also need to own the infrastructure around it.
+
+## A practical decision framework
+
+Before approving an internal build, ask the following questions:
+
+| Question                                             | Stronger signal to build                                      | Stronger signal to use a platform                              |
+| ---------------------------------------------------- | ------------------------------------------------------------- | -------------------------------------------------------------- |
+| Is localisation technology part of the core product? | Yes, it directly differentiates the product                   | No, it supports product expansion                              |
+| Are the workflows genuinely unique?                  | Existing systems cannot support them                          | They can be handled through configuration or integration       |
+| Who will own the system after launch?                | A dedicated platform team                                     | A temporary project team or individual engineer                |
+| Can you evaluate quality across every target market? | You have language experts and evaluation infrastructure       | You primarily need proven workflows and human review           |
+| How quickly must the business see value?             | The company can invest over a longer horizon                  | The team needs operational improvement soon                    |
+| Are you prepared to maintain every integration?      | Integration ownership is strategically valuable               | Maintenance would distract from core product work              |
+| Does internal ownership create a durable advantage?  | Yes, the capability is difficult for competitors to reproduce | No, the main value comes from using the capability effectively |
+
+The last question is the most important.
+
+Custom technology is not automatically strategic technology. Sometimes a company builds something internally and assumes that ownership itself creates an advantage. In practice, the advantage usually comes from proprietary knowledge, distribution, customer insight or a distinctive operating model—not from maintaining another integration layer.
+
+## Do not build an agent simply because you can
+
+The rapid improvement of language models has lowered the barrier to experimentation, which is good for the localisation industry. More teams can test ideas, automate repetitive work and explore better ways to bring product context into translation.
+
+But lower development barriers can also hide the distance between a prototype and a dependable system.
+
+A convincing demo proves that a model can generate a translation. It does not prove that the system can manage context, preserve product integrity, support human reviewers, operate securely and improve across thousands of changes and multiple markets.
+
+Building your own localisation agent makes sense when owning that capability is strategically important enough to justify owning all of those responsibilities.
+
+For most product and localisation teams, the better path is to adopt an agentic platform that works with their existing tools, keeps human expertise central and gives them control over the knowledge that makes their product distinctive.
+
+That is the philosophy behind Hyperlocalise. We are building an AI workforce for localisation teams: agents that gather context, apply market knowledge, assist with translation and quality assurance, and help teams keep pace with product development without replacing the tools or people they already trust.
+
+The future of localisation will not be defined by who can send text to a language model. It will be defined by who can turn organisational knowledge and local expertise into a reliable, scalable way of working.
+
+## See Hyperlocalise’s localisation agents in action
+
+If you are weighing build versus buy, we can walk through how an agentic localisation workflow fits your stack, your review process, and the markets you need to support.
+
+[Get a Demo](https://calendar.app.google/gEiRwNvAZ1ERXvT26)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds a new English Product blog post, **Should You Build Your Own Localisation Agent?**, dated 2026-07-25.

The article covers build-vs-buy for localisation agents (prototype vs production scope, when to build, when a platform fits, hybrid ownership) and closes with a **Get a Demo** CTA to the existing demo calendar link. It also links to the related TMS-agnostic article via `/blog/how-to-add-ai-translation-without-replacing-tms`.

## How to test

- Confirm the post appears on `/en/blog` and opens at `/en/blog/should-you-build-your-own-localisation-agent`
- Confirm the in-article **Get a Demo** link opens `https://calendar.app.google/gEiRwNvAZ1ERXvT26`
- Confirm the related TMS article link resolves correctly
- Local checks run: `vp test src/lib/blog/` (pass), `vp check --fix` (pass)

## Checklist

- [x] I ran relevant checks locally (`vp test src/lib/blog/`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abaa4712-e141-409d-9fa1-e036db871619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abaa4712-e141-409d-9fa1-e036db871619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

