### PR TITLE
feat(automations): add list and create Issue Sheet tools

### DIFF
--- a/apps/hyperlocalise-web/src/agents/README.md
+++ b/apps/hyperlocalise-web/src/agents/README.md
@@ -30,7 +30,8 @@ Each package uses Eve-inspired slots under `agent/`:
 
 - **Plan**: deterministic tool order from `toolConfig` and `executorAgent` skill metadata
 - **Execution**: `ToolLoopAgent` with `prepareStep` forcing each planned tool
-- **Tools**: GitHub workflows, Contentful translation, Slack, and email notifications
+- **Tools**: GitHub workflows, Contentful translation, Issue Sheet list/create,
+  Slack, and email notifications
 
 Child executors remain specialized packages (`contentful`, `github-repository`) but are invoked as orchestrator tools rather than separate dispatch branches.
 

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/build-workspace-orchestrator-tools.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/build-workspace-orchestrator-tools.ts
@@ -15,7 +15,9 @@ import type { ToolSet } from "ai";
 import type { WorkspaceOrchestratorSession } from "./context";
 import type { WorkspaceOrchestratorToolName } from "./plan";
 import { createAssignTranslateWithAgentTool } from "./tools/assign_translate_with_agent";
+import { createCreateIssueTool } from "./tools/create_issue";
 import { createNativeTmsJobTool } from "./tools/create_native_tms_job";
+import { createListIssuesTool } from "./tools/list_issues";
 import { createNotifyEmailTool } from "./tools/notify_email";
 import { createNotifySlackTool } from "./tools/notify_slack";
 import { createRecallMemoryTool } from "./tools/recall_memory";
@@ -35,6 +37,8 @@ const TOOL_BUILDERS: Record<
   run_contentful_translation: createRunContentfulTranslationTool,
   create_native_tms_job: createNativeTmsJobTool,
   assign_translate_with_agent: createAssignTranslateWithAgentTool,
+  list_issues: createListIssuesTool,
+  create_issue: createCreateIssueTool,
   use_semrush: createUseSemrushTool,
   use_ahrefs: createUseAhrefsTool,
   notify_slack: createNotifySlackTool,

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.test.ts
@@ -132,6 +132,21 @@ describe("buildWorkspaceOrchestratorPlan", () => {
     expect(plan.tools).toEqual(["create_native_tms_job"]);
   });
 
