### PR TITLE
feat(startups): add OpenGraph image for startups page

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/startups/opengraph-image.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/startups/opengraph-image.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { getIntlShape } from "@/lib/app-i18n/intl";
+import {
+  createMarketingOgImage,
+  marketingOgImageContentType,
+  marketingOgImageSize,
+  toMarketingOgHeading,
+} from "@/lib/og/create-marketing-og-image";
+
+import { getStartupsRouteMetadata } from "./startups-route-metadata";
+
+export const alt = "Hyperlocalise for Startups";
+export const size = marketingOgImageSize;
+export const contentType = marketingOgImageContentType;
+
+type StartupsOgImageProps = {
+  params: Promise<{ lang: string }>;
+};
+
+export default async function Image({ params }: StartupsOgImageProps) {
+  const { lang } = await params;
+  const intl = getIntlShape(lang);
+  const metadata = getStartupsRouteMetadata(intl);
+
+  return createMarketingOgImage({
+    heading: toMarketingOgHeading(metadata.title),
+    description: metadata.description,
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds a missing route-level `opengraph-image.tsx` for the marketing `/startups` page, matching other marketing pages (`company`, `pricing`, etc.). It uses the shared `createMarketingOgImage` helper with the startups page title and description.

## How to test

- Confirm `/[lang]/startups/opengraph-image` returns a 1200×630 PNG
- Confirm link previews for the startups page include an OG image
- Ran `vp check --fix` and `vp test` in `apps/hyperlocalise-web` (all passed)

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c62f885-dc91-41f7-959b-1d50e12c0bb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c62f885-dc91-41f7-959b-1d50e12c0bb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

