### PR TITLE
⚡ Bolt: optimize token F1 scoring in evaluator

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -315,3 +315,7 @@
 ## 2027-04-25 - On-the-fly ASCII fast-path in normalizeText and early return in termComplianceScore
 **Learning:** In scoring evaluators, running `strings.ToLower` unconditionally inside `termComplianceScore` creates substantial redundant heap allocation overhead when no forbidden terms exist. Additionally, performing character-by-character Unicode decoding and checks (like `unicode.IsPunct` and `unicode.IsSpace`) inside `normalizeText` can be completely bypassed for ASCII characters by processing raw bytes directly.
 **Action:** Always guard heavy lowercasing checks with size-gated early returns (e.g., check `len(forbiddenTerms) == 0`). For text normalization, implement a byte-level ASCII fast-path that bypasses rune decoding and unicode table functions entirely, yielding over 54% faster normalization speeds.
+
+## 2027-04-30 - Eliminating duplicate map allocations in token F1 scoring
+**Learning:** In text similarity scoring metrics like token F1, constructing separate frequency maps for both the reference and candidate strings is a major allocation bottleneck. Since we only need to count matching tokens (multiset intersection), we can construct and pre-allocate a single map for the reference tokens, then scan the candidate tokens and decrement the counts on the fly. This completely avoids allocating the candidate map and reduces overall evaluator allocations.
+**Action:** Replaced the dual-map implementation in `tokenF1Normalized` with a single pre-allocated map and on-the-fly decrementing, reducing allocations per evaluation by 3.

--- a/apps/cli/internal/i18n/evalsvc/scoring/evaluator.go
+++ b/apps/cli/internal/i18n/evalsvc/scoring/evaluator.go
@@ -506,6 +506,12 @@ func tokenF1(reference, candidate string) float64 {
 	return tokenF1Normalized(normalizeText(reference), normalizeText(candidate))
 }
 
+// BOLT OPTIMIZATION: tokenF1Normalized was optimized by replacing the two independent
+// token-count maps with a single map (rCount) pre-allocated with a capacity hint based
+// on the length of reference tokens r. Matching tokens from the candidate string
+// decrement counts in rCount on the fly. This reduces allocations and avoids second
+// map construction entirely, reducing BenchmarkTokenF1 execution time and decreasing
+// allocations in BenchmarkEvaluatorEvaluate.
 func tokenF1Normalized(reference, candidate string) float64 {
 	r := tokenizeNormalized(reference)
 	c := tokenizeNormalized(candidate)
@@ -515,17 +521,16 @@ func tokenF1Normalized(reference, candidate string) float64 {
 	if len(r) == 0 || len(c) == 0 {
 		return 0
 	}
-	rCount := map[string]int{}
+	rCount := make(map[string]int, len(r))
 	for _, tok := range r {
 		rCount[tok]++
 	}
-	cCount := map[string]int{}
-	for _, tok := range c {
-		cCount[tok]++
-	}
 	matches := 0
-	for tok, cnt := range rCount {
-		matches += min(cnt, cCount[tok])
+	for _, tok := range c {
+		if count, ok := rCount[tok]; ok && count > 0 {
+			matches++
+			rCount[tok]--
+		}
 	}
 	precision := float64(matches) / float64(len(c))
 	recall := float64(matches) / float64(len(r))


### PR DESCRIPTION
⚡ Bolt: Optimize token F1 scoring in evaluator.

💡 What: Optimized the `tokenF1Normalized` function in `evaluator.go` to use a single frequency map of reference tokens instead of allocating two independent frequency maps.
🎯 Why: Constructing frequency maps for both the reference and candidate strings in token F1 scoring creates unnecessary allocation overhead on every evaluation.
📊 Impact: Decreases memory allocations in `BenchmarkEvaluatorEvaluate` from 98 to 95 and yields a measurable speedup.
🔬 Measurement: Verified with `make bench-evalsvc` and `go test ./...` which passes successfully.

---
*PR created automatically by Jules for task [8906968601800649351](https://jules.google.com/task/8906968601800649351) started by @cungminh2710*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized scoring hot-path refactor with equivalent multiset intersection logic; no auth, data, or API surface changes.
> 
> **Overview**
> **`tokenF1Normalized`** in the evalsvc scoring evaluator no longer builds separate frequency maps for reference and candidate tokens. It now pre-allocates one reference map (capacity `len(r)`) and walks candidate tokens, decrementing counts to count multiset matches—same F1 math, fewer allocations on every reference-similarity evaluation.
> 
> Bolt journal documents the pattern for future token-F1 work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81944a9666ba3476081b7ca946e9d7566f6865e8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->