### PR TITLE
feat(agent): add glossary search guardrails

### DIFF
--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-skills/crowdin.md
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-skills/crowdin.md
@@ -6,7 +6,7 @@ provider: crowdin
 
 ## Crowdin TMS
 
-Use Crowdin tools when the user asks about translation work in a Hyperlocalise project linked to Crowdin. This skill covers all Crowdin-specific agent capabilities; new tools are added here as the integration grows.
+Use Crowdin tools when the user asks about translation work in a Hyperlocalise project linked to Crowdin. This shared skill covers capabilities available whenever the Crowdin integration is active.
 
 ### Prerequisites
 
@@ -22,31 +22,7 @@ Use Crowdin tools when the user asks about translation work in a Hyperlocalise p
 - Summarize results concisely with percentages, counts, and the Crowdin project name when helpful.
 - If Crowdin is not configured for the project, say so clearly and stop — do not guess progress.
 
-### Terminology policy
-
-- Before advising on product names, feature names, or UI terms, call `search_crowdin_glossary`.
-- Follow preferred and forbidden glossary hits exactly.
-- If a term is missing, translate for native-like UX and explicitly flag that it is not in the Crowdin glossary.
-- Do not invent a default of keeping official product or feature names in English unless the glossary or project context says so.
-- When the conversation or CAT page is attached to a Crowdin-linked Hyperlocalise project, pass `projectId` so search uses project concordance. Otherwise search organization glossaries.
-
 ### Available tools
-
-#### `search_crowdin_glossary`
-
-Search Crowdin glossaries for source expressions.
-
-| Situation                                        | Parameters                                                      |
-| ------------------------------------------------ | --------------------------------------------------------------- |
-| CAT or conversation has a Crowdin-linked project | pass `projectId`, `sourceLocale`, `targetLocale`, `expressions` |
-| Crowdin connected, no project                    | omit `projectId`; org-level concordance                         |
-| Multiple candidate terms                         | pass several `expressions`                                      |
-
-Response fields:
-
-- `scope`: `"organization"` or `"project"`.
-- `matches`: glossary name/id, source/target terms, status (for example preferred/forbidden), and description when present.
-- Empty `matches` means the term was not found — translate for native-like UX and flag the gap.
 
 #### `check_crowdin_progress`
 

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-skills/crowdin.md
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-skills/crowdin.md
@@ -22,7 +22,31 @@ Use Crowdin tools when the user asks about translation work in a Hyperlocalise p
 - Summarize results concisely with percentages, counts, and the Crowdin project name when helpful.
 - If Crowdin is not configured for the project, say so clearly and stop — do not guess progress.
 
+### Terminology policy
+
+- Before advising on product names, feature names, or UI terms, call `search_crowdin_glossary`.
+- Follow preferred and forbidden glossary hits exactly.
+- If a term is missing, translate for native-like UX and explicitly flag that it is not in the Crowdin glossary.
+- Do not invent a default of keeping official product or feature names in English unless the glossary or project context says so.
+- When the conversation or CAT page is attached to a Crowdin-linked Hyperlocalise project, pass `projectId` so search uses project concordance. Otherwise search organization glossaries.
+
 ### Available tools
+
+#### `search_crowdin_glossary`
+
+Search Crowdin glossaries for source expressions.
+
+| Situation                                        | Parameters                                                      |
+| ------------------------------------------------ | --------------------------------------------------------------- |
+| CAT or conversation has a Crowdin-linked project | pass `projectId`, `sourceLocale`, `targetLocale`, `expressions` |
+| Crowdin connected, no project                    | omit `projectId`; org-level concordance                         |
+| Multiple candidate terms                         | pass several `expressions`                                      |
+
+Response fields:
+
+- `scope`: `"organization"` or `"project"`.
+- `matches`: glossary name/id, source/target terms, status (for example preferred/forbidden), and description when present.
+- Empty `matches` means the term was not found — translate for native-like UX and flag the gap.
 
 #### `check_crowdin_progress`
 

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/build-native-glossary-tsquery.test.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/build-native-glossary-tsquery.test.ts
@@ -25,4 +25,12 @@ describe("buildNativeGlossaryTsQuery", () => {
     expect(buildNativeGlossaryTsQuery("!!!")).toBe("");
     expect(buildNativeGlossaryTsQuery("'-\"")).toBe("");
   });
+
+  it("caps terms at 50 to match concordance search", () => {
+    const words = Array.from({ length: 60 }, (_, index) => `term${index}`);
+    const tsQuery = buildNativeGlossaryTsQuery(words.join(" "));
+    expect(tsQuery.split(" & ")).toHaveLength(50);
+    expect(tsQuery.startsWith("term0:*")).toBe(true);
+    expect(tsQuery.endsWith("term49:*")).toBe(true);
+  });
 });

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/build-native-glossary-tsquery.test.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/build-native-glossary-tsquery.test.ts
@@ -12,7 +12,7 @@
  */
 import { describe, expect, it } from "vite-plus/test";
 
