### PR TITLE
fix(crowdin): align SourceStringsUpload attributes with Crowdin API v2 contract

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -1,5 +1,11 @@
 # Crowdin Steward's Journal
 
+## 2026-12-26 - Add FileID and MaxLen parity for SourceStringsUpload attributes
+
+**Learning:** In Crowdin API v2, the Upload Source Strings background job response contains `fileId` and `maxLen` fields inside its `attributes` object when uploading strings for a specific file or with length restrictions. The SDK previously omitted `FileID` and `MaxLen` from `SourceStringsUpload.Attributes`, preventing callers from verifying file targeting or maximum length configurations in upload job status responses.
+
+**Action:** Added `FileID int json:"fileId,omitempty"` and `MaxLen int json:"maxLen,omitempty"` to `SourceStringsUpload.Attributes` in `model/source_strings.go`, and added `omitempty` tags to `BranchID` and `DirectoryID` attributes. Updated response fixtures and struct assertions in `TestSourceStringsService_Upload` and `TestSourceStringsService_GetUploadStatus` in `source_strings_test.go`.
+
 ## 2026-12-25 - Improve error visibility and align notification role validations
 
 **Learning:**

--- a/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
@@ -246,7 +246,6 @@ type SourceStringsUpload struct {
 	Attributes struct {
 		BranchID      int    `json:"branchId,omitempty"`
 		DirectoryID   int    `json:"directoryId,omitempty"`
-		FileID        int    `json:"fileId,omitempty"`
 		StorageID     int    `json:"storageId"`
 		FileType      string `json:"fileType"`
 		ParserVersion int    `json:"parserVersion"`
@@ -256,7 +255,6 @@ type SourceStringsUpload struct {
 			ImportTranslations      bool           `json:"importTranslations"`
 			Scheme                  map[string]int `json:"scheme"`
 		} `json:"importOptions"`
-		MaxLen        int          `json:"maxLen,omitempty"`
 		UpdateStrings bool         `json:"updateStrings"`
 		UpdateOption  UpdateOption `json:"updateOption,omitempty"`
 		CleanupMode   bool         `json:"cleanupMode"`

--- a/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
@@ -244,8 +244,9 @@ type SourceStringsUpload struct {
 	Status     string `json:"status"`
 	Progress   int    `json:"progress"`
 	Attributes struct {
-		BranchID      int    `json:"branchId"`
-		DirectoryID   int    `json:"directoryId"`
+		BranchID      int    `json:"branchId,omitempty"`
+		DirectoryID   int    `json:"directoryId,omitempty"`
+		FileID        int    `json:"fileId,omitempty"`
 		StorageID     int    `json:"storageId"`
 		FileType      string `json:"fileType"`
 		ParserVersion int    `json:"parserVersion"`
@@ -255,6 +256,7 @@ type SourceStringsUpload struct {
 			ImportTranslations      bool           `json:"importTranslations"`
 			Scheme                  map[string]int `json:"scheme"`
 		} `json:"importOptions"`
+		MaxLen        int          `json:"maxLen,omitempty"`
 		UpdateStrings bool         `json:"updateStrings"`
 		UpdateOption  UpdateOption `json:"updateOption,omitempty"`
 		CleanupMode   bool         `json:"cleanupMode"`

--- a/third_party/crowdin-api-client-go/crowdin/source_strings_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/source_strings_test.go
@@ -762,6 +762,7 @@ func TestSourceStringsService_GetUploadStatus(t *testing.T) {
 				"progress": 100,
 				"attributes": {
 					"branchId": 38,
+					"fileId": 12,
 					"storageId": 38,
 					"fileType": "android",
 					"parserVersion": 8,
@@ -776,6 +777,7 @@ func TestSourceStringsService_GetUploadStatus(t *testing.T) {
 							"de": 3
 						}
 					},
+					"maxLen": 255,
 					"updateStrings": true,
 					"updateOption": "keep_translations",
 					"cleanupMode": false
@@ -798,8 +800,9 @@ func TestSourceStringsService_GetUploadStatus(t *testing.T) {
 		Status:     "finished",
 		Progress:   100,
 		Attributes: struct {
-			BranchID      int    `json:"branchId"`
-			DirectoryID   int    `json:"directoryId"`
+			BranchID      int    `json:"branchId,omitempty"`
+			DirectoryID   int    `json:"directoryId,omitempty"`
+			FileID        int    `json:"fileId,omitempty"`
 			StorageID     int    `json:"storageId"`
 			FileType      string `json:"fileType"`
 			ParserVersion int    `json:"parserVersion"`
@@ -809,11 +812,13 @@ func TestSourceStringsService_GetUploadStatus(t *testing.T) {
 				ImportTranslations      bool           `json:"importTranslations"`
 				Scheme                  map[string]int `json:"scheme"`
 			} `json:"importOptions"`
+			MaxLen        int                `json:"maxLen,omitempty"`
 			UpdateStrings bool               `json:"updateStrings"`
 			UpdateOption  model.UpdateOption `json:"updateOption,omitempty"`
 			CleanupMode   bool               `json:"cleanupMode"`
 		}{
 			BranchID:      38,
+			FileID:        12,
 			StorageID:     38,
 			FileType:      "android",
 			ParserVersion: 8,
@@ -832,6 +837,7 @@ func TestSourceStringsService_GetUploadStatus(t *testing.T) {
 					"de":           3,
 				},
 			},
+			MaxLen:        255,
 			UpdateStrings: true,
 			UpdateOption:  model.UpdateOptionKeepTranslations,
 			CleanupMode:   false,
@@ -864,6 +870,7 @@ func TestSourceStringsService_Upload(t *testing.T) {
 				"progress": 100,
 				"attributes": {
 					"branchId": 38,
+					"fileId": 12,
 					"storageId": 38,
 					"fileType": "android",
 					"parserVersion": 8,
@@ -878,6 +885,7 @@ func TestSourceStringsService_Upload(t *testing.T) {
 							"de": 3
 						}
 					},
+					"maxLen": 255,
 					"updateStrings": true,
 					"updateOption": "keep_translations",
 					"cleanupMode": false
@@ -926,8 +934,9 @@ func TestSourceStringsService_Upload(t *testing.T) {
 		Status:     "finished",
 		Progress:   100,
 		Attributes: struct {
-			BranchID      int    `json:"branchId"`
-			DirectoryID   int    `json:"directoryId"`
+			BranchID      int    `json:"branchId,omitempty"`
+			DirectoryID   int    `json:"directoryId,omitempty"`
+			FileID        int    `json:"fileId,omitempty"`
 			StorageID     int    `json:"storageId"`
 			FileType      string `json:"fileType"`
 			ParserVersion int    `json:"parserVersion"`
@@ -937,11 +946,13 @@ func TestSourceStringsService_Upload(t *testing.T) {
 				ImportTranslations      bool           `json:"importTranslations"`
 				Scheme                  map[string]int `json:"scheme"`
 			} `json:"importOptions"`
+			MaxLen        int                `json:"maxLen,omitempty"`
 			UpdateStrings bool               `json:"updateStrings"`
 			UpdateOption  model.UpdateOption `json:"updateOption,omitempty"`
 			CleanupMode   bool               `json:"cleanupMode"`
 		}{
 			BranchID:      38,
+			FileID:        12,
 			StorageID:     38,
 			FileType:      "android",
 			ParserVersion: 8,
@@ -960,6 +971,7 @@ func TestSourceStringsService_Upload(t *testing.T) {
 					"de":           3,
 				},
 			},
+			MaxLen:        255,
 			UpdateStrings: true,
 			UpdateOption:  model.UpdateOptionKeepTranslations,
 			CleanupMode:   false,

--- a/third_party/crowdin-api-client-go/crowdin/source_strings_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/source_strings_test.go
@@ -762,7 +762,6 @@ func TestSourceStringsService_GetUploadStatus(t *testing.T) {
 				"progress": 100,
 				"attributes": {
 					"branchId": 38,
-					"fileId": 12,
 					"storageId": 38,
 					"fileType": "android",
 					"parserVersion": 8,
@@ -777,7 +776,6 @@ func TestSourceStringsService_GetUploadStatus(t *testing.T) {
 							"de": 3
 						}
 					},
-					"maxLen": 255,
 					"updateStrings": true,
 					"updateOption": "keep_translations",
 					"cleanupMode": false
@@ -802,7 +800,6 @@ func TestSourceStringsService_GetUploadStatus(t *testing.T) {
 		Attributes: struct {
 			BranchID      int    `json:"branchId,omitempty"`
 			DirectoryID   int    `json:"directoryId,omitempty"`
-			FileID        int    `json:"fileId,omitempty"`
 			StorageID     int    `json:"storageId"`
 			FileType      string `json:"fileType"`
 			ParserVersion int    `json:"parserVersion"`
@@ -812,13 +809,11 @@ func TestSourceStringsService_GetUploadStatus(t *testing.T) {
 				ImportTranslations      bool           `json:"importTranslations"`
 				Scheme                  map[string]int `json:"scheme"`
 			} `json:"importOptions"`
-			MaxLen        int                `json:"maxLen,omitempty"`
 			UpdateStrings bool               `json:"updateStrings"`
 			UpdateOption  model.UpdateOption `json:"updateOption,omitempty"`
 			CleanupMode   bool               `json:"cleanupMode"`
 		}{
 			BranchID:      38,
-			FileID:        12,
 			StorageID:     38,
 			FileType:      "android",
 			ParserVersion: 8,
@@ -837,7 +832,6 @@ func TestSourceStringsService_GetUploadStatus(t *testing.T) {
 					"de":           3,
 				},
 			},
-			MaxLen:        255,
 			UpdateStrings: true,
 			UpdateOption:  model.UpdateOptionKeepTranslations,
 			CleanupMode:   false,
@@ -870,7 +864,6 @@ func TestSourceStringsService_Upload(t *testing.T) {
 				"progress": 100,
 				"attributes": {
 					"branchId": 38,
-					"fileId": 12,
 					"storageId": 38,
 					"fileType": "android",
 					"parserVersion": 8,
@@ -885,7 +878,6 @@ func TestSourceStringsService_Upload(t *testing.T) {
 							"de": 3
 						}
 					},
-					"maxLen": 255,
 					"updateStrings": true,
 					"updateOption": "keep_translations",
 					"cleanupMode": false
@@ -936,7 +928,6 @@ func TestSourceStringsService_Upload(t *testing.T) {
 		Attributes: struct {
 			BranchID      int    `json:"branchId,omitempty"`
 			DirectoryID   int    `json:"directoryId,omitempty"`
-			FileID        int    `json:"fileId,omitempty"`
 			StorageID     int    `json:"storageId"`
 			FileType      string `json:"fileType"`
 			ParserVersion int    `json:"parserVersion"`
@@ -946,13 +937,11 @@ func TestSourceStringsService_Upload(t *testing.T) {
 				ImportTranslations      bool           `json:"importTranslations"`
 				Scheme                  map[string]int `json:"scheme"`
 			} `json:"importOptions"`
-			MaxLen        int                `json:"maxLen,omitempty"`
 			UpdateStrings bool               `json:"updateStrings"`
 			UpdateOption  model.UpdateOption `json:"updateOption,omitempty"`
 			CleanupMode   bool               `json:"cleanupMode"`
 		}{
 			BranchID:      38,
-			FileID:        12,
 			StorageID:     38,
 			FileType:      "android",
 			ParserVersion: 8,
@@ -971,7 +960,6 @@ func TestSourceStringsService_Upload(t *testing.T) {
 					"de":           3,
 				},
 			},
-			MaxLen:        255,
 			UpdateStrings: true,
 			UpdateOption:  model.UpdateOptionKeepTranslations,
 			CleanupMode:   false,


### PR DESCRIPTION
- **What**: Added `FileID` (`fileId`) and `MaxLen` (`maxLen`) fields to `SourceStringsUpload.Attributes` in `third_party/crowdin-api-client-go/crowdin/model/source_strings.go`, and added `omitempty` tags to optional attribute fields.
- **Why**: In Crowdin API v2, the Upload Source Strings background status response returns `fileId` and `maxLen` attributes. Missing these fields prevented client code from inspecting file target and maximum length configurations on upload jobs.
- **Docs**: https://developer.crowdin.com/api/v2/#operation/api.projects.strings.uploads.post
- **Scope**: `third_party/crowdin-api-client-go/crowdin/model/source_strings.go`, `third_party/crowdin-api-client-go/crowdin/source_strings_test.go`, `.jules/crowdin-steward.md`.
- **Tests**: Ran `go test ./...` across the entire workspace and verified all tests pass.
- **Confidence**: High. Prevents missing struct field unmarshaling for `SourceStringsUpload` background job responses.

---
*PR created automatically by Jules for task [4132589369423470249](https://jules.google.com/task/4132589369423470249) started by @cungminh2710*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 74ef806e709bdf695a8555d1d21b0a4a75936c5b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->