### PR TITLE
test(providers): align batch translate tests with partial-output fix

### DIFF
--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.test.ts
@@ -652,10 +652,16 @@ describe("translateProviderJobFiles", () => {
     expect(stopTranslationSandboxMock).not.toHaveBeenCalled();
   });
 
-  it("stops the sandbox and records a warning when the batch hl run fails", async () => {
+  it("stops the sandbox and proposes nothing when a failed batch flushes no outputs", async () => {
     runSandboxCommandMock.mockResolvedValue({
       exitCode: 1,
       output: "hl run crashed",
+    });
+    readTranslatedFileMock.mockImplementation(async (_sandboxId: string, path: string) => {
+      if (path.includes("-fr")) {
+        throw new Error("translated output not found");
+      }
+      return Buffer.from('{"hello":"Hello"}', "utf8");
     });
 
     const result = await translateProviderJobFiles({
@@ -688,9 +694,12 @@ describe("translateProviderJobFiles", () => {
     expect(createTranslationSandboxMock).toHaveBeenCalledTimes(1);
     expect(stopTranslationSandboxMock).toHaveBeenCalledTimes(1);
     expect(result.changedItems).toEqual([]);
-    expect(
-      result.warnings.some((warning) => warning.includes("Batch file translation failed")),
-    ).toBe(true);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Batch file translation failed"),
+        expect.stringContaining("File translation failed for a.json (fr)"),
+      ]),
+    );
   });
 
   it("continues the batch when one sandbox source download fails", async () => {
@@ -747,8 +756,8 @@ describe("translateProviderJobFiles", () => {
     expect(buildMultiFileMultiLocaleTempConfigMock).toHaveBeenCalledWith(
       [
         {
-          from: "work_file-2_b.json",
-          to: "work_file-2_b-{{target}}.json",
+          from: "work_file-2_69453e62c1ee_b.json",
+          to: "work_file-2_69453e62c1ee_b-{{target}}.json",
         },
       ],
       "en",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

`main` is red on Web CI ([run 31230267414](https://github.com/hyperlocalise/hyperlocalise/actions/runs/31230267414)): 2 failing tests in `apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.test.ts`.

Two PRs merged two minutes apart and raced. [#1720](https://github.com/hyperlocalise/hyperlocalise/pull/1720) (`fix(providers): preserve partial batch translation outputs`) changed `translateProviderJobFiles` behaviour, and [#1718](https://github.com/hyperlocalise/hyperlocalise/pull/1718) (`test: cover issue subscription fan-out and batch translate edges`) added tests written against the pre-fix behaviour. Both passed on their own branches; the combination fails.

This updates the two stale expectations to match the shipped behaviour:

- `stops the sandbox and records a warning when the batch hl run fails` asserted `changedItems` was empty after a failed `hl run`. #1720 intentionally made a failed aggregate run still harvest whatever outputs it flushed, so the readable `fr` output is now proposed. Rather than weaken the assertion into a duplicate of #1720's own partial-failure test, the scenario now drops the flushed output (`readTranslatedFile` throws for the target locale) so it covers the distinct hard-failure path: batch failed, nothing readable, nothing proposed. Renamed to `stops the sandbox and proposes nothing when a failed batch flushes no outputs`, and it now also asserts the per-file warning alongside the batch warning.
- `continues the batch when one sandbox source download fails` expected the sandbox work filename `work_file-2_b.json`. #1720 added a `fileId` hash to `sandboxWorkFilename` to avoid collisions between IDs that sanitize to the same string, so the expectation becomes `work_file-2_69453e62c1ee_b.json`. This matches how the sibling tests in this file already spell out hashed filenames.

Test-only change; no production code touched.

## How to test

```
cd apps/hyperlocalise-web
vp test run src/lib/providers/agent-runs/provider-agent-file-translate.test.ts
vp test
vp check --fix
```

Before (on `main`): `Tests 2 failed | 3647 passed (3649)`.
After: `Test Files 576 passed (576)` / `Tests 3649 passed (3649)`, and `vp check` reports 0 errors (the one remaining warning is pre-existing in `.storybook/main.ts`).

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`; no Go code changed, so `make fmt`/`make lint`/`make test` are not applicable)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fdecd-4a22-7dee-bd57-80c6e501cb52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fdecd-4a22-7dee-bd57-80c6e501cb52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

