### PR TITLE
fix(localisation-audit): accept es-419 and skip empty-evidence credits

### DIFF
--- a/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.ts
@@ -13,7 +13,7 @@
 import { readBoundedResponseBody, withPublicHttpFetch } from "@/lib/security/public-http-fetch";
 
 import type { CrawlLocalisationAuditSampleOptions, HtmlPageRenderer } from "./crawl-renderer";
-import { resolveFocusLocaleCode } from "./credits/shared";
+import { LOCALE_PREFIX, pathLocaleFromUrl, resolveFocusLocaleCode } from "./credits/shared";
 import { crawledPageFromSignals, parsePageSignals } from "./html-parse";
 import { AuditBrowserSetupError } from "./sandbox-browser-error";
 import type {
@@ -34,9 +34,6 @@ const MAX_PAGES = 15;
 const FETCH_TIMEOUT_MS = 12_000;
 const MAX_REDIRECTS = 5;
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
-
-const LOCALE_PREFIX = /^\/([a-z]{2}(?:-[a-z]{2})?)(\/|$)/i;
-const LOCALE_CODE = /^[a-z]{2}(?:-[a-z]{2})?$/i;
 
 const FETCH_TEXT_HEADERS: Record<string, string> = {
   "User-Agent": USER_AGENT,
@@ -209,7 +206,7 @@ async function fetchSitemapSignals(origin: string): Promise<LocalisationAuditSit
         continue;
       }
       try {
-        if (localeFromPath(new URL(absolute).pathname) && localizedUrls.length < MAX_SITEMAP_URLS) {
+        if (pathLocaleFromUrl(absolute) && localizedUrls.length < MAX_SITEMAP_URLS) {
           localizedUrls.push(absolute);
         }
       } catch {
@@ -225,19 +222,6 @@ async function fetchSitemapSignals(origin: string): Promise<LocalisationAuditSit
     sitemapUrls: [...sitemapUrls],
     localizedUrls,
   };
-}
-
-function normalizeLocaleCode(value: string): string | null {
-  const normalized = value.trim().replaceAll("_", "-").toLowerCase();
-  if (normalized === "x-default" || !LOCALE_CODE.test(normalized)) {
-    return null;
-  }
-  return normalized;
-}
-
-function localeFromPath(pathname: string): string | null {
-  const match = pathname.match(LOCALE_PREFIX);
-  return match ? normalizeLocaleCode(match[1]!) : null;
 }
 
 function seedFocusLocaleRoots(origin: string, focusLocales: string[]): string[] {

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics.test.ts
@@ -12,6 +12,7 @@
  */
 import { describe, expect, it } from "vite-plus/test";
 
+import { contextualHeuristicScorers } from "./heuristics/contextual";
 import { linguisticHeuristicScorers } from "./heuristics/linguistic";
 import { technicalHeuristicScorers } from "./heuristics/technical";
 import { visualHeuristicScorers } from "./heuristics/visual";
@@ -569,6 +570,20 @@ describe("technical heuristic credits", () => {
 
     expect(outcome.status).toBe("na");
   });
+
+  it("does not score accessibility localisation when there are no accessible names", () => {
+    const outcome = technicalHeuristicScorers["accessibility-localisation"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://www.dropbox.com/es/",
+          htmlLang: "es-419",
+          textSample: "Almacena fotos, documentos y videos.",
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("na");
+  });
 });
 
 describe("linguistic heuristic credits", () => {
@@ -614,6 +629,45 @@ describe("linguistic heuristic credits", () => {
     );
 
     expect(outcome.status).toBe("inconclusive");
+  });
+});
+
+describe("contextual heuristic credits", () => {
+  it("does not score cultural adaptation when the sample has no currency or contact details", () => {
+    const outcome = contextualHeuristicScorers["cultural-adaptation"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://www.dropbox.com/es/",
+          htmlLang: "es-419",
+          headings: ["Almacena y comparte archivos"],
+          textSample: "Almacena fotos, documentos y videos. Comparte carpetas con tu equipo.",
+        }),
+        emptyCrawledPage({
+          url: "https://www.dropbox.com/de/",
+          htmlLang: "de",
+          headings: ["Dateien speichern und teilen"],
+          textSample: "Speichere Fotos, Dokumente und Videos. Teile Ordner mit deinem Team.",
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("na");
+  });
+
+  it("still flags US-style dollar amounts on a non-English page", () => {
+    const outcome = contextualHeuristicScorers["cultural-adaptation"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://example.com/de/pricing",
+          htmlLang: "de",
+          textSample: "Pläne ab $12 pro Monat für Teams.",
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("scored");
+    if (outcome.status !== "scored") return;
+    expect(outcome.findings.some((finding) => finding.id.startsWith("cultural-"))).toBe(true);
   });
 });
 
@@ -718,5 +772,58 @@ describe("visual heuristic credits", () => {
       ]),
     );
     expect(outcome).toEqual({ status: "scored", score: 92, findings: [] });
+  });
+
+  it("does not score visual hierarchy when headings are not excessively long", () => {
+    const outcome = visualHeuristicScorers["visual-hierarchy"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://www.dropbox.com/es/",
+          htmlLang: "es-419",
+          headings: ["Almacena, comparte y accede a tus archivos"],
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("na");
+  });
+
+  it("still flags headings that are excessively long", () => {
+    const outcome = visualHeuristicScorers["visual-hierarchy"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://example.com/de/",
+          htmlLang: "de",
+          headings: [
+            "Speichere, teile und greife von jedem Gerät aus auf alle deine Dateien, Fotos und Dokumente zu, jederzeit und überall",
+          ],
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("scored");
+    if (outcome.status !== "scored") return;
+    expect(outcome.findings.some((finding) => finding.id.startsWith("hierarchy-heading-"))).toBe(
+      true,
+    );
+  });
+
+  it("does not score component consistency when button counts match across locales", () => {
+    const outcome = visualHeuristicScorers["component-consistency"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://www.dropbox.com/en/",
+          htmlLang: "en",
+          buttons: ["Get started", "Sign in"],
+        }),
+        emptyCrawledPage({
+          url: "https://www.dropbox.com/es/",
+          htmlLang: "es-419",
+          buttons: ["Comenzar", "Iniciar sesión"],
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("na");
   });
 });

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics.test.ts
@@ -85,6 +85,41 @@ describe("technical heuristic credits", () => {
     expect(outcome.score).toBe(100);
   });
 
+  it("accepts UN M.49 html lang tags such as es-419", () => {
+    const outcome = technicalHeuristicScorers["locale-detection"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://www.dropbox.com/es/",
+          htmlLang: "es-419",
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("scored");
+    if (outcome.status !== "scored") return;
+    expect(outcome.findings.some((finding) => finding.id.includes("invalid"))).toBe(false);
+    expect(outcome.findings.some((finding) => finding.id.includes("mismatch"))).toBe(false);
+    expect(outcome.score).toBe(100);
+  });
+
+  it("still flags html lang values that are not BCP 47 tags", () => {
+    const outcome = technicalHeuristicScorers["locale-detection"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://example.com/",
+          htmlLang: "espanol",
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("scored");
+    if (outcome.status !== "scored") return;
+    expect(outcome.findings.some((finding) => finding.title === "Incorrect language code")).toBe(
+      true,
+    );
+    expect(outcome.score).toBeLessThan(100);
+  });
+
   it("emits one missing-language finding for many pages", () => {
     const outcome = technicalHeuristicScorers["locale-detection"]!(
       context([
@@ -220,6 +255,60 @@ describe("technical heuristic credits", () => {
     expect(outcome.findings.some((finding) => finding.id === "language-switcher-homepage")).toBe(
       false,
     );
+  });
+
+  it("treats locale-root links as the same page when already on a locale homepage", () => {
+    const outcome = technicalHeuristicScorers["language-switcher"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://www.dropbox.com/de/",
+          htmlLang: "de",
+          anchors: [
+            { href: "https://www.dropbox.com/es/", text: "Español" },
+            { href: "https://www.dropbox.com/fr/", text: "Français" },
+          ],
+        }),
+        emptyCrawledPage({
+          url: "https://www.dropbox.com/es/",
+          htmlLang: "es-419",
+          anchors: [
+            { href: "https://www.dropbox.com/de/", text: "Deutsch" },
+            { href: "https://www.dropbox.com/fr/", text: "Français" },
+          ],
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("scored");
+    if (outcome.status !== "scored") return;
+    expect(outcome.score).toBeGreaterThanOrEqual(90);
+    expect(outcome.findings.some((finding) => finding.id === "language-switcher-homepage")).toBe(
+      false,
+    );
+  });
+
+  it("still flags language links that drop a nested path to the locale homepage", () => {
+    const outcome = technicalHeuristicScorers["language-switcher"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://www.dropbox.com/de/business",
+          htmlLang: "de",
+          anchors: [{ href: "https://www.dropbox.com/es/", text: "Español" }],
+        }),
+        emptyCrawledPage({
+          url: "https://www.dropbox.com/es/business",
+          htmlLang: "es",
+          anchors: [{ href: "https://www.dropbox.com/de/", text: "Deutsch" }],
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("scored");
+    if (outcome.status !== "scored") return;
+    expect(outcome.findings.some((finding) => finding.id === "language-switcher-homepage")).toBe(
+      true,
+    );
+    expect(outcome.score).toBeLessThan(75);
   });
 
   it("fails like Lighthouse when no valid sitemap is discoverable", () => {
@@ -382,6 +471,15 @@ describe("technical heuristic credits", () => {
     expect(locales[0]?.source).toBe("url_prefix");
   });
 
+  it("keeps UN M.49 html lang tags such as es-419", () => {
+    const locales = detectLocales(
+      [emptyCrawledPage({ url: "https://www.dropbox.com/es/", htmlLang: "es-419" })],
+      [],
+    );
+    expect(locales.map((entry) => entry.locale)).toEqual(["es-419"]);
+    expect(locales[0]?.source).toBe("html_lang");
+  });
+
   it("keeps bare language and region markets as distinct locales", () => {
     const locales = detectLocales(
       [
@@ -447,6 +545,29 @@ describe("technical heuristic credits", () => {
     if (outcome.status !== "scored") return;
     expect(outcome.score).toBeGreaterThanOrEqual(90);
     expect(outcome.findings).toHaveLength(0);
+  });
+
+  it("does not score international formatting when the sample has no dates, numbers, or currency", () => {
+    const outcome = technicalHeuristicScorers["international-formatting"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://www.dropbox.com/es/",
+          htmlLang: "es-419",
+          headings: ["Almacena, comparte y accede a tus archivos"],
+          textSample:
+            "Dropbox te permite almacenar fotos, documentos y videos. Comparte carpetas y colabora en archivos.",
+        }),
+        emptyCrawledPage({
+          url: "https://www.dropbox.com/de/",
+          htmlLang: "de",
+          headings: ["Dateien speichern, teilen und darauf zugreifen"],
+          textSample:
+            "Mit Dropbox kannst du Fotos, Dokumente und Videos speichern. Teile Ordner und arbeite an Dateien zusammen.",
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("na");
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/contextual.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/contextual.ts
@@ -91,7 +91,7 @@ const scoreCulturalAdaptation: HeuristicScorer = (context) => {
     return scored(Math.max(50, 80 - findings.length * 10), findings);
   }
   if (!sawSignal) {
-    return { status: "inconclusive", evidence: { reason: "no_cultural_signals" } };
+    return { status: "na" };
   }
   return scored(88, findings);
 };

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/technical.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/technical.ts
@@ -947,7 +947,7 @@ const scoreAccessibilityLocalisation: HeuristicScorer = (context) => {
     }
   }
   if (inspected === 0) {
-    return { status: "inconclusive", evidence: { reason: "no_accessible_names" } };
+    return { status: "na" };
   }
   return scored(score, findings);
 };

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/technical.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/technical.ts
@@ -19,7 +19,9 @@ import {
   formatFindingWhere,
   htmlLangMatchesPathLocale,
   htmlLangSuggestionForPathLocale,
+  isWellFormedHtmlLang,
   languageOf,
+  LOCALE_SUBDOMAIN,
   looksPrimarilyEnglish,
   pageLocale,
   pathLocaleFromUrl,
@@ -64,7 +66,7 @@ const scoreLocaleDetection: HeuristicScorer = (context) => {
   for (const page of okPages) {
     if (!page.htmlLang) {
       missingLangPages.push(page);
-    } else if (!/^[a-z]{2}(?:-[A-Za-z]{2})?$/.test(page.htmlLang.trim())) {
+    } else if (!isWellFormedHtmlLang(page.htmlLang)) {
       score -= 12;
       findings.push(
         creditFinding({
@@ -77,7 +79,7 @@ const scoreLocaleDetection: HeuristicScorer = (context) => {
           where: formatFindingWhere({ section: "Document head", tag: "<html lang>" }),
           url: page.url,
           evidence: `<html lang="${page.htmlLang}">`,
-          advice: "Use a well-formed BCP 47 language tag, such as en or fr-FR.",
+          advice: "Use a well-formed BCP 47 language tag, such as en, fr-FR, or es-419.",
         }),
       );
     }
@@ -127,7 +129,8 @@ const scoreLocaleDetection: HeuristicScorer = (context) => {
           missingLang === 1
             ? "html lang is missing"
             : `html lang is missing on ${missingLang} pages, e.g. ${sampleUrls}`,
-        advice: "Set html lang to a BCP 47 language tag for each page locale, such as en or fr-FR.",
+        advice:
+          "Set html lang to a BCP 47 language tag for each page locale, such as en, fr-FR, or es-419.",
       }),
     );
   }
@@ -163,7 +166,7 @@ const scoreLocaleRouting: HeuristicScorer = (context) => {
     if (pathLocaleFromUrl(page.url)) strategies.add("prefix");
     try {
       const host = new URL(page.url).hostname;
-      if (/^[a-z]{2}(?:-[a-z]{2})?\./i.test(host) && !host.toLowerCase().startsWith("www.")) {
+      if (LOCALE_SUBDOMAIN.test(host) && !host.toLowerCase().startsWith("www.")) {
         strategies.add("subdomain");
       }
     } catch {
@@ -249,11 +252,12 @@ const scoreLanguageSwitcher: HeuristicScorer = (context) => {
       }
       found += 1;
       const targetPath = pathWithoutLocale(href.toString());
-      if (currentPath && targetPath && currentPath !== "/" && targetPath === currentPath) {
+      if (currentPath && targetPath && currentPath === targetPath) {
         preservesPath += 1;
       } else if (
-        targetPath === "/" ||
-        (targetPath && targetPath.split("/").filter(Boolean).length <= 1)
+        currentPath &&
+        currentPath !== "/" &&
+        (targetPath === "/" || (targetPath && targetPath.split("/").filter(Boolean).length <= 1))
       ) {
         localeRootOnly += 1;
         droppedSwitcher ??= {
@@ -898,7 +902,7 @@ const scoreInternationalFormatting: HeuristicScorer = (context) => {
     }
   }
   if (!sawPattern) {
-    return { status: "inconclusive", evidence: { reason: "no_formatting_examples" } };
+    return { status: "na" };
   }
   return scored(mismatches > 0 ? Math.max(40, 90 - mismatches * 14) : 90, findings);
 };

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/visual.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/visual.ts
@@ -434,7 +434,7 @@ const scoreVisualHierarchy: HeuristicScorer = (context) => {
   if (findings.length > 0) {
     return scored(Math.max(55, 82 - findings.length * 6), findings);
   }
-  return { status: "inconclusive", evidence: { reason: "no_long_headings" } };
+  return { status: "na" };
 };
 
 const scoreComponentConsistency: HeuristicScorer = (context) => {
@@ -464,7 +464,7 @@ const scoreComponentConsistency: HeuristicScorer = (context) => {
       ]);
     }
   }
-  return { status: "inconclusive", evidence: { reason: "no_component_drift" } };
+  return { status: "na" };
 };
 
 const lunaProxy: HeuristicScorer = () => ({

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/luna.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/luna.ts
@@ -108,6 +108,8 @@ export async function scoreCreditsWithLuna(input: {
         "Return one result per credit id. Prefer fewer, concrete findings (max 3 per credit).",
         "For visual credits without screenshots, treat overflow/layout/responsive as informed estimates and keep confidence at or below 74.",
         "High-confidence only when the evidence is explicit.",
+        "Locale-prefixed URLs that share the same path after the locale, including homepages such as /de/ and /es/, are equivalent pages. Do not treat that as dropping the current path.",
+        "If the evidence has no dates, numbers, or currency, do not score or penalize international formatting.",
         "Always include every schema field. Use null for where, evidence, advice, or url when unknown.",
         "where is the page section and HTML tag, like 'Hero · <h1>' or 'Header · <nav>'. Not the page URL.",
         "evidence is a verbatim quote or markup fragment with enough context to verify the claim.",

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/luna.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/luna.ts
@@ -109,7 +109,7 @@ export async function scoreCreditsWithLuna(input: {
         "For visual credits without screenshots, treat overflow/layout/responsive as informed estimates and keep confidence at or below 74.",
         "High-confidence only when the evidence is explicit.",
         "Locale-prefixed URLs that share the same path after the locale, including homepages such as /de/ and /es/, are equivalent pages. Do not treat that as dropping the current path.",
-        "If the evidence has no dates, numbers, or currency, do not score or penalize international formatting.",
+        "If the evidence has no dates, numbers, currency, addresses, accessible names, long headings, or component drift, do not invent a finding or lower the score for those credits.",
         "Always include every schema field. Use null for where, evidence, advice, or url when unknown.",
         "where is the page section and HTML tag, like 'Hero · <h1>' or 'Header · <nav>'. Not the page URL.",
         "evidence is a verbatim quote or markup fragment with enough context to verify the claim.",

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/runner.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/runner.test.ts
@@ -170,7 +170,7 @@ describe("runLocalisationAuditCredits", () => {
     expect(result.linguisticNotes).toHaveLength(1);
   });
 
-  it("marks international formatting N/A when pages have no date, number, or currency evidence", async () => {
+  it("marks credits N/A when the sample has nothing to measure", async () => {
     generateTextMock.mockResolvedValue({ output: { credits: [], notes: [] } });
 
     const result = await runLocalisationAuditCredits({
@@ -198,13 +198,44 @@ describe("runLocalisationAuditCredits", () => {
       score: null,
       method: "na",
     });
+    expect(result.credits.find((credit) => credit.id === "cultural-adaptation")).toEqual({
+      id: "cultural-adaptation",
+      dimension: "contextual",
+      score: null,
+      method: "na",
+    });
+    expect(result.credits.find((credit) => credit.id === "accessibility-localisation")).toEqual({
+      id: "accessibility-localisation",
+      dimension: "technical",
+      score: null,
+      method: "na",
+    });
+    expect(result.credits.find((credit) => credit.id === "visual-hierarchy")).toEqual({
+      id: "visual-hierarchy",
+      dimension: "visual",
+      score: null,
+      method: "na",
+    });
+    expect(result.credits.find((credit) => credit.id === "component-consistency")).toEqual({
+      id: "component-consistency",
+      dimension: "visual",
+      score: null,
+      method: "na",
+    });
     expect(result.findings.some((finding) => finding.creditId === "international-formatting")).toBe(
+      false,
+    );
+    expect(result.findings.some((finding) => finding.creditId === "cultural-adaptation")).toBe(
       false,
     );
 
     if (generateTextMock.mock.calls.length > 0) {
       const prompt = String(generateTextMock.mock.calls[0]?.[0]?.prompt ?? "");
       expect(prompt).not.toContain('"id":"international-formatting"');
+      expect(prompt).not.toContain('"id":"cultural-adaptation"');
+      expect(prompt).not.toContain('"id":"accessibility-localisation"');
+      expect(prompt).not.toContain('"id":"visual-hierarchy"');
+      expect(prompt).not.toContain('"id":"component-consistency"');
     }
   });
 });

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/runner.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/runner.test.ts
@@ -169,4 +169,42 @@ describe("runLocalisationAuditCredits", () => {
     expect(result.findings.some((finding) => finding.title === "Awkward phrasing")).toBe(true);
     expect(result.linguisticNotes).toHaveLength(1);
   });
+
+  it("marks international formatting N/A when pages have no date, number, or currency evidence", async () => {
+    generateTextMock.mockResolvedValue({ output: { credits: [], notes: [] } });
+
+    const result = await runLocalisationAuditCredits({
+      pages: [
+        emptyCrawledPage({
+          url: "https://www.dropbox.com/es/",
+          htmlLang: "es-419",
+          headings: ["Almacena y comparte archivos"],
+          textSample: "Almacena fotos, documentos y videos. Comparte carpetas con tu equipo.",
+        }),
+        emptyCrawledPage({
+          url: "https://www.dropbox.com/de/",
+          htmlLang: "de",
+          headings: ["Dateien speichern und teilen"],
+          textSample: "Speichere Fotos, Dokumente und Videos. Teile Ordner mit deinem Team.",
+        }),
+      ],
+      focusLocales: [],
+    });
+
+    const formatting = result.credits.find((credit) => credit.id === "international-formatting");
+    expect(formatting).toEqual({
+      id: "international-formatting",
+      dimension: "technical",
+      score: null,
+      method: "na",
+    });
+    expect(result.findings.some((finding) => finding.creditId === "international-formatting")).toBe(
+      false,
+    );
+
+    if (generateTextMock.mock.calls.length > 0) {
+      const prompt = String(generateTextMock.mock.calls[0]?.[0]?.prompt ?? "");
+      expect(prompt).not.toContain('"id":"international-formatting"');
+    }
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared-locale.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared-locale.test.ts
@@ -19,7 +19,9 @@ import {
   htmlLangSuggestionForPathLocale,
   isCjkLanguage,
   isRtlLanguage,
+  isWellFormedHtmlLang,
   pageLocale,
+  pathLocaleFromUrl,
   textHasEasternArabicDigits,
   textHasGregorianCalendarSignals,
   textHasHijriCalendarSignals,
@@ -39,6 +41,7 @@ describe("htmlLangSuggestionForPathLocale", () => {
     expect(htmlLangSuggestionForPathLocale("en_AU")).toBe("en-AU");
     expect(htmlLangSuggestionForPathLocale("FR")).toBe("fr");
     expect(htmlLangSuggestionForPathLocale("pt-br")).toBe("pt-BR");
+    expect(htmlLangSuggestionForPathLocale("es-419")).toBe("es-419");
   });
 });
 
@@ -57,6 +60,7 @@ describe("htmlLangMatchesPathLocale", () => {
   it("accepts language-region html lang when the path is a bare language", () => {
     expect(htmlLangMatchesPathLocale("en-AU", "en")).toBe(true);
     expect(htmlLangMatchesPathLocale("fr-CA", "fr")).toBe(true);
+    expect(htmlLangMatchesPathLocale("es-419", "es")).toBe(true);
     expect(htmlLangMatchesPathLocale("en-AU", "fr")).toBe(false);
   });
 });
@@ -66,6 +70,7 @@ describe("canonicalPathLocale and pageLocale", () => {
     expect(canonicalPathLocale("au")).toBe("en-au");
     expect(canonicalPathLocale("JP")).toBe("ja-jp");
     expect(formatBcp47Locale("en_au")).toBe("en-AU");
+    expect(formatBcp47Locale("es-419")).toBe("es-419");
   });
 
   it("prefers canonical path locale over html lang when both are present", () => {
@@ -77,6 +82,31 @@ describe("canonicalPathLocale and pageLocale", () => {
         }),
       ),
     ).toBe("en-au");
+  });
+});
+
+describe("isWellFormedHtmlLang", () => {
+  it("accepts UN M.49 regions and other well-formed BCP 47 tags", () => {
+    expect(isWellFormedHtmlLang("es-419")).toBe(true);
+    expect(isWellFormedHtmlLang("zh-Hans")).toBe(true);
+    expect(isWellFormedHtmlLang("en-US")).toBe(true);
+    expect(isWellFormedHtmlLang("fr")).toBe(true);
+  });
+
+  it("rejects tags that are not well-formed BCP 47", () => {
+    expect(isWellFormedHtmlLang("english")).toBe(false);
+    expect(isWellFormedHtmlLang("espanol")).toBe(false);
+    expect(isWellFormedHtmlLang("en-U")).toBe(false);
+    expect(isWellFormedHtmlLang("x-default")).toBe(false);
+    expect(isWellFormedHtmlLang("")).toBe(false);
+  });
+});
+
+describe("pathLocaleFromUrl", () => {
+  it("reads UN M.49 locale prefixes from the path", () => {
+    expect(pathLocaleFromUrl("https://www.dropbox.com/es-419/")).toBe("es-419");
+    expect(pathLocaleFromUrl("https://www.dropbox.com/es/")).toBe("es");
+    expect(pathLocaleFromUrl("https://www.dropbox.com/de/")).toBe("de");
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared.ts
@@ -18,8 +18,11 @@ import type {
   LocalisationAuditLocaleSignal,
 } from "../types";
 
-export const LOCALE_PREFIX = /^\/([a-z]{2}(?:-[a-z]{2})?)(\/|$)/i;
-export const LOCALE_CODE = /^[a-z]{2}(?:-[a-z]{2})?$/i;
+/** ISO 639-1 plus optional script (ISO 15924) and region (ISO 3166-1 or UN M.49). */
+const LOCALE_TOKEN = "[a-z]{2}(?:-[a-z]{4})?(?:-[a-z]{2}|-[0-9]{3})?";
+export const LOCALE_PREFIX = new RegExp(`^/(${LOCALE_TOKEN})(/|$)`, "i");
+export const LOCALE_CODE = new RegExp(`^${LOCALE_TOKEN}$`, "i");
+export const LOCALE_SUBDOMAIN = new RegExp(`^(${LOCALE_TOKEN})\\.`, "i");
 const RTL_LANGUAGES = new Set(["ar", "he", "fa", "ur", "ps", "yi"]);
 const CJK_LANGUAGES = new Set(["zh", "ja", "ko"]);
 
@@ -92,13 +95,45 @@ export function languageOf(locale: string): string {
   return normalizeLocale(locale).split("-")[0] ?? "";
 }
 
-/** Format a normalized locale as a conventional BCP 47 tag (e.g. en-AU). */
+/**
+ * Whether a value is a structurally valid BCP 47 language tag for `html lang`.
+ * Accepts UN M.49 regions such as `es-419` (Latin America) and scripts such as `zh-Hans`.
+ */
+export function isWellFormedHtmlLang(value: string): boolean {
+  const trimmed = value.trim().replaceAll("_", "-");
+  if (!trimmed || normalizeLocale(trimmed) === "x-default") {
+    return false;
+  }
+  const language = languageOf(trimmed);
+  if (!/^[a-z]{2,3}$/.test(language)) {
+    return false;
+  }
+  try {
+    return Intl.getCanonicalLocales(trimmed).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/** Format a normalized locale as a conventional BCP 47 tag (e.g. en-AU, es-419). */
 export function formatBcp47Locale(locale: string): string {
   const normalized = normalizeLocale(locale);
-  const [language, region] = normalized.split("-");
-  if (!language) return normalized;
-  if (!region) return language;
-  return `${language}-${region.toUpperCase()}`;
+  try {
+    return Intl.getCanonicalLocales(normalized)[0] ?? normalized;
+  } catch {
+    const parts = normalized.split("-").filter(Boolean);
+    const language = parts[0];
+    if (!language) return normalized;
+    return [
+      language,
+      ...parts.slice(1).map((part) => {
+        if (/^\d{3}$/.test(part)) return part;
+        if (part.length === 4) return `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`;
+        if (part.length === 2) return part.toUpperCase();
+        return part;
+      }),
+    ].join("-");
+  }
 }
 
 /**
@@ -325,7 +360,7 @@ export function detectLocales(
     sampleUrl?: string,
   ) => {
     const key = normalizeLocale(locale);
-    if (!key || key === "x-default" || !LOCALE_CODE.test(key)) return;
+    if (!key || key === "x-default" || !isWellFormedHtmlLang(key)) return;
     if (!byLocale.has(key)) {
       byLocale.set(key, { locale: key, source, sampleUrl });
     }
@@ -361,7 +396,7 @@ export function detectLocales(
     }
     try {
       const host = new URL(page.url).hostname;
-      const hostMatch = host.match(/^([a-z]{2}(?:-[a-z]{2})?)\./i);
+      const hostMatch = host.match(LOCALE_SUBDOMAIN);
       if (hostMatch?.[1] && hostMatch[1].toLowerCase() !== "www") {
         const hostLocale = canonicalPathLocale(hostMatch[1]);
         add(hostLocale, "url_subdomain", page.url);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Public localisation audits were flagging valid locale setups as defects, then inventing more findings when the sample had nothing to measure.

- **`es-419` is valid BCP 47.** `html lang="es-419"` (UN M.49 Latin America) is accepted, including on `/es/`. Paths such as `/es-419/` are recognized too.
- **Locale homepages are the same page.** Switcher links from `/de/` to `/es/` preserve the current path. Nested paths that actually drop to `/es/` still fail.
- **No evidence means N/A, not a Luna penalty.** These credits are skipped when the sample has nothing to measure:
  - international formatting (no dates, numbers, or currency)
  - cultural adaptation (no currency or contact details)
  - accessibility localisation (no aria-label / alt text)
  - visual hierarchy (no excessively long headings)
  - component consistency (no button-count drift)

Real defects still score: dollar amounts on a German page, headings over 80 characters, untranslated CJK accessible names, and so on.

## How to test

- `vp test src/lib/localisation-audit/credits/heuristics.test.ts src/lib/localisation-audit/credits/runner.test.ts src/lib/localisation-audit/credits/luna.test.ts` in `apps/hyperlocalise-web`
- `vp check --fix` in `apps/hyperlocalise-web`

## Checklist

- [x] I ran relevant checks locally (`vp test` on the audit credit tests, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-129d2975-435b-4b74-8fc0-e48fabea098d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-129d2975-435b-4b74-8fc0-e48fabea098d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

