### PR TITLE
fix(web): keep file-tree … menu content after translate dialog

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.test.tsx
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { useState } from "react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IntlProvider } from "react-intl";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+import { createProjectFileRecord } from "./project-files.fixture";
+import { ProjectFilesTree } from "./project-files-tree";
+
+async function openOptionsMenu(container: HTMLElement) {
+  const host = container.querySelector("file-tree-container");
+  expect(host).toBeTruthy();
+
+  const row = host?.shadowRoot?.querySelector(
+    '[data-item-path="marketing/pricing.json"]',
+  ) as HTMLElement | null;
+  expect(row).toBeTruthy();
+  await userEvent.hover(row!);
+
+  const trigger = host?.shadowRoot?.querySelector('[aria-label="Options"]') as HTMLElement | null;
+  expect(trigger).toBeTruthy();
+  await userEvent.click(trigger!);
+}
+
+/**
+ * Recreate the production failure mode: parent re-renders with a new `files`
+ * array identity (and opens a modal) after Translate with agent. Pierre's host
+ * effect used to drop React `renderContextMenu` wiring; the "..." trigger then
+ * stayed expanded with no menu content.
+ */
+function FilesPageWithChurningFiles() {
+  const [translateOpen, setTranslateOpen] = useState(false);
+  const [renderCount, setRenderCount] = useState(0);
+
+  const file = createProjectFileRecord({
+    sourcePath: "marketing/pricing.json",
+    storedFileId: "file_pricing",
+    provider: null,
+  });
+
+  return (
+    <>
+      <div style={{ width: 640, height: 480 }}>
+        <ProjectFilesTree
+          files={[file]}
+          selectedSourcePath={file.sourcePath}
+          onSelectFile={vi.fn()}
+          fileActions={{
+            organizationSlug: "acme",
+            projectId: "proj_1",
+            highlightLocale: null,
+            projectTargetLocales: ["fr"],
+            sourceLocale: "en",
+            onViewStrings: vi.fn(),
+            onTranslateFile: () => {
+              setRenderCount((count) => count + 1);
+              setTranslateOpen(true);
+            },
+            onImportFile: vi.fn(),
+            onDownloadFile: vi.fn(),
+          }}
+        />
+      </div>
+      <p data-testid="render-count">{renderCount}</p>
+      <Dialog open={translateOpen} onOpenChange={setTranslateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Translate with agent</DialogTitle>
+          </DialogHeader>
+          <DialogFooter>
+            <Button type="button" onClick={() => setTranslateOpen(false)}>
+              Cancel
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+describe("ProjectFilesTree context menu", () => {
+  it("shows Translate with agent in the row Options menu", async () => {
+    const file = createProjectFileRecord({
+      sourcePath: "marketing/pricing.json",
+      storedFileId: "file_pricing",
+      provider: null,
+    });
+
+    const { container } = render(
+      <IntlProvider locale="en" messages={{}}>
+        <div style={{ width: 640, height: 480 }}>
+          <ProjectFilesTree
+            files={[file]}
+            selectedSourcePath={file.sourcePath}
+            onSelectFile={vi.fn()}
+            fileActions={{
+              organizationSlug: "acme",
+              projectId: "proj_1",
+              highlightLocale: null,
+              projectTargetLocales: ["fr"],
+              sourceLocale: "en",
+              onViewStrings: vi.fn(),
+              onTranslateFile: vi.fn(),
+              onImportFile: vi.fn(),
+              onDownloadFile: vi.fn(),
+            }}
+          />
+        </div>
+      </IntlProvider>,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector("file-tree-container")).toBeTruthy();
+    });
+
+    await openOptionsMenu(container);
+
+    await waitFor(() => {
+      const menu = document.querySelector('[data-file-tree-context-menu-root="true"]');
+      expect(menu).toBeTruthy();
+      expect(menu?.textContent).toContain("Translate with agent");
+    });
+  });
+
+  it("keeps Options menu content after translate dialog open/close with files churn", async () => {
+    const { container } = render(
+      <IntlProvider locale="en" messages={{}}>
+        <FilesPageWithChurningFiles />
+      </IntlProvider>,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector("file-tree-container")).toBeTruthy();
+    });
+
+    await openOptionsMenu(container);
+    const firstMenu = await waitFor(() => {
+      const menu = document.querySelector('[data-file-tree-context-menu-root="true"]');
+      expect(menu).toBeTruthy();
+      return menu as HTMLElement;
+    });
+
+    await userEvent.click(within(firstMenu).getByRole("button", { name: "Translate with agent" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "Translate with agent" });
+    expect(screen.getByTestId("render-count")).toHaveTextContent("1");
+    await userEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Translate with agent" }),
+      ).not.toBeInTheDocument();
+    });
+
+    await openOptionsMenu(container);
+
+    await waitFor(() => {
+      const menu = document.querySelector('[data-file-tree-context-menu-root="true"]');
+      expect(menu).toBeTruthy();
+      expect(menu?.textContent).toContain("Translate with agent");
+      expect(menu?.textContent).toContain("Import translations");
+      expect(menu?.textContent).toContain("Download");
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
@@ -211,13 +211,13 @@ function ProjectFilesTreeView({
   contextMenuHandlersRef.current = {
     onOpen: (itemPath, context) => {
       if (!latestStateRef.current.fileActions) {
-        setActiveFileContextMenu(null);
+        context.close({ restoreFocus: false });
         return;
       }
 
       const file = latestStateRef.current.fileByPath.get(itemPath);
       if (!file) {
-        setActiveFileContextMenu(null);
+        context.close({ restoreFocus: false });
         return;
       }
 
@@ -229,13 +229,12 @@ function ProjectFilesTreeView({
   };
 
   useEffect(() => {
-    if (!fileActions) {
-      setActiveFileContextMenu(null);
+    if (!activeFileContextMenu) {
       return;
     }
 
-    if (activeFileContextMenu && !fileByPath.has(activeFileContextMenu.file.sourcePath)) {
-      setActiveFileContextMenu(null);
+    if (!fileActions || !fileByPath.has(activeFileContextMenu.file.sourcePath)) {
+      activeFileContextMenu.context.close({ restoreFocus: false });
     }
   }, [activeFileContextMenu, fileActions, fileByPath]);
 
@@ -293,7 +292,7 @@ function ProjectFilesTreeView({
             buttonVisibility: "when-needed",
             onOpen: (item, context) => {
               if (item.kind !== "file") {
-                contextMenuHandlersRef.current.onClose();
+                context.close({ restoreFocus: false });
                 return;
               }
               contextMenuHandlersRef.current.onOpen(item.path, context);
@@ -357,12 +356,15 @@ function ProjectFilesTreeView({
     return null;
   }
 
+  const activeMenuFile = activeFileContextMenu
+    ? (fileByPath.get(activeFileContextMenu.file.sourcePath) ?? null)
+    : null;
   const activeMenuCapabilities =
-    activeFileContextMenu && fileActions
+    activeMenuFile && fileActions
       ? buildProjectFileActionCapabilities({
           organizationSlug: fileActions.organizationSlug,
           projectId: fileActions.projectId,
-          file: activeFileContextMenu.file,
+          file: activeMenuFile,
           highlightLocale: fileActions.highlightLocale,
           projectTargetLocales: fileActions.projectTargetLocales,
           branch: fileActions.branch,
@@ -385,9 +387,9 @@ function ProjectFilesTreeView({
         preloadedData={preloadedData ?? undefined}
         style={treeStyle}
       />
-      {activeFileContextMenu && fileActions && activeMenuCapabilities ? (
+      {activeFileContextMenu && activeMenuFile && fileActions && activeMenuCapabilities ? (
         <ProjectFileTreeContextMenu
-          file={activeFileContextMenu.file}
+          file={activeMenuFile}
           context={activeFileContextMenu.context}
           fileActions={fileActions}
           capabilities={activeMenuCapabilities}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree.tsx
@@ -12,8 +12,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useEffect, useMemo, useRef, type CSSProperties } from "react";
-import type { FileTreeRowDecorationContext } from "@pierre/trees";
+import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
+import type { ContextMenuOpenContext, FileTreeRowDecorationContext } from "@pierre/trees";
 import { FileTree as PierreFileTree, useFileTree } from "@pierre/trees/react";
 import { preloadFileTree } from "@pierre/trees/ssr";
 import "@pierre/trees/web-components";
@@ -35,6 +35,11 @@ const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
   dateStyle: "medium",
   timeStyle: "short",
 });
+
+type ActiveFileContextMenu = {
+  file: ProjectFileRecord;
+  context: ContextMenuOpenContext;
+};
 
 function buildProjectFilesTreeStyle(fillHeight: boolean): CSSProperties {
   return {
@@ -151,6 +156,7 @@ function ProjectFilesTreeView({
   const treeStyle = useMemo(() => buildProjectFilesTreeStyle(fillHeight), [fillHeight]);
   const displayFiles = useMemo(() => dedupeProjectFilesBySourcePath(files), [files]);
   const paths = useMemo(() => displayFiles.map((file) => file.sourcePath), [displayFiles]);
+  const pathsKey = useMemo(() => paths.join("\0"), [paths]);
   const fileByPath = useMemo(
     () => new Map(displayFiles.map((file) => [file.sourcePath, file])),
     [displayFiles],
@@ -164,18 +170,33 @@ function ProjectFilesTreeView({
     onSelectFile,
     onActivateFile,
   });
-  const preloadedData = useMemo(
-    () =>
-      paths.length > 0
-        ? preloadFileTree({
-            id: "project-files-tree",
-            initialExpansion: "open",
-            paths,
-            initialVisibleRowCount: Math.max(paths.length, 8),
-          })
-        : null,
-    [paths],
+  const [activeFileContextMenu, setActiveFileContextMenu] = useState<ActiveFileContextMenu | null>(
+    null,
   );
+  const contextMenuHandlersRef = useRef({
+    onOpen: (_itemPath: string, _context: ContextMenuOpenContext) => {},
+    onClose: () => {},
+  });
+
+  /**
+   * Keep preload payload stable across parent re-renders that only change the
+   * `files` array identity. Pierre's React host effect resets composition to the
+   * model baseline whenever `preloadedData` changes; churning that object after
+   * dialogs open left the "..." menu shell open with no React content.
+   */
+  const preloadedData = useMemo(() => {
+    if (pathsKey.length === 0) {
+      return null;
+    }
+
+    const nextPaths = pathsKey.split("\0");
+    return preloadFileTree({
+      id: "project-files-tree",
+      initialExpansion: "open",
+      paths: nextPaths,
+      initialVisibleRowCount: Math.max(nextPaths.length, 8),
+    });
+  }, [pathsKey]);
 
   useEffect(() => {
     latestStateRef.current = {
@@ -186,6 +207,37 @@ function ProjectFilesTreeView({
       onSelectFile,
     };
   }, [fileActions, fileByPath, intl, onActivateFile, onSelectFile]);
+
+  contextMenuHandlersRef.current = {
+    onOpen: (itemPath, context) => {
+      if (!latestStateRef.current.fileActions) {
+        setActiveFileContextMenu(null);
+        return;
+      }
+
+      const file = latestStateRef.current.fileByPath.get(itemPath);
+      if (!file) {
+        setActiveFileContextMenu(null);
+        return;
+      }
+
+      setActiveFileContextMenu({ file, context });
+    },
+    onClose: () => {
+      setActiveFileContextMenu(null);
+    },
+  };
+
+  useEffect(() => {
+    if (!fileActions) {
+      setActiveFileContextMenu(null);
+      return;
+    }
+
+    if (activeFileContextMenu && !fileByPath.has(activeFileContextMenu.file.sourcePath)) {
+      setActiveFileContextMenu(null);
+    }
+  }, [activeFileContextMenu, fileActions, fileByPath]);
 
   useEffect(() => {
     if (!onActivateFile) {
@@ -216,6 +268,13 @@ function ProjectFilesTreeView({
     return () => container.removeEventListener("dblclick", handleDoubleClick);
   }, [onActivateFile]);
 
+  /**
+   * Own context-menu onOpen/onClose on the model baseline instead of
+   * `renderContextMenu`. Pierre's React wrapper rewrites renderContextMenu
+   * callbacks onto a composition object that is discarded whenever the host
+   * effect re-runs (for example after preload identity churn). Baseline
+   * callbacks survive that reset, so the "..." menu keeps rendering.
+   */
   const { model } = useFileTree({
     id: "project-files-tree",
     flattenEmptyDirectories: true,
@@ -232,6 +291,16 @@ function ProjectFilesTreeView({
             enabled: true,
             triggerMode: "button",
             buttonVisibility: "when-needed",
+            onOpen: (item, context) => {
+              if (item.kind !== "file") {
+                contextMenuHandlersRef.current.onClose();
+                return;
+              }
+              contextMenuHandlersRef.current.onOpen(item.path, context);
+            },
+            onClose: () => {
+              contextMenuHandlersRef.current.onClose();
+            },
           },
         }
       : undefined,
@@ -288,6 +357,19 @@ function ProjectFilesTreeView({
     return null;
   }
 
+  const activeMenuCapabilities =
+    activeFileContextMenu && fileActions
+      ? buildProjectFileActionCapabilities({
+          organizationSlug: fileActions.organizationSlug,
+          projectId: fileActions.projectId,
+          file: activeFileContextMenu.file,
+          highlightLocale: fileActions.highlightLocale,
+          projectTargetLocales: fileActions.projectTargetLocales,
+          branch: fileActions.branch,
+          intl,
+        })
+      : null;
+
   return (
     <div
       ref={containerRef}
@@ -301,42 +383,16 @@ function ProjectFilesTreeView({
         id="project-files-tree"
         model={model}
         preloadedData={preloadedData ?? undefined}
-        renderContextMenu={
-          fileActions
-            ? (item, context) => {
-                if (item.kind !== "file") {
-                  return null;
-                }
-
-                const file = latestStateRef.current.fileByPath.get(item.path);
-                const actions = latestStateRef.current.fileActions;
-                if (!file || !actions) {
-                  return null;
-                }
-
-                const capabilities = buildProjectFileActionCapabilities({
-                  organizationSlug: actions.organizationSlug,
-                  projectId: actions.projectId,
-                  file,
-                  highlightLocale: actions.highlightLocale,
-                  projectTargetLocales: actions.projectTargetLocales,
-                  branch: actions.branch,
-                  intl: latestStateRef.current.intl,
-                });
-
-                return (
-                  <ProjectFileTreeContextMenu
-                    file={file}
-                    context={context}
-                    fileActions={actions}
-                    capabilities={capabilities}
-                  />
-                );
-              }
-            : undefined
-        }
         style={treeStyle}
       />
+      {activeFileContextMenu && fileActions && activeMenuCapabilities ? (
+        <ProjectFileTreeContextMenu
+          file={activeFileContextMenu.file}
+          context={activeFileContextMenu.context}
+          fileActions={fileActions}
+          capabilities={activeMenuCapabilities}
+        />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On the project files page, clicking the row **…** control after **Translate with agent** opened the menu shell (`aria-expanded="true"`) but rendered no actions.

## Cause

`@pierre/trees` React `FileTree` resets model composition to the original baseline whenever its host effect re-runs (including when `preloadedData` gets a new object identity on parent re-render). We were wiring the menu through `renderContextMenu`, whose `onOpen` lived on that disposable composition object. After the translate dialog caused a re-render/preload churn, Pierre still toggled the trigger open, but React never received `onOpen`, so the menu stayed empty.

## Fix

- Own context-menu `onOpen` / `onClose` on the `useFileTree` model baseline and render `ProjectFileTreeContextMenu` as a sibling instead of via `renderContextMenu`.
- Stabilize `preloadedData` with a paths content key so array-identity-only re-renders do not churn the host effect.
- Add a regression test that opens Translate with agent, closes the dialog, then asserts the … menu still shows Translate / Import / Download.

## Test plan

- [x] `vp test` for files `_components` (includes new tree context menu coverage)
- [x] `vp check --fix` in `apps/hyperlocalise-web`
- [ ] Manually: open a native file’s … menu → Translate with agent → Cancel → open … again and confirm actions appear
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f0c4ec3-6b4b-479e-939f-2a6bd4d77e37?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f0c4ec3-6b4b-479e-939f-2a6bd4d77e37&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

