### PR TITLE
feat(automations): add translate-on-source-upload agent template

### DIFF
--- a/apps/hyperlocalise-web/lang/de-DE.json
+++ b/apps/hyperlocalise-web/lang/de-DE.json
@@ -9941,6 +9941,30 @@
   "nSqpG2XwMB": {
     "defaultMessage": "Nach Namen suchen ..."
   },
+  "nTmsAssignAgent": {
+    "defaultMessage": "Translate with agent",
+    "description": "Menu item and tool title for assigning Translate with agent"
+  },
+  "nTmsAssignAgentDesc": {
+    "defaultMessage": "Assign the created job to Translate with agent and start localisation.",
+    "description": "Description for the Translate with agent automation tool"
+  },
+  "nTmsCreateJob": {
+    "defaultMessage": "Create job",
+    "description": "Menu item and tool title for creating a native TMS job"
+  },
+  "nTmsCreateJobDesc": {
+    "defaultMessage": "Create a native TMS translation job for uploaded source files in the project selected above.",
+    "description": "Description for the Create job automation tool"
+  },
+  "nTmsRemoveAssignAgent": {
+    "defaultMessage": "Remove Translate with agent",
+    "description": "Accessible label to remove the Translate with agent tool"
+  },
+  "nTmsRemoveCreateJob": {
+    "defaultMessage": "Remove Create job",
+    "description": "Accessible label to remove the Create job tool"
+  },
   "nULuPBbLbZ": {
     "defaultMessage": "Preismeldungen lokalisieren"
   },

--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -12355,6 +12355,30 @@
     "defaultMessage": "Search by name...",
     "description": "Placeholder for the projects search field"
   },
