### PR TITLE
feat(overview): show locale and assignee on triage job rows

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.stories.tsx
@@ -49,6 +49,15 @@ export const Default: Story = {
     await expect(canvas.getByRole("button", { name: "Create job" })).toBeInTheDocument();
     await expect(canvas.getByText("Needs you now")).toBeInTheDocument();
     await expect(canvas.getByText("Waiting for review")).toBeInTheDocument();
+    await expect(
+      canvas.getByText((content) => content.includes("fr-FR") && content.includes("Otto")),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByText(
+        (content) =>
+          content.includes("de-DE") && content.includes("es-ES") && content.includes("Mina"),
+      ),
+    ).toBeInTheDocument();
     await expect(canvas.getByText("Translation guidance")).toBeInTheDocument();
     await expect(canvas.getByText("Sync")).toBeInTheDocument();
     await expect(canvas.queryByText("Locale health")).toBeNull();

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
@@ -127,7 +127,9 @@ function TriageRow({
         <TypographyP className="truncate text-sm font-medium text-foreground">{title}</TypographyP>
         <TypographyP className="mt-0.5 text-xs text-muted-foreground">{description}</TypographyP>
         {meta ? (
-          <TypographyP className="mt-0.5 truncate text-xs text-muted-foreground">{meta}</TypographyP>
+          <TypographyP className="mt-0.5 truncate text-xs text-muted-foreground">
+            {meta}
+          </TypographyP>
         ) : null}
       </div>
       <span className="inline-flex shrink-0 items-center gap-1 text-sm font-medium text-foreground">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
@@ -27,7 +27,11 @@ import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resour
 
 import { OverviewSectionHeader } from "../../../_components/overview/overview-section-header";
 import { CreateJobDialog } from "../../../jobs/_components/create-job-dialog";
-import { getJobName, type ApiJob } from "../../../jobs/_components/jobs-page-view";
+import {
+  getJobName,
+  taskDetailSummary,
+  type ApiJob,
+} from "../../../jobs/_components/jobs-page-view";
 import type { ProjectListRow } from "../../_components/project-list";
 import { ProjectOverviewMeshStage } from "./project-overview-mesh-stage";
 import { projectOverviewPageContentMessages as messages } from "./project-overview-page-content.messages";
@@ -44,33 +48,54 @@ function buildProjectJobHref(organizationSlug: string, projectId: string, jobId:
   return `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(jobId)}`;
 }
 
+function resolveTriageJobMeta(
+  job: ApiJob | undefined,
+  intl: ReturnType<typeof useIntl>,
+): string | null {
+  if (!job) {
+    return null;
+  }
+
+  const hasLocales = Boolean(job.externalTargetLocales?.length || job.reviewTargetLocale);
+  const hasAssignees = Boolean(job.externalAssignedUsers?.length);
+  if (!hasLocales && !hasAssignees) {
+    return null;
+  }
+
+  return taskDetailSummary(job, intl);
+}
+
 function resolveTriageCopy(
   item: ProjectOverviewTriageItem,
   intl: ReturnType<typeof useIntl>,
-): { title: string; description: string; cta: string } {
+): { title: string; description: string; meta: string | null; cta: string } {
   switch (item.kind) {
     case "review":
       return {
         title: getJobName(item.job!, intl),
         description: intl.formatMessage(messages.triageReviewTitle),
+        meta: resolveTriageJobMeta(item.job, intl),
         cta: intl.formatMessage(messages.reviewCta),
       };
     case "failed":
       return {
         title: getJobName(item.job!, intl),
         description: intl.formatMessage(messages.triageFailedTitle),
+        meta: resolveTriageJobMeta(item.job, intl),
         cta: intl.formatMessage(messages.openJobCta),
       };
     case "job":
       return {
         title: getJobName(item.job!, intl),
         description: intl.formatMessage(messages.triageJobRunning),
+        meta: resolveTriageJobMeta(item.job, intl),
         cta: intl.formatMessage(messages.openJobCta),
       };
     case "guidance":
       return {
         title: intl.formatMessage(messages.triageGuidanceTitle),
         description: intl.formatMessage(messages.triageGuidanceDescription),
+        meta: null,
         cta: intl.formatMessage(messages.addGuidanceCta),
       };
     default: {
@@ -84,11 +109,13 @@ function TriageRow({
   href,
   title,
   description,
+  meta,
   cta,
 }: {
   href: string;
   title: string;
   description: string;
+  meta: string | null;
   cta: string;
 }) {
   return (
@@ -99,6 +126,9 @@ function TriageRow({
       <div className="min-w-0">
         <TypographyP className="truncate text-sm font-medium text-foreground">{title}</TypographyP>
         <TypographyP className="mt-0.5 text-xs text-muted-foreground">{description}</TypographyP>
+        {meta ? (
+          <TypographyP className="mt-0.5 truncate text-xs text-muted-foreground">{meta}</TypographyP>
+        ) : null}
       </div>
       <span className="inline-flex shrink-0 items-center gap-1 text-sm font-medium text-foreground">
         {cta}
@@ -257,6 +287,7 @@ export function ProjectOverviewPageContentView({
                       href={href}
                       title={copy.title}
                       description={copy.description}
+                      meta={copy.meta}
                       cta={copy.cta}
                     />
                   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview.fixture.ts
@@ -86,8 +86,8 @@ export const projectOverviewJobsFixture: ApiJob[] = [
     externalStatus: null,
     externalTitle: null,
     externalDueDate: null,
-    externalTargetLocales: null,
-    externalAssignedUsers: null,
+    externalTargetLocales: ["de-DE", "es-ES"],
+    externalAssignedUsers: ["Mina"],
     externalSyncState: null,
   },
   {
@@ -117,7 +117,7 @@ export const projectOverviewJobsFixture: ApiJob[] = [
     externalTitle: null,
     externalDueDate: null,
     externalTargetLocales: null,
-    externalAssignedUsers: null,
+    externalAssignedUsers: ["Otto"],
     externalSyncState: null,
   },
 ];

--- a/docs/adr/2026-08-05-overview-triage-locale-assignee-design.md
+++ b/docs/adr/2026-08-05-overview-triage-locale-assignee-design.md
@@ -1,0 +1,38 @@
+# Overview triage: locale and assignee meta
+
+## Problem
+
+Project Overview **Needs you now** job rows show title, status, and CTA only.
+Locale and assignee sit in empty horizontal space, so triage needs a click into
+the job for context the Jobs list already surfaces.
+
+## Decision
+
+Add a third muted meta line under status on job triage rows, using the existing
+`taskDetailSummary` helper from the Jobs module (`locales · assignees`).
+
+- Show the line only when the summary has real data (omit “No locales or assignees”).
+- Leave guidance rows unchanged (no job payload).
+- Do not change triage queries, caps, or CTA layout.
+
+## Row shape
+
+1. Job title  
+2. Status (`Waiting for review` / `Job failed` / `In progress`)  
+3. Meta (`fr-FR · Mina`) when present  
+4. CTA (`Review` / `Open job`)
+
+## Data
+
+Reuse `ApiJob` fields already loaded for Overview triage:
+
+- Locales: `externalTargetLocales`, else `reviewTargetLocale`
+- Assignees: `externalAssignedUsers`
+
+No API or query changes.
+
+## Out of scope
+
+- Middle-column layout for locale/assignee
+- Expanding `taskDetailSummary` for native `inputPayload.targetLocales` or owner
+- Jobs list UI changes


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

**Needs you now** job rows on Project Overview now show a muted meta line under status with locale and assignee, via the same `taskDetailSummary` helper as the Jobs list (e.g. `French (France) (fr-FR) · Otto`). The line is omitted when neither is set; guidance rows are unchanged.

Design: `docs/adr/2026-08-05-overview-triage-locale-assignee-design.md`.

## How to test

- `vp test` for `projects/[projectId]/_components` (view-model tests)
- `vp check --fix` in `apps/hyperlocalise-web`
- Storybook: **App/Project/Overview/Page → Default** — meta lines under status for both job rows

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48b9b8b6-6f5e-41a3-892f-1842f9bd507a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48b9b8b6-6f5e-41a3-892f-1842f9bd507a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

