### PR TITLE
feat(web): add status page link to marketing footer Resources

### DIFF
--- a/apps/hyperlocalise-web/src/components/marketing/marketing-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/marketing-page-content.messages.ts
@@ -117,7 +117,7 @@ export const marketingPageMessages = defineMessages({
   },
   footerStatus: {
     defaultMessage: "Status",
-    id: "vKKxRpw7Y7",
+    id: "az1dhUOnH0",
     description: "Marketing footer resource link label for the status page",
   },
 });

--- a/apps/hyperlocalise-web/src/components/marketing/marketing-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/marketing-page-content.messages.ts
@@ -115,6 +115,11 @@ export const marketingPageMessages = defineMessages({
     id: "qgNLOHiYyJ",
     description: "Marketing footer resource link label for the company page",
   },
+  footerStatus: {
+    defaultMessage: "Status",
+    id: "vKKxRpw7Y7",
+    description: "Marketing footer resource link label for the status page",
+  },
 });
 
 export type MarketingPageMessageKey = keyof typeof marketingPageMessages;

--- a/apps/hyperlocalise-web/src/components/marketing/marketing-page-content.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/marketing-page-content.ts
@@ -19,6 +19,7 @@ export const githubReleasesUrl = "https://github.com/hyperlocalise/hyperlocalise
 export const docsUrl = "https://hyperlocalise.dev";
 export const cliDocsUrl = "https://hyperlocalise.dev/commands/overview";
 export const contactUrl = "mailto:minh@hyperlocalise.com";
+export const statusUrl = "https://status.hyperlocalise.com/";
 export const linkedInCompanyUrl = "https://www.linkedin.com/company/hyperlocalise/";
 
 export type MarketingFooterLink = {
@@ -80,6 +81,7 @@ export const footerColumns: MarketingFooterColumn[] = [
       { label: "Blog", href: "/en/blog" },
       { labelKey: "footerGitHubAction", href: githubActionUrl },
       { labelKey: "footerContact", href: contactUrl },
+      { labelKey: "footerStatus", href: statusUrl },
     ],
   },
   {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds a **Status** link under the marketing footer Resources column that points to https://status.hyperlocalise.com/. External links already open in a new tab.

## How to test

- Open any marketing page footer and confirm Resources includes Status
- Click Status and confirm it opens https://status.hyperlocalise.com/
- `vp check --fix` and `vp test` in `apps/hyperlocalise-web`

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`; `vp test` after Postgres/env setup)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e2fbbc23-a0f0-4635-a81c-0e1233f39530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2fbbc23-a0f0-4635-a81c-0e1233f39530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

