### PR TITLE
fix(ci): remove GoReleaser git remote normalization step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,39 +24,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Normalize git remote for GoReleaser
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          # Blacksmith/checkouts may leave a scheme-less remote (github.com/owner/repo)
-          # or set url.insteadOf rules that rewrite https:// back to scheme-less URLs.
-          # GoReleaser parses `git ls-remote --get-url` for changelog generation and
-          # mis-reads scheme-less remotes as owner=github.com/owner.
-          repo="${GITHUB_REPOSITORY#https://github.com/}"
-          repo="${repo#github.com/}"
-          repo="${repo%.git}"
-          origin_url="https://github.com/${repo}.git"
-
-          while IFS= read -r key; do
-            instead_of="$(git config --get "$key" || true)"
-            if [[ "$instead_of" == "$origin_url" || "$instead_of" == "https://github.com/${repo}" ]]; then
-              section="${key%.insteadof}"
-              git config --global --unset-all "$key" || true
-              git config --global --remove-section "$section" 2>/dev/null || true
-            fi
-          done < <(git config --global --get-regexp '^url\..*\.insteadof$' 2>/dev/null | cut -d' ' -f1 || true)
-
-          git remote set-url origin "$origin_url"
-          git remote set-url --push origin "$origin_url"
-
-          resolved="$(git ls-remote --get-url origin)"
-          echo "origin remote: $resolved"
-          if [[ ! "$resolved" =~ ^https://github.com/[^/]+/[^/]+$ ]]; then
-            echo "unexpected origin remote format for GoReleaser: $resolved" >&2
-            exit 1
-          fi
-
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the "Normalize git remote for GoReleaser" step from the release workflow.

## Problem

The normalization step added in #1744 fails on Blacksmith runners:

```
origin remote: http://192.168.127.1:1052/github.com/hyperlocalise/hyperlocalise.git
unexpected origin remote format for GoReleaser: http://192.168.127.1:1052/github.com/hyperlocalise/hyperlocalise.git
```

Blacksmith's git proxy rewrites the origin URL after `git remote set-url`, so the validation check always fails even after attempting to clear `url.insteadOf` rules.

## Why this is safe

- Changelog generation uses `use: git` (changed in #1744), so it reads local git history from the checkout — not the remote URL.
- Release publishing uses explicit `owner`/`name` in `.goreleaser.yml` plus `GITHUB_TOKEN`.

No remote URL normalization is required for either path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c81ea0fb-8e37-47de-adc6-f6956170a139?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c81ea0fb-8e37-47de-adc6-f6956170a139&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

