### PR TITLE
feat(chat): compact explore tool activity like Cursor

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.stories.tsx
@@ -219,3 +219,82 @@ export const ScreenshotProgressAndReasoning: Story = {
     ).toBeInTheDocument();
   },
 };
+
+export const CompactExploreToolsStreaming: Story = {
+  args: {
+    messages: [messagesFixture[0]],
+    isStreaming: true,
+    streamedAssistant: createStreamedAssistantMessage({
+      message: {
+        id: "stream-explore-live",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-grep",
+            toolCallId: "grep-save",
+            state: "output-available",
+            input: { pattern: "Save", path: "apps/web/src" },
+            output: { matches: 2 },
+          },
+          {
+            type: "tool-read",
+            toolCallId: "read-form",
+            state: "input-available",
+            input: { path: "apps/web/src/components/settings/account-form.tsx" },
+          },
+        ],
+      },
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Reading account-form.tsx")).toBeInTheDocument();
+    await expect(canvas.queryByText(/^grep$/i)).not.toBeInTheDocument();
+  },
+};
+
+export const CompactExploreToolsCompleted: Story = {
+  args: {
+    messages: [messagesFixture[0]],
+    isStreaming: false,
+    streamedAssistant: createStreamedAssistantMessage({
+      message: {
+        id: "stream-explore-done",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-grep",
+            toolCallId: "grep-save",
+            state: "output-available",
+            input: { pattern: "Save", path: "apps/web/src" },
+            output: { matches: 2 },
+          },
+          {
+            type: "tool-read",
+            toolCallId: "read-form",
+            state: "output-available",
+            input: { path: "apps/web/src/components/settings/account-form.tsx" },
+            output: { content: "..." },
+          },
+          {
+            type: "tool-grep",
+            toolCallId: "grep-cancel",
+            state: "output-available",
+            input: { pattern: "Cancel" },
+            output: { matches: 1 },
+          },
+          {
+            type: "text",
+            text: "I found the Save label in the account settings form.",
+            state: "done",
+          },
+        ],
+      },
+    }),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Explored account-form.tsx, 2 searches")).toBeInTheDocument();
+    await expect(
+      canvas.getByText("I found the Save label in the account settings form."),
+    ).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
@@ -30,6 +30,7 @@ import { AiElementErrorBoundary } from "@/components/ai-elements/ai-element-erro
 import { MessageResponse } from "@/components/ai-elements/message";
 import { Reasoning, ReasoningContent, ReasoningTrigger } from "@/components/ai-elements/reasoning";
 import { Source, Sources, SourcesContent, SourcesTrigger } from "@/components/ai-elements/sources";
+import { ExploreToolActivity } from "@/components/ai-elements/explore-tool-activity";
 import {
   getImageToolOutput,
   serializeToolJson,
@@ -39,6 +40,7 @@ import {
   ToolInput,
   ToolOutput,
 } from "@/components/ai-elements/tool";
+import { groupToolActivityBlocks } from "@/components/ai-elements/tool-activity";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Marker, MarkerContent, MarkerIcon } from "@/components/ui/marker";
 import { Message, MessageAvatar, MessageContent, MessageFooter } from "@/components/ui/message";
