### PR TITLE
feat(web): show medical device compliance automation on homepage

### DIFF
--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -111,6 +111,10 @@
     "defaultMessage": "—",
     "description": "Placeholder when a provider detail value is empty"
   },
+  "+MYLJhmlev": {
+    "defaultMessage": "Run a scheduled compliance check on medical device labelling and IFU translations. Compare locales against approved terminology, flag missing translations for regulated markets, check unit and warning phrase consistency, then report blockers for review. Do not publish.",
+    "description": "Sample agent instructions in the marketing automation editor mock"
+  },
   "+Pn3eYONmL": {
     "defaultMessage": "Semrush",
     "description": "Menu item and tool title for Semrush SEO data"
@@ -995,10 +999,6 @@
     "defaultMessage": "View strings",
     "description": "Button or link to open the job CAT workspace"
   },
-  "21wXbXIpMt": {
-    "defaultMessage": "Help Center",
-    "description": "Contentful space label in the marketing automation editor mock"
-  },
   "22cLivfsp0": {
     "defaultMessage": "Workspace",
     "description": "Automations page header eyebrow label"
@@ -1431,10 +1431,6 @@
     "defaultMessage": "Registration: {status}",
     "description": "Webhook registration status line with localized status value"
   },
-  "3nHm7zuXbR": {
-    "defaultMessage": "Translate Contentful article",
-    "description": "Automation name shown in the marketing automation editor mock"
-  },
   "3r10YA/kX+": {
     "defaultMessage": "Config version: <version>{configVersion}</version>",
     "description": "Metadata label showing saved automation config version"
@@ -1831,6 +1827,10 @@
     "defaultMessage": "Unknown repository",
     "description": "Label when a selected repository id is not in the loaded list"
   },
