### PR TITLE
fix(localisation-audit): wrap long finding evidence on mobile

### DIFF
--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-result-page.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-result-page.stories.tsx
@@ -87,6 +87,9 @@ export const PublicFullReport: Story = {
     await expect(canvas.getAllByText("What we saw").length).toBeGreaterThan(0);
     await expect(canvas.getAllByText("How to fix it").length).toBeGreaterThan(0);
     await expect(canvas.getByText("Document head · <html lang>")).toBeInTheDocument();
+    await expect(
+      canvas.getByText(/src="\/_next\/image\?url=%2Fimages%2Fgame%2Fmath-sudoku\.png/),
+    ).toBeInTheDocument();
     await expect(canvas.getByRole("heading", { name: "Full findings" })).toBeInTheDocument();
     await expect(canvas.getByRole("heading", { name: "Email me a summary" })).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Re-run audit" })).toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-result.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-result.tsx
@@ -153,17 +153,13 @@ function DimensionScoreCircle({
   );
 }
 
-function looksLikeMarkup(value: string) {
-  return value.includes("<") && value.includes(">");
-}
-
 function FindingDetail({ label, children }: { label: string; children: ReactNode }) {
   return (
-    <div className="mt-3">
+    <div className="mt-3 min-w-0">
       <p className="text-xs font-medium tracking-[0.14em] text-muted-foreground uppercase">
         {label}
       </p>
-      <div className="mt-1">{children}</div>
+      <div className="mt-1.5 min-w-0">{children}</div>
     </div>
   );
 }
@@ -182,14 +178,15 @@ function FindingList({
   }
 
   return (
-    <ul className="space-y-6">
+    <ul className="min-w-0 space-y-6">
       {findings.map((finding) => {
         const tone = severityTone(finding.severity);
-        const evidenceLooksLikeMarkup =
-          finding.evidence != null && looksLikeMarkup(finding.evidence);
         const findingHref = sanitizeLocalisationAuditFindingUrl(finding.url, domainKey);
         return (
-          <li key={finding.id} className="border-t border-border pt-6 first:border-t-0 first:pt-0">
+          <li
+            key={finding.id}
+            className="min-w-0 border-t border-border pt-6 first:border-t-0 first:pt-0"
+          >
             <div className="flex flex-wrap items-center gap-2">
               <Badge variant="outline" className={cn("capitalize", auditToneBadgeClass(tone))}>
                 {finding.severity}
@@ -199,11 +196,11 @@ function FindingList({
                 {finding.confidence != null ? ` · ${finding.confidence}% confidence` : ""}
               </span>
             </div>
-            <p className="mt-2 text-lg font-medium">{finding.title}</p>
+            <p className="mt-2 text-lg font-medium text-pretty">{finding.title}</p>
             <p className="mt-1 text-pretty text-muted-foreground">{finding.summary}</p>
             {finding.where || findingHref ? (
               <FindingDetail label={copy.findingWhereLabel}>
-                {finding.where ? <p className="text-sm">{finding.where}</p> : null}
+                {finding.where ? <p className="text-sm wrap-break-word">{finding.where}</p> : null}
                 {findingHref ? (
                   <a
                     href={findingHref}
@@ -218,19 +215,14 @@ function FindingList({
             ) : null}
             {finding.evidence ? (
               <FindingDetail label={copy.findingEvidenceLabel}>
-                <p
-                  className={cn(
-                    "whitespace-pre-wrap text-sm text-muted-foreground",
-                    evidenceLooksLikeMarkup ? "font-mono" : "italic",
-                  )}
-                >
-                  {evidenceLooksLikeMarkup ? finding.evidence : `“${finding.evidence}”`}
+                <p className="min-w-0 font-mono text-sm wrap-break-word whitespace-pre-wrap text-muted-foreground">
+                  {finding.evidence}
                 </p>
               </FindingDetail>
             ) : null}
             {finding.advice ? (
               <FindingDetail label={copy.findingAdviceLabel}>
-                <p className="text-pretty text-sm">{finding.advice}</p>
+                <p className="text-pretty text-sm wrap-break-word">{finding.advice}</p>
               </FindingDetail>
             ) : null}
           </li>

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit.fixture.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit.fixture.ts
@@ -151,6 +151,18 @@ const FINDING_SEEDS: Array<{
     confidence: 90,
   },
   {
+    creditId: "localized-images",
+    severity: "medium",
+    title: "Image still looks like the source locale",
+    summary: "Alt text or filename on a ja-jp page appears to be English.",
+    where: "Page body · <img alt>",
+    url: "https://acme.example/ja-JP",
+    evidence:
+      'alt="5 New Games to Play in March 2026 (Under 5 Minutes)" src="/_next/image?url=%2Fimages%2Fgame%2Fmath-sudoku.png&w=3840&q=75&dpl=dpl_EPL3L2dMJPgnPiUChJy6wt58CTGu"',
+    advice: "Localize the image asset and alt text for this page locale.",
+    confidence: 95,
+  },
+  {
     creditId: "text-overflow",
     severity: "medium",
     title: "German nav labels clip at tablet width",

--- a/apps/hyperlocalise-web/src/emails/localisation-audit-report-email.tsx
+++ b/apps/hyperlocalise-web/src/emails/localisation-audit-report-email.tsx
@@ -369,6 +369,8 @@ const evidenceBody = {
   fontFamily:
     'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
   whiteSpace: "pre-wrap" as const,
+  wordBreak: "break-word" as const,
+  overflowWrap: "anywhere" as const,
 };
 
 const findingUrl = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Fix mobile overflow in localisation audit finding lists when "What we saw" contains long unbroken strings (e.g. Next.js `/_next/image?...` URLs).
- Always render evidence in monospace with `wrap-break-word`, matching the email report.
- Add a Storybook fixture covering the long `alt`/`src` evidence case.

## Why this happened

Finding evidence used `whitespace-pre-wrap` without a word-break rule. URLs have no spaces, so they refused to wrap. Attribute-style evidence (`alt="..." src="..."`) also skipped monospace because `looksLikeMarkup` only detected `<...>`, so it rendered as italic prose instead of code.

## UI components

Yes, partially: severity uses `Badge`, and the page uses shared `Button` / `Typography` / form controls. There is no dedicated Code/pre UI primitive, so evidence stayed as a styled `<p>` — the bug was missing overflow CSS on that custom markup, not a missing Badge.

## Test plan

- [x] `vp test` (localisation-audit / email related)
- [x] `vp check --fix`
- [ ] Mobile viewport: long `/_next/image` evidence wraps inside the finding card
- [ ] Storybook `Marketing/LocalisationAudit/Result` → `PublicFullReport`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0036d-c91f-7a77-b4e6-f826643deeb8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0036d-c91f-7a77-b4e6-f826643deeb8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

