### PR TITLE
fix(crowdin): validate export translation request mutual exclusivity

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -1,5 +1,11 @@
 # Crowdin Steward's Journal
 
+## 2026-07-29 - Validate derived exportWithMinApprovalsCount from exportApprovedOnly
+
+**Learning:** `ExportTranslationRequest.MarshalJSON` maps `exportApprovedOnly=true` to `exportWithMinApprovalsCount=1` when no explicit approval count is set. Validating only the explicit `ExportWithMinApprovalsCount` field let `exportApprovedOnly=true` + `exportStringsThatPassedWorkflow=true` pass client validation and still serialize into the incompatible API pair.
+
+**Action:** Updated `ExportTranslationRequest.Validate()` to apply the same derived approvals-count logic as `MarshalJSON` before enforcing mutual exclusivity with `exportStringsThatPassedWorkflow`, and added regression tests covering both the derived and explicit-zero cases.
+
 ## 2026-12-20 - Add ExportTranslationRequest validation parity
 
 **Learning:** In Crowdin API v2, the Export Project Translation request body contains several fields that are strictly mutually exclusive, such as `branchIds`, `directoryIds`, and `fileIds` (only one can be targeted per request), as well as boolean flag pairs like `skipUntranslatedStrings`/`skipUntranslatedFiles` and `exportWithMinApprovalsCount`/`exportStringsThatPassedWorkflow`. Lacking client-side validation for these constraints could lead to invalid payloads being transmitted and failing at the API gateway layer.

--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -1,5 +1,11 @@
 # Crowdin Steward's Journal
 
+## 2026-12-20 - Add ExportTranslationRequest validation parity
+
+**Learning:** In Crowdin API v2, the Export Project Translation request body contains several fields that are strictly mutually exclusive, such as `branchIds`, `directoryIds`, and `fileIds` (only one can be targeted per request), as well as boolean flag pairs like `skipUntranslatedStrings`/`skipUntranslatedFiles` and `exportWithMinApprovalsCount`/`exportStringsThatPassedWorkflow`. Lacking client-side validation for these constraints could lead to invalid payloads being transmitted and failing at the API gateway layer.
+
+**Action:** Added validations to `ExportTranslationRequest.Validate()` in `model/translations.go` to enforce these mutual exclusivity constraints and expanded the unit test suite in `model/translations_test.go` and `translations_test.go` to assert correct validation behavior and request alignment.
+
 ## 2026-12-19 - Align AI Translate with Crowdin API v2
 
 **Learning:** The `POST /ai/translate` endpoint accepts several optional body fields like `sourceLanguageId`, `aiPromptId`, `tmIds`, `glossaryIds`, and `instructions` to customize on-demand translations. Additionally, its response contains `sourceLanguageId` and `targetLanguageId`. The initial SDK implementation was heavily simplified and missing these fields, which prevented utilizing Corporate AI pipelines with custom glossaries and translation memories.

--- a/third_party/crowdin-api-client-go/crowdin/model/translations.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translations.go
@@ -697,8 +697,15 @@ func (r *ExportTranslationRequest) Validate() error {
 		return errors.New("skipUntranslatedStrings and skipUntranslatedFiles must not be true at the same request")
 	}
 
