### PR TITLE
feat(sandbox): reap Vercel snapshots and shorten retention to 3 days

### DIFF
--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -79,6 +79,7 @@ import { createBillingRoutes } from "./routes/billing/billing.route";
 import { createBlogOgImageRoutes } from "./routes/blog-og-image/blog-og-image.route";
 import { createGithubRepositoryAutomationDispatchRoutes } from "./routes/cron/github-repository-automation-dispatch.route";
 import { createSandboxCleanupRoutes } from "./routes/cron/sandbox-cleanup.route";
+import { createSnapshotCleanupRoutes } from "./routes/cron/snapshot-cleanup.route";
 import {
   createProviderAgentCommentQueue,
   createProviderAgentQaQueue,
@@ -151,7 +152,8 @@ function createInternalRoutes() {
       "/cron/github-repository-automation-dispatch",
       createGithubRepositoryAutomationDispatchRoutes(),
     )
-    .route("/cron/sandbox-cleanup", createSandboxCleanupRoutes());
+    .route("/cron/sandbox-cleanup", createSandboxCleanupRoutes())
+    .route("/cron/snapshot-cleanup", createSnapshotCleanupRoutes());
 }
 
 function createAuthRoutes() {

--- a/apps/hyperlocalise-web/src/api/routes/cron/snapshot-cleanup.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/cron/snapshot-cleanup.route.test.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { testClient } from "hono/testing";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+const runSnapshotCleanupMock = vi.fn(async () => ({
+  scanned: 3,
+  expired: 2,
+  deleted: 2,
+  failed: 0,
+  skippedYoung: 1,
+  skippedDeleted: 0,
+  deletedBytes: 2048,
+}));
+
+async function createClient(input?: { cronSecret?: string | null }) {
+  const cronSecret = input?.cronSecret === null ? undefined : (input?.cronSecret ?? "cron-secret");
+
+  vi.resetModules();
+  vi.doMock("@/lib/agent-runtime/workspaces/snapshot-cleanup", () => ({
+    runSnapshotCleanup: runSnapshotCleanupMock,
+  }));
+  vi.doMock("@/lib/env", () => ({
+    env: {
+      CRON_SECRET: cronSecret,
+      SNAPSHOT_CLEANUP_MAX_PER_TICK: 50,
+    },
+  }));
+
+  const { createSnapshotCleanupRoutes } = await import("./snapshot-cleanup.route");
+
+  return testClient(createSnapshotCleanupRoutes());
+}
+
+describe("snapshot cleanup cron route", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("@/lib/agent-runtime/workspaces/snapshot-cleanup");
+    vi.doUnmock("@/lib/env");
+    runSnapshotCleanupMock.mockClear();
+  });
+
+  it("rejects requests without the cron secret", async () => {
+    const client = await createClient();
+
+    const response = await client.index.$get();
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "unauthorized" });
+  });
+
+  it("rejects requests when CRON_SECRET is not configured", async () => {
+    const client = await createClient({ cronSecret: null });
+
+    const response = await client.index.$get(
+      {},
+      {
+        headers: {
+          authorization: "Bearer cron-secret",
+        },
+      },
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({ error: "snapshot_cleanup_misconfigured" });
+  });
+
+  it("runs snapshot cleanup when authorized", async () => {
+    const client = await createClient();
+
+    const response = await client.index.$get(
+      {},
+      {
+        headers: {
+          authorization: "Bearer cron-secret",
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      results: {
+        scanned: 3,
+        expired: 2,
+        deleted: 2,
+        failed: 0,
+        skippedYoung: 1,
+        skippedDeleted: 0,
+        deletedBytes: 2048,
+      },
+    });
+    expect(runSnapshotCleanupMock).toHaveBeenCalledTimes(1);
+    expect(runSnapshotCleanupMock).toHaveBeenCalledWith({ limit: 50 });
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/cron/snapshot-cleanup.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/cron/snapshot-cleanup.route.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { Hono } from "hono";
+
+import { verifyCronRequest } from "@/api/routes/cron/cron-auth";
+import { env } from "@/lib/env";
+import { createLogger } from "@/lib/log";
+import { runSnapshotCleanup } from "@/lib/agent-runtime/workspaces/snapshot-cleanup";
+
+const logger = createLogger("cron-snapshot-cleanup");
+
+export function createSnapshotCleanupRoutes() {
+  return new Hono().get("/", async (c) => {
+    logger.info("cron tick received");
+
+    const auth = verifyCronRequest(c.req.raw);
+    if (!auth.ok) {
+      if (auth.reason === "misconfigured") {
+        logger.warn({ reason: "misconfigured" }, "cron tick rejected; CRON_SECRET is not set");
+        return c.json({ error: "snapshot_cleanup_misconfigured" }, 503);
+      }
+
+      logger.warn(
+        {
+          reason: "unauthorized",
+          hasAuthorizationHeader: auth.hasAuthorizationHeader,
+          hasCronSecretHeader: auth.hasCronSecretHeader,
+        },
+        "cron tick rejected; missing or invalid cron secret",
+      );
+      return c.json({ error: "unauthorized" }, 401);
+    }
+
+    const results = await runSnapshotCleanup({
+      limit: env.SNAPSHOT_CLEANUP_MAX_PER_TICK,
+    });
+
+    logger.info(results, "cron tick completed");
+
+    return c.json({ results }, 200);
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/sandbox-cleanup.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/sandbox-cleanup.test.ts
@@ -17,15 +17,15 @@ import { runSandboxCleanup, SANDBOX_CLEANUP_MAX_AGE_MS } from "./sandbox-cleanup
 describe("runSandboxCleanup", () => {
   const now = new Date("2026-07-18T12:00:00.000Z");
 
-  it("deletes sandboxes older than seven days and stops at the first young sandbox", async () => {
-    const eightDaysAgo = now.getTime() - 8 * 24 * 60 * 60 * 1000;
-    const nineDaysAgo = now.getTime() - 9 * 24 * 60 * 60 * 1000;
+  it("deletes sandboxes older than three days and stops at the first young sandbox", async () => {
+    const fourDaysAgo = now.getTime() - 4 * 24 * 60 * 60 * 1000;
+    const fiveDaysAgo = now.getTime() - 5 * 24 * 60 * 60 * 1000;
     const oneDayAgo = now.getTime() - 1 * 24 * 60 * 60 * 1000;
 
     const deleteSandbox = vi.fn(async () => undefined);
     const listed = [
-      { name: "old-a", createdAt: nineDaysAgo, status: "stopped" },
-      { name: "old-b", createdAt: eightDaysAgo, status: "stopped" },
+      { name: "old-a", createdAt: fiveDaysAgo, status: "stopped" },
+      { name: "old-b", createdAt: fourDaysAgo, status: "stopped" },
       { name: "young-c", createdAt: oneDayAgo, status: "stopped" },
       { name: "young-d", createdAt: oneDayAgo, status: "running" },
     ];

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/sandbox-cleanup.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/sandbox-cleanup.ts
@@ -17,7 +17,7 @@ import { createLogger } from "@/lib/log";
 const logger = createLogger("sandbox-cleanup");
 
 /** Sandboxes older than this are eligible for permanent deletion. */
-export const SANDBOX_CLEANUP_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+export const SANDBOX_CLEANUP_MAX_AGE_MS = 3 * 24 * 60 * 60 * 1000;
 
 /** Default max deletes per cron tick to stay within serverless time limits. */
 export const SANDBOX_CLEANUP_DEFAULT_LIMIT = 100;

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/snapshot-cleanup.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/snapshot-cleanup.test.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { runSnapshotCleanup, SNAPSHOT_CLEANUP_MAX_AGE_MS } from "./snapshot-cleanup";
+
+describe("runSnapshotCleanup", () => {
+  const now = new Date("2026-07-18T12:00:00.000Z");
+
+  it("deletes snapshots older than three days and stops at the first young snapshot", async () => {
+    const fourDaysAgo = now.getTime() - 4 * 24 * 60 * 60 * 1000;
+    const fiveDaysAgo = now.getTime() - 5 * 24 * 60 * 60 * 1000;
+    const oneDayAgo = now.getTime() - 1 * 24 * 60 * 60 * 1000;
+
+    const deleteSnapshot = vi.fn(async () => undefined);
+    const listed = [
+      { id: "snap-old-a", createdAt: fiveDaysAgo, status: "created", sizeBytes: 100 },
+      { id: "snap-old-b", createdAt: fourDaysAgo, status: "created", sizeBytes: 250 },
+      { id: "snap-young-c", createdAt: oneDayAgo, status: "created", sizeBytes: 400 },
+      { id: "snap-young-d", createdAt: oneDayAgo, status: "created", sizeBytes: 500 },
+    ];
+
+    const result = await runSnapshotCleanup({
+      deps: {
+        now,
+        listSnapshots: async () => listed,
+        deleteSnapshot,
+      },
+    });
+
+    expect(result).toEqual({
+      scanned: 3,
+      expired: 2,
+      deleted: 2,
+      failed: 0,
+      skippedYoung: 1,
+      skippedDeleted: 0,
+      deletedBytes: 350,
+    });
+    expect(deleteSnapshot).toHaveBeenCalledTimes(2);
+    expect(deleteSnapshot).toHaveBeenCalledWith("snap-old-a", undefined);
+    expect(deleteSnapshot).toHaveBeenCalledWith("snap-old-b", undefined);
+  });
+
+  it("skips snapshots already in the deleted state", async () => {
+    const old = now.getTime() - SNAPSHOT_CLEANUP_MAX_AGE_MS - 1;
+    const deleteSnapshot = vi.fn(async () => undefined);
+    const listed = [
+      { id: "snap-gone", createdAt: old, status: "deleted", sizeBytes: 100 },
+      { id: "snap-old", createdAt: old, status: "created", sizeBytes: 100 },
+    ];
+
+    const result = await runSnapshotCleanup({
+      deps: {
+        now,
+        listSnapshots: async () => listed,
+        deleteSnapshot,
+      },
+    });
+
+    expect(result).toMatchObject({
+      scanned: 2,
+      expired: 1,
+      deleted: 1,
+      skippedDeleted: 1,
+    });
+    expect(deleteSnapshot).toHaveBeenCalledTimes(1);
+    expect(deleteSnapshot).toHaveBeenCalledWith("snap-old", undefined);
+  });
+
+  it("respects the per-tick delete limit", async () => {
+    const old = now.getTime() - SNAPSHOT_CLEANUP_MAX_AGE_MS - 1;
+    const listed = Array.from({ length: 5 }, (_, index) => ({
+      id: `snap-old-${index}`,
+      createdAt: old - index,
+      status: "created",
+      sizeBytes: 10,
+    }));
+    const deleteSnapshot = vi.fn(async () => undefined);
+
+    const result = await runSnapshotCleanup({
+      limit: 2,
+      deps: {
+        now,
+        listSnapshots: async () => listed,
+        deleteSnapshot,
+      },
+    });
+
+    expect(result.expired).toBe(2);
+    expect(result.deleted).toBe(2);
+    expect(deleteSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it("counts delete failures without aborting the rest", async () => {
+    const old = now.getTime() - SNAPSHOT_CLEANUP_MAX_AGE_MS - 1;
+    const listed = [
+      { id: "snap-a", createdAt: old, status: "created", sizeBytes: 100 },
+      { id: "snap-b", createdAt: old, status: "created", sizeBytes: 200 },
+    ];
+    const deleteSnapshot = vi.fn(async (snapshotId: string) => {
+      if (snapshotId === "snap-a") {
+        throw new Error("delete failed");
+      }
+    });
+
+    const result = await runSnapshotCleanup({
+      deps: {
+        now,
+        listSnapshots: async () => listed,
+        deleteSnapshot,
+      },
+    });
+
+    expect(result).toMatchObject({
+      expired: 2,
+      deleted: 1,
+      failed: 1,
+      deletedBytes: 200,
+    });
+  });
+
+  it("returns empty counts when nothing is expired", async () => {
+    const listed = [
+      {
+        id: "snap-young",
+        createdAt: now.getTime() - 60_000,
+        status: "created",
+        sizeBytes: 100,
+      },
+    ];
+
+    const result = await runSnapshotCleanup({
+      deps: {
+        now,
+        listSnapshots: async () => listed,
+        deleteSnapshot: vi.fn(async () => undefined),
+      },
+    });
+
+    expect(result).toEqual({
+      scanned: 1,
+      expired: 0,
+      deleted: 0,
+      failed: 0,
+      skippedYoung: 1,
+      skippedDeleted: 0,
+      deletedBytes: 0,
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/snapshot-cleanup.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/snapshot-cleanup.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { Snapshot } from "@vercel/sandbox";
+
+import { createLogger } from "@/lib/log";
+
+const logger = createLogger("snapshot-cleanup");
+
+/** Snapshots older than this are eligible for permanent deletion. */
+export const SNAPSHOT_CLEANUP_MAX_AGE_MS = 3 * 24 * 60 * 60 * 1000;
+
+/** Default max deletes per cron tick to stay within serverless time limits. */
+export const SNAPSHOT_CLEANUP_DEFAULT_LIMIT = 100;
+
+/**
+ * Page size for `Snapshot.list`. Kept separate from the delete cap and clamped
+ * to the Vercel snapshots API max (`limit` max 50).
+ */
+const SNAPSHOT_LIST_PAGE_SIZE = 50;
+
+/** Bounded concurrency when calling the Vercel Snapshot delete API. */
+const SNAPSHOT_DELETE_CONCURRENCY = 5;
+
+export type SnapshotCleanupResult = {
+  scanned: number;
+  expired: number;
+  deleted: number;
+  failed: number;
+  skippedYoung: number;
+  /** Snapshots already in the `deleted` state; listed but not re-deleted. */
+  skippedDeleted: number;
+  /** Sum of `sizeBytes` for successfully deleted snapshots. */
+  deletedBytes: number;
+};
+
+type ListedSnapshot = {
+  id: string;
+  createdAt: number;
+  status: string;
+  sizeBytes: number;
+};
+
+type ListedSnapshotIterable = AsyncIterable<ListedSnapshot> | Iterable<ListedSnapshot>;
+
+type SnapshotCleanupDeps = {
+  listSnapshots?: (params: {
+    sortOrder: "asc";
+    pageSize: number;
+    signal?: AbortSignal;
+  }) => Promise<ListedSnapshotIterable>;
+  deleteSnapshot?: (snapshotId: string, signal?: AbortSignal) => Promise<void>;
+  now?: Date;
+};
+
+async function defaultListSnapshots(params: {
+  sortOrder: "asc";
+  pageSize: number;
+  signal?: AbortSignal;
+}): Promise<ListedSnapshotIterable> {
+  return Snapshot.list({
+    sortOrder: params.sortOrder,
+    limit: params.pageSize,
+    signal: params.signal,
+  });
+}
+
+async function defaultDeleteSnapshot(snapshotId: string, signal?: AbortSignal): Promise<void> {
+  const snapshot = await Snapshot.get({ snapshotId, signal });
+  await snapshot.delete({ signal });
+}
+
+function isExpired(createdAtMs: number, nowMs: number, maxAgeMs: number) {
+  return nowMs - createdAtMs >= maxAgeMs;
+}
+
+async function deleteWithBoundedConcurrency(
+  targets: { id: string; sizeBytes: number }[],
+  concurrency: number,
+  deleteSnapshot: (snapshotId: string, signal?: AbortSignal) => Promise<void>,
+  signal?: AbortSignal,
+): Promise<{ deleted: number; failed: number; deletedBytes: number }> {
+  let deleted = 0;
+  let failed = 0;
+  let deletedBytes = 0;
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < targets.length) {
+      if (signal?.aborted) {
+        return;
+      }
+
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      const target = targets[currentIndex];
+      if (!target) {
+        return;
+      }
+
+      try {
+        await deleteSnapshot(target.id, signal);
+        deleted += 1;
+        deletedBytes += target.sizeBytes;
+      } catch (error) {
+        failed += 1;
+        logger.warn(
+          {
+            snapshotId: target.id,
+            error: error instanceof Error ? error.message : "unknown",
+          },
+          "failed to delete expired snapshot",
+        );
+      }
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(concurrency, targets.length) }, () => worker());
+  await Promise.all(workers);
+  return { deleted, failed, deletedBytes };
+}
+
+/**
+ * Lists Vercel sandbox snapshots oldest-first and permanently deletes those
+ * older than {@link SNAPSHOT_CLEANUP_MAX_AGE_MS}. Stops once a young snapshot is
+ * seen (list is sorted by createdAt ascending) or the per-tick limit is reached.
+ *
+ * Sandboxes are persistent by default, so snapshots accrue from ordinary
+ * `stop()` calls even though nothing here creates them explicitly.
+ */
+export async function runSnapshotCleanup(input?: {
+  limit?: number;
+  maxAgeMs?: number;
+  signal?: AbortSignal;
+  deps?: SnapshotCleanupDeps;
+}): Promise<SnapshotCleanupResult> {
+  const limit = input?.limit ?? SNAPSHOT_CLEANUP_DEFAULT_LIMIT;
+  const maxAgeMs = input?.maxAgeMs ?? SNAPSHOT_CLEANUP_MAX_AGE_MS;
+  const nowMs = (input?.deps?.now ?? new Date()).getTime();
+  const listSnapshots = input?.deps?.listSnapshots ?? defaultListSnapshots;
+  const deleteSnapshot = input?.deps?.deleteSnapshot ?? defaultDeleteSnapshot;
+
+  const result: SnapshotCleanupResult = {
+    scanned: 0,
+    expired: 0,
+    deleted: 0,
+    failed: 0,
+    skippedYoung: 0,
+    skippedDeleted: 0,
+    deletedBytes: 0,
+  };
+
+  const expiredTargets: { id: string; sizeBytes: number }[] = [];
+  const listed = await listSnapshots({
+    sortOrder: "asc",
+    pageSize: Math.min(limit, SNAPSHOT_LIST_PAGE_SIZE),
+    signal: input?.signal,
+  });
+
+  for await (const snapshot of listed) {
+    if (input?.signal?.aborted) {
+      break;
+    }
+
+    result.scanned += 1;
+
+    if (!isExpired(snapshot.createdAt, nowMs, maxAgeMs)) {
+      result.skippedYoung += 1;
+      // Remaining pages are newer when sorted by createdAt ascending.
+      break;
+    }
+
+    if (snapshot.status === "deleted") {
+      result.skippedDeleted += 1;
+      continue;
+    }
+
+    result.expired += 1;
+    expiredTargets.push({ id: snapshot.id, sizeBytes: snapshot.sizeBytes });
+
+    if (expiredTargets.length >= limit) {
+      break;
+    }
+  }
+
+  if (expiredTargets.length === 0) {
+    logger.info(result, "snapshot cleanup completed; nothing to delete");
+    return result;
+  }
+
+  const deleteResult = await deleteWithBoundedConcurrency(
+    expiredTargets,
+    SNAPSHOT_DELETE_CONCURRENCY,
+    deleteSnapshot,
+    input?.signal,
+  );
+  result.deleted = deleteResult.deleted;
+  result.failed = deleteResult.failed;
+  result.deletedBytes = deleteResult.deletedBytes;
+
+  logger.info(result, "snapshot cleanup completed");
+  return result;
+}

--- a/apps/hyperlocalise-web/src/lib/env.ts
+++ b/apps/hyperlocalise-web/src/lib/env.ts
@@ -173,6 +173,9 @@ export const env = createEnv({
     /** Maximum sandboxes deleted per sandbox cleanup cron tick. */
     SANDBOX_CLEANUP_MAX_PER_TICK: z.coerce.number().int().positive().default(100),
 
+    /** Maximum snapshots deleted per snapshot cleanup cron tick. */
+    SNAPSHOT_CLEANUP_MAX_PER_TICK: z.coerce.number().int().positive().default(100),
+
     /** Canva app ID used to verify Canva JWTs for the integration API. */
     CANVA_APP_ID: z.string().min(1).optional(),
 
@@ -289,6 +292,7 @@ export const env = createEnv({
     GITHUB_REPOSITORY_AUTOMATION_DISPATCH_MAX_REPOS_PER_TICK:
       process.env.GITHUB_REPOSITORY_AUTOMATION_DISPATCH_MAX_REPOS_PER_TICK,
     SANDBOX_CLEANUP_MAX_PER_TICK: process.env.SANDBOX_CLEANUP_MAX_PER_TICK,
+    SNAPSHOT_CLEANUP_MAX_PER_TICK: process.env.SNAPSHOT_CLEANUP_MAX_PER_TICK,
     CANVA_APP_ID: process.env.CANVA_APP_ID ?? (isTestEnv ? "test-canva-app-id" : undefined),
     CANVA_CORS_ORIGINS: process.env.CANVA_CORS_ORIGINS,
     CANVA_APP_ORIGIN: process.env.CANVA_APP_ORIGIN,

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
@@ -86,6 +86,8 @@ describe("sandbox command runner", () => {
     expect(sandboxMocks.create).toHaveBeenCalledWith({
       runtime: "node26",
       timeout: 600_000,
+      snapshotExpiration: 3 * 24 * 60 * 60 * 1000,
+      keepLastSnapshots: { count: 3, deleteEvicted: true },
     });
     expect(sandboxMocks.runCommand).toHaveBeenCalledWith({
       cmd: "sh",

--- a/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.test.ts
+++ b/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.test.ts
@@ -10,14 +10,28 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { describe, expect, it } from "vite-plus/test";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const sandboxMocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  runCommand: vi.fn(),
+}));
+
+vi.mock("@vercel/sandbox", () => ({
+  Sandbox: {
+    create: sandboxMocks.create,
+  },
+}));
 
 import {
+  createConfiguredVercelSandbox,
   installRequiredSandboxToolsCommand,
   sandboxChromiumDnfPackages,
   sandboxHyperlocaliseReleaseVersion,
   sandboxPlaywrightVersion,
   sandboxRipgrepReleaseVersion,
+  sandboxSnapshotExpirationMs,
+  sandboxSnapshotRetentionCount,
 } from "@/lib/vercel-sandbox-config";
 
 describe("installRequiredSandboxToolsCommand", () => {
@@ -89,5 +103,41 @@ describe("installRequiredSandboxToolsCommand", () => {
       'https://github.com/hyperlocalise/hyperlocalise/releases/download/${HL_VERSION}/${ARCHIVE}" || return 1',
     );
     expect(installRequiredSandboxToolsCommand).toContain("command -v hl >/dev/null 2>&1");
+  });
+});
+
+describe("createConfiguredVercelSandbox", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sandboxMocks.runCommand.mockResolvedValue({ exitCode: 0, output: vi.fn() });
+    sandboxMocks.create.mockResolvedValue({
+      name: "sandbox_123",
+      runCommand: sandboxMocks.runCommand,
+    });
+  });
+
+  it("bounds snapshot growth with an expiration and retention policy", async () => {
+    await createConfiguredVercelSandbox();
+
+    expect(sandboxMocks.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshotExpiration: sandboxSnapshotExpirationMs,
+        keepLastSnapshots: { count: sandboxSnapshotRetentionCount, deleteEvicted: true },
+      }),
+    );
+  });
+
+  it("keeps caller-supplied snapshot settings", async () => {
+    await createConfiguredVercelSandbox({
+      snapshotExpiration: 0,
+      keepLastSnapshots: { count: 1 },
+    });
+
+    expect(sandboxMocks.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshotExpiration: 0,
+        keepLastSnapshots: { count: 1 },
+      }),
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
+++ b/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
@@ -58,6 +58,17 @@ type VercelSandboxCreateOptions = Parameters<typeof Sandbox.create>[0];
 
 export const defaultVercelSandboxRuntime = "node26";
 
+/**
+ * Sandboxes are persistent by default, so every `stop()` (including the
+ * stop/resume recovery path) can mint a snapshot. Expire them on the same
+ * horizon the snapshot cleanup cron sweeps so storage stays bounded even if the
+ * cron is paused.
+ */
+export const sandboxSnapshotExpirationMs = 3 * 24 * 60 * 60 * 1000;
+
+/** Snapshots retained per sandbox; older ones are evicted as new ones are created. Vercel allows 1-10. */
+export const sandboxSnapshotRetentionCount = 3;
+
 const installRipgrepFromGithubRelease = [
   "install_ripgrep_from_github_release() {",
   `  RG_VERSION="${sandboxRipgrepReleaseVersion}"`,
@@ -173,12 +184,19 @@ export async function createConfiguredVercelSandbox(
 ): Promise<Sandbox> {
   const shouldUseDefaultRuntime =
     !("runtime" in options) && !("image" in options) && options.source?.type !== "snapshot";
-  const createOptions: VercelSandboxCreateOptions = shouldUseDefaultRuntime
-    ? ({
-        ...options,
-        runtime: defaultVercelSandboxRuntime,
-      } as VercelSandboxCreateOptions)
-    : options;
+  const createOptions = {
+    ...options,
+    ...(shouldUseDefaultRuntime ? { runtime: defaultVercelSandboxRuntime } : {}),
+    ...("snapshotExpiration" in options ? {} : { snapshotExpiration: sandboxSnapshotExpirationMs }),
+    ...("keepLastSnapshots" in options
+      ? {}
+      : {
+          keepLastSnapshots: {
+            count: sandboxSnapshotRetentionCount,
+            deleteEvicted: true,
+          },
+        }),
+  } as VercelSandboxCreateOptions;
 
   const sandbox = await Sandbox.create(createOptions);
 

--- a/apps/hyperlocalise-web/vercel.json
+++ b/apps/hyperlocalise-web/vercel.json
@@ -7,6 +7,10 @@
     {
       "path": "/api/cron/sandbox-cleanup",
       "schedule": "0 3 * * *"
+    },
+    {
+      "path": "/api/cron/snapshot-cleanup",
+      "schedule": "0 4 * * *"
     }
   ]
 }


### PR DESCRIPTION
## What changed

We reaped Vercel sandboxes but never their snapshots. Sandboxes are persistent by default, so every `stop()` can mint a snapshot — including the stop/resume recovery path in `SandboxLifecycle.recoverSession`, which can fire repeatedly within a single translation job. Nothing created snapshots explicitly (`VercelSandboxRuntime.snapshot()` still throws), and nothing deleted them, so they accumulated with no expiry and no retention cap.

This bounds them two ways.

**Active retention.** `createConfiguredVercelSandbox` now sets `snapshotExpiration` (3 days) and `keepLastSnapshots` (3 per sandbox, `deleteEvicted: true`) on every create, so the platform bounds growth even if the cron is paused. The retention cap is what protects against the stop/resume loop. Caller-supplied values still win.

**Scheduled cleanup.** New `runSnapshotCleanup` mirrors `runSandboxCleanup`: lists oldest-first, breaks at the first snapshot under the age threshold, deletes with bounded concurrency of 5, counts failures without aborting. Two differences — it skips snapshots already in the `deleted` state rather than re-issuing deletes that would inflate the failure count, and it sums `sizeBytes` into `deletedBytes` so each sweep reports how much storage it reclaimed. Exposed at `/api/cron/snapshot-cleanup`, capped by a new `SNAPSHOT_CLEANUP_MAX_PER_TICK` env var (default 100), scheduled at `0 4 * * *` — an hour after sandbox cleanup so snapshots orphaned by that sweep get picked up the same night.

**Retention window.** `SANDBOX_CLEANUP_MAX_AGE_MS` drops from 7 days to 3, matching the new `SNAPSHOT_CLEANUP_MAX_AGE_MS`.

One thing I could not verify from the SDK typings: whether deleting a sandbox cascades to its snapshots. Either way the daily sweep catches orphans within the 3-day window.

## How to test

```
vp check --fix
vp test run src/lib/vercel-sandbox-config.test.ts src/lib/agent-runtime/workspaces/ src/api/routes/cron/ src/lib/translation/sandbox-translation.test.ts
```

52 tests pass across the cleanup modules, cron routes, and sandbox config. New coverage: age-threshold cutoff, already-deleted skip, per-tick limit, partial delete failures, empty result, and the create-time retention defaults plus caller override.

The full suite has 34 unrelated failing files — stale local DB schema (`relation "issue_sheet_activities" does not exist`, clears with `vp run db:migrate`) and pre-existing mobx type errors in `chat-dock-store.ts` from the MobX v7 upgrade in fe55baf88. Both reproduce on a clean tree with this branch stashed.

No Go code changed, so `make fmt`/`make lint`/`make test` do not apply.

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)