@@ -390,6 +392,10 @@ function AssistantMessageParts({
   const sourceParts = message.parts.filter(isSourcePart);
   const toolParts = message.parts.filter(isToolPart);
   const latestTodoCallId = toolParts.findLast(isTodoWritePart)?.toolCallId;
+  const visibleToolParts = toolParts.filter(
+    (part) => !isTodoWritePart(part) || part.toolCallId === latestTodoCallId,
+  );
+  const toolBlocks = groupToolActivityBlocks(visibleToolParts);
   const statusPart = message.parts.findLast(isStatusPart);
   const toolProgressByCallId = new Map(
     message.parts
@@ -429,18 +435,43 @@ function AssistantMessageParts({
           </AiElementErrorBoundary>
         ) : null,
       )}
-      {toolParts.map((part, index) => {
-        if (isTodoWritePart(part) && part.toolCallId !== latestTodoCallId) {
-          return null;
+      {toolBlocks.map((block, blockIndex) => {
+        if (block.kind === "explore") {
+          return (
+            <AiElementErrorBoundary
+              key={`explore-${block.parts[0]?.toolCallId ?? blockIndex}`}
+              scope="tool"
+              resetKeys={block.parts.flatMap((part) => [
+                part.type,
+                part.state,
+                part.toolCallId,
+                serializeToolJson(part.input),
+                serializeToolJson(part.output),
+                part.errorText ?? "",
+              ])}
+            >
+              <ExploreToolActivity
+                parts={block.parts}
+                renderToolPart={(part, index) => (
+                  <AssistantToolPart
+                    key={`${part.toolCallId}-${index}`}
+                    part={part}
+                    progressMessage={toolProgressByCallId.get(part.toolCallId)}
+                  />
+                )}
+              />
+            </AiElementErrorBoundary>
+          );
         }
 
+        const part = block.part;
         const todoItems = isTodoWritePart(part)
           ? (getAgentTodoItems(part.output) ?? getAgentTodoItems(part.input))
           : null;
 
         return (
           <AiElementErrorBoundary
-            key={`${part.type}-${index}`}
+            key={`${part.type}-${part.toolCallId}-${blockIndex}`}
             scope="tool"
             resetKeys={[
               part.type,
@@ -466,7 +497,7 @@ function AssistantMessageParts({
         <AiElementErrorBoundary scope="message" resetKeys={[text, isStreaming]}>
           <MessageResponse isAnimating={isStreaming}>{text}</MessageResponse>
         </AiElementErrorBoundary>
-      ) : isStreaming && reasoningParts.length === 0 && toolParts.length === 0 ? (
+      ) : isStreaming && reasoningParts.length === 0 && visibleToolParts.length === 0 ? (
         <Marker role="status">
           <MarkerIcon>
             <Spinner />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
@@ -532,9 +532,10 @@ function AssistantToolPart({
         state: part.state,
       };
   const hasImageOutput = Boolean(getImageToolOutput(part.output));
-  // null = follow hasImageOutput; once the user toggles, keep their choice.
+  const hasFailed = part.state === "output-error" || part.state === "output-denied";
+  // null = follow image/error defaults; once the user toggles, keep their choice.
   const [userOpen, setUserOpen] = useState<boolean | null>(null);
-  const open = userOpen ?? hasImageOutput;
+  const open = userOpen ?? (hasImageOutput || hasFailed);
   const isRunning = part.state === "input-streaming" || part.state === "input-available";
 
   return (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
@@ -533,9 +533,10 @@ function AssistantToolPart({
       };
   const hasImageOutput = Boolean(getImageToolOutput(part.output));
   const hasFailed = part.state === "output-error" || part.state === "output-denied";
-  // null = follow image/error defaults; once the user toggles, keep their choice.
+  // null = follow image default; once the user toggles, keep their choice — except
+  // failures always win so a collapse during flight cannot hide later error details.
   const [userOpen, setUserOpen] = useState<boolean | null>(null);
-  const open = userOpen ?? (hasImageOutput || hasFailed);
+  const open = hasFailed || (userOpen ?? hasImageOutput);
   const isRunning = part.state === "input-streaming" || part.state === "input-available";
 
   return (

--- a/apps/hyperlocalise-web/src/components/ai-elements/explore-tool-activity.test.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/explore-tool-activity.test.tsx
@@ -78,4 +78,15 @@ describe("ExploreToolActivity", () => {
     expect(screen.getByText("Couldn't explore account-form.tsx")).toBeInTheDocument();
     expect(screen.getByText(/detail:read-output-error/)).toBeInTheDocument();
   });
+
+  it("keeps the failure rollup visible while a sibling explore tool is still pending", () => {
+    renderActivity([
+      toolPart("grep", { pattern: "Save" }, "output-error"),
+      toolPart("read", { path: "apps/web/src/account-form.tsx" }, "input-available"),
+    ]);
+
+    expect(screen.getByText("Couldn't explore account-form.tsx")).toBeInTheDocument();
+    expect(screen.queryByText("Reading account-form.tsx")).not.toBeInTheDocument();
+    expect(screen.getByText(/detail:grep-output-error/)).toBeInTheDocument();
+  });
 });

--- a/apps/hyperlocalise-web/src/components/ai-elements/explore-tool-activity.test.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/explore-tool-activity.test.tsx
@@ -89,4 +89,30 @@ describe("ExploreToolActivity", () => {
     expect(screen.queryByText("Reading account-form.tsx")).not.toBeInTheDocument();
     expect(screen.getByText(/detail:grep-output-error/)).toBeInTheDocument();
   });
+
+  it("opens a previously mounted rollup when a tool later fails", () => {
+    const successParts = [
+      toolPart("grep", { pattern: "Save" }),
+      toolPart("read", { path: "apps/web/src/account-form.tsx" }),
+    ];
+    const { rerender } = renderActivity(successParts);
+
+    expect(screen.getByText("Explored account-form.tsx, 1 search")).toBeInTheDocument();
+    expect(screen.queryByText(/^detail:/)).not.toBeInTheDocument();
+
+    rerender(
+      <IntlProvider locale="en">
+        <ExploreToolActivity
+          parts={[
+            toolPart("grep", { pattern: "Save" }),
+            toolPart("read", { path: "apps/web/src/account-form.tsx" }, "output-error"),
+          ]}
+          renderToolPart={(part) => <div key={part.toolCallId}>detail:{part.toolCallId}</div>}
+        />
+      </IntlProvider>,
+    );
+
+    expect(screen.getByText("Couldn't explore account-form.tsx")).toBeInTheDocument();
+    expect(screen.getByText(/detail:read-output-error/)).toBeInTheDocument();
+  });
 });

--- a/apps/hyperlocalise-web/src/components/ai-elements/explore-tool-activity.test.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/explore-tool-activity.test.tsx
@@ -68,4 +68,14 @@ describe("ExploreToolActivity", () => {
     expect(screen.getByText("Explored account-form.tsx, 2 searches")).toBeInTheDocument();
     expect(screen.queryByText(/^detail:/)).not.toBeInTheDocument();
   });
+
+  it("opens a failure rollup when any explore tool errors", () => {
+    renderActivity([
+      toolPart("grep", { pattern: "Save" }),
+      toolPart("read", { path: "apps/web/src/account-form.tsx" }, "output-error"),
+    ]);
+
+    expect(screen.getByText("Couldn't explore account-form.tsx")).toBeInTheDocument();
+    expect(screen.getByText(/detail:read-output-error/)).toBeInTheDocument();
+  });
 });

--- a/apps/hyperlocalise-web/src/components/ai-elements/explore-tool-activity.test.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/explore-tool-activity.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import { IntlProvider } from "react-intl";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { ExploreToolActivity } from "./explore-tool-activity";
+import type { ToolPart } from "./tool-activity";
+
+vi.mock("dot-anime-react", () => ({
+  ScrambleText: ({ text }: { text: string }) => <span>{text}</span>,
+}));
+
+function toolPart(
+  name: string,
+  input: Record<string, unknown>,
+  state: ToolPart["state"] = "output-available",
+): ToolPart {
+  return {
+    type: `tool-${name}`,
+    toolCallId: `${name}-${state}-${JSON.stringify(input)}`,
+    state,
+    input,
+  } as ToolPart;
+}
+
+function renderActivity(parts: ToolPart[]) {
+  return render(
+    <IntlProvider locale="en">
+      <ExploreToolActivity
+        parts={parts}
+        renderToolPart={(part) => <div key={part.toolCallId}>detail:{part.toolCallId}</div>}
+      />
+    </IntlProvider>,
+  );
+}
+
+describe("ExploreToolActivity", () => {
+  it("shows a friendly live status for the latest in-flight explore tool", () => {
+    renderActivity([
+      toolPart("grep", { pattern: "Save" }, "output-available"),
+      toolPart("read", { path: "apps/web/src/account-form.tsx" }, "input-available"),
+    ]);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Reading account-form.tsx");
+    expect(screen.queryByText(/Explored/)).not.toBeInTheDocument();
+  });
+
+  it("shows a collapsed explore rollup when the group finishes", () => {
+    renderActivity([
+      toolPart("grep", { pattern: "Save" }),
+      toolPart("read", { path: "apps/web/src/account-form.tsx" }),
+      toolPart("grep", { pattern: "Cancel" }),
+    ]);
+
+    expect(screen.getByText("Explored account-form.tsx, 2 searches")).toBeInTheDocument();
+    expect(screen.queryByText(/^detail:/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/explore-tool-activity.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/explore-tool-activity.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { ScrambleText } from "dot-anime-react";
+import { ChevronDownIcon } from "lucide-react";
+import { useReducedMotion } from "motion/react";
+import type { ReactNode } from "react";
+import { useIntl } from "react-intl";
+
+import { Task, TaskContent, TaskTrigger } from "@/components/ai-elements/task";
+import {
+  getExploreRollupStats,
+  getToolName,
+  getToolPartSubject,
+  isToolPartRunning,
+  type ToolPart,
+} from "./tool-activity";
+import { toolActivityMessages } from "./tool-activity.messages";
+
+function formatLiveExploreLabel(
+  intl: ReturnType<typeof useIntl>,
+  part: ToolPart,
+): string {
+  const toolName = getToolName(part);
+  const detail = getToolPartSubject(part);
+
+  switch (toolName) {
+    case "grep":
+    case "fuzzySearch":
+      return detail
+        ? intl.formatMessage(toolActivityMessages.searchingDetail, { detail })
+        : intl.formatMessage(toolActivityMessages.searching);
+    case "read":
+      return detail
+        ? intl.formatMessage(toolActivityMessages.readingDetail, { detail })
+        : intl.formatMessage(toolActivityMessages.reading);
+    case "glob":
+      return detail
+        ? intl.formatMessage(toolActivityMessages.findingDetail, { detail })
+        : intl.formatMessage(toolActivityMessages.findingFiles);
+    case "detectRepoConfig":
+      return intl.formatMessage(toolActivityMessages.checkingRepoConfig);
+    case "gitHistory":
+      return intl.formatMessage(toolActivityMessages.checkingGitHistory);
+    default:
+      return intl.formatMessage(toolActivityMessages.working);
+  }
+}
+
+function formatExploreRollupLabel(
+  intl: ReturnType<typeof useIntl>,
+  parts: ToolPart[],
+): string {
+  const { subject, readCount, onlyReads, count } = getExploreRollupStats(parts);
+
+  if (onlyReads) {
+    if (readCount === 1 && subject) {
+      return intl.formatMessage(toolActivityMessages.openedFile, { subject });
+    }
+    return intl.formatMessage(toolActivityMessages.openedFiles, {
+      count: readCount || parts.length,
+    });
+  }
+
+  if (subject) {
+    return intl.formatMessage(toolActivityMessages.exploredSubject, { subject, count });
+  }
+  return intl.formatMessage(toolActivityMessages.exploredCodebase, { count });
+}
+
+export function ExploreToolActivity({
+  parts,
+  renderToolPart,
+}: {
+  parts: ToolPart[];
+  renderToolPart: (part: ToolPart, index: number) => ReactNode;
+}) {
+  const intl = useIntl();
+  const shouldReduceMotion = useReducedMotion();
+  const latestPart = parts.at(-1);
+  const isLive = parts.some(isToolPartRunning);
+
+  if (!latestPart) {
+    return null;
+  }
+
+  if (isLive) {
+    const liveLabel = formatLiveExploreLabel(intl, latestPart);
+    return (
+      <div
+        className="mb-1 min-w-0 py-0.5 text-sm text-muted-foreground"
+        role="status"
+        aria-live="polite"
+      >
+        <ScrambleText
+          key={`${latestPart.toolCallId}:${liveLabel}`}
+          text={liveLabel}
+          duration={600}
+          interval={28}
+          animate={!shouldReduceMotion}
+          className="block truncate"
+        />
+      </div>
+    );
+  }
+
+  const rollupLabel = formatExploreRollupLabel(intl, parts);
+
+  return (
+    <Task defaultOpen={false} className="mb-1 w-full">
+      <TaskTrigger title={rollupLabel} className="w-full">
+        <div className="flex w-full min-w-0 cursor-pointer items-center gap-1.5 py-0.5 text-start text-sm text-muted-foreground transition-colors hover:text-foreground">
+          <span className="min-w-0 truncate">{rollupLabel}</span>
+          <ChevronDownIcon className="size-3.5 shrink-0 opacity-0 transition-all group-hover:opacity-100 group-data-[state=open]:rotate-180 group-data-[state=open]:opacity-100" />
+        </div>
+      </TaskTrigger>
+      <TaskContent className="text-sm [&_>div]:mt-2 [&_>div]:space-y-0">
+        {parts.map((part, index) => renderToolPart(part, index))}
+      </TaskContent>
+    </Task>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/ai-elements/explore-tool-activity.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/explore-tool-activity.tsx
@@ -28,10 +28,7 @@ import {
 } from "./tool-activity";
 import { toolActivityMessages } from "./tool-activity.messages";
 
-function formatLiveExploreLabel(
-  intl: ReturnType<typeof useIntl>,
-  part: ToolPart,
-): string {
+function formatLiveExploreLabel(intl: ReturnType<typeof useIntl>, part: ToolPart): string {
   const toolName = getToolName(part);
   const detail = getToolPartSubject(part);
 
@@ -58,10 +55,7 @@ function formatLiveExploreLabel(
   }
 }
 
-function formatExploreRollupLabel(
-  intl: ReturnType<typeof useIntl>,
-  parts: ToolPart[],
-): string {
+function formatExploreRollupLabel(intl: ReturnType<typeof useIntl>, parts: ToolPart[]): string {
   const { subject, readCount, onlyReads, count } = getExploreRollupStats(parts);
 
   if (onlyReads) {

--- a/apps/hyperlocalise-web/src/components/ai-elements/explore-tool-activity.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/explore-tool-activity.tsx
@@ -23,6 +23,7 @@ import {
   getExploreRollupStats,
   getToolName,
   getToolPartSubject,
+  isToolPartFailed,
   isToolPartRunning,
   type ToolPart,
 } from "./tool-activity";
@@ -55,8 +56,18 @@ function formatLiveExploreLabel(intl: ReturnType<typeof useIntl>, part: ToolPart
   }
 }
 
-function formatExploreRollupLabel(intl: ReturnType<typeof useIntl>, parts: ToolPart[]): string {
+function formatExploreRollupLabel(
+  intl: ReturnType<typeof useIntl>,
+  parts: ToolPart[],
+  hasFailed: boolean,
+): string {
   const { subject, readCount, onlyReads, count } = getExploreRollupStats(parts);
+
+  if (hasFailed) {
+    return subject
+      ? intl.formatMessage(toolActivityMessages.exploreFailedSubject, { subject })
+      : intl.formatMessage(toolActivityMessages.exploreFailed);
+  }
 
   if (onlyReads) {
     if (readCount === 1 && subject) {
@@ -84,6 +95,7 @@ export function ExploreToolActivity({
   const shouldReduceMotion = useReducedMotion();
   const latestPart = parts.at(-1);
   const isLive = parts.some(isToolPartRunning);
+  const hasFailed = parts.some(isToolPartFailed);
 
   if (!latestPart) {
     return null;
@@ -109,12 +121,18 @@ export function ExploreToolActivity({
     );
   }
 
-  const rollupLabel = formatExploreRollupLabel(intl, parts);
+  const rollupLabel = formatExploreRollupLabel(intl, parts, hasFailed);
 
   return (
-    <Task defaultOpen={false} className="mb-1 w-full">
+    <Task defaultOpen={hasFailed} className="mb-1 w-full">
       <TaskTrigger title={rollupLabel} className="w-full">
-        <div className="flex w-full min-w-0 cursor-pointer items-center gap-1.5 py-0.5 text-start text-sm text-muted-foreground transition-colors hover:text-foreground">
+        <div
+          className={
+            hasFailed
+              ? "flex w-full min-w-0 cursor-pointer items-center gap-1.5 py-0.5 text-start text-sm text-destructive transition-colors hover:text-destructive/90"
+              : "flex w-full min-w-0 cursor-pointer items-center gap-1.5 py-0.5 text-start text-sm text-muted-foreground transition-colors hover:text-foreground"
+          }
+        >
           <span className="min-w-0 truncate">{rollupLabel}</span>
           <ChevronDownIcon className="size-3.5 shrink-0 opacity-0 transition-all group-hover:opacity-100 group-data-[state=open]:rotate-180 group-data-[state=open]:opacity-100" />
         </div>

--- a/apps/hyperlocalise-web/src/components/ai-elements/explore-tool-activity.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/explore-tool-activity.tsx
@@ -101,7 +101,9 @@ export function ExploreToolActivity({
     return null;
   }
 
-  if (isLive) {
+  // Prefer the failure rollup while any grouped tool has already failed/denied,
+  // even if a sibling explore call is still pending.
+  if (isLive && !hasFailed) {
     const liveLabel = formatLiveExploreLabel(intl, latestPart);
     return (
       <div

--- a/apps/hyperlocalise-web/src/components/ai-elements/explore-tool-activity.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/explore-tool-activity.tsx
@@ -15,7 +15,7 @@
 import { ScrambleText } from "dot-anime-react";
 import { ChevronDownIcon } from "lucide-react";
 import { useReducedMotion } from "motion/react";
-import type { ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { useIntl } from "react-intl";
 
 import { Task, TaskContent, TaskTrigger } from "@/components/ai-elements/task";
@@ -96,6 +96,14 @@ export function ExploreToolActivity({
   const latestPart = parts.at(-1);
   const isLive = parts.some(isToolPartRunning);
   const hasFailed = parts.some(isToolPartFailed);
+  // Controlled: defaultOpen would not reopen when a mounted rollup later fails.
+  const [open, setOpen] = useState(hasFailed);
+
+  useEffect(() => {
+    if (hasFailed) {
+      setOpen(true);
+    }
+  }, [hasFailed]);
 
   if (!latestPart) {
     return null;
@@ -126,7 +134,7 @@ export function ExploreToolActivity({
   const rollupLabel = formatExploreRollupLabel(intl, parts, hasFailed);
 
   return (
-    <Task defaultOpen={hasFailed} className="mb-1 w-full">
+    <Task open={open} onOpenChange={setOpen} className="mb-1 w-full">
       <TaskTrigger title={rollupLabel} className="w-full">
         <div
           className={

--- a/apps/hyperlocalise-web/src/components/ai-elements/tool-activity.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/tool-activity.messages.ts
@@ -16,69 +16,69 @@ import { defineMessages } from "react-intl";
 
 export const toolActivityMessages = defineMessages({
   searching: {
-    id: "tActSearch00",
+    id: "n3a+6mF2IX",
     defaultMessage: "Searching",
     description: "Live explore status when the agent is searching without a subject",
   },
   searchingDetail: {
-    id: "tActSearch01",
+    id: "yJSROTn1AA",
     defaultMessage: "Searching {detail}",
     description: "Live explore status when the agent is searching for a subject",
   },
   reading: {
-    id: "tActRead0000",
+    id: "ufFJx4vPTD",
     defaultMessage: "Reading",
     description: "Live explore status when the agent is reading a file without a subject",
   },
   readingDetail: {
-    id: "tActRead0001",
+    id: "JRvO1zUFRY",
     defaultMessage: "Reading {detail}",
     description: "Live explore status when the agent is reading a named file",
   },
   findingFiles: {
-    id: "tActFind0000",
+    id: "m8UlToMOXC",
     defaultMessage: "Finding files",
     description: "Live explore status when the agent is listing files without a pattern",
   },
   findingDetail: {
-    id: "tActFind0001",
+    id: "/iIPpWEOXd",
     defaultMessage: "Finding {detail}",
     description: "Live explore status when the agent is listing files with a pattern",
   },
   checkingRepoConfig: {
-    id: "tActRepoCfg0",
+    id: "zLa51T7B2l",
     defaultMessage: "Checking repository config",
     description: "Live explore status when the agent inspects repository localization config",
   },
   checkingGitHistory: {
-    id: "tActGitHist0",
+    id: "fFie7livIj",
     defaultMessage: "Checking git history",
     description: "Live explore status when the agent inspects git history",
   },
   working: {
-    id: "tActWorking0",
+    id: "U9HdNspgPF",
     defaultMessage: "Working…",
     description: "Fallback live explore status for an unknown explore tool",
   },
   exploredSubject: {
-    id: "tActExplrd0",
+    id: "6V8CrxumwV",
     defaultMessage:
       "{count, plural, one {Explored {subject}, # search} other {Explored {subject}, # searches}}",
     description: "Collapsed explore rollup with a subject and search count",
   },
   exploredCodebase: {
-    id: "tActExplrd1",
+    id: "40cOR2CWgx",
     defaultMessage:
       "{count, plural, one {Explored the codebase, # search} other {Explored the codebase, # searches}}",
     description: "Collapsed explore rollup without a subject",
   },
   openedFile: {
-    id: "tActOpen000",
+    id: "4f79gyGj6Q",
     defaultMessage: "Opened {subject}",
     description: "Collapsed explore rollup for a single file read",
   },
   openedFiles: {
-    id: "tActOpen001",
+    id: "PtTFfFyjEn",
     defaultMessage: "{count, plural, one {Opened # file} other {Opened # files}}",
     description: "Collapsed explore rollup for multiple file reads",
   },

--- a/apps/hyperlocalise-web/src/components/ai-elements/tool-activity.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/tool-activity.messages.ts
@@ -1,0 +1,85 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const toolActivityMessages = defineMessages({
+  searching: {
+    id: "tActSearch00",
+    defaultMessage: "Searching",
+    description: "Live explore status when the agent is searching without a subject",
+  },
+  searchingDetail: {
+    id: "tActSearch01",
+    defaultMessage: "Searching {detail}",
+    description: "Live explore status when the agent is searching for a subject",
+  },
+  reading: {
+    id: "tActRead0000",
+    defaultMessage: "Reading",
+    description: "Live explore status when the agent is reading a file without a subject",
+  },
+  readingDetail: {
+    id: "tActRead0001",
+    defaultMessage: "Reading {detail}",
+    description: "Live explore status when the agent is reading a named file",
+  },
+  findingFiles: {
+    id: "tActFind0000",
+    defaultMessage: "Finding files",
+    description: "Live explore status when the agent is listing files without a pattern",
+  },
+  findingDetail: {
+    id: "tActFind0001",
+    defaultMessage: "Finding {detail}",
+    description: "Live explore status when the agent is listing files with a pattern",
+  },
+  checkingRepoConfig: {
+    id: "tActRepoCfg0",
+    defaultMessage: "Checking repository config",
+    description: "Live explore status when the agent inspects repository localization config",
+  },
+  checkingGitHistory: {
+    id: "tActGitHist0",
+    defaultMessage: "Checking git history",
+    description: "Live explore status when the agent inspects git history",
+  },
+  working: {
+    id: "tActWorking0",
+    defaultMessage: "Working…",
+    description: "Fallback live explore status for an unknown explore tool",
+  },
+  exploredSubject: {
+    id: "tActExplrd0",
+    defaultMessage:
+      "{count, plural, one {Explored {subject}, # search} other {Explored {subject}, # searches}}",
+    description: "Collapsed explore rollup with a subject and search count",
+  },
+  exploredCodebase: {
+    id: "tActExplrd1",
+    defaultMessage:
+      "{count, plural, one {Explored the codebase, # search} other {Explored the codebase, # searches}}",
+    description: "Collapsed explore rollup without a subject",
+  },
+  openedFile: {
+    id: "tActOpen000",
+    defaultMessage: "Opened {subject}",
+    description: "Collapsed explore rollup for a single file read",
+  },
+  openedFiles: {
+    id: "tActOpen001",
+    defaultMessage: "{count, plural, one {Opened # file} other {Opened # files}}",
+    description: "Collapsed explore rollup for multiple file reads",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/tool-activity.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/tool-activity.messages.ts
@@ -82,4 +82,14 @@ export const toolActivityMessages = defineMessages({
     defaultMessage: "{count, plural, one {Opened # file} other {Opened # files}}",
     description: "Collapsed explore rollup for multiple file reads",
   },
+  exploreFailedSubject: {
+    id: "T8Ggt03ksb",
+    defaultMessage: "Couldn't explore {subject}",
+    description: "Completed explore rollup when at least one tool failed and a subject is known",
+  },
+  exploreFailed: {
+    id: "WhBlkGYmVr",
+    defaultMessage: "Couldn't explore the codebase",
+    description: "Completed explore rollup when at least one tool failed and no subject is known",
+  },
 });

--- a/apps/hyperlocalise-web/src/components/ai-elements/tool-activity.test.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/tool-activity.test.ts
@@ -45,6 +45,7 @@ describe("tool-activity helpers", () => {
         toolCallId: "dyn-read",
         state: "output-available",
         input: { path: "src/a.tsx" },
+        output: { content: "ok" },
       }),
     ).toBe(true);
   });
@@ -84,10 +85,7 @@ describe("tool-activity helpers", () => {
       count: 2,
     });
 
-    const readsOnly = [
-      toolPart("read", { path: "a.tsx" }),
-      toolPart("read", { path: "b.tsx" }),
-    ];
+    const readsOnly = [toolPart("read", { path: "a.tsx" }), toolPart("read", { path: "b.tsx" })];
     expect(getExploreRollupStats(readsOnly)).toMatchObject({
       onlyReads: true,
       readCount: 2,

--- a/apps/hyperlocalise-web/src/components/ai-elements/tool-activity.test.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/tool-activity.test.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  formatToolSubject,
+  getExploreRollupStats,
+  getToolName,
+  groupToolActivityBlocks,
+  isExploreToolPart,
+  type ToolPart,
+} from "./tool-activity";
+
+function toolPart(
+  name: string,
+  input: Record<string, unknown>,
+  state: ToolPart["state"] = "output-available",
+): ToolPart {
+  return {
+    type: `tool-${name}`,
+    toolCallId: `${name}-${JSON.stringify(input)}`,
+    state,
+    input,
+  } as ToolPart;
+}
+
+describe("tool-activity helpers", () => {
+  it("detects explore tools from static and dynamic parts", () => {
+    expect(isExploreToolPart(toolPart("grep", { pattern: "Save" }))).toBe(true);
+    expect(isExploreToolPart(toolPart("captureScreenshot", {}))).toBe(false);
+    expect(
+      isExploreToolPart({
+        type: "dynamic-tool",
+        toolName: "read",
+        toolCallId: "dyn-read",
+        state: "output-available",
+        input: { path: "src/a.tsx" },
+      }),
+    ).toBe(true);
+  });
+
+  it("groups consecutive explore tools and breaks on action tools", () => {
+    const parts = [
+      toolPart("grep", { pattern: "Save" }),
+      toolPart("read", { path: "apps/web/src/account-form.tsx" }),
+      toolPart("captureScreenshot", { target: { storyId: "story" } }),
+      toolPart("glob", { pattern: "**/*.tsx" }),
+    ];
+
+    expect(groupToolActivityBlocks(parts)).toEqual([
+      { kind: "explore", parts: [parts[0], parts[1]] },
+      { kind: "single", part: parts[2] },
+      { kind: "explore", parts: [parts[3]] },
+    ]);
+  });
+
+  it("formats path subjects to basenames", () => {
+    expect(formatToolSubject("apps/web/src/account-form.tsx")).toBe("account-form.tsx");
+    expect(formatToolSubject("Save")).toBe("Save");
+    expect(getToolName(toolPart("fuzzySearch", { query: "label" }))).toBe("fuzzySearch");
+  });
+
+  it("summarizes explore rollups for searches and reads", () => {
+    const mixed = [
+      toolPart("grep", { pattern: "Save" }),
+      toolPart("read", { path: "apps/web/src/account-form.tsx" }),
+      toolPart("grep", { pattern: "Cancel" }),
+    ];
+    expect(getExploreRollupStats(mixed)).toMatchObject({
+      subject: "account-form.tsx",
+      searchCount: 2,
+      readCount: 1,
+      onlyReads: false,
+      count: 2,
+    });
+
+    const readsOnly = [
+      toolPart("read", { path: "a.tsx" }),
+      toolPart("read", { path: "b.tsx" }),
+    ];
+    expect(getExploreRollupStats(readsOnly)).toMatchObject({
+      onlyReads: true,
+      readCount: 2,
+      subject: "b.tsx",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/tool-activity.test.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/tool-activity.test.ts
@@ -18,6 +18,7 @@ import {
   getToolName,
   groupToolActivityBlocks,
   isExploreToolPart,
+  isToolPartFailed,
   type ToolPart,
 } from "./tool-activity";
 
@@ -69,6 +70,12 @@ describe("tool-activity helpers", () => {
     expect(formatToolSubject("apps/web/src/account-form.tsx")).toBe("account-form.tsx");
     expect(formatToolSubject("Save")).toBe("Save");
     expect(getToolName(toolPart("fuzzySearch", { query: "label" }))).toBe("fuzzySearch");
+  });
+
+  it("detects failed tool states", () => {
+    expect(isToolPartFailed(toolPart("grep", { pattern: "Save" }, "output-error"))).toBe(true);
+    expect(isToolPartFailed(toolPart("grep", { pattern: "Save" }, "output-denied"))).toBe(true);
+    expect(isToolPartFailed(toolPart("grep", { pattern: "Save" }))).toBe(false);
   });
 
   it("summarizes explore rollups for searches and reads", () => {

--- a/apps/hyperlocalise-web/src/components/ai-elements/tool-activity.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/tool-activity.ts
@@ -51,6 +51,10 @@ export function isToolPartRunning(part: ToolPart): boolean {
   return part.state === "input-streaming" || part.state === "input-available";
 }
 
+export function isToolPartFailed(part: ToolPart): boolean {
+  return part.state === "output-error" || part.state === "output-denied";
+}
+
 export function groupToolActivityBlocks(parts: ToolPart[]): ToolActivityBlock[] {
   const blocks: ToolActivityBlock[] = [];
 

--- a/apps/hyperlocalise-web/src/components/ai-elements/tool-activity.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/tool-activity.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { DynamicToolUIPart, ToolUIPart } from "ai";
+
+import { extractToolInputDetail } from "./tool";
+
+export type ToolPart = ToolUIPart | DynamicToolUIPart;
+
+/** Repository read tools that collapse into Cursor-style explore rollups. */
+export const EXPLORE_TOOL_NAMES = new Set([
+  "grep",
+  "fuzzySearch",
+  "read",
+  "glob",
+  "detectRepoConfig",
+  "gitHistory",
+]);
+
+export const SEARCH_TOOL_NAMES = new Set(["grep", "fuzzySearch", "glob"]);
+export const READ_TOOL_NAMES = new Set(["read"]);
+
+export type ToolActivityBlock =
+  | { kind: "explore"; parts: ToolPart[] }
+  | { kind: "single"; part: ToolPart };
+
+export function getToolName(part: ToolPart): string {
+  if (part.type === "dynamic-tool") {
+    return part.toolName;
+  }
+  if (typeof part.type === "string" && part.type.startsWith("tool-")) {
+    return part.type.slice("tool-".length);
+  }
+  return "tool";
+}
+
+export function isExploreToolPart(part: ToolPart): boolean {
+  return EXPLORE_TOOL_NAMES.has(getToolName(part));
+}
+
+export function isToolPartRunning(part: ToolPart): boolean {
+  return part.state === "input-streaming" || part.state === "input-available";
+}
+
+export function groupToolActivityBlocks(parts: ToolPart[]): ToolActivityBlock[] {
+  const blocks: ToolActivityBlock[] = [];
+
+  for (const part of parts) {
+    const last = blocks.at(-1);
+    if (isExploreToolPart(part) && last?.kind === "explore") {
+      last.parts.push(part);
+      continue;
+    }
+    if (isExploreToolPart(part)) {
+      blocks.push({ kind: "explore", parts: [part] });
+      continue;
+    }
+    blocks.push({ kind: "single", part });
+  }
+
+  return blocks;
+}
+
+export function formatToolSubject(detail: string | null): string | null {
+  if (!detail) {
+    return null;
+  }
+
+  const trimmed = detail.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const withoutQuery = trimmed.split(/[?#]/)[0] ?? trimmed;
+  const base = withoutQuery.split(/[/\\]/).filter(Boolean).at(-1);
+  return base && base.length > 0 ? base : trimmed;
+}
+
+export function getToolPartSubject(part: ToolPart): string | null {
+  return formatToolSubject(extractToolInputDetail(part.input));
+}
+
+function isPathLikeSubject(subject: string): boolean {
+  return subject.includes("/") || subject.includes("\\") || /\.\w{1,8}$/.test(subject);
+}
+
+export function getExploreSubject(parts: ToolPart[]): string | null {
+  const reversed = [...parts].reverse();
+
+  for (const part of reversed) {
+    if (!READ_TOOL_NAMES.has(getToolName(part))) {
+      continue;
+    }
+    const subject = getToolPartSubject(part);
+    if (subject) {
+      return subject;
+    }
+  }
+
+  for (const part of reversed) {
+    const detail = extractToolInputDetail(part.input);
+    if (detail && isPathLikeSubject(detail)) {
+      return formatToolSubject(detail);
+    }
+  }
+
+  for (const part of reversed) {
+    const subject = getToolPartSubject(part);
+    if (subject) {
+      return subject;
+    }
+  }
+
+  return null;
+}
+
+export function getExploreRollupStats(parts: ToolPart[]): {
+  subject: string | null;
+  searchCount: number;
+  readCount: number;
+  onlyReads: boolean;
+  count: number;
+} {
+  const subject = getExploreSubject(parts);
+  const searchCount = parts.filter((part) => SEARCH_TOOL_NAMES.has(getToolName(part))).length;
+  const readCount = parts.filter((part) => READ_TOOL_NAMES.has(getToolName(part))).length;
+  const onlyReads = searchCount === 0 && readCount > 0;
+  const count = searchCount > 0 ? searchCount : parts.length;
+
+  return { subject, searchCount, readCount, onlyReads, count };
+}

--- a/docs/plans/2026-08-09-compact-agent-tool-activity-design.md
+++ b/docs/plans/2026-08-09-compact-agent-tool-activity-design.md
@@ -1,0 +1,54 @@
+# Compact agent tool activity
+
+## Problem
+
+Inbox and chat-dock assistant messages list every tool call (`grep`, `read`, …) as its
+own row. Non-technical users see a wall of implementation detail instead of progress.
+
+Cursor collapses exploration into muted rollups such as “Explored release.yml, 5
+searches”, and shows a single live status line while work is in flight.
+
+## Decision
+
+UI-only change in the shared message renderer (`AssistantMessageParts`):
+
+1. Group consecutive **explore** tools into one block.
+2. While any tool in that block is in flight, show one live line with
+   `ScrambleText` from `dot-anime-react` and friendly copy (“Searching Save”,
+   “Reading account-form.tsx”).
+3. When the block finishes, show a collapsed rollup (“Explored account-form.tsx,
+   5 searches”). Expand reveals existing per-tool `Tool` rows.
+4. Keep action tools (`captureScreenshot`, `write`, `applyPatch`, `todoWrite`,
+   translation/TMS tools, and anything not on the explore allowlist) as individual
+   rows.
+
+Reuse unused `Task` / `TaskTrigger` for the rollup shell. No stream, API, or
+persistence changes.
+
+## Explore allowlist
+
+Roll up only these repository read tools:
+
+- `grep`, `fuzzySearch`, `read`, `glob`, `detectRepoConfig`, `gitHistory`
+
+Unknown tools stay individual. An action tool breaks the consecutive group.
+
+## Copy
+
+| State | Example |
+|-------|---------|
+| Live scramble | Searching {detail} / Reading {detail} / Finding files / Checking repository config |
+| Done with searches | Explored {subject}, {count} searches |
+| Reads only | Opened {subject} / Opened {count} files |
+| No subject | Explored the codebase, {count} searches |
+
+Subject comes from `extractToolInputDetail`, with path basenames. Honor
+`prefers-reduced-motion` by disabling scramble animation.
+
+## Success criteria
+
+- Long explore runs read as one or two muted lines by default.
+- Latest in-flight explore tool updates with scramble text.
+- Screenshots, todos, and writes remain visible as today.
+- Inbox and chat dock share the same behavior.
+- `vp test` and `vp check --fix` pass.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Agent chat was listing every `grep` / `read` as its own row, which is noisy for non-technical users. This change matches Cursor’s compact pattern:

- Consecutive explore tools (`grep`, `fuzzySearch`, `read`, `glob`, `detectRepoConfig`, `gitHistory`) collapse into one muted rollup (e.g. “Explored account-form.tsx, 2 searches”).
- While an explore tool is in flight, show a single friendly live line via `ScrambleText` from the existing `dot-anime-react` dependency (“Searching Save”, “Reading account-form.tsx”).
- Screenshots, todos, writes, and other action tools stay as individual rows.
- Expand the rollup to see the existing per-tool detail cards.

## Design

See `docs/plans/2026-08-09-compact-agent-tool-activity-design.md`.

## Test plan

- [x] Unit tests for grouping / subject / rollup stats
- [x] Component tests for live scramble label and completed rollup
- [x] `vp check` / `vp check --fix` in `apps/hyperlocalise-web`
- [x] Storybook stories: `CompactExploreToolsStreaming`, `CompactExploreToolsCompleted`
- [ ] Manual: stream an explore-heavy turn in inbox/chat dock and confirm compact UI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5852bb05-1fa1-4684-810f-5b816250dd74?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5852bb05-1fa1-4684-810f-5b816250dd74&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

