### PR TITLE
feat(cat): add File view for image (and future binary) files

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view-panel.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view-panel.test.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it, vi } from "vite-plus/test";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { CatTestProviders } from "@/components/cat/shared/cat-test-utils";
+import type { CatSegment } from "@/components/cat/shared/types";
+
+import { CatFileViewPanel } from "./cat-file-view-panel";
+
+function imageSegment(overrides: Partial<CatSegment> = {}): CatSegment {
+  return {
+    id: "img-1",
+    index: 1,
+    key: "assets/hero.png",
+    sourceText: "assets/hero.png",
+    targetText: "",
+    sourcePath: "assets/hero.png",
+    sourceLocale: "en",
+    targetLocale: "de",
+    status: "needs_review",
+    contentKind: "image_file",
+    sourceAssetUrl: "https://example.com/source.png",
+    targetAssetUrl: "https://example.com/target.png",
+    ...overrides,
+  };
+}
+
+describe("CatFileViewPanel", () => {
+  it("renders translated pane before source pane", () => {
+    render(
+      <CatTestProviders>
+        <CatFileViewPanel
+          segment={imageSegment()}
+          viewerId="image"
+          filename="hero.png"
+        />
+      </CatTestProviders>,
+    );
+
+    expect(screen.getByRole("heading", { name: /Translated \(de\)/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Source \(en\)/i })).toBeInTheDocument();
+    expect(screen.getByAltText("Translated image")).toHaveAttribute(
+      "src",
+      "https://example.com/target.png",
+    );
+    expect(screen.getByAltText("Source image")).toHaveAttribute(
+      "src",
+      "https://example.com/source.png",
+    );
+
+    const translatedHeading = screen.getByRole("heading", { name: /Translated \(de\)/i });
+    const sourceHeading = screen.getByRole("heading", { name: /Source \(en\)/i });
+    expect(
+      translatedHeading.compareDocumentPosition(sourceHeading) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("uploads a translated image file", async () => {
+    const user = userEvent.setup();
+    const onUpload = vi.fn();
+
+    render(
+      <CatTestProviders>
+        <CatFileViewPanel
+          segment={imageSegment({ targetAssetUrl: null })}
+          viewerId="image"
+          onUpload={onUpload}
+        />
+      </CatTestProviders>,
+    );
+
+    const file = new File(["png"], "de-hero.png", { type: "image/png" });
+    const input = document.querySelector('input[type="file"]');
+    expect(input).toBeTruthy();
+    await user.upload(input as HTMLInputElement, file);
+
+    expect(onUpload).toHaveBeenCalledWith(file);
+  });
+
+  it("shows unsupported preview when no viewer is registered", () => {
+    render(
+      <CatTestProviders>
+        <CatFileViewPanel segment={imageSegment()} viewerId={null} />
+      </CatTestProviders>,
+    );
+
+    expect(
+      screen.getAllByText("Preview is not available for this file type yet.").length,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view-panel.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view-panel.test.tsx
@@ -43,11 +43,7 @@ describe("CatFileViewPanel", () => {
   it("renders translated pane before source pane", () => {
     render(
       <CatTestProviders>
-        <CatFileViewPanel
-          segment={imageSegment()}
-          viewerId="image"
-          filename="hero.png"
-        />
+        <CatFileViewPanel segment={imageSegment()} viewerId="image" filename="hero.png" />
       </CatTestProviders>,
     );
 

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view-panel.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view-panel.test.tsx
@@ -98,4 +98,44 @@ describe("CatFileViewPanel", () => {
       screen.getAllByText("Preview is not available for this file type yet.").length,
     ).toBeGreaterThan(0);
   });
+
+  it("prefers the segment source path over an aggregate filename", () => {
+    render(
+      <CatTestProviders>
+        <CatFileViewPanel
+          segment={imageSegment({ sourcePath: "marketing/hero.png" })}
+          viewerId="image"
+          filename="All Files"
+        />
+      </CatTestProviders>,
+    );
+
+    expect(screen.getByText("marketing/hero.png")).toBeInTheDocument();
+    expect(screen.queryByText("All Files")).not.toBeInTheDocument();
+  });
+
+  it("navigates previous and next files", async () => {
+    const user = userEvent.setup();
+    const onPrevious = vi.fn();
+    const onNext = vi.fn();
+
+    render(
+      <CatTestProviders>
+        <CatFileViewPanel
+          segment={imageSegment()}
+          viewerId="image"
+          hasPreviousSegment
+          hasNextSegment
+          onPrevious={onPrevious}
+          onNext={onNext}
+        />
+      </CatTestProviders>,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Previous file/i }));
+    await user.click(screen.getByRole("button", { name: /Next file/i }));
+
+    expect(onPrevious).toHaveBeenCalledTimes(1);
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view-panel.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view-panel.test.tsx
@@ -10,9 +10,11 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { describe, expect, it, vi } from "vite-plus/test";
+// @vitest-environment happy-dom
+
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vite-plus/test";
 
 import { CatTestProviders } from "@/components/cat/shared/cat-test-utils";
 import type { CatSegment } from "@/components/cat/shared/types";

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view-panel.tsx
@@ -25,10 +25,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/primitives/cn";
 
 import { catFileViewMessages } from "./cat-file-view.messages";
-import {
-  CAT_IMAGE_FILE_UPLOAD_ACCEPT,
-  CatImageFileViewerPane,
-} from "./cat-image-file-viewer";
+import { CAT_IMAGE_FILE_UPLOAD_ACCEPT, CatImageFileViewerPane } from "./cat-image-file-viewer";
 
 export function CatFileViewPanel({
   segment,
@@ -66,10 +63,7 @@ export function CatFileViewPanel({
   const canTriggerApprove = Boolean(canApprove && hasTarget && !isApproving && !isImageBusy);
   const uploadAccept = viewerId === "image" ? CAT_IMAGE_FILE_UPLOAD_ACCEPT : undefined;
 
-  const sourceSrc =
-    viewerId === "image"
-      ? (segment.sourceAssetUrl ?? null)
-      : null;
+  const sourceSrc = viewerId === "image" ? (segment.sourceAssetUrl ?? null) : null;
   const targetSrc =
     viewerId === "image"
       ? (segment.targetAssetUrl ??
@@ -93,12 +87,7 @@ export function CatFileViewPanel({
         <div className="flex flex-wrap items-center gap-2">
           <CatWorkspaceViewSwitcherConnected />
           {onApprove ? (
-            <Button
-              variant="default"
-              size="sm"
-              disabled={!canTriggerApprove}
-              onClick={onApprove}
-            >
+            <Button variant="default" size="sm" disabled={!canTriggerApprove} onClick={onApprove}>
               {isApproving ? <Spinner className="size-4 text-primary-foreground" /> : null}
               {resolvedPrimaryActionLabel}
             </Button>

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view-panel.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ReactNode } from "react";
+import { Loader2, RefreshCw, Upload } from "lucide-react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { CatWorkspaceViewSwitcherConnected } from "@/components/cat/workspace/cat-workspace-view-switcher-connected";
+import { SegmentStatusBadge } from "@/components/cat/segment/cat-segment-status";
+import type { CatSegment } from "@/components/cat/shared/types";
+import type { CatFileViewerId } from "@/components/cat/workspace/cat-file-view-capabilities";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/primitives/cn";
+
+import { catFileViewMessages } from "./cat-file-view.messages";
+import {
+  CAT_IMAGE_FILE_UPLOAD_ACCEPT,
+  CatImageFileViewerPane,
+} from "./cat-image-file-viewer";
+
+export function CatFileViewPanel({
+  segment,
+  viewerId,
+  filename,
+  canEdit = true,
+  canApprove = true,
+  isApproving = false,
+  isImageBusy = false,
+  isSegmentTargetLoading = false,
+  primaryActionLabel,
+  onApprove,
+  onUpload,
+  onRegenerate,
+  className,
+}: {
+  segment: CatSegment;
+  viewerId: CatFileViewerId | null;
+  filename?: string;
+  canEdit?: boolean;
+  canApprove?: boolean;
+  isApproving?: boolean;
+  isImageBusy?: boolean;
+  isSegmentTargetLoading?: boolean;
+  primaryActionLabel?: string;
+  onApprove?: () => void;
+  onUpload?: (file: File) => void;
+  onRegenerate?: () => void;
+  className?: string;
+}) {
+  const intl = useIntl();
+  const resolvedPrimaryActionLabel =
+    primaryActionLabel ?? intl.formatMessage(catFileViewMessages.approve);
+  const hasTarget = Boolean(segment.targetAssetUrl || segment.targetText.trim());
+  const canTriggerApprove = Boolean(canApprove && hasTarget && !isApproving && !isImageBusy);
+  const uploadAccept = viewerId === "image" ? CAT_IMAGE_FILE_UPLOAD_ACCEPT : undefined;
+
+  const sourceSrc =
+    viewerId === "image"
+      ? (segment.sourceAssetUrl ?? null)
+      : null;
+  const targetSrc =
+    viewerId === "image"
+      ? (segment.targetAssetUrl ??
+        (/^https?:\/\//i.test(segment.targetText) ? segment.targetText : null))
+      : null;
+
+  return (
+    <div className={cn("flex h-full min-h-0 flex-col bg-background", className)}>
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-4 py-3 lg:px-5">
+        <div className="min-w-0 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <SegmentStatusBadge status={segment.status} />
+            <p className="truncate font-mono text-xs text-muted-foreground">
+              {filename || segment.sourcePath || segment.key}
+            </p>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {segment.sourceLocale} → {segment.targetLocale}
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <CatWorkspaceViewSwitcherConnected />
+          {onApprove ? (
+            <Button
+              variant="default"
+              size="sm"
+              disabled={!canTriggerApprove}
+              onClick={onApprove}
+            >
+              {isApproving ? <Spinner className="size-4 text-primary-foreground" /> : null}
+              {resolvedPrimaryActionLabel}
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="grid h-full min-h-0 gap-4 p-4 lg:grid-cols-2 lg:gap-6 lg:p-6">
+          <FileViewPane
+            title={
+              <FormattedMessage
+                {...catFileViewMessages.targetHeading}
+                values={{ locale: segment.targetLocale }}
+              />
+            }
+            toolbar={
+              <div className="flex flex-wrap items-center gap-2">
+                {onRegenerate ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="xs"
+                    disabled={!canEdit || isImageBusy}
+                    onClick={onRegenerate}
+                  >
+                    {isImageBusy ? (
+                      <Loader2 className="size-3 animate-spin" aria-hidden />
+                    ) : (
+                      <RefreshCw className="size-3" aria-hidden />
+                    )}
+                    <FormattedMessage {...catFileViewMessages.regenerate} />
+                  </Button>
+                ) : null}
+                {onUpload && uploadAccept ? (
+                  <label
+                    className={cn(
+                      "inline-flex h-6 cursor-pointer items-center gap-1 rounded border border-input bg-background px-2.5 text-xs font-medium shadow-xs transition-colors hover:bg-accent hover:text-accent-foreground",
+                      !canEdit || isImageBusy ? "pointer-events-none opacity-50" : "",
+                    )}
+                  >
+                    <Upload className="size-3" aria-hidden />
+                    <FormattedMessage {...catFileViewMessages.uploadFile} />
+                    <input
+                      type="file"
+                      accept={uploadAccept}
+                      className="sr-only"
+                      disabled={!canEdit || isImageBusy}
+                      onChange={(event) => {
+                        const file = event.target.files?.[0];
+                        if (file) {
+                          onUpload(file);
+                        }
+                        event.currentTarget.value = "";
+                      }}
+                    />
+                  </label>
+                ) : null}
+              </div>
+            }
+          >
+            {viewerId === "image" ? (
+              <CatImageFileViewerPane
+                role="target"
+                src={targetSrc}
+                isLoading={isSegmentTargetLoading}
+              />
+            ) : (
+              <UnsupportedPreview />
+            )}
+          </FileViewPane>
+
+          <FileViewPane
+            title={
+              <FormattedMessage
+                {...catFileViewMessages.sourceHeading}
+                values={{ locale: segment.sourceLocale }}
+              />
+            }
+          >
+            {viewerId === "image" ? (
+              <CatImageFileViewerPane role="source" src={sourceSrc} />
+            ) : (
+              <UnsupportedPreview />
+            )}
+          </FileViewPane>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FileViewPane({
+  title,
+  toolbar,
+  children,
+}: {
+  title: ReactNode;
+  toolbar?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <section className="flex min-h-0 flex-col gap-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-xs font-medium text-muted-foreground">{title}</h3>
+        {toolbar}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function UnsupportedPreview() {
+  return (
+    <div className="flex min-h-56 items-center justify-center border border-dashed border-border bg-muted/30 px-4 text-center text-sm text-muted-foreground">
+      <FormattedMessage {...catFileViewMessages.previewUnsupported} />
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view-panel.tsx
@@ -13,6 +13,8 @@
  * Version 2.0 or later.
  */
 import type { ReactNode } from "react";
+import { ArrowLeft01Icon, ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { Loader2, RefreshCw, Upload } from "lucide-react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -37,6 +39,10 @@ export function CatFileViewPanel({
   isImageBusy = false,
   isSegmentTargetLoading = false,
   primaryActionLabel,
+  hasPreviousSegment = false,
+  hasNextSegment = false,
+  onPrevious,
+  onNext,
   onApprove,
   onUpload,
   onRegenerate,
@@ -51,6 +57,10 @@ export function CatFileViewPanel({
   isImageBusy?: boolean;
   isSegmentTargetLoading?: boolean;
   primaryActionLabel?: string;
+  hasPreviousSegment?: boolean;
+  hasNextSegment?: boolean;
+  onPrevious?: () => void;
+  onNext?: () => void;
   onApprove?: () => void;
   onUpload?: (file: File) => void;
   onRegenerate?: () => void;
@@ -62,6 +72,7 @@ export function CatFileViewPanel({
   const hasTarget = Boolean(segment.targetAssetUrl || segment.targetText.trim());
   const canTriggerApprove = Boolean(canApprove && hasTarget && !isApproving && !isImageBusy);
   const uploadAccept = viewerId === "image" ? CAT_IMAGE_FILE_UPLOAD_ACCEPT : undefined;
+  const displayName = segment.sourcePath || filename || segment.key;
 
   const sourceSrc = viewerId === "image" ? (segment.sourceAssetUrl ?? null) : null;
   const targetSrc =
@@ -76,15 +87,35 @@ export function CatFileViewPanel({
         <div className="min-w-0 space-y-1">
           <div className="flex flex-wrap items-center gap-2">
             <SegmentStatusBadge status={segment.status} />
-            <p className="truncate font-mono text-xs text-muted-foreground">
-              {filename || segment.sourcePath || segment.key}
-            </p>
+            <p className="truncate font-mono text-xs text-muted-foreground">{displayName}</p>
           </div>
           <p className="text-sm text-muted-foreground">
             {segment.sourceLocale} → {segment.targetLocale}
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
+          {onPrevious || onNext ? (
+            <div className="flex items-center gap-1">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={onPrevious}
+                disabled={!hasPreviousSegment || !onPrevious}
+                aria-label={intl.formatMessage(catFileViewMessages.previousFileAria)}
+              >
+                <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={onNext}
+                disabled={!hasNextSegment || !onNext}
+                aria-label={intl.formatMessage(catFileViewMessages.nextFileAria)}
+              >
+                <HugeiconsIcon icon={ArrowRight01Icon} className="size-4" />
+              </Button>
+            </div>
+          ) : null}
           <CatWorkspaceViewSwitcherConnected />
           {onApprove ? (
             <Button variant="default" size="sm" disabled={!canTriggerApprove} onClick={onApprove}>

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view.messages.ts
@@ -65,4 +65,14 @@ export const catFileViewMessages = defineMessages({
     id: "GWzwxQbAhe",
     description: "Alt text for the translated image in CAT File view",
   },
+  previousFileAria: {
+    defaultMessage: "Previous file",
+    id: "tUQYErY0nj",
+    description: "Accessible label for previous-file navigation in CAT File view",
+  },
+  nextFileAria: {
+    defaultMessage: "Next file",
+    id: "ShnGyATeRG",
+    description: "Accessible label for next-file navigation in CAT File view",
+  },
 });

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view.messages.ts
@@ -17,52 +17,52 @@ import { defineMessages } from "react-intl";
 export const catFileViewMessages = defineMessages({
   sourceHeading: {
     defaultMessage: "Source ({locale})",
-    id: "k2FmVp9xQw",
+    id: "LZCFkSSHP6",
     description: "Heading for the source file pane in CAT File view",
   },
   targetHeading: {
     defaultMessage: "Translated ({locale})",
-    id: "n8RtYc4hLm",
+    id: "VkWvhhKis5",
     description: "Heading for the translated file pane in CAT File view",
   },
   uploadFile: {
     defaultMessage: "Upload translated file",
-    id: "p3WsKd7nBv",
+    id: "NglzlEjVxr",
     description: "Button to upload a replacement translated file in CAT File view",
   },
   regenerate: {
     defaultMessage: "Regenerate",
-    id: "q6HjXe1oZa",
+    id: "xVvlWpH5FH",
     description: "Button to regenerate the translated file with the agent in CAT File view",
   },
   approve: {
     defaultMessage: "Approve",
-    id: "r9UcMb5tYi",
+    id: "NXryL5pUgk",
     description: "Primary action to approve the translated file in CAT File view",
   },
   previewUnsupported: {
     defaultMessage: "Preview is not available for this file type yet.",
-    id: "s4LgNf2wPj",
+    id: "x8Rt8oWLMk",
     description: "Empty state when CAT File view has no registered preview adapter",
   },
   sourceEmpty: {
     defaultMessage: "Source file unavailable",
-    id: "t7ApQd8kRu",
+    id: "1c3qg2u74K",
     description: "Empty state when the CAT File view source preview cannot be shown",
   },
   targetEmpty: {
     defaultMessage: "No translated file yet",
-    id: "u1CvEs6mXo",
+    id: "3wxYCVb3wu",
     description: "Empty state when the CAT File view target preview has no file",
   },
   imageSourceAlt: {
     defaultMessage: "Source image",
-    id: "v5DwGt3nYp",
+    id: "86pJK6MuXF",
     description: "Alt text for the source image in CAT File view",
   },
   imageTargetAlt: {
     defaultMessage: "Translated image",
-    id: "w8FxHu0qZs",
+    id: "GWzwxQbAhe",
     description: "Alt text for the translated image in CAT File view",
   },
 });

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view.messages.ts
@@ -1,0 +1,68 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const catFileViewMessages = defineMessages({
+  sourceHeading: {
+    defaultMessage: "Source ({locale})",
+    id: "k2FmVp9xQw",
+    description: "Heading for the source file pane in CAT File view",
+  },
+  targetHeading: {
+    defaultMessage: "Translated ({locale})",
+    id: "n8RtYc4hLm",
+    description: "Heading for the translated file pane in CAT File view",
+  },
+  uploadFile: {
+    defaultMessage: "Upload translated file",
+    id: "p3WsKd7nBv",
+    description: "Button to upload a replacement translated file in CAT File view",
+  },
+  regenerate: {
+    defaultMessage: "Regenerate",
+    id: "q6HjXe1oZa",
+    description: "Button to regenerate the translated file with the agent in CAT File view",
+  },
+  approve: {
+    defaultMessage: "Approve",
+    id: "r9UcMb5tYi",
+    description: "Primary action to approve the translated file in CAT File view",
+  },
+  previewUnsupported: {
+    defaultMessage: "Preview is not available for this file type yet.",
+    id: "s4LgNf2wPj",
+    description: "Empty state when CAT File view has no registered preview adapter",
+  },
+  sourceEmpty: {
+    defaultMessage: "Source file unavailable",
+    id: "t7ApQd8kRu",
+    description: "Empty state when the CAT File view source preview cannot be shown",
+  },
+  targetEmpty: {
+    defaultMessage: "No translated file yet",
+    id: "u1CvEs6mXo",
+    description: "Empty state when the CAT File view target preview has no file",
+  },
+  imageSourceAlt: {
+    defaultMessage: "Source image",
+    id: "v5DwGt3nYp",
+    description: "Alt text for the source image in CAT File view",
+  },
+  imageTargetAlt: {
+    defaultMessage: "Translated image",
+    id: "w8FxHu0qZs",
+    description: "Alt text for the translated image in CAT File view",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-image-file-viewer.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-image-file-viewer.tsx
@@ -47,12 +47,5 @@ export function CatImageFileViewerPane({
     );
   }
 
-  return (
-    <CatImagePreview
-      src={src}
-      alt={alt}
-      emptyLabel={emptyLabel}
-      className="min-h-56"
-    />
-  );
+  return <CatImagePreview src={src} alt={alt} emptyLabel={emptyLabel} className="min-h-56" />;
 }

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-image-file-viewer.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-image-file-viewer.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useIntl } from "react-intl";
+
+import { CatImagePreview } from "@/components/cat/editor/cat-image-preview";
+
+import { catFileViewMessages } from "./cat-file-view.messages";
+
+export const CAT_IMAGE_FILE_UPLOAD_ACCEPT = "image/png,image/jpeg,image/webp";
+
+export function CatImageFileViewerPane({
+  role,
+  src,
+  isLoading,
+}: {
+  role: "source" | "target";
+  src?: string | null;
+  isLoading?: boolean;
+}) {
+  const intl = useIntl();
+  const alt =
+    role === "source"
+      ? intl.formatMessage(catFileViewMessages.imageSourceAlt)
+      : intl.formatMessage(catFileViewMessages.imageTargetAlt);
+  const emptyLabel =
+    role === "source"
+      ? intl.formatMessage(catFileViewMessages.sourceEmpty)
+      : intl.formatMessage(catFileViewMessages.targetEmpty);
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-56 items-center justify-center border border-dashed border-border text-sm text-muted-foreground">
+        <span className="size-5 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <CatImagePreview
+      src={src}
+      alt={alt}
+      emptyLabel={emptyLabel}
+      className="min-h-56"
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
@@ -877,6 +877,11 @@ export const catWorkspaceViewModeMessages = defineMessages({
     id: "EkIRMNMq59",
     description: "CAT workspace view mode with source and translation columns",
   },
+  fileView: {
+    defaultMessage: "File view",
+    id: "y2BnJk8vTq",
+    description: "CAT workspace view mode that previews source and translated files side by side",
+  },
 });
 
 export const catSideBySidePanelMessages = defineMessages({

--- a/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
@@ -879,7 +879,7 @@ export const catWorkspaceViewModeMessages = defineMessages({
   },
   fileView: {
     defaultMessage: "File view",
-    id: "y2BnJk8vTq",
+    id: "aHtGik8gUy",
     description: "CAT workspace view mode that previews source and translated files side by side",
   },
 });

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-file-view-capabilities.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-file-view-capabilities.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  clampCatWorkspaceViewMode,
+  isCatFileViewAvailable,
+  resolveCatFileViewCapabilities,
+} from "./cat-file-view-capabilities";
+
+describe("cat-file-view-capabilities", () => {
+  it("enables file view for image paths", () => {
+    const capabilities = resolveCatFileViewCapabilities({
+      sourcePath: "assets/hero.png",
+    });
+
+    expect(capabilities).toEqual({
+      family: "image",
+      availableViews: ["file", "comfortable", "side-by-side"],
+      defaultView: "file",
+      viewerId: "image",
+    });
+    expect(isCatFileViewAvailable(capabilities)).toBe(true);
+  });
+
+  it("enables file view for image_file content kind", () => {
+    const capabilities = resolveCatFileViewCapabilities({
+      sourcePath: "CAT_ALL_FILES",
+      contentKind: "image_file",
+    });
+
+    expect(capabilities.family).toBe("image");
+    expect(capabilities.viewerId).toBe("image");
+    expect(capabilities.defaultView).toBe("file");
+  });
+
+  it("keeps segment views for text files", () => {
+    const capabilities = resolveCatFileViewCapabilities({
+      sourcePath: "locales/en.json",
+    });
+
+    expect(capabilities).toEqual({
+      family: "text",
+      availableViews: ["comfortable", "side-by-side"],
+      defaultView: "comfortable",
+      viewerId: null,
+    });
+    expect(isCatFileViewAvailable(capabilities)).toBe(false);
+  });
+
+  it("reserves file-only views for office paths", () => {
+    const capabilities = resolveCatFileViewCapabilities({
+      sourcePath: "docs/brief.docx",
+    });
+
+    expect(capabilities.family).toBe("office");
+    expect(capabilities.availableViews).toEqual(["file"]);
+    expect(capabilities.viewerId).toBeNull();
+  });
+
+  it("clamps disallowed modes to the family default", () => {
+    const text = resolveCatFileViewCapabilities({ sourcePath: "a.json" });
+    expect(clampCatWorkspaceViewMode("file", text)).toBe("comfortable");
+
+    const image = resolveCatFileViewCapabilities({ sourcePath: "a.webp" });
+    expect(clampCatWorkspaceViewMode("comfortable", image)).toBe("comfortable");
+    expect(clampCatWorkspaceViewMode("file", image)).toBe("file");
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-file-view-capabilities.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-file-view-capabilities.ts
@@ -25,8 +25,15 @@ export type CatFileViewCapabilities = {
   viewerId: CatFileViewerId | null;
 };
 
-const SEGMENT_VIEWS = ["comfortable", "side-by-side"] as const satisfies readonly CatWorkspaceViewMode[];
-const IMAGE_VIEWS = ["file", "comfortable", "side-by-side"] as const satisfies readonly CatWorkspaceViewMode[];
+const SEGMENT_VIEWS = [
+  "comfortable",
+  "side-by-side",
+] as const satisfies readonly CatWorkspaceViewMode[];
+const IMAGE_VIEWS = [
+  "file",
+  "comfortable",
+  "side-by-side",
+] as const satisfies readonly CatWorkspaceViewMode[];
 const OFFICE_VIEWS = ["file"] as const satisfies readonly CatWorkspaceViewMode[];
 
 const OFFICE_EXTENSIONS = new Set([".docx", ".xlsx", ".xls", ".pptx"]);

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-file-view-capabilities.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-file-view-capabilities.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { inferSupportedImageTranslationFileFormat } from "@/lib/translation/file-formats";
+
+import type { CatWorkspaceViewMode } from "./cat-workspace-view-mode";
+
+export type CatFileViewFamily = "image" | "text" | "office";
+
+export type CatFileViewerId = "image";
+
+export type CatFileViewCapabilities = {
+  family: CatFileViewFamily;
+  availableViews: readonly CatWorkspaceViewMode[];
+  defaultView: CatWorkspaceViewMode;
+  viewerId: CatFileViewerId | null;
+};
+
+const SEGMENT_VIEWS = ["comfortable", "side-by-side"] as const satisfies readonly CatWorkspaceViewMode[];
+const IMAGE_VIEWS = ["file", "comfortable", "side-by-side"] as const satisfies readonly CatWorkspaceViewMode[];
+const OFFICE_VIEWS = ["file"] as const satisfies readonly CatWorkspaceViewMode[];
+
+const OFFICE_EXTENSIONS = new Set([".docx", ".xlsx", ".xls", ".pptx"]);
+
+function extensionOf(sourcePath: string): string | null {
+  const basename = sourcePath.split(/[\\/]/).pop() ?? sourcePath;
+  const dotIndex = basename.lastIndexOf(".");
+  if (dotIndex <= 0) {
+    return null;
+  }
+  return basename.slice(dotIndex).toLowerCase();
+}
+
+export function resolveCatFileViewCapabilities(input: {
+  sourcePath?: string | null;
+  contentKind?: "text" | "image_file" | "image_url" | null;
+}): CatFileViewCapabilities {
+  const sourcePath = input.sourcePath?.trim() ?? "";
+  const contentKind = input.contentKind ?? null;
+
+  if (contentKind === "image_file" || inferSupportedImageTranslationFileFormat(sourcePath)) {
+    return {
+      family: "image",
+      availableViews: IMAGE_VIEWS,
+      defaultView: "file",
+      viewerId: "image",
+    };
+  }
+
+  const extension = extensionOf(sourcePath);
+  if (extension && OFFICE_EXTENSIONS.has(extension)) {
+    return {
+      family: "office",
+      availableViews: OFFICE_VIEWS,
+      defaultView: "file",
+      // Office adapters are not registered yet; shell shows empty panes.
+      viewerId: null,
+    };
+  }
+
+  // String CAT files and unknown paths stay in segment views.
+  return {
+    family: "text",
+    availableViews: SEGMENT_VIEWS,
+    defaultView: "comfortable",
+    viewerId: null,
+  };
+}
+
+export function clampCatWorkspaceViewMode(
+  mode: CatWorkspaceViewMode,
+  capabilities: CatFileViewCapabilities,
+): CatWorkspaceViewMode {
+  if (capabilities.availableViews.includes(mode)) {
+    return mode;
+  }
+  return capabilities.defaultView;
+}
+
+export function isCatFileViewAvailable(capabilities: CatFileViewCapabilities) {
+  return capabilities.availableViews.includes("file");
+}

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
@@ -127,6 +127,8 @@ const CatWorkspaceContainerObserver = observer(function CatWorkspaceContainerObs
     onQueueFilterChange,
     buildSegmentShareUrl,
     canLookupFreshContext,
+    hasMoreQueue,
+    onLoadMoreQueue,
   });
 
   return (

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-view-mode-sync.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-view-mode-sync.tsx
@@ -16,6 +16,11 @@ import { reaction } from "mobx";
 import { observer } from "mobx-react-lite";
 import { useEffect } from "react";
 
+import {
+  clampCatWorkspaceViewMode,
+  resolveCatFileViewCapabilities,
+  type CatFileViewFamily,
+} from "./cat-file-view-capabilities";
 import { useCatWorkspace } from "./cat-workspace-context";
 
 export const CatWorkspaceViewModeSync = observer(function CatWorkspaceViewModeSync({
@@ -34,6 +39,41 @@ export const CatWorkspaceViewModeSync = observer(function CatWorkspaceViewModeSy
       { fireImmediately: true },
     );
   }, [onPageLimitChange, store]);
+
+  useEffect(() => {
+    let previousFamily: CatFileViewFamily | null = null;
+
+    return reaction(
+      () => {
+        const selected = store.selectedSegmentView;
+        return {
+          viewMode: store.ui.viewMode,
+          sourcePath: selected?.sourcePath ?? store.fileContext.sourcePath,
+          contentKind: selected?.contentKind,
+        };
+      },
+      ({ viewMode, sourcePath, contentKind }) => {
+        const capabilities = resolveCatFileViewCapabilities({ sourcePath, contentKind });
+        let nextMode = clampCatWorkspaceViewMode(viewMode, capabilities);
+
+        // Entering a binary-first family selects File view by default.
+        // Staying in the same family keeps an explicit Comfortable / Side by side choice.
+        if (
+          (capabilities.family === "image" || capabilities.family === "office") &&
+          previousFamily !== capabilities.family
+        ) {
+          nextMode = capabilities.defaultView;
+        }
+
+        previousFamily = capabilities.family;
+
+        if (nextMode !== viewMode) {
+          store.ui.setViewMode(nextMode);
+        }
+      },
+      { fireImmediately: true },
+    );
+  }, [store]);
 
   return null;
 });

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-view-mode.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-view-mode.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import {
   CAT_WORKSPACE_VIEW_MODE_STORAGE_KEY,
   catPageLimitForViewMode,
+  isCatWorkspaceViewMode,
   readCatWorkspaceViewMode,
   writeCatWorkspaceViewMode,
 } from "./cat-workspace-view-mode";
@@ -38,6 +39,15 @@ describe("cat-workspace-view-mode", () => {
     expect(readCatWorkspaceViewMode()).toBe("side-by-side");
   });
 
+  it("reads stored file view mode", () => {
+    const getItem = vi.fn().mockReturnValue("file");
+    vi.stubGlobal("window", {
+      localStorage: { getItem, setItem: vi.fn() },
+    });
+
+    expect(readCatWorkspaceViewMode()).toBe("file");
+  });
+
   it("writes view mode to storage", () => {
     const setItem = vi.fn();
     vi.stubGlobal("window", {
@@ -52,5 +62,11 @@ describe("cat-workspace-view-mode", () => {
   it("maps view mode to page limits", () => {
     expect(catPageLimitForViewMode("comfortable")).toBe(50);
     expect(catPageLimitForViewMode("side-by-side")).toBe(20);
+    expect(catPageLimitForViewMode("file")).toBe(1);
+  });
+
+  it("recognizes valid view modes", () => {
+    expect(isCatWorkspaceViewMode("file")).toBe(true);
+    expect(isCatWorkspaceViewMode("grid")).toBe(false);
   });
 });

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-view-mode.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-view-mode.test.ts
@@ -62,7 +62,8 @@ describe("cat-workspace-view-mode", () => {
   it("maps view mode to page limits", () => {
     expect(catPageLimitForViewMode("comfortable")).toBe(50);
     expect(catPageLimitForViewMode("side-by-side")).toBe(20);
-    expect(catPageLimitForViewMode("file")).toBe(1);
+    // File view keeps Comfortable page size so aggregate queue selections survive.
+    expect(catPageLimitForViewMode("file")).toBe(50);
   });
 
   it("recognizes valid view modes", () => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-view-mode.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-view-mode.ts
@@ -18,7 +18,9 @@ export const CAT_COMFORTABLE_PAGE_LIMIT = 50;
 export const CAT_SIDE_BY_SIDE_PAGE_LIMIT = 20;
 export const CAT_FILE_VIEW_PAGE_LIMIT = 1;
 
-export function isCatWorkspaceViewMode(value: string | null | undefined): value is CatWorkspaceViewMode {
+export function isCatWorkspaceViewMode(
+  value: string | null | undefined,
+): value is CatWorkspaceViewMode {
   return value === "comfortable" || value === "side-by-side" || value === "file";
 }
 

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-view-mode.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-view-mode.ts
@@ -10,12 +10,17 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-export type CatWorkspaceViewMode = "comfortable" | "side-by-side";
+export type CatWorkspaceViewMode = "comfortable" | "side-by-side" | "file";
 
 export const CAT_WORKSPACE_VIEW_MODE_STORAGE_KEY = "cat-workspace-view-mode:v1";
 
 export const CAT_COMFORTABLE_PAGE_LIMIT = 50;
 export const CAT_SIDE_BY_SIDE_PAGE_LIMIT = 20;
+export const CAT_FILE_VIEW_PAGE_LIMIT = 1;
+
+export function isCatWorkspaceViewMode(value: string | null | undefined): value is CatWorkspaceViewMode {
+  return value === "comfortable" || value === "side-by-side" || value === "file";
+}
 
 export function readCatWorkspaceViewMode(): CatWorkspaceViewMode {
   if (typeof window === "undefined") {
@@ -24,7 +29,7 @@ export function readCatWorkspaceViewMode(): CatWorkspaceViewMode {
 
   try {
     const stored = window.localStorage.getItem(CAT_WORKSPACE_VIEW_MODE_STORAGE_KEY);
-    if (stored === "comfortable" || stored === "side-by-side") {
+    if (isCatWorkspaceViewMode(stored)) {
       return stored;
     }
   } catch {
@@ -47,5 +52,11 @@ export function writeCatWorkspaceViewMode(mode: CatWorkspaceViewMode) {
 }
 
 export function catPageLimitForViewMode(mode: CatWorkspaceViewMode) {
-  return mode === "side-by-side" ? CAT_SIDE_BY_SIDE_PAGE_LIMIT : CAT_COMFORTABLE_PAGE_LIMIT;
+  if (mode === "side-by-side") {
+    return CAT_SIDE_BY_SIDE_PAGE_LIMIT;
+  }
+  if (mode === "file") {
+    return CAT_FILE_VIEW_PAGE_LIMIT;
+  }
+  return CAT_COMFORTABLE_PAGE_LIMIT;
 }

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-view-mode.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-view-mode.ts
@@ -16,7 +16,9 @@ export const CAT_WORKSPACE_VIEW_MODE_STORAGE_KEY = "cat-workspace-view-mode:v1";
 
 export const CAT_COMFORTABLE_PAGE_LIMIT = 50;
 export const CAT_SIDE_BY_SIDE_PAGE_LIMIT = 20;
-export const CAT_FILE_VIEW_PAGE_LIMIT = 1;
+/** File view is presentation-only; keep Comfortable queue page size so aggregate
+ * selections (e.g. All Files) are not dropped when the query refetches. */
+export const CAT_FILE_VIEW_PAGE_LIMIT = CAT_COMFORTABLE_PAGE_LIMIT;
 
 export function isCatWorkspaceViewMode(
   value: string | null | undefined,
@@ -57,6 +59,7 @@ export function catPageLimitForViewMode(mode: CatWorkspaceViewMode) {
   if (mode === "side-by-side") {
     return CAT_SIDE_BY_SIDE_PAGE_LIMIT;
   }
+  // File view renders one selected unit but must not shrink the queue query.
   if (mode === "file") {
     return CAT_FILE_VIEW_PAGE_LIMIT;
   }

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-view-switcher-connected.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-view-switcher-connected.tsx
@@ -14,6 +14,7 @@
  */
 import { observer } from "mobx-react-lite";
 
+import { resolveCatFileViewCapabilities } from "./cat-file-view-capabilities";
 import { useOptionalCatWorkspace } from "./cat-workspace-context";
 import { CatWorkspaceViewSwitcher } from "./cat-workspace-view-switcher";
 import type { CatWorkspaceViewMode } from "./cat-workspace-view-mode";
@@ -22,13 +23,21 @@ export const CatWorkspaceViewSwitcherConnected = observer(
   function CatWorkspaceViewSwitcherConnected({
     value,
     onChange,
+    availableViews,
     className,
   }: {
     value?: CatWorkspaceViewMode;
     onChange?: (mode: CatWorkspaceViewMode) => void;
+    availableViews?: readonly CatWorkspaceViewMode[];
     className?: string;
   }) {
     const store = useOptionalCatWorkspace();
+    const selectedSegment = store?.selectedSegmentView ?? null;
+    const capabilities = resolveCatFileViewCapabilities({
+      sourcePath: selectedSegment?.sourcePath ?? store?.fileContext.sourcePath,
+      contentKind: selectedSegment?.contentKind,
+    });
+    const resolvedAvailableViews = availableViews ?? capabilities.availableViews;
     const resolvedValue = store?.ui.viewMode ?? value ?? "comfortable";
     const resolvedOnChange = store
       ? (mode: CatWorkspaceViewMode) => store.ui.setViewMode(mode)
@@ -42,6 +51,7 @@ export const CatWorkspaceViewSwitcherConnected = observer(
       <CatWorkspaceViewSwitcher
         value={resolvedValue}
         onChange={resolvedOnChange}
+        availableViews={resolvedAvailableViews}
         className={className}
       />
     );

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-view-switcher.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-view-switcher.tsx
@@ -30,7 +30,10 @@ import { catWorkspaceViewModeMessages } from "@/components/cat/shared/cat.messag
 import type { CatWorkspaceViewMode } from "@/components/cat/workspace/cat-workspace-view-mode";
 import { isCatWorkspaceViewMode } from "@/components/cat/workspace/cat-workspace-view-mode";
 
-const DEFAULT_AVAILABLE_VIEWS = ["comfortable", "side-by-side"] as const satisfies readonly CatWorkspaceViewMode[];
+const DEFAULT_AVAILABLE_VIEWS = [
+  "comfortable",
+  "side-by-side",
+] as const satisfies readonly CatWorkspaceViewMode[];
 
 function viewModeIcon(mode: CatWorkspaceViewMode) {
   if (mode === "file") {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-view-switcher.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-view-switcher.tsx
@@ -12,7 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { LayoutGridIcon, LayoutThreeColumnIcon } from "@hugeicons/core-free-icons";
+import { File01Icon, LayoutGridIcon, LayoutThreeColumnIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -28,17 +28,43 @@ import { cn } from "@/lib/primitives/cn";
 
 import { catWorkspaceViewModeMessages } from "@/components/cat/shared/cat.messages";
 import type { CatWorkspaceViewMode } from "@/components/cat/workspace/cat-workspace-view-mode";
+import { isCatWorkspaceViewMode } from "@/components/cat/workspace/cat-workspace-view-mode";
+
+const DEFAULT_AVAILABLE_VIEWS = ["comfortable", "side-by-side"] as const satisfies readonly CatWorkspaceViewMode[];
+
+function viewModeIcon(mode: CatWorkspaceViewMode) {
+  if (mode === "file") {
+    return File01Icon;
+  }
+  if (mode === "side-by-side") {
+    return LayoutGridIcon;
+  }
+  return LayoutThreeColumnIcon;
+}
+
+function viewModeLabel(mode: CatWorkspaceViewMode) {
+  if (mode === "file") {
+    return catWorkspaceViewModeMessages.fileView;
+  }
+  if (mode === "side-by-side") {
+    return catWorkspaceViewModeMessages.sideBySideView;
+  }
+  return catWorkspaceViewModeMessages.comfortableView;
+}
 
 export function CatWorkspaceViewSwitcher({
   value,
   onChange,
+  availableViews = DEFAULT_AVAILABLE_VIEWS,
   className,
 }: {
   value: CatWorkspaceViewMode;
   onChange: (mode: CatWorkspaceViewMode) => void;
+  availableViews?: readonly CatWorkspaceViewMode[];
   className?: string;
 }) {
   const intl = useIntl();
+  const modes = availableViews.length > 0 ? availableViews : DEFAULT_AVAILABLE_VIEWS;
 
   return (
     <DropdownMenu>
@@ -52,33 +78,25 @@ export function CatWorkspaceViewSwitcher({
           />
         }
       >
-        <HugeiconsIcon
-          icon={value === "side-by-side" ? LayoutGridIcon : LayoutThreeColumnIcon}
-          className="size-4"
-        />
+        <HugeiconsIcon icon={viewModeIcon(value)} className="size-4" />
         <span className="hidden text-xs sm:inline">
-          {value === "side-by-side" ? (
-            <FormattedMessage {...catWorkspaceViewModeMessages.sideBySideView} />
-          ) : (
-            <FormattedMessage {...catWorkspaceViewModeMessages.comfortableView} />
-          )}
+          <FormattedMessage {...viewModeLabel(value)} />
         </span>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-40">
         <DropdownMenuRadioGroup
           value={value}
           onValueChange={(nextValue) => {
-            if (nextValue === "comfortable" || nextValue === "side-by-side") {
+            if (isCatWorkspaceViewMode(nextValue) && modes.includes(nextValue)) {
               onChange(nextValue);
             }
           }}
         >
-          <DropdownMenuRadioItem value="comfortable">
-            <FormattedMessage {...catWorkspaceViewModeMessages.comfortableView} />
-          </DropdownMenuRadioItem>
-          <DropdownMenuRadioItem value="side-by-side">
-            <FormattedMessage {...catWorkspaceViewModeMessages.sideBySideView} />
-          </DropdownMenuRadioItem>
+          {modes.map((mode) => (
+            <DropdownMenuRadioItem key={mode} value={mode}>
+              <FormattedMessage {...viewModeLabel(mode)} />
+            </DropdownMenuRadioItem>
+          ))}
         </DropdownMenuRadioGroup>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
@@ -20,6 +20,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/primitives/cn";
 
 import { CatEditorPanel } from "@/components/cat/editor/cat-editor-panel";
+import { CatFileViewPanel } from "@/components/cat/file-view/cat-file-view-panel";
 import { CatIntelligencePanel } from "@/components/cat/intelligence/cat-intelligence-panel";
 import { CatQueuePanel } from "@/components/cat/queue/cat-queue-panel";
 import { CatSegmentKeyMeta } from "@/components/cat/segment/cat-segment-key-meta";
@@ -27,6 +28,7 @@ import { CatSideBySidePanel } from "@/components/cat/side-by-side/cat-side-by-si
 import type { CatWorkspaceViewProps } from "@/components/cat/shared/dependencies";
 import { catWorkspaceMessages } from "@/components/cat/shared/cat.messages";
 
+import { resolveCatFileViewCapabilities } from "./cat-file-view-capabilities";
 import { CatPanelErrorBoundary } from "./cat-panel-error-boundary";
 import { useCatWorkspace } from "./cat-workspace-context";
 import { catWorkspaceViewMessages } from "./cat-workspace.messages";
@@ -119,6 +121,7 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
   const isCompact = useIsCompactWorkspace();
   const [activePanel, setActivePanel] = useState<CatWorkspacePanel>("edit");
   const isSideBySideDesktop = viewMode === "side-by-side" && !isCompact;
+  const isFileView = viewMode === "file";
   const selectedSegmentIdForIntelligence = intelligenceSegmentId;
   const isIntelligencePanelVisible = Boolean(
     selectedSegmentIdForIntelligence &&
@@ -386,7 +389,45 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
     );
   }
 
+  function renderFileViewPanel() {
+    const capabilities = resolveCatFileViewCapabilities({
+      sourcePath: editorSegment.sourcePath ?? shell.fileContext.sourcePath,
+      contentKind: editorSegment.contentKind,
+    });
+
+    return (
+      <CatPanelErrorBoundary scope="editor" resetKeys={[viewMode, editorSegment.id]}>
+        <CatFileViewPanel
+          segment={editorSegment}
+          viewerId={capabilities.viewerId}
+          filename={shell.fileContext.filename}
+          canEdit={canApprove}
+          canApprove={canApprove}
+          isApproving={isApproving}
+          isImageBusy={isImageBusy}
+          isSegmentTargetLoading={isSegmentTargetLoading}
+          primaryActionLabel={shell.primaryActionLabel}
+          onApprove={() => void review.onApprove(editorSegment.id, editorSegment.targetText)}
+          onUpload={
+            editing.onUploadImage
+              ? (file) => void editing.onUploadImage?.(editorSegment.id, file)
+              : undefined
+          }
+          onRegenerate={
+            editing.onRegenerateImage
+              ? () => void editing.onRegenerateImage?.(editorSegment.id)
+              : undefined
+          }
+        />
+      </CatPanelErrorBoundary>
+    );
+  }
+
   function renderEditorPanel() {
+    if (isFileView) {
+      return renderFileViewPanel();
+    }
+
     return (
       <CatPanelErrorBoundary scope="editor" resetKeys={[editorSegment.id]}>
         <CatEditorPanel
@@ -541,71 +582,77 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
       )}
     >
       {isCompact ? (
-        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-          <div className="shrink-0 border-b border-border px-4 py-3">
-            <div className="min-w-0 space-y-1">
-              <p className="font-mono text-xs text-muted-foreground tabular-nums">
-                {totalSegments != null ? (
-                  <FormattedMessage
-                    {...catWorkspaceViewMessages.segmentPosition}
-                    values={{
-                      position: String(segmentPosition).padStart(2, "0"),
-                      total: String(totalSegments).padStart(2, "0"),
-                    }}
-                  />
-                ) : (
-                  <FormattedMessage
-                    {...catWorkspaceViewMessages.segmentPositionOpenEnded}
-                    values={{
-                      position: String(segmentPosition).padStart(2, "0"),
-                    }}
-                  />
-                )}
-              </p>
-              <CatSegmentKeyMeta
-                segmentKey={editorSegment.key}
-                sourcePath={editorSegment.sourcePath}
-                keyClassName="text-sm font-medium text-foreground"
-              />
+        isFileView ? (
+          renderFileViewPanel()
+        ) : (
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+            <div className="shrink-0 border-b border-border px-4 py-3">
+              <div className="min-w-0 space-y-1">
+                <p className="font-mono text-xs text-muted-foreground tabular-nums">
+                  {totalSegments != null ? (
+                    <FormattedMessage
+                      {...catWorkspaceViewMessages.segmentPosition}
+                      values={{
+                        position: String(segmentPosition).padStart(2, "0"),
+                        total: String(totalSegments).padStart(2, "0"),
+                      }}
+                    />
+                  ) : (
+                    <FormattedMessage
+                      {...catWorkspaceViewMessages.segmentPositionOpenEnded}
+                      values={{
+                        position: String(segmentPosition).padStart(2, "0"),
+                      }}
+                    />
+                  )}
+                </p>
+                <CatSegmentKeyMeta
+                  segmentKey={editorSegment.key}
+                  sourcePath={editorSegment.sourcePath}
+                  keyClassName="text-sm font-medium text-foreground"
+                />
+              </div>
             </div>
-          </div>
 
-          <Tabs
-            value={activePanel}
-            onValueChange={(value) => setActivePanel(value as CatWorkspacePanel)}
-            className="min-h-0 flex-1 gap-0 overflow-hidden"
-          >
-            <TabsList className="mx-4 mt-3 grid h-10 w-auto grid-cols-3">
-              <TabsTrigger value="edit">
-                <FormattedMessage {...catWorkspaceMessages.tabEdit} />
-              </TabsTrigger>
-              <TabsTrigger value="queue">
-                <FormattedMessage {...catWorkspaceMessages.tabQueue} />
-              </TabsTrigger>
-              <TabsTrigger value="ai">
-                <FormattedMessage {...catWorkspaceMessages.tabAi} />
-              </TabsTrigger>
-            </TabsList>
-            <TabsContent
-              value="edit"
-              className="mt-3 min-h-0 flex-1 overflow-hidden data-[state=active]:flex data-[state=active]:flex-col"
+            <Tabs
+              value={activePanel}
+              onValueChange={(value) => setActivePanel(value as CatWorkspacePanel)}
+              className="min-h-0 flex-1 gap-0 overflow-hidden"
             >
-              {renderEditorPanel()}
-            </TabsContent>
-            <TabsContent
-              value="queue"
-              className="mt-3 min-h-0 flex-1 overflow-hidden data-[state=active]:flex data-[state=active]:flex-col"
-            >
-              {renderQueuePanel()}
-            </TabsContent>
-            <TabsContent
-              value="ai"
-              className="mt-3 min-h-0 flex-1 overflow-hidden data-[state=active]:flex data-[state=active]:flex-col"
-            >
-              {activePanel === "ai" ? renderIntelligencePanel() : null}
-            </TabsContent>
-          </Tabs>
-        </div>
+              <TabsList className="mx-4 mt-3 grid h-10 w-auto grid-cols-3">
+                <TabsTrigger value="edit">
+                  <FormattedMessage {...catWorkspaceMessages.tabEdit} />
+                </TabsTrigger>
+                <TabsTrigger value="queue">
+                  <FormattedMessage {...catWorkspaceMessages.tabQueue} />
+                </TabsTrigger>
+                <TabsTrigger value="ai">
+                  <FormattedMessage {...catWorkspaceMessages.tabAi} />
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent
+                value="edit"
+                className="mt-3 min-h-0 flex-1 overflow-hidden data-[state=active]:flex data-[state=active]:flex-col"
+              >
+                {renderEditorPanel()}
+              </TabsContent>
+              <TabsContent
+                value="queue"
+                className="mt-3 min-h-0 flex-1 overflow-hidden data-[state=active]:flex data-[state=active]:flex-col"
+              >
+                {renderQueuePanel()}
+              </TabsContent>
+              <TabsContent
+                value="ai"
+                className="mt-3 min-h-0 flex-1 overflow-hidden data-[state=active]:flex data-[state=active]:flex-col"
+              >
+                {activePanel === "ai" ? renderIntelligencePanel() : null}
+              </TabsContent>
+            </Tabs>
+          </div>
+        )
+      ) : isFileView ? (
+        renderFileViewPanel()
       ) : isSideBySideDesktop ? (
         renderSideBySidePanel()
       ) : (

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
@@ -407,6 +407,10 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
           isImageBusy={isImageBusy}
           isSegmentTargetLoading={isSegmentTargetLoading}
           primaryActionLabel={shell.primaryActionLabel}
+          hasPreviousSegment={hasPreviousSegment}
+          hasNextSegment={hasNextSegment}
+          onPrevious={navigation.onPreviousSegment}
+          onNext={navigation.onNextSegment}
           onApprove={() => void review.onApprove(editorSegment.id, editorSegment.targetText)}
           onUpload={
             editing.onUploadImage

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-domain-stores.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-domain-stores.test.ts
@@ -269,6 +269,12 @@ describe("CatWorkspaceUiStore", () => {
     expect(ui.viewMode).toBe("side-by-side");
     expect(ui.pageLimit).toBe(20);
     expect(ui.isSideBySideView).toBe(true);
+    expect(ui.isFileView).toBe(false);
+
+    ui.setViewMode("file");
+
+    expect(ui.isFileView).toBe(true);
+    expect(ui.pageLimit).toBe(1);
   });
 
   it("honors an explicit initial view mode without reading storage", () => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-domain-stores.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-domain-stores.test.ts
@@ -274,7 +274,7 @@ describe("CatWorkspaceUiStore", () => {
     ui.setViewMode("file");
 
     expect(ui.isFileView).toBe(true);
-    expect(ui.pageLimit).toBe(1);
+    expect(ui.pageLimit).toBe(50);
   });
 
   it("honors an explicit initial view mode without reading storage", () => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-workspace-ui-store.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-workspace-ui-store.ts
@@ -44,6 +44,10 @@ export class CatWorkspaceUiStore {
     return this.viewMode === "side-by-side";
   }
 
+  get isFileView() {
+    return this.viewMode === "file";
+  }
+
   setViewMode(mode: CatWorkspaceViewMode) {
     this.viewMode = mode;
     if (this.#persistViewMode) {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.test.tsx
@@ -708,6 +708,107 @@ describe("useCatWorkspaceRuntime", () => {
     expect(store.dirtySegmentIds.has("seg-02")).toBe(true);
   });
 
+  it("loads the next queue page when Next is pressed at the loaded boundary", () => {
+    const firstPage = createCatWorkspaceState({
+      selectedSegmentId: "seg-02",
+      segments: [
+        {
+          id: "seg-01",
+          index: 1,
+          key: "first",
+          sourceText: "First",
+          targetText: "Premier",
+          sourceLocale: "en-US",
+          targetLocale: "vi",
+          status: "reviewed",
+        },
+        {
+          id: "seg-02",
+          index: 2,
+          key: "second",
+          sourceText: "Second",
+          targetText: "",
+          sourceLocale: "en-US",
+          targetLocale: "vi",
+          status: "pending",
+        },
+      ],
+    });
+    const store = createCatWorkspace(firstPage);
+    const onLoadMoreQueue = vi.fn(() => {
+      store.ingestQueue(
+        createCatWorkspaceState({
+          selectedSegmentId: "seg-02",
+          segments: [
+            {
+              id: "seg-01",
+              index: 1,
+              key: "first",
+              sourceText: "First",
+              targetText: "Premier",
+              sourceLocale: "en-US",
+              targetLocale: "vi",
+              status: "reviewed",
+            },
+            {
+              id: "seg-02",
+              index: 2,
+              key: "second",
+              sourceText: "Second",
+              targetText: "",
+              sourceLocale: "en-US",
+              targetLocale: "vi",
+              status: "pending",
+            },
+            {
+              id: "seg-03",
+              index: 3,
+              key: "third",
+              sourceText: "Third",
+              targetText: "Troisième",
+              sourceLocale: "en-US",
+              targetLocale: "vi",
+              status: "pending",
+            },
+          ],
+        }),
+      );
+    });
+
+    const { result } = renderHook(
+      () =>
+        useCatWorkspaceRuntime({
+          store,
+          services: { validateFormat: mockValidateFormat },
+          hasMoreQueue: true,
+          onLoadMoreQueue,
+        }),
+      { wrapper: CatTestProviders },
+    );
+
+    act(() => {
+      result.current.dependencies.navigation.onNextSegment();
+    });
+
+    expect(onLoadMoreQueue).toHaveBeenCalledTimes(1);
+    expect(store.selectedSegmentId).toBe("seg-03");
+  });
+
+  it("does not call load-more when a next loaded segment already exists", () => {
+    const onLoadMoreQueue = vi.fn();
+    const { result, store } = renderController(undefined, {
+      hasMoreQueue: true,
+      onLoadMoreQueue,
+    });
+
+    act(() => {
+      result.current.dependencies.navigation.onNextSegment();
+    });
+
+    expect(onLoadMoreQueue).not.toHaveBeenCalled();
+    expect(store.selectedSegmentId).toBe("seg-03");
+  });
+
   it("does not re-select when focusing the current dirty segment", () => {
     const onSelectSegment = vi.fn();
     const { result, store } = renderController(undefined, {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/use-cat-workspace-runtime.ts
@@ -12,7 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useIntl } from "react-intl";
 
 import {
@@ -75,6 +75,9 @@ export interface UseCatWorkspaceRuntimeInput {
   onQueueFilterChange?: (filter: CatQueueFilter) => void;
   buildSegmentShareUrl?: (segment: CatSegment) => string | null;
   canLookupFreshContext?: boolean;
+  /** When true, Next at the loaded-page boundary should fetch more queue rows. */
+  hasMoreQueue?: boolean;
+  onLoadMoreQueue?: () => void;
 }
 
 export function useCatWorkspaceRuntime({
@@ -88,10 +91,13 @@ export function useCatWorkspaceRuntime({
   onQueueFilterChange,
   buildSegmentShareUrl,
   canLookupFreshContext = true,
+  hasMoreQueue = false,
+  onLoadMoreQueue,
 }: UseCatWorkspaceRuntimeInput) {
   const intl = useIntl();
   const queueFilter = queueFilterProp ?? store.queueFilter;
   const usesServerQueueFilter = Boolean(onQueueFilterChange);
+  const pendingAdvanceFromSegmentIdRef = useRef<string | null>(null);
 
   const validateFormat = serviceOverrides?.validateFormat;
   const runQaChecks = serviceOverrides?.runQaChecks;
@@ -163,6 +169,30 @@ export function useCatWorkspaceRuntime({
     [intelligenceController],
   );
 
+  useEffect(() => {
+    const fromId = pendingAdvanceFromSegmentIdRef.current;
+    if (!fromId) {
+      return;
+    }
+
+    const visibleSegments = store.getFilteredQueueSegments(queueFilter, usesServerQueueFilter);
+    const nextId = getAdjacentSegmentId(visibleSegments, fromId, 1);
+    if (nextId) {
+      pendingAdvanceFromSegmentIdRef.current = null;
+      const currentId =
+        store.findSegmentIdByKeyOrId(store.selectedSegmentId) ?? store.selectedSegmentId;
+      const resolvedFromId = store.findSegmentIdByKeyOrId(fromId) ?? fromId;
+      if (currentId === resolvedFromId) {
+        store.setSelectedSegmentId(nextId);
+      }
+      return;
+    }
+
+    if (!hasMoreQueue) {
+      pendingAdvanceFromSegmentIdRef.current = null;
+    }
+  }, [hasMoreQueue, queueFilter, queuePanelSegments, store, usesServerQueueFilter]);
+
   const dependencies = useMemo<CatWorkspaceDependencies>(() => {
     const editing: CatWorkspaceEditing = {
       onTargetChange: (segmentId: string, value: string) => {
@@ -202,10 +232,12 @@ export function useCatWorkspaceRuntime({
           return;
         }
 
+        pendingAdvanceFromSegmentIdRef.current = null;
         store.setSelectedSegmentId(selectedSegmentId);
         onSelectSegment?.(segmentId);
       },
       onPreviousSegment: () => {
+        pendingAdvanceFromSegmentIdRef.current = null;
         const visibleSegments = store.getFilteredQueueSegments(queueFilter, usesServerQueueFilter);
         const previousId = getAdjacentSegmentId(visibleSegments, store.selectedSegmentId, -1);
         if (previousId) {
@@ -215,9 +247,29 @@ export function useCatWorkspaceRuntime({
       },
       onNextSegment: () => {
         const visibleSegments = store.getFilteredQueueSegments(queueFilter, usesServerQueueFilter);
-        const nextId = getAdjacentSegmentId(visibleSegments, store.selectedSegmentId, 1);
+        const currentId = store.selectedSegmentId;
+        const nextId = getAdjacentSegmentId(visibleSegments, currentId, 1);
         if (nextId) {
+          pendingAdvanceFromSegmentIdRef.current = null;
           store.setSelectedSegmentId(nextId);
+          onNextSegment?.();
+          return;
+        }
+
+        if (hasMoreQueue && onLoadMoreQueue) {
+          pendingAdvanceFromSegmentIdRef.current = currentId;
+          onLoadMoreQueue();
+          // Sync loaders (tests / already-buffered pages) can populate the store
+          // before the pending-advance effect runs.
+          const refreshedSegments = store.getFilteredQueueSegments(
+            queueFilter,
+            usesServerQueueFilter,
+          );
+          const loadedNextId = getAdjacentSegmentId(refreshedSegments, currentId, 1);
+          if (loadedNextId) {
+            pendingAdvanceFromSegmentIdRef.current = null;
+            store.setSelectedSegmentId(loadedNextId);
+          }
         }
         onNextSegment?.();
       },
@@ -260,9 +312,14 @@ export function useCatWorkspaceRuntime({
       },
     };
   }, [
+    editingOverrides?.onRegenerateImage,
+    editingOverrides?.onTreatAsImage,
+    editingOverrides?.onUploadImage,
     generateAiRecommendation,
+    hasMoreQueue,
     intelligenceController,
     onAskQuestion,
+    onLoadMoreQueue,
     onNextSegment,
     onPreviousSegment,
     onReviewInSequence,
@@ -280,6 +337,7 @@ export function useCatWorkspaceRuntime({
 
   const handleQueueFilterChange = useCallback(
     (filter: CatQueueFilter) => {
+      pendingAdvanceFromSegmentIdRef.current = null;
       if (onQueueFilterChange) {
         onQueueFilterChange(filter);
         return;

--- a/docs/plans/2026-08-01-cat-file-view-design.md
+++ b/docs/plans/2026-08-01-cat-file-view-design.md
@@ -1,0 +1,88 @@
+# CAT File view
+
+## Problem
+
+CAT treats every file as a segment queue. Image files already use asset
+previews in Comfortable and Side by side, but that layout is still string-first.
+Office formats (docx, xlsx) and other whole-file assets need the same treatment
+later. We need a generic File view that compares source and translated files
+side by side, with upload and preview, without baking image-only UI into the
+workspace shell.
+
+## Decision
+
+Add a third CAT view mode, `file`, gated by a format→views capability map.
+Ship a pluggable viewer registry. Image is the first adapter. Whole-file binary
+replace only (Approach A).
+
+## Architecture
+
+### View modes
+
+`CatWorkspaceViewMode = "comfortable" | "side-by-side" | "file"`.
+
+### Capability map
+
+Resolve allowed views from `sourcePath` and/or `contentKind`:
+
+| Family | Formats (v1) | Available views | Default |
+|--------|----------------|-----------------|---------|
+| Image | `png`, `jpeg`/`jpg`, `webp`, or `contentKind: image_file` | `file`, `comfortable`, `side-by-side` | `file` |
+| Text/string | json, xliff, … | `comfortable`, `side-by-side` | stored preference or `comfortable` |
+| Office (later) | docx, xlsx, … | `file` (+ segment views only if extraction lands later) | `file` |
+
+The view switcher lists only allowed modes. If the persisted mode is not
+allowed for the open file, clamp to the family default.
+
+### Viewer registry
+
+Each adapter declares:
+
+- viewer id (e.g. `image`)
+- accepted upload MIME types
+- preview renderer for source and target panes
+- optional regenerate action
+
+The File view shell owns layout and shared actions (approve, upload). Adapters
+only render previews and declare capabilities.
+
+## UI
+
+File view shell:
+
+- Header: filename, locales, status, approve
+- Two panes: **translated (target) on the left**, **source on the right**
+- Toolbar on the target pane: upload, regenerate when supported
+- Compact layouts stack target above source
+
+For image files, reuse `CatImagePreview` and existing upload / regenerate /
+approve APIs. URL-backed `image_url` keys stay in segment views; File view is
+for file-backed binaries.
+
+## Data flow
+
+1. Open CAT → resolve capabilities from path / `contentKind`.
+2. Clamp view mode; auto-select `file` for image family.
+3. File view reads source and target asset URLs from the synthetic image
+   segment / variant APIs.
+4. Upload → existing image upload route → refresh target preview.
+5. Regenerate / Approve → existing image variant flows.
+
+## Errors
+
+- Unsupported upload MIME → surface error; keep prior target.
+- Missing source bytes → empty source pane with a clear empty state.
+- Disallowed view mode → silent clamp.
+
+## Testing
+
+- Capability map and default/clamp helpers
+- View switcher filters modes
+- File view layout (target left, source right)
+- Image adapter upload preview wiring
+
+## Out of scope
+
+- docx / xlsx preview adapters (registry hooks only)
+- Generalizing `project_image_variants` to generic file variants
+- Hybrid string extraction inside File view

--- a/docs/plans/2026-08-01-cat-file-view-design.md
+++ b/docs/plans/2026-08-01-cat-file-view-design.md
@@ -50,10 +50,14 @@ only render previews and declare capabilities.
 
 File view shell:
 
-- Header: filename, locales, status, approve
+- Header: filename, locales, status, prev/next, approve
 - Two panes: **translated (target) on the left**, **source on the right**
 - Toolbar on the target pane: upload, regenerate when supported
 - Compact layouts stack target above source
+
+File view is presentation-only for the selected unit. Queue page size stays at
+the Comfortable limit (`50`) so aggregate workspaces (for example All Files)
+do not refetch with `limit=1` and drop the selected image.
 
 For image files, reuse `CatImagePreview` and existing upload / regenerate /
 approve APIs. URL-backed `image_url` keys stay in segment views; File view is


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add a third CAT view mode, **File view**, gated by a format→views capability map (images get File / Comfortable / Side by side; string files stay on segment views; office formats reserved for later).
- Ship a pluggable File view shell with **translated on the left** and **source on the right**, plus upload / regenerate / approve for the image adapter.
- Auto-select File view when entering an image family file; clamp persisted modes that the open file does not allow.

## Design

See `docs/plans/2026-08-01-cat-file-view-design.md`.

## Review follow-ups

- **Codex P1:** File view keeps the Comfortable queue page size (`50`) so aggregate workspaces (All Files) do not refetch with `limit=1` and drop the selected image.
- **Codex P2:** Next at the loaded-page boundary calls `onLoadMoreQueue` and advances to the first newly loaded segment (needed in File view where the queue load-more control is hidden).
- Added prev/next in File view for aggregate navigation.
- Header prefers the segment `sourcePath` over an aggregate filename like “All Files”.

## How to test

- Open a PNG/JPEG/WebP source in CAT and confirm File view is selected by default
- Confirm translated image is on the left and source on the right
- Upload a translated image and verify the target preview updates
- In All Files, select a non-first image and switch to / auto-enter File view — selection should stay
- Use prev/next in File view to move through the loaded queue
- On the last loaded item with more pages available, Next should fetch the next page and move to the first new item
- Open a JSON file and confirm File view is not offered
- `vp test` (focused CAT suite) and `vp check --fix` in `apps/hyperlocalise-web`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fbb0b-58b4-7644-983a-e449c7712f28?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fbb0b-58b4-7644-983a-e449c7712f28&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

