### PR TITLE
fix(crowdin): implement enterprise translation corrections api

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -1,5 +1,11 @@
 # Crowdin Steward's Journal
 
+## 2026-12-24 - Implement Corrections API for Crowdin Enterprise parity
+
+**Learning:** In Crowdin Enterprise API v2, proofreaders can create translation corrections. However, the Go SDK lacked model representations and endpoint methods for managing corrections (such as list, get, add, restore, and delete corrections). This gap prevented enterprise users from managing the translation correction lifecycle programmatically.
+
+**Action:** Added `Correction` resource models, list/get options, list/get/add response wrappers, and an add request with standard validation to `model/string_translations.go`. Implemented `ListCorrections`, `GetCorrection`, `AddCorrection`, `RestoreCorrection`, `DeleteCorrection`, and `DeleteCorrections` (which operates on a specific `stringId` query param) in `StringTranslationsService`. Developed focused unit tests asserting query serialization, request validation, and endpoint execution under the `crowdin` and `crowdin/model` packages.
+
 ## 2026-12-23 - Add CorrectionID query filter to List Translation Approvals
 
 **Learning:** In Crowdin API v2 (and particularly Crowdin Enterprise), proofreaders can create translation corrections. Correspondingly, the List Translation Approvals endpoint (`GET /api/v2/projects/{projectId}/approvals`) supports filtering by `correctionId`. However, the Go SDK's `ApprovalsListOptions` lacked a `CorrectionID` parameter and did not encode it in its `Values()` query string serialization, making it impossible for workflows to filter approvals by a specific proofreading correction.

--- a/third_party/crowdin-api-client-go/crowdin/model/string_translations.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/string_translations.go
@@ -305,6 +305,115 @@ func (o *TranslationGetOptions) Values() (url.Values, bool) {
 	return v, len(v) > 0
 }
 
+// Correction represents a Crowdin translation correction (Enterprise only).
+type Correction struct {
+	ID                 int        `json:"id"`
+	Text               string     `json:"text"`
+	PluralCategoryName string     `json:"pluralCategoryName"`
+	User               *ShortUser `json:"user"`
+	CreatedAt          string     `json:"createdAt"`
+}
+
+// CorrectionGetResponse defines the structure of the response when
+// getting a single translation correction.
+type CorrectionGetResponse struct {
+	Data *Correction `json:"data"`
+}
+
+// CorrectionsListResponse defines the structure of the response when
+// getting a list of translation corrections.
+type CorrectionsListResponse struct {
+	Data       []*CorrectionGetResponse `json:"data"`
+	Pagination *Pagination              `json:"pagination"`
+}
+
+// CorrectionsListOptions specifies the optional parameters to the
+// StringTranslationsService.ListCorrections method.
+type CorrectionsListOptions struct {
+	// String Identifier. Filter corrections by `stringId`.
+	// Note: Required in Crowdin Enterprise.
+	StringID int `json:"stringId,omitempty"`
+	// Sort corrections.
+	OrderBy string `json:"orderBy,omitempty"`
+	// Enable denormalize placeholders.
+	// Enum: 0, 1. Default: 0.
+	DenormalizePlaceholders *int `json:"denormalizePlaceholders,omitempty"`
+
+	ListOptions
+}
+
+// Values returns the url.Values representation of the CorrectionsListOptions.
+// It implements the crowdin.ListOptionsProvider interface.
+func (o *CorrectionsListOptions) Values() (url.Values, bool) {
+	if o == nil {
+		return nil, false
+	}
+
+	v, _ := o.ListOptions.Values()
+
+	if o.StringID > 0 {
+		v.Add("stringId", strconv.Itoa(o.StringID))
+	}
+	if o.OrderBy != "" {
+		v.Add("orderBy", o.OrderBy)
+	}
+	if o.DenormalizePlaceholders != nil &&
+		(*o.DenormalizePlaceholders == 0 || *o.DenormalizePlaceholders == 1) {
+		v.Add("denormalizePlaceholders", strconv.Itoa(*o.DenormalizePlaceholders))
+	}
+
+	return v, len(v) > 0
+}
+
+// CorrectionAddRequest defines the structure of the request
+// to add a translation correction.
+type CorrectionAddRequest struct {
+	// String Identifier.
+	StringID int `json:"stringId"`
+	// Correction text.
+	Text string `json:"text"`
+	// Plural form. Enum: zero, one, two, few, many, and other.
+	PluralCategoryName string `json:"pluralCategoryName,omitempty"`
+}
+
+// Validate checks if the CorrectionAddRequest is valid.
+// It implements the crowdin.RequestValidator interface.
+func (r *CorrectionAddRequest) Validate() error {
+	if r == nil {
+		return errors.New("request cannot be nil")
+	}
+	if r.StringID == 0 {
+		return errors.New("string ID is required")
+	}
+	if r.Text == "" {
+		return errors.New("text is required")
+	}
+	return nil
+}
+
+// CorrectionGetOptions specifies the optional parameters to the
+// StringTranslationsService.GetCorrection method.
+type CorrectionGetOptions struct {
+	// Enable denormalize placeholders.
+	// Enum: 0, 1. Default: 0.
+	DenormalizePlaceholders *int `json:"denormalizePlaceholders,omitempty"`
+}
+
+// Values returns the url.Values representation of the CorrectionGetOptions.
+// It implements the crowdin.ListOptionsProvider interface.
+func (o *CorrectionGetOptions) Values() (url.Values, bool) {
+	if o == nil {
+		return nil, false
+	}
+
+	v := url.Values{}
+	if o.DenormalizePlaceholders != nil &&
+		(*o.DenormalizePlaceholders == 0 || *o.DenormalizePlaceholders == 1) {
+		v.Add("denormalizePlaceholders", strconv.Itoa(*o.DenormalizePlaceholders))
+	}
+	return v, len(v) > 0
+}
+
 // StringTranslationsListOptions specifies the optional parameters to the
 // StringTranslationsService.ListTranslations method.
 type StringTranslationsListOptions struct {

--- a/third_party/crowdin-api-client-go/crowdin/model/string_translations_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/string_translations_test.go
@@ -46,6 +46,135 @@ func TestApprovalsListOptionsValues(t *testing.T) {
 	}
 }
 
