### PR TITLE
feat(analytics): dual-write GA and track product usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,9 @@ go build -o $(go env GOPATH)/bin/golangci-lint github.com/golangci/golangci-lint
   WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
   NEXT_PUBLIC_WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
  WORKOS_COOKIE_PASSWORD=this-is-a-test-cookie-password-at-least-32-characters
- AUTUMN_API_KEY=am_sk_test_placeholder
+  AUTUMN_API_KEY=am_sk_test_placeholder
+  # Optional. Enables server-side GA4 custom events via Measurement Protocol.
+  # GA_MEASUREMENT_PROTOCOL_API_SECRET=
  ```
 - Run `vp run db:migrate` after starting Postgres to apply Drizzle migrations.
 - The `make test` target uses coverage flags that may warn about a missing `covdata` tool — all actual tests still pass. Use `go test ./...` if you want a clean exit code without coverage.

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.test.ts
@@ -34,6 +34,8 @@ vi.mock("@/api/auth/workos-session", async (importOriginal) => {
 });
 
 import { createApp } from "@/api/app";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import { db, schema } from "@/lib/database";
 
 import { createTeamTestFixture } from "../team/team.fixture";
@@ -285,5 +287,44 @@ describe("glossaryRoutes", () => {
     expect(memberListBody.projects.map((project) => project.projectId)).not.toContain(
       betaProject.id,
     );
+  });
+
+  it("emits product usage analytics when creating a glossary and a term", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const trackSpy = vi.spyOn(serverAnalytics, "track").mockImplementation(() => {});
+
+    const createResponse = await fixture.createGlossaryViaApi(identity, undefined, headers);
+    expect(createResponse.status).toBe(201);
+    expect(trackSpy).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.glossaryCreated, {
+      status: "created",
+      source: "glossary",
+    });
+
+    const glossaryId = ((await createResponse.json()) as { glossary: { id: string } }).glossary.id;
+    const termResponse = await client.api.orgs[":organizationSlug"].glossaries[
+      ":glossaryId"
+    ].terms.$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          glossaryId,
+        },
+        json: {
+          sourceTerm: "Checkout",
+          targetTerm: "Pago",
+          caseSensitive: false,
+          forbidden: false,
+        },
+      },
+      { headers },
+    );
+
+    expect(termResponse.status).toBe(201);
+    expect(trackSpy).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.glossaryTermCreated, {
+      status: "created",
+      source: "glossary",
+    });
+    trackSpy.mockRestore();
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.ts
@@ -17,6 +17,8 @@ import { validator } from "hono/validator";
 import { buildAccessibleProjectsWhere } from "@/api/auth/team-access";
 import { workosAuthMiddleware, type ApiAuthContext, type AuthVariables } from "@/api/auth/workos";
 import { conflictResponse } from "@/api/errors";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import { parseCsvRows } from "@/lib/csv/parse-csv-rows";
 import { db, schema } from "@/lib/database";
 import type { Glossary } from "@/lib/database/types";
@@ -129,6 +131,10 @@ const glossaryStore: GlossaryStore = {
       })
       .returning();
 
+    serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.glossaryCreated, {
+      status: "created",
+      source: "glossary",
+    });
     return glossary;
   },
   async getById(auth, glossaryId) {
@@ -248,7 +254,15 @@ async function createGlossaryTerm(
     .onConflictDoNothing()
     .returning();
 
-  return term ?? null;
+  if (!term) {
+    return null;
+  }
+
+  serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.glossaryTermCreated, {
+    status: "created",
+    source: "glossary",
+  });
+  return term;
 }
 
 async function createGlossaryTerms(

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.route.test.ts
@@ -33,6 +33,8 @@ vi.mock("@/api/auth/workos-session", async (importOriginal) => {
 });
 
 import { createApp } from "@/api/app";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import { db } from "@/lib/database";
 
 import { createMemoryTestFixture } from "./memory.fixture";
@@ -180,5 +182,18 @@ describe("memoryRoutes", () => {
         matchScore: 0,
       }),
     ]);
+  });
+
+  it("emits product usage analytics when creating a translation memory", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const trackSpy = vi.spyOn(serverAnalytics, "track").mockImplementation(() => {});
+
+    const response = await fixture.createMemoryViaApi(identity);
+    expect(response.status).toBe(201);
+    expect(trackSpy).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.memoryCreated, {
+      status: "created",
+      source: "memory",
+    });
+    trackSpy.mockRestore();
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.route.ts
@@ -21,6 +21,8 @@ import { validator } from "hono/validator";
 
 import { workosAuthMiddleware, type ApiAuthContext, type AuthVariables } from "@/api/auth/workos";
 import { conflictResponse, badRequestResponse } from "@/api/errors";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import { parseCsvRows } from "@/lib/csv/parse-csv-rows";
 import { db, schema } from "@/lib/database";
 import type { Memory } from "@/lib/database/types";
@@ -130,6 +132,10 @@ const memoryStore: MemoryStore = {
       })
       .returning();
 
+    serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.memoryCreated, {
+      status: "created",
+      source: "memory",
+    });
     return memory;
   },
   async getById(auth, memoryId) {

--- a/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.test.ts
@@ -17,6 +17,8 @@ import { testClient } from "hono/testing";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { app } from "@/api/app";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import { db, schema } from "@/lib/database";
 
 import { createProjectTestFixture } from "./project.fixture";
@@ -118,6 +120,7 @@ describe("Issue Sheet routes", () => {
     const { identity, project } = await projectFixture.createStoredProjectFixture();
     const headers = await projectFixture.authHeadersFor(identity);
     const organizationSlug = identity.organization.slug ?? "missing-slug";
+    const trackSpy = vi.spyOn(serverAnalytics, "track").mockImplementation(() => {});
 
     const createResponse = await issueSheet().$post(
       {
@@ -147,6 +150,11 @@ describe("Issue Sheet routes", () => {
       targetLocale: "de-DE",
       values: { priority: "P1" },
     });
+    expect(trackSpy).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.issueCreated, {
+      status: "created",
+      source: "issue_sheet",
+    });
+    trackSpy.mockRestore();
 
     const listResponse = await issueSheet().$get(
       {

--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -20,6 +20,8 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 import { eq } from "drizzle-orm";
 
 import { app } from "@/api/app";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import { db, schema } from "@/lib/database";
 import { ensureRepositorySourceFile } from "@/lib/file-storage/records";
 import { upsertProjectTranslationKeysFromEntries } from "@/lib/projects/translations/project-translation-service";
@@ -391,6 +393,7 @@ describe("project file CAT routes", () => {
         aiReasoning: "Natural French greeting.",
       }),
     );
+    const trackSpy = vi.spyOn(serverAnalytics, "track").mockImplementation(() => {});
 
     const response = await client.api.orgs[":organizationSlug"].projects[
       ":projectId"
@@ -421,6 +424,11 @@ describe("project file CAT routes", () => {
       aiSuggestion: "Bonjour",
       aiReasoning: "Natural French greeting.",
     });
+    expect(trackSpy).toHaveBeenCalledWith(
+      PRODUCT_USAGE_ANALYTICS_EVENTS.catAiRecommendationRequested,
+      { source: "external_tms" },
+    );
+    trackSpy.mockRestore();
     expect(ensureOrganizationProjectRecordMock).toHaveBeenCalledWith(
       expect.objectContaining({
         projectId: "ext:crowdin:42",
@@ -606,6 +614,7 @@ describe("project file CAT routes", () => {
       .limit(1);
     expect(translationKey).toBeDefined();
 
+    const trackSpy = vi.spyOn(serverAnalytics, "track").mockImplementation(() => {});
     const postResponse = await client.api.orgs[":organizationSlug"].projects[
       ":projectId"
     ].files.detail.cat.comments.$post(
@@ -626,6 +635,11 @@ describe("project file CAT routes", () => {
 
     expect(postResponse.status).toBe(200);
     expect(saveTmsProviderLiveCatCommentMock).not.toHaveBeenCalled();
+    expect(trackSpy).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.catCommentCreated, {
+      source: "native",
+      feature: "comment",
+    });
+    trackSpy.mockRestore();
 
     const response = await client.api.orgs[":organizationSlug"].projects[
       ":projectId"
@@ -686,6 +700,106 @@ describe("project file CAT routes", () => {
       },
     ]);
     expect(commentsBody.comments[0]?.externalCommentId).toBeTruthy();
+  });
+
+  it("emits product usage analytics for native CAT draft, approve, and status updates", async () => {
+    const { identity, project, organization } = await projectFixture.createStoredProjectFixture();
+    const headers = await projectFixture.authHeadersFor(identity);
+    const sourcePath = "locales/en.json";
+    const sourceFile = await ensureRepositorySourceFile({
+      organizationId: organization.id,
+      projectId: project.id,
+      sourcePath,
+    });
+
+    const { imported } = await upsertProjectTranslationKeysFromEntries({
+      organizationId: organization.id,
+      projectId: project.id,
+      repositorySourceFileId: sourceFile.id,
+      entries: [{ key: "greeting", text: "Hello", context: null }],
+    });
+    expect(imported).toBe(1);
+
+    const [translationKey] = await db
+      .select({ id: schema.projectTranslationKeys.id })
+      .from(schema.projectTranslationKeys)
+      .where(eq(schema.projectTranslationKeys.repositorySourceFileId, sourceFile.id))
+      .limit(1);
+    expect(translationKey).toBeDefined();
+
+    const trackSpy = vi.spyOn(serverAnalytics, "track").mockImplementation(() => {});
+    const draftResponse = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.translations.$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
+        json: {
+          sourcePath,
+          targetLocale: "fr-FR",
+          externalStringId: translationKey!.id,
+          text: "Bonjour",
+          approve: false,
+        },
+      },
+      { headers },
+    );
+    expect(draftResponse.status).toBe(200);
+    expect(trackSpy).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.catSegmentDraftSaved, {
+      source: "native",
+      status: "draft",
+    });
+
+    const approveResponse = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.translations.$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
+        json: {
+          sourcePath,
+          targetLocale: "fr-FR",
+          externalStringId: translationKey!.id,
+          text: "Bonjour",
+          approve: true,
+        },
+      },
+      { headers },
+    );
+    expect(approveResponse.status).toBe(200);
+    expect(trackSpy).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.catSegmentApproved, {
+      source: "native",
+      status: "approved",
+    });
+
+    trackSpy.mockClear();
+    const statusResponse = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.translations.status.$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
+        json: {
+          sourcePath,
+          targetLocale: "fr-FR",
+          externalStringId: translationKey!.id,
+          status: "approved",
+        },
+      },
+      { headers },
+    );
+    expect(statusResponse.status).toBe(200);
+    expect(trackSpy).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.catSegmentApproved, {
+      source: "native",
+      status: "approved",
+    });
+    trackSpy.mockRestore();
   });
 
   it("loads native segment targets with All Files sourcePath=*", async () => {
@@ -1681,6 +1795,7 @@ describe("project file CAT routes", () => {
       externalTranslationId: "9001",
       isApproved: false,
     });
+    const trackSpy = vi.spyOn(serverAnalytics, "track").mockImplementation(() => {});
 
     const response = await client.api.orgs[":organizationSlug"].projects[
       ":projectId"
@@ -1711,6 +1826,11 @@ describe("project file CAT routes", () => {
       { targetLocale: "fr", externalStringId: "1001", externalResourceId: "101", text: "Bonjour" },
       expect.objectContaining({ actorUserId: expect.any(String) }),
     );
+    expect(trackSpy).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.catSegmentDraftSaved, {
+      source: "external_tms",
+      status: "draft",
+    });
+    trackSpy.mockRestore();
   });
 
   it("denies CAT translation saves without write-back permission", async () => {
@@ -1749,6 +1869,7 @@ describe("project file CAT routes", () => {
       locale: "fr",
       author: "Reviewer",
     });
+    const trackSpy = vi.spyOn(serverAnalytics, "track").mockImplementation(() => {});
 
     const response = await client.api.orgs[":organizationSlug"].projects[
       ":projectId"
@@ -1789,6 +1910,11 @@ describe("project file CAT routes", () => {
       },
       expect.objectContaining({ actorUserId: expect.any(String) }),
     );
+    expect(trackSpy).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.catCommentCreated, {
+      source: "external_tms",
+      feature: "comment",
+    });
+    trackSpy.mockRestore();
   });
 
   it("posts Crowdin CAT issues with issue type for users with write-back permission", async () => {
@@ -1802,6 +1928,7 @@ describe("project file CAT routes", () => {
       locale: "fr",
       author: "Reviewer",
     });
+    const trackSpy = vi.spyOn(serverAnalytics, "track").mockImplementation(() => {});
 
     const response = await client.api.orgs[":organizationSlug"].projects[
       ":projectId"
@@ -1839,6 +1966,11 @@ describe("project file CAT routes", () => {
       },
       expect.objectContaining({ actorUserId: expect.any(String) }),
     );
+    expect(trackSpy).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.catCommentCreated, {
+      source: "external_tms",
+      feature: "issue",
+    });
+    trackSpy.mockRestore();
   });
 
   it("resolves Crowdin CAT issues for users with write-back permission", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -36,6 +36,8 @@ import {
 import { db, schema, type DatabaseClient } from "@/lib/database";
 import type { Project } from "@/lib/database/types";
 import { getFileStorageAdapter, type FileStorageAdapter } from "@/lib/file-storage";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import { isReleaseCatAllFilesEnabled } from "@/lib/flags/release-flags";
 import { createLogger } from "@/lib/log";
 import {
@@ -1058,6 +1060,16 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
             return badRequestResponse(c, "translation_key_not_found", "Translation key not found");
           }
 
+          serverAnalytics.track(
+            body.approve
+              ? PRODUCT_USAGE_ANALYTICS_EVENTS.catSegmentApproved
+              : PRODUCT_USAGE_ANALYTICS_EVENTS.catSegmentDraftSaved,
+            {
+              source: "native",
+              status: body.approve ? "approved" : "draft",
+            },
+          );
+
           return c.json({ translation }, 200);
         }
 
@@ -1077,6 +1089,16 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           if (!translation) {
             return projectNotFoundResponse(c);
           }
+
+          serverAnalytics.track(
+            translation.isApproved
+              ? PRODUCT_USAGE_ANALYTICS_EVENTS.catSegmentApproved
+              : PRODUCT_USAGE_ANALYTICS_EVENTS.catSegmentDraftSaved,
+            {
+              source: "external_tms",
+              status: translation.isApproved ? "approved" : "draft",
+            },
+          );
 
           return c.json({ translation }, 200);
         } catch (error) {
@@ -1133,6 +1155,11 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
             );
           }
 
+          serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.catCommentCreated, {
+            source: "native",
+            feature: "comment",
+          });
+
           return c.json({ comment }, 200);
         }
 
@@ -1154,6 +1181,11 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           if (!comment) {
             return projectNotFoundResponse(c);
           }
+
+          serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.catCommentCreated, {
+            source: "external_tms",
+            feature: body.type === "issue" ? "issue" : "comment",
+          });
 
           return c.json({ comment }, 200);
         } catch (error) {
@@ -1355,6 +1387,10 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           return badRequestResponse(c, result.error.code, result.error.message);
         }
 
+        serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.catAiRecommendationRequested, {
+          source: target.kind === "provider" ? "external_tms" : "native",
+        });
+
         return c.json({ recommendation: result.value }, 200);
       },
     )
@@ -1398,6 +1434,13 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
 
         if (!translation) {
           return badRequestResponse(c, "translation_not_found", "Translation not found");
+        }
+
+        if (body.status === "approved") {
+          serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.catSegmentApproved, {
+            source: "native",
+            status: "approved",
+          });
         }
 
         return c.json({ translation }, 200);

--- a/apps/hyperlocalise-web/src/api/routes/workspace-automation/workspace-automation.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/workspace-automation/workspace-automation.route.test.ts
@@ -47,6 +47,8 @@ vi.mock("@/workflows/adapters", async (importOriginal) => {
 
 import { createApp } from "@/api/app";
 import { createAuthTestFixture } from "@/api/test-auth.fixture";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import { db, schema } from "@/lib/database";
 
 const client = testClient(createApp());
@@ -412,6 +414,7 @@ describe("workspace automation routes", () => {
       idempotencyKey: `manual:${created.automation.id}:test-run`,
       inputSnapshot: { reason: "operator_test" },
     };
+    const trackSpy = vi.spyOn(serverAnalytics, "track").mockImplementation(() => {});
     const firstRunResponse = await client.api.orgs[":organizationSlug"].automations[
       ":automationId"
     ].runs.$post(
@@ -448,6 +451,12 @@ describe("workspace automation routes", () => {
     };
     expect(firstRun.dispatch).toMatchObject({ outcome: "enqueued", inserted: true });
     expect(secondRun.dispatch).toMatchObject({ outcome: "enqueued", inserted: false });
+    expect(trackSpy).toHaveBeenCalledTimes(1);
+    expect(trackSpy).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.automationRunStarted, {
+      status: "queued",
+      source: "manual",
+    });
+    trackSpy.mockRestore();
     expect(firstRun.automationRun.outputSummary.orchestratorEnqueuedAt).toBeTruthy();
     expect(workspaceAutomationExecutionEnqueueMock).toHaveBeenCalledTimes(1);
     expect(secondRun.automationRun).toMatchObject({

--- a/apps/hyperlocalise-web/src/app/layout.tsx
+++ b/apps/hyperlocalise-web/src/app/layout.tsx
@@ -24,6 +24,7 @@ import { getAppLocale } from "@/lib/app-i18n/server-locale";
 import type { AppLocale } from "@/lib/app-i18n/locales";
 import { SITE_URL } from "@/lib/seo/site-url";
 import { GoogleAnalytics } from "@next/third-parties/google";
+import { GA_MEASUREMENT_ID } from "@/lib/analytics/google-analytics";
 import { cn } from "@/lib/primitives/cn";
 import "./globals.css";
 
@@ -117,7 +118,7 @@ export default async function RootLayout({
         </AuthKitProvider>
       </body>
 
-      <GoogleAnalytics gaId="G-ET30XL0TE6" />
+      <GoogleAnalytics gaId={GA_MEASUREMENT_ID} />
     </html>
   );
 }

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.ts
@@ -10,6 +10,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import { createLogger } from "@/lib/log";
 import { composeWorkspaceAutomationInstructions } from "@/agents/automations/workspace/agent/compose-workspace-instructions";
 import {
@@ -253,10 +255,18 @@ async function dispatchWorkspaceAutomationViaOrchestrator(input: {
     },
   });
 
+  const insertedRun = enqueued ? inserted : false;
+  if (insertedRun) {
+    serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.automationRunStarted, {
+      status: "queued",
+      source: input.triggerSource,
+    });
+  }
+
   return {
     outcome: "enqueued",
     runId: run.id,
-    inserted: enqueued ? inserted : false,
+    inserted: insertedRun,
   };
 }
 

--- a/apps/hyperlocalise-web/src/lib/analytics/analytics.ts
+++ b/apps/hyperlocalise-web/src/lib/analytics/analytics.ts
@@ -19,13 +19,24 @@ export type AnalyticsTrackFn = (
 ) => void | Promise<void>;
 
 /**
- * Provider-neutral analytics facade. Adapters wrap @vercel/analytics client/server.
+ * Provider-neutral analytics facade. Client/server adapters wrap Vercel Analytics
+ * and Google Analytics (gtag on the client, Measurement Protocol on the server).
  */
 export class Analytics {
-  constructor(private readonly trackFn: AnalyticsTrackFn) {}
+  private readonly trackFns: AnalyticsTrackFn[];
+
+  constructor(trackFn: AnalyticsTrackFn | AnalyticsTrackFn[]) {
+    this.trackFns = Array.isArray(trackFn) ? trackFn : [trackFn];
+  }
 
   track(name: string, properties?: AnalyticsProperties): void {
     const sanitized = sanitizeAnalyticsProperties(properties);
-    void this.trackFn(name, sanitized);
+    for (const trackFn of this.trackFns) {
+      try {
+        void trackFn(name, sanitized);
+      } catch {
+        // A failing provider must not block other providers or the product path.
+      }
+    }
   }
 }

--- a/apps/hyperlocalise-web/src/lib/analytics/events.test.ts
+++ b/apps/hyperlocalise-web/src/lib/analytics/events.test.ts
@@ -64,6 +64,19 @@ describe("analytics sanitization", () => {
     expect(calls).toEqual([[LOCALISATION_AUDIT_ANALYTICS_EVENTS.start, { outcome: "created" }]]);
   });
 
+  it("keeps CAT source and feature properties", () => {
+    expect(
+      sanitizeAnalyticsProperties({
+        source: "native",
+        feature: "comment",
+        email: "leak@example.com",
+      }),
+    ).toEqual({
+      source: "native",
+      feature: "comment",
+    });
+  });
+
   it("maps token bands without sending raw counts", () => {
     expect(tokenBand(0)).toBe("none");
     expect(tokenBand(12)).toBe("low");

--- a/apps/hyperlocalise-web/src/lib/analytics/events.test.ts
+++ b/apps/hyperlocalise-web/src/lib/analytics/events.test.ts
@@ -15,8 +15,12 @@ import { describe, expect, it } from "vite-plus/test";
 import { Analytics } from "./analytics";
 import {
   LOCALISATION_AUDIT_ANALYTICS_EVENTS,
+  PRODUCT_USAGE_ANALYTICS_EVENTS,
+  productUsageEventForAutumnEventName,
+  productUsageSourceForMeterSource,
   sanitizeAnalyticsProperties,
   scoreBand,
+  tokenBand,
 } from "./events";
 
 describe("analytics sanitization", () => {
@@ -58,5 +62,49 @@ describe("analytics sanitization", () => {
     });
 
     expect(calls).toEqual([[LOCALISATION_AUDIT_ANALYTICS_EVENTS.start, { outcome: "created" }]]);
+  });
+
+  it("maps token bands without sending raw counts", () => {
+    expect(tokenBand(0)).toBe("none");
+    expect(tokenBand(12)).toBe("low");
+    expect(tokenBand(1000)).toBe("mid");
+    expect(tokenBand(10_000)).toBe("high");
+  });
+
+  it("maps Autumn meter names onto product usage events", () => {
+    expect(productUsageEventForAutumnEventName("translation_job.completed")).toBe(
+      PRODUCT_USAGE_ANALYTICS_EVENTS.translationJobCompleted,
+    );
+    expect(productUsageEventForAutumnEventName("agent_run.completed")).toBe(
+      PRODUCT_USAGE_ANALYTICS_EVENTS.agentRunCompleted,
+    );
+    expect(productUsageEventForAutumnEventName("ai_tokens.consumed")).toBe(
+      PRODUCT_USAGE_ANALYTICS_EVENTS.aiTokensConsumed,
+    );
+    expect(productUsageEventForAutumnEventName("unknown")).toBeNull();
+    expect(productUsageSourceForMeterSource("translation_job_complete")).toBe("translation_job");
+    expect(productUsageSourceForMeterSource("agent_runtime_complete")).toBe("agent_run");
+  });
+
+  it("fans out to every adapter and isolates provider failures", () => {
+    const calls: string[] = [];
+    const analytics = new Analytics([
+      (name) => {
+        calls.push(`first:${name}`);
+      },
+      () => {
+        throw new Error("provider down");
+      },
+      (name) => {
+        calls.push(`third:${name}`);
+      },
+    ]);
+
+    analytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.projectCreated, { status: "created" });
+
+    expect(calls).toEqual([
+      `first:${PRODUCT_USAGE_ANALYTICS_EVENTS.projectCreated}`,
+      `third:${PRODUCT_USAGE_ANALYTICS_EVENTS.projectCreated}`,
+    ]);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/analytics/events.ts
+++ b/apps/hyperlocalise-web/src/lib/analytics/events.ts
@@ -33,13 +33,23 @@ export type LocalisationAuditAnalyticsEvent =
 export const PRODUCT_USAGE_ANALYTICS_EVENTS = {
   translationJobCompleted: "translation_job_completed",
   translationJobFailed: "translation_job_failed",
+  translationJobCreated: "translation_job_created",
   agentRunCompleted: "agent_run_completed",
   agentRunFailed: "agent_run_failed",
   aiTokensConsumed: "ai_tokens_consumed",
   projectCreated: "project_created",
   automationCreated: "automation_created",
+  automationRunStarted: "automation_run_started",
   integrationConnected: "integration_connected",
   seatAdded: "seat_added",
+  catSegmentApproved: "cat_segment_approved",
+  catSegmentDraftSaved: "cat_segment_draft_saved",
+  catCommentCreated: "cat_comment_created",
+  catAiRecommendationRequested: "cat_ai_recommendation_requested",
+  issueCreated: "issue_created",
+  glossaryCreated: "glossary_created",
+  glossaryTermCreated: "glossary_term_created",
+  memoryCreated: "memory_created",
 } as const;
 
 export type ProductUsageAnalyticsEvent =

--- a/apps/hyperlocalise-web/src/lib/analytics/events.ts
+++ b/apps/hyperlocalise-web/src/lib/analytics/events.ts
@@ -30,6 +30,33 @@ export const LOCALISATION_AUDIT_ANALYTICS_EVENTS = {
 export type LocalisationAuditAnalyticsEvent =
   (typeof LOCALISATION_AUDIT_ANALYTICS_EVENTS)[keyof typeof LOCALISATION_AUDIT_ANALYTICS_EVENTS];
 
+export const PRODUCT_USAGE_ANALYTICS_EVENTS = {
+  translationJobCompleted: "translation_job_completed",
+  translationJobFailed: "translation_job_failed",
+  agentRunCompleted: "agent_run_completed",
+  agentRunFailed: "agent_run_failed",
+  aiTokensConsumed: "ai_tokens_consumed",
+  projectCreated: "project_created",
+  automationCreated: "automation_created",
+  integrationConnected: "integration_connected",
+  seatAdded: "seat_added",
+} as const;
+
+export type ProductUsageAnalyticsEvent =
+  (typeof PRODUCT_USAGE_ANALYTICS_EVENTS)[keyof typeof PRODUCT_USAGE_ANALYTICS_EVENTS];
+
+const AUTUMN_EVENT_TO_PRODUCT_USAGE: Record<string, ProductUsageAnalyticsEvent> = {
+  "translation_job.completed": PRODUCT_USAGE_ANALYTICS_EVENTS.translationJobCompleted,
+  "agent_run.completed": PRODUCT_USAGE_ANALYTICS_EVENTS.agentRunCompleted,
+  "ai_tokens.consumed": PRODUCT_USAGE_ANALYTICS_EVENTS.aiTokensConsumed,
+};
+
+const AUTUMN_EVENT_TO_SOURCE: Record<string, string> = {
+  "translation_job.completed": "translation_job",
+  "agent_run.completed": "agent_run",
+  "ai_tokens.consumed": "ai_tokens",
+};
+
 const ALLOWED_PROPERTY_KEYS = new Set([
   "outcome",
   "status",
@@ -39,6 +66,8 @@ const ALLOWED_PROPERTY_KEYS = new Set([
   "source",
   "retryable",
   "delivery",
+  "token_band",
+  "feature",
 ]);
 
 /** Drop PII / high-cardinality values and keep at most two allowed keys. */
@@ -66,4 +95,27 @@ export function scoreBand(score: number | null | undefined): string {
   if (score >= 50) return "needs_improvement";
   if (score >= 25) return "poor";
   return "critical";
+}
+
+export function tokenBand(totalTokens: number | null | undefined): string {
+  if (totalTokens == null || Number.isNaN(totalTokens) || totalTokens <= 0) return "none";
+  if (totalTokens < 1000) return "low";
+  if (totalTokens < 10_000) return "mid";
+  return "high";
+}
+
+export function productUsageEventForAutumnEventName(
+  autumnEventName: string,
+): ProductUsageAnalyticsEvent | null {
+  return AUTUMN_EVENT_TO_PRODUCT_USAGE[autumnEventName] ?? null;
+}
+
+export function productUsageSourceForAutumnEventName(autumnEventName: string): string {
+  return AUTUMN_EVENT_TO_SOURCE[autumnEventName] ?? "other";
+}
+
+export function productUsageSourceForMeterSource(source: string): string {
+  if (source.includes("translation")) return "translation_job";
+  if (source.includes("agent")) return "agent_run";
+  return "other";
 }

--- a/apps/hyperlocalise-web/src/lib/analytics/google-analytics-server.test.ts
+++ b/apps/hyperlocalise-web/src/lib/analytics/google-analytics-server.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { GA_MEASUREMENT_ID } from "./google-analytics";
+import { trackGoogleAnalyticsServerEvent } from "./google-analytics-server";
+
+describe("trackGoogleAnalyticsServerEvent", () => {
+  it("no-ops when the Measurement Protocol secret is missing", async () => {
+    const fetchFn = vi.fn(
+      async () => new Response("{}", { status: 204 }),
+    ) as unknown as typeof fetch;
+
+    await trackGoogleAnalyticsServerEvent("project_created", { status: "created" }, { fetchFn });
+
+    expect(vi.mocked(fetchFn)).not.toHaveBeenCalled();
+  });
+
+  it("posts a GA4 Measurement Protocol event", async () => {
+    const fetchFn = vi.fn(
+      async () => new Response("{}", { status: 204 }),
+    ) as unknown as typeof fetch;
+
+    await trackGoogleAnalyticsServerEvent(
+      "translation_job_completed",
+      { status: "succeeded", source: "translation_job" },
+      {
+        apiSecret: "test-secret",
+        clientId: "client-1",
+        fetchFn,
+      },
+    );
+
+    expect(vi.mocked(fetchFn)).toHaveBeenCalledOnce();
+    const [requestUrl, requestInit] = vi.mocked(fetchFn).mock.calls[0] ?? [];
+    if (typeof requestUrl !== "string") {
+      throw new Error("Expected Measurement Protocol URL string");
+    }
+    expect(requestUrl).toContain(`measurement_id=${GA_MEASUREMENT_ID}`);
+    expect(requestUrl).toContain("api_secret=test-secret");
+    expect(requestInit).toMatchObject({ method: "POST" });
+    const requestBody = requestInit?.body;
+    if (typeof requestBody !== "string") {
+      throw new Error("Expected JSON string request body");
+    }
+    expect(JSON.parse(requestBody)).toEqual({
+      client_id: "client-1",
+      events: [
+        {
+          name: "translation_job_completed",
+          params: { status: "succeeded", source: "translation_job" },
+        },
+      ],
+    });
+  });
+
+  it("swallows network failures", async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+
+    await expect(
+      trackGoogleAnalyticsServerEvent(
+        "seat_added",
+        { status: "created" },
+        {
+          apiSecret: "test-secret",
+          fetchFn,
+        },
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/analytics/google-analytics-server.ts
+++ b/apps/hyperlocalise-web/src/lib/analytics/google-analytics-server.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { randomUUID } from "node:crypto";
+
+import { GA_MEASUREMENT_ID } from "./google-analytics";
+
+const GA_MEASUREMENT_PROTOCOL_URL = "https://www.google-analytics.com/mp/collect";
+
+export type GoogleAnalyticsServerTrackOptions = {
+  measurementId?: string;
+  apiSecret?: string;
+  fetchFn?: typeof fetch;
+  clientId?: string;
+};
+
+function measurementProtocolApiSecret(options?: GoogleAnalyticsServerTrackOptions) {
+  return options?.apiSecret ?? process.env.GA_MEASUREMENT_PROTOCOL_API_SECRET;
+}
+
+/** Fire-and-forget GA4 Measurement Protocol event. No-ops without an API secret. */
+export async function trackGoogleAnalyticsServerEvent(
+  name: string,
+  properties?: Record<string, string | number | boolean>,
+  options?: GoogleAnalyticsServerTrackOptions,
+): Promise<void> {
+  const apiSecret = measurementProtocolApiSecret(options);
+  if (!apiSecret) return;
+
+  const measurementId = options?.measurementId ?? GA_MEASUREMENT_ID;
+  const fetchFn = options?.fetchFn ?? fetch;
+  const url = new URL(GA_MEASUREMENT_PROTOCOL_URL);
+  url.searchParams.set("measurement_id", measurementId);
+  url.searchParams.set("api_secret", apiSecret);
+
+  try {
+    await fetchFn(url.toString(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        client_id: options?.clientId ?? randomUUID(),
+        events: [
+          {
+            name,
+            params: properties ?? {},
+          },
+        ],
+      }),
+    });
+  } catch {
+    // Analytics must not break the product path.
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/analytics/google-analytics.ts
+++ b/apps/hyperlocalise-web/src/lib/analytics/google-analytics.ts
@@ -10,18 +10,6 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-"use client";
 
-import { sendGAEvent } from "@next/third-parties/google";
-import { track } from "@vercel/analytics";
-
-import { Analytics } from "./analytics";
-
-export const clientAnalytics = new Analytics([
-  (name, properties) => {
-    track(name, properties);
-  },
-  (name, properties) => {
-    sendGAEvent("event", name, properties ?? {});
-  },
-]);
+/** GA4 measurement ID used by the layout snippet and Measurement Protocol. */
+export const GA_MEASUREMENT_ID = "G-ET30XL0TE6";

--- a/apps/hyperlocalise-web/src/lib/analytics/server.ts
+++ b/apps/hyperlocalise-web/src/lib/analytics/server.ts
@@ -13,5 +13,9 @@
 import { track } from "@vercel/analytics/server";
 
 import { Analytics } from "./analytics";
+import { trackGoogleAnalyticsServerEvent } from "./google-analytics-server";
 
-export const serverAnalytics = new Analytics((name, properties) => track(name, properties));
+export const serverAnalytics = new Analytics([
+  (name, properties) => track(name, properties),
+  (name, properties) => trackGoogleAnalyticsServerEvent(name, properties),
+]);

--- a/apps/hyperlocalise-web/src/lib/billing/usage-control.test.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/usage-control.test.ts
@@ -18,6 +18,8 @@ import { eq } from "drizzle-orm";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
 import { createAuthTestFixture } from "@/api/test-auth.fixture";
+import { serverAnalytics } from "@/lib/analytics/server";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { db, schema } from "@/lib/database";
 import { isErr } from "@/lib/primitives/result/results";
 import {
@@ -240,6 +242,34 @@ describe("usage-control", () => {
       feature_id: "ai_tokens",
       value: 100,
       idempotency_key: `${operationKey}:ai_tokens`,
+    });
+  });
+
+  it("emits product usage analytics when a billed feature completes", async () => {
+    const { operationKey, organization } = await reservedUsageEvent();
+    const trackSpy = vi.spyOn(serverAnalytics, "track").mockImplementation(() => {});
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(new Response("{}", { status: 200 })) as unknown as typeof fetch;
+
+    await completeAndTrackBillableUsage({
+      organizationId: organization.id,
+      operationKey,
+      autumnEventName: "translation_job.completed",
+      unit: "job",
+      tokenUsage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      aiCreditSource: "translation_job_complete",
+      autumnApiKey: "am_sk_test",
+      fetchFn,
+    });
+
+    expect(trackSpy).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.translationJobCompleted, {
+      status: "succeeded",
+      source: "translation_job",
+    });
+    expect(trackSpy).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.aiTokensConsumed, {
+      source: "translation_job",
+      token_band: "low",
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/billing/usage-control.test.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/usage-control.test.ts
@@ -106,6 +106,37 @@ describe("usage-control", () => {
     expect(rows).toHaveLength(1);
   });
 
+  it("emits product usage analytics when a translation job usage event is first reserved", async () => {
+    const organization = await createOrganization();
+    const operationKey = `usage_${randomUUID()}`;
+    const trackSpy = vi.spyOn(serverAnalytics, "track").mockImplementation(() => {});
+
+    const first = await reserveUsageEvent({
+      organizationId: organization.id,
+      featureId: usageFeatureIds.translationJobs,
+      operationKey,
+      source: "translation_job_create",
+      quantity: 1,
+    });
+    const second = await reserveUsageEvent({
+      organizationId: organization.id,
+      featureId: usageFeatureIds.translationJobs,
+      operationKey,
+      source: "translation_job_create",
+      quantity: 1,
+    });
+
+    if (isErr(first) || isErr(second)) {
+      throw new Error("Expected usage event reservations to succeed");
+    }
+
+    expect(trackSpy).toHaveBeenCalledTimes(1);
+    expect(trackSpy).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.translationJobCreated, {
+      status: "created",
+      source: "translation_job",
+    });
+  });
+
   it("returns an error when marking a missing usage event succeeded", async () => {
     const operationKey = `missing_${randomUUID()}`;
     const result = await markUsageEventSucceededByOperationKey({ operationKey });

--- a/apps/hyperlocalise-web/src/lib/billing/usage-control.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/usage-control.ts
@@ -17,6 +17,14 @@ import type { DatabaseClient } from "@/lib/database";
 import { db, schema } from "@/lib/database";
 import { env } from "@/lib/env";
 import { err, ok, type Result } from "@/lib/primitives/result/results";
+import {
+  PRODUCT_USAGE_ANALYTICS_EVENTS,
+  productUsageEventForAutumnEventName,
+  productUsageSourceForAutumnEventName,
+  productUsageSourceForMeterSource,
+  tokenBand,
+} from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 
 const AUTUMN_API_VERSION = "2.2.0";
 const AUTUMN_TRACK_USAGE_URL = "https://api.useautumn.com/v1/balances.track";
@@ -281,6 +289,11 @@ export async function trackAiCreditUsageInAutumn(input: {
     return markResult;
   }
 
+  serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.aiTokensConsumed, {
+    source: productUsageSourceForMeterSource(input.source),
+    token_band: tokenBand(input.tokenUsage.totalTokens),
+  });
+
   return trackUsageEventInAutumnByOperationKey({
     db: input.db,
     operationKey,
@@ -407,6 +420,14 @@ export async function completeAndTrackBillableUsage(input: {
 
   if (!markUsageResult.ok) {
     return markUsageResult;
+  }
+
+  const productEvent = productUsageEventForAutumnEventName(input.autumnEventName);
+  if (productEvent) {
+    serverAnalytics.track(productEvent, {
+      status: "succeeded",
+      source: productUsageSourceForAutumnEventName(input.autumnEventName),
+    });
   }
 
   const trackUsageResult = await trackUsageEventInAutumnByOperationKey({

--- a/apps/hyperlocalise-web/src/lib/billing/usage-control.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/usage-control.ts
@@ -112,7 +112,15 @@ export async function reserveUsageEvent(input: {
     .onConflictDoNothing({ target: schema.usageEvents.operationKey })
     .returning({ id: schema.usageEvents.id });
 
-  if (event) return ok(event);
+  if (event) {
+    if (input.featureId === usageFeatureIds.translationJobs) {
+      serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.translationJobCreated, {
+        status: "created",
+        source: "translation_job",
+      });
+    }
+    return ok(event);
+  }
 
   const [existing] = await database
     .select({ id: schema.usageEvents.id })

--- a/apps/hyperlocalise-web/src/lib/billing/workspace-resource-limits.test.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/workspace-resource-limits.test.ts
@@ -14,9 +14,11 @@ import "dotenv/config";
 
 import { randomUUID } from "node:crypto";
 
-import { beforeAll, describe, expect, it, afterEach } from "vite-plus/test";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
 import { createAuthTestFixture } from "@/api/test-auth.fixture";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import { db, schema } from "@/lib/database";
 import { isErr } from "@/lib/primitives/result/results";
 import {
@@ -33,6 +35,7 @@ beforeAll(async () => {
 });
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await authFixture.cleanup();
 });
 
@@ -156,6 +159,42 @@ describe("workspace resource limits", () => {
         currentUsage: 1,
         requestedUsage: 2,
       },
+    });
+  });
+
+  it("emits product usage analytics when a workspace resource is created", async () => {
+    const { organization, user } = await createOrganization();
+    const trackSpy = vi.spyOn(serverAnalytics, "track").mockImplementation(() => {});
+
+    const result = await withWorkspaceResourceLimit(
+      {
+        organizationId: organization.id,
+        featureId: workspaceResourceFeatureIds.projects,
+        autumnApiKey: "",
+      },
+      async (tx) => {
+        const [project] = await tx
+          .insert(schema.projects)
+          .values({
+            id: `project_${randomUUID()}`,
+            organizationId: organization.id,
+            createdByUserId: user.id,
+            name: "Analytics project",
+            description: "",
+            translationContext: "",
+            source: "native",
+            sourceLocale: "en",
+            targetLocales: ["fr"],
+          })
+          .returning();
+        return project;
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(trackSpy).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.projectCreated, {
+      status: "created",
+      source: workspaceResourceFeatureIds.projects,
     });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/billing/workspace-resource-limits.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/workspace-resource-limits.ts
@@ -18,6 +18,8 @@ import { getAutumnSecretKey } from "@/lib/billing/autumn-config";
 import type { DatabaseClient, DatabaseTransaction } from "@/lib/database";
 import { db, schema } from "@/lib/database";
 import { err, ok, type Result } from "@/lib/primitives/result/results";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 
 export const workspaceResourceFeatureIds = {
   seats: autumnFeatureIds.seats,
@@ -28,6 +30,13 @@ export const workspaceResourceFeatureIds = {
 
 export type WorkspaceResourceFeatureId =
   (typeof workspaceResourceFeatureIds)[keyof typeof workspaceResourceFeatureIds];
+
+const WORKSPACE_RESOURCE_ANALYTICS_EVENTS = {
+  [workspaceResourceFeatureIds.seats]: PRODUCT_USAGE_ANALYTICS_EVENTS.seatAdded,
+  [workspaceResourceFeatureIds.projects]: PRODUCT_USAGE_ANALYTICS_EVENTS.projectCreated,
+  [workspaceResourceFeatureIds.automations]: PRODUCT_USAGE_ANALYTICS_EVENTS.automationCreated,
+  [workspaceResourceFeatureIds.integrations]: PRODUCT_USAGE_ANALYTICS_EVENTS.integrationConnected,
+} as const;
 
 export type WorkspaceResourceLimitError =
   | {
@@ -313,7 +322,13 @@ export async function withWorkspaceResourceLimit<T>(
     });
     if (!limitResult.ok) return limitResult;
 
-    return ok(await fn(tx));
+    const value = await fn(tx);
+    const eventName = WORKSPACE_RESOURCE_ANALYTICS_EVENTS[input.featureId];
+    serverAnalytics.track(eventName, {
+      status: "created",
+      source: input.featureId,
+    });
+    return ok(value);
   };
 
   if (input.db) return run(input.db);

--- a/apps/hyperlocalise-web/src/lib/env.ts
+++ b/apps/hyperlocalise-web/src/lib/env.ts
@@ -121,6 +121,12 @@ export const env = createEnv({
     /** Autumn secret key for server-side usage checks and tracking. */
     AUTUMN_API_KEY: z.string().min(1).optional(),
 
+    /**
+     * GA4 Measurement Protocol API secret. Optional — without it, server-side
+     * custom events still go to Vercel Analytics but are skipped for Google.
+     */
+    GA_MEASUREMENT_PROTOCOL_API_SECRET: z.string().min(1).optional(),
+
     /** Object storage adapter for durable uploaded and generated files. */
     FILE_STORAGE_PROVIDER: z.enum(["vercel_blob"]).default("vercel_blob"),
 
@@ -289,6 +295,7 @@ export const env = createEnv({
       (isTestEnv ? "test-slack-oauth-state-secret" : undefined),
     SLACK_REDIRECT_URI: process.env.SLACK_REDIRECT_URI,
     AUTUMN_API_KEY: process.env.AUTUMN_API_KEY,
+    GA_MEASUREMENT_PROTOCOL_API_SECRET: process.env.GA_MEASUREMENT_PROTOCOL_API_SECRET,
     FILE_STORAGE_PROVIDER: process.env.FILE_STORAGE_PROVIDER,
     FILE_STORAGE_ACCESS: process.env.FILE_STORAGE_ACCESS,
     BLOB_READ_WRITE_TOKEN:

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-service.ts
@@ -21,6 +21,8 @@ import {
   type IssueSheetUpdateIssueBody,
 } from "@/api/routes/project/issue-sheet.schema";
 import type { IssueSheetImportBody } from "@/api/routes/project/issue-sheet.schema";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import { db, schema, type DatabaseClient } from "@/lib/database";
 import type { IssueSheetColumnConfig } from "@/lib/database/schema/issue-sheet";
 import type { OrganizationMembershipRole } from "@/lib/database/types";
@@ -1159,6 +1161,10 @@ export class IssueSheetService {
     if (!created) {
       throw new Error("issue_sheet_issue_load_failed");
     }
+    serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.issueCreated, {
+      status: "created",
+      source: "issue_sheet",
+    });
     return created;
   }
 

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/agent-runs.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/agent-runs.test.ts
@@ -16,6 +16,8 @@ import { eq } from "drizzle-orm";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { db, schema } from "@/lib/database";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 
 import { createProjectTestFixture } from "../../../api/routes/project/project.fixture";
 import {
@@ -45,6 +47,7 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
   await projectFixture.cleanup();
 });
@@ -213,6 +216,7 @@ describe("agent runs", () => {
 
   it("fails a run and preserves partial output", async () => {
     const { project } = await createTestProject();
+    const trackSpy = vi.spyOn(serverAnalytics, "track").mockImplementation(() => {});
 
     const created = await createAgentRun({
       organizationId: project.organizationId,
@@ -237,6 +241,10 @@ describe("agent runs", () => {
     expect(failed.completedAt).toBeTruthy();
     expect(failed.outputSummary).toEqual({ processed: 2 });
     expect(failed.warnings).toEqual(["provider API error after 2 items"]);
+    expect(trackSpy).toHaveBeenCalledWith(PRODUCT_USAGE_ANALYTICS_EVENTS.agentRunFailed, {
+      status: "failed",
+      source: "comment_only",
+    });
   });
 
   it("fails a queued run and preserves provider context", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/agent-runs.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/agent-runs.ts
@@ -18,6 +18,8 @@ import {
   reserveUsageEvent,
   usageFeatureIds,
 } from "@/lib/billing/usage-control";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import { db, schema } from "@/lib/database";
 import type { AgentRunKind, AgentRunStatus } from "@/lib/database/types";
 import { isErr } from "@/lib/primitives/result/results";
@@ -219,7 +221,7 @@ export async function failAgentRun(input: {
   changedItems?: AgentRunChangedItem[];
   warnings?: string[];
 }) {
-  return finishAgentRun({
+  const run = await finishAgentRun({
     runId: input.runId,
     organizationId: input.organizationId,
     status: "failed",
@@ -228,6 +230,11 @@ export async function failAgentRun(input: {
     warnings: input.warnings,
     sourceStatuses: ["queued", "running"],
   });
+  serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.agentRunFailed, {
+    status: "failed",
+    source: run.kind,
+  });
+  return run;
 }
 
 export async function cancelAgentRun(input: { runId: string; organizationId: string }) {

--- a/apps/hyperlocalise-web/src/lib/translation/jobs.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/jobs.ts
@@ -13,6 +13,8 @@
 import { and, eq, isNull, or } from "drizzle-orm";
 
 import { stringTranslationJobInputSchema } from "@/api/routes/project/job.schema";
+import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
 import { db, schema } from "@/lib/database";
 import type { TranslationJobEventData } from "@/lib/workflow/types";
 import { persistStringJobTranslations } from "@/lib/projects/translations/project-translation-service";
@@ -463,6 +465,11 @@ class TranslationJobCompletionService {
         `translation job ${input.jobId} is not owned by workflow run ${input.workflowRunId}`,
       );
     }
+
+    serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.translationJobFailed, {
+      status: "failed",
+      source: "translation_job",
+    });
 
     const failedJob = await this.repository.getStored(input.jobId, input.projectId);
     if (!failedJob) {

--- a/apps/hyperlocalise-web/src/workflows/steps/translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/translation-job.ts
@@ -199,6 +199,13 @@ export async function markEmailTranslationJobFailed(input: {
       .set({ outcomeKind: "error" })
       .where(eq(schema.translationJobDetails.jobId, input.jobId));
   });
+
+  const { PRODUCT_USAGE_ANALYTICS_EVENTS } = await import("@/lib/analytics/events");
+  const { serverAnalytics } = await import("@/lib/analytics/server");
+  serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.translationJobFailed, {
+    status: "failed",
+    source: "email_translation_job",
+  });
 }
 
 export async function getProjectOrganizationStep(projectId: string): Promise<string> {

--- a/docs/adr/2026-07-25-localisation-audit-agent-design.md
+++ b/docs/adr/2026-07-25-localisation-audit-agent-design.md
@@ -63,7 +63,7 @@ Public Hono routes under `/api/localisation-audit` start/retry runs, expose teas
 
 ## Analytics
 
-- Typed `Analytics` class under `src/lib/analytics` wraps `@vercel/analytics` (client) and `@vercel/analytics/server`.
+- Typed `Analytics` class under `src/lib/analytics` wraps `@vercel/analytics` (client/server) and Google Analytics (`sendGAEvent` on the client, Measurement Protocol on the server).
 - Funnel events: start, reuse, retry, completed, failed, teaser view, report-email request/sent, email verified, CTA click.
 - Properties are limited to two low-cardinality, non-PII keys. Never send email, domain, URL, free text, or raw findings.
 - Authoritative outcomes emit from the server; client emits teaser view and CTA intent only.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Extends product-usage analytics beyond billing outcomes to CAT and the remaining product mutations.

CAT (native and connected TMS):
- `cat_segment_approved` / `cat_segment_draft_saved` on translation save
- `cat_segment_approved` on native status updates to approved
- `cat_comment_created` for comments and TMS issues
- `cat_ai_recommendation_requested` after a successful CAT AI recommendation

Other product usage:
- `translation_job_created` when a new translation-job usage event is reserved (idempotent retries are not counted)
- `issue_created` for new Issue Sheet rows (not existing linked-issue returns)
- `glossary_created` / `glossary_term_created` (single-term adds, not bulk import)
- `memory_created`
- `automation_run_started` for newly inserted queued automation runs

Events still go through the existing Analytics facade (Vercel + GA). Properties stay at most two non-PII keys (`source`, `status`/`feature`).

Intentionally not tracked: concordance, visual context, CAT image regen/upload, glossary/TM bulk import, TM entries, `agent_run_created`, marketing CTAs, audit-funnel gaps.

## How to test

- `vp check --fix` and `vp test` in `apps/hyperlocalise-web`
- Confirm CAT save/approve, comments, recommendations, job create, issue create, glossary/TM create, and automation run tests assert `serverAnalytics.track`

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18cd353c-ec03-481c-9eda-d7889955fb34?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18cd353c-ec03-481c-9eda-d7889955fb34&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

