### PR TITLE
fix(crowdin): correct GetManagers API v2 signature and path

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -235,3 +235,9 @@
 **Learning:** In Crowdin API v2, `parentId` is an optional field when listing groups. Specifically, querying root-level groups requires setting `parentId=0`. However, the Go SDK typed `ParentID` as an `int` and had a condition `o.ParentID > 0` before appending it to query parameters, making root group filtering impossible.
 
 **Action:** Changed `ParentID` type to `*int` in `GroupsListOptions` and updated `Values()` serialization logic to append the parameter as long as `ParentID != nil`. Updated unit tests in both `model/groups_test.go` and `groups_test.go` to explicitly verify `parentId=0` query parameter construction.
+
+## 2026-12-19 - Fix GetManagers endpoint path and signature mismatch
+
+**Learning:** In the Crowdin Enterprise API v2, the endpoint to get a single group manager is `GET /api/v2/groups/{groupId}/managers/{userId}` (using both the group ID and the manager's user ID as identifiers). However, the Go SDK's `GetManagers` function incorrectly omitted the `userID` parameter, constructed the incorrect list-level endpoint path `/api/v2/groups/{groupId}/managers`, and attempted to decode the response as a single resource `ManagerGetResponse`. This would cause JSON unmarshaling failures or retrieve incorrect resources under real workloads.
+
+**Action:** Updated `GetManagers` in `crowdin/users.go` to accept `userID int` and updated its API request path to `/api/v2/groups/%d/managers/%d`. Fixed `TestManagersService_Get` in `crowdin/users_test.go` to supply a valid user ID and assert the correct URL structure.

--- a/third_party/crowdin-api-client-go/crowdin/users.go
+++ b/third_party/crowdin-api-client-go/crowdin/users.go
@@ -192,9 +192,9 @@ func (s *UsersService) ListManagers(ctx context.Context, groupID int, opts *mode
 // Get returns a manager by its identifier.
 //
 // https://support.crowdin.com/developer/enterprise/api/v2/#tag/Users/operation/api.groups.managers.get
-func (s *UsersService) GetManagers(ctx context.Context, groupID int) (*model.Manager, *Response, error) {
+func (s *UsersService) GetManagers(ctx context.Context, groupID, userID int) (*model.Manager, *Response, error) {
 	res := new(model.ManagerGetResponse)
-	resp, err := s.client.Get(ctx, fmt.Sprintf("/api/v2/groups/%d/managers", groupID), nil, res)
+	resp, err := s.client.Get(ctx, fmt.Sprintf("/api/v2/groups/%d/managers/%d", groupID, userID), nil, res)
 
 	return res.Data, resp, err
 }

--- a/third_party/crowdin-api-client-go/crowdin/users_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/users_test.go
@@ -1609,9 +1609,9 @@ func TestManagersService_Get(t *testing.T) {
 	client, mux, teardown := setupClient()
 	defer teardown()
 
-	mux.HandleFunc("/api/v2/groups/1/managers", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v2/groups/1/managers/12", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		testURL(t, r, "/api/v2/groups/1/managers")
+		testURL(t, r, "/api/v2/groups/1/managers/12")
 		fmt.Fprint(w, `{
 				"data": {
 				  "id": 27,
@@ -1649,7 +1649,7 @@ func TestManagersService_Get(t *testing.T) {
 		  }`)
 	})
 
-	managers, _, err := client.Users.GetManagers(context.Background(), 1)
+	managers, _, err := client.Users.GetManagers(context.Background(), 1, 12)
 	if err != nil {
 		t.Errorf("Managers.Get returned error: %v", err)
 	}


### PR DESCRIPTION
What: Fixed the GetManagers method signature in the Go SDK to accept a `userID` parameter, and updated the request URI to use the correct `GET /api/v2/groups/{groupId}/managers/{userId}` path instead of the list-level path `/api/v2/groups/{groupId}/managers`.

Why: In Crowdin Enterprise API v2, retrieving a single manager requires specifying both the group ID and the manager's user ID. Previously, the Go SDK's `GetManagers` function omitted the `userID` parameter and queried the list-level path, which returned an array that failed to unmarshal into a single resource response envelope (`ManagerGetResponse`).

Docs: https://support.crowdin.com/developer/enterprise/api/v2/#tag/Users/operation/api.groups.managers.get

Scope: Modified `third_party/crowdin-api-client-go/crowdin/users.go`, `third_party/crowdin-api-client-go/crowdin/users_test.go`, and added journal entry to `.jules/crowdin-steward.md`.

Tests: Passed `go test ./third_party/crowdin-api-client-go/crowdin` with the corrected unit tests.

Confidence: Extremely high; matches official Crowdin v2 documentation and passes all local test suites.

---
*PR created automatically by Jules for task [17838488878392124835](https://jules.google.com/task/17838488878392124835) started by @cungminh2710*