### PR TITLE
fix(providers): resolve legacy proposal fileIds before Crowdin write-back

### DIFF
--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-writeback.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-writeback.test.ts
@@ -24,6 +24,7 @@ import { serializeAgentRunProposalItem } from "./agent-run-proposals";
 import { executeProviderAgentWriteback } from "./provider-agent-writeback";
 
 const pushExternalTmsTranslationsMock = vi.hoisted(() => vi.fn());
+const pullExternalTmsTaskContentMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/providers/shared/tms-provider-content", async (importOriginal) => {
   const actual =
@@ -31,6 +32,7 @@ vi.mock("@/lib/providers/shared/tms-provider-content", async (importOriginal) =>
   return {
     ...actual,
     pushExternalTmsTranslations: (...args: unknown[]) => pushExternalTmsTranslationsMock(...args),
+    pullExternalTmsTaskContent: (...args: unknown[]) => pullExternalTmsTaskContentMock(...args),
   };
 });
 
@@ -61,6 +63,7 @@ describe("provider-agent-writeback", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     pushExternalTmsTranslationsMock.mockReset();
+    pullExternalTmsTaskContentMock.mockReset();
   });
 
   it("pushes accepted proposals and records per-item write-back results", async () => {
@@ -235,6 +238,40 @@ describe("provider-agent-writeback", () => {
     });
 
     await startAgentRun({ runId: sourceRun.id, organizationId });
+
+    pullExternalTmsTaskContentMock.mockResolvedValue({
+      runId: "pull-run-2",
+      status: "succeeded",
+      providerKind: "crowdin",
+      providerCredentialId: "cred-1",
+      projectId,
+      content: {
+        externalJobId: "task-2",
+        targetLocales: ["fr-FR", "de-DE"],
+        units: [
+          {
+            externalStringId: "hash-1",
+            key: "cta.label",
+            sourceText: "Buy now",
+            fileId: "101",
+            translations: [],
+          },
+          {
+            externalStringId: "hash-2",
+            key: "cta.label",
+            sourceText: "Buy now",
+            fileId: "102",
+            translations: [],
+          },
+        ],
+      },
+      counts: {
+        unitsDiscovered: 2,
+        translationsDiscovered: 0,
+        approvedTranslations: 0,
+      },
+      failures: [],
+    });
 
     await completeAgentRun({
       runId: sourceRun.id,
@@ -456,5 +493,257 @@ describe("provider-agent-writeback", () => {
         ]),
       }),
     );
+  });
+
+  it("resolves fileIds for legacy proposals missing fileId from task content", async () => {
+    const projectId = randomUUID();
+    const orgSuffix = randomUUID();
+
+    const [organization] = await db
+      .insert(schema.organizations)
+      .values({
+        workosOrganizationId: `org_${orgSuffix}`,
+        name: "Legacy Write-back Org",
+        slug: `legacy-writeback-${orgSuffix.slice(0, 8)}`,
+      })
+      .returning();
+    const organizationId = organization!.id;
+
+    await db.insert(schema.projects).values({
+      id: projectId,
+      organizationId,
+      name: "External TMS Project",
+      source: "external_tms",
+      externalProviderKind: "crowdin",
+      externalProjectId: "123",
+    });
+
+    const job = await createTestJob({ organizationId, projectId });
+
+    const sourceRun = await createAgentRun({
+      organizationId,
+      providerKind: "crowdin",
+      externalJobId: "task-legacy",
+      kind: "translate",
+      hyperlocaliseJobId: job.id,
+      inputSnapshot: { projectId },
+    });
+
+    await startAgentRun({ runId: sourceRun.id, organizationId });
+
+    await completeAgentRun({
+      runId: sourceRun.id,
+      organizationId,
+      outputSummary: { proposals: 2 },
+      changedItems: [
+        {
+          itemId: "s1:fr-FR",
+          externalStringId: "s1",
+          key: "title",
+          locale: "fr-FR",
+          sourceText: "Title A",
+          from: "",
+          to: "Titre A",
+          reviewState: "accepted",
+          changedFields: ["target"],
+          warnings: {},
+        },
+        {
+          itemId: "s2:fr-FR",
+          externalStringId: "s2",
+          key: "title",
+          locale: "fr-FR",
+          sourceText: "Title B",
+          from: "",
+          to: "Titre B",
+          reviewState: "accepted",
+          changedFields: ["target"],
+          warnings: {},
+        },
+      ],
+    });
+
+    const writebackRun = await createAgentRun({
+      organizationId,
+      providerKind: "crowdin",
+      externalJobId: "task-legacy",
+      kind: "translate",
+      hyperlocaliseJobId: job.id,
+      inputSnapshot: {
+        action: "push_approved_changes",
+        projectId,
+        hyperlocaliseJobId: job.id,
+      },
+    });
+
+    pullExternalTmsTaskContentMock.mockResolvedValue({
+      runId: "pull-run-legacy",
+      status: "succeeded",
+      providerKind: "crowdin",
+      providerCredentialId: "cred-1",
+      projectId,
+      content: {
+        externalJobId: "task-legacy",
+        targetLocales: ["fr-FR"],
+        units: [
+          {
+            externalStringId: "s1",
+            key: "title",
+            sourceText: "Title A",
+            fileId: "11",
+            translations: [],
+          },
+          {
+            externalStringId: "s2",
+            key: "title",
+            sourceText: "Title B",
+            fileId: "22",
+            translations: [],
+          },
+        ],
+      },
+      counts: {
+        unitsDiscovered: 2,
+        translationsDiscovered: 0,
+        approvedTranslations: 0,
+      },
+      failures: [],
+    });
+
+    pushExternalTmsTranslationsMock.mockResolvedValue({
+      runId: "sync-run-legacy",
+      status: "succeeded",
+      providerKind: "crowdin",
+      providerCredentialId: "cred-1",
+      projectId,
+      counts: {
+        translationsRequested: 2,
+        translationsUploaded: 2,
+        translationsFailed: 0,
+        asyncOperations: 0,
+      },
+      failures: [],
+      asyncOperations: [],
+    });
+
+    const result = await executeProviderAgentWriteback({
+      agentRunId: writebackRun.id,
+      organizationId,
+    });
+
+    expect(result).toMatchObject({ ok: true, uploaded: 2, failed: 0 });
+    expect(pullExternalTmsTaskContentMock).toHaveBeenCalledOnce();
+    expect(pushExternalTmsTranslationsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        translations: expect.arrayContaining([
+          expect.objectContaining({
+            externalStringId: "s1",
+            key: "title",
+            text: "Titre A",
+            fileId: "11",
+          }),
+          expect.objectContaining({
+            externalStringId: "s2",
+            key: "title",
+            text: "Titre B",
+            fileId: "22",
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it("does not pull task content when every proposal already has fileId", async () => {
+    const projectId = randomUUID();
+    const orgSuffix = randomUUID();
+
+    const [organization] = await db
+      .insert(schema.organizations)
+      .values({
+        workosOrganizationId: `org_${orgSuffix}`,
+        name: "No-pull Write-back Org",
+        slug: `no-pull-writeback-${orgSuffix.slice(0, 8)}`,
+      })
+      .returning();
+    const organizationId = organization!.id;
+
+    await db.insert(schema.projects).values({
+      id: projectId,
+      organizationId,
+      name: "External TMS Project",
+      source: "external_tms",
+      externalProviderKind: "crowdin",
+      externalProjectId: "123",
+    });
+
+    const job = await createTestJob({ organizationId, projectId });
+
+    const sourceRun = await createAgentRun({
+      organizationId,
+      providerKind: "crowdin",
+      externalJobId: "task-no-pull",
+      kind: "translate",
+      hyperlocaliseJobId: job.id,
+      inputSnapshot: { projectId },
+    });
+
+    await startAgentRun({ runId: sourceRun.id, organizationId });
+
+    await completeAgentRun({
+      runId: sourceRun.id,
+      organizationId,
+      outputSummary: { proposals: 1 },
+      changedItems: [
+        serializeAgentRunProposalItem({
+          itemId: "hash-1:fr-FR",
+          externalStringId: "hash-1",
+          key: "cta.label",
+          locale: "fr-FR",
+          sourceText: "Buy now",
+          from: "",
+          to: "Acheter",
+          reviewState: "accepted",
+          changedFields: ["target"],
+          warnings: {},
+          fileId: "101",
+        }),
+      ],
+    });
+
+    const writebackRun = await createAgentRun({
+      organizationId,
+      providerKind: "crowdin",
+      externalJobId: "task-no-pull",
+      kind: "translate",
+      hyperlocaliseJobId: job.id,
+      inputSnapshot: {
+        action: "push_approved_changes",
+        projectId,
+        hyperlocaliseJobId: job.id,
+      },
+    });
+
+    pushExternalTmsTranslationsMock.mockResolvedValue({
+      runId: "sync-run-no-pull",
+      status: "succeeded",
+      providerKind: "crowdin",
+      providerCredentialId: "cred-1",
+      projectId,
+      counts: {
+        translationsRequested: 1,
+        translationsUploaded: 1,
+        translationsFailed: 0,
+        asyncOperations: 0,
+      },
+      failures: [],
+      asyncOperations: [],
+    });
+
+    await executeProviderAgentWriteback({
+      agentRunId: writebackRun.id,
+      organizationId,
+    });
+
+    expect(pullExternalTmsTaskContentMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-writeback.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-writeback.ts
@@ -22,13 +22,21 @@ import {
   listAgentRuns,
   startAgentRun,
 } from "../agent-runs/agent-runs";
-import { pushExternalTmsTranslations } from "@/lib/providers/shared/tms-provider-content";
+import {
+  pullExternalTmsTaskContent,
+  pushExternalTmsTranslations,
+} from "@/lib/providers/shared/tms-provider-content";
 import type {
   ExternalTmsApprovedTranslationUpload,
   ExternalTmsContentSyncFailure,
+  ExternalTmsTaskContent,
 } from "@/lib/providers/jobs/tms-provider-types";
+import type { ExternalTmsProviderKind } from "@/lib/providers/credentials/organization-external-tms-provider-credentials";
 import type { ProviderTranslationWritebackChangedItem } from "@/lib/providers/shared/provider-feedback-types";
-import { getProviderTranslationPusher } from "@/lib/providers/adapters/tms-provider-registry";
+import {
+  getProviderContentPuller,
+  getProviderTranslationPusher,
+} from "@/lib/providers/adapters/tms-provider-registry";
 
 export type ProviderAgentWritebackResult =
   | {
@@ -233,6 +241,96 @@ function buildWritebackChangedItems(input: {
   return changedItems;
 }
 
+function buildFileIdByExternalStringId(content: ExternalTmsTaskContent) {
+  const fileIdByExternalStringId = new Map<string, string>();
+
+  for (const unit of content.units) {
+    if (unit.externalStringId && unit.fileId?.trim()) {
+      fileIdByExternalStringId.set(unit.externalStringId, unit.fileId);
+    }
+  }
+
+  return fileIdByExternalStringId;
+}
+
+async function enrichProposalsWithResolvedFileIds(input: {
+  proposals: AcceptedAgentRunProposal[];
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  externalJobId: string;
+  actorUserId?: string | null;
+}) {
+  const legacyProposals = input.proposals.filter((proposal) => !proposal.fileId?.trim());
+  if (legacyProposals.length === 0) {
+    return {
+      proposals: input.proposals,
+      prePushFailures: [] as ExternalTmsContentSyncFailure[],
+    };
+  }
+
+  const pullContent = getProviderContentPuller(input.providerKind);
+
+  let content: ExternalTmsTaskContent;
+  try {
+    const pullResult = await pullExternalTmsTaskContent({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      providerKind: input.providerKind,
+      externalJobId: input.externalJobId,
+      pullContent,
+      actorUserId: input.actorUserId,
+    });
+    content = pullResult.content;
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to resolve legacy proposal fileIds";
+    return {
+      proposals: input.proposals,
+      prePushFailures: legacyProposals.map((proposal) => ({
+        externalStringId: proposal.externalStringId,
+        locale: proposal.locale,
+        message: `legacy_proposal_file_id_resolution_failed: ${message}`,
+      })),
+    };
+  }
+
+  const fileIdByExternalStringId = buildFileIdByExternalStringId(content);
+  const prePushFailures: ExternalTmsContentSyncFailure[] = [];
+
+  const proposals = input.proposals.map((proposal) => {
+    if (proposal.fileId?.trim()) {
+      return proposal;
+    }
+
+    const resolvedFileId = fileIdByExternalStringId.get(proposal.externalStringId);
+    if (!resolvedFileId) {
+      prePushFailures.push({
+        externalStringId: proposal.externalStringId,
+        locale: proposal.locale,
+        message: "legacy_proposal_missing_file_id",
+      });
+      return proposal;
+    }
+
+    return { ...proposal, fileId: resolvedFileId };
+  });
+
+  return { proposals, prePushFailures };
+}
+
+function toApprovedTranslationUpload(
+  proposal: AcceptedAgentRunProposal,
+): ExternalTmsApprovedTranslationUpload {
+  return {
+    externalStringId: proposal.externalStringId,
+    key: proposal.key,
+    locale: proposal.locale,
+    text: proposal.to,
+    ...(proposal.fileId?.trim() ? { fileId: proposal.fileId } : {}),
+  };
+}
+
 export async function executeProviderAgentWriteback(input: {
   agentRunId: string;
   organizationId: string;
@@ -409,13 +507,58 @@ export async function executeProviderAgentWriteback(input: {
     };
   }
 
-  const translations: ExternalTmsApprovedTranslationUpload[] = proposalsToPush.map((proposal) => ({
-    externalStringId: proposal.externalStringId,
-    key: proposal.key,
-    locale: proposal.locale,
-    text: proposal.to,
-    ...(proposal.fileId?.trim() ? { fileId: proposal.fileId } : {}),
-  }));
+  const { proposals: proposalsWithFileIds, prePushFailures } =
+    await enrichProposalsWithResolvedFileIds({
+      proposals: proposalsToPush,
+      organizationId: input.organizationId,
+      projectId,
+      providerKind: run.providerKind,
+      externalJobId: run.externalJobId,
+      actorUserId: run.actorUserId,
+    });
+
+  const prePushFailureKeys = new Set(
+    prePushFailures.map((failure) => `${failure.externalStringId ?? ""}:${failure.locale ?? ""}`),
+  );
+  const pushableProposals = proposalsWithFileIds.filter(
+    (proposal) => !prePushFailureKeys.has(`${proposal.externalStringId}:${proposal.locale}`),
+  );
+  const translations = pushableProposals.map(toApprovedTranslationUpload);
+
+  if (translations.length === 0 && prePushFailures.length > 0) {
+    const changedItems = buildWritebackChangedItems({
+      proposals: acceptedProposals,
+      skippedItemIds: previouslyUploadedItemIds,
+      uploaded: 0,
+      failed: prePushFailures.length,
+      failures: prePushFailures,
+    });
+    const warnings = prePushFailures.map(
+      (failure) => `${failure.locale ?? "unknown"}: ${failure.message}`,
+    );
+
+    await failAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+      outputSummary: {
+        code: "provider_translation_push_failed",
+        uploaded: 0,
+        skipped: skippedCount,
+        failed: prePushFailures.length,
+        translationsRequested: 0,
+        acceptedProposals: acceptedProposals.length,
+      },
+      changedItems,
+      warnings,
+    });
+
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "provider_translation_push_failed",
+      message: warnings[0] ?? "Provider translation write-back failed",
+    };
+  }
 
   try {
     const pushResult = await pushExternalTmsTranslations({
@@ -428,17 +571,18 @@ export async function executeProviderAgentWriteback(input: {
       actorUserId: run.actorUserId,
     });
 
+    const mergedFailures = [...prePushFailures, ...pushResult.failures];
     const changedItems = buildWritebackChangedItems({
       proposals: acceptedProposals,
       skippedItemIds: previouslyUploadedItemIds,
       uploaded: pushResult.counts.translationsUploaded,
-      failed: pushResult.counts.translationsFailed,
-      failures: pushResult.failures,
+      failed: pushResult.counts.translationsFailed + prePushFailures.length,
+      failures: mergedFailures,
     });
 
     const uploaded = changedItems.filter((item) => item.status === "uploaded").length;
     const failed = changedItems.filter((item) => item.status === "failed").length;
-    const warnings = pushResult.failures.map(
+    const warnings = mergedFailures.map(
       (failure) => `${failure.locale ?? "unknown"}: ${failure.message}`,
     );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

PR #1741 added `fileId` to new agent proposals and forwarded it during write-back, but legacy accepted proposals persisted before that change still omit `fileId`. The conditional spread in write-back left those uploads without a file identifier, so Crowdin fell back to `task.fileIds[0]` and could write same-key translations to the wrong file in multi-file tasks.

Write-back now pulls task content when any proposal is missing `fileId`, resolves `externalStringId → fileId` from the pulled units, and fails closed for proposals that still cannot be resolved instead of letting the provider misroute them.

## How to test

- `vp test src/lib/providers/agent-runs/provider-agent-writeback.test.ts`
- Verify legacy proposals without `fileId` receive resolved file IDs from task content before push
- Verify proposals that already have `fileId` do not trigger an extra content pull

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38d818aa-a767-4aa2-956b-c3e5151f1a24?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38d818aa-a767-4aa2-956b-c3e5151f1a24&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

