### PR TITLE
refactor(web): rename Issue Sheet label and heading to Issues

### DIFF
--- a/apps/hyperlocalise-web/lang/de-DE.json
+++ b/apps/hyperlocalise-web/lang/de-DE.json
@@ -3423,7 +3423,7 @@
     "defaultMessage": "Nicht zugewiesen"
   },
   "FRn2vWc0wk": {
-    "defaultMessage": "Problemliste"
+    "defaultMessage": "Probleme"
   },
   "FRwUYE4HKC": {
     "defaultMessage": "Finnisch (Finnland)"
@@ -10434,7 +10434,7 @@
     "defaultMessage": "Fragen Sie nach beliebigen Strings"
   },
   "rDacSGpJfq": {
-    "defaultMessage": "Issue Sheet"
+    "defaultMessage": "Probleme"
   },
   "rDkQbK1OIB": {
     "defaultMessage": "Übersprungen"
@@ -11415,7 +11415,7 @@
     "defaultMessage": "Kommentar konnte nicht veröffentlicht werden. Bitte erneut versuchen."
   },
   "wAvI6goI3/": {
-    "defaultMessage": "Problembogen"
+    "defaultMessage": "Probleme"
   },
   "wB36ZpuzG3": {
     "defaultMessage": "3 Zeichenfolgen geändert, 1 Übersetzungsproblem vor dem Zusammenführen angesprochen"

--- a/apps/hyperlocalise-web/lang/de-DE.json
+++ b/apps/hyperlocalise-web/lang/de-DE.json
@@ -2660,6 +2660,9 @@
   "BeBJ6Gf6JS": {
     "defaultMessage": "Warnung bei Abweichungen nach der Veröffentlichung"
   },
+  "BeXUx2ytXa": {
+    "defaultMessage": "Probleme"
+  },
   "Bfwle3X1Yy": {
     "defaultMessage": "Verbinde {provider}, um die Ressource {resource} des Anbieters anzuzeigen."
   },
@@ -3421,9 +3424,6 @@
   },
   "FPj5rPYXJV": {
     "defaultMessage": "Nicht zugewiesen"
-  },
-  "FRn2vWc0wk": {
-    "defaultMessage": "Probleme"
   },
   "FRwUYE4HKC": {
     "defaultMessage": "Finnisch (Finnland)"
@@ -8009,6 +8009,9 @@
   "enjVtZumks": {
     "defaultMessage": "Für diese Aufgabe ist kein Zielgebietsschema verfügbar."
   },
+  "enrIL8oTbj": {
+    "defaultMessage": "Probleme"
+  },
   "eogv8qHzO7": {
     "defaultMessage": "Direkte und vertraute französische SaaS-CTA-Formulierung."
   },
@@ -9055,6 +9058,9 @@
   },
   "jletyEWDwl": {
     "defaultMessage": "Actions for {email}"
+  },
+  "jmazd5AXy4": {
+    "defaultMessage": "Probleme"
   },
   "joOR4TGsxW": {
     "defaultMessage": "Noch keine Beiträge. Schau bald wieder vorbei."
@@ -10433,9 +10439,6 @@
   "rDFwnPnMxA": {
     "defaultMessage": "Fragen Sie nach beliebigen Strings"
   },
-  "rDacSGpJfq": {
-    "defaultMessage": "Probleme"
-  },
   "rDkQbK1OIB": {
     "defaultMessage": "Übersprungen"
   },
@@ -11413,9 +11416,6 @@
   },
   "wAW00AgfLK": {
     "defaultMessage": "Kommentar konnte nicht veröffentlicht werden. Bitte erneut versuchen."
-  },
-  "wAvI6goI3/": {
-    "defaultMessage": "Probleme"
   },
   "wB36ZpuzG3": {
     "defaultMessage": "3 Zeichenfolgen geändert, 1 Übersetzungsproblem vor dem Zusammenführen angesprochen"

--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -3323,6 +3323,10 @@
     "defaultMessage": "Alert on post-publish drift",
     "description": "Capability 6 title for the localisation-quality-monitoring use case"
   },
