### PR TITLE
feat(localisation-audit): luxury landing copy and Playwright crawl

### DIFF
--- a/apps/hyperlocalise-web/lang/de-DE.json
+++ b/apps/hyperlocalise-web/lang/de-DE.json
@@ -7158,7 +7158,7 @@
     "defaultMessage": "Zielsprache"
   },
   "Xr/7GtH4gF": {
-    "defaultMessage": "Führen Sie auf jeder Website eine kostenlose Prüfung der Lokalisierungsqualität durch. Bewerten Sie die technische und sprachliche Bereitschaft und schalten Sie anschließend den vollständigen Bericht frei."
+    "defaultMessage": "Geben Sie eine URL ein, um zu sehen, wie sich Ihre Website in anderen Sprachen anfühlt. Eine klare Bewertung, danach der vollständige Bericht per E-Mail."
   },
   "Xs0cc+EY83": {
     "defaultMessage": "Agent-Aktionen"

--- a/apps/hyperlocalise-web/lang/de-DE.json
+++ b/apps/hyperlocalise-web/lang/de-DE.json
@@ -7157,7 +7157,7 @@
   "XqfvXT5zJ1": {
     "defaultMessage": "Zielsprache"
   },
-  "Xr/7GtH4gF": {
+  "M/3YJiyMT3": {
     "defaultMessage": "Geben Sie eine URL ein, um zu sehen, wie sich Ihre Website in anderen Sprachen anfühlt. Eine klare Bewertung, danach der vollständige Bericht per E-Mail."
   },
   "Xs0cc+EY83": {

--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -9016,7 +9016,7 @@
     "description": "Label for the target locale radio list in the download dialog"
   },
   "Xr/7GtH4gF": {
-    "defaultMessage": "Run a free localisation health check on any website. Score technical and linguistic readiness, then unlock the full report.",
+    "defaultMessage": "Enter a URL to see how your site feels in other languages. A clear score, then the full report by email.",
     "description": "Meta description for the public localisation audit landing page"
   },
   "Xs0cc+EY83": {

--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -9015,7 +9015,7 @@
     "defaultMessage": "Target locale",
     "description": "Label for the target locale radio list in the download dialog"
   },
-  "Xr/7GtH4gF": {
+  "M/3YJiyMT3": {
     "defaultMessage": "Enter a URL to see how your site feels in other languages. A clear score, then the full report by email.",
     "description": "Meta description for the public localisation audit landing page"
   },

--- a/apps/hyperlocalise-web/lang/fr-FR.json
+++ b/apps/hyperlocalise-web/lang/fr-FR.json
@@ -7157,7 +7157,7 @@
   "XqfvXT5zJ1": {
     "defaultMessage": "Paramètres régionaux cibles"
   },
-  "Xr/7GtH4gF": {
+  "M/3YJiyMT3": {
     "defaultMessage": "Saisissez une URL pour voir comment votre site se sent dans d’autres langues. Un score clair, puis le rapport complet par e-mail."
   },
   "Xs0cc+EY83": {

--- a/apps/hyperlocalise-web/lang/fr-FR.json
+++ b/apps/hyperlocalise-web/lang/fr-FR.json
@@ -7158,7 +7158,7 @@
     "defaultMessage": "Paramètres régionaux cibles"
   },
   "Xr/7GtH4gF": {
-    "defaultMessage": "Effectuez gratuitement un audit de localisation sur n’importe quel site web. Évaluez sa préparation technique et linguistique, puis déverrouillez le rapport complet."
+    "defaultMessage": "Saisissez une URL pour voir comment votre site se sent dans d’autres langues. Un score clair, puis le rapport complet par e-mail."
   },
   "Xs0cc+EY83": {
     "defaultMessage": "Agent Actions"

--- a/apps/hyperlocalise-web/lang/vi-VN.json
+++ b/apps/hyperlocalise-web/lang/vi-VN.json
@@ -7158,7 +7158,7 @@
     "defaultMessage": "Target locale"
   },
   "Xr/7GtH4gF": {
-    "defaultMessage": "Chạy kiểm tra tình trạng bản địa hóa miễn phí trên bất kỳ trang web nào. Đánh giá mức độ sẵn sàng về kỹ thuật và ngôn ngữ, sau đó mở khóa báo cáo đầy đủ."
+    "defaultMessage": "Nhập URL để xem trang của bạn cảm nhận thế nào ở ngôn ngữ khác. Điểm số rõ ràng, rồi báo cáo đầy đủ qua email."
   },
   "Xs0cc+EY83": {
     "defaultMessage": "Agent Actions"

--- a/apps/hyperlocalise-web/lang/vi-VN.json
+++ b/apps/hyperlocalise-web/lang/vi-VN.json
@@ -7157,7 +7157,7 @@
   "XqfvXT5zJ1": {
     "defaultMessage": "Target locale"
   },
-  "Xr/7GtH4gF": {
+  "M/3YJiyMT3": {
     "defaultMessage": "Nhập URL để xem trang của bạn cảm nhận thế nào ở ngôn ngữ khác. Điểm số rõ ràng, rồi báo cáo đầy đủ qua email."
   },
   "Xs0cc+EY83": {

--- a/apps/hyperlocalise-web/lang/zh-CN.json
+++ b/apps/hyperlocalise-web/lang/zh-CN.json
@@ -7157,7 +7157,7 @@
   "XqfvXT5zJ1": {
     "defaultMessage": "Target locale"
   },
-  "Xr/7GtH4gF": {
+  "M/3YJiyMT3": {
     "defaultMessage": "输入网址，了解网站在其他语言中的感受。先看清晰评分，再用邮箱查看完整报告。"
   },
   "Xs0cc+EY83": {

--- a/apps/hyperlocalise-web/lang/zh-CN.json
+++ b/apps/hyperlocalise-web/lang/zh-CN.json
@@ -7158,7 +7158,7 @@
     "defaultMessage": "Target locale"
   },
   "Xr/7GtH4gF": {
-    "defaultMessage": "免费检查任意网站的本地化状况。评估技术和语言准备度，然后解锁完整报告。"
+    "defaultMessage": "输入网址，了解网站在其他语言中的感受。先看清晰评分，再用邮箱查看完整报告。"
   },
   "Xs0cc+EY83": {
     "defaultMessage": "Agent Actions"

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/localisation-audit-route-metadata.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/localisation-audit-route-metadata.ts
@@ -21,7 +21,7 @@ export function getLocalisationAuditRouteMetadata(intl: IntlShape) {
     }),
     description: intl.formatMessage({
       defaultMessage:
-        "Run a free localisation health check on any website. Score technical and linguistic readiness, then unlock the full report.",
+        "Enter a URL to see how your site feels in other languages. A clear score, then the full report by email.",
       id: "Xr/7GtH4gF",
       description: "Meta description for the public localisation audit landing page",
     }),

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/localisation-audit-route-metadata.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/localisation-audit-route-metadata.ts
@@ -22,7 +22,7 @@ export function getLocalisationAuditRouteMetadata(intl: IntlShape) {
     description: intl.formatMessage({
       defaultMessage:
         "Enter a URL to see how your site feels in other languages. A clear score, then the full report by email.",
-      id: "Xr/7GtH4gF",
+      id: "M/3YJiyMT3",
       description: "Meta description for the public localisation audit landing page",
     }),
   };

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-form.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-form.tsx
@@ -18,14 +18,19 @@ import { useState, type FormEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/primitives/cn";
 
 import { getLocalisationAuditPageCopy } from "./localisation-audit-page-content";
 
+const MESH_INPUT_CLASS =
+  "h-11 border-white/25 bg-white/15 text-white placeholder:text-white/55 focus-visible:border-white/60 focus-visible:ring-white/30";
+
 type LocalisationAuditFormProps = {
   locale: string;
+  tone?: "default" | "mesh";
 };
 
-export function LocalisationAuditForm({ locale }: LocalisationAuditFormProps) {
+export function LocalisationAuditForm({ locale, tone = "default" }: LocalisationAuditFormProps) {
   const copy = getLocalisationAuditPageCopy(locale);
   const router = useRouter();
   const [url, setUrl] = useState("");
@@ -74,10 +79,17 @@ export function LocalisationAuditForm({ locale }: LocalisationAuditFormProps) {
     }
   }
 
+  const onMesh = tone === "mesh";
+
   return (
-    <form onSubmit={onSubmit} className="mt-10 max-w-xl space-y-6">
+    <form onSubmit={onSubmit} className="max-w-xl space-y-6">
       <div className="space-y-2">
-        <Label htmlFor="localisation-audit-url">{copy.urlLabel}</Label>
+        <Label
+          htmlFor="localisation-audit-url"
+          className={onMesh ? "text-white" : undefined}
+        >
+          {copy.urlLabel}
+        </Label>
         <Input
           id="localisation-audit-url"
           name="url"
@@ -88,25 +100,47 @@ export function LocalisationAuditForm({ locale }: LocalisationAuditFormProps) {
           placeholder={copy.urlPlaceholder}
           value={url}
           onChange={(event) => setUrl(event.target.value)}
+          className={onMesh ? MESH_INPUT_CLASS : undefined}
         />
       </div>
       <div className="space-y-2">
-        <Label htmlFor="localisation-audit-focus">{copy.focusLabel}</Label>
+        <Label
+          htmlFor="localisation-audit-focus"
+          className={onMesh ? "text-white" : undefined}
+        >
+          {copy.focusLabel}
+        </Label>
         <Input
           id="localisation-audit-focus"
           name="focusLocales"
           placeholder={copy.focusPlaceholder}
           value={focusLocales}
           onChange={(event) => setFocusLocales(event.target.value)}
+          className={onMesh ? MESH_INPUT_CLASS : undefined}
         />
-        <p className="text-sm text-muted-foreground">{copy.focusHint}</p>
+        <p className={cn("text-sm", onMesh ? "text-white/70" : "text-muted-foreground")}>
+          {copy.focusHint}
+        </p>
       </div>
-      {error ? <p className="text-sm text-destructive">{error}</p> : null}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-        <Button type="submit" size="lg" disabled={pending}>
+      {error ? (
+        <p className={cn("text-sm", onMesh ? "text-red-200" : "text-destructive")}>{error}</p>
+      ) : null}
+      <div className="flex flex-col gap-3">
+        <Button
+          type="submit"
+          size="lg"
+          disabled={pending}
+          className={
+            onMesh
+              ? "bg-white text-neutral-950 hover:bg-white/90 disabled:bg-white/70"
+              : undefined
+          }
+        >
           {pending ? copy.submitting : copy.submit}
         </Button>
-        <p className="text-sm text-muted-foreground">{copy.onePerDomain}</p>
+        <p className={cn("text-sm", onMesh ? "text-white/70" : "text-muted-foreground")}>
+          {copy.onePerDomain}
+        </p>
       </div>
     </form>
   );

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-form.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-form.tsx
@@ -84,10 +84,7 @@ export function LocalisationAuditForm({ locale, tone = "default" }: Localisation
   return (
     <form onSubmit={onSubmit} className="max-w-xl space-y-6">
       <div className="space-y-2">
-        <Label
-          htmlFor="localisation-audit-url"
-          className={onMesh ? "text-white" : undefined}
-        >
+        <Label htmlFor="localisation-audit-url" className={onMesh ? "text-white" : undefined}>
           {copy.urlLabel}
         </Label>
         <Input
@@ -104,10 +101,7 @@ export function LocalisationAuditForm({ locale, tone = "default" }: Localisation
         />
       </div>
       <div className="space-y-2">
-        <Label
-          htmlFor="localisation-audit-focus"
-          className={onMesh ? "text-white" : undefined}
-        >
+        <Label htmlFor="localisation-audit-focus" className={onMesh ? "text-white" : undefined}>
           {copy.focusLabel}
         </Label>
         <Input
@@ -131,9 +125,7 @@ export function LocalisationAuditForm({ locale, tone = "default" }: Localisation
           size="lg"
           disabled={pending}
           className={
-            onMesh
-              ? "bg-white text-neutral-950 hover:bg-white/90 disabled:bg-white/70"
-              : undefined
+            onMesh ? "bg-white text-neutral-950 hover:bg-white/90 disabled:bg-white/70" : undefined
           }
         >
           {pending ? copy.submitting : copy.submit}

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page-content.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page-content.ts
@@ -24,42 +24,40 @@ export function getLocalisationAuditGuideHref(): string {
 
 export function getLocalisationAuditPageCopy(_locale: string) {
   return {
-    headline: "Localisation health check",
+    headline: "See how your brand travels.",
     subcopy:
-      "Paste a URL. Get a public score, see how you rank against other domains, and unlock the full report with your work email.",
-    urlLabel: "Website URL",
-    urlPlaceholder: "https://example.com",
-    focusLabel: "Focus markets (optional)",
-    focusPlaceholder: "fr, de",
-    focusHint: "Up to two locales for a deeper linguistic pass.",
-    submit: "Run free audit",
-    submitting: "Starting audit…",
-    onePerDomain:
-      "One free audit per domain, and 10 audits a day across all sites. If we already audited it, you will see the public teaser report.",
-    methodologyHeading: "What we check",
-    technicalChecks: [
-      "Locale detection, routing, language switcher, hreflang, and canonicals",
-      "Localized metadata, sitemaps, structured data, and formatting",
-      "Accessibility localisation on sampled pages",
+      "Enter a URL. We'll read a few public pages and tell you how the site feels in other languages.",
+    urlLabel: "Website",
+    urlPlaceholder: "https://your-site.com",
+    focusLabel: "Languages to look at (optional)",
+    focusPlaceholder: "French, German",
+    focusHint: "We'll look more closely at up to two.",
+    submit: "See my score",
+    submitting: "Looking now…",
+    onePerDomain: "One free look per site. Ten a day across all sites.",
+    methodologyHeading: "What we notice",
+    notices: [
+      {
+        title: "Voice",
+        body: "Does the writing still sound like you, once the language changes?",
+      },
+      {
+        title: "Presence",
+        body: "Do pages still feel considered — layout, images, and all?",
+      },
+      {
+        title: "Discovery",
+        body: "Can visitors find the right version of the site?",
+      },
     ],
-    linguisticChecks: [
-      "Translation completeness, terminology, and cross-page consistency",
-      "Accuracy, fluency, brand voice, and grammar when heuristics are inconclusive",
-      "Contextual and visual credits on the same sampled pages",
-    ],
-    crawlLimits:
-      "Smart sample of about 10–15 public pages. We do not log in, submit forms, or crawl private areas.",
-    privacyNote:
-      "Safe crawl only: public HTML over HTTPS, SSRF-guarded fetches, and no credentialed access.",
-    disclosure:
-      "Successful teaser reports are public and indexable. Email verification unlocks the full report for that domain.",
-    sampleFindingTitle: "Sample finding",
+    scopeNote: "We only read public pages. We never sign in or fill in forms.",
+    disclosure: "Scores are public. Use your work email to see the full report.",
+    sampleFindingTitle: "A typical note",
     sampleFindingBody:
-      "Critical · Missing hreflang return tags between EN and FR can split SEO equity across locales.",
-    leaderboardHeading: "Public localisation leaderboard",
-    leaderboardSubcopy:
-      "Teaser scores are public. Compare domains, then run your own audit to see where you rank.",
-    leaderboardEmpty: "No public audits yet. Run the first health check and claim the top spot.",
+      "French and English pages don't point to each other, so visitors can miss the other language entirely.",
+    leaderboardHeading: "How other sites score",
+    leaderboardSubcopy: "Public scores, side by side. Check yours to see where you stand.",
+    leaderboardEmpty: "No public scores yet. Be the first.",
   };
 }
 

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page.stories.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect } from "storybook/test";
+
+import { LocalisationAuditPage } from "./localisation-audit-page";
+import { localisationAuditDomainSlug } from "./localisation-audit.fixture";
+
+const meta = {
+  title: "Marketing/LocalisationAudit/Landing",
+  component: LocalisationAuditPage,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    locale: "en",
+    leaderboard: [
+      {
+        rank: 1,
+        domainKey: "acme.example",
+        domainSlug: localisationAuditDomainSlug,
+        score: 86,
+        completedAt: new Date("2026-08-01T12:00:00.000Z"),
+      },
+    ],
+  },
+} satisfies Meta<typeof LocalisationAuditPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByRole("heading", { name: "See how your brand travels." }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "See my score" })).toBeInTheDocument();
+    await expect(canvas.getByRole("heading", { name: "What we notice" })).toBeInTheDocument();
+    await expect(canvas.getByRole("heading", { name: "How other sites score" })).toBeInTheDocument();
+    await expect(canvas.queryByText("hreflang")).not.toBeInTheDocument();
+    await expect(canvas.queryByText(/SSRF/)).not.toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page.stories.tsx
@@ -46,7 +46,9 @@ export const Default: Story = {
     ).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "See my score" })).toBeInTheDocument();
     await expect(canvas.getByRole("heading", { name: "What we notice" })).toBeInTheDocument();
-    await expect(canvas.getByRole("heading", { name: "How other sites score" })).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("heading", { name: "How other sites score" }),
+    ).toBeInTheDocument();
     await expect(canvas.queryByText("hreflang")).not.toBeInTheDocument();
     await expect(canvas.queryByText(/SSRF/)).not.toBeInTheDocument();
   },

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page.tsx
@@ -10,9 +10,10 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { MeshStage, SAGE_MESH_GRADIENT_SRC } from "@/components/marketing/hero-frame-mesh-stage";
 import { MarketingFooter } from "@/components/marketing/marketing-footer";
 import { footerColumns } from "@/components/marketing/marketing-page-content";
-import { TypographyH1, TypographyH2, TypographyP } from "@/components/ui/typography";
+import { TypographyH1, TypographyH2, TypographyH3, TypographyP } from "@/components/ui/typography";
 import type { LocalisationAuditLeaderboardEntry } from "@/lib/localisation-audit/store";
 
 import { LocalisationAuditForm } from "./localisation-audit-form";
@@ -33,44 +34,46 @@ export function LocalisationAuditPage({ locale, leaderboard }: LocalisationAudit
         <section className="px-5 pt-16 pb-20 sm:px-8 sm:pt-20 sm:pb-24 lg:px-10">
           <div className="max-w-3xl space-y-5">
             <TypographyH1>{copy.headline}</TypographyH1>
-            <TypographyP className="text-lg text-muted-foreground">{copy.subcopy}</TypographyP>
+            <TypographyP className="max-w-2xl text-lg text-muted-foreground sm:text-xl">
+              {copy.subcopy}
+            </TypographyP>
           </div>
-          <LocalisationAuditForm locale={locale} />
+          <MeshStage
+            className="mt-10 max-w-2xl"
+            meshSrc={SAGE_MESH_GRADIENT_SRC}
+            contentClassName="p-0"
+            priority
+          >
+            <div className="relative">
+              <div
+                className="absolute inset-0 bg-gradient-to-b from-black/55 via-black/35 to-black/65"
+                aria-hidden
+              />
+              <div className="relative p-6 sm:p-8 lg:p-10">
+                <LocalisationAuditForm locale={locale} tone="mesh" />
+              </div>
+            </div>
+          </MeshStage>
         </section>
 
         <LocalisationAuditLeaderboard locale={locale} entries={leaderboard} />
 
         <section className="border-t border-border px-5 py-16 sm:px-8 lg:px-10">
           <TypographyH2 className="pb-0">{copy.methodologyHeading}</TypographyH2>
-          <div className="mt-8 grid gap-10 md:grid-cols-2">
-            <div>
-              <p className="text-xs font-medium tracking-[0.14em] text-muted-foreground uppercase">
-                Technical
-              </p>
-              <ul className="mt-4 space-y-3 text-muted-foreground">
-                {copy.technicalChecks.map((item) => (
-                  <li key={item}>{item}</li>
-                ))}
-              </ul>
-            </div>
-            <div>
-              <p className="text-xs font-medium tracking-[0.14em] text-muted-foreground uppercase">
-                Linguistic
-              </p>
-              <ul className="mt-4 space-y-3 text-muted-foreground">
-                {copy.linguisticChecks.map((item) => (
-                  <li key={item}>{item}</li>
-                ))}
-              </ul>
-            </div>
+          <div className="mt-10 grid gap-10 md:grid-cols-3">
+            {copy.notices.map((notice) => (
+              <div key={notice.title} className="space-y-3">
+                <TypographyH3 className="pb-0 text-xl tracking-tight md:text-2xl">
+                  {notice.title}
+                </TypographyH3>
+                <p className="max-w-sm text-muted-foreground">{notice.body}</p>
+              </div>
+            ))}
           </div>
-          <TypographyP className="mt-10 max-w-3xl text-muted-foreground">
-            {copy.crawlLimits}
+          <TypographyP className="mt-12 max-w-2xl text-muted-foreground">
+            {copy.scopeNote}
           </TypographyP>
-          <TypographyP className="mt-4 max-w-3xl text-muted-foreground">
-            {copy.privacyNote}
-          </TypographyP>
-          <TypographyP className="mt-4 max-w-3xl text-muted-foreground">
+          <TypographyP className="mt-3 max-w-2xl text-muted-foreground">
             {copy.disclosure}
           </TypographyP>
           <div className="mt-10 max-w-2xl rounded-xl border border-border bg-muted/30 p-6">

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/crawl-renderer.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/crawl-renderer.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+export type RenderedHtmlPage = {
+  requestedUrl: string;
+  url: string;
+  status: number;
+  html: string;
+};
+
+export type HtmlPageRenderer = {
+  render(urls: string[]): Promise<RenderedHtmlPage[]>;
+  close(): Promise<void>;
+};
+
+export type CrawlLocalisationAuditSampleOptions = {
+  createRenderer?: () => Promise<HtmlPageRenderer>;
+};

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.test.ts
@@ -12,6 +12,9 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
+import type { HtmlPageRenderer, RenderedHtmlPage } from "./crawl-renderer";
+import { AuditBrowserSetupError } from "./sandbox-browser-error";
+
 const { withPublicHttpFetchMock } = vi.hoisted(() => ({
   withPublicHttpFetchMock: vi.fn(),
 }));
@@ -26,110 +29,113 @@ vi.mock("@/lib/security/public-http-fetch", async (importOriginal) => {
 
 import { crawlLocalisationAuditSample } from "./crawl";
 
-function htmlResponse(html: string, init?: ResponseInit) {
-  return new Response(html, {
-    status: 200,
-    headers: { "content-type": "text/html; charset=utf-8" },
-    ...init,
-  });
+function htmlPage(
+  requestedUrl: string,
+  html: string,
+  overrides?: Partial<RenderedHtmlPage>,
+): RenderedHtmlPage {
+  return {
+    requestedUrl,
+    url: overrides?.url ?? requestedUrl,
+    status: overrides?.status ?? 200,
+    html,
+    ...overrides,
+  };
+}
+
+function rendererFromPages(pages: RenderedHtmlPage[]): HtmlPageRenderer {
+  const byRequest = new Map(pages.map((page) => [page.requestedUrl, page]));
+  const rendered: string[] = [];
+  return {
+    async render(urls) {
+      rendered.push(...urls);
+      return urls.flatMap((url) => {
+        const page = byRequest.get(url);
+        return page ? [page] : [];
+      });
+    },
+    async close() {},
+    rendered,
+  } as HtmlPageRenderer & { rendered: string[] };
+}
+
+function mockBrowser(pages: RenderedHtmlPage[]) {
+  const renderer = rendererFromPages(pages);
+  return {
+    renderer,
+    createRenderer: async () => renderer,
+    renderedUrls: (renderer as HtmlPageRenderer & { rendered: string[] }).rendered,
+  };
 }
 
 describe("crawlLocalisationAuditSample", () => {
   beforeEach(() => {
     withPublicHttpFetchMock.mockReset();
-  });
-
-  it("uses redirect: manual and never requests redirect: follow", async () => {
     withPublicHttpFetchMock.mockImplementation(async (url, init, handler) => {
       expect(init?.redirect).toBe("manual");
-      if (url === "https://example.com/") {
-        return handler(
-          htmlResponse("<html lang='en'><title>Home</title><body>Hello world page</body></html>"),
-        );
+      if (url.endsWith("/robots.txt") || url.endsWith("/sitemap.xml")) {
+        return handler(new Response("Not found", { status: 404 }));
       }
-      return handler(htmlResponse("<html><body>Other page content here for sample</body></html>"));
+      throw new Error(`unexpected fetch: ${url}`);
     });
+  });
 
-    const result = await crawlLocalisationAuditSample({
-      origin: "https://example.com",
-      sourceUrl: "https://example.com/",
-    });
+  it("renders HTML in the supplied browser session instead of fetching pages", async () => {
+    const { createRenderer, renderedUrls } = mockBrowser([
+      htmlPage(
+        "https://example.com/",
+        "<html lang='en'><title>Home</title><body>Hello world page</body></html>",
+      ),
+    ]);
+
+    const result = await crawlLocalisationAuditSample(
+      { origin: "https://example.com", sourceUrl: "https://example.com/" },
+      { createRenderer },
+    );
 
     expect(result.pages.length).toBeGreaterThan(0);
-    expect(withPublicHttpFetchMock.mock.calls.every((call) => call[1]?.redirect === "manual")).toBe(
-      true,
+    expect(result.pages[0]?.title).toBe("Home");
+    expect(renderedUrls).toContain("https://example.com/");
+    expect(
+      withPublicHttpFetchMock.mock.calls.every(
+        (call) => String(call[0]).includes("robots.txt") || String(call[0]).includes("sitemap.xml"),
+      ),
+    ).toBe(true);
+  });
+
+  it("follows a rendered homepage redirect and crawls the final URL", async () => {
+    const { createRenderer } = mockBrowser([
+      htmlPage(
+        "https://example.com/",
+        `<html lang="en"><head><title>EN</title><link rel="alternate" hreflang="fr" href="/fr" /></head><body><a href="/pricing">Pricing</a> Welcome to the English homepage content.</body></html>`,
+        { url: "https://example.com/en" },
+      ),
+      htmlPage(
+        "https://example.com/fr",
+        "<html lang='fr'><title>Accueil</title><body>Page d accueil francaise avec contenu.</body></html>",
+      ),
+      htmlPage(
+        "https://example.com/pricing",
+        "<html><body>Secondary page with enough text content for parsing.</body></html>",
+      ),
+    ]);
+
+    const result = await crawlLocalisationAuditSample(
+      { origin: "https://example.com", sourceUrl: "https://example.com/" },
+      { createRenderer },
     );
-  });
-
-  it("re-validates each redirect hop so private Location targets are not fetched", async () => {
-    const fetchedUrls: string[] = [];
-    withPublicHttpFetchMock.mockImplementation(async (url, _init, handler) => {
-      fetchedUrls.push(url);
-      if (url === "https://example.com/") {
-        return handler(
-          new Response(null, {
-            status: 302,
-            headers: { location: "http://127.0.0.1/secret" },
-          }),
-        );
-      }
-      // Simulate withPublicHttpFetch rejecting the private hop.
-      throw new Error("URL host is not allowed.");
-    });
-
-    const result = await crawlLocalisationAuditSample({
-      origin: "https://example.com",
-      sourceUrl: "https://example.com/",
-    });
-
-    expect(result.pages).toEqual([]);
-    expect(fetchedUrls).toEqual(["https://example.com/", "http://127.0.0.1/secret"]);
-  });
-
-  it("follows a same-host public redirect and crawls the final URL", async () => {
-    withPublicHttpFetchMock.mockImplementation(async (url, _init, handler) => {
-      if (url === "https://example.com/") {
-        return handler(
-          new Response(null, {
-            status: 301,
-            headers: { location: "https://example.com/en" },
-          }),
-        );
-      }
-      if (url === "https://example.com/en") {
-        return handler(
-          htmlResponse(
-            `<html lang="en"><head><title>EN</title><link rel="alternate" hreflang="fr" href="/fr" /></head><body><a href="/pricing">Pricing</a> Welcome to the English homepage content.</body></html>`,
-          ),
-        );
-      }
-      return handler(
-        htmlResponse(
-          "<html><body>Secondary page with enough text content for parsing.</body></html>",
-        ),
-      );
-    });
-
-    const result = await crawlLocalisationAuditSample({
-      origin: "https://example.com",
-      sourceUrl: "https://example.com/",
-    });
 
     expect(result.pages.some((page) => page.url === "https://example.com/en")).toBe(true);
     expect(result.pages.find((page) => page.url === "https://example.com/en")?.title).toBe("EN");
   });
 
-  it("returns an empty sample when the home page fetch fails instead of throwing", async () => {
-    withPublicHttpFetchMock.mockImplementation(async () => {
-      throw new Error("URL host is not allowed.");
-    });
+  it("returns an empty sample when the home page render fails instead of throwing", async () => {
+    const result = await crawlLocalisationAuditSample(
+      { origin: "https://example.com", sourceUrl: "https://example.com/" },
+      { createRenderer: async () => rendererFromPages([]) },
+    );
 
-    await expect(
-      crawlLocalisationAuditSample({
-        origin: "https://example.com",
-        sourceUrl: "https://example.com/",
-      }),
-    ).resolves.toEqual({
+    expect(result).toEqual({
       pages: [],
       sitemap: {
         robotsFound: false,
@@ -141,114 +147,71 @@ describe("crawlLocalisationAuditSample", () => {
     });
   });
 
-  it("reuses one abort signal across redirect hops so the page timeout does not reset", async () => {
-    const signals: AbortSignal[] = [];
-    withPublicHttpFetchMock.mockImplementation(async (url, init, handler) => {
-      if (init?.signal) {
-        signals.push(init.signal);
-      }
-      if (url === "https://example.com/") {
-        return handler(
-          new Response(null, {
-            status: 302,
-            headers: { location: "https://example.com/en" },
-          }),
-        );
-      }
-      if (url === "https://example.com/en") {
-        return handler(
-          htmlResponse(
-            "<html lang='en'><title>EN</title><body>Welcome to the English homepage content.</body></html>",
-          ),
-        );
-      }
-      return handler(
-        htmlResponse(
-          "<html><body>Secondary page with enough text content for parsing.</body></html>",
-        ),
-      );
-    });
-
-    await crawlLocalisationAuditSample({
-      origin: "https://example.com",
-      sourceUrl: "https://example.com/",
-    });
-
-    expect(signals.length).toBeGreaterThanOrEqual(2);
-    expect(signals[0]).toBe(signals[1]);
+  it("rethrows browser setup failures so the workflow step can retry", async () => {
+    await expect(
+      crawlLocalisationAuditSample(
+        { origin: "https://example.com", sourceUrl: "https://example.com/" },
+        {
+          createRenderer: async () => {
+            throw new AuditBrowserSetupError("audit browser runtime install failed");
+          },
+        },
+      ),
+    ).rejects.toThrow(AuditBrowserSetupError);
   });
 
   it("crawls homepage links and hreflang without inventing high-value paths", async () => {
-    const fetchedUrls: string[] = [];
-    withPublicHttpFetchMock.mockImplementation(async (url, _init, handler) => {
-      fetchedUrls.push(url);
-      if (url === "https://example.com/") {
-        return handler(
-          htmlResponse(
-            `<html lang="en"><head><title>Home</title><link rel="alternate" hreflang="fr" href="/fr" /><link rel="alternate" hreflang="x-default" href="/" /></head><body><a href="/de">Deutsch</a> Welcome to the homepage content sample.</body></html>`,
-          ),
-        );
-      }
-      if (url === "https://example.com/fr") {
-        return handler(
-          htmlResponse(
-            "<html lang='fr'><title>Accueil</title><body>Page d accueil francaise avec contenu.</body></html>",
-          ),
-        );
-      }
-      return handler(
-        htmlResponse(
-          "<html><body>Secondary page with enough text content for parsing.</body></html>",
-        ),
-      );
-    });
+    const { createRenderer, renderedUrls } = mockBrowser([
+      htmlPage(
+        "https://example.com/",
+        `<html lang="en"><head><title>Home</title><link rel="alternate" hreflang="fr" href="/fr" /><link rel="alternate" hreflang="x-default" href="/" /></head><body><a href="/de">Deutsch</a> Welcome to the homepage content sample.</body></html>`,
+      ),
+      htmlPage(
+        "https://example.com/fr",
+        "<html lang='fr'><title>Accueil</title><body>Page d accueil francaise avec contenu.</body></html>",
+      ),
+      htmlPage(
+        "https://example.com/de",
+        "<html lang='de'><title>Start</title><body>Deutsche Startseite mit genug Inhalt.</body></html>",
+      ),
+    ]);
 
-    const result = await crawlLocalisationAuditSample({
-      origin: "https://example.com",
-      sourceUrl: "https://example.com/",
-    });
+    const result = await crawlLocalisationAuditSample(
+      { origin: "https://example.com", sourceUrl: "https://example.com/" },
+      { createRenderer },
+    );
 
-    expect(fetchedUrls).toContain("https://example.com/fr");
-    expect(fetchedUrls).toContain("https://example.com/de");
-    expect(fetchedUrls).not.toContain("https://example.com/ja/pricing");
-    expect(fetchedUrls).not.toContain("https://example.com/fr/pricing");
-    expect(fetchedUrls).not.toContain("https://example.com/pricing");
+    expect(renderedUrls).toContain("https://example.com/fr");
+    expect(renderedUrls).toContain("https://example.com/de");
+    expect(renderedUrls).not.toContain("https://example.com/ja/pricing");
+    expect(renderedUrls).not.toContain("https://example.com/fr/pricing");
+    expect(renderedUrls).not.toContain("https://example.com/pricing");
     expect(result.pages.some((page) => page.url === "https://example.com/fr")).toBe(true);
   });
 
   it("seeds requested focus locale roots without inventing high-value paths", async () => {
-    const fetchedUrls: string[] = [];
-    withPublicHttpFetchMock.mockImplementation(async (url, _init, handler) => {
-      fetchedUrls.push(url);
-      if (url === "https://example.com/") {
-        return handler(
-          htmlResponse(
-            "<html lang='en'><head><title>Home</title></head><body>Welcome to the homepage content sample.</body></html>",
-          ),
-        );
-      }
-      if (url === "https://example.com/ja") {
-        return handler(
-          htmlResponse(
-            "<html lang='ja'><title>ホーム</title><body>日本語のホームページのサンプルコンテンツです。</body></html>",
-          ),
-        );
-      }
-      return handler(
-        htmlResponse(
-          "<html><body>Secondary page with enough text content for parsing.</body></html>",
-        ),
-      );
-    });
+    const { createRenderer, renderedUrls } = mockBrowser([
+      htmlPage(
+        "https://example.com/",
+        "<html lang='en'><head><title>Home</title></head><body>Welcome to the homepage content sample.</body></html>",
+      ),
+      htmlPage(
+        "https://example.com/ja",
+        "<html lang='ja'><title>ホーム</title><body>日本語のホームページのサンプルコンテンツです。</body></html>",
+      ),
+    ]);
 
-    const result = await crawlLocalisationAuditSample({
-      origin: "https://example.com",
-      sourceUrl: "https://example.com/",
-      focusLocales: ["ja", "x-default"],
-    });
+    const result = await crawlLocalisationAuditSample(
+      {
+        origin: "https://example.com",
+        sourceUrl: "https://example.com/",
+        focusLocales: ["ja", "x-default"],
+      },
+      { createRenderer },
+    );
 
-    expect(fetchedUrls).toContain("https://example.com/ja");
-    expect(fetchedUrls).not.toContain("https://example.com/ja/pricing");
+    expect(renderedUrls).toContain("https://example.com/ja");
+    expect(renderedUrls).not.toContain("https://example.com/ja/pricing");
     expect(result.pages.some((page) => page.url === "https://example.com/ja")).toBe(true);
   });
 
@@ -270,24 +233,20 @@ describe("crawlLocalisationAuditSample", () => {
           ),
         );
       }
-      if (url === "https://example.com/") {
-        return handler(
-          htmlResponse(
-            "<html lang='en'><title>Home</title><body>Welcome to the homepage content sample.</body></html>",
-          ),
-        );
-      }
-      return handler(
-        htmlResponse(
-          "<html><body>Secondary page with enough text content for parsing.</body></html>",
-        ),
-      );
+      throw new Error(`unexpected fetch: ${url}`);
     });
 
-    const result = await crawlLocalisationAuditSample({
-      origin: "https://example.com",
-      sourceUrl: "https://example.com/",
-    });
+    const { createRenderer } = mockBrowser([
+      htmlPage(
+        "https://example.com/",
+        "<html lang='en'><title>Home</title><body>Welcome to the homepage content sample.</body></html>",
+      ),
+    ]);
+
+    const result = await crawlLocalisationAuditSample(
+      { origin: "https://example.com", sourceUrl: "https://example.com/" },
+      { createRenderer },
+    );
 
     expect(result.sitemap.robotsFound).toBe(true);
     expect(result.sitemap.robotsSitemapDirectives).toContain("https://example.com/sitemap.xml");
@@ -315,24 +274,20 @@ describe("crawlLocalisationAuditSample", () => {
           ),
         );
       }
-      if (url === "https://example.com/") {
-        return handler(
-          htmlResponse(
-            "<html lang='en'><title>Home</title><body>Welcome to the homepage content sample.</body></html>",
-          ),
-        );
-      }
-      return handler(
-        htmlResponse(
-          "<html><body>Secondary page with enough text content for parsing.</body></html>",
-        ),
-      );
+      throw new Error(`unexpected fetch: ${url}`);
     });
 
-    const result = await crawlLocalisationAuditSample({
-      origin: "https://example.com",
-      sourceUrl: "https://example.com/",
-    });
+    const { createRenderer } = mockBrowser([
+      htmlPage(
+        "https://example.com/",
+        "<html lang='en'><title>Home</title><body>Welcome to the homepage content sample.</body></html>",
+      ),
+    ]);
+
+    const result = await crawlLocalisationAuditSample(
+      { origin: "https://example.com", sourceUrl: "https://example.com/" },
+      { createRenderer },
+    );
 
     expect(result.sitemap.robotsHasRelativeSitemapDirective).toBe(true);
     expect(result.sitemap.robotsSitemapDirectives).toContain("https://example.com/sitemap.xml");
@@ -353,27 +308,41 @@ describe("crawlLocalisationAuditSample", () => {
           new Response("Not found", { status: 404, headers: { "content-type": "text/plain" } }),
         );
       }
-      if (url === "https://example.com/") {
-        return handler(
-          htmlResponse(
-            "<html lang='en'><title>Home</title><body>Welcome to the homepage content sample.</body></html>",
-          ),
-        );
-      }
-      return handler(
-        htmlResponse(
-          "<html><body>Secondary page with enough text content for parsing.</body></html>",
-        ),
-      );
+      throw new Error(`unexpected fetch: ${url}`);
     });
 
-    const result = await crawlLocalisationAuditSample({
-      origin: "https://example.com",
-      sourceUrl: "https://example.com/",
-    });
+    const { createRenderer } = mockBrowser([
+      htmlPage(
+        "https://example.com/",
+        "<html lang='en'><title>Home</title><body>Welcome to the homepage content sample.</body></html>",
+      ),
+    ]);
+
+    const result = await crawlLocalisationAuditSample(
+      { origin: "https://example.com", sourceUrl: "https://example.com/" },
+      { createRenderer },
+    );
 
     expect(result.sitemap.robotsFound).toBe(true);
     expect(result.sitemap.robotsSitemapDirectives).toEqual([]);
     expect(result.sitemap.sitemapUrls).toEqual([]);
+  });
+
+  it("uses redirect: manual for robots and sitemap fetches", async () => {
+    const { createRenderer } = mockBrowser([
+      htmlPage(
+        "https://example.com/",
+        "<html lang='en'><title>Home</title><body>Hello world page</body></html>",
+      ),
+    ]);
+
+    await crawlLocalisationAuditSample(
+      { origin: "https://example.com", sourceUrl: "https://example.com/" },
+      { createRenderer },
+    );
+
+    expect(withPublicHttpFetchMock.mock.calls.every((call) => call[1]?.redirect === "manual")).toBe(
+      true,
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.test.ts
@@ -153,7 +153,7 @@ describe("crawlLocalisationAuditSample", () => {
         { origin: "https://example.com", sourceUrl: "https://example.com/" },
         {
           createRenderer: async () => {
-            throw new AuditBrowserSetupError("audit browser runtime install failed");
+            throw new AuditBrowserSetupError("sandbox image is missing Playwright");
           },
         },
       ),

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.test.ts
@@ -129,6 +129,55 @@ describe("crawlLocalisationAuditSample", () => {
     expect(result.pages.find((page) => page.url === "https://example.com/en")?.title).toBe("EN");
   });
 
+  it("keeps redirected secondary pages in the sample via requested URL", async () => {
+    const { createRenderer } = mockBrowser([
+      htmlPage(
+        "https://example.com/",
+        `<html lang="en"><head><title>Home</title><link rel="alternate" hreflang="fr" href="/fr" /></head><body>Welcome to the homepage content sample.</body></html>`,
+      ),
+      htmlPage(
+        "https://example.com/fr",
+        "<html lang='fr'><title>Accueil</title><body>Page d accueil francaise avec contenu.</body></html>",
+        { url: "https://example.com/fr/" },
+      ),
+    ]);
+
+    const result = await crawlLocalisationAuditSample(
+      { origin: "https://example.com", sourceUrl: "https://example.com/" },
+      { createRenderer },
+    );
+
+    expect(result.pages.some((page) => page.url === "https://example.com/fr/")).toBe(true);
+    expect(result.pages.find((page) => page.url === "https://example.com/fr/")?.title).toBe(
+      "Accueil",
+    );
+  });
+
+  it("seeds focus locale roots from English language names", async () => {
+    const { createRenderer, renderedUrls } = mockBrowser([
+      htmlPage(
+        "https://example.com/",
+        "<html lang='en'><head><title>Home</title></head><body>Welcome to the homepage content sample.</body></html>",
+      ),
+      htmlPage(
+        "https://example.com/fr",
+        "<html lang='fr'><title>Accueil</title><body>Page d accueil francaise avec contenu.</body></html>",
+      ),
+    ]);
+
+    const result = await crawlLocalisationAuditSample(
+      {
+        origin: "https://example.com",
+        sourceUrl: "https://example.com/",
+        focusLocales: ["French"],
+      },
+      { createRenderer },
+    );
+
+    expect(renderedUrls).toContain("https://example.com/fr");
+    expect(result.pages.some((page) => page.url === "https://example.com/fr")).toBe(true);
+  });
+
   it("returns an empty sample when the home page render fails instead of throwing", async () => {
     const result = await crawlLocalisationAuditSample(
       { origin: "https://example.com", sourceUrl: "https://example.com/" },

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.ts
@@ -10,16 +10,23 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-with-concurrency";
 import { readBoundedResponseBody, withPublicHttpFetch } from "@/lib/security/public-http-fetch";
 
-import { crawledPageFromSignals, emptyParsedPage, parsePageSignals } from "./html-parse";
+import type { CrawlLocalisationAuditSampleOptions, HtmlPageRenderer } from "./crawl-renderer";
+import { crawledPageFromSignals, parsePageSignals } from "./html-parse";
+import { AuditBrowserSetupError } from "./sandbox-browser-error";
 import type {
   LocalisationAuditCrawledPage,
   LocalisationAuditCrawlResult,
   LocalisationAuditSitemapSignal,
 } from "./types";
 import { EMPTY_SITEMAP_SIGNAL } from "./types";
+
+export type {
+  CrawlLocalisationAuditSampleOptions,
+  HtmlPageRenderer,
+  RenderedHtmlPage,
+} from "./crawl-renderer";
 
 const USER_AGENT = "HyperlocaliseLocalisationAudit/1.0 (+https://hyperlocalise.com)";
 const MAX_PAGES = 15;
@@ -29,12 +36,6 @@ const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
 const LOCALE_PREFIX = /^\/([a-z]{2}(?:-[a-z]{2})?)(\/|$)/i;
 const LOCALE_CODE = /^[a-z]{2}(?:-[a-z]{2})?$/i;
-
-const FETCH_HEADERS: Record<string, string> = {
-  "User-Agent": USER_AGENT,
-  Accept: "text/html,application/xhtml+xml;q=0.9,*/*;q=0.1",
-  "Accept-Language": "en-US,en;q=0.9",
-};
 
 const FETCH_TEXT_HEADERS: Record<string, string> = {
   "User-Agent": USER_AGENT,
@@ -74,20 +75,12 @@ type SafeFetchResult<T> = { ok: true; value: T } | { ok: false };
 
 /**
  * Follow redirects manually so each hop is re-validated by withPublicHttpFetch.
- * Never use redirect:"follow" — undici can connect to IP-literal Location targets
- * without the DNS pin, bypassing the SSRF guard.
- *
- * One AbortController + FETCH_TIMEOUT_MS deadline covers the whole redirect chain
- * (not a fresh 12s budget per hop).
- *
- * Returns a discriminated result (not `T | null`) so Turbopack cannot DCE the
- * failure branch after await — it has been observed to strip `if (!home)` as
- * "compile-time falsy" when the helper returned null.
+ * Used for robots.txt and sitemaps only — HTML pages render in Playwright.
  */
 async function fetchPublicWithSafeRedirects<T>(
   startUrl: string,
   handler: (response: Response, finalUrl: string) => Promise<T>,
-  headers: Record<string, string> = FETCH_HEADERS,
+  headers: Record<string, string> = FETCH_TEXT_HEADERS,
 ): Promise<SafeFetchResult<T>> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
@@ -139,17 +132,13 @@ async function fetchPublicWithSafeRedirects<T>(
 }
 
 async function fetchText(url: string): Promise<string | null> {
-  const result = await fetchPublicWithSafeRedirects(
-    url,
-    async (response) => {
-      if (response.status < 200 || response.status >= 400) {
-        return null;
-      }
-      const body = await readBoundedResponseBody(response);
-      return new TextDecoder("utf-8", { fatal: false }).decode(body);
-    },
-    FETCH_TEXT_HEADERS,
-  );
+  const result = await fetchPublicWithSafeRedirects(url, async (response) => {
+    if (response.status < 200 || response.status >= 400) {
+      return null;
+    }
+    const body = await readBoundedResponseBody(response);
+    return new TextDecoder("utf-8", { fatal: false }).decode(body);
+  });
   return result.ok ? result.value : null;
 }
 
@@ -237,47 +226,6 @@ async function fetchSitemapSignals(origin: string): Promise<LocalisationAuditSit
   };
 }
 
-async function fetchPage(url: string): Promise<LocalisationAuditCrawledPage | null> {
-  const result = await fetchPublicWithSafeRedirects(url, async (response, finalUrl) => {
-    const contentType = response.headers.get("content-type") ?? "";
-    if (!contentType.includes("text/html") && !contentType.includes("application/xhtml")) {
-      return emptyParsedPage(finalUrl, response.status);
-    }
-
-    const body = await readBoundedResponseBody(response);
-    const html = new TextDecoder("utf-8", { fatal: false }).decode(body);
-    return crawledPageFromSignals({
-      url: finalUrl,
-      status: response.status,
-      signals: parsePageSignals(html),
-    });
-  });
-  return result.ok ? result.value : null;
-}
-
-async function fetchPageWithAnchors(url: string): Promise<
-  SafeFetchResult<{
-    page: LocalisationAuditCrawledPage;
-    candidateUrls: string[];
-  }>
-> {
-  return fetchPublicWithSafeRedirects(url, async (response, finalUrl) => {
-    const body = await readBoundedResponseBody(response);
-    const html = new TextDecoder("utf-8", { fatal: false }).decode(body);
-    const signals = parsePageSignals(html);
-    const page = crawledPageFromSignals({
-      url: finalUrl,
-      status: response.status,
-      signals,
-    });
-    const candidateUrls = [
-      ...signals.hreflang.map((entry) => toAbsoluteUrl(finalUrl, entry.href)).filter(Boolean),
-      ...signals.anchors.map((anchor) => toAbsoluteUrl(finalUrl, anchor.href)).filter(Boolean),
-    ] as string[];
-    return { page, candidateUrls };
-  });
-}
-
 function normalizeLocaleCode(value: string): string | null {
   const normalized = value.trim().replaceAll("_", "-").toLowerCase();
   if (normalized === "x-default" || !LOCALE_CODE.test(normalized)) {
@@ -323,62 +271,103 @@ function scoreCandidate(url: string, origin: string): number {
   }
 }
 
-export async function crawlLocalisationAuditSample(input: {
-  origin: string;
-  sourceUrl: string;
-  focusLocales?: string[];
-}): Promise<LocalisationAuditCrawlResult> {
+function pageFromRendered(html: string, url: string, status: number): LocalisationAuditCrawledPage {
+  return crawledPageFromSignals({
+    url,
+    status,
+    signals: parsePageSignals(html),
+  });
+}
+
+async function defaultCreateRenderer(): Promise<HtmlPageRenderer> {
+  const { createAuditBrowserSession } = await import("./sandbox-browser");
+  return createAuditBrowserSession();
+}
+
+export async function crawlLocalisationAuditSample(
+  input: {
+    origin: string;
+    sourceUrl: string;
+    focusLocales?: string[];
+  },
+  options?: CrawlLocalisationAuditSampleOptions,
+): Promise<LocalisationAuditCrawlResult> {
   try {
-    return await crawlLocalisationAuditSampleInner(input);
-  } catch {
-    // Soft-fail unexpected errors (and any remaining Turbopack null-guard DCE)
-    // so the workflow step does not retry forever on an empty crawl.
+    return await crawlLocalisationAuditSampleInner(input, options);
+  } catch (error) {
+    if (error instanceof AuditBrowserSetupError) {
+      throw error;
+    }
     return { pages: [], sitemap: EMPTY_SITEMAP_SIGNAL };
   }
 }
 
-async function crawlLocalisationAuditSampleInner(input: {
-  origin: string;
-  sourceUrl: string;
-  focusLocales?: string[];
-}): Promise<LocalisationAuditCrawlResult> {
-  const homeResult = await fetchPageWithAnchors(input.sourceUrl);
-  if (homeResult.ok === false) {
-    return { pages: [], sitemap: EMPTY_SITEMAP_SIGNAL };
-  }
-
-  const { page: homePage, candidateUrls } = homeResult.value;
-  const originHost = new URL(input.origin).hostname;
-  const seeded = new Set<string>([homePage.url]);
-  for (const candidate of candidateUrls) {
-    if (sameHost(originHost, candidate)) {
-      seeded.add(candidate.split("#")[0]!);
+async function crawlLocalisationAuditSampleInner(
+  input: {
+    origin: string;
+    sourceUrl: string;
+    focusLocales?: string[];
+  },
+  options?: CrawlLocalisationAuditSampleOptions,
+): Promise<LocalisationAuditCrawlResult> {
+  const createRenderer = options?.createRenderer ?? defaultCreateRenderer;
+  const renderer = await createRenderer();
+  try {
+    const homeRendered = (await renderer.render([input.sourceUrl]))[0];
+    if (!homeRendered) {
+      return { pages: [], sitemap: EMPTY_SITEMAP_SIGNAL };
     }
-  }
-  for (const seed of seedFocusLocaleRoots(input.origin, input.focusLocales ?? [])) {
-    if (sameHost(originHost, seed)) {
-      seeded.add(seed);
-    }
-  }
 
-  const ranked = [...seeded]
-    .map((url) => ({ url, score: scoreCandidate(url, input.origin) }))
-    .filter((entry) => entry.score >= 0)
-    .toSorted((a, b) => b.score - a.score)
-    .slice(0, MAX_PAGES);
-
-  const [pages, sitemap] = await Promise.all([
-    mapWithConcurrency(ranked, 4, async (entry) => {
-      if (entry.url === homePage.url) {
-        return homePage;
+    const homePage = pageFromRendered(homeRendered.html, homeRendered.url, homeRendered.status);
+    const signals = parsePageSignals(homeRendered.html);
+    const originHost = new URL(input.origin).hostname;
+    const seeded = new Set<string>([homePage.url]);
+    const candidateUrls = [
+      ...signals.hreflang
+        .map((entry) => toAbsoluteUrl(homeRendered.url, entry.href))
+        .filter(Boolean),
+      ...signals.anchors
+        .map((anchor) => toAbsoluteUrl(homeRendered.url, anchor.href))
+        .filter(Boolean),
+    ] as string[];
+    for (const candidate of candidateUrls) {
+      if (sameHost(originHost, candidate)) {
+        seeded.add(candidate.split("#")[0]!);
       }
-      return fetchPage(entry.url);
-    }),
-    fetchSitemapSignals(input.origin),
-  ]);
+    }
+    for (const seed of seedFocusLocaleRoots(input.origin, input.focusLocales ?? [])) {
+      if (sameHost(originHost, seed)) {
+        seeded.add(seed);
+      }
+    }
 
-  return {
-    pages: pages.filter((page): page is LocalisationAuditCrawledPage => page != null),
-    sitemap,
-  };
+    const ranked = [...seeded]
+      .map((url) => ({ url, score: scoreCandidate(url, input.origin) }))
+      .filter((entry) => entry.score >= 0)
+      .toSorted((a, b) => b.score - a.score)
+      .slice(0, MAX_PAGES);
+
+    const otherUrls = ranked
+      .filter((entry) => entry.url !== homePage.url)
+      .map((entry) => entry.url);
+    const [otherRendered, sitemap] = await Promise.all([
+      otherUrls.length > 0 ? renderer.render(otherUrls) : Promise.resolve([]),
+      fetchSitemapSignals(input.origin),
+    ]);
+
+    const pagesByUrl = new Map<string, LocalisationAuditCrawledPage>();
+    pagesByUrl.set(homePage.url, homePage);
+    for (const rendered of otherRendered) {
+      pagesByUrl.set(rendered.url, pageFromRendered(rendered.html, rendered.url, rendered.status));
+    }
+
+    return {
+      pages: ranked
+        .map((entry) => pagesByUrl.get(entry.url))
+        .filter((page): page is LocalisationAuditCrawledPage => page != null),
+      sitemap,
+    };
+  } finally {
+    await renderer.close().catch(() => undefined);
+  }
 }

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.ts
@@ -13,6 +13,7 @@
 import { readBoundedResponseBody, withPublicHttpFetch } from "@/lib/security/public-http-fetch";
 
 import type { CrawlLocalisationAuditSampleOptions, HtmlPageRenderer } from "./crawl-renderer";
+import { resolveFocusLocaleCode } from "./credits/shared";
 import { crawledPageFromSignals, parsePageSignals } from "./html-parse";
 import { AuditBrowserSetupError } from "./sandbox-browser-error";
 import type {
@@ -242,7 +243,7 @@ function localeFromPath(pathname: string): string | null {
 function seedFocusLocaleRoots(origin: string, focusLocales: string[]): string[] {
   const urls: string[] = [];
   for (const raw of focusLocales) {
-    const locale = normalizeLocaleCode(raw);
+    const locale = resolveFocusLocaleCode(raw);
     if (!locale) continue;
     try {
       urls.push(new URL(`/${locale}`, origin).toString());
@@ -358,7 +359,10 @@ async function crawlLocalisationAuditSampleInner(
     const pagesByUrl = new Map<string, LocalisationAuditCrawledPage>();
     pagesByUrl.set(homePage.url, homePage);
     for (const rendered of otherRendered) {
-      pagesByUrl.set(rendered.url, pageFromRendered(rendered.html, rendered.url, rendered.status));
+      const page = pageFromRendered(rendered.html, rendered.url, rendered.status);
+      // Ranked seeds use pre-render URLs; Playwright may land on a redirected final URL.
+      pagesByUrl.set(rendered.requestedUrl, page);
+      pagesByUrl.set(rendered.url, page);
     }
 
     return {

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics.test.ts
@@ -358,6 +358,12 @@ describe("technical heuristic credits", () => {
     expect(locales.some((entry) => entry.locale === "x-default")).toBe(false);
   });
 
+  it("resolves English language names in focus locales", () => {
+    const locales = detectLocales([], ["French", "German"]);
+    expect(locales.map((entry) => entry.locale).toSorted()).toEqual(["de", "fr"]);
+    expect(locales.every((entry) => entry.source === "focus")).toBe(true);
+  });
+
   it("keeps subdomain language when html lang is absent", () => {
     const locales = detectLocales(
       [emptyCrawledPage({ url: "https://fr.example.com/", htmlLang: null })],

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared.ts
@@ -23,6 +23,47 @@ export const LOCALE_CODE = /^[a-z]{2}(?:-[a-z]{2})?$/i;
 const RTL_LANGUAGES = new Set(["ar", "he", "fa", "ur", "ps", "yi"]);
 const CJK_LANGUAGES = new Set(["zh", "ja", "ko"]);
 
+/** English language display names → ISO 639-1, for focus inputs like "French". */
+const ENGLISH_LANGUAGE_NAME_TO_CODE: ReadonlyMap<string, string> = (() => {
+  const map = new Map<string, string>();
+  if (typeof Intl === "undefined" || !("DisplayNames" in Intl)) {
+    return map;
+  }
+  const displayNames = new Intl.DisplayNames(["en"], { type: "language" });
+  for (let a = 97; a <= 122; a += 1) {
+    for (let b = 97; b <= 122; b += 1) {
+      const code = String.fromCharCode(a, b);
+      try {
+        const name = displayNames.of(code);
+        if (!name) continue;
+        const key = name.trim().toLowerCase();
+        if (!key || key === code || LOCALE_CODE.test(key)) continue;
+        if (!map.has(key)) {
+          map.set(key, code);
+        }
+      } catch {
+        // skip invalid/unsupported language codes
+      }
+    }
+  }
+  return map;
+})();
+
+/**
+ * Accepts BCP 47-style codes (`fr`, `pt-BR`) or English language names (`French`).
+ * Returns a lowercase canonical code, or null when the value is not a focus locale.
+ */
+export function resolveFocusLocaleCode(value: string): string | null {
+  const normalized = normalizeLocale(value);
+  if (!normalized || normalized === "x-default") {
+    return null;
+  }
+  if (LOCALE_CODE.test(normalized)) {
+    return normalized;
+  }
+  return ENGLISH_LANGUAGE_NAME_TO_CODE.get(normalized) ?? null;
+}
+
 /**
  * URL path prefixes that are market/region codes, not ISO 639 language tags.
  * Mapped to the BCP 47 html lang value sites should declare.
@@ -299,7 +340,10 @@ export function detectLocales(
   };
 
   for (const focus of focusLocales) {
-    add(focus, "focus");
+    const code = resolveFocusLocaleCode(focus);
+    if (code) {
+      add(code, "focus");
+    }
   }
 
   for (const page of pages) {

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/sandbox-browser-error.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/sandbox-browser-error.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+export class AuditBrowserSetupError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AuditBrowserSetupError";
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/sandbox-browser.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/sandbox-browser.test.ts
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const sandboxMocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  runCommand: vi.fn(),
+  writeFiles: vi.fn(),
+  readFileToBuffer: vi.fn(),
+  stop: vi.fn(),
+  output: vi.fn(),
+}));
+
+const assertResolvablePublicHttpUrlMock = vi.hoisted(() => vi.fn());
+
+const envMock = vi.hoisted(() => ({
+  VERCEL_SANDBOX_IMAGE: undefined as string | undefined,
+}));
+
+vi.mock("@/lib/env", () => ({
+  env: envMock,
+}));
+
+vi.mock("@/lib/flags/release-flags", () => ({
+  isReleaseSandboxVcrImageEnabled: vi.fn(async () => false),
+}));
+
+vi.mock("@vercel/sandbox", () => ({
+  Sandbox: {
+    create: sandboxMocks.create,
+  },
+}));
+
+vi.mock("@/lib/vercel-sandbox-config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/vercel-sandbox-config")>();
+  return {
+    ...actual,
+    createConfiguredVercelSandbox: sandboxMocks.create,
+  };
+});
+
+vi.mock("@/lib/security/public-http-fetch", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/security/public-http-fetch")>();
+  return {
+    ...actual,
+    assertResolvablePublicHttpUrl: assertResolvablePublicHttpUrlMock,
+  };
+});
+
+import { ok } from "@/lib/primitives/result/results";
+
+import {
+  buildAuditPlaywrightScript,
+  createAuditBrowserSession,
+  isBlockedBrowserNavigationUrl,
+  managedAuditBrowserRuntimeCommand,
+} from "./sandbox-browser";
+import { AuditBrowserSetupError } from "./sandbox-browser-error";
+
+describe("audit browser navigation guard", () => {
+  it("blocks private and non-http targets before Playwright sees them", () => {
+    expect(isBlockedBrowserNavigationUrl("http://127.0.0.1/secret")).toBe(true);
+    expect(isBlockedBrowserNavigationUrl("http://localhost/admin")).toBe(true);
+    expect(isBlockedBrowserNavigationUrl("http://169.254.169.254/latest/meta-data")).toBe(true);
+    expect(isBlockedBrowserNavigationUrl("file:///etc/passwd")).toBe(true);
+    expect(isBlockedBrowserNavigationUrl("https://example.com/fr")).toBe(false);
+  });
+});
+
+describe("audit Playwright script", () => {
+  it("renders with Chromium, waits for JavaScript, and aborts private navigations", () => {
+    const script = buildAuditPlaywrightScript();
+    expect(script).toContain(
+      'require("/tmp/hyperlocalise-browser-runtime/node_modules/playwright")',
+    );
+    expect(script).toContain('waitUntil: "load"');
+    expect(script).toContain('waitForLoadState("networkidle"');
+    expect(script).toContain("page.route");
+    expect(script).toContain("isBlockedNavigationUrl");
+    expect(script).toContain("HyperlocaliseLocalisationAudit/1.0");
+    expect(managedAuditBrowserRuntimeCommand()).toContain("install chromium");
+  });
+});
+
+describe("createAuditBrowserSession", () => {
+  beforeEach(() => {
+    sandboxMocks.create.mockReset();
+    sandboxMocks.runCommand.mockReset();
+    sandboxMocks.writeFiles.mockReset();
+    sandboxMocks.readFileToBuffer.mockReset();
+    sandboxMocks.stop.mockReset();
+    sandboxMocks.output.mockReset();
+    assertResolvablePublicHttpUrlMock.mockReset();
+
+    sandboxMocks.output.mockResolvedValue("ok");
+    sandboxMocks.runCommand.mockResolvedValue({
+      exitCode: 0,
+      output: sandboxMocks.output,
+    });
+    sandboxMocks.writeFiles.mockResolvedValue(undefined);
+    sandboxMocks.stop.mockResolvedValue(undefined);
+    sandboxMocks.create.mockResolvedValue({
+      runCommand: sandboxMocks.runCommand,
+      writeFiles: sandboxMocks.writeFiles,
+      readFileToBuffer: sandboxMocks.readFileToBuffer,
+      stop: sandboxMocks.stop,
+    });
+    assertResolvablePublicHttpUrlMock.mockImplementation(async (url: string) => ok(new URL(url)));
+  });
+
+  it("installs Playwright once, then renders vetted URLs from the sandbox", async () => {
+    sandboxMocks.readFileToBuffer.mockImplementation(async ({ path }: { path: string }) => {
+      if (path.endsWith("manifest.json")) {
+        return Buffer.from(
+          JSON.stringify({
+            pages: [
+              {
+                requestedUrl: "https://example.com/",
+                url: "https://example.com/en",
+                status: 200,
+                htmlPath: "/tmp/hl-audit-browser/0.html",
+              },
+            ],
+          }),
+        );
+      }
+      if (path.endsWith("0.html")) {
+        return Buffer.from("<html lang='en'><title>EN</title><body>Hello</body></html>");
+      }
+      throw new Error(`unexpected read: ${path}`);
+    });
+
+    const session = await createAuditBrowserSession();
+    const pages = await session.render(["https://example.com/", "http://127.0.0.1/secret"]);
+    await session.close();
+
+    expect(pages).toEqual([
+      {
+        requestedUrl: "https://example.com/",
+        url: "https://example.com/en",
+        status: 200,
+        html: "<html lang='en'><title>EN</title><body>Hello</body></html>",
+      },
+    ]);
+    expect(assertResolvablePublicHttpUrlMock).toHaveBeenCalledWith("https://example.com/");
+    expect(assertResolvablePublicHttpUrlMock).not.toHaveBeenCalledWith("http://127.0.0.1/secret");
+    expect(sandboxMocks.writeFiles).toHaveBeenCalledWith([
+      expect.objectContaining({
+        path: "/tmp/hl-audit-browser/urls.json",
+        content: Buffer.from(JSON.stringify({ urls: ["https://example.com/"] }), "utf8"),
+      }),
+    ]);
+    expect(sandboxMocks.stop).toHaveBeenCalled();
+  });
+
+  it("throws a setup error when Playwright cannot be installed", async () => {
+    sandboxMocks.runCommand.mockResolvedValueOnce({
+      exitCode: 87,
+      output: sandboxMocks.output,
+    });
+    sandboxMocks.output.mockResolvedValueOnce("browser_runtime_install_failed");
+
+    await expect(createAuditBrowserSession()).rejects.toThrow(AuditBrowserSetupError);
+    expect(sandboxMocks.stop).toHaveBeenCalled();
+  });
+
+  it("drops rendered pages whose final URL is private", async () => {
+    sandboxMocks.readFileToBuffer.mockResolvedValue(
+      Buffer.from(
+        JSON.stringify({
+          pages: [
+            {
+              requestedUrl: "https://example.com/",
+              url: "http://127.0.0.1/secret",
+              status: 200,
+              htmlPath: "/tmp/hl-audit-browser/0.html",
+            },
+          ],
+        }),
+      ),
+    );
+
+    const session = await createAuditBrowserSession();
+    const pages = await session.render(["https://example.com/"]);
+
+    expect(pages).toEqual([]);
+    expect(sandboxMocks.readFileToBuffer).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/sandbox-browser.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/sandbox-browser.test.ts
@@ -63,7 +63,7 @@ import {
   buildAuditPlaywrightScript,
   createAuditBrowserSession,
   isBlockedBrowserNavigationUrl,
-  managedAuditBrowserRuntimeCommand,
+  prepareAuditBrowserRuntimeCommand,
 } from "./sandbox-browser";
 import { AuditBrowserSetupError } from "./sandbox-browser-error";
 
@@ -88,7 +88,9 @@ describe("audit Playwright script", () => {
     expect(script).toContain("page.route");
     expect(script).toContain("isBlockedNavigationUrl");
     expect(script).toContain("HyperlocaliseLocalisationAudit/1.0");
-    expect(managedAuditBrowserRuntimeCommand()).toContain("install chromium");
+    expect(prepareAuditBrowserRuntimeCommand()).toContain("browser_runtime_missing");
+    expect(prepareAuditBrowserRuntimeCommand()).not.toContain("npm ");
+    expect(prepareAuditBrowserRuntimeCommand()).not.toContain("install chromium");
   });
 });
 
@@ -118,7 +120,7 @@ describe("createAuditBrowserSession", () => {
     assertResolvablePublicHttpUrlMock.mockImplementation(async (url: string) => ok(new URL(url)));
   });
 
-  it("installs Playwright once, then renders vetted URLs from the sandbox", async () => {
+  it("uses the sandbox image Playwright, then renders vetted URLs", async () => {
     sandboxMocks.readFileToBuffer.mockImplementation(async ({ path }: { path: string }) => {
       if (path.endsWith("manifest.json")) {
         return Buffer.from(
@@ -154,6 +156,16 @@ describe("createAuditBrowserSession", () => {
     ]);
     expect(assertResolvablePublicHttpUrlMock).toHaveBeenCalledWith("https://example.com/");
     expect(assertResolvablePublicHttpUrlMock).not.toHaveBeenCalledWith("http://127.0.0.1/secret");
+    expect(sandboxMocks.create).toHaveBeenCalledWith({
+      timeout: 10 * 60 * 1000,
+    });
+    expect(sandboxMocks.runCommand.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        cmd: "bash",
+        args: ["-lc", expect.stringContaining("browser_runtime_missing")],
+      }),
+    );
+    expect(sandboxMocks.runCommand.mock.calls[0]?.[0].args[1]).not.toContain("install chromium");
     expect(sandboxMocks.writeFiles).toHaveBeenCalledWith([
       expect.objectContaining({
         path: "/tmp/hl-audit-browser/urls.json",
@@ -163,14 +175,16 @@ describe("createAuditBrowserSession", () => {
     expect(sandboxMocks.stop).toHaveBeenCalled();
   });
 
-  it("throws a setup error when Playwright cannot be installed", async () => {
+  it("throws a setup error when the sandbox image is missing Playwright", async () => {
     sandboxMocks.runCommand.mockResolvedValueOnce({
       exitCode: 87,
       output: sandboxMocks.output,
     });
-    sandboxMocks.output.mockResolvedValueOnce("browser_runtime_install_failed");
+    sandboxMocks.output.mockResolvedValueOnce("browser_runtime_missing");
 
-    await expect(createAuditBrowserSession()).rejects.toThrow(AuditBrowserSetupError);
+    const error = await createAuditBrowserSession().catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(AuditBrowserSetupError);
+    expect(error).toEqual(expect.objectContaining({ message: expect.stringMatching(/missing Playwright/) }));
     expect(sandboxMocks.stop).toHaveBeenCalled();
   });
 

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/sandbox-browser.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/sandbox-browser.test.ts
@@ -88,6 +88,11 @@ describe("audit Playwright script", () => {
     expect(script).toContain("page.route");
     expect(script).toContain("isBlockedNavigationUrl");
     expect(script).toContain("HyperlocaliseLocalisationAudit/1.0");
+    expect(script).toContain("isBlockedIpv4Address");
+    expect(script).toContain("isBlockedIpv6Address");
+    expect(script).toContain('hostname.startsWith("::ffff:")');
+    expect(script).toContain("first === 192 && second === 0");
+    expect(script).toContain("second === 18 || second === 19");
     expect(prepareAuditBrowserRuntimeCommand()).toContain("browser_runtime_missing");
     expect(prepareAuditBrowserRuntimeCommand()).not.toContain("npm ");
     expect(prepareAuditBrowserRuntimeCommand()).not.toContain("install chromium");

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/sandbox-browser.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/sandbox-browser.test.ts
@@ -184,7 +184,9 @@ describe("createAuditBrowserSession", () => {
 
     const error = await createAuditBrowserSession().catch((caught: unknown) => caught);
     expect(error).toBeInstanceOf(AuditBrowserSetupError);
-    expect(error).toEqual(expect.objectContaining({ message: expect.stringMatching(/missing Playwright/) }));
+    expect(error).toEqual(
+      expect.objectContaining({ message: expect.stringMatching(/missing Playwright/) }),
+    );
     expect(sandboxMocks.stop).toHaveBeenCalled();
   });
 

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/sandbox-browser.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/sandbox-browser.ts
@@ -18,11 +18,7 @@ import {
   MAX_PUBLIC_HTTP_RESPONSE_BYTES,
 } from "@/lib/security/public-http-fetch";
 import { isBlockedHost, isPublicHttpUrl } from "@/lib/security/ssrf-guard";
-import {
-  createConfiguredVercelSandbox,
-  installChromiumSystemDependenciesFunction,
-  sandboxPlaywrightVersion,
-} from "@/lib/vercel-sandbox-config";
+import { createConfiguredVercelSandbox } from "@/lib/vercel-sandbox-config";
 
 import type { HtmlPageRenderer, RenderedHtmlPage } from "./crawl-renderer";
 import { AuditBrowserSetupError } from "./sandbox-browser-error";
@@ -37,9 +33,13 @@ export const AUDIT_BROWSER_NETWORKIDLE_TIMEOUT_MS = 4_000;
 export const AUDIT_BROWSER_SETTLE_MS = 400;
 export const AUDIT_BROWSER_VIEWPORT = { width: 1440, height: 1000 } as const;
 
-const MANAGED_PLAYWRIGHT_VERSION = sandboxPlaywrightVersion;
-const MANAGED_BROWSER_RUNTIME_DIR = "/tmp/hyperlocalise-browser-runtime";
-const MANAGED_PLAYWRIGHT_MODULE = `${MANAGED_BROWSER_RUNTIME_DIR}/node_modules/playwright`;
+/**
+ * Playwright + Chromium baked into the hyperlocalise-sandbox VCR image.
+ * Same path the agent screenshot tool uses. Do not install at crawl time.
+ */
+const SANDBOX_BROWSER_RUNTIME_DIR = "/tmp/hyperlocalise-browser-runtime";
+const SANDBOX_PLAYWRIGHT_MODULE = `${SANDBOX_BROWSER_RUNTIME_DIR}/node_modules/playwright`;
+const SANDBOX_PLAYWRIGHT_BROWSERS_DIR = `${SANDBOX_BROWSER_RUNTIME_DIR}/ms-playwright`;
 const AUDIT_BROWSER_DIR = "/tmp/hl-audit-browser";
 const AUDIT_BROWSER_SCRIPT_PATH = `${AUDIT_BROWSER_DIR}/render.cjs`;
 const AUDIT_BROWSER_INPUT_PATH = `${AUDIT_BROWSER_DIR}/urls.json`;
@@ -62,40 +62,17 @@ function shellQuote(value: string) {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
-export function managedAuditBrowserRuntimeCommand() {
-  const runtimeDir = shellQuote(MANAGED_BROWSER_RUNTIME_DIR);
-  const playwrightVersion = shellQuote(`playwright@${MANAGED_PLAYWRIGHT_VERSION}`);
-  const browsersPath = shellQuote(`${MANAGED_BROWSER_RUNTIME_DIR}/ms-playwright`);
-  const playwrightBin = shellQuote(`${MANAGED_BROWSER_RUNTIME_DIR}/node_modules/.bin/playwright`);
+export function prepareAuditBrowserRuntimeCommand() {
+  const playwrightModule = shellQuote(SANDBOX_PLAYWRIGHT_MODULE);
+  const browsersPath = shellQuote(SANDBOX_PLAYWRIGHT_BROWSERS_DIR);
   const auditDir = shellQuote(AUDIT_BROWSER_DIR);
 
   return [
     "set -euo pipefail",
-    `mkdir -p ${runtimeDir} ${auditDir}`,
-    "if ! command -v npm >/dev/null 2>&1; then",
-    `  echo "${ERROR_CODE_PREFIX}package_manager_unavailable" >&2`,
-    "  exit 86",
-    "fi",
-    `if [ ! -d ${shellQuote(MANAGED_PLAYWRIGHT_MODULE)} ]; then`,
-    `  npm --prefix ${runtimeDir} init -y >/dev/null 2>&1 || true`,
-    `  if ! npm --prefix ${runtimeDir} install --no-audit --no-fund ${playwrightVersion} >/tmp/hyperlocalise-playwright-install.log 2>&1; then`,
-    `    cat /tmp/hyperlocalise-playwright-install.log >&2 || true`,
-    `    echo "${ERROR_CODE_PREFIX}browser_runtime_install_failed" >&2`,
-    "    exit 87",
-    "  fi",
-    "fi",
-    installChromiumSystemDependenciesFunction,
-    "if command -v ldconfig >/dev/null 2>&1 && ! ldconfig -p 2>/dev/null | grep -q 'libnspr4\\.so'; then",
-    "  if ! install_chromium_system_dependencies >/tmp/hyperlocalise-chromium-deps.log 2>&1; then",
-    "    cat /tmp/hyperlocalise-chromium-deps.log >&2 || true",
-    `    echo "${ERROR_CODE_PREFIX}browser_system_deps_unavailable" >&2`,
-    "    exit 89",
-    "  fi",
-    "fi",
-    `if ! PLAYWRIGHT_BROWSERS_PATH=${browsersPath} ${playwrightBin} install chromium >/tmp/hyperlocalise-chromium-install.log 2>&1; then`,
-    `  cat /tmp/hyperlocalise-chromium-install.log >&2 || true`,
-    `  echo "${ERROR_CODE_PREFIX}browser_binary_unavailable" >&2`,
-    "  exit 88",
+    `mkdir -p ${auditDir}`,
+    `if [ ! -d ${playwrightModule} ] || [ ! -d ${browsersPath} ]; then`,
+    `  echo "${ERROR_CODE_PREFIX}browser_runtime_missing" >&2`,
+    "  exit 87",
     "fi",
   ].join("\n");
 }
@@ -106,7 +83,7 @@ export function managedAuditBrowserRuntimeCommand() {
  */
 export function buildAuditPlaywrightScript() {
   return `
-const { chromium } = require(${JSON.stringify(MANAGED_PLAYWRIGHT_MODULE)});
+const { chromium } = require(${JSON.stringify(SANDBOX_PLAYWRIGHT_MODULE)});
 const fs = require("node:fs");
 const path = require("node:path");
 
@@ -242,22 +219,23 @@ export async function createAuditBrowserSession(): Promise<HtmlPageRenderer> {
     timeout: AUDIT_BROWSER_SANDBOX_TIMEOUT_MS,
   });
 
-  const install = await sandbox.runCommand({
+  const prepare = await sandbox.runCommand({
     cmd: "bash",
-    args: ["-lc", managedAuditBrowserRuntimeCommand()],
-    sudo: true,
+    args: ["-lc", prepareAuditBrowserRuntimeCommand()],
   });
-  if (install.exitCode !== 0) {
-    const output = await install.output("both");
+  if (prepare.exitCode !== 0) {
+    const output = await prepare.output("both");
     await sandbox.stop().catch(() => undefined);
-    throw new AuditBrowserSetupError(`audit browser runtime install failed: ${output}`);
+    throw new AuditBrowserSetupError(
+      `sandbox image is missing Playwright at ${SANDBOX_BROWSER_RUNTIME_DIR}: ${output}`,
+    );
   }
 
   await sandbox.writeFiles([
     { path: AUDIT_BROWSER_SCRIPT_PATH, content: Buffer.from(buildAuditPlaywrightScript(), "utf8") },
   ]);
 
-  const browsersPath = shellQuote(`${MANAGED_BROWSER_RUNTIME_DIR}/ms-playwright`);
+  const browsersPath = shellQuote(SANDBOX_PLAYWRIGHT_BROWSERS_DIR);
 
   return {
     async render(urls: string[]): Promise<RenderedHtmlPage[]> {

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/sandbox-browser.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/sandbox-browser.ts
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Sandbox } from "@vercel/sandbox";
+
+import { isErr } from "@/lib/primitives/result/results";
+import {
+  assertResolvablePublicHttpUrl,
+  MAX_PUBLIC_HTTP_RESPONSE_BYTES,
+} from "@/lib/security/public-http-fetch";
+import { isBlockedHost, isPublicHttpUrl } from "@/lib/security/ssrf-guard";
+import {
+  createConfiguredVercelSandbox,
+  installChromiumSystemDependenciesFunction,
+  sandboxPlaywrightVersion,
+} from "@/lib/vercel-sandbox-config";
+
+import type { HtmlPageRenderer, RenderedHtmlPage } from "./crawl-renderer";
+import { AuditBrowserSetupError } from "./sandbox-browser-error";
+
+export { AuditBrowserSetupError } from "./sandbox-browser-error";
+
+export const AUDIT_BROWSER_SANDBOX_TIMEOUT_MS = 10 * 60 * 1000;
+export const AUDIT_BROWSER_USER_AGENT =
+  "HyperlocaliseLocalisationAudit/1.0 (+https://hyperlocalise.com)";
+export const AUDIT_BROWSER_NAV_TIMEOUT_MS = 20_000;
+export const AUDIT_BROWSER_NETWORKIDLE_TIMEOUT_MS = 4_000;
+export const AUDIT_BROWSER_SETTLE_MS = 400;
+export const AUDIT_BROWSER_VIEWPORT = { width: 1440, height: 1000 } as const;
+
+const MANAGED_PLAYWRIGHT_VERSION = sandboxPlaywrightVersion;
+const MANAGED_BROWSER_RUNTIME_DIR = "/tmp/hyperlocalise-browser-runtime";
+const MANAGED_PLAYWRIGHT_MODULE = `${MANAGED_BROWSER_RUNTIME_DIR}/node_modules/playwright`;
+const AUDIT_BROWSER_DIR = "/tmp/hl-audit-browser";
+const AUDIT_BROWSER_SCRIPT_PATH = `${AUDIT_BROWSER_DIR}/render.cjs`;
+const AUDIT_BROWSER_INPUT_PATH = `${AUDIT_BROWSER_DIR}/urls.json`;
+const AUDIT_BROWSER_MANIFEST_PATH = `${AUDIT_BROWSER_DIR}/manifest.json`;
+const ERROR_CODE_PREFIX = "HYPERLOCALISE_AUDIT_BROWSER_ERROR_CODE=";
+
+export function isBlockedBrowserNavigationUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return true;
+    }
+    return isBlockedHost(parsed.hostname);
+  } catch {
+    return true;
+  }
+}
+
+function shellQuote(value: string) {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+export function managedAuditBrowserRuntimeCommand() {
+  const runtimeDir = shellQuote(MANAGED_BROWSER_RUNTIME_DIR);
+  const playwrightVersion = shellQuote(`playwright@${MANAGED_PLAYWRIGHT_VERSION}`);
+  const browsersPath = shellQuote(`${MANAGED_BROWSER_RUNTIME_DIR}/ms-playwright`);
+  const playwrightBin = shellQuote(`${MANAGED_BROWSER_RUNTIME_DIR}/node_modules/.bin/playwright`);
+  const auditDir = shellQuote(AUDIT_BROWSER_DIR);
+
+  return [
+    "set -euo pipefail",
+    `mkdir -p ${runtimeDir} ${auditDir}`,
+    "if ! command -v npm >/dev/null 2>&1; then",
+    `  echo "${ERROR_CODE_PREFIX}package_manager_unavailable" >&2`,
+    "  exit 86",
+    "fi",
+    `if [ ! -d ${shellQuote(MANAGED_PLAYWRIGHT_MODULE)} ]; then`,
+    `  npm --prefix ${runtimeDir} init -y >/dev/null 2>&1 || true`,
+    `  if ! npm --prefix ${runtimeDir} install --no-audit --no-fund ${playwrightVersion} >/tmp/hyperlocalise-playwright-install.log 2>&1; then`,
+    `    cat /tmp/hyperlocalise-playwright-install.log >&2 || true`,
+    `    echo "${ERROR_CODE_PREFIX}browser_runtime_install_failed" >&2`,
+    "    exit 87",
+    "  fi",
+    "fi",
+    installChromiumSystemDependenciesFunction,
+    "if command -v ldconfig >/dev/null 2>&1 && ! ldconfig -p 2>/dev/null | grep -q 'libnspr4\\.so'; then",
+    "  if ! install_chromium_system_dependencies >/tmp/hyperlocalise-chromium-deps.log 2>&1; then",
+    "    cat /tmp/hyperlocalise-chromium-deps.log >&2 || true",
+    `    echo "${ERROR_CODE_PREFIX}browser_system_deps_unavailable" >&2`,
+    "    exit 89",
+    "  fi",
+    "fi",
+    `if ! PLAYWRIGHT_BROWSERS_PATH=${browsersPath} ${playwrightBin} install chromium >/tmp/hyperlocalise-chromium-install.log 2>&1; then`,
+    `  cat /tmp/hyperlocalise-chromium-install.log >&2 || true`,
+    `  echo "${ERROR_CODE_PREFIX}browser_binary_unavailable" >&2`,
+    "  exit 88",
+    "fi",
+  ].join("\n");
+}
+
+/**
+ * CJS script that runs inside the sandbox. It launches one Chromium, visits
+ * each vetted URL, waits for JS to settle, and writes rendered HTML to disk.
+ */
+export function buildAuditPlaywrightScript() {
+  return `
+const { chromium } = require(${JSON.stringify(MANAGED_PLAYWRIGHT_MODULE)});
+const fs = require("node:fs");
+const path = require("node:path");
+
+const input = JSON.parse(fs.readFileSync(${JSON.stringify(AUDIT_BROWSER_INPUT_PATH)}, "utf8"));
+const outputDir = ${JSON.stringify(AUDIT_BROWSER_DIR)};
+const maxHtmlBytes = ${MAX_PUBLIC_HTTP_RESPONSE_BYTES};
+const navTimeoutMs = ${AUDIT_BROWSER_NAV_TIMEOUT_MS};
+const networkIdleTimeoutMs = ${AUDIT_BROWSER_NETWORKIDLE_TIMEOUT_MS};
+const settleMs = ${AUDIT_BROWSER_SETTLE_MS};
+
+function isBlockedHost(hostname) {
+  const host = String(hostname || "").toLowerCase().replace(/^\\[|\\]$/g, "").replace(/\\.$/, "");
+  if (!host || host === "localhost" || host.endsWith(".localhost")) return true;
+  if (host === "::1" || host === "127.0.0.1" || host === "0.0.0.0") return true;
+  if (host === "169.254.169.254" || host.startsWith("169.254.")) return true;
+  const ipv4 = host.split(".");
+  if (ipv4.length === 4 && ipv4.every((part) => /^\\d+$/.test(part))) {
+    const [a, b] = ipv4.map((part) => Number(part));
+    if (a === 0 || a === 10 || a === 127 || a >= 224) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 100 && b >= 64 && b <= 127) return true;
+  }
+  if (host.includes(":")) {
+    if (host.startsWith("fe80:") || host.startsWith("fc") || host.startsWith("fd")) return true;
+  }
+  return false;
+}
+
+function isBlockedNavigationUrl(value) {
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return true;
+    return isBlockedHost(parsed.hostname);
+  } catch {
+    return true;
+  }
+}
+
+function truncateHtml(html) {
+  const bytes = Buffer.byteLength(html, "utf8");
+  if (bytes <= maxHtmlBytes) return html;
+  return Buffer.from(html, "utf8").subarray(0, maxHtmlBytes).toString("utf8");
+}
+
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    userAgent: ${JSON.stringify(AUDIT_BROWSER_USER_AGENT)},
+    viewport: ${JSON.stringify(AUDIT_BROWSER_VIEWPORT)},
+    locale: "en-US",
+  });
+  const pages = [];
+  for (const url of input.urls || []) {
+    const page = await context.newPage();
+    await page.route("**/*", (route) => {
+      const requestUrl = route.request().url();
+      if (isBlockedNavigationUrl(requestUrl)) {
+        return route.abort();
+      }
+      return route.continue();
+    });
+    let status = 0;
+    try {
+      const response = await page.goto(url, { waitUntil: "load", timeout: navTimeoutMs });
+      status = response ? response.status() : 0;
+      await page.waitForLoadState("networkidle", { timeout: networkIdleTimeoutMs }).catch(() => undefined);
+      if (settleMs > 0) {
+        await page.waitForTimeout(settleMs);
+      }
+      const finalUrl = page.url();
+      if (isBlockedNavigationUrl(finalUrl)) {
+        pages.push({ requestedUrl: url, url: finalUrl, status: 0, error: "blocked_final_url" });
+        continue;
+      }
+      const htmlPath = path.join(outputDir, pages.length + ".html");
+      fs.writeFileSync(htmlPath, truncateHtml(await page.content()));
+      pages.push({ requestedUrl: url, url: finalUrl, status, htmlPath });
+    } catch (error) {
+      pages.push({
+        requestedUrl: url,
+        url,
+        status,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      await page.close();
+    }
+  }
+  fs.writeFileSync(${JSON.stringify(AUDIT_BROWSER_MANIFEST_PATH)}, JSON.stringify({ pages }));
+  await browser.close();
+})().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exit(1);
+});
+`.trimStart();
+}
+
+type AuditBrowserManifestPage = {
+  requestedUrl: string;
+  url: string;
+  status: number;
+  htmlPath?: string;
+  error?: string;
+};
+
+async function readSandboxText(sandbox: Sandbox, filePath: string): Promise<string | null> {
+  try {
+    const buffer = await sandbox.readFileToBuffer({ path: filePath });
+    return buffer?.toString("utf8") ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function filterPublicUrls(urls: string[]): Promise<string[]> {
+  const allowed: string[] = [];
+  for (const url of urls) {
+    if (!isPublicHttpUrl(url) || isBlockedBrowserNavigationUrl(url)) {
+      continue;
+    }
+    const resolved = await assertResolvablePublicHttpUrl(url);
+    if (isErr(resolved)) {
+      continue;
+    }
+    allowed.push(url);
+  }
+  return allowed;
+}
+
+export async function createAuditBrowserSession(): Promise<HtmlPageRenderer> {
+  const sandbox = await createConfiguredVercelSandbox({
+    timeout: AUDIT_BROWSER_SANDBOX_TIMEOUT_MS,
+  });
+
+  const install = await sandbox.runCommand({
+    cmd: "bash",
+    args: ["-lc", managedAuditBrowserRuntimeCommand()],
+    sudo: true,
+  });
+  if (install.exitCode !== 0) {
+    const output = await install.output("both");
+    await sandbox.stop().catch(() => undefined);
+    throw new AuditBrowserSetupError(`audit browser runtime install failed: ${output}`);
+  }
+
+  await sandbox.writeFiles([
+    { path: AUDIT_BROWSER_SCRIPT_PATH, content: Buffer.from(buildAuditPlaywrightScript(), "utf8") },
+  ]);
+
+  const browsersPath = shellQuote(`${MANAGED_BROWSER_RUNTIME_DIR}/ms-playwright`);
+
+  return {
+    async render(urls: string[]): Promise<RenderedHtmlPage[]> {
+      const allowed = await filterPublicUrls(urls);
+      if (allowed.length === 0) {
+        return [];
+      }
+
+      await sandbox.writeFiles([
+        {
+          path: AUDIT_BROWSER_INPUT_PATH,
+          content: Buffer.from(JSON.stringify({ urls: allowed }), "utf8"),
+        },
+      ]);
+
+      const result = await sandbox.runCommand({
+        cmd: "bash",
+        args: [
+          "-lc",
+          [
+            "set -euo pipefail",
+            `export PLAYWRIGHT_BROWSERS_PATH=${browsersPath}`,
+            `node ${shellQuote(AUDIT_BROWSER_SCRIPT_PATH)}`,
+          ].join("\n"),
+        ],
+      });
+      if (result.exitCode !== 0) {
+        return [];
+      }
+
+      const manifestText = await readSandboxText(sandbox, AUDIT_BROWSER_MANIFEST_PATH);
+      if (!manifestText) {
+        return [];
+      }
+
+      let manifest: { pages?: AuditBrowserManifestPage[] };
+      try {
+        manifest = JSON.parse(manifestText) as { pages?: AuditBrowserManifestPage[] };
+      } catch {
+        return [];
+      }
+
+      const rendered: RenderedHtmlPage[] = [];
+      for (const page of manifest.pages ?? []) {
+        if (!page.htmlPath || page.error) {
+          continue;
+        }
+        if (!isPublicHttpUrl(page.url) || isBlockedBrowserNavigationUrl(page.url)) {
+          continue;
+        }
+        const finalResolved = await assertResolvablePublicHttpUrl(page.url);
+        if (isErr(finalResolved)) {
+          continue;
+        }
+        const html = await readSandboxText(sandbox, page.htmlPath);
+        if (html == null) {
+          continue;
+        }
+        rendered.push({
+          requestedUrl: page.requestedUrl,
+          url: page.url,
+          status: page.status,
+          html,
+        });
+      }
+      return rendered;
+    },
+    async close() {
+      await sandbox.stop();
+    },
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/sandbox-browser.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/sandbox-browser.ts
@@ -94,22 +94,77 @@ const navTimeoutMs = ${AUDIT_BROWSER_NAV_TIMEOUT_MS};
 const networkIdleTimeoutMs = ${AUDIT_BROWSER_NETWORKIDLE_TIMEOUT_MS};
 const settleMs = ${AUDIT_BROWSER_SETTLE_MS};
 
+function parseIpv4Octets(hostname) {
+  const octets = hostname.split(".");
+  if (octets.length !== 4) return null;
+  const bytes = octets.map((octet) => Number(octet));
+  if (bytes.some((byte, index) => !Number.isInteger(byte) || byte < 0 || byte > 255 || octets[index] === "")) {
+    return null;
+  }
+  return bytes;
+}
+
+function isBlockedIpv4Address(hostname) {
+  const bytes = parseIpv4Octets(hostname);
+  if (!bytes) return false;
+  const [first, second, third] = bytes;
+  return (
+    first === 0 ||
+    first === 10 ||
+    first === 127 ||
+    first >= 224 ||
+    (first === 100 && second >= 64 && second <= 127) ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 0) ||
+    (first === 192 && second === 168) ||
+    (first === 198 && (second === 18 || second === 19 || (second === 51 && third === 100))) ||
+    (first === 203 && second === 0 && third === 113)
+  );
+}
+
+function ipv4FromIpv4MappedIpv6(hostname) {
+  if (!/^::ffff:/i.test(hostname)) return null;
+  const rest = hostname.slice(7);
+  if (rest.includes(".")) return rest;
+  const [highPart, lowPart] = rest.split(":");
+  if (!highPart || !lowPart) return null;
+  const high = Number.parseInt(highPart, 16);
+  const low = Number.parseInt(lowPart, 16);
+  if (Number.isNaN(high) || Number.isNaN(low)) return null;
+  return ((high >> 8) & 0xff) + "." + (high & 0xff) + "." + ((low >> 8) & 0xff) + "." + (low & 0xff);
+}
+
+function isBlockedIpv6Address(hostname) {
+  if (!hostname.includes(":")) return false;
+  if (
+    hostname === "::" ||
+    hostname === "::1" ||
+    hostname.startsWith("::ffff:") ||
+    hostname.startsWith("64:ff9b:") ||
+    hostname.startsWith("100:") ||
+    hostname.startsWith("2001:2:") ||
+    hostname.startsWith("2001:db8:") ||
+    hostname.startsWith("fc") ||
+    hostname.startsWith("fd") ||
+    hostname.startsWith("fe80:") ||
+    hostname.startsWith("fe8") ||
+    hostname.startsWith("fe9") ||
+    hostname.startsWith("fea") ||
+    hostname.startsWith("feb")
+  ) {
+    return true;
+  }
+  const mappedIpv4 = ipv4FromIpv4MappedIpv6(hostname);
+  if (mappedIpv4 && isBlockedIpv4Address(mappedIpv4)) return true;
+  return false;
+}
+
 function isBlockedHost(hostname) {
   const host = String(hostname || "").toLowerCase().replace(/^\\[|\\]$/g, "").replace(/\\.$/, "");
   if (!host || host === "localhost" || host.endsWith(".localhost")) return true;
-  if (host === "::1" || host === "127.0.0.1" || host === "0.0.0.0") return true;
-  if (host === "169.254.169.254" || host.startsWith("169.254.")) return true;
-  const ipv4 = host.split(".");
-  if (ipv4.length === 4 && ipv4.every((part) => /^\\d+$/.test(part))) {
-    const [a, b] = ipv4.map((part) => Number(part));
-    if (a === 0 || a === 10 || a === 127 || a >= 224) return true;
-    if (a === 172 && b >= 16 && b <= 31) return true;
-    if (a === 192 && b === 168) return true;
-    if (a === 100 && b >= 64 && b <= 127) return true;
-  }
-  if (host.includes(":")) {
-    if (host.startsWith("fe80:") || host.startsWith("fc") || host.startsWith("fd")) return true;
-  }
+  if (parseIpv4Octets(host)) return isBlockedIpv4Address(host);
+  if (host.includes(":")) return isBlockedIpv6Address(host);
   return false;
 }
 

--- a/apps/hyperlocalise-web/src/workflows/steps/localisation-audit.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/localisation-audit.ts
@@ -12,7 +12,6 @@
  */
 import { LOCALISATION_AUDIT_ANALYTICS_EVENTS, scoreBand } from "@/lib/analytics/events";
 import { serverAnalytics } from "@/lib/analytics/server";
-import { crawlLocalisationAuditSample } from "@/lib/localisation-audit/crawl";
 import { runLocalisationAuditCredits } from "@/lib/localisation-audit/credits/runner";
 import {
   aggregateLocalisationAuditCredits,
@@ -109,6 +108,7 @@ export async function crawlLocalisationAuditStep(input: {
   focusLocales?: string[];
 }): Promise<LocalisationAuditCrawlResult> {
   "use step";
+  const { crawlLocalisationAuditSample } = await import("@/lib/localisation-audit/crawl");
   return crawlLocalisationAuditSample(input);
 }
 

--- a/docs/adr/2026-07-25-localisation-audit-agent-design.md
+++ b/docs/adr/2026-07-25-localisation-audit-agent-design.md
@@ -19,7 +19,7 @@ Offer a public localisation health check as a lead magnet. Visitors paste a URL,
 Deterministic Vercel workflow (`"use workflow"` + `"use step"`):
 
 1. Claim audit for the current attempt / mark running
-2. Crawl smart sample (~10–15 URLs: homepage, locale roots, high-value nav targets)
+2. Crawl smart sample (~10–15 URLs: homepage, locale roots, high-value nav targets). HTML pages render in a Vercel sandbox with Playwright so JavaScript sites are visible; robots.txt and sitemaps still use the SSRF-guarded HTTP fetch.
 3. Technical checks (hreflang, lang mismatches, locale URL discovery, mixed language signals)
 4. Light LLM linguistic review on focus locales (sampled strings) when `OPENAI_API_KEY` is set; otherwise heuristics only
 5. Score + persist teaser + full report (attempt-guarded writes)

--- a/docs/adr/2026-07-25-localisation-audit-agent-design.md
+++ b/docs/adr/2026-07-25-localisation-audit-agent-design.md
@@ -19,7 +19,7 @@ Offer a public localisation health check as a lead magnet. Visitors paste a URL,
 Deterministic Vercel workflow (`"use workflow"` + `"use step"`):
 
 1. Claim audit for the current attempt / mark running
-2. Crawl smart sample (~10–15 URLs: homepage, locale roots, high-value nav targets). HTML pages render in a Vercel sandbox with Playwright so JavaScript sites are visible; robots.txt and sitemaps still use the SSRF-guarded HTTP fetch.
+2. Crawl smart sample (~10–15 URLs: homepage, locale roots, high-value nav targets). HTML pages render in a Vercel sandbox with Playwright so JavaScript sites are visible; robots.txt and sitemaps still use the SSRF-guarded HTTP fetch. The crawl creates that sandbox through `createConfiguredVercelSandbox`, the same helper as the agent workspace, so it uses the `hyperlocalise-sandbox` VCR image when the release flag and `VERCEL_SANDBOX_IMAGE` are set. Playwright and Chromium come from that image at `/tmp/hyperlocalise-browser-runtime`; the crawl does not install them at runtime.
 3. Technical checks (hreflang, lang mismatches, locale URL discovery, mixed language signals)
 4. Light LLM linguistic review on focus locales (sampled strings) when `OPENAI_API_KEY` is set; otherwise heuristics only
 5. Score + persist teaser + full report (attempt-guarded writes)

--- a/docs/adr/2026-08-08-sandbox-vcr-image-release-flag-design.md
+++ b/docs/adr/2026-08-08-sandbox-vcr-image-release-flag-design.md
@@ -43,6 +43,10 @@ covers warm reuse and image drift.
 
 ## Out of scope
 
-- Removing bootstrap or screenshot Playwright install paths
+- Removing bootstrap or agent screenshot Playwright install paths
 - Per-organization WorkOS gating
 - Using the image for Vercel Functions
+
+Localisation-audit crawls already use `createConfiguredVercelSandbox` and the
+image Playwright at `/tmp/hyperlocalise-browser-runtime`. They do not install
+Playwright at crawl time.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Public localisation-audit landing copy is simpler, and the form sits on the sage mesh used elsewhere on marketing pages.

HTML crawls render JavaScript sites with Playwright in a Vercel sandbox. That sandbox is created with `createConfiguredVercelSandbox`, the same helper as the agent workspace, so it uses the `hyperlocalise-sandbox` VCR image when the release flag and `VERCEL_SANDBOX_IMAGE` are set. Playwright and Chromium come from that image at `/tmp/hyperlocalise-browser-runtime`. The crawl no longer installs Playwright at runtime; it fails setup if the image is missing the browser runtime.

robots.txt and sitemaps still use the SSRF-guarded HTTP fetch. Navigation stays SSRF-guarded (pre-check, Playwright route abort, final-URL re-check).

## How to test

- `vp test src/lib/localisation-audit/sandbox-browser.test.ts src/lib/localisation-audit/crawl.test.ts src/workflows/steps/localisation-audit.test.ts`
- `vp check --fix` on the touched localisation-audit files
- Enable `release-sandbox-vcr-image` and set `VERCEL_SANDBOX_IMAGE` to the published `hyperlocalise-sandbox` ref, then run a public audit against a JS-rendered site

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-134319e4-3174-48ac-9b76-6429a19eb976?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-134319e4-3174-48ac-9b76-6429a19eb976&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

