### PR TITLE
fix(crowdin): align AI translate with official API contract

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -1,5 +1,11 @@
 # Crowdin Steward's Journal
 
+## 2026-12-19 - Align AI Translate with Crowdin API v2
+
+**Learning:** The `POST /ai/translate` endpoint accepts several optional body fields like `sourceLanguageId`, `aiPromptId`, `tmIds`, `glossaryIds`, and `instructions` to customize on-demand translations. Additionally, its response contains `sourceLanguageId` and `targetLanguageId`. The initial SDK implementation was heavily simplified and missing these fields, which prevented utilizing Corporate AI pipelines with custom glossaries and translation memories.
+
+**Action:** Updated `AITranslateRequest` and `AITranslate` response models in `crowdin/model/ai.go` to include the missing fields with proper JSON mappings, and expanded the test suite in `crowdin/ai_test.go` and `crowdin/model/ai_test.go` to validate and test serialize/parse these fields end-to-end.
+
 ## 2026-12-12 - Fix CheckGlossaryImportStatus importID type mismatch
 
 **Learning:** In Crowdin API v2, the glossary import background job is initiated by `ImportGlossary` which returns a string UUID `identifier` representing the job. Consequently, checking the status of this background job via the Check Glossary Import Status endpoint (`GET /api/v2/glossaries/{glossaryId}/imports/{importId}`) requires passing this string UUID. However, the SDK incorrectly typed `importID` as an `int` and formatted the request URL using `%d`, rendering the status check unusable under real-world scenarios.

--- a/third_party/crowdin-api-client-go/crowdin/ai_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/ai_test.go
@@ -1249,12 +1249,19 @@ func TestAIService_Translate(t *testing.T) {
 		testURL(t, r, path)
 		testJSONBody(t, r, `{
 			"strings": ["Chef's Special: Spicy Tuna Roll"],
-			"targetLanguageId": "de"
+			"targetLanguageId": "de",
+			"sourceLanguageId": "en",
+			"aiPromptId": 82,
+			"tmIds": [102, 305],
+			"glossaryIds": [12],
+			"instructions": ["Keep dish names appetizing", "Do not translate brand names"]
 		}`)
 
 		fmt.Fprint(w, `{
 			"data": {
-				"translations": ["Chef-Spezialität: Pikante Thunfisch-Rolle"]
+				"sourceLanguageId": "en",
+				"targetLanguageId": "de",
+				"translations": ["Chef's Special: Würzige Thunfischrolle"]
 			}
 		}`)
 	})
@@ -1262,13 +1269,20 @@ func TestAIService_Translate(t *testing.T) {
 	req := &model.AITranslateRequest{
 		Strings:          []string{"Chef's Special: Spicy Tuna Roll"},
 		TargetLanguageID: "de",
+		SourceLanguageID: "en",
+		AIPromptID:       82,
+		TMIDs:            []int{102, 305},
+		GlossaryIDs:      []int{12},
+		Instructions:     []string{"Keep dish names appetizing", "Do not translate brand names"},
 	}
 	res, resp, err := client.AI.Translate(context.Background(), 1, req)
 	require.NoError(t, err)
 	assert.NotNil(t, resp)
 
 	expected := &model.AITranslate{
-		Translations: []string{"Chef-Spezialität: Pikante Thunfisch-Rolle"},
+		SourceLanguageID: "en",
+		TargetLanguageID: "de",
+		Translations:     []string{"Chef's Special: Würzige Thunfischrolle"},
 	}
 	assert.Equal(t, expected, res)
 }

