### PR TITLE
fix(jobs): name native file jobs from filename and time

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.test.ts
@@ -14,18 +14,21 @@ import "dotenv/config";
 
 import { randomUUID } from "node:crypto";
 
+import { eq } from "drizzle-orm";
 import { testClient } from "hono/testing";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
-import { app } from "@/api/app";
+import { app, createApp } from "@/api/app";
 import { db, schema } from "@/lib/database";
 import { upsertExternalTmsJobRecords } from "@/lib/projects/external-tms/external-tms-sync-service";
 import * as tmsProviderAssigneeCandidates from "@/lib/providers/jobs/tms-provider-assignee-candidates";
 import { encodeProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 import { ensureDefaultWorkspaceTeam } from "@/lib/teams/default-workspace-team";
+import type { TranslationJobEventData } from "@/lib/workflow/types";
 
 import { createProjectTestFixture } from "./project.fixture";
 import { createTeamTestFixture } from "../team/team.fixture";
+import { insertStoredSourceFile } from "../public-jobs/public-jobs.fixture";
 import type { ProjectResponse } from "./project.schema";
 import type { TeamResponse } from "../team/team.schema";
 import type { WorkspaceJobsResponse } from "./job.schema";
@@ -394,5 +397,125 @@ describe("workspace job list", () => {
 
     expect(createdProjectIds).toEqual([alphaProjectBody.project.id]);
     expect(createdProjectIds).not.toContain(betaProjectBody.project.id);
+  });
+});
+
+describe("project job create", () => {
+  const enqueueJob = vi.fn(async (event: TranslationJobEventData) => ({
+    ids: [event.jobId],
+  }));
+  const createClient = testClient(
+    createApp({
+      jobQueue: {
+        enqueue: enqueueJob,
+      },
+    }),
+  );
+  const createFixture = createProjectTestFixture(createClient);
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await createFixture.cleanup();
+  });
+
+  it("defaults file job metadata.title from filename and UTC time", async () => {
+    const { identity, organization, project } = await createFixture.createStoredProjectFixture();
+    const headers = await createFixture.authHeadersFor(identity);
+    const sourceFile = await insertStoredSourceFile({
+      organizationId: organization.id,
+      projectId: project.id,
+      filename: "messages.json",
+      contentType: "application/json",
+    });
+
+    const response = await createClient.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].jobs.$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
+        json: {
+          type: "file",
+          fileInput: {
+            sourceFileId: sourceFile.id,
+            fileFormat: "json",
+            sourceLocale: "en-US",
+            targetLocales: ["fr-FR"],
+          },
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as { job: { id: string } };
+    const [job] = await db
+      .select({ inputPayload: schema.jobs.inputPayload })
+      .from(schema.jobs)
+      .where(eq(schema.jobs.id, body.job.id))
+      .limit(1);
+
+    expect(job?.inputPayload).toMatchObject({
+      sourceFileId: sourceFile.id,
+    });
+    expect(
+      (job?.inputPayload as { metadata?: { title?: string } } | undefined)?.metadata?.title,
+    ).toMatch(/^messages\.json · \d{4}-\d{2}-\d{2} \d{2}:\d{2}$/);
+    expect(enqueueJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "translation",
+        type: "file",
+        jobId: body.job.id,
+      }),
+    );
+  });
+
+  it("keeps an explicit job title over the generated default", async () => {
+    const { identity, organization, project } = await createFixture.createStoredProjectFixture();
+    const headers = await createFixture.authHeadersFor(identity);
+    const sourceFile = await insertStoredSourceFile({
+      organizationId: organization.id,
+      projectId: project.id,
+      filename: "messages.json",
+      contentType: "application/json",
+    });
+
+    const response = await createClient.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].jobs.$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
+        json: {
+          type: "file",
+          title: "Release notes · JP + KO",
+          fileInput: {
+            sourceFileId: sourceFile.id,
+            fileFormat: "json",
+            sourceLocale: "en-US",
+            targetLocales: ["fr-FR"],
+          },
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as { job: { id: string } };
+    const [job] = await db
+      .select({ inputPayload: schema.jobs.inputPayload })
+      .from(schema.jobs)
+      .where(eq(schema.jobs.id, body.job.id))
+      .limit(1);
+
+    expect(job?.inputPayload).toMatchObject({
+      metadata: {
+        title: "Release notes · JP + KO",
+      },
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -54,6 +54,7 @@ import {
   listOrganizationJobs,
   listOrganizationProjectJobs,
 } from "@/lib/projects/jobs/organization-job-query-service";
+import { mergeNativeFileTranslationJobMetadata } from "@/lib/projects/jobs/enqueue-file-translation-job";
 import type {
   JobQueue,
   ProviderAgentCommentQueue,
@@ -397,7 +398,7 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
       }
 
       const inputPayload = payload.type === "string" ? payload.stringInput : payload.fileInput;
-      const enrichedInputPayload =
+      let enrichedInputPayload =
         payload.title && payload.title.trim().length > 0
           ? {
               ...inputPayload,
@@ -476,6 +477,14 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
             400,
           );
         }
+
+        enrichedInputPayload = {
+          ...enrichedInputPayload,
+          metadata: mergeNativeFileTranslationJobMetadata(
+            sourceFile.filename,
+            enrichedInputPayload.metadata,
+          ),
+        };
       }
 
       const jobId = `job_${randomUUID()}`;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-layout-helpers.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-layout-helpers.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { createIntl, createIntlCache } from "react-intl";
+import { describe, expect, it } from "vite-plus/test";
+
+import { createNativeJobDetail } from "./job-detail.fixture";
+import { jobDetailTaskLayoutFromRecord } from "./job-detail-layout-helpers";
+
+const intl = createIntl({ locale: "en-US", messages: {} }, createIntlCache());
+
+describe("jobDetailTaskLayoutFromRecord", () => {
+  it("prefers metadata.title over sourceFileId for native job titles", () => {
+    const job = createNativeJobDetail({
+      inputPayload: {
+        sourceFileId: "file_abc123",
+        sourceLocale: "en",
+        targetLocales: ["fr-FR"],
+        fileFormat: "json",
+        metadata: { title: "messages.json · 2026-07-31 22:11" },
+      },
+    });
+
+    const layout = jobDetailTaskLayoutFromRecord(job, intl);
+
+    expect(layout.title).toBe("messages.json · 2026-07-31 22:11");
+  });
+
+  it("falls back to sourceFileId when metadata.title is missing", () => {
+    const job = createNativeJobDetail({
+      inputPayload: {
+        sourceFileId: "file_abc123",
+        sourceLocale: "en",
+        targetLocales: ["fr-FR"],
+        fileFormat: "json",
+      },
+    });
+
+    const layout = jobDetailTaskLayoutFromRecord(job, intl);
+
+    expect(layout.title).toBe("file_abc123");
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-layout-helpers.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-layout-helpers.tsx
@@ -108,6 +108,24 @@ function getInputPayloadString(job: JobDetailRecord, key: string) {
   return typeof value === "string" && value.length > 0 ? value : null;
 }
 
+function getInputPayloadMetadataTitle(job: JobDetailRecord) {
+  if (
+    typeof job.inputPayload !== "object" ||
+    !job.inputPayload ||
+    !("metadata" in job.inputPayload)
+  ) {
+    return null;
+  }
+
+  const metadata = (job.inputPayload as { metadata?: unknown }).metadata;
+  if (typeof metadata !== "object" || !metadata || !("title" in metadata)) {
+    return null;
+  }
+
+  const title = (metadata as { title?: unknown }).title;
+  return typeof title === "string" && title.length > 0 ? title : null;
+}
+
 export function jobDetailTaskTitle(input: JobDetailTaskLayoutInput) {
   return input.title ?? input.id;
 }
@@ -265,9 +283,10 @@ export function jobDetailTaskLayoutFromRecord(
   title: string;
 } {
   const sourcePath = getInputPayloadString(job, "sourceFileId");
+  const metadataTitle = getInputPayloadMetadataTitle(job);
   const input: JobDetailTaskLayoutInput = {
     id: job.id,
-    title: job.externalTitle ?? sourcePath ?? job.id,
+    title: job.externalTitle ?? metadataTitle ?? sourcePath ?? job.id,
     status: job.status,
     updatedAt: job.updatedAt,
     externalProviderKind: job.externalProviderKind,

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/enqueue-file-translation-job.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/enqueue-file-translation-job.test.ts
@@ -112,13 +112,32 @@ vi.mock("@/lib/database", () => {
 });
 
 import {
+  buildNativeFileTranslationJobTitle,
+  createFileTranslationJob,
   enqueueExistingFileTranslationJob,
   enqueueFileTranslationJob,
 } from "./enqueue-file-translation-job";
 
+describe("buildNativeFileTranslationJobTitle", () => {
+  it("formats filename with a UTC timestamp", () => {
+    expect(
+      buildNativeFileTranslationJobTitle("messages.json", new Date("2026-07-31T22:11:45.000Z")),
+    ).toBe("messages.json · 2026-07-31 22:11");
+  });
+
+  it("falls back when filename is blank", () => {
+    expect(buildNativeFileTranslationJobTitle("   ", new Date("2026-01-02T03:04:00.000Z"))).toBe(
+      "file · 2026-01-02 03:04",
+    );
+  });
+});
+
 describe("enqueueFileTranslationJob", () => {
+  let capturedJobValues: Record<string, unknown> | null;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    capturedJobValues = null;
     validateJobLocalesAgainstProjectMock.mockReturnValue(ok(undefined));
     assertOrganizationCanEnqueueTranslationJobInTransactionMock.mockResolvedValue(ok(undefined));
     reserveUsageEventMock.mockResolvedValue(ok(undefined));
@@ -134,18 +153,15 @@ describe("enqueueFileTranslationJob", () => {
     ]);
     transactionMock.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
       const tx = {
-        insert: vi.fn(() => ({
-          values: vi.fn(() => ({
-            returning: vi.fn().mockResolvedValue([{ id: "job_test", projectId: "project_1" }]),
-          })),
-        })),
+        insert: vi.fn(),
       };
       // First insert returns the job; second insert is translationJobDetails (no returning).
       let insertCount = 0;
       tx.insert = vi.fn(() => ({
-        values: vi.fn(() => {
+        values: vi.fn((values: Record<string, unknown>) => {
           insertCount += 1;
           if (insertCount === 1) {
+            capturedJobValues = values;
             return {
               returning: vi.fn().mockResolvedValue([{ id: "job_test", projectId: "project_1" }]),
             };
@@ -183,6 +199,66 @@ describe("enqueueFileTranslationJob", () => {
         jobId: "job_test",
       }),
     );
+  });
+
+  it("sets a human-readable metadata title from filename and UTC time", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-31T22:11:45.000Z"));
+    getStoredFileForJobScopeMock.mockResolvedValue({
+      id: "file_json",
+      filename: "messages.json",
+    });
+
+    try {
+      const result = await createFileTranslationJob({
+        organizationId: "org_1",
+        projectId: "project_1",
+        sourceFileId: "file_json",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR"],
+        fileFormat: "json",
+      });
+
+      expect(result).toEqual({
+        ok: true,
+        jobId: "job_test",
+        projectId: "project_1",
+        sourceFileVersionId: "version_1",
+      });
+      expect(capturedJobValues?.inputPayload).toEqual({
+        sourceFileId: "file_json",
+        fileFormat: "json",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR"],
+        metadata: {
+          title: "messages.json · 2026-07-31 22:11",
+        },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a caller-supplied metadata title", async () => {
+    getStoredFileForJobScopeMock.mockResolvedValue({
+      id: "file_json",
+      filename: "messages.json",
+    });
+
+    const result = await createFileTranslationJob({
+      organizationId: "org_1",
+      projectId: "project_1",
+      sourceFileId: "file_json",
+      sourceLocale: "en-US",
+      targetLocales: ["fr-FR"],
+      fileFormat: "json",
+      metadata: { title: "Release notes · JP + KO" },
+    });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(capturedJobValues?.inputPayload).toMatchObject({
+      metadata: { title: "Release notes · JP + KO" },
+    });
   });
 
   it("rejects unsupported source file formats", async () => {

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/enqueue-file-translation-job.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/enqueue-file-translation-job.test.ts
@@ -116,6 +116,7 @@ import {
   createFileTranslationJob,
   enqueueExistingFileTranslationJob,
   enqueueFileTranslationJob,
+  mergeNativeFileTranslationJobMetadata,
 } from "./enqueue-file-translation-job";
 
 describe("buildNativeFileTranslationJobTitle", () => {
@@ -129,6 +130,33 @@ describe("buildNativeFileTranslationJobTitle", () => {
     expect(buildNativeFileTranslationJobTitle("   ", new Date("2026-01-02T03:04:00.000Z"))).toBe(
       "file · 2026-01-02 03:04",
     );
+  });
+});
+
+describe("mergeNativeFileTranslationJobMetadata", () => {
+  it("defaults title from filename and keeps caller fields", () => {
+    expect(
+      mergeNativeFileTranslationJobMetadata(
+        "messages.json",
+        { instructions: "Keep brand names" },
+        new Date("2026-07-31T22:11:45.000Z"),
+      ),
+    ).toEqual({
+      title: "messages.json · 2026-07-31 22:11",
+      instructions: "Keep brand names",
+    });
+  });
+
+  it("keeps a caller-supplied title", () => {
+    expect(
+      mergeNativeFileTranslationJobMetadata(
+        "messages.json",
+        { title: "Release notes · JP + KO" },
+        new Date("2026-07-31T22:11:45.000Z"),
+      ),
+    ).toEqual({
+      title: "Release notes · JP + KO",
+    });
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/enqueue-file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/enqueue-file-translation-job.ts
@@ -90,6 +90,18 @@ export function buildNativeFileTranslationJobTitle(
   return `${trimmed} · ${year}-${month}-${day} ${hours}:${minutes}`;
 }
 
+/** Default `metadata.title` from filename/time; caller-supplied title still wins. */
+export function mergeNativeFileTranslationJobMetadata(
+  filename: string,
+  metadata?: Record<string, string>,
+  at: Date = new Date(),
+): Record<string, string> {
+  return {
+    title: buildNativeFileTranslationJobTitle(filename, at),
+    ...metadata,
+  };
+}
+
 async function markFileTranslationJobEnqueueFailed(input: {
   organizationId: string;
   jobId: string;
@@ -210,18 +222,12 @@ export async function createFileTranslationJob(
     };
   }
 
-  const defaultTitle = buildNativeFileTranslationJobTitle(sourceFile.filename);
-  const metadata = {
-    title: defaultTitle,
-    ...input.metadata,
-  };
-
   const inputPayload = {
     sourceFileId: input.sourceFileId,
     fileFormat,
     sourceLocale: input.sourceLocale,
     targetLocales: input.targetLocales,
-    metadata,
+    metadata: mergeNativeFileTranslationJobMetadata(sourceFile.filename, input.metadata),
   };
 
   const jobId = `job_${randomUUID()}`;

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/enqueue-file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/enqueue-file-translation-job.ts
@@ -76,6 +76,20 @@ export type EnqueueExistingFileTranslationJobResult =
   | { ok: true; jobId: string; projectId: string }
   | { ok: false; code: string; message: string };
 
+/** Human-readable native file job title: `{filename} · {YYYY-MM-DD HH:mm}` (UTC). */
+export function buildNativeFileTranslationJobTitle(
+  filename: string,
+  at: Date = new Date(),
+): string {
+  const trimmed = filename.trim() || "file";
+  const year = at.getUTCFullYear();
+  const month = String(at.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(at.getUTCDate()).padStart(2, "0");
+  const hours = String(at.getUTCHours()).padStart(2, "0");
+  const minutes = String(at.getUTCMinutes()).padStart(2, "0");
+  return `${trimmed} · ${year}-${month}-${day} ${hours}:${minutes}`;
+}
+
 async function markFileTranslationJobEnqueueFailed(input: {
   organizationId: string;
   jobId: string;
@@ -196,12 +210,18 @@ export async function createFileTranslationJob(
     };
   }
 
+  const defaultTitle = buildNativeFileTranslationJobTitle(sourceFile.filename);
+  const metadata = {
+    title: defaultTitle,
+    ...input.metadata,
+  };
+
   const inputPayload = {
     sourceFileId: input.sourceFileId,
     fileFormat,
     sourceLocale: input.sourceLocale,
     targetLocales: input.targetLocales,
-    ...(input.metadata ? { metadata: input.metadata } : {}),
+    metadata,
   };
 
   const jobId = `job_${randomUUID()}`;

--- a/docs/plans/2026-07-31-native-file-job-display-names-design.md
+++ b/docs/plans/2026-07-31-native-file-job-display-names-design.md
@@ -32,6 +32,7 @@ resolution to the same order:
 
 ## Scope
 
-- `createFileTranslationJob` (covers UI Translate with agent, automations, and
-  other callers)
+- `createFileTranslationJob` (automations and other helper callers)
+- Project jobs create route (`job.route.ts`) used by Translate with agent UI
+- Shared `mergeNativeFileTranslationJobMetadata` helper for both paths
 - Job detail layout title resolution

--- a/docs/plans/2026-07-31-native-file-job-display-names-design.md
+++ b/docs/plans/2026-07-31-native-file-job-display-names-design.md
@@ -1,0 +1,37 @@
+# Native file job display names
+
+## Problem
+
+Translate with agent creates native file translation jobs whose UI name falls
+back to `inputPayload.sourceFileId` (a `file_…` UUID). That is not readable in
+job lists or detail pages.
+
+## Decision
+
+When creating a native file translation job, set
+`inputPayload.metadata.title` to:
+
+```
+{filename} · {YYYY-MM-DD HH:mm}
+```
+
+- Use the stored file basename (`sourceFile.filename`).
+- Use a fixed UTC stamp so the persisted title is timezone-stable.
+- Keep the existing ` · ` separator used elsewhere in job title copy.
+- Caller-supplied `metadata.title` still wins when provided.
+
+## Display
+
+`getJobName` already prefers `metadata.title`. Align job detail title
+resolution to the same order:
+
+1. `externalTitle`
+2. `metadata.title`
+3. `sourceFileId` (legacy fallback)
+4. job id
+
+## Scope
+
+- `createFileTranslationJob` (covers UI Translate with agent, automations, and
+  other callers)
+- Job detail layout title resolution


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Native file translation jobs (including Translate with agent) no longer show the stored file UUID as the job name. Create now persists `metadata.title` as `{filename} · {YYYY-MM-DD HH:mm}` (UTC).

Also covers the UI create path in `job.route.ts` (used by Translate with agent), which does not call `createFileTranslationJob`. Both paths share `mergeNativeFileTranslationJobMetadata`. Job detail title resolution prefers that title. Caller-supplied titles still win.

## How to test

- `vp test` on `enqueue-file-translation-job.test.ts`, `job.route.test.ts`, and `job-detail-layout-helpers.test.ts`
- `vp check --fix` in `apps/hyperlocalise-web`
- Manually start Translate with agent on a project file and confirm the jobs list shows e.g. `messages.json · 2026-07-31 22:11`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fba39-a234-7b33-9647-25cab95ed956?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fba39-a234-7b33-9647-25cab95ed956&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

