### PR TITLE
fix(markdown): reject orphan link closers and chip HL*PH in CAT

### DIFF
--- a/apps/cli/internal/i18n/runsvc/export_test.go
+++ b/apps/cli/internal/i18n/runsvc/export_test.go
@@ -77,3 +77,44 @@ func TestExportPrefilledTargetReconstructsEmptyPrefilledMarkdown(t *testing.T) {
 		t.Fatalf("content = %q, want source markdown template %q", string(content), sourceMarkdown)
 	}
 }
+
+func TestExportPrefilledTargetRejectsBrokenExistingMarkdownLinks(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "_posts", "en", "cat.md")
+	targetPath := filepath.Join(dir, "_posts", "vi-VN", "cat.md")
+	sourceMarkdown := "Need a [next-generation CAT tool](/product/next-gen-cat-tool) today.\n"
+	brokenTarget := "Cần một công cụ CAT thế hệ mới](/product/next-gen-cat-tool) ngay.\n"
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("mkdir source dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte(sourceMarkdown), 0o644); err != nil {
+		t.Fatalf("write source markdown: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte(brokenTarget), 0o644); err != nil {
+		t.Fatalf("write broken target markdown: %v", err)
+	}
+
+	content, err := ExportPrefilledTarget(ExportInput{
+		TargetPath:   targetPath,
+		SourcePath:   sourcePath,
+		SourceLocale: "en-US",
+		TargetLocale: "vi-VN",
+		Prefilled:    map[string]string{},
+		ProjectRoot:  dir,
+	})
+	if err != nil {
+		t.Fatalf("ExportPrefilledTarget: %v", err)
+	}
+	if strings.Contains(string(content), "thế hệ mới](/product") {
+		t.Fatalf("expected orphan closer not preserved, got %q", content)
+	}
+	if !strings.Contains(string(content), "[next-generation CAT tool](/product/next-gen-cat-tool)") {
+		t.Fatalf("expected source fallback with valid link, got %q", content)
+	}
+	if strings.ContainsRune(string(content), '\x1e') || strings.Contains(string(content), "HLMDPH_") {
+		t.Fatalf("expected no leaked HLMDPH sentinels, got %q", content)
+	}
+}

--- a/apps/hyperlocalise-web/_posts/fr-FR/ai-translation-is-not-enough-context-aware-localisation.md
+++ b/apps/hyperlocalise-web/_posts/fr-FR/ai-translation-is-not-enough-context-aware-localisation.md
@@ -122,7 +122,7 @@ L’IA peut traduire des mots.
 
 La localisation contextuelle aide les équipes à traduire la signification du produit, l’intention de la marque et l’expérience client.
 
-Chez Hyperlocalise, nous développons un outil TAO de nouvelle génération](/product/next-gen-cat-tool) conçu autour de cette idée : l’assistance de l’IA, le contexte produit, les connaissances réutilisables et la révision humaine travaillant ensemble dans un même flux de travail de localisation.
+Chez Hyperlocalise, nous développons un [outil TAO de nouvelle génération](/product/next-gen-cat-tool) conçu autour de cette idée : l’assistance de l’IA, le contexte produit, les connaissances réutilisables et la révision humaine travaillant ensemble dans un même flux de travail de localisation.
 
 [Découvrez notre outil CAT nouvelle génération](/product/next-gen-cat-tool) et voyez comment la localisation IA contextuelle peut aider votre équipe à traduire avec plus de précision, de cohérence et d’assurance.
 

--- a/apps/hyperlocalise-web/_posts/fr-FR/from-translation-management-to-translation-intelligence.md
+++ b/apps/hyperlocalise-web/_posts/fr-FR/from-translation-management-to-translation-intelligence.md
@@ -192,7 +192,7 @@ Cela crée un modèle human-in-the-loop plus efficace.
 
 Les linguistes et les experts du marché consacrent moins de temps à vérifier des contenus prévisibles et davantage de temps aux décisions qui exigent un jugement culturel, une interprétation stratégique ou une responsabilité.
 
-C’est aussi la direction de l’expérience CAT de nouvelle génération](/product/next-gen-cat-tool) : ne pas supprimer les humains de la localisation, mais leur offrir un meilleur contexte, des recommandations plus pertinentes et une vue plus claire des domaines où leur expertise compte.
+C’est aussi la direction de l’[expérience CAT de nouvelle génération](/product/next-gen-cat-tool) : ne pas supprimer les humains de la localisation, mais leur offrir un meilleur contexte, des recommandations plus pertinentes et une vue plus claire des domaines où leur expertise compte.
 
 ## De l'assurance qualité à l'évaluation continue
 
@@ -292,4 +292,4 @@ Cela rendra l’organisation plus intelligente quant à la manière dont elle co
 - [Hyperlocalise](/)
 - [Vue d’ensemble de la gestion des traductions — RWS](https://www.rws.com/glossary/translation-management/)
 - [Recherche en traduction automatique contextuelle — ScienceDirect](https://www.sciencedirect.com/science/article/pii/S2589004224021035)
-- L'évaluation humaine et le contexte au niveau du document dans la traduction automatique — arXiv](https://arxiv.org/abs/2104.14478)
+- [L'évaluation humaine et le contexte au niveau du document dans la traduction automatique — arXiv](https://arxiv.org/abs/2104.14478)

--- a/apps/hyperlocalise-web/_posts/fr-FR/hyperlocalisation-why-global-growth-needs-more-than-translation.md
+++ b/apps/hyperlocalise-web/_posts/fr-FR/hyperlocalisation-why-global-growth-needs-more-than-translation.md
@@ -129,7 +129,7 @@ Nous pensons que le savoir doit devenir réutilisable.
 
 Un système de localisation doit apprendre de la manière dont une entreprise communique. Il doit se souvenir de la façon dont les termes sont utilisés dans l’ensemble des produits. Il doit comprendre comment les relecteurs prennent leurs décisions. Il doit reconnaître les tendances dans les retours du marché. Il doit aider les équipes à appliquer les bonnes règles et le bon contexte sans exiger la même configuration manuelle à chaque fois.
 
-C’est ce que nous entendons par intelligence de localisation auto-évolutive](/product/self-evolving-knowledge).
+C’est ce que nous entendons par [intelligence de localisation auto-évolutive](/product/self-evolving-knowledge).
 
 Le système devrait devenir plus utile à chaque projet. Il devrait réduire les questions répétées, améliorer la cohérence et aider les équipes à prendre de meilleures décisions au fil du temps. Plus une entreprise localise, plus son intelligence de localisation devrait se renforcer.
 

--- a/apps/hyperlocalise-web/_posts/vi-VN/ai-translation-is-not-enough-context-aware-localisation.md
+++ b/apps/hyperlocalise-web/_posts/vi-VN/ai-translation-is-not-enough-context-aware-localisation.md
@@ -92,7 +92,7 @@ Các nhóm sản phẩm triển khai liên tục. Các nhóm marketing ra mắt 
 
 Một giao diện dịch thuật chỉ hiển thị văn bản nguồn và văn bản đích thì không còn đủ nữa.
 
-Các nhóm toàn cầu cần một công cụ CAT thế hệ mới](/product/next-gen-cat-tool) đưa ngữ cảnh vào chính trải nghiệm dịch. Không phải là điều được nghĩ đến sau cùng. Không phải là một tài liệu riêng biệt. Không phải là một chuỗi Slack mà ai đó phải tìm kiếm. Mà là một phần của quy trình làm việc, nơi dịch thuật và rà soát thực sự diễn ra.
+Các nhóm toàn cầu cần một [công cụ CAT thế hệ mới](/product/next-gen-cat-tool) đưa ngữ cảnh vào chính trải nghiệm dịch. Không phải là điều được nghĩ đến sau cùng. Không phải là một tài liệu riêng biệt. Không phải là một chuỗi Slack mà ai đó phải tìm kiếm. Mà là một phần của quy trình làm việc, nơi dịch thuật và rà soát thực sự diễn ra.
 
 Đó là hướng mà chúng tôi đang xây dựng tại Hyperlocalise.
 

--- a/apps/hyperlocalise-web/_posts/vi-VN/hyperlocalisation-why-global-growth-needs-more-than-translation.md
+++ b/apps/hyperlocalise-web/_posts/vi-VN/hyperlocalisation-why-global-growth-needs-more-than-translation.md
@@ -117,7 +117,7 @@ Hyperlocalise đang xây dựng cho một tương lai nơi các quy trình bản
 
 Điều đó có nghĩa là trải nghiệm dịch thuật nên hiểu sản phẩm. Nó nên hiểu thương hiệu. Nó nên hiểu thị trường. Nó nên hiểu các quyết định trước đây. Và nó nên được cải thiện khi đội ngũ tiếp tục làm việc.
 
-Công cụ CAT thế hệ mới của chúng tôi ](/product/next-gen-cat-tool) đưa ngữ cảnh sản phẩm, quy tắc bảng thuật ngữ, ảnh chụp màn hình và phản hồi của người duyệt vào chính trải nghiệm dịch thuật — để các quyết định siêu bản địa hóa diễn ra ngay tại nơi công việc thực sự được thực hiện.
+[Công cụ CAT thế hệ mới của chúng tôi](/product/next-gen-cat-tool) đưa ngữ cảnh sản phẩm, quy tắc bảng thuật ngữ, ảnh chụp màn hình và phản hồi của người duyệt vào chính trải nghiệm dịch thuật — để các quyết định siêu bản địa hóa diễn ra ngay tại nơi công việc thực sự được thực hiện.
 
 ## Tầm nhìn của chúng tôi: trí tuệ bản địa hóa tự tiến hóa
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-source-strings-preview.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-source-strings-preview.tsx
@@ -15,6 +15,7 @@
 import { FormattedMessage, useIntl } from "react-intl";
 
 import type { ProjectSourceStringsPreview } from "@/api/routes/project/project.schema";