+  it("plans list_issues before create_issue when both are enabled", () => {
+    const plan = buildWorkspaceOrchestratorPlan(
+      automation({
+        projectId: "project-1",
+        toolConfig: {
+          listIssues: { enabled: true },
+          createIssue: { enabled: true },
+          slack: { enabled: true, channelId: "C123" },
+        },
+      }),
+    );
+
+    expect(plan.tools).toEqual(["list_issues", "create_issue", "notify_slack"]);
+  });
+
   it("includes use_semrush when a Semrush connection is enabled", () => {
     const plan = buildWorkspaceOrchestratorPlan(
       automation({

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.ts
@@ -17,7 +17,9 @@ import {
 import {
   hasWorkspaceAutomationAssignTranslateWithAgentTool,
   hasWorkspaceAutomationContentfulWorkflow,
+  hasWorkspaceAutomationCreateIssueTool,
   hasWorkspaceAutomationCreateNativeTmsJobTool,
+  hasWorkspaceAutomationListIssuesTool,
   type WorkspaceAutomationRecord,
   type WorkspaceAutomationToolConfig,
 } from "@/lib/agents/workspace-automations";
@@ -30,6 +32,8 @@ export const WORKSPACE_ORCHESTRATOR_TOOL_NAMES = [
   "run_contentful_translation",
   "create_native_tms_job",
   "assign_translate_with_agent",
+  "list_issues",
+  "create_issue",
   "use_semrush",
   "use_ahrefs",
   "notify_slack",
@@ -54,6 +58,8 @@ const WORKFLOW_TOOLS: WorkspaceOrchestratorToolName[] = [
   "run_contentful_translation",
   "create_native_tms_job",
   "assign_translate_with_agent",
+  "list_issues",
+  "create_issue",
   "use_semrush",
   "use_ahrefs",
 ];
@@ -81,6 +87,10 @@ function workflowToolEnabled(
       return hasWorkspaceAutomationCreateNativeTmsJobTool(toolConfig);
     case "assign_translate_with_agent":
       return hasWorkspaceAutomationAssignTranslateWithAgentTool(toolConfig);
+    case "list_issues":
+      return hasWorkspaceAutomationListIssuesTool(toolConfig);
+    case "create_issue":
+      return hasWorkspaceAutomationCreateIssueTool(toolConfig);
     case "use_semrush":
       return Boolean(toolConfig.semrush?.enabled && toolConfig.semrush.connectionId);
     case "use_ahrefs":
@@ -128,6 +138,8 @@ function orderWorkflowTools(input: {
       ...enabled.filter((tool) => tool === "use_github_repository"),
       ...enabled.filter((tool) => tool === "create_native_tms_job"),
       ...enabled.filter((tool) => tool === "assign_translate_with_agent"),
+      ...enabled.filter((tool) => tool === "list_issues"),
+      ...enabled.filter((tool) => tool === "create_issue"),
       ...enabled.filter((tool) => tool === "use_semrush"),
       ...enabled.filter((tool) => tool === "use_ahrefs"),
     ];
@@ -139,6 +151,8 @@ function orderWorkflowTools(input: {
     ...enabled.filter((tool) => tool === "run_contentful_translation"),
     ...enabled.filter((tool) => tool === "create_native_tms_job"),
     ...enabled.filter((tool) => tool === "assign_translate_with_agent"),
+    ...enabled.filter((tool) => tool === "list_issues"),
+    ...enabled.filter((tool) => tool === "create_issue"),
     ...enabled.filter((tool) => tool === "use_semrush"),
     ...enabled.filter((tool) => tool === "use_ahrefs"),
   ];

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_issue.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_issue.test.ts
@@ -163,7 +163,15 @@ describe("createCreateIssueTool", () => {
       projectId: "project-1",
       createdCount: 1,
       skipped: false,
-      issues: [{ id: "issue-existing", key: "ISS-9", title: "Existing", status: "open", issueType: "qa_failure" }],
+      issues: [
+        {
+          id: "issue-existing",
+          key: "ISS-9",
+          title: "Existing",
+          status: "open",
+          issueType: "qa_failure",
+        },
+      ],
     };
     const tool = createCreateIssueTool(session({ outputSummary: { createIssue: existing } }));
 

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_issue.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_issue.test.ts
@@ -23,6 +23,7 @@ import { createCreateIssueTool } from "./create_issue";
 const mocks = vi.hoisted(() => ({
   createIssue: vi.fn(),
   updateWorkspaceAutomationRun: vi.fn(),
+  resolveWorkspaceIssuesFlag: vi.fn(),
 }));
 
 vi.mock("@/lib/projects/issue-sheet/issue-sheet-service", () => ({
@@ -35,11 +36,16 @@ vi.mock("@/lib/agents/workspace-automations", () => ({
   updateWorkspaceAutomationRun: (...args: unknown[]) => mocks.updateWorkspaceAutomationRun(...args),
 }));
 
+vi.mock("@/lib/flags/workspace-flags", () => ({
+  resolveWorkspaceIssuesFlag: (...args: unknown[]) => mocks.resolveWorkspaceIssuesFlag(...args),
+}));
+
 function session(
   overrides: {
     outputSummary?: Record<string, unknown>;
     toolConfig?: WorkspaceAutomationRecord["toolConfig"];
     authorUserId?: string | null;
+    projectId?: string | null;
   } = {},
 ): WorkspaceOrchestratorSession {
   const automation = {
@@ -49,7 +55,7 @@ function session(
     status: "active",
     name: "File findings",
     instructions: "",
-    projectId: "project-1",
+    projectId: overrides.projectId === undefined ? "project-1" : overrides.projectId,
     triggerConfig: { mode: "manual" },
     repositoryTarget: { kind: "none" },
     toolConfig: overrides.toolConfig ?? { createIssue: { enabled: true } },
@@ -65,7 +71,7 @@ function session(
     organizationId: automation.organizationId,
     triggerSource: "manual",
     status: "running",
-    inputSnapshot: {},
+    inputSnapshot: { projectId: "snapshot-project" },
     outputSummary: overrides.outputSummary ?? {},
     error: null,
     githubRepositoryAutomationJobId: null,
@@ -92,6 +98,7 @@ function session(
 describe("createCreateIssueTool", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.resolveWorkspaceIssuesFlag.mockResolvedValue(true);
     mocks.createIssue.mockResolvedValue({
       id: "issue-1",
       key: "ISS-1",
@@ -102,7 +109,7 @@ describe("createCreateIssueTool", () => {
     mocks.updateWorkspaceAutomationRun.mockResolvedValue(undefined);
   });
 
-  it("creates issues and links them to the automation run", async () => {
+  it("creates issues with run-scoped external refs and no agent_runs FK", async () => {
     const currentSession = session();
     const tool = createCreateIssueTool(currentSession);
 
@@ -127,18 +134,31 @@ describe("createCreateIssueTool", () => {
         title: "Missing glossary term",
         issueType: "glossary_violation",
         priority: "P0",
-        linkedAgentRunId: "run-1",
-        linkKind: "agent_run",
+        linkKind: "manual",
         linkLabel: "File findings",
+        externalRef: "workspace-automation-run:run-1:0",
       }),
     });
+    expect(mocks.createIssue.mock.calls[0]?.[0].body.linkedAgentRunId).toBeUndefined();
     expect(result).toMatchObject({
       projectId: "project-1",
       createdCount: 1,
       skipped: false,
-      issues: [{ id: "issue-1", key: "ISS-1" }],
+      completed: true,
+      issues: [{ id: "issue-1", key: "ISS-1", externalRef: "workspace-automation-run:run-1:0" }],
     });
     expect(mocks.updateWorkspaceAutomationRun).toHaveBeenCalled();
+  });
+
+  it("uses the automation project, not the input snapshot project", async () => {
+    const tool = createCreateIssueTool(session());
+    await tool.execute!(
+      { issues: [{ title: "One" }] },
+      { toolCallId: "call-1", messages: [], context: {} },
+    );
+    expect(mocks.createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: "project-1" }),
+    );
   });
 
   it("treats an empty issues array as a successful no-op", async () => {
@@ -154,15 +174,17 @@ describe("createCreateIssueTool", () => {
     expect(result).toMatchObject({
       createdCount: 0,
       skipped: true,
+      completed: true,
       issues: [],
     });
   });
 
-  it("returns existing create output for idempotent retries", async () => {
+  it("returns completed create output for idempotent retries", async () => {
     const existing = {
       projectId: "project-1",
       createdCount: 1,
       skipped: false,
+      completed: true,
       issues: [
         {
           id: "issue-existing",
@@ -170,6 +192,7 @@ describe("createCreateIssueTool", () => {
           title: "Existing",
           status: "open",
           issueType: "qa_failure",
+          externalRef: "workspace-automation-run:run-1:0",
         },
       ],
     };
@@ -182,5 +205,63 @@ describe("createCreateIssueTool", () => {
 
     expect(result).toEqual(existing);
     expect(mocks.createIssue).not.toHaveBeenCalled();
+  });
+
+  it("resumes from partial progress without recreating earlier issues", async () => {
+    mocks.createIssue.mockResolvedValue({
+      id: "issue-2",
+      key: "ISS-2",
+      title: "Second",
+      status: "open",
+      issueType: "qa_failure",
+    });
+    const partial = {
+      projectId: "project-1",
+      createdCount: 1,
+      skipped: false,
+      completed: false,
+      issues: [
+        {
+          id: "issue-1",
+          key: "ISS-1",
+          title: "First",
+          status: "open",
+          issueType: "qa_failure",
+          externalRef: "workspace-automation-run:run-1:0",
+        },
+      ],
+    };
+    const tool = createCreateIssueTool(session({ outputSummary: { createIssue: partial } }));
+
+    const result = await tool.execute!(
+      { issues: [{ title: "First" }, { title: "Second" }] },
+      { toolCallId: "call-1", messages: [], context: {} },
+    );
+
+    expect(mocks.createIssue).toHaveBeenCalledTimes(1);
+    expect(mocks.createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          title: "Second",
+          externalRef: "workspace-automation-run:run-1:1",
+        }),
+      }),
+    );
+    expect(result).toMatchObject({
+      createdCount: 2,
+      completed: true,
+      issues: [{ id: "issue-1" }, { id: "issue-2" }],
+    });
+  });
+
+  it("rejects when workspace Issues is disabled", async () => {
+    mocks.resolveWorkspaceIssuesFlag.mockResolvedValue(false);
+    const tool = createCreateIssueTool(session());
+    await expect(
+      tool.execute!(
+        { issues: [{ title: "Nope" }] },
+        { toolCallId: "call-1", messages: [], context: {} },
+      ),
+    ).rejects.toThrow("issues_feature_unavailable");
   });
 });

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_issue.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_issue.test.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import type {
+  WorkspaceAutomationRecord,
+  WorkspaceAutomationRunRecord,
+} from "@/lib/agents/workspace-automations";
+
+import type { WorkspaceOrchestratorSession } from "../context";
+import { createCreateIssueTool } from "./create_issue";
+
+const mocks = vi.hoisted(() => ({
+  createIssue: vi.fn(),
+  updateWorkspaceAutomationRun: vi.fn(),
+}));
+
+vi.mock("@/lib/projects/issue-sheet/issue-sheet-service", () => ({
+  IssueSheetService: class {
+    createIssue = mocks.createIssue;
+  },
+}));
+
+vi.mock("@/lib/agents/workspace-automations", () => ({
+  updateWorkspaceAutomationRun: (...args: unknown[]) => mocks.updateWorkspaceAutomationRun(...args),
+}));
+
+function session(
+  overrides: {
+    outputSummary?: Record<string, unknown>;
+    toolConfig?: WorkspaceAutomationRecord["toolConfig"];
+    authorUserId?: string | null;
+  } = {},
+): WorkspaceOrchestratorSession {
+  const automation = {
+    id: "automation-1",
+    organizationId: "org-1",
+    authorUserId: overrides.authorUserId === undefined ? "user-1" : overrides.authorUserId,
+    status: "active",
+    name: "File findings",
+    instructions: "",
+    projectId: "project-1",
+    triggerConfig: { mode: "manual" },
+    repositoryTarget: { kind: "none" },
+    toolConfig: overrides.toolConfig ?? { createIssue: { enabled: true } },
+    configVersion: 1,
+    nextRunAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  } satisfies WorkspaceAutomationRecord;
+
+  const run = {
+    id: "run-1",
+    automationId: automation.id,
+    organizationId: automation.organizationId,
+    triggerSource: "manual",
+    status: "running",
+    inputSnapshot: {},
+    outputSummary: overrides.outputSummary ?? {},
+    error: null,
+    githubRepositoryAutomationJobId: null,
+    idempotencyKey: null,
+    startedAt: null,
+    completedAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  } satisfies WorkspaceAutomationRunRecord;
+
+  return {
+    organizationId: automation.organizationId,
+    automation,
+    run,
+    plan: { tools: ["create_issue"] },
+    repository: null,
+    composedInstructions: "",
+    stepResults: {},
+    terminalStatus: null,
+    terminalError: null,
+  };
+}
+
+describe("createCreateIssueTool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createIssue.mockResolvedValue({
+      id: "issue-1",
+      key: "ISS-1",
+      title: "Missing glossary term",
+      status: "open",
+      issueType: "glossary_violation",
+    });
+    mocks.updateWorkspaceAutomationRun.mockResolvedValue(undefined);
+  });
+
+  it("creates issues and links them to the automation run", async () => {
+    const currentSession = session();
+    const tool = createCreateIssueTool(currentSession);
+
+    const result = await tool.execute!(
+      {
+        issues: [
+          {
+            title: "Missing glossary term",
+            issueType: "glossary_violation",
+            priority: "P0",
+          },
+        ],
+      },
+      { toolCallId: "call-1", messages: [], context: {} },
+    );
+
+    expect(mocks.createIssue).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      projectId: "project-1",
+      actorUserId: "user-1",
+      body: expect.objectContaining({
+        title: "Missing glossary term",
+        issueType: "glossary_violation",
+        priority: "P0",
+        linkedAgentRunId: "run-1",
+        linkKind: "agent_run",
+        linkLabel: "File findings",
+      }),
+    });
+    expect(result).toMatchObject({
+      projectId: "project-1",
+      createdCount: 1,
+      skipped: false,
+      issues: [{ id: "issue-1", key: "ISS-1" }],
+    });
+    expect(mocks.updateWorkspaceAutomationRun).toHaveBeenCalled();
+  });
+
+  it("treats an empty issues array as a successful no-op", async () => {
+    const currentSession = session();
+    const tool = createCreateIssueTool(currentSession);
+
+    const result = await tool.execute!(
+      { issues: [] },
+      { toolCallId: "call-1", messages: [], context: {} },
+    );
+
+    expect(mocks.createIssue).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      createdCount: 0,
+      skipped: true,
+      issues: [],
+    });
+  });
+
+  it("returns existing create output for idempotent retries", async () => {
+    const existing = {
+      projectId: "project-1",
+      createdCount: 1,
+      skipped: false,
+      issues: [{ id: "issue-existing", key: "ISS-9", title: "Existing", status: "open", issueType: "qa_failure" }],
+    };
+    const tool = createCreateIssueTool(session({ outputSummary: { createIssue: existing } }));
+
+    const result = await tool.execute!(
+      { issues: [{ title: "Should not create" }] },
+      { toolCallId: "call-1", messages: [], context: {} },
+    );
+
+    expect(result).toEqual(existing);
+    expect(mocks.createIssue).not.toHaveBeenCalled();
+  });
+});

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_issue.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_issue.ts
@@ -18,6 +18,7 @@ import {
   issueSheetIssueTypeSchema,
 } from "@/api/routes/project/issue-sheet.schema";
 import { updateWorkspaceAutomationRun } from "@/lib/agents/workspace-automations";
+import { resolveWorkspaceIssuesFlag } from "@/lib/flags/workspace-flags";
 import { IssueSheetService } from "@/lib/projects/issue-sheet/issue-sheet-service";
 
 import type { WorkspaceOrchestratorSession } from "../context";
@@ -47,13 +48,33 @@ const createIssueInputSchema = z.object({
     ),
 });
 
-function resolveProjectId(session: WorkspaceOrchestratorSession): string | null {
-  const fromSnapshot =
-    typeof session.run.inputSnapshot.projectId === "string"
-      ? session.run.inputSnapshot.projectId.trim()
-      : "";
-  const fromAutomation = session.automation.projectId?.trim() || "";
-  return fromSnapshot || fromAutomation || null;
+type CreatedIssueSummary = {
+  id: string;
+  key: string | null;
+  title: string;
+  status: string;
+  issueType: string;
+  externalRef: string;
+};
+
+function buildCreateIssueExternalRef(runId: string, index: number): string {
+  return `workspace-automation-run:${runId}:${index}`;
+}
+
+async function persistCreateIssueOutput(
+  session: WorkspaceOrchestratorSession,
+  output: Record<string, unknown>,
+) {
+  session.stepResults.create_issue = output;
+  await updateWorkspaceAutomationRun({
+    runId: session.run.id,
+    organizationId: session.organizationId,
+    outputSummary: {
+      ...session.run.outputSummary,
+      createIssue: output,
+    },
+  });
+  mergeToolOutputSummaryIntoSessionRun(session, { createIssue: output });
 }
 
 export function createCreateIssueTool(session: WorkspaceOrchestratorSession) {
@@ -67,13 +88,20 @@ export function createCreateIssueTool(session: WorkspaceOrchestratorSession) {
         throw new Error("create_issue_not_configured");
       }
 
+      const issuesFeatureEnabled = await resolveWorkspaceIssuesFlag({
+        organizationId: session.organizationId,
+      });
+      if (!issuesFeatureEnabled) {
+        throw new Error("issues_feature_unavailable");
+      }
+
       const existingOutput = readCreateIssue(session.run.outputSummary, session.stepResults);
-      if (existingOutput) {
+      if (existingOutput?.completed === true) {
         session.stepResults.create_issue = existingOutput;
         return existingOutput;
       }
 
-      const projectId = resolveProjectId(session);
+      const projectId = session.automation.projectId?.trim() || null;
       if (!projectId) {
         throw new Error("project_required");
       }
@@ -83,16 +111,37 @@ export function createCreateIssueTool(session: WorkspaceOrchestratorSession) {
         throw new Error("automation_author_required");
       }
 
-      const service = new IssueSheetService();
-      const created: Array<{
-        id: string;
-        key: string | null;
-        title: string;
-        status: string;
-        issueType: string;
-      }> = [];
+      const created: CreatedIssueSummary[] = Array.isArray(existingOutput?.issues)
+        ? (existingOutput.issues as CreatedIssueSummary[]).filter(
+            (issue) =>
+              issue &&
+              typeof issue === "object" &&
+              typeof issue.id === "string" &&
+              typeof issue.externalRef === "string",
+          )
+        : [];
 
-      for (const issue of issues) {
+      if (issues.length === 0) {
+        const output = {
+          projectId,
+          createdCount: 0,
+          skipped: true,
+          completed: true,
+          issues: [],
+        };
+        await persistCreateIssueOutput(session, output);
+        return output;
+      }
+
+      const service = new IssueSheetService();
+      const linkLabel = session.automation.name.slice(0, 200) || "Agent Automation";
+
+      for (let index = created.length; index < issues.length; index += 1) {
+        const issue = issues[index];
+        if (!issue) {
+          continue;
+        }
+        const externalRef = buildCreateIssueExternalRef(session.run.id, index);
         const record = await service.createIssue({
           organizationId: session.organizationId,
           projectId,
@@ -107,9 +156,10 @@ export function createCreateIssueTool(session: WorkspaceOrchestratorSession) {
             translationKeyId: issue.translationKeyId,
             assigneeUserId: issue.assigneeUserId,
             priority: issue.priority,
-            linkedAgentRunId: session.run.id,
-            linkKind: "agent_run",
-            linkLabel: session.automation.name.slice(0, 200) || "Agent Automation",
+            // workspace_automation_runs are not agent_runs; use externalRef for idempotent linkage.
+            linkKind: "manual",
+            linkLabel,
+            externalRef,
           },
         });
         created.push({
@@ -118,28 +168,27 @@ export function createCreateIssueTool(session: WorkspaceOrchestratorSession) {
           title: record.title,
           status: record.status,
           issueType: record.issueType,
+          externalRef,
         });
+
+        const partialOutput = {
+          projectId,
+          createdCount: created.length,
+          skipped: false,
+          completed: created.length >= issues.length,
+          issues: created,
+        };
+        await persistCreateIssueOutput(session, partialOutput);
       }
 
       const output = {
         projectId,
         createdCount: created.length,
-        skipped: issues.length === 0,
+        skipped: false,
+        completed: true,
         issues: created,
       };
-
-      session.stepResults.create_issue = output;
-
-      await updateWorkspaceAutomationRun({
-        runId: session.run.id,
-        organizationId: session.organizationId,
-        outputSummary: {
-          ...session.run.outputSummary,
-          createIssue: output,
-        },
-      });
-      mergeToolOutputSummaryIntoSessionRun(session, { createIssue: output });
-
+      await persistCreateIssueOutput(session, output);
       return output;
     },
   });

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_issue.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_issue.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { z } from "zod";
+
+import { defineAgentTool } from "@/agents/_runtime/define-agent-tool";
+import {
+  issueSheetIssueStatusSchema,
+  issueSheetIssueTypeSchema,
+} from "@/api/routes/project/issue-sheet.schema";
+import { updateWorkspaceAutomationRun } from "@/lib/agents/workspace-automations";
+import { IssueSheetService } from "@/lib/projects/issue-sheet/issue-sheet-service";
+
+import type { WorkspaceOrchestratorSession } from "../context";
+import {
+  mergeToolOutputSummaryIntoSessionRun,
+  readCreateIssue,
+} from "../workspace-orchestrator-output-summary";
+
+const createIssueItemSchema = z.object({
+  title: z.string().trim().min(1).max(300),
+  description: z.string().max(20_000).optional(),
+  issueType: issueSheetIssueTypeSchema.optional(),
+  status: issueSheetIssueStatusSchema.optional(),
+  targetLocale: z.string().trim().min(1).max(32).optional(),
+  sourcePath: z.string().trim().min(1).max(2048).optional(),
+  translationKeyId: z.string().uuid().optional(),
+  assigneeUserId: z.string().uuid().optional(),
+  priority: z.enum(["P0", "P1", "P2"]).optional(),
+});
+
+const createIssueInputSchema = z.object({
+  issues: z
+    .array(createIssueItemSchema)
+    .max(20)
+    .describe(
+      "Issues to create on the project Issue Sheet. Pass an empty array when nothing should be filed this run.",
+    ),
+});
+
+function resolveProjectId(session: WorkspaceOrchestratorSession): string | null {
+  const fromSnapshot =
+    typeof session.run.inputSnapshot.projectId === "string"
+      ? session.run.inputSnapshot.projectId.trim()
+      : "";
+  const fromAutomation = session.automation.projectId?.trim() || "";
+  return fromSnapshot || fromAutomation || null;
+}
+
+export function createCreateIssueTool(session: WorkspaceOrchestratorSession) {
+  return defineAgentTool({
+    description:
+      "Create Hyperlocalise Issue Sheet issues for the automation project. Pass an empty issues array when there is nothing actionable to file.",
+    inputSchema: createIssueInputSchema,
+    execute: async ({ issues }) => {
+      const createConfig = session.automation.toolConfig.createIssue;
+      if (!createConfig?.enabled) {
+        throw new Error("create_issue_not_configured");
+      }
+
+      const existingOutput = readCreateIssue(session.run.outputSummary, session.stepResults);
+      if (existingOutput) {
+        session.stepResults.create_issue = existingOutput;
+        return existingOutput;
+      }
+
+      const projectId = resolveProjectId(session);
+      if (!projectId) {
+        throw new Error("project_required");
+      }
+
+      const actorUserId = session.automation.authorUserId?.trim() || null;
+      if (!actorUserId) {
+        throw new Error("automation_author_required");
+      }
+
+      const service = new IssueSheetService();
+      const created: Array<{
+        id: string;
+        key: string | null;
+        title: string;
+        status: string;
+        issueType: string;
+      }> = [];
+
+      for (const issue of issues) {
+        const record = await service.createIssue({
+          organizationId: session.organizationId,
+          projectId,
+          actorUserId,
+          body: {
+            title: issue.title,
+            description: issue.description,
+            issueType: issue.issueType,
+            status: issue.status,
+            targetLocale: issue.targetLocale,
+            sourcePath: issue.sourcePath,
+            translationKeyId: issue.translationKeyId,
+            assigneeUserId: issue.assigneeUserId,
+            priority: issue.priority,
+            linkedAgentRunId: session.run.id,
+            linkKind: "agent_run",
+            linkLabel: session.automation.name.slice(0, 200) || "Agent Automation",
+          },
+        });
+        created.push({
+          id: record.id,
+          key: record.key,
+          title: record.title,
+          status: record.status,
+          issueType: record.issueType,
+        });
+      }
+
+      const output = {
+        projectId,
+        createdCount: created.length,
+        skipped: issues.length === 0,
+        issues: created,
+      };
+
+      session.stepResults.create_issue = output;
+
+      await updateWorkspaceAutomationRun({
+        runId: session.run.id,
+        organizationId: session.organizationId,
+        outputSummary: {
+          ...session.run.outputSummary,
+          createIssue: output,
+        },
+      });
+      mergeToolOutputSummaryIntoSessionRun(session, { createIssue: output });
+
+      return output;
+    },
+  });
+}

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/list_issues.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/list_issues.test.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import type {
+  WorkspaceAutomationRecord,
+  WorkspaceAutomationRunRecord,
+} from "@/lib/agents/workspace-automations";
+
+import type { WorkspaceOrchestratorSession } from "../context";
+import { createListIssuesTool } from "./list_issues";
+
+const mocks = vi.hoisted(() => ({
+  listIssues: vi.fn(),
+}));
+
+vi.mock("@/lib/projects/issue-sheet/issue-sheet-service", () => ({
+  IssueSheetService: class {
+    listIssues = mocks.listIssues;
+  },
+}));
+
+function session(
+  overrides: {
+    toolConfig?: WorkspaceAutomationRecord["toolConfig"];
+    authorUserId?: string | null;
+    projectId?: string | null;
+  } = {},
+): WorkspaceOrchestratorSession {
+  const automation = {
+    id: "automation-1",
+    organizationId: "org-1",
+    authorUserId: overrides.authorUserId === undefined ? "user-1" : overrides.authorUserId,
+    status: "active",
+    name: "Issue triage",
+    instructions: "",
+    projectId: overrides.projectId === undefined ? "project-1" : overrides.projectId,
+    triggerConfig: { mode: "manual" },
+    repositoryTarget: { kind: "none" },
+    toolConfig: overrides.toolConfig ?? { listIssues: { enabled: true } },
+    configVersion: 1,
+    nextRunAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  } satisfies WorkspaceAutomationRecord;
+
+  const run = {
+    id: "run-1",
+    automationId: automation.id,
+    organizationId: automation.organizationId,
+    triggerSource: "manual",
+    status: "running",
+    inputSnapshot: {},
+    outputSummary: {},
+    error: null,
+    githubRepositoryAutomationJobId: null,
+    idempotencyKey: null,
+    startedAt: null,
+    completedAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  } satisfies WorkspaceAutomationRunRecord;
+
+  return {
+    organizationId: automation.organizationId,
+    automation,
+    run,
+    plan: { tools: ["list_issues"] },
+    repository: null,
+    composedInstructions: "",
+    stepResults: {},
+    terminalStatus: null,
+    terminalError: null,
+  };
+}
+
+describe("createListIssuesTool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listIssues.mockResolvedValue({
+      total: 1,
+      summary: { total: 1, open: 1, inProgress: 0, resolved: 0, wontFix: 0 },
+      columns: [],
+      issues: [
+        {
+          id: "issue-1",
+          key: "ISS-1",
+          title: "Broken placeholder",
+          description: "Missing {name}",
+          issueType: "translation_mistake",
+          status: "open",
+          targetLocale: "fr-FR",
+          assigneeUserId: null,
+          sourcePath: "app.json",
+          translationKeyId: null,
+          updatedAt: "2026-08-13T00:00:00.000Z",
+          values: { priority: "P1" },
+        },
+      ],
+    });
+  });
+
+  it("lists compact issues for the automation project", async () => {
+    const currentSession = session();
+    const tool = createListIssuesTool(currentSession);
+
+    const result = await tool.execute!(
+      { status: "open", limit: 10 },
+      { toolCallId: "call-1", messages: [], context: {} },
+    );
+
+    expect(mocks.listIssues).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      projectId: "project-1",
+      actorUserId: "user-1",
+      query: {
+        status: "open",
+        issueType: undefined,
+        priority: undefined,
+        search: undefined,
+        sort: "status",
+        limit: 10,
+        offset: 0,
+      },
+    });
+    expect(result).toMatchObject({
+      projectId: "project-1",
+      total: 1,
+      issues: [
+        {
+          id: "issue-1",
+          key: "ISS-1",
+          title: "Broken placeholder",
+          priority: "P1",
+        },
+      ],
+    });
+    expect(currentSession.stepResults.list_issues).toMatchObject({ total: 1 });
+  });
+
+  it("rejects when the list tool is not enabled", async () => {
+    const tool = createListIssuesTool(session({ toolConfig: {} }));
+    await expect(
+      tool.execute!({}, { toolCallId: "call-1", messages: [], context: {} }),
+    ).rejects.toThrow("list_issues_not_configured");
+  });
+
+  it("rejects when the automation has no author", async () => {
+    const tool = createListIssuesTool(session({ authorUserId: null }));
+    await expect(
+      tool.execute!({}, { toolCallId: "call-1", messages: [], context: {} }),
+    ).rejects.toThrow("automation_author_required");
+  });
+});

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/list_issues.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/list_issues.test.ts
@@ -22,12 +22,17 @@ import { createListIssuesTool } from "./list_issues";
 
 const mocks = vi.hoisted(() => ({
   listIssues: vi.fn(),
+  resolveWorkspaceIssuesFlag: vi.fn(),
 }));
 
 vi.mock("@/lib/projects/issue-sheet/issue-sheet-service", () => ({
   IssueSheetService: class {
     listIssues = mocks.listIssues;
   },
+}));
+
+vi.mock("@/lib/flags/workspace-flags", () => ({
+  resolveWorkspaceIssuesFlag: (...args: unknown[]) => mocks.resolveWorkspaceIssuesFlag(...args),
 }));
 
 function session(
@@ -60,7 +65,7 @@ function session(
     organizationId: automation.organizationId,
     triggerSource: "manual",
     status: "running",
-    inputSnapshot: {},
+    inputSnapshot: { projectId: "snapshot-project" },
     outputSummary: {},
     error: null,
     githubRepositoryAutomationJobId: null,
@@ -87,6 +92,7 @@ function session(
 describe("createListIssuesTool", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.resolveWorkspaceIssuesFlag.mockResolvedValue(true);
     mocks.listIssues.mockResolvedValue({
       total: 1,
       summary: { total: 1, open: 1, inProgress: 0, resolved: 0, wontFix: 0 },
@@ -148,6 +154,14 @@ describe("createListIssuesTool", () => {
     expect(currentSession.stepResults.list_issues).toMatchObject({ total: 1 });
   });
 
+  it("ignores snapshot projectId overrides", async () => {
+    const tool = createListIssuesTool(session());
+    await tool.execute!({}, { toolCallId: "call-1", messages: [], context: {} });
+    expect(mocks.listIssues).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: "project-1" }),
+    );
+  });
+
   it("rejects when the list tool is not enabled", async () => {
     const tool = createListIssuesTool(session({ toolConfig: {} }));
     await expect(
@@ -160,5 +174,13 @@ describe("createListIssuesTool", () => {
     await expect(
       tool.execute!({}, { toolCallId: "call-1", messages: [], context: {} }),
     ).rejects.toThrow("automation_author_required");
+  });
+
+  it("rejects when workspace Issues is disabled", async () => {
+    mocks.resolveWorkspaceIssuesFlag.mockResolvedValue(false);
+    const tool = createListIssuesTool(session());
+    await expect(
+      tool.execute!({}, { toolCallId: "call-1", messages: [], context: {} }),
+    ).rejects.toThrow("issues_feature_unavailable");
   });
 });

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/list_issues.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/list_issues.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { z } from "zod";
+
+import { defineAgentTool } from "@/agents/_runtime/define-agent-tool";
+import {
+  issueSheetIssueStatusSchema,
+  issueSheetIssueTypeSchema,
+  issueSheetPrioritySchema,
+} from "@/api/routes/project/issue-sheet.schema";
+import { IssueSheetService } from "@/lib/projects/issue-sheet/issue-sheet-service";
+
+import type { WorkspaceOrchestratorSession } from "../context";
+
+const listIssuesInputSchema = z.object({
+  status: issueSheetIssueStatusSchema.or(z.literal("all")).optional(),
+  issueType: issueSheetIssueTypeSchema.or(z.literal("all")).optional(),
+  priority: issueSheetPrioritySchema.optional(),
+  search: z.string().trim().max(200).optional(),
+  limit: z.number().int().min(1).max(100).optional(),
+  offset: z.number().int().min(0).optional(),
+});
+
+function resolveProjectId(session: WorkspaceOrchestratorSession): string | null {
+  const fromSnapshot =
+    typeof session.run.inputSnapshot.projectId === "string"
+      ? session.run.inputSnapshot.projectId.trim()
+      : "";
+  const fromAutomation = session.automation.projectId?.trim() || "";
+  return fromSnapshot || fromAutomation || null;
+}
+
+function compactIssue(issue: {
+  id: string;
+  key: string | null;
+  title: string;
+  description: string;
+  issueType: string;
+  status: string;
+  targetLocale: string | null;
+  assigneeUserId: string | null;
+  sourcePath: string | null;
+  translationKeyId: string | null;
+  updatedAt: string;
+  values: Record<string, unknown>;
+}) {
+  const priority = issue.values.priority;
+  return {
+    id: issue.id,
+    key: issue.key,
+    title: issue.title,
+    description: issue.description.slice(0, 500),
+    issueType: issue.issueType,
+    status: issue.status,
+    targetLocale: issue.targetLocale,
+    assigneeUserId: issue.assigneeUserId,
+    sourcePath: issue.sourcePath,
+    translationKeyId: issue.translationKeyId,
+    priority: typeof priority === "string" ? priority : null,
+    updatedAt: issue.updatedAt,
+  };
+}
+
+export function createListIssuesTool(session: WorkspaceOrchestratorSession) {
+  return defineAgentTool({
+    description:
+      "List Hyperlocalise Issue Sheet issues for the automation project. Use filters to triage open work before creating or notifying.",
+    inputSchema: listIssuesInputSchema,
+    execute: async (input) => {
+      const listConfig = session.automation.toolConfig.listIssues;
+      if (!listConfig?.enabled) {
+        throw new Error("list_issues_not_configured");
+      }
+
+      const projectId = resolveProjectId(session);
+      if (!projectId) {
+        throw new Error("project_required");
+      }
+
+      const actorUserId = session.automation.authorUserId?.trim() || null;
+      if (!actorUserId) {
+        throw new Error("automation_author_required");
+      }
+
+      const service = new IssueSheetService();
+      const result = await service.listIssues({
+        organizationId: session.organizationId,
+        projectId,
+        actorUserId,
+        query: {
+          status: input.status,
+          issueType: input.issueType,
+          priority: input.priority,
+          search: input.search,
+          sort: "status",
+          limit: input.limit ?? 50,
+          offset: input.offset ?? 0,
+        },
+      });
+
+      const output = {
+        projectId,
+        total: result.total,
+        summary: result.summary,
+        issues: result.issues.map(compactIssue),
+      };
+
+      session.stepResults.list_issues = output;
+      return output;
+    },
+  });
+}

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/list_issues.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/list_issues.ts
@@ -18,6 +18,7 @@ import {
   issueSheetIssueTypeSchema,
   issueSheetPrioritySchema,
 } from "@/api/routes/project/issue-sheet.schema";
+import { resolveWorkspaceIssuesFlag } from "@/lib/flags/workspace-flags";
 import { IssueSheetService } from "@/lib/projects/issue-sheet/issue-sheet-service";
 
 import type { WorkspaceOrchestratorSession } from "../context";
@@ -30,15 +31,6 @@ const listIssuesInputSchema = z.object({
   limit: z.number().int().min(1).max(100).optional(),
   offset: z.number().int().min(0).optional(),
 });
-
-function resolveProjectId(session: WorkspaceOrchestratorSession): string | null {
-  const fromSnapshot =
-    typeof session.run.inputSnapshot.projectId === "string"
-      ? session.run.inputSnapshot.projectId.trim()
-      : "";
-  const fromAutomation = session.automation.projectId?.trim() || "";
-  return fromSnapshot || fromAutomation || null;
-}
 
 function compactIssue(issue: {
   id: string;
@@ -82,7 +74,14 @@ export function createListIssuesTool(session: WorkspaceOrchestratorSession) {
         throw new Error("list_issues_not_configured");
       }
 
-      const projectId = resolveProjectId(session);
+      const issuesFeatureEnabled = await resolveWorkspaceIssuesFlag({
+        organizationId: session.organizationId,
+      });
+      if (!issuesFeatureEnabled) {
+        throw new Error("issues_feature_unavailable");
+      }
+
+      const projectId = session.automation.projectId?.trim() || null;
       if (!projectId) {
         throw new Error("project_required");
       }

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-orchestrator-output-summary.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-orchestrator-output-summary.ts
@@ -107,6 +107,35 @@ export function readAssignTranslateWithAgent(
   return null;
 }
 
+function isCreateIssueOutput(value: Record<string, unknown>): boolean {
+  return Array.isArray(value.issues) && typeof value.createdCount === "number";
+}
+
+export function readCreateIssue(
+  outputSummary: Record<string, unknown>,
+  stepResults: Partial<Record<WorkspaceOrchestratorToolName, Record<string, unknown>>>,
+): Record<string, unknown> | null {
+  const fromCurrentStep = stepResults.create_issue;
+  if (fromCurrentStep && isCreateIssueOutput(fromCurrentStep)) {
+    return fromCurrentStep;
+  }
+
+  const fromOutput = outputSummary.createIssue;
+  if (fromOutput && typeof fromOutput === "object" && !Array.isArray(fromOutput)) {
+    const record = fromOutput as Record<string, unknown>;
+    if (isCreateIssueOutput(record)) {
+      return record;
+    }
+  }
+
+  const fromPriorStep = readStepResult(outputSummary.orchestratorStepResults, "create_issue");
+  if (fromPriorStep && isCreateIssueOutput(fromPriorStep)) {
+    return fromPriorStep;
+  }
+
+  return null;
+}
+
 export function buildWorkspaceOrchestratorOutputSummary(
   base: Record<string, unknown>,
   stepResults: Partial<Record<WorkspaceOrchestratorToolName, Record<string, unknown>>>,
@@ -117,12 +146,14 @@ export function buildWorkspaceOrchestratorOutputSummary(
   const contentfulTranslationRunId = readContentfulTranslationRunId(base, stepResults);
   const createNativeTmsJob = readCreateNativeTmsJob(base, stepResults);
   const assignTranslateWithAgent = readAssignTranslateWithAgent(base, stepResults);
+  const createIssue = readCreateIssue(base, stepResults);
 
   return {
     ...base,
     ...(contentfulTranslationRunId ? { contentfulTranslationRunId } : {}),
     ...(createNativeTmsJob ? { createNativeTmsJob } : {}),
     ...(assignTranslateWithAgent ? { assignTranslateWithAgent } : {}),
+    ...(createIssue ? { createIssue } : {}),
     orchestratorStepResults: stepResults,
     ...(options?.notificationWarnings && options.notificationWarnings.length > 0
       ? { notificationWarnings: options.notificationWarnings }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/[automationId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/[automationId]/page.tsx
@@ -37,6 +37,7 @@ export default async function AutomationDetailPage({
       <AutomationDetailPageContent
         organizationSlug={organizationSlug}
         automationId={automationId}
+        issuesAvailable={flags.issues}
         knowledgeAvailable={flags.knowledge}
         canUpdateKnowledgeMemory={hasCapability(auth.membership.role, "workspace:update")}
       />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.tsx
@@ -33,11 +33,13 @@ import { WorkspaceAutomationEditor } from "./workspace-automation-form";
 export function AutomationDetailPageContent({
   organizationSlug,
   automationId,
+  issuesAvailable = false,
   knowledgeAvailable = false,
   canUpdateKnowledgeMemory = false,
 }: {
   organizationSlug: string;
   automationId: string;
+  issuesAvailable?: boolean;
   knowledgeAvailable?: boolean;
   canUpdateKnowledgeMemory?: boolean;
 }) {
@@ -164,6 +166,7 @@ export function AutomationDetailPageContent({
         organizationSlug={organizationSlug}
         form={form}
         errors={errors}
+        issuesAvailable={issuesAvailable}
         knowledgeAvailable={knowledgeAvailable}
         canUpdateKnowledgeMemory={canUpdateKnowledgeMemory}
         onChange={setForm}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-new-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-new-page-content.tsx
@@ -35,11 +35,13 @@ import { WorkspaceAutomationEditor } from "./workspace-automation-form";
 export function AutomationsNewPageContent({
   organizationSlug,
   initialForm = createDefaultWorkspaceAutomationFormState(),
+  issuesAvailable = false,
   knowledgeAvailable = false,
   canUpdateKnowledgeMemory = false,
 }: {
   organizationSlug: string;
   initialForm?: WorkspaceAutomationFormState;
+  issuesAvailable?: boolean;
   knowledgeAvailable?: boolean;
   canUpdateKnowledgeMemory?: boolean;
 }) {
@@ -96,6 +98,7 @@ export function AutomationsNewPageContent({
         organizationSlug={organizationSlug}
         form={form}
         errors={errors}
+        issuesAvailable={issuesAvailable}
         knowledgeAvailable={knowledgeAvailable}
         canUpdateKnowledgeMemory={canUpdateKnowledgeMemory}
         onChange={setForm}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -367,6 +367,46 @@ export const workspaceAutomationFormMessages = defineMessages({
     id: "dg15k+jhq4",
     description: "Menu item and tool title for assigning Translate with agent",
   },
+  listIssues: {
+    defaultMessage: "List issues",
+    id: "IssLstTl01",
+    description: "Menu item and tool title for listing Issue Sheet issues",
+  },
+  listIssuesDescription: {
+    defaultMessage: "Read Issue Sheet issues for the selected project during this automation.",
+    id: "IssLstDs01",
+    description: "Description for the List issues automation tool",
+  },
+  createIssue: {
+    defaultMessage: "Create issue",
+    id: "IssCrtTl01",
+    description: "Menu item and tool title for creating Issue Sheet issues",
+  },
+  createIssueDescription: {
+    defaultMessage: "File Issue Sheet issues for the selected project from automation findings.",
+    id: "IssCrtDs01",
+    description: "Description for the Create issue automation tool",
+  },
+  issuesUnavailableDescription: {
+    defaultMessage: "Enable workspace Issues before using Issue Sheet tools in automations.",
+    id: "IssUnaDs01",
+    description: "Description when workspace Issues feature flag is off",
+  },
+  enableIssuesFirstShortcut: {
+    defaultMessage: "Enable first",
+    id: "IssEnbSc01",
+    description: "Shortcut shown when workspace Issues is not enabled for the organization",
+  },
+  removeListIssues: {
+    defaultMessage: "Remove List issues tool",
+    id: "IssRmLst01",
+    description: "Accessible label to remove the List issues tool",
+  },
+  removeCreateIssue: {
+    defaultMessage: "Remove Create issue tool",
+    id: "IssRmCrt01",
+    description: "Accessible label to remove the Create issue tool",
+  },
   mcpServer: {
     defaultMessage: "MCP Server",
     id: "j3sarok4E/",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -369,42 +369,42 @@ export const workspaceAutomationFormMessages = defineMessages({
   },
   listIssues: {
     defaultMessage: "List issues",
-    id: "IssLstTl01",
+    id: "DeCrAOQFGT",
     description: "Menu item and tool title for listing Issue Sheet issues",
   },
   listIssuesDescription: {
     defaultMessage: "Read Issue Sheet issues for the selected project during this automation.",
-    id: "IssLstDs01",
+    id: "04BDy8jZlJ",
     description: "Description for the List issues automation tool",
   },
   createIssue: {
     defaultMessage: "Create issue",
-    id: "IssCrtTl01",
+    id: "SGKONsO7tY",
     description: "Menu item and tool title for creating Issue Sheet issues",
   },
   createIssueDescription: {
     defaultMessage: "File Issue Sheet issues for the selected project from automation findings.",
-    id: "IssCrtDs01",
+    id: "MweQRnF9MU",
     description: "Description for the Create issue automation tool",
   },
   issuesUnavailableDescription: {
     defaultMessage: "Enable workspace Issues before using Issue Sheet tools in automations.",
-    id: "IssUnaDs01",
+    id: "uyibAnXll7",
     description: "Description when workspace Issues feature flag is off",
   },
   enableIssuesFirstShortcut: {
     defaultMessage: "Enable first",
-    id: "IssEnbSc01",
+    id: "SCwFU6O6EH",
     description: "Shortcut shown when workspace Issues is not enabled for the organization",
   },
   removeListIssues: {
     defaultMessage: "Remove List issues tool",
-    id: "IssRmLst01",
+    id: "N7Y/6FnTVv",
     description: "Accessible label to remove the List issues tool",
   },
   removeCreateIssue: {
     defaultMessage: "Remove Create issue tool",
-    id: "IssRmCrt01",
+    id: "iIHDh1dH3y",
     description: "Accessible label to remove the Create issue tool",
   },
   mcpServer: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -21,6 +21,7 @@ import {
   FolderLibraryIcon,
   GitBranchIcon,
   SlackIcon,
+  Task01Icon,
   Upload01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -335,6 +336,8 @@ function toolCount(form: WorkspaceAutomationFormState) {
     Number(form.contentfulEnabled) +
     Number(form.createNativeTmsJobEnabled) +
     Number(form.assignTranslateWithAgentEnabled) +
+    Number(form.listIssuesEnabled) +
+    Number(form.createIssueEnabled) +
     Number(form.knowledgeEnabled) +
     Number(form.mcpEnabled) +
     Number(form.semrushEnabled) +
@@ -1087,6 +1090,7 @@ function AddToolMenu({
   emailConnected,
   form,
   githubConnected,
+  issuesAvailable,
   knowledgeAvailable,
   mcpConnected,
   onChange,
@@ -1100,6 +1104,7 @@ function AddToolMenu({
   emailConnected: boolean;
   form: WorkspaceAutomationFormState;
   githubConnected: boolean;
+  issuesAvailable: boolean;
   knowledgeAvailable: boolean;
   mcpConnected: boolean;
   onChange: (next: WorkspaceAutomationFormState) => void;
@@ -1315,6 +1320,42 @@ function AddToolMenu({
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuItem
+              disabled={form.listIssuesEnabled || !issuesAvailable}
+              onClick={() => onChange({ ...form, listIssuesEnabled: true })}
+            >
+              <HugeiconsIcon icon={Task01Icon} strokeWidth={1.8} className="size-4" />
+              <FormattedMessage {...workspaceAutomationFormMessages.listIssues} />
+              {form.listIssuesEnabled ? (
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                </DropdownMenuShortcut>
+              ) : !issuesAvailable ? (
+                <DropdownMenuShortcut>
+                  <FormattedMessage
+                    {...workspaceAutomationFormMessages.enableIssuesFirstShortcut}
+                  />
+                </DropdownMenuShortcut>
+              ) : null}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={form.createIssueEnabled || !issuesAvailable}
+              onClick={() => onChange({ ...form, createIssueEnabled: true })}
+            >
+              <HugeiconsIcon icon={Task01Icon} strokeWidth={1.8} className="size-4" />
+              <FormattedMessage {...workspaceAutomationFormMessages.createIssue} />
+              {form.createIssueEnabled ? (
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                </DropdownMenuShortcut>
+              ) : !issuesAvailable ? (
+                <DropdownMenuShortcut>
+                  <FormattedMessage
+                    {...workspaceAutomationFormMessages.enableIssuesFirstShortcut}
+                  />
+                </DropdownMenuShortcut>
+              ) : null}
+            </DropdownMenuItem>
+            <DropdownMenuItem
               disabled={form.mcpEnabled || !mcpConnected}
               onClick={() => onChange({ ...form, mcpEnabled: true })}
             >
@@ -1474,6 +1515,7 @@ function ToolsSettings({
   errors,
   form,
   githubConnected,
+  issuesAvailable,
   knowledgeAvailable,
   mcpServerConnections,
   onChange,
@@ -1493,6 +1535,7 @@ function ToolsSettings({
   errors: Record<string, string | undefined>;
   form: WorkspaceAutomationFormState;
   githubConnected: boolean;
+  issuesAvailable: boolean;
   knowledgeAvailable: boolean;
   mcpServerConnections: McpServerConnectionOption[];
   onChange: (next: WorkspaceAutomationFormState) => void;
@@ -2097,6 +2140,52 @@ function ToolsSettings({
           />
         ) : null}
 
+        {form.listIssuesEnabled ? (
+          <EditorRow
+            icon={<HugeiconsIcon icon={Task01Icon} strokeWidth={1.8} className="size-4" />}
+            title={<FormattedMessage {...workspaceAutomationFormMessages.listIssues} />}
+            description={
+              issuesAvailable ? (
+                <FormattedMessage {...workspaceAutomationFormMessages.listIssuesDescription} />
+              ) : (
+                <FormattedMessage
+                  {...workspaceAutomationFormMessages.issuesUnavailableDescription}
+                />
+              )
+            }
+            action={
+              <DeleteToolButton
+                disabled={disabled}
+                label={intl.formatMessage(workspaceAutomationFormMessages.removeListIssues)}
+                onClick={() => onChange({ ...form, listIssuesEnabled: false })}
+              />
+            }
+          />
+        ) : null}
+
+        {form.createIssueEnabled ? (
+          <EditorRow
+            icon={<HugeiconsIcon icon={Task01Icon} strokeWidth={1.8} className="size-4" />}
+            title={<FormattedMessage {...workspaceAutomationFormMessages.createIssue} />}
+            description={
+              issuesAvailable ? (
+                <FormattedMessage {...workspaceAutomationFormMessages.createIssueDescription} />
+              ) : (
+                <FormattedMessage
+                  {...workspaceAutomationFormMessages.issuesUnavailableDescription}
+                />
+              )
+            }
+            action={
+              <DeleteToolButton
+                disabled={disabled}
+                label={intl.formatMessage(workspaceAutomationFormMessages.removeCreateIssue)}
+                onClick={() => onChange({ ...form, createIssueEnabled: false })}
+              />
+            }
+          />
+        ) : null}
+
         {form.mcpEnabled ? (
           <EditorRow
             icon={<HugeiconsIcon icon={FolderLibraryIcon} strokeWidth={1.8} className="size-4" />}
@@ -2291,6 +2380,7 @@ function ToolsSettings({
           emailConnected={emailConnected}
           form={form}
           githubConnected={githubConnected}
+          issuesAvailable={issuesAvailable}
           knowledgeAvailable={knowledgeAvailable}
           mcpConnected={mcpConnected}
           onChange={onChange}
@@ -2408,6 +2498,7 @@ export function WorkspaceAutomationEditor({
   disabled,
   errors,
   form,
+  issuesAvailable = false,
   knowledgeAvailable = false,
   mode,
   onChange,
@@ -2419,6 +2510,7 @@ export function WorkspaceAutomationEditor({
   disabled?: boolean;
   errors: Record<string, string | undefined>;
   form: WorkspaceAutomationFormState;
+  issuesAvailable?: boolean;
   knowledgeAvailable?: boolean;
   mode: "create" | "detail";
   onChange: (next: WorkspaceAutomationFormState) => void;
@@ -2726,6 +2818,7 @@ export function WorkspaceAutomationEditor({
             errors={errors}
             form={form}
             githubConnected={githubConnected}
+            issuesAvailable={issuesAvailable}
             knowledgeAvailable={knowledgeAvailable}
             mcpServerConnections={mcpServerConnections}
             onChange={onChange}
@@ -2755,6 +2848,7 @@ export function WorkspaceAutomationForm(props: {
   form: WorkspaceAutomationFormState;
   errors: Record<string, string | undefined>;
   disabled?: boolean;
+  issuesAvailable?: boolean;
   knowledgeAvailable?: boolean;
   canUpdateKnowledgeMemory?: boolean;
   onChange: (next: WorkspaceAutomationFormState) => void;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/new/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/new/page.tsx
@@ -50,6 +50,7 @@ export default async function NewAutomationPage({
       <AutomationsNewPageContent
         organizationSlug={organizationSlug}
         initialForm={initialForm}
+        issuesAvailable={flags.issues}
         knowledgeAvailable={flags.knowledge}
         canUpdateKnowledgeMemory={hasCapability(auth.membership.role, "workspace:update")}
       />

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
@@ -299,6 +299,27 @@ describe("workspace automation view model", () => {
     expect(payload.toolConfig.createNativeTmsJob).not.toHaveProperty("projectId");
   });
 
+  it("maps list and create issue tools to API payload and requires a project", () => {
+    const form = {
+      ...createDefaultWorkspaceAutomationFormState(),
+      name: "Triage issues",
+      instructions: "List open issues and file new findings.",
+      listIssuesEnabled: true,
+      createIssueEnabled: true,
+    };
+
+    expect(validateWorkspaceAutomationFormState(form)).toMatchObject({
+      projectId: "Choose a Hyperlocalise project.",
+    });
+
+    const readyForm = { ...form, projectId: "project-1" };
+    expect(validateWorkspaceAutomationFormState(readyForm)).toEqual({});
+    expect(formStateToWorkspaceAutomationPayload(readyForm).toolConfig).toEqual({
+      listIssues: { enabled: true },
+      createIssue: { enabled: true },
+    });
+  });
+
   it("prefills and maps the translate-on-source-upload template", () => {
     const form = createWorkspaceAutomationFormStateFromTemplate(
       "translate-on-source-upload",

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
@@ -65,6 +65,8 @@ export type WorkspaceAutomationFormState = {
   createNativeTmsJobUseProjectTargetLocales: boolean;
   createNativeTmsJobTargetLocales: string[];
   assignTranslateWithAgentEnabled: boolean;
+  listIssuesEnabled: boolean;
+  createIssueEnabled: boolean;
   knowledgeEnabled: boolean;
   knowledgeAllowUpdates: boolean;
   mcpEnabled: boolean;
@@ -83,6 +85,9 @@ function workspaceAutomationFormNeedsProject(form: WorkspaceAutomationFormState)
     return true;
   }
   if (form.createNativeTmsJobEnabled || form.assignTranslateWithAgentEnabled) {
+    return true;
+  }
+  if (form.listIssuesEnabled || form.createIssueEnabled) {
     return true;
   }
   return form.githubEnabled && form.githubMode === "sync";
@@ -187,6 +192,8 @@ export function createDefaultWorkspaceAutomationFormState(): WorkspaceAutomation
     createNativeTmsJobUseProjectTargetLocales: true,
     createNativeTmsJobTargetLocales: [],
     assignTranslateWithAgentEnabled: false,
+    listIssuesEnabled: false,
+    createIssueEnabled: false,
     knowledgeEnabled: false,
     knowledgeAllowUpdates: false,
     mcpEnabled: false,
@@ -207,6 +214,8 @@ export function createWorkspaceAutomationFormStateFromRecord(
   const contentful = automation.toolConfig.contentful;
   const createNativeTmsJob = automation.toolConfig.createNativeTmsJob;
   const assignTranslateWithAgent = automation.toolConfig.assignTranslateWithAgent;
+  const listIssues = automation.toolConfig.listIssues;
+  const createIssue = automation.toolConfig.createIssue;
   const knowledge = automation.toolConfig.knowledge;
   const mcp = automation.toolConfig.mcp;
   const semrush = automation.toolConfig.semrush;
@@ -266,6 +275,8 @@ export function createWorkspaceAutomationFormStateFromRecord(
       ? [...createNativeTmsJob.targetLocales]
       : [],
     assignTranslateWithAgentEnabled: Boolean(assignTranslateWithAgent?.enabled),
+    listIssuesEnabled: Boolean(listIssues?.enabled),
+    createIssueEnabled: Boolean(createIssue?.enabled),
     knowledgeEnabled: Boolean(knowledge?.enabled),
     knowledgeAllowUpdates: Boolean(knowledge?.allowUpdates),
     mcpEnabled: Boolean(mcp?.enabled),
@@ -428,6 +439,20 @@ export function formStateToWorkspaceAutomationPayload(form: WorkspaceAutomationF
     ...(form.assignTranslateWithAgentEnabled
       ? {
           assignTranslateWithAgent: {
+            enabled: true,
+          },
+        }
+      : {}),
+    ...(form.listIssuesEnabled
+      ? {
+          listIssues: {
+            enabled: true,
+          },
+        }
+      : {}),
+    ...(form.createIssueEnabled
+      ? {
+          createIssue: {
             enabled: true,
           },
         }
@@ -638,6 +663,8 @@ export function workspaceAutomationFormCanActivate(form: WorkspaceAutomationForm
     form.contentfulEnabled ||
     form.createNativeTmsJobEnabled ||
     form.assignTranslateWithAgentEnabled ||
+    form.listIssuesEnabled ||
+    form.createIssueEnabled ||
     form.mcpEnabled ||
     form.semrushEnabled ||
     form.ahrefsEnabled

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
@@ -150,6 +150,7 @@ export const WORKSPACE_AUTOMATION_API_ERROR_MESSAGES: Record<string, string> = {
   ahrefs_connection_not_found:
     "The selected Ahrefs connection was not found. Choose another connection.",
   ahrefs_not_connected: "Enable the selected Ahrefs connection in Integrations before using it.",
+  issues_feature_unavailable: "Enable workspace Issues before using Issue Sheet automation tools.",
   github_repository_not_enabled: "Enable this repository before configuring automation.",
   github_repository_archived: "Archived repositories cannot use automations.",
   project_not_found: "The selected project could not be found.",
@@ -650,6 +651,8 @@ export function mapWorkspaceAutomationApiErrorToFieldErrors(
     case "ahrefs_connection_not_found":
     case "ahrefs_not_connected":
       return { ahrefsConnectionId: message };
+    case "issues_feature_unavailable":
+      return { form: message };
     default:
       return { form: message };
   }

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
@@ -126,7 +126,7 @@ export const WORKSPACE_AUTOMATION_API_ERROR_MESSAGES: Record<string, string> = {
     "Use GitHub repo automations with a scheduled or manual trigger, not GitHub push.",
   github_push_branches_required: "Add at least one branch pattern for GitHub push triggers.",
   scheduled_workflow_required:
-    "Scheduled automations require at least one GitHub or Contentful workflow.",
+    "Scheduled automations require at least one GitHub, Contentful, or Issues workflow tool.",
   slack_not_connected: "Connect Slack in Integrations before enabling Slack notifications.",
   slack_channel_required: "Choose a Slack channel for notifications.",
   email_not_connected: "Enable the email agent in Integrations before using email notifications.",

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
@@ -355,7 +355,8 @@ describe("workspace automations", () => {
     }
     expect(notificationOnlySchedule.error).toMatchObject({
       code: "scheduled_workflow_required",
-      message: "Scheduled automations require at least one GitHub or Contentful workflow.",
+      message:
+        "Scheduled automations require at least one GitHub, Contentful, or Issues workflow tool.",
     });
 
     const manualNotification = expectOk(
@@ -383,7 +384,8 @@ describe("workspace automations", () => {
     }
     expect(scheduledUpdate.error).toMatchObject({
       code: "scheduled_workflow_required",
-      message: "Scheduled automations require at least one GitHub or Contentful workflow.",
+      message:
+        "Scheduled automations require at least one GitHub, Contentful, or Issues workflow tool.",
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -306,7 +306,7 @@ export type WorkspaceAutomationConfigValidationError =
     }
   | {
       code: "scheduled_workflow_required";
-      message: "Scheduled automations require at least one GitHub or Contentful workflow.";
+      message: "Scheduled automations require at least one GitHub, Contentful, or Issues workflow tool.";
     }
   | {
       code: "contentful_connection_required";

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -14,6 +14,7 @@ import { and, asc, desc, eq, isNotNull, isNull, lte, or, sql } from "drizzle-orm
 import { z } from "zod";
 
 import { db, schema, type DatabaseClient } from "@/lib/database";
+import { resolveWorkspaceIssuesFlag } from "@/lib/flags/workspace-flags";
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 import { optionalProjectIdSchema } from "@/lib/projects/identity/project-id";
 import { lockAhrefsConnectionForUpdate } from "@/lib/ahrefs/connections";
@@ -383,6 +384,10 @@ export type WorkspaceAutomationConfigValidationError =
   | {
       code: "ahrefs_not_connected";
       message: "Enable the selected Ahrefs connection in Integrations before using it.";
+    }
+  | {
+      code: "issues_feature_unavailable";
+      message: "Enable workspace Issues before using Issue Sheet automation tools.";
     };
 
 type AutomationRow = typeof schema.workspaceAutomations.$inferSelect;
@@ -900,6 +905,22 @@ export async function validateWorkspaceAutomationIntegrations(input: {
       return err({
         code: "ahrefs_not_connected",
         message: "Enable the selected Ahrefs connection in Integrations before using it.",
+      });
+    }
+  }
+
+  if (
+    hasWorkspaceAutomationListIssuesTool(input.toolConfig) ||
+    hasWorkspaceAutomationCreateIssueTool(input.toolConfig)
+  ) {
+    const issuesEnabled = await resolveWorkspaceIssuesFlag({
+      organizationId: input.organizationId,
+      dbClient: database,
+    });
+    if (!issuesEnabled) {
+      return err({
+        code: "issues_feature_unavailable",
+        message: "Enable workspace Issues before using Issue Sheet automation tools.",
       });
     }
   }

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -143,6 +143,18 @@ const assignTranslateWithAgentToolConfigSchema = z
   })
   .default({ enabled: false });
 
+const listIssuesToolConfigSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+  })
+  .default({ enabled: false });
+
+const createIssueToolConfigSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+  })
+  .default({ enabled: false });
+
 const knowledgeToolConfigSchema = z
   .object({
     enabled: z.boolean().default(false),
@@ -224,6 +236,8 @@ const toolConfigObjectSchema = z
     contentful: contentfulToolConfigSchema.optional(),
     createNativeTmsJob: createNativeTmsJobToolConfigSchema.optional(),
     assignTranslateWithAgent: assignTranslateWithAgentToolConfigSchema.optional(),
+    listIssues: listIssuesToolConfigSchema.optional(),
+    createIssue: createIssueToolConfigSchema.optional(),
     knowledge: knowledgeToolConfigSchema.optional(),
     mcp: mcpToolConfigSchema.optional(),
     semrush: semrushToolConfigSchema.optional(),
@@ -261,6 +275,8 @@ export type WorkspaceAutomationCreateNativeTmsJobToolConfig = z.infer<
 export type WorkspaceAutomationAssignTranslateWithAgentToolConfig = z.infer<
   typeof assignTranslateWithAgentToolConfigSchema
 >;
+export type WorkspaceAutomationListIssuesToolConfig = z.infer<typeof listIssuesToolConfigSchema>;
+export type WorkspaceAutomationCreateIssueToolConfig = z.infer<typeof createIssueToolConfigSchema>;
 export type WorkspaceAutomationKnowledgeToolConfig = z.infer<typeof knowledgeToolConfigSchema>;
 export type WorkspaceAutomationMcpToolConfig = z.infer<typeof mcpToolConfigSchema>;
 export type WorkspaceAutomationSemrushToolConfig = z.infer<typeof semrushToolConfigSchema>;
@@ -390,6 +406,14 @@ export function hasWorkspaceAutomationAssignTranslateWithAgentTool(
   return Boolean(toolConfig.assignTranslateWithAgent?.enabled);
 }
 
+export function hasWorkspaceAutomationListIssuesTool(toolConfig: WorkspaceAutomationToolConfig) {
+  return Boolean(toolConfig.listIssues?.enabled);
+}
+
+export function hasWorkspaceAutomationCreateIssueTool(toolConfig: WorkspaceAutomationToolConfig) {
+  return Boolean(toolConfig.createIssue?.enabled);
+}
+
 export function hasWorkspaceAutomationKnowledgeTool(toolConfig: WorkspaceAutomationToolConfig) {
   return Boolean(toolConfig.knowledge?.enabled);
 }
@@ -484,6 +508,12 @@ export function workspaceAutomationNeedsProject(input: {
   ) {
     return true;
   }
+  if (
+    hasWorkspaceAutomationListIssuesTool(input.toolConfig) ||
+    hasWorkspaceAutomationCreateIssueTool(input.toolConfig)
+  ) {
+    return true;
+  }
   return hasWorkspaceAutomationGithubWorkflow(input.toolConfig);
 }
 
@@ -574,11 +604,14 @@ function validateWorkspaceAutomationConfig(input: {
     input.triggerConfig.mode === "scheduled" &&
     !hasWorkspaceAutomationGithubAgentTool(input.toolConfig) &&
     !hasWorkspaceAutomationGithubWorkflow(input.toolConfig) &&
-    !hasWorkspaceAutomationContentfulWorkflow(input.toolConfig)
+    !hasWorkspaceAutomationContentfulWorkflow(input.toolConfig) &&
+    !hasWorkspaceAutomationListIssuesTool(input.toolConfig) &&
+    !hasWorkspaceAutomationCreateIssueTool(input.toolConfig)
   ) {
     return err({
       code: "scheduled_workflow_required",
-      message: "Scheduled automations require at least one GitHub or Contentful workflow.",
+      message:
+        "Scheduled automations require at least one GitHub, Contentful, or Issues workflow tool.",
     });
   }
 

--- a/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
@@ -175,6 +175,43 @@ export async function resolveWorkspaceKnowledgeFlag(input: {
   }
 }
 
+/**
+ * Resolves workspaceIssuesFlag from an internal organizationId for callers without a live HTTP
+ * auth context — workspace-automation tool execution and config validation. Mirrors
+ * resolveWorkspaceKnowledgeFlag: Issue Sheet HTTP routes already reject when the flag is off, but
+ * automation create/update and orchestrator tools can still reach IssueSheetService unless we
+ * re-check here.
+ */
+export async function resolveWorkspaceIssuesFlag(input: {
+  organizationId: string;
+  dbClient?: Pick<typeof db, "select">;
+}): Promise<boolean> {
+  const dbClient = input.dbClient ?? db;
+  if (typeof dbClient.select !== "function") {
+    return false;
+  }
+
+  try {
+    const [organization] = await dbClient
+      .select({ workosOrganizationId: schema.organizations.workosOrganizationId })
+      .from(schema.organizations)
+      .where(eq(schema.organizations.id, input.organizationId))
+      .limit(1);
+
+    if (!organization) {
+      return false;
+    }
+
+    return (
+      (await workspaceIssuesFlag.run({
+        identify: () => ({ organization: { id: organization.workosOrganizationId } }),
+      })) === true
+    );
+  } catch {
+    return false;
+  }
+}
+
 export async function requireWorkspaceFeatureFlag(
   workspaceFlag: Flag<boolean, WorkosFlagEntities>,
   auth: Pick<AppAuthContext, "activeOrganization" | "user">,

--- a/docs/plans/2026-08-13-issue-sheet-automation-tools-design.md
+++ b/docs/plans/2026-08-13-issue-sheet-automation-tools-design.md
@@ -19,20 +19,22 @@ Add two first-class orchestrator tools that call `IssueSheetService`:
 Both require the automation header `projectId` (Issue Sheet is project-scoped).
 Both use `automation.authorUserId` as the Issue Sheet actor (reporter / list
 viewer). Missing author or project fails the tool with a stable error code.
+Both re-check `workspace-issues` at save time and at tool execution.
 
 ### `list_issues`
 
 Optional filters (`status`, `issueType`, `priority`, `search`, `limit`,
 `offset`). Returns a compact list plus totals so the model can triage without
-shipping full column payloads.
+shipping full column payloads. Always scopes to `automation.projectId`.
 
 ### `create_issue`
 
 Accepts `issues: [...]` (max 20). An empty array is a successful no-op so a
 forced plan step can skip filing when there is nothing actionable. Each created
-issue links to the automation run (`linkKind: agent_run`,
-`linkedAgentRunId: run.id`). Persist created IDs in `outputSummary.createIssue`
-for idempotent retries.
+issue uses `linkKind: manual` plus a stable
+`externalRef` (`workspace-automation-run:<runId>:<index>`) for idempotent
+retries — do not set `linkedAgentRunId`, which FKs to `agent_runs`, not
+workspace automation runs. Persist progress after each successful create.
 
 ### UI
 

--- a/docs/plans/2026-08-13-issue-sheet-automation-tools-design.md
+++ b/docs/plans/2026-08-13-issue-sheet-automation-tools-design.md
@@ -1,0 +1,56 @@
+# Issue Sheet tools for Agent Automation
+
+## Problem
+
+Workspace Agent Automations can run GitHub, Contentful, native TMS, SEO, and
+notification tools, but cannot read or file Hyperlocalise Issues. Teams that
+already use Issue Sheet need automations to list open work and create issues
+from findings.
+
+## Decision
+
+Add two first-class orchestrator tools that call `IssueSheetService`:
+
+| Tool | `toolConfig` key | Plan order |
+|------|------------------|------------|
+| `list_issues` | `listIssues.enabled` | Before `create_issue` |
+| `create_issue` | `createIssue.enabled` | After list / other workflows |
+
+Both require the automation header `projectId` (Issue Sheet is project-scoped).
+Both use `automation.authorUserId` as the Issue Sheet actor (reporter / list
+viewer). Missing author or project fails the tool with a stable error code.
+
+### `list_issues`
+
+Optional filters (`status`, `issueType`, `priority`, `search`, `limit`,
+`offset`). Returns a compact list plus totals so the model can triage without
+shipping full column payloads.
+
+### `create_issue`
+
+Accepts `issues: [...]` (max 20). An empty array is a successful no-op so a
+forced plan step can skip filing when there is nothing actionable. Each created
+issue links to the automation run (`linkKind: agent_run`,
+`linkedAgentRunId: run.id`). Persist created IDs in `outputSummary.createIssue`
+for idempotent retries.
+
+### UI
+
+Add **List issues** and **Create issue** under Supported tools when the
+`workspace-issues` flag is on. Settings rows are enable/remove only; project
+comes from the automation header.
+
+## Alternatives considered
+
+1. **Single nested `use_issues` tool** (Semrush-style) — rejected for v1; list
+   and create are distinct enablement choices and do not need a nested MCP loop.
+2. **Linear / GitHub Issues** — out of scope; Linear remains Coming soon.
+3. **Inbound Hyperlocalise MCP tools** — separate surface; not required for
+   Agent Automation.
+
+## Out of scope
+
+- Update / comment / assign tools
+- Org-wide Issues list (non-project)
+- Templates that enable these tools by default
+- Changing Linear Coming soon


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Agent Automation tools for Hyperlocalise Issue Sheet:

- **`list_issues`** — list/filter project issues (compact payload)
- **`create_issue`** — create zero or more issues from findings (empty array = no-op)

Both tools use the automation header project and `authorUserId` as the Issue Sheet actor. Created issues use a stable `externalRef` for idempotent retries (not `linkedAgentRunId`, which FKs to `agent_runs`). UI entries appear under Add Tool when the `workspace-issues` flag is enabled; the flag is also enforced on save and at tool execution.

## Design

See `docs/plans/2026-08-13-issue-sheet-automation-tools-design.md`.

## Verification

- `vp test` focused suites for issue tools / automations
- `vp check --fix` — 0 errors

## Review follow-ups

Addressed Codex P1/P2 findings: FK-safe linking, partial-batch persistence, project scoping, and Issues feature-flag checks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40974820-8ba5-452d-9e4e-78c19a7114ba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40974820-8ba5-452d-9e4e-78c19a7114ba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

