### PR TITLE
fix(slack): bind bot token for automation notifications

### DIFF
--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/notify_slack.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/notify_slack.ts
@@ -33,6 +33,7 @@ export function createNotifySlackTool(session: WorkspaceOrchestratorSession) {
 
       const text = message?.trim() || buildOrchestratorRunSummaryMessage(session);
       const result = await runWorkspaceAutomationSlackNotificationTool({
+        organizationId: session.organizationId,
         channelId: slack.channelId,
         message: text,
       });

--- a/apps/hyperlocalise-web/src/lib/agents/slack/helpers.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/helpers.ts
@@ -36,6 +36,40 @@ export async function findSlackConnector(teamId: string, options: { enabledOnly?
   return connectors[0];
 }
 
+export async function findSlackConnectorForOrganization(
+  organizationId: string,
+  options: { enabledOnly?: boolean } = {},
+) {
+  const conditions = [
+    eq(schema.connectors.organizationId, organizationId),
+    eq(schema.connectors.kind, "slack"),
+  ];
+  if (options.enabledOnly ?? true) {
+    conditions.push(eq(schema.connectors.enabled, true));
+  }
+
+  const [connector] = await db
+    .select()
+    .from(schema.connectors)
+    .where(and(...conditions))
+    .limit(1);
+
+  return connector ?? null;
+}
+
+export function getSlackConnectorTeamId(
+  connector: {
+    config: unknown;
+  } | null,
+): string | null {
+  if (!connector) {
+    return null;
+  }
+
+  const teamId = (connector.config as { teamId?: unknown } | null)?.teamId;
+  return typeof teamId === "string" && teamId.trim().length > 0 ? teamId : null;
+}
+
 export async function findSlackConnectorOwnedByAnotherOrganization(input: {
   teamId: string;
   organizationId: string;

--- a/apps/hyperlocalise-web/src/lib/agents/slack/post-channel-message.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/post-channel-message.test.ts
@@ -10,15 +10,27 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { describe, expect, it, vi } from "vite-plus/test";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-const { chatConstructorMock, createSlackAdapterMock, initializeMock, postChannelMessageMock } =
-  vi.hoisted(() => ({
-    chatConstructorMock: vi.fn(),
-    createSlackAdapterMock: vi.fn(() => ({ kind: "slack-adapter" })),
-    initializeMock: vi.fn(),
-    postChannelMessageMock: vi.fn(async () => undefined),
-  }));
+const {
+  chatConstructorMock,
+  createSlackAdapterMock,
+  findSlackConnectorForOrganizationMock,
+  getInstallationMock,
+  getSlackConnectorTeamIdMock,
+  initializeMock,
+  postChannelMessageMock,
+  withBotTokenMock,
+} = vi.hoisted(() => ({
+  chatConstructorMock: vi.fn(),
+  createSlackAdapterMock: vi.fn(() => ({ kind: "slack-adapter" })),
+  findSlackConnectorForOrganizationMock: vi.fn(),
+  getInstallationMock: vi.fn(),
+  getSlackConnectorTeamIdMock: vi.fn(),
+  initializeMock: vi.fn(),
+  postChannelMessageMock: vi.fn(async () => undefined),
+  withBotTokenMock: vi.fn(async <T>(_token: string, fn: () => T) => fn()),
+}));
 
 vi.mock("@/lib/env", () => ({
   env: {
@@ -30,6 +42,11 @@ vi.mock("@/lib/env", () => ({
 
 vi.mock("@/lib/agents/runtime/state", () => ({
   createChatStateAdapter: vi.fn(() => ({ kind: "state-adapter" })),
+}));
+
+vi.mock("@/lib/agents/slack/helpers", () => ({
+  findSlackConnectorForOrganization: findSlackConnectorForOrganizationMock,
+  getSlackConnectorTeamId: getSlackConnectorTeamIdMock,
 }));
 
 vi.mock("@chat-adapter/slack", () => ({
@@ -49,7 +66,9 @@ vi.mock("chat", () => ({
     getAdapter(adapterName: string) {
       return {
         adapterName,
+        getInstallation: getInstallationMock,
         postChannelMessage: postChannelMessageMock,
+        withBotToken: withBotTokenMock,
       };
     }
   },
@@ -78,18 +97,33 @@ async function waitForInitializeCall() {
 }
 
 describe("postSlackChannelMessage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    findSlackConnectorForOrganizationMock.mockResolvedValue({
+      id: "connector-1",
+      config: { teamId: "T123" },
+    });
+    getSlackConnectorTeamIdMock.mockReturnValue("T123");
+    getInstallationMock.mockResolvedValue({ botToken: "xoxb-token" });
+    withBotTokenMock.mockImplementation(async <T>(_token: string, fn: () => T) => fn());
+    postChannelMessageMock.mockResolvedValue(undefined);
+    initializeMock.mockResolvedValue(undefined);
+  });
+
   it("shares initialization across concurrent callers before posting messages", async () => {
     const initialized = createDeferred<void>();
     initializeMock.mockReturnValueOnce(initialized.promise);
     const { postSlackChannelMessage } = await import("./post-channel-message");
 
     const firstPost = postSlackChannelMessage({
+      organizationId: "org-1",
       channelId: "C123",
       text: "first",
     });
     await waitForInitializeCall();
 
     const secondPost = postSlackChannelMessage({
+      organizationId: "org-1",
       channelId: "slack:C123",
       text: "second",
     });
@@ -103,8 +137,44 @@ describe("postSlackChannelMessage", () => {
     initialized.resolve();
     await Promise.all([firstPost, secondPost]);
 
+    expect(getInstallationMock).toHaveBeenCalledWith("T123");
+    expect(withBotTokenMock).toHaveBeenCalledTimes(2);
+    expect(withBotTokenMock).toHaveBeenNthCalledWith(1, "xoxb-token", expect.any(Function), {
+      installationId: "T123",
+    });
     expect(postChannelMessageMock).toHaveBeenCalledTimes(2);
     expect(postChannelMessageMock).toHaveBeenNthCalledWith(1, "slack:C123", "first");
     expect(postChannelMessageMock).toHaveBeenNthCalledWith(2, "slack:C123", "second");
+  });
+
+  it("fails when the organization has no Slack connector team", async () => {
+    getSlackConnectorTeamIdMock.mockReturnValueOnce(null);
+    const { postSlackChannelMessage } = await import("./post-channel-message");
+
+    await expect(
+      postSlackChannelMessage({
+        organizationId: "org-1",
+        channelId: "C123",
+        text: "hello",
+      }),
+    ).rejects.toThrow("Slack is not connected for this organization.");
+
+    expect(getInstallationMock).not.toHaveBeenCalled();
+    expect(postChannelMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("fails when the Slack installation token is missing", async () => {
+    getInstallationMock.mockResolvedValueOnce(null);
+    const { postSlackChannelMessage } = await import("./post-channel-message");
+
+    await expect(
+      postSlackChannelMessage({
+        organizationId: "org-1",
+        channelId: "C123",
+        text: "hello",
+      }),
+    ).rejects.toThrow("Slack installation not found for this organization.");
+
+    expect(postChannelMessageMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agents/slack/post-channel-message.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/post-channel-message.ts
@@ -13,9 +13,19 @@
 import { Chat, type Adapter } from "chat";
 
 import { createChatStateAdapter } from "@/lib/agents/runtime/state";
+import {
+  findSlackConnectorForOrganization,
+  getSlackConnectorTeamId,
+} from "@/lib/agents/slack/helpers";
 import { env } from "@/lib/env";
 
 type SlackChat = Chat<{ slack: Adapter<unknown, unknown> }>;
+
+type SlackOutboundAdapter = {
+  getInstallation: (teamId: string) => Promise<{ botToken?: string } | null>;
+  postChannelMessage: (channelId: string, message: string) => Promise<unknown>;
+  withBotToken: <T>(token: string, fn: () => T, options?: { installationId?: string }) => T;
+};
 
 let slackChatPromise: Promise<SlackChat> | null = null;
 
@@ -55,16 +65,32 @@ async function initializeSlackChat(): Promise<SlackChat> {
   return slackChat;
 }
 
+function toCanonicalSlackChannelId(channelId: string) {
+  return channelId.startsWith("slack:") ? channelId : `slack:${channelId}`;
+}
+
 export async function postSlackChannelMessage(input: {
+  organizationId: string;
   channelId: string;
   text: string;
 }): Promise<void> {
+  const connector = await findSlackConnectorForOrganization(input.organizationId);
+  const teamId = getSlackConnectorTeamId(connector);
+  if (!teamId) {
+    throw new Error("Slack is not connected for this organization.");
+  }
+
   const chat = await getSlackChat();
-  const adapter = chat.getAdapter("slack") as {
-    postChannelMessage: (channelId: string, message: string) => Promise<unknown>;
-  };
-  const channelId = input.channelId.startsWith("slack:")
-    ? input.channelId
-    : `slack:${input.channelId}`;
-  await adapter.postChannelMessage(channelId, input.text);
+  const adapter = chat.getAdapter("slack") as unknown as SlackOutboundAdapter;
+  const installation = await adapter.getInstallation(teamId);
+  if (!installation?.botToken) {
+    throw new Error("Slack installation not found for this organization.");
+  }
+
+  const channelId = toCanonicalSlackChannelId(input.channelId);
+  await adapter.withBotToken(
+    installation.botToken,
+    () => adapter.postChannelMessage(channelId, input.text),
+    { installationId: teamId },
+  );
 }

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-notifications.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-notifications.ts
@@ -55,6 +55,7 @@ export async function notifyWorkspaceAutomationTerminalRun(input: {
   const slack = input.automation.toolConfig.slack;
   if (slack?.enabled && slack.channelId) {
     const result = await runWorkspaceAutomationSlackNotificationTool({
+      organizationId: input.automation.organizationId,
       channelId: slack.channelId,
       message,
     });

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation/notification-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation/notification-tools.ts
@@ -21,6 +21,7 @@ export type WorkspaceAutomationNotificationError = {
 };
 
 export async function runWorkspaceAutomationSlackNotificationTool(input: {
+  organizationId: string;
   channelId: string;
   message: string;
 }): Promise<Result<void, WorkspaceAutomationNotificationError>> {
@@ -33,7 +34,11 @@ export async function runWorkspaceAutomationSlackNotificationTool(input: {
 
   try {
     const { postSlackChannelMessage } = await import("@/lib/agents/slack/post-channel-message");
-    await postSlackChannelMessage({ channelId: input.channelId, text: input.message });
+    await postSlackChannelMessage({
+      organizationId: input.organizationId,
+      channelId: input.channelId,
+      text: input.message,
+    });
     return ok(undefined);
   } catch (error) {
     return err({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Workspace automation `notify_slack` failed in production with:

> No bot token available. In multi-workspace mode, ensure the webhook is being processed.

Slack is connected via multi-workspace OAuth. Background automation posts are outside webhook request context, so Chat SDK has no bot token unless we bind one explicitly.

## Fix

- Resolve the organization's Slack connector `teamId`
- Load the stored installation via `getInstallation(teamId)`
- Post inside `withBotToken(..., { installationId: teamId })`
- Thread `organizationId` through the notify call path

## Test plan

- [x] `vp test src/lib/agents/slack/post-channel-message.test.ts`
- [x] `vp check --fix` (no new errors)
- [ ] Re-run a workspace automation with Slack notify enabled and confirm the channel message sends

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38176915-3953-4a2b-adb7-e5ab926d6498?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38176915-3953-4a2b-adb7-e5ab926d6498&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