-import { buildNativeGlossaryTsQuery } from "./search_native_glossary";
+import { buildNativeGlossaryTsQuery } from "./build-native-glossary-tsquery";
 
 describe("buildNativeGlossaryTsQuery", () => {
   it("strips apostrophes, quotes, and hyphens before building prefix terms", () => {

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/build-native-glossary-tsquery.test.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/build-native-glossary-tsquery.test.ts
@@ -16,9 +16,15 @@ import { buildNativeGlossaryTsQuery } from "./build-native-glossary-tsquery";
 
 describe("buildNativeGlossaryTsQuery", () => {
   it("strips apostrophes, quotes, and hyphens before building prefix terms", () => {
-    expect(buildNativeGlossaryTsQuery("What's new")).toBe("What:* & s:* & new:*");
-    expect(buildNativeGlossaryTsQuery(`"Talk to Heidi"`)).toBe("Talk:* & to:* & Heidi:*");
-    expect(buildNativeGlossaryTsQuery("multi-word term")).toBe("multi:* & word:* & term:*");
+    expect(buildNativeGlossaryTsQuery("What's new")).toBe("What:* | s:* | new:*");
+    expect(buildNativeGlossaryTsQuery(`"Talk to Heidi"`)).toBe("Talk:* | to:* | Heidi:*");
+    expect(buildNativeGlossaryTsQuery("multi-word term")).toBe("multi:* | word:* | term:*");
+  });
+
+  it("matches individual glossary terms within a source sentence", () => {
+    expect(buildNativeGlossaryTsQuery("Click Home to continue")).toBe(
+      "Click:* | Home:* | to:* | continue:*",
+    );
   });
 
   it("returns an empty string when input is only punctuation", () => {
@@ -29,7 +35,7 @@ describe("buildNativeGlossaryTsQuery", () => {
   it("caps terms at 50 to match concordance search", () => {
     const words = Array.from({ length: 60 }, (_, index) => `term${index}`);
     const tsQuery = buildNativeGlossaryTsQuery(words.join(" "));
-    expect(tsQuery.split(" & ")).toHaveLength(50);
+    expect(tsQuery.split(" | ")).toHaveLength(50);
     expect(tsQuery.startsWith("term0:*")).toBe(true);
     expect(tsQuery.endsWith("term49:*")).toBe(true);
   });

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/build-native-glossary-tsquery.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/build-native-glossary-tsquery.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+/**
+ * Build a prefix-ready tsquery string from free-form user input.
+ *
+ * Strips characters that have special meaning in Postgres tsquery syntax
+ * so that untrusted input cannot break the query. Matches
+ * `buildGlossaryTsQuery` in lib/translation/concordance.ts (including quotes
+ * and hyphens common in UI copy such as "What's new").
+ */
+export function buildNativeGlossaryTsQuery(input: string): string {
+  return input
+    .replace(/[&|!():*<>'"-]/g, " ")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => `${word}:*`)
+    .join(" & ");
+}

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/build-native-glossary-tsquery.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/build-native-glossary-tsquery.ts
@@ -11,6 +11,9 @@
  * Version 2.0 or later.
  */
 
+/** Matches `maxContextSearchTerms` in lib/translation/concordance.ts. */
+const MAX_NATIVE_GLOSSARY_SEARCH_TERMS = 50;
+
 /**
  * Build a prefix-ready tsquery string from free-form user input.
  *
@@ -25,6 +28,7 @@ export function buildNativeGlossaryTsQuery(input: string): string {
     .trim()
     .split(/\s+/)
     .filter(Boolean)
+    .slice(0, MAX_NATIVE_GLOSSARY_SEARCH_TERMS)
     .map((word) => `${word}:*`)
     .join(" & ");
 }

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/build-native-glossary-tsquery.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/build-native-glossary-tsquery.ts
@@ -15,12 +15,13 @@
 const MAX_NATIVE_GLOSSARY_SEARCH_TERMS = 50;
 
 /**
- * Build a prefix-ready tsquery string from free-form user input.
+ * Build a prefix-ready candidate tsquery from free-form user input.
  *
  * Strips characters that have special meaning in Postgres tsquery syntax
  * so that untrusted input cannot break the query. Matches
  * `buildGlossaryTsQuery` in lib/translation/concordance.ts (including quotes
- * and hyphens common in UI copy such as "What's new").
+ * and hyphens common in UI copy such as "What's new"). Terms are joined with
+ * OR so glossary entries can match words within a longer source sentence.
  */
 export function buildNativeGlossaryTsQuery(input: string): string {
   return input
@@ -30,5 +31,5 @@ export function buildNativeGlossaryTsQuery(input: string): string {
     .filter(Boolean)
     .slice(0, MAX_NATIVE_GLOSSARY_SEARCH_TERMS)
     .map((word) => `${word}:*`)
-    .join(" & ");
+    .join(" | ");
 }

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_crowdin_glossary.test.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_crowdin_glossary.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { ok } from "@/lib/primitives/result/results";
+
+import { createSearchCrowdinGlossaryTool } from "./search_crowdin_glossary";
+
+const { searchGlossaryForAgentMock } = vi.hoisted(() => ({
+  searchGlossaryForAgentMock: vi.fn(),
+}));
+
+vi.mock("@/lib/providers/adapters/crowdin/crowdin-provider", () => ({
+  crowdinTmsProvider: {
+    searchGlossaryForAgent: (...args: unknown[]) => searchGlossaryForAgentMock(...args),
+  },
+}));
+
+describe("createSearchCrowdinGlossaryTool", () => {
+  it("keeps search organization-scoped unless projectId is explicit", async () => {
+    searchGlossaryForAgentMock.mockResolvedValue(
+      ok({ scope: "organization", crowdinProjectId: null, matches: [] }),
+    );
+    const tool = createSearchCrowdinGlossaryTool({
+      organizationId: "org-1",
+      localUserId: "user-1",
+    });
+
+    await tool.execute?.(
+      {
+        expressions: ["Talk to Heidi"],
+        sourceLocale: "en",
+        targetLocale: "vi",
+        limit: 20,
+      },
+      {} as never,
+    );
+
+    expect(searchGlossaryForAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: "org-1",
+        projectId: undefined,
+      }),
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_crowdin_glossary.test.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_crowdin_glossary.test.ts
@@ -10,7 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { describe, expect, it, vi } from "vite-plus/test";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { ok } from "@/lib/primitives/result/results";
 
@@ -27,6 +27,10 @@ vi.mock("@/lib/providers/adapters/crowdin/crowdin-provider", () => ({
 }));
 
 describe("createSearchCrowdinGlossaryTool", () => {
+  beforeEach(() => {
+    searchGlossaryForAgentMock.mockReset();
+  });
+
   it("keeps search organization-scoped when neither input nor context has projectId", async () => {
     searchGlossaryForAgentMock.mockResolvedValue(
       ok({ scope: "organization", crowdinProjectId: null, matches: [] }),
@@ -34,11 +38,8 @@ describe("createSearchCrowdinGlossaryTool", () => {
     const tool = createSearchCrowdinGlossaryTool({
       organizationId: "org-1",
       localUserId: "user-1",
-<<<<<<< HEAD
       projectId: null,
-=======
       glossarySearchEnabled: true,
->>>>>>> c1e00152 (feat(agent): gate glossary search behind workspace flag)
     });
 
     await tool.execute?.(
@@ -59,7 +60,6 @@ describe("createSearchCrowdinGlossaryTool", () => {
     );
   });
 
-<<<<<<< HEAD
   it("falls back to conversation projectId when input omits it", async () => {
     searchGlossaryForAgentMock.mockResolvedValue(
       ok({ scope: "project", crowdinProjectId: 42, matches: [] }),
@@ -68,6 +68,7 @@ describe("createSearchCrowdinGlossaryTool", () => {
       organizationId: "org-1",
       localUserId: "user-1",
       projectId: "project-1",
+      glossarySearchEnabled: true,
     });
 
     await tool.execute?.(
@@ -86,11 +87,13 @@ describe("createSearchCrowdinGlossaryTool", () => {
         projectId: "project-1",
       }),
     );
-=======
+  });
+
   it("fails closed when glossary search is disabled", async () => {
     const tool = createSearchCrowdinGlossaryTool({
       organizationId: "org-1",
       localUserId: "user-1",
+      projectId: null,
       glossarySearchEnabled: false,
     });
 
@@ -109,6 +112,5 @@ describe("createSearchCrowdinGlossaryTool", () => {
       error: "Glossary search is not enabled for this workspace.",
     });
     expect(searchGlossaryForAgentMock).not.toHaveBeenCalled();
->>>>>>> c1e00152 (feat(agent): gate glossary search behind workspace flag)
   });
 });

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_crowdin_glossary.test.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_crowdin_glossary.test.ts
@@ -34,7 +34,11 @@ describe("createSearchCrowdinGlossaryTool", () => {
     const tool = createSearchCrowdinGlossaryTool({
       organizationId: "org-1",
       localUserId: "user-1",
+<<<<<<< HEAD
       projectId: null,
+=======
+      glossarySearchEnabled: true,
+>>>>>>> c1e00152 (feat(agent): gate glossary search behind workspace flag)
     });
 
     await tool.execute?.(
@@ -55,6 +59,7 @@ describe("createSearchCrowdinGlossaryTool", () => {
     );
   });
 
+<<<<<<< HEAD
   it("falls back to conversation projectId when input omits it", async () => {
     searchGlossaryForAgentMock.mockResolvedValue(
       ok({ scope: "project", crowdinProjectId: 42, matches: [] }),
@@ -81,5 +86,29 @@ describe("createSearchCrowdinGlossaryTool", () => {
         projectId: "project-1",
       }),
     );
+=======
+  it("fails closed when glossary search is disabled", async () => {
+    const tool = createSearchCrowdinGlossaryTool({
+      organizationId: "org-1",
+      localUserId: "user-1",
+      glossarySearchEnabled: false,
+    });
+
+    await expect(
+      tool.execute?.(
+        {
+          expressions: ["Talk to Heidi"],
+          sourceLocale: "en",
+          targetLocale: "vi",
+          limit: 20,
+        },
+        {} as never,
+      ),
+    ).resolves.toEqual({
+      success: false,
+      error: "Glossary search is not enabled for this workspace.",
+    });
+    expect(searchGlossaryForAgentMock).not.toHaveBeenCalled();
+>>>>>>> c1e00152 (feat(agent): gate glossary search behind workspace flag)
   });
 });

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_crowdin_glossary.test.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_crowdin_glossary.test.ts
@@ -12,12 +12,14 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
+import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 import { ok } from "@/lib/primitives/result/results";
 
 import { createSearchCrowdinGlossaryTool } from "./search_crowdin_glossary";
 
-const { searchGlossaryForAgentMock } = vi.hoisted(() => ({
+const { searchGlossaryForAgentMock, toolCanAccessProjectMock } = vi.hoisted(() => ({
   searchGlossaryForAgentMock: vi.fn(),
+  toolCanAccessProjectMock: vi.fn(),
 }));
 
 vi.mock("@/lib/providers/adapters/crowdin/crowdin-provider", () => ({
@@ -26,21 +28,37 @@ vi.mock("@/lib/providers/adapters/crowdin/crowdin-provider", () => ({
   },
 }));
 
+vi.mock("@/lib/tools/tool-access", () => ({
+  toolCanAccessProject: (...args: unknown[]) => toolCanAccessProjectMock(...args),
+}));
+
+function createToolContext(
+  overrides: Partial<Pick<ToolContext, "projectId" | "glossarySearchEnabled">> = {},
+): ToolContext {
+  return {
+    conversationId: "conv-1",
+    organizationId: "org-1",
+    localUserId: "user-1",
+    membershipRole: "member",
+    projectId: null,
+    db: {} as never,
+    glossarySearchEnabled: true,
+    ...overrides,
+  };
+}
+
 describe("createSearchCrowdinGlossaryTool", () => {
   beforeEach(() => {
     searchGlossaryForAgentMock.mockReset();
+    toolCanAccessProjectMock.mockReset();
+    toolCanAccessProjectMock.mockResolvedValue({ id: "project-1" });
   });
 
   it("keeps search organization-scoped when neither input nor context has projectId", async () => {
     searchGlossaryForAgentMock.mockResolvedValue(
       ok({ scope: "organization", crowdinProjectId: null, matches: [] }),
     );
-    const tool = createSearchCrowdinGlossaryTool({
-      organizationId: "org-1",
-      localUserId: "user-1",
-      projectId: null,
-      glossarySearchEnabled: true,
-    });
+    const tool = createSearchCrowdinGlossaryTool(createToolContext());
 
     await tool.execute?.(
       {
@@ -52,6 +70,7 @@ describe("createSearchCrowdinGlossaryTool", () => {
       {} as never,
     );
 
+    expect(toolCanAccessProjectMock).not.toHaveBeenCalled();
     expect(searchGlossaryForAgentMock).toHaveBeenCalledWith(
       expect.objectContaining({
         organizationId: "org-1",
@@ -64,12 +83,7 @@ describe("createSearchCrowdinGlossaryTool", () => {
     searchGlossaryForAgentMock.mockResolvedValue(
       ok({ scope: "project", crowdinProjectId: 42, matches: [] }),
     );
-    const tool = createSearchCrowdinGlossaryTool({
-      organizationId: "org-1",
-      localUserId: "user-1",
-      projectId: "project-1",
-      glossarySearchEnabled: true,
-    });
+    const tool = createSearchCrowdinGlossaryTool(createToolContext({ projectId: "project-1" }));
 
     await tool.execute?.(
       {
@@ -81,6 +95,10 @@ describe("createSearchCrowdinGlossaryTool", () => {
       {} as never,
     );
 
+    expect(toolCanAccessProjectMock).toHaveBeenCalledWith(
+      expect.objectContaining({ organizationId: "org-1" }),
+      "project-1",
+    );
     expect(searchGlossaryForAgentMock).toHaveBeenCalledWith(
       expect.objectContaining({
         organizationId: "org-1",
@@ -89,13 +107,33 @@ describe("createSearchCrowdinGlossaryTool", () => {
     );
   });
 
-  it("fails closed when glossary search is disabled", async () => {
-    const tool = createSearchCrowdinGlossaryTool({
-      organizationId: "org-1",
-      localUserId: "user-1",
-      projectId: null,
-      glossarySearchEnabled: false,
+  it("rejects project-scoped search when the caller cannot access the project", async () => {
+    toolCanAccessProjectMock.mockResolvedValue(null);
+    const tool = createSearchCrowdinGlossaryTool(
+      createToolContext({ projectId: "project-forbidden" }),
+    );
+
+    await expect(
+      tool.execute?.(
+        {
+          expressions: ["Talk to Heidi"],
+          sourceLocale: "en",
+          targetLocale: "vi",
+          limit: 20,
+        },
+        {} as never,
+      ),
+    ).resolves.toEqual({
+      success: false,
+      error: "Project not found or not accessible.",
     });
+    expect(searchGlossaryForAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when glossary search is disabled", async () => {
+    const tool = createSearchCrowdinGlossaryTool(
+      createToolContext({ glossarySearchEnabled: false }),
+    );
 
     await expect(
       tool.execute?.(

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_crowdin_glossary.test.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_crowdin_glossary.test.ts
@@ -27,13 +27,14 @@ vi.mock("@/lib/providers/adapters/crowdin/crowdin-provider", () => ({
 }));
 
 describe("createSearchCrowdinGlossaryTool", () => {
-  it("keeps search organization-scoped unless projectId is explicit", async () => {
+  it("keeps search organization-scoped when neither input nor context has projectId", async () => {
     searchGlossaryForAgentMock.mockResolvedValue(
       ok({ scope: "organization", crowdinProjectId: null, matches: [] }),
     );
     const tool = createSearchCrowdinGlossaryTool({
       organizationId: "org-1",
       localUserId: "user-1",
+      projectId: null,
     });
 
     await tool.execute?.(
@@ -50,6 +51,34 @@ describe("createSearchCrowdinGlossaryTool", () => {
       expect.objectContaining({
         organizationId: "org-1",
         projectId: undefined,
+      }),
+    );
+  });
+
+  it("falls back to conversation projectId when input omits it", async () => {
+    searchGlossaryForAgentMock.mockResolvedValue(
+      ok({ scope: "project", crowdinProjectId: 42, matches: [] }),
+    );
+    const tool = createSearchCrowdinGlossaryTool({
+      organizationId: "org-1",
+      localUserId: "user-1",
+      projectId: "project-1",
+    });
+
+    await tool.execute?.(
+      {
+        expressions: ["Talk to Heidi"],
+        sourceLocale: "en",
+        targetLocale: "vi",
+        limit: 20,
+      },
+      {} as never,
+    );
+
+    expect(searchGlossaryForAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: "org-1",
+        projectId: "project-1",
       }),
     );
   });

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_crowdin_glossary.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_crowdin_glossary.ts
@@ -67,7 +67,11 @@ export type SearchCrowdinGlossaryToolInput = z.infer<typeof searchCrowdinGlossar
 export type SearchCrowdinGlossaryToolOutput = z.infer<typeof searchCrowdinGlossaryOutputSchema>;
 
 export function createSearchCrowdinGlossaryTool(
+<<<<<<< HEAD
   ctx: Pick<ToolContext, "organizationId" | "localUserId" | "projectId">,
+=======
+  ctx: Pick<ToolContext, "organizationId" | "localUserId" | "glossarySearchEnabled">,
+>>>>>>> c1e00152 (feat(agent): gate glossary search behind workspace flag)
 ) {
   return defineAgentTool({
     description:
@@ -75,7 +79,17 @@ export function createSearchCrowdinGlossaryTool(
     inputSchema: searchCrowdinGlossaryInputSchema,
     outputSchema: searchCrowdinGlossaryOutputSchema,
     execute: async (input) => {
+<<<<<<< HEAD
       const projectId = input.projectId ?? ctx.projectId ?? undefined;
+=======
+      if (ctx.glossarySearchEnabled !== true) {
+        return {
+          success: false,
+          error: "Glossary search is not enabled for this workspace.",
+        };
+      }
+
+>>>>>>> c1e00152 (feat(agent): gate glossary search behind workspace flag)
       const result = await crowdinTmsProvider.searchGlossaryForAgent({
         organizationId: ctx.organizationId,
         actorUserId: ctx.localUserId,

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_crowdin_glossary.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_crowdin_glossary.ts
@@ -67,11 +67,7 @@ export type SearchCrowdinGlossaryToolInput = z.infer<typeof searchCrowdinGlossar
 export type SearchCrowdinGlossaryToolOutput = z.infer<typeof searchCrowdinGlossaryOutputSchema>;
 
 export function createSearchCrowdinGlossaryTool(
-<<<<<<< HEAD
-  ctx: Pick<ToolContext, "organizationId" | "localUserId" | "projectId">,
-=======
-  ctx: Pick<ToolContext, "organizationId" | "localUserId" | "glossarySearchEnabled">,
->>>>>>> c1e00152 (feat(agent): gate glossary search behind workspace flag)
+  ctx: Pick<ToolContext, "organizationId" | "localUserId" | "projectId" | "glossarySearchEnabled">,
 ) {
   return defineAgentTool({
     description:
@@ -79,9 +75,6 @@ export function createSearchCrowdinGlossaryTool(
     inputSchema: searchCrowdinGlossaryInputSchema,
     outputSchema: searchCrowdinGlossaryOutputSchema,
     execute: async (input) => {
-<<<<<<< HEAD
-      const projectId = input.projectId ?? ctx.projectId ?? undefined;
-=======
       if (ctx.glossarySearchEnabled !== true) {
         return {
           success: false,
@@ -89,7 +82,7 @@ export function createSearchCrowdinGlossaryTool(
         };
       }
 
->>>>>>> c1e00152 (feat(agent): gate glossary search behind workspace flag)
+      const projectId = input.projectId ?? ctx.projectId ?? undefined;
       const result = await crowdinTmsProvider.searchGlossaryForAgent({
         organizationId: ctx.organizationId,
         actorUserId: ctx.localUserId,

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_crowdin_glossary.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_crowdin_glossary.ts
@@ -67,18 +67,19 @@ export type SearchCrowdinGlossaryToolInput = z.infer<typeof searchCrowdinGlossar
 export type SearchCrowdinGlossaryToolOutput = z.infer<typeof searchCrowdinGlossaryOutputSchema>;
 
 export function createSearchCrowdinGlossaryTool(
-  ctx: Pick<ToolContext, "organizationId" | "localUserId">,
+  ctx: Pick<ToolContext, "organizationId" | "localUserId" | "projectId">,
 ) {
   return defineAgentTool({
     description:
-      "Search Crowdin glossaries for preferred or forbidden terminology. Defaults to organization-wide concordance; pass projectId for a Crowdin-linked Hyperlocalise project.",
+      "Search Crowdin glossaries for preferred or forbidden terminology. Uses the conversation project when set; pass projectId to override, or omit both for organization glossaries.",
     inputSchema: searchCrowdinGlossaryInputSchema,
     outputSchema: searchCrowdinGlossaryOutputSchema,
     execute: async (input) => {
+      const projectId = input.projectId ?? ctx.projectId ?? undefined;
       const result = await crowdinTmsProvider.searchGlossaryForAgent({
         organizationId: ctx.organizationId,
         actorUserId: ctx.localUserId,
-        projectId: input.projectId,
+        projectId,
         sourceLocale: input.sourceLocale,
         targetLocale: input.targetLocale,
         expressions: input.expressions,

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_crowdin_glossary.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_crowdin_glossary.ts
@@ -16,6 +16,7 @@ import { defineAgentTool } from "@/agents/_runtime/define-agent-tool";
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 import { crowdinTmsProvider } from "@/lib/providers/adapters/crowdin/crowdin-provider";
 import { isErr } from "@/lib/primitives/result/results";
+import { toolCanAccessProject } from "@/lib/tools/tool-access";
 
 const searchCrowdinGlossaryInputSchema = z.object({
   expressions: z
@@ -66,9 +67,7 @@ const searchCrowdinGlossaryOutputSchema = z.object({
 export type SearchCrowdinGlossaryToolInput = z.infer<typeof searchCrowdinGlossaryInputSchema>;
 export type SearchCrowdinGlossaryToolOutput = z.infer<typeof searchCrowdinGlossaryOutputSchema>;
 
-export function createSearchCrowdinGlossaryTool(
-  ctx: Pick<ToolContext, "organizationId" | "localUserId" | "projectId" | "glossarySearchEnabled">,
-) {
+export function createSearchCrowdinGlossaryTool(ctx: ToolContext) {
   return defineAgentTool({
     description:
       "Search Crowdin glossaries for preferred or forbidden terminology. Uses the conversation project when set; pass projectId to override, or omit both for organization glossaries.",
@@ -83,6 +82,16 @@ export function createSearchCrowdinGlossaryTool(
       }
 
       const projectId = input.projectId ?? ctx.projectId ?? undefined;
+      if (projectId) {
+        const accessibleProject = await toolCanAccessProject(ctx, projectId);
+        if (!accessibleProject) {
+          return {
+            success: false,
+            error: "Project not found or not accessible.",
+          };
+        }
+      }
+
       const result = await crowdinTmsProvider.searchGlossaryForAgent({
         organizationId: ctx.organizationId,
         actorUserId: ctx.localUserId,

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_crowdin_glossary.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_crowdin_glossary.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { z } from "zod";
+
+import { defineAgentTool } from "@/agents/_runtime/define-agent-tool";
+import type { ToolContext } from "@/lib/agent-contracts/tool-context";
+import { crowdinTmsProvider } from "@/lib/providers/adapters/crowdin/crowdin-provider";
+import { isErr } from "@/lib/primitives/result/results";
+
+const searchCrowdinGlossaryInputSchema = z.object({
+  expressions: z
+    .array(z.string().trim().min(1))
+    .min(1)
+    .max(20)
+    .describe("Source expressions or terms to look up in Crowdin glossaries."),
+  sourceLocale: z
+    .string()
+    .trim()
+    .min(1)
+    .describe("Crowdin source language ID, for example 'en' or 'en-US'."),
+  targetLocale: z
+    .string()
+    .trim()
+    .min(1)
+    .describe("Crowdin target language ID, for example 'de' or 'vi'."),
+  projectId: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe(
+      "Optional Hyperlocalise project ID linked to Crowdin. When set, searches that project's glossaries; otherwise searches organization glossaries.",
+    ),
+  limit: z.number().int().min(1).max(50).default(20).describe("Maximum matches to return."),
+});
+
+const searchCrowdinGlossaryOutputSchema = z.object({
+  success: z.boolean(),
+  error: z.string().optional(),
+  scope: z.enum(["organization", "project"]).optional(),
+  crowdinProjectId: z.number().nullable().optional(),
+  matches: z
+    .array(
+      z.object({
+        glossaryId: z.number(),
+        glossaryName: z.string(),
+        sourceTerm: z.string(),
+        targetTerm: z.string(),
+        status: z.string().nullable(),
+        description: z.string().nullable(),
+      }),
+    )
+    .optional(),
+});
+
+export type SearchCrowdinGlossaryToolInput = z.infer<typeof searchCrowdinGlossaryInputSchema>;
+export type SearchCrowdinGlossaryToolOutput = z.infer<typeof searchCrowdinGlossaryOutputSchema>;
+
+export function createSearchCrowdinGlossaryTool(
+  ctx: Pick<ToolContext, "organizationId" | "localUserId">,
+) {
+  return defineAgentTool({
+    description:
+      "Search Crowdin glossaries for preferred or forbidden terminology. Defaults to organization-wide concordance; pass projectId for a Crowdin-linked Hyperlocalise project.",
+    inputSchema: searchCrowdinGlossaryInputSchema,
+    outputSchema: searchCrowdinGlossaryOutputSchema,
+    execute: async (input) => {
+      const result = await crowdinTmsProvider.searchGlossaryForAgent({
+        organizationId: ctx.organizationId,
+        actorUserId: ctx.localUserId,
+        projectId: input.projectId,
+        sourceLocale: input.sourceLocale,
+        targetLocale: input.targetLocale,
+        expressions: input.expressions,
+        limit: input.limit,
+      });
+
+      if (isErr(result)) {
+        return {
+          success: false,
+          error: result.error.message,
+        };
+      }
+
+      return {
+        success: true,
+        scope: result.value.scope,
+        crowdinProjectId: result.value.crowdinProjectId,
+        matches: result.value.matches,
+      };
+    },
+  });
+}

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_native_glossary.test.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_native_glossary.test.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildNativeGlossaryTsQuery } from "./search_native_glossary";
+
+describe("buildNativeGlossaryTsQuery", () => {
+  it("strips apostrophes, quotes, and hyphens before building prefix terms", () => {
+    expect(buildNativeGlossaryTsQuery("What's new")).toBe("What:* & s:* & new:*");
+    expect(buildNativeGlossaryTsQuery(`"Talk to Heidi"`)).toBe("Talk:* & to:* & Heidi:*");
+    expect(buildNativeGlossaryTsQuery("multi-word term")).toBe("multi:* & word:* & term:*");
+  });
+
+  it("returns an empty string when input is only punctuation", () => {
+    expect(buildNativeGlossaryTsQuery("!!!")).toBe("");
+    expect(buildNativeGlossaryTsQuery("'-\"")).toBe("");
+  });
+});

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_native_glossary.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_native_glossary.ts
@@ -16,6 +16,7 @@ import { z } from "zod";
 import { defineAgentTool } from "@/agents/_runtime/define-agent-tool";
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 import { schema } from "@/lib/database";
+import { sourceContainsTerm } from "@/lib/glossary/validate-glossary-terms-in-translation";
 import { toolCanAccessProject, toolProjectLinkedGlossaryWhere } from "@/lib/tools/tool-access";
 
 import { buildNativeGlossaryTsQuery } from "./build-native-glossary-tsquery";
@@ -130,6 +131,7 @@ export function createSearchNativeGlossaryTool(ctx: ToolContext) {
           targetTerm: schema.glossaryTerms.targetTerm,
           description: schema.glossaryTerms.description,
           forbidden: schema.glossaryTerms.forbidden,
+          caseSensitive: schema.glossaryTerms.caseSensitive,
           glossaryId: schema.glossaryTerms.glossaryId,
           glossaryName: schema.glossaries.name,
           rank: sql<number>`ts_rank(${schema.glossaryTerms.searchVector}, to_tsquery('simple', ${tsQuery}))`.as(
@@ -142,9 +144,18 @@ export function createSearchNativeGlossaryTool(ctx: ToolContext) {
         .orderBy(desc(sql`rank`))
         .limit(input.limit);
 
+      // FTS also matches target/description; keep only entries whose source term
+      // appears in the query text (same post-filter as concordance search).
+      const sourceMatchedTerms = terms.filter((term) =>
+        sourceContainsTerm(input.sourceText, {
+          sourceTerm: term.sourceTerm,
+          caseSensitive: term.caseSensitive ?? false,
+        }),
+      );
+
       return {
         success: true,
-        terms: terms.map((term) => ({
+        terms: sourceMatchedTerms.map((term) => ({
           id: term.id,
           sourceTerm: term.sourceTerm,
           targetTerm: term.targetTerm,

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_native_glossary.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_native_glossary.ts
@@ -66,6 +66,13 @@ export function createSearchNativeGlossaryTool(ctx: ToolContext) {
     inputSchema: searchNativeGlossaryInputSchema,
     outputSchema: searchNativeGlossaryOutputSchema,
     execute: async (input) => {
+      if (ctx.glossarySearchEnabled !== true) {
+        return {
+          success: false,
+          error: "Glossary search is not enabled for this workspace.",
+        };
+      }
+
       const projectId = input.projectId ?? ctx.projectId ?? undefined;
       const tsQuery = buildNativeGlossaryTsQuery(input.sourceText);
       if (!tsQuery) {

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_native_glossary.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_native_glossary.ts
@@ -112,6 +112,11 @@ export function createSearchNativeGlossaryTool(ctx: ToolContext) {
 
       const conditions = [
         sql`${schema.glossaryTerms.searchVector} @@ to_tsquery('simple', ${tsQuery})`,
+        sql`case
+          when coalesce(${schema.glossaryTerms.caseSensitive}, false)
+            then position(${schema.glossaryTerms.sourceTerm} in ${input.sourceText}) > 0
+          else position(lower(${schema.glossaryTerms.sourceTerm}) in lower(${input.sourceText})) > 0
+        end`,
         await toolProjectLinkedGlossaryWhere(ctx),
         eq(schema.glossaries.source, "native"),
         eq(schema.glossaries.sourceLocale, input.sourceLocale),
@@ -144,8 +149,8 @@ export function createSearchNativeGlossaryTool(ctx: ToolContext) {
         .orderBy(desc(sql`rank`))
         .limit(input.limit);
 
-      // FTS also matches target/description; keep only entries whose source term
-      // appears in the query text (same post-filter as concordance search).
+      // Keep the shared application-level check as a defense against database
+      // and JavaScript containment semantics drifting apart.
       const sourceMatchedTerms = terms.filter((term) =>
         sourceContainsTerm(input.sourceText, {
           sourceTerm: term.sourceTerm,

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_native_glossary.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_native_glossary.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { z } from "zod";
+
+import { defineAgentTool } from "@/agents/_runtime/define-agent-tool";
+import type { ToolContext } from "@/lib/agent-contracts/tool-context";
+import { schema } from "@/lib/database";
+import { toolCanAccessProject, toolProjectLinkedGlossaryWhere } from "@/lib/tools/tool-access";
+
+/**
+ * Build a prefix-ready tsquery string from free-form user input.
+ *
+ * Strips characters that have special meaning in Postgres tsquery syntax
+ * so that untrusted input cannot break the query.
+ */
+function buildTsQuery(input: string): string {
+  return input
+    .replace(/[&|!():*<>]/g, " ")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => `${word}:*`)
+    .join(" & ");
+}
+
+const searchNativeGlossaryInputSchema = z.object({
+  sourceText: z
+    .string()
+    .trim()
+    .min(1)
+    .describe("Source text or term to look up in native glossaries."),
+  sourceLocale: z.string().trim().min(1).describe("BCP-47 source locale tag."),
+  targetLocale: z.string().trim().min(1).describe("BCP-47 target locale tag."),
+  projectId: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe("Optional Hyperlocalise project ID to restrict to attached native glossaries."),
+  limit: z.number().int().min(1).max(20).default(10).describe("Maximum results to return."),
+});
+
+const searchNativeGlossaryOutputSchema = z.object({
+  success: z.boolean(),
+  error: z.string().optional(),
+  terms: z
+    .array(
+      z.object({
+        id: z.string(),
+        sourceTerm: z.string(),
+        targetTerm: z.string(),
+        description: z.string().nullable(),
+        forbidden: z.boolean().nullable(),
+        glossaryId: z.string(),
+        glossaryName: z.string(),
+        rank: z.number(),
+      }),
+    )
+    .optional(),
+});
+
+export type SearchNativeGlossaryToolInput = z.infer<typeof searchNativeGlossaryInputSchema>;
+export type SearchNativeGlossaryToolOutput = z.infer<typeof searchNativeGlossaryOutputSchema>;
+
+export function createSearchNativeGlossaryTool(ctx: ToolContext) {
+  return defineAgentTool({
+    description:
+      "Search Hyperlocalise-native glossary terms for a source text and locale pair. Does not search Crowdin or other external TMS glossaries.",
+    inputSchema: searchNativeGlossaryInputSchema,
+    outputSchema: searchNativeGlossaryOutputSchema,
+    execute: async (input) => {
+      const projectId = input.projectId ?? ctx.projectId ?? undefined;
+      const tsQuery = buildTsQuery(input.sourceText);
+      if (!tsQuery) {
+        return { success: true, terms: [] };
+      }
+
+      let glossaryIds: string[] | undefined;
+      if (projectId) {
+        const accessibleProject = await toolCanAccessProject(ctx, projectId);
+        if (!accessibleProject) {
+          return {
+            success: false,
+            error: "Project not found or not accessible.",
+          };
+        }
+
+        const attached = await ctx.db
+          .select({ glossaryId: schema.projectGlossaries.glossaryId })
+          .from(schema.projectGlossaries)
+          .innerJoin(
+            schema.glossaries,
+            eq(schema.projectGlossaries.glossaryId, schema.glossaries.id),
+          )
+          .where(
+            and(
+              eq(schema.projectGlossaries.projectId, projectId),
+              eq(schema.projectGlossaries.organizationId, ctx.organizationId),
+              eq(schema.glossaries.source, "native"),
+            ),
+          );
+        glossaryIds = attached.map((row) => row.glossaryId);
+        if (glossaryIds.length === 0) {
+          return { success: true, terms: [] };
+        }
+      }
+
+      const conditions = [
+        sql`${schema.glossaryTerms.searchVector} @@ to_tsquery('simple', ${tsQuery})`,
+        await toolProjectLinkedGlossaryWhere(ctx),
+        eq(schema.glossaries.source, "native"),
+        eq(schema.glossaries.sourceLocale, input.sourceLocale),
+        eq(schema.glossaries.targetLocale, input.targetLocale),
+        eq(schema.glossaries.status, "active"),
+        eq(schema.glossaryTerms.reviewStatus, "approved"),
+      ];
+
+      if (glossaryIds) {
+        conditions.push(inArray(schema.glossaryTerms.glossaryId, glossaryIds));
+      }
+
+      const terms = await ctx.db
+        .select({
+          id: schema.glossaryTerms.id,
+          sourceTerm: schema.glossaryTerms.sourceTerm,
+          targetTerm: schema.glossaryTerms.targetTerm,
+          description: schema.glossaryTerms.description,
+          forbidden: schema.glossaryTerms.forbidden,
+          glossaryId: schema.glossaryTerms.glossaryId,
+          glossaryName: schema.glossaries.name,
+          rank: sql<number>`ts_rank(${schema.glossaryTerms.searchVector}, to_tsquery('simple', ${tsQuery}))`.as(
+            "rank",
+          ),
+        })
+        .from(schema.glossaryTerms)
+        .innerJoin(schema.glossaries, eq(schema.glossaryTerms.glossaryId, schema.glossaries.id))
+        .where(and(...conditions))
+        .orderBy(desc(sql`rank`))
+        .limit(input.limit);
+
+      return {
+        success: true,
+        terms: terms.map((term) => ({
+          id: term.id,
+          sourceTerm: term.sourceTerm,
+          targetTerm: term.targetTerm,
+          description: term.description,
+          forbidden: term.forbidden,
+          glossaryId: term.glossaryId,
+          glossaryName: term.glossaryName,
+          rank: term.rank,
+        })),
+      };
+    },
+  });
+}

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_native_glossary.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_native_glossary.ts
@@ -18,23 +18,7 @@ import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 import { schema } from "@/lib/database";
 import { toolCanAccessProject, toolProjectLinkedGlossaryWhere } from "@/lib/tools/tool-access";
 
-/**
- * Build a prefix-ready tsquery string from free-form user input.
- *
- * Strips characters that have special meaning in Postgres tsquery syntax
- * so that untrusted input cannot break the query. Matches
- * `buildGlossaryTsQuery` in lib/translation/concordance.ts (including quotes
- * and hyphens common in UI copy such as "What's new").
- */
-export function buildNativeGlossaryTsQuery(input: string): string {
-  return input
-    .replace(/[&|!():*<>'"-]/g, " ")
-    .trim()
-    .split(/\s+/)
-    .filter(Boolean)
-    .map((word) => `${word}:*`)
-    .join(" & ");
-}
+import { buildNativeGlossaryTsQuery } from "./build-native-glossary-tsquery";
 
 const searchNativeGlossaryInputSchema = z.object({
   sourceText: z

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_native_glossary.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/search_native_glossary.ts
@@ -22,11 +22,13 @@ import { toolCanAccessProject, toolProjectLinkedGlossaryWhere } from "@/lib/tool
  * Build a prefix-ready tsquery string from free-form user input.
  *
  * Strips characters that have special meaning in Postgres tsquery syntax
- * so that untrusted input cannot break the query.
+ * so that untrusted input cannot break the query. Matches
+ * `buildGlossaryTsQuery` in lib/translation/concordance.ts (including quotes
+ * and hyphens common in UI copy such as "What's new").
  */
-function buildTsQuery(input: string): string {
+export function buildNativeGlossaryTsQuery(input: string): string {
   return input
-    .replace(/[&|!():*<>]/g, " ")
+    .replace(/[&|!():*<>'"-]/g, " ")
     .trim()
     .split(/\s+/)
     .filter(Boolean)
@@ -81,7 +83,7 @@ export function createSearchNativeGlossaryTool(ctx: ToolContext) {
     outputSchema: searchNativeGlossaryOutputSchema,
     execute: async (input) => {
       const projectId = input.projectId ?? ctx.projectId ?? undefined;
-      const tsQuery = buildTsQuery(input.sourceText);
+      const tsQuery = buildNativeGlossaryTsQuery(input.sourceText);
       if (!tsQuery) {
         return { success: true, terms: [] };
       }

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/agent.test.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/agent.test.ts
@@ -47,4 +47,19 @@ describe("buildHyperlocaliseDynamicSections", () => {
     expect(sections.join("\n")).toContain("search_native_glossary");
     expect(sections.join("\n")).not.toContain("search_crowdin_glossary");
   });
+
+  it("routes live Crowdin project ids without a local projects row", () => {
+    const sections = buildHyperlocaliseDynamicSections({
+      surface: "web",
+      projectId: "ext:crowdin:42",
+      attachedProject: {
+        projectId: "ext:crowdin:42",
+        projectSource: "external_tms",
+        externalProviderKind: "crowdin",
+      },
+    });
+
+    expect(sections.join("\n")).toContain("ext:crowdin:42");
+    expect(sections.join("\n")).toContain("search_crowdin_glossary");
+  });
 });

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/agent.test.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/agent.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildHyperlocaliseDynamicSections } from "./agent";
+
+describe("buildHyperlocaliseDynamicSections", () => {
+  it("routes Crowdin-linked projects to Crowdin glossary search", () => {
+    const sections = buildHyperlocaliseDynamicSections({
+      surface: "web",
+      projectId: "project-1",
+      attachedProject: {
+        projectId: "project-1",
+        projectName: "Heidi",
+        projectSource: "external_tms",
+        externalProviderKind: "crowdin",
+      },
+    });
+
+    expect(sections.join("\n")).toContain("Heidi (project-1)");
+    expect(sections.join("\n")).toContain("search_crowdin_glossary");
+    expect(sections.join("\n")).not.toContain("search_native_glossary");
+  });
+
+  it("routes native projects to native glossary search", () => {
+    const sections = buildHyperlocaliseDynamicSections({
+      surface: "web",
+      projectId: "project-2",
+      attachedProject: {
+        projectId: "project-2",
+        projectName: "Native app",
+        projectSource: "native",
+        externalProviderKind: null,
+      },
+    });
+
+    expect(sections.join("\n")).toContain("search_native_glossary");
+    expect(sections.join("\n")).not.toContain("search_crowdin_glossary");
+  });
+});

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/agent.test.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/agent.test.ts
@@ -15,10 +15,11 @@ import { describe, expect, it } from "vite-plus/test";
 import { buildHyperlocaliseDynamicSections } from "./agent";
 
 describe("buildHyperlocaliseDynamicSections", () => {
-  it("routes Crowdin-linked projects to Crowdin glossary search", () => {
+  it("routes Crowdin-linked projects to Crowdin glossary search when enabled", () => {
     const sections = buildHyperlocaliseDynamicSections({
       surface: "web",
       projectId: "project-1",
+      glossarySearchEnabled: true,
       attachedProject: {
         projectId: "project-1",
         projectName: "Heidi",
@@ -32,10 +33,11 @@ describe("buildHyperlocaliseDynamicSections", () => {
     expect(sections.join("\n")).not.toContain("search_native_glossary");
   });
 
-  it("routes native projects to native glossary search", () => {
+  it("routes native projects to native glossary search when enabled", () => {
     const sections = buildHyperlocaliseDynamicSections({
       surface: "web",
       projectId: "project-2",
+      glossarySearchEnabled: true,
       attachedProject: {
         projectId: "project-2",
         projectName: "Native app",
@@ -48,10 +50,29 @@ describe("buildHyperlocaliseDynamicSections", () => {
     expect(sections.join("\n")).not.toContain("search_crowdin_glossary");
   });
 
+  it("omits glossary tool routing when the feature flag is off", () => {
+    const sections = buildHyperlocaliseDynamicSections({
+      surface: "web",
+      projectId: "project-2",
+      glossarySearchEnabled: false,
+      attachedProject: {
+        projectId: "project-2",
+        projectName: "Native app",
+        projectSource: "native",
+        externalProviderKind: null,
+      },
+    });
+
+    expect(sections.join("\n")).toContain("Native app (project-2)");
+    expect(sections.join("\n")).not.toContain("search_native_glossary");
+    expect(sections.join("\n")).not.toContain("search_crowdin_glossary");
+  });
+
   it("routes live Crowdin project ids without a local projects row", () => {
     const sections = buildHyperlocaliseDynamicSections({
       surface: "web",
       projectId: "ext:crowdin:42",
+      glossarySearchEnabled: true,
       attachedProject: {
         projectId: "ext:crowdin:42",
         projectSource: "external_tms",

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/agent.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/agent.ts
@@ -22,9 +22,17 @@ export type HyperlocaliseAgentSurface = "web" | "slack" | "github";
 export const hyperlocaliseAgentStepLimit = 16;
 export const hyperlocaliseAgentMaxOutputTokens = 4_000;
 
+export type HyperlocaliseAttachedProjectContext = {
+  projectId: string;
+  projectName?: string | null;
+  projectSource?: "native" | "external_tms" | null;
+  externalProviderKind?: string | null;
+};
+
 export function buildHyperlocaliseDynamicSections(input: {
   surface: HyperlocaliseAgentSurface;
   projectId: string | null;
+  attachedProject?: HyperlocaliseAttachedProjectContext | null;
   additionalInstructions?: string;
 }): string[] {
   const dynamicSections: string[] = [];
@@ -39,11 +47,33 @@ export function buildHyperlocaliseDynamicSections(input: {
     );
   }
 
-  if (input.projectId) {
-    dynamicSections.push(
+  const attachedProject = input.attachedProject;
+  const projectId = attachedProject?.projectId ?? input.projectId;
+  if (projectId) {
+    const projectLabel = attachedProject?.projectName?.trim()
+      ? `${attachedProject.projectName} (${projectId})`
+      : projectId;
+    const projectLines = [
       "Project context:",
-      `- This conversation is attached to project ${input.projectId}.`,
-    );
+      `- This conversation is attached to project ${projectLabel}.`,
+    ];
+
+    if (attachedProject?.projectSource === "external_tms") {
+      const provider = attachedProject.externalProviderKind?.trim() || "external TMS";
+      projectLines.push(`- Project source: external TMS (${provider}).`);
+      if (attachedProject.externalProviderKind === "crowdin") {
+        projectLines.push(
+          "- For terminology, prefer `search_crowdin_glossary` with this projectId before advising on product or feature names.",
+        );
+      }
+    } else if (attachedProject?.projectSource === "native") {
+      projectLines.push("- Project source: native Hyperlocalise.");
+      projectLines.push(
+        "- For terminology, prefer `search_native_glossary` with this projectId before advising on product or feature names.",
+      );
+    }
+
+    dynamicSections.push(...projectLines);
   }
 
   if (input.additionalInstructions?.trim()) {

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/agent.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/agent.ts
@@ -33,9 +33,11 @@ export function buildHyperlocaliseDynamicSections(input: {
   surface: HyperlocaliseAgentSurface;
   projectId: string | null;
   attachedProject?: HyperlocaliseAttachedProjectContext | null;
+  glossarySearchEnabled?: boolean;
   additionalInstructions?: string;
 }): string[] {
   const dynamicSections: string[] = [];
+  const glossarySearchEnabled = input.glossarySearchEnabled === true;
 
   if (input.surface === "slack") {
     dynamicSections.push(
@@ -61,16 +63,18 @@ export function buildHyperlocaliseDynamicSections(input: {
     if (attachedProject?.projectSource === "external_tms") {
       const provider = attachedProject.externalProviderKind?.trim() || "external TMS";
       projectLines.push(`- Project source: external TMS (${provider}).`);
-      if (attachedProject.externalProviderKind === "crowdin") {
+      if (glossarySearchEnabled && attachedProject.externalProviderKind === "crowdin") {
         projectLines.push(
           "- For terminology, prefer `search_crowdin_glossary` with this projectId before advising on product or feature names.",
         );
       }
     } else if (attachedProject?.projectSource === "native") {
       projectLines.push("- Project source: native Hyperlocalise.");
-      projectLines.push(
-        "- For terminology, prefer `search_native_glossary` with this projectId before advising on product or feature names.",
-      );
+      if (glossarySearchEnabled) {
+        projectLines.push(
+          "- For terminology, prefer `search_native_glossary` with this projectId before advising on product or feature names.",
+        );
+      }
     }
 
     dynamicSections.push(...projectLines);

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.ts
@@ -135,6 +135,7 @@ export function createWebChatAgentUIStreamResponse(input: {
         messageText: input.messageText,
         hasTranslationAttachments: input.hasTranslationAttachments,
         knowledgeMemoryEnabled: input.toolContext.knowledgeMemoryEnabled === true,
+        glossarySearchEnabled: input.toolContext.glossarySearchEnabled === true,
         repositorySource: "chat_ui",
         db: input.toolContext.db,
         reportToolProgress: ({ toolCallId, message }) => {
@@ -251,6 +252,7 @@ export async function runWebChatAgentTurn(input: {
     messageText: input.messageText,
     hasTranslationAttachments: input.hasTranslationAttachments,
     knowledgeMemoryEnabled: input.toolContext.knowledgeMemoryEnabled === true,
+    glossarySearchEnabled: input.toolContext.glossarySearchEnabled === true,
     repositorySource: "chat_ui",
     db: input.toolContext.db,
   });

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/conversation.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/conversation.md
@@ -10,13 +10,20 @@ You are Hyperlocalise's conversational localization agent.
 
 Use the capability skills and tools available for this turn. Match the user's request to the right skill:
 
-- **tms-tools** — read-only linked TMS progress, locale completion, and project status (when a TMS is integrated)
+- **glossary-tools** — search Hyperlocalise-native glossaries before advising on terminology
+- **tms-tools** — Crowdin progress/status and Crowdin glossary search (when a TMS is integrated)
 - **repo-tools** — read-only search and inspection tools for the connected GitHub repository, including git history of source localization files
 - **find-context** — find localization context for source strings/keys using repo-tools (meaning, UI surface, translation guidance), including bulk context for recently changed keys discovered via `gitHistory`
 - **translation-tools** — translate files, images, or inline strings and create translation jobs
 - **knowledge-memory** — answer questions about organization Memory.md and apply explicit updates when enabled
 - **web-tools** — fetch public web pages and documentation as markdown
 - **visual-mock** — inspect repository UI code and create or plan mock UI screenshots for visual context when enabled
+
+### Terminology guardrails
+
+- Before advising whether a product, feature, or UI term should stay in English, search the glossary (`search_crowdin_glossary` for Crowdin-linked work, `search_native_glossary` for native).
+- Follow glossary hits exactly. If a term is missing, translate for native-like UX and flag that it is not in the glossary.
+- Do not invent a "keep official names in English" rule unless glossary or project context says so.
 
 ### Routing rules
 

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/conversation.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/conversation.md
@@ -10,8 +10,8 @@ You are Hyperlocalise's conversational localization agent.
 
 Use the capability skills and tools available for this turn. Match the user's request to the right skill:
 
-- **glossary-tools** — search Hyperlocalise-native glossaries before advising on terminology
-- **tms-tools** — Crowdin progress/status and Crowdin glossary search (when a TMS is integrated)
+- **glossary-tools** — search Hyperlocalise-native glossaries before advising on terminology when glossary search is enabled
+- **tms-tools** — Crowdin progress/status, and Crowdin glossary search when glossary search is enabled and a TMS is integrated
 - **repo-tools** — read-only search and inspection tools for the connected GitHub repository, including git history of source localization files
 - **find-context** — find localization context for source strings/keys using repo-tools (meaning, UI surface, translation guidance), including bulk context for recently changed keys discovered via `gitHistory`
 - **translation-tools** — translate files, images, or inline strings and create translation jobs
@@ -20,6 +20,8 @@ Use the capability skills and tools available for this turn. Match the user's re
 - **visual-mock** — inspect repository UI code and create or plan mock UI screenshots for visual context when enabled
 
 ### Terminology guardrails
+
+When glossary search tools are available for this turn:
 
 - Before advising whether a product, feature, or UI term should stay in English, search the glossary (`search_crowdin_glossary` for Crowdin-linked work, `search_native_glossary` for native).
 - Follow glossary hits exactly. If a term is missing, translate for native-like UX and flag that it is not in the glossary.

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/crowdin-glossary-tools.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/crowdin-glossary-tools.md
@@ -1,0 +1,36 @@
+---
+id: crowdin-glossary-tools
+requiresTmsIntegration: true
+requiresGlossarySearch: true
+tools: search_crowdin_glossary
+---
+
+## Crowdin glossary tools
+
+Use Crowdin glossary concordance for terminology only when this capability skill is active.
+
+### Terminology policy
+
+- Before advising on product names, feature names, or UI terms, call `search_crowdin_glossary`.
+- Follow preferred and forbidden glossary hits exactly.
+- If a term is missing, translate for native-like UX and explicitly flag that it is not in the Crowdin glossary.
+- Do not invent a default of keeping official product or feature names in English unless the glossary or project context says so.
+- When the conversation or CAT page is attached to a Crowdin-linked Hyperlocalise project, pass `projectId` so search uses project concordance. Otherwise search organization glossaries.
+
+### Tool
+
+#### `search_crowdin_glossary`
+
+Search Crowdin glossaries for source expressions.
+
+| Situation                                        | Parameters                                                      |
+| ------------------------------------------------ | --------------------------------------------------------------- |
+| CAT or conversation has a Crowdin-linked project | pass `projectId`, `sourceLocale`, `targetLocale`, `expressions` |
+| Crowdin connected, no project                    | omit `projectId`; org-level concordance                         |
+| Multiple candidate terms                         | pass several `expressions`                                      |
+
+Response fields:
+
+- `scope`: `"organization"` or `"project"`.
+- `matches`: glossary name/id, source/target terms, status (for example preferred/forbidden), and description when present.
+- Empty `matches` means the term was not found — translate for native-like UX and flag the gap.

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/glossary-tools.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/glossary-tools.md
@@ -1,0 +1,26 @@
+---
+id: glossary-tools
+always: true
+tools: search_native_glossary
+---
+
+## Glossary tools (native)
+
+Use native glossary search before advising on product names, feature names, UI labels, or other terminology for Hyperlocalise-native projects and native glossaries.
+
+### Terminology policy
+
+- Always search before deciding whether a term should stay in English or be translated.
+- Follow glossary hits exactly (preferred target form; never use forbidden terms).
+- If a term is missing from the glossary, translate for native-like UX and explicitly flag that the term is not in the glossary.
+- Do not invent a default of keeping official product or feature names in English unless a glossary entry or project context says so.
+
+### Tool
+
+#### `search_native_glossary`
+
+Search Hyperlocalise-native glossaries (not Crowdin/external TMS).
+
+- Prefer the conversation or CAT project: pass `projectId` when known.
+- Provide `sourceLocale` and `targetLocale` for the locale pair under discussion.
+- Empty `terms` means the term was not found — translate for native-like UX and flag the gap.

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/glossary-tools.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/glossary-tools.md
@@ -1,6 +1,6 @@
 ---
 id: glossary-tools
-always: true
+requiresGlossarySearch: true
 tools: search_native_glossary
 ---
 

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/tms-tools.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/tms-tools.md
@@ -1,14 +1,13 @@
 ---
 id: tms-tools
 requiresTmsIntegration: true
-tools: check_crowdin_progress,search_crowdin_glossary
+tools: check_crowdin_progress
 sharedSkills: crowdin
 ---
 
 ## TMS tools
 
-Use these tools for read-only Crowdin status: project progress, locale completion, and file or string status. When glossary search is enabled for this turn, also use Crowdin glossary concordance for terminology.
+Use these tools for read-only Crowdin status: project progress, locale completion, and file or string status.
 
 - Resolve the Hyperlocalise project by name with `list_projects` when the conversation is not attached to one yet.
 - Attach the project with `update_interaction_project` or pass `projectId` to TMS tools when project scope helps.
-- When `search_crowdin_glossary` is available, use it for terminology advice on Crowdin-linked work before guessing whether a term stays in English.

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/tms-tools.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/tms-tools.md
@@ -1,13 +1,14 @@
 ---
 id: tms-tools
 requiresTmsIntegration: true
-tools: check_crowdin_progress
+tools: check_crowdin_progress,search_crowdin_glossary
 sharedSkills: crowdin
 ---
 
 ## TMS tools
 
-Use these tools for read-only status in the workspace's linked TMS: project progress, locale completion, file or string status, and sync health.
+Use these tools for read-only Crowdin status and terminology: project progress, locale completion, file or string status, and glossary concordance.
 
 - Resolve the Hyperlocalise project by name with `list_projects` when the conversation is not attached to one yet.
-- Attach the project with `update_interaction_project` or pass `projectId` to TMS tools.
+- Attach the project with `update_interaction_project` or pass `projectId` to TMS tools when project scope helps.
+- For terminology advice on Crowdin-linked work, use `search_crowdin_glossary` before guessing whether a term stays in English.

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/tms-tools.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/tms-tools.md
@@ -7,8 +7,8 @@ sharedSkills: crowdin
 
 ## TMS tools
 
-Use these tools for read-only Crowdin status and terminology: project progress, locale completion, file or string status, and glossary concordance.
+Use these tools for read-only Crowdin status: project progress, locale completion, and file or string status. When glossary search is enabled for this turn, also use Crowdin glossary concordance for terminology.
 
 - Resolve the Hyperlocalise project by name with `list_projects` when the conversation is not attached to one yet.
 - Attach the project with `update_interaction_project` or pass `projectId` to TMS tools when project scope helps.
-- For terminology advice on Crowdin-linked work, use `search_crowdin_glossary` before guessing whether a term stays in English.
+- When `search_crowdin_glossary` is available, use it for terminology advice on Crowdin-linked work before guessing whether a term stays in English.

--- a/apps/hyperlocalise-web/src/api/auth/team-access.ts
+++ b/apps/hyperlocalise-web/src/api/auth/team-access.ts
@@ -263,9 +263,12 @@ export async function buildAccessibleInteractionsWhere(auth: ApiAuthContext): Pr
   }
 
   const accessibleProjectIds = await getAccessibleProjectIds(auth);
+  // Personal chat_ui threads stay visible to their author when unscoped or when
+  // attached to a live provider project id (`ext:…`). Those ids are not in the
+  // local projects table, so team-scoped `inArray` alone would hide them.
   const ownedWorkspaceChatFilter = and(
-    isNull(schema.interactions.projectId),
     eq(schema.interactions.source, "chat_ui"),
+    or(isNull(schema.interactions.projectId), sql`${schema.interactions.projectId} like 'ext:%'`),
     exists(
       db
         .select({ id: schema.interactionMessages.id })

--- a/apps/hyperlocalise-web/src/api/routes/conversation/chat-glossary-search-capability.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/chat-glossary-search-capability.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { workspaceGlossarySearchFlagRunMock } = vi.hoisted(() => ({
+  workspaceGlossarySearchFlagRunMock: vi.fn(),
+}));
+
+vi.mock("@/lib/flags/workspace-flags", () => ({
+  workspaceGlossarySearchFlag: { run: workspaceGlossarySearchFlagRunMock },
+}));
+
+import { resolveChatGlossarySearchCapability } from "./chat-glossary-search-capability";
+
+const auth = {
+  organization: { workosOrganizationId: "org_workos_123" },
+  user: { workosUserId: "user_workos_123" },
+} as never;
+
+describe("resolveChatGlossarySearchCapability", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns true only when the organization flag resolves to true", async () => {
+    workspaceGlossarySearchFlagRunMock.mockResolvedValue(true);
+
+    await expect(resolveChatGlossarySearchCapability(auth)).resolves.toBe(true);
+
+    const identify = workspaceGlossarySearchFlagRunMock.mock.calls[0]?.[0].identify;
+    expect(identify()).toEqual({
+      organization: { id: "org_workos_123" },
+      user: { id: "user_workos_123" },
+    });
+  });
+
+  it.each([false, undefined, null])("fails closed for a %s result", async (result) => {
+    workspaceGlossarySearchFlagRunMock.mockResolvedValue(result);
+
+    await expect(resolveChatGlossarySearchCapability(auth)).resolves.toBe(false);
+  });
+
+  it("fails closed when flag evaluation throws", async () => {
+    workspaceGlossarySearchFlagRunMock.mockRejectedValue(new Error("flag unavailable"));
+
+    await expect(resolveChatGlossarySearchCapability(auth)).resolves.toBe(false);
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/conversation/chat-glossary-search-capability.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/chat-glossary-search-capability.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { AuthVariables } from "@/api/auth/workos";
+import { workspaceGlossarySearchFlag } from "@/lib/flags/workspace-flags";
+
+export async function resolveChatGlossarySearchCapability(auth: AuthVariables["auth"]) {
+  try {
+    return (
+      (await workspaceGlossarySearchFlag.run({
+        identify: () => ({
+          organization: { id: auth.organization.workosOrganizationId },
+          user: { id: auth.user.workosUserId },
+        }),
+      })) === true
+    );
+  } catch {
+    return false;
+  }
+}

--- a/apps/hyperlocalise-web/src/api/routes/conversation/chat-stream.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/chat-stream.route.ts
@@ -23,6 +23,7 @@ import { createWebChatAgentUIStreamResponse } from "@/agents/hyperlocalise/agent
 import { db, schema } from "@/lib/database";
 import { interactionHasTranslationAttachments } from "@/lib/conversations/interactions";
 
+import { resolveChatGlossarySearchCapability } from "./chat-glossary-search-capability";
 import { resolveChatKnowledgeMemoryCapability } from "./chat-knowledge-memory-capability";
 import { conversationIdParamsSchema } from "./conversation.schema";
 import { extractLastUserMessage } from "./chat-stream-message";
@@ -113,10 +114,12 @@ export function createChatStreamRoutes() {
         return c.json({ error: "stale_user_message" }, 409);
       }
 
-      const [hasTranslationAttachments, knowledgeMemoryEnabled] = await Promise.all([
-        interactionHasTranslationAttachments(conversationId),
-        resolveChatKnowledgeMemoryCapability(c.var.auth),
-      ]);
+      const [hasTranslationAttachments, knowledgeMemoryEnabled, glossarySearchEnabled] =
+        await Promise.all([
+          interactionHasTranslationAttachments(conversationId),
+          resolveChatKnowledgeMemoryCapability(c.var.auth),
+          resolveChatGlossarySearchCapability(c.var.auth),
+        ]);
 
       return createWebChatAgentUIStreamResponse({
         conversationId,
@@ -129,6 +132,7 @@ export function createChatStreamRoutes() {
           projectId: conversation.projectId ?? null,
           db,
           knowledgeMemoryEnabled,
+          glossarySearchEnabled,
         },
         hasTranslationAttachments,
         usageOperationKey: `chat-agent-turn:${targetUserMessage.id}:agent_runs`,

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
@@ -34,6 +34,7 @@ import {
   setWebConversationRepositorySession,
 } from "@/lib/agent-runtime/loops/conversation-repository-session";
 import { resolveWebProjectRepositoryGitHubContext } from "@/lib/agents/repository-context";
+import { isEncodedProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 
 import { createChatStreamRoutes } from "./chat-stream.route";
 import {
@@ -48,6 +49,18 @@ import {
 
 const maxMessageUploadBytes = 25 * 1024 * 1024;
 const maxMessageUploadFiles = 5;
+
+/**
+ * `stored_files.project_id` FKs to local `projects.id`. Live provider IDs
+ * (`ext:…`) are valid conversation scope but must not be written onto files.
+ */
+function resolveStoredFileProjectId(projectId: string | null | undefined): string | null {
+  if (!projectId || isEncodedProviderProjectId(projectId)) {
+    return null;
+  }
+
+  return projectId;
+}
 
 const messageUploadBodyLimit = createMiddleware(async (c, next) => {
   const rawRequest = c.req.raw;
@@ -409,11 +422,12 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
       const adapter = options.fileStorageAdapter ?? getFileStorageAdapter();
       const organizationSlug = c.var.auth.activeOrganization.slug ?? "";
 
+      const storedFileProjectId = resolveStoredFileProjectId(projectId);
       const uploadResults = await Promise.allSettled(
         files.map(async (file) =>
           createStoredFile({
             organizationId: orgId,
-            projectId,
+            projectId: storedFileProjectId,
             createdByUserId: c.var.auth.user.localUserId,
             role: "source",
             sourceKind: "chat_upload",
@@ -611,11 +625,12 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
         const adapter = options.fileStorageAdapter ?? getFileStorageAdapter();
         const organizationSlug = c.var.auth.activeOrganization.slug ?? "";
 
+        const storedFileProjectId = resolveStoredFileProjectId(conversation.projectId);
         const uploadResults = await Promise.allSettled(
           files.map(async (file) =>
             createStoredFile({
               organizationId: orgId,
-              projectId: conversation.projectId,
+              projectId: storedFileProjectId,
               createdByUserId: c.var.auth.user.localUserId,
               role: "source",
               sourceKind: "chat_upload",

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
@@ -38,7 +38,7 @@ import { readApiResponseError } from "@/lib/api-error";
 import { ChatDockEmptyState } from "./chat-dock-empty-state";
 import { chatDockMessages } from "./chat-dock.messages";
 import { CHAT_DOCK_MAX_CONCURRENT_STREAMS } from "./chat-dock-persistence";
-import type { ChatDockStore } from "./chat-dock-store";
+import { resolveChatDockMessageProjectId, type ChatDockStore } from "./chat-dock-store";
 import { getChatStreamManager } from "./chat-stream-manager";
 
 const COLLAPSE_GLYPH = "−";
@@ -116,9 +116,11 @@ export const ChatDockPanel = observer(function ChatDockPanel({
     }
   }, [intl, messagesQuery.error, messagesQuery.isError, store, tab]);
 
+  const persistedConversation = conversationsQuery.data?.find(
+    (entry) => entry.id === conversationId,
+  );
   const conversation =
-    conversationsQuery.data?.find((entry) => entry.id === conversationId) ??
-    (tab ? buildPlaceholderConversation(tab) : undefined);
+    persistedConversation ?? (tab ? buildPlaceholderConversation(tab) : undefined);
 
   useEffect(() => {
     if (conversation && tab && !tab.isPending && conversation.title !== tab.title) {
@@ -169,9 +171,17 @@ export const ChatDockPanel = observer(function ChatDockPanel({
   ]);
 
   const createConversationMutation = useMutation({
-    mutationFn: async (input: { text: string; files: File[]; repositoryFullName?: string }) => {
+    mutationFn: async (input: {
+      text: string;
+      files: File[];
+      projectId?: string;
+      repositoryFullName?: string;
+    }) => {
       const formData = new FormData();
       formData.set("text", input.text.trim() || "Please translate the attached source file.");
+      if (input.projectId) {
+        formData.set("projectId", input.projectId);
+      }
       if (input.repositoryFullName) {
         formData.set("repositoryFullName", input.repositoryFullName);
       }
@@ -216,6 +226,13 @@ export const ChatDockPanel = observer(function ChatDockPanel({
         return;
       }
 
+      const projectId = resolveChatDockMessageProjectId({
+        explicitProjectId: options?.projectId,
+        pageContext: store.pageContext,
+        isPending: tab.isPending,
+        conversationProjectId: persistedConversation?.projectId,
+      });
+
       if (tab.isPending) {
         const pendingId = tab.id;
         try {
@@ -223,6 +240,7 @@ export const ChatDockPanel = observer(function ChatDockPanel({
           const result = await createConversationMutation.mutateAsync({
             text,
             files,
+            projectId,
             repositoryFullName: options?.repositoryFullName,
           });
           store.setDraft(pendingId, "");
@@ -245,7 +263,12 @@ export const ChatDockPanel = observer(function ChatDockPanel({
 
       try {
         store.setLastError(tab.id, null);
-        await sendMessageMutation.mutateAsync({ text, files, ...options });
+        await sendMessageMutation.mutateAsync({
+          text,
+          files,
+          projectId,
+          repositoryFullName: options?.repositoryFullName,
+        });
         store.setDraft(tab.id, "");
         await queryClient.invalidateQueries({ queryKey: messagesQueryKey(tab.id) });
         await queryClient.invalidateQueries({
@@ -266,6 +289,7 @@ export const ChatDockPanel = observer(function ChatDockPanel({
       sendMessageMutation,
       store,
       tab,
+      persistedConversation?.projectId,
     ],
   );
 

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.test.ts
@@ -13,7 +13,7 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import { CHAT_DOCK_MAX_CONCURRENT_STREAMS } from "./chat-dock-persistence";
-import { ChatDockStore } from "./chat-dock-store";
+import { ChatDockStore, resolveChatDockMessageProjectId } from "./chat-dock-store";
 
 function createMemoryStorage() {
   const data: Record<string, string> = {};
@@ -31,6 +31,46 @@ function createMemoryStorage() {
 }
 
 describe("ChatDockStore", () => {
+  it("only applies CAT project context to new or unscoped conversations", () => {
+    const pageContext = {
+      kind: "cat-segment" as const,
+      segmentId: "segment-1",
+      key: "checkout.submit",
+      sourceText: "Submit",
+      projectId: "cat-project",
+    };
+
+    expect(
+      resolveChatDockMessageProjectId({
+        pageContext,
+        isPending: true,
+        conversationProjectId: undefined,
+      }),
+    ).toBe("cat-project");
+    expect(
+      resolveChatDockMessageProjectId({
+        pageContext,
+        isPending: false,
+        conversationProjectId: null,
+      }),
+    ).toBe("cat-project");
+    expect(
+      resolveChatDockMessageProjectId({
+        pageContext,
+        isPending: false,
+        conversationProjectId: "existing-project",
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveChatDockMessageProjectId({
+        explicitProjectId: "selected-project",
+        pageContext,
+        isPending: false,
+        conversationProjectId: "existing-project",
+      }),
+    ).toBe("selected-project");
+  });
+
   it("opens, selects, and closes tabs", () => {
     const store = new ChatDockStore(createMemoryStorage());
     store.setOrganizationSlug("acme");

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.test.ts
@@ -58,6 +58,13 @@ describe("ChatDockStore", () => {
       resolveChatDockMessageProjectId({
         pageContext,
         isPending: false,
+        conversationProjectId: undefined,
+      }),
+    ).toBe("cat-project");
+    expect(
+      resolveChatDockMessageProjectId({
+        pageContext,
+        isPending: false,
         conversationProjectId: "existing-project",
       }),
     ).toBeUndefined();

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.test.ts
@@ -60,7 +60,7 @@ describe("ChatDockStore", () => {
         isPending: false,
         conversationProjectId: undefined,
       }),
-    ).toBe("cat-project");
+    ).toBeUndefined();
     expect(
       resolveChatDockMessageProjectId({
         pageContext,

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.ts
@@ -50,7 +50,30 @@ export type ChatDockPageContext = {
   sourceText: string;
   contextLabel?: string;
   sourcePath?: string;
+  sourceLocale?: string;
+  targetLocale?: string;
+  projectId?: string;
+  projectName?: string;
+  projectSource?: "native" | "external_tms";
+  externalProviderKind?: string | null;
 };
+
+export function resolveChatDockMessageProjectId(input: {
+  explicitProjectId?: string;
+  pageContext: ChatDockPageContext | null;
+  isPending: boolean;
+  conversationProjectId: string | null | undefined;
+}) {
+  if (input.explicitProjectId) {
+    return input.explicitProjectId;
+  }
+
+  if (!input.isPending && input.conversationProjectId !== null) {
+    return undefined;
+  }
+
+  return input.pageContext?.projectId;
+}
 
 const STREAM_ERROR_MESSAGE = "Sorry, I encountered an error while generating a response.";
 

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.ts
@@ -68,7 +68,9 @@ export function resolveChatDockMessageProjectId(input: {
     return input.explicitProjectId;
   }
 
-  if (!input.isPending && input.conversationProjectId !== null) {
+  // Only skip CAT attach when the conversation is known to already have a project.
+  // `undefined` means the conversation row is not loaded yet; treat like unscoped.
+  if (!input.isPending && input.conversationProjectId != null) {
     return undefined;
   }
 

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-store.ts
@@ -68,9 +68,10 @@ export function resolveChatDockMessageProjectId(input: {
     return input.explicitProjectId;
   }
 
-  // Only skip CAT attach when the conversation is known to already have a project.
-  // `undefined` means the conversation row is not loaded yet; treat like unscoped.
-  if (!input.isPending && input.conversationProjectId != null) {
+  // Existing conversations: only auto-attach when the row is loaded and unscoped.
+  // `undefined` means the conversation list/row is still loading — do not guess.
+  // A non-null projectId means the conversation is already scoped — do not reassign.
+  if (!input.isPending && input.conversationProjectId !== null) {
     return undefined;
   }
 

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-chat-dock-page-context-bridge.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-chat-dock-page-context-bridge.test.tsx
@@ -39,7 +39,7 @@ function createWrapper(initialSegmentId = "seg-02") {
     return (
       <AppShellStoreProvider defaultNavigationGroups={[]}>
         <CatWorkspaceProvider initialState={initialState}>
-          <CatChatDockPageContextBridge />
+          <CatChatDockPageContextBridge projectId="proj_1" />
           {children}
         </CatWorkspaceProvider>
       </AppShellStoreProvider>
@@ -61,6 +61,7 @@ describe("CatChatDockPageContextBridge", () => {
       expect(result.current.chatDock.pageContext).toMatchObject({
         kind: "cat-segment",
         segmentId: "seg-02",
+        projectId: "proj_1",
       });
     });
 
@@ -72,6 +73,10 @@ describe("CatChatDockPageContextBridge", () => {
 
     expect(context.key).toBeTruthy();
     expect(context.sourceText).toBeTruthy();
+    expect(context.projectSource).toBe("native");
+    expect(context.externalProviderKind).toBeNull();
+    expect(context.sourceLocale).toBeTruthy();
+    expect(context.targetLocale).toBeTruthy();
 
     result.current.workspace.setSelectedSegmentId("seg-01");
 

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-chat-dock-page-context-bridge.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-chat-dock-page-context-bridge.tsx
@@ -20,28 +20,44 @@ import { useOptionalAppShellStore } from "@/components/app-shell/store/app-shell
 
 import { useCatWorkspace } from "./cat-workspace-context";
 
-function toChatDockPageContext(
-  segmentId: string,
-  key: string,
-  sourceText: string,
-  contextLabel: string | undefined,
-  sourcePath: string | undefined,
-): ChatDockPageContext {
+function resolveProjectSource(providerKind: string | null | undefined): "native" | "external_tms" {
+  return providerKind ? "external_tms" : "native";
+}
+
+function toChatDockPageContext(input: {
+  segmentId: string;
+  key: string;
+  sourceText: string;
+  contextLabel: string | undefined;
+  sourcePath: string | undefined;
+  sourceLocale: string;
+  targetLocale: string;
+  providerKind: string | null;
+  projectId?: string;
+  projectName?: string;
+}): ChatDockPageContext {
   return {
     kind: "cat-segment",
-    segmentId,
-    key,
-    sourceText,
-    contextLabel,
-    sourcePath,
+    segmentId: input.segmentId,
+    key: input.key,
+    sourceText: input.sourceText,
+    contextLabel: input.contextLabel,
+    sourcePath: input.sourcePath,
+    sourceLocale: input.sourceLocale,
+    targetLocale: input.targetLocale,
+    projectId: input.projectId,
+    projectName: input.projectName,
+    projectSource: resolveProjectSource(input.providerKind),
+    externalProviderKind: input.providerKind,
   };
 }
 
 /**
  * Mirrors the selected CAT segment into ChatDockStore.pageContext so suggestion
- * pills can reference the current string. Chat dock sits outside CatWorkspaceProvider.
+ * pills and the chat agent can reference the current string and project/TMS kind.
+ * Chat dock sits outside CatWorkspaceProvider.
  */
-export function CatChatDockPageContextBridge() {
+export function CatChatDockPageContextBridge({ projectId }: { projectId?: string }) {
   const workspace = useCatWorkspace();
   const appShell = useOptionalAppShellStore();
 
@@ -58,20 +74,24 @@ export function CatChatDockPageContextBridge() {
           return null;
         }
 
-        return toChatDockPageContext(
-          segment.id,
-          segment.key,
-          segment.sourceText,
-          segment.contextLabel,
-          workspace.fileContext.sourcePath,
-        );
+        return toChatDockPageContext({
+          segmentId: segment.id,
+          key: segment.key,
+          sourceText: segment.sourceText,
+          contextLabel: segment.contextLabel,
+          sourcePath: workspace.fileContext.sourcePath,
+          sourceLocale: workspace.fileContext.sourceLocale,
+          targetLocale: workspace.fileContext.targetLocale,
+          providerKind: workspace.fileContext.providerKind,
+          projectId,
+        });
       },
       (context) => {
         chatDock.setPageContext(context);
       },
       { fireImmediately: true },
     );
-  }, [appShell, workspace]);
+  }, [appShell, projectId, workspace]);
 
   useEffect(() => {
     const chatDock = appShell?.chatDock;

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
@@ -133,7 +133,7 @@ const CatWorkspaceContainerObserver = observer(function CatWorkspaceContainerObs
 
   return (
     <>
-      <CatChatDockPageContextBridge />
+      <CatChatDockPageContextBridge projectId={lazySegment?.projectId} />
       {onPageLimitChange ? (
         <CatWorkspaceViewModeSync onPageLimitChange={onPageLimitChange} />
       ) : null}

--- a/apps/hyperlocalise-web/src/lib/agent-contracts/tool-context.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-contracts/tool-context.ts
@@ -60,6 +60,8 @@ export type ToolContext = {
   db: typeof db;
   /** Resolved at the web API boundary; omitted and false both disable Knowledge Memory tools. */
   knowledgeMemoryEnabled?: boolean;
+  /** Resolved at the web API boundary; omitted and false both disable glossary search tools. */
+  glossarySearchEnabled?: boolean;
   /** Repository agent context (optional, populated for repository workflows). */
   workMode?: RepositoryAgentWorkMode;
   repositorySource?: RepositoryAgentTaskSource;

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/context.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/context.ts
@@ -10,6 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import type { HyperlocaliseAttachedProjectContext } from "@/agents/hyperlocalise/agent/agent";
 import type { HyperlocaliseAgentSurface } from "@/lib/agent-runtime/loops/hyperlocalise-agent";
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
@@ -23,6 +24,7 @@ export type HyperlocaliseAgentRuntimeContext = {
   hasFileAttachments: boolean;
   hasTmsIntegration: boolean;
   hasVisualMockSkill?: boolean;
+  attachedProject?: HyperlocaliseAttachedProjectContext | null;
   additionalInstructions?: string;
 };
 
@@ -59,6 +61,7 @@ export function resolveAgentRuntimeContext(
     hasFileAttachments: context.hasFileAttachments ?? false,
     hasTmsIntegration: context.hasTmsIntegration ?? false,
     hasVisualMockSkill: context.hasVisualMockSkill ?? false,
+    attachedProject: context.attachedProject ?? null,
     additionalInstructions: context.additionalInstructions,
   });
 }

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.test.ts
@@ -65,7 +65,10 @@ describe("conversation skill agent", () => {
       surface: "slack",
       hasFileAttachments: false,
       hasTmsIntegration: false,
-      toolContext: baseToolContext,
+      toolContext: {
+        ...baseToolContext,
+        glossarySearchEnabled: true,
+      },
     });
 
     expect(toolLoopAgentMock).toHaveBeenCalledWith(
@@ -160,24 +163,46 @@ describe("conversation skill agent", () => {
       surface: "slack",
       hasFileAttachments: false,
       hasTmsIntegration: true,
-      toolContext: baseToolContext,
+      toolContext: {
+        ...baseToolContext,
+        glossarySearchEnabled: true,
+      },
     });
 
     expect(toolLoopAgentMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        activeTools: expect.arrayContaining(["check_crowdin_progress"]),
+        activeTools: expect.arrayContaining(["check_crowdin_progress", "search_crowdin_glossary"]),
         tools: expect.objectContaining({
           check_crowdin_progress: expect.any(Object),
+          search_crowdin_glossary: expect.any(Object),
         }),
       }),
     );
 
     const settings = toolLoopAgentMock.mock.calls.at(-1)?.[0] as {
       instructions: string;
+      activeTools: string[];
     };
 
     expect(settings.instructions).toContain("TMS tools");
     expect(settings.instructions).toContain("Crowdin TMS");
+  });
+
+  it("omits glossary search tools when the feature flag is off", () => {
+    createConversationSkillAgent({
+      surface: "web",
+      hasFileAttachments: false,
+      hasTmsIntegration: true,
+      toolContext: baseToolContext,
+    });
+
+    const settings = toolLoopAgentMock.mock.calls.at(-1)?.[0] as {
+      activeTools: string[];
+    };
+
+    expect(settings.activeTools).toContain("check_crowdin_progress");
+    expect(settings.activeTools).not.toContain("search_native_glossary");
+    expect(settings.activeTools).not.toContain("search_crowdin_glossary");
   });
 
   it("adds repo and file job tools when runtime context allows them", () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.test.ts
@@ -186,6 +186,9 @@ describe("conversation skill agent", () => {
 
     expect(settings.instructions).toContain("TMS tools");
     expect(settings.instructions).toContain("Crowdin TMS");
+    expect(settings.instructions).toContain(
+      "Before advising on product names, feature names, or UI terms, call `search_crowdin_glossary`.",
+    );
   });
 
   it("omits glossary search tools when the feature flag is off", () => {
@@ -197,12 +200,14 @@ describe("conversation skill agent", () => {
     });
 
     const settings = toolLoopAgentMock.mock.calls.at(-1)?.[0] as {
+      instructions: string;
       activeTools: string[];
     };
 
     expect(settings.activeTools).toContain("check_crowdin_progress");
     expect(settings.activeTools).not.toContain("search_native_glossary");
     expect(settings.activeTools).not.toContain("search_crowdin_glossary");
+    expect(settings.instructions).not.toContain("search_crowdin_glossary");
   });
 
   it("adds repo and file job tools when runtime context allows them", () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.test.ts
@@ -74,10 +74,12 @@ describe("conversation skill agent", () => {
           "list_projects",
           "get_project_context",
           "update_interaction_project",
+          "search_native_glossary",
           "translate_string",
         ]),
         tools: expect.objectContaining({
           list_projects: expect.any(Object),
+          search_native_glossary: expect.any(Object),
           translate_string: expect.any(Object),
         }),
         providerOptions: {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.test.ts
@@ -207,7 +207,10 @@ describe("conversation skill agent", () => {
     expect(settings.activeTools).toContain("check_crowdin_progress");
     expect(settings.activeTools).not.toContain("search_native_glossary");
     expect(settings.activeTools).not.toContain("search_crowdin_glossary");
-    expect(settings.instructions).not.toContain("search_crowdin_glossary");
+    expect(settings.instructions).not.toContain("## Crowdin glossary tools");
+    expect(settings.instructions).not.toContain(
+      "Before advising on product names, feature names, or UI terms, call `search_crowdin_glossary`.",
+    );
   });
 
   it("adds repo and file job tools when runtime context allows them", () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.ts
@@ -44,6 +44,7 @@ export function createConversationSkillAgent(
       surface: runtime.surface,
       projectId: runtime.toolContext.projectId,
       skillPlan,
+      attachedProject: runtime.attachedProject,
       additionalInstructions: runtime.additionalInstructions,
     }),
     tools,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-skill-agent.ts
@@ -45,6 +45,7 @@ export function createConversationSkillAgent(
       projectId: runtime.toolContext.projectId,
       skillPlan,
       attachedProject: runtime.attachedProject,
+      glossarySearchEnabled: runtime.toolContext.glossarySearchEnabled === true,
       additionalInstructions: runtime.additionalInstructions,
     }),
     tools,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
@@ -172,6 +172,7 @@ describe("conversation turn preparation", () => {
         toolContext: expect.objectContaining({
           reportToolProgress,
           knowledgeMemoryEnabled: true,
+          glossarySearchEnabled: false,
         }),
       }),
     );

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
@@ -102,6 +102,7 @@ import {
   prepareConversationAgentTurn,
   REPOSITORY_ACCESS_CONTENTION_FOLLOW_UP,
   resolveConversationRepositoryContext,
+  resolveVirtualAttachedProjectContext,
 } from "./conversation-turn";
 
 const baseClassification = {
@@ -112,6 +113,22 @@ const baseClassification = {
   currentMessageSpecifiesRepository: false,
   confidence: 0.9,
 };
+
+describe("resolveVirtualAttachedProjectContext", () => {
+  it("recovers Crowdin provider metadata from live encoded project ids", () => {
+    expect(resolveVirtualAttachedProjectContext("ext:crowdin:42")).toEqual({
+      projectId: "ext:crowdin:42",
+      projectSource: "external_tms",
+      externalProviderKind: "crowdin",
+    });
+  });
+
+  it("returns projectId only for unknown non-database ids", () => {
+    expect(resolveVirtualAttachedProjectContext("missing-project")).toEqual({
+      projectId: "missing-project",
+    });
+  });
+});
 
 describe("conversation turn preparation", () => {
   beforeEach(() => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
@@ -12,11 +12,16 @@
  */
 import type { ModelMessage } from "ai";
 
-import type { HyperlocaliseAgentSurface } from "@/agents/hyperlocalise/agent/agent";
+import type {
+  HyperlocaliseAgentSurface,
+  HyperlocaliseAttachedProjectContext,
+} from "@/agents/hyperlocalise/agent/agent";
 import type { RepositoryAgentGitHubContext } from "@/lib/agent-contracts/repository-task";
 import type { RepositoryAgentTaskSource } from "@/lib/agent-contracts/repository-task";
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
+import { schema } from "@/lib/database";
 import type { OrganizationMembershipRole } from "@/lib/database/types";
+import { and, eq } from "drizzle-orm";
 import {
   buildRepositoryGitHubContextInstructions,
   getOrganizationRepositoryConnectorConfig,
@@ -53,6 +58,45 @@ export const REPOSITORY_ACCESS_CONTENTION_FOLLOW_UP =
 
 export function buildFileTranslationInstructions() {
   return `When a message includes stored source file IDs, create file translation jobs with type "file", the provided sourceFileId and fileFormat, targetLocales, and sourceLocale. Use sourceLocale "auto" if the user did not specify a source locale. Supported file job formats: ${supportedFileTranslationFileFormats.join(", ")}.`;
+}
+
+async function loadAttachedProjectContext(input: {
+  db: ToolContext["db"];
+  organizationId: string;
+  projectId: string | null;
+}): Promise<HyperlocaliseAttachedProjectContext | null> {
+  if (!input.projectId) {
+    return null;
+  }
+
+  const [project] = await input.db
+    .select({
+      id: schema.projects.id,
+      name: schema.projects.name,
+      source: schema.projects.source,
+      externalProviderKind: schema.projects.externalProviderKind,
+    })
+    .from(schema.projects)
+    .where(
+      and(
+        eq(schema.projects.id, input.projectId),
+        eq(schema.projects.organizationId, input.organizationId),
+      ),
+    )
+    .limit(1);
+
+  if (!project) {
+    return {
+      projectId: input.projectId,
+    };
+  }
+
+  return {
+    projectId: project.id,
+    projectName: project.name,
+    projectSource: project.source,
+    externalProviderKind: project.externalProviderKind,
+  };
 }
 
 export function buildMissingRepositoryContextInstructions(followUp: string) {
@@ -365,12 +409,17 @@ export async function prepareConversationAgentTurn(
     }
   }
 
-  const [hasTmsIntegration, hasVisualMockSkill] = await Promise.all([
+  const [hasTmsIntegration, hasVisualMockSkill, attachedProject] = await Promise.all([
     resolveOrganizationHasTmsIntegration(input.organizationId),
     resolveWorkspaceVisualMockFlag({
       organizationId: input.organizationId,
       localUserId: input.localUserId,
       dbClient: input.db,
+    }),
+    loadAttachedProjectContext({
+      db: input.db,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
     }),
   ]);
 
@@ -400,6 +449,7 @@ export async function prepareConversationAgentTurn(
     hasFileAttachments: input.hasTranslationAttachments,
     hasTmsIntegration,
     hasVisualMockSkill,
+    attachedProject,
     additionalInstructions: [buildFileTranslationInstructions(), repositoryInstructions]
       .filter((instruction): instruction is string => instruction !== null)
       .join("\n\n"),

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
@@ -339,6 +339,7 @@ export type PrepareConversationAgentTurnInput = {
   messageText: string;
   hasTranslationAttachments: boolean;
   knowledgeMemoryEnabled?: boolean;
+  glossarySearchEnabled?: boolean;
   repositorySession?: ConversationRepositorySession | null;
   connectorConfig?: Record<string, unknown> | null;
   channelId?: string | null;
@@ -454,6 +455,7 @@ export async function prepareConversationAgentTurn(
       db: input.db,
       reportToolProgress: input.reportToolProgress,
       knowledgeMemoryEnabled: input.knowledgeMemoryEnabled === true,
+      glossarySearchEnabled: input.glossarySearchEnabled === true,
       ...(sandboxId
         ? {
             sandboxId,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
@@ -31,6 +31,7 @@ import {
   createRepositorySandbox,
   stopRepositorySandbox,
 } from "@/lib/agent-runtime/workspaces/repository-sandbox";
+import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 import { supportedFileTranslationFileFormats } from "@/lib/translation/file-formats";
 import { createLogger, serializeErrorForLog } from "@/lib/log";
 
@@ -60,6 +61,25 @@ export function buildFileTranslationInstructions() {
   return `When a message includes stored source file IDs, create file translation jobs with type "file", the provided sourceFileId and fileFormat, targetLocales, and sourceLocale. Use sourceLocale "auto" if the user did not specify a source locale. Supported file job formats: ${supportedFileTranslationFileFormats.join(", ")}.`;
 }
 
+/**
+ * Build attached-project context when there is no local `projects` row.
+ * Live CAT / TMS ids (`ext:crowdin:42`) encode the provider kind in the id.
+ */
+export function resolveVirtualAttachedProjectContext(
+  projectId: string,
+): HyperlocaliseAttachedProjectContext {
+  const encodedProject = parseProviderProjectId(projectId);
+  if (!encodedProject) {
+    return { projectId };
+  }
+
+  return {
+    projectId,
+    projectSource: "external_tms",
+    externalProviderKind: encodedProject.providerKind,
+  };
+}
+
 async function loadAttachedProjectContext(input: {
   db: ToolContext["db"];
   organizationId: string;
@@ -86,9 +106,7 @@ async function loadAttachedProjectContext(input: {
     .limit(1);
 
   if (!project) {
-    return {
-      projectId: input.projectId,
-    };
+    return resolveVirtualAttachedProjectContext(input.projectId);
   }
 
   return {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/hyperlocalise-agent.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/hyperlocalise-agent.ts
@@ -33,6 +33,7 @@ import {
   hyperlocaliseAgentMaxOutputTokens,
   hyperlocaliseAgentStepLimit,
   type HyperlocaliseAgentSurface,
+  type HyperlocaliseAttachedProjectContext,
 } from "@/agents/hyperlocalise/agent/agent";
 import {
   createConversationSkillAgent,
@@ -71,6 +72,7 @@ type CreateHyperlocaliseAgentInput<TOOLS extends ToolSet> = {
 type CreateConversationAgentInput = {
   surface: HyperlocaliseAgentSurface;
   toolContext: ToolContext;
+  attachedProject?: HyperlocaliseAttachedProjectContext | null;
   additionalInstructions?: string;
   onEnd?: ConversationSkillAgentOnFinish;
 };
@@ -174,6 +176,7 @@ export {
 export function createConversationToolLoopAgent({
   surface,
   toolContext,
+  attachedProject = null,
   additionalInstructions,
   onEnd,
   hasFileAttachments = false,
@@ -190,6 +193,7 @@ export function createConversationToolLoopAgent({
     hasFileAttachments,
     hasTmsIntegration,
     hasVisualMockSkill,
+    attachedProject,
     additionalInstructions: additionalInstructions?.trim() || undefined,
   };
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/compose-conversation-skill-instructions.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/compose-conversation-skill-instructions.ts
@@ -14,13 +14,17 @@ import { composeInstructions } from "@/agents/_runtime/compose-instructions";
 
 import type { ConversationSkillPlan } from "./conversation-skill-registry";
 
-import type { HyperlocaliseAgentSurface } from "@/agents/hyperlocalise/agent/agent";
+import type {
+  HyperlocaliseAgentSurface,
+  HyperlocaliseAttachedProjectContext,
+} from "@/agents/hyperlocalise/agent/agent";
 import { buildHyperlocaliseDynamicSections } from "@/agents/hyperlocalise/agent/agent";
 
 export function buildConversationSkillInstructions(input: {
   surface: HyperlocaliseAgentSurface;
   projectId: string | null;
   skillPlan: ConversationSkillPlan;
+  attachedProject?: HyperlocaliseAttachedProjectContext | null;
   additionalInstructions?: string;
 }) {
   return composeInstructions({

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/compose-conversation-skill-instructions.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/compose-conversation-skill-instructions.ts
@@ -25,6 +25,7 @@ export function buildConversationSkillInstructions(input: {
   projectId: string | null;
   skillPlan: ConversationSkillPlan;
   attachedProject?: HyperlocaliseAttachedProjectContext | null;
+  glossarySearchEnabled?: boolean;
   additionalInstructions?: string;
 }) {
   return composeInstructions({

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
@@ -12,6 +12,11 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
+vi.hoisted(() => {
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/hyperlocalise_test";
+  process.env.PROVIDER_CREDENTIALS_MASTER_KEY ??= "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=";
+});
+
 vi.mock("@/lib/agent-runtime/tools/knowledge-memory-tools", () => ({
   createGetKnowledgeMemoryTool: vi.fn(() => ({ description: "get Knowledge Memory" })),
   createUpdateKnowledgeMemoryTool: vi.fn(() => ({ description: "update Knowledge Memory" })),

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
@@ -56,7 +56,7 @@ describe("conversation skill registry", () => {
 
     const glossarySkill = skills.find((skill) => skill.id === "glossary-tools");
     expect(glossarySkill).toMatchObject({
-      always: true,
+      requiresGlossarySearch: true,
       tools: ["search_native_glossary"],
     });
 
@@ -379,6 +379,7 @@ describe("conversation skill registry", () => {
         membershipRole: "member",
         projectId: null,
         db: {} as never,
+        glossarySearchEnabled: true,
       },
     });
 
@@ -391,6 +392,50 @@ describe("conversation skill registry", () => {
       expect.arrayContaining(["list_projects", "search_native_glossary", "translate_string"]),
     );
     expect(plan.toolNames).not.toContain("check_crowdin_progress");
+  });
+
+  it("activates glossary-tools only when glossary search is enabled", () => {
+    const glossarySkill = listConversationSkills().find((skill) => skill.id === "glossary-tools");
+    expect(glossarySkill).toBeDefined();
+
+    const activationContext = (glossarySearchEnabled?: boolean) =>
+      toConversationSkillActivationContext({
+        hasFileAttachments: false,
+        hasTmsIntegration: false,
+        toolContext: {
+          conversationId: "conv_1",
+          organizationId: "org_1",
+          localUserId: "user_1",
+          membershipRole: "member",
+          projectId: null,
+          db: {} as never,
+          glossarySearchEnabled,
+        },
+      });
+
+    expect(isConversationSkillActivated(glossarySkill!, activationContext(true))).toBe(true);
+    expect(isConversationSkillActivated(glossarySkill!, activationContext(false))).toBe(false);
+    expect(isConversationSkillActivated(glossarySkill!, activationContext())).toBe(false);
+  });
+
+  it("filters Crowdin glossary search when the feature flag is off", () => {
+    const toolNames = filterAvailableConversationToolNames(
+      ["check_crowdin_progress", "search_crowdin_glossary", "search_native_glossary"],
+      {
+        hasFileAttachments: false,
+        toolContext: {
+          conversationId: "conv_1",
+          organizationId: "org_1",
+          localUserId: "user_1",
+          membershipRole: "member",
+          projectId: null,
+          db: {} as never,
+          glossarySearchEnabled: false,
+        },
+      },
+    );
+
+    expect(toolNames).toEqual(["check_crowdin_progress"]);
   });
 
   it("exposes translate_string without a project but gates file jobs", () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
@@ -43,6 +43,7 @@ describe("conversation skill registry", () => {
     expect(skills.map((skill) => skill.id).sort()).toEqual(
       expect.arrayContaining([
         "conversation",
+        "crowdin-glossary-tools",
         "find-context",
         "glossary-tools",
         "knowledge-memory",
@@ -68,8 +69,15 @@ describe("conversation skill registry", () => {
     const tmsSkill = skills.find((skill) => skill.id === "tms-tools");
     expect(tmsSkill).toMatchObject({
       requiresTmsIntegration: true,
-      tools: ["check_crowdin_progress", "search_crowdin_glossary"],
+      tools: ["check_crowdin_progress"],
       sharedSkills: ["crowdin"],
+    });
+
+    const crowdinGlossarySkill = skills.find((skill) => skill.id === "crowdin-glossary-tools");
+    expect(crowdinGlossarySkill).toMatchObject({
+      requiresTmsIntegration: true,
+      requiresGlossarySearch: true,
+      tools: ["search_crowdin_glossary"],
     });
 
     const translationSkill = skills.find((skill) => skill.id === "translation-tools");
@@ -421,6 +429,30 @@ describe("conversation skill registry", () => {
     expect(isConversationSkillActivated(glossarySkill!, activationContext(true))).toBe(true);
     expect(isConversationSkillActivated(glossarySkill!, activationContext(false))).toBe(false);
     expect(isConversationSkillActivated(glossarySkill!, activationContext())).toBe(false);
+  });
+
+  it("activates Crowdin glossary tools only when both capabilities are enabled", () => {
+    const skill = listConversationSkills().find((item) => item.id === "crowdin-glossary-tools");
+    expect(skill).toBeDefined();
+
+    const activationContext = (hasTmsIntegration: boolean, glossarySearchEnabled: boolean) =>
+      toConversationSkillActivationContext({
+        hasFileAttachments: false,
+        hasTmsIntegration,
+        toolContext: {
+          conversationId: "conv_1",
+          organizationId: "org_1",
+          localUserId: "user_1",
+          membershipRole: "member",
+          projectId: null,
+          db: {} as never,
+          glossarySearchEnabled,
+        },
+      });
+
+    expect(isConversationSkillActivated(skill!, activationContext(true, true))).toBe(true);
+    expect(isConversationSkillActivated(skill!, activationContext(true, false))).toBe(false);
+    expect(isConversationSkillActivated(skill!, activationContext(false, true))).toBe(false);
   });
 
   it("filters Crowdin glossary search when the feature flag is off", () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.test.ts
@@ -39,6 +39,7 @@ describe("conversation skill registry", () => {
       expect.arrayContaining([
         "conversation",
         "find-context",
+        "glossary-tools",
         "knowledge-memory",
         "repo-tools",
         "tms-tools",
@@ -53,10 +54,16 @@ describe("conversation skill registry", () => {
       tools: ["list_projects", "get_project_context", "update_interaction_project"],
     });
 
+    const glossarySkill = skills.find((skill) => skill.id === "glossary-tools");
+    expect(glossarySkill).toMatchObject({
+      always: true,
+      tools: ["search_native_glossary"],
+    });
+
     const tmsSkill = skills.find((skill) => skill.id === "tms-tools");
     expect(tmsSkill).toMatchObject({
       requiresTmsIntegration: true,
-      tools: ["check_crowdin_progress"],
+      tools: ["check_crowdin_progress", "search_crowdin_glossary"],
       sharedSkills: ["crowdin"],
     });
 
@@ -379,7 +386,10 @@ describe("conversation skill registry", () => {
       expect.arrayContaining(["conversation", "translation-tools"]),
     );
     expect(plan.instructionSkillIds).not.toContain("tms-tools");
-    expect(plan.toolNames).toEqual(expect.arrayContaining(["list_projects", "translate_string"]));
+    expect(plan.instructionSkillIds).toEqual(expect.arrayContaining(["glossary-tools"]));
+    expect(plan.toolNames).toEqual(
+      expect.arrayContaining(["list_projects", "search_native_glossary", "translate_string"]),
+    );
     expect(plan.toolNames).not.toContain("check_crowdin_progress");
   });
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.ts
@@ -16,6 +16,8 @@ import type { ToolSet } from "ai";
 import { hasCapability } from "@/api/auth/policy";
 import { getAgentManifest, type AgentSkillDocument } from "@/agents/_runtime/loader";
 import { createCheckCrowdinProgressTool } from "@/agents/_runtime/shared-tools/check_crowdin_progress";
+import { createSearchCrowdinGlossaryTool } from "@/agents/_runtime/shared-tools/search_crowdin_glossary";
+import { createSearchNativeGlossaryTool } from "@/agents/_runtime/shared-tools/search_native_glossary";
 import { createTranslateStringTool } from "@/agents/_runtime/shared-tools/translate_string";
 import type { HyperlocaliseAgentRuntimeContext } from "@/lib/agent-runtime/context";
 import { repositoryWorkspaceToolNames } from "@/lib/agent-contracts/repository-workspace-tools";
@@ -87,6 +89,8 @@ const conversationSkillToolFactories: Record<string, ConversationSkillToolFactor
   get_project_context: (toolContext) => createGetProjectContextTool(toolContext),
   update_interaction_project: (toolContext) => createUpdateInteractionProjectTool(toolContext),
   check_crowdin_progress: (toolContext) => createCheckCrowdinProgressTool(toolContext),
+  search_crowdin_glossary: (toolContext) => createSearchCrowdinGlossaryTool(toolContext),
+  search_native_glossary: (toolContext) => createSearchNativeGlossaryTool(toolContext),
   get_knowledge_memory: (toolContext) => createGetKnowledgeMemoryTool(toolContext),
   update_knowledge_memory: (toolContext) => createUpdateKnowledgeMemoryTool(toolContext),
 };

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/skills/conversation-skill-registry.ts
@@ -63,6 +63,7 @@ export type ConversationSkillMetadata = {
   requiresProjectOrAttachments: boolean;
   requiresVisualMockSkill: boolean;
   requiresKnowledgeMemory: boolean;
+  requiresGlossarySearch: boolean;
   tools: string[];
   sharedSkills: string[];
 };
@@ -80,6 +81,7 @@ export type ConversationSkillActivationContext = {
   hasTmsIntegration: boolean;
   hasVisualMockSkill: boolean;
   knowledgeMemoryEnabled: boolean;
+  glossarySearchEnabled: boolean;
 };
 
 type ConversationSkillToolFactory = (toolContext: ToolContext) => ToolSet[string];
@@ -133,6 +135,7 @@ export function parseConversationSkillMetadata(
     requiresProjectOrAttachments: frontmatter.requiresProjectOrAttachments === "true",
     requiresVisualMockSkill: frontmatter.requiresVisualMockSkill === "true",
     requiresKnowledgeMemory: frontmatter.requiresKnowledgeMemory === "true",
+    requiresGlossarySearch: frontmatter.requiresGlossarySearch === "true",
     tools: parseCommaSeparated(frontmatter.tools),
     sharedSkills: parseCommaSeparated(frontmatter.sharedSkills),
   };
@@ -156,6 +159,7 @@ export function toConversationSkillActivationContext(
     hasTmsIntegration: runtime.hasTmsIntegration,
     hasVisualMockSkill: runtime.hasVisualMockSkill ?? false,
     knowledgeMemoryEnabled: runtime.toolContext.knowledgeMemoryEnabled === true,
+    glossarySearchEnabled: runtime.toolContext.glossarySearchEnabled === true,
   };
 }
 
@@ -199,6 +203,10 @@ export function isConversationSkillActivated(
     return false;
   }
 
+  if (skill.requiresGlossarySearch && !context.glossarySearchEnabled) {
+    return false;
+  }
+
   const hasActivationRule =
     skill.requiresSandbox ||
     skill.requiresTmsIntegration ||
@@ -206,7 +214,8 @@ export function isConversationSkillActivated(
     skill.requiresFileAttachments !== undefined ||
     skill.requiresProjectOrAttachments ||
     skill.requiresVisualMockSkill ||
-    skill.requiresKnowledgeMemory;
+    skill.requiresKnowledgeMemory ||
+    skill.requiresGlossarySearch;
 
   return hasActivationRule;
 }
@@ -244,6 +253,13 @@ export function filterAvailableConversationToolNames(
     if (
       toolName === "update_knowledge_memory" &&
       !hasCapability(runtime.toolContext.membershipRole, "workspace:update")
+    ) {
+      return false;
+    }
+
+    if (
+      (toolName === "search_native_glossary" || toolName === "search_crowdin_glossary") &&
+      runtime.toolContext.glossarySearchEnabled !== true
     ) {
       return false;
     }

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/manifest.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/manifest.ts
@@ -43,6 +43,8 @@ export const toolManifests = [
   { name: "createTranslationJob", domain: "translation", sideEffect: "external_write" },
   { name: "translate_string", domain: "translation", sideEffect: "none" },
   { name: "check_crowdin_progress", domain: "tms", sideEffect: "none" },
+  { name: "search_crowdin_glossary", domain: "tms", sideEffect: "none" },
+  { name: "search_native_glossary", domain: "project", sideEffect: "none" },
   { name: "list_projects", domain: "project", sideEffect: "none" },
   { name: "get_project_context", domain: "project", sideEffect: "none" },
   { name: "update_interaction_project", domain: "project", sideEffect: "workspace_write" },

--- a/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
@@ -158,6 +158,7 @@ describe("filterNavigationByWorkspaceFlags", () => {
       knowledge: false,
       visualMock: false,
       issues: false,
+      glossarySearch: false,
     });
 
     const itemLabels = filtered.flatMap((group) => group.items.map((item) => item.label));
@@ -175,6 +176,7 @@ describe("filterNavigationByWorkspaceFlags", () => {
       knowledge: true,
       visualMock: true,
       issues: true,
+      glossarySearch: true,
     });
 
     const itemLabels = filtered.flatMap((group) => group.items.map((item) => item.label));

--- a/apps/hyperlocalise-web/src/lib/flags/workos-flag-entities.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-flag-entities.ts
@@ -14,6 +14,7 @@ export const WORKSPACE_AUTOMATIONS_FLAG = "workspace-automations";
 export const WORKSPACE_KNOWLEDGE_FLAG = "workspace-knowledge";
 export const WORKSPACE_VISUAL_MOCK_FLAG = "workspace-visual-mock";
 export const WORKSPACE_ISSUES_FLAG = "workspace-issues";
+export const WORKSPACE_GLOSSARY_SEARCH_FLAG = "workspace-glossary-search";
 export const WORKSPACE_FEATURE_UNAVAILABLE_REASON = "feature-unavailable";
 
 export type WorkosFlagEntities = {
@@ -26,6 +27,7 @@ export type WorkspaceFeatureFlagState = {
   knowledge: boolean;
   visualMock: boolean;
   issues: boolean;
+  glossarySearch: boolean;
 };
 
 export const DISABLED_WORKSPACE_FEATURE_FLAGS: WorkspaceFeatureFlagState = {
@@ -33,4 +35,5 @@ export const DISABLED_WORKSPACE_FEATURE_FLAGS: WorkspaceFeatureFlagState = {
   knowledge: false,
   visualMock: false,
   issues: false,
+  glossarySearch: false,
 };

--- a/apps/hyperlocalise-web/src/lib/flags/workspace-flag-navigation.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workspace-flag-navigation.ts
@@ -14,6 +14,7 @@ import type { NavigationGroup, NavigationItem } from "@/components/app-shell/nav
 
 import {
   WORKSPACE_AUTOMATIONS_FLAG,
+  WORKSPACE_GLOSSARY_SEARCH_FLAG,
   WORKSPACE_ISSUES_FLAG,
   WORKSPACE_KNOWLEDGE_FLAG,
   WORKSPACE_VISUAL_MOCK_FLAG,
@@ -26,6 +27,7 @@ function workspaceFlagEnabledByKey(flags: WorkspaceFeatureFlagState): Record<str
     [WORKSPACE_KNOWLEDGE_FLAG]: flags.knowledge,
     [WORKSPACE_VISUAL_MOCK_FLAG]: flags.visualMock,
     [WORKSPACE_ISSUES_FLAG]: flags.issues,
+    [WORKSPACE_GLOSSARY_SEARCH_FLAG]: flags.glossarySearch,
   };
 }
 

--- a/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
@@ -22,6 +22,7 @@ import { workosAdapter } from "./workos-adapter";
 import {
   WORKSPACE_AUTOMATIONS_FLAG,
   WORKSPACE_FEATURE_UNAVAILABLE_REASON,
+  WORKSPACE_GLOSSARY_SEARCH_FLAG,
   WORKSPACE_ISSUES_FLAG,
   WORKSPACE_KNOWLEDGE_FLAG,
   WORKSPACE_VISUAL_MOCK_FLAG,
@@ -62,19 +63,28 @@ export const workspaceIssuesFlag = flag<boolean, WorkosFlagEntities>({
   adapter: workosAdapter(),
 });
 
+export const workspaceGlossarySearchFlag = flag<boolean, WorkosFlagEntities>({
+  key: WORKSPACE_GLOSSARY_SEARCH_FLAG,
+  defaultValue: false,
+  description:
+    "Conversational agent glossary search (native and Crowdin) for terminology-safe advice.",
+  adapter: workosAdapter(),
+});
+
 export async function evaluateWorkspaceFeatureFlags(
   auth: Pick<AppAuthContext, "activeOrganization" | "user">,
 ): Promise<WorkspaceFeatureFlagState> {
   const identify = () => createWorkosIdentify(auth);
 
-  const [automations, knowledge, visualMock, issues] = await Promise.all([
+  const [automations, knowledge, visualMock, issues, glossarySearch] = await Promise.all([
     workspaceAutomationsFlag.run({ identify }),
     workspaceKnowledgeFlag.run({ identify }),
     workspaceVisualMockFlag.run({ identify }),
     workspaceIssuesFlag.run({ identify }),
+    workspaceGlossarySearchFlag.run({ identify }),
   ]);
 
-  return { automations, knowledge, visualMock, issues };
+  return { automations, knowledge, visualMock, issues, glossarySearch };
 }
 
 export async function resolveWorkspaceVisualMockFlag(input: {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -559,6 +559,8 @@ export interface CrowdinGlossaryConcordanceSearchRequest {
   sourceLanguageId: string;
   targetLanguageId: string;
   expressions: string[];
+  /** Owner whose glossaries to search for org-level concordance. Defaults to the authenticated account. */
+  userId?: number | null;
 }
 
 export interface CrowdinGlossaryConcordanceTerm {
@@ -1294,7 +1296,7 @@ export class CrowdinApiClient {
   }
 
   /**
-   * Search glossary concordance for source expressions.
+   * Search glossary concordance for source expressions within a Crowdin project.
    */
   async glossaryConcordanceSearch(
     projectId: number,
@@ -1306,6 +1308,27 @@ export class CrowdinApiClient {
         sourceLanguageId: input.sourceLanguageId,
         targetLanguageId: input.targetLanguageId,
         expressions: input.expressions,
+      },
+    );
+
+    return response.data.map((item) => item.data);
+  }
+
+  /**
+   * Search glossary concordance across organization glossaries (not project-scoped).
+   *
+   * @see https://support.crowdin.com/developer/api/v2/#operation/api.glossaries.concordance.post
+   */
+  async organizationGlossaryConcordanceSearch(
+    input: CrowdinGlossaryConcordanceSearchRequest,
+  ): Promise<CrowdinGlossaryConcordanceSearchResult[]> {
+    const response = await this.post<CrowdinListResponse<CrowdinGlossaryConcordanceSearchResult>>(
+      `/glossaries/concordance`,
+      {
+        sourceLanguageId: input.sourceLanguageId,
+        targetLanguageId: input.targetLanguageId,
+        expressions: input.expressions,
+        ...(input.userId !== undefined ? { userId: input.userId } : {}),
       },
     );
 

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-auth.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-auth.ts
@@ -438,6 +438,24 @@ export class CrowdinAuth {
     });
   }
 
+  /** Loads the organization Crowdin TMS credential without requiring a linked project. */
+  async loadOrganizationCredential(
+    organizationId: string,
+  ): Promise<CrowdinProjectCredential["credential"] | null> {
+    const [credential] = await db
+      .select()
+      .from(schema.organizationExternalTmsProviderCredentials)
+      .where(
+        and(
+          eq(schema.organizationExternalTmsProviderCredentials.organizationId, organizationId),
+          eq(schema.organizationExternalTmsProviderCredentials.providerKind, "crowdin"),
+        ),
+      )
+      .limit(1);
+
+    return credential ?? null;
+  }
+
   async loadProjectCredential(input: {
     organizationId: string;
     projectId: string;

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-glossary-search.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-glossary-search.test.ts
@@ -92,6 +92,76 @@ describe("crowdinTmsProvider.searchGlossaryForAgent", () => {
     expect(String(fetchMock.mock.calls[0]?.[0])).not.toContain("/projects/");
   });
 
+  it("preserves every same-locale target term and its status", async () => {
+    loadOrganizationCredentialMock.mockResolvedValue(baseCredential);
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              data: {
+                glossary: { id: 9, name: "Product glossary" },
+                sourceTerms: [
+                  { id: 1, languageId: "en", text: "Home", status: "preferred" },
+                ],
+                targetTerms: [
+                  {
+                    id: 2,
+                    languageId: "vi",
+                    text: "Trang chủ",
+                    status: "preferred",
+                    description: "Use this term",
+                  },
+                  {
+                    id: 3,
+                    languageId: "vi",
+                    text: "Nhà",
+                    status: "forbidden",
+                    description: "Do not use",
+                  },
+                  { id: 4, languageId: "fr", text: "Accueil", status: "preferred" },
+                ],
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const result = await crowdinTmsProvider.searchGlossaryForAgent({
+      organizationId: "org-1",
+      actorUserId: "user-1",
+      sourceLocale: "en",
+      targetLocale: "vi",
+      expressions: ["Home"],
+    });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      return;
+    }
+
+    expect(result.value.matches).toEqual([
+      {
+        glossaryId: 9,
+        glossaryName: "Product glossary",
+        sourceTerm: "Home",
+        targetTerm: "Trang chủ",
+        status: "preferred",
+        description: "Use this term",
+      },
+      {
+        glossaryId: 9,
+        glossaryName: "Product glossary",
+        sourceTerm: "Home",
+        targetTerm: "Nhà",
+        status: "forbidden",
+        description: "Do not use",
+      },
+    ]);
+  });
+
   it("uses project concordance when a Crowdin-linked project is provided", async () => {
     loadProjectCredentialMock.mockResolvedValue({
       externalProjectId: "42",

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-glossary-search.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-glossary-search.test.ts
@@ -101,9 +101,7 @@ describe("crowdinTmsProvider.searchGlossaryForAgent", () => {
             {
               data: {
                 glossary: { id: 9, name: "Product glossary" },
-                sourceTerms: [
-                  { id: 1, languageId: "en", text: "Home", status: "preferred" },
-                ],
+                sourceTerms: [{ id: 1, languageId: "en", text: "Home", status: "preferred" }],
                 targetTerms: [
                   {
                     id: 2,

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-glossary-search.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-glossary-search.test.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { isErr, isOk } from "@/lib/primitives/result/results";
+
+import { crowdinTmsProvider } from "./crowdin-provider";
+
+const { loadOrganizationCredentialMock, loadProjectCredentialMock, fetchMock } = vi.hoisted(() => ({
+  loadOrganizationCredentialMock: vi.fn(),
+  loadProjectCredentialMock: vi.fn(),
+  fetchMock: vi.fn(),
+}));
+
+const baseCredential = {
+  encryptionAlgorithm: "aes-256-gcm",
+  keyVersion: 1,
+  ciphertext: "cipher",
+  iv: "iv",
+  authTag: "tag",
+  baseUrl: "https://api.crowdin.test/api/v2",
+  providerKind: "crowdin" as const,
+  authMode: "api_token",
+};
+
+vi.mock("./crowdin-auth", () => ({
+  crowdinAuth: {
+    loadOrganizationCredential: (...args: unknown[]) => loadOrganizationCredentialMock(...args),
+    loadProjectCredential: (...args: unknown[]) => loadProjectCredentialMock(...args),
+  },
+}));
+
+vi.mock("@/lib/providers/shared/tms-provider-content", () => ({
+  resolveExternalTmsSecretMaterialForActor: vi.fn(async () => "token"),
+}));
+
+function concordanceHit(source: string, target: string) {
+  return {
+    glossary: { id: 9, name: "Product glossary" },
+    sourceTerms: [{ id: 1, languageId: "en", text: source, status: "preferred" }],
+    targetTerms: [{ id: 2, languageId: "vi", text: target, status: "preferred" }],
+  };
+}
+
+describe("crowdinTmsProvider.searchGlossaryForAgent", () => {
+  beforeEach(() => {
+    loadOrganizationCredentialMock.mockReset();
+    loadProjectCredentialMock.mockReset();
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("uses organization concordance when no projectId is provided", async () => {
+    loadOrganizationCredentialMock.mockResolvedValue(baseCredential);
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [{ data: concordanceHit("Talk to Heidi", "Nói chuyện với Heidi") }],
+        }),
+        {
+          status: 200,
+        },
+      ),
+    );
+
+    const result = await crowdinTmsProvider.searchGlossaryForAgent({
+      organizationId: "org-1",
+      actorUserId: "user-1",
+      sourceLocale: "en",
+      targetLocale: "vi",
+      expressions: ["Talk to Heidi"],
+    });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      return;
+    }
+
+    expect(result.value.scope).toBe("organization");
+    expect(result.value.matches[0]?.targetTerm).toBe("Nói chuyện với Heidi");
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/glossaries/concordance");
+    expect(String(fetchMock.mock.calls[0]?.[0])).not.toContain("/projects/");
+  });
+
+  it("uses project concordance when a Crowdin-linked project is provided", async () => {
+    loadProjectCredentialMock.mockResolvedValue({
+      externalProjectId: "42",
+      credential: baseCredential,
+    });
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [{ data: concordanceHit("Talk to Heidi", "Nói chuyện với Heidi") }],
+        }),
+        {
+          status: 200,
+        },
+      ),
+    );
+
+    const result = await crowdinTmsProvider.searchGlossaryForAgent({
+      organizationId: "org-1",
+      actorUserId: "user-1",
+      projectId: "project-1",
+      sourceLocale: "en",
+      targetLocale: "vi",
+      expressions: ["Talk to Heidi"],
+    });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      return;
+    }
+
+    expect(result.value.scope).toBe("project");
+    expect(result.value.crowdinProjectId).toBe(42);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/projects/42/glossaries/concordance");
+  });
+
+  it("returns not configured when Crowdin credentials are missing", async () => {
+    loadOrganizationCredentialMock.mockResolvedValue(null);
+
+    const result = await crowdinTmsProvider.searchGlossaryForAgent({
+      organizationId: "org-1",
+      sourceLocale: "en",
+      targetLocale: "vi",
+      expressions: ["Talk to Heidi"],
+    });
+
+    expect(isErr(result)).toBe(true);
+    if (!isErr(result)) {
+      return;
+    }
+
+    expect(result.error.code).toBe("crowdin_not_configured");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
@@ -177,6 +177,27 @@ const CROWDIN_USER_CONNECTION_ERROR_MESSAGES: Record<string, string> = {
     "Reconnect your Crowdin account after the workspace authentication mode changed.",
 };
 
+/** Agent-facing Crowdin glossary concordance match. */
+export type CrowdinAgentGlossaryMatch = {
+  glossaryId: number;
+  glossaryName: string;
+  sourceTerm: string;
+  targetTerm: string;
+  status: string | null;
+  description: string | null;
+};
+
+/** Successful Crowdin glossary search for the conversational agent. */
+export type SearchCrowdinGlossaryResult = {
+  scope: "organization" | "project";
+  crowdinProjectId: number | null;
+  matches: CrowdinAgentGlossaryMatch[];
+};
+
+type CrowdinGlossarySearchError =
+  | { code: "crowdin_not_configured"; message: string }
+  | { code: "crowdin_api_error"; message: string };
+
 /**
  * Crowdin implementation of the shared TMS provider contract.
  *
@@ -1669,6 +1690,130 @@ export class CrowdinTmsProvider extends TmsProvider {
   }
 
   /**
+   * Agent glossary search: org-level concordance by default, project concordance when
+   * a Crowdin-linked Hyperlocalise project is provided.
+   */
+  async searchGlossaryForAgent(input: {
+    organizationId: string;
+    actorUserId?: string | null;
+    projectId?: string;
+    sourceLocale: string;
+    targetLocale: string;
+    expressions: string[];
+    limit?: number;
+  }): Promise<Result<SearchCrowdinGlossaryResult, CrowdinGlossarySearchError>> {
+    const expressions = input.expressions.map((expression) => expression.trim()).filter(Boolean);
+    if (expressions.length === 0) {
+      return ok({
+        scope: input.projectId ? "project" : "organization",
+        crowdinProjectId: null,
+        matches: [],
+      });
+    }
+
+    const limit = Math.min(Math.max(input.limit ?? 20, 1), 50);
+    let client: CrowdinApiClient;
+    let crowdinProjectId: number | null;
+
+    if (input.projectId) {
+      const clientResult = await this.createProgressClient({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        actorUserId: input.actorUserId,
+      });
+      if (isErr(clientResult)) {
+        return err({
+          code:
+            clientResult.error.code === "crowdin_not_configured"
+              ? "crowdin_not_configured"
+              : "crowdin_api_error",
+          message: clientResult.error.message,
+        });
+      }
+      client = clientResult.value.client;
+      crowdinProjectId = clientResult.value.crowdinProjectId;
+    } else {
+      const clientResult = await this.createOrganizationGlossaryClient({
+        organizationId: input.organizationId,
+        actorUserId: input.actorUserId,
+      });
+      if (isErr(clientResult)) {
+        return err({
+          code:
+            clientResult.error.code === "crowdin_not_configured"
+              ? "crowdin_not_configured"
+              : "crowdin_api_error",
+          message: clientResult.error.message,
+        });
+      }
+      client = clientResult.value.client;
+      crowdinProjectId = null;
+    }
+
+    try {
+      const results = crowdinProjectId
+        ? await client.glossaryConcordanceSearch(crowdinProjectId, {
+            sourceLanguageId: input.sourceLocale,
+            targetLanguageId: input.targetLocale,
+            expressions,
+          })
+        : await client.organizationGlossaryConcordanceSearch({
+            sourceLanguageId: input.sourceLocale,
+            targetLanguageId: input.targetLocale,
+            expressions,
+          });
+
+      const matches: CrowdinAgentGlossaryMatch[] = [];
+      for (const result of results) {
+        const sourceTerm = this.pickTermText(result.sourceTerms, input.sourceLocale);
+        const targetTerm = this.pickTermText(result.targetTerms, input.targetLocale);
+        if (!sourceTerm || !targetTerm) {
+          continue;
+        }
+
+        const status =
+          this.pickTermStatus(result.targetTerms, input.targetLocale) ??
+          this.pickTermStatus(result.sourceTerms, input.sourceLocale);
+        const description =
+          result.targetTerms.find((term) => term.languageId === input.targetLocale)?.description ??
+          result.sourceTerms.find((term) => term.languageId === input.sourceLocale)?.description ??
+          null;
+
+        matches.push({
+          glossaryId: result.glossary.id,
+          glossaryName: result.glossary.name,
+          sourceTerm,
+          targetTerm,
+          status,
+          description: description?.trim() ? description.trim() : null,
+        });
+
+        if (matches.length >= limit) {
+          break;
+        }
+      }
+
+      return ok({
+        scope: crowdinProjectId ? "project" : "organization",
+        crowdinProjectId,
+        matches,
+      });
+    } catch (error) {
+      if (error instanceof CrowdinApiError && error.status === 401) {
+        return err({
+          code: "crowdin_api_error",
+          message: "Crowdin authentication failed. Reconnect Crowdin and try again.",
+        });
+      }
+
+      return err({
+        code: "crowdin_api_error",
+        message: error instanceof Error ? error.message : "Crowdin glossary search failed.",
+      });
+    }
+  }
+
+  /**
    * Live CAT concordance: parallel glossary and TM search for a source expression.
    *
    * Throws {@link TmsProviderLiveError} on auth, permission, or fetch failures.
@@ -1863,6 +2008,53 @@ export class CrowdinTmsProvider extends TmsProvider {
         markers,
       },
     ];
+  }
+
+  private async createOrganizationGlossaryClient(input: {
+    organizationId: string;
+    actorUserId?: string | null;
+  }): Promise<
+    Result<
+      { client: CrowdinApiClient },
+      Extract<CrowdinGlossarySearchError, { code: "crowdin_not_configured" | "crowdin_api_error" }>
+    >
+  > {
+    const credential = await crowdinAuth.loadOrganizationCredential(input.organizationId);
+    if (!credential) {
+      return err({
+        code: "crowdin_not_configured" as const,
+        message:
+          "Crowdin is not connected for this workspace. Connect Crowdin before searching glossaries.",
+      });
+    }
+
+    let token: string;
+    try {
+      token = await resolveExternalTmsSecretMaterialForActor({
+        credential,
+        organizationId: input.organizationId,
+        actorUserId: input.actorUserId,
+      });
+    } catch (error) {
+      if (error instanceof Error) {
+        const message = CROWDIN_USER_CONNECTION_ERROR_MESSAGES[error.message];
+        if (message) {
+          return err({
+            code: "crowdin_api_error" as const,
+            message: message.replace("checking Crowdin progress", "searching Crowdin glossaries"),
+          });
+        }
+      }
+
+      throw error;
+    }
+
+    return ok({
+      client: this.createClient({
+        credential,
+        secretMaterial: token,
+      }),
+    });
   }
 
   private async createProgressClient(input: {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
@@ -1764,32 +1764,35 @@ export class CrowdinTmsProvider extends TmsProvider {
           });
 
       const matches: CrowdinAgentGlossaryMatch[] = [];
-      for (const result of results) {
-        const sourceTerm = this.pickTermText(result.sourceTerms, input.sourceLocale);
-        const targetTerm = this.pickTermText(result.targetTerms, input.targetLocale);
-        if (!sourceTerm || !targetTerm) {
+      resultsLoop: for (const result of results) {
+        const sourceTerms = result.sourceTerms
+          .filter((term) => term.languageId === input.sourceLocale)
+          .map((term) => ({ ...term, text: term.text.trim() }))
+          .filter((term) => term.text);
+        const targetTerms = result.targetTerms
+          .filter((term) => term.languageId === input.targetLocale)
+          .map((term) => ({ ...term, text: term.text.trim() }))
+          .filter((term) => term.text);
+        if (sourceTerms.length === 0 || targetTerms.length === 0) {
           continue;
         }
 
-        const status =
-          this.pickTermStatus(result.targetTerms, input.targetLocale) ??
-          this.pickTermStatus(result.sourceTerms, input.sourceLocale);
-        const description =
-          result.targetTerms.find((term) => term.languageId === input.targetLocale)?.description ??
-          result.sourceTerms.find((term) => term.languageId === input.sourceLocale)?.description ??
-          null;
+        for (const sourceTerm of sourceTerms) {
+          for (const targetTerm of targetTerms) {
+            const description = targetTerm.description ?? sourceTerm.description ?? null;
+            matches.push({
+              glossaryId: result.glossary.id,
+              glossaryName: result.glossary.name,
+              sourceTerm: sourceTerm.text,
+              targetTerm: targetTerm.text,
+              status: targetTerm.status ?? sourceTerm.status ?? null,
+              description: description?.trim() ? description.trim() : null,
+            });
 
-        matches.push({
-          glossaryId: result.glossary.id,
-          glossaryName: result.glossary.name,
-          sourceTerm,
-          targetTerm,
-          status,
-          description: description?.trim() ? description.trim() : null,
-        });
-
-        if (matches.length >= limit) {
-          break;
+            if (matches.length >= limit) {
+              break resultsLoop;
+            }
+          }
         }
       }
 

--- a/docs/adr/2026-08-03-agent-glossary-search-guardrails-design.md
+++ b/docs/adr/2026-08-03-agent-glossary-search-guardrails-design.md
@@ -1,0 +1,53 @@
+# Agent Glossary Search Guardrails Design
+
+## Date
+
+2026-08-03
+
+## Context
+
+Users reported that Hyperlocalise chat advised keeping product or feature names such as "Talk to Heidi" in English. That default is wrong for teams that localize UI for a native feel. Glossary entries should decide terminology; when a term is missing, the agent should still translate and flag the gap.
+
+Today the conversational agent has Crowdin progress tools but no glossary search tools. Glossary influence on machine translation is passive (context injection). Native glossary FTS tools exist but are unwired. Crowdin also exposes org-level glossary concordance (`POST /glossaries/concordance`) in addition to project-scoped concordance (`POST /projects/{id}/glossaries/concordance`); Hyperlocalise only used the project endpoint.
+
+## Decision
+
+### Scope
+
+- Conversational Hyperlocalise agent only (web chat / chat dock).
+- Search-only tools (no glossary CRUD).
+- Out of scope: CAT AI recommendation prompts, `translate_string`, and file-job binding prompts.
+
+### Terminology policy
+
+1. Before advising on product, feature, or UI terms, search the appropriate glossary tool.
+2. Follow preferred and forbidden glossary hits exactly.
+3. If a term is missing, translate for native-like UX and explicitly flag that it is not in the glossary.
+4. Do not invent a "keep official names in English" default unless glossary or project context says so.
+
+### Tools and skills
+
+| Tool | Skill | Behavior |
+|------|-------|----------|
+| `search_crowdin_glossary` | `tms-tools` + shared `crowdin` | Default: org-level `POST /glossaries/concordance`. Optional Hyperlocalise `projectId` → project concordance. |
+| `search_native_glossary` | `glossary-tools` (always on) | Postgres FTS over native (`source = native`) glossaries; prefer project-attached when `projectId` is set. |
+
+### CAT → chat context
+
+Extend chat-dock `cat-segment` page context with project id/name, `projectSource` (`native` \| `external_tms`), and `externalProviderKind`. When chatting from CAT, auto-attach that project to the conversation when unset, and inject dynamic instructions so the agent prefers Crowdin vs native glossary search.
+
+### Routing
+
+| Context | Preferred tool |
+|---------|----------------|
+| Crowdin-linked project (CAT or conversation) | `search_crowdin_glossary` with `projectId` |
+| Crowdin connected, no project | `search_crowdin_glossary` org-level |
+| Native project | `search_native_glossary` |
+| Unclear | Search both when available; prefer hits over guesses |
+
+## Consequences
+
+- Chat advice about terminology becomes glossary-backed instead of model heuristics.
+- Crowdin glossary lookup works without a Hyperlocalise project via org-level concordance.
+- CAT chat sessions carry project and TMS-kind context for better tool choice.
+- CAT AI recommend and binding MT paths remain unchanged until a follow-up.

--- a/docs/adr/2026-08-03-agent-glossary-search-guardrails-design.md
+++ b/docs/adr/2026-08-03-agent-glossary-search-guardrails-design.md
@@ -29,15 +29,15 @@ Today the conversational agent has Crowdin progress tools but no glossary search
 
 Roll out behind WorkOS workspace flag `workspace-glossary-search` (default off). When disabled:
 
-- `glossary-tools` does not activate
-- `search_crowdin_glossary` is filtered out of `tms-tools`
+- `glossary-tools` and `crowdin-glossary-tools` do not activate
+- Crowdin's always-loaded shared skill contains no glossary tool instructions
 - project dynamic instructions omit glossary tool routing
 
 ### Tools and skills
 
 | Tool | Skill | Behavior |
 |------|-------|----------|
-| `search_crowdin_glossary` | `tms-tools` + shared `crowdin` | Default: org-level `POST /glossaries/concordance`. Optional Hyperlocalise `projectId` → project concordance. Gated by `workspace-glossary-search`. |
+| `search_crowdin_glossary` | `crowdin-glossary-tools` | Default: org-level `POST /glossaries/concordance`. Optional Hyperlocalise `projectId` → project concordance. Requires both TMS integration and `workspace-glossary-search`. |
 | `search_native_glossary` | `glossary-tools` (`requiresGlossarySearch`) | Postgres FTS over native (`source = native`) glossaries; prefer project-attached when `projectId` is set. |
 
 ### CAT → chat context

--- a/docs/adr/2026-08-03-agent-glossary-search-guardrails-design.md
+++ b/docs/adr/2026-08-03-agent-glossary-search-guardrails-design.md
@@ -53,6 +53,11 @@ Extend chat-dock `cat-segment` page context with project id/name, `projectSource
 | Native project | `search_native_glossary` |
 | Unclear | Search both when available; prefer hits over guesses |
 
+### Search result completeness
+
+- Build native FTS candidates with token alternatives so a glossary term can match within a longer source sentence. Require the stored source term to occur in the input, with the term's case-sensitivity setting, before applying the result limit.
+- Preserve every Crowdin source and target term for the requested locales. Return each source-target combination with the target term's status and description, falling back to source metadata when needed.
+
 ## Consequences
 
 - Chat advice about terminology becomes glossary-backed instead of model heuristics.

--- a/docs/adr/2026-08-03-agent-glossary-search-guardrails-design.md
+++ b/docs/adr/2026-08-03-agent-glossary-search-guardrails-design.md
@@ -25,12 +25,20 @@ Today the conversational agent has Crowdin progress tools but no glossary search
 3. If a term is missing, translate for native-like UX and explicitly flag that it is not in the glossary.
 4. Do not invent a "keep official names in English" default unless glossary or project context says so.
 
+### Feature flag
+
+Roll out behind WorkOS workspace flag `workspace-glossary-search` (default off). When disabled:
+
+- `glossary-tools` does not activate
+- `search_crowdin_glossary` is filtered out of `tms-tools`
+- project dynamic instructions omit glossary tool routing
+
 ### Tools and skills
 
 | Tool | Skill | Behavior |
 |------|-------|----------|
-| `search_crowdin_glossary` | `tms-tools` + shared `crowdin` | Default: org-level `POST /glossaries/concordance`. Optional Hyperlocalise `projectId` → project concordance. |
-| `search_native_glossary` | `glossary-tools` (always on) | Postgres FTS over native (`source = native`) glossaries; prefer project-attached when `projectId` is set. |
+| `search_crowdin_glossary` | `tms-tools` + shared `crowdin` | Default: org-level `POST /glossaries/concordance`. Optional Hyperlocalise `projectId` → project concordance. Gated by `workspace-glossary-search`. |
+| `search_native_glossary` | `glossary-tools` (`requiresGlossarySearch`) | Postgres FTS over native (`source = native`) glossaries; prefer project-attached when `projectId` is set. |
 
 ### CAT → chat context
 


### PR DESCRIPTION
## What changed

- add read-only Crowdin organization/project glossary concordance and native glossary search tools
- make conversational terminology advice glossary-first, translating and flagging terms that are missing
- carry CAT project/provider context into chat without reassigning already-scoped conversations
- document the design and add regression coverage

## How to test

- `vp check --fix`
- `vp test src/components/app-shell/chat-dock/chat-dock-store.test.ts src/components/cat/workspace/cat-chat-dock-page-context-bridge.test.tsx src/agents/_runtime/shared-tools/search_crowdin_glossary.test.ts src/lib/providers/adapters/crowdin/crowdin-glossary-search.test.ts src/lib/agent-runtime/skills/conversation-skill-registry.test.ts src/lib/agent-runtime/loops/conversation-skill-agent.test.ts src/agents/hyperlocalise/agent/agent.test.ts`
- Full `vp test` was attempted; DB-backed tests require PostgreSQL on `localhost:5432` and could not connect in this environment.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)