### PR TITLE
feat(blog): Startmate Winter ’26 press release

### DIFF
--- a/apps/hyperlocalise-web/_posts/en/startmate-backs-hyperlocalise-ai-localisation-platform.md
+++ b/apps/hyperlocalise-web/_posts/en/startmate-backs-hyperlocalise-ai-localisation-platform.md
@@ -1,0 +1,65 @@
+---
+title: "Startmate Backs Hyperlocalise’s AI Localisation Platform"
+date: 2026-07-31T00:00:00.000Z
+excerpt: Sydney startup joins Startmate’s Winter ’26 Accelerator to build the intelligence and execution layer for global growth — with AUD $120,000 in pre-seed funding.
+category: Company
+tags:
+  - Startmate
+  - Winter ’26
+  - Accelerator
+  - funding
+  - localisation
+  - localization
+  - language AI
+  - AI agents
+  - translation intelligence
+  - product localisation
+  - global growth
+---
+
+**SYDNEY, Australia — 31 July 2026** — Hyperlocalise, the agentic localisation platform helping product teams launch successfully in every market, today announced it has secured AUD $120,000 in pre-seed funding from Startmate after being selected for its Winter ’26 Accelerator cohort.
+
+Hyperlocalise was chosen as one of 17 companies joining the highly selective program, which brings together ambitious founders from Australia and New Zealand building globally significant businesses. Coverage of the cohort announcement is available from [Startmate](https://www.startmate.com/writing/meet-our-winter-26-accelerator-cohort) and [Startup Daily](https://www.startupdaily.net/topic/accelerator/startmate-backs-17-startups-for-its-winter-intake/).
+
+## An AI workforce for localisation teams
+
+The company is building an AI workforce for localisation teams. Its agents gather product context, preserve organisational knowledge, automate repetitive localisation work, and help teams translate and adapt every customer touchpoint with greater speed and market nuance.
+
+Unlike tools that require companies to replace their existing localisation systems, Hyperlocalise is designed to work alongside the technology and workflows teams already use, while keeping human reviewers firmly in control.
+
+“Companies do not struggle to go global because they lack translation tools. They struggle because the knowledge needed to make good localisation decisions is scattered across people, products and platforms,” said Minh Cung, co-founder of Hyperlocalise.
+
+“We are building Hyperlocalise so localisation teams can scale at the same speed as product development. Our goal is not to replace the people who understand customers and cultures. It is to give them an AI workforce that learns alongside them, carries context between projects and removes the repetitive work standing between a product and its global customers.”
+
+## Closing the gap between product and every market
+
+Localisation remains a fragmented and heavily manual process for many companies. Product context is often spread across design files, tickets, documentation, messaging platforms and the knowledge of individual employees. Translators and market reviewers must repeatedly search for information, clarify intent and coordinate feedback across time zones.
+
+As product release cycles accelerate, these operational bottlenecks can delay international launches by weeks or months. Hyperlocalise brings the workflow into an agentic system that can support translation, transcreation, visual context, asset localisation and human review while maintaining brand voice and local market requirements.
+
+The Startmate funding will support the continued development of Hyperlocalise’s agent automation, self-evolving knowledge system and next-generation computer-assisted translation workspace. The company will also expand its pilot partnerships and integrations with existing localisation technology stacks.
+
+## Founded for global growth
+
+Hyperlocalise was founded by Minh Cung and Hans Bui, who bring experience across localisation engineering, global product development, payments and international launches.
+
+Cung previously spent four years building global localisation infrastructure at Canva, including contributing to Magic Translate, before leading localisation engineering at Heidi Health. Bui brings product and commercial experience from Samsung, where he worked across payment solutions, partnerships and global flagship launches, as well as Tyro Payments.
+
+“At Canva, I saw that localisation could be one of the highest-leverage growth investments a company makes,” Cung said. “Every language can unlock new customers, stronger engagement and deeper trust. We started Hyperlocalise because we want more companies to access that opportunity without localisation becoming the bottleneck.”
+
+During Startmate’s 12-week Accelerator, Hyperlocalise will work with experienced founders, operators, mentors and investors from across Australia and New Zealand. The program will culminate in Demo Day on 20 October 2026, followed by a week in San Francisco connecting participating companies with the US startup and investment ecosystem.
+
+Hyperlocalise’s long-term vision is to become the intelligence and execution layer for global growth: the platform companies use not simply to translate their products, but to make them feel genuinely local in every market.
+
+## Press coverage
+
+- [Meet our Winter ’26 Accelerator Cohort](https://www.startmate.com/writing/meet-our-winter-26-accelerator-cohort) — Startmate
+- [Startmate backs 17 startups for its winter intake](https://www.startupdaily.net/topic/accelerator/startmate-backs-17-startups-for-its-winter-intake/) — Startup Daily
+
+## About Hyperlocalise
+
+Hyperlocalise is an agentic localisation platform that helps product and localisation teams launch globally in days. Its AI workforce brings product, brand and market context into every localisation decision, automates repetitive workflows and enables first-class human review without forcing teams to replace their existing tools.
+
+Hyperlocalise was founded in Sydney, Australia, by Minh Cung and Hans Bui.
+
+For more information, visit [hyperlocalise.com](/), or [read more about translation intelligence](/blog/what-is-translation-intelligence).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds a new Company blog post publishing Hyperlocalise’s Startmate Winter ’26 Accelerator press release (AUD $120,000 pre-seed).
- Links out to press coverage from [Startmate](https://www.startmate.com/writing/meet-our-winter-26-accelerator-cohort) and [Startup Daily](https://www.startupdaily.net/topic/accelerator/startmate-backs-17-startups-for-its-winter-intake/).

## How to test

- Confirm post appears on `/en/blog` with title, excerpt, and date 31 July 2026
- Open `/en/blog/startmate-backs-hyperlocalise-ai-localisation-platform` and verify Startmate + Startup Daily links
- Spot-check markdown rendering for quotes and About section

## Checklist

- [x] Ran `vp check --fix` and `vp test` in `apps/hyperlocalise-web`
- [ ] Translations for other locales can sync via the usual Hyperlocalise blog bucket
- [ ] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31f9355c-e53e-42a4-ac3e-7d63a00585f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31f9355c-e53e-42a4-ac3e-7d63a00585f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