+  "nTmsAssignAgent": {
+    "defaultMessage": "Translate with agent",
+    "description": "Menu item and tool title for assigning Translate with agent"
+  },
+  "nTmsAssignAgentDesc": {
+    "defaultMessage": "Assign the created job to Translate with agent and start localisation.",
+    "description": "Description for the Translate with agent automation tool"
+  },
+  "nTmsCreateJob": {
+    "defaultMessage": "Create job",
+    "description": "Menu item and tool title for creating a native TMS job"
+  },
+  "nTmsCreateJobDesc": {
+    "defaultMessage": "Create a native TMS translation job for uploaded source files in the project selected above.",
+    "description": "Description for the Create job automation tool"
+  },
+  "nTmsRemoveAssignAgent": {
+    "defaultMessage": "Remove Translate with agent",
+    "description": "Accessible label to remove the Translate with agent tool"
+  },
+  "nTmsRemoveCreateJob": {
+    "defaultMessage": "Remove Create job",
+    "description": "Accessible label to remove the Create job tool"
+  },
   "nULuPBbLbZ": {
     "defaultMessage": "Localise Pricing Messages",
     "description": "Subtitle under the translate task title in the translation flow illustration"

--- a/apps/hyperlocalise-web/lang/fr-FR.json
+++ b/apps/hyperlocalise-web/lang/fr-FR.json
@@ -9941,6 +9941,30 @@
   "nSqpG2XwMB": {
     "defaultMessage": "Search by name..."
   },
+  "nTmsAssignAgent": {
+    "defaultMessage": "Translate with agent",
+    "description": "Menu item and tool title for assigning Translate with agent"
+  },
+  "nTmsAssignAgentDesc": {
+    "defaultMessage": "Assign the created job to Translate with agent and start localisation.",
+    "description": "Description for the Translate with agent automation tool"
+  },
+  "nTmsCreateJob": {
+    "defaultMessage": "Create job",
+    "description": "Menu item and tool title for creating a native TMS job"
+  },
+  "nTmsCreateJobDesc": {
+    "defaultMessage": "Create a native TMS translation job for uploaded source files in the project selected above.",
+    "description": "Description for the Create job automation tool"
+  },
+  "nTmsRemoveAssignAgent": {
+    "defaultMessage": "Remove Translate with agent",
+    "description": "Accessible label to remove the Translate with agent tool"
+  },
+  "nTmsRemoveCreateJob": {
+    "defaultMessage": "Remove Create job",
+    "description": "Accessible label to remove the Create job tool"
+  },
   "nULuPBbLbZ": {
     "defaultMessage": "Localise Pricing Messages"
   },

--- a/apps/hyperlocalise-web/lang/vi-VN.json
+++ b/apps/hyperlocalise-web/lang/vi-VN.json
@@ -9941,6 +9941,30 @@
   "nSqpG2XwMB": {
     "defaultMessage": "Search by name..."
   },
+  "nTmsAssignAgent": {
+    "defaultMessage": "Translate with agent",
+    "description": "Menu item and tool title for assigning Translate with agent"
+  },
+  "nTmsAssignAgentDesc": {
+    "defaultMessage": "Assign the created job to Translate with agent and start localisation.",
+    "description": "Description for the Translate with agent automation tool"
+  },
+  "nTmsCreateJob": {
+    "defaultMessage": "Create job",
+    "description": "Menu item and tool title for creating a native TMS job"
+  },
+  "nTmsCreateJobDesc": {
+    "defaultMessage": "Create a native TMS translation job for uploaded source files in the project selected above.",
+    "description": "Description for the Create job automation tool"
+  },
+  "nTmsRemoveAssignAgent": {
+    "defaultMessage": "Remove Translate with agent",
+    "description": "Accessible label to remove the Translate with agent tool"
+  },
+  "nTmsRemoveCreateJob": {
+    "defaultMessage": "Remove Create job",
+    "description": "Accessible label to remove the Create job tool"
+  },
   "nULuPBbLbZ": {
     "defaultMessage": "Localise Pricing Messages"
   },

--- a/apps/hyperlocalise-web/lang/zh-CN.json
+++ b/apps/hyperlocalise-web/lang/zh-CN.json
@@ -9941,6 +9941,30 @@
   "nSqpG2XwMB": {
     "defaultMessage": "Search by name..."
   },
+  "nTmsAssignAgent": {
+    "defaultMessage": "Translate with agent",
+    "description": "Menu item and tool title for assigning Translate with agent"
+  },
+  "nTmsAssignAgentDesc": {
+    "defaultMessage": "Assign the created job to Translate with agent and start localisation.",
+    "description": "Description for the Translate with agent automation tool"
+  },
+  "nTmsCreateJob": {
+    "defaultMessage": "Create job",
+    "description": "Menu item and tool title for creating a native TMS job"
+  },
+  "nTmsCreateJobDesc": {
+    "defaultMessage": "Create a native TMS translation job for uploaded source files in the project selected above.",
+    "description": "Description for the Create job automation tool"
+  },
+  "nTmsRemoveAssignAgent": {
+    "defaultMessage": "Remove Translate with agent",
+    "description": "Accessible label to remove the Translate with agent tool"
+  },
+  "nTmsRemoveCreateJob": {
+    "defaultMessage": "Remove Create job",
+    "description": "Accessible label to remove the Create job tool"
+  },
   "nULuPBbLbZ": {
     "defaultMessage": "Localise Pricing Messages"
   },

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.test.ts
@@ -93,13 +93,34 @@ describe("buildWorkspaceOrchestratorPlan", () => {
     expect(plan.tools).toEqual([]);
   });
 
-  it("plans native TMS create then assign when translation workflow is enabled", () => {
+  it("plans native TMS create then assign when both tools are enabled", () => {
     const plan = buildWorkspaceOrchestratorPlan(
       automation({
         projectId: "project-1",
         triggerConfig: { mode: "source_upload" },
         toolConfig: {
-          translation: {
+          createNativeTmsJob: {
+            enabled: true,
+            useProjectTargetLocales: true,
+            targetLocales: [],
+          },
+          assignTranslateWithAgent: {
+            enabled: true,
+          },
+        },
+      }),
+    );
+
+    expect(plan.tools).toEqual(["create_native_tms_job", "assign_translate_with_agent"]);
+  });
+
+  it("plans create job only when Translate with agent is disabled", () => {
+    const plan = buildWorkspaceOrchestratorPlan(
+      automation({
+        projectId: "project-1",
+        triggerConfig: { mode: "source_upload" },
+        toolConfig: {
+          createNativeTmsJob: {
             enabled: true,
             useProjectTargetLocales: true,
             targetLocales: [],
@@ -108,7 +129,7 @@ describe("buildWorkspaceOrchestratorPlan", () => {
       }),
     );
 
-    expect(plan.tools).toEqual(["create_native_tms_job", "assign_translate_with_agent"]);
+    expect(plan.tools).toEqual(["create_native_tms_job"]);
   });
 
   it("includes use_semrush when a Semrush connection is enabled", () => {

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.ts
@@ -15,8 +15,9 @@ import {
   hasWorkspaceAutomationGithubWorkflow,
 } from "@/lib/agents/workspace-automation-github-mapping";
 import {
+  hasWorkspaceAutomationAssignTranslateWithAgentTool,
   hasWorkspaceAutomationContentfulWorkflow,
-  hasWorkspaceAutomationTranslationWorkflow,
+  hasWorkspaceAutomationCreateNativeTmsJobTool,
   type WorkspaceAutomationRecord,
   type WorkspaceAutomationToolConfig,
 } from "@/lib/agents/workspace-automations";
@@ -69,8 +70,9 @@ function workflowToolEnabled(
     case "run_contentful_translation":
       return hasWorkspaceAutomationContentfulWorkflow(toolConfig);
     case "create_native_tms_job":
+      return hasWorkspaceAutomationCreateNativeTmsJobTool(toolConfig);
     case "assign_translate_with_agent":
-      return hasWorkspaceAutomationTranslationWorkflow(toolConfig);
+      return hasWorkspaceAutomationAssignTranslateWithAgentTool(toolConfig);
     case "use_semrush":
       return Boolean(toolConfig.semrush?.enabled && toolConfig.semrush.connectionId);
     case "use_ahrefs":

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/skills/translate-on-source-upload.md
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/skills/translate-on-source-upload.md
@@ -1,0 +1,17 @@
+---
+id: translate-on-source-upload
+name: Translate on source upload
+category: popular
+defaultTrigger: source_upload
+activatable: true
+---
+
+Create a native translation job when a source file is uploaded, then translate it with the Hyperlocalise agent.
+
+Workflow:
+
+- Read the uploaded source file and version from the source-upload trigger.
+- Create a native TMS translation job for the project target locales.
+- Assign the job to Translate with agent so localisation starts immediately.
+- Preserve keys, placeholders, ICU syntax, glossary terms, and file structure.
+- Summarize the job created and locales started for translation.

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/assign_translate_with_agent.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/assign_translate_with_agent.test.ts
@@ -56,10 +56,13 @@ function session(
     triggerConfig: { mode: "source_upload" },
     repositoryTarget: { kind: "none" },
     toolConfig: {
-      translation: {
+      createNativeTmsJob: {
         enabled: true,
         useProjectTargetLocales: true,
         targetLocales: [],
+      },
+      assignTranslateWithAgent: {
+        enabled: true,
       },
     },
     configVersion: 1,

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/assign_translate_with_agent.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/assign_translate_with_agent.ts
@@ -43,9 +43,9 @@ export function createAssignTranslateWithAgentTool(session: WorkspaceOrchestrato
         .describe("Optional operator note to include in the run record."),
     }),
     execute: async ({ jobId, summary }) => {
-      const translationConfig = session.automation.toolConfig.translation;
-      if (!translationConfig?.enabled || !session.automation.projectId?.trim()) {
-        throw new Error("translation_workflow_not_configured");
+      const assignConfig = session.automation.toolConfig.assignTranslateWithAgent;
+      if (!assignConfig?.enabled || !session.automation.projectId?.trim()) {
+        throw new Error("assign_translate_with_agent_not_configured");
       }
 
       const existingOutput = readAssignTranslateWithAgent(

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_native_tms_job.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_native_tms_job.test.ts
@@ -71,7 +71,7 @@ function session(
     triggerConfig: { mode: "source_upload" },
     repositoryTarget: { kind: "none" },
     toolConfig: {
-      translation: {
+      createNativeTmsJob: {
         enabled: true,
         useProjectTargetLocales: true,
         targetLocales: [],
@@ -213,7 +213,7 @@ describe("createNativeTmsJobTool", () => {
 
   it("uses configured target locales when project locales are not selected", async () => {
     const currentSession = session();
-    currentSession.automation.toolConfig.translation = {
+    currentSession.automation.toolConfig.createNativeTmsJob = {
       enabled: true,
       useProjectTargetLocales: false,
       targetLocales: ["ja-JP"],
@@ -242,7 +242,7 @@ describe("createNativeTmsJobTool", () => {
 
   it("rejects empty configured target locales", async () => {
     const currentSession = session();
-    currentSession.automation.toolConfig.translation = {
+    currentSession.automation.toolConfig.createNativeTmsJob = {
       enabled: true,
       useProjectTargetLocales: false,
       targetLocales: [],

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_native_tms_job.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_native_tms_job.ts
@@ -35,10 +35,10 @@ export function createNativeTmsJobTool(session: WorkspaceOrchestratorSession) {
         .describe("Optional operator note to include in the run record."),
     }),
     execute: async ({ summary }) => {
-      const translationConfig = session.automation.toolConfig.translation;
+      const createNativeTmsJobConfig = session.automation.toolConfig.createNativeTmsJob;
       const automationProjectId = session.automation.projectId?.trim() || null;
-      if (!translationConfig?.enabled || !automationProjectId) {
-        throw new Error("translation_workflow_not_configured");
+      if (!createNativeTmsJobConfig?.enabled || !automationProjectId) {
+        throw new Error("create_native_tms_job_not_configured");
       }
 
       const existingOutput = readCreateNativeTmsJob(session.run.outputSummary, session.stepResults);
@@ -71,11 +71,11 @@ export function createNativeTmsJobTool(session: WorkspaceOrchestratorSession) {
         throw new Error("translation_project_not_found");
       }
 
-      const configuredLocales = translationConfig.useProjectTargetLocales
+      const configuredLocales = createNativeTmsJobConfig.useProjectTargetLocales
         ? Array.isArray(project.targetLocales)
           ? project.targetLocales.filter((locale): locale is string => typeof locale === "string")
           : []
-        : translationConfig.targetLocales;
+        : createNativeTmsJobConfig.targetLocales;
 
       if (configuredLocales.length === 0) {
         throw new Error("translation_target_locales_missing");

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-template-manifest.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-template-manifest.test.ts
@@ -48,8 +48,9 @@ describe("workspace template manifest", () => {
       activatable: true,
       defaultForm: {
         triggerMode: "source_upload",
-        translationEnabled: true,
-        translationUseProjectTargetLocales: true,
+        createNativeTmsJobEnabled: true,
+        createNativeTmsJobUseProjectTargetLocales: true,
+        assignTranslateWithAgentEnabled: true,
       },
     });
     expect(template?.description).toContain("native translation job");

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-template-manifest.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-template-manifest.test.ts
@@ -37,10 +37,31 @@ describe("workspace template manifest", () => {
     expect(validateTemplate?.instructions).toContain("protected branches");
   });
 
+  it("merges translate-on-source-upload skill onto the gallery template", () => {
+    const [template] = mergeWorkspaceTemplateSkills(WORKSPACE_AUTOMATION_TEMPLATES_BASE).filter(
+      (entry) => entry.id === "translate-on-source-upload",
+    );
+
+    expect(template).toMatchObject({
+      name: "Translate on source upload",
+      category: "popular",
+      activatable: true,
+      defaultForm: {
+        triggerMode: "source_upload",
+        translationEnabled: true,
+        translationUseProjectTargetLocales: true,
+      },
+    });
+    expect(template?.description).toContain("native translation job");
+    expect(template?.instructions).toContain("Translate with agent");
+  });
+
   it("reads executor agent and category from skill frontmatter", () => {
     expect(getTemplateExecutorAgent("translate-contentful-article")).toBe("contentful");
     expect(getTemplateExecutorAgent("validate-localisation-on-push")).toBe("github-repository");
+    expect(getTemplateExecutorAgent("translate-on-source-upload")).toBeNull();
     expect(getTemplateCategoryFromSkill("validate-localisation-on-push")).toBe("quality");
+    expect(getTemplateCategoryFromSkill("translate-on-source-upload")).toBe("popular");
   });
 
   it("keeps summarize changes daily template content from base definition", () => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-template-flow.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-template-flow.stories.tsx
@@ -70,6 +70,15 @@ export const ContentfulTranslation: Story = {
   },
 };
 
+export const SourceUploadTranslation: Story = {
+  ...templateStory("translate-on-source-upload"),
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByLabelText("Source upload → Create job → Translate with agent"),
+    ).toBeInTheDocument();
+  },
+};
+
 export const ScheduledSummary: Story = {
   ...templateStory("summarize-changes-daily"),
   play: async ({ canvas }) => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -346,10 +346,15 @@ export const workspaceAutomationFormMessages = defineMessages({
     id: "ywFNKJfKqp",
     description: "Menu item and tool title for Contentful translation",
   },
-  translate: {
-    defaultMessage: "Translate",
-    id: "rVbcl0T6/F",
-    description: "Menu item and tool title for translation jobs",
+  createJob: {
+    defaultMessage: "Create job",
+    id: "iN2TlQe/rc",
+    description: "Menu item and tool title for creating a native TMS job",
+  },
+  translateWithAgent: {
+    defaultMessage: "Translate with agent",
+    id: "dg15k+jhq4",
+    description: "Menu item and tool title for assigning Translate with agent",
   },
   mcpServer: {
     defaultMessage: "MCP Server",
@@ -589,16 +594,26 @@ export const workspaceAutomationFormMessages = defineMessages({
     id: "GuEU+qQCHt",
     description: "Toggle label for overwriting Contentful target locales",
   },
-  translateDescription: {
+  createJobDescription: {
     defaultMessage:
-      "Queue translation jobs for uploaded source files in the project selected above.",
-    id: "1AN+Q/JkbE",
-    description: "Description for the translate tool",
+      "Create a native TMS translation job for uploaded source files in the project selected above.",
+    id: "pryVUr/AGB",
+    description: "Description for the Create job automation tool",
   },
-  removeTranslate: {
-    defaultMessage: "Remove Translate",
-    id: "xKI0yR66AU",
-    description: "Accessible label to remove the translate tool",
+  translateWithAgentDescription: {
+    defaultMessage: "Assign the created job to Translate with agent and start localisation.",
+    id: "YZ2plskMsH",
+    description: "Description for the Translate with agent automation tool",
+  },
+  removeCreateJob: {
+    defaultMessage: "Remove Create job",
+    id: "w29ko2pN3n",
+    description: "Accessible label to remove the Create job tool",
+  },
+  removeTranslateWithAgent: {
+    defaultMessage: "Remove Translate with agent",
+    id: "9u6IERsgZA",
+    description: "Accessible label to remove the Translate with agent tool",
   },
   useProjectTargetLocales: {
     defaultMessage: "Use project target locales",
@@ -607,8 +622,8 @@ export const workspaceAutomationFormMessages = defineMessages({
   },
   chooseProjectForTargetLocales: {
     defaultMessage: "Choose a project above to pick target locales.",
-    id: "dn9Ff93vY2",
-    description: "Empty state when translation target locales need a project first",
+    id: "mzBTNMYPpo",
+    description: "Empty state when Create job target locales need a project first",
   },
   noRunsYet: {
     defaultMessage: "No runs yet.",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -333,7 +333,8 @@ function toolCount(form: WorkspaceAutomationFormState) {
     Number(form.slackEnabled) +
     Number(form.emailEnabled) +
     Number(form.contentfulEnabled) +
-    Number(form.translationEnabled) +
+    Number(form.createNativeTmsJobEnabled) +
+    Number(form.assignTranslateWithAgentEnabled) +
     Number(form.knowledgeEnabled) +
     Number(form.mcpEnabled) +
     Number(form.semrushEnabled) +
@@ -490,7 +491,8 @@ function HeaderProjectSelector({
   const intl = useIntl();
   const usesTranslationProject =
     form.triggerMode === "source_upload" ||
-    (form.translationEnabled && (form.triggerMode !== "github" || !form.githubEnabled));
+    ((form.createNativeTmsJobEnabled || form.assignTranslateWithAgentEnabled) &&
+      (form.triggerMode !== "github" || !form.githubEnabled));
   const selectableProjects = usesTranslationProject
     ? projects.filter((project) => project.source !== "external_tms")
     : projects;
@@ -827,8 +829,9 @@ function AddTriggerMenu({
                 onChange({
                   ...form,
                   triggerMode: "source_upload",
-                  translationEnabled: true,
-                  translationUseProjectTargetLocales: true,
+                  createNativeTmsJobEnabled: true,
+                  createNativeTmsJobUseProjectTargetLocales: true,
+                  assignTranslateWithAgentEnabled: true,
                 })
               }
             >
@@ -1271,19 +1274,41 @@ function AddToolMenu({
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuItem
-              disabled={form.translationEnabled}
+              disabled={form.createNativeTmsJobEnabled}
               onClick={() =>
                 onChange({
                   ...form,
-                  translationEnabled: true,
-                  translationUseProjectTargetLocales: true,
+                  createNativeTmsJobEnabled: true,
+                  createNativeTmsJobUseProjectTargetLocales: true,
                   triggerMode: form.triggerMode === "manual" ? "source_upload" : form.triggerMode,
                 })
               }
             >
               <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} className="size-4" />
-              <FormattedMessage {...workspaceAutomationFormMessages.translate} />
-              {form.translationEnabled ? (
+              <FormattedMessage {...workspaceAutomationFormMessages.createJob} />
+              {form.createNativeTmsJobEnabled ? (
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                </DropdownMenuShortcut>
+              ) : null}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={form.assignTranslateWithAgentEnabled}
+              onClick={() =>
+                onChange({
+                  ...form,
+                  createNativeTmsJobEnabled: true,
+                  createNativeTmsJobUseProjectTargetLocales: form.createNativeTmsJobEnabled
+                    ? form.createNativeTmsJobUseProjectTargetLocales
+                    : true,
+                  assignTranslateWithAgentEnabled: true,
+                  triggerMode: form.triggerMode === "manual" ? "source_upload" : form.triggerMode,
+                })
+              }
+            >
+              <HugeiconsIcon icon={BrainCircuitIcon} strokeWidth={1.8} className="size-4" />
+              <FormattedMessage {...workspaceAutomationFormMessages.translateWithAgent} />
+              {form.assignTranslateWithAgentEnabled ? (
                 <DropdownMenuShortcut>
                   <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
                 </DropdownMenuShortcut>
@@ -1497,8 +1522,8 @@ function ToolsSettings({
   const selectedProject = projects.find((project) => project.id === form.projectId);
   const contentfulAvailableTargetLocales = selectedProject?.targetLocales ?? [];
   const showContentfulEntryId = form.triggerMode === "scheduled";
-  const translationAvailableTargetLocales = selectedProject?.targetLocales ?? [];
-  const translationTargetLocalesFieldId = "translation-target-locales";
+  const createNativeTmsJobAvailableTargetLocales = selectedProject?.targetLocales ?? [];
+  const createNativeTmsJobTargetLocalesFieldId = "create-native-tms-job-target-locales";
   const intl = useIntl();
   const [memoriesOpen, setMemoriesOpen] = useState(false);
 
@@ -1956,23 +1981,27 @@ function ToolsSettings({
           </EditorRow>
         ) : null}
 
-        {form.translationEnabled ? (
+        {form.createNativeTmsJobEnabled ? (
           <EditorRow
             icon={<HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} className="size-4" />}
-            title={<FormattedMessage {...workspaceAutomationFormMessages.translate} />}
+            title={<FormattedMessage {...workspaceAutomationFormMessages.createJob} />}
             description={
-              <FormattedMessage {...workspaceAutomationFormMessages.translateDescription} />
+              <FormattedMessage {...workspaceAutomationFormMessages.createJobDescription} />
             }
             action={
               <DeleteToolButton
                 disabled={disabled}
-                label={intl.formatMessage(workspaceAutomationFormMessages.removeTranslate)}
+                label={intl.formatMessage(workspaceAutomationFormMessages.removeCreateJob)}
                 onClick={() =>
                   onChange({
                     ...form,
-                    translationEnabled: false,
-                    translationTargetLocales: [],
-                    triggerMode: form.triggerMode === "source_upload" ? "manual" : form.triggerMode,
+                    createNativeTmsJobEnabled: false,
+                    createNativeTmsJobTargetLocales: [],
+                    assignTranslateWithAgentEnabled: false,
+                    triggerMode:
+                      form.triggerMode === "source_upload" && !form.contentfulEnabled
+                        ? "manual"
+                        : form.triggerMode,
                   })
                 }
               />
@@ -1985,42 +2014,68 @@ function ToolsSettings({
                 </span>
                 <Switch
                   size="sm"
-                  checked={form.translationUseProjectTargetLocales}
+                  checked={form.createNativeTmsJobUseProjectTargetLocales}
                   disabled={disabled}
                   onCheckedChange={(checked) =>
                     onChange({
                       ...form,
-                      translationUseProjectTargetLocales: checked,
-                      translationTargetLocales: checked ? [] : form.translationTargetLocales,
+                      createNativeTmsJobUseProjectTargetLocales: checked,
+                      createNativeTmsJobTargetLocales: checked
+                        ? []
+                        : form.createNativeTmsJobTargetLocales,
                     })
                   }
                 />
               </label>
-              {!form.translationUseProjectTargetLocales ? (
+              {!form.createNativeTmsJobUseProjectTargetLocales ? (
                 <div className="grid gap-1.5">
                   <Label
-                    id={translationTargetLocalesFieldId}
+                    id={createNativeTmsJobTargetLocalesFieldId}
                     className="text-xs text-muted-foreground"
                   >
                     <FormattedMessage {...workspaceAutomationFormMessages.targetLocalesLabel} />
                   </Label>
                   <ContentfulTargetLocalesPicker
-                    availableLocales={translationAvailableTargetLocales}
+                    availableLocales={createNativeTmsJobAvailableTargetLocales}
                     disabled={disabled}
                     emptyMessage={intl.formatMessage(
                       workspaceAutomationFormMessages.chooseProjectForTargetLocales,
                     )}
-                    error={errors.translationTargetLocales}
-                    labelledBy={translationTargetLocalesFieldId}
-                    selectedLocales={form.translationTargetLocales}
-                    onChange={(translationTargetLocales) =>
-                      onChange({ ...form, translationTargetLocales })
+                    error={errors.createNativeTmsJobTargetLocales}
+                    labelledBy={createNativeTmsJobTargetLocalesFieldId}
+                    selectedLocales={form.createNativeTmsJobTargetLocales}
+                    onChange={(createNativeTmsJobTargetLocales) =>
+                      onChange({ ...form, createNativeTmsJobTargetLocales })
                     }
                   />
                 </div>
               ) : null}
             </div>
           </EditorRow>
+        ) : null}
+
+        {form.assignTranslateWithAgentEnabled ? (
+          <EditorRow
+            icon={<HugeiconsIcon icon={BrainCircuitIcon} strokeWidth={1.8} className="size-4" />}
+            title={<FormattedMessage {...workspaceAutomationFormMessages.translateWithAgent} />}
+            description={
+              <FormattedMessage
+                {...workspaceAutomationFormMessages.translateWithAgentDescription}
+              />
+            }
+            action={
+              <DeleteToolButton
+                disabled={disabled}
+                label={intl.formatMessage(workspaceAutomationFormMessages.removeTranslateWithAgent)}
+                onClick={() =>
+                  onChange({
+                    ...form,
+                    assignTranslateWithAgentEnabled: false,
+                  })
+                }
+              />
+            }
+          />
         ) : null}
 
         {form.mcpEnabled ? (
@@ -2560,7 +2615,8 @@ export function WorkspaceAutomationEditor({
               )}
             </span>
           </label>
-          {form.translationEnabled ||
+          {form.createNativeTmsJobEnabled ||
+          form.assignTranslateWithAgentEnabled ||
           form.contentfulEnabled ||
           (form.githubEnabled && form.githubMode === "sync") ||
           form.triggerMode === "source_upload" ? (

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.test.ts
@@ -824,10 +824,13 @@ describe("workspace automation dispatcher", () => {
         triggerConfig: { mode: "source_upload" },
         repositoryTarget: { kind: "none" },
         toolConfig: {
-          translation: {
+          createNativeTmsJob: {
             enabled: true,
             useProjectTargetLocales: true,
             targetLocales: [],
+          },
+          assignTranslateWithAgent: {
+            enabled: true,
           },
         },
       }),
@@ -842,10 +845,13 @@ describe("workspace automation dispatcher", () => {
         triggerConfig: { mode: "source_upload" },
         repositoryTarget: { kind: "none" },
         toolConfig: {
-          translation: {
+          createNativeTmsJob: {
             enabled: true,
             useProjectTargetLocales: true,
             targetLocales: [],
+          },
+          assignTranslateWithAgent: {
+            enabled: true,
           },
         },
       }),

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.ts
@@ -30,7 +30,7 @@ import {
   createWorkspaceAutomationRun,
   getWorkspaceAutomationRunByIdempotencyKey,
   hasWorkspaceAutomationContentfulWorkflow,
-  hasWorkspaceAutomationTranslationWorkflow,
+  hasWorkspaceAutomationCreateNativeTmsJobTool,
   listDueContentfulWorkspaceAutomations,
   listSourceUploadWorkspaceAutomations,
   listWorkspaceAutomations,
@@ -566,7 +566,7 @@ export async function dispatchWorkspaceAutomationsForSourceUpload(input: {
   const results: WorkspaceAutomationDispatchResult[] = [];
 
   for (const automation of automations) {
-    if (!hasWorkspaceAutomationTranslationWorkflow(automation.toolConfig)) {
+    if (!hasWorkspaceAutomationCreateNativeTmsJobTool(automation.toolConfig)) {
       continue;
     }
 

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.test.ts
@@ -31,8 +31,9 @@ describe("workspace automation templates", () => {
       activatable: true,
       defaultForm: {
         triggerMode: "source_upload",
-        translationEnabled: true,
-        translationUseProjectTargetLocales: true,
+        createNativeTmsJobEnabled: true,
+        createNativeTmsJobUseProjectTargetLocales: true,
+        assignTranslateWithAgentEnabled: true,
       },
     });
   });

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  getWorkspaceAutomationTemplate,
+  getWorkspaceAutomationTemplateFlow,
+  WORKSPACE_AUTOMATION_TEMPLATES_BASE,
+} from "./workspace-automation-templates";
+
+describe("workspace automation templates", () => {
+  it("exposes an activatable source-upload translation template", () => {
+    const template = getWorkspaceAutomationTemplate(
+      "translate-on-source-upload",
+      WORKSPACE_AUTOMATION_TEMPLATES_BASE,
+    );
+
+    expect(template).toMatchObject({
+      id: "translate-on-source-upload",
+      category: "popular",
+      activatable: true,
+      defaultForm: {
+        triggerMode: "source_upload",
+        translationEnabled: true,
+        translationUseProjectTargetLocales: true,
+      },
+    });
+  });
+
+  it("builds the source-upload template flow with create job and translate tools", () => {
+    const template = getWorkspaceAutomationTemplate(
+      "translate-on-source-upload",
+      WORKSPACE_AUTOMATION_TEMPLATES_BASE,
+    );
+    expect(template).not.toBeNull();
+
+    expect(getWorkspaceAutomationTemplateFlow(template!)).toEqual({
+      trigger: { id: "source-upload", label: "Source upload" },
+      tools: [
+        { id: "create-job", label: "Create job" },
+        { id: "translate-with-agent", label: "Translate with agent" },
+      ],
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
@@ -63,8 +63,9 @@ export const WORKSPACE_AUTOMATION_TEMPLATES_BASE: WorkspaceAutomationTemplate[] 
     defaultForm: {
       name: "Translate on source upload",
       triggerMode: "source_upload",
-      translationEnabled: true,
-      translationUseProjectTargetLocales: true,
+      createNativeTmsJobEnabled: true,
+      createNativeTmsJobUseProjectTargetLocales: true,
+      assignTranslateWithAgentEnabled: true,
     },
   },
   {
@@ -747,8 +748,10 @@ export function getWorkspaceAutomationTemplateFlow(
     }
   }
 
-  if (form.translationEnabled) {
+  if (form.createNativeTmsJobEnabled) {
     tools.push({ id: "create-job", label: "Create job" });
+  }
+  if (form.assignTranslateWithAgentEnabled) {
     tools.push({ id: "translate-with-agent", label: "Translate with agent" });
   }
 

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
@@ -44,6 +44,30 @@ export const WORKSPACE_AUTOMATION_TEMPLATE_CATEGORIES: Array<{
 
 export const WORKSPACE_AUTOMATION_TEMPLATES_BASE: WorkspaceAutomationTemplate[] = [
   {
+    id: "translate-on-source-upload",
+    category: "popular",
+    name: "Translate on source upload",
+    description:
+      "When a source file is uploaded, create a native translation job and translate it with the Hyperlocalise agent.",
+    instructions: [
+      "Create a native translation job when a source file is uploaded, then translate it with the Hyperlocalise agent.",
+      "",
+      "Workflow:",
+      "- Read the uploaded source file and version from the source-upload trigger.",
+      "- Create a native TMS translation job for the project target locales.",
+      "- Assign the job to Translate with agent so localisation starts immediately.",
+      "- Preserve keys, placeholders, ICU syntax, glossary terms, and file structure.",
+      "- Summarize the job created and locales started for translation.",
+    ].join("\n"),
+    activatable: true,
+    defaultForm: {
+      name: "Translate on source upload",
+      triggerMode: "source_upload",
+      translationEnabled: true,
+      translationUseProjectTargetLocales: true,
+    },
+  },
+  {
     id: "translate-contentful-article",
     category: "popular",
     name: "Translate Contentful article",
@@ -56,7 +80,7 @@ export const WORKSPACE_AUTOMATION_TEMPLATES_BASE: WorkspaceAutomationTemplate[] 
       "- Read the updated entry and metadata from Contentful.",
       "- Detect translatable title, body, SEO, tags, CTA fields, and localized image assets.",
       "- Localize embedded or linked images when the entry contains image content.",
-      "- Preserve placeholders, links, product terms, glossary terms, tone, and rich text structure.",
+      "- Preserve placeholders, links, product terms, glossary terms, and file structure.",
       "- Run QA checks before writeback.",
       "- Write localized fields back as Contentful drafts for review. Do not publish.",
     ].join("\n"),
@@ -700,9 +724,11 @@ export function getWorkspaceAutomationTemplateFlow(
       ? { id: "github-push", label: "GitHub push" }
       : triggerMode === "contentful"
         ? { id: "contentful-webhook", label: "Contentful webhook" }
-        : triggerMode === "scheduled"
-          ? { id: "scheduled", label: scheduledTriggerLabel(form) }
-          : { id: "manual", label: "Manual" };
+        : triggerMode === "source_upload"
+          ? { id: "source-upload", label: "Source upload" }
+          : triggerMode === "scheduled"
+            ? { id: "scheduled", label: scheduledTriggerLabel(form) }
+            : { id: "manual", label: "Manual" };
 
   const tools: WorkspaceAutomationTemplateFlowNode[] = [];
 
@@ -719,6 +745,11 @@ export function getWorkspaceAutomationTemplateFlow(
     if (!form.pushSourceEnabled && !form.pullTranslationsEnabled && !form.validationEnabled) {
       tools.push({ id: "github", label: "GitHub" });
     }
+  }
+
+  if (form.translationEnabled) {
+    tools.push({ id: "create-job", label: "Create job" });
+    tools.push({ id: "translate-with-agent", label: "Translate with agent" });
   }
 
   if (form.slackEnabled) {

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
@@ -224,27 +224,31 @@ describe("workspace automation view model", () => {
     });
   });
 
-  it("maps source upload translation settings to API payload", () => {
+  it("maps source upload create job and translate-with-agent tools to API payload", () => {
     const form = {
       ...createDefaultWorkspaceAutomationFormState(),
       name: "Translate uploads",
       instructions: "Queue jobs after each upload.",
       triggerMode: "source_upload" as const,
       projectId: "project-1",
-      translationEnabled: true,
-      translationUseProjectTargetLocales: true,
+      createNativeTmsJobEnabled: true,
+      createNativeTmsJobUseProjectTargetLocales: true,
+      assignTranslateWithAgentEnabled: true,
     };
 
     expect(validateWorkspaceAutomationFormState(form)).toEqual({});
     const payload = formStateToWorkspaceAutomationPayload(form);
     expect(payload.projectId).toBe("project-1");
     expect(payload.triggerConfig).toEqual({ mode: "source_upload" });
-    expect(payload.toolConfig.translation).toEqual({
+    expect(payload.toolConfig.createNativeTmsJob).toEqual({
       enabled: true,
       useProjectTargetLocales: true,
       targetLocales: [],
     });
-    expect(payload.toolConfig.translation).not.toHaveProperty("projectId");
+    expect(payload.toolConfig.assignTranslateWithAgent).toEqual({
+      enabled: true,
+    });
+    expect(payload.toolConfig.createNativeTmsJob).not.toHaveProperty("projectId");
   });
 
   it("prefills and maps the translate-on-source-upload template", () => {
@@ -255,8 +259,9 @@ describe("workspace automation view model", () => {
     expect(form).toMatchObject({
       name: "Translate on source upload",
       triggerMode: "source_upload",
-      translationEnabled: true,
-      translationUseProjectTargetLocales: true,
+      createNativeTmsJobEnabled: true,
+      createNativeTmsJobUseProjectTargetLocales: true,
+      assignTranslateWithAgentEnabled: true,
     });
     expect(form?.instructions).toContain("Translate with agent");
 
@@ -269,23 +274,37 @@ describe("workspace automation view model", () => {
       projectId: "project-1",
       triggerConfig: { mode: "source_upload" },
       toolConfig: {
-        translation: {
+        createNativeTmsJob: {
           enabled: true,
           useProjectTargetLocales: true,
           targetLocales: [],
+        },
+        assignTranslateWithAgent: {
+          enabled: true,
         },
       },
     });
   });
 
-  it("requires translation tool when source upload trigger is selected", () => {
+  it("requires Create job when source upload trigger is selected", () => {
     const form = {
       ...createDefaultWorkspaceAutomationFormState(),
       triggerMode: "source_upload" as const,
     };
 
     expect(validateWorkspaceAutomationFormState(form)).toMatchObject({
-      trigger: "Source upload triggers require translation jobs to be enabled.",
+      trigger: "Source upload triggers require Create job to be enabled.",
+    });
+  });
+
+  it("requires Create job when Translate with agent is enabled alone", () => {
+    const form = {
+      ...createDefaultWorkspaceAutomationFormState(),
+      assignTranslateWithAgentEnabled: true,
+    };
+
+    expect(validateWorkspaceAutomationFormState(form)).toMatchObject({
+      form: "Translate with agent requires Create job to be enabled.",
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
@@ -247,6 +247,37 @@ describe("workspace automation view model", () => {
     expect(payload.toolConfig.translation).not.toHaveProperty("projectId");
   });
 
+  it("prefills and maps the translate-on-source-upload template", () => {
+    const form = createWorkspaceAutomationFormStateFromTemplate(
+      "translate-on-source-upload",
+      mergedTemplates,
+    );
+    expect(form).toMatchObject({
+      name: "Translate on source upload",
+      triggerMode: "source_upload",
+      translationEnabled: true,
+      translationUseProjectTargetLocales: true,
+    });
+    expect(form?.instructions).toContain("Translate with agent");
+
+    const readyForm = {
+      ...form!,
+      projectId: "project-1",
+    };
+    expect(validateWorkspaceAutomationFormState(readyForm)).toEqual({});
+    expect(formStateToWorkspaceAutomationPayload(readyForm)).toMatchObject({
+      projectId: "project-1",
+      triggerConfig: { mode: "source_upload" },
+      toolConfig: {
+        translation: {
+          enabled: true,
+          useProjectTargetLocales: true,
+          targetLocales: [],
+        },
+      },
+    });
+  });
+
   it("requires translation tool when source upload trigger is selected", () => {
     const form = {
       ...createDefaultWorkspaceAutomationFormState(),

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
@@ -61,9 +61,10 @@ export type WorkspaceAutomationFormState = {
   contentfulOverwriteDraftLocales: boolean;
   contentfulRunQa: boolean;
   contentfulWriteDrafts: boolean;
-  translationEnabled: boolean;
-  translationUseProjectTargetLocales: boolean;
-  translationTargetLocales: string[];
+  createNativeTmsJobEnabled: boolean;
+  createNativeTmsJobUseProjectTargetLocales: boolean;
+  createNativeTmsJobTargetLocales: string[];
+  assignTranslateWithAgentEnabled: boolean;
   knowledgeEnabled: boolean;
   mcpEnabled: boolean;
   mcpConnectionId: string;
@@ -80,7 +81,7 @@ function workspaceAutomationFormNeedsProject(form: WorkspaceAutomationFormState)
   if (form.contentfulEnabled) {
     return true;
   }
-  if (form.translationEnabled) {
+  if (form.createNativeTmsJobEnabled || form.assignTranslateWithAgentEnabled) {
     return true;
   }
   return form.githubEnabled && form.githubMode === "sync";
@@ -99,7 +100,7 @@ export type WorkspaceAutomationFieldErrors = Partial<
     | "contentfulConnectionId"
     | "contentfulTargetLocales"
     | "contentfulEntryId"
-    | "translationTargetLocales"
+    | "createNativeTmsJobTargetLocales"
     | "mcpConnectionId"
     | "semrushConnectionId"
     | "ahrefsConnectionId"
@@ -127,8 +128,10 @@ export const WORKSPACE_AUTOMATION_API_ERROR_MESSAGES: Record<string, string> = {
   contentful_connection_required: "Choose a Contentful connection.",
   contentful_target_locales_required: "Add at least one target locale for Contentful translation.",
   contentful_entry_id_required: "Scheduled Contentful automations need an entry ID.",
-  translation_target_locales_required: "Add at least one target locale for translation jobs.",
-  source_upload_workflow_required: "Source upload triggers require translation jobs to be enabled.",
+  create_native_tms_job_target_locales_required: "Add at least one target locale for Create job.",
+  assign_translate_with_agent_requires_create_job:
+    "Translate with agent requires Create job to be enabled.",
+  source_upload_workflow_required: "Source upload triggers require Create job to be enabled.",
   mcp_connection_required: "Choose an MCP server connection.",
   mcp_connection_not_found:
     "The selected MCP server connection was not found. Choose another connection.",
@@ -179,9 +182,10 @@ export function createDefaultWorkspaceAutomationFormState(): WorkspaceAutomation
     contentfulOverwriteDraftLocales: false,
     contentfulRunQa: true,
     contentfulWriteDrafts: true,
-    translationEnabled: false,
-    translationUseProjectTargetLocales: true,
-    translationTargetLocales: [],
+    createNativeTmsJobEnabled: false,
+    createNativeTmsJobUseProjectTargetLocales: true,
+    createNativeTmsJobTargetLocales: [],
+    assignTranslateWithAgentEnabled: false,
     knowledgeEnabled: false,
     mcpEnabled: false,
     mcpConnectionId: "",
@@ -199,7 +203,8 @@ export function createWorkspaceAutomationFormStateFromRecord(
   const slack = automation.toolConfig.slack;
   const email = automation.toolConfig.email;
   const contentful = automation.toolConfig.contentful;
-  const translation = automation.toolConfig.translation;
+  const createNativeTmsJob = automation.toolConfig.createNativeTmsJob;
+  const assignTranslateWithAgent = automation.toolConfig.assignTranslateWithAgent;
   const knowledge = automation.toolConfig.knowledge;
   const mcp = automation.toolConfig.mcp;
   const semrush = automation.toolConfig.semrush;
@@ -253,9 +258,12 @@ export function createWorkspaceAutomationFormStateFromRecord(
     contentfulOverwriteDraftLocales: Boolean(contentful?.overwriteDraftLocales),
     contentfulRunQa: contentful?.runQa ?? true,
     contentfulWriteDrafts: contentful?.writeDrafts ?? true,
-    translationEnabled: Boolean(translation?.enabled),
-    translationUseProjectTargetLocales: translation?.useProjectTargetLocales ?? true,
-    translationTargetLocales: translation?.targetLocales ? [...translation.targetLocales] : [],
+    createNativeTmsJobEnabled: Boolean(createNativeTmsJob?.enabled),
+    createNativeTmsJobUseProjectTargetLocales: createNativeTmsJob?.useProjectTargetLocales ?? true,
+    createNativeTmsJobTargetLocales: createNativeTmsJob?.targetLocales
+      ? [...createNativeTmsJob.targetLocales]
+      : [],
+    assignTranslateWithAgentEnabled: Boolean(assignTranslateWithAgent?.enabled),
     knowledgeEnabled: Boolean(knowledge?.enabled),
     mcpEnabled: Boolean(mcp?.enabled),
     mcpConnectionId: mcp?.connectionId ?? "",
@@ -403,14 +411,21 @@ export function formStateToWorkspaceAutomationPayload(form: WorkspaceAutomationF
           },
         }
       : {}),
-    ...(form.translationEnabled
+    ...(form.createNativeTmsJobEnabled
       ? {
-          translation: {
+          createNativeTmsJob: {
             enabled: true,
-            useProjectTargetLocales: form.translationUseProjectTargetLocales,
-            targetLocales: form.translationUseProjectTargetLocales
+            useProjectTargetLocales: form.createNativeTmsJobUseProjectTargetLocales,
+            targetLocales: form.createNativeTmsJobUseProjectTargetLocales
               ? []
-              : form.translationTargetLocales,
+              : form.createNativeTmsJobTargetLocales,
+          },
+        }
+      : {}),
+    ...(form.assignTranslateWithAgentEnabled
+      ? {
+          assignTranslateWithAgent: {
+            enabled: true,
           },
         }
       : {}),
@@ -518,14 +533,21 @@ export function validateWorkspaceAutomationFormState(
     }
   }
 
-  if (form.translationEnabled) {
-    if (!form.translationUseProjectTargetLocales && form.translationTargetLocales.length === 0) {
-      errors.translationTargetLocales = "Add at least one target locale.";
+  if (form.createNativeTmsJobEnabled) {
+    if (
+      !form.createNativeTmsJobUseProjectTargetLocales &&
+      form.createNativeTmsJobTargetLocales.length === 0
+    ) {
+      errors.createNativeTmsJobTargetLocales = "Add at least one target locale.";
     }
   }
 
-  if (form.triggerMode === "source_upload" && !form.translationEnabled) {
-    errors.trigger = "Source upload triggers require translation jobs to be enabled.";
+  if (form.assignTranslateWithAgentEnabled && !form.createNativeTmsJobEnabled) {
+    errors.form = "Translate with agent requires Create job to be enabled.";
+  }
+
+  if (form.triggerMode === "source_upload" && !form.createNativeTmsJobEnabled) {
+    errors.trigger = "Source upload triggers require Create job to be enabled.";
   }
 
   if (form.mcpEnabled && !form.mcpConnectionId) {
@@ -581,8 +603,10 @@ export function mapWorkspaceAutomationApiErrorToFieldErrors(
       return { contentfulTargetLocales: message };
     case "contentful_entry_id_required":
       return { contentfulEntryId: message };
-    case "translation_target_locales_required":
-      return { translationTargetLocales: message };
+    case "create_native_tms_job_target_locales_required":
+      return { createNativeTmsJobTargetLocales: message };
+    case "assign_translate_with_agent_requires_create_job":
+      return { form: message };
     case "mcp_connection_required":
     case "mcp_connection_not_found":
     case "mcp_not_connected":
@@ -606,7 +630,8 @@ export function workspaceAutomationFormCanActivate(form: WorkspaceAutomationForm
     form.slackEnabled ||
     form.emailEnabled ||
     form.contentfulEnabled ||
-    form.translationEnabled ||
+    form.createNativeTmsJobEnabled ||
+    form.assignTranslateWithAgentEnabled ||
     form.mcpEnabled ||
     form.semrushEnabled ||
     form.ahrefsEnabled

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
@@ -32,6 +32,7 @@ import {
   pauseWorkspaceAutomation,
   updateWorkspaceAutomation,
   updateWorkspaceAutomationRun,
+  workspaceAutomationConfigSchema,
 } from "./workspace-automations";
 
 const organizationIds: string[] = [];
@@ -112,6 +113,34 @@ async function seedWorkspaceAutomationScope() {
     githubInstallationRepositoryId: repository.id,
   };
 }
+
+describe("workspaceAutomationConfigSchema native TMS tools", () => {
+  it("migrates legacy translation toolConfig into create and assign tools", () => {
+    const config = workspaceAutomationConfigSchema.parse({
+      triggerConfig: { mode: "source_upload" },
+      repositoryTarget: { kind: "none" },
+      toolConfig: {
+        translation: {
+          enabled: true,
+          useProjectTargetLocales: false,
+          targetLocales: ["ja-JP"],
+        },
+      },
+    });
+
+    expect(config.toolConfig).toMatchObject({
+      createNativeTmsJob: {
+        enabled: true,
+        useProjectTargetLocales: false,
+        targetLocales: ["ja-JP"],
+      },
+      assignTranslateWithAgent: {
+        enabled: true,
+      },
+    });
+    expect(config.toolConfig).not.toHaveProperty("translation");
+  });
+});
 
 describe("hoistLegacyWorkspaceAutomationProjectId", () => {
   it("hoists when every legacy tool projectId agrees", () => {

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -129,13 +129,19 @@ const contentfulToolConfigSchema = z
     writeDrafts: true,
   });
 
-const translationToolConfigSchema = z
+const createNativeTmsJobToolConfigSchema = z
   .object({
     enabled: z.boolean().default(false),
     useProjectTargetLocales: z.boolean().default(true),
     targetLocales: z.array(z.string().trim().min(1).max(32)).max(20).default([]),
   })
   .default({ enabled: false, useProjectTargetLocales: true, targetLocales: [] });
+
+const assignTranslateWithAgentToolConfigSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+  })
+  .default({ enabled: false });
 
 const knowledgeToolConfigSchema = z
   .object({
@@ -164,19 +170,70 @@ const ahrefsToolConfigSchema = z
   })
   .default({ enabled: false });
 
-const toolConfigSchema = z
+function migrateLegacyTranslationToolConfig(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
+  const { translation: legacyTranslation, ...rest } = value;
+  if (!legacyTranslation || typeof legacyTranslation !== "object") {
+    return rest;
+  }
+
+  const legacy = legacyTranslation as {
+    enabled?: unknown;
+    useProjectTargetLocales?: unknown;
+    targetLocales?: unknown;
+  };
+  if (!legacy.enabled) {
+    return rest;
+  }
+
+  const hasCreateNativeTmsJob =
+    rest.createNativeTmsJob && typeof rest.createNativeTmsJob === "object";
+  const hasAssignTranslateWithAgent =
+    rest.assignTranslateWithAgent && typeof rest.assignTranslateWithAgent === "object";
+
+  return {
+    ...rest,
+    ...(hasCreateNativeTmsJob
+      ? {}
+      : {
+          createNativeTmsJob: {
+            enabled: true,
+            useProjectTargetLocales: legacy.useProjectTargetLocales ?? true,
+            targetLocales: Array.isArray(legacy.targetLocales) ? legacy.targetLocales : [],
+          },
+        }),
+    ...(hasAssignTranslateWithAgent
+      ? {}
+      : {
+          assignTranslateWithAgent: {
+            enabled: true,
+          },
+        }),
+  };
+}
+
+const toolConfigObjectSchema = z
   .object({
     github: githubToolConfigSchema.optional(),
     slack: slackToolConfigSchema.optional(),
     email: emailToolConfigSchema.optional(),
     contentful: contentfulToolConfigSchema.optional(),
-    translation: translationToolConfigSchema.optional(),
+    createNativeTmsJob: createNativeTmsJobToolConfigSchema.optional(),
+    assignTranslateWithAgent: assignTranslateWithAgentToolConfigSchema.optional(),
     knowledge: knowledgeToolConfigSchema.optional(),
     mcp: mcpToolConfigSchema.optional(),
     semrush: semrushToolConfigSchema.optional(),
     ahrefs: ahrefsToolConfigSchema.optional(),
   })
   .default({});
+
+const toolConfigSchema = z.preprocess((value) => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return migrateLegacyTranslationToolConfig(value as Record<string, unknown>);
+}, toolConfigObjectSchema);
 
 export const workspaceAutomationConfigSchema = z.object({
   projectId: optionalProjectIdSchema,
@@ -195,11 +252,17 @@ export type WorkspaceAutomationRepositoryTarget = z.infer<typeof repositoryTarge
 export type WorkspaceAutomationSlackToolConfig = z.infer<typeof slackToolConfigSchema>;
 export type WorkspaceAutomationEmailToolConfig = z.infer<typeof emailToolConfigSchema>;
 export type WorkspaceAutomationContentfulToolConfig = z.infer<typeof contentfulToolConfigSchema>;
+export type WorkspaceAutomationCreateNativeTmsJobToolConfig = z.infer<
+  typeof createNativeTmsJobToolConfigSchema
+>;
+export type WorkspaceAutomationAssignTranslateWithAgentToolConfig = z.infer<
+  typeof assignTranslateWithAgentToolConfigSchema
+>;
 export type WorkspaceAutomationKnowledgeToolConfig = z.infer<typeof knowledgeToolConfigSchema>;
 export type WorkspaceAutomationMcpToolConfig = z.infer<typeof mcpToolConfigSchema>;
 export type WorkspaceAutomationSemrushToolConfig = z.infer<typeof semrushToolConfigSchema>;
 export type WorkspaceAutomationAhrefsToolConfig = z.infer<typeof ahrefsToolConfigSchema>;
-export type WorkspaceAutomationToolConfig = z.infer<typeof toolConfigSchema>;
+export type WorkspaceAutomationToolConfig = z.infer<typeof toolConfigObjectSchema>;
 
 export type WorkspaceAutomationConfigValidationError =
   | {
@@ -255,12 +318,16 @@ export type WorkspaceAutomationConfigValidationError =
       message: "Add at least one email recipient for automation notifications.";
     }
   | {
-      code: "translation_target_locales_required";
-      message: "Enabled translation tools require at least one target locale.";
+      code: "create_native_tms_job_target_locales_required";
+      message: "Create job requires at least one target locale.";
+    }
+  | {
+      code: "assign_translate_with_agent_requires_create_job";
+      message: "Translate with agent requires Create job to be enabled.";
     }
   | {
       code: "source_upload_workflow_required";
-      message: "Source upload triggers require translation jobs to be enabled.";
+      message: "Source upload triggers require Create job to be enabled.";
     }
   | {
       code: "mcp_connection_required";
@@ -308,10 +375,16 @@ export function hasWorkspaceAutomationContentfulWorkflow(
   return Boolean(toolConfig.contentful?.enabled);
 }
 
-export function hasWorkspaceAutomationTranslationWorkflow(
+export function hasWorkspaceAutomationCreateNativeTmsJobTool(
   toolConfig: WorkspaceAutomationToolConfig,
 ) {
-  return Boolean(toolConfig.translation?.enabled);
+  return Boolean(toolConfig.createNativeTmsJob?.enabled);
+}
+
+export function hasWorkspaceAutomationAssignTranslateWithAgentTool(
+  toolConfig: WorkspaceAutomationToolConfig,
+) {
+  return Boolean(toolConfig.assignTranslateWithAgent?.enabled);
 }
 
 export function hasWorkspaceAutomationKnowledgeTool(toolConfig: WorkspaceAutomationToolConfig) {
@@ -358,17 +431,18 @@ function readOptionalProjectId(value: unknown): string | null {
 export function hoistLegacyWorkspaceAutomationProjectId(
   toolConfig: Record<string, unknown> | WorkspaceAutomationToolConfig,
 ): string | null {
+  const rawToolConfig = toolConfig as Record<string, unknown>;
   const contentful =
-    toolConfig.contentful && typeof toolConfig.contentful === "object"
-      ? (toolConfig.contentful as { projectId?: unknown }).projectId
+    rawToolConfig.contentful && typeof rawToolConfig.contentful === "object"
+      ? (rawToolConfig.contentful as { projectId?: unknown }).projectId
       : undefined;
   const translation =
-    toolConfig.translation && typeof toolConfig.translation === "object"
-      ? (toolConfig.translation as { projectId?: unknown }).projectId
+    rawToolConfig.translation && typeof rawToolConfig.translation === "object"
+      ? (rawToolConfig.translation as { projectId?: unknown }).projectId
       : undefined;
   const github =
-    toolConfig.github && typeof toolConfig.github === "object"
-      ? (toolConfig.github as { projectId?: unknown }).projectId
+    rawToolConfig.github && typeof rawToolConfig.github === "object"
+      ? (rawToolConfig.github as { projectId?: unknown }).projectId
       : undefined;
 
   // Only hoist when every non-empty legacy tool projectId agrees. The pre-header
@@ -394,7 +468,10 @@ export function workspaceAutomationNeedsProject(input: {
   if (hasWorkspaceAutomationContentfulWorkflow(input.toolConfig)) {
     return true;
   }
-  if (hasWorkspaceAutomationTranslationWorkflow(input.toolConfig)) {
+  if (
+    hasWorkspaceAutomationCreateNativeTmsJobTool(input.toolConfig) ||
+    hasWorkspaceAutomationAssignTranslateWithAgentTool(input.toolConfig)
+  ) {
     return true;
   }
   return hasWorkspaceAutomationGithubWorkflow(input.toolConfig);
@@ -533,23 +610,36 @@ function validateWorkspaceAutomationConfig(input: {
     });
   }
 
-  const translationTools = input.toolConfig.translation;
-  if (translationTools?.enabled) {
-    if (!translationTools.useProjectTargetLocales && translationTools.targetLocales.length === 0) {
+  const createNativeTmsJob = input.toolConfig.createNativeTmsJob;
+  if (createNativeTmsJob?.enabled) {
+    if (
+      !createNativeTmsJob.useProjectTargetLocales &&
+      createNativeTmsJob.targetLocales.length === 0
+    ) {
       return err({
-        code: "translation_target_locales_required",
-        message: "Enabled translation tools require at least one target locale.",
+        code: "create_native_tms_job_target_locales_required",
+        message: "Create job requires at least one target locale.",
       });
     }
   }
 
   if (
+    hasWorkspaceAutomationAssignTranslateWithAgentTool(input.toolConfig) &&
+    !hasWorkspaceAutomationCreateNativeTmsJobTool(input.toolConfig)
+  ) {
+    return err({
+      code: "assign_translate_with_agent_requires_create_job",
+      message: "Translate with agent requires Create job to be enabled.",
+    });
+  }
+
+  if (
     input.triggerConfig.mode === "source_upload" &&
-    !hasWorkspaceAutomationTranslationWorkflow(input.toolConfig)
+    !hasWorkspaceAutomationCreateNativeTmsJobTool(input.toolConfig)
   ) {
     return err({
       code: "source_upload_workflow_required",
-      message: "Source upload triggers require translation jobs to be enabled.",
+      message: "Source upload triggers require Create job to be enabled.",
     });
   }
 
@@ -1201,12 +1291,18 @@ export async function listSourceUploadWorkspaceAutomations(input: {
         eq(schema.workspaceAutomations.organizationId, input.organizationId),
         eq(schema.workspaceAutomations.status, "active"),
         sql`${schema.workspaceAutomations.triggerConfig}->>'mode' = 'source_upload'`,
-        sql`${schema.workspaceAutomations.toolConfig}->'translation'->>'enabled' = 'true'`,
+        sql`(
+          ${schema.workspaceAutomations.toolConfig}->'createNativeTmsJob'->>'enabled' = 'true'
+          OR ${schema.workspaceAutomations.toolConfig}->'translation'->>'enabled' = 'true'
+        )`,
         or(
           eq(schema.workspaceAutomations.projectId, input.projectId),
           and(
             isNull(schema.workspaceAutomations.projectId),
-            sql`${schema.workspaceAutomations.toolConfig}->'translation'->>'projectId' = ${input.projectId}`,
+            sql`(
+              ${schema.workspaceAutomations.toolConfig}->'createNativeTmsJob'->>'projectId' = ${input.projectId}
+              OR ${schema.workspaceAutomations.toolConfig}->'translation'->>'projectId' = ${input.projectId}
+            )`,
           ),
         ),
       ),

--- a/docs/plans/2026-07-17-native-tms-automation-tools-design.md
+++ b/docs/plans/2026-07-17-native-tms-automation-tools-design.md
@@ -20,7 +20,9 @@ Replace `create_translation_jobs` with two workspace orchestrator tools:
 
 - Workspace automation orchestrator only
 - Reuse the native file-translation workflow queue
-- Keep `toolConfig.translation` as the enablement gate
+- Enablement is split across `toolConfig.createNativeTmsJob` and
+  `toolConfig.assignTranslateWithAgent` (see
+  `2026-08-04-native-tms-automation-two-tools-design.md`)
 
 ## Out of scope
 

--- a/docs/plans/2026-08-04-native-tms-automation-two-tools-design.md
+++ b/docs/plans/2026-08-04-native-tms-automation-two-tools-design.md
@@ -1,0 +1,37 @@
+# Native TMS automation two-tool config
+
+## Problem
+
+`toolConfig.translation` / `translationEnabled` hid two distinct orchestrator
+steps behind one vague toggle.
+
+## Decision
+
+Split enablement to match the orchestrator tools:
+
+```ts
+toolConfig: {
+  createNativeTmsJob: {
+    enabled: true,
+    useProjectTargetLocales: true,
+    targetLocales: [],
+  },
+  assignTranslateWithAgent: {
+    enabled: true,
+  },
+}
+```
+
+Form fields mirror those keys. Locales live on Create job.
+
+## Rules
+
+- Translate with agent requires Create job
+- Source-upload trigger requires Create job
+- The translate-on-source-upload template enables both
+- Legacy `toolConfig.translation.enabled` migrates to both tools on read/write
+
+## Out of scope
+
+- Changing orchestrator tool names
+- Auto-provisioning automations per project

--- a/docs/plans/2026-08-04-translate-on-source-upload-template-design.md
+++ b/docs/plans/2026-08-04-translate-on-source-upload-template-design.md
@@ -1,0 +1,54 @@
+# Translate on source upload template
+
+## Problem
+
+Native TMS already dispatches `source_upload` automations that create a job and
+run Translate with agent. Users still had to assemble that flow by hand. The
+Automations gallery had no activatable template for it.
+
+## Decision
+
+Add one activatable workspace automation template:
+
+- **Trigger:** source upload
+- **Tools:** create native TMS job → Translate with agent
+- **Defaults:** use project target locales
+
+Ship it as:
+
+1. Skill `translate-on-source-upload` under the workspace orchestrator agent
+2. Matching gallery entry in `WORKSPACE_AUTOMATION_TEMPLATES_BASE`
+3. Template flow labels for source upload and the two translation tools
+
+## Scope
+
+- Gallery template + skill merge only
+- Reuse existing ingest → dispatch → orchestrator tools
+
+## Out of scope
+
+- New orchestrator tools or job statuses
+- Auto-provisioning the automation for every project
+- External TMS (Crowdin/Phrase/Lokalise/Smartling) upload paths
+
+## Data flow
+
+```
+source upload
+  → source file ingest
+  → source_upload workspace automation
+  → create_native_tms_job
+  → assign_translate_with_agent
+  → file translation workflow
+```
+
+## Activation
+
+Activating the template opens the automation form with:
+
+- `triggerMode: source_upload`
+- `translationEnabled: true`
+- `translationUseProjectTargetLocales: true`
+
+The user chooses a project, then saves. After ingest of a new source version,
+matching active automations dispatch as today.

--- a/docs/plans/2026-08-04-translate-on-source-upload-template-design.md
+++ b/docs/plans/2026-08-04-translate-on-source-upload-template-design.md
@@ -47,8 +47,9 @@ source upload
 Activating the template opens the automation form with:
 
 - `triggerMode: source_upload`
-- `translationEnabled: true`
-- `translationUseProjectTargetLocales: true`
+- `createNativeTmsJobEnabled: true`
+- `createNativeTmsJobUseProjectTargetLocales: true`
+- `assignTranslateWithAgentEnabled: true`
 
 The user chooses a project, then saves. After ingest of a new source version,
 matching active automations dispatch as today.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an activatable Automations gallery template for native TMS source uploads, and splits the vague `translation` tool into two explicit tools that match the orchestrator.

## Changes

### Template
- New skill `translate-on-source-upload`
- Gallery template: Source upload → Create job → Translate with agent

### Tool config split
Replaces `toolConfig.translation` / `translationEnabled` with:

- `createNativeTmsJob` — create native TMS job (+ locale settings)
- `assignTranslateWithAgent` — assign Translate with agent

Rules:
- Translate with agent requires Create job
- Source-upload trigger requires Create job
- Legacy `translation.enabled` migrates to both tools on read/write

## Test plan

- [x] Unit tests for template, form mapping, plan, tools, legacy migration, dispatcher
- [x] `vp check --fix`
- [ ] Activate **Translate on source upload** for a native project
- [ ] Upload a source file and confirm a job is created and agent translation starts
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d094c93-bd4e-4ef7-a33b-b0ed69eb1501?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d094c93-bd4e-4ef7-a33b-b0ed69eb1501&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

