### PR TITLE
fix(crowdin): add CorrectionID query filter to List Translation Approvals

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -1,5 +1,11 @@
 # Crowdin Steward's Journal
 
+## 2026-12-23 - Add CorrectionID query filter to List Translation Approvals
+
+**Learning:** In Crowdin API v2 (and particularly Crowdin Enterprise), proofreaders can create translation corrections. Correspondingly, the List Translation Approvals endpoint (`GET /api/v2/projects/{projectId}/approvals`) supports filtering by `correctionId`. However, the Go SDK's `ApprovalsListOptions` lacked a `CorrectionID` parameter and did not encode it in its `Values()` query string serialization, making it impossible for workflows to filter approvals by a specific proofreading correction.
+
+**Action:** Added `CorrectionID` to `ApprovalsListOptions` in `model/string_translations.go` and updated `Values()` to serialize it as `correctionId` if greater than 0. Expanded tests in both `model/string_translations_test.go` and `string_translations_test.go` to cover and assert correct `CorrectionID` serialization.
+
 ## 2026-12-22 - Embed ListOptions in DictionariesListOptions
 
 **Learning:** In Crowdin API v2, the List Dictionaries endpoint (`GET /api/v2/projects/{projectId}/dictionaries`) supports standard pagination parameters (`limit` and `offset`). However, `DictionariesListOptions` did not embed `ListOptions` or include standard pagination parameters in its `Values()` query string serialization. This caused queries with explicit limits/offsets to be ignored under actual workflows.

--- a/third_party/crowdin-api-client-go/crowdin/model/string_translations.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/string_translations.go
@@ -54,6 +54,9 @@ type ApprovalsListOptions struct {
 	// Translation Identifier.
 	// Note: If specified, `fileId`, `stringId` and `languageId` are ignored.
 	TranslationID int `json:"translationId,omitempty"`
+	// Correction Identifier.
+	// Note: If specified, `fileId`, `stringId` and `languageId` are ignored.
+	CorrectionID int `json:"correctionId,omitempty"`
 
 	ListOptions
 }
@@ -87,6 +90,9 @@ func (o *ApprovalsListOptions) Values() (url.Values, bool) {
 	}
 	if o.TranslationID > 0 {
 		v.Add("translationId", strconv.Itoa(o.TranslationID))
+	}
+	if o.CorrectionID > 0 {
+		v.Add("correctionId", strconv.Itoa(o.CorrectionID))
 	}
 
 	return v, len(v) > 0

--- a/third_party/crowdin-api-client-go/crowdin/model/string_translations_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/string_translations_test.go
@@ -25,9 +25,10 @@ func TestApprovalsListOptionsValues(t *testing.T) {
 			opts: &ApprovalsListOptions{
 				OrderBy: "createdAt desc,id", FileID: 1, LabelIDs: []int{1, 2},
 				ExcludeLabelIDs: []int{3, 4}, StringID: 2, LanguageID: "en", TranslationID: 3,
-				ListOptions: ListOptions{Offset: 1, Limit: 10},
+				CorrectionID: 4,
+				ListOptions:  ListOptions{Offset: 1, Limit: 10},
 			},
-			out: "excludeLabelIds=3%2C4&fileId=1&labelIds=1%2C2&languageId=en&limit=10&offset=1&orderBy=createdAt+desc%2Cid&stringId=2&translationId=3",
+			out: "correctionId=4&excludeLabelIds=3%2C4&fileId=1&labelIds=1%2C2&languageId=en&limit=10&offset=1&orderBy=createdAt+desc%2Cid&stringId=2&translationId=3",
 		},
 	}
 

--- a/third_party/crowdin-api-client-go/crowdin/string_translations_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/string_translations_test.go
@@ -40,12 +40,13 @@ func TestStringTranslationsService_ListApprovals(t *testing.T) {
 				StringID:        2345,
 				LanguageID:      "uk",
 				TranslationID:   190695,
+				CorrectionID:    9876,
 				ListOptions: model.ListOptions{
 					Offset: 10,
 					Limit:  25,
 				},
 			},
-			expect: "?excludeLabelIds=3%2C4&fileId=1&labelIds=1%2C2&languageId=uk&limit=25&offset=10&orderBy=createdAt+desc%2Cid&stringId=2345&translationId=190695",
+			expect: "?correctionId=9876&excludeLabelIds=3%2C4&fileId=1&labelIds=1%2C2&languageId=uk&limit=25&offset=10&orderBy=createdAt+desc%2Cid&stringId=2345&translationId=190695",
 		},
 	}
 


### PR DESCRIPTION
The List Translation Approvals endpoint in Crowdin API v2 supports filtering by `correctionId` (especially on Crowdin Enterprise). This query parameter filter was missing from `ApprovalsListOptions` and was not encoded in its serialization method.

This PR adds `CorrectionID` to the query options and serializes it, aligning the client with the official contract. Unit tests have been updated and verified successfully.

---
*PR created automatically by Jules for task [18147310344647485941](https://jules.google.com/task/18147310344647485941) started by @cungminh2710*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK option and query encoding only; no auth or runtime behavior changes beyond optional API filtering.
> 
> **Overview**
> Adds **`CorrectionID`** to **`ApprovalsListOptions`** so List Translation Approvals can filter by Crowdin’s **`correctionId`** query param (notably for Enterprise proofreading corrections). **`Values()`** now emits **`correctionId`** when the ID is greater than zero, matching **`translationId`** behavior.
> 
> Model and **`ListApprovals`** HTTP tests were updated to assert the new query string; the steward journal documents the API parity fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bebbc271c28cd23ed5685354ae1f5f97f56f3806. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->