### PR TITLE
fix(web): expand Issues Storybook coverage

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.stories.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect } from "storybook/test";
+
+import {
+  issueDetailLoadingMswHandlers,
+  issueDetailUnavailableMswHandlers,
+  issueSheetMswHandlers,
+} from "../../projects/[projectId]/issue-sheet/_components/issue-sheet-msw-handlers";
+import {
+  issueSheetIssuesFixture,
+  issueSheetOrganizationSlug,
+  issueSheetProjectId,
+} from "../../projects/[projectId]/issue-sheet/_components/issue-sheet.fixture";
+import { IssueDetailPanel } from "./issue-detail-panel";
+
+const issue = issueSheetIssuesFixture[0];
+
+const meta = {
+  title: "App/Issues/Detail",
+  component: IssueDetailPanel,
+  decorators: [
+    (Story) => (
+      <div className="flex h-dvh flex-col">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    organizationSlug: issueSheetOrganizationSlug,
+    projectId: issueSheetProjectId,
+    issueId: issue.id,
+  },
+} satisfies Meta<typeof IssueDetailPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: issueSheetMswHandlers,
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(
+      await canvas.findByDisplayValue("Source string needs context"),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Linked context")).toBeInTheDocument();
+    await expect(canvas.getByText("Owner note")).toBeInTheDocument();
+    await expect(
+      canvas.getByText("No comments or activity yet. Start the discussion."),
+    ).toBeVisible();
+  },
+};
+
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: issueDetailLoadingMswHandlers,
+    },
+  },
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(
+      0,
+    );
+  },
+};
+
+export const Unavailable: Story = {
+  parameters: {
+    msw: {
+      handlers: issueDetailUnavailableMswHandlers,
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByText("Could not load this issue.")).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-grouped-list.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-grouped-list.stories.tsx
@@ -14,10 +14,12 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { expect, fn, userEvent } from "storybook/test";
 
 import {
+  createOrganizationIssue,
   issuesOrganizationSlug,
   issuesSummaryFixture,
   organizationIssuesFixture,
 } from "../issues/_components/issues.fixture";
+import { issueSheetMswHandlers } from "../projects/[projectId]/issue-sheet/_components/issue-sheet-msw-handlers";
 import { IssueGroupedList } from "./issue-grouped-list";
 
 const meta = {
@@ -25,6 +27,9 @@ const meta = {
   component: IssueGroupedList,
   parameters: {
     layout: "padded",
+    msw: {
+      handlers: issueSheetMswHandlers,
+    },
   },
   args: {
     organizationSlug: issuesOrganizationSlug,
@@ -110,5 +115,58 @@ export const Empty: Story = {
   },
   play: async ({ canvas }) => {
     await expect(canvas.getByText("No issues")).toBeInTheDocument();
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    issues: [],
+    summary: undefined,
+    isLoading: true,
+  },
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(
+      0,
+    );
+  },
+};
+
+export const Error: Story = {
+  args: {
+    issues: [],
+    summary: undefined,
+    isError: true,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Failed to load")).toBeInTheDocument();
+  },
+};
+
+export const NarrowRow: Story = {
+  decorators: [
+    (Story) => (
+      <div className="max-w-sm">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    issues: [
+      createOrganizationIssue({
+        updatedAt: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+      }),
+    ],
+    summary: {
+      open: 1,
+      inProgress: 0,
+      resolved: 0,
+      wontFix: 0,
+    },
+  },
+  play: async ({ canvas }) => {
+    const date = canvas.getByText("30m");
+    await expect(date).toBeVisible();
+    await expect(date.scrollWidth).toBeLessThanOrEqual(date.clientWidth);
+    await expect(date.getAttribute("title")).toMatch(/30 minutes ago/i);
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-grouped-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-grouped-list.tsx
@@ -54,7 +54,7 @@ function IssueRowSkeleton() {
       <Skeleton className="h-4 w-64 max-w-[50%]" />
       <Skeleton className="ms-auto h-4 w-16" />
       <Skeleton className="size-6 rounded-full" />
-      <Skeleton className="h-4 w-12" />
+      <Skeleton className="h-4 w-10" />
     </div>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-create-issue-dialog.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-create-issue-dialog.stories.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, fn } from "storybook/test";
+
+import { IssueSheetCreateIssueDialog } from "./issue-sheet-create-issue-dialog";
+import { issueSheetMswHandlers } from "./issue-sheet-msw-handlers";
+import {
+  issueSheetOrganizationSlug,
+  issueSheetProjectFixture,
+  issueSheetProjectId,
+} from "./issue-sheet.fixture";
+
+const projects = [
+  { id: issueSheetProjectFixture.id, name: issueSheetProjectFixture.name },
+  { id: "project_mobile", name: "Mobile app" },
+];
+
+const meta = {
+  title: "App/Issues/Create Dialog",
+  component: IssueSheetCreateIssueDialog,
+  parameters: {
+    layout: "centered",
+    msw: {
+      handlers: issueSheetMswHandlers,
+    },
+  },
+  args: {
+    open: true,
+    organizationSlug: issueSheetOrganizationSlug,
+    projectId: issueSheetProjectId,
+    projects,
+    onOpenChange: fn(),
+    onCreated: fn(async () => {}),
+  },
+} satisfies Meta<typeof IssueSheetCreateIssueDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ProjectScoped: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("dialog", { name: "Add issue" })).toBeInTheDocument();
+    await expect(canvas.getByLabelText("Title")).toBeInTheDocument();
+    await expect(canvas.queryByText("Project")).not.toBeInTheDocument();
+  },
+};
+
+export const OrganizationScoped: Story = {
+  args: {
+    projectId: undefined,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("dialog", { name: "Add issue" })).toBeInTheDocument();
+    await expect(canvas.getByText("Project")).toBeInTheDocument();
+    await expect(canvas.getByText("Select a project")).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-msw-handlers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/_components/issue-sheet-msw-handlers.ts
@@ -25,6 +25,22 @@ export const issueSheetMswHandlers = [
     HttpResponse.json({ project: issueSheetProjectFixture }),
   ),
   http.get(issueSheetBasePath, () => HttpResponse.json(issueSheetResponseFixture)),
+  http.get(`${issueSheetBasePath}/assignable-members`, () =>
+    HttpResponse.json({
+      members: [
+        {
+          userId: "user_otto",
+          workosUserId: "workos_otto",
+          email: "otto@example.com",
+          firstName: "Otto",
+          lastName: "Klein",
+          displayName: "Otto Klein",
+          avatarUrl: null,
+          isCurrentUser: true,
+        },
+      ],
+    }),
+  ),
   http.get(`${issueSheetBasePath}/:issueId`, ({ params }) => {
     const issue = issueSheetIssuesFixture.find((row) => row.id === params.issueId);
     if (!issue) {
@@ -32,6 +48,13 @@ export const issueSheetMswHandlers = [
     }
     return HttpResponse.json({ issue });
   }),
+  http.get(`${issueSheetBasePath}/:issueId/feed`, () =>
+    HttpResponse.json({
+      items: [],
+      total: 0,
+      nextCursor: null,
+    }),
+  ),
   http.patch(`${issueSheetBasePath}/:issueId`, async ({ params, request }) => {
     const body = (await request.json()) as Record<string, unknown>;
     const issue = issueSheetIssuesFixture.find((row) => row.id === params.issueId);
@@ -132,5 +155,18 @@ export const issueSheetErrorMswHandlers = [
   ),
   http.get(issueSheetBasePath, () =>
     HttpResponse.json({ error: "issue_sheet_load_failed" }, { status: 500 }),
+  ),
+];
+
+export const issueDetailLoadingMswHandlers = [
+  http.get(`${issueSheetBasePath}/:issueId`, async () => {
+    await delay("infinite");
+    return HttpResponse.json({ issue: issueSheetIssuesFixture[0] });
+  }),
+];
+
+export const issueDetailUnavailableMswHandlers = [
+  http.get(`${issueSheetBasePath}/:issueId`, () =>
+    HttpResponse.json({ error: "issue_not_found" }, { status: 404 }),
   ),
 ];

--- a/docs/plans/2026-08-04-issues-storybook-coverage-design.md
+++ b/docs/plans/2026-08-04-issues-storybook-coverage-design.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Add focused Storybook coverage for Issue Detail and Create Issue. Fix issue-row dates so localized values remain visible at narrow widths.
+Add focused Storybook coverage for Issue Detail and Create Issue. Verify compact issue-row dates remain visible at narrow widths.
 
 ## Scope
 
@@ -13,20 +13,20 @@ Add focused Storybook coverage for Issue Detail and Create Issue. Fix issue-row 
 - Add Create Issue stories for project-scoped and organization-scoped flows.
 - Add grouped-list loading, error, and narrow-row regression stories.
 - Reuse the existing Issue Sheet fixtures and MSW handlers.
-- Let the date column use its intrinsic width while the issue title truncates.
+- Keep the compact date column and its loading skeleton aligned.
 
 ## Non-goals
 
 - Comprehensive comment, import, custom-column, or validation interaction stories.
 - Product behavior or API changes.
-- Compact date formatting.
+- Changes to compact date formatting.
 
 ## Implementation
 
 1. Extend Issue Sheet MSW handlers for detail dependencies: assignable members and the issue feed.
 2. Add stories for the full detail page and open create dialog.
 3. Add missing grouped-list state stories and a narrow viewport regression.
-4. Replace the fixed date width with non-wrapping intrinsic sizing.
+4. Align the date skeleton width and add a narrow-row regression for the compact timestamp.
 5. Run `vp test` and `vp check --fix` in `apps/hyperlocalise-web`.
 
 ## Success criteria
@@ -34,4 +34,4 @@ Add focused Storybook coverage for Issue Detail and Create Issue. Fix issue-row 
 - Storybook renders Issue Detail without unhandled requests.
 - Storybook shows Create Issue in both supported project-selection modes.
 - Loading and unavailable detail states have explicit stories.
-- Dates remain fully visible in narrow issue rows.
+- Compact dates remain fully visible in narrow issue rows, with the full relative date in the title.

--- a/docs/plans/2026-08-04-issues-storybook-coverage-design.md
+++ b/docs/plans/2026-08-04-issues-storybook-coverage-design.md
@@ -1,0 +1,37 @@
+# Issues Storybook coverage — Design
+
+**Status:** Approved  
+**Date:** 2026-08-04
+
+## Summary
+
+Add focused Storybook coverage for Issue Detail and Create Issue. Fix issue-row dates so localized values remain visible at narrow widths.
+
+## Scope
+
+- Add Issue Detail stories for populated, loading, and unavailable states.
+- Add Create Issue stories for project-scoped and organization-scoped flows.
+- Add grouped-list loading, error, and narrow-row regression stories.
+- Reuse the existing Issue Sheet fixtures and MSW handlers.
+- Let the date column use its intrinsic width while the issue title truncates.
+
+## Non-goals
+
+- Comprehensive comment, import, custom-column, or validation interaction stories.
+- Product behavior or API changes.
+- Compact date formatting.
+
+## Implementation
+
+1. Extend Issue Sheet MSW handlers for detail dependencies: assignable members and the issue feed.
+2. Add stories for the full detail page and open create dialog.
+3. Add missing grouped-list state stories and a narrow viewport regression.
+4. Replace the fixed date width with non-wrapping intrinsic sizing.
+5. Run `vp test` and `vp check --fix` in `apps/hyperlocalise-web`.
+
+## Success criteria
+
+- Storybook renders Issue Detail without unhandled requests.
+- Storybook shows Create Issue in both supported project-selection modes.
+- Loading and unavailable detail states have explicit stories.
+- Dates remain fully visible in narrow issue rows.


### PR DESCRIPTION
## What changed

- add focused Issue Detail stories for populated, loading, and unavailable states
- add project- and organization-scoped Create Issue dialog stories with supporting MSW handlers
- cover grouped-list loading, error, and narrow timestamp states, and align the timestamp skeleton width

## How to test

- `vp check` on the changed web files
- `vp run build-storybook`
- `vp test` was attempted, but database-backed suites could not connect to local PostgreSQL

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)