### PR TITLE
fix(localisation-audit): improve findings, CJK depth, and Arabic/RTL checks

### DIFF
--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit.fixture.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit.fixture.ts
@@ -298,7 +298,9 @@ const linguisticNotes: LocalisationAuditReport["linguisticNotes"] = [
 
 function createReport(scoreBand: LocalisationAuditFixtureScoreBand): LocalisationAuditReport {
   const credits = createLocalisationAuditCredits(scoreBand);
-  const { score, dimensionScores } = aggregateLocalisationAuditCredits(credits);
+  const { score, dimensionScores } = aggregateLocalisationAuditCredits(credits, {
+    localeCount: detectedLocales.length,
+  });
   const findings = createLocalisationAuditFindings();
   return {
     score,

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.test.ts
@@ -131,7 +131,13 @@ describe("crawlLocalisationAuditSample", () => {
       }),
     ).resolves.toEqual({
       pages: [],
-      sitemap: { robotsFound: false, sitemapUrls: [], localizedUrls: [] },
+      sitemap: {
+        robotsFound: false,
+        robotsSitemapDirectives: [],
+        robotsHasRelativeSitemapDirective: false,
+        sitemapUrls: [],
+        localizedUrls: [],
+      },
     });
   });
 
@@ -284,9 +290,52 @@ describe("crawlLocalisationAuditSample", () => {
     });
 
     expect(result.sitemap.robotsFound).toBe(true);
+    expect(result.sitemap.robotsSitemapDirectives).toContain("https://example.com/sitemap.xml");
+    expect(result.sitemap.robotsHasRelativeSitemapDirective).toBe(false);
     expect(result.sitemap.sitemapUrls).toContain("https://example.com/sitemap.xml");
     expect(result.sitemap.localizedUrls).toContain("https://example.com/fr/pricing");
     expect(result.pages.some((page) => page.url === "https://example.com/sitemap.xml")).toBe(false);
+  });
+
+  it("records relative Sitemap directives from robots.txt", async () => {
+    withPublicHttpFetchMock.mockImplementation(async (url, _init, handler) => {
+      if (url === "https://example.com/robots.txt") {
+        return handler(
+          new Response("Sitemap: /sitemap.xml\n", {
+            status: 200,
+            headers: { "content-type": "text/plain" },
+          }),
+        );
+      }
+      if (url === "https://example.com/sitemap.xml") {
+        return handler(
+          new Response(
+            `<?xml version="1.0"?><urlset><loc>https://example.com/about</loc></urlset>`,
+            { status: 200, headers: { "content-type": "application/xml" } },
+          ),
+        );
+      }
+      if (url === "https://example.com/") {
+        return handler(
+          htmlResponse(
+            "<html lang='en'><title>Home</title><body>Welcome to the homepage content sample.</body></html>",
+          ),
+        );
+      }
+      return handler(
+        htmlResponse(
+          "<html><body>Secondary page with enough text content for parsing.</body></html>",
+        ),
+      );
+    });
+
+    const result = await crawlLocalisationAuditSample({
+      origin: "https://example.com",
+      sourceUrl: "https://example.com/",
+    });
+
+    expect(result.sitemap.robotsHasRelativeSitemapDirective).toBe(true);
+    expect(result.sitemap.robotsSitemapDirectives).toContain("https://example.com/sitemap.xml");
   });
 
   it("does not keep a sitemap URL when robots.txt exists but sitemap.xml cannot be fetched", async () => {
@@ -324,6 +373,7 @@ describe("crawlLocalisationAuditSample", () => {
     });
 
     expect(result.sitemap.robotsFound).toBe(true);
+    expect(result.sitemap.robotsSitemapDirectives).toEqual([]);
     expect(result.sitemap.sitemapUrls).toEqual([]);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.ts
@@ -176,10 +176,16 @@ async function fetchSitemapSignals(origin: string): Promise<LocalisationAuditSit
   const robots = await fetchText(robotsUrl);
   const robotsFound = robots != null;
   const sitemapUrls = new Set<string>();
+  const robotsSitemapDirectives: string[] = [];
+  let robotsHasRelativeSitemapDirective = false;
   if (robots) {
     for (const raw of parseRobotsSitemaps(robots)) {
+      if (!/^https?:\/\//i.test(raw.trim())) {
+        robotsHasRelativeSitemapDirective = true;
+      }
       const absolute = toAbsoluteUrl(origin, raw);
       if (absolute) {
+        robotsSitemapDirectives.push(absolute);
         sitemapUrls.add(absolute);
       }
     }
@@ -224,6 +230,8 @@ async function fetchSitemapSignals(origin: string): Promise<LocalisationAuditSit
 
   return {
     robotsFound,
+    robotsSitemapDirectives,
+    robotsHasRelativeSitemapDirective,
     sitemapUrls: [...sitemapUrls],
     localizedUrls,
   };

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/catalog.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/catalog.ts
@@ -213,7 +213,16 @@ export const LOCALISATION_AUDIT_CREDITS: LocalisationAuditCreditDefinition[] = [
     dimension: "visual",
     title: "Font and script support",
     mode: "heuristic",
-    rubric: "Typography should support the target script without generic fallback-only stacks.",
+    rubric:
+      "Typography should support the target script without generic fallback-only stacks, tofu glyphs, or missing CJK fonts.",
+  },
+  {
+    id: "cjk-typography",
+    dimension: "visual",
+    title: "CJK typography",
+    mode: "heuristic",
+    rubric:
+      "Korean pages should avoid word-break: break-all and prefer word-break: keep-all; CJK forms should use local name-field conventions.",
   },
   {
     id: "localized-images",

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/catalog.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/catalog.ts
@@ -76,7 +76,8 @@ export const LOCALISATION_AUDIT_CREDITS: LocalisationAuditCreditDefinition[] = [
     dimension: "technical",
     title: "International formatting",
     mode: "hybrid",
-    rubric: "Dates, numbers, and currency should match locale conventions.",
+    rubric:
+      "Dates, numbers, currency, Arabic Western digits, and Gregorian calendars should match locale conventions.",
   },
   {
     id: "accessibility-localisation",
@@ -206,7 +207,8 @@ export const LOCALISATION_AUDIT_CREDITS: LocalisationAuditCreditDefinition[] = [
     dimension: "visual",
     title: "RTL support",
     mode: "hybrid",
-    rubric: "RTL locales should set dir and mirror layout, navigation, and forms.",
+    rubric:
+      "RTL locales should set dir=rtl, avoid direction:ltr overrides, and prefer logical CSS over physical left/right properties.",
   },
   {
     id: "font-and-script",

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/catalog.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/catalog.ts
@@ -61,7 +61,8 @@ export const LOCALISATION_AUDIT_CREDITS: LocalisationAuditCreditDefinition[] = [
     dimension: "technical",
     title: "Sitemap",
     mode: "heuristic",
-    rubric: "Localized URLs should appear in the sitemap when a sitemap is published.",
+    rubric:
+      "Like Lighthouse: a valid XML sitemap must be discoverable, robots.txt should reference it with an absolute Sitemap: URL, and localized URLs should appear for published locales.",
   },
   {
     id: "structured-data",

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/catalog.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/catalog.ts
@@ -103,8 +103,9 @@ export const LOCALISATION_AUDIT_CREDITS: LocalisationAuditCreditDefinition[] = [
     id: "cross-page-consistency",
     dimension: "linguistic",
     title: "Cross-page consistency",
-    mode: "hybrid",
-    rubric: "Related navigation and messaging should stay consistent across the locale.",
+    mode: "na",
+    rubric:
+      "Related navigation and messaging should stay consistent across the locale. Skipped in the public audit because label variance is usually noise.",
   },
   {
     id: "translation-accuracy",

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics.test.ts
@@ -476,4 +476,58 @@ describe("visual heuristic credits", () => {
     );
     expect(outcome.status).toBe("na");
   });
+
+  it("flags Korean break-all, Western name fields, and tofu glyphs", () => {
+    const wordBreak = visualHeuristicScorers["cjk-typography"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://example.com/ko",
+          htmlLang: "ko",
+          textSample: "한국어 본문 예시입니다. 더 많은 한글 텍스트가 필요합니다.",
+          wordBreakValues: ["break-all"],
+          formFieldLabels: ["First name", "last_name"],
+          fontFamilies: ["Arial"],
+        }),
+      ]),
+    );
+    expect(wordBreak.status).toBe("scored");
+    if (wordBreak.status !== "scored") return;
+    expect(wordBreak.findings.map((finding) => finding.id)).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/^cjk-wordbreak-breakall-/),
+        expect.stringMatching(/^cjk-naming-/),
+      ]),
+    );
+
+    const fonts = visualHeuristicScorers["font-and-script"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://example.com/ko",
+          htmlLang: "ko",
+          textSample: "한글과 tofu □ 가 함께 있습니다.",
+          fontFamilies: ["Arial", "sans-serif"],
+        }),
+      ]),
+    );
+    expect(fonts.status).toBe("scored");
+    if (fonts.status !== "scored") return;
+    expect(fonts.findings.some((finding) => finding.id.startsWith("font-tofu-"))).toBe(true);
+    expect(fonts.findings.some((finding) => finding.title.includes("CJK-capable"))).toBe(true);
+  });
+
+  it("passes Korean pages with keep-all and a CJK font", () => {
+    const outcome = visualHeuristicScorers["cjk-typography"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://example.com/ko",
+          htmlLang: "ko",
+          textSample: "한국어 본문 예시입니다. 더 많은 한글 텍스트가 필요합니다.",
+          wordBreakValues: ["keep-all"],
+          formFieldLabels: ["성", "이름"],
+          fontFamilies: ["Noto Sans KR"],
+        }),
+      ]),
+    );
+    expect(outcome).toEqual({ status: "scored", score: 92, findings: [] });
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics.test.ts
@@ -404,6 +404,44 @@ describe("technical heuristic credits", () => {
     );
     expect(outcome.status).toBe("na");
   });
