### PR TITLE
fix(cat): match native queue search against target text

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
@@ -60,13 +60,13 @@ export const catQueuePanelMessages = defineMessages({
     description: "Accessible label for the queue overflow actions button",
   },
   searchPlaceholder: {
-    defaultMessage: "Search key or text…",
-    id: "8TtvvjSylP",
+    defaultMessage: "Search key, source, or translation…",
+    id: "extNy23p4p",
     description: "Placeholder for CAT queue search input",
   },
   searchAria: {
-    defaultMessage: "Search segments by key or source text",
-    id: "Wk16E7zAqa",
+    defaultMessage: "Search segments by key, source text, or translation",
+    id: "Kjim0yzISM",
     description: "Accessible label for CAT queue search input",
   },
   emptySearchResults: {

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-search.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-search.test.ts
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import "dotenv/config";
+
+import { randomUUID } from "node:crypto";
+
+import { eq } from "drizzle-orm";
+import { afterEach, beforeAll, describe, expect, it } from "vite-plus/test";
+
+import { createAuthTestFixture } from "@/api/test-auth.fixture";
+import { db, schema } from "@/lib/database";
+import { ensureRepositorySourceFile } from "@/lib/file-storage/records";
+import { getNativeProjectCatFile } from "@/lib/projects/cat/native-cat-service";
+import { upsertProjectTranslationKeysFromEntries } from "@/lib/projects/translations/project-translation-service";
+import { ensureDefaultWorkspaceTeam } from "@/lib/teams/default-workspace-team";
+
+const authFixture = createAuthTestFixture();
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+});
+
+afterEach(async () => {
+  await authFixture.cleanup();
+});
+
+describe("native CAT queue search", () => {
+  async function seedProjectWithSegments() {
+    const { organization, user } = await authFixture.createLocalWorkosIdentity();
+    const team = await ensureDefaultWorkspaceTeam(organization.id);
+    const [project] = await db
+      .insert(schema.projects)
+      .values({
+        id: `project_${randomUUID()}`,
+        organizationId: organization.id,
+        teamId: team.id,
+        createdByUserId: user.id,
+        name: "Tourfinder",
+        description: "",
+        translationContext: "",
+        sourceLocale: "en-US",
+        targetLocales: ["vi-VN"],
+      })
+      .returning();
+
+    const sourcePath = "lang/en-US.json";
+    const sourceFile = await ensureRepositorySourceFile({
+      organizationId: organization.id,
+      projectId: project!.id,
+      sourcePath,
+    });
+
+    await upsertProjectTranslationKeysFromEntries({
+      organizationId: organization.id,
+      projectId: project!.id,
+      repositorySourceFileId: sourceFile.id,
+      entries: [
+        { key: "nav.last", text: "Last", context: null },
+        { key: "hero.title", text: "Welcome home", context: "Homepage hero" },
+        { key: "cta.start", text: "Get started finally", context: null },
+        { key: "settings.rate_limit", text: "Rate limit exceeded", context: null },
+      ],
+    });
+
+    const keys = await db
+      .select({
+        id: schema.projectTranslationKeys.id,
+        key: schema.projectTranslationKeys.key,
+      })
+      .from(schema.projectTranslationKeys)
+      .where(eq(schema.projectTranslationKeys.repositorySourceFileId, sourceFile.id));
+
+    const lastKey = keys.find((row) => row.key === "nav.last");
+    expect(lastKey).toBeDefined();
+
+    await db.insert(schema.projectTranslations).values({
+      organizationId: organization.id,
+      projectId: project!.id,
+      translationKeyId: lastKey!.id,
+      targetLocale: "vi-VN",
+      text: "cuối cùng",
+      status: "draft",
+    });
+
+    return { organization, project: project!, sourcePath };
+  }
+
+  async function search(input: {
+    organizationId: string;
+    projectId: string;
+    sourcePath: string;
+    search: string;
+  }) {
+    return getNativeProjectCatFile({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      sourcePath: input.sourcePath,
+      targetLocale: "vi-VN",
+      canEditTranslations: true,
+      organizationSlug: "tripsocial",
+      pagination: {
+        offset: 0,
+        limit: 50,
+        search: input.search,
+        queueFilter: "all",
+        paginated: true,
+      },
+    });
+  }
+
+  it("matches source text content", async () => {
+    const { organization, project, sourcePath } = await seedProjectWithSegments();
+    const result = await search({
+      organizationId: organization.id,
+      projectId: project.id,
+      sourcePath,
+      search: "Welcome",
+    });
+
+    expect(result?.segments.map((segment) => segment.key)).toEqual(["hero.title"]);
+    expect(result?.pagination?.totalCount).toBe(1);
+  });
+
+  it("matches multi-word source text case-insensitively", async () => {
+    const { organization, project, sourcePath } = await seedProjectWithSegments();
+    const result = await search({
+      organizationId: organization.id,
+      projectId: project.id,
+      sourcePath,
+      search: "welcome HOME",
+    });
+
+    expect(result?.segments.map((segment) => segment.key)).toEqual(["hero.title"]);
+  });
+
+  it("matches context text", async () => {
+    const { organization, project, sourcePath } = await seedProjectWithSegments();
+    const result = await search({
+      organizationId: organization.id,
+      projectId: project.id,
+      sourcePath,
+      search: "Homepage hero",
+    });
+
+    expect(result?.segments.map((segment) => segment.key)).toEqual(["hero.title"]);
+  });
+
+  it("matches target translation text for the active locale", async () => {
+    const { organization, project, sourcePath } = await seedProjectWithSegments();
+    const result = await search({
+      organizationId: organization.id,
+      projectId: project.id,
+      sourcePath,
+      search: "cuối cùng",
+    });
+
+    expect(result?.segments.map((segment) => segment.key)).toEqual(["nav.last"]);
+    expect(result?.segments[0]?.sourceText).toBe("Last");
+    expect(result?.pagination?.totalCount).toBe(1);
+  });
+
+  it("treats underscores in the query as literals", async () => {
+    const { organization, project, sourcePath } = await seedProjectWithSegments();
+    const result = await search({
+      organizationId: organization.id,
+      projectId: project.id,
+      sourcePath,
+      search: "rate_limit",
+    });
+
+    expect(result?.segments.map((segment) => segment.key)).toEqual(["settings.rate_limit"]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
@@ -61,19 +61,46 @@ function translationKeysSourcePathFilter(sourcePaths: readonly string[] | null |
   return inArray(schema.repositorySourceFiles.sourcePath, [...sourcePaths]);
 }
 
-function translationKeysSearchCondition(search: string | undefined) {
-  const query = search?.trim();
+function escapeIlikePattern(value: string) {
+  return value.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
+}
+
+function translationKeysSearchCondition(input: {
+  search?: string;
+  organizationId: string;
+  projectId: string;
+  targetLocale?: string;
+}) {
+  const query = input.search?.trim();
   if (!query) {
     return undefined;
   }
 
-  const pattern = `%${query}%`;
+  const pattern = `%${escapeIlikePattern(query)}%`;
 
-  return or(
+  const keySourceOrContext = or(
     ilike(schema.projectTranslationKeys.key, pattern),
     ilike(schema.projectTranslationKeys.sourceText, pattern),
     ilike(schema.projectTranslationKeys.context, pattern),
   );
+
+  if (!input.targetLocale) {
+    return keySourceOrContext;
+  }
+
+  // Also match target translation text for the active CAT locale so translators
+  // can find segments by the content they see in either column.
+  const targetTextMatch = sql`exists (
+    select 1
+    from ${schema.projectTranslations}
+    where ${schema.projectTranslations.translationKeyId} = ${schema.projectTranslationKeys.id}
+      and ${schema.projectTranslations.organizationId} = ${input.organizationId}
+      and ${schema.projectTranslations.projectId} = ${input.projectId}
+      and ${schema.projectTranslations.targetLocale} = ${input.targetLocale}
+      and ${schema.projectTranslations.text} ilike ${pattern}
+  )`;
+
+  return or(keySourceOrContext, targetTextMatch);
 }
 
 function translationKeysQueueFilterCondition(input: {
@@ -268,7 +295,7 @@ export class ProjectTranslationService extends ProjectServiceBase {
       .where(
         and(
           translationKeysFileConditions(input),
-          translationKeysSearchCondition(input.search),
+          translationKeysSearchCondition(input),
           input.targetLocale
             ? translationKeysQueueFilterCondition({
                 organizationId: input.organizationId,
@@ -310,7 +337,7 @@ export class ProjectTranslationService extends ProjectServiceBase {
       .where(
         and(
           translationKeysFileConditions(input),
-          translationKeysSearchCondition(input.search),
+          translationKeysSearchCondition(input),
           input.targetLocale
             ? translationKeysQueueFilterCondition({
                 organizationId: input.organizationId,
@@ -345,7 +372,7 @@ export class ProjectTranslationService extends ProjectServiceBase {
         and(
           translationKeysProjectConditions(input),
           translationKeysSourcePathFilter(input.sourcePaths),
-          translationKeysSearchCondition(input.search),
+          translationKeysSearchCondition(input),
           input.targetLocale
             ? translationKeysQueueFilterCondition({
                 organizationId: input.organizationId,
@@ -393,7 +420,7 @@ export class ProjectTranslationService extends ProjectServiceBase {
         and(
           translationKeysProjectConditions(input),
           translationKeysSourcePathFilter(input.sourcePaths),
-          translationKeysSearchCondition(input.search),
+          translationKeysSearchCondition(input),
           input.targetLocale
             ? translationKeysQueueFilterCondition({
                 organizationId: input.organizationId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Native CAT queue search only matched key, source text, and context. Searching translation content (e.g. `cuối cùng` on a `vi-VN` file) returned **No segments match your search** / **0 loaded**.

## Fix

- Include the active locale’s `project_translations.text` in native CAT search via an `EXISTS` subquery
- Escape LIKE metacharacters (`%`, `_`, `\`) so queries with underscores match literally
- Update search placeholder/aria copy to mention translations
- Add integration coverage for source, context, target, case-insensitive, and underscore queries

## Test plan

- [x] `vp test src/lib/projects/cat/native-cat-search.test.ts`
- [x] `vp check --fix`
- [ ] In a native project CAT file with target locale set, search by English source text — expect matching segments
- [ ] Search by target translation text — expect matching segments
- [ ] Search a key containing `_` — expect exact key match, not wildcard matches

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1941bc21-c46a-495f-ae75-e236c411a700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1941bc21-c46a-495f-ae75-e236c411a700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

