### PR TITLE
feat(localisation-audit): backfill company profile on re-run

### DIFF
--- a/apps/hyperlocalise-web/src/lib/localisation-audit/company-profile.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/company-profile.test.ts
@@ -15,6 +15,9 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   buildHeuristicCompanyProfile,
   collectCompanyProfileEvidence,
+  companyProfileFromAuditPayloads,
+  isCompanyProfileIncomplete,
+  mergeCompanyProfiles,
   pickCompanyLogoUrl,
 } from "./company-profile";
 import { emptyCrawledPage } from "./types";
@@ -104,5 +107,70 @@ describe("collectCompanyProfileEvidence", () => {
     expect(evidence?.pageUrl).toBe("https://acme.example/");
     expect(evidence?.title).toBe("Acme");
     expect(evidence?.logoUrl).toBe("https://acme.example/logo.png");
+  });
+});
+
+const completeProfile = {
+  name: "Acme",
+  logoUrl: "https://acme.example/logo.png",
+  productSummary: "Payments for global teams.",
+  brandVoice: "calm, precise",
+  industry: "Fintech",
+  confidence: 80,
+};
+
+describe("isCompanyProfileIncomplete", () => {
+  it("treats a missing profile and any blank cover field as incomplete", () => {
+    expect(isCompanyProfileIncomplete(null)).toBe(true);
+    expect(isCompanyProfileIncomplete(completeProfile)).toBe(false);
+    expect(isCompanyProfileIncomplete({ ...completeProfile, logoUrl: null })).toBe(true);
+    expect(isCompanyProfileIncomplete({ ...completeProfile, productSummary: "  " })).toBe(true);
+    expect(isCompanyProfileIncomplete({ ...completeProfile, brandVoice: null })).toBe(true);
+  });
+});
+
+describe("mergeCompanyProfiles", () => {
+  it("fills gaps from the incoming profile and keeps stored values when the crawl misses them", () => {
+    expect(mergeCompanyProfiles(null, completeProfile)).toEqual(completeProfile);
+
+    const merged = mergeCompanyProfiles(
+      {
+        name: "Acme",
+        logoUrl: "https://acme.example/old-logo.png",
+        productSummary: null,
+        brandVoice: null,
+        industry: "Fintech",
+        confidence: 40,
+      },
+      {
+        name: "Acme Inc",
+        logoUrl: null,
+        productSummary: "Payments for global teams.",
+        brandVoice: "calm, precise",
+        industry: null,
+        confidence: 70,
+      },
+    );
+
+    expect(merged).toEqual({
+      name: "Acme Inc",
+      logoUrl: "https://acme.example/old-logo.png",
+      productSummary: "Payments for global teams.",
+      brandVoice: "calm, precise",
+      industry: "Fintech",
+      confidence: 70,
+    });
+  });
+});
+
+describe("companyProfileFromAuditPayloads", () => {
+  it("prefers the full report profile over the teaser", () => {
+    expect(
+      companyProfileFromAuditPayloads({
+        teaser: { companyProfile: { ...completeProfile, name: "Teaser" } },
+        report: { companyProfile: completeProfile },
+      }),
+    ).toEqual(completeProfile);
+    expect(companyProfileFromAuditPayloads({ teaser: null, report: null })).toBeNull();
   });
 });

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/company-profile.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/company-profile.ts
@@ -240,3 +240,52 @@ export async function buildLocalisationAuditCompanyProfile(input: {
   }
   return inferCompanyProfileWithLuna(evidence);
 }
