### PR TITLE
feat(jobs): editable assignees, title, and description on detail

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.test.ts
@@ -574,3 +574,105 @@ describe("project job list triage", () => {
     expect(body.jobs.some((job) => job.id === succeededJob.id)).toBe(false);
   });
 });
+
+describe("workspace job update", () => {
+  it("updates native job title, description, and owner", async () => {
+    const { identity, organization, project, user } =
+      await projectFixture.createStoredProjectFixture();
+    const headers = await projectFixture.authHeadersFor(identity);
+    const [job] = await insertNativeJob({
+      organizationId: organization.id,
+      projectId: project.id,
+      createdByUserId: user.id,
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].jobs[":jobId"].$patch(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          jobId: job.id,
+        },
+        json: {
+          title: "Updated launch copy",
+          description: "Please prioritize EU locales",
+          ownerWorkosUserId: identity.user.workosUserId,
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      job: {
+        ownerUserId: string | null;
+        inputPayload: { metadata?: { title?: string; description?: string } };
+      };
+    };
+    expect(body.job.ownerUserId).toBe(user.id);
+    expect(body.job.inputPayload.metadata).toMatchObject({
+      title: "Updated launch copy",
+      description: "Please prioritize EU locales",
+    });
+  });
+
+  it("unassigns a native job owner", async () => {
+    const { identity, organization, project, user } =
+      await projectFixture.createStoredProjectFixture();
+    const headers = await projectFixture.authHeadersFor(identity);
+    const [job] = await insertNativeJob({
+      organizationId: organization.id,
+      projectId: project.id,
+      createdByUserId: user.id,
+      ownerUserId: user.id,
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].jobs[":jobId"].$patch(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          jobId: job.id,
+        },
+        json: {
+          ownerWorkosUserId: null,
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { job: { ownerUserId: string | null } };
+    expect(body.job.ownerUserId).toBeNull();
+  });
+
+  it("rejects assignee updates for users without project access", async () => {
+    const { identity, organization, project } = await projectFixture.createStoredProjectFixture();
+    const headers = await projectFixture.authHeadersFor(identity);
+    const outsider = projectFixture.createWorkosIdentityForOrganization(
+      identity.organization,
+      "translator",
+    );
+    await projectFixture.authHeadersFor(outsider);
+    const [job] = await insertNativeJob({
+      organizationId: organization.id,
+      projectId: project.id,
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].jobs[":jobId"].$patch(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          jobId: job.id,
+        },
+        json: {
+          ownerWorkosUserId: outsider.user.workosUserId,
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "assignee_not_assignable",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -108,8 +108,10 @@ import {
   jobListQuerySchema,
   jobParamsSchema,
   jobProjectParamsSchema,
+  updateJobBodySchema,
   workspaceJobParamsSchema,
 } from "./job.schema";
+import { updateNativeJob } from "@/lib/projects/jobs/update-native-job";
 
 type CreateJobRoutesOptions = {
   jobQueue: JobQueue<TranslationJobEventData>;
@@ -224,6 +226,19 @@ const validateJobParams = validator("param", (value, c) => {
     return notFoundResponse(c, "job_not_found", "Job not found");
   }
 
+  return parsed.data;
+});
+
+const validateUpdateJobBody = validator("json", (value, c) => {
+  const parsed = updateJobBodySchema.safeParse(value);
+  if (!parsed.success) {
+    return validationErrorResponse(
+      c,
+      "invalid_job_update",
+      "Invalid job update payload",
+      parsed.error.issues,
+    );
+  }
   return parsed.data;
 });
 
@@ -1441,6 +1456,69 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
         )
         .where(and(eq(schema.jobs.id, params.jobId), await buildAccessibleJobsWhere(c.var.auth)))
         .limit(1);
+
+      return c.json({ job }, 200);
+    })
+    .patch("/:jobId", validateWorkspaceJobParams, validateUpdateJobBody, async (c) => {
+      if (!isJobMutationAllowed(c.var.auth.membership.role)) {
+        return projectForbiddenResponse(c);
+      }
+
+      const params = c.req.valid("param");
+      const body = c.req.valid("json");
+      const result = await updateNativeJob({
+        organizationId: c.var.auth.organization.localOrganizationId,
+        jobId: params.jobId,
+        body,
+        accessWhere: await buildAccessibleJobsWhere(c.var.auth),
+      });
+
+      if (isErr(result)) {
+        switch (result.error.code) {
+          case "job_not_found":
+            return notFoundResponse(c, "job_not_found", "Job not found");
+          case "provider_job_not_updatable":
+            return conflictResponse(
+              c,
+              result.error.code,
+              result.error.message,
+            );
+          case "owner_not_found":
+          case "assignee_not_assignable":
+          case "project_required":
+            return badRequestResponse(c, result.error.code, result.error.message);
+          default:
+            return internalErrorResponse(c);
+        }
+      }
+
+      const [job] = await db
+        .select(jobWithProjectSelect)
+        .from(schema.jobs)
+        .leftJoin(
+          schema.translationJobDetails,
+          eq(schema.translationJobDetails.jobId, schema.jobs.id),
+        )
+        .leftJoin(schema.reviewJobDetails, eq(schema.reviewJobDetails.jobId, schema.jobs.id))
+        .leftJoin(schema.syncJobDetails, eq(schema.syncJobDetails.jobId, schema.jobs.id))
+        .leftJoin(
+          schema.assetManagementJobDetails,
+          eq(schema.assetManagementJobDetails.jobId, schema.jobs.id),
+        )
+        .leftJoin(schema.externalJobDetails, eq(schema.externalJobDetails.jobId, schema.jobs.id))
+        .leftJoin(
+          schema.projects,
+          and(
+            eq(schema.projects.id, schema.jobs.projectId),
+            eq(schema.projects.organizationId, schema.jobs.organizationId),
+          ),
+        )
+        .where(and(eq(schema.jobs.id, params.jobId), await buildAccessibleJobsWhere(c.var.auth)))
+        .limit(1);
+
+      if (!job) {
+        return notFoundResponse(c, "job_not_found", "Job not found");
+      }
 
       return c.json({ job }, 200);
     })

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -1478,11 +1478,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
           case "job_not_found":
             return notFoundResponse(c, "job_not_found", "Job not found");
           case "provider_job_not_updatable":
-            return conflictResponse(
-              c,
-              result.error.code,
-              result.error.message,
-            );
+            return conflictResponse(c, result.error.code, result.error.message);
           case "owner_not_found":
           case "assignee_not_assignable":
           case "project_required":

--- a/apps/hyperlocalise-web/src/api/routes/project/job.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.schema.ts
@@ -72,6 +72,20 @@ export const createJobBodySchema = z.discriminatedUnion("type", [
   }),
 ]);
 
+export const updateJobBodySchema = z
+  .object({
+    title: z.string().trim().min(1).max(256).optional(),
+    description: z.string().trim().max(2_048).nullable().optional(),
+    ownerWorkosUserId: z.string().trim().min(1).max(256).nullable().optional(),
+  })
+  .refine(
+    (body) =>
+      body.title !== undefined ||
+      body.description !== undefined ||
+      body.ownerWorkosUserId !== undefined,
+    { message: "At least one of title, description, or ownerWorkosUserId is required" },
+  );
+
 /** Statuses counted by project `openJobCount` and listed by `open=true`. */
 export const openJobStatusValues = ["queued", "running", "waiting_for_review"] as const;
 

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.test.ts
@@ -1013,8 +1013,9 @@ describe("tmsProviderRoutes", () => {
   it("allows Crowdin job field updates for jobs:write roles", async () => {
     const identity = fixture.createWorkosIdentityWithRole("translator");
     const headers = await fixture.authHeadersFor(identity);
-    const updateFields = vi.spyOn(tmsProviderLive, "updateTmsProviderLiveJobFields").mockResolvedValue(
-      {
+    const updateFields = vi
+      .spyOn(tmsProviderLive, "updateTmsProviderLiveJobFields")
+      .mockResolvedValue({
         ...createLiveProviderJob({
           id: "ext:crowdin:902807:5001",
           externalTitle: "Updated Crowdin task",
@@ -1022,8 +1023,7 @@ describe("tmsProviderRoutes", () => {
         externalJobId: "5001",
         externalUrl: null,
         externalProviderPayload: {},
-      },
-    );
+      });
 
     const response = await client.api.orgs[":organizationSlug"]["tms-provider"].jobs[
       ":encodedJobId"

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.test.ts
@@ -1009,4 +1009,92 @@ describe("tmsProviderRoutes", () => {
       expect.objectContaining({ languageId: "fr" }),
     );
   });
+
+  it("allows Crowdin job field updates for jobs:write roles", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("translator");
+    const headers = await fixture.authHeadersFor(identity);
+    const updateFields = vi.spyOn(tmsProviderLive, "updateTmsProviderLiveJobFields").mockResolvedValue(
+      {
+        ...createLiveProviderJob({
+          id: "ext:crowdin:902807:5001",
+          externalTitle: "Updated Crowdin task",
+        }),
+        externalJobId: "5001",
+        externalUrl: null,
+        externalProviderPayload: {},
+      },
+    );
+
+    const response = await client.api.orgs[":organizationSlug"]["tms-provider"].jobs[
+      ":encodedJobId"
+    ].$patch(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing",
+          encodedJobId: "ext:crowdin:902807:5001",
+        },
+        json: { title: "Updated Crowdin task" },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    expect(updateFields).toHaveBeenCalledTimes(1);
+  });
+
+  it("forbids Smartling job field updates for non-operator roles", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("translator");
+    const headers = await fixture.authHeadersFor(identity);
+    const updateFields = vi.spyOn(tmsProviderLive, "updateTmsProviderLiveJobFields");
+
+    const response = await client.api.orgs[":organizationSlug"]["tms-provider"].jobs[
+      ":encodedJobId"
+    ].$patch(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing",
+          encodedJobId: "ext:smartling:project-a:job-1",
+        },
+        json: { title: "Updated Smartling job" },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "forbidden" });
+    expect(updateFields).not.toHaveBeenCalled();
+  });
+
+  it("allows Smartling job field updates for workspace operators", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("localization_manager");
+    const headers = await fixture.authHeadersFor(identity);
+    const updateFields = vi
+      .spyOn(tmsProviderLive, "updateTmsProviderLiveJobFields")
+      .mockResolvedValue({
+        ...createLiveProviderJob({
+          id: "ext:smartling:project-a:job-1",
+          externalProviderKind: "smartling",
+          externalTitle: "Updated Smartling job",
+        }),
+        externalJobId: "job-1",
+        externalUrl: null,
+        externalProviderPayload: {},
+      });
+
+    const response = await client.api.orgs[":organizationSlug"]["tms-provider"].jobs[
+      ":encodedJobId"
+    ].$patch(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing",
+          encodedJobId: "ext:smartling:project-a:job-1",
+        },
+        json: { title: "Updated Smartling job" },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    expect(updateFields).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
@@ -47,6 +47,7 @@ import {
   getTmsProviderLiveJobDetail,
   getTmsProviderLiveProjectLocaleReadiness,
   updateTmsProviderLiveJobDescription,
+  updateTmsProviderLiveJobFields,
   getTmsProviderLiveProject,
   listTmsProviderLiveFilesForProject,
   listTmsProviderLiveGlossaries,
@@ -82,6 +83,20 @@ const localeReadinessQuerySchema = z.object({
 const updateJobDescriptionBodySchema = z.object({
   description: z.string().max(2_048),
 });
+
+const updateTmsProviderJobBodySchema = z
+  .object({
+    title: z.string().trim().min(1).max(256).optional(),
+    description: z.string().trim().max(2_048).nullable().optional(),
+    assigneeExternalUserIds: z.array(z.string().trim().min(1).max(128)).max(50).optional(),
+  })
+  .refine(
+    (body) =>
+      body.title !== undefined ||
+      body.description !== undefined ||
+      body.assigneeExternalUserIds !== undefined,
+    { message: "At least one of title, description, or assigneeExternalUserIds is required" },
+  );
 
 const createTmsProviderJobAgentRunBodySchema = z.object({
   projectId: projectIdSchema,
@@ -160,6 +175,15 @@ const validateUpdateJobDescriptionBody = validator("json", (value, c) => {
   const parsed = updateJobDescriptionBodySchema.safeParse(value);
   if (!parsed.success) {
     return c.json({ error: "invalid_request_body" }, 400);
+  }
+
+  return parsed.data;
+});
+
+const validateUpdateTmsProviderJobBody = validator("json", (value, c) => {
+  const parsed = updateTmsProviderJobBodySchema.safeParse(value);
+  if (!parsed.success) {
+    return badRequestResponse(c, "invalid_job_update", "Invalid provider job update payload");
   }
 
   return parsed.data;
@@ -478,6 +502,29 @@ export function createTmsProviderRoutes(options: CreateTmsProviderRoutesOptions 
         }
 
         return c.body(null, 204);
+      } catch (error) {
+        return tmsProviderLiveErrorResponse(c, error);
+      }
+    })
+    .patch("/jobs/:encodedJobId", validateUpdateTmsProviderJobBody, async (c) => {
+      if (!canEditTmsProviderJobDescription(c.var.auth)) {
+        return c.json({ error: "forbidden" }, 403);
+      }
+
+      const body = c.req.valid("json");
+
+      try {
+        const job = await updateTmsProviderLiveJobFields(
+          c.var.auth.organization.localOrganizationId,
+          c.req.param("encodedJobId"),
+          body,
+          c.var.auth.user.localUserId,
+        );
+        if (!job) {
+          return c.json({ error: "job_not_found" }, 404);
+        }
+
+        return c.json({ job }, 200);
       } catch (error) {
         return tmsProviderLiveErrorResponse(c, error);
       }

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
@@ -207,9 +207,8 @@ const validateCreateTmsProviderJobsBody = validator("json", (value, c) => {
   return parsed.data;
 });
 
-function canEditTmsProviderJobDescription(auth: AuthVariables["auth"]) {
-  const role = auth.membership.role;
-  return role === "admin" || (role === "localization_manager" && hasCapability(role, "jobs:write"));
+function canEditTmsProviderJobFields(auth: AuthVariables["auth"]) {
+  return isJobMutationAllowed(auth.membership.role);
 }
 
 type CreateTmsProviderRoutesOptions = {
@@ -507,7 +506,7 @@ export function createTmsProviderRoutes(options: CreateTmsProviderRoutesOptions 
       }
     })
     .patch("/jobs/:encodedJobId", validateUpdateTmsProviderJobBody, async (c) => {
-      if (!canEditTmsProviderJobDescription(c.var.auth)) {
+      if (!canEditTmsProviderJobFields(c.var.auth)) {
         return c.json({ error: "forbidden" }, 403);
       }
 
@@ -530,7 +529,7 @@ export function createTmsProviderRoutes(options: CreateTmsProviderRoutesOptions 
       }
     })
     .patch("/jobs/:encodedJobId/description", validateUpdateJobDescriptionBody, async (c) => {
-      if (!canEditTmsProviderJobDescription(c.var.auth)) {
+      if (!canEditTmsProviderJobFields(c.var.auth)) {
         return c.json({ error: "forbidden" }, 403);
       }
 

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
@@ -20,7 +20,7 @@ import {
   isJobMutationAllowed,
   isJobProviderActionAllowed,
 } from "@/api/auth/capability-guards";
-import { hasCapability } from "@/api/auth/policy";
+import { hasCapability, isWorkspaceOperatorRole } from "@/api/auth/policy";
 import { canAccessProject } from "@/api/auth/team-access";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
 import {
@@ -207,7 +207,17 @@ const validateCreateTmsProviderJobsBody = validator("json", (value, c) => {
   return parsed.data;
 });
 
-function canEditTmsProviderJobFields(auth: AuthVariables["auth"]) {
+/**
+ * Crowdin uses per-user OAuth, so `jobs:write` is enough (provider enforces project access).
+ * Smartling uses shared org credentials — restrict field edits to workspace operators.
+ */
+function canEditTmsProviderJobFields(
+  auth: AuthVariables["auth"],
+  providerKind: string | null | undefined,
+) {
+  if (providerKind === "smartling") {
+    return isWorkspaceOperatorRole(auth.membership.role);
+  }
   return isJobMutationAllowed(auth.membership.role);
 }
 
@@ -506,7 +516,9 @@ export function createTmsProviderRoutes(options: CreateTmsProviderRoutesOptions 
       }
     })
     .patch("/jobs/:encodedJobId", validateUpdateTmsProviderJobBody, async (c) => {
-      if (!canEditTmsProviderJobFields(c.var.auth)) {
+      const encodedJobId = c.req.param("encodedJobId");
+      const parsedJobId = parseProviderJobId(encodedJobId);
+      if (!canEditTmsProviderJobFields(c.var.auth, parsedJobId?.providerKind)) {
         return c.json({ error: "forbidden" }, 403);
       }
 
@@ -515,7 +527,7 @@ export function createTmsProviderRoutes(options: CreateTmsProviderRoutesOptions 
       try {
         const job = await updateTmsProviderLiveJobFields(
           c.var.auth.organization.localOrganizationId,
-          c.req.param("encodedJobId"),
+          encodedJobId,
           body,
           c.var.auth.user.localUserId,
         );
@@ -529,7 +541,9 @@ export function createTmsProviderRoutes(options: CreateTmsProviderRoutesOptions 
       }
     })
     .patch("/jobs/:encodedJobId/description", validateUpdateJobDescriptionBody, async (c) => {
-      if (!canEditTmsProviderJobFields(c.var.auth)) {
+      const encodedJobId = c.req.param("encodedJobId");
+      const parsedJobId = parseProviderJobId(encodedJobId);
+      if (!canEditTmsProviderJobFields(c.var.auth, parsedJobId?.providerKind)) {
         return c.json({ error: "forbidden" }, 403);
       }
 
@@ -538,7 +552,7 @@ export function createTmsProviderRoutes(options: CreateTmsProviderRoutesOptions 
       try {
         const job = await updateTmsProviderLiveJobDescription(
           c.var.auth.organization.localOrganizationId,
-          c.req.param("encodedJobId"),
+          encodedJobId,
           body.description,
           c.var.auth.user.localUserId,
         );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-assignable-issue-members.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-assignable-issue-members.ts
@@ -20,6 +20,7 @@ import { issueSheetApiPath } from "./issue-detail-utils";
 
 export type AssignableIssueMember = {
   userId: string;
+  workosUserId: string;
   email: string;
   firstName: string | null;
   lastName: string | null;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/provider-job-description-field.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/provider-job-description-field.tsx
@@ -169,7 +169,7 @@ export function ProviderJobDescriptionField({
     mutationFn: async (nextDraft: string) => {
       const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].jobs[
         ":encodedJobId"
-      ].description.$patch({
+      ].$patch({
         param: { organizationSlug, encodedJobId },
         json: { description: nextDraft },
       });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-assignee-field.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-assignee-field.messages.ts
@@ -1,0 +1,68 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const jobDetailAssigneeFieldMessages = defineMessages({
+  loadMembersFailed: {
+    defaultMessage: "Couldn't load assignable members",
+    id: "5PG+VBWgIw",
+    description: "Error when job assignee member list fails to load",
+  },
+  saveFailed: {
+    defaultMessage: "Couldn't update assignees",
+    id: "R6n/KCAp4a",
+    description: "Toast when job assignee save fails",
+  },
+  saveSuccess: {
+    defaultMessage: "Assignees updated",
+    id: "uHbVM9Pw9Y",
+    description: "Toast when job assignees are saved",
+  },
+  unassigned: {
+    defaultMessage: "Unassigned",
+    id: "FlKUTB/6A0",
+    description: "Label when a native job has no owner",
+  },
+  triggerAria: {
+    defaultMessage: "Assignees",
+    id: "xVxao1E4rb",
+    description: "Accessible label for the Crowdin multi-assignee picker trigger",
+  },
+  searchPlaceholder: {
+    defaultMessage: "Search members…",
+    id: "fM2wynVWWB",
+    description: "Placeholder in the Crowdin assignee picker search field",
+  },
+  empty: {
+    defaultMessage: "No members found",
+    id: "zPUQ6rTETA",
+    description: "Empty state in the Crowdin assignee picker",
+  },
+  loading: {
+    defaultMessage: "Loading…",
+    id: "bFbk34uFYE",
+    description: "Loading state in the Crowdin assignee picker",
+  },
+  clearAll: {
+    defaultMessage: "Clear all",
+    id: "dAeEJyCLaY",
+    description: "Action to clear all Crowdin assignees",
+  },
+  selectedCount: {
+    defaultMessage: "{count, plural, =0 {No assignees} one {# assignee} other {# assignees}}",
+    id: "/140Sd9x8r",
+    description: "Crowdin assignee picker trigger label with selection count",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-assignee-field.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-assignee-field.tsx
@@ -12,7 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -162,6 +162,12 @@ export function CrowdinJobAssigneesField({
   const intl = useIntl();
   const queryClient = useQueryClient();
   const [open, setOpen] = useState(false);
+  const [draftSelectedIds, setDraftSelectedIds] = useState(selectedExternalUserIds);
+  const draftSelectedIdsRef = useRef(selectedExternalUserIds);
+  const selectedExternalUserIdsRef = useRef(selectedExternalUserIds);
+  const saveInFlightRef = useRef(false);
+  const queuedSelectedIdsRef = useRef<string[] | null>(null);
+  selectedExternalUserIdsRef.current = selectedExternalUserIds;
 
   const membersQuery = useQuery({
     queryKey: ["tms-project-members", organizationSlug, externalProjectId, "job-detail"],
@@ -224,8 +230,40 @@ export function CrowdinJobAssigneesField({
     },
   });
 
+  useEffect(() => {
+    if (!saveInFlightRef.current && queuedSelectedIdsRef.current == null) {
+      draftSelectedIdsRef.current = selectedExternalUserIds;
+      setDraftSelectedIds(selectedExternalUserIds);
+    }
+  }, [selectedExternalUserIds]);
+
+  const persistAssignees = (next: string[]) => {
+    draftSelectedIdsRef.current = next;
+    setDraftSelectedIds(next);
+    if (saveInFlightRef.current) {
+      queuedSelectedIdsRef.current = next;
+      return;
+    }
+    saveInFlightRef.current = true;
+    saveAssignees.mutate(next, {
+      onSettled: (_data, error) => {
+        saveInFlightRef.current = false;
+        const queued = queuedSelectedIdsRef.current;
+        queuedSelectedIdsRef.current = null;
+        if (queued) {
+          persistAssignees(queued);
+          return;
+        }
+        if (error) {
+          draftSelectedIdsRef.current = selectedExternalUserIdsRef.current;
+          setDraftSelectedIds(selectedExternalUserIdsRef.current);
+        }
+      },
+    });
+  };
+
   const members = membersQuery.data ?? [];
-  const selectedSet = useMemo(() => new Set(selectedExternalUserIds), [selectedExternalUserIds]);
+  const selectedSet = useMemo(() => new Set(draftSelectedIds), [draftSelectedIds]);
   const selectedLabels = useMemo(() => {
     const fromMembers = members
       .filter((member) => selectedSet.has(member.externalUserId))
@@ -277,7 +315,7 @@ export function CrowdinJobAssigneesField({
               <CommandItem
                 value="clear-all"
                 onSelect={() => {
-                  saveAssignees.mutate([]);
+                  persistAssignees([]);
                   setOpen(false);
                 }}
               >
@@ -295,8 +333,8 @@ export function CrowdinJobAssigneesField({
                     value={`${member.externalUserId} ${label} ${member.username}`}
                     data-checked={checked || undefined}
                     onSelect={() => {
-                      const next = toggleValue(selectedExternalUserIds, member.externalUserId);
-                      saveAssignees.mutate(next);
+                      const next = toggleValue(draftSelectedIdsRef.current, member.externalUserId);
+                      persistAssignees(next);
                     }}
                   >
                     <span

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-assignee-field.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-assignee-field.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
+import { toast } from "sonner";
+
+import { IssueAssigneePicker } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-assignee-picker";
+import {
+  assignableMembersQueryKey,
+  type AssignableIssueMember,
+} from "@/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-assignable-issue-members";
+import { issueSheetApiPath } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-utils";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { readApiResponseError } from "@/lib/api-error";
+import { apiClient } from "@/lib/api-client-instance";
+import { cn } from "@/lib/primitives/cn";
+
+import { jobDetailAssigneeFieldMessages as messages } from "./job-detail-assignee-field.messages";
+
+type CrowdinMember = {
+  externalUserId: string;
+  username: string;
+  displayName: string;
+  role?: string | null;
+};
+
+async function readUpdateError(response: Response, fallback: string) {
+  const body = (await response.json().catch(() => null)) as {
+    error?: string;
+    message?: string;
+  } | null;
+  return body?.message ?? body?.error ?? `${fallback} (${response.status})`;
+}
+
+function toggleValue(values: string[], value: string) {
+  return values.includes(value) ? values.filter((item) => item !== value) : [...values, value];
+}
+
+export function NativeJobOwnerField({
+  organizationSlug,
+  projectId,
+  jobId,
+  ownerUserId,
+  queryKey,
+  disabled = false,
+}: {
+  organizationSlug: string;
+  projectId: string;
+  jobId: string;
+  ownerUserId: string | null;
+  queryKey: readonly unknown[];
+  disabled?: boolean;
+}) {
+  const intl = useIntl();
+  const queryClient = useQueryClient();
+
+  const membersQuery = useQuery({
+    queryKey: assignableMembersQueryKey(organizationSlug, projectId),
+    queryFn: async () => {
+      const response = await fetch(
+        `${issueSheetApiPath(organizationSlug, projectId)}/assignable-members`,
+      );
+      if (!response.ok) {
+        throw await readApiResponseError(response, intl.formatMessage(messages.loadMembersFailed));
+      }
+      const body = (await response.json()) as { members: AssignableIssueMember[] };
+      return body.members;
+    },
+  });
+
+  const saveOwner = useMutation({
+    mutationFn: async (nextOwnerUserId: string | null) => {
+      const member =
+        nextOwnerUserId == null
+          ? null
+          : (membersQuery.data?.find((item) => item.userId === nextOwnerUserId) ?? null);
+      const ownerWorkosUserId = member?.workosUserId ?? null;
+      if (nextOwnerUserId && !ownerWorkosUserId) {
+        throw new Error(intl.formatMessage(messages.saveFailed));
+      }
+
+      const response = await apiClient.api.orgs[":organizationSlug"].jobs[":jobId"].$patch({
+        param: { organizationSlug, jobId },
+        json: { ownerWorkosUserId },
+      });
+      if (!response.ok) {
+        throw new Error(await readUpdateError(response, intl.formatMessage(messages.saveFailed)));
+      }
+      const body = (await response.json()) as { job: { ownerUserId: string | null } };
+      return body.job;
+    },
+    onSuccess: async (job) => {
+      queryClient.setQueryData(queryKey, (current: unknown) => {
+        if (!current || typeof current !== "object" || Array.isArray(current)) {
+          return job;
+        }
+        return { ...current, ownerUserId: job.ownerUserId };
+      });
+      await queryClient.invalidateQueries({ queryKey: ["jobs", organizationSlug] });
+      toast.success(intl.formatMessage(messages.saveSuccess));
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : intl.formatMessage(messages.saveFailed));
+    },
+  });
+
+  return (
+    <IssueAssigneePicker
+      value={ownerUserId}
+      members={membersQuery.data ?? []}
+      onChange={(next) => saveOwner.mutate(next)}
+      disabled={disabled || saveOwner.isPending}
+      isLoading={membersQuery.isLoading}
+      size="ghost"
+      currentLabel={intl.formatMessage(messages.unassigned)}
+    />
+  );
+}
+
+export function CrowdinJobAssigneesField({
+  organizationSlug,
+  encodedJobId,
+  externalProjectId,
+  selectedExternalUserIds,
+  fallbackLabels,
+  queryKey,
+  disabled = false,
+}: {
+  organizationSlug: string;
+  encodedJobId: string;
+  externalProjectId: string;
+  selectedExternalUserIds: string[];
+  fallbackLabels: string[];
+  queryKey: readonly unknown[];
+  disabled?: boolean;
+}) {
+  const intl = useIntl();
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+
+  const membersQuery = useQuery({
+    queryKey: ["tms-project-members", organizationSlug, externalProjectId, "job-detail"],
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].projects[
+        ":externalProjectId"
+      ].members.$get({
+        param: { organizationSlug, externalProjectId },
+      });
+      if (!response.ok) {
+        throw new Error(intl.formatMessage(messages.loadMembersFailed));
+      }
+      const body = (await response.json()) as { members: CrowdinMember[] };
+      return body.members;
+    },
+  });
+
+  const saveAssignees = useMutation({
+    mutationFn: async (assigneeExternalUserIds: string[]) => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].jobs[
+        ":encodedJobId"
+      ].$patch({
+        param: { organizationSlug, encodedJobId },
+        json: { assigneeExternalUserIds },
+      });
+      if (!response.ok) {
+        throw new Error(await readUpdateError(response, intl.formatMessage(messages.saveFailed)));
+      }
+      const body = (await response.json()) as {
+        job: {
+          externalAssignedUsers?: string[] | null;
+          externalProviderPayload?: Record<string, unknown>;
+        };
+      };
+      return body.job;
+    },
+    onSuccess: async (job) => {
+      queryClient.setQueryData(queryKey, (current: unknown) => {
+        if (!current || typeof current !== "object" || Array.isArray(current)) {
+          return job;
+        }
+        const currentJob = current as {
+          externalAssignedUsers?: string[] | null;
+          externalProviderPayload?: Record<string, unknown>;
+        };
+        return {
+          ...currentJob,
+          externalAssignedUsers: job.externalAssignedUsers ?? currentJob.externalAssignedUsers,
+          externalProviderPayload: {
+            ...currentJob.externalProviderPayload,
+            ...job.externalProviderPayload,
+          },
+        };
+      });
+      await queryClient.invalidateQueries({ queryKey: ["jobs", organizationSlug] });
+      toast.success(intl.formatMessage(messages.saveSuccess));
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : intl.formatMessage(messages.saveFailed));
+    },
+  });
+
+  const members = membersQuery.data ?? [];
+  const selectedSet = useMemo(() => new Set(selectedExternalUserIds), [selectedExternalUserIds]);
+  const selectedLabels = useMemo(() => {
+    const fromMembers = members
+      .filter((member) => selectedSet.has(member.externalUserId))
+      .map((member) => member.displayName || member.username);
+    if (fromMembers.length > 0) {
+      return fromMembers;
+    }
+    return fallbackLabels;
+  }, [fallbackLabels, members, selectedSet]);
+
+  const triggerLabel =
+    selectedLabels.length > 0
+      ? selectedLabels.join(", ")
+      : intl.formatMessage(messages.selectedCount, { count: 0 });
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <Button
+            type="button"
+            variant="ghost"
+            size="default"
+            disabled={disabled || saveAssignees.isPending || membersQuery.isLoading}
+            aria-label={intl.formatMessage(messages.triggerAria)}
+            className="h-auto justify-between gap-2 px-2 py-1.5 font-normal hover:bg-muted/60"
+          />
+        }
+      >
+        <span className="min-w-0 flex-1 truncate text-left text-sm">{triggerLabel}</span>
+        <HugeiconsIcon
+          icon={ArrowDown01Icon}
+          strokeWidth={2}
+          className="size-4 shrink-0 text-muted-foreground"
+        />
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-80 p-0" sideOffset={4}>
+        <Command>
+          <CommandInput placeholder={intl.formatMessage(messages.searchPlaceholder)} />
+          <CommandList>
+            <CommandEmpty>
+              {membersQuery.isLoading ? (
+                <FormattedMessage {...messages.loading} />
+              ) : (
+                <FormattedMessage {...messages.empty} />
+              )}
+            </CommandEmpty>
+            <CommandGroup>
+              <CommandItem
+                value="clear-all"
+                onSelect={() => {
+                  saveAssignees.mutate([]);
+                  setOpen(false);
+                }}
+              >
+                <FormattedMessage {...messages.clearAll} />
+              </CommandItem>
+            </CommandGroup>
+            <CommandSeparator />
+            <CommandGroup>
+              {members.map((member) => {
+                const label = member.displayName || member.username;
+                const checked = selectedSet.has(member.externalUserId);
+                return (
+                  <CommandItem
+                    key={member.externalUserId}
+                    value={`${member.externalUserId} ${label} ${member.username}`}
+                    data-checked={checked || undefined}
+                    onSelect={() => {
+                      const next = toggleValue(selectedExternalUserIds, member.externalUserId);
+                      saveAssignees.mutate(next);
+                    }}
+                  >
+                    <span
+                      className={cn(
+                        "size-3.5 shrink-0 rounded-sm border border-border",
+                        checked && "bg-primary border-primary",
+                      )}
+                      aria-hidden
+                    />
+                    <span className="min-w-0 flex-1 truncate">
+                      <span className="block truncate">{label}</span>
+                      {member.role ? (
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {member.username} · {member.role}
+                        </span>
+                      ) : (
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {member.username}
+                        </span>
+                      )}
+                    </span>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-editable-title.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-editable-title.messages.ts
@@ -1,0 +1,33 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const jobDetailEditableTitleMessages = defineMessages({
+  titleAriaLabel: {
+    defaultMessage: "Job title",
+    id: "AXYQB+ayG/",
+    description: "Accessible label for the editable job title field",
+  },
+  titleRequired: {
+    defaultMessage: "Title is required",
+    id: "M30SNTxWXn",
+    description: "Toast when saving a job with an empty title",
+  },
+  saveFailed: {
+    defaultMessage: "Couldn't save title",
+    id: "kO32zaHAd6",
+    description: "Toast when job title save fails",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-editable-title.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-editable-title.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useEffect, useState } from "react";
+import { useIntl } from "react-intl";
+import { toast } from "sonner";
+
+import { Textarea } from "@/components/ui/textarea";
+import { TypographyH1 } from "@/components/ui/typography";
+import { cn } from "@/lib/primitives/cn";
+
+import { jobDetailEditableTitleMessages as messages } from "./job-detail-editable-title.messages";
+
+export function JobDetailEditableTitle({
+  title,
+  editable,
+  disabled = false,
+  onSave,
+}: {
+  title: string;
+  editable: boolean;
+  disabled?: boolean;
+  onSave?: (nextTitle: string) => Promise<void>;
+}) {
+  const intl = useIntl();
+  const [draft, setDraft] = useState(title);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    setDraft(title);
+  }, [title]);
+
+  if (!editable || !onSave) {
+    return <TypographyH1>{title}</TypographyH1>;
+  }
+
+  const commit = async () => {
+    const next = draft.trim();
+    if (!next) {
+      setDraft(title);
+      toast.error(intl.formatMessage(messages.titleRequired));
+      return;
+    }
+    if (next === title) {
+      setDraft(title);
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await onSave(next);
+    } catch (error) {
+      setDraft(title);
+      toast.error(error instanceof Error ? error.message : intl.formatMessage(messages.saveFailed));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Textarea
+      value={draft}
+      onChange={(event) => setDraft(event.currentTarget.value)}
+      onBlur={() => {
+        void commit();
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" && !event.shiftKey) {
+          event.preventDefault();
+          event.currentTarget.blur();
+        }
+        if (event.key === "Escape") {
+          event.preventDefault();
+          setDraft(title);
+          event.currentTarget.blur();
+        }
+      }}
+      disabled={disabled || isSaving}
+      aria-label={intl.formatMessage(messages.titleAriaLabel)}
+      rows={1}
+      className={cn(
+        "font-heading min-h-10 shrink-0 overflow-hidden rounded-none border-transparent bg-transparent px-0 py-1 text-3xl font-semibold tracking-[-0.04em] text-balance text-foreground shadow-none md:min-h-14 md:text-6xl",
+        "focus-visible:border-transparent focus-visible:ring-0",
+      )}
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-layout-helpers.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-layout-helpers.tsx
@@ -108,7 +108,7 @@ function getInputPayloadString(job: JobDetailRecord, key: string) {
   return typeof value === "string" && value.length > 0 ? value : null;
 }
 
-function getInputPayloadMetadataTitle(job: JobDetailRecord) {
+function getInputPayloadMetadataString(job: JobDetailRecord, key: string) {
   if (
     typeof job.inputPayload !== "object" ||
     !job.inputPayload ||
@@ -118,12 +118,20 @@ function getInputPayloadMetadataTitle(job: JobDetailRecord) {
   }
 
   const metadata = (job.inputPayload as { metadata?: unknown }).metadata;
-  if (typeof metadata !== "object" || !metadata || !("title" in metadata)) {
+  if (typeof metadata !== "object" || !metadata || !(key in metadata)) {
     return null;
   }
 
-  const title = (metadata as { title?: unknown }).title;
-  return typeof title === "string" && title.length > 0 ? title : null;
+  const value = (metadata as Record<string, unknown>)[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function getInputPayloadMetadataTitle(job: JobDetailRecord) {
+  return getInputPayloadMetadataString(job, "title");
+}
+
+export function getInputPayloadMetadataDescription(job: JobDetailRecord) {
+  return getInputPayloadMetadataString(job, "description") ?? "";
 }
 
 export function jobDetailTaskTitle(input: JobDetailTaskLayoutInput) {
@@ -231,6 +239,7 @@ export function jobDetailTaskProperties(
     { label: intl.formatMessage(messages.labelTaskType), value: taskType },
     { label: intl.formatMessage(messages.labelTargetLocales), value: targetLocales },
     {
+      id: "assignees",
       label: intl.formatMessage(messages.labelAssignees),
       value:
         input.externalAssignedUsers && input.externalAssignedUsers.length > 0

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-page-content.tsx
@@ -32,12 +32,12 @@ export function JobDetailPageContent({
   jobId,
   organizationSlug,
   projectId,
-  canEditProviderJobDescription,
+  canEditJobFields,
 }: {
   jobId: string;
   organizationSlug: string;
   projectId: string;
-  canEditProviderJobDescription: boolean;
+  canEditJobFields: boolean;
 }) {
   const activeTmsProviderQuery = useActiveTmsProvider(organizationSlug);
   const encodedProviderJobFromRoute = parseProviderJobId(jobId);
@@ -91,7 +91,7 @@ export function JobDetailPageContent({
         jobId={encodedProviderJobId}
         organizationSlug={organizationSlug}
         projectId={projectId}
-        canEditProviderJobDescription={canEditProviderJobDescription}
+        canEditJobFields={canEditJobFields}
       />
     );
   }
@@ -101,6 +101,7 @@ export function JobDetailPageContent({
       jobId={jobId}
       organizationSlug={organizationSlug}
       projectId={projectId}
+      canEditJobFields={canEditJobFields}
     />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-page-content.tsx
@@ -90,9 +90,7 @@ export function JobDetailPageContent({
   if (useLiveProviderJob && encodedProviderJobId) {
     const providerKind = parseProviderJobId(encodedProviderJobId)?.providerKind;
     const canEditProviderJobFields =
-      providerKind === "smartling"
-        ? canEditSharedCredentialProviderJobFields
-        : canEditJobFields;
+      providerKind === "smartling" ? canEditSharedCredentialProviderJobFields : canEditJobFields;
 
     return (
       <ProviderLiveJobDetailContent

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-page-content.tsx
@@ -33,11 +33,13 @@ export function JobDetailPageContent({
   organizationSlug,
   projectId,
   canEditJobFields,
+  canEditSharedCredentialProviderJobFields = false,
 }: {
   jobId: string;
   organizationSlug: string;
   projectId: string;
   canEditJobFields: boolean;
+  canEditSharedCredentialProviderJobFields?: boolean;
 }) {
   const activeTmsProviderQuery = useActiveTmsProvider(organizationSlug);
   const encodedProviderJobFromRoute = parseProviderJobId(jobId);
@@ -86,12 +88,18 @@ export function JobDetailPageContent({
   }
 
   if (useLiveProviderJob && encodedProviderJobId) {
+    const providerKind = parseProviderJobId(encodedProviderJobId)?.providerKind;
+    const canEditProviderJobFields =
+      providerKind === "smartling"
+        ? canEditSharedCredentialProviderJobFields
+        : canEditJobFields;
+
     return (
       <ProviderLiveJobDetailContent
         jobId={encodedProviderJobId}
         organizationSlug={organizationSlug}
         projectId={projectId}
-        canEditJobFields={canEditJobFields}
+        canEditJobFields={canEditProviderJobFields}
       />
     );
   }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-task-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-task-view.tsx
@@ -93,7 +93,7 @@ export function JobDetailTaskView({
   renderCommentsSection?: JobDetailTaskCommentsRenderer;
   secondaryProperties?: JobDetailViewProperty[];
   showComments?: boolean;
-  title?: string;
+  title?: ReactNode;
 }) {
   const [activeTab, setActiveTab] = useState<JobDetailTaskTab>("overview");
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-view.tsx
@@ -37,6 +37,7 @@ export type JobDetailViewMetric = {
 };
 
 export type JobDetailViewProperty = {
+  id?: string;
   label: string;
   value: ReactNode;
 };
@@ -155,7 +156,7 @@ export function JobDetailView({
   renderError?: JobDetailErrorRenderer;
   renderMain?: () => ReactNode;
   secondaryProperties?: JobDetailViewProperty[];
-  title?: string;
+  title?: ReactNode;
 }) {
   const jobsListHref = buildJobsListHrefProp(organizationSlug, projectId);
   const intl = useIntl();
@@ -172,7 +173,11 @@ export function JobDetailView({
             href: jobsListHref,
             children: intl.formatMessage(messages.jobsBackLink),
           })}
-          <TypographyH1>{title ?? jobId}</TypographyH1>
+          {typeof title === "string" || title == null ? (
+            <TypographyH1>{title ?? jobId}</TypographyH1>
+          ) : (
+            title
+          )}
           {metrics.length > 0 ? (
             <div className="mt-4 flex flex-wrap items-center gap-x-6 gap-y-2">
               {metrics.map((metric) => (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-description-field.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-description-field.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useIntl } from "react-intl";
+import { toast } from "sonner";
+
+import { ProviderJobDescriptionFieldView } from "../../../../../jobs/_components/provider-job-description-field";
+import { apiClient } from "@/lib/api-client-instance";
+
+import { providerJobDescriptionFieldMessages } from "../../../../../jobs/_components/provider-job-description-field.messages";
+
+export function NativeJobDescriptionField({
+  organizationSlug,
+  jobId,
+  description,
+  editable,
+  queryKey,
+}: {
+  organizationSlug: string;
+  jobId: string;
+  description: string;
+  editable: boolean;
+  queryKey: readonly unknown[];
+}) {
+  const intl = useIntl();
+  const queryClient = useQueryClient();
+
+  const saveMutation = useMutation({
+    mutationFn: async (nextDraft: string) => {
+      const response = await apiClient.api.orgs[":organizationSlug"].jobs[":jobId"].$patch({
+        param: { organizationSlug, jobId },
+        json: { description: nextDraft },
+      });
+
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as {
+          error?: string;
+          message?: string;
+        } | null;
+        throw new Error(
+          body?.message ??
+            body?.error ??
+            intl.formatMessage(providerJobDescriptionFieldMessages.saveFailedWithStatus, {
+              status: response.status,
+            }),
+        );
+      }
+
+      const body = (await response.json()) as {
+        job: { inputPayload?: unknown };
+      };
+
+      queryClient.setQueryData(queryKey, (current: unknown) => {
+        if (!current || typeof current !== "object" || Array.isArray(current)) {
+          return body.job;
+        }
+        return {
+          ...current,
+          inputPayload: body.job.inputPayload,
+        };
+      });
+
+      return nextDraft;
+    },
+    onSuccess: () => {
+      toast.success(intl.formatMessage(providerJobDescriptionFieldMessages.saveSuccess));
+    },
+  });
+
+  return (
+    <ProviderJobDescriptionFieldView
+      description={description}
+      editable={editable}
+      isSaving={saveMutation.isPending}
+      onSaveDescription={(nextDescription) => saveMutation.mutateAsync(nextDescription)}
+      onSaveError={(error) => {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : intl.formatMessage(providerJobDescriptionFieldMessages.saveFailedFallback),
+        );
+      }}
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-content.messages.ts
@@ -20,6 +20,11 @@ export const nativeJobDetailContentMessages = defineMessages({
     id: "VCIZRHU93Q",
     description: "Error when the native job detail request fails",
   },
+  failedToUpdateJob: {
+    defaultMessage: "Failed to update job",
+    id: "pF/btP7bSZ",
+    description: "Error when a native job title, description, or owner update fails",
+  },
   jobWrongProject: {
     defaultMessage: "Job does not belong to this project",
     id: "w1oESvG6DH",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-content.tsx
@@ -21,7 +21,6 @@ import { ListIcon } from "lucide-react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
 
-import { MarkdownPreview } from "@/components/markdown-editor/markdown-editor";
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -36,12 +35,16 @@ import { useAppShellBreadcrumbAppend } from "@/components/app-shell/store/use-ap
 import { apiClient } from "@/lib/api-client-instance";
 import { buildJobCatHref, canOpenJobCat } from "@/lib/projects/job-cat-routing";
 
-import { getProviderPayloadString } from "../../../../../jobs/_components/provider-crowdin-job-display";
-
-import { jobDetailTaskLayoutFromRecord } from "./job-detail-layout-helpers";
+import { NativeJobOwnerField } from "./job-detail-assignee-field";
+import { JobDetailEditableTitle } from "./job-detail-editable-title";
+import {
+  getInputPayloadMetadataDescription,
+  jobDetailTaskLayoutFromRecord,
+} from "./job-detail-layout-helpers";
 import { JobDetailTaskView } from "./job-detail-task-view";
 import type { JobDetailRecord } from "./job-detail-types";
 import { JobProviderDetailSection } from "./job-provider-detail-section";
+import { NativeJobDescriptionField } from "./native-job-description-field";
 import {
   isNativeFileTranslationJob,
   NativeJobSourceFilesSection,
@@ -71,10 +74,12 @@ export function NativeJobDetailContent({
   jobId,
   organizationSlug,
   projectId,
+  canEditJobFields = false,
 }: {
   jobId: string;
   organizationSlug: string;
   projectId: string;
+  canEditJobFields?: boolean;
 }) {
   const [markFailedDialogOpen, setMarkFailedDialogOpen] = useState(false);
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
@@ -190,10 +195,54 @@ export function NativeJobDetailContent({
   const layout = job ? jobDetailTaskLayoutFromRecord(job, intl) : null;
   const catHref = job ? buildJobCatHref(organizationSlug, projectId, job) : null;
   const showCatAction = job ? canOpenJobCat(job) : false;
-  const providerDescription =
-    job && isProviderBackedJob(job)
-      ? (getProviderPayloadString(job.externalProviderPayload, "description") ?? "")
-      : "";
+  const isNativeEditable = Boolean(job && canEditJobFields && !isProviderBackedJob(job));
+  const nativeDescription =
+    job && !isProviderBackedJob(job) ? getInputPayloadMetadataDescription(job) : "";
+
+  const saveTitle = useMutation({
+    mutationFn: async (nextTitle: string) => {
+      const response = await apiClient.api.orgs[":organizationSlug"].jobs[":jobId"].$patch({
+        param: { organizationSlug, jobId },
+        json: { title: nextTitle },
+      });
+      if (!response.ok) {
+        throw new Error(
+          await parseActionError(response, intl.formatMessage(messages.failedToUpdateJob)),
+        );
+      }
+      const body = (await response.json()) as { job: JobDetailRecord };
+      return body.job;
+    },
+    onSuccess: async (updatedJob) => {
+      queryClient.setQueryData(jobQueryKey, updatedJob);
+      await queryClient.invalidateQueries({ queryKey: ["jobs", organizationSlug] });
+    },
+  });
+
+  const properties = (layout?.properties ?? []).map((property) => {
+    if (property.id !== "assignees" || !isNativeEditable || !job) {
+      return property;
+    }
+    return {
+      ...property,
+      value: (
+        <NativeJobOwnerField
+          organizationSlug={organizationSlug}
+          projectId={projectId}
+          jobId={jobId}
+          ownerUserId={job.ownerUserId}
+          queryKey={jobQueryKey}
+          disabled={
+            retryJob.isPending ||
+            markJobFailed.isPending ||
+            cancelJob.isPending ||
+            saveTitle.isPending
+          }
+        />
+      ),
+    };
+  });
+
   useAppShellBreadcrumbAppend({
     id: "job-detail",
     label: layout?.title,
@@ -268,18 +317,39 @@ export function NativeJobDetailContent({
         jobId={jobId}
         organizationSlug={organizationSlug}
         projectId={projectId}
-        title={layout?.title}
+        title={
+          <JobDetailEditableTitle
+            title={layout?.title ?? jobId}
+            editable={isNativeEditable}
+            disabled={
+              retryJob.isPending ||
+              markJobFailed.isPending ||
+              cancelJob.isPending ||
+              saveTitle.isPending
+            }
+            onSave={async (nextTitle) => {
+              await saveTitle.mutateAsync(nextTitle);
+            }}
+          />
+        }
         metrics={layout?.metrics ?? []}
-        properties={layout?.properties ?? []}
+        properties={properties}
         secondaryProperties={layout?.secondaryProperties ?? []}
         headerActions={headerActions}
         isLoading={jobQuery.isLoading}
         error={jobQuery.isError ? jobQuery.error : undefined}
-        description={providerDescription}
+        description={nativeDescription}
+        canEditDescription={isNativeEditable}
         renderDescriptionField={
-          providerDescription.trim().length > 0
-            ? ({ description }) => (
-                <MarkdownPreview value={description} className="border-border bg-card" />
+          isNativeEditable
+            ? ({ description, editable }) => (
+                <NativeJobDescriptionField
+                  organizationSlug={organizationSlug}
+                  jobId={jobId}
+                  description={description}
+                  editable={editable}
+                  queryKey={jobQueryKey}
+                />
               )
             : undefined
         }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-content.tsx
@@ -31,9 +31,12 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import { MarkdownPreview } from "@/components/markdown-editor/markdown-editor";
 import { useAppShellBreadcrumbAppend } from "@/components/app-shell/store/use-app-shell-breadcrumb";
 import { apiClient } from "@/lib/api-client-instance";
 import { buildJobCatHref, canOpenJobCat } from "@/lib/projects/job-cat-routing";
+
+import { getProviderPayloadString } from "../../../../../jobs/_components/provider-crowdin-job-display";
 
 import { NativeJobOwnerField } from "./job-detail-assignee-field";
 import { JobDetailEditableTitle } from "./job-detail-editable-title";
@@ -195,9 +198,13 @@ export function NativeJobDetailContent({
   const layout = job ? jobDetailTaskLayoutFromRecord(job, intl) : null;
   const catHref = job ? buildJobCatHref(organizationSlug, projectId, job) : null;
   const showCatAction = job ? canOpenJobCat(job) : false;
-  const isNativeEditable = Boolean(job && canEditJobFields && !isProviderBackedJob(job));
-  const nativeDescription =
-    job && !isProviderBackedJob(job) ? getInputPayloadMetadataDescription(job) : "";
+  const isProviderBacked = Boolean(job && isProviderBackedJob(job));
+  const isNativeEditable = Boolean(job && canEditJobFields && !isProviderBacked);
+  const description = job
+    ? isProviderBacked
+      ? (getProviderPayloadString(job.externalProviderPayload, "description") ?? "")
+      : getInputPayloadMetadataDescription(job)
+    : "";
 
   const saveTitle = useMutation({
     mutationFn: async (nextTitle: string) => {
@@ -338,20 +345,24 @@ export function NativeJobDetailContent({
         headerActions={headerActions}
         isLoading={jobQuery.isLoading}
         error={jobQuery.isError ? jobQuery.error : undefined}
-        description={nativeDescription}
+        description={description}
         canEditDescription={isNativeEditable}
         renderDescriptionField={
           isNativeEditable
-            ? ({ description, editable }) => (
+            ? ({ description: fieldDescription, editable }) => (
                 <NativeJobDescriptionField
                   organizationSlug={organizationSlug}
                   jobId={jobId}
-                  description={description}
+                  description={fieldDescription}
                   editable={editable}
                   queryKey={jobQueryKey}
                 />
               )
-            : undefined
+            : description.trim().length > 0
+              ? ({ description: fieldDescription }) => (
+                  <MarkdownPreview value={fieldDescription} className="border-border bg-card" />
+                )
+              : undefined
         }
         renderFilesSection={
           job && isNativeFileTranslationJob(job)

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
@@ -45,12 +45,12 @@ export function ProviderLiveJobDetailContent({
   jobId,
   organizationSlug,
   projectId,
-  canEditProviderJobDescription,
+  canEditJobFields,
 }: {
   jobId: string;
   organizationSlug: string;
   projectId: string;
-  canEditProviderJobDescription: boolean;
+  canEditJobFields: boolean;
 }) {
   const router = useRouter();
   const intl = useIntl();
@@ -128,7 +128,7 @@ export function ProviderLiveJobDetailContent({
         jobId={jobId}
         organizationSlug={organizationSlug}
         projectId={projectId}
-        canEditProviderJobDescription={canEditProviderJobDescription}
+        canEditJobFields={canEditJobFields}
         job={jobQuery.data}
         isLoading={jobQuery.isLoading}
         error={jobQuery.isError ? jobQuery.error : undefined}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-view.tsx
@@ -14,17 +14,23 @@
  */
 import Link from "next/link";
 import { type ReactNode } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { LinkSquare02Icon, RefreshIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ListIcon } from "lucide-react";
 import { FormattedMessage, useIntl } from "react-intl";
+import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
+import { apiClient } from "@/lib/api-client-instance";
 import { buildJobCatHref, canOpenJobCat } from "@/lib/projects/job-cat-routing";
 import type { TmsProviderLiveJobDetail } from "@/lib/providers/jobs/tms-provider-live";
+import { parseProviderJobId } from "@/lib/providers/jobs/tms-provider-resource-id";
 
 import { getProviderPayloadString } from "../../../../../jobs/_components/provider-crowdin-job-display";
 
+import { CrowdinJobAssigneesField } from "./job-detail-assignee-field";
+import { JobDetailEditableTitle } from "./job-detail-editable-title";
 import {
   defaultRenderBackLink,
   defaultRenderError,
@@ -40,6 +46,14 @@ import { buildJobsListHref } from "./job-detail-types";
 import { jobDetailTaskLayoutFromLiveJob } from "./job-detail-layout-helpers";
 import { providerLiveJobDetailViewMessages as messages } from "./provider-live-job-detail-view.messages";
 
+function readAssigneeExternalUserIds(payload: Record<string, unknown> | null | undefined) {
+  const value = payload?.assigneeExternalUserIds;
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
 export type ProviderLiveDescriptionFieldRenderer = JobDetailTaskDescriptionRenderer;
 
 export type ProviderLiveFilesSectionRenderer = (props: {
@@ -51,7 +65,7 @@ export type ProviderLiveFilesSectionRenderer = (props: {
 
 export function ProviderLiveJobDetailView({
   buildJobsListHref: buildJobsListHrefProp = buildJobsListHref,
-  canEditProviderJobDescription = false,
+  canEditJobFields = false,
   error,
   isLoading,
   isRefreshing = false,
@@ -72,7 +86,7 @@ export function ProviderLiveJobDetailView({
   showComments = false,
 }: {
   buildJobsListHref?: typeof buildJobsListHref;
-  canEditProviderJobDescription?: boolean;
+  canEditJobFields?: boolean;
   error?: unknown;
   isLoading: boolean;
   isRefreshing?: boolean;
@@ -93,11 +107,20 @@ export function ProviderLiveJobDetailView({
   showComments?: boolean;
 }) {
   const intl = useIntl();
+  const queryClient = useQueryClient();
+  const jobQueryKey = ["tms-provider-job", organizationSlug, jobId] as const;
+  const parsedJobId = parseProviderJobId(jobId);
   const providerDescription = job
     ? (getProviderPayloadString(job.externalProviderPayload, "description") ?? "")
     : "";
-  const canEditProviderDescription = Boolean(
-    job && canEditProviderJobDescription && job.id.startsWith("ext:"),
+  const canEditProviderFields = Boolean(
+    job &&
+    canEditJobFields &&
+    job.id.startsWith("ext:") &&
+    (job.externalProviderKind === "crowdin" || job.externalProviderKind === "smartling"),
+  );
+  const canEditAssignees = Boolean(
+    canEditProviderFields && job?.externalProviderKind === "crowdin" && parsedJobId,
   );
   const catHref = job ? buildJobCatHref(organizationSlug, projectId, job) : null;
   const showViewStrings = job ? canOpenJobCat(job) && Boolean(catHref) : false;
@@ -107,6 +130,53 @@ export function ProviderLiveJobDetailView({
         localeReadinessOverride,
       })
     : null;
+
+  const saveTitle = useMutation({
+    mutationFn: async (nextTitle: string) => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].jobs[
+        ":encodedJobId"
+      ].$patch({
+        param: { organizationSlug, encodedJobId: jobId },
+        json: { title: nextTitle },
+      });
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as {
+          error?: string;
+          message?: string;
+        } | null;
+        throw new Error(body?.message ?? body?.error ?? `Save failed (${response.status})`);
+      }
+      const body = (await response.json()) as { job: TmsProviderLiveJobDetail };
+      return body.job;
+    },
+    onSuccess: async (updatedJob) => {
+      queryClient.setQueryData(jobQueryKey, updatedJob);
+      await queryClient.invalidateQueries({ queryKey: ["jobs", organizationSlug] });
+    },
+    onError: (saveError) => {
+      toast.error(saveError instanceof Error ? saveError.message : "Couldn't save title");
+    },
+  });
+
+  const properties = (layout?.properties ?? []).map((property) => {
+    if (property.id !== "assignees" || !canEditAssignees || !job || !parsedJobId) {
+      return property;
+    }
+    return {
+      ...property,
+      value: (
+        <CrowdinJobAssigneesField
+          organizationSlug={organizationSlug}
+          encodedJobId={jobId}
+          externalProjectId={parsedJobId.externalProjectId}
+          selectedExternalUserIds={readAssigneeExternalUserIds(job.externalProviderPayload)}
+          fallbackLabels={job.externalAssignedUsers ?? []}
+          queryKey={jobQueryKey}
+          disabled={isRefreshing || isDeleting}
+        />
+      ),
+    };
+  });
 
   const headerActions = job ? (
     <>
@@ -189,9 +259,18 @@ export function ProviderLiveJobDetailView({
       jobId={jobId}
       organizationSlug={organizationSlug}
       projectId={projectId}
-      title={layout?.title}
+      title={
+        <JobDetailEditableTitle
+          title={layout?.title ?? jobId}
+          editable={canEditProviderFields}
+          disabled={isRefreshing || isDeleting || saveTitle.isPending}
+          onSave={async (nextTitle) => {
+            await saveTitle.mutateAsync(nextTitle);
+          }}
+        />
+      }
       metrics={layout?.metrics ?? []}
-      properties={layout?.properties ?? []}
+      properties={properties}
       secondaryProperties={layout?.secondaryProperties ?? []}
       headerActions={headerActions}
       isLoading={isLoading}
@@ -199,7 +278,7 @@ export function ProviderLiveJobDetailView({
       renderBackLink={renderBackLink}
       renderError={renderError}
       description={providerDescription}
-      canEditDescription={canEditProviderDescription}
+      canEditDescription={canEditProviderFields}
       renderDescriptionField={renderDescriptionField}
       renderFilesSection={filesRenderer}
       showComments={showComments}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/page.tsx
@@ -24,14 +24,14 @@ export default async function ProjectJobDetailPage({
   const { organizationSlug, projectId: rawProjectId, jobId } = await params;
   const projectId = normalizeProjectId(rawProjectId);
   const auth = await requireAppAuthContext({ organizationSlug });
-  const canEditProviderJobDescription = hasCapability(auth.membership.role, "jobs:write");
+  const canEditJobFields = hasCapability(auth.membership.role, "jobs:write");
 
   return (
     <JobDetailPageContent
       jobId={jobId}
       organizationSlug={organizationSlug}
       projectId={projectId}
-      canEditProviderJobDescription={canEditProviderJobDescription}
+      canEditJobFields={canEditJobFields}
     />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/page.tsx
@@ -10,7 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { hasCapability } from "@/api/auth/policy";
+import { hasCapability, isWorkspaceOperatorRole } from "@/api/auth/policy";
 import { normalizeProjectId } from "@/lib/projects/identity/project-id";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
@@ -25,6 +25,7 @@ export default async function ProjectJobDetailPage({
   const projectId = normalizeProjectId(rawProjectId);
   const auth = await requireAppAuthContext({ organizationSlug });
   const canEditJobFields = hasCapability(auth.membership.role, "jobs:write");
+  const canEditSharedCredentialProviderJobFields = isWorkspaceOperatorRole(auth.membership.role);
 
   return (
     <JobDetailPageContent
@@ -32,6 +33,7 @@ export default async function ProjectJobDetailPage({
       organizationSlug={organizationSlug}
       projectId={projectId}
       canEditJobFields={canEditJobFields}
+      canEditSharedCredentialProviderJobFields={canEditSharedCredentialProviderJobFields}
     />
   );
 }

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-assignee.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-assignee.ts
@@ -26,6 +26,7 @@ export type IssueAssigneeNotAssignableError = {
 
 export type AssignableIssueMember = {
   userId: string;
+  workosUserId: string;
   email: string;
   firstName: string | null;
   lastName: string | null;
@@ -174,6 +175,7 @@ export async function listAssignableIssueMembers(input: {
   const memberships = await database
     .select({
       userId: schema.users.id,
+      workosUserId: schema.users.workosUserId,
       email: schema.users.email,
       firstName: schema.users.firstName,
       lastName: schema.users.lastName,
@@ -227,6 +229,7 @@ export async function listAssignableIssueMembers(input: {
     )
     .map((row) => ({
       userId: row.userId,
+      workosUserId: row.workosUserId,
       email: row.email,
       firstName: row.firstName,
       lastName: row.lastName,

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/update-native-job.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/update-native-job.ts
@@ -99,7 +99,7 @@ export async function updateNativeJob(input: {
       .leftJoin(schema.externalJobDetails, eq(schema.externalJobDetails.jobId, schema.jobs.id))
       .where(and(eq(schema.jobs.id, input.jobId), input.accessWhere))
       .limit(1)
-      .for("update");
+      .for("update", { of: schema.jobs });
 
     if (!existing) {
       return err({ code: "job_not_found" as const });

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/update-native-job.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/update-native-job.ts
@@ -82,111 +82,117 @@ export async function updateNativeJob(input: {
   database?: DatabaseClient;
 }): Promise<Result<{ id: string }, UpdateNativeJobError>> {
   const database = input.database ?? db;
+  const ownerChanging = Object.hasOwn(input.body, "ownerWorkosUserId");
+  const titleChanging = input.body.title !== undefined;
+  const descriptionChanging = Object.hasOwn(input.body, "description");
 
-  const [existing] = await database
-    .select({
-      id: schema.jobs.id,
-      projectId: schema.jobs.projectId,
-      inputPayload: schema.jobs.inputPayload,
-      ownerUserId: schema.jobs.ownerUserId,
-      externalProviderKind: schema.externalJobDetails.providerKind,
-    })
-    .from(schema.jobs)
-    .leftJoin(schema.externalJobDetails, eq(schema.externalJobDetails.jobId, schema.jobs.id))
-    .where(and(eq(schema.jobs.id, input.jobId), input.accessWhere))
-    .limit(1);
+  return database.transaction(async (tx) => {
+    const [existing] = await tx
+      .select({
+        id: schema.jobs.id,
+        projectId: schema.jobs.projectId,
+        inputPayload: schema.jobs.inputPayload,
+        ownerUserId: schema.jobs.ownerUserId,
+        externalProviderKind: schema.externalJobDetails.providerKind,
+      })
+      .from(schema.jobs)
+      .leftJoin(schema.externalJobDetails, eq(schema.externalJobDetails.jobId, schema.jobs.id))
+      .where(and(eq(schema.jobs.id, input.jobId), input.accessWhere))
+      .limit(1)
+      .for("update");
 
-  if (!existing) {
-    return err({ code: "job_not_found" });
-  }
+    if (!existing) {
+      return err({ code: "job_not_found" as const });
+    }
 
-  if (existing.externalProviderKind) {
-    return err({
-      code: "provider_job_not_updatable",
-      message: "Use the TMS provider job update endpoint for provider-backed jobs",
-    });
-  }
-
-  if (!existing.projectId) {
-    return err({
-      code: "project_required",
-      message: "Job must belong to a project to update owner or metadata",
-    });
-  }
-
-  let nextOwnerUserId = existing.ownerUserId;
-  if (Object.hasOwn(input.body, "ownerWorkosUserId")) {
-    if (input.body.ownerWorkosUserId == null) {
-      nextOwnerUserId = null;
-    } else {
-      const resolvedOwnerId = await resolveOwnerUserId({
-        organizationId: input.organizationId,
-        workosUserId: input.body.ownerWorkosUserId,
-        database,
+    if (existing.externalProviderKind) {
+      return err({
+        code: "provider_job_not_updatable" as const,
+        message: "Use the TMS provider job update endpoint for provider-backed jobs",
       });
-      if (!resolvedOwnerId) {
-        return err({
-          code: "owner_not_found",
-          message: "Assigned owner must be an organization member",
+    }
+
+    if (!existing.projectId) {
+      return err({
+        code: "project_required" as const,
+        message: "Job must belong to a project to update owner or metadata",
+      });
+    }
+
+    const updates: {
+      ownerUserId?: string | null;
+      inputPayload?: Record<string, unknown>;
+      updatedAt: Date;
+    } = {
+      updatedAt: new Date(),
+    };
+
+    if (ownerChanging) {
+      if (input.body.ownerWorkosUserId == null) {
+        updates.ownerUserId = null;
+      } else {
+        const resolvedOwnerId = await resolveOwnerUserId({
+          organizationId: input.organizationId,
+          workosUserId: input.body.ownerWorkosUserId,
+          database: tx,
         });
+        if (!resolvedOwnerId) {
+          return err({
+            code: "owner_not_found" as const,
+            message: "Assigned owner must be an organization member",
+          });
+        }
+
+        const assignable = await assertAssignableIssueAssignee({
+          organizationId: input.organizationId,
+          projectId: existing.projectId,
+          assigneeUserId: resolvedOwnerId,
+          database: tx,
+        });
+        if (isErr(assignable)) {
+          return err({
+            code: "assignee_not_assignable" as const,
+            message: "Assigned owner must be an active member with project access",
+          });
+        }
+        updates.ownerUserId = resolvedOwnerId;
+      }
+    }
+
+    if (titleChanging || descriptionChanging) {
+      const currentPayload = isPlainRecord(existing.inputPayload) ? existing.inputPayload : {};
+      const metadata = readMetadata(existing.inputPayload);
+
+      if (titleChanging) {
+        metadata.title = input.body.title!;
       }
 
-      const assignable = await assertAssignableIssueAssignee({
-        organizationId: input.organizationId,
-        projectId: existing.projectId,
-        assigneeUserId: resolvedOwnerId,
-        database,
-      });
-      if (isErr(assignable)) {
-        return err({
-          code: "assignee_not_assignable",
-          message: "Assigned owner must be an active member with project access",
-        });
+      if (descriptionChanging) {
+        if (input.body.description == null || input.body.description.trim().length === 0) {
+          delete metadata.description;
+        } else {
+          metadata.description = input.body.description.trim();
+        }
       }
-      nextOwnerUserId = resolvedOwnerId;
-    }
-  }
 
-  const currentPayload = isPlainRecord(existing.inputPayload) ? existing.inputPayload : {};
-  const metadata = readMetadata(existing.inputPayload);
-  let metadataChanged = false;
-
-  if (input.body.title !== undefined) {
-    metadata.title = input.body.title;
-    metadataChanged = true;
-  }
-
-  if (Object.hasOwn(input.body, "description")) {
-    if (input.body.description == null || input.body.description.trim().length === 0) {
-      delete metadata.description;
-    } else {
-      metadata.description = input.body.description.trim();
-    }
-    metadataChanged = true;
-  }
-
-  const nextPayload = metadataChanged
-    ? {
+      updates.inputPayload = {
         ...currentPayload,
         metadata,
-      }
-    : currentPayload;
+      };
+    }
 
-  const [updated] = await database
-    .update(schema.jobs)
-    .set({
-      ownerUserId: nextOwnerUserId,
-      ...(metadataChanged ? { inputPayload: nextPayload } : {}),
-      updatedAt: new Date(),
-    })
-    .where(
-      and(eq(schema.jobs.id, input.jobId), eq(schema.jobs.organizationId, input.organizationId)),
-    )
-    .returning({ id: schema.jobs.id });
+    const [updated] = await tx
+      .update(schema.jobs)
+      .set(updates)
+      .where(
+        and(eq(schema.jobs.id, input.jobId), eq(schema.jobs.organizationId, input.organizationId)),
+      )
+      .returning({ id: schema.jobs.id });
 
-  if (!updated) {
-    return err({ code: "job_not_found" });
-  }
+    if (!updated) {
+      return err({ code: "job_not_found" as const });
+    }
 
-  return ok(updated);
+    return ok(updated);
+  });
 }

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/update-native-job.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/update-native-job.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { and, eq, type SQL } from "drizzle-orm";
+
+import { db, schema, type DatabaseClient } from "@/lib/database";
+import { assertAssignableIssueAssignee } from "@/lib/projects/issue-sheet/issue-sheet-assignee";
+import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
+
+export type UpdateNativeJobInput = {
+  title?: string;
+  description?: string | null;
+  ownerWorkosUserId?: string | null;
+};
+
+export type UpdateNativeJobError =
+  | { code: "job_not_found" }
+  | { code: "provider_job_not_updatable"; message: string }
+  | { code: "owner_not_found"; message: string }
+  | { code: "assignee_not_assignable"; message: string }
+  | { code: "project_required"; message: string };
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readMetadata(inputPayload: unknown): Record<string, string> {
+  if (!isPlainRecord(inputPayload)) {
+    return {};
+  }
+  const metadata = inputPayload.metadata;
+  if (!isPlainRecord(metadata)) {
+    return {};
+  }
+  const next: Record<string, string> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (typeof value === "string") {
+      next[key] = value;
+    }
+  }
+  return next;
+}
+
+async function resolveOwnerUserId(input: {
+  organizationId: string;
+  workosUserId: string;
+  database: DatabaseClient;
+}): Promise<string | null> {
+  const [owner] = await input.database
+    .select({ id: schema.users.id })
+    .from(schema.users)
+    .innerJoin(
+      schema.organizationMemberships,
+      eq(schema.organizationMemberships.userId, schema.users.id),
+    )
+    .where(
+      and(
+        eq(schema.users.workosUserId, input.workosUserId),
+        eq(schema.organizationMemberships.organizationId, input.organizationId),
+      ),
+    )
+    .limit(1);
+
+  return owner?.id ?? null;
+}
+
+/** Updates native job title, description, and/or owner. Rejects provider-backed jobs. */
+export async function updateNativeJob(input: {
+  organizationId: string;
+  jobId: string;
+  body: UpdateNativeJobInput;
+  accessWhere: SQL;
+  database?: DatabaseClient;
+}): Promise<Result<{ id: string }, UpdateNativeJobError>> {
+  const database = input.database ?? db;
+
+  const [existing] = await database
+    .select({
+      id: schema.jobs.id,
+      projectId: schema.jobs.projectId,
+      inputPayload: schema.jobs.inputPayload,
+      ownerUserId: schema.jobs.ownerUserId,
+      externalProviderKind: schema.externalJobDetails.providerKind,
+    })
+    .from(schema.jobs)
+    .leftJoin(schema.externalJobDetails, eq(schema.externalJobDetails.jobId, schema.jobs.id))
+    .where(and(eq(schema.jobs.id, input.jobId), input.accessWhere))
+    .limit(1);
+
+  if (!existing) {
+    return err({ code: "job_not_found" });
+  }
+
+  if (existing.externalProviderKind) {
+    return err({
+      code: "provider_job_not_updatable",
+      message: "Use the TMS provider job update endpoint for provider-backed jobs",
+    });
+  }
+
+  if (!existing.projectId) {
+    return err({
+      code: "project_required",
+      message: "Job must belong to a project to update owner or metadata",
+    });
+  }
+
+  let nextOwnerUserId = existing.ownerUserId;
+  if (Object.hasOwn(input.body, "ownerWorkosUserId")) {
+    if (input.body.ownerWorkosUserId == null) {
+      nextOwnerUserId = null;
+    } else {
+      const resolvedOwnerId = await resolveOwnerUserId({
+        organizationId: input.organizationId,
+        workosUserId: input.body.ownerWorkosUserId,
+        database,
+      });
+      if (!resolvedOwnerId) {
+        return err({
+          code: "owner_not_found",
+          message: "Assigned owner must be an organization member",
+        });
+      }
+
+      const assignable = await assertAssignableIssueAssignee({
+        organizationId: input.organizationId,
+        projectId: existing.projectId,
+        assigneeUserId: resolvedOwnerId,
+        database,
+      });
+      if (isErr(assignable)) {
+        return err({
+          code: "assignee_not_assignable",
+          message: "Assigned owner must be an active member with project access",
+        });
+      }
+      nextOwnerUserId = resolvedOwnerId;
+    }
+  }
+
+  const currentPayload = isPlainRecord(existing.inputPayload) ? existing.inputPayload : {};
+  const metadata = readMetadata(existing.inputPayload);
+  let metadataChanged = false;
+
+  if (input.body.title !== undefined) {
+    metadata.title = input.body.title;
+    metadataChanged = true;
+  }
+
+  if (Object.hasOwn(input.body, "description")) {
+    if (input.body.description == null || input.body.description.trim().length === 0) {
+      delete metadata.description;
+    } else {
+      metadata.description = input.body.description.trim();
+    }
+    metadataChanged = true;
+  }
+
+  const nextPayload = metadataChanged
+    ? {
+        ...currentPayload,
+        metadata,
+      }
+    : currentPayload;
+
+  const [updated] = await database
+    .update(schema.jobs)
+    .set({
+      ownerUserId: nextOwnerUserId,
+      ...(metadataChanged ? { inputPayload: nextPayload } : {}),
+      updatedAt: new Date(),
+    })
+    .where(
+      and(eq(schema.jobs.id, input.jobId), eq(schema.jobs.organizationId, input.organizationId)),
+    )
+    .returning({ id: schema.jobs.id });
+
+  if (!updated) {
+    return err({ code: "job_not_found" });
+  }
+
+  return ok(updated);
+}

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -1313,15 +1313,15 @@ describe("CrowdinApiClient", () => {
     }) as unknown as typeof fetch;
     const client = createClient(fetchMock);
 
-    await expect(
-      client.editTaskFields(1, 9, { assigneeExternalUserIds: ["abc"] }),
-    ).rejects.toThrow("invalid_crowdin_assignee_id");
-    await expect(
-      client.editTaskFields(1, 9, { assigneeExternalUserIds: ["01"] }),
-    ).rejects.toThrow("invalid_crowdin_assignee_id");
-    await expect(
-      client.editTaskFields(1, 9, { assigneeExternalUserIds: ["0"] }),
-    ).rejects.toThrow("invalid_crowdin_assignee_id");
+    await expect(client.editTaskFields(1, 9, { assigneeExternalUserIds: ["abc"] })).rejects.toThrow(
+      "invalid_crowdin_assignee_id",
+    );
+    await expect(client.editTaskFields(1, 9, { assigneeExternalUserIds: ["01"] })).rejects.toThrow(
+      "invalid_crowdin_assignee_id",
+    );
+    await expect(client.editTaskFields(1, 9, { assigneeExternalUserIds: ["0"] })).rejects.toThrow(
+      "invalid_crowdin_assignee_id",
+    );
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -1307,6 +1307,47 @@ describe("CrowdinApiClient", () => {
     expect(progress[0]?.translationProgress).toBe(50);
   });
 
+  it("editTaskFields rejects non-canonical Crowdin assignee ids", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify(createTaskPayload(9)), { status: 200 });
+    }) as unknown as typeof fetch;
+    const client = createClient(fetchMock);
+
+    await expect(
+      client.editTaskFields(1, 9, { assigneeExternalUserIds: ["abc"] }),
+    ).rejects.toThrow("invalid_crowdin_assignee_id");
+    await expect(
+      client.editTaskFields(1, 9, { assigneeExternalUserIds: ["01"] }),
+    ).rejects.toThrow("invalid_crowdin_assignee_id");
+    await expect(
+      client.editTaskFields(1, 9, { assigneeExternalUserIds: ["0"] }),
+    ).rejects.toThrow("invalid_crowdin_assignee_id");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("editTaskFields patches canonical Crowdin assignee ids", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify(createTaskPayload(9)), { status: 200 });
+    }) as unknown as typeof fetch;
+    const client = createClient(fetchMock);
+
+    await client.editTaskFields(1, 9, { assigneeExternalUserIds: ["12", "34"] });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.crowdin.test/api/v2/projects/1/tasks/9",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify([
+          {
+            op: "replace",
+            path: "/assignees",
+            value: [{ id: 12 }, { id: 34 }],
+          },
+        ]),
+      }),
+    );
+  });
+
   it("logs each API request with method and endpoint", async () => {
     const fetchMock = vi.fn(async () => {
       return new Response(

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -1184,10 +1184,18 @@ export class CrowdinApiClient {
       });
     }
     if (fields.assigneeExternalUserIds !== undefined) {
-      const assignees = fields.assigneeExternalUserIds
-        .map((externalUserId) => Number(externalUserId))
-        .filter((id) => Number.isFinite(id) && id > 0)
-        .map((id) => ({ id }));
+      const assignees: Array<{ id: number }> = [];
+      for (const externalUserId of fields.assigneeExternalUserIds) {
+        const trimmed = externalUserId.trim();
+        if (!/^[1-9]\d*$/.test(trimmed)) {
+          throw new Error("invalid_crowdin_assignee_id");
+        }
+        const id = Number(trimmed);
+        if (!Number.isSafeInteger(id) || String(id) !== trimmed) {
+          throw new Error("invalid_crowdin_assignee_id");
+        }
+        assignees.push({ id });
+      }
       patches.push({ op: "replace", path: "/assignees", value: assignees });
     }
 

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -1140,16 +1140,62 @@ export class CrowdinApiClient {
     return this.listPaginated<CrowdinProjectMember>(`/projects/${projectId}/members`);
   }
 
+  async editTask(
+    projectId: number,
+    taskId: number,
+    patches: Array<{ op: "replace" | "add" | "remove"; path: string; value?: unknown }>,
+  ): Promise<CrowdinTaskDetails> {
+    const response = await this.patch<CrowdinGetResponse<CrowdinTaskDetails>>(
+      `/projects/${projectId}/tasks/${taskId}`,
+      patches,
+    );
+    return response.data;
+  }
+
   async editTaskDescription(
     projectId: number,
     taskId: number,
     description: string,
   ): Promise<CrowdinTaskDetails> {
-    const response = await this.patch<CrowdinGetResponse<CrowdinTaskDetails>>(
-      `/projects/${projectId}/tasks/${taskId}`,
-      [{ op: "replace", path: "/description", value: description }],
-    );
-    return response.data;
+    return this.editTask(projectId, taskId, [
+      { op: "replace", path: "/description", value: description },
+    ]);
+  }
+
+  async editTaskFields(
+    projectId: number,
+    taskId: number,
+    fields: {
+      title?: string;
+      description?: string | null;
+      assigneeExternalUserIds?: string[];
+    },
+  ): Promise<CrowdinTaskDetails> {
+    const patches: Array<{ op: "replace"; path: string; value: unknown }> = [];
+
+    if (fields.title !== undefined) {
+      patches.push({ op: "replace", path: "/title", value: fields.title });
+    }
+    if (fields.description !== undefined) {
+      patches.push({
+        op: "replace",
+        path: "/description",
+        value: fields.description ?? "",
+      });
+    }
+    if (fields.assigneeExternalUserIds !== undefined) {
+      const assignees = fields.assigneeExternalUserIds
+        .map((externalUserId) => Number(externalUserId))
+        .filter((id) => Number.isFinite(id) && id > 0)
+        .map((id) => ({ id }));
+      patches.push({ op: "replace", path: "/assignees", value: assignees });
+    }
+
+    if (patches.length === 0) {
+      return this.getTask(projectId, taskId);
+    }
+
+    return this.editTask(projectId, taskId, patches);
   }
 
   async listTaskComments(projectId: number, taskId: number): Promise<CrowdinTaskComment[]> {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
@@ -1470,6 +1470,8 @@ export class CrowdinTmsProvider extends TmsProvider {
         sourceLanguageId,
         targetLanguageId: task.targetLanguageId ?? null,
         targetLanguageIds: targetLocales,
+        assigneeExternalUserIds:
+          task.assignees?.map((assignee) => String(assignee.id)).filter(Boolean) ?? [],
         localeReadiness: localeReadinessKey
           ? (localeReadinessByLanguage[localeReadinessKey] ?? null)
           : localeReadinessByLanguage,

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/smartling/smartling-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/smartling/smartling-api.ts
@@ -846,18 +846,36 @@ export class SmartlingApiClient {
     return normalizeSmartlingJobSummary(data);
   }
 
+  async updateJob(
+    projectId: string,
+    translationJobUid: string,
+    fields: {
+      jobName?: string;
+      description?: string | null;
+    },
+  ): Promise<SmartlingJobDetails> {
+    const token = await this.getAccessToken();
+    const body: Record<string, string> = {};
+    if (fields.jobName !== undefined) {
+      body.jobName = fields.jobName;
+    }
+    if (fields.description !== undefined) {
+      body.description = fields.description ?? "";
+    }
+    const data = await this.put<SmartlingJobDetails>(
+      `${this.jobsBaseUrl}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(translationJobUid)}`,
+      token,
+      body,
+    );
+    return normalizeSmartlingJobSummary(data);
+  }
+
   async updateJobDescription(
     projectId: string,
     translationJobUid: string,
     description: string,
   ): Promise<SmartlingJobDetails> {
-    const token = await this.getAccessToken();
-    const data = await this.put<SmartlingJobDetails>(
-      `${this.jobsBaseUrl}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(translationJobUid)}`,
-      token,
-      { description },
-    );
-    return normalizeSmartlingJobSummary(data);
+    return this.updateJob(projectId, translationJobUid, { description });
   }
 
   async listContextBindings(

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.test.ts
@@ -28,6 +28,7 @@ describe("getTmsProviderLiveErrorStatus", () => {
     ["crowdin_auth_invalid", 401],
     ["no_active_tms_provider", 404],
     ["invalid_encoded_job_id", 400],
+    ["invalid_crowdin_assignee_id", 400],
     ["crowdin_cat_all_files_query_too_large", 400],
     ["invalid_smartling_project_id", 400],
     ["invalid_smartling_string_id", 400],

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.ts
@@ -59,6 +59,7 @@ export function getTmsProviderLiveErrorStatus(code: string): TmsProviderLiveErro
     case "phrase_target_locale_not_found":
     case "invalid_job_update":
     case "unsupported_job_field_update":
+    case "invalid_crowdin_assignee_id":
       return 400;
     case "provider_fetcher_unavailable":
     case "provider_description_edit_unsupported":

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.ts
@@ -57,6 +57,8 @@ export function getTmsProviderLiveErrorStatus(code: string): TmsProviderLiveErro
     case "invalid_smartling_string_id":
     case "invalid_smartling_comment_id":
     case "phrase_target_locale_not_found":
+    case "invalid_job_update":
+    case "unsupported_job_field_update":
       return 400;
     case "provider_fetcher_unavailable":
     case "provider_description_edit_unsupported":

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -3801,12 +3801,7 @@ export async function updateTmsProviderLiveJobDescription(
   description: string,
   actorUserId: string,
 ): Promise<TmsProviderLiveJobDetail | null> {
-  return updateTmsProviderLiveJobFields(
-    organizationId,
-    encodedJobId,
-    { description },
-    actorUserId,
-  );
+  return updateTmsProviderLiveJobFields(organizationId, encodedJobId, { description }, actorUserId);
 }
 
 function dedupeGlossaries(items: TmsProviderLiveGlossary[]) {

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -3766,6 +3766,12 @@ export async function updateTmsProviderLiveJobFields(
       ...(hasAssignees ? { assigneeExternalUserIds: fields.assigneeExternalUserIds } : {}),
     });
   } catch (error) {
+    if (error instanceof Error && error.message === "invalid_crowdin_assignee_id") {
+      throw new TmsProviderLiveError(
+        "invalid_crowdin_assignee_id",
+        "Assignee ids must be canonical positive Crowdin member ids.",
+      );
+    }
     if (error instanceof CrowdinApiError && error.status === 401) {
       throw new TmsProviderLiveError(
         "crowdin_user_auth_invalid",

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -3606,15 +3606,31 @@ export async function listTmsProviderLiveProjectMembers(
   }
 }
 
-export async function updateTmsProviderLiveJobDescription(
+export type UpdateTmsProviderLiveJobFields = {
+  title?: string;
+  description?: string | null;
+  assigneeExternalUserIds?: string[];
+};
+
+export async function updateTmsProviderLiveJobFields(
   organizationId: string,
   encodedJobId: string,
-  description: string,
+  fields: UpdateTmsProviderLiveJobFields,
   actorUserId: string,
 ): Promise<TmsProviderLiveJobDetail | null> {
   const parsed = parseProviderJobId(encodedJobId);
   if (!parsed) {
     throw new TmsProviderLiveError("invalid_encoded_job_id", "Job id is not a provider job id.");
+  }
+
+  const hasTitle = fields.title !== undefined;
+  const hasDescription = fields.description !== undefined;
+  const hasAssignees = fields.assigneeExternalUserIds !== undefined;
+  if (!hasTitle && !hasDescription && !hasAssignees) {
+    throw new TmsProviderLiveError(
+      "invalid_job_update",
+      "At least one of title, description, or assigneeExternalUserIds is required.",
+    );
   }
 
   const context = await loadActiveTmsProviderContext(organizationId, { actorUserId });
@@ -3624,12 +3640,19 @@ export async function updateTmsProviderLiveJobDescription(
 
   if (context.providerKind !== "crowdin" && context.providerKind !== "smartling") {
     throw new TmsProviderLiveError(
-      "provider_description_edit_unsupported",
-      `Description edits are not supported for ${context.providerKind}.`,
+      "unsupported_job_field_update",
+      `Job field edits are not supported for ${context.providerKind}.`,
     );
   }
 
   if (context.providerKind === "smartling") {
+    if (hasAssignees) {
+      throw new TmsProviderLiveError(
+        "unsupported_job_field_update",
+        "Assignee updates are not supported for Smartling jobs.",
+      );
+    }
+
     const projectId = parsed.externalProjectId.trim();
     const jobUid = parsed.externalJobId.trim();
     if (!projectId || !jobUid) {
@@ -3652,7 +3675,10 @@ export async function updateTmsProviderLiveJobDescription(
     let projectDetails: Awaited<ReturnType<typeof client.getProjectDetails>>;
     try {
       [updatedJob, projectDetails] = await Promise.all([
-        client.updateJobDescription(projectId, jobUid, description),
+        client.updateJob(projectId, jobUid, {
+          ...(hasTitle ? { jobName: fields.title } : {}),
+          ...(hasDescription ? { description: fields.description } : {}),
+        }),
         client.getProjectDetails(projectId),
       ]);
     } catch (error) {
@@ -3732,9 +3758,13 @@ export async function updateTmsProviderLiveJobDescription(
     baseUrl: context.credential.baseUrl ?? undefined,
   });
 
-  let updatedTask: Awaited<ReturnType<typeof client.editTaskDescription>>;
+  let updatedTask: Awaited<ReturnType<typeof client.editTaskFields>>;
   try {
-    updatedTask = await client.editTaskDescription(projectId, taskId, description);
+    updatedTask = await client.editTaskFields(projectId, taskId, {
+      ...(hasTitle ? { title: fields.title } : {}),
+      ...(hasDescription ? { description: fields.description } : {}),
+      ...(hasAssignees ? { assigneeExternalUserIds: fields.assigneeExternalUserIds } : {}),
+    });
   } catch (error) {
     if (error instanceof CrowdinApiError && error.status === 401) {
       throw new TmsProviderLiveError(
@@ -3763,6 +3793,20 @@ export async function updateTmsProviderLiveJobDescription(
       providerPayload,
     },
   });
+}
+
+export async function updateTmsProviderLiveJobDescription(
+  organizationId: string,
+  encodedJobId: string,
+  description: string,
+  actorUserId: string,
+): Promise<TmsProviderLiveJobDetail | null> {
+  return updateTmsProviderLiveJobFields(
+    organizationId,
+    encodedJobId,
+    { description },
+    actorUserId,
+  );
 }
 
 function dedupeGlossaries(items: TmsProviderLiveGlossary[]) {

--- a/docs/plans/2026-08-03-job-detail-editable-fields-design.md
+++ b/docs/plans/2026-08-03-job-detail-editable-fields-design.md
@@ -1,0 +1,124 @@
+# Job detail editable fields — Design
+
+**Status:** Approved  
+**Date:** 2026-08-03
+
+## Summary
+
+Let users edit assignees, title, and description on Jobs detail, with parity to Issues where the models map. Native jobs use a single owner plus local title/description. Crowdin and Smartling sync supported fields to the TMS. Other providers stay read-only for these fields.
+
+## Goals
+
+- Assign or unassign a native job owner from detail (single assignee)
+- Assign Crowdin task members from detail (multi-assignee)
+- Edit title and description on native, Crowdin, and Smartling jobs
+- Keep create-dialog assignee sources and validation rules
+- Leave status, due date, locales, and non-Crowdin/Smartling provider assignees out of this change
+
+## Field matrix
+
+| Field | Native | Crowdin | Smartling | Other providers |
+|-------|--------|---------|-----------|-----------------|
+| Title | `inputPayload.metadata.title` | PATCH `/title` | `jobName` via update job | Read-only |
+| Description | `inputPayload.metadata.description` | PATCH `/description` | existing description update | Read-only |
+| Assignees | single `ownerUserId` | multi `assigneeExternalUserIds` | Read-only (no simple assignee API) | Read-only |
+
+## APIs
+
+### Native
+
+`PATCH /api/orgs/:org/projects/:projectId/jobs/:jobId`
+
+Body (all optional; at least one required):
+
+```ts
+{
+  title?: string;                 // 1–256 chars
+  description?: string | null;    // max 2048; null clears
+  ownerWorkosUserId?: string | null; // null unassigns
+}
+```
+
+- Requires `jobs:write`
+- Owner must be an active org member with project access (same spirit as issue assignability)
+- Writes title/description into `inputPayload.metadata`
+- Returns the updated job record
+
+### Provider
+
+Replace description-only route with:
+
+`PATCH /api/orgs/:org/tms-provider/jobs/:encodedJobId`
+
+Body (all optional; at least one required):
+
+```ts
+{
+  title?: string;
+  description?: string | null;
+  assigneeExternalUserIds?: string[]; // Crowdin only
+}
+```
+
+- Crowdin: title, description, assignees via JSON Patch
+- Smartling: title + description; assignee updates return `unsupported_job_field_update`
+- Other providers: `unsupported_job_field_update`
+- Keep the old `/description` path as a thin alias or migrate callers in the same change
+
+## UI
+
+### Assignees
+
+- Properties sidebar: replace the comma-joined string with a picker for native and Crowdin
+- Native: Issue-like single-select (Unassign, Assign to me, members)
+- Crowdin: multi-select toggle list matching create dialog
+- Smartling / unsupported: keep read-only text
+
+### Title
+
+- Inline editable header (blur/Enter save, Escape cancel)
+- Reject empty titles client-side before PATCH
+
+### Description
+
+- Crowdin/Smartling: keep `ProviderJobDescriptionField`, driven by the unified PATCH
+- Native: same editor/preview slot; store in `metadata.description`
+
+### Interaction
+
+- Disable controls while a mutation is pending
+- Optimistic detail-cache patch; invalidate job lists afterward
+- On failure, show the error and revert optimistic values
+
+## Data flow
+
+1. Detail loads job + assignable members (org members for native; TMS project members for Crowdin)
+2. User edits title, description, or assignees → PATCH
+3. Server checks permission, job existence, and provider field support
+4. Native updates DB; Crowdin/Smartling call provider APIs and refresh cached external fields
+5. Client updates detail cache and list/“assigned to me” queries
+
+## Errors
+
+| Code | When |
+|------|------|
+| `assignee_not_assignable` | Native owner is inactive or lacks project access |
+| `unsupported_job_field_update` | Field not supported for provider kind |
+| Provider auth / not found | Existing Crowdin/Smartling error mapping |
+| Empty title | Validation reject (min 1 char) |
+
+## Testing
+
+- Native PATCH: title, description, owner assign/unassign, invalid owner
+- Crowdin PATCH: title, description, assignees
+- Smartling PATCH: title, description; assignees rejected
+- Unsupported provider → 400
+- Layout helpers: picker vs read-only by provider
+- Mutation/UI coverage where Issues/description patterns already exist
+
+## Out of scope
+
+- Smartling assignee editing
+- Due date, status picker, locale edits
+- Phrase/Lokalise field edits
+- Job activity feed for assignee changes


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Make Jobs detail editable for assignees, title, and description — similar to Issues — for native jobs and Crowdin/Smartling provider jobs.

## Scope

| Field | Native | Crowdin | Smartling |
|-------|--------|---------|-----------|
| Title | editable | editable | editable |
| Description | editable | editable | editable |
| Assignees | single owner | multi | read-only (no simple API) |

## Design

See `docs/plans/2026-08-03-job-detail-editable-fields-design.md`.

## Changes

- Native `PATCH /jobs/:jobId` for title / description / `ownerWorkosUserId` (project-access assignability)
- Unified TMS `PATCH /tms-provider/jobs/:encodedJobId` for title / description / Crowdin assignees (description route kept as alias)
- Detail UI: Issue-like owner picker, Crowdin multi-assignee picker, inline title, description editor
- Route tests for native title/description/owner assign + unassign + invalid assignee

## Review fixes

- Crowdin assignee toggles serialize via draft/queue state (no stale overwrite)
- Provider descriptions restored on native detail fallback view
- Smartling field edits restricted to workspace operators (shared org credentials); Crowdin keeps `jobs:write`
- Native updates run in a transaction with `FOR UPDATE OF jobs` and only write fields present in the body
- Invalid Crowdin assignee ids rejected as `400 invalid_crowdin_assignee_id`

## Out of scope

- Smartling assignees, due date, status picker, Phrase/Lokalise field edits
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-870e2191-e735-4c21-b89b-d1c85bf4e21e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-870e2191-e735-4c21-b89b-d1c85bf4e21e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