+func TestCorrectionsListOptionsValues(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *CorrectionsListOptions
+		out  string
+	}{
+		{
+			name: "nil options",
+			opts: nil,
+		},
+		{
+			name: "empty options",
+			opts: &CorrectionsListOptions{},
+		},
+		{
+			name: "with denormalizePlaceholders = 0",
+			opts: &CorrectionsListOptions{DenormalizePlaceholders: toPtr(0)},
+			out:  "denormalizePlaceholders=0",
+		},
+		{
+			name: "with all options",
+			opts: &CorrectionsListOptions{
+				StringID:                123,
+				OrderBy:                 "createdAt desc",
+				DenormalizePlaceholders: toPtr(1),
+				ListOptions:             ListOptions{Offset: 5, Limit: 15},
+			},
+			out: "denormalizePlaceholders=1&limit=15&offset=5&orderBy=createdAt+desc&stringId=123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, ok := tt.opts.Values()
+			if len(tt.out) > 0 {
+				assert.True(t, ok)
+				assert.Equal(t, tt.out, v.Encode())
+			} else {
+				assert.False(t, ok)
+				assert.Empty(t, v)
+			}
+		})
+	}
+}
+
+func TestCorrectionAddRequestValidate(t *testing.T) {
+	tests := []struct {
+		name  string
+		req   *CorrectionAddRequest
+		err   string
+		valid bool
+	}{
+		{
+			name: "nil request",
+			req:  nil,
+			err:  "request cannot be nil",
+		},
+		{
+			name: "empty request",
+			req:  &CorrectionAddRequest{},
+			err:  "string ID is required",
+		},
+		{
+			name: "missing text",
+			req:  &CorrectionAddRequest{StringID: 123},
+			err:  "text is required",
+		},
+		{
+			name: "valid request",
+			req: &CorrectionAddRequest{
+				StringID:           123,
+				Text:               "Corrected text",
+				PluralCategoryName: "few",
+			},
+			valid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.req.Validate(); tt.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.err)
+			}
+		})
+	}
+}
+
+func TestCorrectionGetOptionsValues(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *CorrectionGetOptions
+		out  string
+	}{
+		{
+			name: "nil options",
+			opts: nil,
+		},
+		{
+			name: "empty options",
+			opts: &CorrectionGetOptions{},
+		},
+		{
+			name: "with denormalizePlaceholders = 0",
+			opts: &CorrectionGetOptions{DenormalizePlaceholders: toPtr(0)},
+			out:  "denormalizePlaceholders=0",
+		},
+		{
+			name: "with denormalizePlaceholders = 1",
+			opts: &CorrectionGetOptions{DenormalizePlaceholders: toPtr(1)},
+			out:  "denormalizePlaceholders=1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, ok := tt.opts.Values()
+			if len(tt.out) > 0 {
+				assert.True(t, ok)
+				assert.Equal(t, tt.out, v.Encode())
+			} else {
+				assert.False(t, ok)
+				assert.Empty(t, v)
+			}
+		})
+	}
+}
+
 func TestTranslationAlignmentRequestValidate(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/third_party/crowdin-api-client-go/crowdin/string_translations.go
+++ b/third_party/crowdin-api-client-go/crowdin/string_translations.go
@@ -293,3 +293,73 @@ func (s *StringTranslationsService) AddVote(ctx context.Context, projectID int, 
 func (s *StringTranslationsService) CancelVote(ctx context.Context, projectID, voteID int) (*Response, error) {
 	return s.client.Delete(ctx, fmt.Sprintf("/api/v2/projects/%d/votes/%d", projectID, voteID), nil)
 }
+
+// ListCorrections returns a list of translation corrections (Enterprise only).
+//
+// https://developer.crowdin.com/api/v2/#operation/api.projects.corrections.getMany
+func (s *StringTranslationsService) ListCorrections(ctx context.Context, projectID int, opts *model.CorrectionsListOptions) (
+	[]*model.Correction, *Response, error,
+) {
+	res := new(model.CorrectionsListResponse)
+	resp, err := s.client.Get(ctx, fmt.Sprintf("/api/v2/projects/%d/corrections", projectID), opts, res)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	list := make([]*model.Correction, 0, len(res.Data))
+	for _, correction := range res.Data {
+		list = append(list, correction.Data)
+	}
+
+	return list, resp, nil
+}
+
+// GetCorrection returns a single translation correction by its identifier (Enterprise only).
+//
+// https://developer.crowdin.com/api/v2/#operation/api.projects.corrections.get
+func (s *StringTranslationsService) GetCorrection(ctx context.Context, projectID, correctionID int, opts *model.CorrectionGetOptions) (
+	*model.Correction, *Response, error,
+) {
+	res := new(model.CorrectionGetResponse)
+	resp, err := s.client.Get(ctx, fmt.Sprintf("/api/v2/projects/%d/corrections/%d", projectID, correctionID), opts, res)
+
+	return res.Data, resp, err
+}
+
+// AddCorrection adds a new translation correction (Enterprise only).
+//
+// https://developer.crowdin.com/api/v2/#operation/api.projects.corrections.post
+func (s *StringTranslationsService) AddCorrection(ctx context.Context, projectID int, req *model.CorrectionAddRequest) (
+	*model.Correction, *Response, error,
+) {
+	res := new(model.CorrectionGetResponse)
+	resp, err := s.client.Post(ctx, fmt.Sprintf("/api/v2/projects/%d/corrections", projectID), req, res)
+
+	return res.Data, resp, err
+}
+
+// RestoreCorrection restores a correction by its identifier (Enterprise only).
+//
+// https://developer.crowdin.com/api/v2/#operation/api.projects.corrections.put
+func (s *StringTranslationsService) RestoreCorrection(ctx context.Context, projectID, correctionID int) (
+	*model.Correction, *Response, error,
+) {
+	res := new(model.CorrectionGetResponse)
+	resp, err := s.client.Put(ctx, fmt.Sprintf("/api/v2/projects/%d/corrections/%d", projectID, correctionID), nil, res)
+
+	return res.Data, resp, err
+}
+
+// DeleteCorrection deletes a correction by its identifier (Enterprise only).
+//
+// https://developer.crowdin.com/api/v2/#operation/api.projects.corrections.delete
+func (s *StringTranslationsService) DeleteCorrection(ctx context.Context, projectID, correctionID int) (*Response, error) {
+	return s.client.Delete(ctx, fmt.Sprintf("/api/v2/projects/%d/corrections/%d", projectID, correctionID), nil)
+}
+
+// DeleteCorrections deletes corrections by its string identifier (Enterprise only).
+//
+// https://developer.crowdin.com/api/v2/#operation/api.projects.corrections.deleteMany
+func (s *StringTranslationsService) DeleteCorrections(ctx context.Context, projectID, stringID int) (*Response, error) {
+	return s.client.Delete(ctx, fmt.Sprintf("/api/v2/projects/%d/corrections?stringId=%d", projectID, stringID), nil)
+}

--- a/third_party/crowdin-api-client-go/crowdin/string_translations_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/string_translations_test.go
@@ -354,6 +354,297 @@ func TestStringTranslationsService_RemoveStringApprovals(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
 
+func TestStringTranslationsService_ListCorrections(t *testing.T) {
+	client, mux, teardown := setupClient()
+	defer teardown()
+
+	cases := []struct {
+		name   string
+		opts   *model.CorrectionsListOptions
+		expect string
+	}{
+		{
+			name:   "nil options",
+			opts:   nil,
+			expect: "",
+		},
+		{
+			name:   "empty options",
+			opts:   &model.CorrectionsListOptions{},
+			expect: "",
+		},
+		{
+			name: "with options",
+			opts: &model.CorrectionsListOptions{
+				StringID:                123,
+				OrderBy:                 "createdAt desc",
+				DenormalizePlaceholders: ToPtr(1),
+				ListOptions:             model.ListOptions{Offset: 5, Limit: 15},
+			},
+			expect: "?denormalizePlaceholders=1&limit=15&offset=5&orderBy=createdAt+desc&stringId=123",
+		},
+	}
+
+	for projectID, tt := range cases {
+		path := fmt.Sprintf("/api/v2/projects/%d/corrections", projectID)
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, http.MethodGet)
+			testURL(t, r, path+tt.expect)
+
+			fmt.Fprint(w, `{
+				"data": [
+					{
+						"data": {
+							"id": 190695,
+							"text": "This string has been corrected",
+							"pluralCategoryName": "few",
+							"user": {
+								"id": 19,
+								"username": "john_doe",
+								"fullName": "John Smith",
+								"avatarUrl": ""
+							},
+							"createdAt": "2019-09-23T11:26:54+00:00"
+						}
+					}
+				],
+				"pagination": {
+					"offset": 5,
+					"limit": 15
+				}
+			}`)
+		})
+
+		list, resp, err := client.StringTranslations.ListCorrections(context.Background(), projectID, tt.opts)
+		require.NoError(t, err)
+
+		expected := []*model.Correction{
+			{
+				ID:                 190695,
+				Text:               "This string has been corrected",
+				PluralCategoryName: "few",
+				User: &model.ShortUser{
+					ID:        19,
+					Username:  "john_doe",
+					FullName:  "John Smith",
+					AvatarURL: "",
+				},
+				CreatedAt: "2019-09-23T11:26:54+00:00",
+			},
+		}
+		assert.Equal(t, expected, list)
+
+		expectedPagination := model.Pagination{Offset: 5, Limit: 15}
+		assert.Equal(t, expectedPagination, resp.Pagination)
+	}
+}
+
+func TestStringTranslationsService_ListCorrections_invalidJSON(t *testing.T) {
+	client, mux, teardown := setupClient()
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/projects/1/corrections", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `invalid json`)
+	})
+
+	res, _, err := client.StringTranslations.ListCorrections(context.Background(), 1, nil)
+	require.Error(t, err)
+	assert.Nil(t, res)
+}
+
+func TestStringTranslationsService_GetCorrection(t *testing.T) {
+	client, mux, teardown := setupClient()
+	defer teardown()
+
+	cases := []struct {
+		name   string
+		opts   *model.CorrectionGetOptions
+		expect string
+	}{
+		{
+			name:   "nil options",
+			opts:   nil,
+			expect: "",
+		},
+		{
+			name:   "with options",
+			opts:   &model.CorrectionGetOptions{DenormalizePlaceholders: ToPtr(1)},
+			expect: "?denormalizePlaceholders=1",
+		},
+	}
+
+	for projectID, tt := range cases {
+		path := fmt.Sprintf("/api/v2/projects/%d/corrections/190695", projectID)
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, http.MethodGet)
+			testURL(t, r, path+tt.expect)
+
+			fmt.Fprint(w, `{
+				"data": {
+					"id": 190695,
+					"text": "This string has been corrected",
+					"pluralCategoryName": "few",
+					"user": {
+						"id": 19,
+						"username": "john_doe",
+						"fullName": "John Smith",
+						"avatarUrl": ""
+					},
+					"createdAt": "2019-09-23T11:26:54+00:00"
+				}
+			}`)
+		})
+
+		correction, resp, err := client.StringTranslations.GetCorrection(context.Background(), projectID, 190695, tt.opts)
+		require.NoError(t, err)
+
+		expected := &model.Correction{
+			ID:                 190695,
+			Text:               "This string has been corrected",
+			PluralCategoryName: "few",
+			User: &model.ShortUser{
+				ID:        19,
+				Username:  "john_doe",
+				FullName:  "John Smith",
+				AvatarURL: "",
+			},
+			CreatedAt: "2019-09-23T11:26:54+00:00",
+		}
+		assert.Equal(t, expected, correction)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+}
+
+func TestStringTranslationsService_AddCorrection(t *testing.T) {
+	client, mux, teardown := setupClient()
+	defer teardown()
+
+	const path = "/api/v2/projects/1/corrections"
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		testURL(t, r, path)
+		testBody(t, r, `{"stringId":123,"text":"This string has been corrected","pluralCategoryName":"few"}`+"\n")
+
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{
+			"data": {
+				"id": 190695,
+				"text": "This string has been corrected",
+				"pluralCategoryName": "few",
+				"user": {
+					"id": 19,
+					"username": "john_doe",
+					"fullName": "John Smith",
+					"avatarUrl": ""
+				},
+				"createdAt": "2019-09-23T11:26:54+00:00"
+			}
+		}`)
+	})
+
+	req := &model.CorrectionAddRequest{
+		StringID:           123,
+		Text:               "This string has been corrected",
+		PluralCategoryName: "few",
+	}
+	correction, resp, err := client.StringTranslations.AddCorrection(context.Background(), 1, req)
+	require.NoError(t, err)
+
+	expected := &model.Correction{
+		ID:                 190695,
+		Text:               "This string has been corrected",
+		PluralCategoryName: "few",
+		User: &model.ShortUser{
+			ID:        19,
+			Username:  "john_doe",
+			FullName:  "John Smith",
+			AvatarURL: "",
+		},
+		CreatedAt: "2019-09-23T11:26:54+00:00",
+	}
+	assert.Equal(t, expected, correction)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+}
+
+func TestStringTranslationsService_RestoreCorrection(t *testing.T) {
+	client, mux, teardown := setupClient()
+	defer teardown()
+
+	const path = "/api/v2/projects/1/corrections/190695"
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+		testURL(t, r, path)
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"data": {
+				"id": 190695,
+				"text": "This string has been corrected",
+				"pluralCategoryName": "few",
+				"user": {
+					"id": 19,
+					"username": "john_doe",
+					"fullName": "John Smith",
+					"avatarUrl": ""
+				},
+				"createdAt": "2019-09-23T11:26:54+00:00"
+			}
+		}`)
+	})
+
+	correction, resp, err := client.StringTranslations.RestoreCorrection(context.Background(), 1, 190695)
+	require.NoError(t, err)
+
+	expected := &model.Correction{
+		ID:                 190695,
+		Text:               "This string has been corrected",
+		PluralCategoryName: "few",
+		User: &model.ShortUser{
+			ID:        19,
+			Username:  "john_doe",
+			FullName:  "John Smith",
+			AvatarURL: "",
+		},
+		CreatedAt: "2019-09-23T11:26:54+00:00",
+	}
+	assert.Equal(t, expected, correction)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestStringTranslationsService_DeleteCorrection(t *testing.T) {
+	client, mux, teardown := setupClient()
+	defer teardown()
+
+	const path = "/api/v2/projects/1/corrections/190695"
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		testURL(t, r, path)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	resp, err := client.StringTranslations.DeleteCorrection(context.Background(), 1, 190695)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestStringTranslationsService_DeleteCorrections(t *testing.T) {
+	client, mux, teardown := setupClient()
+	defer teardown()
+
+	const path = "/api/v2/projects/1/corrections"
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		testURL(t, r, path+"?stringId=123")
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	resp, err := client.StringTranslations.DeleteCorrections(context.Background(), 1, 123)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
 func TestStringTranslationsService_RemoveApproval(t *testing.T) {
 	client, mux, teardown := setupClient()
 	defer teardown()


### PR DESCRIPTION
This patch implements complete support for the Crowdin Enterprise Translation Corrections API v2 in the Go SDK fork, ensuring parity and programmatic lifecycle management for corrections. It adds `Correction` models, query options, request/response wrappers, and service methods to `StringTranslationsService`. It also includes comprehensive unit tests verifying endpoint execution, serialization, and validation constraints.

---
*PR created automatically by Jules for task [2207377565888193402](https://jules.google.com/task/2207377565888193402) started by @cungminh2710*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive third-party SDK API surface with tests only; no changes to application auth, data paths, or production runtime behavior.
> 
> **Overview**
> Adds **Crowdin Enterprise Translation Corrections API v2** support to the vendored Go SDK so proofreading corrections can be managed programmatically.
> 
> New **`Correction`** models, list/get query options (including pagination and `denormalizePlaceholders`), **`CorrectionAddRequest`** with client-side validation, and **`StringTranslationsService`** methods: list, get, add, restore, delete one correction, and bulk delete by **`stringId`**. Unit tests cover query serialization, validation, and HTTP contract behavior. A steward journal entry documents the parity work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eede3d04c6f7300b3a99542b66bb5c64adb8238c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->