### PR TITLE
🧪 Scout: API base URL validation security tests

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -191,3 +191,7 @@
 ## 2026-11-05 - [YAML Pruning Validation and Sequence Stability]
 **Learning:** When testing YAML pruning/round-tripping behavior using `MarshalYAMLWithPrune`, mapping nodes are selectively pruned according to prune keys, but sequence/array nodes are kept intact to prevent shift-index instability. Comprehensive testing must verify both the pruning of unwanted mapping leaf strings and the complete preservation of array elements and block/line comments.
 **Action:** Use table-driven tests or multi-layered assertions that round-trip through both the marshaler and parser to ensure that template structures, comments, and array stable indices are verified end-to-end.
+
+## 2026-11-10 - [API Base URL Security Validation Boundaries]
+**Learning:** `ValidateAPIBaseURL` enforces strict security validations (preventing SSRF, open redirects, or credential leaks) by requiring public unicast IPs under HTTPS on production domains, while allowing localhost/loopback over HTTP or HTTPS. Testing this logic requires table-driven test cases covering URL query/fragments, user credentials, DNS trickery/suffix domains, bracketed IPv6 loopback structures, and RFC1918 private space IPs.
+**Action:** When testing host, URL, or API endpoints, design comprehensive test matrices covering parsing anomalies (percent encoding errors), protocol/scheme requirements, and address routing properties (loopback vs public vs multicast/private unicast).

--- a/pkg/hyperlocaliseapi/url_scout_test.go
+++ b/pkg/hyperlocaliseapi/url_scout_test.go
@@ -1,0 +1,134 @@
+package hyperlocaliseapi
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateAPIBaseURL_ScoutEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		baseURL string
+		wantErr string
+	}{
+		{
+			name:    "empty string",
+			baseURL: "",
+			wantErr: "must include scheme and host",
+		},
+		{
+			name:    "whitespace only",
+			baseURL: "   ",
+			wantErr: "must include scheme and host",
+		},
+		{
+			name:    "invalid url structure (percent encoding error)",
+			baseURL: "https://hyperlocalise.com/%invalid",
+			wantErr: "invalid url",
+		},
+		{
+			name:    "missing scheme",
+			baseURL: "api.hyperlocalise.com",
+			wantErr: "must include scheme and host",
+		},
+		{
+			name:    "missing host",
+			baseURL: "https:///path",
+			wantErr: "must include scheme and host",
+		},
+		{
+			name:    "includes userinfo (username)",
+			baseURL: "https://user@api.hyperlocalise.com",
+			wantErr: "must not include userinfo, query, or fragment",
+		},
+		{
+			name:    "includes userinfo (username and password)",
+			baseURL: "https://user:password@api.hyperlocalise.com",
+			wantErr: "must not include userinfo, query, or fragment",
+		},
+		{
+			name:    "includes query parameter",
+			baseURL: "https://api.hyperlocalise.com?foo=bar",
+			wantErr: "must not include userinfo, query, or fragment",
+		},
+		{
+			name:    "includes hash fragment",
+			baseURL: "https://api.hyperlocalise.com#section",
+			wantErr: "must not include userinfo, query, or fragment",
+		},
+		{
+			name:    "http scheme is blocked on production domains",
+			baseURL: "http://api.hyperlocalise.com",
+			wantErr: "must use https",
+		},
+		{
+			name:    "http scheme is allowed on IPv4 localhost",
+			baseURL: "http://127.0.0.1:8080",
+			wantErr: "",
+		},
+		{
+			name:    "http scheme is allowed on named localhost",
+			baseURL: "http://localhost:3000",
+			wantErr: "",
+		},
+		{
+			name:    "http scheme is allowed on IPv6 localhost loopback",
+			baseURL: "http://[::1]:3000",
+			wantErr: "",
+		},
+		{
+			name:    "https scheme is not allowed on IPv6 localhost loopback because only http loopback is bypassable",
+			baseURL: "https://[::1]:3000",
+			wantErr: "not allowed",
+		},
+		{
+			name:    "malicious domain tricks (suffix mismatch)",
+			baseURL: "https://hyperlocalise.com.attacker.com",
+			wantErr: "not allowed",
+		},
+		{
+			name:    "malicious domain tricks (partial match)",
+			baseURL: "https://fakehyperlocalise.com",
+			wantErr: "not allowed",
+		},
+		{
+			name:    "subdomain of allowed domain is allowed",
+			baseURL: "https://sub.api.hyperlocalise.com/v1",
+			wantErr: "",
+		},
+		{
+			name:    "allowed domain with trailing dot is allowed",
+			baseURL: "https://hyperlocalise.com.",
+			wantErr: "",
+		},
+		{
+			name:    "non-global unicast private IP (RFC1918) is blocked",
+			baseURL: "https://10.0.0.1/api",
+			wantErr: "not allowed",
+		},
+		{
+			name:    "multicast IP is blocked",
+			baseURL: "https://224.0.0.1/api",
+			wantErr: "not allowed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateAPIBaseURL(tt.baseURL)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("ValidateAPIBaseURL(%q) unexpected error: %v", tt.baseURL, err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("ValidateAPIBaseURL(%q) expected error containing %q, got nil", tt.baseURL, tt.wantErr)
+				} else if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("ValidateAPIBaseURL(%q) error %q does not contain %q", tt.baseURL, err.Error(), tt.wantErr)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### 🧪 Scout: API base URL validation security tests

- **💡 What:** Added a comprehensive table-driven unit test suite in `pkg/hyperlocaliseapi/url_scout_test.go` to cover and protect security boundaries for API base URL host and scheme validation.
- **🎯 Why:** Covers SSRF, open redirect, and credential leak risks on untrusted hosts, ensuring we only trust approved hosts (such as `.hyperlocalise.com` subdomains) or legitimate localhost loops.
- **🧩 Scope:** Covers the host and protocol checking code in `pkg/hyperlocaliseapi/url.go`.
- **✅ Verification:** All package tests ran and passed cleanly. Rebuilt and executed golangci-lint which reported 0 issues.
- **🛡️ Confidence:** Prevents bypass regressions via DNS prefix/suffix hijacking attempts, invalid protocol structures, IPv4/IPv6 loopback anomalies, or credential inclusions.

---
*PR created automatically by Jules for task [3343941446724098563](https://jules.google.com/task/3343941446724098563) started by @cungminh2710*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and documentation changes; no production validation logic is modified.
> 
> **Overview**
> Adds a parallel, table-driven test suite **`TestValidateAPIBaseURL_ScoutEdgeCases`** that locks in **`ValidateAPIBaseURL`** behavior for SSRF- and misconfiguration-style inputs: malformed/empty URLs, forbidden userinfo/query/fragment, HTTPS requirements on production hosts vs **HTTP** on loopback, domain suffix/prefix bypass attempts, and blocked private/multicast IPs.
> 
> Also documents testing guidance for this validator in **`.jules/scout.md`** so future URL/host security tests use a similar matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ea5fe0e3be66eb4c2b3451836493d20a4fd58ea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->