### PR TITLE
fix(ci): normalize git remote URL before GoReleaser release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Normalize git remote for GoReleaser
+        run: git remote set-url origin "https://github.com/${{ github.repository }}.git"
+
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes GoReleaser release failures at the changelog generation step with:

```
GET .../repos/github.com/hyperlocalise/hyperlocalise/compare/...: 404 Not Found
```

On Blacksmith runners, `git ls-remote --get-url` can return a scheme-less remote (`github.com/owner/repo`). GoReleaser's changelog pipe parses that as owner `github.com/owner`, which produces an invalid GitHub API path.

## Fix

Add a workflow step after checkout to force a standard HTTPS remote before GoReleaser runs:

```yaml
git remote set-url origin "https://github.com/${{ github.repository }}.git"
```

## Test plan

- [ ] Merge and re-run the release workflow (re-tag `v1.8.27` or push a new patch tag)
- [ ] Confirm GoReleaser passes "generating changelog" and publishes the release
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea539b7a-06d3-4b31-91c1-450cb7144761?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea539b7a-06d3-4b31-91c1-450cb7144761&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

