### PR TITLE
fix(crowdin): align notification validations and improve 400 bad request error visibility

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -1,5 +1,15 @@
 # Crowdin Steward's Journal
 
+## 2026-12-25 - Improve error visibility and align notification role validations
+
+**Learning:**
+1) When a `400 Bad Request` returned a standard `error` payload instead of a list of `errors`, the client's `determineErrorType` incorrectly fell back to returning an un-unmarshalable Go error string rather than a pointer to an `ErrorResponse`. This caused the client to obscure the underlying Crowdin API error message with a generic `client: server returned 400 status code`.
+2) In Crowdin API v2, sending notifications to project members supports all project member roles, including `language_coordinator`, `developer`, `translator`, and `proofreader` in addition to `owner` and `manager`. Lacking these roles in client-side validations prevented valid notification requests from being sent.
+
+**Action:**
+1) Updated `determineErrorType` in `crowdin.go` and `errors_test.go` to explicitly check for the presence of a standard `"error"` key in the parsed JSON response of a `400 Bad Request` and return `&model.ErrorResponse{Response: resp}` to allow the detailed error code and message to be correctly unmarshaled and returned.
+2) Expanded `Notification.Validate()` inside `model/notifications.go` to accept all valid project-level roles (`language_coordinator`, `developer`, `translator`, `proofreader`). Added focused unit and contract test cases asserting both error unmarshaling and role validation edge cases.
+
 ## 2026-12-24 - Implement Corrections API for Crowdin Enterprise parity
 
 **Learning:** In Crowdin Enterprise API v2, proofreaders can create translation corrections. However, the Go SDK lacked model representations and endpoint methods for managing corrections (such as list, get, add, restore, and delete corrections). This gap prevented enterprise users from managing the translation correction lifecycle programmatically.

--- a/third_party/crowdin-api-client-go/crowdin/crowdin.go
+++ b/third_party/crowdin-api-client-go/crowdin/crowdin.go
@@ -414,6 +414,9 @@ func determineErrorType(res *http.Request, resp *http.Response, body []byte) err
 			}
 			return &model.ValidationErrorResponse{Response: resp, Status: resp.StatusCode}
 		}
+		if _, ok := b["error"]; ok {
+			return &model.ErrorResponse{Response: resp}
+		}
 		return fmt.Errorf("client: error while determining error type")
 	default:
 		return &model.ErrorResponse{Response: resp}

--- a/third_party/crowdin-api-client-go/crowdin/crowdin_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/crowdin_test.go
@@ -277,6 +277,18 @@ func TestRequestWithVariousErrorHandling(t *testing.T) {
 		err  string
 	}{
 		{
+			name: "400 with standard error payload",
+			path: "/path",
+			body: []byte(`{
+				"error": {
+					"message": "Some bad request error",
+					"code": 400
+				}
+			}`),
+			code: http.StatusBadRequest,
+			err:  "400 Some bad request error",
+		},
+		{
 			name: "not found error",
 			path: "/path",
 			body: []byte(`{

--- a/third_party/crowdin-api-client-go/crowdin/model/errors_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/errors_test.go
@@ -116,6 +116,17 @@ func TestParseErrorResponse(t *testing.T) {
 		err  string
 	}{
 		{
+			resp: &http.Response{StatusCode: http.StatusBadRequest},
+			body: []byte(`{
+				"error": {
+					"message": "Some bad request error",
+					"code": 400
+				}
+			}`),
+			code: 400,
+			err:  "400 Some bad request error",
+		},
+		{
 			resp: &http.Response{StatusCode: http.StatusNotFound},
 			body: []byte(`{
 				"error": {
@@ -436,6 +447,9 @@ func determineErrorType(resp *http.Response, body []byte, graph bool) error {
 				}
 			}
 			return &ValidationErrorResponse{Response: resp, Status: resp.StatusCode}
+		}
+		if _, ok := b["error"]; ok {
+			return &ErrorResponse{Response: resp}
 		}
 		return nil
 	default:

--- a/third_party/crowdin-api-client-go/crowdin/model/notifications.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/notifications.go
@@ -14,7 +14,7 @@ type Notification struct {
 	// User identifiers.
 	UserIDs []int `json:"userIds,omitempty"`
 
-	// Enum: owner, manager.
+	// Enum: owner, manager, language_coordinator, developer, translator, proofreader.
 	Role string `json:"role,omitempty"`
 }
 
@@ -30,8 +30,14 @@ func (r *Notification) Validate() error {
 	if len(r.UserIDs) > 0 && r.Role != "" {
 		return errors.New("can't specify both user IDs and role")
 	}
-	if r.Role != "" && r.Role != "owner" && r.Role != "manager" {
-		return errors.New("role must be either owner or manager")
+	if r.Role != "" &&
+		r.Role != "owner" &&
+		r.Role != "manager" &&
+		r.Role != "language_coordinator" &&
+		r.Role != "developer" &&
+		r.Role != "translator" &&
+		r.Role != "proofreader" {
+		return errors.New("role must be either owner, manager, language_coordinator, developer, translator, or proofreader")
 	}
 
 	return nil

--- a/third_party/crowdin-api-client-go/crowdin/model/notifications_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/notifications_test.go
@@ -41,7 +41,7 @@ func TestNotificationValidate(t *testing.T) {
 				Role:    "invalid",
 				Message: "notification message",
 			},
-			err: "role must be either owner or manager",
+			err: "role must be either owner, manager, language_coordinator, developer, translator, or proofreader",
 		},
 		{
 			name:  "valid request (message only)",
@@ -49,9 +49,49 @@ func TestNotificationValidate(t *testing.T) {
 			valid: true,
 		},
 		{
-			name: "valid request (with role)",
+			name: "valid request (with role owner)",
 			req: &Notification{
 				Role:    "owner",
+				Message: "notification message",
+			},
+			valid: true,
+		},
+		{
+			name: "valid request (with role manager)",
+			req: &Notification{
+				Role:    "manager",
+				Message: "notification message",
+			},
+			valid: true,
+		},
+		{
+			name: "valid request (with role language_coordinator)",
+			req: &Notification{
+				Role:    "language_coordinator",
+				Message: "notification message",
+			},
+			valid: true,
+		},
+		{
+			name: "valid request (with role developer)",
+			req: &Notification{
+				Role:    "developer",
+				Message: "notification message",
+			},
+			valid: true,
+		},
+		{
+			name: "valid request (with role translator)",
+			req: &Notification{
+				Role:    "translator",
+				Message: "notification message",
+			},
+			valid: true,
+		},
+		{
+			name: "valid request (with role proofreader)",
+			req: &Notification{
+				Role:    "proofreader",
 				Message: "notification message",
 			},
 			valid: true,


### PR DESCRIPTION
- What: Updated `determineErrorType` to unmarshal standard `error` payloads under `400 Bad Request` status codes rather than falling back to an un-unmarshalable string format. Also expanded allowed client-side validation roles in `Notification.Validate` to match the Crowdin API v2 contract.
- Why: This avoids hiding detailed API error messages behind generic `client: server returned 400 status code` errors, and lets users notify all valid project-level roles.
- Docs:
  - https://developer.crowdin.com/api/v2/#operation/api.projects.notify.post
- Scope: `third_party/crowdin-api-client-go/crowdin/`
- Tests: Focused unit and contract tests in `model/notifications_test.go`, `model/errors_test.go`, and `crowdin_test.go` were added and executed successfully.
- Confidence: Prevent generic unmarshal errors and restrictive validation regressions.

---
*PR created automatically by Jules for task [8487098068289440822](https://jules.google.com/task/8487098068289440822) started by @cungminh2710*