+import { CatMessagePreview } from "@/components/cat/editor/cat-target-editor";
 import { TypographyP } from "@/components/ui/typography";
 
 import { projectFileSourceStringsPreviewMessages as messages } from "./project-file-source-strings-preview.messages";
@@ -68,7 +69,7 @@ function SourceStringsTable({ preview }: { preview: ProjectSourceStringsPreview 
                 <tr key={entry.id ?? entry.key} className="align-top">
                   <td className="px-3 py-2 font-mono text-foreground">{entry.key}</td>
                   <td className="max-w-[14rem] px-3 py-2 whitespace-pre-wrap text-subtle-foreground">
-                    {entry.text}
+                    <CatMessagePreview message={entry.text} />
                   </td>
                   <td className="max-w-[12rem] px-3 py-2 whitespace-pre-wrap text-muted-foreground">
                     {entry.context?.trim()

--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-target-editor.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-target-editor.tsx
@@ -61,6 +61,8 @@ function tokenVisualKind(token: CatMessageToken): CatMessageTokenVisualKind {
       return "pound";
     case "tag":
       return "tag";
+    case "markup":
+      return "markup";
     default:
       return "placeholder";
   }
@@ -134,6 +136,15 @@ function createCatMessageFormatExtension() {
 
               analysis.tokens.forEach((token) => {
                 decorationRangesForToken(textRanges, token).forEach(({ from, to }) => {
+                  if (token.kind === "markup") {
+                    decorations.push(
+                      Decoration.inline(from, to, {
+                        class: cn(tokenClassName(token), "cat-mf-markup-chip"),
+                        "data-cat-label": token.displayLabel ?? token.name,
+                      }),
+                    );
+                    return;
+                  }
                   decorations.push(Decoration.inline(from, to, { class: tokenClassName(token) }));
                 });
               });
@@ -178,16 +189,24 @@ function tokenLabel(token: CatMessageToken) {
     return `<${token.name}>`;
   }
 
+  if (token.kind === "markup") {
+    return token.displayLabel ?? token.name;
+  }
+
   return token.literal || `{${token.name}}`;
 }
 
 function presentTokenSignatures(analysis: CatMessageAnalysis) {
   return new Set(
-    analysis.tokens.map((token) =>
-      token.kind === "icu"
-        ? `${token.kind}:${token.name}:${token.type}`
-        : `${token.kind}:${token.name}`,
-    ),
+    analysis.tokens.map((token) => {
+      if (token.kind === "icu") {
+        return `${token.kind}:${token.name}:${token.type}`;
+      }
+      if (token.kind === "markup") {
+        return `${token.kind}:${token.literal}`;
+      }
+      return `${token.kind}:${token.name}`;
+    }),
   );
 }
 
@@ -216,7 +235,10 @@ export function CatMessagePreview({ message, className }: { message: string; cla
     }
     parts.push({
       key: token.id,
-      text: message.slice(token.start, token.end),
+      text:
+        token.kind === "markup"
+          ? (token.displayLabel ?? token.name)
+          : message.slice(token.start, token.end),
       token,
     });
     cursor = token.end;
@@ -236,6 +258,7 @@ export function CatMessagePreview({ message, className }: { message: string; cla
               "rounded-md border px-1 py-0.5 font-mono text-[0.9em]",
               catMessageTokenToneClass(tokenVisualKind(part.token)),
             )}
+            title={part.token.kind === "markup" ? part.token.literal : undefined}
           >
             {part.text}
           </span>
@@ -401,6 +424,10 @@ export function CatTargetEditor({
             : "rounded-2xl border border-border bg-background shadow-sm transition-colors",
           "focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50",
           "[&_.cat-mf-token]:rounded-md [&_.cat-mf-token]:px-1 [&_.cat-mf-token]:py-0.5 [&_.cat-mf-token]:font-mono [&_.cat-mf-token]:text-[0.9em]",
+          // Collapse raw HL*PH sentinel glyphs; ::before paints the short MD#n / HT#n / LQ#n chip.
+          "[&_.cat-mf-markup-chip]:text-[0px] [&_.cat-mf-markup-chip]:leading-none",
+          "[&_.cat-mf-markup-chip::before]:content-[attr(data-cat-label)] [&_.cat-mf-markup-chip::before]:text-[0.9rem]",
+          "[&_.cat-mf-markup-chip::before]:font-mono [&_.cat-mf-markup-chip::before]:leading-normal",
           "[&_.tiptap_p.is-editor-empty:first-child::before]:text-muted-foreground",
           "[&_.tiptap_p.is-editor-empty:first-child::before]:content-[attr(data-placeholder)]",
           "[&_.tiptap_p.is-editor-empty:first-child::before]:float-left",

--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-target-editor.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-target-editor.tsx
@@ -25,6 +25,7 @@ import { cn } from "@/lib/primitives/cn";
 
 import {
   analyzeCatMessageFormat,
+  catMessageTokenSignature,
   compareCatMessageFormats,
   missingCatMessageTokens,
   type CatIcuBlockSummary,
@@ -197,17 +198,7 @@ function tokenLabel(token: CatMessageToken) {
 }
 
 function presentTokenSignatures(analysis: CatMessageAnalysis) {
-  return new Set(
-    analysis.tokens.map((token) => {
-      if (token.kind === "icu") {
-        return `${token.kind}:${token.name}:${token.type}`;
-      }
-      if (token.kind === "markup") {
-        return `${token.kind}:${token.literal}`;
-      }
-      return `${token.kind}:${token.name}`;
-    }),
-  );
+  return new Set(analysis.tokens.map((token) => catMessageTokenSignature(token)));
 }
 
 export function CatMessagePreview({ message, className }: { message: string; className?: string }) {
@@ -488,11 +479,7 @@ export function CatTargetEditor({
           </span>
           {sourceTokens.map((token) => {
             const isMissing = missingTokens.some((missingToken) => missingToken.id === token.id);
-            const isPresent = targetSignatures.has(
-              token.kind === "icu"
-                ? `${token.kind}:${token.name}:${token.type}`
-                : `${token.kind}:${token.name}`,
-            );
+            const isPresent = targetSignatures.has(catMessageTokenSignature(token));
 
             return (
               <Button

--- a/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/intelligence/cat-intelligence-panel.tsx
@@ -23,6 +23,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import { FormattedMessage, useIntl } from "react-intl";
 
+import { formatInternalMarkupForDisplay } from "@/components/cat/message-format/cat-internal-markup";
 import { MarkdownContent } from "@/components/markdown-editor/markdown-editor";
 import {
   AlertDialog,
@@ -248,9 +249,11 @@ function TranslationMemoryRow({
       </div>
       <div className="space-y-1">
         <p className="text-pretty text-xs leading-relaxed text-muted-foreground">
-          {match.sourceText}
+          {formatInternalMarkupForDisplay(match.sourceText)}
         </p>
-        <p className="text-pretty text-sm leading-relaxed text-foreground">{match.targetText}</p>
+        <p className="text-pretty text-sm leading-relaxed text-foreground">
+          {formatInternalMarkupForDisplay(match.targetText)}
+        </p>
       </div>
     </li>
   );

--- a/apps/hyperlocalise-web/src/components/cat/message-format/cat-internal-markup.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/message-format/cat-internal-markup.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  extractInternalMarkupSpans,
+  formatInternalMarkupForDisplay,
+  hasInternalMarkup,
+  internalMarkupLabel,
+} from "./cat-internal-markup";
+
+const md0 = "\u001eHLMDPH_8E6DFE8F53EA_0\u001f";
+const md1 = "\u001eHLMDPH_0EB5FD589564_1\u001f";
+const ht0 = "\u001eHLHTPH_AABBCCDDEEFF_0\u001f";
+const lq0 = "\u001eHLLQPH_112233445566_0\u001f";
+
+describe("cat internal markup helpers", () => {
+  it("extracts markdown boundary sentinels with short labels", () => {
+    const message = `${md0}next-generation CAT tool${md1}`;
+    const spans = extractInternalMarkupSpans(message);
+
+    expect(spans).toEqual([
+      {
+        family: "MD",
+        index: 0,
+        literal: md0,
+        start: 0,
+        end: md0.length,
+        label: "MD#0",
+      },
+      {
+        family: "MD",
+        index: 1,
+        literal: md1,
+        start: md0.length + "next-generation CAT tool".length,
+        end: md0.length + "next-generation CAT tool".length + md1.length,
+        label: "MD#1",
+      },
+    ]);
+  });
+
+  it("extracts HTML and Liquid sentinels", () => {
+    const message = `Click ${ht0}here${ht0} ${lq0}`;
+    const spans = extractInternalMarkupSpans(message);
+
+    expect(spans.map((span) => span.label)).toEqual(["HT#0", "HT#0", "LQ#0"]);
+    expect(spans.every((span) => span.literal.startsWith("\u001e"))).toBe(true);
+  });
+
+  it("formats sentinels for plain-text display without leaking control bytes", () => {
+    const formatted = formatInternalMarkupForDisplay(
+      `Global teams need a ${md0}next-generation CAT tool${md1} today.`,
+    );
+
+    expect(formatted).toBe("Global teams need a MD#0next-generation CAT toolMD#1 today.");
+    expect(formatted.includes("\u001e")).toBe(false);
+    expect(formatted.includes("HLMDPH")).toBe(false);
+  });
+
+  it("detects presence of internal markup", () => {
+    expect(hasInternalMarkup(`plain ${md0} text`)).toBe(true);
+    expect(hasInternalMarkup("plain text")).toBe(false);
+  });
+
+  it("builds stable labels", () => {
+    expect(internalMarkupLabel("MD", 2)).toBe("MD#2");
+    expect(internalMarkupLabel("HT", 0)).toBe("HT#0");
+    expect(internalMarkupLabel("LQ", 11)).toBe("LQ#11");
+  });
+
+  it("returns no spans for empty or non-sentinel text", () => {
+    expect(extractInternalMarkupSpans("")).toEqual([]);
+    expect(extractInternalMarkupSpans("Hello {name}")).toEqual([]);
+    expect(extractInternalMarkupSpans("HLMDPH_FAKE_0")).toEqual([]);
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/message-format/cat-internal-markup.ts
+++ b/apps/hyperlocalise-web/src/components/cat/message-format/cat-internal-markup.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+/** Families match Go sentinels: HLMDPH (markdown), HLHTPH (HTML), HLLQPH (Liquid). */
+export type CatInternalMarkupFamily = "MD" | "HT" | "LQ";
+
+export interface CatInternalMarkupSpan {
+  family: CatInternalMarkupFamily;
+  index: number;
+  literal: string;
+  start: number;
+  end: number;
+  label: string;
+}
+
+// RS/US delimiters match Go HLMDPH / HLHTPH / HLLQPH sentinels (\x1e...\x1f).
+const INTERNAL_MARKUP_PATTERN = new RegExp(
+  `${String.fromCharCode(0x1e)}HL(MD|HT|LQ)PH_[A-Z0-9]+_(\\d+)${String.fromCharCode(0x1f)}`,
+  "g",
+);
+
+function familyFromMatch(raw: string): CatInternalMarkupFamily {
+  switch (raw) {
+    case "MD":
+      return "MD";
+    case "HT":
+      return "HT";
+    case "LQ":
+      return "LQ";
+    default:
+      return "MD";
+  }
+}
+
+export function internalMarkupLabel(family: CatInternalMarkupFamily, index: number) {
+  return `${family}#${index}`;
+}
+
+/** Extract Hyperlocalise internal markup sentinels from a segment string. */
+export function extractInternalMarkupSpans(message: string): CatInternalMarkupSpan[] {
+  const spans: CatInternalMarkupSpan[] = [];
+  for (const match of message.matchAll(INTERNAL_MARKUP_PATTERN)) {
+    const literal = match[0];
+    const family = familyFromMatch(match[1] ?? "MD");
+    const index = Number.parseInt(match[2] ?? "0", 10);
+    const start = match.index ?? 0;
+    spans.push({
+      family,
+      index,
+      literal,
+      start,
+      end: start + literal.length,
+      label: internalMarkupLabel(family, index),
+    });
+  }
+  return spans;
+}
+
+/** Replace sentinels with short labels for plain-text UI (queue rows, etc.). */
+export function formatInternalMarkupForDisplay(message: string): string {
+  return message.replace(INTERNAL_MARKUP_PATTERN, (_literal, family: string, index: string) =>
+    internalMarkupLabel(familyFromMatch(family), Number.parseInt(index, 10)),
+  );
+}
+
+export function hasInternalMarkup(message: string): boolean {
+  INTERNAL_MARKUP_PATTERN.lastIndex = 0;
+  return INTERNAL_MARKUP_PATTERN.test(message);
+}

--- a/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-format-i18n.ts
+++ b/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-format-i18n.ts
@@ -100,6 +100,25 @@ export function localizeCatMessageParityIssue(
         ),
       };
     }
+    case "token-order": {
+      const tokens = issue.tokens?.join(", ") ?? "";
+      return {
+        label: intl.formatMessage({
+          defaultMessage: "Markup order",
+          id: "UL3odPVruI",
+          description: "CAT format check label when markup sentinel order does not match source",
+        }),
+        message: intl.formatMessage(
+          {
+            defaultMessage:
+              "Target must keep source order for markup tokens {tokens}. Swapped openers and closers break export.",
+            id: "xrvyWAPhPg",
+            description: "CAT format check message when markup sentinel nesting/order is wrong",
+          },
+          { tokens },
+        ),
+      };
+    }
     default:
       return {
         label: issue.kind,

--- a/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-format.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-format.test.ts
@@ -83,4 +83,90 @@ describe("cat message format utilities", () => {
       }),
     );
   });
+
+  it("extracts markdown HLMDPH boundary tokens as markup chips", () => {
+    const md0 = "\u001eHLMDPH_8E6DFE8F53EA_0\u001f";
+    const md1 = "\u001eHLMDPH_0EB5FD589564_1\u001f";
+    const analysis = analyzeCatMessageFormat(`${md0}next-generation CAT tool${md1}`);
+
+    expect(analysis.tokens).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "markup",
+          name: "MD#0",
+          displayLabel: "MD#0",
+          literal: md0,
+        }),
+        expect.objectContaining({
+          kind: "markup",
+          name: "MD#1",
+          displayLabel: "MD#1",
+          literal: md1,
+        }),
+      ]),
+    );
+    expect(analysis.placeholders).toHaveLength(2);
+    expect(analysis.parseError).toBeUndefined();
+  });
+
+  it("reports missing markdown boundary tokens with short labels", () => {
+    const md0 = "\u001eHLMDPH_8E6DFE8F53EA_0\u001f";
+    const md1 = "\u001eHLMDPH_0EB5FD589564_1\u001f";
+    const issues = compare(
+      `${md0}next-generation CAT tool${md1}`,
+      `outil CAT nouvelle génération${md1}`,
+    );
+
+    expect(issues).toContainEqual(
+      expect.objectContaining({
+        kind: "missing-token",
+        tokens: ["MD#0"],
+      }),
+    );
+  });
+
+  it("reports extra markdown boundary tokens", () => {
+    const md0 = "\u001eHLMDPH_8E6DFE8F53EA_0\u001f";
+    const md1 = "\u001eHLMDPH_0EB5FD589564_1\u001f";
+    const issues = compare(`plain ${md1}`, `${md0}plain ${md1}`);
+
+    expect(issues).toContainEqual(
+      expect.objectContaining({
+        kind: "extra-token",
+        tokens: ["MD#0"],
+      }),
+    );
+  });
+
+  it("accepts matching markdown boundary tokens", () => {
+    const md0 = "\u001eHLMDPH_8E6DFE8F53EA_0\u001f";
+    const md1 = "\u001eHLMDPH_0EB5FD589564_1\u001f";
+    const issues = compare(
+      `${md0}next-generation CAT tool${md1}`,
+      `${md0}outil CAT de nouvelle génération${md1}`,
+    );
+
+    expect(issues).toEqual([]);
+  });
+
+  it("treats differently hashed sentinels with the same index as a mismatch", () => {
+    const sourceToken = "\u001eHLMDPH_AAAAAAAAAAAA_0\u001f";
+    const targetToken = "\u001eHLMDPH_BBBBBBBBBBBB_0\u001f";
+    const issues = compare(`${sourceToken}label`, `${targetToken}libellé`);
+
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "missing-token", tokens: ["MD#0"] }),
+        expect.objectContaining({ kind: "extra-token", tokens: ["MD#0"] }),
+      ]),
+    );
+  });
+
+  it("coexists ICU placeholders with HTML markup sentinels", () => {
+    const ht0 = "\u001eHLHTPH_AABBCCDDEEFF_0\u001f";
+    const analysis = analyzeCatMessageFormat(`Hello {name}${ht0}`);
+
+    expect(analysis.tokens.map((token) => token.kind).toSorted()).toEqual(["argument", "markup"]);
+    expect(analysis.placeholders).toHaveLength(2);
+  });
 });

--- a/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-format.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-format.test.ts
@@ -169,4 +169,65 @@ describe("cat message format utilities", () => {
     expect(analysis.tokens.map((token) => token.kind).toSorted()).toEqual(["argument", "markup"]);
     expect(analysis.placeholders).toHaveLength(2);
   });
+
+  it("reports duplicated markup sentinels as extra tokens", () => {
+    const ht0 = "\u001eHLHTPH_AABBCCDDEEFF_0\u001f";
+    const ht1 = "\u001eHLHTPH_112233445566_1\u001f";
+    const issues = compare(`Click ${ht0}here${ht1}`, `Cliquez ${ht0}${ht0}ici${ht1}`);
+
+    expect(issues).toContainEqual(
+      expect.objectContaining({
+        kind: "extra-token",
+        tokens: ["HT#0"],
+      }),
+    );
+    expect(issues.filter((issue) => issue.kind === "missing-token")).toHaveLength(0);
+  });
+
+  it("reports missing duplicate markup sentinel occurrences", () => {
+    const ht0 = "\u001eHLHTPH_AABBCCDDEEFF_0\u001f";
+    const ht1 = "\u001eHLHTPH_112233445566_1\u001f";
+    const issues = compare(`Click ${ht0}${ht0}here${ht1}`, `Cliquez ${ht0}ici${ht1}`);
+
+    expect(issues).toContainEqual(
+      expect.objectContaining({
+        kind: "missing-token",
+        tokens: ["HT#0"],
+      }),
+    );
+  });
+
+  it("still reports ICU parse errors when markup tokens are present", () => {
+    const md0 = "\u001eHLMDPH_8E6DFE8F53EA_0\u001f";
+    const md1 = "\u001eHLMDPH_0EB5FD589564_1\u001f";
+    const issues = compare(
+      `${md0}{count, plural, one {# file} other {# files}}${md1}`,
+      `${md0}{count, plural, one {# fichier}}${md1}`,
+    );
+
+    expect(issues).toContainEqual(
+      expect.objectContaining({
+        kind: "parse-error",
+        parseTarget: "target",
+      }),
+    );
+    expect(issues.filter((issue) => issue.kind === "missing-token")).toHaveLength(0);
+    expect(issues.filter((issue) => issue.kind === "extra-token")).toHaveLength(0);
+  });
+
+  it("reports markup mismatches alongside ICU parse errors", () => {
+    const md0 = "\u001eHLMDPH_8E6DFE8F53EA_0\u001f";
+    const md1 = "\u001eHLMDPH_0EB5FD589564_1\u001f";
+    const issues = compare(
+      `${md0}{count, plural, one {# file} other {# files}}${md1}`,
+      `{count, plural, one {# fichier}}${md1}`,
+    );
+
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "parse-error", parseTarget: "target" }),
+        expect.objectContaining({ kind: "missing-token", tokens: ["MD#0"] }),
+      ]),
+    );
+  });
 });