+
+  it("flags Eastern Arabic-Indic numerals and Hijri-only dates on Arabic pages", () => {
+    const outcome = technicalHeuristicScorers["international-formatting"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://example.com/ar/pricing",
+          htmlLang: "ar",
+          textSample: "السعر ١٢٣ ر.س. تاريخ الإطلاق: ١٥ رمضان ١٤٤٦",
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("scored");
+    if (outcome.status !== "scored") return;
+    expect(outcome.findings.map((finding) => finding.id)).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/^formatting-arabic-numerals-/),
+        expect.stringMatching(/^formatting-hijri-calendar-/),
+      ]),
+    );
+  });
+
+  it("accepts Western digits and Gregorian Arabic month names", () => {
+    const outcome = technicalHeuristicScorers["international-formatting"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://example.com/ar/blog",
+          htmlLang: "ar",
+          textSample: "نشر في 14 أغسطس 2026 بسعر 99 ر.س.",
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("scored");
+    if (outcome.status !== "scored") return;
+    expect(outcome.score).toBeGreaterThanOrEqual(90);
+    expect(outcome.findings).toHaveLength(0);
+  });
 });
 
 describe("linguistic heuristic credits", () => {
@@ -466,8 +504,32 @@ describe("visual heuristic credits", () => {
 
     expect(outcome.status).toBe("scored");
     if (outcome.status !== "scored") return;
-    expect(outcome.score).toBe(28);
+    expect(outcome.score).toBeLessThan(60);
     expect(outcome.findings[0]?.severity).toBe("critical");
+    expect(outcome.findings[0]?.id).toBe("rtl-missing-dir");
+  });
+
+  it("flags RTL CSS direction:ltr and physical left/right properties", () => {
+    const outcome = visualHeuristicScorers["rtl-support"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://example.com/ar",
+          htmlLang: "ar",
+          dir: "rtl",
+          directionValues: ["ltr"],
+          physicalHorizontalCss: ["float: left", "margin-left: 16px"],
+          logicalHorizontalCss: [],
+        }),
+      ]),
+    );
+    expect(outcome.status).toBe("scored");
+    if (outcome.status !== "scored") return;
+    expect(outcome.findings.map((finding) => finding.id)).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/^rtl-css-direction-ltr-/),
+        expect.stringMatching(/^rtl-css-physical-/),
+      ]),
+    );
   });
 
   it("marks RTL support N/A when no RTL locale is present", () => {

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics.test.ts
@@ -172,6 +172,56 @@ describe("technical heuristic credits", () => {
     expect(outcome.score).toBeLessThan(80);
   });
 
+  it("does not flag same-region canonical URLs as cross-locale", () => {
+    const outcome = technicalHeuristicScorers["canonical-urls"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://example.com/au/pricing",
+          htmlLang: "en-AU",
+          canonical: "https://example.com/au/pricing",
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("scored");
+    if (outcome.status !== "scored") return;
+    expect(outcome.findings.some((finding) => finding.id.startsWith("canonical-locale-"))).toBe(
+      false,
+    );
+    expect(outcome.score).toBe(100);
+  });
+
+  it("does not treat same-region nav links as language switchers", () => {
+    const outcome = technicalHeuristicScorers["language-switcher"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://example.com/au/pricing",
+          htmlLang: "en-AU",
+          anchors: [
+            { href: "/au/", text: "Home" },
+            { href: "/au/about", text: "About" },
+            { href: "/fr/pricing", text: "Français" },
+          ],
+        }),
+        emptyCrawledPage({
+          url: "https://example.com/fr/pricing",
+          htmlLang: "fr",
+          anchors: [
+            { href: "/fr/", text: "Accueil" },
+            { href: "/au/pricing", text: "English" },
+          ],
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("scored");
+    if (outcome.status !== "scored") return;
+    expect(outcome.score).toBeGreaterThanOrEqual(75);
+    expect(outcome.findings.some((finding) => finding.id === "language-switcher-homepage")).toBe(
+      false,
+    );
+  });
+
   it("fails like Lighthouse when no valid sitemap is discoverable", () => {
     const outcome = technicalHeuristicScorers.sitemap!(
       context([emptyCrawledPage({ url: "https://example.com/", htmlLang: "en" })]),
@@ -324,6 +374,17 @@ describe("technical heuristic credits", () => {
     );
     expect(locales.map((entry) => entry.locale)).toEqual(["en-au"]);
     expect(locales[0]?.source).toBe("url_prefix");
+  });
+
+  it("keeps bare language and region markets as distinct locales", () => {
+    const locales = detectLocales(
+      [
+        emptyCrawledPage({ url: "https://example.com/en/pricing", htmlLang: "en" }),
+        emptyCrawledPage({ url: "https://example.com/au/pricing", htmlLang: "en" }),
+      ],
+      [],
+    );
+    expect(locales.map((entry) => entry.locale).toSorted()).toEqual(["en", "en-au"]);
   });
 
   it("marks cross-page consistency N/A so noisy nav labels are skipped", () => {

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics.test.ts
@@ -47,6 +47,60 @@ describe("technical heuristic credits", () => {
     if (outcome.status !== "scored") return;
     expect(outcome.score).toBeLessThan(100);
     expect(outcome.findings.some((finding) => finding.id.includes("mismatch"))).toBe(true);
+    expect(outcome.findings.find((finding) => finding.id.includes("mismatch"))?.advice).toContain(
+      'html lang="fr"',
+    );
+  });
+
+  it("maps region path prefixes to BCP 47 html lang suggestions", () => {
+    const outcome = technicalHeuristicScorers["locale-detection"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://example.com/au/services",
+          htmlLang: "fr",
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("scored");
+    if (outcome.status !== "scored") return;
+    const mismatch = outcome.findings.find((finding) => finding.id.includes("mismatch"));
+    expect(mismatch?.advice).toBe('Set html lang="en-AU" so it matches this page’s URL locale.');
+    expect(mismatch?.advice).not.toContain('html lang="au"');
+  });
+
+  it("does not flag en html lang on an /au/ path as a mismatch", () => {
+    const outcome = technicalHeuristicScorers["locale-detection"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://example.com/au/services",
+          htmlLang: "en",
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("scored");
+    if (outcome.status !== "scored") return;
+    expect(outcome.findings.some((finding) => finding.id.includes("mismatch"))).toBe(false);
+    expect(outcome.score).toBe(100);
+  });
+
+  it("emits one missing-language finding for many pages", () => {
+    const outcome = technicalHeuristicScorers["locale-detection"]!(
+      context([
+        emptyCrawledPage({ url: "https://example.com/", htmlLang: null }),
+        emptyCrawledPage({ url: "https://example.com/about", htmlLang: null }),
+        emptyCrawledPage({ url: "https://example.com/pricing", htmlLang: null }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("scored");
+    if (outcome.status !== "scored") return;
+    const missing = outcome.findings.filter(
+      (finding) => finding.title === "Missing language declaration",
+    );
+    expect(missing).toHaveLength(1);
+    expect(missing[0]?.summary).toContain("3 sampled pages");
   });
 
   it("scores missing hreflang as high severity when multiple locales exist", () => {
@@ -174,9 +228,45 @@ describe("technical heuristic credits", () => {
       ],
       ["pt_BR"],
     );
-    expect(locales.map((entry) => entry.locale).toSorted()).toEqual(["fr", "fr-fr", "pt-br"]);
-    expect(locales.find((entry) => entry.locale === "fr")?.source).toBe("url_subdomain");
+    expect(locales.map((entry) => entry.locale).toSorted()).toEqual(["fr-fr", "pt-br"]);
+    expect(locales.find((entry) => entry.locale === "fr-fr")?.source).toBe("html_lang");
     expect(locales.some((entry) => entry.locale === "x-default")).toBe(false);
+  });
+
+  it("keeps subdomain language when html lang is absent", () => {
+    const locales = detectLocales(
+      [emptyCrawledPage({ url: "https://fr.example.com/", htmlLang: null })],
+      [],
+    );
+    expect(locales.map((entry) => entry.locale)).toEqual(["fr"]);
+    expect(locales[0]?.source).toBe("url_subdomain");
+  });
+
+  it("maps region URL prefixes to language-region locale signals", () => {
+    const locales = detectLocales(
+      [emptyCrawledPage({ url: "https://example.com/au/pricing", htmlLang: "en" })],
+      [],
+    );
+    expect(locales.map((entry) => entry.locale)).toEqual(["en-au"]);
+    expect(locales[0]?.source).toBe("url_prefix");
+  });
+
+  it("marks cross-page consistency N/A so noisy nav labels are skipped", () => {
+    const outcome = linguisticHeuristicScorers["cross-page-consistency"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://example.com/en/a",
+          htmlLang: "en",
+          anchors: [{ href: "/intl-en/digital-gov", text: "Digital gov" }],
+        }),
+        emptyCrawledPage({
+          url: "https://example.com/en/b",
+          htmlLang: "en",
+          anchors: [{ href: "/intl-en/digital-gov", text: "Digital GOV" }],
+        }),
+      ]),
+    );
+    expect(outcome.status).toBe("na");
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics.test.ts
@@ -172,33 +172,25 @@ describe("technical heuristic credits", () => {
     expect(outcome.score).toBeLessThan(80);
   });
 
-  it("marks sitemap N/A when none was found", () => {
+  it("fails like Lighthouse when no valid sitemap is discoverable", () => {
     const outcome = technicalHeuristicScorers.sitemap!(
       context([emptyCrawledPage({ url: "https://example.com/", htmlLang: "en" })]),
     );
-    expect(outcome.status).toBe("na");
-  });
-
-  it("marks sitemap N/A when none was fetched, even if robots.txt exists", () => {
-    const outcome = technicalHeuristicScorers.sitemap!(
-      context(
-        [
-          emptyCrawledPage({ url: "https://example.com/", htmlLang: "en" }),
-          emptyCrawledPage({ url: "https://example.com/fr/", htmlLang: "fr" }),
+    expect(outcome).toEqual(
+      expect.objectContaining({
+        status: "scored",
+        score: 18,
+        findings: [
+          expect.objectContaining({
+            id: "sitemap-missing",
+            severity: "high",
+          }),
         ],
-        {
-          sitemap: {
-            robotsFound: true,
-            sitemapUrls: [],
-            localizedUrls: [],
-          },
-        },
-      ),
+      }),
     );
-    expect(outcome.status).toBe("na");
   });
 
-  it("scores a sitemap that lists locale URLs", () => {
+  it("flags a reachable sitemap that robots.txt does not reference", () => {
     const outcome = technicalHeuristicScorers.sitemap!(
       context(
         [
@@ -208,13 +200,96 @@ describe("technical heuristic credits", () => {
         {
           sitemap: {
             robotsFound: true,
+            robotsSitemapDirectives: [],
+            robotsHasRelativeSitemapDirective: false,
             sitemapUrls: ["https://example.com/sitemap.xml"],
             localizedUrls: ["https://example.com/fr/pricing"],
           },
         },
       ),
     );
-    expect(outcome).toEqual({ status: "scored", score: 92, findings: [] });
+    expect(outcome.status).toBe("scored");
+    if (outcome.status !== "scored") return;
+    expect(outcome.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "sitemap-robots-unreferenced",
+          severity: "high",
+        }),
+      ]),
+    );
+    expect(outcome.score).toBeLessThan(80);
+  });
+
+  it("flags missing localized URLs when robots.txt references the sitemap", () => {
+    const outcome = technicalHeuristicScorers.sitemap!(
+      context(
+        [
+          emptyCrawledPage({ url: "https://example.com/", htmlLang: "en" }),
+          emptyCrawledPage({ url: "https://example.com/fr/", htmlLang: "fr" }),
+        ],
+        {
+          sitemap: {
+            robotsFound: true,
+            robotsSitemapDirectives: ["https://example.com/sitemap.xml"],
+            robotsHasRelativeSitemapDirective: false,
+            sitemapUrls: ["https://example.com/sitemap.xml"],
+            localizedUrls: [],
+          },
+        },
+      ),
+    );
+    expect(outcome.status).toBe("scored");
+    if (outcome.status !== "scored") return;
+    expect(outcome.findings.some((finding) => finding.id === "sitemap-missing-locales")).toBe(true);
+    expect(outcome.score).toBeLessThan(70);
+  });
+
+  it("scores a sitemap that lists locale URLs and is referenced from robots.txt", () => {
+    const outcome = technicalHeuristicScorers.sitemap!(
+      context(
+        [
+          emptyCrawledPage({ url: "https://example.com/", htmlLang: "en" }),
+          emptyCrawledPage({ url: "https://example.com/fr/", htmlLang: "fr" }),
+        ],
+        {
+          sitemap: {
+            robotsFound: true,
+            robotsSitemapDirectives: ["https://example.com/sitemap.xml"],
+            robotsHasRelativeSitemapDirective: false,
+            sitemapUrls: ["https://example.com/sitemap.xml"],
+            localizedUrls: ["https://example.com/fr/pricing"],
+          },
+        },
+      ),
+    );
+    expect(outcome).toEqual({ status: "scored", score: 100, findings: [] });
+  });
+
+  it("flags relative Sitemap directives and incomplete locale coverage", () => {
+    const outcome = technicalHeuristicScorers.sitemap!(
+      context(
+        [
+          emptyCrawledPage({ url: "https://example.com/en/", htmlLang: "en" }),
+          emptyCrawledPage({ url: "https://example.com/fr/", htmlLang: "fr" }),
+        ],
+        {
+          sitemap: {
+            robotsFound: true,
+            robotsSitemapDirectives: ["https://example.com/sitemap.xml"],
+            robotsHasRelativeSitemapDirective: true,
+            sitemapUrls: ["https://example.com/sitemap.xml"],
+            localizedUrls: ["https://example.com/fr/pricing"],
+          },
+        },
+      ),
+    );
+    expect(outcome.status).toBe("scored");
+    if (outcome.status !== "scored") return;
+    expect(outcome.findings.map((finding) => finding.id).toSorted()).toEqual([
+      "sitemap-incomplete-locales",
+      "sitemap-robots-relative",
+    ]);
   });
 
   it("detects subdomain locale signals and normalizes underscore locale tags", () => {

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/linguistic.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/linguistic.ts
@@ -206,46 +206,11 @@ const scoreTerminologyConsistency: HeuristicScorer = (context) => {
   return scored(Math.max(40, 88 - findings.length * 12), findings);
 };
 
-const scoreCrossPageConsistency: HeuristicScorer = (context) => {
-  const findings: LocalisationAuditFinding[] = [];
-  for (const [language, pages] of groupPagesByLanguage(context.pages)) {
-    if (pages.length < 2) continue;
-    const byHref = new Map<string, Set<string>>();
-    for (const page of pages) {
-      for (const anchor of page.anchors) {
-        const key = anchor.href.replace(LOCALE_IN_PATH, "/");
-        if (!anchor.text || anchor.text.length < 2) continue;
-        const labels = byHref.get(key) ?? new Set();
-        labels.add(anchor.text.trim());
-        byHref.set(key, labels);
-      }
-    }
-    for (const [href, labels] of byHref) {
-      if (labels.size > 1) {
-        findings.push(
-          creditFinding({
-            id: `cross-page-${findings.length}`,
-            creditId: "cross-page-consistency",
-            category: "linguistic",
-            severity: "medium",
-            title: "Inconsistent navigation labels",
-            summary: `The same ${language} destination is labelled in ${labels.size} different ways.`,
-            where: formatFindingWhere({ section: "Header", tag: "<nav> or <a>" }),
-            url: pages[0]?.url,
-            evidence: `${href}: ${[...labels].slice(0, 3).join(" / ")}`,
-            advice: "Use one translated label for the same destination across pages.",
-          }),
-        );
-      }
-    }
-  }
-  if (findings.length === 0) {
-    return { status: "inconclusive", evidence: { reason: "no_repeated_nav" } };
-  }
-  return scored(Math.max(45, 90 - findings.length * 10), findings);
+const scoreCrossPageConsistency: HeuristicScorer = () => {
+  // Nav-label variance across pages is usually noise for lead-gen audits
+  // (e.g. "Digital gov" vs "Digital GOV") and is not scored here.
+  return { status: "na" };
 };
-
-const LOCALE_IN_PATH = /\/[a-z]{2}(?:-[a-z]{2})?(?=\/|$)/i;
 
 const lunaOnly: HeuristicScorer = () => ({ status: "inconclusive" });
 

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/technical.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/technical.ts
@@ -863,7 +863,8 @@ const scoreInternationalFormatting: HeuristicScorer = (context) => {
               text.match(/[\u0660-\u0669\u06F0-\u06F9][\u0660-\u0669\u06F0-\u06F9\s.,/-]*/)?.[0] ??
                 "Eastern Arabic-Indic digits",
             ),
-            advice: "Use Western digits (0-9) on Arabic pages unless the market explicitly requires Eastern numerals.",
+            advice:
+              "Use Western digits (0-9) on Arabic pages unless the market explicitly requires Eastern numerals.",
             confidence: 90,
           }),
         );
@@ -886,7 +887,8 @@ const scoreInternationalFormatting: HeuristicScorer = (context) => {
             where: formatFindingWhere({ section: "Page body", tag: "sampled copy" }),
             url: page.url,
             evidence: clipFindingEvidence(text.slice(0, 220)),
-            advice: "Show Gregorian calendar dates on Arabic product pages (optionally offer Hijri as a secondary format).",
+            advice:
+              "Show Gregorian calendar dates on Arabic product pages (optionally offer Hijri as a secondary format).",
             confidence: 82,
           }),
         );

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/technical.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/technical.ts
@@ -12,6 +12,7 @@
  */
 import type { LocalisationAuditCrawledPage, LocalisationAuditFinding } from "../../types";
 import {
+  canonicalPathLocale,
   clampScore,
   clipFindingEvidence,
   creditFinding,
@@ -232,7 +233,8 @@ const scoreLanguageSwitcher: HeuristicScorer = (context) => {
       } catch {
         continue;
       }
-      const targetLocale = pathLocaleFromUrl(href.toString());
+      const targetPathLocale = pathLocaleFromUrl(href.toString());
+      const targetLocale = targetPathLocale ? canonicalPathLocale(targetPathLocale) : null;
       const looksLikeSwitcher =
         Boolean(targetLocale) ||
         LANGUAGE_NAME.test(anchor.text.trim()) ||
@@ -479,7 +481,8 @@ const scoreCanonicalUrls: HeuristicScorer = (context) => {
       );
       continue;
     }
-    const canonicalLocale = pathLocaleFromUrl(canonicalUrl.toString());
+    const canonicalPathToken = pathLocaleFromUrl(canonicalUrl.toString());
+    const canonicalLocale = canonicalPathToken ? canonicalPathLocale(canonicalPathToken) : null;
     if (pageLoc && canonicalLocale && languageOf(pageLoc) !== languageOf(canonicalLocale)) {
       score -= 30;
       findings.push(

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/technical.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/technical.ts
@@ -16,9 +16,10 @@ import {
   clipFindingEvidence,
   creditFinding,
   formatFindingWhere,
+  htmlLangMatchesPathLocale,
+  htmlLangSuggestionForPathLocale,
   languageOf,
   looksPrimarilyEnglish,
-  normalizeLocale,
   pageLocale,
   pathLocaleFromUrl,
   pathWithoutLocale,
@@ -54,27 +55,10 @@ const scoreLocaleDetection: HeuristicScorer = (context) => {
     ]);
   }
 
-  let missingLang = 0;
+  const missingLangPages: LocalisationAuditCrawledPage[] = [];
   for (const page of okPages) {
     if (!page.htmlLang) {
-      missingLang += 1;
-      if (findings.length < 5) {
-        findings.push(
-          creditFinding({
-            id: `locale-detection-missing-${findings.length}`,
-            creditId: "locale-detection",
-            category: "technical",
-            severity: "high",
-            title: "Missing language declaration",
-            summary:
-              "The page does not set html lang, so browsers and assistive tech cannot identify the locale.",
-            where: formatFindingWhere({ section: "Document head", tag: "<html lang>" }),
-            url: page.url,
-            evidence: "html lang is missing",
-            advice: "Set html lang to the page locale on this URL.",
-          }),
-        );
-      }
+      missingLangPages.push(page);
     } else if (!/^[a-z]{2}(?:-[A-Za-z]{2})?$/.test(page.htmlLang.trim())) {
       score -= 12;
       findings.push(
@@ -94,11 +78,8 @@ const scoreLocaleDetection: HeuristicScorer = (context) => {
     }
 
     const pathLocale = pathLocaleFromUrl(page.url);
-    if (
-      pathLocale &&
-      page.htmlLang &&
-      normalizeLocale(pathLocale) !== normalizeLocale(page.htmlLang)
-    ) {
+    if (pathLocale && page.htmlLang && !htmlLangMatchesPathLocale(page.htmlLang, pathLocale)) {
+      const suggested = htmlLangSuggestionForPathLocale(pathLocale);
       score -= 18;
       findings.push(
         creditFinding({
@@ -107,18 +88,43 @@ const scoreLocaleDetection: HeuristicScorer = (context) => {
           category: "technical",
           severity: "high",
           title: "URL locale and html lang disagree",
-          summary: `Path suggests ${pathLocale} but html lang is ${page.htmlLang}.`,
+          summary: `Path locale ${pathLocale} expects html lang ${suggested}, but the page declares ${page.htmlLang}.`,
           where: formatFindingWhere({ section: "Document head", tag: "<html lang>" }),
           url: page.url,
           evidence: `<html lang="${page.htmlLang}"> while the path locale is ${pathLocale}`,
-          advice: `Set html lang="${pathLocale}" so it matches this page’s URL locale.`,
+          advice: `Set html lang="${suggested}" so it matches this page’s URL locale.`,
         }),
       );
     }
   }
 
-  if (missingLang > 0) {
+  if (missingLangPages.length > 0) {
+    const missingLang = missingLangPages.length;
     score -= Math.min(60, missingLang * 20);
+    const sampleUrls = missingLangPages
+      .slice(0, 3)
+      .map((page) => page.url)
+      .join(", ");
+    findings.push(
+      creditFinding({
+        id: "locale-detection-missing",
+        creditId: "locale-detection",
+        category: "technical",
+        severity: "high",
+        title: "Missing language declaration",
+        summary:
+          missingLang === 1
+            ? "The page does not set html lang, so browsers and assistive tech cannot identify the locale."
+            : `${missingLang} sampled pages do not set html lang, so browsers and assistive tech cannot identify the locale.`,
+        where: formatFindingWhere({ section: "Document head", tag: "<html lang>" }),
+        url: missingLangPages[0]?.url,
+        evidence:
+          missingLang === 1
+            ? "html lang is missing"
+            : `html lang is missing on ${missingLang} pages, e.g. ${sampleUrls}`,
+        advice: "Set html lang to a BCP 47 language tag for each page locale, such as en or fr-FR.",
+      }),
+    );
   }
   return scored(score, findings);
 };
@@ -178,13 +184,13 @@ const scoreLocaleRouting: HeuristicScorer = (context) => {
   }
 
   if (context.detectedLocales.length <= 1) {
-    score -= 8;
+    score -= 28;
     findings.push(
       creditFinding({
         id: "locale-routing-single-locale",
         creditId: "locale-routing",
         category: "technical",
-        severity: "info",
+        severity: "medium",
         title: "Only one locale signal detected",
         summary:
           "The sample found little evidence of multi-locale routing (hreflang, locale prefixes, or html lang variety).",
@@ -192,10 +198,12 @@ const scoreLocaleRouting: HeuristicScorer = (context) => {
         url: context.pages[0]?.url,
         evidence: `Detected locale signals: ${context.detectedLocales.map((entry) => entry.locale).join(", ") || "none"}`,
         advice:
-          "Expose additional locales through hreflang, locale prefixes, or html lang variety.",
+          "Publish additional locales through locale URL prefixes, hreflang alternates, and matching html lang tags.",
         confidence: 90,
       }),
     );
+  } else if (context.detectedLocales.length === 2) {
+    score -= 8;
   }
 
   return scored(score, findings);

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/technical.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/technical.ts
@@ -591,32 +591,149 @@ const scoreLocalizedSeoMetadata: HeuristicScorer = (context) => {
 
 const scoreSitemap: HeuristicScorer = (context) => {
   const { sitemap } = context;
+  const findings: LocalisationAuditFinding[] = [];
+  let score = 100;
+
+  // Lighthouse-style: a valid, fetchable sitemap is required (not N/A when missing).
   if (sitemap.sitemapUrls.length === 0) {
-    return { status: "na" };
-  }
-  if (context.detectedLocales.length <= 1) {
-    return sitemap.sitemapUrls.length > 0 ? scored(90, []) : { status: "na" };
-  }
-  if (sitemap.localizedUrls.length === 0) {
-    return scored(42, [
+    return scored(18, [
       creditFinding({
-        id: "sitemap-missing-locales",
+        id: "sitemap-missing",
         creditId: "sitemap",
         category: "technical",
-        severity: "medium",
-        title: "Sitemap is missing localized URLs",
-        summary: "A sitemap was found, but sampled entries do not include locale-prefixed URLs.",
+        severity: "high",
+        title: "Valid sitemap not found",
+        summary:
+          "No fetchable XML sitemap with URL entries was found at /sitemap.xml or via robots.txt.",
         where: formatFindingWhere({ section: "Sitemap", tag: "sitemap.xml" }),
-        url: sitemap.sitemapUrls[0],
-        evidence: sitemap.sitemapUrls[0]
-          ? `Sitemap ${sitemap.sitemapUrls[0]} has no locale-prefixed URLs in the sample`
-          : "A sitemap was found, but sampled entries have no locale-prefixed URLs.",
-        advice: "Include localized URLs in the sitemap for every published locale.",
-        confidence: 90,
+        url: sitemap.robotsSitemapDirectives[0],
+        evidence: sitemap.robotsFound
+          ? sitemap.robotsSitemapDirectives.length > 0
+            ? `robots.txt references ${sitemap.robotsSitemapDirectives.join(", ")}, but no sitemap returned usable <loc> entries`
+            : "robots.txt was found, but it does not reference a sitemap and /sitemap.xml was missing or empty"
+          : "robots.txt was missing and /sitemap.xml was missing or empty",
+        advice:
+          "Publish a valid XML sitemap and reference it from robots.txt with an absolute Sitemap: URL.",
+        confidence: 100,
       }),
     ]);
   }
-  return scored(92, []);
+
+  if (!sitemap.robotsFound) {
+    score -= 18;
+    findings.push(
+      creditFinding({
+        id: "sitemap-robots-missing",
+        creditId: "sitemap",
+        category: "technical",
+        severity: "medium",
+        title: "robots.txt is missing",
+        summary: "A sitemap was found, but robots.txt is missing so crawlers may not discover it.",
+        where: formatFindingWhere({ section: "robots.txt", tag: "Sitemap:" }),
+        url: sitemap.sitemapUrls[0],
+        evidence: `Sitemap ${sitemap.sitemapUrls[0]} is reachable, but /robots.txt was not found`,
+        advice:
+          "Add a robots.txt that includes an absolute Sitemap: directive for the sitemap URL.",
+        confidence: 95,
+      }),
+    );
+  } else if (sitemap.robotsSitemapDirectives.length === 0) {
+    score -= 28;
+    findings.push(
+      creditFinding({
+        id: "sitemap-robots-unreferenced",
+        creditId: "sitemap",
+        category: "technical",
+        severity: "high",
+        title: "robots.txt does not reference the sitemap",
+        summary:
+          "A sitemap is reachable, but robots.txt does not include a Sitemap: directive pointing to it.",
+        where: formatFindingWhere({ section: "robots.txt", tag: "Sitemap:" }),
+        url: sitemap.sitemapUrls[0],
+        evidence: `Reachable sitemap ${sitemap.sitemapUrls[0]} is not listed in robots.txt`,
+        advice: `Add "Sitemap: ${sitemap.sitemapUrls[0]}" to robots.txt.`,
+        confidence: 100,
+      }),
+    );
+  }
+
+  if (sitemap.robotsHasRelativeSitemapDirective) {
+    score -= 12;
+    findings.push(
+      creditFinding({
+        id: "sitemap-robots-relative",
+        creditId: "sitemap",
+        category: "technical",
+        severity: "medium",
+        title: "Sitemap directive uses a relative URL",
+        summary: "robots.txt should declare Sitemap: with a fully qualified absolute URL.",
+        where: formatFindingWhere({ section: "robots.txt", tag: "Sitemap:" }),
+        url: sitemap.sitemapUrls[0],
+        evidence: "At least one Sitemap: directive in robots.txt is relative rather than absolute",
+        advice: "Use an absolute Sitemap: URL, for example https://example.com/sitemap.xml.",
+        confidence: 98,
+      }),
+    );
+  }
+
+  if (context.detectedLocales.length > 1) {
+    if (sitemap.localizedUrls.length === 0) {
+      score -= 40;
+      findings.push(
+        creditFinding({
+          id: "sitemap-missing-locales",
+          creditId: "sitemap",
+          category: "technical",
+          severity: "medium",
+          title: "Sitemap is missing localized URLs",
+          summary: "A sitemap was found, but sampled entries do not include locale-prefixed URLs.",
+          where: formatFindingWhere({ section: "Sitemap", tag: "sitemap.xml" }),
+          url: sitemap.sitemapUrls[0],
+          evidence: sitemap.sitemapUrls[0]
+            ? `Sitemap ${sitemap.sitemapUrls[0]} has no locale-prefixed URLs in the sample`
+            : "A sitemap was found, but sampled entries have no locale-prefixed URLs.",
+          advice: "Include localized URLs in the sitemap for every published locale.",
+          confidence: 90,
+        }),
+      );
+    } else {
+      const pathLanguagesOnSite = new Set(
+        context.pages.flatMap((page) => {
+          const pathLocale = pathLocaleFromUrl(page.url);
+          return pathLocale ? [languageOf(pathLocale)] : [];
+        }),
+      );
+      const languagesInSitemap = new Set(
+        sitemap.localizedUrls.flatMap((url) => {
+          const pathLocale = pathLocaleFromUrl(url);
+          return pathLocale ? [languageOf(pathLocale)] : [];
+        }),
+      );
+      const missingLanguages = [...pathLanguagesOnSite].filter(
+        (language) => !languagesInSitemap.has(language),
+      );
+      if (missingLanguages.length > 0) {
+        score -= Math.min(30, missingLanguages.length * 12);
+        findings.push(
+          creditFinding({
+            id: "sitemap-incomplete-locales",
+            creditId: "sitemap",
+            category: "technical",
+            severity: "medium",
+            title: "Sitemap omits some published locales",
+            summary: `Locale-prefixed pages for ${missingLanguages.join(", ")} do not appear in sampled sitemap URLs.`,
+            where: formatFindingWhere({ section: "Sitemap", tag: "sitemap.xml" }),
+            url: sitemap.sitemapUrls[0],
+            evidence: `Sitemap locales in sample: ${[...languagesInSitemap].join(", ") || "none"}; missing: ${missingLanguages.join(", ")}`,
+            advice: "Include URLs for every published locale prefix in the sitemap.",
+            confidence: 88,
+          }),
+        );
+      }
+    }
+  }
+
+  return scored(score, findings);
 };
 
 const scoreStructuredData: HeuristicScorer = (context) => {

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/technical.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/technical.ts
@@ -24,6 +24,10 @@ import {
   pageLocale,
   pathLocaleFromUrl,
   pathWithoutLocale,
+  textHasEasternArabicDigits,
+  textHasGregorianCalendarSignals,
+  textHasHijriCalendarSignals,
+  textHasWesternDigits,
 } from "../shared";
 import type { HeuristicCreditOutcome, HeuristicScorer } from "../types";
 
@@ -839,11 +843,62 @@ const scoreInternationalFormatting: HeuristicScorer = (context) => {
         }),
       );
     }
+
+    if (language === "ar") {
+      if (textHasEasternArabicDigits(text)) {
+        sawPattern = true;
+        mismatches += 1;
+        findings.push(
+          creditFinding({
+            id: `formatting-arabic-numerals-${findings.length}`,
+            creditId: "international-formatting",
+            category: "technical",
+            severity: "medium",
+            title: "Arabic page uses Eastern Arabic-Indic numerals",
+            summary:
+              "Sampled copy uses Eastern Arabic-Indic digits; Western digits (0-9) are preferred for most product UIs.",
+            where: formatFindingWhere({ section: "Page body", tag: "sampled copy" }),
+            url: page.url,
+            evidence: clipFindingEvidence(
+              text.match(/[\u0660-\u0669\u06F0-\u06F9][\u0660-\u0669\u06F0-\u06F9\s.,/-]*/)?.[0] ??
+                "Eastern Arabic-Indic digits",
+            ),
+            advice: "Use Western digits (0-9) on Arabic pages unless the market explicitly requires Eastern numerals.",
+            confidence: 90,
+          }),
+        );
+      } else if (textHasWesternDigits(text)) {
+        sawPattern = true;
+      }
+
+      if (textHasHijriCalendarSignals(text) && !textHasGregorianCalendarSignals(text)) {
+        sawPattern = true;
+        mismatches += 1;
+        findings.push(
+          creditFinding({
+            id: `formatting-hijri-calendar-${findings.length}`,
+            creditId: "international-formatting",
+            category: "technical",
+            severity: "medium",
+            title: "Arabic page appears to use Hijri calendar dates",
+            summary:
+              "Hijri month names were found without clear Gregorian date signals; product UIs usually keep Gregorian calendars.",
+            where: formatFindingWhere({ section: "Page body", tag: "sampled copy" }),
+            url: page.url,
+            evidence: clipFindingEvidence(text.slice(0, 220)),
+            advice: "Show Gregorian calendar dates on Arabic product pages (optionally offer Hijri as a secondary format).",
+            confidence: 82,
+          }),
+        );
+      } else if (textHasGregorianCalendarSignals(text)) {
+        sawPattern = true;
+      }
+    }
   }
   if (!sawPattern) {
     return { status: "inconclusive", evidence: { reason: "no_formatting_examples" } };
   }
-  return scored(mismatches > 0 ? 48 : 90, findings);
+  return scored(mismatches > 0 ? Math.max(40, 90 - mismatches * 14) : 90, findings);
 };
 
 const scoreAccessibilityLocalisation: HeuristicScorer = (context) => {

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/visual.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/visual.ts
@@ -118,11 +118,16 @@ const scoreRtlSupport: HeuristicScorer = (context) => {
   if (rtlPages.length === 0) {
     return { status: "na" };
   }
+
+  const findings: LocalisationAuditFinding[] = [];
+  let score = 100;
+
   const missingDir = rtlPages.filter((page) => page.dir !== "rtl");
   if (missingDir.length > 0) {
     const sample = missingDir[0]!;
     const lang = sample.htmlLang ?? pageLocale(sample) ?? "ar";
-    return scored(28, [
+    score -= 45;
+    findings.push(
       creditFinding({
         id: "rtl-missing-dir",
         creditId: "rtl-support",
@@ -136,15 +141,60 @@ const scoreRtlSupport: HeuristicScorer = (context) => {
         advice: 'Set dir="rtl" on RTL pages.',
         confidence: 98,
       }),
-    ]);
+    );
   }
-  return {
-    status: "inconclusive",
-    evidence: {
-      reason: "dir_present_layout_mirroring_unknown",
-      urls: rtlPages.map((page) => page.url),
-    },
-  };
+
+  for (const page of rtlPages) {
+    const directions = page.directionValues.map((value) => value.toLowerCase());
+    if (directions.some((value) => value.includes("ltr"))) {
+      score -= 30;
+      findings.push(
+        creditFinding({
+          id: `rtl-css-direction-ltr-${findings.length}`,
+          creditId: "rtl-support",
+          category: "visual",
+          severity: "high",
+          title: "RTL page CSS forces direction: ltr",
+          summary: "Sampled CSS sets direction: ltr on an RTL locale page.",
+          where: formatFindingWhere({ section: "CSS", tag: "direction" }),
+          url: page.url,
+          evidence: `direction: ${page.directionValues.join(", ")}`,
+          advice: "Use direction: rtl (or rely on html dir=rtl) instead of forcing LTR in CSS.",
+          confidence: 95,
+        }),
+      );
+    }
+
+    if (
+      page.physicalHorizontalCss.length > 0 &&
+      page.logicalHorizontalCss.length === 0 &&
+      !directions.some((value) => value.includes("rtl"))
+    ) {
+      score -= 18;
+      findings.push(
+        creditFinding({
+          id: `rtl-css-physical-${findings.length}`,
+          creditId: "rtl-support",
+          category: "visual",
+          severity: "medium",
+          title: "RTL page uses physical left/right CSS",
+          summary:
+            "Sampled CSS uses float/margin/padding/left/right without logical inline properties, so layout may not mirror in RTL.",
+          where: formatFindingWhere({ section: "CSS", tag: "margin/float/text-align" }),
+          url: page.url,
+          evidence: clipFindingEvidence(page.physicalHorizontalCss.slice(0, 4).join("; ")),
+          advice:
+            "Prefer logical properties such as margin-inline-start, inset-inline, and text-align: start for RTL layouts.",
+          confidence: 84,
+        }),
+      );
+    }
+  }
+
+  if (findings.length === 0) {
+    return scored(92, []);
+  }
+  return scored(score, findings);
 };
 
 const GENERIC_FONTS = new Set(["arial", "helvetica", "sans-serif", "serif", "system-ui", "tahoma"]);

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/visual.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/visual.ts
@@ -16,6 +16,8 @@ import {
   clipFindingEvidence,
   creditFinding,
   dominantScript,
+  findTofuGlyphs,
+  fontStackLooksCjkCapable,
   formatFindingWhere,
   groupPagesByLanguage,
   isCjkLanguage,
@@ -26,6 +28,9 @@ import {
   pageLocale,
   pathWithoutLocale,
   sourceLanguage,
+  textHasCjkScript,
+  textHasHangul,
+  westernNameFields,
 } from "../shared";
 import type { HeuristicCreditOutcome, HeuristicScorer } from "../types";
 
@@ -151,24 +156,52 @@ const scoreFontAndScript: HeuristicScorer = (context) => {
     const locale = pageLocale(page);
     if (!locale || isLatinScriptLanguage(locale)) continue;
     inspected += 1;
-    const script = dominantScript(page.textSample);
-    if (script === "latin") continue;
+    const text = page.textSample;
+    const tofu = findTofuGlyphs(text);
+    if (tofu.length > 0) {
+      findings.push(
+        creditFinding({
+          id: `font-tofu-${findings.length}`,
+          creditId: "font-and-script",
+          category: "visual",
+          severity: "high",
+          title: "Tofu glyphs suggest missing font coverage",
+          summary: `A ${locale} page contains replacement or empty-box characters that usually mean glyphs failed to render.`,
+          where: formatFindingWhere({ section: "Page body", tag: "sampled copy" }),
+          url: page.url,
+          evidence: clipFindingEvidence(`Tofu glyphs ${tofu.join(" ")} in: ${text.slice(0, 180)}`),
+          advice:
+            "Ship a font that covers the page script (for example Noto Sans CJK) so characters do not render as □ or �.",
+          confidence: 96,
+        }),
+      );
+    }
+
+    const script = dominantScript(text);
+    if (script === "latin" && !textHasCjkScript(text) && !isRtlLanguage(locale)) continue;
     const families = page.fontFamilies.map((family) => family.toLowerCase());
     if (families.length === 0) continue;
     const onlyGeneric = families.every((family) => GENERIC_FONTS.has(family));
-    if (onlyGeneric) {
+    const needsCjkFont = isCjkLanguage(locale) && textHasCjkScript(text);
+    if (onlyGeneric || (needsCjkFont && !fontStackLooksCjkCapable(page.fontFamilies))) {
       findings.push(
         creditFinding({
           id: `font-generic-${findings.length}`,
           creditId: "font-and-script",
           category: "visual",
-          severity: "medium",
-          title: "Typography may not support the target script",
-          summary: `A ${locale} page only declares generic fallback fonts.`,
+          severity: needsCjkFont ? "high" : "medium",
+          title: needsCjkFont
+            ? "No CJK-capable font detected"
+            : "Typography may not support the target script",
+          summary: needsCjkFont
+            ? `A ${locale} page shows CJK text but the embedded/inline font stack has no known CJK typeface.`
+            : `A ${locale} page only declares generic fallback fonts.`,
           where: formatFindingWhere({ section: "Page body", tag: "font-family" }),
           url: page.url,
-          evidence: `font-family: ${page.fontFamilies.join(", ")}`,
-          advice: "Ship a font that covers the target script instead of a generic fallback stack.",
+          evidence: `font-family: ${page.fontFamilies.join(", ") || "(none declared in sampled CSS)"}`,
+          advice: needsCjkFont
+            ? "Include a CJK font such as Noto Sans CJK, Malgun Gothic, Hiragino, or PingFang in the stack."
+            : "Ship a font that covers the target script instead of a generic fallback stack.",
         }),
       );
     }
@@ -176,7 +209,115 @@ const scoreFontAndScript: HeuristicScorer = (context) => {
   if (inspected === 0) {
     return { status: "na" };
   }
-  return scored(findings.length > 0 ? 62 : 90, findings);
+  return scored(findings.length > 0 ? Math.max(35, 90 - findings.length * 14) : 90, findings);
+};
+
+const scoreCjkTypography: HeuristicScorer = (context) => {
+  const cjkPages = context.pages.filter((page) => {
+    const locale = pageLocale(page);
+    return locale != null && isCjkLanguage(locale);
+  });
+  if (cjkPages.length === 0) {
+    return { status: "na" };
+  }
+
+  const findings: LocalisationAuditFinding[] = [];
+  let score = 100;
+
+  for (const page of cjkPages) {
+    const locale = pageLocale(page)!;
+    const language = languageOf(locale);
+    const text = page.textSample;
+
+    if (language === "ko" && textHasHangul(text)) {
+      const wordBreaks = page.wordBreakValues.map((value) => value.toLowerCase());
+      if (wordBreaks.some((value) => value.includes("break-all"))) {
+        score -= 28;
+        findings.push(
+          creditFinding({
+            id: `cjk-wordbreak-breakall-${findings.length}`,
+            creditId: "cjk-typography",
+            category: "visual",
+            severity: "high",
+            title: "Korean text uses word-break: break-all",
+            summary:
+              "break-all can split Hangul mid-word and makes Korean body copy harder to read.",
+            where: formatFindingWhere({ section: "CSS", tag: "word-break" }),
+            url: page.url,
+            evidence: `word-break: ${page.wordBreakValues.join(", ")}`,
+            advice: "Use word-break: keep-all for Korean text instead of break-all.",
+            confidence: 94,
+          }),
+        );
+      } else if (wordBreaks.length > 0 && !wordBreaks.some((value) => value.includes("keep-all"))) {
+        score -= 14;
+        findings.push(
+          creditFinding({
+            id: `cjk-wordbreak-missing-keepall-${findings.length}`,
+            creditId: "cjk-typography",
+            category: "visual",
+            severity: "medium",
+            title: "Korean page omits word-break: keep-all",
+            summary: "Sampled CSS sets word-break but not keep-all, so Hangul may wrap awkwardly.",
+            where: formatFindingWhere({ section: "CSS", tag: "word-break" }),
+            url: page.url,
+            evidence: `word-break: ${page.wordBreakValues.join(", ")}`,
+            advice: "Set word-break: keep-all on Korean body copy and UI text.",
+            confidence: 82,
+          }),
+        );
+      } else if (wordBreaks.length === 0 && page.fontFamilies.length > 0) {
+        // Only warn when we clearly sampled embedded CSS but saw no keep-all rule.
+        score -= 8;
+        findings.push(
+          creditFinding({
+            id: `cjk-wordbreak-unspecified-${findings.length}`,
+            creditId: "cjk-typography",
+            category: "visual",
+            severity: "low",
+            title: "No Korean word-break rule found in sampled CSS",
+            summary:
+              "Embedded CSS was found, but it does not declare word-break: keep-all for Hangul.",
+            where: formatFindingWhere({ section: "CSS", tag: "word-break" }),
+            url: page.url,
+            evidence: "Sampled <style>/inline CSS declares fonts but no word-break: keep-all",
+            advice: "Add word-break: keep-all for Korean text containers.",
+            confidence: 72,
+          }),
+        );
+      }
+    }
+
+    const westernNames = westernNameFields(page.formFieldLabels);
+    if (westernNames.length > 0) {
+      score -= 16;
+      findings.push(
+        creditFinding({
+          id: `cjk-naming-${findings.length}`,
+          creditId: "cjk-typography",
+          category: "visual",
+          severity: "medium",
+          title: "Western name fields on a CJK page",
+          summary: `A ${locale} form still uses Western first/last name labels instead of local naming conventions.`,
+          where: formatFindingWhere({ section: "Form", tag: "<label> or <input>" }),
+          url: page.url,
+          evidence: clipFindingEvidence(westernNames.slice(0, 4).join(" / ")),
+          advice:
+            language === "ko"
+              ? "Prefer 성 / 이름 (or a single 이름 field) instead of First name / Last name."
+              : language === "ja"
+                ? "Prefer 姓 / 名 instead of First name / Last name."
+                : "Prefer 姓 / 名 (or the local name-order labels) instead of First name / Last name.",
+          confidence: 88,
+        }),
+      );
+    }
+  }
+
+  if (findings.length === 0) {
+    return scored(92, []);
+  }
+  return scored(score, findings);
 };
 
 const scoreLocalizedImages: HeuristicScorer = (context) => {
@@ -285,6 +426,7 @@ export const visualHeuristicScorers: Record<string, HeuristicScorer> = {
   "text-expansion": scoreTextExpansion,
   "rtl-support": scoreRtlSupport,
   "font-and-script": scoreFontAndScript,
+  "cjk-typography": scoreCjkTypography,
   "localized-images": scoreLocalizedImages,
   "visual-hierarchy": scoreVisualHierarchy,
   "component-consistency": scoreComponentConsistency,

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/runner.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/runner.ts
@@ -29,6 +29,7 @@ import type {
   HeuristicScorer,
   LunaCreditInput,
 } from "./types";
+import { collapseRepeatedFindings } from "../score";
 
 const heuristicScorers: Record<string, HeuristicScorer> = {
   ...technicalHeuristicScorers,
@@ -141,7 +142,7 @@ export async function runLocalisationAuditCredits(input: {
 
   return {
     credits,
-    findings,
+    findings: collapseRepeatedFindings(findings),
     detectedLocales,
     linguisticNotes: luna.linguisticNotes,
   };

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared.ts
@@ -106,6 +106,38 @@ export function isCjkLanguage(locale: string): boolean {
   return CJK_LANGUAGES.has(languageOf(locale));
 }
 
+/** Replacement / empty-box glyphs that often indicate missing font coverage ("tofu"). */
+export const TOFU_GLYPH_RE = /[\uFFFD\u25A1\u25A0\u25AF□�]/u;
+export const HANGUL_RE = /[\uAC00-\uD7AF]/u;
+export const CJK_IDEOGRAPH_RE = /[\u4E00-\u9FFF]/u;
+export const KANA_RE = /[\u3040-\u30FF]/u;
+
+const CJK_FONT_HINT_RE =
+  /noto\s*sans\s*cjk|noto\s*serif\s*cjk|source\s*han|malgun|gulim|batang|dotum|nanum|apple\s*sd\s*gothic|apple\s*gothic|hiragino|yu\s*gothic|yu\s*mincho|meiryo|ms\s*p?gothic|ms\s*p?mincho|pingfang|heiti|songti|stsong|microsoft\s*yahei|simsun|simhei|dengxian|wenquanyi|sarasa|ibm\s*plex\s*sans\s*(jp|kr|sc|tc)|pretendard|spoqa|kopub|apple\s*myungjo|noto\s*sans\s*kr|noto\s*sans\s*jp|noto\s*sans\s*sc|noto\s*sans\s*tc/i;
+
+const WESTERN_NAME_FIELD_RE =
+  /\b(first[\s_-]?name|last[\s_-]?name|given[\s_-]?name|family[\s_-]?name|surname|forename)\b/i;
+
+export function textHasHangul(text: string): boolean {
+  return HANGUL_RE.test(text);
+}
+
+export function textHasCjkScript(text: string): boolean {
+  return HANGUL_RE.test(text) || CJK_IDEOGRAPH_RE.test(text) || KANA_RE.test(text);
+}
+
+export function findTofuGlyphs(text: string): string[] {
+  return [...new Set(text.match(new RegExp(TOFU_GLYPH_RE.source, "gu")) ?? [])];
+}
+
+export function fontStackLooksCjkCapable(fontFamilies: string[]): boolean {
+  return fontFamilies.some((family) => CJK_FONT_HINT_RE.test(family));
+}
+
+export function westernNameFields(labels: string[]): string[] {
+  return labels.filter((label) => WESTERN_NAME_FIELD_RE.test(label));
+}
+
 export function isLatinScriptLanguage(locale: string): boolean {
   const language = languageOf(locale);
   return (

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared.ts
@@ -212,6 +212,10 @@ export function detectLocales(
   focusLocales: string[],
 ): LocalisationAuditLocaleSignal[] {
   const byLocale = new Map<string, LocalisationAuditLocaleSignal>();
+  /** Bare language tags that appear as their own URL/subdomain market prefixes. */
+  const bareLanguagesFromRouting = new Set<string>();
+  /** Languages that have a language-region tag from URL/subdomain routing. */
+  const languagesWithRegionFromRouting = new Set<string>();
 
   const add = (
     locale: string,
@@ -222,6 +226,14 @@ export function detectLocales(
     if (!key || key === "x-default" || !LOCALE_CODE.test(key)) return;
     if (!byLocale.has(key)) {
       byLocale.set(key, { locale: key, source, sampleUrl });
+    }
+  };
+
+  const noteRoutingLocale = (canonical: string) => {
+    if (canonical.includes("-")) {
+      languagesWithRegionFromRouting.add(languageOf(canonical));
+    } else {
+      bareLanguagesFromRouting.add(canonical);
     }
   };
 
@@ -238,34 +250,50 @@ export function detectLocales(
     }
     const pathLocale = pathLocaleFromUrl(page.url);
     if (pathLocale) {
-      add(canonicalPathLocale(pathLocale), "url_prefix", page.url);
+      const canonical = canonicalPathLocale(pathLocale);
+      add(canonical, "url_prefix", page.url);
+      noteRoutingLocale(canonical);
     }
     try {
       const host = new URL(page.url).hostname;
       const hostMatch = host.match(/^([a-z]{2}(?:-[a-z]{2})?)\./i);
       if (hostMatch?.[1] && hostMatch[1].toLowerCase() !== "www") {
-        add(hostMatch[1], "url_subdomain", page.url);
+        const hostLocale = canonicalPathLocale(hostMatch[1]);
+        add(hostLocale, "url_subdomain", page.url);
+        noteRoutingLocale(hostLocale);
       }
     } catch {
       // ignore bad URLs
     }
   }
 
-  return collapseLanguageRegionSignals([...byLocale.values()]).toSorted((a, b) =>
-    a.locale.localeCompare(b.locale),
-  );
+  return collapseLanguageRegionSignals(
+    [...byLocale.values()],
+    bareLanguagesFromRouting,
+    languagesWithRegionFromRouting,
+  ).toSorted((a, b) => a.locale.localeCompare(b.locale));
 }
 
-/** Prefer `en-au` over bare `en` when both signals describe the same language. */
+/**
+ * Prefer `en-au` over bare `en` when the bare tag is only a redundant html/hreflang
+ * annotation. Keep bare `en` when URL routing also has both `/en/` and a region
+ * market like `/au/` (distinct markets, same language).
+ */
 function collapseLanguageRegionSignals(
   signals: LocalisationAuditLocaleSignal[],
+  bareLanguagesFromRouting: Set<string>,
+  languagesWithRegionFromRouting: Set<string>,
 ): LocalisationAuditLocaleSignal[] {
   const languagesWithRegion = new Set(
     signals.filter((entry) => entry.locale.includes("-")).map((entry) => languageOf(entry.locale)),
   );
-  return signals.filter(
-    (entry) => entry.locale.includes("-") || !languagesWithRegion.has(entry.locale),
-  );
+  return signals.filter((entry) => {
+    if (entry.locale.includes("-")) return true;
+    if (!languagesWithRegion.has(entry.locale)) return true;
+    return (
+      bareLanguagesFromRouting.has(entry.locale) && languagesWithRegionFromRouting.has(entry.locale)
+    );
+  });
 }
 
 export function groupPagesByLanguage(

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared.ts
@@ -32,8 +32,6 @@ const PATH_REGION_TO_HTML_LANG: Record<string, string> = {
   us: "en-US",
   nz: "en-NZ",
   gb: "en-GB",
-  /** Corporate sites use /uk/ for United Kingdom English; ISO 639 `uk` is Ukrainian. */
-  uk: "en-GB",
   jp: "ja-JP",
   kr: "ko-KR",
   cn: "zh-CN",

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared.ts
@@ -23,12 +23,81 @@ export const LOCALE_CODE = /^[a-z]{2}(?:-[a-z]{2})?$/i;
 const RTL_LANGUAGES = new Set(["ar", "he", "fa", "ur", "ps", "yi"]);
 const CJK_LANGUAGES = new Set(["zh", "ja", "ko"]);
 
+/**
+ * URL path prefixes that are market/region codes, not ISO 639 language tags.
+ * Mapped to the BCP 47 html lang value sites should declare.
+ */
+const PATH_REGION_TO_HTML_LANG: Record<string, string> = {
+  au: "en-AU",
+  us: "en-US",
+  nz: "en-NZ",
+  gb: "en-GB",
+  /** Corporate sites use /uk/ for United Kingdom English; ISO 639 `uk` is Ukrainian. */
+  uk: "en-GB",
+  jp: "ja-JP",
+  kr: "ko-KR",
+  cn: "zh-CN",
+  tw: "zh-TW",
+  hk: "zh-HK",
+  mx: "es-MX",
+  in: "en-IN",
+  za: "en-ZA",
+  ph: "en-PH",
+};
+
 export function normalizeLocale(value: string): string {
   return value.trim().replaceAll("_", "-").toLowerCase();
 }
 
 export function languageOf(locale: string): string {
   return normalizeLocale(locale).split("-")[0] ?? "";
+}
+
+/** Format a normalized locale as a conventional BCP 47 tag (e.g. en-AU). */
+export function formatBcp47Locale(locale: string): string {
+  const normalized = normalizeLocale(locale);
+  const [language, region] = normalized.split("-");
+  if (!language) return normalized;
+  if (!region) return language;
+  return `${language}-${region.toUpperCase()}`;
+}
+
+/**
+ * Path locale token → suggested `html lang` value.
+ * Region-only prefixes like `au` map to `en-AU`, not the invalid tag `au`.
+ */
+export function htmlLangSuggestionForPathLocale(pathLocale: string): string {
+  const normalized = normalizeLocale(pathLocale);
+  if (normalized.includes("-")) {
+    return formatBcp47Locale(normalized);
+  }
+  const regionMapped = PATH_REGION_TO_HTML_LANG[normalized];
+  if (regionMapped) return regionMapped;
+  return normalized;
+}
+
+/** Canonical locale signal for a URL path prefix (region paths become language-region tags). */
+export function canonicalPathLocale(pathLocale: string): string {
+  return normalizeLocale(htmlLangSuggestionForPathLocale(pathLocale));
+}
+
+/**
+ * Whether declared html lang agrees with the URL path locale.
+ * `en` matches path `/au/` (suggested `en-AU`); `fr` on `/au/` does not.
+ */
+export function htmlLangMatchesPathLocale(htmlLang: string, pathLocale: string): boolean {
+  const html = normalizeLocale(htmlLang);
+  const suggested = normalizeLocale(htmlLangSuggestionForPathLocale(pathLocale));
+  if (html === suggested) return true;
+  if (languageOf(html) !== languageOf(suggested)) return false;
+  // Bare language tag matches a language-region suggestion for the same language.
+  if (!html.includes("-") && suggested.includes("-")) return true;
+  // Language-region path matches a bare html lang for the same language.
+  if (html.includes("-") && !suggested.includes("-") && languageOf(html) === suggested) {
+    return true;
+  }
+  // Same language-region family (en-AU vs en-au already normalized; en-GB vs en-AU disagree on region)
+  return html === suggested;
 }
 
 export function isRtlLanguage(locale: string): boolean {
@@ -66,7 +135,9 @@ export function pathLocaleFromUrl(url: string): string | null {
 }
 
 export function pageLocale(page: LocalisationAuditCrawledPage): string | null {
-  return pathLocaleFromUrl(page.url) ?? (page.htmlLang ? normalizeLocale(page.htmlLang) : null);
+  const pathLocale = pathLocaleFromUrl(page.url);
+  if (pathLocale) return canonicalPathLocale(pathLocale);
+  return page.htmlLang ? normalizeLocale(page.htmlLang) : null;
 }
 
 export function pathWithoutLocale(url: string): string | null {
@@ -169,7 +240,7 @@ export function detectLocales(
     }
     const pathLocale = pathLocaleFromUrl(page.url);
     if (pathLocale) {
-      add(pathLocale, "url_prefix", page.url);
+      add(canonicalPathLocale(pathLocale), "url_prefix", page.url);
     }
     try {
       const host = new URL(page.url).hostname;
@@ -182,7 +253,21 @@ export function detectLocales(
     }
   }
 
-  return [...byLocale.values()].toSorted((a, b) => a.locale.localeCompare(b.locale));
+  return collapseLanguageRegionSignals([...byLocale.values()]).toSorted((a, b) =>
+    a.locale.localeCompare(b.locale),
+  );
+}
+
+/** Prefer `en-au` over bare `en` when both signals describe the same language. */
+function collapseLanguageRegionSignals(
+  signals: LocalisationAuditLocaleSignal[],
+): LocalisationAuditLocaleSignal[] {
+  const languagesWithRegion = new Set(
+    signals.filter((entry) => entry.locale.includes("-")).map((entry) => languageOf(entry.locale)),
+  );
+  return signals.filter(
+    (entry) => entry.locale.includes("-") || !languagesWithRegion.has(entry.locale),
+  );
 }
 
 export function groupPagesByLanguage(

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared.ts
@@ -138,6 +138,35 @@ export function westernNameFields(labels: string[]): string[] {
   return labels.filter((label) => WESTERN_NAME_FIELD_RE.test(label));
 }
 
+/** Eastern Arabic-Indic (U+0660–U+0669) and Extended Arabic-Indic / Persian (U+06F0–U+06F9). */
+export const EASTERN_ARABIC_DIGIT_RE = /[\u0660-\u0669\u06F0-\u06F9]/u;
+export const WESTERN_DIGIT_RE = /[0-9]/u;
+
+const HIJRI_MONTH_RE =
+  /محرم|صفر|ربيع(?:\s*الأول|\s*الثاني)?|جمادى(?:\s*الأولى|\s*الآخرة)?|رجب|شعبان|رمضان|شوال|ذو\s*القعدة|ذو\s*الحجة|muharram|safar|rabi[a']?\s*(?:al-?)?awwal|rabi[a']?\s*(?:al-?)?thani|jumada|rajab|sha'?ban|ramadan|shawwal|dhul[-\s]?qi'?dah|dhul[-\s]?hijjah/iu;
+
+const GREGORIAN_ARABIC_MONTH_RE =
+  /يناير|فبراير|مارس|أبريل|ابريل|مايو|يونيو|يوليو|أغسطس|اغسطس|سبتمبر|أكتوبر|اكتوبر|نوفمبر|ديسمبر/u;
+
+const GREGORIAN_LATIN_DATE_RE =
+  /\b(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\b|\b(?:20\d{2}|19\d{2})\b/i;
+
+export function textHasEasternArabicDigits(text: string): boolean {
+  return EASTERN_ARABIC_DIGIT_RE.test(text);
+}
+
+export function textHasWesternDigits(text: string): boolean {
+  return WESTERN_DIGIT_RE.test(text);
+}
+
+export function textHasHijriCalendarSignals(text: string): boolean {
+  return HIJRI_MONTH_RE.test(text);
+}
+
+export function textHasGregorianCalendarSignals(text: string): boolean {
+  return GREGORIAN_ARABIC_MONTH_RE.test(text) || GREGORIAN_LATIN_DATE_RE.test(text);
+}
+
 export function isLatinScriptLanguage(locale: string): boolean {
   const language = languageOf(locale);
   return (

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/html-parse.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/html-parse.test.ts
@@ -86,6 +86,33 @@ describe("parsePageSignals", () => {
     expect(signals.fontFamilies).toContain("Noto Sans");
   });
 
+  it("extracts word-break CSS and Western name form fields", () => {
+    const signals = parsePageSignals(`
+      <html lang="ko">
+        <head>
+          <style>
+            body { font-family: "Malgun Gothic", sans-serif; word-break: break-all; }
+            p { line-break: strict; }
+          </style>
+        </head>
+        <body>
+          <label>First name</label>
+          <input name="last_name" placeholder="Last name" autocomplete="family-name" />
+          <p>한국어 본문 □</p>
+        </body>
+      </html>
+    `);
+
+    expect(signals.wordBreakValues).toContain("break-all");
+    expect(signals.lineBreakValues).toContain("strict");
+    expect(signals.fontFamilies).toContain("Malgun Gothic");
+    expect(signals.formFieldLabels).toEqual(
+      expect.arrayContaining(["First name", "last_name", "Last name", "family-name"]),
+    );
+    expect(signals.textSample).toContain("한국어");
+    expect(signals.textSample).toContain("□");
+  });
+
   it("truncates long text samples with an ellipsis", () => {
     const longText = "word ".repeat(1_200);
     const signals = parsePageSignals(`<html><body><p>${longText}</p></body></html>`);

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/html-parse.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/html-parse.test.ts
@@ -113,6 +113,27 @@ describe("parsePageSignals", () => {
     expect(signals.textSample).toContain("□");
   });
 
+  it("extracts RTL direction and physical horizontal CSS", () => {
+    const signals = parsePageSignals(`
+      <html lang="ar" dir="rtl">
+        <head>
+          <style>
+            .nav { direction: rtl; }
+            .bad { direction: ltr; float: left; margin-left: 12px; text-align: left; }
+            .ok { margin-inline-start: 12px; text-align: start; }
+          </style>
+        </head>
+        <body><p>مرحبا</p></body>
+      </html>
+    `);
+
+    expect(signals.directionValues).toEqual(expect.arrayContaining(["rtl", "ltr"]));
+    expect(signals.physicalHorizontalCss.some((value) => value.includes("float: left"))).toBe(true);
+    expect(
+      signals.logicalHorizontalCss.some((value) => value.includes("margin-inline-start")),
+    ).toBe(true);
+  });
+
   it("truncates long text samples with an ellipsis", () => {
     const longText = "word ".repeat(1_200);
     const signals = parsePageSignals(`<html><body><p>${longText}</p></body></html>`);

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/html-parse.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/html-parse.ts
@@ -36,6 +36,9 @@ export type ParsedPageSignals = {
   buttons: string[];
   headings: string[];
   fontFamilies: string[];
+  wordBreakValues: string[];
+  lineBreakValues: string[];
+  formFieldLabels: string[];
 };
 
 const MAX_TEXT_SAMPLE = 4_000;
@@ -46,8 +49,13 @@ const MAX_BUTTONS = 40;
 const MAX_HEADINGS = 40;
 const MAX_JSON_LD = 8;
 const MAX_FONT_FAMILIES = 12;
+const MAX_WORD_BREAK_VALUES = 8;
+const MAX_LINE_BREAK_VALUES = 8;
+const MAX_FORM_FIELD_LABELS = 40;
 
 const FONT_FAMILY_RE = /font-family\s*:\s*([^;}{]+)/gi;
+const WORD_BREAK_RE = /word-break\s*:\s*([^;}{]+)/gi;
+const LINE_BREAK_RE = /line-break\s*:\s*([^;}{]+)/gi;
 
 function pushUnique(list: string[], value: string, max: number) {
   const trimmed = value.replace(/\s+/g, " ").trim();
@@ -55,6 +63,18 @@ function pushUnique(list: string[], value: string, max: number) {
     return;
   }
   list.push(trimmed);
+}
+
+function collectCssProperty(css: string, pattern: RegExp, values: string[], max: number) {
+  pattern.lastIndex = 0;
+  let match: RegExpExecArray | null = pattern.exec(css);
+  while (match) {
+    const value = match[1]?.trim().toLowerCase();
+    if (value) {
+      pushUnique(values, value, max);
+    }
+    match = pattern.exec(css);
+  }
 }
 
 function collectFontFamilies(css: string, fontFamilies: string[]) {
@@ -66,6 +86,24 @@ function collectFontFamilies(css: string, fontFamilies: string[]) {
       pushUnique(fontFamilies, family, MAX_FONT_FAMILIES);
     }
     match = FONT_FAMILY_RE.exec(css);
+  }
+}
+
+function collectCssSignals(
+  css: string,
+  fontFamilies: string[],
+  wordBreakValues: string[],
+  lineBreakValues: string[],
+) {
+  collectFontFamilies(css, fontFamilies);
+  collectCssProperty(css, WORD_BREAK_RE, wordBreakValues, MAX_WORD_BREAK_VALUES);
+  collectCssProperty(css, LINE_BREAK_RE, lineBreakValues, MAX_LINE_BREAK_VALUES);
+}
+
+function pushFormFieldLabel(labels: string[], ...candidates: Array<string | undefined>) {
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    pushUnique(labels, candidate, MAX_FORM_FIELD_LABELS);
   }
 }
 
@@ -139,6 +177,11 @@ export function parsePageSignals(html: string): ParsedPageSignals {
   const buttons: string[] = [];
   const headings: string[] = [];
   const fontFamilies: string[] = [];
+  const wordBreakValues: string[] = [];
+  const lineBreakValues: string[] = [];
+  const formFieldLabels: string[] = [];
+  let inLabel = false;
+  let labelBuffer = "";
 
   const parser = new Parser(
     {
@@ -159,7 +202,7 @@ export function parsePageSignals(html: string): ParsedPageSignals {
           pushUnique(ariaLabels, attributes["aria-label"], MAX_ARIA_LABELS);
         }
         if (attributes.style) {
-          collectFontFamilies(attributes.style, fontFamilies);
+          collectCssSignals(attributes.style, fontFamilies, wordBreakValues, lineBreakValues);
         }
         if (tag === "script") {
           const type = (attributes.type ?? "").toLowerCase();
@@ -234,6 +277,20 @@ export function parsePageSignals(html: string): ParsedPageSignals {
         ) {
           pushUnique(buttons, attributes.value, MAX_BUTTONS);
         }
+        if (tag === "label") {
+          inLabel = true;
+          labelBuffer = "";
+        }
+        if (tag === "input" || tag === "textarea" || tag === "select") {
+          pushFormFieldLabel(
+            formFieldLabels,
+            attributes.placeholder,
+            attributes.name,
+            attributes["aria-label"],
+            attributes.autocomplete,
+            attributes.id,
+          );
+        }
         if (tag === "h1" || tag === "h2" || tag === "h3") {
           headingTag = tag;
           headingBuffer = "";
@@ -254,6 +311,9 @@ export function parsePageSignals(html: string): ParsedPageSignals {
         }
         if (inButton) {
           buttonBuffer += text;
+        }
+        if (inLabel) {
+          labelBuffer += text;
         }
         if (headingTag) {
           headingBuffer += text;
@@ -278,7 +338,7 @@ export function parsePageSignals(html: string): ParsedPageSignals {
           inScriptOrStyle = false;
         }
         if (tag === "style") {
-          collectFontFamilies(styleBuffer, fontFamilies);
+          collectCssSignals(styleBuffer, fontFamilies, wordBreakValues, lineBreakValues);
           inStyle = false;
           styleBuffer = "";
           inScriptOrStyle = false;
@@ -301,6 +361,11 @@ export function parsePageSignals(html: string): ParsedPageSignals {
           pushUnique(buttons, buttonBuffer, MAX_BUTTONS);
           inButton = false;
           buttonBuffer = "";
+        }
+        if (tag === "label") {
+          pushFormFieldLabel(formFieldLabels, labelBuffer);
+          inLabel = false;
+          labelBuffer = "";
         }
         if (tag === headingTag) {
           pushUnique(headings, headingBuffer, MAX_HEADINGS);
@@ -338,6 +403,9 @@ export function parsePageSignals(html: string): ParsedPageSignals {
     buttons,
     headings,
     fontFamilies,
+    wordBreakValues,
+    lineBreakValues,
+    formFieldLabels,
   };
 }
 
@@ -365,6 +433,9 @@ export function crawledPageFromSignals(input: {
     buttons: input.signals.buttons,
     headings: input.signals.headings,
     fontFamilies: input.signals.fontFamilies,
+    wordBreakValues: input.signals.wordBreakValues,
+    lineBreakValues: input.signals.lineBreakValues,
+    formFieldLabels: input.signals.formFieldLabels,
     anchors: input.signals.anchors,
   };
 }
@@ -391,6 +462,9 @@ export function emptyParsedPage(url: string, status: number): LocalisationAuditC
       buttons: [],
       headings: [],
       fontFamilies: [],
+      wordBreakValues: [],
+      lineBreakValues: [],
+      formFieldLabels: [],
     },
   });
 }

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/html-parse.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/html-parse.ts
@@ -38,6 +38,9 @@ export type ParsedPageSignals = {
   fontFamilies: string[];
   wordBreakValues: string[];
   lineBreakValues: string[];
+  directionValues: string[];
+  physicalHorizontalCss: string[];
+  logicalHorizontalCss: string[];
   formFieldLabels: string[];
 };
 
@@ -51,11 +54,18 @@ const MAX_JSON_LD = 8;
 const MAX_FONT_FAMILIES = 12;
 const MAX_WORD_BREAK_VALUES = 8;
 const MAX_LINE_BREAK_VALUES = 8;
+const MAX_DIRECTION_VALUES = 8;
+const MAX_HORIZONTAL_CSS = 12;
 const MAX_FORM_FIELD_LABELS = 40;
 
 const FONT_FAMILY_RE = /font-family\s*:\s*([^;}{]+)/gi;
 const WORD_BREAK_RE = /word-break\s*:\s*([^;}{]+)/gi;
 const LINE_BREAK_RE = /line-break\s*:\s*([^;}{]+)/gi;
+const DIRECTION_RE = /(?:^|[;{\s])direction\s*:\s*([^;}{]+)/gi;
+const PHYSICAL_HORIZONTAL_RE =
+  /(?:float\s*:\s*(?:left|right)|(?:margin|padding)-(?:left|right)\s*:\s*[^;}{]+|(?:^|[;{\s])(?:left|right)\s*:\s*[^;}{]+|text-align\s*:\s*(?:left|right))/gi;
+const LOGICAL_HORIZONTAL_RE =
+  /(?:margin|padding|inset)-inline(?:-start|-end)?\s*:\s*[^;}{]+|text-align\s*:\s*(?:start|end)|inline-(?:start|end)\s*:\s*[^;}{]+/gi;
 
 function pushUnique(list: string[], value: string, max: number) {
   const trimmed = value.replace(/\s+/g, " ").trim();
@@ -77,6 +87,15 @@ function collectCssProperty(css: string, pattern: RegExp, values: string[], max:
   }
 }
 
+function collectCssSnippets(css: string, pattern: RegExp, values: string[], max: number) {
+  pattern.lastIndex = 0;
+  let match: RegExpExecArray | null = pattern.exec(css);
+  while (match) {
+    pushUnique(values, match[0]!.replace(/\s+/g, " ").trim().toLowerCase(), max);
+    match = pattern.exec(css);
+  }
+}
+
 function collectFontFamilies(css: string, fontFamilies: string[]) {
   FONT_FAMILY_RE.lastIndex = 0;
   let match: RegExpExecArray | null = FONT_FAMILY_RE.exec(css);
@@ -94,10 +113,16 @@ function collectCssSignals(
   fontFamilies: string[],
   wordBreakValues: string[],
   lineBreakValues: string[],
+  directionValues: string[],
+  physicalHorizontalCss: string[],
+  logicalHorizontalCss: string[],
 ) {
   collectFontFamilies(css, fontFamilies);
   collectCssProperty(css, WORD_BREAK_RE, wordBreakValues, MAX_WORD_BREAK_VALUES);
   collectCssProperty(css, LINE_BREAK_RE, lineBreakValues, MAX_LINE_BREAK_VALUES);
+  collectCssProperty(css, DIRECTION_RE, directionValues, MAX_DIRECTION_VALUES);
+  collectCssSnippets(css, PHYSICAL_HORIZONTAL_RE, physicalHorizontalCss, MAX_HORIZONTAL_CSS);
+  collectCssSnippets(css, LOGICAL_HORIZONTAL_RE, logicalHorizontalCss, MAX_HORIZONTAL_CSS);
 }
 
 function pushFormFieldLabel(labels: string[], ...candidates: Array<string | undefined>) {
@@ -179,6 +204,9 @@ export function parsePageSignals(html: string): ParsedPageSignals {
   const fontFamilies: string[] = [];
   const wordBreakValues: string[] = [];
   const lineBreakValues: string[] = [];
+  const directionValues: string[] = [];
+  const physicalHorizontalCss: string[] = [];
+  const logicalHorizontalCss: string[] = [];
   const formFieldLabels: string[] = [];
   let inLabel = false;
   let labelBuffer = "";
@@ -202,7 +230,15 @@ export function parsePageSignals(html: string): ParsedPageSignals {
           pushUnique(ariaLabels, attributes["aria-label"], MAX_ARIA_LABELS);
         }
         if (attributes.style) {
-          collectCssSignals(attributes.style, fontFamilies, wordBreakValues, lineBreakValues);
+          collectCssSignals(
+            attributes.style,
+            fontFamilies,
+            wordBreakValues,
+            lineBreakValues,
+            directionValues,
+            physicalHorizontalCss,
+            logicalHorizontalCss,
+          );
         }
         if (tag === "script") {
           const type = (attributes.type ?? "").toLowerCase();
@@ -338,7 +374,15 @@ export function parsePageSignals(html: string): ParsedPageSignals {
           inScriptOrStyle = false;
         }
         if (tag === "style") {
-          collectCssSignals(styleBuffer, fontFamilies, wordBreakValues, lineBreakValues);
+          collectCssSignals(
+            styleBuffer,
+            fontFamilies,
+            wordBreakValues,
+            lineBreakValues,
+            directionValues,
+            physicalHorizontalCss,
+            logicalHorizontalCss,
+          );
           inStyle = false;
           styleBuffer = "";
           inScriptOrStyle = false;
@@ -405,6 +449,9 @@ export function parsePageSignals(html: string): ParsedPageSignals {
     fontFamilies,
     wordBreakValues,
     lineBreakValues,
+    directionValues,
+    physicalHorizontalCss,
+    logicalHorizontalCss,
     formFieldLabels,
   };
 }
@@ -435,6 +482,9 @@ export function crawledPageFromSignals(input: {
     fontFamilies: input.signals.fontFamilies,
     wordBreakValues: input.signals.wordBreakValues,
     lineBreakValues: input.signals.lineBreakValues,
+    directionValues: input.signals.directionValues,
+    physicalHorizontalCss: input.signals.physicalHorizontalCss,
+    logicalHorizontalCss: input.signals.logicalHorizontalCss,
     formFieldLabels: input.signals.formFieldLabels,
     anchors: input.signals.anchors,
   };
@@ -464,6 +514,9 @@ export function emptyParsedPage(url: string, status: number): LocalisationAuditC
       fontFamilies: [],
       wordBreakValues: [],
       lineBreakValues: [],
+      directionValues: [],
+      physicalHorizontalCss: [],
+      logicalHorizontalCss: [],
       formFieldLabels: [],
     },
   });

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/score.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/score.test.ts
@@ -12,7 +12,12 @@
  */
 import { describe, expect, it } from "vite-plus/test";
 
-import { aggregateLocalisationAuditCredits, pickHeadlineFindings } from "./score";
+import {
+  aggregateLocalisationAuditCredits,
+  collapseRepeatedFindings,
+  localeCoverageFactor,
+  pickHeadlineFindings,
+} from "./score";
 import type { LocalisationAuditCreditResult, LocalisationAuditFinding } from "./types";
 
 function credit(
@@ -29,13 +34,17 @@ function credit(
 function finding(
   severity: LocalisationAuditFinding["severity"],
   id: string,
+  extras?: Partial<LocalisationAuditFinding>,
 ): LocalisationAuditFinding {
   return {
     id,
     category: "technical",
     severity,
-    title: id,
-    summary: id,
+    title: extras?.title ?? id,
+    summary: extras?.summary ?? id,
+    creditId: extras?.creditId,
+    url: extras?.url,
+    evidence: extras?.evidence,
   };
 }
 
@@ -108,6 +117,47 @@ describe("aggregateLocalisationAuditCredits", () => {
         credit({ id: "d", dimension: "visual", score: 100 }),
       ]).score,
     ).toBe(100);
+  });
+
+  it("scales the overall score so more locales rank higher", () => {
+    const credits = [
+      credit({ id: "a", dimension: "technical", score: 100 }),
+      credit({ id: "b", dimension: "linguistic", score: 100 }),
+      credit({ id: "c", dimension: "contextual", score: 100 }),
+      credit({ id: "d", dimension: "visual", score: 100 }),
+    ];
+    const single = aggregateLocalisationAuditCredits(credits, { localeCount: 1 });
+    const multi = aggregateLocalisationAuditCredits(credits, { localeCount: 4 });
+    expect(single.score).toBe(72);
+    expect(multi.score).toBe(100);
+    expect(multi.score).toBeGreaterThan(single.score);
+    expect(localeCoverageFactor(0)).toBe(0.55);
+    expect(localeCoverageFactor(2)).toBe(0.86);
+  });
+});
+
+describe("collapseRepeatedFindings", () => {
+  it("merges same-title findings across pages into one", () => {
+    const collapsed = collapseRepeatedFindings([
+      finding("high", "m1", {
+        creditId: "locale-detection",
+        title: "Missing language declaration",
+        summary: "The page does not set html lang.",
+        url: "https://example.com/a",
+        evidence: "html lang is missing",
+      }),
+      finding("high", "m2", {
+        creditId: "locale-detection",
+        title: "Missing language declaration",
+        summary: "The page does not set html lang.",
+        url: "https://example.com/b",
+        evidence: "html lang is missing",
+      }),
+    ]);
+
+    expect(collapsed).toHaveLength(1);
+    expect(collapsed[0]?.summary).toContain("Affects 2 sampled pages");
+    expect(collapsed[0]?.evidence).toContain("Seen on 2 pages");
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/score.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/score.ts
@@ -43,7 +43,22 @@ function roundScore(value: number): number {
   return Math.max(0, Math.min(100, Math.round(value)));
 }
 
-export function aggregateLocalisationAuditCredits(credits: LocalisationAuditCreditResult[]): {
+/**
+ * Multi-locale sites should outrank single-locale samples on the leaderboard.
+ * Coverage scales the dimension mean so thin locale footprints cannot top the board.
+ */
+export function localeCoverageFactor(localeCount: number): number {
+  if (localeCount <= 0) return 0.55;
+  if (localeCount === 1) return 0.72;
+  if (localeCount === 2) return 0.86;
+  if (localeCount === 3) return 0.94;
+  return 1;
+}
+
+export function aggregateLocalisationAuditCredits(
+  credits: LocalisationAuditCreditResult[],
+  options?: { localeCount?: number },
+): {
   score: number;
   dimensionScores: LocalisationAuditDimensionScores;
 } {
@@ -70,12 +85,58 @@ export function aggregateLocalisationAuditCredits(credits: LocalisationAuditCred
     applicableScores.push(averaged);
   }
 
-  const overall = applicableScores.length === 0 ? 0 : mean(applicableScores);
+  const base = applicableScores.length === 0 ? 0 : mean(applicableScores);
+  const coverage =
+    options?.localeCount === undefined ? 1 : localeCoverageFactor(options.localeCount);
 
   return {
-    score: roundScore(overall),
+    score: roundScore(base * coverage),
     dimensionScores,
   };
+}
+
+/**
+ * Collapse repeated same-title findings (e.g. missing lang on every page) into one lead-gen item.
+ */
+export function collapseRepeatedFindings(
+  findings: LocalisationAuditFinding[],
+): LocalisationAuditFinding[] {
+  const groups = new Map<string, LocalisationAuditFinding[]>();
+  for (const finding of findings) {
+    const key = `${finding.creditId ?? ""}::${finding.title}`;
+    const list = groups.get(key) ?? [];
+    list.push(finding);
+    groups.set(key, list);
+  }
+
+  const collapsed: LocalisationAuditFinding[] = [];
+  for (const group of groups.values()) {
+    if (group.length === 1) {
+      collapsed.push(group[0]!);
+      continue;
+    }
+
+    const primary = group.toSorted(
+      (a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity],
+    )[0]!;
+    const urls = [
+      ...new Set(group.map((item) => item.url).filter((url): url is string => Boolean(url))),
+    ];
+    const count = Math.max(group.length, urls.length);
+    collapsed.push({
+      ...primary,
+      summary:
+        count > 1 && !/\d+\s+sampled pages/i.test(primary.summary)
+          ? `${primary.summary} Affects ${count} sampled pages.`
+          : primary.summary,
+      evidence:
+        urls.length > 1
+          ? `${primary.evidence ? `${primary.evidence}\n` : ""}Seen on ${urls.length} pages, e.g. ${urls.slice(0, 3).join(", ")}`
+          : primary.evidence,
+      url: primary.url ?? urls[0],
+    });
+  }
+  return collapsed;
 }
 
 export function pickHeadlineFindings(

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/types.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/types.ts
@@ -92,6 +92,11 @@ export type LocalisationAuditCrawledPage = {
 
 export type LocalisationAuditSitemapSignal = {
   robotsFound: boolean;
+  /** Absolute Sitemap: URLs declared in robots.txt (relative refs are resolved). */
+  robotsSitemapDirectives: string[];
+  /** True when robots.txt used a relative Sitemap: URL (Lighthouse expects absolute). */
+  robotsHasRelativeSitemapDirective: boolean;
+  /** Successfully fetched sitemap documents that contained <loc> entries. */
   sitemapUrls: string[];
   localizedUrls: string[];
 };
@@ -182,6 +187,8 @@ export const LOCALISATION_AUDIT_REPORT_TOKEN_TTL_MS = 24 * 60 * 60 * 1000;
 
 export const EMPTY_SITEMAP_SIGNAL: LocalisationAuditSitemapSignal = {
   robotsFound: false,
+  robotsSitemapDirectives: [],
+  robotsHasRelativeSitemapDirective: false,
   sitemapUrls: [],
   localizedUrls: [],
 };

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/types.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/types.ts
@@ -87,6 +87,12 @@ export type LocalisationAuditCrawledPage = {
   buttons: string[];
   headings: string[];
   fontFamilies: string[];
+  /** word-break values from inline/embedded CSS. */
+  wordBreakValues: string[];
+  /** line-break values from inline/embedded CSS. */
+  lineBreakValues: string[];
+  /** Form label / placeholder / name / autocomplete samples for naming checks. */
+  formFieldLabels: string[];
   anchors: Array<{ href: string; text: string }>;
 };
 
@@ -214,6 +220,9 @@ export function emptyCrawledPage(
     buttons: [],
     headings: [],
     fontFamilies: [],
+    wordBreakValues: [],
+    lineBreakValues: [],
+    formFieldLabels: [],
     anchors: [],
     ...partial,
   };

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/types.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/types.ts
@@ -91,6 +91,12 @@ export type LocalisationAuditCrawledPage = {
   wordBreakValues: string[];
   /** line-break values from inline/embedded CSS. */
   lineBreakValues: string[];
+  /** direction values from inline/embedded CSS. */
+  directionValues: string[];
+  /** Physical horizontal CSS snippets (float/margin/padding/left/right/text-align). */
+  physicalHorizontalCss: string[];
+  /** Logical horizontal CSS snippets (margin-inline, inset-inline, text-align: start/end). */
+  logicalHorizontalCss: string[];
   /** Form label / placeholder / name / autocomplete samples for naming checks. */
   formFieldLabels: string[];
   anchors: Array<{ href: string; text: string }>;
@@ -222,6 +228,9 @@ export function emptyCrawledPage(
     fontFamilies: [],
     wordBreakValues: [],
     lineBreakValues: [],
+    directionValues: [],
+    physicalHorizontalCss: [],
+    logicalHorizontalCss: [],
     formFieldLabels: [],
     anchors: [],
     ...partial,

--- a/apps/hyperlocalise-web/src/workflows/steps/localisation-audit.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/localisation-audit.ts
@@ -149,7 +149,9 @@ export async function analyzeLocalisationAuditStep(input: {
     focusLocales: input.focusLocales,
     sitemap: input.sitemap,
   });
-  const { score, dimensionScores } = aggregateLocalisationAuditCredits(scored.credits);
+  const { score, dimensionScores } = aggregateLocalisationAuditCredits(scored.credits, {
+    localeCount: scored.detectedLocales.length,
+  });
   const completedAt = new Date().toISOString();
 
   const report: LocalisationAuditReport = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Fixes and extends lead-gen localisation audit findings:

1. **Wrong `html lang` advice for region paths** — `/au/` no longer suggests `lang="au"`. Region prefixes map to BCP 47 tags (`en-AU`), and bare `lang="en"` on `/au/` is treated as compatible.
2. **Single-locale scores were too high** — overall score is scaled by locale coverage, and single-locale routing is penalised more strongly so multi-locale sites rank higher.
3. **Repeated findings** — same issue across many pages (e.g. missing `html lang`) collapses into one finding with an affected-page count.
4. **Noisy nav-label finding** — “Inconsistent navigation labels” is no longer scored in the public audit.
5. **Lighthouse-style sitemap checks** — missing sitemap is a scored failure (not N/A); robots.txt must reference the sitemap with an absolute `Sitemap:` URL; locale-prefixed URLs are checked for coverage.
6. **CJK typography pack** — Korean `word-break: break-all` / missing `keep-all`, Western First/Last name fields on CJK forms, tofu glyphs (`□`/`�`), and missing CJK-capable font stacks.
7. **Arabic Western digits, Gregorian calendar, RTL CSS** — flag Eastern Arabic-Indic numerals and Hijri-only dates; expand RTL checks for `direction: ltr` and physical left/right CSS without logical properties.

## How to test

```bash
cd apps/hyperlocalise-web
vp test src/lib/localisation-audit/html-parse.test.ts \
  src/lib/localisation-audit/credits/heuristics.test.ts
vp check
```

## Checklist

- [x] I ran relevant checks locally (`vp test` on audit modules, `vp check`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00040-5567-7bdc-aa88-bfadb9d23d50?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00040-5567-7bdc-aa88-bfadb9d23d50&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