+  "5YseOmwLin": {
+    "defaultMessage": "Scheduled",
+    "description": "Scheduled trigger title in the marketing automation editor mock"
+  },
   "5YusqFJjvU": {
     "defaultMessage": "Refresh the page to try again.",
     "description": "Fallback error guidance when loading members fails"
@@ -1910,6 +1910,10 @@
   "5yXqdk0MWc": {
     "defaultMessage": "From new article to monitored locale coverage",
     "description": "Workflow section title for the help-center-localisation use case"
+  },
+  "6/+JsEuq89": {
+    "defaultMessage": "Use approved medical terminology and regulatory glossary as guidance.",
+    "description": "Knowledge memories tool description in the marketing automation editor mock"
   },
   "6/4F992ZiW": {
     "defaultMessage": "Unable to remove project",
@@ -2362,10 +2366,6 @@
   "7nMUUnudcv": {
     "defaultMessage": "Smartling",
     "description": "Smartling TMS integration name on the integrations page"
-  },
-  "7pTwJNAe0D": {
-    "defaultMessage": "Notify #localization when drafts are ready.",
-    "description": "Slack tool description in the marketing automation editor mock"
   },
   "7qHTh1/iSP": {
     "defaultMessage": "Failed to create translation job",
@@ -4623,6 +4623,10 @@
     "defaultMessage": "Copied!",
     "description": "Aria label after copying the inbound email address"
   },
+  "H8bNcbLNen": {
+    "defaultMessage": "Medical device compliance check",
+    "description": "Automation name shown in the marketing automation editor mock"
+  },
   "HA9fSDFTe4": {
     "defaultMessage": "Replaced <wrong>marches</wrong> with <right>marchés</right> so the French pricing copy is spelled correctly.",
     "description": "Success body after the agent commits the PR fix, wrapping code examples"
@@ -5491,6 +5495,10 @@
     "defaultMessage": "Inbox",
     "description": "Eyebrow label above the marketing chat dock mock section"
   },
+  "LLQAT26N2S": {
+    "defaultMessage": "08:00 UTC",
+    "description": "Schedule time pill in the marketing automation editor mock"
+  },
   "LMGo1sN8VQ": {
     "defaultMessage": "This glossary is used only by the projects listed here.",
     "description": "Section description for projects assigned to a glossary"
@@ -5650,10 +5658,6 @@
   "M7pTNyMB/G": {
     "defaultMessage": "{count, plural, one {# proposal} other {# proposals}}",
     "description": "Count of reviewable proposals on an agent run"
-  },
-  "M8WTB2rTQG": {
-    "defaultMessage": "Translate fields, run QA, and write drafts for review.",
-    "description": "Contentful tool description in the marketing automation editor mock"
   },
   "MB3Jte6am8": {
     "defaultMessage": "{count}/{maxLength} characters",
@@ -7899,10 +7903,6 @@
     "defaultMessage": "Choose a target locale to open this file in the CAT workspace.",
     "description": "Empty state when no target locale is available for the CAT file"
   },
-  "W+LYiFgyzf": {
-    "defaultMessage": "Use organization knowledge as guidance for this automation.",
-    "description": "Knowledge memories tool description in the marketing automation editor mock"
-  },
   "W/3juG8Ln3": {
     "defaultMessage": "Hyperlocalise runs quality checks at every stage — draft, review, sync, and after publish.",
     "description": "Workflow section description for the localisation-quality-monitoring use case"
@@ -8667,6 +8667,10 @@
     "defaultMessage": "Unavailable",
     "description": "Shown in project snapshot when open job count fails to load"
   },
+  "ZAAVT7ICJL": {
+    "defaultMessage": "Notify #compliance when findings need review.",
+    "description": "Slack tool description in the marketing automation editor mock"
+  },
   "ZAEjcUnwS/": {
     "defaultMessage": "{count} total",
     "description": "Badge showing total issue count on the Issue Sheet page"
@@ -9015,10 +9019,6 @@
     "defaultMessage": "Latest posts",
     "description": "Marketing homepage recent blog posts section title"
   },
-  "agJVrVF8yQ": {
-    "defaultMessage": "Translate help center article updates into the configured target locales. Read the updated entry, localize title, body, SEO, and CTAs, run QA, then write drafts back for review. Do not publish.",
-    "description": "Sample agent instructions in the marketing automation editor mock"
-  },
   "ah1fHcY0dZ": {
     "defaultMessage": "View jobs",
     "description": "Button linking to the project jobs page from the empty jobs card"
@@ -9314,10 +9314,6 @@
   "c7ggsCcxGl": {
     "defaultMessage": "AI translation draft",
     "description": "Workflow step 3 label for the product-localisation use case"
-  },
-  "c8Cee1xOoy": {
-    "defaultMessage": "Contentful webhook",
-    "description": "Contentful webhook trigger title in the marketing automation editor mock"
   },
   "c8ULJQ9Qs8": {
     "defaultMessage": "{matchPercent}% match",
@@ -10734,6 +10730,10 @@
   "hpZLGfM1av": {
     "defaultMessage": "Clear filters",
     "description": "Button to reset glossary list filters"
+  },
+  "hr7MzZuStw": {
+    "defaultMessage": "Check locale coverage, terminology, and compliance gates.",
+    "description": "Validation tool description in the marketing automation editor mock"
   },
   "hsNMISsI79": {
     "defaultMessage": "80% off Growth to launch globally in days.",
@@ -13103,6 +13103,10 @@
     "defaultMessage": "Locales",
     "description": "App shell breadcrumb title for the locales page"
   },
+  "s/3fnj/Eu/": {
+    "defaultMessage": "Daily",
+    "description": "Schedule cadence pill in the marketing automation editor mock"
+  },
   "s0zzQZDyx9": {
     "defaultMessage": "Source connection",
     "description": "Heading for the external TMS source connection section"
@@ -14427,10 +14431,6 @@
     "defaultMessage": "Cannot save translation because the provider file identifier is missing.",
     "description": "Error when a CAT save cannot resolve the TMS provider file identifier"
   },
-  "xNGsvx/Hks": {
-    "defaultMessage": "Contentful translate",
-    "description": "Contentful tool title in the marketing automation editor mock"
-  },
   "xOFZqYtkn0": {
     "defaultMessage": "A few things need your attention",
     "description": "Dashboard hero title when pending actions need review"
@@ -14807,10 +14807,6 @@
     "defaultMessage": "Comment on selected ({count})",
     "description": "Button to leave provider comments on selected findings"
   },
-  "yxdCe3Hn5q": {
-    "defaultMessage": "Article",
-    "description": "Content type label in the marketing automation editor mock"
-  },
   "z+yNDK6TMM": {
     "defaultMessage": "Comfortable",
     "description": "CAT workspace view mode with queue, editor, and intelligence panels"
@@ -14898,6 +14894,10 @@
   "zHmiYq4Tm1": {
     "defaultMessage": "Translation Memories",
     "description": "Translation memories page heading"
+  },
+  "zIGAcrN6+O": {
+    "defaultMessage": "Validation",
+    "description": "Validation tool title in the marketing automation editor mock"
   },
   "zIinCypcXs": {
     "defaultMessage": "View settings",

--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -111,10 +111,6 @@
     "defaultMessage": "—",
     "description": "Placeholder when a provider detail value is empty"
   },
-  "+MYLJhmlev": {
-    "defaultMessage": "Run a scheduled compliance check on medical device labelling and IFU translations. Compare locales against approved terminology, flag missing translations for regulated markets, check unit and warning phrase consistency, then report blockers for review. Do not publish.",
-    "description": "Sample agent instructions in the marketing automation editor mock"
-  },
   "+Pn3eYONmL": {
     "defaultMessage": "Semrush",
     "description": "Menu item and tool title for Semrush SEO data"
@@ -955,6 +951,10 @@
     "defaultMessage": "AI tokens / month",
     "description": "Pricing matrix row label for AI tokens"
   },
+  "1xBioz9EDW": {
+    "defaultMessage": "Validation",
+    "description": "Validation tool title in the marketing automation editor mock"
+  },
   "1xnSvhvUmv": {
     "defaultMessage": "Generate locale drafts with your LLM",
     "description": "Workflow step 3 description for the help-center-localisation use case"
@@ -1374,6 +1374,10 @@
   "3cr478PtNy": {
     "defaultMessage": "Remove {label}",
     "description": "Accessible label for removing an active issue filter chip"
+  },
+  "3cyl65gUFm": {
+    "defaultMessage": "Medical device compliance check",
+    "description": "Automation name shown in the marketing automation editor mock"
   },
   "3dfZO0kB4v": {
     "defaultMessage": "Seats",
@@ -1827,10 +1831,6 @@
     "defaultMessage": "Unknown repository",
     "description": "Label when a selected repository id is not in the loaded list"
   },
-  "5YseOmwLin": {
-    "defaultMessage": "Scheduled",
-    "description": "Scheduled trigger title in the marketing automation editor mock"
-  },
   "5YusqFJjvU": {
     "defaultMessage": "Refresh the page to try again.",
     "description": "Fallback error guidance when loading members fails"
@@ -1910,10 +1910,6 @@
   "5yXqdk0MWc": {
     "defaultMessage": "From new article to monitored locale coverage",
     "description": "Workflow section title for the help-center-localisation use case"
-  },
-  "6/+JsEuq89": {
-    "defaultMessage": "Use approved medical terminology and regulatory glossary as guidance.",
-    "description": "Knowledge memories tool description in the marketing automation editor mock"
   },
   "6/4F992ZiW": {
     "defaultMessage": "Unable to remove project",
@@ -3255,6 +3251,10 @@
     "defaultMessage": "{sourceLocale} → {targetLocale}",
     "description": "Locale pair badge on the glossary detail page"
   },
+  "BQ2Um1RaCK": {
+    "defaultMessage": "Use approved medical terminology and regulatory glossary as guidance.",
+    "description": "Knowledge memories tool description in the marketing automation editor mock"
+  },
   "BUP/2Zum32": {
     "defaultMessage": "Human-in-the-loop escalation",
     "description": "Differentiator point 3 for the localisation-quality-monitoring use case"
@@ -4399,6 +4399,10 @@
     "defaultMessage": "Upload a source file before creating a translation job.",
     "description": "Validation error when creating a job without a stored source file"
   },
+  "GC8iH4BPwj": {
+    "defaultMessage": "Scheduled",
+    "description": "Scheduled trigger title in the marketing automation editor mock"
+  },
   "GDx1gijvA4": {
     "defaultMessage": "TMS agnostic",
     "description": "Differentiator point 1 for the help-center-localisation use case"
@@ -4622,10 +4626,6 @@
   "H7MZFgXFSw": {
     "defaultMessage": "Copied!",
     "description": "Aria label after copying the inbound email address"
-  },
-  "H8bNcbLNen": {
-    "defaultMessage": "Medical device compliance check",
-    "description": "Automation name shown in the marketing automation editor mock"
   },
   "HA9fSDFTe4": {
     "defaultMessage": "Replaced <wrong>marches</wrong> with <right>marchés</right> so the French pricing copy is spelled correctly.",
@@ -5495,10 +5495,6 @@
     "defaultMessage": "Inbox",
     "description": "Eyebrow label above the marketing chat dock mock section"
   },
-  "LLQAT26N2S": {
-    "defaultMessage": "08:00 UTC",
-    "description": "Schedule time pill in the marketing automation editor mock"
-  },
   "LMGo1sN8VQ": {
     "defaultMessage": "This glossary is used only by the projects listed here.",
     "description": "Section description for projects assigned to a glossary"
@@ -5662,6 +5658,10 @@
   "MB3Jte6am8": {
     "defaultMessage": "{count}/{maxLength} characters",
     "description": "Live character count for the CAT target translation against a max length limit"
+  },
+  "MCViSbp0Sq": {
+    "defaultMessage": "Run a scheduled compliance check on medical device labelling and IFU translations. Compare locales against approved terminology, flag missing translations for regulated markets, check unit and warning phrase consistency, then report blockers for review. Do not publish.",
+    "description": "Sample agent instructions in the marketing automation editor mock"
   },
   "MDFHda6r2V": {
     "defaultMessage": "Description saved",
@@ -8159,6 +8159,10 @@
     "defaultMessage": "No issues found",
     "description": "Empty state title when QA completed with zero findings"
   },
+  "X6g1omP0I1": {
+    "defaultMessage": "Notify #compliance when findings need review.",
+    "description": "Slack tool description in the marketing automation editor mock"
+  },
   "X7qkN/IoEW": {
     "defaultMessage": "How can I help you today?",
     "description": "Empty-state heading inside the marketing chat dock mock"
@@ -8666,10 +8670,6 @@
   "Z9kckxHp8S": {
     "defaultMessage": "Unavailable",
     "description": "Shown in project snapshot when open job count fails to load"
-  },
-  "ZAAVT7ICJL": {
-    "defaultMessage": "Notify #compliance when findings need review.",
-    "description": "Slack tool description in the marketing automation editor mock"
   },
   "ZAEjcUnwS/": {
     "defaultMessage": "{count} total",
@@ -9562,6 +9562,10 @@
   "dRBR6Rd4hs": {
     "defaultMessage": "Built for engineering and localisation operations",
     "description": "Differentiator point 5 for the github-release-localisation use case"
+  },
+  "dStMwhojOw": {
+    "defaultMessage": "08:00 UTC",
+    "description": "Schedule time pill in the marketing automation editor mock"
   },
   "dTKdfkqH71": {
     "defaultMessage": "Create job",
@@ -10731,10 +10735,6 @@
     "defaultMessage": "Clear filters",
     "description": "Button to reset glossary list filters"
   },
-  "hr7MzZuStw": {
-    "defaultMessage": "Check locale coverage, terminology, and compliance gates.",
-    "description": "Validation tool description in the marketing automation editor mock"
-  },
   "hsNMISsI79": {
     "defaultMessage": "80% off Growth to launch globally in days.",
     "description": "Offer line under the startups page headline"
@@ -11138,6 +11138,10 @@
   "jPddLz1mvi": {
     "defaultMessage": "No source files linked to this job.",
     "description": "Empty state when a synced provider job has no source files"
+  },
+  "jQ5TgyeZII": {
+    "defaultMessage": "Check locale coverage, terminology, and compliance gates.",
+    "description": "Validation tool description in the marketing automation editor mock"
   },
   "jRn12WvzpR": {
     "defaultMessage": "Format",
@@ -13103,10 +13107,6 @@
     "defaultMessage": "Locales",
     "description": "App shell breadcrumb title for the locales page"
   },
-  "s/3fnj/Eu/": {
-    "defaultMessage": "Daily",
-    "description": "Schedule cadence pill in the marketing automation editor mock"
-  },
   "s0zzQZDyx9": {
     "defaultMessage": "Source connection",
     "description": "Heading for the external TMS source connection section"
@@ -14351,6 +14351,10 @@
     "defaultMessage": "Already in TMS",
     "description": "Write-back status when a finding already had a provider comment"
   },
+  "x3xLP2YerQ": {
+    "defaultMessage": "Daily",
+    "description": "Schedule cadence pill in the marketing automation editor mock"
+  },
   "x6H592pqcv": {
     "defaultMessage": "Select connection",
     "description": "Placeholder when no Contentful connection is selected"
@@ -14894,10 +14898,6 @@
   "zHmiYq4Tm1": {
     "defaultMessage": "Translation Memories",
     "description": "Translation memories page heading"
-  },
-  "zIGAcrN6+O": {
-    "defaultMessage": "Validation",
-    "description": "Validation tool title in the marketing automation editor mock"
   },
   "zIinCypcXs": {
     "defaultMessage": "View settings",

--- a/apps/hyperlocalise-web/src/components/marketing/automation-editor-illustration.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/automation-editor-illustration.messages.ts
@@ -17,7 +17,7 @@ import { defineMessages } from "react-intl";
 export const automationEditorIllustrationMessages = defineMessages({
   automationName: {
     defaultMessage: "Medical device compliance check",
-    id: "H8bNcbLNen",
+    id: "3cyl65gUFm",
     description: "Automation name shown in the marketing automation editor mock",
   },
   settingsTab: {
@@ -32,17 +32,17 @@ export const automationEditorIllustrationMessages = defineMessages({
   },
   scheduledTrigger: {
     defaultMessage: "Scheduled",
-    id: "5YseOmwLin",
+    id: "GC8iH4BPwj",
     description: "Scheduled trigger title in the marketing automation editor mock",
   },
   scheduleCadence: {
     defaultMessage: "Daily",
-    id: "s/3fnj/Eu/",
+    id: "x3xLP2YerQ",
     description: "Schedule cadence pill in the marketing automation editor mock",
   },
   scheduleTime: {
     defaultMessage: "08:00 UTC",
-    id: "LLQAT26N2S",
+    id: "dStMwhojOw",
     description: "Schedule time pill in the marketing automation editor mock",
   },
   instructionsSection: {
@@ -53,7 +53,7 @@ export const automationEditorIllustrationMessages = defineMessages({
   instructionsBody: {
     defaultMessage:
       "Run a scheduled compliance check on medical device labelling and IFU translations. Compare locales against approved terminology, flag missing translations for regulated markets, check unit and warning phrase consistency, then report blockers for review. Do not publish.",
-    id: "+MYLJhmlev",
+    id: "MCViSbp0Sq",
     description: "Sample agent instructions in the marketing automation editor mock",
   },
   toolsSection: {
@@ -68,17 +68,17 @@ export const automationEditorIllustrationMessages = defineMessages({
   },
   toolKnowledgeDescription: {
     defaultMessage: "Use approved medical terminology and regulatory glossary as guidance.",
-    id: "6/+JsEuq89",
+    id: "BQ2Um1RaCK",
     description: "Knowledge memories tool description in the marketing automation editor mock",
   },
   toolValidation: {
     defaultMessage: "Validation",
-    id: "zIGAcrN6+O",
+    id: "1xBioz9EDW",
     description: "Validation tool title in the marketing automation editor mock",
   },
   toolValidationDescription: {
     defaultMessage: "Check locale coverage, terminology, and compliance gates.",
-    id: "hr7MzZuStw",
+    id: "jQ5TgyeZII",
     description: "Validation tool description in the marketing automation editor mock",
   },
   toolSlack: {
@@ -88,7 +88,7 @@ export const automationEditorIllustrationMessages = defineMessages({
   },
   toolSlackDescription: {
     defaultMessage: "Notify #compliance when findings need review.",
-    id: "ZAAVT7ICJL",
+    id: "X6g1omP0I1",
     description: "Slack tool description in the marketing automation editor mock",
   },
   addTool: {

--- a/apps/hyperlocalise-web/src/components/marketing/automation-editor-illustration.messages.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/automation-editor-illustration.messages.ts
@@ -16,8 +16,8 @@ import { defineMessages } from "react-intl";
 
 export const automationEditorIllustrationMessages = defineMessages({
   automationName: {
-    defaultMessage: "Translate Contentful article",
-    id: "3nHm7zuXbR",
+    defaultMessage: "Medical device compliance check",
+    id: "H8bNcbLNen",
     description: "Automation name shown in the marketing automation editor mock",
   },
   settingsTab: {
@@ -30,20 +30,20 @@ export const automationEditorIllustrationMessages = defineMessages({
     id: "11wuxnX/XF",
     description: "Triggers section heading in the marketing automation editor mock",
   },
-  contentfulWebhook: {
-    defaultMessage: "Contentful webhook",
-    id: "c8Cee1xOoy",
-    description: "Contentful webhook trigger title in the marketing automation editor mock",
+  scheduledTrigger: {
+    defaultMessage: "Scheduled",
+    id: "5YseOmwLin",
+    description: "Scheduled trigger title in the marketing automation editor mock",
   },
-  space: {
-    defaultMessage: "Help Center",
-    id: "21wXbXIpMt",
-    description: "Contentful space label in the marketing automation editor mock",
+  scheduleCadence: {
+    defaultMessage: "Daily",
+    id: "s/3fnj/Eu/",
+    description: "Schedule cadence pill in the marketing automation editor mock",
   },
-  contentType: {
-    defaultMessage: "Article",
-    id: "yxdCe3Hn5q",
-    description: "Content type label in the marketing automation editor mock",
+  scheduleTime: {
+    defaultMessage: "08:00 UTC",
+    id: "LLQAT26N2S",
+    description: "Schedule time pill in the marketing automation editor mock",
   },
   instructionsSection: {
     defaultMessage: "Agent Instructions",
@@ -52,8 +52,8 @@ export const automationEditorIllustrationMessages = defineMessages({
   },
   instructionsBody: {
     defaultMessage:
-      "Translate help center article updates into the configured target locales. Read the updated entry, localize title, body, SEO, and CTAs, run QA, then write drafts back for review. Do not publish.",
-    id: "agJVrVF8yQ",
+      "Run a scheduled compliance check on medical device labelling and IFU translations. Compare locales against approved terminology, flag missing translations for regulated markets, check unit and warning phrase consistency, then report blockers for review. Do not publish.",
+    id: "+MYLJhmlev",
     description: "Sample agent instructions in the marketing automation editor mock",
   },
   toolsSection: {
@@ -67,19 +67,19 @@ export const automationEditorIllustrationMessages = defineMessages({
     description: "Knowledge memories tool title in the marketing automation editor mock",
   },
   toolKnowledgeDescription: {
-    defaultMessage: "Use organization knowledge as guidance for this automation.",
-    id: "W+LYiFgyzf",
+    defaultMessage: "Use approved medical terminology and regulatory glossary as guidance.",
+    id: "6/+JsEuq89",
     description: "Knowledge memories tool description in the marketing automation editor mock",
   },
-  toolContentful: {
-    defaultMessage: "Contentful translate",
-    id: "xNGsvx/Hks",
-    description: "Contentful tool title in the marketing automation editor mock",
+  toolValidation: {
+    defaultMessage: "Validation",
+    id: "zIGAcrN6+O",
+    description: "Validation tool title in the marketing automation editor mock",
   },
-  toolContentfulDescription: {
-    defaultMessage: "Translate fields, run QA, and write drafts for review.",
-    id: "M8WTB2rTQG",
-    description: "Contentful tool description in the marketing automation editor mock",
+  toolValidationDescription: {
+    defaultMessage: "Check locale coverage, terminology, and compliance gates.",
+    id: "hr7MzZuStw",
+    description: "Validation tool description in the marketing automation editor mock",
   },
   toolSlack: {
     defaultMessage: "Slack",
@@ -87,8 +87,8 @@ export const automationEditorIllustrationMessages = defineMessages({
     description: "Slack tool title in the marketing automation editor mock",
   },
   toolSlackDescription: {
-    defaultMessage: "Notify #localization when drafts are ready.",
-    id: "7pTwJNAe0D",
+    defaultMessage: "Notify #compliance when findings need review.",
+    id: "ZAAVT7ICJL",
     description: "Slack tool description in the marketing automation editor mock",
   },
   addTool: {

--- a/apps/hyperlocalise-web/src/components/marketing/automation-editor-illustration.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/automation-editor-illustration.tsx
@@ -14,7 +14,12 @@
  */
 import type { ReactNode } from "react";
 
-import { BrainCircuitIcon, File01Icon, PlusSignIcon } from "@hugeicons/core-free-icons";
+import {
+  BrainCircuitIcon,
+  Clock01Icon,
+  PlusSignIcon,
+  SecurityCheckIcon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage } from "react-intl";
 
@@ -74,17 +79,6 @@ function Pill({ children }: { children: ReactNode }) {
   );
 }
 
-function ContentfulMark() {
-  return (
-    <span
-      className="flex size-4 items-center justify-center rounded-[0.2rem] bg-[#FC6176] text-[0.55rem] font-bold text-white"
-      aria-hidden
-    >
-      C
-    </span>
-  );
-}
-
 export function AutomationEditorIllustration({ className }: { className?: string }) {
   return (
     <div
@@ -111,17 +105,17 @@ export function AutomationEditorIllustration({ className }: { className?: string
         >
           <MockPanel>
             <MockRow
-              icon={<HugeiconsIcon icon={File01Icon} strokeWidth={1.8} className="size-4" />}
+              icon={<HugeiconsIcon icon={Clock01Icon} strokeWidth={1.8} className="size-4" />}
               title={
-                <FormattedMessage {...automationEditorIllustrationMessages.contentfulWebhook} />
+                <FormattedMessage {...automationEditorIllustrationMessages.scheduledTrigger} />
               }
               trailing={
                 <div className="flex flex-wrap items-center gap-1.5">
                   <Pill>
-                    <FormattedMessage {...automationEditorIllustrationMessages.space} />
+                    <FormattedMessage {...automationEditorIllustrationMessages.scheduleCadence} />
                   </Pill>
                   <Pill>
-                    <FormattedMessage {...automationEditorIllustrationMessages.contentType} />
+                    <FormattedMessage {...automationEditorIllustrationMessages.scheduleTime} />
                   </Pill>
                 </div>
               }
@@ -153,11 +147,13 @@ export function AutomationEditorIllustration({ className }: { className?: string
               }
             />
             <MockRow
-              icon={<ContentfulMark />}
-              title={<FormattedMessage {...automationEditorIllustrationMessages.toolContentful} />}
+              icon={
+                <HugeiconsIcon icon={SecurityCheckIcon} strokeWidth={1.8} className="size-4" />
+              }
+              title={<FormattedMessage {...automationEditorIllustrationMessages.toolValidation} />}
               description={
                 <FormattedMessage
-                  {...automationEditorIllustrationMessages.toolContentfulDescription}
+                  {...automationEditorIllustrationMessages.toolValidationDescription}
                 />
               }
             />

--- a/apps/hyperlocalise-web/src/components/marketing/automation-editor-illustration.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/automation-editor-illustration.tsx
@@ -147,9 +147,7 @@ export function AutomationEditorIllustration({ className }: { className?: string
               }
             />
             <MockRow
-              icon={
-                <HugeiconsIcon icon={SecurityCheckIcon} strokeWidth={1.8} className="size-4" />
-              }
+              icon={<HugeiconsIcon icon={SecurityCheckIcon} strokeWidth={1.8} className="size-4" />}
               title={<FormattedMessage {...automationEditorIllustrationMessages.toolValidation} />}
               description={
                 <FormattedMessage


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Replaced the homepage Agent Automation card mock from Contentful translation to a scheduled medical device compliance check:

- Automation name: **Medical device compliance check**
- Trigger: **Scheduled** with Daily / 08:00 UTC
- Instructions cover IFU/labelling compliance, terminology, and regulated-market gaps
- Tools: Memories, Validation, Slack (`#compliance`)
- Updated `lang/en-US.json` with new message IDs so translated locales fall back cleanly until sync

## How to test

- Open the marketing homepage Agent Automation card and confirm the new mock copy
- `vp check --fix` (passed)
- `vp test` (passed: 3270 tests)

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dac6507f-3302-482e-98ff-dc23267e114f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dac6507f-3302-482e-98ff-dc23267e114f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

