### PR TITLE
test(cli): add unit tests for cliotel telemetry helper

### DIFF
--- a/apps/cli/internal/cliotel/BUILD.bazel
+++ b/apps/cli/internal/cliotel/BUILD.bazel
@@ -1,8 +1,8 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "cliotel",
-    srcs = glob(["*.go"]),
+    srcs = glob(["*.go"], exclude = ["*_test.go"]),
     importpath = "github.com/hyperlocalise/hyperlocalise/apps/cli/internal/cliotel",
     visibility = ["//visibility:public"],
     deps = [
@@ -13,5 +13,14 @@ go_library(
         "@io_opentelemetry_go_otel_exporters_otlp_otlptrace_otlptracehttp//:otlptracehttp",
         "@io_opentelemetry_go_otel_sdk//resource:resource",
         "@io_opentelemetry_go_otel_sdk//trace:trace",
+    ],
+)
+
+go_test(
+    name = "cliotel_test",
+    srcs = glob(["*_test.go"]),
+    embed = [":cliotel"],
+    deps = [
+        "@com_github_spf13_cobra//:cobra",
     ],
 )

--- a/apps/cli/internal/cliotel/cliotel_scout_test.go
+++ b/apps/cli/internal/cliotel/cliotel_scout_test.go
@@ -1,0 +1,136 @@
+package cliotel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestCommandSpanName(t *testing.T) {
+	rootCmd := &cobra.Command{Use: "hyperlocalise"}
+	runCmd := &cobra.Command{Use: "run"}
+	rootCmd.AddCommand(runCmd)
+
+	tests := []struct {
+		name     string
+		cmd      *cobra.Command
+		expected string
+	}{
+		{
+			name:     "root command span name",
+			cmd:      rootCmd,
+			expected: "hyperlocalise",
+		},
+		{
+			name:     "sub command span name",
+			cmd:      runCmd,
+			expected: "hyperlocalise.run",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CommandSpanName(tt.cmd)
+			if got != tt.expected {
+				t.Errorf("CommandSpanName() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTelemetryEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      map[string]string
+		expected bool
+	}{
+		{
+			name:     "disabled by default",
+			env:      map[string]string{},
+			expected: false,
+		},
+		{
+			name: "opted in but missing endpoints",
+			env: map[string]string{
+				"HYPERLOCALISE_OTEL": "1",
+			},
+			expected: false,
+		},
+		{
+			name: "opted in and with endpoint",
+			env: map[string]string{
+				"HYPERLOCALISE_OTEL":          "1",
+				"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
+			},
+			expected: true,
+		},
+		{
+			name: "opted in and with traces endpoint",
+			env: map[string]string{
+				"HYPERLOCALISE_OTEL":                 "1",
+				"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:4318/v1/traces",
+			},
+			expected: true,
+		},
+		{
+			name: "opted in with endpoint but sdk disabled",
+			env: map[string]string{
+				"HYPERLOCALISE_OTEL":          "1",
+				"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
+				"OTEL_SDK_DISABLED":           "true",
+			},
+			expected: false,
+		},
+		{
+			name: "sdk disabled in any casing",
+			env: map[string]string{
+				"HYPERLOCALISE_OTEL":          "1",
+				"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
+				"OTEL_SDK_DISABLED":           "TrUe",
+			},
+			expected: false,
+		},
+		{
+			name: "opt in has invalid value",
+			env: map[string]string{
+				"HYPERLOCALISE_OTEL":          "true",
+				"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HYPERLOCALISE_OTEL", "")
+			t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+			t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+			t.Setenv("OTEL_SDK_DISABLED", "")
+
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			got := Enabled()
+			if got != tt.expected {
+				t.Errorf("Enabled() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestInitWhenDisabled(t *testing.T) {
+	t.Setenv("HYPERLOCALISE_OTEL", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+	t.Setenv("OTEL_SDK_DISABLED", "")
+
+	shutdown, err := Init(context.Background(), "1.0.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if shutdown != nil {
+		t.Fatalf("expected nil shutdown func, got %T", shutdown)
+	}
+}


### PR DESCRIPTION
This PR adds thorough behavior-driven unit tests for the cliotel package to increase confidence in the CLI telemetry configuration, span name creation, and disabled-state fallback behavior.

---
*PR created automatically by Jules for task [1684601717419562684](https://jules.google.com/task/1684601717419562684) started by @cungminh2710*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or configuration behavior modified.
> 
> **Overview**
> Adds **`cliotel_scout_test.go`** with unit coverage for the CLI OpenTelemetry helpers—no production code changes.
> 
> **`CommandSpanName`** is checked for root vs nested Cobra commands (e.g. `hyperlocalise` vs `hyperlocalise.run`). **`Enabled()`** is exercised across env combinations: default off, opt-in without endpoints, valid OTLP endpoint or traces endpoint, `OTEL_SDK_DISABLED` (including mixed case), and invalid `HYPERLOCALISE_OTEL` values other than `"1"`. **`Init`** when telemetry is disabled is asserted to return no error and a **nil** shutdown callback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17d7c2a0f8c9969be7c683443f15b6dc5dd67781. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->