### PR TITLE
fix(cat): move visual editor types out of vercelignored fixture

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/visual-editor/cat-visual-editor-canvas.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/visual-editor/cat-visual-editor-canvas.tsx
@@ -27,12 +27,12 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/primitives/cn";
 
+import { catVisualEditorMessages } from "./cat-visual-editor.messages";
 import type {
   CatVisualEditorDevice,
   CatVisualEditorPreviewKind,
   CatVisualEditorSegment,
-} from "./cat-visual-editor.fixture";
-import { catVisualEditorMessages } from "./cat-visual-editor.messages";
+} from "./cat-visual-editor.types";
 import { CatVisualEditorPreview } from "./cat-visual-editor-preview";
 
 const DEVICE_WIDTH: Record<CatVisualEditorDevice, string> = {

--- a/apps/hyperlocalise-web/src/components/cat/visual-editor/cat-visual-editor-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/visual-editor/cat-visual-editor-detail-panel.tsx
@@ -35,8 +35,8 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { useIsMac } from "@/hooks/use-is-mac";
 import { cn } from "@/lib/primitives/cn";
 
-import type { CatVisualEditorSegment } from "./cat-visual-editor.fixture";
 import { catVisualEditorMessages } from "./cat-visual-editor.messages";
+import type { CatVisualEditorSegment } from "./cat-visual-editor.types";
 
 export function CatVisualEditorDetailPanel({
   segment,

--- a/apps/hyperlocalise-web/src/components/cat/visual-editor/cat-visual-editor-files-sidebar.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/visual-editor/cat-visual-editor-files-sidebar.tsx
@@ -19,8 +19,8 @@ import { ProjectFilesTree } from "@/app/[lang]/(authenticated)/org/[organization
 import { Progress, ProgressLabel, ProgressValue } from "@/components/ui/progress";
 import { cn } from "@/lib/primitives/cn";
 
-import type { CatVisualEditorProgress } from "./cat-visual-editor.fixture";
 import { catVisualEditorMessages } from "./cat-visual-editor.messages";
+import type { CatVisualEditorProgress } from "./cat-visual-editor.types";
 
 export function CatVisualEditorFilesSidebar({
   files,

--- a/apps/hyperlocalise-web/src/components/cat/visual-editor/cat-visual-editor-preview.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/visual-editor/cat-visual-editor-preview.tsx
@@ -19,10 +19,7 @@ import { QueueStatusDot } from "@/components/cat/segment/cat-segment-status";
 import { cn } from "@/lib/primitives/cn";
 
 import { catVisualEditorMessages } from "./cat-visual-editor.messages";
-import type {
-  CatVisualEditorPreviewKind,
-  CatVisualEditorSegment,
-} from "./cat-visual-editor.types";
+import type { CatVisualEditorPreviewKind, CatVisualEditorSegment } from "./cat-visual-editor.types";
 
 function textForSegment(segment: CatVisualEditorSegment | undefined, fallback: string) {
   if (!segment) {

--- a/apps/hyperlocalise-web/src/components/cat/visual-editor/cat-visual-editor-preview.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/visual-editor/cat-visual-editor-preview.tsx
@@ -18,11 +18,11 @@ import { FormattedMessage } from "react-intl";
 import { QueueStatusDot } from "@/components/cat/segment/cat-segment-status";
 import { cn } from "@/lib/primitives/cn";
 
+import { catVisualEditorMessages } from "./cat-visual-editor.messages";
 import type {
   CatVisualEditorPreviewKind,
   CatVisualEditorSegment,
-} from "./cat-visual-editor.fixture";
-import { catVisualEditorMessages } from "./cat-visual-editor.messages";
+} from "./cat-visual-editor.types";
 
 function textForSegment(segment: CatVisualEditorSegment | undefined, fallback: string) {
   if (!segment) {

--- a/apps/hyperlocalise-web/src/components/cat/visual-editor/cat-visual-editor-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/visual-editor/cat-visual-editor-workspace.tsx
@@ -20,13 +20,13 @@ import type { CatSegmentStatus } from "@/components/cat/shared/types";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
 import { cn } from "@/lib/primitives/cn";
 
+import { catVisualEditorMessages } from "./cat-visual-editor.messages";
 import type {
   CatVisualEditorDevice,
   CatVisualEditorFilePage,
   CatVisualEditorFixture,
   CatVisualEditorSegment,
-} from "./cat-visual-editor.fixture";
-import { catVisualEditorMessages } from "./cat-visual-editor.messages";
+} from "./cat-visual-editor.types";
 import { CatVisualEditorCanvas } from "./cat-visual-editor-canvas";
 import { CatVisualEditorDetailPanel } from "./cat-visual-editor-detail-panel";
 import { CatVisualEditorFilesSidebar } from "./cat-visual-editor-files-sidebar";

--- a/apps/hyperlocalise-web/src/components/cat/visual-editor/cat-visual-editor.fixture.ts
+++ b/apps/hyperlocalise-web/src/components/cat/visual-editor/cat-visual-editor.fixture.ts
@@ -12,44 +12,25 @@
  */
 import { createProjectFileRecord } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files.fixture";
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
-import type { CatSegment, CatSegmentIntelligence } from "@/components/cat/shared/types";
+import type { CatSegmentIntelligence } from "@/components/cat/shared/types";
 
-export type CatVisualEditorDevice = "desktop" | "tablet" | "mobile";
+import type {
+  CatVisualEditorFilePage,
+  CatVisualEditorFixture,
+  CatVisualEditorPreviewKind,
+  CatVisualEditorProgress,
+  CatVisualEditorSegment,
+} from "./cat-visual-editor.types";
 
-export type CatVisualEditorPreviewKind = "home" | "pricing" | "generic";
-
-export type CatVisualEditorNodeMeta = {
-  tagName: "H1" | "H2" | "P" | "A" | "BUTTON" | "SPAN";
-  selector: string;
-};
-
-export type CatVisualEditorSegment = CatSegment & {
-  node: CatVisualEditorNodeMeta;
-};
-
-export type CatVisualEditorProgress = {
-  locale: string;
-  percent: number;
-  translated: number;
-  inReview: number;
-  untranslated: number;
-};
-
-export type CatVisualEditorFilePage = {
-  sourcePath: string;
-  previewUrl: string;
-  previewKind: CatVisualEditorPreviewKind;
-  progress: CatVisualEditorProgress;
-  segments: CatVisualEditorSegment[];
-  defaultSelectedSegmentId: string;
-  intelligenceBySegmentId: Record<string, CatSegmentIntelligence>;
-};
-
-export type CatVisualEditorFixture = {
-  files: ProjectFileRecord[];
-  selectedSourcePath: string;
-  pagesBySourcePath: Record<string, CatVisualEditorFilePage>;
-};
+export type {
+  CatVisualEditorDevice,
+  CatVisualEditorFilePage,
+  CatVisualEditorFixture,
+  CatVisualEditorNodeMeta,
+  CatVisualEditorPreviewKind,
+  CatVisualEditorProgress,
+  CatVisualEditorSegment,
+} from "./cat-visual-editor.types";
 
 const SOURCE_LOCALE = "en-US";
 const TARGET_LOCALE = "de-DE";

--- a/apps/hyperlocalise-web/src/components/cat/visual-editor/cat-visual-editor.types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/visual-editor/cat-visual-editor.types.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+import type { CatSegment, CatSegmentIntelligence } from "@/components/cat/shared/types";
+
+export type CatVisualEditorDevice = "desktop" | "tablet" | "mobile";
+
+export type CatVisualEditorPreviewKind = "home" | "pricing" | "generic";
+
+export type CatVisualEditorNodeMeta = {
+  tagName: "H1" | "H2" | "P" | "A" | "BUTTON" | "SPAN";
+  selector: string;
+};
+
+export type CatVisualEditorSegment = CatSegment & {
+  node: CatVisualEditorNodeMeta;
+};
+
+export type CatVisualEditorProgress = {
+  locale: string;
+  percent: number;
+  translated: number;
+  inReview: number;
+  untranslated: number;
+};
+
+export type CatVisualEditorFilePage = {
+  sourcePath: string;
+  previewUrl: string;
+  previewKind: CatVisualEditorPreviewKind;
+  progress: CatVisualEditorProgress;
+  segments: CatVisualEditorSegment[];
+  defaultSelectedSegmentId: string;
+  intelligenceBySegmentId: Record<string, CatSegmentIntelligence>;
+};
+
+export type CatVisualEditorFixture = {
+  files: ProjectFileRecord[];
+  selectedSourcePath: string;
+  pagesBySourcePath: Record<string, CatVisualEditorFilePage>;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Vercel production deploys failed after #1781 because production CAT visual editor components imported types from `cat-visual-editor.fixture.ts`, and `.vercelignore` excludes `**/*.fixture.ts`.

## Fix

- Move shared visual editor types into `cat-visual-editor.types.ts`
- Point production components at the types module
- Keep Storybook fixture data in the ignored `.fixture.ts` file (re-export types for story convenience)

## Test plan

- [x] `vp check --fix` in `apps/hyperlocalise-web`
- [x] `vp test` in `apps/hyperlocalise-web` (601 files / 3907 tests passed)
- [ ] Confirm Vercel production deploy succeeds after merge

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff04e-5361-7a3a-8e1e-ff5af27d1334?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff04e-5361-7a3a-8e1e-ff5af27d1334&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

