### PR TITLE
fix(e2e): navigate after fixture auth session create

### DIFF
--- a/apps/hyperlocalise-web/src/e2e/fixtures/browser.ts
+++ b/apps/hyperlocalise-web/src/e2e/fixtures/browser.ts
@@ -15,7 +15,18 @@ import { afterAll, beforeAll } from "vite-plus/test";
 
 import { E2E_SETUP_TOKEN_HEADER } from "../../lib/e2e/config";
 
-import { E2E_BASE_URL } from "../constants";
+import { E2E_BASE_URL, organizationDashboardPath } from "../constants";
+
+const ONBOARDING_PATH = "/auth/onboarding";
+
+type FixtureSessionResponse = {
+  session: {
+    email: string;
+    organizationSlug?: string;
+    workosOrganizationId?: string;
+    workosUserId: string;
+  };
+};
 
 function requireE2eSetupToken() {
   const token = process.env.E2E_AUTH_SECRET?.trim();
@@ -42,6 +53,14 @@ async function createFixtureSession(page: Page, body: Record<string, string>) {
   }
 
   await trackFixtureSession(page);
+
+  return (await response.json()) as FixtureSessionResponse;
+}
+
+async function gotoAfterLogin(page: Page, path: string) {
+  await page.goto(new URL(path, E2E_BASE_URL).toString(), {
+    waitUntil: "domcontentloaded",
+  });
 }
 
 type E2eBrowserContext = {
@@ -108,8 +127,15 @@ export function getE2ePage() {
 
 export async function loginForOnboarding(page: Page) {
   await createFixtureSession(page, { mode: "onboarding" });
+  await gotoAfterLogin(page, ONBOARDING_PATH);
 }
 
 export async function loginAsAdmin(page: Page) {
-  await createFixtureSession(page, { role: "admin" });
+  const { session } = await createFixtureSession(page, { role: "admin" });
+  const organizationSlug = session.organizationSlug?.trim();
+  if (!organizationSlug) {
+    throw new Error("E2E fixture login did not return an organization slug");
+  }
+
+  await gotoAfterLogin(page, organizationDashboardPath(organizationSlug));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Local Playwright e2e flows stopped landing on real pages after fixture auth was hardened. Login helpers only minted a `wos-session` cookie via `POST /api/e2e/auth/session` and never navigated, while the old `/e2e/login` redirect path had been removed.

### Fix
- Parse the fixture session response after login
- Admin login navigates to `/en/org/{slug}/dashboard`
- Onboarding login navigates to `/auth/onboarding`
- Keep `waitUntil: "domcontentloaded"` so each flow's visible-element assertions decide readiness

## Test plan
- [x] `vp check --fix` in `apps/hyperlocalise-web`
- [x] `vp test` in `apps/hyperlocalise-web` (536 files / 3292 tests)
- [ ] Manual: app with `E2E_AUTH_MODE=fixture` + `E2E_AUTH_SECRET`, then `vp run test:e2e`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb821-5f4e-7201-bae0-4d736f383b93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb821-5f4e-7201-bae0-4d736f383b93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