+  "BeXUx2ytXa": {
+    "defaultMessage": "Issues",
+    "description": "Section title for the project Issue Sheet page"
+  },
   "Bfwle3X1Yy": {
     "defaultMessage": "Connect {provider} to view provider {resource}.",
     "description": "Error heading when TMS provider data cannot load because the user has not connected their account"
@@ -4274,10 +4278,6 @@
   "FPj5rPYXJV": {
     "defaultMessage": "Unassigned",
     "description": "Issue list assignee filter option for issues with no assignee"
-  },
-  "FRn2vWc0wk": {
-    "defaultMessage": "Issues",
-    "description": "App shell breadcrumb title for the issue sheet page"
   },
   "FRwUYE4HKC": {
     "defaultMessage": "Finnish (Finland)",
@@ -10047,6 +10047,10 @@
     "defaultMessage": "No target locale is available for this task.",
     "description": "Empty state when all-files CAT mode has no selectable target locale"
   },
+  "enrIL8oTbj": {
+    "defaultMessage": "Issues",
+    "description": "Project sidebar navigation item for the project issue sheet"
+  },
   "eogv8qHzO7": {
     "defaultMessage": "Direct and familiar French SaaS CTA phrasing.",
     "description": "AI reasoning for the CTA segment in the hero CAT mock"
@@ -11346,6 +11350,10 @@
   "jletyEWDwl": {
     "defaultMessage": "Actions for {email}",
     "description": "Accessible label for a team member row actions menu"
+  },
+  "jmazd5AXy4": {
+    "defaultMessage": "Issues",
+    "description": "App shell breadcrumb title for the issue sheet page"
   },
   "joOR4TGsxW": {
     "defaultMessage": "No posts yet. Check back soon.",
@@ -13047,10 +13055,6 @@
     "defaultMessage": "Ask about any string",
     "description": "AI feature capability title: ask about strings"
   },
-  "rDacSGpJfq": {
-    "defaultMessage": "Issues",
-    "description": "Project sidebar navigation item for the project issue sheet"
-  },
   "rDkQbK1OIB": {
     "defaultMessage": "Skipped",
     "description": "Automation run status badge for skipped"
@@ -14286,10 +14290,6 @@
   "wAW00AgfLK": {
     "defaultMessage": "Failed to post comment. Try again.",
     "description": "Error message when posting a segment comment to the TMS fails"
-  },
-  "wAvI6goI3/": {
-    "defaultMessage": "Issues",
-    "description": "Section title for the project Issue Sheet page"
   },
   "wB36ZpuzG3": {
     "defaultMessage": "3 strings changed, 1 translation issue called out before merge",

--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -4276,7 +4276,7 @@
     "description": "Issue list assignee filter option for issues with no assignee"
   },
   "FRn2vWc0wk": {
-    "defaultMessage": "Issue Sheet",
+    "defaultMessage": "Issues",
     "description": "App shell breadcrumb title for the issue sheet page"
   },
   "FRwUYE4HKC": {
@@ -13048,7 +13048,7 @@
     "description": "AI feature capability title: ask about strings"
   },
   "rDacSGpJfq": {
-    "defaultMessage": "Issue Sheet",
+    "defaultMessage": "Issues",
     "description": "Project sidebar navigation item for the project issue sheet"
   },
   "rDkQbK1OIB": {
@@ -14288,7 +14288,7 @@
     "description": "Error message when posting a segment comment to the TMS fails"
   },
   "wAvI6goI3/": {
-    "defaultMessage": "Issue Sheet",
+    "defaultMessage": "Issues",
     "description": "Section title for the project Issue Sheet page"
   },
   "wB36ZpuzG3": {

--- a/apps/hyperlocalise-web/lang/fr-FR.json
+++ b/apps/hyperlocalise-web/lang/fr-FR.json
@@ -3423,7 +3423,7 @@
     "defaultMessage": "Unassigned"
   },
   "FRn2vWc0wk": {
-    "defaultMessage": "Fiche d’incident"
+    "defaultMessage": "Problèmes"
   },
   "FRwUYE4HKC": {
     "defaultMessage": "finnois (Finlande)"
@@ -10434,7 +10434,7 @@
     "defaultMessage": "Posez des questions sur n’importe quelle chaîne"
   },
   "rDacSGpJfq": {
-    "defaultMessage": "Fiche des problèmes"
+    "defaultMessage": "Problèmes"
   },
   "rDkQbK1OIB": {
     "defaultMessage": "Skipped"
@@ -11415,7 +11415,7 @@
     "defaultMessage": "Échec de la publication du commentaire. Réessayez."
   },
   "wAvI6goI3/": {
-    "defaultMessage": "Issue Sheet"
+    "defaultMessage": "Problèmes"
   },
   "wB36ZpuzG3": {
     "defaultMessage": "3 strings changed, 1 translation issue called out before merge"

--- a/apps/hyperlocalise-web/lang/fr-FR.json
+++ b/apps/hyperlocalise-web/lang/fr-FR.json
@@ -2660,6 +2660,9 @@
   "BeBJ6Gf6JS": {
     "defaultMessage": "Alerte sur la dérive après publication"
   },
+  "BeXUx2ytXa": {
+    "defaultMessage": "Problèmes"
+  },
   "Bfwle3X1Yy": {
     "defaultMessage": "Connectez {provider} pour afficher {resource} du fournisseur."
   },
@@ -3421,9 +3424,6 @@
   },
   "FPj5rPYXJV": {
     "defaultMessage": "Unassigned"
-  },
-  "FRn2vWc0wk": {
-    "defaultMessage": "Problèmes"
   },
   "FRwUYE4HKC": {
     "defaultMessage": "finnois (Finlande)"
@@ -8009,6 +8009,9 @@
   "enjVtZumks": {
     "defaultMessage": "No target locale is available for this task."
   },
+  "enrIL8oTbj": {
+    "defaultMessage": "Problèmes"
+  },
   "eogv8qHzO7": {
     "defaultMessage": "Direct and familiar French SaaS CTA phrasing."
   },
@@ -9055,6 +9058,9 @@
   },
   "jletyEWDwl": {
     "defaultMessage": "Actions for {email}"
+  },
+  "jmazd5AXy4": {
+    "defaultMessage": "Problèmes"
   },
   "joOR4TGsxW": {
     "defaultMessage": "Aucun article pour le moment. Revenez bientôt."
@@ -10433,9 +10439,6 @@
   "rDFwnPnMxA": {
     "defaultMessage": "Posez des questions sur n’importe quelle chaîne"
   },
-  "rDacSGpJfq": {
-    "defaultMessage": "Problèmes"
-  },
   "rDkQbK1OIB": {
     "defaultMessage": "Skipped"
   },
@@ -11413,9 +11416,6 @@
   },
   "wAW00AgfLK": {
     "defaultMessage": "Échec de la publication du commentaire. Réessayez."
-  },
-  "wAvI6goI3/": {
-    "defaultMessage": "Problèmes"
   },
   "wB36ZpuzG3": {
     "defaultMessage": "3 strings changed, 1 translation issue called out before merge"

--- a/apps/hyperlocalise-web/lang/vi-VN.json
+++ b/apps/hyperlocalise-web/lang/vi-VN.json
@@ -3423,7 +3423,7 @@
     "defaultMessage": "Unassigned"
   },
   "FRn2vWc0wk": {
-    "defaultMessage": "Phiếu sự cố"
+    "defaultMessage": "Vấn đề"
   },
   "FRwUYE4HKC": {
     "defaultMessage": "Tiếng Phần Lan (Phần Lan)"
@@ -10434,7 +10434,7 @@
     "defaultMessage": "Hỏi về bất kỳ chuỗi nào"
   },
   "rDacSGpJfq": {
-    "defaultMessage": "Bảng vấn đề"
+    "defaultMessage": "Vấn đề"
   },
   "rDkQbK1OIB": {
     "defaultMessage": "Skipped"
@@ -11415,7 +11415,7 @@
     "defaultMessage": "Không thể đăng bình luận. Hãy thử lại."
   },
   "wAvI6goI3/": {
-    "defaultMessage": "Issue Sheet"
+    "defaultMessage": "Vấn đề"
   },
   "wB36ZpuzG3": {
     "defaultMessage": "3 strings changed, 1 translation issue called out before merge"

--- a/apps/hyperlocalise-web/lang/vi-VN.json
+++ b/apps/hyperlocalise-web/lang/vi-VN.json
@@ -2660,6 +2660,9 @@
   "BeBJ6Gf6JS": {
     "defaultMessage": "Cảnh báo khi có sự sai lệch sau khi xuất bản"
   },
+  "BeXUx2ytXa": {
+    "defaultMessage": "Vấn đề"
+  },
   "Bfwle3X1Yy": {
     "defaultMessage": "Connect {provider} to view provider {resource}."
   },
@@ -3421,9 +3424,6 @@
   },
   "FPj5rPYXJV": {
     "defaultMessage": "Unassigned"
-  },
-  "FRn2vWc0wk": {
-    "defaultMessage": "Vấn đề"
   },
   "FRwUYE4HKC": {
     "defaultMessage": "Tiếng Phần Lan (Phần Lan)"
@@ -8009,6 +8009,9 @@
   "enjVtZumks": {
     "defaultMessage": "No target locale is available for this task."
   },
+  "enrIL8oTbj": {
+    "defaultMessage": "Vấn đề"
+  },
   "eogv8qHzO7": {
     "defaultMessage": "Direct and familiar French SaaS CTA phrasing."
   },
@@ -9055,6 +9058,9 @@
   },
   "jletyEWDwl": {
     "defaultMessage": "Actions for {email}"
+  },
+  "jmazd5AXy4": {
+    "defaultMessage": "Vấn đề"
   },
   "joOR4TGsxW": {
     "defaultMessage": "Chưa có bài viết nào. Hãy quay lại sau."
@@ -10433,9 +10439,6 @@
   "rDFwnPnMxA": {
     "defaultMessage": "Hỏi về bất kỳ chuỗi nào"
   },
-  "rDacSGpJfq": {
-    "defaultMessage": "Vấn đề"
-  },
   "rDkQbK1OIB": {
     "defaultMessage": "Skipped"
   },
@@ -11413,9 +11416,6 @@
   },
   "wAW00AgfLK": {
     "defaultMessage": "Không thể đăng bình luận. Hãy thử lại."
-  },
-  "wAvI6goI3/": {
-    "defaultMessage": "Vấn đề"
   },
   "wB36ZpuzG3": {
     "defaultMessage": "3 strings changed, 1 translation issue called out before merge"

--- a/apps/hyperlocalise-web/lang/zh-CN.json
+++ b/apps/hyperlocalise-web/lang/zh-CN.json
@@ -3423,7 +3423,7 @@
     "defaultMessage": "Unassigned"
   },
   "FRn2vWc0wk": {
-    "defaultMessage": "问题表"
+    "defaultMessage": "问题"
   },
   "FRwUYE4HKC": {
     "defaultMessage": "芬兰语（芬兰）"
@@ -10434,7 +10434,7 @@
     "defaultMessage": "询问任何字符串"
   },
   "rDacSGpJfq": {
-    "defaultMessage": "问题表"
+    "defaultMessage": "问题"
   },
   "rDkQbK1OIB": {
     "defaultMessage": "Skipped"
@@ -11415,7 +11415,7 @@
     "defaultMessage": "发表评论失败。请重试。"
   },
   "wAvI6goI3/": {
-    "defaultMessage": "Issue Sheet"
+    "defaultMessage": "问题"
   },
   "wB36ZpuzG3": {
     "defaultMessage": "3 strings changed, 1 translation issue called out before merge"

--- a/apps/hyperlocalise-web/lang/zh-CN.json
+++ b/apps/hyperlocalise-web/lang/zh-CN.json
@@ -2660,6 +2660,9 @@
   "BeBJ6Gf6JS": {
     "defaultMessage": "发布后漂移告警"
   },
+  "BeXUx2ytXa": {
+    "defaultMessage": "问题"
+  },
   "Bfwle3X1Yy": {
     "defaultMessage": "连接 {provider} 以查看提供商{resource}。"
   },
@@ -3421,9 +3424,6 @@
   },
   "FPj5rPYXJV": {
     "defaultMessage": "Unassigned"
-  },
-  "FRn2vWc0wk": {
-    "defaultMessage": "问题"
   },
   "FRwUYE4HKC": {
     "defaultMessage": "芬兰语（芬兰）"
@@ -8009,6 +8009,9 @@
   "enjVtZumks": {
     "defaultMessage": "No target locale is available for this task."
   },
+  "enrIL8oTbj": {
+    "defaultMessage": "问题"
+  },
   "eogv8qHzO7": {
     "defaultMessage": "Direct and familiar French SaaS CTA phrasing."
   },
@@ -9055,6 +9058,9 @@
   },
   "jletyEWDwl": {
     "defaultMessage": "Actions for {email}"
+  },
+  "jmazd5AXy4": {
+    "defaultMessage": "问题"
   },
   "joOR4TGsxW": {
     "defaultMessage": "还没有帖子。请稍后再来查看。"
@@ -10433,9 +10439,6 @@
   "rDFwnPnMxA": {
     "defaultMessage": "询问任何字符串"
   },
-  "rDacSGpJfq": {
-    "defaultMessage": "问题"
-  },
   "rDkQbK1OIB": {
     "defaultMessage": "Skipped"
   },
@@ -11413,9 +11416,6 @@
   },
   "wAW00AgfLK": {
     "defaultMessage": "发表评论失败。请重试。"
-  },
-  "wAvI6goI3/": {
-    "defaultMessage": "问题"
   },
   "wB36ZpuzG3": {
     "defaultMessage": "3 strings changed, 1 translation issue called out before merge"

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.messages.ts
@@ -17,7 +17,7 @@ import { defineMessages } from "react-intl";
 export const issueSheetPageContentMessages = defineMessages({
   sectionTitle: {
     defaultMessage: "Issues",
-    id: "wAvI6goI3/",
+    id: "BeXUx2ytXa",
     description: "Section title for the project Issue Sheet page",
   },
   sectionDescription: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.messages.ts
@@ -16,7 +16,7 @@ import { defineMessages } from "react-intl";
 
 export const issueSheetPageContentMessages = defineMessages({
   sectionTitle: {
-    defaultMessage: "Issue Sheet",
+    defaultMessage: "Issues",
     id: "wAvI6goI3/",
     description: "Section title for the project Issue Sheet page",
   },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-page-content.stories.tsx
@@ -49,7 +49,7 @@ export const Default: Story = {
     },
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText("Issue Sheet")).toBeInTheDocument();
+    await expect(canvas.getByText("Issues")).toBeInTheDocument();
     await expect(canvas.getByText("Source string needs context")).toBeInTheDocument();
     await expect(canvas.getByText("3 total")).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Issue" })).toBeInTheDocument();
@@ -64,7 +64,7 @@ export const Loading: Story = {
     },
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText("Issue Sheet")).toBeInTheDocument();
+    await expect(canvas.getByText("Issues")).toBeInTheDocument();
     await expect(canvas.getByText("Loading issues…")).toBeInTheDocument();
   },
 };
@@ -90,7 +90,7 @@ export const Error: Story = {
     },
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText("Issue Sheet")).toBeInTheDocument();
+    await expect(canvas.getByText("Issues")).toBeInTheDocument();
     await expect(canvas.getByText("Issues could not be loaded.")).toBeInTheDocument();
     await expect(canvas.queryByText("No issues in this view.")).not.toBeInTheDocument();
   },

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
@@ -27,7 +27,7 @@ describe("getAppShellTitle", () => {
     ["/org/acme/projects/proj_1", "proj_1"],
     ["/org/acme/projects/proj_1/files", "Files"],
     ["/org/acme/projects/proj_1/jobs", "Jobs"],
-    ["/org/acme/projects/proj_1/issue-sheet", "Issue Sheet"],
+    ["/org/acme/projects/proj_1/issue-sheet", "Issues"],
     ["/org/acme/projects/proj_1/agent-runs", "Agent Runs"],
     ["/org/acme/projects/proj_1/activity", "Activity"],
     ["/org/acme/projects/proj_1/context", "Context"],
@@ -124,11 +124,11 @@ describe("getAppShellBreadcrumbs", () => {
     ).toEqual([
       { label: "Projects", href: "/org/acme/projects" },
       { label: "Checkout", href: "/org/acme/projects/proj_1" },
-      { label: "Issue Sheet" },
+      { label: "Issues" },
     ]);
   });
 
-  it("links Issue Sheet when viewing a permanent issue detail URL", () => {
+  it("links Issues when viewing a permanent issue detail URL", () => {
     expect(
       getAppShellBreadcrumbs(
         "/org/acme/projects/proj_1/issue-sheet/11111111-1111-4111-8111-111111111111",
@@ -138,7 +138,7 @@ describe("getAppShellBreadcrumbs", () => {
     ).toEqual([
       { label: "Projects", href: "/org/acme/projects" },
       { label: "Checkout", href: "/org/acme/projects/proj_1" },
-      { label: "Issue Sheet", href: "/org/acme/projects/proj_1/issue-sheet" },
+      { label: "Issues", href: "/org/acme/projects/proj_1/issue-sheet" },
     ]);
   });
 

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
@@ -203,7 +203,7 @@ function formatRouteTitle(intl: IntlShape, key: RouteTitleKey): string {
       });
     case "issue-sheet":
       return intl.formatMessage({
-        defaultMessage: "Issue Sheet",
+        defaultMessage: "Issues",
         id: "FRn2vWc0wk",
         description: "App shell breadcrumb title for the issue sheet page",
       });

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
@@ -204,7 +204,7 @@ function formatRouteTitle(intl: IntlShape, key: RouteTitleKey): string {
     case "issue-sheet":
       return intl.formatMessage({
         defaultMessage: "Issues",
-        id: "FRn2vWc0wk",
+        id: "jmazd5AXy4",
         description: "App shell breadcrumb title for the issue sheet page",
       });
     case "jobs":

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -188,10 +188,10 @@ describe("path builders", () => {
       ["Files", "/org/acme/projects/proj_1/files"],
       ["Strings", "/org/acme/projects/proj_1/strings"],
       ["Jobs", "/org/acme/projects/proj_1/jobs"],
-      ["Issue Sheet", "/org/acme/projects/proj_1/issue-sheet"],
+      ["Issues", "/org/acme/projects/proj_1/issue-sheet"],
       ["Settings", "/org/acme/projects/proj_1/settings"],
     ]);
-    expect(items.find((item) => item.label === "Issue Sheet")?.featureFlagKey).toBe(
+    expect(items.find((item) => item.label === "Issues")?.featureFlagKey).toBe(
       WORKSPACE_ISSUES_FLAG,
     );
   });

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -301,7 +301,7 @@ export function buildProjectNavigationItems(
     },
     {
       label: intl.formatMessage({
-        defaultMessage: "Issue Sheet",
+        defaultMessage: "Issues",
         id: "rDacSGpJfq",
         description: "Project sidebar navigation item for the project issue sheet",
       }),

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -302,7 +302,7 @@ export function buildProjectNavigationItems(
     {
       label: intl.formatMessage({
         defaultMessage: "Issues",
-        id: "rDacSGpJfq",
+        id: "enrIL8oTbj",
         description: "Project sidebar navigation item for the project issue sheet",
       }),
       href: project("issue-sheet"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Renames the project Issue Sheet **sidebar label**, **breadcrumb title**, and **page section heading** to **Issues**. Locale catalogs and tests/stories that assert that copy are updated to match, including regenerated formatjs message IDs.

## How to test

- Confirm project sidebar shows **Issues** for the issue-sheet route
- Confirm the issue-sheet page heading reads **Issues**
- Confirm breadcrumbs on `/projects/:id/issue-sheet` and issue detail URLs use **Issues**
- `vp test src/components/app-shell/navigation-config.test.ts src/components/app-shell/app-shell-title.test.ts`
- `vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b49bbd6b-865d-4c66-8d93-0575a53ae10e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b49bbd6b-865d-4c66-8d93-0575a53ae10e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

