### PR TITLE
feat(cat): add Issue Sheet CTA to issue comment section

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-comments-section.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-comments-section.stories.tsx
@@ -12,7 +12,7 @@
  */
 import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { expect, userEvent, waitFor, within } from "storybook/test";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 
 import type {
   CatSegment,
@@ -36,6 +36,7 @@ type CommentsStoryHostProps = {
   resolvingCommentId?: string | null;
   commentPostError?: string;
   simulatePostDelayMs?: number;
+  onOpenIssueSheet?: () => void;
 };
 
 function CommentsStoryHost({
@@ -48,6 +49,7 @@ function CommentsStoryHost({
   resolvingCommentId: forcedResolvingId,
   commentPostError,
   simulatePostDelayMs = 0,
+  onOpenIssueSheet,
 }: CommentsStoryHostProps) {
   const [segment, setSegment] = useState(initialSegment);
   const [isPostingComment, setIsPostingComment] = useState(false);
@@ -109,6 +111,7 @@ function CommentsStoryHost({
           }
           commentPostError={commentPostError}
           onAddComment={handleAddComment}
+          onOpenIssueSheet={onOpenIssueSheet}
           onResolveComment={handleResolveComment}
         />
       </div>
@@ -157,8 +160,9 @@ export const WithCommentsAndIssues: Story = {
     initialSegment: createCatEditorCommentsSegment({
       comments: catEditorCommentsFixture,
     }),
+    onOpenIssueSheet: fn(),
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByText("3")).toBeInTheDocument();
     await expect(
@@ -169,6 +173,11 @@ export const WithCommentsAndIssues: Story = {
     ).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Resolve" })).toBeInTheDocument();
     await expect(canvas.getAllByText("Issue")).toHaveLength(3);
+
+    const issueSheetButton = canvas.getByRole("button", { name: "Issues" });
+    await expect(issueSheetButton).toBeInTheDocument();
+    await userEvent.click(issueSheetButton);
+    await expect(args.onOpenIssueSheet).toHaveBeenCalledTimes(1);
   },
 };
 
@@ -216,13 +225,15 @@ export const CommentOnly: Story = {
 export const RaiseIssueInteraction: Story = {
   args: {
     initialSegment: createCatEditorCommentsSegment({ comments: [] }),
+    onOpenIssueSheet: fn(),
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
 
     await userEvent.click(canvas.getByRole("tab", { name: "Issue" }));
     await waitFor(() => expect(canvas.getByText("Issue type")).toBeInTheDocument());
     await expect(canvas.getByText("General question")).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Issues" })).toBeInTheDocument();
 
     const input = canvas.getByPlaceholderText("Add a comment...");
     await userEvent.type(input, "Wrong tone for ja-JP.");
@@ -232,5 +243,8 @@ export const RaiseIssueInteraction: Story = {
     await waitFor(() => expect(canvas.getByText("Wrong tone for ja-JP.")).toBeInTheDocument());
     await expect(canvas.getByText("1")).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Resolve" })).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole("button", { name: "Issues" }));
+    await expect(args.onOpenIssueSheet).toHaveBeenCalledTimes(1);
   },
 };

--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-comments-section.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-comments-section.stories.tsx
@@ -219,6 +219,77 @@ export const CommentOnly: Story = {
     const canvas = within(canvasElement);
     await expect(canvas.queryByRole("tab", { name: "Issue" })).not.toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Add comment" })).toBeInTheDocument();
+    await expect(canvas.queryByRole("button", { name: "Issues" })).not.toBeInTheDocument();
+  },
+};
+
+export const IssueSheetCtaWithExistingIssues: Story = {
+  args: {
+    initialSegment: createCatEditorCommentsSegment({
+      comments: catEditorCommentsFixture,
+    }),
+    onOpenIssueSheet: fn(),
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const issueSheetButton = canvas.getByRole("button", { name: "Issues" });
+
+    await expect(issueSheetButton).toBeInTheDocument();
+    await expect(issueSheetButton).toBeEnabled();
+
+    await userEvent.click(issueSheetButton);
+    await expect(args.onOpenIssueSheet).toHaveBeenCalledTimes(1);
+  },
+};
+
+export const IssueSheetCtaOnIssueTab: Story = {
+  args: {
+    initialSegment: createCatEditorCommentsSegment({ comments: [] }),
+    onOpenIssueSheet: fn(),
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.queryByRole("button", { name: "Issues" })).not.toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole("tab", { name: "Issue" }));
+    await waitFor(() => expect(canvas.getByRole("button", { name: "Issues" })).toBeInTheDocument());
+
+    await userEvent.click(canvas.getByRole("button", { name: "Issues" }));
+    await expect(args.onOpenIssueSheet).toHaveBeenCalledTimes(1);
+  },
+};
+
+export const IssueSheetCtaHiddenOnCommentTab: Story = {
+  args: {
+    initialSegment: createCatEditorCommentsSegment({
+      comments: [catEditorCommentsFixture[0]!],
+    }),
+    onOpenIssueSheet: fn(),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole("tab", { name: "Comment" })).toHaveAttribute(
+      "data-state",
+      "active",
+    );
+    await expect(canvas.queryByRole("button", { name: "Issues" })).not.toBeInTheDocument();
+  },
+};
+
+export const IssueSheetCtaDisabledWhilePosting: Story = {
+  args: {
+    initialSegment: createCatEditorCommentsSegment({
+      comments: catEditorCommentsFixture,
+    }),
+    isPostingComment: true,
+    onOpenIssueSheet: fn(),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole("button", { name: "Issues" })).toBeDisabled();
   },
 };
 

--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-comments-section.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-comments-section.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment happy-dom
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { renderWithCatProviders } from "@/components/cat/shared/cat-test-utils";
+import type { CatSegmentCommentInput } from "@/components/cat/shared/types";
+
+import { CatEditorCommentsSection } from "./cat-editor-comments-section";
+import {
+  catEditorCommentsFixture,
+  createCatEditorCommentsSegment,
+} from "./cat-editor-comments-section.fixture";
+
+function renderCommentsSection(
+  overrides: Partial<Parameters<typeof CatEditorCommentsSection>[0]> = {},
+) {
+  const segment = createCatEditorCommentsSegment({
+    comments: [],
+    ...overrides.segment,
+  });
+
+  const props = {
+    segment,
+    isLoading: false,
+    canAddComment: true,
+    supportsIssueComments: true,
+    isPostingComment: false,
+    isResolvingComment: false,
+    resolvingCommentId: null,
+    onAddComment: vi.fn(),
+    onResolveComment: vi.fn(),
+    ...overrides,
+  };
+
+  return {
+    props,
+    ...renderWithCatProviders(<CatEditorCommentsSection {...props} />),
+  };
+}
+
+describe("CatEditorCommentsSection", () => {
+  it("shows the Issue Sheet CTA when the segment has issue comments", () => {
+    renderCommentsSection({
+      segment: createCatEditorCommentsSegment({
+        comments: catEditorCommentsFixture,
+      }),
+      onOpenIssueSheet: vi.fn(),
+    });
+
+    expect(screen.getByRole("button", { name: "Issues" })).toBeInTheDocument();
+  });
+
+  it("shows the Issue Sheet CTA when the Issue tab is selected", async () => {
+    const user = userEvent.setup();
+
+    renderCommentsSection({
+      onOpenIssueSheet: vi.fn(),
+    });
+
+    expect(screen.queryByRole("button", { name: "Issues" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Issue" }));
+
+    expect(screen.getByRole("button", { name: "Issues" })).toBeInTheDocument();
+  });
+
+  it("hides the Issue Sheet CTA on the Comment tab when there are no issue comments", () => {
+    renderCommentsSection({
+      segment: createCatEditorCommentsSegment({
+        comments: [catEditorCommentsFixture[0]!],
+      }),
+      onOpenIssueSheet: vi.fn(),
+    });
+
+    expect(screen.queryByRole("button", { name: "Issues" })).not.toBeInTheDocument();
+  });
+
+  it("hides the Issue Sheet CTA when no handler is provided", () => {
+    renderCommentsSection({
+      segment: createCatEditorCommentsSegment({
+        comments: catEditorCommentsFixture,
+      }),
+    });
+
+    expect(screen.queryByRole("button", { name: "Issues" })).not.toBeInTheDocument();
+  });
+
+  it("hides the Issue Sheet CTA when issue comments are unsupported", () => {
+    renderCommentsSection({
+      supportsIssueComments: false,
+      segment: createCatEditorCommentsSegment({
+        comments: catEditorCommentsFixture,
+      }),
+      onOpenIssueSheet: vi.fn(),
+    });
+
+    expect(screen.queryByRole("button", { name: "Issues" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "Issue" })).not.toBeInTheDocument();
+  });
+
+  it("invokes onOpenIssueSheet when the Issues button is clicked", async () => {
+    const user = userEvent.setup();
+    const onOpenIssueSheet = vi.fn();
+
+    renderCommentsSection({
+      segment: createCatEditorCommentsSegment({
+        comments: catEditorCommentsFixture,
+      }),
+      onOpenIssueSheet,
+    });
+
+    await user.click(screen.getByRole("button", { name: "Issues" }));
+
+    expect(onOpenIssueSheet).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the Issue Sheet CTA while posting a comment", () => {
+    renderCommentsSection({
+      segment: createCatEditorCommentsSegment({
+        comments: catEditorCommentsFixture,
+      }),
+      isPostingComment: true,
+      onOpenIssueSheet: vi.fn(),
+    });
+
+    expect(screen.getByRole("button", { name: "Issues" })).toBeDisabled();
+  });
+
+  it("disables the Issue Sheet CTA while resolving an issue", () => {
+    renderCommentsSection({
+      segment: createCatEditorCommentsSegment({
+        comments: catEditorCommentsFixture,
+      }),
+      isResolvingComment: true,
+      resolvingCommentId: "issue-open-1",
+      onOpenIssueSheet: vi.fn(),
+    });
+
+    expect(screen.getByRole("button", { name: "Issues" })).toBeDisabled();
+  });
+
+  it("posts a plain comment without issue metadata on the Comment tab", async () => {
+    const user = userEvent.setup();
+    const onAddComment = vi.fn<(input: CatSegmentCommentInput) => void>();
+
+    renderCommentsSection({ onAddComment });
+
+    await user.type(screen.getByPlaceholderText("Add a comment..."), "Needs another review pass.");
+    await user.click(screen.getByRole("button", { name: "Add comment" }));
+
+    expect(onAddComment).toHaveBeenCalledWith({
+      text: "Needs another review pass.",
+    });
+  });
+
+  it("posts an issue with issue metadata on the Issue tab", async () => {
+    const user = userEvent.setup();
+    const onAddComment = vi.fn<(input: CatSegmentCommentInput) => void>();
+
+    renderCommentsSection({ onAddComment });
+
+    await user.click(screen.getByRole("tab", { name: "Issue" }));
+    await user.type(screen.getByPlaceholderText("Add a comment..."), "Source label is ambiguous.");
+    await user.click(screen.getByRole("button", { name: "Raise issue" }));
+
+    expect(onAddComment).toHaveBeenCalledWith({
+      text: "Source label is ambiguous.",
+      type: "issue",
+      issueType: "general_question",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-comments-section.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-comments-section.tsx
@@ -176,6 +176,7 @@ export function CatEditorCommentsSection({
   resolvingCommentId,
   commentPostError,
   onAddComment,
+  onOpenIssueSheet,
   onResolveComment,
 }: {
   segment: CatSegment;
@@ -187,6 +188,7 @@ export function CatEditorCommentsSection({
   resolvingCommentId: string | null;
   commentPostError?: string;
   onAddComment?: (input: CatSegmentCommentInput) => void | Promise<void>;
+  onOpenIssueSheet?: () => void;
   onResolveComment?: (commentId: string) => void | Promise<void>;
 }) {
   const intl = useIntl();
@@ -201,6 +203,11 @@ export function CatEditorCommentsSection({
   const commentInputType = commentInputTypes[segment.id] ?? "comment";
   const issueType = issueTypes[segment.id] ?? "general_question";
   const trimmedCommentDraft = commentDraft.trim();
+  const hasIssueComments = segmentComments.some((comment) => comment.type === "issue");
+  const showIssueSheetCta =
+    Boolean(onOpenIssueSheet) &&
+    supportsIssueComments &&
+    (commentInputType === "issue" || hasIssueComments);
 
   function handleCommentDraftChange(value: string) {
     setCommentDrafts((current) => ({ ...current, [segment.id]: value }));
@@ -294,7 +301,19 @@ export function CatEditorCommentsSection({
         </div>
       ) : null}
       {commentPostError ? <p className="text-sm text-flame-100">{commentPostError}</p> : null}
-      <div className="flex justify-end">
+      <div className="flex items-center justify-between gap-2">
+        {showIssueSheetCta ? (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onOpenIssueSheet}
+            disabled={isPostingComment || isResolvingComment}
+          >
+            <FormattedMessage {...catEditorPanelMessages.addToIssueSheet} />
+          </Button>
+        ) : (
+          <span />
+        )}
         <Button
           variant="ghost"
           size="sm"

--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-panel.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-panel.test.tsx
@@ -12,7 +12,7 @@
  */
 // @vitest-environment happy-dom
 
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vite-plus/test";
 
@@ -101,6 +101,40 @@ describe("CatEditorPanel UI", () => {
     });
 
     expect(screen.getByText("Failed to post comment.")).toBeInTheDocument();
+  });
+
+  it("opens the linked Issue Sheet from the comments section", async () => {
+    const user = userEvent.setup();
+    const onAddToIssueSheet = vi.fn();
+
+    renderEditorPanel({
+      canAddComment: true,
+      providerKind: null,
+      onAddToIssueSheet,
+      segment: {
+        ...createCatWorkspaceState({ selectedSegmentId: "seg-02" }).segments!.find(
+          (item) => item.id === "seg-02",
+        )!,
+        comments: [
+          {
+            id: "issue-open-1",
+            type: "issue",
+            status: "unresolved",
+            text: "Needs clarification.",
+            createdAt: "2026-06-11T14:30:00.000Z",
+            locale: "ja-JP",
+            author: "Reviewer",
+          },
+        ],
+      },
+    });
+
+    const commentsSection = screen.getByText("Comments").closest("section");
+    expect(commentsSection).not.toBeNull();
+
+    await user.click(within(commentsSection!).getByRole("button", { name: "Issues" }));
+
+    expect(onAddToIssueSheet).toHaveBeenCalledTimes(1);
   });
 
   it("invokes navigation handlers from the action bar", async () => {

--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-panel.tsx
@@ -247,6 +247,7 @@ export function CatEditorPanel({
             resolvingCommentId={resolvingCommentId}
             commentPostError={commentPostError}
             onAddComment={onAddComment}
+            onOpenIssueSheet={onAddToIssueSheet}
             onResolveComment={onResolveComment}
           />
         </div>

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-intelligence-panel.tsx
@@ -61,6 +61,7 @@ export function CatSideBySideIntelligencePanel({
   onRefreshContext,
   onUseTmMatch,
   onAddComment,
+  onOpenIssueSheet,
   onResolveComment,
   placement = "bottom",
   className,
@@ -89,6 +90,7 @@ export function CatSideBySideIntelligencePanel({
   onRefreshContext?: () => void;
   onUseTmMatch?: (match: CatTranslationMemoryMatch) => void;
   onAddComment?: (input: CatSegmentCommentInput) => void | Promise<void>;
+  onOpenIssueSheet?: () => void;
   onResolveComment?: (commentId: string) => void | Promise<void>;
   placement?: "bottom" | "right";
   className?: string;
@@ -160,6 +162,7 @@ export function CatSideBySideIntelligencePanel({
       canAddComment={canAddComment}
       supportsIssueComments={supportsIssueComments}
       onAddComment={onAddComment}
+      onOpenIssueSheet={onOpenIssueSheet}
       onResolveComment={onResolveComment}
     />
   );

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-panel.tsx
@@ -428,6 +428,11 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
               ? (commentId) => onResolveComment(intelligenceSegmentId, commentId)
               : undefined
           }
+          onOpenIssueSheet={
+            onAddToIssueSheet && intelligenceSegment
+              ? () => onAddToIssueSheet(intelligenceSegmentId)
+              : undefined
+          }
           placement="right"
           className="h-full"
         />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an **Issues** CTA to the CAT segment comment section so translators can open the linked Issue Sheet while reviewing or raising issues — without scrolling back to the editor action bar.

The button appears when:
- Issue comments are enabled for the segment, and
- The user is on the **Issue** tab or the segment already has issue comments

Clicking it opens the same linked-issues dialog as the existing **Issues** action in the editor toolbar.

## Changes

- `CatEditorCommentsSection`: new `onOpenIssueSheet` prop and outline **Issues** button in the comment footer
- Wired through `CatEditorPanel` and `CatSideBySideIntelligencePanel`
- **Unit tests** (`cat-editor-comments-section.test.tsx`): visibility rules, click handler, disabled states, comment/issue posting
- **Integration test** (`cat-editor-panel.test.tsx`): comments-section Issues button opens linked Issue Sheet
- **Storybook stories**: dedicated stories for Issue Sheet CTA visibility, Issue tab behavior, hidden state, and disabled-while-posting

## Test plan

- [x] `vp check --fix`
- [x] `vp test src/components/cat/editor/cat-editor-comments-section.test.tsx` (10 tests)
- [x] `vp test src/components/cat/editor/cat-editor-panel.test.tsx` (includes comments-section integration)
- [ ] Manual: open a segment with issue comments → **Issues** button visible in comment footer
- [ ] Manual: switch to **Issue** tab on a segment with no issues → **Issues** button visible
- [ ] Manual: click **Issues** → linked Issue Sheet dialog opens
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a90455f-c554-4d04-9415-7ed6e6c7da67?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a90455f-c554-4d04-9415-7ed6e6c7da67&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

