### PR TITLE
test(knowledge): use Japanese guidance and Japan market playbook story fixtures

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/knowledge/_components/knowledge-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/knowledge/_components/knowledge-page-view.stories.tsx
@@ -13,7 +13,10 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { expect, fn, userEvent } from "storybook/test";
 
-import { createKnowledgeEditorViewFixture } from "./knowledge.fixture";
+import {
+  createKnowledgeEditorViewFixture,
+  japanMarketPlaybookMemoryFixture,
+} from "./knowledge.fixture";
 import { KnowledgePageView } from "./knowledge-page-view";
 
 const meta = {
@@ -66,6 +69,35 @@ export const WithMemory: Story = {
     await expect(canvas.getByText("Unsaved changes")).toBeInTheDocument();
     await expect(canvas.queryByText("Retrieval preview")).not.toBeInTheDocument();
     await expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+
+    await expect(
+      await canvas.findByRole("heading", { name: "Japanese voice" }),
+    ).toBeInTheDocument();
+    await expect(await canvas.findByText(/です・ます調/)).toBeInTheDocument();
+    await expect(await canvas.findByText(/ワークスペース/)).toBeInTheDocument();
+  },
+};
+
+export const JapanMarketPlaybook: Story = {
+  args: {
+    mode: "editor",
+    editor: createKnowledgeEditorViewFixture({
+      savedKnowledgeMemory: japanMarketPlaybookMemoryFixture,
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Global guidance" })).toBeInTheDocument();
+    await expect(canvas.getByText("Version 4")).toBeInTheDocument();
+    await expect(canvas.getByText("All changes saved")).toBeInTheDocument();
+
+    await expect(
+      await canvas.findByRole("heading", { name: "Japan market playbook" }),
+    ).toBeInTheDocument();
+    await expect(
+      await canvas.findByRole("heading", { name: "Japan launch calendar" }),
+    ).toBeInTheDocument();
+    await expect(await canvas.findByText(/税込/)).toBeInTheDocument();
+    await expect(await canvas.findByText(/ゴールデンウィーク/)).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/knowledge/_components/knowledge-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/knowledge/_components/knowledge-page-view.stories.tsx
@@ -96,7 +96,10 @@ export const JapanMarketPlaybook: Story = {
     await expect(
       await canvas.findByRole("heading", { name: "Japan launch calendar" }),
     ).toBeInTheDocument();
-    await expect(await canvas.findByText(/税込/)).toBeInTheDocument();
+    await expect(
+      await canvas.findByRole("heading", { name: "Japan support expectations" }),
+    ).toBeInTheDocument();
+    await expect(await canvas.findByText(/銀行振込/)).toBeInTheDocument();
     await expect(await canvas.findByText(/ゴールデンウィーク/)).toBeInTheDocument();
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/knowledge/_components/knowledge.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/knowledge/_components/knowledge.fixture.ts
@@ -15,32 +15,79 @@ import { KNOWLEDGE_MEMORY_CONTENT_MAX_LENGTH } from "@/lib/knowledge-memory/know
 
 import type { KnowledgeMemoryEditorViewProps } from "./knowledge-memory-editor-view";
 
+export const japaneseKnowledgeContent = `## Tone
+- Keep product copy practical and direct.
+- Keep Hyperlocalise untranslated in every locale.
+
+## Japanese voice
+### ja-JP
+- Write UI copy in です・ます調 and keep one register per screen.
+- Prefer 「ご確認ください」 over 「ご確認いただけますでしょうか」, and never stack 二重敬語.
+- Call the reader お客様 in billing and support copy, and drop the pronoun in button labels.
+
+## Japanese glossary
+### ja-JP
+- workspace: ワークスペース, never 作業領域.
+- job: ジョブ, including in help articles.
+- string: テキスト in the product UI, 文字列 in developer documentation.
+
+## Japanese formatting
+### ja-JP
+- Use 全角 punctuation (、。) with 半角 digits and Latin product names.
+- Keep one 半角 space between Japanese text and Latin words, and none inside 全角 parentheses.
+- Write dates as 2026年7月20日 and prices as ¥1,280（税込）.
+`;
+
+export const japanMarketPlaybookContent = `## Japan market playbook
+### ja-JP
+- Lead with review workflow and reliability: buyers ask who checks the output before they ask how fast it is.
+- Show 税込 prices on every plan, and note that 請求書 and 銀行振込 are available next to card payment.
+- Link 特定商取引法に基づく表記 from the footer of every marketing page.
+
+## Japan launch calendar
+### ja-JP
+- Skip campaign sends during 年末年始 (Dec 29 to Jan 3), ゴールデンウィーク, and お盆.
+- The fiscal year starts in April, so budget conversations land best in January and February.
+
+## Japan support expectations
+### ja-JP
+- Reply within one 営業日, in Japanese, signed with the team name instead of an individual.
+- Restate the reported issue and quote the 問い合わせ番号 before proposing a fix.
+`;
+
 export const knowledgeMemoryFixture: KnowledgeMemoryRecord = {
   revisionId: "11111111-1111-4111-8111-111111111111",
   version: 3,
-  content: `## Tone
-- Keep product copy practical and direct.
-- Keep Hyperlocalise untranslated.
-
-## Glossary notes
-- Prefer "workspace" over "organization" in product UI.
-`,
-  summary: "Clarify tone and glossary notes",
+  content: japaneseKnowledgeContent,
+  summary: "Clarify ja-JP voice, glossary, and formatting",
   updatedAt: "2026-07-20T10:15:00.000Z",
+  updatedByUserId: "user_fixture",
+};
+
+export const japanMarketPlaybookMemoryFixture: KnowledgeMemoryRecord = {
+  revisionId: "22222222-2222-4222-8222-222222222222",
+  version: 4,
+  content: `${japaneseKnowledgeContent}\n${japanMarketPlaybookContent}`,
+  summary: "Add Japan market playbook, calendar, and support expectations",
+  updatedAt: "2026-07-24T04:30:00.000Z",
   updatedByUserId: "user_fixture",
 };
 
 export function createKnowledgeEditorViewFixture(
   overrides: Partial<KnowledgeMemoryEditorViewProps> = {},
 ): KnowledgeMemoryEditorViewProps {
-  const content = overrides.content ?? knowledgeMemoryFixture.content;
+  const savedKnowledgeMemory =
+    overrides.savedKnowledgeMemory === undefined
+      ? knowledgeMemoryFixture
+      : overrides.savedKnowledgeMemory;
+  const content = overrides.content ?? savedKnowledgeMemory?.content ?? "";
 
   return {
     content,
     onContentChange: () => undefined,
     summary: "",
     onSummaryChange: () => undefined,
-    savedKnowledgeMemory: knowledgeMemoryFixture,
+    savedKnowledgeMemory,
     characterCount: content.length,
     characterLimit: KNOWLEDGE_MEMORY_CONTENT_MAX_LENGTH,
     isOverLimit: content.length > KNOWLEDGE_MEMORY_CONTENT_MAX_LENGTH,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The Knowledge storybook fixtures used placeholder guidance ("Keep product copy practical and direct", "Prefer workspace over organization"). They now carry realistic examples of what a customer would actually store in global guidance:

- `japaneseKnowledgeContent` — ja-JP voice (です・ます調, no 二重敬語), glossary (ワークスペース, ジョブ, テキスト vs 文字列), and formatting rules (全角/半角 punctuation, `2026年7月20日`, `¥1,280（税込）`).
- `japanMarketPlaybookContent` — Japan market playbook, launch calendar (年末年始, ゴールデンウィーク, お盆), and support expectations (営業日, 問い合わせ番号).

Both use the `## Section` / `### ja-JP` shape the knowledge memory retriever parses, so the stories reflect how locale-scoped sections look in the editor.

## Stories

- `WithMemory` renders the Japanese guidance document and now asserts the ja-JP sections render inside the markdown editor.
- New `JapanMarketPlaybook` story renders version 4 of the same document after the playbook sections were appended, in a saved (no unsaved changes) state.

`createKnowledgeEditorViewFixture` now derives `content` from the passed `savedKnowledgeMemory`, so a story can swap the whole document with one override.

## Verification

- `vp check --fix` — clean (2231 files, no lint or type errors).
- `vp test run` — 567 files, 3573 tests passing.
- Both stories' play functions pass in Storybook, and the Japanese text renders as real glyphs.

[knowledge_storybook_japanese_and_market_playbook_stories_passing.mp4](https://cursor.com/agents/bc-019fd04b-a29c-7768-a989-3f80694fe950/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fknowledge_storybook_japanese_and_market_playbook_stories_passing.mp4)

[Japan Market Playbook story with passing interactions](https://cursor.com/agents/bc-019fd04b-a29c-7768-a989-3f80694fe950/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstory_japan_market_playbook.webp)

[With Memory story rendering Japanese guidance](https://cursor.com/agents/bc-019fd04b-a29c-7768-a989-3f80694fe950/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstory_japanese_guidance.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd04b-a29c-7768-a989-3f80694fe950?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd04b-a29c-7768-a989-3f80694fe950&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

