### PR TITLE
fix(automations): stop forcing memory tools

### DIFF
--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.test.ts
@@ -164,9 +164,7 @@ describe("buildWorkspaceOrchestratorPlan", () => {
     expect(plan.tools).toEqual(["use_ahrefs", "notify_slack"]);
   });
 
-  it("runs recall_memory before workflow and notification tools", () => {
-    // Every planned tool is forced in this exact order (agent.ts's prepareStep), so recalled
-    // guidance must be available before the tools it's meant to inform run, not after.
+    it("does not plan recall_memory when knowledge is enabled", () => {
     const plan = buildWorkspaceOrchestratorPlan(
       automation({
         projectId: "project-1",
@@ -184,14 +182,10 @@ describe("buildWorkspaceOrchestratorPlan", () => {
       }),
     );
 
-    expect(plan.tools).toEqual(["recall_memory", "run_github_workflows", "notify_slack"]);
+        expect(plan.tools).toEqual(["run_github_workflows", "notify_slack"]);
   });
 
-  it("includes save_memory, forced, positioned after workflow tools and before notifications, when allowUpdates is on", () => {
-    // save_memory is a forced tool like every other planned tool (see plan.ts's MEMORY_TOOLS
-    // comment for why): agent.ts's ToolLoopAgent only continues past a step that produced a tool
-    // call, so an "optional, model may skip" step positioned before other forced tools risked the
-    // run ending before those later tools — e.g. a Slack/email notification — ever ran.
+    it("does not plan save_memory when knowledge updates are allowed", () => {
     const plan = buildWorkspaceOrchestratorPlan(
       automation({
         projectId: "project-1",
@@ -209,12 +203,7 @@ describe("buildWorkspaceOrchestratorPlan", () => {
       }),
     );
 
-    expect(plan.tools).toEqual([
-      "recall_memory",
-      "run_github_workflows",
-      "save_memory",
-      "notify_slack",
-    ]);
+        expect(plan.tools).toEqual(["run_github_workflows", "notify_slack"]);
   });
 
   it("doesn't plan save_memory when allowUpdates is off", () => {
@@ -231,21 +220,16 @@ describe("buildWorkspaceOrchestratorPlan", () => {
 });
 
 describe("planHasActionableTool", () => {
-  it("is false for a recall_memory-only plan", () => {
-    // Regression for a Codex finding: dispatchManualWorkspaceAutomationRun (and other dispatch
-    // paths) used to check plan.tools.length === 0 to decide whether a run is meaningful. Once
-    // recall_memory could be the plan's only tool, that check passed for a plan that reads Memory
-    // and performs no workflow or notification action, letting a no-op run be dispatched and
-    // reported as successful.
+    it("is false when only knowledge recall is enabled", () => {
     const plan = buildWorkspaceOrchestratorPlan(
       automation({ toolConfig: { knowledge: { enabled: true, allowUpdates: false } } }),
     );
 
-    expect(plan.tools).toEqual(["recall_memory"]);
+        expect(plan.tools).toEqual([]);
     expect(planHasActionableTool(plan)).toBe(false);
   });
 
-  it("is true once a workflow or notification tool is planned alongside memory", () => {
+    it("is true when a notification tool is planned alongside disabled memory execution", () => {
     const plan = buildWorkspaceOrchestratorPlan(
       automation({
         projectId: "project-1",
@@ -256,7 +240,7 @@ describe("planHasActionableTool", () => {
       }),
     );
 
-    expect(plan.tools).toEqual(["recall_memory", "notify_slack"]);
+        expect(plan.tools).toEqual(["notify_slack"]);
     expect(planHasActionableTool(plan)).toBe(true);
   });
 
@@ -264,20 +248,12 @@ describe("planHasActionableTool", () => {
     expect(planHasActionableTool(buildWorkspaceOrchestratorPlan(automation()))).toBe(false);
   });
 
-  it("is false for a plan of only recall_memory and save_memory", () => {
-    // Regression for a Codex finding: save_memory living outside MEMORY_TOOLS (so agent.ts can
-    // force it — see plan.ts's MEMORY_TOOLS comment) made this predicate treat it as actionable.
-    // But whether save_memory writes anything is entirely the model's call (it can always return
-    // entry: null), so a plan of only these two tools is never a *guaranteed* effect the way a
-    // workflow or notification tool is — and workspaceAutomationFormCanActivate already excludes
-    // Memory (both directions) from what makes an automation activatable in the UI. Treating this
-    // as actionable would let dispatchManualWorkspaceAutomationRun accept and bill a run the UI
-    // itself wouldn't have allowed the automation to be created with.
+    it("is false when knowledge recall and updates are enabled without another tool", () => {
     const plan = buildWorkspaceOrchestratorPlan(
       automation({ toolConfig: { knowledge: { enabled: true, allowUpdates: true } } }),
     );
 
-    expect(plan.tools).toEqual(["recall_memory", "save_memory"]);
+        expect(plan.tools).toEqual([]);
     expect(planHasActionableTool(plan)).toBe(false);
   });
 });

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.test.ts
@@ -164,7 +164,7 @@ describe("buildWorkspaceOrchestratorPlan", () => {
     expect(plan.tools).toEqual(["use_ahrefs", "notify_slack"]);
   });
 
-    it("does not plan recall_memory when knowledge is enabled", () => {
+  it("does not plan recall_memory when knowledge is enabled", () => {
     const plan = buildWorkspaceOrchestratorPlan(
       automation({
         projectId: "project-1",
@@ -182,10 +182,10 @@ describe("buildWorkspaceOrchestratorPlan", () => {
       }),
     );
 
-        expect(plan.tools).toEqual(["run_github_workflows", "notify_slack"]);
+    expect(plan.tools).toEqual(["run_github_workflows", "notify_slack"]);
   });
 
-    it("does not plan save_memory when knowledge updates are allowed", () => {
+  it("does not plan save_memory when knowledge updates are allowed", () => {
     const plan = buildWorkspaceOrchestratorPlan(
       automation({
         projectId: "project-1",
@@ -203,7 +203,7 @@ describe("buildWorkspaceOrchestratorPlan", () => {
       }),
     );
 
-        expect(plan.tools).toEqual(["run_github_workflows", "notify_slack"]);
+    expect(plan.tools).toEqual(["run_github_workflows", "notify_slack"]);
   });
 
   it("doesn't plan save_memory when allowUpdates is off", () => {
@@ -220,16 +220,16 @@ describe("buildWorkspaceOrchestratorPlan", () => {
 });
 
 describe("planHasActionableTool", () => {
-    it("is false when only knowledge recall is enabled", () => {
+  it("is false when only knowledge recall is enabled", () => {
     const plan = buildWorkspaceOrchestratorPlan(
       automation({ toolConfig: { knowledge: { enabled: true, allowUpdates: false } } }),
     );
 
-        expect(plan.tools).toEqual([]);
+    expect(plan.tools).toEqual([]);
     expect(planHasActionableTool(plan)).toBe(false);
   });
 
-    it("is true when a notification tool is planned alongside disabled memory execution", () => {
+  it("is true when a notification tool is planned alongside disabled memory execution", () => {
     const plan = buildWorkspaceOrchestratorPlan(
       automation({
         projectId: "project-1",
@@ -240,7 +240,7 @@ describe("planHasActionableTool", () => {
       }),
     );
 
-        expect(plan.tools).toEqual(["notify_slack"]);
+    expect(plan.tools).toEqual(["notify_slack"]);
     expect(planHasActionableTool(plan)).toBe(true);
   });
 
@@ -248,12 +248,12 @@ describe("planHasActionableTool", () => {
     expect(planHasActionableTool(buildWorkspaceOrchestratorPlan(automation()))).toBe(false);
   });
 
-    it("is false when knowledge recall and updates are enabled without another tool", () => {
+  it("is false when knowledge recall and updates are enabled without another tool", () => {
     const plan = buildWorkspaceOrchestratorPlan(
       automation({ toolConfig: { knowledge: { enabled: true, allowUpdates: true } } }),
     );
 
-        expect(plan.tools).toEqual([]);
+    expect(plan.tools).toEqual([]);
     expect(planHasActionableTool(plan)).toBe(false);
   });
 });

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.ts
@@ -18,8 +18,6 @@ import {
   hasWorkspaceAutomationAssignTranslateWithAgentTool,
   hasWorkspaceAutomationContentfulWorkflow,
   hasWorkspaceAutomationCreateNativeTmsJobTool,
-  hasWorkspaceAutomationKnowledgeTool,
-  hasWorkspaceAutomationKnowledgeUpdatesAllowed,
   type WorkspaceAutomationRecord,
   type WorkspaceAutomationToolConfig,
 } from "@/lib/agents/workspace-automations";
@@ -62,27 +60,11 @@ const WORKFLOW_TOOLS: WorkspaceOrchestratorToolName[] = [
 
 const NOTIFICATION_TOOLS: WorkspaceOrchestratorToolName[] = ["notify_slack", "notify_email"];
 
-// Not part of WORKFLOW_TOOLS: memory tools are general availability, not ordered workflow steps,
-// so they skip orderWorkflowTools' template-skill-executor reordering entirely.
-//
-// save_memory is forced (not offered as an "auto" step) rather than grouped into MEMORY_TOOLS
-// below: forcing every planned tool via toolChoice ({type:"tool",...}) is the only way agent.ts's
-// ToolLoopAgent reliably reaches the tools planned after it — the underlying loop only continues
-// past a step that produced zero tool calls, so a toolChoice: "auto" step risked the model ending
-// the run before a later forced notification tool ever ran (a real Codex finding against an
-// earlier version of this file). It's still not "invented content on every run" per the
-// *original* finding against forcing it: its schema accepts entry: null as an explicit "nothing
-// to remember" decision.
-const MEMORY_TOOLS: WorkspaceOrchestratorToolName[] = ["recall_memory"];
-const SAVE_MEMORY_TOOLS: WorkspaceOrchestratorToolName[] = ["save_memory"];
-// Both memory tools together, used only by planHasActionableTool: whether save_memory actually
-// writes anything is entirely the model's call (it can always return entry: null), so a plan
-// offering only recall_memory and/or save_memory isn't a guaranteed real effect the way a
-// workflow or notification tool is. workspaceAutomationFormCanActivate already excludes Memory
-// (both directions) from the set of tools that make an automation activatable in the UI; treating
-// save_memory as actionable here would let dispatchManualWorkspaceAutomationRun accept and bill a
-// run the UI itself wouldn't have allowed the automation to be created with in the first place.
-const MEMORY_ONLY_TOOLS: WorkspaceOrchestratorToolName[] = [...MEMORY_TOOLS, ...SAVE_MEMORY_TOOLS];
+// Memory tools remain in the tool-name union while the retrieval redesign is pending, but they
+// must not be added to execution plans. The orchestrator forces every planned tool, so planning
+// recall_memory/save_memory made both calls mandatory on every run. Keeping them out of plans
+// disables automation memory execution without affecting the human editor or chat memory tools.
+const MEMORY_ONLY_TOOLS: WorkspaceOrchestratorToolName[] = ["recall_memory", "save_memory"];
 
 function workflowToolEnabled(
   tool: WorkspaceOrchestratorToolName,
@@ -121,20 +103,6 @@ function notificationToolEnabled(
         toolConfig.email.recipients &&
         toolConfig.email.recipients.length > 0,
       );
-    default:
-      return false;
-  }
-}
-
-function memoryToolEnabled(
-  tool: WorkspaceOrchestratorToolName,
-  toolConfig: WorkspaceAutomationToolConfig,
-): boolean {
-  switch (tool) {
-    case "recall_memory":
-      return hasWorkspaceAutomationKnowledgeTool(toolConfig);
-    case "save_memory":
-      return hasWorkspaceAutomationKnowledgeUpdatesAllowed(toolConfig);
     default:
       return false;
   }
@@ -187,27 +155,15 @@ export function buildWorkspaceOrchestratorPlan(
   const notificationTools = NOTIFICATION_TOOLS.filter((tool) =>
     notificationToolEnabled(tool, automation.toolConfig),
   );
-  const memoryTools = MEMORY_TOOLS.filter((tool) => memoryToolEnabled(tool, automation.toolConfig));
-  const saveMemoryTools = SAVE_MEMORY_TOOLS.filter((tool) =>
-    memoryToolEnabled(tool, automation.toolConfig),
-  );
 
-  // recall_memory runs first and save_memory runs last before notifications: every planned tool
-  // executes strictly in this order (agent.ts's prepareStep forces each one in turn), so recalled
-  // guidance lands before the workflow tools it's meant to inform, and a memory write reflects
-  // what those tools actually did before the run's notification summarizes the outcome.
   return {
-    tools: [...memoryTools, ...workflowTools, ...saveMemoryTools, ...notificationTools],
+    tools: [...workflowTools, ...notificationTools],
   };
 }
 
 /**
- * Whether the plan includes at least one tool beyond the memory tools — callers use this instead
- * of a raw plan.tools.length check to decide whether a run is meaningful enough to dispatch. A
- * plan of only recall_memory and/or save_memory means the run would, at best, read Memory and
- * *maybe* write to it if the model decides to — never a guaranteed workflow or notification
- * effect, and consistent with workspaceAutomationFormCanActivate excluding Memory from the tools
- * that make an automation activatable in the UI.
+ * Whether the plan includes an actionable workflow or notification tool. Memory tools are
+ * excluded defensively even though buildWorkspaceOrchestratorPlan no longer emits them.
  */
 export function planHasActionableTool(plan: WorkspaceOrchestratorPlan): boolean {
   return plan.tools.some((tool) => !MEMORY_ONLY_TOOLS.includes(tool));

--- a/docs/plans/2026-08-09-disable-forced-automation-memory-tools-design.md
+++ b/docs/plans/2026-08-09-disable-forced-automation-memory-tools-design.md
@@ -1,0 +1,34 @@
+# Disable forced automation memory tools
+
+## Problem
+
+Workspace automation plans currently include `recall_memory` whenever organization memory is
+enabled and `save_memory` whenever updates are allowed. The orchestrator forces every planned
+tool call, so both memory operations run on every eligible automation. A nullable save entry
+avoids mandatory writes, but it does not make the tool call optional.
+
+This behavior adds model work and can inject unrelated fallback guidance or append low-quality
+content. Making either step use automatic tool choice is unsafe in the current loop because a
+skipped tool can end the run before required workflow or notification tools execute.
+
+## Decision
+
+Do not add `recall_memory` or `save_memory` to generated workspace automation plans.
+
+- Keep workflow and notification planning unchanged.
+- Keep organization memory storage, the Knowledge editor, and chat memory tools unchanged.
+- Preserve the automation memory configuration fields for compatibility with saved automation
+  records and the planned retrieval redesign.
+- Keep the memory tool implementations temporarily, but make them unreachable from generated
+  automation plans.
+
+This is an immediate safety change, not the final retrieval architecture. Optional automation
+memory access requires an orchestrator design where skipping an optional call cannot terminate
+required execution.
+
+## Verification
+
+- Planning tests must prove that enabling memory or memory updates does not add memory tools.
+- Plans containing workflow and notification tools must otherwise remain unchanged.
+- Memory-only automation configuration must still produce no actionable plan.
+- Run the web test and check suites before finalizing.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

- Stop adding `recall_memory` and `save_memory` to generated workspace automation plans.
- Preserve workflow and notification planning behavior.
- Keep memory configuration and tool implementations in place for compatibility while retrieval is redesigned.
- Document the temporary runtime disablement and its rationale.

## How to test

- `vp test` — 582 files and 3,769 tests passed.
- `vp check --fix` — passed with one pre-existing `.storybook/main.ts` warning.

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe8d8-a004-77ee-a3a5-73a236e5dd66?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe8d8-a004-77ee-a3a5-73a236e5dd66&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

