### PR TITLE
fix(localisation-audit): restore crawl, BotID paths, and locale-prefixed sampling

### DIFF
--- a/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.test.ts
@@ -119,6 +119,19 @@ describe("crawlLocalisationAuditSample", () => {
     expect(pages.find((page) => page.url === "https://example.com/en")?.title).toBe("EN");
   });
 
+  it("returns an empty sample when the home page fetch fails instead of throwing", async () => {
+    withPublicHttpFetchMock.mockImplementation(async () => {
+      throw new Error("URL host is not allowed.");
+    });
+
+    await expect(
+      crawlLocalisationAuditSample({
+        origin: "https://example.com",
+        sourceUrl: "https://example.com/",
+      }),
+    ).resolves.toEqual([]);
+  });
+
   it("reuses one abort signal across redirect hops so the page timeout does not reset", async () => {
     const signals: AbortSignal[] = [];
     withPublicHttpFetchMock.mockImplementation(async (url, init, handler) => {

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.test.ts
@@ -168,4 +168,42 @@ describe("crawlLocalisationAuditSample", () => {
     expect(signals.length).toBeGreaterThanOrEqual(2);
     expect(signals[0]).toBe(signals[1]);
   });
+
+  it("seeds locale-prefixed high-value paths from focusLocales and homepage hreflang", async () => {
+    const fetchedUrls: string[] = [];
+    withPublicHttpFetchMock.mockImplementation(async (url, _init, handler) => {
+      fetchedUrls.push(url);
+      if (url === "https://example.com/") {
+        return handler(
+          htmlResponse(
+            `<html lang="en"><head><title>Home</title><link rel="alternate" hreflang="fr" href="/fr" /><link rel="alternate" hreflang="x-default" href="/" /></head><body><a href="/de">Deutsch</a> Welcome to the homepage content sample.</body></html>`,
+          ),
+        );
+      }
+      if (url === "https://example.com/fr/pricing") {
+        return handler(
+          htmlResponse(
+            "<html lang='fr'><title>Tarifs</title><body>Page tarifaire francaise avec contenu.</body></html>",
+          ),
+        );
+      }
+      return handler(
+        htmlResponse(
+          "<html><body>Secondary page with enough text content for parsing.</body></html>",
+        ),
+      );
+    });
+
+    const pages = await crawlLocalisationAuditSample({
+      origin: "https://example.com",
+      sourceUrl: "https://example.com/",
+      focusLocales: ["ja"],
+    });
+
+    expect(fetchedUrls).toContain("https://example.com/ja/pricing");
+    expect(fetchedUrls).toContain("https://example.com/fr/pricing");
+    expect(fetchedUrls).toContain("https://example.com/de/pricing");
+    expect(fetchedUrls).not.toContain("https://example.com/x-default/pricing");
+    expect(pages.some((page) => page.url === "https://example.com/fr/pricing")).toBe(true);
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.ts
@@ -18,12 +18,14 @@ import type { LocalisationAuditCrawledPage } from "./types";
 
 const USER_AGENT = "HyperlocaliseLocalisationAudit/1.0 (+https://hyperlocalise.com)";
 const MAX_PAGES = 15;
+const MAX_DISCOVERED_LOCALES = 5;
 const FETCH_TIMEOUT_MS = 12_000;
 const MAX_REDIRECTS = 5;
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 const HIGH_VALUE_PATHS = ["/pricing", "/product", "/products", "/about", "/company", "/blog"];
 
 const LOCALE_PREFIX = /^\/([a-z]{2}(?:-[a-z]{2})?)(\/|$)/i;
+const LOCALE_CODE = /^[a-z]{2}(?:-[a-z]{2})?$/i;
 
 const FETCH_HEADERS = {
   "User-Agent": USER_AGENT,
@@ -179,6 +181,79 @@ async function fetchPageWithAnchors(url: string): Promise<
   });
 }
 
+function normalizeLocaleCode(value: string): string | null {
+  const normalized = value.trim().replaceAll("_", "-").toLowerCase();
+  if (normalized === "x-default" || !LOCALE_CODE.test(normalized)) {
+    return null;
+  }
+  return normalized;
+}
+
+function localeFromPath(pathname: string): string | null {
+  const match = pathname.match(LOCALE_PREFIX);
+  return match ? normalizeLocaleCode(match[1]!) : null;
+}
+
+function isHighValuePath(path: string): boolean {
+  return HIGH_VALUE_PATHS.some((candidate) => path === candidate || path.endsWith(candidate));
+}
+
+/**
+ * Prefer focus locales, then hreflang, then locale prefixes seen on same-host
+ * homepage links — capped so prefixed high-value probes stay within MAX_PAGES.
+ */
+function discoverLocales(input: {
+  focusLocales: string[];
+  hreflang: Array<{ locale: string }>;
+  candidateUrls: string[];
+  originHost: string;
+}): string[] {
+  const ordered: string[] = [];
+  const seen = new Set<string>();
+
+  const add = (raw: string) => {
+    const locale = normalizeLocaleCode(raw);
+    if (!locale || seen.has(locale)) {
+      return;
+    }
+    seen.add(locale);
+    ordered.push(locale);
+  };
+
+  for (const locale of input.focusLocales) {
+    add(locale);
+  }
+  for (const entry of input.hreflang) {
+    add(entry.locale);
+  }
+  for (const url of input.candidateUrls) {
+    if (!sameHost(input.originHost, url)) {
+      continue;
+    }
+    try {
+      const locale = localeFromPath(new URL(url).pathname);
+      if (locale) {
+        add(locale);
+      }
+    } catch {
+      // ignore malformed candidate URLs
+    }
+  }
+
+  return ordered.slice(0, MAX_DISCOVERED_LOCALES);
+}
+
+function seedHighValuePaths(origin: string, locales: string[]): string[] {
+  const seeds: string[] = [];
+  for (const path of HIGH_VALUE_PATHS) {
+    seeds.push(new URL(path, origin).toString());
+    for (const locale of locales) {
+      seeds.push(new URL(`/${locale}${path}`, origin).toString());
+    }
+  }
+  return seeds;
+}
+
 function scoreCandidate(url: string, origin: string): number {
   try {
     const parsed = new URL(url);
@@ -189,9 +264,8 @@ function scoreCandidate(url: string, origin: string): number {
     const path = parsed.pathname.replace(/\/+$/, "") || "/";
     if (path === "/") return 100;
     if (LOCALE_PREFIX.test(path) && path.split("/").filter(Boolean).length <= 1) return 90;
-    if (HIGH_VALUE_PATHS.some((candidate) => path === candidate || path.endsWith(candidate))) {
-      return 80;
-    }
+    if (isHighValuePath(path) && localeFromPath(path)) return 85;
+    if (isHighValuePath(path)) return 80;
     if (LOCALE_PREFIX.test(path)) return 60;
     if (path.split("/").filter(Boolean).length <= 2) return 40;
     return 10;
@@ -203,6 +277,7 @@ function scoreCandidate(url: string, origin: string): number {
 export async function crawlLocalisationAuditSample(input: {
   origin: string;
   sourceUrl: string;
+  focusLocales?: string[];
 }): Promise<LocalisationAuditCrawledPage[]> {
   try {
     return await crawlLocalisationAuditSampleInner(input);
@@ -216,6 +291,7 @@ export async function crawlLocalisationAuditSample(input: {
 async function crawlLocalisationAuditSampleInner(input: {
   origin: string;
   sourceUrl: string;
+  focusLocales?: string[];
 }): Promise<LocalisationAuditCrawledPage[]> {
   const homeResult = await fetchPageWithAnchors(input.sourceUrl);
   if (homeResult.ok === false) {
@@ -224,9 +300,15 @@ async function crawlLocalisationAuditSampleInner(input: {
 
   const { page: homePage, candidateUrls } = homeResult.value;
   const originHost = new URL(input.origin).hostname;
+  const locales = discoverLocales({
+    focusLocales: input.focusLocales ?? [],
+    hreflang: homePage.hreflang,
+    candidateUrls,
+    originHost,
+  });
   const seeded = new Set<string>([homePage.url]);
-  for (const path of HIGH_VALUE_PATHS) {
-    seeded.add(new URL(path, input.origin).toString());
+  for (const url of seedHighValuePaths(input.origin, locales)) {
+    seeded.add(url);
   }
   for (const candidate of candidateUrls) {
     if (sameHost(originHost, candidate)) {

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.ts
@@ -57,6 +57,8 @@ type SafeFetchOutcome<T> =
   | { kind: "redirect"; nextUrl: string }
   | { kind: "fail" };
 
+type SafeFetchResult<T> = { ok: true; value: T } | { ok: false };
+
 /**
  * Follow redirects manually so each hop is re-validated by withPublicHttpFetch.
  * Never use redirect:"follow" — undici can connect to IP-literal Location targets
@@ -64,18 +66,22 @@ type SafeFetchOutcome<T> =
  *
  * One AbortController + FETCH_TIMEOUT_MS deadline covers the whole redirect chain
  * (not a fresh 12s budget per hop).
+ *
+ * Returns a discriminated result (not `T | null`) so Turbopack cannot DCE the
+ * failure branch after await — it has been observed to strip `if (!home)` as
+ * "compile-time falsy" when the helper returned null.
  */
 async function fetchPublicWithSafeRedirects<T>(
   startUrl: string,
   handler: (response: Response, finalUrl: string) => Promise<T>,
-): Promise<T | null> {
+): Promise<SafeFetchResult<T>> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
     let currentUrl = startUrl;
     for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
       if (controller.signal.aborted) {
-        return null;
+        return { ok: false };
       }
       try {
         const outcome = await withPublicHttpFetch(
@@ -105,21 +111,21 @@ async function fetchPublicWithSafeRedirects<T>(
           continue;
         }
         if (outcome.kind === "ok") {
-          return outcome.value;
+          return { ok: true, value: outcome.value };
         }
-        return null;
+        return { ok: false };
       } catch {
-        return null;
+        return { ok: false };
       }
     }
-    return null;
+    return { ok: false };
   } finally {
     clearTimeout(timeout);
   }
 }
 
 async function fetchPage(url: string): Promise<LocalisationAuditCrawledPage | null> {
-  return fetchPublicWithSafeRedirects(url, async (response, finalUrl) => {
+  const result = await fetchPublicWithSafeRedirects(url, async (response, finalUrl) => {
     const contentType = response.headers.get("content-type") ?? "";
     if (!contentType.includes("text/html") && !contentType.includes("application/xhtml")) {
       return {
@@ -144,12 +150,15 @@ async function fetchPage(url: string): Promise<LocalisationAuditCrawledPage | nu
       hreflang: signals.hreflang,
     };
   });
+  return result.ok ? result.value : null;
 }
 
-async function fetchPageWithAnchors(url: string): Promise<{
-  page: LocalisationAuditCrawledPage;
-  candidateUrls: string[];
-} | null> {
+async function fetchPageWithAnchors(url: string): Promise<
+  SafeFetchResult<{
+    page: LocalisationAuditCrawledPage;
+    candidateUrls: string[];
+  }>
+> {
   return fetchPublicWithSafeRedirects(url, async (response, finalUrl) => {
     const body = await readBoundedResponseBody(response);
     const html = new TextDecoder("utf-8", { fatal: false }).decode(body);
@@ -195,17 +204,31 @@ export async function crawlLocalisationAuditSample(input: {
   origin: string;
   sourceUrl: string;
 }): Promise<LocalisationAuditCrawledPage[]> {
-  const home = await fetchPageWithAnchors(input.sourceUrl);
-  if (!home) {
+  try {
+    return await crawlLocalisationAuditSampleInner(input);
+  } catch {
+    // Soft-fail unexpected errors (and any remaining Turbopack null-guard DCE)
+    // so the workflow step does not retry forever on an empty crawl.
+    return [];
+  }
+}
+
+async function crawlLocalisationAuditSampleInner(input: {
+  origin: string;
+  sourceUrl: string;
+}): Promise<LocalisationAuditCrawledPage[]> {
+  const homeResult = await fetchPageWithAnchors(input.sourceUrl);
+  if (homeResult.ok === false) {
     return [];
   }
 
+  const { page: homePage, candidateUrls } = homeResult.value;
   const originHost = new URL(input.origin).hostname;
-  const seeded = new Set<string>([home.page.url]);
+  const seeded = new Set<string>([homePage.url]);
   for (const path of HIGH_VALUE_PATHS) {
     seeded.add(new URL(path, input.origin).toString());
   }
-  for (const candidate of home.candidateUrls) {
+  for (const candidate of candidateUrls) {
     if (sameHost(originHost, candidate)) {
       seeded.add(candidate.split("#")[0]!);
     }
@@ -218,8 +241,8 @@ export async function crawlLocalisationAuditSample(input: {
     .slice(0, MAX_PAGES);
 
   const pages = await mapWithConcurrency(ranked, 4, async (entry) => {
-    if (entry.url === home.page.url) {
-      return home.page;
+    if (entry.url === homePage.url) {
+      return homePage;
     }
     return fetchPage(entry.url);
   });

--- a/apps/hyperlocalise-web/src/lib/security/public-http-fetch.test.ts
+++ b/apps/hyperlocalise-web/src/lib/security/public-http-fetch.test.ts
@@ -111,6 +111,27 @@ describe("public-http-fetch", () => {
       });
     });
     expect(pinned).toEqual({ address: "93.184.216.34", family: 4 });
+
+    const pinnedAll = await new Promise<Array<{ address: string; family: number }>>(
+      (resolve, reject) => {
+        lookup?.(
+          "api.example.com",
+          { all: true },
+          (error: Error | null, addresses: Array<{ address: string; family: number }> | string) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+            if (typeof addresses === "string") {
+              reject(new Error("expected address list for options.all"));
+              return;
+            }
+            resolve(addresses);
+          },
+        );
+      },
+    );
+    expect(pinnedAll).toEqual([{ address: "93.184.216.34", family: 4 }]);
     expect(undiciMock.close).toHaveBeenCalled();
   });
 

--- a/apps/hyperlocalise-web/src/lib/security/public-http-fetch.ts
+++ b/apps/hyperlocalise-web/src/lib/security/public-http-fetch.ts
@@ -60,7 +60,15 @@ export async function withPublicHttpFetch<T>(
   const { address, family } = hostResult.value;
   const dispatcher = new Agent({
     connect: {
-      lookup(_hostname, _options, callback) {
+      // Node 20+/undici often call custom lookup with `{ all: true }`. In that
+      // mode the callback must receive `[{ address, family }]`; the legacy
+      // `(address, family)` shape yields ERR_INVALID_IP_ADDRESS and every
+      // public crawl fails.
+      lookup(_hostname, options, callback) {
+        if (options?.all) {
+          callback(null, [{ address, family }]);
+          return;
+        }
         callback(null, address, family);
       },
     },

--- a/apps/hyperlocalise-web/src/proxy.test.ts
+++ b/apps/hyperlocalise-web/src/proxy.test.ts
@@ -52,6 +52,19 @@ describe("isUnsupportedLocalePath", () => {
     expect(isUnsupportedLocalePath("/crowdin-app/manifest.json")).toBe(false);
   });
 
+  it("allows opaque UUID roots used by BotID challenge scripts", () => {
+    expect(
+      isUnsupportedLocalePath(
+        "/149e9513-01fa-4fb0-aad4-566afd725d1b/2d206a39-8ed7-437e-a3be-862e0f06eea3/a-4-a/c.js",
+      ),
+    ).toBe(false);
+    expect(
+      isUnsupportedLocalePath(
+        "/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/2d206a39-8ed7-437e-a3be-862e0f06eea3/p.js",
+      ),
+    ).toBe(false);
+  });
+
   it("rejects removed fixture browser routes", () => {
     expect(isUnsupportedLocalePath("/e2e/login")).toBe(true);
   });
@@ -170,6 +183,21 @@ describe("proxy", () => {
 
     expect(authkitProxyMock).toHaveBeenCalledOnce();
     expect(response?.status).toBe(200);
+  });
+
+  it("does not 404 opaque UUID challenge paths as unsupported locale paths", async () => {
+    authkitProxyMock.mockReset();
+    authkitProxyMock.mockResolvedValueOnce(NextResponse.next());
+
+    const response = await proxy(
+      createRequest(
+        "/149e9513-01fa-4fb0-aad4-566afd725d1b/2d206a39-8ed7-437e-a3be-862e0f06eea3/a-4-a/c.js",
+      ),
+      {} as never,
+    );
+
+    expect(response?.status).not.toBe(404);
+    expect(authkitProxyMock).toHaveBeenCalledOnce();
   });
 
   it("runs Crowdin App iframe pages through AuthKit before applying frame-ancestors CSP", async () => {

--- a/apps/hyperlocalise-web/src/proxy.ts
+++ b/apps/hyperlocalise-web/src/proxy.ts
@@ -124,6 +124,9 @@ const PUBLIC_LOCALIZED_PATHS = new Set([
 ]);
 const PROTECTED_LOCALIZED_PREFIXES = ["/dashboard", "/org"];
 const NON_LOCALE_ROOT_PREFIXES = ["/auth", "/install", "/api", "/crowdin-app"];
+// BotID (and similar) use opaque UUID first segments; locales never do.
+const UUID_PATH_SEGMENT_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function splitLocalePath(pathname: string): {
   locale: string | null;
@@ -190,6 +193,11 @@ export function isUnsupportedLocalePath(pathname: string): boolean {
     return false;
   }
 
+  // Skip opaque UUID roots (BotID challenge scripts) — not /[lang] candidates.
+  if (UUID_PATH_SEGMENT_RE.test(firstSegment)) {
+    return false;
+  }
+
   return true;
 }
 
@@ -244,7 +252,8 @@ export default async function proxy(request: NextRequest, event: NextFetchEvent)
 
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|favicon.ico|images|api|mcp|\\.well-known|install|sitemap\\.xml|robots\\.txt).*)",
+    // Exclude opaque UUID roots (BotID challenge scripts) so locale proxy does not 404 them.
+    "/((?!_next/static|_next/image|favicon.ico|images|api|mcp|\\.well-known|install|sitemap\\.xml|robots\\.txt|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}).*)",
     "/api/:path*",
   ],
 };

--- a/apps/hyperlocalise-web/src/proxy.ts
+++ b/apps/hyperlocalise-web/src/proxy.ts
@@ -125,8 +125,7 @@ const PUBLIC_LOCALIZED_PATHS = new Set([
 const PROTECTED_LOCALIZED_PREFIXES = ["/dashboard", "/org"];
 const NON_LOCALE_ROOT_PREFIXES = ["/auth", "/install", "/api", "/crowdin-app"];
 // BotID (and similar) use opaque UUID first segments; locales never do.
-const UUID_PATH_SEGMENT_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const UUID_PATH_SEGMENT_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function splitLocalePath(pathname: string): {
   locale: string | null;

--- a/apps/hyperlocalise-web/src/workflows/localisation-audit.ts
+++ b/apps/hyperlocalise-web/src/workflows/localisation-audit.ts
@@ -61,6 +61,7 @@ export async function localisationAuditWorkflow(event: LocalisationAuditEventDat
       const pages = await crawlLocalisationAuditStep({
         origin: prepared.origin,
         sourceUrl: prepared.sourceUrl,
+        focusLocales: prepared.focusLocales,
       });
 
       await setLocalisationAuditProgressStep({

--- a/apps/hyperlocalise-web/src/workflows/steps/localisation-audit.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/localisation-audit.ts
@@ -103,6 +103,7 @@ export async function setLocalisationAuditProgressStep(input: {
 export async function crawlLocalisationAuditStep(input: {
   origin: string;
   sourceUrl: string;
+  focusLocales?: string[];
 }): Promise<LocalisationAuditCrawledPage[]> {
   "use step";
   return crawlLocalisationAuditSample(input);


### PR DESCRIPTION
## Summary
- Fix DNS-pinned `withPublicHttpFetch` for Node 20+/undici `{ all: true }` lookups so localisation audit crawls no longer fail with `ERR_INVALID_IP_ADDRESS`.
- Harden crawl failure handling (discriminated fetch result + soft-fail) so Turbopack-stripped null guards cannot crash the workflow into max retries.
- Let BotID opaque UUID challenge script paths bypass locale proxy matching so the audit form challenge can load.
- Seed locale-prefixed high-value paths (`/{locale}/pricing`, etc.) from focus locales, homepage hreflang, and same-host link prefixes (up to 5 locales).

## Test plan
- [ ] `vp test src/lib/security/public-http-fetch.test.ts src/lib/localisation-audit/crawl.test.ts src/proxy.test.ts`
- [ ] Restart `vp run dev`, open localisation audit, run audit against a public site (e.g. `chaoflowerstudio.com`) and confirm it reaches scoring instead of `crawl_failed`
- [ ] Confirm BotID challenge script loads without “Error loading script” / locale 404
- [ ] Confirm a deliberately uncrawlable URL still fails cleanly as `crawl_failed` (no step retry storm)
- [ ] Confirm audits against locale-prefixed sites attempt URLs like `/fr/pricing` when `fr` appears in focus locales / hreflang / homepage links