### PR TITLE
feat(providers): batch file translate into one sandbox hl run

### DIFF
--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.test.ts
@@ -1,0 +1,446 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+vi.hoisted(() => {
+  process.env.CI = "true";
+});
+
+vi.mock("@/lib/env", () => ({
+  env: {
+    OPENAI_API_KEY: "test-openai-api-key",
+    FILE_STORAGE_PROVIDER: "vercel_blob",
+    FILE_STORAGE_ACCESS: "private",
+  },
+}));
+
+const loadTranslationContextProjectMock = vi.fn();
+const loadProviderCrowdinDownloadContextMock = vi.fn();
+const resolveProviderSourceFileDownloadMock = vi.fn();
+const reuseFileTranslationMemoryEntriesMock = vi.fn();
+
+const createTranslationSandboxMock = vi.fn();
+const prepareSandboxMock = vi.fn();
+const stopTranslationSandboxMock = vi.fn();
+const downloadAttachmentMock = vi.fn();
+const downloadCrowdinSourceInSandboxMock = vi.fn();
+const downloadCrowdinTranslationsInSandboxMock = vi.fn();
+const extractSandboxEntriesMock = vi.fn();
+const readTranslatedFileMock = vi.fn();
+const buildMultiFileMultiLocaleTempConfigMock = vi.fn();
+const buildCrowdinMultiFileSandboxConfigMock = vi.fn();
+const writeTempConfigMock = vi.fn();
+const writeFileToSandboxMock = vi.fn();
+const runSandboxCommandMock = vi.fn();
+const getSandboxTranslationEnvMock = vi.fn();
+const getOutputFilenameMock = vi.fn();
+const getOutputFilenamePatternMock = vi.fn();
+
+vi.mock("@/lib/translation/context", () => ({
+  loadTranslationContextProject: (...args: unknown[]) => loadTranslationContextProjectMock(...args),
+}));
+
+vi.mock("@/lib/providers/jobs/download-provider-source-file", () => ({
+  loadProviderCrowdinDownloadContext: (...args: unknown[]) =>
+    loadProviderCrowdinDownloadContextMock(...args),
+  resolveProviderSourceFileDownload: (...args: unknown[]) =>
+    resolveProviderSourceFileDownloadMock(...args),
+}));
+
+vi.mock("@/lib/translation/file-memory", () => ({
+  reuseFileTranslationMemoryEntries: (...args: unknown[]) =>
+    reuseFileTranslationMemoryEntriesMock(...args),
+}));
+
+vi.mock("@/lib/database", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        innerJoin: () => ({
+          innerJoin: () => ({
+            where: () => ({
+              orderBy: () => ({
+                limit: async () => [],
+              }),
+            }),
+          }),
+        }),
+      }),
+    }),
+  },
+  schema: {
+    glossaryTerms: {
+      sourceTerm: "sourceTerm",
+      targetTerm: "targetTerm",
+      description: "description",
+      forbidden: "forbidden",
+      caseSensitive: "caseSensitive",
+      glossaryId: "glossaryId",
+      reviewStatus: "reviewStatus",
+    },
+    glossaries: {
+      id: "id",
+      targetLocale: "targetLocale",
+      sourceLocale: "sourceLocale",
+      status: "status",
+    },
+    projectGlossaries: {
+      projectId: "projectId",
+      glossaryId: "glossaryId",
+      priority: "priority",
+    },
+  },
+}));
+
+vi.mock("@/lib/translation/sandbox", () => ({
+  createTranslationSandbox: (...args: unknown[]) => createTranslationSandboxMock(...args),
+  prepareSandbox: (...args: unknown[]) => prepareSandboxMock(...args),
+  stopTranslationSandbox: (...args: unknown[]) => stopTranslationSandboxMock(...args),
+  downloadAttachment: (...args: unknown[]) => downloadAttachmentMock(...args),
+  downloadCrowdinSourceInSandbox: (...args: unknown[]) =>
+    downloadCrowdinSourceInSandboxMock(...args),
+  downloadCrowdinTranslationsInSandbox: (...args: unknown[]) =>
+    downloadCrowdinTranslationsInSandboxMock(...args),
+  extractSandboxEntries: (...args: unknown[]) => extractSandboxEntriesMock(...args),
+  readTranslatedFile: (...args: unknown[]) => readTranslatedFileMock(...args),
+  buildMultiFileMultiLocaleTempConfig: (...args: unknown[]) =>
+    buildMultiFileMultiLocaleTempConfigMock(...args),
+  buildCrowdinMultiFileSandboxConfig: (...args: unknown[]) =>
+    buildCrowdinMultiFileSandboxConfigMock(...args),
+  writeTempConfig: (...args: unknown[]) => writeTempConfigMock(...args),
+  writeFileToSandbox: (...args: unknown[]) => writeFileToSandboxMock(...args),
+  runSandboxCommand: (...args: unknown[]) => runSandboxCommandMock(...args),
+  getSandboxTranslationEnv: (...args: unknown[]) => getSandboxTranslationEnvMock(...args),
+  getOutputFilename: (...args: unknown[]) => getOutputFilenameMock(...args),
+  getOutputFilenamePattern: (...args: unknown[]) => getOutputFilenamePatternMock(...args),
+  sandboxI18nConfigPath: ".hl-sandbox-i18n.yml",
+}));
+
+import {
+  isProviderFileFullyTranslated,
+  mergeLocaleKeyedPrefills,
+  translateProviderJobFiles,
+} from "./provider-agent-file-translate";
+
+describe("isProviderFileFullyTranslated", () => {
+  it("returns true when every unit has a translation for every locale", () => {
+    expect(
+      isProviderFileFullyTranslated({
+        targetLocales: ["fr", "de"],
+        units: [
+          {
+            externalStringId: "1",
+            key: "hello",
+            sourceText: "Hello",
+            fileId: "file-1",
+            translations: [
+              { locale: "fr", text: "Bonjour" },
+              { locale: "de", text: "Hallo" },
+            ],
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when any unit/locale is missing a translation", () => {
+    expect(
+      isProviderFileFullyTranslated({
+        targetLocales: ["fr", "de"],
+        units: [
+          {
+            externalStringId: "1",
+            key: "hello",
+            sourceText: "Hello",
+            fileId: "file-1",
+            translations: [{ locale: "fr", text: "Bonjour" }],
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("treats blank translations as missing", () => {
+    expect(
+      isProviderFileFullyTranslated({
+        targetLocales: ["fr"],
+        units: [
+          {
+            externalStringId: "1",
+            key: "hello",
+            sourceText: "Hello",
+            fileId: "file-1",
+            translations: [{ locale: "fr", text: "   " }],
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("mergeLocaleKeyedPrefills", () => {
+  it("keeps identical values and drops conflicting keys", () => {
+    expect(
+      mergeLocaleKeyedPrefills([
+        { fr: { hello: "Bonjour", save: "Enregistrer" } },
+        { fr: { hello: "Bonjour", save: "Sauver" } },
+      ]),
+    ).toEqual({
+      fr: { hello: "Bonjour" },
+    });
+  });
+});
+
+describe("translateProviderJobFiles", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadTranslationContextProjectMock.mockResolvedValue({
+      name: "Demo",
+      translationContext: "App UI",
+    });
+    loadProviderCrowdinDownloadContextMock.mockResolvedValue({
+      ok: true,
+      externalProjectId: "123",
+      secretMaterial: "secret",
+      baseUrl: null,
+    });
+    resolveProviderSourceFileDownloadMock.mockResolvedValue({
+      ok: true,
+      downloadUrl: "https://example.com/file.json",
+      filename: "messages.json",
+      fileFormat: "json",
+    });
+    reuseFileTranslationMemoryEntriesMock.mockResolvedValue({});
+    createTranslationSandboxMock.mockResolvedValue({ sandboxId: "sandbox_shared" });
+    prepareSandboxMock.mockResolvedValue(undefined);
+    stopTranslationSandboxMock.mockResolvedValue(undefined);
+    downloadAttachmentMock.mockResolvedValue(undefined);
+    downloadCrowdinSourceInSandboxMock.mockResolvedValue({ ok: true });
+    downloadCrowdinTranslationsInSandboxMock.mockResolvedValue({ ok: false });
+    buildCrowdinMultiFileSandboxConfigMock.mockReturnValue("crowdin-config");
+    buildMultiFileMultiLocaleTempConfigMock.mockReturnValue("i18n-config");
+    writeTempConfigMock.mockResolvedValue(undefined);
+    writeFileToSandboxMock.mockResolvedValue(undefined);
+    getSandboxTranslationEnvMock.mockReturnValue({});
+    runSandboxCommandMock.mockResolvedValue({ exitCode: 0, output: "" });
+    getOutputFilenamePatternMock.mockImplementation(
+      (filename: string) => `${filename.replace(/\.json$/, "")}-{{target}}.json`,
+    );
+    getOutputFilenameMock.mockImplementation(
+      (filename: string, locale: string) => `${filename.replace(/\.json$/, "")}-${locale}.json`,
+    );
+    readTranslatedFileMock.mockImplementation(async (_sandboxId: string, path: string) => {
+      if (path.includes("file-1") && path.includes("-fr")) {
+        return Buffer.from('{"hello":"Bonjour"}', "utf8");
+      }
+      if (path.includes("file-2") && path.includes("-fr")) {
+        return Buffer.from('{"bye":"Au revoir"}', "utf8");
+      }
+      if (path.includes("file-pending") && path.includes("-fr")) {
+        return Buffer.from('{"bye":"Au revoir"}', "utf8");
+      }
+      if (path.includes("file-1")) {
+        return Buffer.from('{"hello":"Hello"}', "utf8");
+      }
+      if (path.includes("file-2") || path.includes("file-pending")) {
+        return Buffer.from('{"bye":"Goodbye"}', "utf8");
+      }
+      return Buffer.from("{}", "utf8");
+    });
+    extractSandboxEntriesMock.mockImplementation(async (_sandboxId: string, path: string) => {
+      if (path.includes("file-1") && path.includes("-fr")) {
+        return { ok: true, entries: { hello: "Bonjour" } };
+      }
+      if ((path.includes("file-2") || path.includes("file-pending")) && path.includes("-fr")) {
+        return { ok: true, entries: { bye: "Au revoir" } };
+      }
+      if (path.includes("file-1")) {
+        return { ok: true, entries: { hello: "Hello" } };
+      }
+      if (path.includes("file-2") || path.includes("file-pending")) {
+        return { ok: true, entries: { bye: "Goodbye" } };
+      }
+      return { ok: true, entries: {} };
+    });
+  });
+
+  it("skips sandbox creation when every source file is already fully translated", async () => {
+    const result = await translateProviderJobFiles({
+      organizationId: "org_1",
+      projectId: "project_1",
+      providerKind: "crowdin",
+      sourceFiles: [
+        {
+          id: "file-1",
+          displayName: "messages.json",
+          sourcePath: "locales/messages.json",
+        },
+      ],
+      content: {
+        externalJobId: "task-1",
+        sourceLocale: "en",
+        targetLocales: ["fr"],
+        units: [
+          {
+            externalStringId: "1",
+            key: "hello",
+            sourceText: "Hello",
+            fileId: "file-1",
+            translations: [{ locale: "fr", text: "Bonjour" }],
+          },
+        ],
+      },
+    });
+
+    expect(result).toMatchObject({
+      filesProcessed: 0,
+      unitsProcessed: 0,
+      skippedExistingLocales: 1,
+      changedItems: [],
+    });
+    expect(createTranslationSandboxMock).not.toHaveBeenCalled();
+    expect(stopTranslationSandboxMock).not.toHaveBeenCalled();
+  });
+
+  it("runs one multi-file hl config for multiple pending files", async () => {
+    const result = await translateProviderJobFiles({
+      organizationId: "org_1",
+      projectId: "project_1",
+      providerKind: "crowdin",
+      sourceFiles: [
+        {
+          id: "file-1",
+          displayName: "a.json",
+          sourcePath: "locales/a.json",
+        },
+        {
+          id: "file-2",
+          displayName: "b.json",
+          sourcePath: "locales/b.json",
+        },
+      ],
+      content: {
+        externalJobId: "task-1",
+        sourceLocale: "en",
+        targetLocales: ["fr"],
+        units: [
+          {
+            externalStringId: "1",
+            key: "hello",
+            sourceText: "Hello",
+            fileId: "file-1",
+            translations: [],
+          },
+          {
+            externalStringId: "2",
+            key: "bye",
+            sourceText: "Goodbye",
+            fileId: "file-2",
+            translations: [],
+          },
+        ],
+      },
+    });
+
+    expect(createTranslationSandboxMock).toHaveBeenCalledTimes(1);
+    expect(prepareSandboxMock).toHaveBeenCalledTimes(1);
+    expect(stopTranslationSandboxMock).toHaveBeenCalledTimes(1);
+    expect(buildMultiFileMultiLocaleTempConfigMock).toHaveBeenCalledTimes(1);
+    expect(buildMultiFileMultiLocaleTempConfigMock).toHaveBeenCalledWith(
+      [
+        {
+          from: "work_file-1_a.json",
+          to: "work_file-1_a-{{target}}.json",
+        },
+        {
+          from: "work_file-2_b.json",
+          to: "work_file-2_b-{{target}}.json",
+        },
+      ],
+      "en",
+      ["fr"],
+      null,
+      expect.objectContaining({ projectName: "Demo" }),
+    );
+    expect(runSandboxCommandMock).toHaveBeenCalledTimes(1);
+    expect(result.filesProcessed).toBe(2);
+    expect(result.unitsProcessed).toBe(2);
+    expect(result.changedItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: "hello", to: "Bonjour" }),
+        expect.objectContaining({ key: "bye", to: "Au revoir" }),
+      ]),
+    );
+  });
+
+  it("does not create a sandbox for fully translated files mixed with pending files", async () => {
+    const result = await translateProviderJobFiles({
+      organizationId: "org_1",
+      projectId: "project_1",
+      providerKind: "crowdin",
+      sourceFiles: [
+        {
+          id: "file-done",
+          displayName: "done.json",
+          sourcePath: "locales/done.json",
+        },
+        {
+          id: "file-pending",
+          displayName: "pending.json",
+          sourcePath: "locales/pending.json",
+        },
+      ],
+      content: {
+        externalJobId: "task-1",
+        sourceLocale: "en",
+        targetLocales: ["fr"],
+        units: [
+          {
+            externalStringId: "1",
+            key: "hello",
+            sourceText: "Hello",
+            fileId: "file-done",
+            translations: [{ locale: "fr", text: "Bonjour" }],
+          },
+          {
+            externalStringId: "2",
+            key: "bye",
+            sourceText: "Goodbye",
+            fileId: "file-pending",
+            translations: [],
+          },
+        ],
+      },
+    });
+
+    expect(createTranslationSandboxMock).toHaveBeenCalledTimes(1);
+    expect(downloadCrowdinSourceInSandboxMock).toHaveBeenCalledTimes(1);
+    expect(downloadCrowdinSourceInSandboxMock).toHaveBeenCalledWith(
+      expect.objectContaining({ externalFileId: "file-pending" }),
+    );
+    expect(buildMultiFileMultiLocaleTempConfigMock).toHaveBeenCalledWith(
+      [
+        {
+          from: "work_file-pending_pending.json",
+          to: "work_file-pending_pending-{{target}}.json",
+        },
+      ],
+      "en",
+      ["fr"],
+      null,
+      expect.any(Object),
+    );
+    expect(result.filesProcessed).toBe(1);
+    expect(result.skippedExistingLocales).toBe(1);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.test.ts
@@ -189,14 +189,42 @@ describe("isProviderFileFullyTranslated", () => {
 });
 
 describe("mergeLocaleKeyedPrefills", () => {
-  it("keeps identical values and drops conflicting keys", () => {
+  it("keeps prefills for keys owned by a single file", () => {
     expect(
       mergeLocaleKeyedPrefills([
-        { fr: { hello: "Bonjour", save: "Enregistrer" } },
-        { fr: { hello: "Bonjour", save: "Sauver" } },
+        { entryKeys: ["hello"], prefillsByLocale: { fr: { hello: "Bonjour" } } },
+        { entryKeys: ["bye"], prefillsByLocale: { fr: { bye: "Au revoir" } } },
       ]),
     ).toEqual({
-      fr: { hello: "Bonjour" },
+      fr: { hello: "Bonjour", bye: "Au revoir" },
+    });
+  });
+
+  it("drops keys shared by more than one file even when the values agree", () => {
+    expect(
+      mergeLocaleKeyedPrefills([
+        {
+          entryKeys: ["hello", "save"],
+          prefillsByLocale: { fr: { hello: "Bonjour", save: "Enregistrer" } },
+        },
+        {
+          entryKeys: ["hello", "save"],
+          prefillsByLocale: { fr: { hello: "Bonjour", save: "Sauver" } },
+        },
+      ]),
+    ).toEqual({
+      fr: {},
+    });
+  });
+
+  it("drops a key another file owns even when only one file has a prefill for it", () => {
+    expect(
+      mergeLocaleKeyedPrefills([
+        { entryKeys: ["title"], prefillsByLocale: { fr: { title: "Titre" } } },
+        { entryKeys: ["title"], prefillsByLocale: { fr: {} } },
+      ]),
+    ).toEqual({
+      fr: {},
     });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
@@ -121,6 +121,42 @@ function unitsForFile(units: ExternalTmsTranslationUnit[], externalFileId: strin
   return units.filter((unit) => unit.fileId === externalFileId);
 }
 
+/** True when every unit already has a non-empty translation for every target locale. */
+export function isProviderFileFullyTranslated(input: {
+  units: ExternalTmsTranslationUnit[];
+  targetLocales: string[];
+}): boolean {
+  if (input.units.length === 0 || input.targetLocales.length === 0) {
+    return true;
+  }
+
+  for (const targetLocale of input.targetLocales) {
+    for (const unit of input.units) {
+      const existing = existingTranslationForLocale(unit, targetLocale);
+      if (!shouldSkipExistingTranslation(existing)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+function countExistingTranslationsForFile(
+  units: ExternalTmsTranslationUnit[],
+  targetLocales: string[],
+): number {
+  let count = 0;
+  for (const targetLocale of targetLocales) {
+    for (const unit of units) {
+      if (shouldSkipExistingTranslation(existingTranslationForLocale(unit, targetLocale))) {
+        count += 1;
+      }
+    }
+  }
+  return count;
+}
+
 export function summarizeProviderUnitFileIds(units: ExternalTmsTranslationUnit[]) {
   const countsByFileId = new Map<string, number>();
   for (const unit of units) {
@@ -151,7 +187,7 @@ function buildGlossaryContext(input: {
   projectName: string;
   projectTranslationContext: string;
   glossaryTerms: SandboxTranslationContext["glossaryTerms"];
-  targetLocale: string;
+  targetLocales: string[];
 }): SandboxTranslationContext {
   const attachedTerms = (input.glossaryTerms ?? []).filter((term) =>
     sourceContainsTerm(input.sourceText, {
@@ -160,85 +196,112 @@ function buildGlossaryContext(input: {
     }),
   );
 
+  const targetLocaleSet = new Set(input.targetLocales);
   return {
     projectName: input.projectName,
     projectTranslationContext: input.projectTranslationContext,
     glossaryTerms: attachedTerms
-      .filter((term) => term.targetLocale === input.targetLocale)
+      .filter((term) => targetLocaleSet.has(term.targetLocale))
       .slice(0, 50),
   };
 }
 
-async function runFileTranslationInSandbox(input: {
+function sandboxWorkFilename(fileId: string, basename: string): string {
+  return `work_${sanitizeSandboxFilename(fileId)}_${sanitizeSandboxFilename(basename)}`;
+}
+
+/** Merge per-file prefills; drop keys that conflict across files for the same locale. */
+export function mergeLocaleKeyedPrefills(
+  filePrefills: Array<Record<string, Record<string, string>>>,
+): Record<string, Record<string, string>> {
+  const merged: Record<string, Record<string, string>> = {};
+  const conflicts = new Set<string>();
+
+  for (const byLocale of filePrefills) {
+    for (const [locale, entries] of Object.entries(byLocale)) {
+      const localeMap = (merged[locale] ??= {});
+      for (const [key, value] of Object.entries(entries)) {
+        const conflictKey = `${locale}\0${key}`;
+        if (conflicts.has(conflictKey)) {
+          continue;
+        }
+        const existing = localeMap[key];
+        if (existing === undefined) {
+          localeMap[key] = value;
+          continue;
+        }
+        if (existing !== value) {
+          delete localeMap[key];
+          conflicts.add(conflictKey);
+        }
+      }
+    }
+  }
+
+  return merged;
+}
+
+async function runMultiFileTranslationInSandbox(input: {
   sandboxId: string;
-  sourceFilename: string;
+  files: Array<{ from: string; to: string }>;
   sourceLocale: string;
-  targetLocale: string;
+  targetLocales: string[];
   context: SandboxTranslationContext;
-  prefilledEntries: Record<string, string>;
+  prefilledByLocale: Record<string, Record<string, string>>;
 }) {
   const {
-    buildTempConfig,
-    extractSandboxEntries,
-    getSandboxOutputFilename,
+    buildMultiFileMultiLocaleTempConfig,
     getSandboxTranslationEnv,
-    readTranslatedFile,
     runSandboxCommand,
     sandboxI18nConfigPath,
     writeFileToSandbox,
     writeTempConfig,
   } = await import("@/lib/translation/sandbox");
 
-  const inputFilename = sanitizeSandboxFilename(input.sourceFilename);
-  const outputFilename = getSandboxOutputFilename(input.sourceFilename, input.targetLocale);
-
-  const config = buildTempConfig(
-    inputFilename,
-    outputFilename,
+  const config = buildMultiFileMultiLocaleTempConfig(
+    input.files,
     input.sourceLocale,
-    input.targetLocale,
+    input.targetLocales,
     null,
     input.context,
   );
   await writeTempConfig(input.sandboxId, config, sandboxI18nConfigPath);
 
-  const prefilledPath = `/tmp/prefilled-${input.targetLocale}.json`;
   let prefilledFlags = "";
-  if (Object.keys(input.prefilledEntries).length > 0) {
+  const localesWithPrefill = Object.entries(input.prefilledByLocale).filter(
+    ([, entries]) => Object.keys(entries).length > 0,
+  );
+  if (localesWithPrefill.length > 0) {
+    const nested: Record<string, Record<string, string>> = {};
+    for (const [locale, entries] of localesWithPrefill) {
+      nested[locale] = entries;
+    }
+    const prefilledPath = "/tmp/prefilled-by-locale.json";
     await writeFileToSandbox(
       input.sandboxId,
       prefilledPath,
-      Buffer.from(JSON.stringify(input.prefilledEntries), "utf8"),
+      Buffer.from(JSON.stringify(nested), "utf8"),
     );
-    prefilledFlags = ` --prefilled-entries '${shellSingleQuote(prefilledPath)}' --prefilled-target-path '${shellSingleQuote(outputFilename)}'`;
+    prefilledFlags = ` --prefilled-entries '${shellSingleQuote(prefilledPath)}'`;
   }
+
+  const localeFlags = input.targetLocales
+    .map((locale) => `--locale '${shellSingleQuote(locale)}'`)
+    .join(" ");
 
   const translation = await runSandboxCommand(
     input.sandboxId,
     "bash",
     [
       "-lc",
-      `hl run --config '${shellSingleQuote(sandboxI18nConfigPath)}' --locale '${shellSingleQuote(input.targetLocale)}' --force --progress off${prefilledFlags}`,
+      `hl run --config '${shellSingleQuote(sandboxI18nConfigPath)}' ${localeFlags} --force --progress off${prefilledFlags}`,
     ],
     { env: getSandboxTranslationEnv() },
   );
 
   if (translation.exitCode !== 0) {
-    throw new Error(`translation failed for ${input.targetLocale}: ${translation.output}`);
+    throw new Error(`translation failed: ${translation.output}`);
   }
-
-  const translatedContent = await readTranslatedFile(input.sandboxId, outputFilename);
-  const translatedEntries = await extractSandboxEntries(input.sandboxId, outputFilename);
-  if (!translatedEntries.ok) {
-    throw new Error(
-      `failed to extract translated entries: ${outputFilename}: exitCode=${translatedEntries.exitCode}`,
-    );
-  }
-
-  return {
-    translatedText: translatedContent.toString("utf8"),
-    translatedEntries: translatedEntries.entries,
-  };
 }
 
 export function shouldUseProviderFileTranslation(input: { sourceFiles: ProviderSourceFileRef[] }) {
@@ -294,6 +357,7 @@ export async function translateProviderJobFiles(input: {
   let filesProcessed = 0;
   let skippedMissingSourcePathCount = 0;
   let skippedNoMatchingUnitsCount = 0;
+  let skippedFullyTranslatedCount = 0;
   let skippedDownloadFailureCount = 0;
 
   logger.info(
@@ -325,6 +389,15 @@ export async function translateProviderJobFiles(input: {
         })
       : null;
 
+  type PendingFileWork = {
+    sourceFile: ProviderSourceFileRef;
+    fileUnits: ExternalTmsTranslationUnit[];
+    inputFilename: string;
+    downloadUrl: string | null;
+  };
+
+  const pendingFiles: PendingFileWork[] = [];
+
   for (const sourceFile of input.sourceFiles) {
     if (!sourceFile.sourcePath?.trim()) {
       skippedMissingSourcePathCount += 1;
@@ -354,6 +427,26 @@ export async function translateProviderJobFiles(input: {
           reason: "no_units_for_file",
         },
         "provider agent file translation skipped source file with no matching units",
+      );
+      continue;
+    }
+
+    if (isProviderFileFullyTranslated({ units: fileUnits, targetLocales })) {
+      const existingCount = countExistingTranslationsForFile(fileUnits, targetLocales);
+      skippedExistingLocales += existingCount;
+      skippedFullyTranslatedCount += 1;
+      logger.info(
+        {
+          ...logContext,
+          sourceFileId: sourceFile.id,
+          displayName: sourceFile.displayName,
+          sourcePath: sourceFile.sourcePath,
+          matchingUnitCount: fileUnits.length,
+          targetLocaleCount: targetLocales.length,
+          skippedExistingLocales: existingCount,
+          reason: "file_fully_translated",
+        },
+        "provider agent file translation skipped fully translated source file before sandbox",
       );
       continue;
     }
@@ -421,243 +514,357 @@ export async function translateProviderJobFiles(input: {
       continue;
     }
 
+    pendingFiles.push({
+      sourceFile,
+      fileUnits,
+      inputFilename,
+      downloadUrl: resolvedDownload?.ok ? resolvedDownload.downloadUrl : null,
+    });
+  }
+
+  if (pendingFiles.length > 0) {
     const {
+      buildCrowdinMultiFileSandboxConfig,
       createTranslationSandbox,
       downloadAttachment,
       downloadCrowdinSourceInSandbox,
       downloadCrowdinTranslationsInSandbox,
       extractSandboxEntries,
-      getSandboxOutputFilename,
+      getOutputFilename,
+      getOutputFilenamePattern,
       prepareSandbox,
       readTranslatedFile,
       stopTranslationSandbox,
+      writeFileToSandbox,
     } = await import("@/lib/translation/sandbox");
+
+    type PreparedFile = {
+      sourceFile: ProviderSourceFileRef;
+      fileUnits: ExternalTmsTranslationUnit[];
+      workFilename: string;
+      outputPattern: string;
+      sourceText: string;
+      sourceEntries: Record<string, string> | null;
+      localesNeedingByLocale: Map<string, ExternalTmsTranslationUnit[]>;
+    };
+
     const { sandboxId } = await createTranslationSandbox();
-
-    let sourceText = "";
-    let sourceEntries: Record<string, string> | null = null;
-
     try {
       await prepareSandbox(sandboxId);
 
-      if (crowdinContext?.ok) {
-        await downloadCrowdinSourceInSandbox({
-          sandboxId,
-          externalFileId: sourceFile.id,
-          sourceFilename: inputFilename,
-          externalProjectId: crowdinContext.externalProjectId,
-          secretMaterial: crowdinContext.secretMaterial,
-          baseUrl: crowdinContext.baseUrl,
-        });
-      } else if (resolvedDownload?.ok) {
-        await downloadAttachment(sandboxId, resolvedDownload.downloadUrl, inputFilename);
-      }
+      const preparedFiles: PreparedFile[] = [];
 
-      const sourceContent = await readTranslatedFile(sandboxId, inputFilename);
-      sourceText = sourceContent.toString("utf8");
+      for (const pending of pendingFiles) {
+        const { sourceFile, fileUnits, inputFilename, downloadUrl } = pending;
+        const workFilename = sandboxWorkFilename(sourceFile.id, inputFilename);
 
-      filesProcessed += 1;
-      logger.info(
-        {
-          ...logContext,
-          sourceFileId: sourceFile.id,
-          displayName: sourceFile.displayName,
-          sourcePath: sourceFile.sourcePath,
-          matchingUnitCount: fileUnits.length,
-          byteLength: sourceContent.byteLength,
-          sandboxId,
-          downloadMethod: crowdinContext?.ok ? "hl-crowdin-download-sources" : "curl",
-        },
-        "provider agent file translation downloaded source file in sandbox",
-      );
-
-      try {
-        const extracted = await extractSandboxEntries(sandboxId, inputFilename);
-        if (extracted.ok) {
-          sourceEntries = extracted.entries;
-        } else {
-          warnings.push(
-            `Could not extract entries for ${sourceFile.displayName ?? sourceFile.id}: exitCode=${extracted.exitCode}`,
-          );
-        }
-      } catch (error) {
-        warnings.push(
-          `Could not extract entries for ${sourceFile.displayName ?? sourceFile.id}: ${
-            error instanceof Error ? error.message : "unknown error"
-          }`,
-        );
-      }
-
-      const fileGlossaryTerms = await loadFileGlossaryTerms({
-        projectId: input.projectId,
-        sourceLocale,
-        targetLocales,
-        sourceText,
-      });
-
-      for (const targetLocale of targetLocales) {
-        const localesNeedingTranslation = fileUnits.filter((unit) => {
-          const existing = existingTranslationForLocale(unit, targetLocale);
-          if (shouldSkipExistingTranslation(existing)) {
-            skippedExistingLocales += 1;
-            return false;
+        try {
+          if (crowdinContext?.ok) {
+            await downloadCrowdinSourceInSandbox({
+              sandboxId,
+              externalFileId: sourceFile.id,
+              sourceFilename: workFilename,
+              externalProjectId: crowdinContext.externalProjectId,
+              secretMaterial: crowdinContext.secretMaterial,
+              baseUrl: crowdinContext.baseUrl,
+            });
+          } else if (downloadUrl) {
+            await downloadAttachment(sandboxId, downloadUrl, workFilename);
           }
-          return true;
-        });
-        unitsProcessed += localesNeedingTranslation.length;
 
-        if (localesNeedingTranslation.length === 0) {
+          const sourceContent = await readTranslatedFile(sandboxId, workFilename);
+          const sourceText = sourceContent.toString("utf8");
+          let sourceEntries: Record<string, string> | null = null;
+
+          filesProcessed += 1;
           logger.info(
             {
               ...logContext,
               sourceFileId: sourceFile.id,
-              targetLocale,
+              displayName: sourceFile.displayName,
+              sourcePath: sourceFile.sourcePath,
               matchingUnitCount: fileUnits.length,
-              reason: "all_units_already_translated",
+              byteLength: sourceContent.byteLength,
+              sandboxId,
+              workFilename,
+              downloadMethod: crowdinContext?.ok ? "hl-crowdin-download-sources" : "curl",
             },
-            "provider agent file translation skipped locale because all units already have translations",
+            "provider agent file translation downloaded source file in sandbox",
           );
-          continue;
-        }
 
-        const existingPrefilled = buildPrefilledEntriesForLocale({
-          units: fileUnits,
-          targetLocale,
-        });
-        let tmPrefilled: Record<string, string> = {};
-        if (sourceEntries) {
-          tmPrefilled = await reuseFileTranslationMemoryEntries({
-            projectId: input.projectId,
-            sourceLocale,
-            targetLocale,
-            sourceEntries,
-          });
-        }
-
-        let crowdinPrefilled: Record<string, string> = {};
-        if (crowdinContext?.ok) {
-          const outputFilename = getSandboxOutputFilename(inputFilename, targetLocale);
-          const downloadResult = await downloadCrowdinTranslationsInSandbox({
-            sandboxId,
-            targetLocale,
-            externalProjectId: crowdinContext.externalProjectId,
-            secretMaterial: crowdinContext.secretMaterial,
-            baseUrl: crowdinContext.baseUrl,
-            mergeApproved: true,
-          });
-          if (downloadResult.ok) {
-            const crowdinEntries = await extractSandboxEntries(sandboxId, outputFilename);
-            crowdinPrefilled = crowdinEntries.ok ? crowdinEntries.entries : {};
-          }
-        }
-
-        const prefilledEntries = { ...tmPrefilled, ...crowdinPrefilled, ...existingPrefilled };
-
-        const localeContext = buildGlossaryContext({
-          sourceText,
-          projectName: project.name,
-          projectTranslationContext: project.translationContext,
-          glossaryTerms: fileGlossaryTerms,
-          targetLocale,
-        });
-
-        try {
-          const { translatedText, translatedEntries } = await runFileTranslationInSandbox({
-            sandboxId,
-            sourceFilename: inputFilename,
-            sourceLocale,
-            targetLocale,
-            context: localeContext,
-            prefilledEntries,
-          });
-
-          const glossaryFailures = validateGlossaryTermsInTranslation({
-            sourceText,
-            translatedText,
-            terms: (localeContext.glossaryTerms ?? []).map((term) => ({
-              sourceTerm: term.sourceTerm,
-              targetTerm: term.targetTerm,
-              targetLocale: term.targetLocale,
-              forbidden: term.forbidden ?? null,
-              caseSensitive: term.caseSensitive ?? null,
-            })),
-          });
-          if (glossaryFailures.length > 0) {
-            warnings.push(
-              `Glossary validation failed for ${sourceFile.displayName ?? sourceFile.id} (${targetLocale})`,
-            );
-          }
-
-          for (const unit of localesNeedingTranslation) {
-            const existing = existingTranslationForLocale(unit, targetLocale);
-            const from = existing?.text ?? "";
-            const to = translatedEntries[unit.key] ?? from;
-            if (!to.trim() || to === from) {
-              continue;
+          try {
+            const extracted = await extractSandboxEntries(sandboxId, workFilename);
+            if (extracted.ok) {
+              sourceEntries = extracted.entries;
+            } else {
+              warnings.push(
+                `Could not extract entries for ${sourceFile.displayName ?? sourceFile.id}: exitCode=${extracted.exitCode}`,
+              );
             }
-
-            const proposalWarnings = detectAgentRunProposalWarnings({
-              sourceText: unit.sourceText,
-              from,
-              to,
-              locale: targetLocale,
-              externalStringId: unit.externalStringId,
-              key: unit.key,
-              glossaryTerms: (localeContext.glossaryTerms ?? []).map((term) => ({
-                sourceTerm: term.sourceTerm,
-                targetTerm: term.targetTerm,
-                targetLocale: term.targetLocale,
-                forbidden: term.forbidden,
-                caseSensitive: term.caseSensitive,
-              })),
-            });
-
-            changedItems.push(
-              serializeAgentRunProposalItem({
-                itemId: buildAgentRunProposalItemId({
-                  externalStringId: unit.externalStringId,
-                  locale: targetLocale,
-                }),
-                externalStringId: unit.externalStringId,
-                key: unit.key,
-                locale: targetLocale,
-                sourceText: unit.sourceText,
-                from,
-                to,
-                reviewState: "pending",
-                changedFields: deriveChangedFields(from, to),
-                warnings: proposalWarnings,
-              }),
+          } catch (error) {
+            warnings.push(
+              `Could not extract entries for ${sourceFile.displayName ?? sourceFile.id}: ${
+                error instanceof Error ? error.message : "unknown error"
+              }`,
             );
           }
+
+          const localesNeedingByLocale = new Map<string, ExternalTmsTranslationUnit[]>();
+          for (const targetLocale of targetLocales) {
+            const localesNeedingTranslation = fileUnits.filter((unit) => {
+              const existing = existingTranslationForLocale(unit, targetLocale);
+              if (shouldSkipExistingTranslation(existing)) {
+                skippedExistingLocales += 1;
+                return false;
+              }
+              return true;
+            });
+            unitsProcessed += localesNeedingTranslation.length;
+            if (localesNeedingTranslation.length > 0) {
+              localesNeedingByLocale.set(targetLocale, localesNeedingTranslation);
+            }
+          }
+
+          if (localesNeedingByLocale.size === 0) {
+            continue;
+          }
+
+          preparedFiles.push({
+            sourceFile,
+            fileUnits,
+            workFilename,
+            outputPattern: getOutputFilenamePattern(workFilename),
+            sourceText,
+            sourceEntries,
+            localesNeedingByLocale,
+          });
         } catch (error) {
+          skippedDownloadFailureCount += 1;
+          logger.warn(
+            {
+              ...logContext,
+              sourceFileId: sourceFile.id,
+              displayName: sourceFile.displayName,
+              sourcePath: sourceFile.sourcePath,
+              matchingUnitCount: fileUnits.length,
+              sandboxId,
+              reason: "sandbox_source_file_download_failed",
+              err: error instanceof Error ? error.message : "unknown error",
+            },
+            "provider agent file translation skipped source file after sandbox download failure",
+          );
           warnings.push(
-            `File translation failed for ${sourceFile.displayName ?? sourceFile.id} (${targetLocale}): ${
-              error instanceof Error ? error.message : "unknown error"
+            `Skipped file ${sourceFile.displayName ?? sourceFile.id}: ${
+              error instanceof Error ? error.message : "sandbox download failed"
             }`,
           );
         }
       }
-    } catch (error) {
-      skippedDownloadFailureCount += 1;
-      logger.warn(
-        {
-          ...logContext,
-          sourceFileId: sourceFile.id,
-          displayName: sourceFile.displayName,
-          sourcePath: sourceFile.sourcePath,
-          matchingUnitCount: fileUnits.length,
-          sandboxId,
-          reason: "sandbox_source_file_download_failed",
-          err: error instanceof Error ? error.message : "unknown error",
-        },
-        "provider agent file translation skipped source file after sandbox download failure",
-      );
-      warnings.push(
-        `Skipped file ${sourceFile.displayName ?? sourceFile.id}: ${
-          error instanceof Error ? error.message : "sandbox download failed"
-        }`,
-      );
+
+      if (preparedFiles.length > 0) {
+        const localesToRun = [
+          ...new Set(preparedFiles.flatMap((file) => [...file.localesNeedingByLocale.keys()])),
+        ].toSorted();
+
+        const combinedSourceText = preparedFiles.map((file) => file.sourceText).join("\n");
+        const glossaryTerms = await loadFileGlossaryTerms({
+          projectId: input.projectId,
+          sourceLocale,
+          targetLocales: localesToRun,
+          sourceText: combinedSourceText,
+        });
+        const batchContext = buildGlossaryContext({
+          sourceText: combinedSourceText,
+          projectName: project.name,
+          projectTranslationContext: project.translationContext,
+          glossaryTerms,
+          targetLocales: localesToRun,
+        });
+
+        const filePrefills: Array<Record<string, Record<string, string>>> = [];
+        for (const prepared of preparedFiles) {
+          const byLocale: Record<string, Record<string, string>> = {};
+          for (const targetLocale of localesToRun) {
+            const existingPrefilled = buildPrefilledEntriesForLocale({
+              units: prepared.fileUnits,
+              targetLocale,
+            });
+            let tmPrefilled: Record<string, string> = {};
+            if (prepared.sourceEntries) {
+              tmPrefilled = await reuseFileTranslationMemoryEntries({
+                projectId: input.projectId,
+                sourceLocale,
+                targetLocale,
+                sourceEntries: prepared.sourceEntries,
+              });
+            }
+            byLocale[targetLocale] = { ...tmPrefilled, ...existingPrefilled };
+          }
+          filePrefills.push(byLocale);
+        }
+
+        if (crowdinContext?.ok) {
+          const crowdinConfig = buildCrowdinMultiFileSandboxConfig({
+            sourceFilenames: preparedFiles.map((file) => file.workFilename),
+            includeBaseUrl: Boolean(crowdinContext.baseUrl?.trim()),
+          });
+          await writeFileToSandbox(
+            sandboxId,
+            "/tmp/crowdin.yml",
+            Buffer.from(crowdinConfig, "utf8"),
+          );
+
+          for (const targetLocale of localesToRun) {
+            const downloadResult = await downloadCrowdinTranslationsInSandbox({
+              sandboxId,
+              targetLocale,
+              externalProjectId: crowdinContext.externalProjectId,
+              secretMaterial: crowdinContext.secretMaterial,
+              baseUrl: crowdinContext.baseUrl,
+              mergeApproved: true,
+            });
+            if (!downloadResult.ok) {
+              continue;
+            }
+
+            for (let index = 0; index < preparedFiles.length; index += 1) {
+              const prepared = preparedFiles[index]!;
+              const outputFilename = getOutputFilename(prepared.workFilename, targetLocale);
+              const crowdinEntries = await extractSandboxEntries(sandboxId, outputFilename);
+              if (!crowdinEntries.ok) {
+                continue;
+              }
+              // Existing/TM prefill wins over Crowdin prefill for the same key.
+              filePrefills[index]![targetLocale] = {
+                ...crowdinEntries.entries,
+                ...filePrefills[index]![targetLocale],
+              };
+            }
+          }
+        }
+
+        const prefilledByLocale = mergeLocaleKeyedPrefills(filePrefills);
+
+        let batchFailed = false;
+        try {
+          await runMultiFileTranslationInSandbox({
+            sandboxId,
+            files: preparedFiles.map((file) => ({
+              from: file.workFilename,
+              to: file.outputPattern,
+            })),
+            sourceLocale,
+            targetLocales: localesToRun,
+            context: batchContext,
+            prefilledByLocale,
+          });
+        } catch (error) {
+          batchFailed = true;
+          warnings.push(
+            `Batch file translation failed: ${
+              error instanceof Error ? error.message : "unknown error"
+            }`,
+          );
+        }
+
+        if (!batchFailed) {
+          const glossaryTermsForValidation = (batchContext.glossaryTerms ?? []).map((term) => ({
+            sourceTerm: term.sourceTerm,
+            targetTerm: term.targetTerm,
+            targetLocale: term.targetLocale,
+            forbidden: term.forbidden ?? null,
+            caseSensitive: term.caseSensitive ?? null,
+          }));
+
+          for (const prepared of preparedFiles) {
+            for (const [
+              targetLocale,
+              localesNeedingTranslation,
+            ] of prepared.localesNeedingByLocale) {
+              const outputFilename = getOutputFilename(prepared.workFilename, targetLocale);
+              try {
+                const translatedContent = await readTranslatedFile(sandboxId, outputFilename);
+                const translatedText = translatedContent.toString("utf8");
+                const translatedEntriesResult = await extractSandboxEntries(
+                  sandboxId,
+                  outputFilename,
+                );
+                if (!translatedEntriesResult.ok) {
+                  warnings.push(
+                    `Failed to extract translations for ${prepared.sourceFile.displayName ?? prepared.sourceFile.id} (${targetLocale})`,
+                  );
+                  continue;
+                }
+                const translatedEntries = translatedEntriesResult.entries;
+
+                const glossaryFailures = validateGlossaryTermsInTranslation({
+                  sourceText: prepared.sourceText,
+                  translatedText,
+                  terms: glossaryTermsForValidation.filter(
+                    (term) => term.targetLocale === targetLocale,
+                  ),
+                });
+                if (glossaryFailures.length > 0) {
+                  warnings.push(
+                    `Glossary validation failed for ${prepared.sourceFile.displayName ?? prepared.sourceFile.id} (${targetLocale})`,
+                  );
+                }
+
+                for (const unit of localesNeedingTranslation) {
+                  const existing = existingTranslationForLocale(unit, targetLocale);
+                  const from = existing?.text ?? "";
+                  const to = translatedEntries[unit.key] ?? from;
+                  if (!to.trim() || to === from) {
+                    continue;
+                  }
+
+                  const proposalWarnings = detectAgentRunProposalWarnings({
+                    sourceText: unit.sourceText,
+                    from,
+                    to,
+                    locale: targetLocale,
+                    externalStringId: unit.externalStringId,
+                    key: unit.key,
+                    glossaryTerms: glossaryTermsForValidation
+                      .filter((term) => term.targetLocale === targetLocale)
+                      .map((term) => ({
+                        sourceTerm: term.sourceTerm,
+                        targetTerm: term.targetTerm,
+                        targetLocale: term.targetLocale,
+                        forbidden: term.forbidden,
+                        caseSensitive: term.caseSensitive,
+                      })),
+                  });
+
+                  changedItems.push(
+                    serializeAgentRunProposalItem({
+                      itemId: buildAgentRunProposalItemId({
+                        externalStringId: unit.externalStringId,
+                        locale: targetLocale,
+                      }),
+                      externalStringId: unit.externalStringId,
+                      key: unit.key,
+                      locale: targetLocale,
+                      sourceText: unit.sourceText,
+                      from,
+                      to,
+                      reviewState: "pending",
+                      changedFields: deriveChangedFields(from, to),
+                      warnings: proposalWarnings,
+                    }),
+                  );
+                }
+              } catch (error) {
+                warnings.push(
+                  `File translation failed for ${prepared.sourceFile.displayName ?? prepared.sourceFile.id} (${targetLocale}): ${
+                    error instanceof Error ? error.message : "unknown error"
+                  }`,
+                );
+              }
+            }
+          }
+        }
+      }
     } finally {
       await stopTranslationSandbox(sandboxId);
     }
@@ -681,6 +888,7 @@ export async function translateProviderJobFiles(input: {
         filesProcessed,
         skippedMissingSourcePathCount,
         skippedNoMatchingUnitsCount,
+        skippedFullyTranslatedCount,
         skippedDownloadFailureCount,
         warningCount: warnings.length,
         unitFileIdCounts,
@@ -702,6 +910,7 @@ export async function translateProviderJobFiles(input: {
         filesProcessed,
         skippedMissingSourcePathCount,
         skippedNoMatchingUnitsCount,
+        skippedFullyTranslatedCount,
         skippedDownloadFailureCount,
         warningCount: warnings.length,
       },

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
@@ -210,30 +210,43 @@ function sandboxWorkFilename(fileId: string, basename: string): string {
   return `work_${sanitizeSandboxFilename(fileId)}_${sanitizeSandboxFilename(basename)}`;
 }
 
-/** Merge per-file prefills; drop keys that conflict across files for the same locale. */
+/**
+ * Merge per-file prefills for a single `hl run`. The CLI matches locale-keyed prefills on locale and
+ * entry key alone, so an entry key that more than one file in the batch owns is dropped instead of
+ * leaking one file's translation into another file that happens to reuse the same key.
+ */
 export function mergeLocaleKeyedPrefills(
-  filePrefills: Array<Record<string, Record<string, string>>>,
+  filePrefills: Array<{
+    entryKeys: Iterable<string>;
+    prefillsByLocale: Record<string, Record<string, string>>;
+  }>,
 ): Record<string, Record<string, string>> {
-  const merged: Record<string, Record<string, string>> = {};
-  const conflicts = new Set<string>();
+  const ownedKeysPerFile = filePrefills.map((file) => {
+    const owned = new Set(file.entryKeys);
+    for (const entries of Object.values(file.prefillsByLocale)) {
+      for (const key of Object.keys(entries)) {
+        owned.add(key);
+      }
+    }
+    return owned;
+  });
 
-  for (const byLocale of filePrefills) {
-    for (const [locale, entries] of Object.entries(byLocale)) {
+  const fileCountByEntryKey = new Map<string, number>();
+  for (const owned of ownedKeysPerFile) {
+    for (const key of owned) {
+      fileCountByEntryKey.set(key, (fileCountByEntryKey.get(key) ?? 0) + 1);
+    }
+  }
+
+  const merged: Record<string, Record<string, string>> = {};
+  for (const file of filePrefills) {
+    for (const [locale, entries] of Object.entries(file.prefillsByLocale)) {
       const localeMap = (merged[locale] ??= {});
       for (const [key, value] of Object.entries(entries)) {
-        const conflictKey = `${locale}\0${key}`;
-        if (conflicts.has(conflictKey)) {
+        if ((fileCountByEntryKey.get(key) ?? 0) > 1) {
           continue;
         }
-        const existing = localeMap[key];
-        if (existing === undefined) {
-          localeMap[key] = value;
-          continue;
-        }
-        if (existing !== value) {
-          delete localeMap[key];
-          conflicts.add(conflictKey);
-        }
+        localeMap[key] = value;
       }
     }
   }
@@ -743,7 +756,15 @@ export async function translateProviderJobFiles(input: {
           }
         }
 
-        const prefilledByLocale = mergeLocaleKeyedPrefills(filePrefills);
+        const prefilledByLocale = mergeLocaleKeyedPrefills(
+          preparedFiles.map((prepared, index) => ({
+            entryKeys: [
+              ...prepared.fileUnits.map((unit) => unit.key),
+              ...Object.keys(prepared.sourceEntries ?? {}),
+            ],
+            prefillsByLocale: filePrefills[index]!,
+          })),
+        );
 
         let batchFailed = false;
         try {
@@ -878,7 +899,11 @@ export async function translateProviderJobFiles(input: {
     filesProcessed,
   };
 
-  if (input.content.units.length > 0 && filesProcessed === 0) {
+  // Every source file being already fully translated is a healthy no-op, not a failed run.
+  const allSourceFilesAlreadyTranslated =
+    skippedFullyTranslatedCount > 0 && skippedFullyTranslatedCount === input.sourceFiles.length;
+
+  if (input.content.units.length > 0 && filesProcessed === 0 && !allSourceFilesAlreadyTranslated) {
     logger.warn(
       {
         ...logContext,

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
@@ -540,6 +540,25 @@ describe("sandbox translation temporary config", () => {
     expect(config).toContain("workspace -> espace de travail (fr-FR)");
     expect(config).toContain("workspace -> Arbeitsbereich (de-DE)");
   });
+
+  it("builds multi-file multi-locale configs in one bucket", async () => {
+    const { buildMultiFileMultiLocaleTempConfig } = await import("@/lib/translation/sandbox");
+    const config = buildMultiFileMultiLocaleTempConfig(
+      [
+        { from: "work_a_messages.json", to: "work_a_messages-{{target}}.json" },
+        { from: "work_b_labels.json", to: "work_b_labels-{{target}}.json" },
+      ],
+      "en-US",
+      ["fr-FR"],
+      null,
+    );
+
+    expect(config).toContain('from: "work_a_messages.json"');
+    expect(config).toContain('to: "work_a_messages-{{target}}.json"');
+    expect(config).toContain('from: "work_b_labels.json"');
+    expect(config).toContain('to: "work_b_labels-{{target}}.json"');
+    expect(config).toContain('- "fr-FR"');
+  });
 });
 
 describe("crowdin sandbox file config", () => {

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
@@ -441,10 +441,35 @@ export class HyperlocaliseCliConfigBuilder {
     instructions: string | null = null,
     context: SandboxTranslationContext | null = null,
   ): string {
+    return this.buildMultiFileMultiLocale(
+      [{ from: inputFile, to: outputPattern }],
+      sourceLocale,
+      targetLocales,
+      instructions,
+      context,
+    );
+  }
+
+  /** One i18n.yml bucket with many source files for a single `hl run`. */
+  buildMultiFileMultiLocale(
+    files: Array<{ from: string; to: string }>,
+    sourceLocale: string | null,
+    targetLocales: string[],
+    instructions: string | null = null,
+    context: SandboxTranslationContext | null = null,
+  ): string {
+    if (files.length === 0) {
+      throw new Error("buildMultiFileMultiLocale requires at least one file mapping");
+    }
+
     const yamlString = (value: string) => JSON.stringify(value);
     const systemPrompt = translationPromptPolicy.buildSandboxConfigPrompt(context, instructions);
     const userPrompt = ["Translate from {{source}} to {{target}}.", "", "{{input}}"].join("\n");
     const targets = targetLocales.map((locale) => `    - ${yamlString(locale)}`);
+    const fileLines = files.flatMap((file) => [
+      `      - from: ${yamlString(file.from)}`,
+      `        to: ${yamlString(file.to)}`,
+    ]);
 
     return [
       "locales:",
@@ -455,8 +480,7 @@ export class HyperlocaliseCliConfigBuilder {
       "buckets:",
       `  ${sandboxFileBucketName}:`,
       "    files:",
-      `      - from: ${yamlString(inputFile)}`,
-      `        to: ${yamlString(outputPattern)}`,
+      ...fileLines,
       "",
       "llm:",
       "  profiles:",
@@ -482,17 +506,29 @@ export class CrowdinSandboxOperations {
   }
 
   buildFileConfig(input: { sourceFilename: string; includeBaseUrl: boolean }): string {
+    return this.buildMultiFileConfig({
+      sourceFilenames: [input.sourceFilename],
+      includeBaseUrl: input.includeBaseUrl,
+    });
+  }
+
+  buildMultiFileConfig(input: { sourceFilenames: string[]; includeBaseUrl: boolean }): string {
+    if (input.sourceFilenames.length === 0) {
+      throw new Error("buildMultiFileConfig requires at least one source filename");
+    }
+
     const lines = ["project_id_env: CROWDIN_PROJECT_ID", "api_token_env: CROWDIN_PERSONAL_TOKEN"];
     if (input.includeBaseUrl) {
       lines.push("base_url_env: CROWDIN_BASE_URL");
     }
 
-    lines.push(
-      "base_path: .",
-      "files:",
-      `  - source: ${input.sourceFilename}`,
-      `    translation: ${this.buildTranslationPath(input.sourceFilename)}`,
-    );
+    lines.push("base_path: .", "files:");
+    for (const sourceFilename of input.sourceFilenames) {
+      lines.push(
+        `  - source: ${sourceFilename}`,
+        `    translation: ${this.buildTranslationPath(sourceFilename)}`,
+      );
+    }
 
     return lines.join("\n");
   }
@@ -665,6 +701,22 @@ export class HyperlocaliseCliRunner {
     return this.configBuilder.buildMultiLocale(
       inputFile,
       outputPattern,
+      sourceLocale,
+      targetLocales,
+      instructions,
+      context,
+    );
+  }
+
+  buildMultiFileMultiLocaleConfig(
+    files: Array<{ from: string; to: string }>,
+    sourceLocale: string | null,
+    targetLocales: string[],
+    instructions: string | null = null,
+    context: SandboxTranslationContext | null = null,
+  ): string {
+    return this.configBuilder.buildMultiFileMultiLocale(
+      files,
       sourceLocale,
       targetLocales,
       instructions,
@@ -883,6 +935,22 @@ export function buildMultiLocaleTempConfig(
   );
 }
 
+export function buildMultiFileMultiLocaleTempConfig(
+  files: Array<{ from: string; to: string }>,
+  sourceLocale: string | null,
+  targetLocales: string[],
+  instructions: string | null = null,
+  context: SandboxTranslationContext | null = null,
+) {
+  return defaultRunner.buildMultiFileMultiLocaleConfig(
+    files,
+    sourceLocale,
+    targetLocales,
+    instructions,
+    context,
+  );
+}
+
 export async function writeTempConfig(
   sandboxId: string,
   configContent: string,
@@ -922,6 +990,13 @@ export function buildCrowdinFileSandboxConfig(input: {
   includeBaseUrl: boolean;
 }) {
   return defaultRunner.crowdin.buildFileConfig(input);
+}
+
+export function buildCrowdinMultiFileSandboxConfig(input: {
+  sourceFilenames: string[];
+  includeBaseUrl: boolean;
+}) {
+  return defaultRunner.crowdin.buildMultiFileConfig(input);
 }
 
 export function getCrowdinSandboxEnv(input: {


### PR DESCRIPTION
## What changed

Provider TMS file translation no longer creates a sandbox per source file. Pending files share one sandbox and a multi-file `i18n.yml`, then run a single `hl run` across needed locales. Fully translated files are skipped before any sandbox work.

## How to test

- [ ] `vp test src/lib/providers/agent-runs/provider-agent-file-translate.test.ts src/lib/translation/sandbox-translation.test.ts`
- [ ] `vp check --fix src/lib/providers/agent-runs/provider-agent-file-translate.ts src/lib/providers/agent-runs/provider-agent-file-translate.test.ts src/lib/translation/sandbox.ts src/lib/translation/sandbox-translation.test.ts`
- [ ] Run Translate with agent on a multi-file TMS job and confirm one sandbox / one `hl run` in logs
- [ ] Confirm a fully translated file is skipped with no sandbox create

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)