### PR TITLE
feat(automations): group Add Tool menu like Google submenu

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -280,6 +280,21 @@ export const workspaceAutomationFormMessages = defineMessages({
     id: "WsiwWcs52J",
     description: "Dropdown section label for available automation tools",
   },
+  githubToolsMenu: {
+    defaultMessage: "GitHub",
+    id: "gH8kQm2nXp",
+    description: "Submenu label grouping GitHub automation tools",
+  },
+  jobsToolsMenu: {
+    defaultMessage: "Jobs",
+    id: "j0b5Tm9kLw",
+    description: "Submenu label grouping native TMS job automation tools",
+  },
+  issuesToolsMenu: {
+    defaultMessage: "Issues",
+    id: "iS5uEs7mNu",
+    description: "Submenu label grouping Issues automation tools",
+  },
   memories: {
     defaultMessage: "Use organization memory",
     id: "4QiNYfF++j",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -282,17 +282,17 @@ export const workspaceAutomationFormMessages = defineMessages({
   },
   githubToolsMenu: {
     defaultMessage: "GitHub",
-    id: "gH8kQm2nXp",
+    id: "g4VoT0162y",
     description: "Submenu label grouping GitHub automation tools",
   },
   jobsToolsMenu: {
     defaultMessage: "Jobs",
-    id: "j0b5Tm9kLw",
+    id: "fyM/dYzEbh",
     description: "Submenu label grouping native TMS job automation tools",
   },
   issuesToolsMenu: {
     defaultMessage: "Issues",
-    id: "iS5uEs7mNu",
+    id: "fVOROtw+GW",
     description: "Submenu label grouping Issues automation tools",
   },
   memories: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -1175,7 +1175,10 @@ function AddToolMenu({
                 <DropdownMenuItem
                   disabled={form.githubEnabled || !githubConnected}
                   onClick={() => {
-                    const defaultRepositoryId = resolveDefaultGithubRepositoryId(form, repositories);
+                    const defaultRepositoryId = resolveDefaultGithubRepositoryId(
+                      form,
+                      repositories,
+                    );
 
                     onChange({
                       ...form,
@@ -1204,7 +1207,10 @@ function AddToolMenu({
                 <DropdownMenuItem
                   disabled={form.githubEnabled || !githubConnected}
                   onClick={() => {
-                    const defaultRepositoryId = resolveDefaultGithubRepositoryId(form, repositories);
+                    const defaultRepositoryId = resolveDefaultGithubRepositoryId(
+                      form,
+                      repositories,
+                    );
 
                     onChange({
                       ...form,
@@ -1304,7 +1310,8 @@ function AddToolMenu({
                       ...form,
                       createNativeTmsJobEnabled: true,
                       createNativeTmsJobUseProjectTargetLocales: true,
-                      triggerMode: form.triggerMode === "manual" ? "source_upload" : form.triggerMode,
+                      triggerMode:
+                        form.triggerMode === "manual" ? "source_upload" : form.triggerMode,
                     })
                   }
                 >
@@ -1326,7 +1333,8 @@ function AddToolMenu({
                         ? form.createNativeTmsJobUseProjectTargetLocales
                         : true,
                       assignTranslateWithAgentEnabled: true,
-                      triggerMode: form.triggerMode === "manual" ? "source_upload" : form.triggerMode,
+                      triggerMode:
+                        form.triggerMode === "manual" ? "source_upload" : form.triggerMode,
                     })
                   }
                 >

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -30,6 +30,7 @@ import { ClockIcon, MailIcon, SearchIcon, Trash2Icon } from "lucide-react";
 import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
 import type { SimpleIcon } from "simple-icons";
 import {
+  siGithub,
   siGoogle,
   siGoogleads,
   siGoogleanalytics,
@@ -1163,65 +1164,75 @@ function AddToolMenu({
             <DropdownMenuLabel>
               <FormattedMessage {...workspaceAutomationFormMessages.supportedTools} />
             </DropdownMenuLabel>
-            <DropdownMenuItem
-              disabled={form.githubEnabled || !githubConnected}
-              onClick={() => {
-                const defaultRepositoryId = resolveDefaultGithubRepositoryId(form, repositories);
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>
+                <AutomationToolMenuIcon icon={siGithub} />
+                <span className="min-w-0 flex-1">
+                  <FormattedMessage {...workspaceAutomationFormMessages.githubToolsMenu} />
+                </span>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="min-w-56">
+                <DropdownMenuItem
+                  disabled={form.githubEnabled || !githubConnected}
+                  onClick={() => {
+                    const defaultRepositoryId = resolveDefaultGithubRepositoryId(form, repositories);
 
-                onChange({
-                  ...form,
-                  githubEnabled: true,
-                  githubMode: "agent",
-                  repositoryTargetKind: "github",
-                  githubInstallationRepositoryId: defaultRepositoryId,
-                  pushSourceEnabled: false,
-                  pullTranslationsEnabled: false,
-                  validationEnabled: false,
-                });
-              }}
-            >
-              <HugeiconsIcon icon={GitBranchIcon} strokeWidth={1.8} className="size-4" />
-              <FormattedMessage {...workspaceAutomationFormMessages.useGithubRepo} />
-              {form.githubEnabled && form.githubMode === "agent" ? (
-                <DropdownMenuShortcut>
-                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                </DropdownMenuShortcut>
-              ) : !githubConnected ? (
-                <DropdownMenuShortcut>
-                  <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
-                </DropdownMenuShortcut>
-              ) : null}
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              disabled={form.githubEnabled || !githubConnected}
-              onClick={() => {
-                const defaultRepositoryId = resolveDefaultGithubRepositoryId(form, repositories);
+                    onChange({
+                      ...form,
+                      githubEnabled: true,
+                      githubMode: "agent",
+                      repositoryTargetKind: "github",
+                      githubInstallationRepositoryId: defaultRepositoryId,
+                      pushSourceEnabled: false,
+                      pullTranslationsEnabled: false,
+                      validationEnabled: false,
+                    });
+                  }}
+                >
+                  <HugeiconsIcon icon={GitBranchIcon} strokeWidth={1.8} className="size-4" />
+                  <FormattedMessage {...workspaceAutomationFormMessages.useGithubRepo} />
+                  {form.githubEnabled && form.githubMode === "agent" ? (
+                    <DropdownMenuShortcut>
+                      <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                    </DropdownMenuShortcut>
+                  ) : !githubConnected ? (
+                    <DropdownMenuShortcut>
+                      <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
+                    </DropdownMenuShortcut>
+                  ) : null}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  disabled={form.githubEnabled || !githubConnected}
+                  onClick={() => {
+                    const defaultRepositoryId = resolveDefaultGithubRepositoryId(form, repositories);
 
-                onChange({
-                  ...form,
-                  githubEnabled: true,
-                  githubMode: "sync",
-                  repositoryTargetKind: "github",
-                  githubInstallationRepositoryId: defaultRepositoryId,
-                  validationEnabled:
-                    form.pushSourceEnabled || form.pullTranslationsEnabled
-                      ? form.validationEnabled
-                      : true,
-                });
-              }}
-            >
-              <HugeiconsIcon icon={GitBranchIcon} strokeWidth={1.8} className="size-4" />
-              <FormattedMessage {...workspaceAutomationFormMessages.githubSyncWorkflows} />
-              {form.githubEnabled && form.githubMode === "sync" ? (
-                <DropdownMenuShortcut>
-                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                </DropdownMenuShortcut>
-              ) : !githubConnected ? (
-                <DropdownMenuShortcut>
-                  <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
-                </DropdownMenuShortcut>
-              ) : null}
-            </DropdownMenuItem>
+                    onChange({
+                      ...form,
+                      githubEnabled: true,
+                      githubMode: "sync",
+                      repositoryTargetKind: "github",
+                      githubInstallationRepositoryId: defaultRepositoryId,
+                      validationEnabled:
+                        form.pushSourceEnabled || form.pullTranslationsEnabled
+                          ? form.validationEnabled
+                          : true,
+                    });
+                  }}
+                >
+                  <HugeiconsIcon icon={GitBranchIcon} strokeWidth={1.8} className="size-4" />
+                  <FormattedMessage {...workspaceAutomationFormMessages.githubSyncWorkflows} />
+                  {form.githubEnabled && form.githubMode === "sync" ? (
+                    <DropdownMenuShortcut>
+                      <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                    </DropdownMenuShortcut>
+                  ) : !githubConnected ? (
+                    <DropdownMenuShortcut>
+                      <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
+                    </DropdownMenuShortcut>
+                  ) : null}
+                </DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
             <DropdownMenuItem
               disabled={form.slackEnabled || !slackConnected}
               onClick={() => onChange({ ...form, slackEnabled: true })}
@@ -1278,83 +1289,103 @@ function AddToolMenu({
                 </DropdownMenuShortcut>
               ) : null}
             </DropdownMenuItem>
-            <DropdownMenuItem
-              disabled={form.createNativeTmsJobEnabled}
-              onClick={() =>
-                onChange({
-                  ...form,
-                  createNativeTmsJobEnabled: true,
-                  createNativeTmsJobUseProjectTargetLocales: true,
-                  triggerMode: form.triggerMode === "manual" ? "source_upload" : form.triggerMode,
-                })
-              }
-            >
-              <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} className="size-4" />
-              <FormattedMessage {...workspaceAutomationFormMessages.createJob} />
-              {form.createNativeTmsJobEnabled ? (
-                <DropdownMenuShortcut>
-                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                </DropdownMenuShortcut>
-              ) : null}
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              disabled={form.assignTranslateWithAgentEnabled}
-              onClick={() =>
-                onChange({
-                  ...form,
-                  createNativeTmsJobEnabled: true,
-                  createNativeTmsJobUseProjectTargetLocales: form.createNativeTmsJobEnabled
-                    ? form.createNativeTmsJobUseProjectTargetLocales
-                    : true,
-                  assignTranslateWithAgentEnabled: true,
-                  triggerMode: form.triggerMode === "manual" ? "source_upload" : form.triggerMode,
-                })
-              }
-            >
-              <HugeiconsIcon icon={BrainCircuitIcon} strokeWidth={1.8} className="size-4" />
-              <FormattedMessage {...workspaceAutomationFormMessages.translateWithAgent} />
-              {form.assignTranslateWithAgentEnabled ? (
-                <DropdownMenuShortcut>
-                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                </DropdownMenuShortcut>
-              ) : null}
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              disabled={form.listIssuesEnabled || !issuesAvailable}
-              onClick={() => onChange({ ...form, listIssuesEnabled: true })}
-            >
-              <HugeiconsIcon icon={Task01Icon} strokeWidth={1.8} className="size-4" />
-              <FormattedMessage {...workspaceAutomationFormMessages.listIssues} />
-              {form.listIssuesEnabled ? (
-                <DropdownMenuShortcut>
-                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                </DropdownMenuShortcut>
-              ) : !issuesAvailable ? (
-                <DropdownMenuShortcut>
-                  <FormattedMessage
-                    {...workspaceAutomationFormMessages.enableIssuesFirstShortcut}
-                  />
-                </DropdownMenuShortcut>
-              ) : null}
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              disabled={form.createIssueEnabled || !issuesAvailable}
-              onClick={() => onChange({ ...form, createIssueEnabled: true })}
-            >
-              <HugeiconsIcon icon={Task01Icon} strokeWidth={1.8} className="size-4" />
-              <FormattedMessage {...workspaceAutomationFormMessages.createIssue} />
-              {form.createIssueEnabled ? (
-                <DropdownMenuShortcut>
-                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                </DropdownMenuShortcut>
-              ) : !issuesAvailable ? (
-                <DropdownMenuShortcut>
-                  <FormattedMessage
-                    {...workspaceAutomationFormMessages.enableIssuesFirstShortcut}
-                  />
-                </DropdownMenuShortcut>
-              ) : null}
-            </DropdownMenuItem>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>
+                <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} className="size-4" />
+                <span className="min-w-0 flex-1">
+                  <FormattedMessage {...workspaceAutomationFormMessages.jobsToolsMenu} />
+                </span>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="min-w-56">
+                <DropdownMenuItem
+                  disabled={form.createNativeTmsJobEnabled}
+                  onClick={() =>
+                    onChange({
+                      ...form,
+                      createNativeTmsJobEnabled: true,
+                      createNativeTmsJobUseProjectTargetLocales: true,
+                      triggerMode: form.triggerMode === "manual" ? "source_upload" : form.triggerMode,
+                    })
+                  }
+                >
+                  <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} className="size-4" />
+                  <FormattedMessage {...workspaceAutomationFormMessages.createJob} />
+                  {form.createNativeTmsJobEnabled ? (
+                    <DropdownMenuShortcut>
+                      <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                    </DropdownMenuShortcut>
+                  ) : null}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  disabled={form.assignTranslateWithAgentEnabled}
+                  onClick={() =>
+                    onChange({
+                      ...form,
+                      createNativeTmsJobEnabled: true,
+                      createNativeTmsJobUseProjectTargetLocales: form.createNativeTmsJobEnabled
+                        ? form.createNativeTmsJobUseProjectTargetLocales
+                        : true,
+                      assignTranslateWithAgentEnabled: true,
+                      triggerMode: form.triggerMode === "manual" ? "source_upload" : form.triggerMode,
+                    })
+                  }
+                >
+                  <HugeiconsIcon icon={BrainCircuitIcon} strokeWidth={1.8} className="size-4" />
+                  <FormattedMessage {...workspaceAutomationFormMessages.translateWithAgent} />
+                  {form.assignTranslateWithAgentEnabled ? (
+                    <DropdownMenuShortcut>
+                      <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                    </DropdownMenuShortcut>
+                  ) : null}
+                </DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>
+                <HugeiconsIcon icon={Task01Icon} strokeWidth={1.8} className="size-4" />
+                <span className="min-w-0 flex-1">
+                  <FormattedMessage {...workspaceAutomationFormMessages.issuesToolsMenu} />
+                </span>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="min-w-56">
+                <DropdownMenuItem
+                  disabled={form.listIssuesEnabled || !issuesAvailable}
+                  onClick={() => onChange({ ...form, listIssuesEnabled: true })}
+                >
+                  <HugeiconsIcon icon={Task01Icon} strokeWidth={1.8} className="size-4" />
+                  <FormattedMessage {...workspaceAutomationFormMessages.listIssues} />
+                  {form.listIssuesEnabled ? (
+                    <DropdownMenuShortcut>
+                      <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                    </DropdownMenuShortcut>
+                  ) : !issuesAvailable ? (
+                    <DropdownMenuShortcut>
+                      <FormattedMessage
+                        {...workspaceAutomationFormMessages.enableIssuesFirstShortcut}
+                      />
+                    </DropdownMenuShortcut>
+                  ) : null}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  disabled={form.createIssueEnabled || !issuesAvailable}
+                  onClick={() => onChange({ ...form, createIssueEnabled: true })}
+                >
+                  <HugeiconsIcon icon={Task01Icon} strokeWidth={1.8} className="size-4" />
+                  <FormattedMessage {...workspaceAutomationFormMessages.createIssue} />
+                  {form.createIssueEnabled ? (
+                    <DropdownMenuShortcut>
+                      <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                    </DropdownMenuShortcut>
+                  ) : !issuesAvailable ? (
+                    <DropdownMenuShortcut>
+                      <FormattedMessage
+                        {...workspaceAutomationFormMessages.enableIssuesFirstShortcut}
+                      />
+                    </DropdownMenuShortcut>
+                  ) : null}
+                </DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
             <DropdownMenuItem
               disabled={form.mcpEnabled || !mcpConnected}
               onClick={() => onChange({ ...form, mcpEnabled: true })}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The Add Tool menu under Supported tools was a flat list of ~12 items. Related tools now nest under `DropdownMenuSub` groups, matching the existing Coming soon → Google pattern.

| Submenu | Tools |
|---------|--------|
| **GitHub** | Use GitHub repo, GitHub sync workflows |
| **Jobs** | Create job, Translate with agent |
| **Issues** | List issues, Create issue |

Single-tool integrations (Slack, Email, Contentful, MCP, Semrush, Ahrefs) stay top-level.

## How to test

- Open automation editor → Add Tool
- Confirm Supported tools shows GitHub / Jobs / Issues as expandable submenus
- Add a tool from each submenu and confirm it still configures correctly
- Confirm Coming soon → Google submenu is unchanged
- `vp check --fix` and `vp test` in `apps/hyperlocalise-web` (both passed)

### Walkthrough

[add_tool_menu_grouped_submenus.mp4](https://cursor.com/agents/bc-019fff9d-ed68-7bf3-b624-0703a126147d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadd_tool_menu_grouped_submenus.mp4)

[Add Tool menu with GitHub, Jobs, Issues groups](https://cursor.com/agents/bc-019fff9d-ed68-7bf3-b624-0703a126147d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadd_tool_menu_grouped_overview.webp)
[GitHub submenu expanded](https://cursor.com/agents/bc-019fff9d-ed68-7bf3-b624-0703a126147d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadd_tool_menu_github_submenu.webp)

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fff9d-ed68-7bf3-b624-0703a126147d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fff9d-ed68-7bf3-b624-0703a126147d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

