### PR TITLE
🧪 Scout: yaml pruning and sequence stability tests

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -187,3 +187,7 @@
 ## 2026-10-25 - [Forbidden Term Score Edge Cases]
 **Learning:** In the translation scoring evaluator, the `forbidden:term` tag-based filtering uses case-insensitive comparison, substring matching, and auto-trims whitespace. Empty tags like "forbidden:" or whitespace-only tags are safely ignored to avoid corrupting aggregate scores with false-positive penalties.
 **Action:** When testing or extending evaluator filters, explicitly verify whitespace padding, case variations, substring/overlap matches, and malformed tags to protect translation safety constraints.
+
+## 2026-11-05 - [YAML Pruning Validation and Sequence Stability]
+**Learning:** When testing YAML pruning/round-tripping behavior using `MarshalYAMLWithPrune`, mapping nodes are selectively pruned according to prune keys, but sequence/array nodes are kept intact to prevent shift-index instability. Comprehensive testing must verify both the pruning of unwanted mapping leaf strings and the complete preservation of array elements and block/line comments.
+**Action:** Use table-driven tests or multi-layered assertions that round-trip through both the marshaler and parser to ensure that template structures, comments, and array stable indices are verified end-to-end.

--- a/internal/i18n/translationfileparser/yaml_parser_scout_test.go
+++ b/internal/i18n/translationfileparser/yaml_parser_scout_test.go
@@ -22,11 +22,12 @@ home:
 	// We want to keep 'hello', 'home.title', and 'home.steps' (and its entries)
 	// We want to prune 'home.cta'
 	// We also want to rewrite 'hello' to 'Bonjour' and 'home.title' to 'Accueil'
+	// Intentionally omit home.steps[1] from pruneKeys: sequence entries must
+	// remain intact regardless of pruning so indexes stay stable.
 	pruneKeys := map[string]struct{}{
 		"hello":         {},
 		"home.title":    {},
 		"home.steps[0]": {},
-		"home.steps[1]": {},
 	}
 
 	values := map[string]string{

--- a/internal/i18n/translationfileparser/yaml_parser_scout_test.go
+++ b/internal/i18n/translationfileparser/yaml_parser_scout_test.go
@@ -1,0 +1,82 @@
+package translationfileparser
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestMarshalYAMLWithPrune_Scout(t *testing.T) {
+	template := []byte(`# Translation file
+hello: Hello
+home:
+  # Title of home page
+  title: Welcome
+  cta: Start
+  # Steps to choose plan
+  steps:
+    - Choose plan
+    - Confirm
+`)
+
+	// We want to keep 'hello', 'home.title', and 'home.steps' (and its entries)
+	// We want to prune 'home.cta'
+	// We also want to rewrite 'hello' to 'Bonjour' and 'home.title' to 'Accueil'
+	pruneKeys := map[string]struct{}{
+		"hello":         {},
+		"home.title":    {},
+		"home.steps[0]": {},
+		"home.steps[1]": {},
+	}
+
+	values := map[string]string{
+		"hello":      "Bonjour",
+		"home.title": "Accueil",
+	}
+
+	got, err := MarshalYAMLWithPrune(template, values, pruneKeys)
+	if err != nil {
+		t.Fatalf("MarshalYAMLWithPrune failed: %v", err)
+	}
+
+	output := string(got)
+
+	// Check if the pruned field is absent
+	if strings.Contains(output, "cta:") || strings.Contains(output, "Start") {
+		t.Fatalf("expected 'home.cta' to be pruned, but output contains it:\n%s", output)
+	}
+
+	// Check if retained fields are present and updated
+	if !strings.Contains(output, "hello: Bonjour") {
+		t.Fatalf("expected 'hello: Bonjour' in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "title: Accueil") {
+		t.Fatalf("expected 'title: Accueil' in output, got:\n%s", output)
+	}
+
+	// Check if sequence fields and comments are preserved
+	if !strings.Contains(output, "# Translation file") || !strings.Contains(output, "# Title of home page") || !strings.Contains(output, "# Steps to choose plan") {
+		t.Fatalf("expected comments to be preserved, got:\n%s", output)
+	}
+
+	if !strings.Contains(output, "- Choose plan") || !strings.Contains(output, "- Confirm") {
+		t.Fatalf("expected sequence entries to be preserved, got:\n%s", output)
+	}
+
+	// Verify we can parse it back correctly using YAMLParser
+	parsed, err := (YAMLParser{}).Parse(got)
+	if err != nil {
+		t.Fatalf("failed to parse pruned YAML output: %v", err)
+	}
+
+	expected := map[string]string{
+		"hello":         "Bonjour",
+		"home.title":    "Accueil",
+		"home.steps[0]": "Choose plan",
+		"home.steps[1]": "Confirm",
+	}
+
+	if !reflect.DeepEqual(parsed, expected) {
+		t.Errorf("parsed pruned YAML = %v, want %v", parsed, expected)
+	}
+}


### PR DESCRIPTION
💡 What: Added `TestMarshalYAMLWithPrune_Scout` behavior-driven unit test verifying `MarshalYAMLWithPrune` pruning, sequence stability, and comment preservation.

🎯 Why: High-value test coverage protecting key pruning in translation workflows, ensuring indices are stable for JSON array equivalence and old keys are successfully removed.

🧩 Scope: `internal/i18n/translationfileparser/yaml_parser_scout_test.go` and `.jules/scout.md`

✅ Verification: Rebuilt golangci-lint on go1.26.1, executed `make test` (all tests passed), `make fmt`, and `make lint` (0 issues).

🛡️ Confidence: Extremely high. Completely deterministic test and pristine documentation history.

---
*PR created automatically by Jules for task [4409709614074908444](https://jules.google.com/task/4409709614074908444) started by @cungminh2710*