+
+function nonEmpty(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+/** True when the cover is missing logo, summary, or other profile fields. */
+export function isCompanyProfileIncomplete(
+  profile: LocalisationAuditCompanyProfile | null | undefined,
+): boolean {
+  if (!profile) {
+    return true;
+  }
+  return (
+    nonEmpty(profile.name) == null ||
+    nonEmpty(profile.logoUrl) == null ||
+    nonEmpty(profile.productSummary) == null ||
+    nonEmpty(profile.brandVoice) == null ||
+    nonEmpty(profile.industry) == null
+  );
+}
+
+/**
+ * Prefer freshly inferred values when present; keep stored values for gaps.
+ * A re-run can fill a legacy row without wiping a logo the new crawl missed.
+ */
+export function mergeCompanyProfiles(
+  existing: LocalisationAuditCompanyProfile | null | undefined,
+  incoming: LocalisationAuditCompanyProfile,
+): LocalisationAuditCompanyProfile {
+  if (!existing) {
+    return incoming;
+  }
+  return {
+    name: nonEmpty(incoming.name) ?? existing.name,
+    logoUrl: nonEmpty(incoming.logoUrl) ?? existing.logoUrl,
+    productSummary: nonEmpty(incoming.productSummary) ?? existing.productSummary,
+    brandVoice: nonEmpty(incoming.brandVoice) ?? existing.brandVoice,
+    industry: nonEmpty(incoming.industry) ?? existing.industry,
+    confidence: Math.max(existing.confidence, incoming.confidence),
+  };
+}
+
+export function companyProfileFromAuditPayloads(input: {
+  teaser?: { companyProfile?: LocalisationAuditCompanyProfile | null } | null;
+  report?: { companyProfile?: LocalisationAuditCompanyProfile | null } | null;
+}): LocalisationAuditCompanyProfile | null {
+  return input.report?.companyProfile ?? input.teaser?.companyProfile ?? null;
+}

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/store.retry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/store.retry.test.ts
@@ -30,6 +30,7 @@ import {
   listLocalisationAuditLeaderboard,
   listPendingLocalisationAuditLeads,
   markLocalisationAuditLeadEmailQueued,
+  patchLocalisationAuditCompanyProfile,
   upsertLocalisationAuditLeadForDelivery,
   verifyLocalisationAuditReportToken,
 } from "./store";
@@ -380,6 +381,95 @@ describe("localisation audit claim/retry", () => {
     expect(failed?.progressStage).toBe("failed");
     expect(failed?.report).toBeNull();
     expect(failed?.errorCode).toBe("localisation_audit_enqueue_failed");
+  });
+
+  it("patches a missing company profile onto a preserved re-run report", async () => {
+    const created = await claimOrReuseLocalisationAudit({
+      domainKey,
+      domainSlug,
+      sourceUrl: `https://${domainKey}/`,
+      focusLocales: [],
+    });
+
+    await completeLocalisationAudit({
+      auditId: created.audit.id,
+      attemptNumber: 1,
+      score: 64,
+      teaser: {
+        score: 64,
+        domainKey,
+        domainSlug,
+        detectedLocales: [],
+        headlineFindings: [],
+        findingsCount: 0,
+        pagesCrawled: 1,
+        completedAt: new Date().toISOString(),
+      },
+      report: {
+        score: 64,
+        domainKey,
+        domainSlug,
+        sourceUrl: `https://${domainKey}/`,
+        focusLocales: [],
+        detectedLocales: [],
+        findings: [],
+        pages: [],
+        linguisticNotes: [],
+        pagesCrawled: 1,
+        completedAt: new Date().toISOString(),
+      },
+    });
+
+    await db
+      .update(schema.localisationAudits)
+      .set({
+        completedAt: new Date(Date.now() - LOCALISATION_AUDIT_RERUN_MS - 1_000),
+      })
+      .where(eq(schema.localisationAudits.id, created.audit.id));
+
+    const rerun = await claimOrReuseLocalisationAudit({
+      domainKey,
+      domainSlug,
+      sourceUrl: `https://${domainKey}/`,
+      focusLocales: [],
+    });
+    expect(rerun.outcome).toBe("reclaimed");
+    expect(rerun.audit.report?.companyProfile).toBeUndefined();
+
+    const profile = {
+      name: "Acme",
+      logoUrl: "https://acme.example/logo.png",
+      productSummary: "Payments for global teams.",
+      brandVoice: "calm, precise",
+      industry: "Fintech",
+      confidence: 80,
+    };
+    const patched = await patchLocalisationAuditCompanyProfile({
+      auditId: rerun.audit.id,
+      attemptNumber: rerun.audit.attemptNumber,
+      companyProfile: profile,
+    });
+    expect(patched?.teaser?.companyProfile).toEqual(profile);
+    expect(patched?.report?.companyProfile).toEqual(profile);
+    expect(patched?.status).toBe("queued");
+    expect(patched?.score).toBe(64);
+
+    const stale = await patchLocalisationAuditCompanyProfile({
+      auditId: rerun.audit.id,
+      attemptNumber: rerun.audit.attemptNumber - 1,
+      companyProfile: { ...profile, name: "Stale" },
+    });
+    expect(stale).toBeNull();
+
+    const restored = await failLocalisationAudit({
+      auditId: rerun.audit.id,
+      attemptNumber: rerun.audit.attemptNumber,
+      errorCode: "localisation_audit_failed",
+      errorMessage: "scoring failed",
+    });
+    expect(restored?.status).toBe("succeeded");
+    expect(restored?.report?.companyProfile).toEqual(profile);
+    expect(restored?.teaser?.companyProfile).toEqual(profile);
   });
 
   it("handles concurrent lead upserts idempotently", async () => {

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/store.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/store.ts
@@ -22,6 +22,7 @@ import {
 
 import { hashLocalisationAuditReportToken, mintLocalisationAuditReportToken } from "./email-unlock";
 import type {
+  LocalisationAuditCompanyProfile,
   LocalisationAuditLeadDeliveryStatus,
   LocalisationAuditProgressStage,
   LocalisationAuditReport,
@@ -443,6 +444,43 @@ export async function markLocalisationAuditRunning(input: {
     progressStage: "preparing",
     status: "running",
   });
+}
+
+/**
+ * Write a company profile onto a preserved teaser/report without changing
+ * status. Used on re-runs so a later scoring failure still keeps logo/summary.
+ */
+export async function patchLocalisationAuditCompanyProfile(input: {
+  auditId: string;
+  attemptNumber: number;
+  companyProfile: LocalisationAuditCompanyProfile;
+}) {
+  const audit = await findLocalisationAuditById(input.auditId);
+  if (!audit || audit.attemptNumber !== input.attemptNumber) {
+    return null;
+  }
+  if (!audit.teaser && !audit.report) {
+    return null;
+  }
+
+  const [row] = await db
+    .update(schema.localisationAudits)
+    .set({
+      teaser: audit.teaser
+        ? { ...audit.teaser, companyProfile: input.companyProfile }
+        : audit.teaser,
+      report: audit.report
+        ? { ...audit.report, companyProfile: input.companyProfile }
+        : audit.report,
+    })
+    .where(
+      and(
+        eq(schema.localisationAudits.id, input.auditId),
+        eq(schema.localisationAudits.attemptNumber, input.attemptNumber),
+      ),
+    )
+    .returning();
+  return row ?? null;
 }
 
 export async function completeLocalisationAudit(input: {

--- a/apps/hyperlocalise-web/src/workflows/steps/localisation-audit.analyze.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/localisation-audit.analyze.test.ts
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const {
+  buildProfileMock,
+  completeMock,
+  creditsMock,
+  failMock,
+  findAuditMock,
+  patchProfileMock,
+  progressMock,
+  trackMock,
+} = vi.hoisted(() => ({
+  buildProfileMock: vi.fn(),
+  completeMock: vi.fn(),
+  creditsMock: vi.fn(),
+  failMock: vi.fn(),
+  findAuditMock: vi.fn(),
+  patchProfileMock: vi.fn(),
+  progressMock: vi.fn(),
+  trackMock: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics/server", () => ({
+  serverAnalytics: { track: trackMock },
+}));
+
+vi.mock("@/lib/localisation-audit/company-profile", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/localisation-audit/company-profile")>();
+  return {
+    ...actual,
+    buildLocalisationAuditCompanyProfile: buildProfileMock,
+  };
+});
+
+vi.mock("@/lib/localisation-audit/credits/runner", () => ({
+  runLocalisationAuditCredits: creditsMock,
+}));
+
+vi.mock("@/lib/localisation-audit/store", () => ({
+  completeLocalisationAudit: completeMock,
+  failLocalisationAudit: failMock,
+  findLocalisationAuditById: findAuditMock,
+  listPendingLocalisationAuditLeads: vi.fn(),
+  markLocalisationAuditLeadEmailFailed: vi.fn(),
+  markLocalisationAuditLeadEmailQueued: vi.fn(),
+  markLocalisationAuditProgress: progressMock,
+  markLocalisationAuditRunning: vi.fn(),
+  patchLocalisationAuditCompanyProfile: patchProfileMock,
+  upsertLocalisationAuditLeadForDelivery: vi.fn(),
+}));
+
+import { emptyCrawledPage, EMPTY_SITEMAP_SIGNAL } from "@/lib/localisation-audit/types";
+
+import { analyzeLocalisationAuditStep } from "./localisation-audit";
+
+const inferredProfile = {
+  name: "Acme",
+  logoUrl: "https://acme.example/logo.png",
+  productSummary: "Payments for global teams.",
+  brandVoice: "calm, precise",
+  industry: "Fintech",
+  confidence: 80,
+};
+
+const pages = [
+  emptyCrawledPage({
+    url: "https://acme.example/",
+    title: "Acme",
+    metaDescription: "Payments for global teams.",
+    iconHrefs: ["/logo.png"],
+  }),
+];
+
+describe("analyzeLocalisationAuditStep company profile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    buildProfileMock.mockResolvedValue(inferredProfile);
+    completeMock.mockResolvedValue({ id: "audit-1" });
+    creditsMock.mockResolvedValue({
+      credits: [],
+      findings: [],
+      linguisticNotes: [],
+      detectedLocales: [],
+    });
+    findAuditMock.mockResolvedValue({
+      id: "audit-1",
+      attemptNumber: 2,
+      teaser: { score: 64, companyProfile: null },
+      report: { score: 64 },
+    });
+    patchProfileMock.mockResolvedValue({ id: "audit-1" });
+    progressMock.mockResolvedValue({ id: "audit-1" });
+  });
+
+  it("patches a missing profile before scoring on a re-run", async () => {
+    const result = await analyzeLocalisationAuditStep({
+      auditId: "audit-1",
+      attemptNumber: 2,
+      domainKey: "acme.example",
+      domainSlug: "acme-example",
+      sourceUrl: "https://acme.example/",
+      focusLocales: [],
+      pages,
+      sitemap: EMPTY_SITEMAP_SIGNAL,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(patchProfileMock).toHaveBeenCalledWith({
+      auditId: "audit-1",
+      attemptNumber: 2,
+      companyProfile: inferredProfile,
+    });
+    expect(creditsMock).toHaveBeenCalled();
+    expect(patchProfileMock.mock.invocationCallOrder[0]).toBeLessThan(
+      creditsMock.mock.invocationCallOrder[0]!,
+    );
+    expect(completeMock.mock.calls[0]?.[0].report.companyProfile).toEqual(inferredProfile);
+    expect(completeMock.mock.calls[0]?.[0].teaser.companyProfile).toEqual(inferredProfile);
+  });
+
+  it("still patches the preserved report when scoring throws", async () => {
+    creditsMock.mockRejectedValue(new Error("luna unavailable"));
+
+    await expect(
+      analyzeLocalisationAuditStep({
+        auditId: "audit-1",
+        attemptNumber: 2,
+        domainKey: "acme.example",
+        domainSlug: "acme-example",
+        sourceUrl: "https://acme.example/",
+        focusLocales: [],
+        pages,
+        sitemap: EMPTY_SITEMAP_SIGNAL,
+      }),
+    ).rejects.toThrow("luna unavailable");
+
+    expect(patchProfileMock).toHaveBeenCalledWith({
+      auditId: "audit-1",
+      attemptNumber: 2,
+      companyProfile: inferredProfile,
+    });
+    expect(completeMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps a stored logo when the new crawl omits it", async () => {
+    findAuditMock.mockResolvedValue({
+      id: "audit-1",
+      attemptNumber: 2,
+      teaser: {
+        companyProfile: {
+          name: "Acme",
+          logoUrl: "https://acme.example/old-logo.png",
+          productSummary: null,
+          brandVoice: null,
+          industry: null,
+          confidence: 40,
+        },
+      },
+      report: { score: 64 },
+    });
+    buildProfileMock.mockResolvedValue({
+      name: "Acme Inc",
+      logoUrl: null,
+      productSummary: "Payments for global teams.",
+      brandVoice: "calm, precise",
+      industry: "Fintech",
+      confidence: 70,
+    });
+
+    await analyzeLocalisationAuditStep({
+      auditId: "audit-1",
+      attemptNumber: 2,
+      domainKey: "acme.example",
+      domainSlug: "acme-example",
+      sourceUrl: "https://acme.example/",
+      focusLocales: [],
+      pages,
+      sitemap: EMPTY_SITEMAP_SIGNAL,
+    });
+
+    const merged = {
+      name: "Acme Inc",
+      logoUrl: "https://acme.example/old-logo.png",
+      productSummary: "Payments for global teams.",
+      brandVoice: "calm, precise",
+      industry: "Fintech",
+      confidence: 70,
+    };
+    expect(patchProfileMock).toHaveBeenCalledWith({
+      auditId: "audit-1",
+      attemptNumber: 2,
+      companyProfile: merged,
+    });
+    expect(completeMock.mock.calls[0]?.[0].report.companyProfile).toEqual(merged);
+  });
+
+  it("does not patch when the stored cover is already complete", async () => {
+    findAuditMock.mockResolvedValue({
+      id: "audit-1",
+      attemptNumber: 2,
+      teaser: { companyProfile: inferredProfile },
+      report: { companyProfile: inferredProfile },
+    });
+
+    await analyzeLocalisationAuditStep({
+      auditId: "audit-1",
+      attemptNumber: 2,
+      domainKey: "acme.example",
+      domainSlug: "acme-example",
+      sourceUrl: "https://acme.example/",
+      focusLocales: [],
+      pages,
+      sitemap: EMPTY_SITEMAP_SIGNAL,
+    });
+
+    expect(patchProfileMock).not.toHaveBeenCalled();
+    expect(completeMock.mock.calls[0]?.[0].report.companyProfile).toEqual(inferredProfile);
+  });
+});

--- a/apps/hyperlocalise-web/src/workflows/steps/localisation-audit.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/localisation-audit.ts
@@ -12,6 +12,12 @@
  */
 import { LOCALISATION_AUDIT_ANALYTICS_EVENTS, scoreBand } from "@/lib/analytics/events";
 import { serverAnalytics } from "@/lib/analytics/server";
+import {
+  buildLocalisationAuditCompanyProfile,
+  companyProfileFromAuditPayloads,
+  isCompanyProfileIncomplete,
+  mergeCompanyProfiles,
+} from "@/lib/localisation-audit/company-profile";
 import { runLocalisationAuditCredits } from "@/lib/localisation-audit/credits/runner";
 import {
   aggregateLocalisationAuditCredits,
@@ -26,6 +32,7 @@ import {
   markLocalisationAuditLeadEmailQueued,
   markLocalisationAuditProgress,
   markLocalisationAuditRunning,
+  patchLocalisationAuditCompanyProfile,
   upsertLocalisationAuditLeadForDelivery,
 } from "@/lib/localisation-audit/store";
 import type {
@@ -138,6 +145,27 @@ export async function analyzeLocalisationAuditStep(input: {
     return { ok: false as const, code: "crawl_failed" as const };
   }
 
+  const audit = await findLocalisationAuditById(input.auditId);
+  const existingProfile = companyProfileFromAuditPayloads({
+    teaser: audit?.teaser,
+    report: audit?.report,
+  });
+  const inferredProfile = await buildLocalisationAuditCompanyProfile({
+    domainKey: input.domainKey,
+    pages: input.pages,
+  });
+  const companyProfile = mergeCompanyProfiles(existingProfile, inferredProfile);
+
+  // Persist cover fields before scoring so a failed re-run still updates
+  // legacy rows that never stored a logo or product summary.
+  if (isCompanyProfileIncomplete(existingProfile)) {
+    await patchLocalisationAuditCompanyProfile({
+      auditId: input.auditId,
+      attemptNumber: input.attemptNumber,
+      companyProfile,
+    });
+  }
+
   await markLocalisationAuditProgress({
     auditId: input.auditId,
     attemptNumber: input.attemptNumber,
@@ -153,13 +181,6 @@ export async function analyzeLocalisationAuditStep(input: {
     localeCount: scored.detectedLocales.length,
   });
   const completedAt = new Date().toISOString();
-
-  const { buildLocalisationAuditCompanyProfile } =
-    await import("@/lib/localisation-audit/company-profile");
-  const companyProfile = await buildLocalisationAuditCompanyProfile({
-    domainKey: input.domainKey,
-    pages: input.pages,
-  });
 
   const report: LocalisationAuditReport = {
     score,

--- a/docs/adr/2026-08-15-localisation-audit-rerun-company-profile-design.md
+++ b/docs/adr/2026-08-15-localisation-audit-rerun-company-profile-design.md
@@ -1,0 +1,25 @@
+# Localisation audit re-run company profile backfill
+
+## Goal
+
+When a public localisation audit is re-run, fetch a missing company cover (logo, product summary, brand voice, industry) and write it onto the stored teaser and report.
+
+## Why
+
+Daily re-runs keep the prior public report until the new analysis completes. Scoring can fail after a successful crawl. Legacy rows created before company profiles existed then stay on a domain-only cover even though the crawl had the evidence.
+
+## Behaviour
+
+1. After crawl, infer a company profile from homepage signals (same path as a first run).
+2. Merge with any stored profile: use new values when present, keep stored values for gaps.
+3. If the stored profile is missing or incomplete, patch `teaser` and `report` JSON before scoring. Status does not change.
+4. If scoring later fails, restore-succeeded still has the patched cover.
+5. If scoring succeeds, the new teaser and report include the merged profile.
+
+Do not start a full re-run only to fill a cover. This runs as part of an already claimed re-run.
+
+## Testing
+
+- Merge and incomplete-profile helpers.
+- Store patch is attempt-guarded and survives fail-restore.
+- Analyze patches before scoring, including when scoring throws.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

On a localisation audit re-run, fetch a missing company cover (logo, product summary, brand voice, industry) and write it onto the stored teaser and report before scoring.

Daily re-runs keep the prior public report until analysis completes. Scoring can fail after a successful crawl, so legacy rows created before company profiles existed stayed on a domain-only cover. The new analyze path:

1. Infers a company profile from the fresh crawl.
2. Merges it with any stored profile (new values win when present; stored values fill gaps).
3. Patches `teaser` and `report` JSON when the stored cover is incomplete, without changing audit status.
4. If scoring later fails, fail-restore still keeps the patched cover.

## How to test

- `vp test src/lib/localisation-audit src/workflows/steps/localisation-audit.analyze.test.ts src/workflows/localisation-audit.test.ts src/api/routes/localisation-audit` (Postgres + migrate for store tests)
- `vp check --fix` in `apps/hyperlocalise-web`

## Checklist

- [x] I ran relevant checks locally (`vp test` for audit suites, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-041db4bd-4169-475d-bf37-d37a2304cc7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-041db4bd-4169-475d-bf37-d37a2304cc7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

