### PR TITLE
fix: use Maya follow-up message as thread composer prompt

### DIFF
--- a/apps/hyperlocalise-web/src/components/marketing/slack-launch-intake-illustration.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/slack-launch-intake-illustration.tsx
@@ -239,9 +239,6 @@ export function SlackLaunchIntakeIllustration({
   const initialPrompt = intl.formatMessage(slackLaunchIntakeIllustrationMessages.channelPrompt, {
     mention: `@${agentName}`,
   });
-  const followUpPrompt = intl.formatMessage(
-    slackLaunchIntakeIllustrationMessages.agentSummaryOutro,
-  );
   const mayaFollowUp = intl.formatMessage(slackLaunchIntakeIllustrationMessages.userFollowUp);
   const threadRef = useRef<HTMLDivElement>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -536,7 +533,7 @@ export function SlackLaunchIntakeIllustration({
             onFollowUp={handleFollowUpPrompt}
             isDone={isDone}
             onReset={handleReset}
-            followUpPrompt={followUpPrompt}
+            followUpPrompt={mayaFollowUp}
           />
         </motion.aside>
       )}


### PR DESCRIPTION
## What changed

Fix the suggested prompt shown in the Slack thread composer.

Previously the thread composer was showing the agent's question ("Want me to open translation tasks and attach the brand brief as context?") as the suggested prompt for the user to click. 

- `slack-launch-intake-illustration.tsx`: replaced `followUpPrompt` variable (which used `agentSummaryOutro`) with `mayaFollowUp` (which uses `userFollowUp`) as the thread composer prompt

## How to test

- Navigate to the landing page section "Start where launch work already happens"
- Click the suggested prompt in the channel composer

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review