-	if (r.ExportWithMinApprovalsCount != nil && r.ExportStringsThatPassedWorkflow != nil) &&
-		(*r.ExportWithMinApprovalsCount > 0 && *r.ExportStringsThatPassedWorkflow) {
+	// MarshalJSON maps exportApprovedOnly=true to exportWithMinApprovalsCount=1 when
+	// ExportWithMinApprovalsCount is unset, so validate the effective approvals count.
+	exportWithMinApprovalsCount := r.ExportWithMinApprovalsCount
+	if r.ExportApprovedOnly != nil && *r.ExportApprovedOnly && exportWithMinApprovalsCount == nil {
+		minApprovalsCount := 1
+		exportWithMinApprovalsCount = &minApprovalsCount
+	}
+	if (exportWithMinApprovalsCount != nil && r.ExportStringsThatPassedWorkflow != nil) &&
+		(*exportWithMinApprovalsCount > 0 && *r.ExportStringsThatPassedWorkflow) {
 		return errors.New("exportWithMinApprovalsCount and exportStringsThatPassedWorkflow must not be true at the same request")
 	}
 

--- a/third_party/crowdin-api-client-go/crowdin/model/translations.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translations.go
@@ -678,6 +678,30 @@ func (r *ExportTranslationRequest) Validate() error {
 		return errors.New("targetLanguageId is required")
 	}
 
+	var count int
+	if len(r.BranchIDs) > 0 {
+		count++
+	}
+	if len(r.DirectoryIDs) > 0 {
+		count++
+	}
+	if len(r.FileIDs) > 0 {
+		count++
+	}
+	if count > 1 {
+		return errors.New("only one of branchIds, directoryIds, or fileIds may be set")
+	}
+
+	if (r.SkipUntranslatedStrings != nil && r.SkipUntranslatedFiles != nil) &&
+		(*r.SkipUntranslatedStrings && *r.SkipUntranslatedFiles) {
+		return errors.New("skipUntranslatedStrings and skipUntranslatedFiles must not be true at the same request")
+	}
+
+	if (r.ExportWithMinApprovalsCount != nil && r.ExportStringsThatPassedWorkflow != nil) &&
+		(*r.ExportWithMinApprovalsCount > 0 && *r.ExportStringsThatPassedWorkflow) {
+		return errors.New("exportWithMinApprovalsCount and exportStringsThatPassedWorkflow must not be true at the same request")
+	}
+
 	return nil
 }
 

--- a/third_party/crowdin-api-client-go/crowdin/model/translations_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translations_test.go
@@ -422,12 +422,74 @@ func TestExportTranslationRequestValidate(t *testing.T) {
 			err:  "targetLanguageId is required",
 		},
 		{
-			name: "valid request",
+			name: "valid request with fileIds",
 			req: &ExportTranslationRequest{
 				TargetLanguageID: "uk", Format: "xliff", FileIDs: []int{1}, LabelIDs: []int{4},
 				SkipUntranslatedFiles: toPtr(false), ExportApprovedOnly: toPtr(false),
 			},
 			valid: true,
+		},
+		{
+			name: "valid request with branchIds",
+			req: &ExportTranslationRequest{
+				TargetLanguageID: "uk", Format: "xliff", BranchIDs: []int{1}, LabelIDs: []int{4},
+				SkipUntranslatedFiles: toPtr(false), ExportApprovedOnly: toPtr(false),
+			},
+			valid: true,
+		},
+		{
+			name: "valid request with directoryIds",
+			req: &ExportTranslationRequest{
+				TargetLanguageID: "uk", Format: "xliff", DirectoryIDs: []int{1}, LabelIDs: []int{4},
+				SkipUntranslatedFiles: toPtr(false), ExportApprovedOnly: toPtr(false),
+			},
+			valid: true,
+		},
+		{
+			name: "branchIds and directoryIds together",
+			req: &ExportTranslationRequest{
+				TargetLanguageID: "uk", BranchIDs: []int{1}, DirectoryIDs: []int{2},
+			},
+			err: "only one of branchIds, directoryIds, or fileIds may be set",
+		},
+		{
+			name: "branchIds and fileIds together",
+			req: &ExportTranslationRequest{
+				TargetLanguageID: "uk", BranchIDs: []int{1}, FileIDs: []int{2},
+			},
+			err: "only one of branchIds, directoryIds, or fileIds may be set",
+		},
+		{
+			name: "directoryIds and fileIds together",
+			req: &ExportTranslationRequest{
+				TargetLanguageID: "uk", DirectoryIDs: []int{1}, FileIDs: []int{2},
+			},
+			err: "only one of branchIds, directoryIds, or fileIds may be set",
+		},
+		{
+			name: "all three together",
+			req: &ExportTranslationRequest{
+				TargetLanguageID: "uk", BranchIDs: []int{1}, DirectoryIDs: []int{2}, FileIDs: []int{3},
+			},
+			err: "only one of branchIds, directoryIds, or fileIds may be set",
+		},
+		{
+			name: "skipUntranslatedStrings and skipUntranslatedFiles both true",
+			req: &ExportTranslationRequest{
+				TargetLanguageID:        "uk",
+				SkipUntranslatedStrings: toPtr(true),
+				SkipUntranslatedFiles:   toPtr(true),
+			},
+			err: "skipUntranslatedStrings and skipUntranslatedFiles must not be true at the same request",
+		},
+		{
+			name: "exportWithMinApprovalsCount > 0 and exportStringsThatPassedWorkflow both true",
+			req: &ExportTranslationRequest{
+				TargetLanguageID:                "uk",
+				ExportWithMinApprovalsCount:     toPtr(1),
+				ExportStringsThatPassedWorkflow: toPtr(true),
+			},
+			err: "exportWithMinApprovalsCount and exportStringsThatPassedWorkflow must not be true at the same request",
 		},
 	}
 

