### PR TITLE
🧪 Scout: add comprehensive I18NConfig validation tests

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -195,3 +195,7 @@
 ## 2026-11-10 - [API Base URL Security Validation Boundaries]
 **Learning:** `ValidateAPIBaseURL` enforces strict security validations (preventing SSRF, open redirects, or credential leaks) by requiring public unicast IPs under HTTPS on production domains, while allowing localhost/loopback over HTTP or HTTPS. Testing this logic requires table-driven test cases covering URL query/fragments, user credentials, DNS trickery/suffix domains, bracketed IPv6 loopback structures, and RFC1918 private space IPs.
 **Action:** When testing host, URL, or API endpoints, design comprehensive test matrices covering parsing anomalies (percent encoding errors), protocol/scheme requirements, and address routing properties (loopback vs public vs multicast/private unicast).
+
+## 2026-11-15 - [I18N Config Hyperlocalise & Struct Validation Boundaries]
+**Learning:** `I18NConfig` includes robust structural validation for map keys (buckets/groups), target locales, file mappings, and `HyperlocaliseConfig` credentials/API base URLs. Since `Load()` automatically overlays default values for empty string inputs before running `Validate()`, some validation constraints (like empty/whitespace `APIBaseURL` or `APIKeyEnv`) are unreachable via configuration file parsing.
+**Action:** When testing configuration rules that can be overwritten by standard defaults, construct the `I18NConfig` struct manually in tests and run the public `.Validate()` method directly to comprehensively check contract enforcement.

