### PR TITLE
fix(web): keep chat SDK out of workflow sandbox bundles

### DIFF
--- a/apps/hyperlocalise-web/src/lib/log.ts
+++ b/apps/hyperlocalise-web/src/lib/log.ts
@@ -12,7 +12,6 @@
  */
 import { initLogger, log as evlog } from "evlog";
 import type { DrainFn, LogLevel, LoggerConfig } from "evlog";
-import type { Logger as ChatLogger } from "chat";
 
 import { errorToLogObject, isError } from "@/lib/serialize-error-for-log";
 
@@ -268,7 +267,20 @@ function emit(level: LogLevel, bindings: LogBindings, input: LogInput, messageOr
   evlog[level](mergeLogContext(bindings, input, messageOrContext));
 }
 
-export function createChatLogger(prefix?: string): ChatLogger {
+/**
+ * Structural logger shape compatible with the Chat SDK `Logger` interface.
+ * Kept local so `@/lib/log` never imports `chat` — that package uses Node
+ * `async_hooks` and must not enter the Workflow DevKit sandbox bundle.
+ */
+export type ChatSdkLogger = {
+  child: (prefix: string) => ChatSdkLogger;
+  debug: (message: string, ...args: unknown[]) => void;
+  error: (message: string, ...args: unknown[]) => void;
+  info: (message: string, ...args: unknown[]) => void;
+  warn: (message: string, ...args: unknown[]) => void;
+};
+
+export function createChatLogger(prefix?: string): ChatSdkLogger {
   const base = createLogger(prefix);
   return {
     child: (subPrefix) => createChatLogger(prefix ? `${prefix}:${subPrefix}` : subPrefix),

--- a/apps/hyperlocalise-web/src/workflows/email-translation.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/email-translation.test.ts
@@ -12,14 +12,6 @@
  */
 import { describe, expect, it, vi } from "vite-plus/test";
 
-vi.mock("@/lib/env", () => ({
-  env: {
-    OPENAI_API_KEY: "test-openai-api-key",
-    RESEND_API_KEY: "test-key",
-    RESEND_FROM_NAME: "Hyperlocalise",
-  },
-}));
-
 import { getTranslatedFileDiagnostics } from "@/lib/translation/diagnostics";
 
 import {
@@ -46,9 +38,19 @@ describe("email translation workflow filenames", () => {
   });
 
   it("passes provider credentials to the sandbox translation command", () => {
-    expect(getSandboxTranslationEnv()).toEqual({
-      OPENAI_API_KEY: "test-openai-api-key",
-    });
+    const previous = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "test-openai-api-key";
+    try {
+      expect(getSandboxTranslationEnv()).toEqual({
+        OPENAI_API_KEY: "test-openai-api-key",
+      });
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENAI_API_KEY;
+      } else {
+        process.env.OPENAI_API_KEY = previous;
+      }
+    }
   });
 });
 

--- a/apps/hyperlocalise-web/src/workflows/email-translation.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/email-translation.test.ts
@@ -10,7 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { describe, expect, it, vi } from "vite-plus/test";
+import { describe, expect, it } from "vite-plus/test";
 
 import { getTranslatedFileDiagnostics } from "@/lib/translation/diagnostics";
 

--- a/apps/hyperlocalise-web/src/workflows/email-translation.ts
+++ b/apps/hyperlocalise-web/src/workflows/email-translation.ts
@@ -13,7 +13,6 @@
 import { getWorkflowMetadata } from "workflow";
 
 import { hyperlocaliseAgentModelId } from "@/lib/agent-runtime/loops/model-id";
-import { env } from "@/lib/env";
 import type { EmailAgentTask, EmailAgentTaskAttachment } from "@/lib/workflow/types";
 import {
   markEmailTranslationJobFailed,
@@ -199,12 +198,15 @@ function shellQuote(value: string): string {
 }
 
 export function getSandboxTranslationEnv(): Record<string, string> {
-  if (!env.OPENAI_API_KEY) {
+  // Read process.env directly so this workflow module never static-imports `@/lib/env`
+  // (t3 env + Next helpers are unsafe in the Workflow DevKit sandbox).
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
     throw new Error("OPENAI_API_KEY is not configured");
   }
 
   return {
-    OPENAI_API_KEY: env.OPENAI_API_KEY,
+    OPENAI_API_KEY: apiKey,
   };
 }
 
@@ -217,6 +219,7 @@ async function sendReplyEmail(
   "use step";
 
   const { Resend } = await import("resend");
+  const { env } = await import("@/lib/env");
   const { inferAttachmentContentType, toBase64AttachmentContent } =
     await import("@/lib/resend/attachments");
 
@@ -272,6 +275,7 @@ async function sendFailureReplyEmail(
   "use step";
 
   const { Resend } = await import("resend");
+  const { env } = await import("@/lib/env");
 
   if (!env.RESEND_API_KEY) {
     throw new Error("Resend is not configured");

--- a/apps/hyperlocalise-web/src/workflows/steps/provider-agent-translation.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/provider-agent-translation.ts
@@ -10,15 +10,14 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { createLogger, serializeErrorForLog } from "@/lib/log";
-
-const logger = createLogger("provider-agent-translation-step");
-
 export async function executeProviderAgentTranslationStep(input: {
   agentRunId: string;
   organizationId: string;
 }) {
   "use step";
+
+  const { createLogger, serializeErrorForLog } = await import("@/lib/log");
+  const logger = createLogger("provider-agent-translation-step");
 
   const stepContext = {
     agentRunId: input.agentRunId,
@@ -76,6 +75,9 @@ export async function failProviderAgentTranslationStep(input: {
   message: string;
 }) {
   "use step";
+
+  const { createLogger } = await import("@/lib/log");
+  const logger = createLogger("provider-agent-translation-step");
 
   logger.warn(
     {

--- a/apps/hyperlocalise-web/src/workflows/steps/sandbox-utils.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/sandbox-utils.ts
@@ -10,14 +10,13 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Sandbox } from "@vercel/sandbox";
-
 export async function runSandboxCommand(
   sandboxId: string,
   command: string,
   args: string[],
   options?: { env?: Record<string, string> },
 ): Promise<{ exitCode: number; output: string }> {
+  const { Sandbox } = await import("@vercel/sandbox");
   const sandbox = await Sandbox.get({ name: sandboxId });
   const result = await sandbox.runCommand({
     cmd: command,

--- a/apps/hyperlocalise-web/src/workflows/steps/workspace-automation-execution.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/workspace-automation-execution.ts
@@ -10,29 +10,42 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { createLogger } from "@/lib/log";
 import type { WorkspaceAutomationExecutionEventData } from "@/lib/workflow/types";
-import type {
-  WorkspaceOrchestratorExecutionError,
-  WorkspaceOrchestratorExecutionSuccess,
-} from "@/agents/automations/workspace/agent/run-workspace-orchestrator";
 
-const logger = createLogger("workspace-automation-step");
-
+/**
+ * Step-local result types (duplicated structurally from the orchestrator module)
+ * so this file — which is statically imported by a `"use workflow"` module —
+ * never pulls the orchestrator / logging graph into the workflow sandbox bundle.
+ */
 export type WorkspaceAutomationStepResult =
   | {
       ok: true;
-      value: WorkspaceOrchestratorExecutionSuccess;
+      value: {
+        runId: string;
+        status: string;
+        planTools: string[];
+        stepResults: Record<string, unknown>;
+      };
     }
   | {
       ok: false;
-      error: WorkspaceOrchestratorExecutionError;
+      error: {
+        code:
+          | "workspace_automation_not_found"
+          | "workspace_automation_run_not_found"
+          | "workspace_orchestrator_failed";
+        message: string;
+        runId?: string;
+      };
     };
 
 export async function executeWorkspaceAutomationStep(
   event: WorkspaceAutomationExecutionEventData,
 ): Promise<WorkspaceAutomationStepResult> {
   "use step";
+
+  const { createLogger } = await import("@/lib/log");
+  const logger = createLogger("workspace-automation-step");
 
   const stepContext = {
     workspaceAutomationRunId: event.workspaceAutomationRunId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Production workflows (`source-file-ingest`, `workspace-automation-execution`) crashed in the Workflow DevKit sandbox with `ReferenceError: require is not defined` while evaluating `chat`’s `async_hooks` import.
- Removed the `chat` type import from `@/lib/log` (replaced with a local structural `ChatSdkLogger`) so logging never pulls Chat SDK into workflow graphs.
- Moved step logger / env / sandbox Node imports behind dynamic `import()` inside `"use step"` so they stay in the Node step bundle.

## Test plan

- [x] `vp check --fix` in `apps/hyperlocalise-web`
- [x] `vp test` in `apps/hyperlocalise-web` (3787 passed)
- [ ] Re-run a source-file-ingest workflow and a workspace-automation-execution workflow in the deployed environment and confirm they no longer fail at sandbox evaluation with `chat` / `async_hooks`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d340aaa-b98e-420e-91d1-8486db603a8f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d340aaa-b98e-420e-91d1-8486db603a8f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

