### PR TITLE
feat(web): rebuild project overview as a job-first Today queue

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/job.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.schema.ts
@@ -72,14 +72,27 @@ export const createJobBodySchema = z.discriminatedUnion("type", [
   }),
 ]);
 
-/** Statuses counted by project `openJobCount` and surfaced on overview pages. */
+/** Statuses counted by project `openJobCount` and listed by `open=true`. */
 export const openJobStatusValues = ["queued", "running", "waiting_for_review"] as const;
+
+/**
+ * Statuses eligible for the project Overview Today queue.
+ * Includes failed jobs (actionable) in addition to open statuses.
+ */
+export const overviewTriageJobStatusValues = [
+  "waiting_for_review",
+  "failed",
+  "queued",
+  "running",
+] as const;
 
 export const jobListQuerySchema = z.object({
   kind: z.enum(schema.jobKindEnum.enumValues).optional(),
   type: z.enum(schema.translationJobTypeEnum.enumValues).optional(),
   status: z.enum(schema.jobStatusEnum.enumValues).optional(),
   open: z.coerce.boolean().optional(),
+  /** Prefer review/failed before other open jobs, then apply `limit`. */
+  triage: z.coerce.boolean().optional(),
   relationship: z.enum(["assigned", "created"]).optional(),
   limit: z.coerce.number().int().min(1).max(100).default(50),
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-mesh-stage.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-mesh-stage.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import Image from "next/image";
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/primitives/cn";
+
+/** Calm / shippable mesh — seafoam. */
+export const PROJECT_OVERVIEW_CALM_MESH_SRC = "/images/mesh/mesh-gradient-1784864145512.jpg";
+/** Action needed mesh — dusk. */
+export const PROJECT_OVERVIEW_ACTION_MESH_SRC = "/images/mesh/mesh-gradient-1784863799475.jpg";
+
+export function ProjectOverviewMeshStage({
+  tone,
+  children,
+  className,
+}: {
+  tone: "action" | "calm";
+  children: ReactNode;
+  className?: string;
+}) {
+  const meshSrc =
+    tone === "action" ? PROJECT_OVERVIEW_ACTION_MESH_SRC : PROJECT_OVERVIEW_CALM_MESH_SRC;
+
+  return (
+    <div
+      className={cn(
+        "relative overflow-hidden rounded-2xl border border-border shadow-sm",
+        className,
+      )}
+    >
+      <Image
+        src={meshSrc}
+        alt=""
+        aria-hidden
+        fill
+        sizes="(min-width: 1024px) 56rem, 100vw"
+        className="object-cover object-center"
+      />
+      <div
+        aria-hidden
+        className="absolute inset-0 bg-gradient-to-br from-background/92 via-background/82 to-background/70 dark:from-background/88 dark:via-background/78 dark:to-background/62"
+      />
+      <div className="relative px-5 py-5 sm:px-6 sm:py-6">{children}</div>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.messages.ts
@@ -41,187 +41,148 @@ export const projectOverviewPageContentMessages = defineMessages({
     description: "Error message when project overview details fail to load",
   },
   defaultProjectDescription: {
-    defaultMessage: "Project hub for localization work.",
-    id: "fbtbMSQ/2I",
+    defaultMessage: "Today’s queue for this project.",
+    id: "6lH73749rG",
     description: "Fallback project description on the project overview page",
   },
-  caughtUpHeroTitle: {
-    defaultMessage: "You’re all caught up",
-    id: "esZVdLzFOW",
-    description: "Project overview hero title when there are no pending actions",
+  needsYouNowTitle: {
+    defaultMessage: "Needs you now",
+    id: "dGhvlRGto0",
+    description: "Heading for the project overview triage band",
   },
-  caughtUpHeroDescription: {
-    defaultMessage:
-      "No pending actions right now. Upload source files or review completed jobs when you’re ready to continue.",
-    id: "VZSf2k42GF",
-    description: "Project overview hero description when there are no pending actions",
+  needsYouNowCount: {
+    defaultMessage: "{count, plural, one {# item} other {# items}}",
+    id: "obkqu+QKmi",
+    description: "Count badge for triage items on project overview",
   },
-  browseFilesCta: {
-    defaultMessage: "Browse files",
-    id: "Q3hdQblIYe",
-    description: "Project overview hero call-to-action when the project is caught up",
+  triageEmptyTitle: {
+    defaultMessage: "No reviews waiting",
+    id: "TVxvj2B1bk",
+    description: "Title when the triage band has no urgent items",
   },
-  attentionHeroTitle: {
-    defaultMessage: "A few things need your attention",
-    id: "3XNlGxtFuq",
-    description: "Project overview hero title when pending actions need review",
+  triageEmptyDescription: {
+    defaultMessage: "Open Files for coverage, or create a job when you are ready.",
+    id: "85veKzf/Q7",
+    description: "Description when the triage band has no urgent items",
   },
-  attentionHeroDescription: {
-    defaultMessage: "Pick up where you left off — {details}.",
-    id: "hx+ozGK2uu",
-    description: "Project overview hero description listing open jobs and files needing attention",
+  reviewCta: {
+    defaultMessage: "Review",
+    id: "v0Xmk6UQW5",
+    description: "CTA for a job waiting for review on project overview",
   },
-  openJobsDetail: {
-    defaultMessage: "{count, plural, one {# open job} other {# open jobs}}",
-    id: "SyMDAHRe17",
-    description: "Fragment listing open job count in the project overview hero",
+  openJobCta: {
+    defaultMessage: "Open job",
+    id: "wdhrNg8UHz",
+    description: "CTA for a failed or active job on project overview",
   },
-  filesNeedingAttentionDetail: {
-    defaultMessage:
-      "{count, plural, one {# file needing attention} other {# files needing attention}}",
-    id: "e3B7xw2yS4",
-    description: "Fragment listing files needing attention in the project overview hero",
+  addGuidanceCta: {
+    defaultMessage: "Add guidance",
+    id: "U+ZJP/RMin",
+    description: "CTA when translation guidance is missing on project overview",
   },
-  pickUpWhereYouLeftOffCta: {
-    defaultMessage: "Pick up where you left off",
-    id: "2P3llDCJQ9",
-    description: "Project overview hero call-to-action when work needs attention",
+  triageReviewTitle: {
+    defaultMessage: "Waiting for review",
+    id: "t4mhc63bGr",
+    description: "Status label for review triage items",
   },
-  snapshotTitle: {
-    defaultMessage: "Project snapshot",
-    id: "tQnsj9c8zW",
-    description: "Title of the project snapshot card on project overview",
+  triageFailedTitle: {
+    defaultMessage: "Job failed",
+    id: "piWs1xE1NT",
+    description: "Status label for failed job triage items",
   },
-  snapshotLocales: {
+  triageGuidanceTitle: {
+    defaultMessage: "Add translation guidance",
+    id: "DGx/LlMkDv",
+    description: "Title when native translation guidance is missing",
+  },
+  triageGuidanceDescription: {
+    defaultMessage: "Shared tone and terminology so agents stay consistent.",
+    id: "+y5oYiRfPw",
+    description: "Description when native translation guidance is missing",
+  },
+  triageJobRunning: {
+    defaultMessage: "In progress",
+    id: "KYKSoue+Dr",
+    description: "Status label for queued or running jobs in triage",
+  },
+  viewAllJobs: {
+    defaultMessage: "View all jobs",
+    id: "QaBpv8qa4h",
+    description: "Link from triage band to the project jobs page",
+  },
+  signalsTitle: {
+    defaultMessage: "Project",
+    id: "RZNls0g+WM",
+    description: "Section heading for lightweight project signals on overview",
+  },
+  signalsLocales: {
     defaultMessage: "Locales",
-    id: "0pVEMuUCAh",
-    description: "Project snapshot row label for source and target locales",
+    id: "wQOKFwmzrC",
+    description: "Label for locale route on project overview signals",
   },
-  snapshotSource: {
-    defaultMessage: "Source",
-    id: "R1inHgae6i",
-    description: "Project snapshot row label for project source type",
+  signalsNoLocales: {
+    defaultMessage: "No target locales yet",
+    id: "Pw5huaM2vN",
+    description: "Shown when the project has no target locales configured",
   },
-  snapshotOpenJobs: {
-    defaultMessage: "Open jobs",
-    id: "qoKaksFa9x",
-    description: "Project snapshot row label for open job count",
+  guidanceTitle: {
+    defaultMessage: "Translation guidance",
+    id: "6KrEdJWOHm",
+    description: "Section heading for translation guidance preview on project overview",
   },
-  nativeProjectSource: {
-    defaultMessage: "Native project",
-    id: "kpZpdwbYk2",
-    description: "Project snapshot source value for Hyperlocalise-native projects",
+  guidanceEdit: {
+    defaultMessage: "Edit",
+    id: "Hvpl2DhEOB",
+    description: "Link to edit translation guidance in project settings",
   },
-  openJobsUnavailable: {
-    defaultMessage: "Unavailable",
-    id: "Z9kckxHp8S",
-    description: "Shown in project snapshot when open job count fails to load",
+  shipTitle: {
+    defaultMessage: "Sync",
+    id: "cE0bfQDgYq",
+    description: "Section heading for native sync status on project overview",
+  },
+  shipLastSynced: {
+    defaultMessage: "Last synced {when}",
+    id: "I28Vekk8WA",
+    description: "Last sync timestamp on project overview ship section",
+  },
+  shipNeverSynced: {
+    defaultMessage: "Not synced yet",
+    id: "wk5x4r43TH",
+    description: "Shown when a native project has never synced",
+  },
+  shipCliHint: {
+    defaultMessage: "Download translations from Files or run <code>sync pull</code>.",
+    id: "1x7rivVz4j",
+    description: "CLI hint in the sync section on project overview",
+  },
+  shipConnectCli: {
+    defaultMessage: "Connect CLI & CI",
+    id: "NQq3ItGutD",
+    description: "Link to project settings for CLI and CI setup",
   },
   viewSettings: {
     defaultMessage: "View settings",
-    id: "zIinCypcXs",
-    description: "Call-to-action on the project snapshot card linking to project settings",
+    id: "PpiEEboJdd",
+    description: "Call-to-action linking to project settings",
   },
-  ongoingSection: {
-    defaultMessage: "Ongoing",
-    id: "AUY6LRuqkn",
-    description: "Section heading for ongoing jobs and files on project overview",
+  viewFiles: {
+    defaultMessage: "View files",
+    id: "9GZvF1K90w",
+    description: "Button linking to the project files page",
   },
-  categoryJob: {
-    defaultMessage: "Job",
-    id: "zliOrjr0oj",
-    description: "Category badge for a job card on project overview",
-  },
-  categoryFile: {
-    defaultMessage: "File",
-    id: "XlCqTK9P8L",
-    description: "Category badge for a file card on project overview",
-  },
-  jobStatusUpdated: {
-    defaultMessage: "{status} · updated {updated}",
-    id: "intwkVhq+i",
-    description: "Status line for an ongoing job card showing status and relative update time",
-  },
-  needsAttention: {
-    defaultMessage: "Needs attention",
-    id: "Jwoqn7hfPq",
-    description: "Fallback status line when a file needs attention but has no readiness summary",
+  viewJobs: {
+    defaultMessage: "View jobs",
+    id: "2c+GvUZLgD",
+    description: "Button linking to the project jobs page",
   },
   jobsUnavailable: {
     defaultMessage: "Jobs unavailable",
     id: "M4sYVolrI+",
     description: "Empty-state title when project jobs fail to load",
   },
-  noActiveJobs: {
-    defaultMessage: "No active jobs",
-    id: "qsiC3fEv6E",
-    description: "Empty-state title when the project has no active jobs",
-  },
   jobsUnavailableDescription: {
     defaultMessage: "We could not load jobs for this project.",
     id: "CvYNnC7KYY",
     description: "Empty-state description when project jobs fail to load",
-  },
-  noActiveJobsDescription: {
-    defaultMessage: "Queued, running, and review jobs will appear here.",
-    id: "VreTPRoxTI",
-    description: "Empty-state description when the project has no active jobs",
-  },
-  viewJobs: {
-    defaultMessage: "View jobs",
-    id: "ah1fHcY0dZ",
-    description: "Button linking to the project jobs page from the empty jobs card",
-  },
-  filesUnavailable: {
-    defaultMessage: "Files unavailable",
-    id: "lnENdnqB3K",
-    description: "Empty-state title when project files fail to load",
-  },
-  noFilesNeedAttention: {
-    defaultMessage: "No files need attention",
-    id: "ng2kCyPWWf",
-    description: "Empty-state title when no project files need attention",
-  },
-  filesUnavailableDescription: {
-    defaultMessage: "We could not load project files.",
-    id: "MtSPbgepa5",
-    description: "Empty-state description when project files fail to load",
-  },
-  noFilesNeedAttentionDescription: {
-    defaultMessage: "Files with missing or changed translations will appear here.",
-    id: "Pu5h/suwW5",
-    description: "Empty-state description when no project files need attention",
-  },
-  viewFiles: {
-    defaultMessage: "View files",
-    id: "3KtrgP1VL6",
-    description: "Button linking to the project files page from the empty files card",
-  },
-  readyToPullTitle: {
-    defaultMessage: "Ready to pull",
-    id: "PMhWQU9+xq",
-    description: "Title of the ready-to-pull callout on project overview",
-  },
-  readyToPullDescription: {
-    defaultMessage:
-      "{count, plural, one {# file has} other {# files have}} completed translations you can download or sync with <code>sync pull</code>.",
-    id: "iczDvJ3VLc",
-    description:
-      "Description of files ready to pull, with the sync pull command highlighted in monospace",
-  },
-  openFiles: {
-    defaultMessage: "Open files",
-    id: "/L2n1hwt0/",
-    description: "Button linking to project files from the ready-to-pull callout",
-  },
-  loadProjectFilesFailed: {
-    defaultMessage: "Failed to load project files",
-    id: "fIXR+y8rly",
-    description: "Error when the project overview files query fails",
-  },
-  invalidProjectFilesResponse: {
-    defaultMessage: "Invalid project files response",
-    id: "kgAiiSB4O6",
-    description: "Error when the project overview files API returns an unexpected payload",
   },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.stories.tsx
@@ -15,9 +15,10 @@ import { expect } from "storybook/test";
 
 import {
   projectOverviewCaughtUpFixture,
-  projectOverviewFilesFixture,
   projectOverviewFixture,
   projectOverviewJobsFixture,
+  projectOverviewMissingGuidanceFixture,
+  projectOverviewTmsFixture,
 } from "./project-overview.fixture";
 import { ProjectOverviewPageContentView } from "./project-overview-page-content";
 
@@ -33,15 +34,9 @@ const meta = {
     project: projectOverviewFixture,
     isProjectLoading: false,
     isProjectError: false,
-    openJobCount: projectOverviewFixture.openJobCount,
-    isOpenJobCountLoading: false,
-    isOpenJobCountError: false,
     jobs: projectOverviewJobsFixture,
     isJobsLoading: false,
     isJobsError: false,
-    files: projectOverviewFilesFixture,
-    isFilesLoading: false,
-    isFilesError: false,
   },
 } satisfies Meta<typeof ProjectOverviewPageContentView>;
 
@@ -52,26 +47,51 @@ export const Default: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("heading", { name: "Website localization" })).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Create job" })).toBeInTheDocument();
-    await expect(canvas.getByRole("link", { name: "View strings" })).toHaveAttribute(
-      "href",
-      "/org/acme/projects/project_website/strings",
-    );
-    await expect(canvas.getByText("A few things need your attention")).toBeInTheDocument();
-    await expect(canvas.getByText("Ongoing")).toBeInTheDocument();
-    await expect(canvas.getByText("home.json")).toBeInTheDocument();
+    await expect(canvas.getByText("Needs you now")).toBeInTheDocument();
+    await expect(canvas.getByText("Waiting for review")).toBeInTheDocument();
+    await expect(canvas.getByText("Translation guidance")).toBeInTheDocument();
+    await expect(canvas.getByText("Sync")).toBeInTheDocument();
+    await expect(canvas.queryByText("Locale health")).toBeNull();
   },
 };
 
 export const CaughtUp: Story = {
   args: {
     project: projectOverviewCaughtUpFixture,
-    openJobCount: projectOverviewCaughtUpFixture.openJobCount,
     jobs: [],
-    files: [projectOverviewFilesFixture[1]!],
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText("You’re all caught up")).toBeInTheDocument();
-    await expect(canvas.getByText("Browse files")).toBeInTheDocument();
+    await expect(canvas.getByText("No reviews waiting")).toBeInTheDocument();
+    await expect(
+      canvas.getByText("Open Files for coverage, or create a job when you are ready."),
+    ).toBeInTheDocument();
+  },
+};
+
+export const MissingGuidance: Story = {
+  args: {
+    project: projectOverviewMissingGuidanceFixture,
+    jobs: [],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Add translation guidance")).toBeInTheDocument();
+    await expect(canvas.getByText("Add guidance")).toBeInTheDocument();
+  },
+};
+
+export const TmsProject: Story = {
+  args: {
+    project: projectOverviewTmsFixture,
+    projectId: "ext:crowdin:42",
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("link", { name: "View strings" })).toHaveAttribute(
+      "href",
+      "/org/acme/projects/ext%3Acrowdin%3A42/strings",
+    );
+    await expect(canvas.queryByText("Sync")).toBeNull();
+    await expect(canvas.queryByText("Translation guidance")).toBeNull();
+    await expect(canvas.getByText("Locales")).toBeInTheDocument();
   },
 };
 
@@ -79,24 +99,11 @@ export const Loading: Story = {
   args: {
     project: null,
     isProjectLoading: true,
-    isOpenJobCountLoading: true,
     isJobsLoading: true,
-    isFilesLoading: true,
-    openJobCount: 0,
     jobs: [],
-    files: [],
   },
   play: async ({ canvas }) => {
     await expect(canvas.queryByRole("button", { name: "Create job" })).toBeNull();
     await expect(canvas.queryByRole("link", { name: "View strings" })).toBeNull();
-  },
-};
-
-export const EmptyOngoing: Story = {
-  args: {
-    project: projectOverviewCaughtUpFixture,
-    openJobCount: projectOverviewCaughtUpFixture.openJobCount,
-    jobs: [],
-    files: [projectOverviewFilesFixture[1]!],
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
@@ -240,25 +240,7 @@ export function ProjectOverviewPageContentView({
               ) : null}
             </div>
 
-            {isJobsError ? (
-              <div className="rounded-xl border border-dashed border-border bg-background/60 px-4 py-4">
-                <TypographyP className="text-sm font-medium text-foreground">
-                  <FormattedMessage {...messages.jobsUnavailable} />
-                </TypographyP>
-                <TypographyP className="mt-1 text-sm text-muted-foreground">
-                  <FormattedMessage {...messages.jobsUnavailableDescription} />
-                </TypographyP>
-                <Button
-                  nativeButton={false}
-                  render={<Link href={jobsHref} />}
-                  variant="outline"
-                  size="sm"
-                  className="mt-3 w-fit"
-                >
-                  <FormattedMessage {...messages.viewJobs} />
-                </Button>
-              </div>
-            ) : triageItems.length > 0 ? (
+            {triageItems.length > 0 ? (
               <div className="flex flex-col gap-2">
                 {triageItems.map((item) => {
                   const copy = resolveTriageCopy(item, intl);
@@ -291,6 +273,24 @@ export function ProjectOverviewPageContentView({
                     <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={1.8} />
                   </Button>
                 </div>
+              </div>
+            ) : isJobsError ? (
+              <div className="rounded-xl border border-dashed border-border bg-background/60 px-4 py-4">
+                <TypographyP className="text-sm font-medium text-foreground">
+                  <FormattedMessage {...messages.jobsUnavailable} />
+                </TypographyP>
+                <TypographyP className="mt-1 text-sm text-muted-foreground">
+                  <FormattedMessage {...messages.jobsUnavailableDescription} />
+                </TypographyP>
+                <Button
+                  nativeButton={false}
+                  render={<Link href={jobsHref} />}
+                  variant="outline"
+                  size="sm"
+                  className="mt-3 w-fit"
+                >
+                  <FormattedMessage {...messages.viewJobs} />
+                </Button>
               </div>
             ) : (
               <div className="space-y-2">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
@@ -14,145 +14,102 @@
  */
 import Link from "next/link";
 import { useState, type ReactNode } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { Add01Icon, File01Icon, LanguageCircleIcon } from "@hugeicons/core-free-icons";
+import { Add01Icon, ArrowRight01Icon, LanguageCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { buildProjectPath } from "@/components/app-shell/navigation-config";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TypographyH1, TypographyP } from "@/components/ui/typography";
-import { parseApiJsonResponse, readApiResponseError } from "@/lib/api-error";
-import { apiClient } from "@/lib/api-client-instance";
 import { supportsCatAllFilesProvider } from "@/lib/projects/cat-all-files";
 import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
-import {
-  projectFilesResponseSchema,
-  type ProjectFileRecord,
-} from "@/api/routes/project/project.schema";
 
-import { OverviewActionCard } from "../../../_components/overview/overview-action-card";
-import {
-  computeProjectPendingActionCount,
-  countFilesNeedingAttention,
-  selectFilesNeedingAttention,
-  selectOngoingJobs,
-} from "../../../_components/overview/overview-attention";
-import { OverviewHeroCard } from "../../../_components/overview/overview-hero-card";
 import { OverviewSectionHeader } from "../../../_components/overview/overview-section-header";
-import { OverviewSnapshotCard } from "../../../_components/overview/overview-snapshot-card";
-import {
-  formatRelativeTimestamp,
-  providerLabel,
-  summarizeLocaleReadiness,
-} from "../../../_components/workspace-files-shared";
-import {
-  countReadyLocales,
-  resolveFileLocaleReadiness,
-} from "@/lib/projects/files/native-locale-readiness";
-import type { Tone } from "../../../_components/workspace-resource-shared";
 import { CreateJobDialog } from "../../../jobs/_components/create-job-dialog";
-import { getJobStatusMessage } from "../../../jobs/_components/jobs-page-view.messages";
-import { getJobName, jobTone, type ApiJob } from "../../../jobs/_components/jobs-page-view";
+import { getJobName, type ApiJob } from "../../../jobs/_components/jobs-page-view";
 import type { ProjectListRow } from "../../_components/project-list";
+import { ProjectOverviewMeshStage } from "./project-overview-mesh-stage";
 import { projectOverviewPageContentMessages as messages } from "./project-overview-page-content.messages";
 import { ProjectPageShell, useProjectPageQuery } from "./project-page-shell";
-import { useProjectOpenJobCountQuery } from "./use-project-open-job-count";
 import { useProjectOverviewJobsQuery } from "./use-project-overview-jobs";
+import {
+  buildProjectOverviewTriageItems,
+  formatProjectLocaleRoute,
+  projectOverviewMeshTone,
+  type ProjectOverviewTriageItem,
+} from "./project-overview-view-model";
 
 function buildProjectJobHref(organizationSlug: string, projectId: string, jobId: string) {
   return `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(jobId)}`;
 }
 
-function buildProjectFileHref(organizationSlug: string, projectId: string, sourcePath: string) {
-  const base = buildProjectPath(organizationSlug, projectId, "files");
-  const params = new URLSearchParams({ sourcePath });
-  return `${base}?${params.toString()}`;
-}
-
-function formatLocaleRoute(sourceLocale: string | null, targetLocales: readonly string[]) {
-  const source = sourceLocale ?? "—";
-  if (targetLocales.length === 0) {
-    return source;
+function resolveTriageCopy(
+  item: ProjectOverviewTriageItem,
+  intl: ReturnType<typeof useIntl>,
+): { title: string; description: string; cta: string } {
+  switch (item.kind) {
+    case "review":
+      return {
+        title: getJobName(item.job!, intl),
+        description: intl.formatMessage(messages.triageReviewTitle),
+        cta: intl.formatMessage(messages.reviewCta),
+      };
+    case "failed":
+      return {
+        title: getJobName(item.job!, intl),
+        description: intl.formatMessage(messages.triageFailedTitle),
+        cta: intl.formatMessage(messages.openJobCta),
+      };
+    case "job":
+      return {
+        title: getJobName(item.job!, intl),
+        description: intl.formatMessage(messages.triageJobRunning),
+        cta: intl.formatMessage(messages.openJobCta),
+      };
+    case "guidance":
+      return {
+        title: intl.formatMessage(messages.triageGuidanceTitle),
+        description: intl.formatMessage(messages.triageGuidanceDescription),
+        cta: intl.formatMessage(messages.addGuidanceCta),
+      };
+    default: {
+      const _exhaustive: never = item.kind;
+      return _exhaustive;
+    }
   }
-
-  const preview = targetLocales.slice(0, 3).join(", ");
-  const suffix = targetLocales.length > 3 ? ` +${targetLocales.length - 3}` : "";
-  return `${source} → ${preview}${suffix}`;
 }
 
-function buildHeroCopy(
-  intl: IntlShape,
-  filesNeedingAttention: number,
-  pendingCount: number,
-  openJobCount: number,
-) {
-  if (pendingCount === 0) {
-    return {
-      title: intl.formatMessage(messages.caughtUpHeroTitle),
-      description: intl.formatMessage(messages.caughtUpHeroDescription),
-      ctaLabel: intl.formatMessage(messages.browseFilesCta),
-      ctaHref: "files",
-    };
-  }
-
-  const parts: string[] = [];
-  if (openJobCount > 0) {
-    parts.push(intl.formatMessage(messages.openJobsDetail, { count: openJobCount }));
-  }
-  if (filesNeedingAttention > 0) {
-    parts.push(
-      intl.formatMessage(messages.filesNeedingAttentionDetail, {
-        count: filesNeedingAttention,
-      }),
-    );
-  }
-
-  return {
-    title: intl.formatMessage(messages.attentionHeroTitle),
-    description: intl.formatMessage(messages.attentionHeroDescription, {
-      details: parts.join(", "),
-    }),
-    ctaLabel: intl.formatMessage(messages.pickUpWhereYouLeftOffCta),
-    ctaHref: "jobs",
-  };
-}
-
-function formatJobStatusLine(intl: IntlShape, job: ApiJob) {
-  return intl.formatMessage(messages.jobStatusUpdated, {
-    status: intl.formatMessage(getJobStatusMessage(job.status)),
-    updated: formatRelativeTimestamp(job.updatedAt),
-  });
-}
-
-function formatFileStatusLine(intl: IntlShape, file: ProjectFileRecord) {
-  const readiness = resolveFileLocaleReadiness(file);
-  const summary = summarizeLocaleReadiness(readiness, intl);
-  return summary ?? intl.formatMessage(messages.needsAttention);
-}
-
-function fileStatusTone(file: ProjectFileRecord): Tone {
-  const readiness = resolveFileLocaleReadiness(file);
-  const hasMissing = Object.values(readiness).some(
-    (value) => value === "missing" || value === "stale" || value === "changed",
+function TriageRow({
+  href,
+  title,
+  description,
+  cta,
+}: {
+  href: string;
+  title: string;
+  description: string;
+  cta: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className="group flex items-center justify-between gap-4 rounded-xl border border-border/70 bg-background/70 px-4 py-3 transition-colors hover:border-border hover:bg-background/90"
+    >
+      <div className="min-w-0">
+        <TypographyP className="truncate text-sm font-medium text-foreground">{title}</TypographyP>
+        <TypographyP className="mt-0.5 text-xs text-muted-foreground">{description}</TypographyP>
+      </div>
+      <span className="inline-flex shrink-0 items-center gap-1 text-sm font-medium text-foreground">
+        {cta}
+        <HugeiconsIcon
+          icon={ArrowRight01Icon}
+          strokeWidth={1.8}
+          className="size-4 transition-transform group-hover:translate-x-0.5"
+        />
+      </span>
+    </Link>
   );
-  if (hasMissing) {
-    return "watch";
-  }
-  return "info";
-}
-
-function countReadyToPullFiles(files: readonly ProjectFileRecord[], targetLocaleCount: number) {
-  if (targetLocaleCount === 0) {
-    return 0;
-  }
-
-  return files.filter((file) => {
-    const readiness = resolveFileLocaleReadiness(file);
-    return countReadyLocales(readiness) > 0;
-  }).length;
 }
 
 export type ProjectOverviewPageContentViewProps = {
@@ -161,15 +118,9 @@ export type ProjectOverviewPageContentViewProps = {
   project: ProjectListRow | null;
   isProjectLoading: boolean;
   isProjectError: boolean;
-  openJobCount: number;
-  isOpenJobCountLoading: boolean;
-  isOpenJobCountError: boolean;
   jobs: readonly ApiJob[];
   isJobsLoading: boolean;
   isJobsError: boolean;
-  files: readonly ProjectFileRecord[];
-  isFilesLoading: boolean;
-  isFilesError: boolean;
   onCreateJob?: () => void;
 };
 
@@ -179,62 +130,37 @@ export function ProjectOverviewPageContentView({
   project,
   isProjectLoading,
   isProjectError,
-  openJobCount,
-  isOpenJobCountLoading,
-  isOpenJobCountError,
   jobs,
   isJobsLoading,
   isJobsError,
-  files,
-  isFilesLoading,
-  isFilesError,
   onCreateJob,
 }: ProjectOverviewPageContentViewProps) {
   const intl = useIntl();
-  const filesNeedingAttention = countFilesNeedingAttention(files);
-  const pendingCount = project ? computeProjectPendingActionCount({ openJobCount }, files) : 0;
-  const ongoingJobs = selectOngoingJobs(jobs);
-  const attentionFiles = selectFilesNeedingAttention(files);
-  const ongoingCount = ongoingJobs.length + attentionFiles.length;
-  const readyToPullCount = project ? countReadyToPullFiles(files, project.targetLocales.length) : 0;
+  const isNative = project?.source === "native";
+  const hasTranslationGuidance = Boolean(project?.translationContextValue?.trim());
   const showViewStrings = supportsCatAllFilesProvider(
     parseProviderProjectId(projectId)?.providerKind,
   );
 
-  const heroCopy = project
-    ? buildHeroCopy(intl, filesNeedingAttention, pendingCount, openJobCount)
-    : null;
+  const triageItems = project
+    ? buildProjectOverviewTriageItems({
+        jobs,
+        isNative: isNative ?? false,
+        hasTranslationGuidance,
+      })
+    : [];
+  const meshTone = projectOverviewMeshTone(triageItems.length);
 
   const projectDescription =
-    project?.descriptionValue ||
-    project?.translationContextValue ||
-    intl.formatMessage(messages.defaultProjectDescription);
+    project?.descriptionValue || intl.formatMessage(messages.defaultProjectDescription);
 
-  const snapshotRows = project
-    ? [
-        {
-          label: intl.formatMessage(messages.snapshotLocales),
-          value: formatLocaleRoute(project.sourceLocale, project.targetLocales),
-        },
-        {
-          label: intl.formatMessage(messages.snapshotSource),
-          value:
-            project.source === "external_tms" && project.externalProviderKind
-              ? providerLabel(project.externalProviderKind)
-              : intl.formatMessage(messages.nativeProjectSource),
-        },
-        {
-          label: intl.formatMessage(messages.snapshotOpenJobs),
-          value: isOpenJobCountLoading
-            ? "…"
-            : isOpenJobCountError
-              ? intl.formatMessage(messages.openJobsUnavailable)
-              : String(openJobCount),
-        },
-      ]
-    : [];
-
+  const settingsHref = buildProjectPath(organizationSlug, projectId, "settings");
+  const filesHref = buildProjectPath(organizationSlug, projectId, "files");
+  const jobsHref = buildProjectPath(organizationSlug, projectId, "jobs");
   const showHeaderActions = Boolean(project) && !isProjectLoading && !isProjectError;
+  const localeRoute = project
+    ? formatProjectLocaleRoute(project.sourceLocale, project.targetLocales)
+    : "";
 
   return (
     <ProjectPageShell className="gap-8">
@@ -279,6 +205,14 @@ export function ProjectOverviewPageContentView({
                 <FormattedMessage {...messages.viewStrings} />
               </Button>
             ) : null}
+            <Button
+              nativeButton={false}
+              render={<Link href={filesHref} />}
+              size="sm"
+              variant="outline"
+            >
+              <FormattedMessage {...messages.viewFiles} />
+            </Button>
             <Button type="button" size="sm" onClick={onCreateJob}>
               <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
               <FormattedMessage {...messages.createJob} />
@@ -287,169 +221,179 @@ export function ProjectOverviewPageContentView({
         ) : null}
       </header>
 
-      <section className="grid gap-4 lg:grid-cols-3">
-        {isProjectLoading ? (
-          <>
-            <Skeleton className="min-h-52 rounded-2xl lg:col-span-2" />
-            <Skeleton className="min-h-52 rounded-2xl" />
-          </>
-        ) : project && heroCopy ? (
-          <>
-            <OverviewHeroCard
-              className="lg:col-span-2"
-              pendingCount={pendingCount}
-              title={heroCopy.title}
-              description={heroCopy.description}
-              ctaLabel={heroCopy.ctaLabel}
-              ctaHref={buildProjectPath(organizationSlug, projectId, heroCopy.ctaHref)}
-            />
-            <OverviewSnapshotCard
-              title={intl.formatMessage(messages.snapshotTitle)}
-              rows={snapshotRows}
-              ctaLabel={intl.formatMessage(messages.viewSettings)}
-              ctaHref={buildProjectPath(organizationSlug, projectId, "settings")}
-            />
-          </>
-        ) : null}
-      </section>
-
-      <section className="space-y-4">
-        <OverviewSectionHeader
-          title={intl.formatMessage(messages.ongoingSection)}
-          count={ongoingCount}
-        />
-
-        <div className="grid gap-4 md:grid-cols-2">
-          {isJobsLoading || isFilesLoading ? (
-            <>
-              <Skeleton className="min-h-44 rounded-2xl" />
-              <Skeleton className="min-h-44 rounded-2xl" />
-            </>
-          ) : (
-            <>
-              {ongoingJobs.length > 0 ? (
-                ongoingJobs.map((job) => (
-                  <OverviewActionCard
-                    key={job.id}
-                    category={intl.formatMessage(messages.categoryJob)}
-                    title={getJobName(job)}
-                    statusLine={formatJobStatusLine(intl, job)}
-                    statusTone={jobTone(job.status)}
-                    viewHref={buildProjectJobHref(organizationSlug, projectId, job.id)}
-                  />
-                ))
-              ) : (
-                <Card className="rounded-2xl border border-dashed border-border bg-muted py-0 ring-0">
-                  <CardContent className="flex h-full flex-col justify-between gap-4 px-5 py-5">
-                    <div>
-                      <TypographyP className="text-sm font-medium text-foreground">
-                        {isJobsError ? (
-                          <FormattedMessage {...messages.jobsUnavailable} />
-                        ) : (
-                          <FormattedMessage {...messages.noActiveJobs} />
-                        )}
-                      </TypographyP>
-                      <TypographyP className="mt-1 text-sm text-muted-foreground">
-                        {isJobsError ? (
-                          <FormattedMessage {...messages.jobsUnavailableDescription} />
-                        ) : (
-                          <FormattedMessage {...messages.noActiveJobsDescription} />
-                        )}
-                      </TypographyP>
-                    </div>
-                    <Button
-                      nativeButton={false}
-                      render={<Link href={buildProjectPath(organizationSlug, projectId, "jobs")} />}
-                      variant="outline"
-                      size="sm"
-                      className="w-fit rounded-full"
-                    >
-                      <FormattedMessage {...messages.viewJobs} />
-                    </Button>
-                  </CardContent>
-                </Card>
-              )}
-
-              {attentionFiles.length > 0 ? (
-                attentionFiles.map((file) => (
-                  <OverviewActionCard
-                    key={file.sourcePath}
-                    category={intl.formatMessage(messages.categoryFile)}
-                    title={file.filename}
-                    statusLine={formatFileStatusLine(intl, file)}
-                    statusTone={fileStatusTone(file)}
-                    viewHref={buildProjectFileHref(organizationSlug, projectId, file.sourcePath)}
-                  />
-                ))
-              ) : (
-                <Card className="rounded-2xl border border-dashed border-border bg-muted py-0 ring-0">
-                  <CardContent className="flex h-full flex-col justify-between gap-4 px-5 py-5">
-                    <div>
-                      <TypographyP className="text-sm font-medium text-foreground">
-                        {isFilesError ? (
-                          <FormattedMessage {...messages.filesUnavailable} />
-                        ) : (
-                          <FormattedMessage {...messages.noFilesNeedAttention} />
-                        )}
-                      </TypographyP>
-                      <TypographyP className="mt-1 text-sm text-muted-foreground">
-                        {isFilesError ? (
-                          <FormattedMessage {...messages.filesUnavailableDescription} />
-                        ) : (
-                          <FormattedMessage {...messages.noFilesNeedAttentionDescription} />
-                        )}
-                      </TypographyP>
-                    </div>
-                    <Button
-                      nativeButton={false}
-                      render={
-                        <Link href={buildProjectPath(organizationSlug, projectId, "files")} />
-                      }
-                      variant="outline"
-                      size="sm"
-                      className="w-fit rounded-full"
-                    >
-                      <FormattedMessage {...messages.viewFiles} />
-                    </Button>
-                  </CardContent>
-                </Card>
-              )}
-            </>
-          )}
-        </div>
-      </section>
-
-      {project && project.source === "native" && readyToPullCount > 0 ? (
-        <Card className="rounded-2xl border border-border bg-muted py-0 ring-0">
-          <CardContent className="flex flex-col gap-3 px-5 py-5 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <TypographyP className="text-sm font-medium text-foreground">
-                <FormattedMessage {...messages.readyToPullTitle} />
+      {isProjectLoading || isJobsLoading ? (
+        <Skeleton className="min-h-56 rounded-2xl" />
+      ) : project ? (
+        <ProjectOverviewMeshStage tone={meshTone}>
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-wrap items-baseline justify-between gap-2">
+              <TypographyP className="font-heading text-xl font-medium text-foreground">
+                <FormattedMessage {...messages.needsYouNowTitle} />
               </TypographyP>
-              <TypographyP className="mt-1 text-sm text-muted-foreground">
-                <FormattedMessage
-                  {...messages.readyToPullDescription}
-                  values={{
-                    count: readyToPullCount,
-                    code: (chunks: ReactNode) => (
-                      <span className="font-mono text-foreground">{chunks}</span>
-                    ),
-                  }}
-                />
-              </TypographyP>
+              {triageItems.length > 0 ? (
+                <TypographyP className="text-sm text-muted-foreground">
+                  <FormattedMessage
+                    {...messages.needsYouNowCount}
+                    values={{ count: triageItems.length }}
+                  />
+                </TypographyP>
+              ) : null}
             </div>
+
+            {isJobsError ? (
+              <div className="rounded-xl border border-dashed border-border bg-background/60 px-4 py-4">
+                <TypographyP className="text-sm font-medium text-foreground">
+                  <FormattedMessage {...messages.jobsUnavailable} />
+                </TypographyP>
+                <TypographyP className="mt-1 text-sm text-muted-foreground">
+                  <FormattedMessage {...messages.jobsUnavailableDescription} />
+                </TypographyP>
+                <Button
+                  nativeButton={false}
+                  render={<Link href={jobsHref} />}
+                  variant="outline"
+                  size="sm"
+                  className="mt-3 w-fit"
+                >
+                  <FormattedMessage {...messages.viewJobs} />
+                </Button>
+              </div>
+            ) : triageItems.length > 0 ? (
+              <div className="flex flex-col gap-2">
+                {triageItems.map((item) => {
+                  const copy = resolveTriageCopy(item, intl);
+                  const href =
+                    item.kind === "guidance"
+                      ? settingsHref
+                      : item.job
+                        ? buildProjectJobHref(organizationSlug, projectId, item.job.id)
+                        : jobsHref;
+
+                  return (
+                    <TriageRow
+                      key={item.id}
+                      href={href}
+                      title={copy.title}
+                      description={copy.description}
+                      cta={copy.cta}
+                    />
+                  );
+                })}
+                <div className="pt-1">
+                  <Button
+                    nativeButton={false}
+                    render={<Link href={jobsHref} />}
+                    variant="ghost"
+                    size="sm"
+                    className="w-fit px-0"
+                  >
+                    <FormattedMessage {...messages.viewAllJobs} />
+                    <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={1.8} />
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <TypographyP className="text-sm font-medium text-foreground">
+                  <FormattedMessage {...messages.triageEmptyTitle} />
+                </TypographyP>
+                <TypographyP className="text-sm text-muted-foreground">
+                  <FormattedMessage {...messages.triageEmptyDescription} />
+                </TypographyP>
+              </div>
+            )}
+          </div>
+        </ProjectOverviewMeshStage>
+      ) : null}
+
+      {project && !isProjectLoading ? (
+        <section className="space-y-4">
+          <OverviewSectionHeader title={intl.formatMessage(messages.signalsTitle)} />
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="rounded-2xl border border-border px-5 py-4">
+              <TypographyP className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                <FormattedMessage {...messages.signalsLocales} />
+              </TypographyP>
+              <TypographyP className="mt-2 font-mono text-sm text-foreground">
+                {project.targetLocales.length > 0 ? (
+                  localeRoute
+                ) : (
+                  <FormattedMessage {...messages.signalsNoLocales} />
+                )}
+              </TypographyP>
+              {project.targetLocales.length === 0 ? (
+                <Button
+                  nativeButton={false}
+                  render={<Link href={settingsHref} />}
+                  variant="ghost"
+                  size="sm"
+                  className="mt-2 px-0"
+                >
+                  <FormattedMessage {...messages.viewSettings} />
+                </Button>
+              ) : null}
+            </div>
+
+            {isNative ? (
+              <div className="rounded-2xl border border-border px-5 py-4">
+                <TypographyP className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                  <FormattedMessage {...messages.shipTitle} />
+                </TypographyP>
+                <TypographyP className="mt-2 text-sm text-foreground">
+                  {project.lastSyncedAt ? (
+                    <FormattedMessage
+                      {...messages.shipLastSynced}
+                      values={{ when: project.lastSyncedAt }}
+                    />
+                  ) : (
+                    <FormattedMessage {...messages.shipNeverSynced} />
+                  )}
+                </TypographyP>
+                <TypographyP className="mt-1 text-sm text-muted-foreground">
+                  <FormattedMessage
+                    {...messages.shipCliHint}
+                    values={{
+                      code: (chunks: ReactNode) => (
+                        <span className="font-mono text-foreground">{chunks}</span>
+                      ),
+                    }}
+                  />
+                </TypographyP>
+                <Button
+                  nativeButton={false}
+                  render={<Link href={settingsHref} />}
+                  variant="ghost"
+                  size="sm"
+                  className="mt-2 px-0"
+                >
+                  <FormattedMessage {...messages.shipConnectCli} />
+                </Button>
+              </div>
+            ) : null}
+          </div>
+        </section>
+      ) : null}
+
+      {isNative && hasTranslationGuidance ? (
+        <section className="space-y-3 rounded-2xl border border-border bg-muted/30 px-5 py-5">
+          <div className="flex items-center justify-between gap-3">
+            <TypographyP className="text-sm font-medium text-foreground">
+              <FormattedMessage {...messages.guidanceTitle} />
+            </TypographyP>
             <Button
               nativeButton={false}
-              render={<Link href={buildProjectPath(organizationSlug, projectId, "files")} />}
-              variant="outline"
+              render={<Link href={settingsHref} />}
+              variant="ghost"
               size="sm"
-              className="w-fit rounded-full"
+              className="shrink-0"
             >
-              <HugeiconsIcon icon={File01Icon} strokeWidth={1.8} />
-              <FormattedMessage {...messages.openFiles} />
+              <FormattedMessage {...messages.guidanceEdit} />
             </Button>
-          </CardContent>
-        </Card>
+          </div>
+          <TypographyP className="line-clamp-3 whitespace-pre-wrap text-sm leading-6 text-muted-foreground">
+            {project?.translationContextValue}
+          </TypographyP>
+        </section>
       ) : null}
     </ProjectPageShell>
   );
@@ -462,40 +406,10 @@ export function ProjectOverviewPageContent({
   organizationSlug: string;
   projectId: string;
 }) {
-  const intl = useIntl();
   const [createJobOpen, setCreateJobOpen] = useState(false);
   const projectQuery = useProjectPageQuery(organizationSlug, projectId);
-  const isLiveTmsProject = Boolean(parseProviderProjectId(projectId));
-  const openJobCountQuery = useProjectOpenJobCountQuery(organizationSlug, projectId, {
-    enabled: projectQuery.isSuccess,
-  });
   const jobsQuery = useProjectOverviewJobsQuery(organizationSlug, projectId, {
     enabled: projectQuery.isSuccess,
-  });
-
-  const filesQuery = useQuery({
-    queryKey: ["project-overview-files", organizationSlug, projectId],
-    enabled: projectQuery.isSuccess && !isLiveTmsProject,
-    queryFn: async () => {
-      const response = await apiClient.api.orgs[":organizationSlug"].projects[
-        ":projectId"
-      ].files.$get({
-        param: { organizationSlug, projectId },
-        query: { limit: "10" },
-      });
-      if (!response.ok) {
-        throw await readApiResponseError(
-          response,
-          intl.formatMessage(messages.loadProjectFilesFailed),
-        );
-      }
-      const { files } = await parseApiJsonResponse(
-        response,
-        projectFilesResponseSchema,
-        intl.formatMessage(messages.invalidProjectFilesResponse),
-      );
-      return files;
-    },
   });
 
   const sourceLocale = projectQuery.data?.sourceLocale?.trim() || "en";
@@ -509,15 +423,9 @@ export function ProjectOverviewPageContent({
         project={projectQuery.data ?? null}
         isProjectLoading={projectQuery.isLoading}
         isProjectError={projectQuery.isError}
-        openJobCount={openJobCountQuery.data ?? 0}
-        isOpenJobCountLoading={openJobCountQuery.isLoading}
-        isOpenJobCountError={openJobCountQuery.isError}
         jobs={jobsQuery.data ?? []}
         isJobsLoading={jobsQuery.isLoading}
         isJobsError={jobsQuery.isError}
-        files={filesQuery.data ?? []}
-        isFilesLoading={filesQuery.isLoading}
-        isFilesError={filesQuery.isError}
         onCreateJob={() => setCreateJobOpen(true)}
       />
       <CreateJobDialog
@@ -528,7 +436,7 @@ export function ProjectOverviewPageContent({
         sourceLocale={sourceLocale}
         targetLocales={targetLocales}
         onCreated={async () => {
-          await Promise.all([jobsQuery.refetch(), openJobCountQuery.refetch()]);
+          await jobsQuery.refetch();
         }}
       />
     </>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-view-model.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import type { ApiJob } from "../../../jobs/_components/jobs-page-view";
+import {
+  buildProjectOverviewTriageItems,
+  formatProjectLocaleRoute,
+  projectOverviewMeshTone,
+} from "./project-overview-view-model";
+
+function job(partial: Partial<ApiJob> & Pick<ApiJob, "id" | "status">): ApiJob {
+  return {
+    projectId: "project_1",
+    createdByUserId: "user_1",
+    kind: "translation",
+    type: "file",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    completedAt: null,
+    workflowRunId: null,
+    lastError: null,
+    inputPayload: null,
+    outcomeKind: null,
+    outcomePayload: null,
+    reviewCriteria: null,
+    reviewTargetLocale: null,
+    syncConnectorKind: null,
+    syncDirection: null,
+    assetType: null,
+    assetOperation: null,
+    externalProviderKind: null,
+    externalTaskId: null,
+    externalStatus: null,
+    externalTitle: null,
+    externalDueDate: null,
+    externalTargetLocales: null,
+    externalAssignedUsers: null,
+    externalSyncState: null,
+    ...partial,
+  };
+}
+
+describe("buildProjectOverviewTriageItems", () => {
+  it("orders review, failed, missing guidance, then other jobs", () => {
+    const items = buildProjectOverviewTriageItems({
+      jobs: [
+        job({ id: "running", status: "running" }),
+        job({ id: "failed", status: "failed" }),
+        job({ id: "review", status: "waiting_for_review" }),
+      ],
+      isNative: true,
+      hasTranslationGuidance: false,
+      limit: 10,
+    });
+
+    expect(items.map((item) => item.kind)).toEqual(["review", "failed", "guidance", "job"]);
+  });
+
+  it("omits guidance when set or when the project is not native", () => {
+    expect(
+      buildProjectOverviewTriageItems({
+        jobs: [],
+        isNative: true,
+        hasTranslationGuidance: true,
+      }),
+    ).toEqual([]);
+
+    expect(
+      buildProjectOverviewTriageItems({
+        jobs: [],
+        isNative: false,
+        hasTranslationGuidance: false,
+      }),
+    ).toEqual([]);
+  });
+
+  it("does not include file-based triage items", () => {
+    const items = buildProjectOverviewTriageItems({
+      jobs: [job({ id: "review", status: "waiting_for_review" })],
+      isNative: true,
+      hasTranslationGuidance: true,
+    });
+
+    expect(items.every((item) => item.kind !== ("file" as string))).toBe(true);
+  });
+});
+
+describe("formatProjectLocaleRoute", () => {
+  it("formats source and target preview", () => {
+    expect(formatProjectLocaleRoute("en-US", ["fr-FR", "de-DE"])).toBe("en-US → fr-FR, de-DE");
+    expect(formatProjectLocaleRoute(null, [])).toBe("—");
+  });
+});
+
+describe("projectOverviewMeshTone", () => {
+  it("uses action tone when triage items exist", () => {
+    expect(projectOverviewMeshTone(2)).toBe("action");
+    expect(projectOverviewMeshTone(0)).toBe("calm");
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-view-model.test.ts
@@ -94,6 +94,59 @@ describe("buildProjectOverviewTriageItems", () => {
 
     expect(items.every((item) => item.kind !== ("file" as string))).toBe(true);
   });
+
+  it("keeps older review jobs ahead of newer in-progress work when capping", () => {
+    const items = buildProjectOverviewTriageItems({
+      jobs: [
+        job({
+          id: "running-new",
+          status: "running",
+          updatedAt: "2026-07-02T00:00:10.000Z",
+        }),
+        job({
+          id: "queued-new",
+          status: "queued",
+          updatedAt: "2026-07-02T00:00:09.000Z",
+        }),
+        job({
+          id: "running-2",
+          status: "running",
+          updatedAt: "2026-07-02T00:00:08.000Z",
+        }),
+        job({
+          id: "queued-2",
+          status: "queued",
+          updatedAt: "2026-07-02T00:00:07.000Z",
+        }),
+        job({
+          id: "running-3",
+          status: "running",
+          updatedAt: "2026-07-02T00:00:06.000Z",
+        }),
+        job({
+          id: "review-old",
+          status: "waiting_for_review",
+          updatedAt: "2026-07-01T00:00:00.000Z",
+        }),
+        job({
+          id: "failed-old",
+          status: "failed",
+          updatedAt: "2026-07-01T00:00:01.000Z",
+        }),
+      ],
+      isNative: true,
+      hasTranslationGuidance: true,
+      limit: 5,
+    });
+
+    expect(items.map((item) => item.job?.id)).toEqual([
+      "review-old",
+      "failed-old",
+      "running-new",
+      "queued-new",
+      "running-2",
+    ]);
+  });
 });
 
 describe("formatProjectLocaleRoute", () => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-view-model.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-view-model.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ApiJob } from "../../../jobs/_components/jobs-page-view";
+
+export const PROJECT_OVERVIEW_TRIAGE_LIMIT = 5;
+
+export type ProjectOverviewTriageKind = "review" | "failed" | "guidance" | "job";
+
+export type ProjectOverviewTriageItem = {
+  id: string;
+  kind: ProjectOverviewTriageKind;
+  job?: ApiJob;
+};
+
+function triageRank(kind: ProjectOverviewTriageKind) {
+  switch (kind) {
+    case "review":
+      return 0;
+    case "failed":
+      return 1;
+    case "guidance":
+      return 2;
+    case "job":
+      return 3;
+    default: {
+      const _exhaustive: never = kind;
+      return _exhaustive;
+    }
+  }
+}
+
+export function buildProjectOverviewTriageItems(input: {
+  jobs: readonly ApiJob[];
+  isNative: boolean;
+  hasTranslationGuidance: boolean;
+  limit?: number;
+}): ProjectOverviewTriageItem[] {
+  const limit = input.limit ?? PROJECT_OVERVIEW_TRIAGE_LIMIT;
+  const items: ProjectOverviewTriageItem[] = [];
+
+  const reviewJobs = input.jobs.filter((job) => job.status === "waiting_for_review");
+  const failedJobs = input.jobs.filter((job) => job.status === "failed");
+  const otherJobs = input.jobs.filter((job) => job.status === "queued" || job.status === "running");
+
+  for (const job of reviewJobs) {
+    items.push({
+      id: `review:${job.id}`,
+      kind: "review",
+      job,
+    });
+  }
+
+  for (const job of failedJobs) {
+    items.push({
+      id: `failed:${job.id}`,
+      kind: "failed",
+      job,
+    });
+  }
+
+  if (input.isNative && !input.hasTranslationGuidance) {
+    items.push({
+      id: "guidance:missing",
+      kind: "guidance",
+    });
+  }
+
+  for (const job of otherJobs) {
+    items.push({
+      id: `job:${job.id}`,
+      kind: "job",
+      job,
+    });
+  }
+
+  return items
+    .toSorted((left, right) => triageRank(left.kind) - triageRank(right.kind))
+    .slice(0, limit);
+}
+
+export function formatProjectLocaleRoute(
+  sourceLocale: string | null,
+  targetLocales: readonly string[],
+) {
+  const source = sourceLocale?.trim() || "—";
+  if (targetLocales.length === 0) {
+    return source;
+  }
+
+  const preview = targetLocales.slice(0, 4).join(", ");
+  const suffix = targetLocales.length > 4 ? ` +${targetLocales.length - 4}` : "";
+  return `${source} → ${preview}${suffix}`;
+}
+
+export function projectOverviewMeshTone(triageCount: number): "action" | "calm" {
+  return triageCount > 0 ? "action" : "calm";
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview.fixture.ts
@@ -10,8 +10,6 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
-
 import type { ApiJob } from "../../../jobs/_components/jobs-page-view";
 import type { ProjectListRow } from "../../_components/project-list";
 
@@ -25,23 +23,39 @@ export const projectOverviewFixture: ProjectListRow = {
   translationContextValue: "Friendly, concise marketing tone",
   created: "Jan 12, 2026, 9:30 AM",
   updated: "Mar 18, 2026, 2:15 PM",
-  source: "external_tms",
-  externalProviderKind: "crowdin",
-  externalProjectId: "42",
+  source: "native",
+  externalProviderKind: null,
+  externalProjectId: null,
   sourceLocale: "en-US",
   targetLocales: ["fr-FR", "de-DE", "es-ES"],
-  externalProjectUrl: "https://crowdin.com/project/website",
+  externalProjectUrl: null,
   isActive: true,
   logoUrl: null,
   lastActivityAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
-  lastSyncedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+  lastSyncedAt: "Mar 18, 2026, 1:00 PM",
   lastSyncErrorAt: null,
   lastSyncErrorMessage: null,
   openJobCount: 2,
 };
 
+export const projectOverviewTmsFixture: ProjectListRow = {
+  ...projectOverviewFixture,
+  source: "external_tms",
+  externalProviderKind: "crowdin",
+  externalProjectId: "42",
+  externalProjectUrl: "https://crowdin.com/project/website",
+  lastSyncedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+};
+
 export const projectOverviewCaughtUpFixture: ProjectListRow = {
   ...projectOverviewFixture,
+  openJobCount: 0,
+};
+
+export const projectOverviewMissingGuidanceFixture: ProjectListRow = {
+  ...projectOverviewFixture,
+  translationContext: "No translation context",
+  translationContextValue: "",
   openJobCount: 0,
 };
 
@@ -58,7 +72,7 @@ export const projectOverviewJobsFixture: ApiJob[] = [
     completedAt: null,
     workflowRunId: null,
     lastError: null,
-    inputPayload: { sourceFileId: "marketing/home.json" },
+    inputPayload: { sourceFileId: "marketing/home.json", metadata: { title: "Home page" } },
     outcomeKind: null,
     outcomePayload: null,
     reviewCriteria: null,
@@ -105,52 +119,5 @@ export const projectOverviewJobsFixture: ApiJob[] = [
     externalTargetLocales: null,
     externalAssignedUsers: null,
     externalSyncState: null,
-  },
-];
-
-export const projectOverviewFilesFixture: ProjectFileRecord[] = [
-  {
-    origin: "provider",
-    sourcePath: "marketing/home.json",
-    sourceHash: null,
-    commitSha: null,
-    workflowRunId: null,
-    uploadedAt: new Date().toISOString(),
-    storedFileId: null,
-    metadata: {},
-    filename: "home.json",
-    byteSize: 2048,
-    provider: {
-      kind: "crowdin",
-      resourceType: "file",
-      externalProjectId: "42",
-      externalResourceId: "101",
-      externalUrl: null,
-      syncState: "changed",
-      sourceLocale: "en-US",
-      targetLocales: ["fr-FR", "de-DE"],
-      localeReadiness: {
-        "fr-FR": "missing",
-        "de-DE": "ready",
-      },
-      revision: null,
-      format: "json",
-      lastSyncedAt: new Date().toISOString(),
-    },
-    latestJob: null,
-  },
-  {
-    origin: "repository",
-    sourcePath: "marketing/pricing.json",
-    sourceHash: "abc123",
-    commitSha: "deadbeef",
-    workflowRunId: null,
-    uploadedAt: new Date().toISOString(),
-    storedFileId: "file_1",
-    metadata: {},
-    filename: "pricing.json",
-    byteSize: 1024,
-    provider: null,
-    latestJob: null,
   },
 ];

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/use-project-overview-jobs.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/use-project-overview-jobs.ts
@@ -17,11 +17,13 @@ import { useQuery } from "@tanstack/react-query";
 import {
   fetchNativeProjectJobs,
   fetchTmsProjectJobs,
-  filterOpenProjectJobs,
+  selectOverviewTriageProjectJobs,
 } from "@/lib/projects/jobs/fetch-project-jobs";
 import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 
 import type { ApiJob } from "../../../jobs/_components/jobs-page-view";
+
+import { PROJECT_OVERVIEW_TRIAGE_LIMIT } from "./project-overview-view-model";
 
 export function useProjectOverviewJobsQuery(
   organizationSlug: string,
@@ -44,12 +46,14 @@ export function useProjectOverviewJobsQuery(
           organizationSlug,
           parsedProviderProject.externalProjectId,
         );
-        return filterOpenProjectJobs(jobs).slice(0, 5) as ApiJob[];
+        return selectOverviewTriageProjectJobs(jobs, PROJECT_OVERVIEW_TRIAGE_LIMIT) as ApiJob[];
       }
 
+      // Server orders by triage priority before applying the cap so older
+      // waiting_for_review / failed jobs are not displaced by newer queued work.
       return (await fetchNativeProjectJobs(organizationSlug, projectId, {
-        open: true,
-        limit: 5,
+        triage: true,
+        limit: PROJECT_OVERVIEW_TRIAGE_LIMIT,
       })) as ApiJob[];
     },
   });

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/fetch-project-jobs.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/fetch-project-jobs.test.ts
@@ -50,6 +50,8 @@ import {
   fetchNativeProjectJobs,
   fetchTmsProjectJobs,
   filterOpenProjectJobs,
+  filterOverviewTriageProjectJobs,
+  selectOverviewTriageProjectJobs,
 } from "./fetch-project-jobs";
 
 function jsonResponse(body: unknown, status = 200) {
@@ -126,6 +128,23 @@ describe("fetchProjectJobs", () => {
     });
   });
 
+  it("loads native project jobs with the triage filter and limit", async () => {
+    const jobs = [
+      createJob({ id: "job_review", status: "waiting_for_review" }),
+      createJob({ id: "job_failed", status: "failed" }),
+    ];
+    nativeJobsGetMock.mockResolvedValue(jsonResponse({ jobs }));
+
+    await expect(
+      fetchNativeProjectJobs("acme", "project_1", { triage: true, limit: 5 }),
+    ).resolves.toEqual(jobs);
+
+    expect(nativeJobsGetMock).toHaveBeenCalledWith({
+      param: { organizationSlug: "acme", projectId: "project_1" },
+      query: { limit: "5", triage: true },
+    });
+  });
+
   it("loads TMS project jobs using the external project id and mine query", async () => {
     const jobs = [
       {
@@ -160,6 +179,49 @@ describe("fetchProjectJobs", () => {
       "queued",
       "running",
       "waiting",
+    ]);
+  });
+
+  it("keeps failed jobs in the Overview triage candidate set", () => {
+    const jobs = [
+      { id: "queued", status: "queued", updatedAt: "2026-07-02T00:00:00.000Z" },
+      { id: "failed", status: "failed", updatedAt: "2026-07-02T00:00:04.000Z" },
+      { id: "succeeded", status: "succeeded", updatedAt: "2026-07-02T00:00:05.000Z" },
+      {
+        id: "waiting",
+        status: "waiting_for_review",
+        updatedAt: "2026-07-02T00:00:02.000Z",
+      },
+    ];
+
+    expect(filterOverviewTriageProjectJobs(jobs).map((job) => job.id)).toEqual([
+      "queued",
+      "failed",
+      "waiting",
+    ]);
+  });
+
+  it("applies the triage cap after review-priority selection", () => {
+    const jobs = [
+      { id: "running-new", status: "running", updatedAt: "2026-07-02T00:00:10.000Z" },
+      { id: "queued-new", status: "queued", updatedAt: "2026-07-02T00:00:09.000Z" },
+      { id: "running-2", status: "running", updatedAt: "2026-07-02T00:00:08.000Z" },
+      { id: "queued-2", status: "queued", updatedAt: "2026-07-02T00:00:07.000Z" },
+      { id: "running-3", status: "running", updatedAt: "2026-07-02T00:00:06.000Z" },
+      {
+        id: "review-old",
+        status: "waiting_for_review",
+        updatedAt: "2026-07-01T00:00:00.000Z",
+      },
+      { id: "failed-old", status: "failed", updatedAt: "2026-07-01T00:00:01.000Z" },
+    ];
+
+    expect(selectOverviewTriageProjectJobs(jobs, 5).map((job) => job.id)).toEqual([
+      "review-old",
+      "failed-old",
+      "running-new",
+      "queued-new",
+      "running-2",
     ]);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/fetch-project-jobs.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/fetch-project-jobs.ts
@@ -10,28 +10,48 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { jobsResponseSchema, openJobStatusValues } from "@/api/routes/project/job.schema";
+import {
+  jobsResponseSchema,
+  openJobStatusValues,
+  overviewTriageJobStatusValues,
+} from "@/api/routes/project/job.schema";
 import { parseApiJsonResponse, readApiResponseError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
 import { readTmsProviderListResponse } from "@/lib/providers/jobs/tms-provider-list-fetch";
 
 const openJobStatuses = new Set<string>(openJobStatusValues);
+const overviewTriageJobStatuses = new Set<string>(overviewTriageJobStatusValues);
 
 type ProjectJobRecord = {
+  id?: string;
   status: string;
   updatedAt: string;
 };
 
+function overviewTriageStatusRank(status: string) {
+  switch (status) {
+    case "waiting_for_review":
+      return 0;
+    case "failed":
+      return 1;
+    case "queued":
+    case "running":
+      return 2;
+    default:
+      return 3;
+  }
+}
+
 export async function fetchNativeProjectJobs(
   organizationSlug: string,
   projectId: string,
-  options?: { open?: boolean; limit?: number },
+  options?: { open?: boolean; triage?: boolean; limit?: number },
 ) {
   const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"].jobs.$get({
     param: { organizationSlug, projectId },
     query: {
       limit: String(options?.limit ?? 50),
-      ...(options?.open ? { open: true } : {}),
+      ...(options?.triage ? { triage: true } : options?.open ? { open: true } : {}),
     },
   });
 
@@ -65,4 +85,32 @@ export async function fetchTmsProjectJobs(
 
 export function filterOpenProjectJobs<T extends ProjectJobRecord>(jobs: readonly T[]): T[] {
   return jobs.filter((job) => openJobStatuses.has(job.status));
+}
+
+/** Keeps Overview triage-eligible statuses, including failed. */
+export function filterOverviewTriageProjectJobs<T extends ProjectJobRecord>(
+  jobs: readonly T[],
+): T[] {
+  return jobs.filter((job) => overviewTriageJobStatuses.has(job.status));
+}
+
+/**
+ * Filters to triage statuses, ranks review → failed → in-progress, then caps.
+ * Use before displaying the Overview Today queue (especially for TMS lists).
+ */
+export function selectOverviewTriageProjectJobs<T extends ProjectJobRecord>(
+  jobs: readonly T[],
+  limit: number,
+): T[] {
+  return filterOverviewTriageProjectJobs(jobs)
+    .toSorted((left, right) => {
+      const rankDiff =
+        overviewTriageStatusRank(left.status) - overviewTriageStatusRank(right.status);
+      if (rankDiff !== 0) {
+        return rankDiff;
+      }
+
+      return right.updatedAt.localeCompare(left.updatedAt);
+    })
+    .slice(0, limit);
 }

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/organization-job-query-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/organization-job-query-service.ts
@@ -10,15 +10,25 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { and, desc, eq, inArray, isNull, ne, or } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, ne, or, sql } from "drizzle-orm";
 
 import type { ApiAuthContext } from "@/api/auth/workos";
-import { openJobStatusValues } from "@/api/routes/project/job.schema";
+import {
+  openJobStatusValues,
+  overviewTriageJobStatusValues,
+} from "@/api/routes/project/job.schema";
 import { buildAccessibleJobsWhere, buildOrganizationJobsListWhere } from "@/api/auth/team-access";
 import { db, schema } from "@/lib/database";
 import { getCurrentUserProviderAssigneeCandidates } from "@/lib/providers/jobs/tms-provider-assignee-candidates";
 import { providerAssignedUsersMatch } from "@/lib/providers/jobs/tms-provider-assignee-match";
 import { ProjectServiceBase } from "@/lib/projects/project-service-base";
+
+/** Review first, then failed, then other triage-eligible statuses. */
+const overviewTriageStatusOrder = sql`CASE ${schema.jobs.status}
+  WHEN 'waiting_for_review' THEN 0
+  WHEN 'failed' THEN 1
+  ELSE 2
+END`;
 
 const jobWithProjectSelect = {
   id: schema.jobs.id,
@@ -68,6 +78,7 @@ type JobListQuery = {
   type?: "string" | "file";
   status?: "queued" | "running" | "succeeded" | "failed" | "waiting_for_review" | "cancelled";
   open?: boolean;
+  triage?: boolean;
   relationship?: "assigned" | "created";
   limit: number;
 };
@@ -77,6 +88,7 @@ function jobListFilters(input: {
   type?: JobListQuery["type"];
   status?: JobListQuery["status"];
   open?: JobListQuery["open"];
+  triage?: JobListQuery["triage"];
   relationship?: JobListQuery["relationship"];
   userId?: string;
   providerAssigneeCandidates?: string[];
@@ -91,7 +103,9 @@ function jobListFilters(input: {
     filters.push(eq(schema.translationJobDetails.type, input.type));
   }
 
-  if (input.open) {
+  if (input.triage) {
+    filters.push(inArray(schema.jobs.status, [...overviewTriageJobStatusValues]));
+  } else if (input.open) {
     filters.push(inArray(schema.jobs.status, [...openJobStatusValues]));
   } else if (input.status) {
     filters.push(eq(schema.jobs.status, input.status));
@@ -170,10 +184,15 @@ export class OrganizationJobQueryService extends ProjectServiceBase {
             type: query.type,
             status: query.status,
             open: query.open,
+            triage: query.triage,
           }),
         ),
       )
-      .orderBy(desc(schema.jobs.updatedAt))
+      .orderBy(
+        ...(query.triage
+          ? [asc(overviewTriageStatusOrder), desc(schema.jobs.updatedAt)]
+          : [desc(schema.jobs.updatedAt)]),
+      )
       .limit(query.limit);
 
     this.log.debug(
@@ -225,13 +244,18 @@ export class OrganizationJobQueryService extends ProjectServiceBase {
             type: query.type,
             status: query.status,
             open: query.open,
+            triage: query.triage,
             relationship: query.relationship,
             userId: auth.user.localUserId,
             providerAssigneeCandidates,
           }),
         ),
       )
-      .orderBy(desc(schema.jobs.updatedAt))
+      .orderBy(
+        ...(query.triage
+          ? [asc(overviewTriageStatusOrder), desc(schema.jobs.updatedAt)]
+          : [desc(schema.jobs.updatedAt)]),
+      )
       .limit(query.limit);
 
     this.log.debug(

--- a/docs/plans/2026-08-01-project-overview-release-control-design.md
+++ b/docs/plans/2026-08-01-project-overview-release-control-design.md
@@ -24,9 +24,13 @@ Coverage stays on **Files**. Workspace Overview stays unchanged.
 | Source | Used for |
 |--------|----------|
 | Project record | Name, description, locales, guidance, last sync |
-| Open jobs (capped ~5) | Triage queue |
+| Triage jobs (capped ~5) | Review / failed / in-progress queue |
 
 No files query. No open-job-count query (derive attention from the jobs list).
+
+Native Overview loads jobs with `triage=true` so the API includes `failed` and
+orders review → failed → queued/running before applying the cap. TMS lists are
+filtered and ranked the same way on the client.
 
 ## Triage priority
 
@@ -35,7 +39,7 @@ No files query. No open-job-count query (derive attention from the jobs list).
 3. Missing translation guidance (native only)
 4. Other open jobs (`queued` / `running`)
 
-Cap ~5. Link to Jobs for the rest.
+Cap ~5 after priority selection. Link to Jobs for the rest.
 
 ## Native vs TMS
 

--- a/docs/plans/2026-08-01-project-overview-release-control-design.md
+++ b/docs/plans/2026-08-01-project-overview-release-control-design.md
@@ -1,0 +1,59 @@
+# Project Overview as Today queue
+
+## Problem
+
+Project Overview was a soft attention hub that mostly mirrored Files and Jobs.
+A coverage-heavy redesign (locale health from file readiness) would force Overview
+to load large file lists — expensive for native projects and especially for live
+TMS providers that fetch the full provider file set before slicing.
+
+## Decision
+
+**Approach A — Today queue.** Overview is a job-first action surface. It does
+**not** load project files or compute locale readiness percentages.
+
+1. **Needs you now** (mesh status stage) — review-first job triage
+2. **Project signals** — locale labels (not %), guidance present/missing (native),
+   last sync (native)
+3. **Deep links** — Files, Jobs, Strings, Settings for heavier work
+
+Coverage stays on **Files**. Workspace Overview stays unchanged.
+
+## Data loaded
+
+| Source | Used for |
+|--------|----------|
+| Project record | Name, description, locales, guidance, last sync |
+| Open jobs (capped ~5) | Triage queue |
+
+No files query. No open-job-count query (derive attention from the jobs list).
+
+## Triage priority
+
+1. Jobs `waiting_for_review`
+2. Jobs `failed`
+3. Missing translation guidance (native only)
+4. Other open jobs (`queued` / `running`)
+
+Cap ~5. Link to Jobs for the rest.
+
+## Native vs TMS
+
+| Signal | Native | External TMS |
+|--------|--------|--------------|
+| Job triage | Yes | Yes |
+| Translation guidance | Yes (triage if missing; preview if set) | Hidden |
+| Last sync / CLI hint | Yes | Hidden |
+| Locale labels | Yes (source → targets, not health %) | Yes |
+
+## Mesh
+
+Contained status stage only. Action mesh when triage has items; calm mesh when
+clear. Soft scrim for contrast.
+
+## Out of scope
+
+- Locale health chips / file readiness on Overview
+- Ready-to-pull file counts (needs Files)
+- Overview summary API (Approach B — later if needed)
+- Aligning workspace `/dashboard`


### PR DESCRIPTION
## What changed

Rebuild Project Overview into a performant **Today queue** for localisation managers:

- Mesh **Needs you now** band: review → failed → missing guidance (native) → in-progress jobs
- Lightweight **Project** signals: locale labels (not readiness %), sync/last sync (native)
- Translation guidance preview when set (native only); hidden for live TMS
- Loads only the project record + capped open jobs — no files query / locale health aggregation
- Design note: `docs/plans/2026-08-01-project-overview-release-control-design.md`

Coverage stays on Files so Overview stays fast for native and external TMS projects.

## How to test

- [ ] Open a native project Overview with jobs waiting for review — triage rows and Review CTAs appear
- [ ] Clear jobs on a native project with guidance set — calm empty state; guidance preview + Sync signals show
- [ ] Native project with empty guidance — “Add translation guidance” triage item → Settings
- [ ] External TMS project — job triage + locale labels; no Sync / guidance bands
- [ ] Confirm Network tab: no project files list request on Overview
- [ ] `cd apps/hyperlocalise-web && vp test src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-view-model.test.ts`
- [ ] `cd apps/hyperlocalise-web && vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`vp test` for overview view-model, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)