--- a/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-format.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-format.test.ts
@@ -230,4 +230,39 @@ describe("cat message format utilities", () => {
       ]),
     );
   });
+
+  it("reports swapped markup sentinel order when the multiset still matches", () => {
+    const md0 = "\u001eHLMDPH_8E6DFE8F53EA_0\u001f";
+    const md1 = "\u001eHLMDPH_0EB5FD589564_1\u001f";
+    const issues = compare(
+      `${md0}next-generation CAT tool${md1}`,
+      `${md1}outil CAT de nouvelle génération${md0}`,
+    );
+
+    expect(issues).toContainEqual(
+      expect.objectContaining({
+        kind: "token-order",
+        tokens: ["MD#0", "MD#1"],
+      }),
+    );
+    expect(issues.filter((issue) => issue.kind === "missing-token")).toHaveLength(0);
+    expect(issues.filter((issue) => issue.kind === "extra-token")).toHaveLength(0);
+  });
+
+  it("reports crossed HTML markup nesting as a token-order issue", () => {
+    const ht0 = "\u001eHLHTPH_AABBCCDDEEFF_0\u001f";
+    const ht1 = "\u001eHLHTPH_112233445566_1\u001f";
+    const ht2 = "\u001eHLHTPH_77889900AABB_2\u001f";
+    const ht3 = "\u001eHLHTPH_CCDDEEFF0011_3\u001f";
+    const issues = compare(
+      `Click ${ht0}${ht1}here${ht2}${ht3}`,
+      `Cliquez ${ht0}${ht1}ici${ht3}${ht2}`,
+    );
+
+    expect(issues).toContainEqual(
+      expect.objectContaining({
+        kind: "token-order",
+      }),
+    );
+  });
 });

