### PR TITLE
fix(ci): unblock GoReleaser changelog on Blacksmith runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,37 @@ jobs:
           fetch-depth: 0
 
       - name: Normalize git remote for GoReleaser
-        run: git remote set-url origin "https://github.com/${{ github.repository }}.git"
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Blacksmith/checkouts may leave a scheme-less remote (github.com/owner/repo)
+          # or set url.insteadOf rules that rewrite https:// back to scheme-less URLs.
+          # GoReleaser parses `git ls-remote --get-url` for changelog generation and
+          # mis-reads scheme-less remotes as owner=github.com/owner.
+          repo="${GITHUB_REPOSITORY#https://github.com/}"
+          repo="${repo#github.com/}"
+          repo="${repo%.git}"
+          origin_url="https://github.com/${repo}.git"
+
+          while IFS= read -r key; do
+            instead_of="$(git config --get "$key" || true)"
+            if [[ "$instead_of" == "$origin_url" || "$instead_of" == "https://github.com/${repo}" ]]; then
+              section="${key%.insteadof}"
+              git config --global --unset-all "$key" || true
+              git config --global --remove-section "$section" 2>/dev/null || true
+            fi
+          done < <(git config --global --get-regexp '^url\..*\.insteadof$' 2>/dev/null | cut -d' ' -f1 || true)
+
+          git remote set-url origin "$origin_url"
+          git remote set-url --push origin "$origin_url"
+
+          resolved="$(git ls-remote --get-url origin)"
+          echo "origin remote: $resolved"
+          if [[ ! "$resolved" =~ ^https://github.com/[^/]+/[^/]+$ ]]; then
+            echo "unexpected origin remote format for GoReleaser: $resolved" >&2
+            exit 1
+          fi
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,7 +55,7 @@ checksum:
 
 changelog:
   sort: asc
-  use: github
+  use: git
   groups:
     - title: Features
       regexp: '^feat(\(.+\))?:.*$'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes GoReleaser release failures at changelog generation:

```
GET .../repos/github.com/hyperlocalise/hyperlocalise/compare/...: 404 Not Found
```

Follow-up to #1742. Remote URL normalization alone is not enough because:

1. GoReleaser `changelog.use: github` parses `git ls-remote --get-url` and **ignores** `release.github.owner/name`.
2. Blacksmith can leave a scheme-less remote (`github.com/owner/repo`) or rewrite HTTPS URLs via `url.insteadOf`.
3. If `GITHUB_REPOSITORY` includes a `github.com/` prefix, the previous step could build a double-prefixed URL.

## Changes

**`.github/workflows/release.yml`**
- Strip accidental `github.com/` / `https://github.com/` prefixes from the repo slug
- Remove `url.*.insteadOf` rules that collapse the origin URL
- Set fetch and push URLs explicitly
- Fail early unless the resolved remote matches `https://github.com/owner/repo`

**`.goreleaser.yml`**
- Switch `changelog.use` from `github` to `git` so changelog generation uses `git log` instead of the GitHub compare API

## Test plan

- [ ] Merge and re-run the release workflow (`v1.8.28` or next patch tag)
- [ ] Confirm GoReleaser passes "generating changelog" and publishes the release
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea539b7a-06d3-4b31-91c1-450cb7144761?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea539b7a-06d3-4b31-91c1-450cb7144761&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