--- a/third_party/crowdin-api-client-go/crowdin/model/translations_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translations_test.go
@@ -491,6 +491,25 @@ func TestExportTranslationRequestValidate(t *testing.T) {
 			},
 			err: "exportWithMinApprovalsCount and exportStringsThatPassedWorkflow must not be true at the same request",
 		},
+		{
+			name: "exportApprovedOnly true and exportStringsThatPassedWorkflow both true",
+			req: &ExportTranslationRequest{
+				TargetLanguageID:                "uk",
+				ExportApprovedOnly:              toPtr(true),
+				ExportStringsThatPassedWorkflow: toPtr(true),
+			},
+			err: "exportWithMinApprovalsCount and exportStringsThatPassedWorkflow must not be true at the same request",
+		},
+		{
+			name: "exportApprovedOnly true with explicit zero approvals and workflow true is valid",
+			req: &ExportTranslationRequest{
+				TargetLanguageID:                "uk",
+				ExportApprovedOnly:              toPtr(true),
+				ExportWithMinApprovalsCount:     toPtr(0),
+				ExportStringsThatPassedWorkflow: toPtr(true),
+			},
+			valid: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/third_party/crowdin-api-client-go/crowdin/translations_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/translations_test.go
@@ -1110,53 +1110,102 @@ func TestTranslationsService_CancelBuild(t *testing.T) {
 }
 
 func TestTranslationsService_ExportProjectTranslation(t *testing.T) {
-	client, mux, teardown := setupClient()
-	defer teardown()
+	tests := []struct {
+		name            string
+		req             *model.ExportTranslationRequest
+		expectedReqBody string
+	}{
+		{
+			name: "with branchIds",
+			req: &model.ExportTranslationRequest{
+				TargetLanguageID:        "uk",
+				Format:                  "xliff",
+				LabelIDs:                []int{1},
+				BranchIDs:               []int{2},
+				SkipUntranslatedStrings: ToPtr(false),
+				SkipUntranslatedFiles:   ToPtr(false),
+				ExportApprovedOnly:      ToPtr(false),
+			},
+			expectedReqBody: `{
+				"targetLanguageId": "uk",
+				"format": "xliff",
+				"labelIds": [1],
+				"branchIds": [2],
+				"skipUntranslatedStrings": false,
+				"skipUntranslatedFiles": false
+			}`,
+		},
+		{
+			name: "with directoryIds",
+			req: &model.ExportTranslationRequest{
+				TargetLanguageID:        "uk",
+				Format:                  "xliff",
+				LabelIDs:                []int{1},
+				DirectoryIDs:            []int{3},
+				SkipUntranslatedStrings: ToPtr(false),
+				SkipUntranslatedFiles:   ToPtr(false),
+				ExportApprovedOnly:      ToPtr(false),
+			},
+			expectedReqBody: `{
+				"targetLanguageId": "uk",
+				"format": "xliff",
+				"labelIds": [1],
+				"directoryIds": [3],
+				"skipUntranslatedStrings": false,
+				"skipUntranslatedFiles": false
+			}`,
+		},
+		{
+			name: "with fileIds",
+			req: &model.ExportTranslationRequest{
+				TargetLanguageID:        "uk",
+				Format:                  "xliff",
+				LabelIDs:                []int{1},
+				FileIDs:                 []int{4},
+				SkipUntranslatedStrings: ToPtr(false),
+				SkipUntranslatedFiles:   ToPtr(false),
+				ExportApprovedOnly:      ToPtr(false),
+			},
+			expectedReqBody: `{
+				"targetLanguageId": "uk",
+				"format": "xliff",
+				"labelIds": [1],
+				"fileIds": [4],
+				"skipUntranslatedStrings": false,
+				"skipUntranslatedFiles": false
+			}`,
+		},
+	}
 
-	const path = "/api/v2/projects/1/translations/exports"
-	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, http.MethodPost)
-		testURL(t, r, path)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, mux, teardown := setupClient()
+			defer teardown()
 
-		expectedReqBody := `{
-			"targetLanguageId": "uk",
-			"format": "xliff",
-			"labelIds": [1],
-			"branchIds": [2],
-			"directoryIds": [3],
-			"fileIds": [4],
-			"skipUntranslatedStrings": false,
-			"skipUntranslatedFiles": false
-		}`
-		testJSONBody(t, r, expectedReqBody)
+			const path = "/api/v2/projects/1/translations/exports"
+			mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+				testMethod(t, r, http.MethodPost)
+				testURL(t, r, path)
+				testJSONBody(t, r, tt.expectedReqBody)
 
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, `{
-			"data": {
-				"url": "https://production-enterprise-importer.downloads.crowdin.com/992000002/2/14.xliff?response-content-disposition",
-				"expireIn": "2023-09-20T10:31:21+00:00"
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, `{
+					"data": {
+						"url": "https://production-enterprise-importer.downloads.crowdin.com/992000002/2/14.xliff?response-content-disposition",
+						"expireIn": "2023-09-20T10:31:21+00:00"
+					}
+				}`)
+			})
+
+			downloadLink, resp, err := client.Translations.ExportProjectTranslation(context.Background(), 1, tt.req)
+			require.NoError(t, err)
+
+			expected := &model.DownloadLink{
+				URL:      "https://production-enterprise-importer.downloads.crowdin.com/992000002/2/14.xliff?response-content-disposition",
+				ExpireIn: "2023-09-20T10:31:21+00:00",
 			}
-		}`)
-	})
-
-	req := &model.ExportTranslationRequest{
-		TargetLanguageID:        "uk",
-		Format:                  "xliff",
-		LabelIDs:                []int{1},
-		BranchIDs:               []int{2},
-		DirectoryIDs:            []int{3},
-		FileIDs:                 []int{4},
-		SkipUntranslatedStrings: ToPtr(false),
-		SkipUntranslatedFiles:   ToPtr(false),
-		ExportApprovedOnly:      ToPtr(false),
+			assert.Equal(t, expected, downloadLink)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		})
 	}