--- a/pkg/i18nconfig/i18n_scout_test.go
+++ b/pkg/i18nconfig/i18n_scout_test.go
@@ -117,6 +117,92 @@ func TestLoad_ScoutEdgeCases(t *testing.T) {
 			}`,
 			errContains: "duplicate locale",
 		},
+		{
+			name: "invalid hyperlocalise api_base_url invalid scheme/host",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x"}}},
+			  "hyperlocalise": {
+			    "api_base_url": "http://production-attacker-domain.com/api",
+			    "project_id": "p123"
+			  }
+			}`,
+			errContains: "must use https",
+		},
+		{
+			name: "invalid hyperlocalise negative timeout seconds",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x"}}},
+			  "hyperlocalise": {
+			    "api_base_url": "https://hyperlocalise.com/api",
+			    "project_id": "p123",
+			    "timeout_seconds": -5
+			  }
+			}`,
+			errContains: "hyperlocalise.timeout_seconds: must be >= 0",
+		},
+		{
+			name: "invalid empty bucket name",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {
+			    "  ": {"files": [{"from": "a", "to": "b"}]}
+			  },
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x"}}}
+			}`,
+			errContains: "buckets: bucket name must not be empty",
+		},
+		{
+			name: "invalid empty group name",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "groups": {
+			    " ": {"targets": ["es-ES"], "buckets": ["ui"]}
+			  },
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x"}}}
+			}`,
+			errContains: "groups: group name must not be empty",
+		},
+		{
+			name: "invalid bucket file mapping missing to",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": ""}]}},
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x"}}}
+			}`,
+			errContains: ".to: must not be empty",
+		},
+		{
+			name: "invalid group duplicate targets",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES", "fr-FR"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "groups": {
+			    "g1": {"targets": ["es-ES", "es-ES"], "buckets": ["ui"]}
+			  },
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x"}}}
+			}`,
+			errContains: "duplicate locale",
+		},
+		{
+			name: "invalid group duplicate buckets",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {
+			    "ui": {"files": [{"from": "a", "to": "b"}]},
+			    "docs": {"files": [{"from": "c", "to": "d"}]}
+			  },
+			  "groups": {
+			    "g1": {"targets": ["es-ES"], "buckets": ["ui", "ui"]}
+			  },
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x"}}}
+			}`,
+			errContains: "duplicate bucket",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -131,6 +217,90 @@ func TestLoad_ScoutEdgeCases(t *testing.T) {
 
 			if !strings.Contains(err.Error(), tc.errContains) {
 				t.Fatalf("expected error containing %q, got: %v", tc.errContains, err)
+			}
+		})
+	}
+}
+
+func TestI18NConfig_ValidateDirect_Scout(t *testing.T) {
+	t.Parallel()
+
+	baseConfig := func() I18NConfig {
+		return I18NConfig{
+			Locales: LocaleConfig{
+				Source:  "en-US",
+				Targets: []string{"es-ES"},
+			},
+			Buckets: map[string]BucketConfig{
+				"ui": {
+					Files: []BucketFileMapping{
+						{From: "a", To: "b"},
+					},
+				},
+			},
+			LLM: LLMConfig{
+				Profiles: map[string]LLMProfile{
+					"default": {
+						Provider: "openai",
+						Model:    "gpt-4",
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		modify      func(*I18NConfig)
+		errContains string
+	}{
+		{
+			name: "invalid hyperlocalise api_base_url empty",
+			modify: func(c *I18NConfig) {
+				c.Hyperlocalise = &HyperlocaliseConfig{
+					APIBaseURL: "  ",
+					ProjectID:  "p123",
+					APIKeyEnv:  "KEY",
+				}
+			},
+			errContains: "hyperlocalise.api_base_url: must not be empty",
+		},
+		{
+			name: "invalid hyperlocalise api_key_env empty",
+			modify: func(c *I18NConfig) {
+				c.Hyperlocalise = &HyperlocaliseConfig{
+					APIBaseURL: "https://hyperlocalise.com/api",
+					ProjectID:  "p123",
+					APIKeyEnv:  "   ",
+				}
+			},
+			errContains: "hyperlocalise.api_key_env: must not be empty",
+		},
+		{
+			name: "invalid hyperlocalise project_id and project_id_env both empty",
+			modify: func(c *I18NConfig) {
+				c.Hyperlocalise = &HyperlocaliseConfig{
+					APIBaseURL:   "https://hyperlocalise.com/api",
+					APIKeyEnv:    "KEY",
+					ProjectID:    "",
+					ProjectIDEnv: "",
+				}
+			},
+			errContains: "hyperlocalise.project_id: must be set when hyperlocalise.project_id_env is empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := baseConfig()
+			tt.modify(&cfg)
+
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.errContains)
+			}
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Fatalf("expected error containing %q, got: %v", tt.errContains, err)
 			}
 		})
 	}


### PR DESCRIPTION
💡 What: Added comprehensive behavior-driven unit tests for I18NConfig schema/validation rules inside pkg/i18nconfig/i18n_scout_test.go.
🎯 Why: Increases trust and confidence in Hyperlocalise's configuration loading logic, ensuring configuration errors (such as invalid API URLs, missing file destinations, and duplicate targets/buckets) are detected early and precisely.
🧩 Scope: pkg/i18nconfig/i18n_scout_test.go
✅ Verification: Ran `go test -v ./pkg/i18nconfig/...` and `go test ./...` which all pass successfully.
🛡️ Confidence: Strong regression protection for the core configuration validation logic, preventing accidental breakage of configuration parsing rules.

---
*PR created automatically by Jules for task [11408958380327948115](https://jules.google.com/task/11408958380327948115) started by @cungminh2710*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and documentation changes; no production validation logic is modified.
> 
> **Overview**
> Adds regression tests for **`I18NConfig`** / **`Load`** validation in `i18n_scout_test.go`, covering **Hyperlocalise** (non-HTTPS `api_base_url`, negative `timeout_seconds`), **buckets/groups** (blank names, empty file `to`, duplicate group targets/buckets), and a new **`TestI18NConfig_ValidateDirect_Scout`** that calls **`Validate()`** on hand-built structs for Hyperlocalise rules that **`Load()`** defaults can mask (empty `api_base_url` / `api_key_env`, missing project id).
> 
> Documents the **`Load()` vs direct `Validate()`** testing pattern in `.jules/scout.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d369b29cd6f942d97f2ad9ac341e53b0c160efc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->