### PR TITLE
feat(web): persist issue detail sidebar collapse state

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
@@ -89,11 +89,8 @@ import { useIssueDetailMutations } from "./use-issue-detail-mutations";
 import { useIssueDetailQuery } from "./use-issue-detail-query";
 import { useIssueSheetColumnsQuery } from "./use-issue-sheet-columns-query";
 import { issueDetailPanelMessages as messages } from "./issue-detail-panel.messages";
-import {
-  readIssueDetailSidebarOpen,
-  writeIssueDetailSidebarOpen,
-  type IssueDetailSidebarScope,
-} from "./issue-detail-sidebar-state";
+import { type IssueDetailSidebarScope } from "./issue-detail-sidebar-state";
+import { useIssueDetailSidebarOpen } from "./use-issue-detail-sidebar-open";
 import { issueSheetSharedMessages as sharedMessages } from "../../projects/[projectId]/issue-sheet/_components/issue-sheet-shared.messages";
 import { formatRelativeTimestamp } from "../workspace-files-shared";
 
@@ -253,19 +250,12 @@ export const IssueDetailPanel = forwardRef<
   const [descriptionDraft, setDescriptionDraft] = useState("");
   const [ownerNoteDraft, setOwnerNoteDraft] = useState("");
   const [customColumnDrafts, setCustomColumnDrafts] = useState<Record<string, string>>({});