-	downloadLink, resp, err := client.Translations.ExportProjectTranslation(context.Background(), 1, req)
-	require.NoError(t, err)
-
-	expected := &model.DownloadLink{
-		URL:      "https://production-enterprise-importer.downloads.crowdin.com/992000002/2/14.xliff?response-content-disposition",
-		ExpireIn: "2023-09-20T10:31:21+00:00",
-	}
-	assert.Equal(t, expected, downloadLink)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }


### PR DESCRIPTION
💡 What:
Added validations to `ExportTranslationRequest.Validate()` in `model/translations.go` to enforce Crowdin API v2 mutual exclusivity rules:
- Only one of `BranchIDs`, `DirectoryIDs`, or `FileIDs` can be specified.
- `SkipUntranslatedStrings` and `SkipUntranslatedFiles` cannot both be true.
- `ExportWithMinApprovalsCount > 0` and `ExportStringsThatPassedWorkflow` cannot both be true.

🎯 Why:
Lacking client-side validation for these constraints allows invalid payloads to be transmitted to the Crowdin API, failing at the API gateway layer.

Docs:
- Crowdin API v2 Export Project Translation: https://developer.crowdin.com/api/v2/#operation/api.projects.translations.exports.post

Scope:
- `third_party/crowdin-api-client-go/crowdin/model/translations.go`
- `third_party/crowdin-api-client-go/crowdin/model/translations_test.go`
- `third_party/crowdin-api-client-go/crowdin/translations_test.go`
- `.jules/crowdin-steward.md`

Tests:
- Added comprehensive model validation test cases to `translations_test.go` (`TestExportTranslationRequestValidate`).
- Updated integration serialization tests in `translations_test.go` (`TestTranslationsService_ExportProjectTranslation`) to run separate valid requests.

Confidence:
Provides compile and runtime-level verification matching the documented Crowdin v2 API contract.

---
*PR created automatically by Jules for task [11751230859559832243](https://jules.google.com/task/11751230859559832243) started by @cungminh2710*