### PR TITLE
fix(crowdin): embed ListOptions in DictionariesListOptions

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -1,5 +1,11 @@
 # Crowdin Steward's Journal
 
+## 2026-12-22 - Embed ListOptions in DictionariesListOptions
+
+**Learning:** In Crowdin API v2, the List Dictionaries endpoint (`GET /api/v2/projects/{projectId}/dictionaries`) supports standard pagination parameters (`limit` and `offset`). However, `DictionariesListOptions` did not embed `ListOptions` or include standard pagination parameters in its `Values()` query string serialization. This caused queries with explicit limits/offsets to be ignored under actual workflows.
+
+**Action:** Updated `DictionariesListOptions` in `model/dictionaries.go` to embed `ListOptions` and updated its `Values()` method to delegate to `o.ListOptions.Values()`. Added comprehensive unit tests validating correct pagination parameter serialization in `model/dictionaries_test.go` and `dictionaries_test.go`.
+
 ## 2026-12-21 - Fix GetManagers endpoint path and signature parity
 
 **Learning:** In Crowdin Enterprise API v2, retrieving a single manager requires specifying both the `groupId` and the `userId` in the path `/api/v2/groups/{groupId}/managers/{userId}`. The SDK previously only accepted `groupID` and requested the listing endpoint `/api/v2/groups/{groupId}/managers` while trying to unmarshal it as a single `ManagerGetResponse` struct. Under real workloads, this led to immediate JSON unmarshaling errors due to array-to-object type mismatch.

--- a/third_party/crowdin-api-client-go/crowdin/dictionaries_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/dictionaries_test.go
@@ -32,6 +32,11 @@ func TestDictionariesService_List(t *testing.T) {
 			opts:          &model.DictionariesListOptions{LanguageIDs: []string{"en", "uk"}},
 			expectedQuery: "?languageIds=en%2Cuk",
 		},
+		{
+			name:          "with options, limit and offset",
+			opts:          &model.DictionariesListOptions{LanguageIDs: []string{"en", "uk"}, ListOptions: model.ListOptions{Limit: 10, Offset: 20}},
+			expectedQuery: "?languageIds=en%2Cuk&limit=10&offset=20",
+		},
 	}
 
 	client, mux, teardown := setupClient()

--- a/third_party/crowdin-api-client-go/crowdin/model/dictionaries.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/dictionaries.go
@@ -26,6 +26,8 @@ type DictionariesListResponse struct {
 type DictionariesListOptions struct {
 	// Filter progress by language identifiers.
 	LanguageIDs []string `json:"languageIds,omitempty"`
+
+	ListOptions
 }
 
 // Values returns the url.Values representation of the DictionariesListOptions.
@@ -35,7 +37,7 @@ func (o *DictionariesListOptions) Values() (url.Values, bool) {
 		return nil, false
 	}
 
-	v := url.Values{}
+	v, _ := o.ListOptions.Values()
 	if len(o.LanguageIDs) > 0 {
 		v.Add("languageIds", JoinSlice(o.LanguageIDs))
 	}

--- a/third_party/crowdin-api-client-go/crowdin/model/dictionaries_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/dictionaries_test.go
@@ -25,6 +25,21 @@ func TestDictionariesListOptionsValues(t *testing.T) {
 			opts: &DictionariesListOptions{LanguageIDs: []string{"en", "fr"}},
 			out:  "languageIds=en%2Cfr",
 		},
+		{
+			name: "with limit and offset",
+			opts: &DictionariesListOptions{
+				ListOptions: ListOptions{Limit: 10, Offset: 20},
+			},
+			out:  "limit=10&offset=20",
+		},
+		{
+			name: "with language IDs, limit and offset",
+			opts: &DictionariesListOptions{
+				LanguageIDs: []string{"en", "fr"},
+				ListOptions: ListOptions{Limit: 10, Offset: 20},
+			},
+			out:  "languageIds=en%2Cfr&limit=10&offset=20",
+		},
 	}
 
 	for _, tt := range tests {

--- a/third_party/crowdin-api-client-go/crowdin/model/dictionaries_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/dictionaries_test.go
@@ -30,7 +30,7 @@ func TestDictionariesListOptionsValues(t *testing.T) {
 			opts: &DictionariesListOptions{
 				ListOptions: ListOptions{Limit: 10, Offset: 20},
 			},
-			out:  "limit=10&offset=20",
+			out: "limit=10&offset=20",
 		},
 		{
 			name: "with language IDs, limit and offset",
@@ -38,7 +38,7 @@ func TestDictionariesListOptionsValues(t *testing.T) {
 				LanguageIDs: []string{"en", "fr"},
 				ListOptions: ListOptions{Limit: 10, Offset: 20},
 			},
-			out:  "languageIds=en%2Cfr&limit=10&offset=20",
+			out: "languageIds=en%2Cfr&limit=10&offset=20",
 		},
 	}
 


### PR DESCRIPTION
- What: Embedded ListOptions inside DictionariesListOptions and updated its Values() serialization.
- Why: This aligns DictionariesListOptions with the official Crowdin API v2 contract which supports standard limit and offset pagination parameters on GET /api/v2/projects/{projectId}/dictionaries.
- Docs: https://developer.crowdin.com/api/v2/#operation/api.projects.dictionaries.getMany
- Scope: third_party/crowdin-api-client-go/crowdin/model/dictionaries.go
- Tests: Focused unit tests in model/dictionaries_test.go and service-level client tests in dictionaries_test.go. All tests passing.
- Confidence: High, fully backwards-compatible addition with complete test coverage.

---
*PR created automatically by Jules for task [9159984420303777439](https://jules.google.com/task/9159984420303777439) started by @cungminh2710*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible SDK query serialization fix in a third-party fork with focused tests; no auth or runtime behavior outside Crowdin API clients.
> 
> **Overview**
> **Fixes dictionary list pagination** so `limit` and `offset` are sent on `GET /api/v2/projects/{projectId}/dictionaries`, matching Crowdin API v2 and other list option types in the fork.
> 
> `DictionariesListOptions` now **embeds** `ListOptions`, and `Values()` **starts from** `ListOptions.Values()` before adding `languageIds`. Callers can set pagination on the same struct without those query params being dropped.
> 
> Adds **unit tests** for query encoding in `model/dictionaries_test.go` and a **client-level** list test in `dictionaries_test.go`. Steward journal entry documents the gap and fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4766d842b79e5a1a83aab94e1ec9f6a64d06a7bf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->