### PR TITLE
fix(cat): prevent blank rows after Needs Review approve

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-virtual-list.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-virtual-list.test.tsx
@@ -41,6 +41,7 @@ type MockVirtualizer = {
 let virtualItems: MockVirtualItem[] = [];
 let virtualizerCount = 0;
 let onVirtualizerChange: ((instance: MockVirtualizer) => void) | undefined;
+let lastGetItemKey: ((index: number) => string | number) | undefined;
 
 function makeVirtualItems(indexes: number[]) {
   return indexes.map((index) => ({
@@ -63,9 +64,11 @@ vi.mock("@tanstack/react-virtual", () => ({
   useVirtualizer: (options: {
     count: number;
     estimateSize?: () => number;
+    getItemKey?: (index: number) => string | number;
     onChange?: (instance: MockVirtualizer) => void;
   }) => {
     virtualizerCount = options.count;
+    lastGetItemKey = options.getItemKey;
     onVirtualizerChange = options.onChange;
     return virtualizer;
   },
@@ -75,9 +78,26 @@ beforeEach(() => {
   virtualItems = makeVirtualItems([0, 1, 2]);
   virtualizerCount = 0;
   onVirtualizerChange = undefined;
+  lastGetItemKey = undefined;
 });
 
 describe("CatQueueVirtualList pagination", () => {
+  it("keys virtual rows by segment id so mid-list removals keep stable measurements", () => {
+    const segments = catSegmentsFixture.slice(0, 3);
+
+    renderWithCatProviders(
+      <CatQueueVirtualList
+        segments={segments}
+        selectedSegmentId={segments[0]!.id}
+        onSelectSegment={vi.fn()}
+      />,
+    );
+
+    expect(lastGetItemKey?.(0)).toBe(segments[0]!.id);
+    expect(lastGetItemKey?.(1)).toBe(segments[1]!.id);
+    expect(lastGetItemKey?.(2)).toBe(segments[2]!.id);
+  });
+
   it("loads the next page when the virtual range reaches the end during scroll", async () => {
     const onNearEnd = vi.fn();
     const segments = catSegmentsFixture.slice(0, 12);

--- a/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-virtual-list.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-virtual-list.tsx
@@ -72,11 +72,16 @@ export function CatQueueVirtualList({
     },
     [hasMore, isLoadingMore, onNearEnd, segments.length],
   );
+  const getItemKey = useCallback(
+    (index: number) => segments[index]?.id ?? index,
+    [segments],
+  );
   const virtualizer = useVirtualizer({
     count: segments.length,
     getScrollElement: () => parentRef.current,
     estimateSize: () => ESTIMATED_ROW_HEIGHT,
     overscan: 8,
+    getItemKey,
     onChange: (instance) => {
       checkForNearEnd(instance.getVirtualItems());
     },
@@ -107,7 +112,7 @@ export function CatQueueVirtualList({
 
           return (
             <li
-              key={segment.id}
+              key={virtualRow.key}
               ref={virtualizer.measureElement}
               data-index={virtualRow.index}
               className="absolute top-0 left-0 w-full"

--- a/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-virtual-list.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-virtual-list.tsx
@@ -72,10 +72,7 @@ export function CatQueueVirtualList({
     },
     [hasMore, isLoadingMore, onNearEnd, segments.length],
   );
-  const getItemKey = useCallback(
-    (index: number) => segments[index]?.id ?? index,
-    [segments],
-  );
+  const getItemKey = useCallback((index: number) => segments[index]?.id ?? index, [segments]);
   const virtualizer = useVirtualizer({
     count: segments.length,
     getScrollElement: () => parentRef.current,

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-virtual-list.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-virtual-list.tsx
@@ -142,11 +142,17 @@ export function CatSideBySideVirtualList({
     [onVisibleSegmentIdsChange, segments],
   );
 
+  const getItemKey = useCallback(
+    (index: number) => segments[index]?.id ?? index,
+    [segments],
+  );
+
   const virtualizer = useVirtualizer({
     count: segments.length,
     getScrollElement: () => parentRef.current,
     estimateSize: () => ESTIMATED_ROW_HEIGHT,
     overscan: 6,
+    getItemKey,
     onChange: (instance) => {
       const virtualItems = instance.getVirtualItems();
       checkForNearEnd(virtualItems);
@@ -184,7 +190,7 @@ export function CatSideBySideVirtualList({
 
           return (
             <div
-              key={segment.id}
+              key={virtualRow.key}
               ref={virtualizer.measureElement}
               data-index={virtualRow.index}
               className="absolute top-0 left-0 w-full"

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-virtual-list.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-virtual-list.tsx
@@ -142,10 +142,7 @@ export function CatSideBySideVirtualList({
     [onVisibleSegmentIdsChange, segments],
   );
 
-  const getItemKey = useCallback(
-    (index: number) => segments[index]?.id ?? index,
-    [segments],
-  );
+  const getItemKey = useCallback((index: number) => segments[index]?.id ?? index, [segments]);
 
   const virtualizer = useVirtualizer({
     count: segments.length,

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.test.ts
@@ -716,7 +716,7 @@ describe("CatWorkspaceOrchestrator hydration", () => {
     ]);
   });
 
-  it("removes clean queue segments that no longer belong after a local status change", () => {
+  it("preserves session-local skipped status across queue hydration and target sync", () => {
     const store = createCatWorkspace(
       createCatWorkspaceState({
         selectedSegmentId: "seg-02",
@@ -745,44 +745,31 @@ describe("CatWorkspaceOrchestrator hydration", () => {
       }),
     );
 
-    store.markSegmentSaved("seg-02", "Deuxième", "reviewed");
-    expect(store.removeQueueSegmentIfClean("seg-02")).toBe(true);
-    expect(store.queueSegments.map((segment) => segment.id)).toEqual(["seg-01"]);
-    expect(store.getSegmentView("seg-02")).toBeUndefined();
-  });
+    store.setSegmentStatus("seg-02", "skipped");
+    store.rememberLocalStatusOverride("seg-02", "skipped");
 
-  it("keeps dirty drafts when asking to remove a filtered-out queue segment", () => {
-    const store = createCatWorkspace(
+    store.hydrateFromServerSnapshot(
       createCatWorkspaceState({
-        selectedSegmentId: "seg-02",
-        segments: [
-          {
-            id: "seg-01",
-            index: 1,
-            key: "first",
-            sourceText: "First",
-            targetText: "Premier",
-            sourceLocale: "en-US",
-            targetLocale: "fr",
-            status: "needs_review",
-          },
-          {
-            id: "seg-02",
-            index: 2,
-            key: "second",
-            sourceText: "Second",
-            targetText: "Deuxième",
-            sourceLocale: "en-US",
-            targetLocale: "fr",
-            status: "needs_review",
-          },
+        selectedSegmentId: "seg-01",
+        queueSegments: [
+          { id: "seg-01", index: 1, key: "first", sourceText: "First" },
+          { id: "seg-02", index: 2, key: "second", sourceText: "Second" },
         ],
       }),
     );
+    store.applySegmentTarget("seg-02", {
+      text: "Deuxième",
+      externalTranslationId: "translation-2",
+      isApproved: false,
+    });
 
-    store.setTargetText("seg-02", "Unsaved");
-    expect(store.removeQueueSegmentIfClean("seg-02")).toBe(false);
-    expect(store.getSegmentView("seg-02")?.targetText).toBe("Unsaved");
+    expect(store.getSegmentView("seg-02")?.status).toBe("skipped");
+    expect(
+      store.getFilteredQueueSegments("needs_review", true).map((segment) => segment.id),
+    ).toEqual(["seg-01"]);
+    expect(store.getFilteredQueueSegments("skipped", false).map((segment) => segment.id)).toEqual([
+      "seg-02",
+    ]);
   });
 
   it("returns composed target text for side-by-side queue rows", () => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.test.ts
@@ -216,6 +216,75 @@ describe("CatWorkspaceOrchestrator hydration", () => {
     expect([...store.checkedSegmentIds]).toEqual([]);
   });
 
+  it("removes clean queue segments that no longer belong after a local status change", () => {
+    const store = createCatWorkspace(
+      createCatWorkspaceState({
+        selectedSegmentId: "seg-02",
+        segments: [
+          {
+            id: "seg-01",
+            index: 1,
+            key: "first",
+            sourceText: "First",
+            targetText: "Premier",
+            sourceLocale: "en-US",
+            targetLocale: "fr",
+            status: "needs_review",
+          },
+          {
+            id: "seg-02",
+            index: 2,
+            key: "second",
+            sourceText: "Second",
+            targetText: "Deuxième",
+            sourceLocale: "en-US",
+            targetLocale: "fr",
+            status: "needs_review",
+          },
+        ],
+      }),
+    );
+
+    store.markSegmentSaved("seg-02", "Deuxième", "reviewed");
+    expect(store.removeQueueSegmentIfClean("seg-02")).toBe(true);
+    expect(store.queueSegments.map((segment) => segment.id)).toEqual(["seg-01"]);
+    expect(store.getSegmentView("seg-02")).toBeUndefined();
+  });
+
+  it("keeps dirty drafts when asking to remove a filtered-out queue segment", () => {
+    const store = createCatWorkspace(
+      createCatWorkspaceState({
+        selectedSegmentId: "seg-02",
+        segments: [
+          {
+            id: "seg-01",
+            index: 1,
+            key: "first",
+            sourceText: "First",
+            targetText: "Premier",
+            sourceLocale: "en-US",
+            targetLocale: "fr",
+            status: "needs_review",
+          },
+          {
+            id: "seg-02",
+            index: 2,
+            key: "second",
+            sourceText: "Second",
+            targetText: "Deuxième",
+            sourceLocale: "en-US",
+            targetLocale: "fr",
+            status: "needs_review",
+          },
+        ],
+      }),
+    );
+
+    store.setTargetText("seg-02", "Unsaved");
+    expect(store.removeQueueSegmentIfClean("seg-02")).toBe(false);
+    expect(store.getSegmentView("seg-02")?.targetText).toBe("Unsaved");
+  });
+
   it("keeps the selected dirty segment visible when a queue refresh filters it out", () => {
     const store = createCatWorkspace(
       createCatWorkspaceState({
@@ -645,6 +714,75 @@ describe("CatWorkspaceOrchestrator hydration", () => {
     expect(store.getQueuePanelSegments("skipped", false)).toEqual([
       expect.objectContaining({ id: "seg-01", status: "skipped" }),
     ]);
+  });
+
+  it("removes clean queue segments that no longer belong after a local status change", () => {
+    const store = createCatWorkspace(
+      createCatWorkspaceState({
+        selectedSegmentId: "seg-02",
+        segments: [
+          {
+            id: "seg-01",
+            index: 1,
+            key: "first",
+            sourceText: "First",
+            targetText: "Premier",
+            sourceLocale: "en-US",
+            targetLocale: "fr",
+            status: "needs_review",
+          },
+          {
+            id: "seg-02",
+            index: 2,
+            key: "second",
+            sourceText: "Second",
+            targetText: "Deuxième",
+            sourceLocale: "en-US",
+            targetLocale: "fr",
+            status: "needs_review",
+          },
+        ],
+      }),
+    );
+
+    store.markSegmentSaved("seg-02", "Deuxième", "reviewed");
+    expect(store.removeQueueSegmentIfClean("seg-02")).toBe(true);
+    expect(store.queueSegments.map((segment) => segment.id)).toEqual(["seg-01"]);
+    expect(store.getSegmentView("seg-02")).toBeUndefined();
+  });
+
+  it("keeps dirty drafts when asking to remove a filtered-out queue segment", () => {
+    const store = createCatWorkspace(
+      createCatWorkspaceState({
+        selectedSegmentId: "seg-02",
+        segments: [
+          {
+            id: "seg-01",
+            index: 1,
+            key: "first",
+            sourceText: "First",
+            targetText: "Premier",
+            sourceLocale: "en-US",
+            targetLocale: "fr",
+            status: "needs_review",
+          },
+          {
+            id: "seg-02",
+            index: 2,
+            key: "second",
+            sourceText: "Second",
+            targetText: "Deuxième",
+            sourceLocale: "en-US",
+            targetLocale: "fr",
+            status: "needs_review",
+          },
+        ],
+      }),
+    );
+
+    store.setTargetText("seg-02", "Unsaved");
+    expect(store.removeQueueSegmentIfClean("seg-02")).toBe(false);
+    expect(store.getSegmentView("seg-02")?.targetText).toBe("Unsaved");
   });
 
   it("returns composed target text for side-by-side queue rows", () => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
@@ -198,6 +198,11 @@ export class CatWorkspaceOrchestrator {
    * ignored. Any other mismatch (e.g. server-normalized text) clears the guard.
    */
   private preSaveTargetTexts = new Map<string, string>();
+  /**
+   * Session-local status overrides (e.g. skip) that are not persisted to the provider.
+   * Survives queue hydration so skipped rows do not reappear under Needs Review.
+   */
+  localStatusOverrides = new Map<string, CatSegmentStatus>();
 
   validationSequence = 0;
   reviewSequence = 0;
@@ -532,7 +537,18 @@ export class CatWorkspaceOrchestrator {
 
   getFilteredQueueSegments(filter: CatQueueFilter, usesServerQueueFilter: boolean) {
     if (usesServerQueueFilter && isServerQueueFilter(filter)) {
-      return this.queueSegments;
+      if (this.localStatusOverrides.size === 0) {
+        return this.queueSegments;
+      }
+
+      // Trust the server page, but hide rows whose session-local status no longer
+      // matches (skip is not persisted; approve may race ahead of refetch).
+      return this.queueSegments.filter((meta) => {
+        if (!this.localStatusOverrides.has(meta.id)) {
+          return true;
+        }
+        return this.matchesQueueFilter(meta.id, filter);
+      });
     }
 
     if (filter === "all") {
@@ -621,6 +637,7 @@ export class CatWorkspaceOrchestrator {
     this.hydratedTargetSegmentIds = new Set();
     this.locallyCommittedTargetTexts = new Map();
     this.preSaveTargetTexts = new Map();
+    this.localStatusOverrides = new Map();
     this.ingestQueue(initialState, initialSegmentKeyOrId);
   }
 
@@ -722,10 +739,11 @@ export class CatWorkspaceOrchestrator {
     }
 
     const targetText = target?.text ?? "";
-    const status = segmentStatusFromTarget(
+    const serverStatus = segmentStatusFromTarget(
       { hasOpenIssues: this.segmentHasOpenIssues(segmentId) },
       target,
     );
+    const status = this.localStatusOverrides.get(segmentId) ?? serverStatus;
     const existingMeta = this.segmentMeta.get(segmentId);
     if (existingMeta) {
       const nextContentKind = target?.contentKind ?? existingMeta.contentKind;
@@ -799,7 +817,12 @@ export class CatWorkspaceOrchestrator {
       (comment) => comment.type === "issue" && isOpenIssueStatus(comment.status),
     );
     const draft = this.drafts.get(segmentId);
-    if (draft && hasOpenIssues && draft.status !== "reviewed") {
+    if (
+      draft &&
+      hasOpenIssues &&
+      draft.status !== "reviewed" &&
+      this.localStatusOverrides.get(segmentId) !== "skipped"
+    ) {
       draft.applyServerStatus("needs_review");
     }
   }
@@ -871,13 +894,26 @@ export class CatWorkspaceOrchestrator {
   private mergeQueueMetaFromSnapshot(nextInitialState: CatWorkspaceState) {
     for (const meta of nextInitialState.queueSegments) {
       this.segmentMeta.set(meta.id, meta);
+      const override = this.localStatusOverrides.get(meta.id);
+      if (!override) {
+        continue;
+      }
+
+      const draft = this.drafts.get(meta.id);
+      if (draft) {
+        draft.applyServerStatus(override);
+      } else {
+        this.drafts.set(meta.id, new CatSegmentDraft(meta.id, "", override));
+      }
     }
 
     const nextSegmentIds = new Set(nextInitialState.queueSegments.map((meta) => meta.id));
     for (const segmentId of this.segmentMeta.keys()) {
       if (!nextSegmentIds.has(segmentId)) {
         const draft = this.drafts.get(segmentId);
-        if (!draft?.isDirty) {
+        const hasLocalOverride = this.localStatusOverrides.has(segmentId);
+        // Keep session-local skipped rows so the Skipped filter can still show them.
+        if (!draft?.isDirty && !hasLocalOverride) {
           this.drafts.delete(segmentId);
           this.segmentMeta.delete(segmentId);
           this.segmentComments.delete(segmentId);
@@ -948,6 +984,10 @@ export class CatWorkspaceOrchestrator {
 
   setSegmentStatus(segmentId: string, status: CatSegmentStatus) {
     this.segments.setStatus(segmentId, status, this.segmentMeta.has(segmentId));
+  }
+
+  rememberLocalStatusOverride(segmentId: string, status: CatSegmentStatus) {
+    this.localStatusOverrides.set(segmentId, status);
   }
 
   markSegmentSaved(segmentId: string, targetText: string, status?: CatSegmentStatus) {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
@@ -959,6 +959,29 @@ export class CatWorkspaceOrchestrator {
     this.locallyCommittedTargetTexts.set(segmentId, targetText);
   }
 
+  /**
+   * Drop a segment from the local queue after a status change that no longer matches
+   * the active filter (e.g. approve while filtered to Needs Review). Keeps dirty drafts.
+   */
+  removeQueueSegmentIfClean(segmentId: string) {
+    if (!this.segmentMeta.has(segmentId)) {
+      return false;
+    }
+
+    const draft = this.drafts.get(segmentId);
+    if (draft?.isDirty) {
+      return false;
+    }
+
+    this.queue.remove(segmentId);
+    this.drafts.delete(segmentId);
+    this.segmentComments.delete(segmentId);
+    this.hydratedTargetSegmentIds.delete(segmentId);
+    this.locallyCommittedTargetTexts.delete(segmentId);
+    this.preSaveTargetTexts.delete(segmentId);
+    return true;
+  }
+
   setFormatChecks(segmentId: string, checks: CatFormatCheck[], isSelected: boolean) {
     this.intelligenceState.setChecks(segmentId, checks, isSelected);
   }

--- a/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-review-controller.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-review-controller.test.ts
@@ -250,6 +250,95 @@ describe("CatReviewController", () => {
       expect(workspace.getSegmentView("seg-02")?.status).toBe("needs_review");
     });
 
+    it("removes the approved row when Needs Review filter no longer matches", async () => {
+      const onApprove = vi.fn().mockResolvedValue("reviewed");
+      const workspace = createTestWorkspace({
+        selectedSegmentId: "seg-02",
+        segments: [
+          {
+            id: "seg-01",
+            index: 1,
+            key: "first",
+            sourceText: "First",
+            targetText: "Premier",
+            sourceLocale: "en-US",
+            targetLocale: "vi",
+            status: "needs_review",
+          },
+          {
+            id: "seg-02",
+            index: 2,
+            key: "second",
+            sourceText: "Second",
+            targetText: "Deuxième",
+            sourceLocale: "en-US",
+            targetLocale: "vi",
+            status: "needs_review",
+          },
+          {
+            id: "seg-03",
+            index: 3,
+            key: "third",
+            sourceText: "Third",
+            targetText: "Troisième",
+            sourceLocale: "en-US",
+            targetLocale: "vi",
+            status: "needs_review",
+          },
+        ],
+      });
+      const { controller } = createController(workspace, {
+        review: { onApprove },
+        queueFilter: "needs_review",
+        usesServerQueueFilter: true,
+      });
+
+      await controller.approve("seg-02", "Deuxième");
+
+      expect(workspace.queueSegments.map((segment) => segment.id)).toEqual(["seg-01", "seg-03"]);
+      expect(workspace.getSegmentView("seg-02")).toBeUndefined();
+      expect(workspace.selectedSegmentId).toBe("seg-03");
+    });
+
+    it("advances selection before dropping the last Needs Review row", async () => {
+      const onApprove = vi.fn().mockResolvedValue("reviewed");
+      const workspace = createTestWorkspace({
+        selectedSegmentId: "seg-02",
+        segments: [
+          {
+            id: "seg-01",
+            index: 1,
+            key: "first",
+            sourceText: "First",
+            targetText: "Premier",
+            sourceLocale: "en-US",
+            targetLocale: "vi",
+            status: "needs_review",
+          },
+          {
+            id: "seg-02",
+            index: 2,
+            key: "second",
+            sourceText: "Second",
+            targetText: "Deuxième",
+            sourceLocale: "en-US",
+            targetLocale: "vi",
+            status: "needs_review",
+          },
+        ],
+      });
+      const { controller } = createController(workspace, {
+        review: { onApprove },
+        queueFilter: "needs_review",
+        usesServerQueueFilter: true,
+      });
+
+      await controller.approve("seg-02", "Deuxième");
+
+      expect(workspace.queueSegments.map((segment) => segment.id)).toEqual(["seg-01"]);
+      expect(workspace.selectedSegmentId).toBe("seg-01");
+    });
+
     it("adds save failure checks when approve fails", async () => {
       const { controller, workspace } = createController(undefined, {
         review: {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-review-controller.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-review-controller.test.ts
@@ -479,6 +479,108 @@ describe("CatReviewController", () => {
       expect(workspace.getSegmentView("seg-02")?.status).toBe("skipped");
       expect(onSkip).toHaveBeenCalledWith("seg-02");
     });
+
+    it("hides skipped rows under Needs Review without losing the local skipped status", () => {
+      const workspace = createTestWorkspace({
+        selectedSegmentId: "seg-02",
+        segments: [
+          {
+            id: "seg-01",
+            index: 1,
+            key: "first",
+            sourceText: "First",
+            targetText: "Premier",
+            sourceLocale: "en-US",
+            targetLocale: "vi",
+            status: "needs_review",
+          },
+          {
+            id: "seg-02",
+            index: 2,
+            key: "second",
+            sourceText: "Second",
+            targetText: "Deuxième",
+            sourceLocale: "en-US",
+            targetLocale: "vi",
+            status: "needs_review",
+          },
+          {
+            id: "seg-03",
+            index: 3,
+            key: "third",
+            sourceText: "Third",
+            targetText: "Troisième",
+            sourceLocale: "en-US",
+            targetLocale: "vi",
+            status: "needs_review",
+          },
+        ],
+      });
+      const { controller } = createController(workspace, {
+        queueFilter: "needs_review",
+        usesServerQueueFilter: true,
+      });
+
+      controller.skip("seg-02");
+
+      expect(workspace.getSegmentView("seg-02")?.status).toBe("skipped");
+      expect(workspace.localStatusOverrides.get("seg-02")).toBe("skipped");
+      expect(
+        workspace.getFilteredQueueSegments("needs_review", true).map((segment) => segment.id),
+      ).toEqual(["seg-01", "seg-03"]);
+      expect(workspace.selectedSegmentId).toBe("seg-03");
+      expect(
+        workspace.getFilteredQueueSegments("skipped", false).map((segment) => segment.id),
+      ).toEqual(["seg-02"]);
+    });
+
+    it("keeps local skipped status after the server queue snapshot refreshes", () => {
+      const workspace = createTestWorkspace({
+        selectedSegmentId: "seg-02",
+        segments: [
+          {
+            id: "seg-01",
+            index: 1,
+            key: "first",
+            sourceText: "First",
+            targetText: "Premier",
+            sourceLocale: "en-US",
+            targetLocale: "vi",
+            status: "needs_review",
+          },
+          {
+            id: "seg-02",
+            index: 2,
+            key: "second",
+            sourceText: "Second",
+            targetText: "Deuxième",
+            sourceLocale: "en-US",
+            targetLocale: "vi",
+            status: "needs_review",
+          },
+        ],
+      });
+      const { controller } = createController(workspace, {
+        queueFilter: "needs_review",
+        usesServerQueueFilter: true,
+      });
+
+      controller.skip("seg-02");
+      workspace.hydrateFromServerSnapshot(
+        createCatWorkspaceState({
+          selectedSegmentId: "seg-01",
+          queueSegments: [
+            { id: "seg-01", index: 1, key: "first", sourceText: "First" },
+            { id: "seg-02", index: 2, key: "second", sourceText: "Second" },
+          ],
+        }),
+      );
+
+      expect(workspace.getSegmentView("seg-02")?.status).toBe("skipped");
+      expect(
+        workspace.getFilteredQueueSegments("needs_review", true).map((segment) => segment.id),
+      ).toEqual(["seg-01"]);
+    });
   });
 
   describe("bulkApprove", () => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-review-controller.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-review-controller.ts
@@ -356,17 +356,33 @@ export class CatReviewController {
   async approve(segmentId: string, targetText: string) {
     this.workspace.isApproving = true;
     try {
-      const nextStatus =
-        (await this.ports.review?.onApprove?.(segmentId, targetText)) ?? "reviewed";
-      this.workspace.markSegmentSaved(segmentId, targetText, nextStatus as CatSegmentStatus);
-      const visibleSegments = this.workspace.getFilteredQueueSegments(
+      // Resolve the next row before the status change so Needs Review (and other
+      // filters) can drop the approved segment without losing navigation.
+      const visibleBeforeApprove = this.workspace.getFilteredQueueSegments(
         this.ports.queueFilter,
         this.ports.usesServerQueueFilter,
       );
-      const currentIndex = visibleSegments.findIndex((segment) => segment.id === segmentId);
+      const currentIndex = visibleBeforeApprove.findIndex((segment) => segment.id === segmentId);
+      const nextSegmentId =
+        currentIndex >= 0 ? visibleBeforeApprove[currentIndex + 1]?.id : undefined;
+
+      const nextStatus =
+        (await this.ports.review?.onApprove?.(segmentId, targetText)) ?? "reviewed";
+      this.workspace.markSegmentSaved(segmentId, targetText, nextStatus as CatSegmentStatus);
+
+      if (
+        this.ports.queueFilter !== "all" &&
+        !this.workspace.matchesQueueFilter(segmentId, this.ports.queueFilter)
+      ) {
+        this.workspace.removeQueueSegmentIfClean(segmentId);
+      }
+
       if (this.workspace.selectedSegmentId === segmentId) {
         this.workspace.setSelectedSegmentId(
-          visibleSegments[currentIndex + 1]?.id ?? this.workspace.selectedSegmentId,
+          nextSegmentId ??
+            (this.workspace.segmentMeta.has(segmentId)
+              ? segmentId
+              : (this.workspace.queueSegments[0]?.id ?? "")),
         );
       }
     } catch (error) {
@@ -447,8 +463,32 @@ export class CatReviewController {
   }
 
   skip(segmentId: string) {
+    const visibleBeforeSkip = this.workspace.getFilteredQueueSegments(
+      this.ports.queueFilter,
+      this.ports.usesServerQueueFilter,
+    );
+    const currentIndex = visibleBeforeSkip.findIndex((segment) => segment.id === segmentId);
+    const nextSegmentId =
+      currentIndex >= 0 ? visibleBeforeSkip[currentIndex + 1]?.id : undefined;
+
     this.workspace.setSegmentStatus(segmentId, "skipped");
     this.ports.review?.onSkip?.(segmentId);
+
+    if (
+      this.ports.queueFilter !== "all" &&
+      !this.workspace.matchesQueueFilter(segmentId, this.ports.queueFilter)
+    ) {
+      this.workspace.removeQueueSegmentIfClean(segmentId);
+    }
+
+    if (this.workspace.selectedSegmentId === segmentId) {
+      this.workspace.setSelectedSegmentId(
+        nextSegmentId ??
+          (this.workspace.segmentMeta.has(segmentId)
+            ? segmentId
+            : (this.workspace.queueSegments[0]?.id ?? "")),
+      );
+    }
   }
 
   async bulkApprove() {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-review-controller.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-review-controller.ts
@@ -468,8 +468,7 @@ export class CatReviewController {
       this.ports.usesServerQueueFilter,
     );
     const currentIndex = visibleBeforeSkip.findIndex((segment) => segment.id === segmentId);
-    const nextSegmentId =
-      currentIndex >= 0 ? visibleBeforeSkip[currentIndex + 1]?.id : undefined;
+    const nextSegmentId = currentIndex >= 0 ? visibleBeforeSkip[currentIndex + 1]?.id : undefined;
 
     this.workspace.setSegmentStatus(segmentId, "skipped");
     this.ports.review?.onSkip?.(segmentId);

--- a/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-review-controller.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-review-controller.ts
@@ -470,22 +470,19 @@ export class CatReviewController {
     const currentIndex = visibleBeforeSkip.findIndex((segment) => segment.id === segmentId);
     const nextSegmentId = currentIndex >= 0 ? visibleBeforeSkip[currentIndex + 1]?.id : undefined;
 
+    // Skip is session-local (no provider persistence). Keep a status override so
+    // hydration cannot resurrect the row under Needs Review / other filters.
     this.workspace.setSegmentStatus(segmentId, "skipped");
+    this.workspace.rememberLocalStatusOverride(segmentId, "skipped");
     this.ports.review?.onSkip?.(segmentId);
 
-    if (
-      this.ports.queueFilter !== "all" &&
-      !this.workspace.matchesQueueFilter(segmentId, this.ports.queueFilter)
-    ) {
-      this.workspace.removeQueueSegmentIfClean(segmentId);
-    }
-
     if (this.workspace.selectedSegmentId === segmentId) {
+      const remaining = this.workspace.getFilteredQueueSegments(
+        this.ports.queueFilter,
+        this.ports.usesServerQueueFilter,
+      );
       this.workspace.setSelectedSegmentId(
-        nextSegmentId ??
-          (this.workspace.segmentMeta.has(segmentId)
-            ? segmentId
-            : (this.workspace.queueSegments[0]?.id ?? "")),
+        nextSegmentId ?? remaining[0]?.id ?? this.workspace.selectedSegmentId,
       );
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Approving or skipping a segment while filtered to **Needs Review** removed that row mid-list. Virtual lists measured by index, so the size cache went stale and left a blank gap.

- Key side-by-side and queue virtual rows by stable segment id (`getItemKey`)
- Drop clean **approved** segments from the local queue as soon as they no longer match the active filter
- Resolve the next selected segment before the status change so navigation survives the removal
- For **skip** (not persisted): keep a session-local status override across hydration so skipped rows stay hidden under Needs Review and still appear under Skipped

## How to test

- `vp test` on the touched CAT controller, orchestrator, and queue virtual-list tests
- `vp check --fix`
- Manually: CAT → Needs Review → approve a mid-list segment → no blank gap; selection advances
- Manually: Needs Review → skip a segment → it stays gone after queue refresh; Skipped filter still lists it
- Repeat in side-by-side and comfortable views

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e3fe93b-8739-4713-a1c7-b2f856b0bce6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e3fe93b-8739-4713-a1c7-b2f856b0bce6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

