### PR TITLE
feat(localisation-audit): add result Open Graph image

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/[domainSlug]/opengraph-image.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/[domainSlug]/opengraph-image.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { getIntlShape } from "@/lib/app-i18n/intl";
+import { isValidDomainSlug } from "@/lib/localisation-audit/domain-slug";
+import { findLocalisationAuditBySlug } from "@/lib/localisation-audit/store";
+import {
+  createLocalisationAuditResultOgImage,
+  marketingOgImageContentType,
+  marketingOgImageSize,
+} from "@/lib/og/create-localisation-audit-result-og-image";
+import { createMarketingOgImage, toMarketingOgHeading } from "@/lib/og/create-marketing-og-image";
+
+export const alt = "Hyperlocalise localisation audit result";
+export const size = marketingOgImageSize;
+export const contentType = marketingOgImageContentType;
+
+type LocalisationAuditResultOgImageProps = {
+  params: Promise<{ lang: string; domainSlug: string }>;
+};
+
+export default async function Image({ params }: LocalisationAuditResultOgImageProps) {
+  const { lang, domainSlug } = await params;
+  const intl = getIntlShape(lang);
+
+  if (!isValidDomainSlug(domainSlug)) {
+    return createMarketingOgImage({
+      heading: "Localisation audit",
+      description: intl.formatMessage({
+        defaultMessage: "The best agentic localisation platform",
+        id: "CYGau9cDQe",
+        description: "Open Graph fallback description for unknown pages",
+      }),
+    });
+  }
+
+  const audit = await findLocalisationAuditBySlug(domainSlug);
+  if (!audit) {
+    return createMarketingOgImage({
+      heading: toMarketingOgHeading("Localisation audit | Hyperlocalise"),
+      description: intl.formatMessage({
+        defaultMessage: "The best agentic localisation platform",
+        id: "CYGau9cDQe",
+        description: "Open Graph fallback description for unknown pages",
+      }),
+    });
+  }
+
+  const dimensionScores = audit.teaser?.dimensionScores ?? audit.report?.dimensionScores ?? null;
+
+  return createLocalisationAuditResultOgImage({
+    domainKey: audit.domainKey,
+    dimensionScores,
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/og/create-localisation-audit-result-og-image.test.ts
+++ b/apps/hyperlocalise-web/src/lib/og/create-localisation-audit-result-og-image.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { createLocalisationAuditResultOgImage } from "./create-localisation-audit-result-og-image";
+
+describe("createLocalisationAuditResultOgImage", () => {
+  it("renders a PNG for a completed audit with dimension scores", async () => {
+    const response = await createLocalisationAuditResultOgImage({
+      domainKey: "acme.example",
+      dimensionScores: {
+        technical: 86,
+        linguistic: 81,
+        contextual: 76,
+        visual: 68,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toContain("image/png");
+    const bytes = await response.arrayBuffer();
+    expect(bytes.byteLength).toBeGreaterThan(10_000);
+  });
+
+  it("renders N/A circles when dimension scores are missing", async () => {
+    const response = await createLocalisationAuditResultOgImage({
+      domainKey: "example.com",
+      dimensionScores: null,
+    });
+
+    expect(response.status).toBe(200);
+    const bytes = await response.arrayBuffer();
+    expect(bytes.byteLength).toBeGreaterThan(10_000);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/og/create-localisation-audit-result-og-image.tsx
+++ b/apps/hyperlocalise-web/src/lib/og/create-localisation-audit-result-og-image.tsx
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { ImageResponse } from "next/og";
+
+import {
+  emailAuditToneColor,
+  emailAuditToneFill,
+  formatDimensionScore,
+  scoreTone,
+} from "@/lib/localisation-audit/score-tone";
+import type { LocalisationAuditDimensionScores } from "@/lib/localisation-audit/types";
+
+import { marketingOgImageContentType, marketingOgImageSize } from "./create-marketing-og-image";
+
+export { marketingOgImageContentType, marketingOgImageSize };
+
+/** Sage mesh used on the localisation audit landing form. */
+const AUDIT_RESULT_OG_MESH_SRC = "images/mesh/mesh-gradient-1784864073608.jpg";
+
+const logoPromise = readFile(join(process.cwd(), "public/images/logo.png"));
+const meshPromise = readFile(join(process.cwd(), "public", AUDIT_RESULT_OG_MESH_SRC));
+const domineFontPromise = readFile(
+  join(process.cwd(), "public/fonts/domine-latin-700-normal.woff"),
+);
+const interFontPromise = readFile(join(process.cwd(), "public/fonts/inter-latin-400-normal.ttf"));
+
+const DIMENSIONS = [
+  { key: "technical", label: "Technical" },
+  { key: "linguistic", label: "Linguistic" },
+  { key: "contextual", label: "Contextual" },
+  { key: "visual", label: "Visual" },
+] as const;
+
+type CreateLocalisationAuditResultOgImageOptions = {
+  domainKey: string;
+  dimensionScores?: LocalisationAuditDimensionScores | null;
+  size?: { width: number; height: number };
+};
+
+function domainFontSize(domainKey: string) {
+  if (domainKey.length > 36) {
+    return 40;
+  }
+  if (domainKey.length > 24) {
+    return 48;
+  }
+  return 56;
+}
+
+export async function createLocalisationAuditResultOgImage({
+  domainKey,
+  dimensionScores = null,
+  size = marketingOgImageSize,
+}: CreateLocalisationAuditResultOgImageOptions) {
+  const [logo, mesh, domineFont, interFont] = await Promise.all([
+    logoPromise,
+    meshPromise,
+    domineFontPromise,
+    interFontPromise,
+  ]);
+
+  const logoSrc = `data:image/png;base64,${logo.toString("base64")}`;
+  const meshSrc = `data:image/jpeg;base64,${mesh.toString("base64")}`;
+  const scores = dimensionScores ?? {
+    technical: null,
+    linguistic: null,
+    contextual: null,
+    visual: null,
+  };
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        position: "relative",
+        overflow: "hidden",
+      }}
+    >
+      <img
+        alt=""
+        height={size.height}
+        src={meshSrc}
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          width: size.width,
+          height: size.height,
+          objectFit: "cover",
+        }}
+        width={size.width}
+      />
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          width: "100%",
+          height: "100%",
+          background:
+            "linear-gradient(180deg, rgba(8, 16, 12, 0.28) 0%, rgba(8, 16, 12, 0.52) 100%)",
+          display: "flex",
+        }}
+      />
+      <div
+        style={{
+          position: "relative",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "64px 72px",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 18,
+          }}
+        >
+          <img alt="" height={56} src={logoSrc} style={{ objectFit: "contain" }} width={56} />
+          <div
+            style={{
+              color: "#ffffff",
+              fontFamily: "Domine",
+              fontSize: 30,
+              fontWeight: 700,
+              letterSpacing: "-0.02em",
+            }}
+          >
+            Hyperlocalise
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 12,
+            maxWidth: 980,
+          }}
+        >
+          <div
+            style={{
+              color: "rgba(255, 255, 255, 0.78)",
+              fontFamily: "Inter",
+              fontSize: 22,
+              fontWeight: 400,
+              letterSpacing: "0.04em",
+              textTransform: "uppercase",
+            }}
+          >
+            Localisation audit
+          </div>
+          <div
+            style={{
+              color: "#ffffff",
+              fontFamily: "Domine",
+              fontSize: domainFontSize(domainKey),
+              fontWeight: 700,
+              letterSpacing: "-0.03em",
+              lineHeight: 1.1,
+            }}
+          >
+            {domainKey}
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            alignItems: "flex-start",
+            gap: 28,
+          }}
+        >
+          {DIMENSIONS.map((dimension) => {
+            const score = scores[dimension.key];
+            const tone = scoreTone(score);
+            const color = emailAuditToneColor(tone);
+            const fill = emailAuditToneFill(tone);
+            return (
+              <div
+                key={dimension.key}
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  gap: 12,
+                  width: 148,
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    width: 88,
+                    height: 88,
+                    borderRadius: 999,
+                    backgroundColor: fill,
+                    color,
+                    fontFamily: "Domine",
+                    fontSize: score == null ? 22 : 30,
+                    fontWeight: 700,
+                  }}
+                >
+                  {formatDimensionScore(score)}
+                </div>
+                <div
+                  style={{
+                    color: "rgba(255, 255, 255, 0.88)",
+                    fontFamily: "Inter",
+                    fontSize: 20,
+                    fontWeight: 400,
+                    textAlign: "center",
+                  }}
+                >
+                  {dimension.label}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>,
+    {
+      ...size,
+      fonts: [
+        { name: "Domine", data: domineFont, weight: 700, style: "normal" },
+        { name: "Inter", data: interFont, weight: 400, style: "normal" },
+      ],
+    },
+  );
+}

--- a/docs/adr/2026-08-15-localisation-audit-result-og-image-design.md
+++ b/docs/adr/2026-08-15-localisation-audit-result-og-image-design.md
@@ -1,0 +1,32 @@
+# Localisation audit result Open Graph image
+
+## Goal
+
+Give each public localisation audit result page a shareable Open Graph image that
+matches the audit landing visual language (sage mesh) and surfaces the four
+dimension scores.
+
+## Design
+
+- Route: `apps/hyperlocalise-web/src/app/[lang]/(marketing)/localisation-audit/[domainSlug]/opengraph-image.tsx`
+- Helper: `createLocalisationAuditResultOgImage` in `src/lib/og/`
+- Canvas: 1200×630 PNG via `next/og` `ImageResponse`
+- Background: sage mesh gradient (`images/mesh/mesh-gradient-1784864073608.jpg`, same
+  asset as the audit landing form) with a dark scrim for readable type
+- Brand lockup: Hyperlocalise logo + company name
+- Subject: audited `domainKey` under a short “Localisation audit” label
+- Scores: Technical, Linguistic, Contextual, Visual circles using the same tone
+  colors as the report email (`emailAuditToneColor` / `emailAuditToneFill`)
+- Missing scores render as `N/A`
+- Unknown or invalid slugs fall back to the standard marketing OG template
+
+## Data
+
+Reads the audit row by `domainSlug`. Dimension scores come from
+`teaser.dimensionScores`, then `report.dimensionScores`. Teaser scores are always
+available on completed public pages, so the OG image does not require email unlock.
+
+## Out of scope
+
+- Site favicons / third-party company logos (audits only store `domainKey`)
+- Overall score on the OG card (request is the four dimension scores)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Dynamic Open Graph image for localisation audit result pages (`/[lang]/localisation-audit/[domainSlug]`).

Share cards show the sage mesh background, Hyperlocalise logo + company name, audited domain, and the four dimension scores (Technical, Linguistic, Contextual, Visual) using the same tone colors as the report email.

Unknown/invalid slugs fall back to the marketing OG template. Scores come from the public teaser (no email unlock). Design notes in `docs/adr/2026-08-15-localisation-audit-result-og-image-design.md`.

[Localisation audit result OG sample](https://cursor.com/agents/bc-01a00375-c929-76b0-bad0-182546126415/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flocalisation_audit_result_og_sample.png)

## How to test

- `vp test src/lib/og/create-localisation-audit-result-og-image.test.ts`
- `vp check --fix`
- Open `/[lang]/localisation-audit/[domainSlug]/opengraph-image` for a completed audit and confirm the mesh card renders

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00375-c929-76b0-bad0-182546126415?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00375-c929-76b0-bad0-182546126415&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

