### PR TITLE
fix(intercom): clear validation when endpoint changes without revalidate

### DIFF
--- a/apps/hyperlocalise-web/src/lib/intercom/connections.test.ts
+++ b/apps/hyperlocalise-web/src/lib/intercom/connections.test.ts
@@ -162,4 +162,46 @@ describe("intercom connections", () => {
     expect(updated?.restEndpoint).toBe("us");
     expect(updated?.maskedAccessTokenSuffix).toBe(created.maskedAccessTokenSuffix);
   });
+
+  it("clears validation metadata when the endpoint changes without revalidation", async () => {
+    const scope = await seedIntercomScope();
+    const created = expectOk(
+      await createIntercomConnection({
+        organizationId: scope.organizationId,
+        userId: scope.userId,
+        displayName: "Validated Intercom",
+        accessToken: "intercom-token-valid",
+        restEndpoint: "us",
+        validate: false,
+      }),
+    );
+
+    const validatedAt = new Date("2026-08-12T12:00:00.000Z");
+    await db
+      .update(schema.intercomConnections)
+      .set({
+        validationStatus: "valid",
+        validationMessage: "Connected as Test App.",
+        lastValidatedAt: validatedAt,
+      })
+      .where(eq(schema.intercomConnections.id, created.id));
+
+    const updated = expectOk(
+      await updateIntercomConnection({
+        organizationId: scope.organizationId,
+        userId: scope.userId,
+        connectionId: created.id,
+        restEndpoint: "eu",
+        validate: false,
+      }),
+    );
+
+    expect(updated).toMatchObject({
+      restEndpoint: "eu",
+      validationStatus: "unvalidated",
+      validationMessage: null,
+      lastValidatedAt: null,
+      maskedAccessTokenSuffix: created.maskedAccessTokenSuffix,
+    });
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/intercom/connections.ts
+++ b/apps/hyperlocalise-web/src/lib/intercom/connections.ts
@@ -318,7 +318,7 @@ export async function updateIntercomConnection(input: {
       validationStatus = "valid";
       validationMessage = validationSuccessMessage(validation.value.appName);
       lastValidatedAt = new Date();
-    } else if (input.accessToken !== undefined) {
+    } else {
       validationStatus = "unvalidated";
       validationMessage = null;
       lastValidatedAt = null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Valid review finding: when `updateIntercomConnection` changes `restEndpoint` without a new token and with `validate: false`, the previous endpoint’s `validationStatus` / `validationMessage` / `lastValidatedAt` were retained. That metadata no longer describes the stored token/endpoint pair.

## Change

- In the `shouldRevalidate && validate === false` branch, always reset validation to `unvalidated` (not only when `accessToken` is present).
- Add a regression test that seeds a previously valid connection, updates only the endpoint with `validate: false`, and asserts validation metadata is cleared.

## Test plan

- [x] `vp test src/lib/intercom/connections.test.ts` (4 passed)
- [x] `vp check --fix`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff7e6-7064-72a8-ae59-15105d650a96?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff7e6-7064-72a8-ae59-15105d650a96&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

