### PR TITLE
fix(cat): remove double border on segment issues list

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-grouped-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-grouped-list.tsx
@@ -256,8 +256,8 @@ export function IssueGroupedList<T extends IssueGroupedListItem>({
   }
 
   return (
-    <div className={cn("space-y-4", className)}>
-      <div className="overflow-hidden rounded-xl border bg-card">
+    <div className="space-y-4">
+      <div className={cn("overflow-hidden rounded-xl border bg-card", className)}>
         {groups.map((group, groupIndex) => {
           // When headers are hidden there is no expand control, so never keep
           // a previously collapsed section empty.

--- a/apps/hyperlocalise-web/src/components/cat/issues/cat-editor-issues-section.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/issues/cat-editor-issues-section.tsx
@@ -226,7 +226,6 @@ export function CatEditorIssuesSection({
         showProject={false}
         isLoading={issuesQuery.isLoading}
         isError={issuesQuery.isError}
-        className="rounded-lg border border-border"
         onIssueActivate={(issue) => {
           router.push(
             buildIssueDetailHref({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The CAT editor Issues panel showed a double outline around the status-grouped issue list (e.g. Open / vi-VN rows).

`IssueGroupedList` already renders a `rounded-xl border bg-card` card. The CAT section was also passing `className="rounded-lg border border-border"`, and in the populated-list path that className was applied to an outer wrapper around the card — producing two concentric borders.

## Changes

- Drop the redundant border `className` from `CatEditorIssuesSection`.
- Apply `className` to the bordered card in `IssueGroupedList`'s populated path (same as loading / empty / error), so a future border-style override cannot recreate the double outline.

## Test plan

- [x] `vp check --fix` in `apps/hyperlocalise-web`
- [x] `vp test src/components/cat/issues/cat-editor-issues-section.test.tsx` (8 passed)
- [ ] Visually confirm CAT Issues panel has a single card border when a segment has open issues
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7f5f1e5-228c-4e81-9120-1cd3bba9ef87?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7f5f1e5-228c-4e81-9120-1cd3bba9ef87&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

