### PR TITLE
🧪 Scout: add behavior-driven PO parser syntax error tests

### DIFF
--- a/internal/i18n/translationfileparser/po_parser_scout_test.go
+++ b/internal/i18n/translationfileparser/po_parser_scout_test.go
@@ -2,6 +2,7 @@ package translationfileparser
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -29,5 +30,59 @@ msgstr "val"
 
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
+	}
+}
+
+func TestPOParser_SyntaxErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{
+			name: "unterminated quoted msgid",
+			input: `msgid "unterminated
+msgstr "value"`,
+			wantErr: "parse msgid",
+		},
+		{
+			name: "unterminated quoted msgstr",
+			input: `msgid "key"
+msgstr "unterminated`,
+			wantErr: "parse msgstr",
+		},
+		{
+			name: "unterminated indexed msgstr[0]",
+			input: `msgid "key"
+msgid_plural "plural"
+msgstr[0] "unterminated`,
+			wantErr: "parse msgstr[0]",
+		},
+		{
+			name: "unterminated continuation line",
+			input: `msgid "key"
+msgstr "value"
+"unterminated continuation`,
+			wantErr: "parse continued string",
+		},
+		{
+			name: "not a quoted string in msgid",
+			input: `msgid missing-quotes
+msgstr "value"`,
+			wantErr: "parse msgid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := POFileParser{}
+			_, err := parser.Parse([]byte(tt.input))
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got: %v", tt.wantErr, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
💡 What: Added a new behavior-driven unit test suite `TestPOParser_SyntaxErrors` to `internal/i18n/translationfileparser/po_parser_scout_test.go`.
🎯 Why: It covers key syntax validation behaviors and error handling for malformed PO files, preventing silent/unexpected failures or regressions.
🧩 Scope: `internal/i18n/translationfileparser/po_parser_scout_test.go`.
✅ Verification: Ran `go test -v ./internal/i18n/translationfileparser/...` and `make lint` / `make fmt`.
🛡️ Confidence: Protects the PO translation file parser from malformed input formatting regressions and ensures proper syntax validation feedback.

---
*PR created automatically by Jules for task [13844402242735591019](https://jules.google.com/task/13844402242735591019) started by @cungminh2710*