### PR TITLE
feat(cat): indicate Crowdin hidden strings

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -618,6 +618,8 @@ export const projectFileCatSegmentSchema = z.object({
   context: z.string().nullable(),
   type: z.string().nullable(),
   maxLength: z.number().int().positive().optional(),
+  /** Crowdin (and similar TMS) hidden/unavailable-for-translators flag. */
+  isHidden: z.boolean().optional(),
   contentKind: projectFileCatContentKindSchema.optional(),
   sourceAssetUrl: z.string().nullable().optional(),
   targetAssetUrl: z.string().nullable().optional(),

--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-header.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-header.tsx
@@ -19,6 +19,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
+import { CatHiddenStringBadge } from "@/components/cat/segment/cat-hidden-string-badge";
 import { SegmentStatusBadge } from "@/components/cat/segment/cat-segment-status";
 import { CatShareSegmentButton } from "@/components/cat/segment/cat-share-segment-button";
 import { catEditorPanelMessages } from "@/components/cat/shared/cat.messages";
@@ -64,6 +65,7 @@ export function CatEditorHeader({
           />
         </span>
         <SegmentStatusBadge status={segment.status} />
+        {segment.isHidden ? <CatHiddenStringBadge /> : null}
         {isTargetDirty ? (
           <Badge variant="outline" className="border-bud-500/40 bg-bud-500/10 text-bud-300">
             <FormattedMessage {...catEditorPanelMessages.unsavedChanges} />

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-mapper.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-mapper.test.ts
@@ -134,6 +134,39 @@ describe("projectFileCatToWorkspaceState", () => {
     expect(state.segmentIntelligence?.["limited-string"]?.maxLength).toBe(24);
   });
 
+  it("maps isHidden from CAT segments into queue state", () => {
+    const state = projectFileCatToWorkspaceState(
+      catFile({
+        segments: [
+          {
+            externalStringId: "hidden-string",
+            key: "legacy.banner",
+            sourceText: "Retired banner",
+            context: null,
+            type: "text",
+            isHidden: true,
+          },
+          {
+            externalStringId: "visible-string",
+            key: "hero.cta",
+            sourceText: "Get started",
+            context: null,
+            type: "text",
+            isHidden: false,
+          },
+        ],
+      }),
+      "en-US",
+      testIntl,
+    );
+
+    expect(state.queueSegments[0]).toMatchObject({
+      id: "hidden-string",
+      isHidden: true,
+    });
+    expect(state.queueSegments[1]).not.toHaveProperty("isHidden");
+  });
+
   it("omits maxLength from workspace state when the CAT segment has a non-positive value", () => {
     const state = projectFileCatToWorkspaceState(
       catFile({

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-mapper.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-mapper.ts
@@ -244,6 +244,7 @@ export function projectFileCatToWorkspaceState(
     ...(segment.looksLikeImageUrl !== undefined
       ? { looksLikeImageUrl: segment.looksLikeImageUrl }
       : {}),
+    ...(segment.isHidden ? { isHidden: true } : {}),
     ...(segment.sourcePath ? { sourcePath: segment.sourcePath } : {}),
     ...(segment.externalResourceId ? { externalResourceId: segment.externalResourceId } : {}),
     ...(segment.resourceType ? { resourceType: segment.resourceType } : {}),

--- a/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-virtual-list.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-virtual-list.tsx
@@ -19,6 +19,7 @@ import { useIntl } from "react-intl";
 import { cn } from "@/lib/primitives/cn";
 
 import { formatInternalMarkupForDisplay } from "@/components/cat/message-format/cat-internal-markup";
+import { CatHiddenStringBadge } from "@/components/cat/segment/cat-hidden-string-badge";
 import { CatSegmentKeyMeta } from "@/components/cat/segment/cat-segment-key-meta";
 import { catQueuePanelMessages } from "@/components/cat/shared/cat.messages";
 import type { CatSegment } from "@/components/cat/shared/types";
@@ -158,6 +159,11 @@ export function CatQueueVirtualList({
                       segmentKey={segment.key}
                       sourcePath={segment.sourcePath}
                       keyClassName="text-xs"
+                      trailing={
+                        segment.isHidden ? (
+                          <CatHiddenStringBadge className="h-5 shrink-0 px-1.5 text-[0.625rem]" />
+                        ) : null
+                      }
                     />
                   </div>
                   <div className="mt-1 flex shrink-0 flex-col items-center gap-1">

--- a/apps/hyperlocalise-web/src/components/cat/segment/cat-hidden-string-badge.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/segment/cat-hidden-string-badge.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+
+import { renderWithCatProviders } from "@/components/cat/shared/cat-test-utils";
+
+import { CatHiddenStringBadge } from "./cat-hidden-string-badge";
+
+describe("CatHiddenStringBadge", () => {
+  it("renders the Hidden label", () => {
+    renderWithCatProviders(<CatHiddenStringBadge />);
+
+    expect(screen.getByText("Hidden")).toBeInTheDocument();
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/segment/cat-hidden-string-badge.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/segment/cat-hidden-string-badge.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { FormattedMessage } from "react-intl";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/primitives/cn";
+
+import { catHiddenStringMessages } from "@/components/cat/shared/cat.messages";
+
+export function CatHiddenStringBadge({ className }: { className?: string }) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn("border-muted-foreground/30 font-normal text-muted-foreground", className)}
+    >
+      <FormattedMessage {...catHiddenStringMessages.hidden} />
+    </Badge>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
@@ -194,6 +194,14 @@ export const catSegmentStatusMessages = defineMessages({
   },
 });
 
+export const catHiddenStringMessages = defineMessages({
+  hidden: {
+    defaultMessage: "Hidden",
+    id: "/d/gbp0E4g",
+    description: "Badge shown when a TMS source string is hidden from translators",
+  },
+});
+
 export const catGlossaryChecksMessages = defineMessages({
   complianceLabel: {
     defaultMessage: "Glossary compliance",

--- a/apps/hyperlocalise-web/src/components/cat/shared/types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/types.ts
@@ -63,6 +63,8 @@ export interface CatQueueSegment {
   targetAssetUrl?: string | null;
   imageVariantId?: string | null;
   looksLikeImageUrl?: boolean;
+  /** TMS hidden string — unavailable to translators, still visible to managers. */
+  isHidden?: boolean;
   /** Set when the queue spans multiple files. */
   sourcePath?: string;
   externalResourceId?: string;
@@ -94,6 +96,8 @@ export interface CatSegment {
   contextLabel?: string;
   status: CatSegmentStatus;
   hasOpenIssues?: boolean;
+  /** TMS hidden string — unavailable to translators, still visible to managers. */
+  isHidden?: boolean;
   tags?: string[];
   maxLength?: number;
   comments?: CatSegmentComment[];

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.tsx
@@ -36,6 +36,7 @@ import {
   CatTargetEditor,
 } from "@/components/cat/editor/cat-target-editor";
 import { analyzeCatMessageFormat } from "@/components/cat/message-format/cat-message-format";
+import { CatHiddenStringBadge } from "@/components/cat/segment/cat-hidden-string-badge";
 import { SegmentStatusBadge } from "@/components/cat/segment/cat-segment-status";
 import { CatSegmentKeyMeta } from "@/components/cat/segment/cat-segment-key-meta";
 import { CatSegmentTags } from "@/components/cat/segment/cat-segment-tags";
@@ -190,6 +191,7 @@ export function CatSideBySideRow({
   const statusAndTags = (
     <div className="flex flex-wrap items-center gap-1.5">
       {isTargetLoading ? null : <SegmentStatusBadge status={segment.status} />}
+      {segment.isHidden ? <CatHiddenStringBadge /> : null}
       {segmentTags.length > 0 ? <CatSegmentTags tags={segmentTags} /> : null}
     </div>
   );

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-segment-view.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-segment-view.ts
@@ -91,6 +91,7 @@ export function toQueueSegment(
     | "targetAssetUrl"
     | "imageVariantId"
     | "looksLikeImageUrl"
+    | "isHidden"
   >,
 ): CatQueueSegment {
   return {
@@ -106,5 +107,6 @@ export function toQueueSegment(
     ...(segment.looksLikeImageUrl !== undefined
       ? { looksLikeImageUrl: segment.looksLikeImageUrl }
       : {}),
+    ...(segment.isHidden ? { isHidden: true } : {}),
   };
 }

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -545,6 +545,7 @@ describe("CrowdinApiClient", () => {
                 text: "Hello",
                 type: "text",
                 context: null,
+                isHidden: false,
                 labelIds: null,
               },
             },
@@ -558,7 +559,12 @@ describe("CrowdinApiClient", () => {
     const strings = await client.listSourceStrings(1, { fileId: 101 });
 
     expect(strings).toHaveLength(1);
-    expect(strings[0]).toMatchObject({ id: 1001, identifier: "hello", fileId: 101 });
+    expect(strings[0]).toMatchObject({
+      id: 1001,
+      identifier: "hello",
+      fileId: 101,
+      isHidden: false,
+    });
   });
 
   it("lists source strings by taskId", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -228,6 +228,7 @@ export interface CrowdinSourceString {
   text: string | Record<string, string>;
   type: string;
   context: string | null;
+  isHidden: boolean;
   labelIds: number[] | null;
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-cat.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-cat.test.ts
@@ -186,6 +186,7 @@ describe("getTmsProviderLiveCatFile", () => {
                   text: "Hello",
                   type: "text",
                   context: "Hero",
+                  isHidden: true,
                   labelIds: null,
                 },
               },
@@ -200,6 +201,7 @@ describe("getTmsProviderLiveCatFile", () => {
                   text: { one: "Start", other: "Start all" },
                   type: "text",
                   context: null,
+                  isHidden: false,
                   labelIds: null,
                 },
               },
@@ -228,6 +230,7 @@ describe("getTmsProviderLiveCatFile", () => {
                   text: { one: "Start", other: "Start all" },
                   type: "text",
                   context: null,
+                  isHidden: false,
                   labelIds: null,
                 },
               },
@@ -347,12 +350,14 @@ describe("getTmsProviderLiveCatFile", () => {
       externalStringId: "1001",
       key: "hero.title",
       sourceText: "Hello",
+      isHidden: true,
     });
     expect(catFile?.segments[0]).not.toHaveProperty("target");
     expect(catFile?.segments[1]).toMatchObject({
       externalStringId: "1002",
       sourceText: JSON.stringify({ one: "Start", other: "Start all" }),
     });
+    expect(catFile?.segments[1]).not.toHaveProperty("isHidden");
     expect(catFile?.segments[1]).not.toHaveProperty("target");
     const requestedPaths = fetchMock.mock.calls.map(([url]) => String(url));
     expect(requestedPaths.some((path) => path.includes("/projects/42/approvals?"))).toBe(false);

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -960,6 +960,26 @@ function crowdinSourceTextValue(text: CrowdinSourceString["text"]) {
   return text;
 }
 
+function mapCrowdinSourceStringToCatSegment(
+  sourceString: CrowdinSourceString,
+  extras: Partial<{
+    sourcePath: string;
+    format: string | null;
+    externalResourceId: string;
+    resourceType: "file" | "key";
+  }> = {},
+) {
+  return {
+    externalStringId: String(sourceString.id),
+    key: sourceString.identifier,
+    sourceText: crowdinCatSourceTextValue(sourceString.text),
+    context: sourceString.context,
+    type: sourceString.type ?? null,
+    ...(sourceString.isHidden ? { isHidden: true as const } : {}),
+    ...extras,
+  };
+}
+
 function crowdinCatSourceTextValue(text: CrowdinSourceString["text"]): string {
   if (typeof text === "string") {
     return text;
@@ -1142,13 +1162,9 @@ async function buildCrowdinLiveCatFile(input: {
       canEditTranslations: input.canEditTranslations,
       truncated,
       pagination,
-      segments: visibleStrings.map((sourceString) => ({
-        externalStringId: String(sourceString.id),
-        key: sourceString.identifier,
-        sourceText: crowdinCatSourceTextValue(sourceString.text),
-        context: sourceString.context,
-        type: sourceString.type ?? null,
-      })),
+      segments: visibleStrings.map((sourceString) =>
+        mapCrowdinSourceStringToCatSegment(sourceString),
+      ),
     };
   } catch (error) {
     if (error instanceof CrowdinApiError && error.status === 401) {
@@ -2389,19 +2405,16 @@ async function buildCrowdinLiveCatAllFiles(input: {
         continue;
       }
 
-      segments.push({
-        externalStringId: String(sourceString.id),
-        key: sourceString.identifier,
-        sourceText: crowdinCatSourceTextValue(sourceString.text),
-        context: sourceString.context,
-        type: sourceString.type ?? null,
-        sourcePath: file.sourcePath,
-        ...(file.provider?.format != null ? { format: file.provider.format } : {}),
-        ...(file.provider?.externalResourceId
-          ? { externalResourceId: file.provider.externalResourceId }
-          : {}),
-        ...(file.provider?.resourceType ? { resourceType: file.provider.resourceType } : {}),
-      });
+      segments.push(
+        mapCrowdinSourceStringToCatSegment(sourceString, {
+          sourcePath: file.sourcePath,
+          ...(file.provider?.format != null ? { format: file.provider.format } : {}),
+          ...(file.provider?.externalResourceId
+            ? { externalResourceId: file.provider.externalResourceId }
+            : {}),
+          ...(file.provider?.resourceType ? { resourceType: file.provider.resourceType } : {}),
+        }),
+      );
     }
 
     const totalCount = page.hasMore ? offset + segments.length + 1 : offset + segments.length;

--- a/docs/adr/2026-08-12-crowdin-hidden-string-cat-ui-design.md
+++ b/docs/adr/2026-08-12-crowdin-hidden-string-cat-ui-design.md
@@ -1,0 +1,27 @@
+# Crowdin Hidden String CAT UI
+
+## Context
+
+Crowdin source strings expose `isHidden`. Hidden strings stay available to managers and proofreaders but are withheld from translators. Our CAT live Crowdin path already returns those strings, but we drop `isHidden` at the API client and never surface it in the editor or queue.
+
+## Decision
+
+Treat hidden as a first-class optional CAT segment flag and show a clear indicator when it is true.
+
+1. Parse `isHidden` on `CrowdinSourceString`.
+2. Pass `isHidden` through `projectFileCatSegmentSchema` and into `CatQueueSegment` / `CatSegment`.
+3. Map it from Crowdin live CAT (single-file and all-files).
+4. Show a compact "Hidden" badge in the editor header, queue row, and side-by-side status row.
+
+Do not block editing. Managers using CAT with Crowdin credentials should still translate hidden strings; the badge is informational, matching Crowdin's manager editor.
+
+## Alternatives considered
+
+- Filter hidden strings out of the queue: wrong for manager workflows that need to see them.
+- Crowdin-only UI branch: rejected; a shared `isHidden` field keeps the CAT UI provider-agnostic if other TMS adapters later map the same concept.
+
+## Testing
+
+- Unit coverage for Crowdin → CAT segment mapping of `isHidden: true`.
+- Mapper coverage that queue/workspace state carries the flag.
+- Light UI assertion that the badge renders when `segment.isHidden` is set.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Crowdin source strings can be marked `isHidden` (withheld from translators; still visible to managers). Live CAT already returned those strings but dropped the flag, so the UI gave no signal.

## Changes

- Parse `isHidden` on Crowdin source strings and pass it through the CAT segment schema into queue/editor segment models
- Show a compact **Hidden** badge in the editor header, queue row, and side-by-side status row
- Editing is unchanged — managers can still translate hidden strings; this is informational only

## Testing

- `vp test` on Crowdin live CAT, mapper, badge, and Crowdin API fixtures
- `vp check --fix` (existing unrelated warnings only)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f86aa06d-e400-4888-a1bf-5e0c9126f1c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f86aa06d-e400-4888-a1bf-5e0c9126f1c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

