### PR TITLE
🔬 Scout: add generic xml parser syntax and validation error tests

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -211,3 +211,7 @@
 ## 2026-11-18 - [File Workflow Error and Retry Mechanics Validation]
 **Learning:** File workflow runner abstractions rely heavily on custom error classification (`IsCode` on wrapped/unwrapped `Error`) and backoff calculations (`retryDelay`). Directly testing these unexported/internal mechanisms in package-level unit tests guarantees configuration safety and prevents infinite spin-loops or panic-inducing divisions-by-zero, which can happen if positive bounds are not strictly enforced during normalization.
 **Action:** When working on asynchronous task executors or API integrations with backoff/retry capability, always verify zero/negative configurations normalization and custom error unwrapping behavior directly in a targeted `_scout_test.go` suite.
+
+## 2026-11-19 - [Generic XML Syntax and Validation Error Cases]
+**Learning:** In token-based custom XML parsers utilizing Go's standard `xml.Decoder`, syntax errors (such as mismatched tags, unexpected closing tags, and unexpected EOF/unclosed elements) are caught and surfaced early by Go's standard parser. Custom validation errors (like duplicate key detection, keyed metadata conflict, mixed content, or stable key omission) require syntactically valid XML structure to be reached.
+**Action:** When writing syntax error and edge-case unit tests for custom XML parsers, separate malformed/invalid XML layout test cases (and expect the underlying `xml.Decoder` syntax errors) from syntactically valid but structurally invalid custom error test cases (and assert precise custom error strings).

--- a/internal/i18n/translationfileparser/generic_xml_parser_scout_test.go
+++ b/internal/i18n/translationfileparser/generic_xml_parser_scout_test.go
@@ -1,0 +1,85 @@
+package translationfileparser
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGenericXMLParser_SyntaxErrors comprehensively tests syntax error flows
+// and validation limits of GenericXMLParser on invalid, malformed, or unsupported files.
+func TestGenericXMLParser_SyntaxErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{
+			name:    "mismatched closing tag",
+			input:   `<locale><message key="hello">Hello</other></locale>`,
+			wantErr: "XML syntax error on line 1: element <message> closed by </other>",
+		},
+		{
+			name:    "unexpected closing tag",
+			input:   `</locale>`,
+			wantErr: "unexpected end element </locale>",
+		},
+		{
+			name:    "unclosed element",
+			input:   `<locale><message key="hello">Hello`,
+			wantErr: "unexpected EOF",
+		},
+		{
+			name:    "empty XML document",
+			input:   `<!-- comment only -->`,
+			wantErr: "empty XML document",
+		},
+		{
+			name:    "duplicate key error",
+			input:   `<locale><message key="hello">Hello</message><message key="hello">Hi</message></locale>`,
+			wantErr: "duplicate key \"hello\"",
+		},
+		{
+			name:    "metadata element key conflict - comment",
+			input:   `<locale><comment key="note">Hello</comment></locale>`,
+			wantErr: "metadata element <comment> cannot have a key/id/name attribute",
+		},
+		{
+			name:    "metadata element key conflict - note",
+			input:   `<locale><note id="1">Hello</note></locale>`,
+			wantErr: "metadata element <note> cannot have a key/id/name attribute",
+		},
+		{
+			name:    "text element with no stable key - root text",
+			input:   `<locale>Hello</locale>`,
+			wantErr: "text element <locale> has no stable key",
+		},
+		{
+			name:    "specialized root elements rejection - plist",
+			input:   `<plist><message key="hello">Hello</message></plist>`,
+			wantErr: "element <plist> should be handled by a specialized parser",
+		},
+		{
+			name:    "specialized root elements rejection - xliff",
+			input:   `<xliff><message key="hello">Hello</message></xliff>`,
+			wantErr: "element <xliff> should be handled by a specialized parser",
+		},
+		{
+			name:    "mixed content with comments inside translatable text",
+			input:   `<locale><message key="msg">Hello <!-- comment --></message></locale>`,
+			wantErr: "mixed content in <message> is unsupported",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := GenericXMLParser{}
+			_, err := parser.Parse([]byte(tt.input))
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got: %v", tt.wantErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
💡 What: Added comprehensive behavior-driven unit tests for validation and syntax error cases of `GenericXMLParser`.
🎯 Why: To safeguard the generic XML parser against malformed input, structural deviations, and illegal configurations without regression.
🧩 Scope: `internal/i18n/translationfileparser/generic_xml_parser_scout_test.go` and `.jules/scout.md`.
✅ Verification: Ran `go test -v ./internal/i18n/translationfileparser/ -run TestGenericXMLParser_SyntaxErrors` and full suite `go test ./...`.
🛡️ Confidence: Extremely high. Both tests and existing files pass cleanly, providing a bulletproof validation suite for Generic XML.

---
*PR created automatically by Jules for task [17343158094938426984](https://jules.google.com/task/17343158094938426984) started by @cungminh2710*