--- a/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-format.ts
+++ b/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-format.ts
@@ -290,9 +290,40 @@ function tokenDisplayName(token: CatMessageToken) {
   return `{${token.name}}`;
 }
 
-function findMissingTokens(sourceTokens: CatMessageToken[], targetTokens: CatMessageToken[]) {
-  const targetSignatures = new Set(targetTokens.map(tokenSignature));
-  return sourceTokens.filter((token) => !targetSignatures.has(tokenSignature(token)));
+function signatureCounts(tokens: CatMessageToken[]) {
+  const counts = new Map<string, { count: number; sample: CatMessageToken }>();
+  for (const token of tokens) {
+    const signature = tokenSignature(token);
+    const entry = counts.get(signature);
+    if (entry) {
+      entry.count += 1;
+      continue;
+    }
+    counts.set(signature, { count: 1, sample: token });
+  }
+  return counts;
+}
+
+/** Tokens present more often on the left than the right (multiset difference). */
+function findMissingTokens(leftTokens: CatMessageToken[], rightTokens: CatMessageToken[]) {
+  const rightCounts = new Map<string, number>();
+  for (const token of rightTokens) {
+    const signature = tokenSignature(token);
+    rightCounts.set(signature, (rightCounts.get(signature) ?? 0) + 1);
+  }
+
+  const missing: CatMessageToken[] = [];
+  for (const [signature, { count, sample }] of signatureCounts(leftTokens)) {
+    const deficit = count - (rightCounts.get(signature) ?? 0);
+    for (let index = 0; index < deficit; index += 1) {
+      missing.push(sample);
+    }
+  }
+  return missing;
+}
+
+function analysisHasMarkup(analysis: CatMessageAnalysis) {
+  return analysis.tokens.some((token) => token.kind === "markup");
 }
 
 export function compareCatMessageFormats(
@@ -300,34 +331,25 @@ export function compareCatMessageFormats(
   target: CatMessageAnalysis,
 ): CatMessageParityIssue[] {
   const issues: CatMessageParityIssue[] = [];
-  const sourceHasMarkup = source.tokens.some((token) => token.kind === "markup");
-  const targetHasMarkup = target.tokens.some((token) => token.kind === "markup");
-  const hasMarkup = sourceHasMarkup || targetHasMarkup;
+  const hasMarkup = analysisHasMarkup(source) || analysisHasMarkup(target);
 
-  // Internal HL*PH sentinels are compared as markup tokens. Pure ICU parse failures
-  // without markup still short-circuit like before.
-  if (source.parseError && !hasMarkup) {
+  if (source.parseError) {
     issues.push({
       kind: "parse-error",
       parseTarget: "source",
       parseErrorMessage: source.parseError.message || undefined,
     });
-    if (target.parseError) {
-      issues.push({
-        kind: "parse-error",
-        parseTarget: "target",
-        parseErrorMessage: target.parseError.message || undefined,
-      });
-    }
-    return issues;
   }
-
-  if (target.parseError && !hasMarkup) {
+  if (target.parseError) {
     issues.push({
       kind: "parse-error",
       parseTarget: "target",
       parseErrorMessage: target.parseError.message || undefined,
     });
+  }
+
+  // Pure ICU parse failures without markup have nothing else useful to compare.
+  if ((source.parseError || target.parseError) && !hasMarkup) {
     return issues;
   }
 
@@ -369,9 +391,19 @@ export function compareCatMessageFormats(
 export function missingCatMessageTokens(sourceMessage: string, targetMessage: string) {
   const source = analyzeCatMessageFormat(sourceMessage);
   const target = analyzeCatMessageFormat(targetMessage);
-  if (source.parseError || target.parseError) {
+  const hasMarkup = analysisHasMarkup(source) || analysisHasMarkup(target);
+  if ((source.parseError || target.parseError) && !hasMarkup) {
     return [];
   }
 
-  return findMissingTokens(source.tokens, target.tokens).filter((token) => token.kind !== "pound");
+  const sourceTokens =
+    source.parseError || target.parseError
+      ? source.tokens.filter((token) => token.kind === "markup")
+      : source.tokens;
+  const targetTokens =
+    source.parseError || target.parseError
+      ? target.tokens.filter((token) => token.kind === "markup")
+      : target.tokens;
+
+  return findMissingTokens(sourceTokens, targetTokens).filter((token) => token.kind !== "pound");
 }

--- a/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-format.ts
+++ b/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-format.ts
@@ -26,7 +26,17 @@ import {
   type SelectElement,
 } from "@formatjs/icu-messageformat-parser";
 
-export type CatMessageTokenKind = "argument" | "icu" | "number" | "date" | "time" | "pound" | "tag";
+import { extractInternalMarkupSpans } from "./cat-internal-markup";
+
+export type CatMessageTokenKind =
+  | "argument"
+  | "icu"
+  | "number"
+  | "date"
+  | "time"
+  | "pound"
+  | "tag"
+  | "markup";
 
 export interface CatMessageToken {
   id: string;
@@ -37,6 +47,8 @@ export interface CatMessageToken {
   end: number;
   options?: string[];
   type?: "plural" | "select" | "selectordinal";
+  /** Short chip label for internal markup sentinels (e.g. MD#0). */
+  displayLabel?: string;
 }
 
 export interface CatIcuBlockSummary {
@@ -176,32 +188,57 @@ function walkElements(
   });
 }
 
+function markupTokensFromMessage(message: string): CatMessageToken[] {
+  return extractInternalMarkupSpans(message).map((span, index) => ({
+    id: `markup-${span.family}-${span.index}-${span.start}-${index}`,
+    kind: "markup" as const,
+    name: span.label,
+    literal: span.literal,
+    start: span.start,
+    end: span.end,
+    displayLabel: span.label,
+  }));
+}
+
+function mergeMessageTokens(markupTokens: CatMessageToken[], icuTokens: CatMessageToken[]) {
+  return [...markupTokens, ...icuTokens].toSorted((first, second) => first.start - second.start);
+}
+
+function placeholderTokens(tokens: CatMessageToken[]) {
+  return tokens.filter((token) =>
+    ["argument", "number", "date", "time", "tag", "markup"].includes(token.kind),
+  );
+}
+
+function icuBlockSummaries(tokens: CatMessageToken[]): CatIcuBlockSummary[] {
+  return tokens
+    .filter((token) => token.kind === "icu" && token.type)
+    .map((token) => ({
+      id: token.id,
+      arg: token.name,
+      type: token.type!,
+      options: token.options ?? [],
+    }));
+}
+
 export function analyzeCatMessageFormat(message: string): CatMessageAnalysis {
+  const markupTokens = markupTokensFromMessage(message);
+
   try {
     const ast = parse(message, {
       captureLocation: true,
       ignoreTag: false,
       requiresOtherClause: true,
     });
-    const tokens: CatMessageToken[] = [];
-    walkElements(ast, message, tokens);
-    const placeholders = tokens.filter((token) =>
-      ["argument", "number", "date", "time", "tag"].includes(token.kind),
-    );
-    const icuBlocks = tokens
-      .filter((token) => token.kind === "icu" && token.type)
-      .map((token) => ({
-        id: token.id,
-        arg: token.name,
-        type: token.type!,
-        options: token.options ?? [],
-      }));
+    const icuTokens: CatMessageToken[] = [];
+    walkElements(ast, message, icuTokens);
+    const tokens = mergeMessageTokens(markupTokens, icuTokens);
 
     return {
       message,
       tokens,
-      placeholders,
-      icuBlocks,
+      placeholders: placeholderTokens(tokens),
+      icuBlocks: icuBlockSummaries(tokens),
     };
   } catch (error) {
     const parserError = error as {
@@ -212,8 +249,8 @@ export function analyzeCatMessageFormat(message: string): CatMessageAnalysis {
 
     return {
       message,
-      tokens: [],
-      placeholders: [],
+      tokens: markupTokens,
+      placeholders: placeholderTokens(markupTokens),
       icuBlocks: [],
       parseError: {
         message: parserError.message ?? "",
@@ -229,6 +266,11 @@ function tokenSignature(token: CatMessageToken) {
     return `${token.kind}:${token.name}:${token.type}`;
   }
 
+  if (token.kind === "markup") {
+    // Exact sentinel bytes must round-trip; label alone is not unique across hashes.
+    return `${token.kind}:${token.literal}`;
+  }
+
   return `${token.kind}:${token.name}`;
 }
 
@@ -239,6 +281,10 @@ function tokenDisplayName(token: CatMessageToken) {
 
   if (token.kind === "tag") {
     return `<${token.name}>`;
+  }
+
+  if (token.kind === "markup") {
+    return token.displayLabel ?? token.name;
   }
 
   return `{${token.name}}`;
@@ -254,8 +300,13 @@ export function compareCatMessageFormats(
   target: CatMessageAnalysis,
 ): CatMessageParityIssue[] {
   const issues: CatMessageParityIssue[] = [];
+  const sourceHasMarkup = source.tokens.some((token) => token.kind === "markup");
+  const targetHasMarkup = target.tokens.some((token) => token.kind === "markup");
+  const hasMarkup = sourceHasMarkup || targetHasMarkup;
 
-  if (source.parseError) {
+  // Internal HL*PH sentinels are compared as markup tokens. Pure ICU parse failures
+  // without markup still short-circuit like before.
+  if (source.parseError && !hasMarkup) {
     issues.push({
       kind: "parse-error",
       parseTarget: "source",
@@ -271,7 +322,7 @@ export function compareCatMessageFormats(
     return issues;
   }
 
-  if (target.parseError) {
+  if (target.parseError && !hasMarkup) {
     issues.push({
       kind: "parse-error",
       parseTarget: "target",
@@ -298,16 +349,18 @@ export function compareCatMessageFormats(
     });
   }
 
-  const missingIcuBlocks = findMissingTokens(
-    source.tokens.filter((token) => token.kind === "icu"),
-    target.tokens.filter((token) => token.kind === "icu"),
-  );
-  if (missingIcuBlocks.length > 0) {
-    const labels = uniqueSorted(missingIcuBlocks.map(tokenDisplayName));
-    issues.push({
-      kind: "icu-mismatch",
-      tokens: labels,
-    });
+  if (!source.parseError && !target.parseError) {
+    const missingIcuBlocks = findMissingTokens(
+      source.tokens.filter((token) => token.kind === "icu"),
+      target.tokens.filter((token) => token.kind === "icu"),
+    );
+    if (missingIcuBlocks.length > 0) {
+      const labels = uniqueSorted(missingIcuBlocks.map(tokenDisplayName));
+      issues.push({
+        kind: "icu-mismatch",
+        tokens: labels,
+      });
+    }
   }
 
   return issues;

--- a/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-format.ts
+++ b/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-format.ts
@@ -71,7 +71,7 @@ export interface CatMessageAnalysis {
 }
 
 export interface CatMessageParityIssue {
-  kind: "missing-token" | "extra-token" | "icu-mismatch" | "parse-error";
+  kind: "missing-token" | "extra-token" | "icu-mismatch" | "token-order" | "parse-error";
   tokens?: string[];
   parseErrorMessage?: string;
   parseTarget?: "source" | "target";
@@ -261,7 +261,8 @@ export function analyzeCatMessageFormat(message: string): CatMessageAnalysis {
   }
 }
 
-function tokenSignature(token: CatMessageToken) {
+/** Stable signature for placeholder parity and required-token UI lookup. */
+export function catMessageTokenSignature(token: CatMessageToken) {
   if (token.kind === "icu") {
     return `${token.kind}:${token.name}:${token.type}`;
   }
@@ -293,7 +294,7 @@ function tokenDisplayName(token: CatMessageToken) {
 function signatureCounts(tokens: CatMessageToken[]) {
   const counts = new Map<string, { count: number; sample: CatMessageToken }>();
   for (const token of tokens) {
-    const signature = tokenSignature(token);
+    const signature = catMessageTokenSignature(token);
     const entry = counts.get(signature);
     if (entry) {
       entry.count += 1;
@@ -308,7 +309,7 @@ function signatureCounts(tokens: CatMessageToken[]) {
 function findMissingTokens(leftTokens: CatMessageToken[], rightTokens: CatMessageToken[]) {
   const rightCounts = new Map<string, number>();
   for (const token of rightTokens) {
-    const signature = tokenSignature(token);
+    const signature = catMessageTokenSignature(token);
     rightCounts.set(signature, (rightCounts.get(signature) ?? 0) + 1);
   }
 
@@ -320,6 +321,29 @@ function findMissingTokens(leftTokens: CatMessageToken[], rightTokens: CatMessag
     }
   }
   return missing;
+}
+
+function markupTokensInOrder(tokens: CatMessageToken[]) {
+  return tokens.filter((token) => token.kind === "markup");
+}
+
+/** True when both sides have the same markup multiset but a different order/nesting. */
+function markupOrderMismatch(source: CatMessageAnalysis, target: CatMessageAnalysis) {
+  const sourceMarkup = markupTokensInOrder(source.tokens);
+  const targetMarkup = markupTokensInOrder(target.tokens);
+  if (sourceMarkup.length < 2 || sourceMarkup.length !== targetMarkup.length) {
+    return false;
+  }
+  if (findMissingTokens(sourceMarkup, targetMarkup).length > 0) {
+    return false;
+  }
+  if (findMissingTokens(targetMarkup, sourceMarkup).length > 0) {
+    return false;
+  }
+  return sourceMarkup.some(
+    (token, index) =>
+      catMessageTokenSignature(token) !== catMessageTokenSignature(targetMarkup[index]!),
+  );
 }
 
 function analysisHasMarkup(analysis: CatMessageAnalysis) {
@@ -367,6 +391,14 @@ export function compareCatMessageFormats(
     const labels = uniqueSorted(extraPlaceholders.map(tokenDisplayName));
     issues.push({
       kind: "extra-token",
+      tokens: labels,
+    });
+  }
+
+  if (markupOrderMismatch(source, target)) {
+    const labels = uniqueSorted(markupTokensInOrder(source.tokens).map(tokenDisplayName));
+    issues.push({
+      kind: "token-order",
       tokens: labels,
     });
   }

--- a/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-token-styles.ts
+++ b/apps/hyperlocalise-web/src/components/cat/message-format/cat-message-token-styles.ts
@@ -10,7 +10,13 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-export type CatMessageTokenVisualKind = "icu" | "placeholder" | "pound" | "tag" | "error";
+export type CatMessageTokenVisualKind =
+  | "icu"
+  | "placeholder"
+  | "pound"
+  | "tag"
+  | "markup"
+  | "error";
 
 export function catMessageTokenToneClass(kind: CatMessageTokenVisualKind) {
   switch (kind) {
@@ -22,6 +28,8 @@ export function catMessageTokenToneClass(kind: CatMessageTokenVisualKind) {
       return "border-grove-500/25 bg-grove-500/10 text-grove-900 dark:text-grove-300";
     case "tag":
       return "border-border bg-skeleton text-foreground";
+    case "markup":
+      return "border-flame-500/25 bg-flame-500/10 text-flame-900 dark:text-flame-200";
     case "error":
       return "rounded-md bg-flame-700/20 text-flame-900 dark:text-flame-100";
   }

--- a/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-virtual-list.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-virtual-list.tsx
@@ -18,6 +18,7 @@ import { useIntl } from "react-intl";
 
 import { cn } from "@/lib/primitives/cn";
 
+import { formatInternalMarkupForDisplay } from "@/components/cat/message-format/cat-internal-markup";
 import { CatSegmentKeyMeta } from "@/components/cat/segment/cat-segment-key-meta";
 import { catQueuePanelMessages } from "@/components/cat/shared/cat.messages";
 import type { CatSegment } from "@/components/cat/shared/types";
@@ -150,7 +151,9 @@ export function CatQueueVirtualList({
                     {String(segment.index).padStart(2, "0")}
                   </span>
                   <div className="min-w-0 flex-1 space-y-1">
-                    <p className="line-clamp-2 text-sm text-foreground">{segment.sourceText}</p>
+                    <p className="line-clamp-2 text-sm text-foreground">
+                      {formatInternalMarkupForDisplay(segment.sourceText)}
+                    </p>
                     <CatSegmentKeyMeta
                       segmentKey={segment.key}
                       sourcePath={segment.sourcePath}

--- a/internal/i18n/segmentvalidate/printf_scout_test.go
+++ b/internal/i18n/segmentvalidate/printf_scout_test.go
@@ -132,6 +132,7 @@ func TestValidateSegmentPrintfExtendedParity(t *testing.T) {
 
 			if formatCheck == nil {
 				t.Fatalf("expected %s check, but none found in %+v", tt.wantID, checks)
+				return
 			}
 
 			if !reflect.DeepEqual(formatCheck.RelatedTokens, tt.wantTokens) {

--- a/internal/i18n/segmentvalidate/validate_pass_label_scout_test.go
+++ b/internal/i18n/segmentvalidate/validate_pass_label_scout_test.go
@@ -158,6 +158,7 @@ func TestValidateSegmentPassLabelReflectsTokenPresence(t *testing.T) {
 			}
 			if formatCheck == nil {
 				t.Fatalf("expected format-parity check, got %+v", checks)
+				return
 			}
 			if formatCheck.Status != StatusPass {
 				t.Fatalf("expected StatusPass, got %+v", formatCheck)

--- a/internal/i18n/segmentvalidate/validate_scout_test.go
+++ b/internal/i18n/segmentvalidate/validate_scout_test.go
@@ -62,6 +62,7 @@ func TestValidateSegmentRelatedTokensWithSpaces(t *testing.T) {
 
 			if formatCheck == nil {
 				t.Fatalf("expected %s check, but none found in %+v", tt.wantID, checks)
+				return
 			}
 
 			if !reflect.DeepEqual(formatCheck.RelatedTokens, tt.wantTokens) {

--- a/internal/i18n/translationfileparser/markdown_parser.go
+++ b/internal/i18n/translationfileparser/markdown_parser.go
@@ -815,10 +815,16 @@ func renderMarkdownPartWithDiagnostics(part markdownPart, translated string, dia
 
 // markdownHasOrphanLinkClosers reports whether s contains a `](` / `][` closer
 // without a matching `[` / `![` opener. Inline code spans and escapes are skipped.
+// Escaped link-like constructs such as `\[label](/url)` are skipped entirely so
+// intentional literal bracket syntax is not treated as an orphan closer.
 func markdownHasOrphanLinkClosers(s string) bool {
 	openerDepth := 0
 	for idx := 0; idx < len(s); {
 		if s[idx] == '\\' && idx+1 < len(s) {
+			if s[idx+1] == '[' {
+				idx = skipEscapedMarkdownBracketConstruct(s, idx)
+				continue
+			}
 			idx += 2
 			continue
 		}
@@ -885,6 +891,58 @@ func markdownHasOrphanLinkClosers(s string) bool {
 		idx++
 	}
 	return false
+}
+
+// skipEscapedMarkdownBracketConstruct advances past `\[…](…)`, `\[…][…]`, or a
+// bare `\[…]` so orphan-closer detection ignores escaped literal link syntax.
+// idx must point at the backslash of `\[`.
+func skipEscapedMarkdownBracketConstruct(s string, idx int) int {
+	idx += 2 // skip \[
+	for idx < len(s) {
+		if s[idx] == '\\' && idx+1 < len(s) {
+			idx += 2
+			continue
+		}
+		if s[idx] == '`' {
+			run := 0
+			for idx+run < len(s) && s[idx+run] == '`' {
+				run++
+			}
+			closing := strings.Repeat("`", run)
+			end := idx + run
+			found := false
+			for end <= len(s)-run {
+				if s[end:end+run] == closing {
+					end += run
+					found = true
+					break
+				}
+				end++
+			}
+			if !found {
+				return idx + run
+			}
+			idx = end
+			continue
+		}
+		if s[idx] != ']' {
+			idx++
+			continue
+		}
+		idx++ // past ]
+		if strings.HasPrefix(s[idx:], "(") {
+			return findMarkdownLinkDestinationEnd(s, idx+1)
+		}
+		if strings.HasPrefix(s[idx:], "[") {
+			closeIdx := strings.IndexByte(s[idx+1:], ']')
+			if closeIdx < 0 {
+				return idx
+			}
+			return idx + 1 + closeIdx + 1
+		}
+		return idx
+	}
+	return idx
 }
 
 func markdownLinkPlaceholderOrderValid(source, rendered string, placeholders map[string]string) bool {

--- a/internal/i18n/translationfileparser/markdown_parser.go
+++ b/internal/i18n/translationfileparser/markdown_parser.go
@@ -801,7 +801,90 @@ func renderMarkdownPartWithDiagnostics(part markdownPart, translated string, dia
 		}
 		return expandMarkdownPlaceholders(part.source, part.placeholders)
 	}
+	// Trusted target-fallback text is already expanded, so placeholder multiset checks
+	// above are skipped. Still reject orphan link/image closers such as
+	// `label](/url)` (missing `[` / `![`) that pre-fix translations can leave behind.
+	if markdownHasOrphanLinkClosers(rendered) {
+		if diags != nil && part.key != "" {
+			diags.SourceFallbackKeys = append(diags.SourceFallbackKeys, part.key)
+		}
+		return expandMarkdownPlaceholders(part.source, part.placeholders)
+	}
 	return rendered
+}
+
+// markdownHasOrphanLinkClosers reports whether s contains a `](` / `][` closer
+// without a matching `[` / `![` opener. Inline code spans and escapes are skipped.
+func markdownHasOrphanLinkClosers(s string) bool {
+	openerDepth := 0
+	for idx := 0; idx < len(s); {
+		if s[idx] == '\\' && idx+1 < len(s) {
+			idx += 2
+			continue
+		}
+		if s[idx] == '`' {
+			run := 0
+			for idx+run < len(s) && s[idx+run] == '`' {
+				run++
+			}
+			closing := strings.Repeat("`", run)
+			end := idx + run
+			found := false
+			for end <= len(s)-run {
+				if s[end:end+run] == closing {
+					end += run
+					found = true
+					break
+				}
+				end++
+			}
+			if !found {
+				idx += run
+				continue
+			}
+			idx = end
+			continue
+		}
+		if s[idx] == '!' && idx+1 < len(s) && s[idx+1] == '[' {
+			openerDepth++
+			idx += 2
+			continue
+		}
+		if s[idx] == '[' {
+			openerDepth++
+			idx++
+			continue
+		}
+		if strings.HasPrefix(s[idx:], "](") {
+			if openerDepth == 0 {
+				return true
+			}
+			openerDepth--
+			idx = findMarkdownLinkDestinationEnd(s, idx+2)
+			continue
+		}
+		if strings.HasPrefix(s[idx:], "][") {
+			if openerDepth == 0 {
+				return true
+			}
+			closeIdx := strings.IndexByte(s[idx+2:], ']')
+			if closeIdx < 0 {
+				return true
+			}
+			openerDepth--
+			idx = idx + 2 + closeIdx + 1
+			continue
+		}
+		if s[idx] == ']' {
+			if openerDepth > 0 {
+				openerDepth--
+			}
+			idx++
+			continue
+		}
+		idx++
+	}
+	return false
 }
 
 func markdownLinkPlaceholderOrderValid(source, rendered string, placeholders map[string]string) bool {

--- a/internal/i18n/translationfileparser/markdown_parser_test.go
+++ b/internal/i18n/translationfileparser/markdown_parser_test.go
@@ -328,7 +328,11 @@ func TestMarkdownHasOrphanLinkClosers(t *testing.T) {
 		{name: "missing_image_opener", in: "View diagram](/d.png) now.", want: true},
 		{name: "missing_reference_opener", in: "See docs][ref] now.", want: true},
 		{name: "code_span_false_positive", in: "Use `label](/url)` literally.", want: false},
-		{name: "escaped_brackets", in: `Keep \[literal](/not-a-link) text.`, want: true},
+		{name: "escaped_brackets", in: `Keep \[literal](/not-a-link) text.`, want: false},
+		{name: "escaped_reference", in: `Keep \[literal][ref] text.`, want: false},
+		{name: "escaped_bare_bracket", in: `Keep \[literal] text.`, want: false},
+		{name: "escaped_then_real_orphan", in: `Keep \[ok](/a) and bad two](/b).`, want: true},
+		{name: "double_escape_real_link", in: `Keep \\[literal](/is-a-link) text.`, want: false},
 		{name: "multiple_links_one_orphan", in: "Good [one](/a) and bad two](/b).", want: true},
 		{name: "blog_style_vietnamese", in: "cần một công cụ CAT thế hệ mới](/product/next-gen-cat-tool) đưa", want: true},
 		{name: "empty", in: "", want: false},
@@ -340,6 +344,19 @@ func TestMarkdownHasOrphanLinkClosers(t *testing.T) {
 				t.Fatalf("markdownHasOrphanLinkClosers(%q) = %v, want %v", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestMarshalMarkdownWithTargetFallbackPreservesEscapedLiteralLinks(t *testing.T) {
+	source := []byte("Type \\[label](/url) to show a literal link.\n")
+	translated := []byte("Gõ \\[label](/url) để hiện liên kết chữ.\n")
+
+	out, diags := MarshalMarkdownWithTargetFallbackDiagnostics(source, translated, map[string]string{}, false)
+	if !strings.Contains(string(out), `Gõ \[label](/url)`) {
+		t.Fatalf("expected escaped literal link translation preserved, got %q", out)
+	}
+	if len(diags.SourceFallbackKeys) != 0 {
+		t.Fatalf("expected no source fallback for escaped literal link, got %+v", diags)
 	}
 }
 

--- a/internal/i18n/translationfileparser/markdown_parser_test.go
+++ b/internal/i18n/translationfileparser/markdown_parser_test.go
@@ -315,6 +315,123 @@ func TestMarshalMarkdownFallsBackWhenImageOpenerPlaceholderIsDropped(t *testing.
 	}
 }
 
+func TestMarkdownHasOrphanLinkClosers(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{name: "balanced_inline_link", in: "See [docs](/docs) now.", want: false},
+		{name: "balanced_image", in: "View ![diagram](/d.png) now.", want: false},
+		{name: "balanced_reference_link", in: "See [docs][ref] now.", want: false},
+		{name: "missing_link_opener", in: "See docs](/docs) now.", want: true},
+		{name: "missing_image_opener", in: "View diagram](/d.png) now.", want: true},
+		{name: "missing_reference_opener", in: "See docs][ref] now.", want: true},
+		{name: "code_span_false_positive", in: "Use `label](/url)` literally.", want: false},
+		{name: "escaped_brackets", in: `Keep \[literal](/not-a-link) text.`, want: true},
+		{name: "multiple_links_one_orphan", in: "Good [one](/a) and bad two](/b).", want: true},
+		{name: "blog_style_vietnamese", in: "cần một công cụ CAT thế hệ mới](/product/next-gen-cat-tool) đưa", want: true},
+		{name: "empty", in: "", want: false},
+		{name: "no_links", in: "Plain prose without markup.", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := markdownHasOrphanLinkClosers(tc.in); got != tc.want {
+				t.Fatalf("markdownHasOrphanLinkClosers(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMarshalMarkdownWithTargetFallbackRejectsMissingLinkOpener(t *testing.T) {
+	source := []byte("Global teams need a [next-generation CAT tool](/product/next-gen-cat-tool) that brings context.\n")
+	broken := []byte("Các nhóm toàn cầu cần một công cụ CAT thế hệ mới](/product/next-gen-cat-tool) đưa ngữ cảnh.\n")
+	good := []byte("Các nhóm toàn cầu cần một [công cụ CAT thế hệ mới](/product/next-gen-cat-tool) đưa ngữ cảnh.\n")
+
+	brokenOut, brokenDiags := MarshalMarkdownWithTargetFallbackDiagnostics(source, broken, map[string]string{}, false)
+	if strings.Contains(string(brokenOut), "thế hệ mới](/product") {
+		t.Fatalf("expected orphan closer rejected, got %q", brokenOut)
+	}
+	if !strings.Contains(string(brokenOut), "[next-generation CAT tool](/product/next-gen-cat-tool)") {
+		t.Fatalf("expected source fallback with valid link, got %q", brokenOut)
+	}
+	if len(brokenDiags.SourceFallbackKeys) == 0 {
+		t.Fatalf("expected source fallback diagnostic for orphan closer, got %+v", brokenDiags)
+	}
+
+	goodOut, goodDiags := MarshalMarkdownWithTargetFallbackDiagnostics(source, good, map[string]string{}, false)
+	if !strings.Contains(string(goodOut), "[công cụ CAT thế hệ mới](/product/next-gen-cat-tool)") {
+		t.Fatalf("expected valid translated link preserved, got %q", goodOut)
+	}
+	if len(goodDiags.SourceFallbackKeys) != 0 {
+		t.Fatalf("expected no source fallback for valid target, got %+v", goodDiags)
+	}
+}
+
+func TestMarshalMarkdownWithTargetFallbackRejectsMissingImageOpener(t *testing.T) {
+	source := []byte("See ![architecture](/images/arch.png) for details.\n")
+	broken := []byte("Xem architecture](/images/arch.png) để biết chi tiết.\n")
+
+	out, diags := MarshalMarkdownWithTargetFallbackDiagnostics(source, broken, map[string]string{}, false)
+	if strings.Contains(string(out), "Xem architecture](/images/arch.png)") {
+		t.Fatalf("expected orphan image closer rejected, got %q", out)
+	}
+	if !strings.Contains(string(out), "![architecture](/images/arch.png)") {
+		t.Fatalf("expected source image fallback, got %q", out)
+	}
+	if len(diags.SourceFallbackKeys) == 0 {
+		t.Fatalf("expected source fallback diagnostic, got %+v", diags)
+	}
+}
+
+func TestMarshalMarkdownWithTargetFallbackRejectsMissingReferenceLinkOpener(t *testing.T) {
+	source := []byte("Read [the docs][docs-ref] first.\n\n[docs-ref]: https://example.com/docs\n")
+	broken := []byte("Đọc the docs][docs-ref] trước.\n\n[docs-ref]: https://example.com/docs\n")
+
+	out, diags := MarshalMarkdownWithTargetFallbackDiagnostics(source, broken, map[string]string{}, false)
+	if strings.Contains(string(out), "Đọc the docs][docs-ref]") {
+		t.Fatalf("expected orphan reference closer rejected, got %q", out)
+	}
+	if !strings.Contains(string(out), "[the docs][docs-ref]") {
+		t.Fatalf("expected source reference link fallback, got %q", out)
+	}
+	if len(diags.SourceFallbackKeys) == 0 {
+		t.Fatalf("expected source fallback diagnostic, got %+v", diags)
+	}
+}
+
+func TestMarshalMarkdownWithTargetFallbackPreservesLinksInsideCodeSpans(t *testing.T) {
+	source := []byte("Use `[label](/url)` as an example.\n")
+	target := []byte("Dùng `[label](/url)` làm ví dụ.\n")
+
+	out, diags := MarshalMarkdownWithTargetFallbackDiagnostics(source, target, map[string]string{}, false)
+	if !strings.Contains(string(out), "`[label](/url)`") {
+		t.Fatalf("expected code-span example preserved, got %q", out)
+	}
+	if len(diags.SourceFallbackKeys) != 0 {
+		t.Fatalf("expected no source fallback for code-span content, got %+v", diags)
+	}
+}
+
+func TestMarshalMarkdownWithTargetFallbackMixedSegmentsFallsBackOnlyBrokenOnes(t *testing.T) {
+	source := []byte("Intro [one](/a).\n\nOther [two](/b).\n")
+	target := []byte("Intro traduit [un](/a).\n\nAutre two](/b).\n")
+
+	out, diags := MarshalMarkdownWithTargetFallbackDiagnostics(source, target, map[string]string{}, false)
+	if !strings.Contains(string(out), "[un](/a)") {
+		t.Fatalf("expected valid translated segment kept, got %q", out)
+	}
+	if !strings.Contains(string(out), "[two](/b)") {
+		t.Fatalf("expected broken segment to fall back to source, got %q", out)
+	}
+	if strings.Contains(string(out), "Autre two](/b)") || strings.Contains(string(out), "Autre [two]") {
+		t.Fatalf("expected broken translated segment not preserved, got %q", out)
+	}
+	if len(diags.SourceFallbackKeys) != 1 {
+		t.Fatalf("expected exactly one source fallback key, got %+v", diags)
+	}
+}
+
 func TestMarshalMarkdownFallsBackWhenLinkPlaceholdersAreInvalid(t *testing.T) {
 	template := []byte("Read [the docs](/docs) now.\n")
 	entries, err := (MarkdownParser{}).Parse(template)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Markdown rebuild via `MarshalMarkdownWithTargetFallback` no longer preserves broken links like `label](/url)` (missing `[` / `![`). Those segments fall back to source instead of writing invalid markdown.
- CAT / source-string previews render internal `HLMDPH` / `HLHTPH` / `HLLQPH` sentinels as short chips (`MD#0`, `HT#1`, `LQ#0`) instead of raw control-byte boundary text.
- Repaired the orphan-link blog posts in `vi-VN` / `fr-FR` that exhibited the failure mode.
- Follow-up from review: CAT placeholder parity compares HL*PH **multisets** (duplicate chips are flagged), and markup-bearing segments still emit ICU `parse-error` issues instead of false passes.
- Follow-up from Codex: require matching **markup sentinel order** (swapped `MD#0`/`MD#1` fails), skip escaped `\[…](…)` constructs in orphan-closer detection so intentional literal links are not replaced with source, and use one shared token signature so present markup chips get muted styling.

## Root cause

1. **Broken / mixed-language blog markdown:** Target-fallback rendering used `trustedFallback=true`, which skipped HLMDPH multiset / link-order validation. Already-expanded broken target text (from pre–Jul 11 delimiter corruption) was copied through unchanged. Separate source-fallback paths (when placeholders are dropped during AI translate) leave English segments in translated posts — that fail-closed behavior remains, but it no longer emits syntactically invalid links.
2. **CAT encoded boundaries:** Ingest stores Go parser sentinels (`\x1eHLMDPH_…\x1f`) as `sourceText`. The CAT UI only chipped ICU/`{name}` tokens, so markdown/HTML/Liquid markup looked like garbage.

## Out of scope (follow-up)

Full CAT expand of HL*PH to editable `[text](url)` needs placeholder maps (not in DB today; go-svc CAT validation is still hard-disabled). Next step is maps-at-ingest or a go-svc maps endpoint, then expand on load / literal→token reprotect on save.

## Test plan

- [x] `go test ./internal/i18n/translationfileparser ./apps/cli/internal/i18n/runsvc ./internal/i18n/segmentvalidate`
- [x] `make lint`
- [x] `vp test` for CAT message-format / editor
- [x] `vp check --fix` in `apps/hyperlocalise-web`
- [x] Multiset, parse-error, and token-order regression tests in `cat-message-format.test.ts`
- [x] Escaped-literal-link marshal regression in `markdown_parser_test.go`
- [ ] Pull/rebuild a markdown locale file that previously had `text](/url)` and confirm it falls back to a valid source link
- [ ] Open a markdown file in CAT and confirm source shows `MD#n` chips, insert still writes full sentinel bytes, and present chips are muted when already in the target
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fba56-c125-748d-bbdf-2416ae260419?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fba56-c125-748d-bbdf-2416ae260419&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

