### PR TITLE
fix(crowdin): 400 bad request error decoding and notification roles

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -1,5 +1,17 @@
 # Crowdin Steward's Journal
 
+## 2026-12-22 - Fix standard 400 Bad Request error decoding
+
+**Learning:** When Crowdin API v2 returns a `400 Bad Request` status code, the response body might contain a standard error schema (`{"error": {"code": 400, "message": "..."}}`) instead of list-based validation errors (`"errors"`). Previously, `determineErrorType` incorrectly assumed all 400 errors were validation/batch-validation errors, resulting in a generic string-format error from `determineErrorType` that failed JSON unmarshaling. This hid the original Crowdin error behind a vague `client: server returned 400 status code`.
+
+**Action:** Updated `determineErrorType` in both `crowdin/crowdin.go` and `crowdin/model/errors_test.go` to explicitly check if `b["error"]` is present as a map and, if so, return `&model.ErrorResponse{Response: resp}` to allow correct unmarshaling of the detailed error payload. Added test cases validating standard 400 Bad Request error unmarshaling end-to-end.
+
+## 2026-12-22 - Align Notification validation with Project Notify roles
+
+**Learning:** The Crowdin Go SDK's `Notification` struct is shared between organization-level and project-level notification endpoints. However, its client-side validation logic restricted the `role` parameter to `"owner"` and `"manager"` only. This blocked valid project notification requests targeting roles like `"translator"`, `"proofreader"`, `"developer"`, or `"language_coordinator"`.
+
+**Action:** Updated `model.Notification.Validate()` in `crowdin/model/notifications.go` to accept all valid project-level and organization-level notification roles (`owner`, `manager`, `language_coordinator`, `developer`, `translator`, `proofreader`). Added comprehensive unit tests asserting validation of these newly allowed roles and updated the old invalid role error message test expectation.
+
 ## 2026-12-21 - Fix GetManagers endpoint path and signature parity
 
 **Learning:** In Crowdin Enterprise API v2, retrieving a single manager requires specifying both the `groupId` and the `userId` in the path `/api/v2/groups/{groupId}/managers/{userId}`. The SDK previously only accepted `groupID` and requested the listing endpoint `/api/v2/groups/{groupId}/managers` while trying to unmarshal it as a single `ManagerGetResponse` struct. Under real workloads, this led to immediate JSON unmarshaling errors due to array-to-object type mismatch.

--- a/third_party/crowdin-api-client-go/crowdin/crowdin.go
+++ b/third_party/crowdin-api-client-go/crowdin/crowdin.go
@@ -414,6 +414,9 @@ func determineErrorType(res *http.Request, resp *http.Response, body []byte) err
 			}
 			return &model.ValidationErrorResponse{Response: resp, Status: resp.StatusCode}
 		}
+		if _, ok := b["error"].(map[string]any); ok {
+			return &model.ErrorResponse{Response: resp}
+		}
 		return fmt.Errorf("client: error while determining error type")
 	default:
 		return &model.ErrorResponse{Response: resp}

--- a/third_party/crowdin-api-client-go/crowdin/crowdin_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/crowdin_test.go
@@ -289,6 +289,18 @@ func TestRequestWithVariousErrorHandling(t *testing.T) {
 			err:  "404 Resource Not Found",
 		},
 		{
+			name: "standard bad request error",
+			path: "/path",
+			body: []byte(`{
+				"error": {
+					"message": "Invalid parameter given",
+					"code": 400
+				}
+			}`),
+			code: http.StatusBadRequest,
+			err:  "400 Invalid parameter given",
+		},
+		{
 			name: "wrong error schema",
 			path: "/path",
 			body: []byte(`{

--- a/third_party/crowdin-api-client-go/crowdin/model/errors_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/errors_test.go
@@ -127,6 +127,17 @@ func TestParseErrorResponse(t *testing.T) {
 			err:  "404 Resource Not Found",
 		},
 		{
+			resp: &http.Response{StatusCode: http.StatusBadRequest},
+			body: []byte(`{
+				"error": {
+					"message": "Invalid parameter given",
+					"code": 400
+				}
+			}`),
+			code: 400,
+			err:  "400 Invalid parameter given",
+		},
+		{
 			resp: &http.Response{StatusCode: http.StatusForbidden},
 			body: []byte(`{
 				"error": {
@@ -436,6 +447,9 @@ func determineErrorType(resp *http.Response, body []byte, graph bool) error {
 				}
 			}
 			return &ValidationErrorResponse{Response: resp, Status: resp.StatusCode}
+		}
+		if _, ok := b["error"].(map[string]any); ok {
+			return &ErrorResponse{Response: resp}
 		}
 		return nil
 	default:

--- a/third_party/crowdin-api-client-go/crowdin/model/notifications.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/notifications.go
@@ -30,8 +30,14 @@ func (r *Notification) Validate() error {
 	if len(r.UserIDs) > 0 && r.Role != "" {
 		return errors.New("can't specify both user IDs and role")
 	}
-	if r.Role != "" && r.Role != "owner" && r.Role != "manager" {
-		return errors.New("role must be either owner or manager")
+	if r.Role != "" &&
+		r.Role != "owner" &&
+		r.Role != "manager" &&
+		r.Role != "language_coordinator" &&
+		r.Role != "developer" &&
+		r.Role != "translator" &&
+		r.Role != "proofreader" {
+		return errors.New("role must be one of: owner, manager, language_coordinator, developer, translator, proofreader")
 	}
 
 	return nil

--- a/third_party/crowdin-api-client-go/crowdin/model/notifications_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/notifications_test.go
@@ -41,7 +41,7 @@ func TestNotificationValidate(t *testing.T) {
 				Role:    "invalid",
 				Message: "notification message",
 			},
-			err: "role must be either owner or manager",
+			err: "role must be one of: owner, manager, language_coordinator, developer, translator, proofreader",
 		},
 		{
 			name:  "valid request (message only)",
@@ -49,9 +49,25 @@ func TestNotificationValidate(t *testing.T) {
 			valid: true,
 		},
 		{
-			name: "valid request (with role)",
+			name: "valid request (with role owner)",
 			req: &Notification{
 				Role:    "owner",
+				Message: "notification message",
+			},
+			valid: true,
+		},
+		{
+			name: "valid request (with role translator)",
+			req: &Notification{
+				Role:    "translator",
+				Message: "notification message",
+			},
+			valid: true,
+		},
+		{
+			name: "valid request (with role proofreader)",
+			req: &Notification{
+				Role:    "proofreader",
 				Message: "notification message",
 			},
 			valid: true,


### PR DESCRIPTION
- What: Fixes standard 400 Bad Request error decoding and expands allowed notification roles in client validation.
- Why: Protects the Hyperlocalise Crowdin fork against hidden API errors and allows using standard project roles in notifications.
- Docs: https://developer.crowdin.com/api/v2/
- Scope: crowdin/crowdin.go, crowdin/model/errors_test.go, crowdin/model/notifications.go, crowdin/model/notifications_test.go, crowdin/crowdin_test.go
- Tests: All tests pass successfully.
- Confidence: 100% confidence. All tests pass and are fully compatible.

---
*PR created automatically by Jules for task [15111530948393396573](https://jules.google.com/task/15111530948393396573) started by @cungminh2710*