### PR TITLE
feat(web): show Support label on footer support button

### DIFF
--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -7421,7 +7421,7 @@
   },
   "UkpQmLO4C5": {
     "defaultMessage": "Support",
-    "description": "Tooltip label for the support email button in the app shell footer"
+    "description": "Label for the support email button in the app shell footer"
   },
   "UnPQUzFk+U": {
     "defaultMessage": "A billing FAQ update needs to reach twelve locales",

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.messages.ts
@@ -20,9 +20,9 @@ export const appShellFooterMessages = defineMessages({
     id: "ecG+jsddyC",
     description: "Accessible label for the support email button in the app shell footer",
   },
-  supportTooltip: {
+  supportLabel: {
     defaultMessage: "Support",
-    id: "UkpQmLO4C5",
-    description: "Tooltip label for the support email button in the app shell footer",
+    id: "VvLbwcYPHK",
+    description: "Label for the support email button in the app shell footer",
   },
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-footer.tsx
@@ -25,7 +25,6 @@ import {
 import { ChatDockErrorBoundary } from "@/components/app-shell/chat-dock/chat-dock-error-boundary";
 import { PlanUsageFooterControl } from "@/components/billing/plan-usage-summary";
 import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { SUPPORT_EMAIL } from "@/lib/support-contact";
 
 import { appShellFooterMessages } from "./app-shell-footer.messages";
@@ -56,23 +55,16 @@ export function AppShellFooter({
           {showPlan ? <PlanUsageFooterControl organizationSlug={organizationSlug} /> : null}
           <div className="ms-auto flex min-w-0 items-center gap-2">
             {showChatDock ? <ChatDockFooterControls organizationSlug={organizationSlug} /> : null}
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Button
-                    variant="ghost"
-                    size="icon-xs"
-                    render={<a href={`mailto:${SUPPORT_EMAIL}`} />}
-                    aria-label={intl.formatMessage(appShellFooterMessages.emailSupportAriaLabel)}
-                  >
-                    <HugeiconsIcon icon={CustomerSupportIcon} strokeWidth={2} />
-                  </Button>
-                }
-              />
-              <TooltipContent side="top" align="end">
-                <FormattedMessage {...appShellFooterMessages.supportTooltip} />
-              </TooltipContent>
-            </Tooltip>
+            <Button
+              variant="ghost"
+              size="xs"
+              className="gap-1.5 px-2"
+              render={<a href={`mailto:${SUPPORT_EMAIL}`} />}
+              aria-label={intl.formatMessage(appShellFooterMessages.emailSupportAriaLabel)}
+            >
+              <HugeiconsIcon icon={CustomerSupportIcon} strokeWidth={2} className="size-3.5" />
+              <FormattedMessage {...appShellFooterMessages.supportLabel} />
+            </Button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The app shell footer Support control was icon-only. It now shows the icon plus a **Support** label, matching nearby footer actions like New request / plan usage.

Also removed the redundant tooltip that only repeated “Support”, and updated the message description accordingly.

## How to test

- Open any authenticated org page and check the bottom-right footer control
- Confirm the support control reads “Support” (with icon) and still opens `mailto:minh@hyperlocalise.com`
- `vp test src/components/app-shell/app-shell-footer.test.tsx`
- `vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e23cd076-f7d8-4f01-b839-c66573b0c191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e23cd076-f7d8-4f01-b839-c66573b0c191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

