### PR TITLE
ci: skip full CI on draft PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ concurrency:
 jobs:
   go-lint:
     name: Go Lint
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - apps/hyperlocalise-web/**
       - .github/workflows/web.yml
@@ -20,8 +21,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  go-lint:
+    name: Go Lint
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Bootstrap Go toolchain
+        uses: ./.github/actions/go-bootstrap
+        with:
+          go-version-file: go.mod
+
+      - name: Verify formatting
+        run: |
+          make fmt
+          git diff --exit-code
+
+      - name: Lint
+        run: make lint
+
   action-self-test:
     name: Action Self Test
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
@@ -61,6 +85,7 @@ jobs:
 
   web-sync-cli-smoke-test:
     name: Web Sync CLI Smoke Test
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: blacksmith-4vcpu-ubuntu-2404
     defaults:
       run:
@@ -89,6 +114,7 @@ jobs:
 
   bazel-build-test:
     name: Bazel Build/Test
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
@@ -108,6 +134,7 @@ jobs:
 
   go-quality:
     name: Go Quality
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
@@ -118,14 +145,6 @@ jobs:
         uses: ./.github/actions/go-bootstrap
         with:
           go-version-file: go.mod
-
-      - name: Verify formatting
-        run: |
-          make fmt
-          git diff --exit-code
-
-      - name: Lint
-        run: make lint
 
       - name: Workspace tests
         run: make test-workspace

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -28,6 +28,9 @@ jobs:
   web-check:
     name: Hyperlocalise Web Check
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # drizzle-kit generate reads DATABASE_URL from config; no live DB needed.
+    env:
+      DATABASE_URL: postgres://hyperlocalise:hyperlocalise@127.0.0.1:5432/hyperlocalise?sslmode=disable
     defaults:
       run:
         working-directory: apps/hyperlocalise-web

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -2,6 +2,7 @@ name: Web CI
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - apps/hyperlocalise-web/**
       - .github/workflows/web.yml
@@ -19,9 +20,52 @@ concurrency:
   group: web-ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  CI: "true"
+  NODE_OPTIONS: --max-old-space-size=8192
+
 jobs:
-  hyperlocalise-web-build:
-    name: Hyperlocalise Web Build
+  web-check:
+    name: Hyperlocalise Web Check
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    defaults:
+      run:
+        working-directory: apps/hyperlocalise-web
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
+        with:
+          cache: true
+
+      - name: Install hyperlocalise-web dependencies
+        run: vp install --frozen-lockfile
+
+      - name: Check for Drizzle migration collisions
+        run: vp run db:check-migrations
+
+      - name: Check for Drizzle migration drift
+        run: |
+          set -euo pipefail
+          vp run db:generate
+          if [ -n "$(git status --porcelain drizzle)" ]; then
+            echo "::error::Drizzle schema and migrations are out of sync."
+            echo "Run 'vp run db:generate' locally and commit the generated files."
+            git status --porcelain drizzle
+            git --no-pager diff -- drizzle
+            exit 1
+          fi
+
+      - name: Check hyperlocalise-web
+        run: vp check
+
+  web-test-build:
+    name: Hyperlocalise Web Test/Build
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: blacksmith-4vcpu-ubuntu-2404
     services:
       postgres:
@@ -38,8 +82,6 @@ jobs:
           --health-timeout 5s
           --health-retries 12
     env:
-      CI: "true"
-      NODE_OPTIONS: --max-old-space-size=8192
       DATABASE_URL: postgres://hyperlocalise:hyperlocalise@127.0.0.1:5432/hyperlocalise?sslmode=disable
       OPENAI_API_KEY: test-openai-api-key
       NEXT_PUBLIC_WAITLIST_URL: https://example.com/waitlist
@@ -72,26 +114,8 @@ jobs:
       - name: Install hyperlocalise-web dependencies
         run: vp install --frozen-lockfile
 
-      - name: Check for Drizzle migration collisions
-        run: vp run db:check-migrations
-
-      - name: Check for Drizzle migration drift
-        run: |
-          set -euo pipefail
-          vp run db:generate
-          if [ -n "$(git status --porcelain drizzle)" ]; then
-            echo "::error::Drizzle schema and migrations are out of sync."
-            echo "Run 'vp run db:generate' locally and commit the generated files."
-            git status --porcelain drizzle
-            git --no-pager diff -- drizzle
-            exit 1
-          fi
-
       - name: Migrate hyperlocalise-web database
         run: vp run db:migrate
-
-      - name: Check hyperlocalise-web
-        run: vp check
 
       - name: Test hyperlocalise-web
         run: vp test

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -27,7 +27,6 @@ env:
 jobs:
   web-check:
     name: Hyperlocalise Web Check
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: blacksmith-4vcpu-ubuntu-2404
     defaults:
       run:

--- a/docs/adr/2026-07-26-draft-pr-ci-gating-design.md
+++ b/docs/adr/2026-07-26-draft-pr-ci-gating-design.md
@@ -8,30 +8,31 @@ PR is ready for review.
 
 ## Design
 
-Skip all CI jobs while a pull request is a draft. Run the full cheap and
-expensive suites on non-draft PRs and on pushes to `main`.
+On draft PRs, run only cheap checks for fast feedback. Skip expensive jobs
+until the PR is non-draft or the push is to `main`.
 
 Trigger `pull_request` with `opened`, `synchronize`, `reopened`, and
-`ready_for_review` so converting a draft to ready re-runs CI. Gate every job
-with:
+`ready_for_review` so converting a draft to ready re-runs the full suite.
+Gate expensive jobs with:
 
 ```yaml
 if: github.event_name == 'push' || github.event.pull_request.draft == false
 ```
 
-Split jobs for parallel feedback, not for different draft policies:
+Cheap jobs have no draft gate and always run when the workflow triggers.
 
-| Workflow | Cheap | Expensive |
+| Workflow | Cheap (draft + non-draft + main) | Expensive (non-draft + main) |
 |---|---|---|
 | `web.yml` | install, migration checks, `vp check` | Postgres, migrate, `vp test`, `vp run build` |
 | `ci.yml` | `make fmt`, `make lint` | Bazel, workspace tests, check-build, action self-test, sync smoke |
 
 Keep existing path filters and concurrency groups. Do not require a `run-ci`
-label; that remains an optional escape hatch later if drafts need forced runs.
+label; that remains an optional escape hatch later if drafts need forced
+expensive runs.
 
 ## Verification
 
-- Push to a draft PR: all jobs skipped.
+- Push to a draft PR: cheap jobs run; expensive jobs skip.
 - Mark the PR ready for review: cheap and expensive jobs run.
 - Further non-draft pushes: both job groups run again.
 - Push to `main`: both job groups run (subject to path filters).

--- a/docs/adr/2026-07-26-draft-pr-ci-gating-design.md
+++ b/docs/adr/2026-07-26-draft-pr-ci-gating-design.md
@@ -1,0 +1,37 @@
+# Draft PR CI gating
+
+## Context
+
+Draft PRs get many small pushes while iterating. Running full CI on every push
+burns Blacksmith minutes on Postgres, Bazel, tests, and Next builds before the
+PR is ready for review.
+
+## Design
+
+Skip all CI jobs while a pull request is a draft. Run the full cheap and
+expensive suites on non-draft PRs and on pushes to `main`.
+
+Trigger `pull_request` with `opened`, `synchronize`, `reopened`, and
+`ready_for_review` so converting a draft to ready re-runs CI. Gate every job
+with:
+
+```yaml
+if: github.event_name == 'push' || github.event.pull_request.draft == false
+```
+
+Split jobs for parallel feedback, not for different draft policies:
+
+| Workflow | Cheap | Expensive |
+|---|---|---|
+| `web.yml` | install, migration checks, `vp check` | Postgres, migrate, `vp test`, `vp run build` |
+| `ci.yml` | `make fmt`, `make lint` | Bazel, workspace tests, check-build, action self-test, sync smoke |
+
+Keep existing path filters and concurrency groups. Do not require a `run-ci`
+label; that remains an optional escape hatch later if drafts need forced runs.
+
+## Verification
+
+- Push to a draft PR: all jobs skipped.
+- Mark the PR ready for review: cheap and expensive jobs run.
+- Further non-draft pushes: both job groups run again.
+- Push to `main`: both job groups run (subject to path filters).


### PR DESCRIPTION
## What changed

Skip all CI jobs while a pull request is a draft, and re-run when it becomes ready for review. Split cheap checks (`go-lint`, `web-check`) from expensive jobs (Bazel, Postgres/test/build, full Go suite) so they run in parallel on non-draft PRs and `main`.

Adds ADR: `docs/adr/2026-07-26-draft-pr-ci-gating-design.md`.

## How to test

- Push to a **draft** PR: all jobs in `CI` / `Web CI` should be skipped.
- Mark the PR **ready for review**: cheap and expensive jobs should run.
- Push again on a non-draft PR: both job groups should run.
- Confirm path filters still apply (web-only vs non-web changes).

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)