### PR TITLE
chore(cli): bump pinned hyperlocalise CLI to 1.8.28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Install Hyperlocalise
         uses: ./install
         with:
-          version: 1.8.24
+          version: 1.8.28
 
       - name: Dry-run sync push
         run: hl sync push --dry-run

--- a/.github/workflows/hyperlocalise-web-localize.yml
+++ b/.github/workflows/hyperlocalise-web-localize.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Hyperlocalise
         uses: ./install
         with:
-          version: 1.8.24
+          version: 1.8.28
 
       - name: Extract source catalog
         run: |
@@ -102,7 +102,7 @@ jobs:
       - name: Install Hyperlocalise
         uses: ./install
         with:
-          version: 1.8.24
+          version: 1.8.28
 
       - name: Extract source catalog
         run: |

--- a/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
+++ b/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
@@ -16,7 +16,7 @@ import { Sandbox } from "@vercel/sandbox";
 export const sandboxRipgrepReleaseVersion = "14.1.1";
 
 /** Pinned hyperlocalise CLI release installed into every sandbox. */
-export const sandboxHyperlocaliseReleaseVersion = "1.8.24";
+export const sandboxHyperlocaliseReleaseVersion = "1.8.28";
 
 /**
  * Pinned Playwright release used for Debian/Ubuntu `install-deps` fallback.

--- a/apps/sandbox-image/Dockerfile
+++ b/apps/sandbox-image/Dockerfile
@@ -22,7 +22,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Keep in sync with apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
 ARG NODE_MAJOR=24
-ARG HYPERLOCALISE_VERSION=1.8.24
+ARG HYPERLOCALISE_VERSION=1.8.28
 ARG PLAYWRIGHT_VERSION=1.61.1
 # Optional pin; omit / leave empty to install the latest Volta release.
 ARG VOLTA_VERSION=


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bump the pinned hyperlocalise CLI release from **1.8.24** to **1.8.28** in all consumers:

- `.github/workflows/ci.yml` — CI install action
- `.github/workflows/hyperlocalise-web-localize.yml` — localize + sync jobs
- `apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts` — Vercel sandbox install
- `apps/sandbox-image/Dockerfile` — sandbox image `HYPERLOCALISE_VERSION`

## Test plan

- [x] Confirm no remaining `1.8.24` pins in the repo
- [x] `vp test src/lib/vercel-sandbox-config.test.ts` (6 passed)
- [x] `vp check --fix` (pass; one pre-existing unrelated warning)
- [ ] CI green on this PR (installs CLI 1.8.28)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8af0f78-c456-4671-9c50-3bf653dfe13b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8af0f78-c456-4671-9c50-3bf653dfe13b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