-  const [sidebarOpen, setSidebarOpen] = useState(() =>
-    readIssueDetailSidebarOpen(sidebarStorageScope, issueId, defaultSidebarOpen),
+  const [sidebarOpen, setSidebarOpen] = useIssueDetailSidebarOpen(
+    sidebarStorageScope,
+    issueId,
+    defaultSidebarOpen,
   );
   const isSaving = updateIssue.isPending || setValue.isPending;
-
-  useEffect(() => {
-    setSidebarOpen(readIssueDetailSidebarOpen(sidebarStorageScope, issueId, defaultSidebarOpen));
-  }, [sidebarStorageScope, issueId, defaultSidebarOpen]);
-
-  const handleSidebarOpenChange = (open: boolean) => {
-    setSidebarOpen(open);
-    writeIssueDetailSidebarOpen(sidebarStorageScope, issueId, open);
-  };
 
   const titleDraftRef = useRef(titleDraft);
   const descriptionDraftRef = useRef(descriptionDraft);
@@ -758,7 +748,7 @@ export const IssueDetailPanel = forwardRef<
 
       <Collapsible
         open={sidebarOpen}
-        onOpenChange={handleSidebarOpenChange}
+        onOpenChange={setSidebarOpen}
         className="flex min-h-0 flex-col overflow-hidden border-t border-border bg-muted/20 md:border-t-0 md:border-s"
       >
         <aside

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
@@ -89,6 +89,11 @@ import { useIssueDetailMutations } from "./use-issue-detail-mutations";
 import { useIssueDetailQuery } from "./use-issue-detail-query";
 import { useIssueSheetColumnsQuery } from "./use-issue-sheet-columns-query";
 import { issueDetailPanelMessages as messages } from "./issue-detail-panel.messages";
+import {
+  readIssueDetailSidebarOpen,
+  writeIssueDetailSidebarOpen,
+  type IssueDetailSidebarScope,
+} from "./issue-detail-sidebar-state";
 import { issueSheetSharedMessages as sharedMessages } from "../../projects/[projectId]/issue-sheet/_components/issue-sheet-shared.messages";
 import { formatRelativeTimestamp } from "../workspace-files-shared";
 
@@ -203,9 +208,17 @@ export const IssueDetailPanel = forwardRef<
     issueId: string;
     onDirtyChange?: (dirty: boolean) => void;
     defaultSidebarOpen?: boolean;
+    sidebarStorageScope?: IssueDetailSidebarScope;
   }
 >(function IssueDetailPanel(
-  { organizationSlug, projectId, issueId, onDirtyChange, defaultSidebarOpen = true },
+  {
+    organizationSlug,
+    projectId,
+    issueId,
+    onDirtyChange,
+    defaultSidebarOpen = true,
+    sidebarStorageScope = "issue-detail",
+  },
   ref,
 ) {
   const intl = useIntl();
@@ -240,8 +253,15 @@ export const IssueDetailPanel = forwardRef<
   const [descriptionDraft, setDescriptionDraft] = useState("");
   const [ownerNoteDraft, setOwnerNoteDraft] = useState("");
   const [customColumnDrafts, setCustomColumnDrafts] = useState<Record<string, string>>({});
-  const [sidebarOpen, setSidebarOpen] = useState(defaultSidebarOpen);
+  const [sidebarOpen, setSidebarOpen] = useState(() =>
+    readIssueDetailSidebarOpen(sidebarStorageScope, defaultSidebarOpen),
+  );
   const isSaving = updateIssue.isPending || setValue.isPending;
+
+  const handleSidebarOpenChange = (open: boolean) => {
+    setSidebarOpen(open);
+    writeIssueDetailSidebarOpen(sidebarStorageScope, open);
+  };
 
   const titleDraftRef = useRef(titleDraft);
   const descriptionDraftRef = useRef(descriptionDraft);
@@ -734,7 +754,7 @@ export const IssueDetailPanel = forwardRef<
 
       <Collapsible
         open={sidebarOpen}
-        onOpenChange={setSidebarOpen}
+        onOpenChange={handleSidebarOpenChange}
         className="flex min-h-0 flex-col overflow-hidden border-t border-border bg-muted/20 md:border-t-0 md:border-s"
       >
         <aside

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-panel.tsx
@@ -254,13 +254,17 @@ export const IssueDetailPanel = forwardRef<
   const [ownerNoteDraft, setOwnerNoteDraft] = useState("");
   const [customColumnDrafts, setCustomColumnDrafts] = useState<Record<string, string>>({});
   const [sidebarOpen, setSidebarOpen] = useState(() =>
-    readIssueDetailSidebarOpen(sidebarStorageScope, defaultSidebarOpen),
+    readIssueDetailSidebarOpen(sidebarStorageScope, issueId, defaultSidebarOpen),
   );
   const isSaving = updateIssue.isPending || setValue.isPending;
 
+  useEffect(() => {
+    setSidebarOpen(readIssueDetailSidebarOpen(sidebarStorageScope, issueId, defaultSidebarOpen));
+  }, [sidebarStorageScope, issueId, defaultSidebarOpen]);
+
   const handleSidebarOpenChange = (open: boolean) => {
     setSidebarOpen(open);
-    writeIssueDetailSidebarOpen(sidebarStorageScope, open);
+    writeIssueDetailSidebarOpen(sidebarStorageScope, issueId, open);
   };
 
   const titleDraftRef = useRef(titleDraft);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-sidebar-state.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-sidebar-state.test.ts
@@ -17,34 +17,46 @@ import {
   writeIssueDetailSidebarOpen,
 } from "./issue-detail-sidebar-state";
 
-describe("issue-detail-sidebar-state", () => {
-  it("returns the fallback when no value is stored", () => {
-    const getItem = vi.fn().mockReturnValue(null);
-    vi.stubGlobal("window", {
-      localStorage: { getItem, setItem: vi.fn() },
-    });
-
-    expect(readIssueDetailSidebarOpen("issue-detail", true)).toBe(true);
-    expect(readIssueDetailSidebarOpen("inbox", false)).toBe(false);
-  });
-
-  it("reads and writes persisted sidebar state per scope", () => {
-    const storage = new Map<string, string>();
-    const getItem = vi.fn((key: string) => storage.get(key) ?? null);
-    const setItem = vi.fn((key: string, value: string) => {
+function createStorageMock() {
+  const storage = new Map<string, string>();
+  return {
+    getItem: vi.fn((key: string) => storage.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
       storage.set(key, value);
-    });
+    }),
+    storage,
+  };
+}
+
+describe("issue-detail-sidebar-state", () => {
+  it("returns the fallback when no value is stored for an issue", () => {
+    const { getItem, setItem } = createStorageMock();
     vi.stubGlobal("window", {
       localStorage: { getItem, setItem },
     });
 
-    writeIssueDetailSidebarOpen("issue-detail", false);
-    writeIssueDetailSidebarOpen("inbox", true);
+    expect(readIssueDetailSidebarOpen("issue-detail", "issue_1", true)).toBe(true);
+    expect(readIssueDetailSidebarOpen("inbox", "issue_2", false)).toBe(false);
+  });
 
-    expect(readIssueDetailSidebarOpen("issue-detail", true)).toBe(false);
-    expect(readIssueDetailSidebarOpen("inbox", false)).toBe(true);
-    expect(setItem).toHaveBeenCalledWith("issue-detail-sidebar-open:v1", "false");
-    expect(setItem).toHaveBeenCalledWith("inbox-issue-sidebar-open:v1", "true");
+  it("reads and writes persisted sidebar state per scope and issue", () => {
+    const { getItem, setItem, storage } = createStorageMock();
+    vi.stubGlobal("window", {
+      localStorage: { getItem, setItem },
+    });
+
+    writeIssueDetailSidebarOpen("issue-detail", "issue_1", false);
+    writeIssueDetailSidebarOpen("issue-detail", "issue_2", true);
+    writeIssueDetailSidebarOpen("inbox", "issue_1", true);
+
+    expect(readIssueDetailSidebarOpen("issue-detail", "issue_1", true)).toBe(false);
+    expect(readIssueDetailSidebarOpen("issue-detail", "issue_2", false)).toBe(true);
+    expect(readIssueDetailSidebarOpen("inbox", "issue_1", false)).toBe(true);
+    expect(readIssueDetailSidebarOpen("inbox", "issue_2", false)).toBe(false);
+    expect(storage.get("issue-detail-sidebar-open:v2")).toBe(
+      JSON.stringify({ issue_1: false, issue_2: true }),
+    );
+    expect(storage.get("inbox-issue-sidebar-open:v2")).toBe(JSON.stringify({ issue_1: true }));
   });
 
   it("ignores invalid stored values", () => {
@@ -53,6 +65,6 @@ describe("issue-detail-sidebar-state", () => {
       localStorage: { getItem, setItem: vi.fn() },
     });
 
-    expect(readIssueDetailSidebarOpen("issue-detail", true)).toBe(true);
+    expect(readIssueDetailSidebarOpen("issue-detail", "issue_1", true)).toBe(true);
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-sidebar-state.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-sidebar-state.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
   readIssueDetailSidebarOpen,
+  subscribeIssueDetailSidebarState,
   writeIssueDetailSidebarOpen,
 } from "./issue-detail-sidebar-state";
 
@@ -66,5 +67,22 @@ describe("issue-detail-sidebar-state", () => {
     });
 
     expect(readIssueDetailSidebarOpen("issue-detail", "issue_1", true)).toBe(true);
+  });
+
+  it("notifies subscribers when sidebar state is written", () => {
+    const { getItem, setItem } = createStorageMock();
+    vi.stubGlobal("window", {
+      localStorage: { getItem, setItem },
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+
+    const listener = vi.fn();
+    const unsubscribe = subscribeIssueDetailSidebarState(listener);
+
+    writeIssueDetailSidebarOpen("issue-detail", "issue_1", false);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    unsubscribe();
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-sidebar-state.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-sidebar-state.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  readIssueDetailSidebarOpen,
+  writeIssueDetailSidebarOpen,
+} from "./issue-detail-sidebar-state";
+
+describe("issue-detail-sidebar-state", () => {
+  it("returns the fallback when no value is stored", () => {
+    const getItem = vi.fn().mockReturnValue(null);
+    vi.stubGlobal("window", {
+      localStorage: { getItem, setItem: vi.fn() },
+    });
+
+    expect(readIssueDetailSidebarOpen("issue-detail", true)).toBe(true);
+    expect(readIssueDetailSidebarOpen("inbox", false)).toBe(false);
+  });
+
+  it("reads and writes persisted sidebar state per scope", () => {
+    const storage = new Map<string, string>();
+    const getItem = vi.fn((key: string) => storage.get(key) ?? null);
+    const setItem = vi.fn((key: string, value: string) => {
+      storage.set(key, value);
+    });
+    vi.stubGlobal("window", {
+      localStorage: { getItem, setItem },
+    });
+
+    writeIssueDetailSidebarOpen("issue-detail", false);
+    writeIssueDetailSidebarOpen("inbox", true);
+
+    expect(readIssueDetailSidebarOpen("issue-detail", true)).toBe(false);
+    expect(readIssueDetailSidebarOpen("inbox", false)).toBe(true);
+    expect(setItem).toHaveBeenCalledWith("issue-detail-sidebar-open:v1", "false");
+    expect(setItem).toHaveBeenCalledWith("inbox-issue-sidebar-open:v1", "true");
+  });
+
+  it("ignores invalid stored values", () => {
+    const getItem = vi.fn().mockReturnValue("maybe");
+    vi.stubGlobal("window", {
+      localStorage: { getItem, setItem: vi.fn() },
+    });
+
+    expect(readIssueDetailSidebarOpen("issue-detail", true)).toBe(true);
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-sidebar-state.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-sidebar-state.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+export type IssueDetailSidebarScope = "issue-detail" | "inbox";
+
+const STORAGE_KEYS: Record<IssueDetailSidebarScope, string> = {
+  "issue-detail": "issue-detail-sidebar-open:v1",
+  inbox: "inbox-issue-sidebar-open:v1",
+};
+
+function parseStoredSidebarOpen(value: string | null): boolean | null {
+  if (value === "true") {
+    return true;
+  }
+  if (value === "false") {
+    return false;
+  }
+  return null;
+}
+
+export function readIssueDetailSidebarOpen(
+  scope: IssueDetailSidebarScope,
+  fallback: boolean,
+): boolean {
+  if (typeof window === "undefined") {
+    return fallback;
+  }
+
+  try {
+    const stored = parseStoredSidebarOpen(window.localStorage.getItem(STORAGE_KEYS[scope]));
+    if (stored !== null) {
+      return stored;
+    }
+  } catch {
+    return fallback;
+  }
+
+  return fallback;
+}
+
+export function writeIssueDetailSidebarOpen(scope: IssueDetailSidebarScope, open: boolean) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEYS[scope], String(open));
+  } catch {
+    // Ignore storage failures in private browsing or restricted environments.
+  }
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-sidebar-state.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-sidebar-state.ts
@@ -19,6 +19,8 @@ const STORAGE_KEYS: Record<IssueDetailSidebarScope, string> = {
 
 type IssueDetailSidebarState = Record<string, boolean>;
 
+const sidebarStateListeners = new Set<() => void>();
+
 function parseStoredSidebarState(value: string | null): IssueDetailSidebarState | null {
   if (!value) {
     return null;
@@ -67,6 +69,38 @@ function writeStoredSidebarState(scope: IssueDetailSidebarScope, state: IssueDet
   }
 }
 
+function notifyIssueDetailSidebarStateListeners() {
+  for (const listener of sidebarStateListeners) {
+    listener();
+  }
+}
+
+function isIssueDetailSidebarStorageKey(key: string | null) {
+  return key === STORAGE_KEYS["issue-detail"] || key === STORAGE_KEYS.inbox;
+}
+
+export function subscribeIssueDetailSidebarState(listener: () => void) {
+  sidebarStateListeners.add(listener);
+
+  if (typeof window === "undefined") {
+    return () => {
+      sidebarStateListeners.delete(listener);
+    };
+  }
+
+  const onStorage = (event: StorageEvent) => {
+    if (isIssueDetailSidebarStorageKey(event.key)) {
+      listener();
+    }
+  };
+  window.addEventListener("storage", onStorage);
+
+  return () => {
+    sidebarStateListeners.delete(listener);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+
 export function readIssueDetailSidebarOpen(
   scope: IssueDetailSidebarScope,
   issueId: string,
@@ -84,4 +118,5 @@ export function writeIssueDetailSidebarOpen(
   const state = readStoredSidebarState(scope);
   state[issueId] = open;
   writeStoredSidebarState(scope, state);
+  notifyIssueDetailSidebarStateListeners();
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-sidebar-state.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-detail-sidebar-state.ts
@@ -13,48 +13,75 @@
 export type IssueDetailSidebarScope = "issue-detail" | "inbox";
 
 const STORAGE_KEYS: Record<IssueDetailSidebarScope, string> = {
-  "issue-detail": "issue-detail-sidebar-open:v1",
-  inbox: "inbox-issue-sidebar-open:v1",
+  "issue-detail": "issue-detail-sidebar-open:v2",
+  inbox: "inbox-issue-sidebar-open:v2",
 };
 
-function parseStoredSidebarOpen(value: string | null): boolean | null {
-  if (value === "true") {
-    return true;
-  }
-  if (value === "false") {
-    return false;
-  }
-  return null;
-}
+type IssueDetailSidebarState = Record<string, boolean>;
 
-export function readIssueDetailSidebarOpen(
-  scope: IssueDetailSidebarScope,
-  fallback: boolean,
-): boolean {
-  if (typeof window === "undefined") {
-    return fallback;
+function parseStoredSidebarState(value: string | null): IssueDetailSidebarState | null {
+  if (!value) {
+    return null;
   }
 
   try {
-    const stored = parseStoredSidebarOpen(window.localStorage.getItem(STORAGE_KEYS[scope]));
-    if (stored !== null) {
-      return stored;
+    const parsed: unknown = JSON.parse(value);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
     }
-  } catch {
-    return fallback;
-  }
 
-  return fallback;
+    const state: IssueDetailSidebarState = {};
+    for (const [issueId, open] of Object.entries(parsed)) {
+      if (typeof open === "boolean") {
+        state[issueId] = open;
+      }
+    }
+
+    return state;
+  } catch {
+    return null;
+  }
 }
 
-export function writeIssueDetailSidebarOpen(scope: IssueDetailSidebarScope, open: boolean) {
+function readStoredSidebarState(scope: IssueDetailSidebarScope): IssueDetailSidebarState {
+  if (typeof window === "undefined") {
+    return {};
+  }
+
+  try {
+    return parseStoredSidebarState(window.localStorage.getItem(STORAGE_KEYS[scope])) ?? {};
+  } catch {
+    return {};
+  }
+}
+
+function writeStoredSidebarState(scope: IssueDetailSidebarScope, state: IssueDetailSidebarState) {
   if (typeof window === "undefined") {
     return;
   }
 
   try {
-    window.localStorage.setItem(STORAGE_KEYS[scope], String(open));
+    window.localStorage.setItem(STORAGE_KEYS[scope], JSON.stringify(state));
   } catch {
     // Ignore storage failures in private browsing or restricted environments.
   }
+}
+
+export function readIssueDetailSidebarOpen(
+  scope: IssueDetailSidebarScope,
+  issueId: string,
+  fallback: boolean,
+): boolean {
+  const stored = readStoredSidebarState(scope)[issueId];
+  return stored ?? fallback;
+}
+
+export function writeIssueDetailSidebarOpen(
+  scope: IssueDetailSidebarScope,
+  issueId: string,
+  open: boolean,
+) {
+  const state = readStoredSidebarState(scope);
+  state[issueId] = open;
+  writeStoredSidebarState(scope, state);
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-detail-sidebar-open.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/use-issue-detail-sidebar-open.ts
@@ -1,0 +1,43 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useCallback, useSyncExternalStore } from "react";
+
+import {
+  readIssueDetailSidebarOpen,
+  subscribeIssueDetailSidebarState,
+  writeIssueDetailSidebarOpen,
+  type IssueDetailSidebarScope,
+} from "./issue-detail-sidebar-state";
+
+export function useIssueDetailSidebarOpen(
+  scope: IssueDetailSidebarScope,
+  issueId: string,
+  defaultSidebarOpen: boolean,
+) {
+  const sidebarOpen = useSyncExternalStore(
+    subscribeIssueDetailSidebarState,
+    () => readIssueDetailSidebarOpen(scope, issueId, defaultSidebarOpen),
+    () => defaultSidebarOpen,
+  );
+
+  const setSidebarOpen = useCallback(
+    (open: boolean) => {
+      writeIssueDetailSidebarOpen(scope, issueId, open);
+    },
+    [scope, issueId],
+  );
+
+  return [sidebarOpen, setSidebarOpen] as const;
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-issue-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-issue-panel.tsx
@@ -64,6 +64,8 @@ export function InboxIssuePanel({
           projectId={projectId}
           issueId={issueId}
           onDirtyChange={setIsDraftDirty}
+          defaultSidebarOpen={false}
+          sidebarStorageScope="inbox"
         />
       </IssueDetailNavigationGuard>
     </section>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Persist the issue detail panel right sidebar open/collapsed state in `localStorage`
- Use separate storage scopes for the standalone issue detail page and the inbox notification issue panel
- Default the inbox notification issue panel to collapsed while remembering the user's toggle preference per context
- Track sidebar state per issue within each scope, so switching issues restores each issue's last sidebar state
- Avoid hydration mismatches and stale sidebar state when switching inbox issues via `useSyncExternalStore`

## Changes

- Added `issue-detail-sidebar-state.ts` with read/write helpers, subscription notifications, and versioned storage keys (`:v2` JSON maps keyed by issue id)
- Added `use-issue-detail-sidebar-open.ts` using `useSyncExternalStore` with `getServerSnapshot` for SSR-safe hydration
- Updated `IssueDetailPanel` to use the hook instead of `useState` + `useEffect`
- Updated `InboxIssuePanel` to use the inbox scope with `defaultSidebarOpen={false}`

## Test plan

- [x] `vp test` for `issue-detail-sidebar-state.test.ts`
- [x] `vp check --fix`
- [ ] Manually open an issue from the Issue Notification Inbox and confirm the properties sidebar starts collapsed
- [ ] Toggle the sidebar and reload — confirm the preference persists for that issue
- [ ] Switch to another issue and confirm it uses its own stored sidebar state without briefly showing the previous issue's sidebar
- [ ] Open an issue from the issue sheet page and confirm sidebar state is tracked independently from inbox
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b55d9106-f030-41da-b6a5-dd7ec49920f9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b55d9106-f030-41da-b6a5-dd7ec49920f9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