--- a/third_party/crowdin-api-client-go/crowdin/model/ai.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/ai.go
@@ -63,6 +63,16 @@ type AITranslateRequest struct {
 	Strings []string `json:"strings"`
 	// Target language identifier.
 	TargetLanguageID string `json:"targetLanguageId"`
+	// Source language identifier. Optional.
+	SourceLanguageID string `json:"sourceLanguageId,omitempty"`
+	// AI Prompt identifier. Optional.
+	AIPromptID int `json:"aiPromptId,omitempty"`
+	// TM identifiers. Optional.
+	TMIDs []int `json:"tmIds,omitempty"`
+	// Glossary identifiers. Optional.
+	GlossaryIDs []int `json:"glossaryIds,omitempty"`
+	// Instructions for translation. Optional.
+	Instructions []string `json:"instructions,omitempty"`
 }
 
 // Validate checks if the request is valid.
@@ -89,7 +99,9 @@ type AITranslateResponse struct {
 
 // AITranslate represents the AI translation result.
 type AITranslate struct {
-	Translations []string `json:"translations"`
+	SourceLanguageID string   `json:"sourceLanguageId"`
+	TargetLanguageID string   `json:"targetLanguageId"`
+	Translations     []string `json:"translations"`
 }
 
 // FineTuningDatasetResponse defines the structure of a response when

--- a/third_party/crowdin-api-client-go/crowdin/model/ai_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/ai_test.go
@@ -50,6 +50,62 @@ func TestFineTuningDatasetAttributesValidate(t *testing.T) {
 	}
 }
 
+func TestAITranslateRequestValidate(t *testing.T) {
+	tests := []struct {
+		name  string
+		req   *AITranslateRequest
+		err   string
+		valid bool
+	}{
+		{
+			name: "nil request",
+			req:  nil,
+			err:  "request cannot be nil",
+		},
+		{
+			name: "empty strings",
+			req:  &AITranslateRequest{TargetLanguageID: "de"},
+			err:  "strings are required",
+		},
+		{
+			name: "empty target language ID",
+			req:  &AITranslateRequest{Strings: []string{"test"}},
+			err:  "targetLanguageId is required",
+		},
+		{
+			name: "valid minimal request",
+			req: &AITranslateRequest{
+				Strings:          []string{"Chef's Special"},
+				TargetLanguageID: "de",
+			},
+			valid: true,
+		},
+		{
+			name: "valid full request",
+			req: &AITranslateRequest{
+				Strings:          []string{"Chef's Special"},
+				TargetLanguageID: "de",
+				SourceLanguageID: "en",
+				AIPromptID:       82,
+				TMIDs:            []int{102, 305},
+				GlossaryIDs:      []int{12},
+				Instructions:     []string{"Do not translate brand names"},
+			},
+			valid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.req.Validate(); tt.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.err)
+			}
+		})
+	}
+}
+
 func TestFineTuningJobsListOptionsValues(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
### What
Implemented the missing optional request fields and response fields for on-demand AI translation (`POST /ai/translate`) in the Crowdin Go client fork.

### Why
Ensures that callers of the Crowdin client can fully utilize the AI translate endpoint to configure specific instructions, prompts, custom glossaries, and translation memories to leverage corporate AI pipelines in a context-aware way, matching official Crowdin API v2 contract.

### Docs
https://crowdin.com/blog/whats-new-at-crowdin-december-2025

### Scope
- `third_party/crowdin-api-client-go/crowdin/model/ai.go`
- `third_party/crowdin-api-client-go/crowdin/ai_test.go`
- `third_party/crowdin-api-client-go/crowdin/model/ai_test.go`
- `.jules/crowdin-steward.md`

### Tests
- Expanded `TestAIService_Translate` in `ai_test.go` to test end-to-end serialization and response parsing.
- Added `TestAITranslateRequestValidate` in `model/ai_test.go` to cover optional field validations.
- Verified all workspace and crowdin package tests pass with 100% accuracy.

### Confidence
Extremely high. Newly added fields use proper JSON struct tags with `omitempty` for backward compatibility. Tests pass cleanly, and the lint is pristine.

---
*PR created automatically by Jules for task [33905115604873903](https://jules.google.com/task/33905115604873903) started by @cungminh2710*