### PR TITLE
fix(sandbox): read VCR team/project config from secrets

### DIFF
--- a/.github/workflows/sandbox-image.yml
+++ b/.github/workflows/sandbox-image.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Compute image tags
         id: meta
         env:
-          TEAM_SLUG: ${{ vars.VERCEL_TEAM_SLUG }}
-          PROJECT_SLUG: ${{ vars.VERCEL_PROJECT_SLUG }}
+          TEAM_SLUG: ${{ secrets.VERCEL_TEAM_SLUG }}
+          PROJECT_SLUG: ${{ secrets.VERCEL_PROJECT_SLUG }}
         run: |
           set -euo pipefail
           if [ "${GITHUB_EVENT_NAME}" = "push" ] || [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
@@ -70,19 +70,19 @@ jobs:
         if: steps.meta.outputs.push == 'true'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_TEAM_ID: ${{ vars.VERCEL_TEAM_ID }}
-          VERCEL_TEAM_SLUG: ${{ vars.VERCEL_TEAM_SLUG }}
-          VERCEL_PROJECT_SLUG: ${{ vars.VERCEL_PROJECT_SLUG }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+          VERCEL_TEAM_SLUG: ${{ secrets.VERCEL_TEAM_SLUG }}
+          VERCEL_PROJECT_SLUG: ${{ secrets.VERCEL_PROJECT_SLUG }}
         run: |
           set -euo pipefail
           missing=()
           [ -n "${VERCEL_TOKEN:-}" ] || missing+=("secrets.VERCEL_TOKEN")
-          [ -n "${VERCEL_TEAM_ID:-}" ] || missing+=("vars.VERCEL_TEAM_ID")
-          [ -n "${VERCEL_TEAM_SLUG:-}" ] || missing+=("vars.VERCEL_TEAM_SLUG")
-          [ -n "${VERCEL_PROJECT_SLUG:-}" ] || missing+=("vars.VERCEL_PROJECT_SLUG")
+          [ -n "${VERCEL_TEAM_ID:-}" ] || missing+=("secrets.VERCEL_TEAM_ID")
+          [ -n "${VERCEL_TEAM_SLUG:-}" ] || missing+=("secrets.VERCEL_TEAM_SLUG")
+          [ -n "${VERCEL_PROJECT_SLUG:-}" ] || missing+=("secrets.VERCEL_PROJECT_SLUG")
           if [ "${#missing[@]}" -gt 0 ]; then
             echo "::error::Missing VCR configuration: ${missing[*]}"
-            echo "See apps/sandbox-image/README.md for required GitHub secrets/variables."
+            echo "See apps/sandbox-image/README.md for required GitHub secrets."
             exit 1
           fi
 
@@ -94,7 +94,7 @@ jobs:
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ vars.VERCEL_TEAM_ID }}
+          username: ${{ secrets.VERCEL_TEAM_ID }}
           password: ${{ secrets.VERCEL_TOKEN }}
 
       - name: Build and push

--- a/apps/sandbox-image/README.md
+++ b/apps/sandbox-image/README.md
@@ -48,9 +48,9 @@ is public, so the Dockerfile build itself does not need VCR.
 | Name | Kind | Purpose |
 |------|------|---------|
 | `VERCEL_TOKEN` | repository secret | Vercel access token with access to the web project |
-| `VERCEL_TEAM_ID` | repository variable | Docker login username (`team_…`) |
-| `VERCEL_TEAM_SLUG` | repository variable | Image path team slug |
-| `VERCEL_PROJECT_SLUG` | repository variable | Image path project slug (hyperlocalise-web) |
+| `VERCEL_TEAM_ID` | repository secret | Docker login username (`team_…`) |
+| `VERCEL_TEAM_SLUG` | repository secret | Image path team slug |
+| `VERCEL_PROJECT_SLUG` | repository secret | Image path project slug (hyperlocalise-web) |
 
 Pushed reference:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The Sandbox Image workflow was reading `VERCEL_TEAM_ID`, `VERCEL_TEAM_SLUG`, and `VERCEL_PROJECT_SLUG` from GitHub Actions **variables**, but these are configured as **secrets**. That caused the main push after #1724 to fail with:

```
Missing VCR configuration: vars.VERCEL_TEAM_ID vars.VERCEL_TEAM_SLUG vars.VERCEL_PROJECT_SLUG
```

- Update `.github/workflows/sandbox-image.yml` to use `secrets.*` for all four VCR values
- Update `apps/sandbox-image/README.md` to document them as repository secrets

## How to test

- [ ] Confirm the four secrets exist on the repo (`VERCEL_TOKEN`, `VERCEL_TEAM_ID`, `VERCEL_TEAM_SLUG`, `VERCEL_PROJECT_SLUG`)
- [ ] After merge (or via `workflow_dispatch` on this branch if secrets are available), confirm Sandbox Image push succeeds and the image appears Ready in Vercel

## Checklist

- [x] Workflow no longer references `vars.VERCEL_*`
- [x] Docs match secret configuration

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f025ce54-1ca2-41c2-82f0-7850cad125f8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f025ce54-1ca2-41c2-82f0-7850cad125f8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

