### PR TITLE
fix(agent): use human progress copy for visual context

### DIFF
--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.test.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.test.ts
@@ -298,7 +298,7 @@ describe("createWebChatAgentUIStreamResponse", () => {
       expect.objectContaining({ knowledgeMemoryEnabled: true }),
     );
     expect(body).toContain("data-status");
-    expect(body).toContain("Preparing");
+    expect(body).toContain("Setting up workspace");
     expect(body).toContain("Which repository should I search?");
     expect(addInteractionMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.ts
@@ -122,7 +122,7 @@ export function createWebChatAgentUIStreamResponse(input: {
       writer.write({
         type: "data-status",
         id: "prep",
-        data: { message: "Preparing…" },
+        data: { message: "Setting up workspace…" },
       });
 
       const prepared = await prepareAndCommitWebConversationTurn(input.conversationId, {

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/visual-mock.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/visual-mock.md
@@ -15,10 +15,10 @@ This is an agent workflow skill, not a screenshot product tool. Compose lower-le
 
 - Clarify the target screen, state, viewport, and purpose only when they cannot be inferred from the request or repository context.
 - Before repository inspection, call `todoWrite` with this workflow checklist and keep it updated after each milestone:
-  1. `Find the target component and an existing Storybook story` — `in-progress`
+  1. `Find the target component and an existing preview` — `in-progress`
   2. `Prepare a representative preview state` — `todo`
   3. `Capture and verify the screenshot` — `todo`
-- Keep exactly one checklist item `in-progress`. When no suitable story exists, mark the first item `completed` and change the second item to `No story found — create a temporary Storybook story with mock data` before using `write` or `applyPatch`. After the preview renders, mark that item `completed` and the capture item `in-progress`. Mark every item `completed` only after screenshot capture succeeds.
+- Keep exactly one checklist item `in-progress`. When no suitable story exists, mark the first item `completed` and change the second item to `No preview found — create a temporary one with mock data` before using `write` or `applyPatch`. After the preview renders, mark that item `completed` and the capture item `in-progress`. Mark every item `completed` only after screenshot capture succeeds.
 - Inspect the repository for the relevant route, component, design system, fixtures, stories, test data, and styling before inventing UI.
 - Locate the component that renders the target string/key (usage site, parent screen, or leaf UI). Prefer capturing that component's UI over freehand descriptions.
 - Prefer an **existing** Storybook story for that component when one already exists. Reuse nearby fixtures, test data, or story args when possible.

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.stories.tsx
@@ -100,7 +100,7 @@ export const CreatingMissingStoryProgress: Story = {
               todos: [
                 {
                   id: "find-story",
-                  content: "Find the target component and an existing Storybook story",
+                  content: "Find the target component and an existing preview",
                   status: "in-progress",
                 },
               ],
@@ -110,7 +110,7 @@ export const CreatingMissingStoryProgress: Story = {
               todos: [
                 {
                   id: "find-story",
-                  content: "Find the target component and an existing Storybook story",
+                  content: "Find the target component and an existing preview",
                   status: "in-progress",
                 },
               ],
@@ -124,12 +124,12 @@ export const CreatingMissingStoryProgress: Story = {
               todos: [
                 {
                   id: "find-story",
-                  content: "Find the target component and an existing Storybook story",
+                  content: "Find the target component and an existing preview",
                   status: "completed",
                 },
                 {
                   id: "prepare-preview",
-                  content: "No story found — create a temporary Storybook story with mock data",
+                  content: "No preview found — create a temporary one with mock data",
                   status: "in-progress",
                 },
                 {
@@ -144,12 +144,12 @@ export const CreatingMissingStoryProgress: Story = {
               todos: [
                 {
                   id: "find-story",
-                  content: "Find the target component and an existing Storybook story",
+                  content: "Find the target component and an existing preview",
                   status: "completed",
                 },
                 {
                   id: "prepare-preview",
-                  content: "No story found — create a temporary Storybook story with mock data",
+                  content: "No preview found — create a temporary one with mock data",
                   status: "in-progress",
                 },
                 {
@@ -167,7 +167,7 @@ export const CreatingMissingStoryProgress: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByText("Progress")).toBeInTheDocument();
     await expect(
-      canvas.getByText("No story found — create a temporary Storybook story with mock data"),
+      canvas.getByText("No preview found — create a temporary one with mock data"),
     ).toBeInTheDocument();
     await expect(canvas.getAllByRole("status")).toHaveLength(1);
   },
@@ -184,7 +184,7 @@ export const ScreenshotProgressAndReasoning: Story = {
         parts: [
           {
             type: "reasoning",
-            text: "I found the matching Storybook story and am verifying the localized state.",
+            text: "I found a matching preview and am checking the localized state.",
             state: "done",
           },
           {
@@ -203,7 +203,7 @@ export const ScreenshotProgressAndReasoning: Story = {
             id: "capture-story",
             data: {
               toolCallId: "capture-story",
-              message: "Preparing browser and loading story…",
+              message: "Loading the preview…",
             },
           },
         ],
@@ -211,11 +211,9 @@ export const ScreenshotProgressAndReasoning: Story = {
     }),
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText("Preparing browser and loading story…")).toBeInTheDocument();
+    await expect(canvas.getByText("Loading the preview…")).toBeInTheDocument();
     await expect(
-      canvas.getByText(
-        "I found the matching Storybook story and am verifying the localized state.",
-      ),
+      canvas.getByText("I found a matching preview and am checking the localized state."),
     ).toBeInTheDocument();
   },
 };

--- a/apps/hyperlocalise-web/src/components/ai-elements/agent-todo-progress.test.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/agent-todo-progress.test.tsx
@@ -21,12 +21,12 @@ import { AgentTodoProgress, getAgentTodoItems } from "./agent-todo-progress";
 const items = [
   {
     id: "find-story",
-    content: "Find the target component and an existing Storybook story",
+    content: "Find the target component and an existing preview",
     status: "completed" as const,
   },
   {
     id: "prepare-preview",
-    content: "No story found — create a temporary Storybook story with mock data",
+    content: "No preview found — create a temporary one with mock data",
     status: "in-progress" as const,
   },
   {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.test.ts
@@ -575,19 +575,19 @@ describe("createCaptureScreenshotTool", () => {
       [
         {
           toolCallId: "test-tool-call",
-          message: "Resolving Storybook…",
+          message: "Looking for a preview…",
         },
       ],
       [
         {
           toolCallId: "test-tool-call",
-          message: "Preparing browser and loading story…",
+          message: "Loading the preview…",
         },
       ],
       [
         {
           toolCallId: "test-tool-call",
-          message: "Uploading screenshot…",
+          message: "Saving the screenshot…",
         },
       ],
     ]);
@@ -737,7 +737,7 @@ describe("createCaptureScreenshotTool", () => {
     expect(exec.mock.calls.filter(([command]) => command === "bash")).toHaveLength(2);
     expect(reportToolProgress).toHaveBeenCalledWith({
       toolCallId: "test-tool-call",
-      message: "Retrying screenshot capture…",
+      message: "Trying the capture again…",
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/capture-screenshot.ts
@@ -1041,7 +1041,7 @@ It does not commit, push, open pull requests, or publish repository changes.`,
 
       ctx.reportToolProgress?.({
         toolCallId,
-        message: "Resolving Storybook…",
+        message: "Looking for a preview…",
       });
       const resolvedPackage = await resolveStorybookPackage(repo);
       if ("errorCode" in resolvedPackage) {
@@ -1109,8 +1109,7 @@ It does not commit, push, open pull requests, or publish repository changes.`,
         attempts = attempt;
         ctx.reportToolProgress?.({
           toolCallId,
-          message:
-            attempt === 1 ? "Preparing browser and loading story…" : "Retrying screenshot capture…",
+          message: attempt === 1 ? "Loading the preview…" : "Trying the capture again…",
         });
         captureResult = await repo.bash.exec("bash", {
           args: ["-lc", captureCommand],
@@ -1157,7 +1156,7 @@ It does not commit, push, open pull requests, or publish repository changes.`,
       const content = Buffer.from(captureResult.stdout.trim(), "base64");
       ctx.reportToolProgress?.({
         toolCallId,
-        message: "Uploading screenshot…",
+        message: "Saving the screenshot…",
       });
       const storedFile = await createStoredFile({
         organizationId: ctx.organizationId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Softens user-facing agent status copy so visual context no longer surfaces Storybook jargon, and renames the workspace prep status to something more natural.

## Changes

- **Workspace status:** `Preparing…` → `Setting up workspace…`
- **Screenshot progress:** generic preview language (`Looking for a preview…`, `Loading the preview…`, `Trying the capture again…`, `Saving the screenshot…`)
- **Visual-mock checklist:** user-visible todo items no longer mention Storybook
- Updated matching tests and inbox Storybook fixtures

Agent-internal Storybook instructions in `visual-mock` stay technical so capture still works; only the human-facing wording changed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c3105bf-c821-4ba8-a61f-b044fb50e7b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c3105bf-c821-4ba8-a61f-b044fb50e7b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

