### PR TITLE
fix(ci): unblock GoReleaser changelog on Blacksmith runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,37 @@ jobs:
           fetch-depth: 0
 
       - name: Normalize git remote for GoReleaser
-        run: git remote set-url origin "https://github.com/${{ github.repository }}.git"
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Blacksmith/checkouts may leave a scheme-less remote (github.com/owner/repo)
+          # or set url.insteadOf rules that rewrite https:// back to scheme-less URLs.
+          # GoReleaser parses `git ls-remote --get-url` for changelog generation and
+          # mis-reads scheme-less remotes as owner=github.com/owner.
+          repo="${GITHUB_REPOSITORY#https://github.com/}"
+          repo="${repo#github.com/}"
+          repo="${repo%.git}"
+          origin_url="https://github.com/${repo}.git"
+
+          while IFS= read -r key; do
+            instead_of="$(git config --get "$key" || true)"
+            if [[ "$instead_of" == "$origin_url" || "$instead_of" == "https://github.com/${repo}" ]]; then
+              section="${key%.insteadof}"
+              git config --global --unset-all "$key" || true
+              git config --global --remove-section "$section" 2>/dev/null || true
+            fi
+          done < <(git config --global --get-regexp '^url\..*\.insteadof$' 2>/dev/null | cut -d' ' -f1 || true)
+
+          git remote set-url origin "$origin_url"
+          git remote set-url --push origin "$origin_url"
+
+          resolved="$(git ls-remote --get-url origin)"
+          echo "origin remote: $resolved"
+          if [[ ! "$resolved" =~ ^https://github.com/[^/]+/[^/]+$ ]]; then
+            echo "unexpected origin remote format for GoReleaser: $resolved" >&2
+            exit 1
+          fi
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,7 +55,7 @@ checksum:
 
 changelog:
   sort: asc
-  use: github
+  use: git
   groups:
     - title: Features
       regexp: '^feat(\(.+\))?:.*$'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

GoReleaser still failed after #1742 with:

```
GET .../repos/github.com/hyperlocalise/hyperlocalise/compare/v1.8.27...v1.8.28: 404 Not Found
```

Root cause: GoReleaser's `changelog.use: github` always parses `git ls-remote --get-url`, ignoring `release.github.owner/name`. On Blacksmith, the resolved remote can still be scheme-less (`github.com/owner/repo`) or get rewritten by `url.insteadOf` rules even after `git remote set-url`.

## Fix

1. **Harden workflow remote setup** — strip accidental `github.com/` prefixes from `GITHUB_REPOSITORY`, remove `insteadOf` rules that collapse the HTTPS URL, set fetch/push URLs explicitly, and fail early if the resolved remote is not `https://github.com/owner/repo`.

2. **Use git for changelog** — switch `.goreleaser.yml` to `changelog.use: git` so changelog generation no longer calls the GitHub compare API or depends on remote URL parsing.

## Test plan

- [ ] Merge and re-run release workflow for `v1.8.28` (or re-tag)
- [ ] Confirm GoReleaser passes "generating changelog" and publishes artifacts
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea539b7a-06d3-4b31-91c1-450cb7144761?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea539b7a-06d3-4b31-91c1-450cb7144761&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

