### PR TITLE
⚡ Bolt: optimize segment profile validation fast-paths and slice allocations

### DIFF
--- a/internal/i18n/segmentvalidate/extra_placeholders.go
+++ b/internal/i18n/segmentvalidate/extra_placeholders.go
@@ -27,7 +27,9 @@ func extractExtraPlaceholders(text string) []string {
 		return nil
 	}
 
-	var out []string
+	// BOLT OPTIMIZATION: Estimate slice capacity from % and $ counts to avoid slice re-allocations.
+	capHint := strings.Count(text, "%") + strings.Count(text, "$")
+	out := make([]string, 0, capHint)
 	// BOLT OPTIMIZATION: Use a single pass FindAllStringIndex on the combined pattern.
 	for _, loc := range combinedPlaceholderPattern.FindAllStringIndex(text, -1) {
 		match := text[loc[0]:loc[1]]
@@ -73,6 +75,11 @@ func validateExtraPlaceholderParity(source, translated string) error {
 }
 
 func validateExtraPlaceholderParityWithTokens(source, translated string) (bool, error) {
+	// BOLT OPTIMIZATION: Dual-string fast-path when neither source nor translated contains
+	// placeholder signal characters (% or $).
+	if !strings.ContainsAny(source, "%$") && !strings.ContainsAny(translated, "%$") {
+		return false, nil
+	}
 	expected := extractExtraPlaceholders(source)
 	got := extractExtraPlaceholders(translated)
 	if stringSlicesEqual(expected, got) {

--- a/internal/i18n/segmentvalidate/extra_placeholders.go
+++ b/internal/i18n/segmentvalidate/extra_placeholders.go
@@ -27,11 +27,16 @@ func extractExtraPlaceholders(text string) []string {
 		return nil
 	}
 
-	// BOLT OPTIMIZATION: Estimate slice capacity from % and $ counts to avoid slice re-allocations.
-	capHint := strings.Count(text, "%") + strings.Count(text, "$")
-	out := make([]string, 0, capHint)
 	// BOLT OPTIMIZATION: Use a single pass FindAllStringIndex on the combined pattern.
-	for _, loc := range combinedPlaceholderPattern.FindAllStringIndex(text, -1) {
+	// Size the output from actual matches so marker-heavy literal text (e.g. "50% off",
+	// "$5") does not allocate a large unused []string backing array.
+	locs := combinedPlaceholderPattern.FindAllStringIndex(text, -1)
+	if len(locs) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(locs))
+	for _, loc := range locs {
 		match := text[loc[0]:loc[1]]
 		// BOLT OPTIMIZATION: Defined patterns are self-delimiting; TrimSpace is redundant.
 

--- a/internal/i18n/segmentvalidate/profile.go
+++ b/internal/i18n/segmentvalidate/profile.go
@@ -149,6 +149,11 @@ func validateSpecialCharParity(source, translated string) error {
 }
 
 func validateSpecialCharParityWithTokens(source, translated string) (bool, error) {
+	// BOLT OPTIMIZATION: Dual-string fast-path when neither source nor translated contains
+	// backslash escape signal character (\).
+	if !strings.Contains(source, "\\") && !strings.Contains(translated, "\\") {
+		return false, nil
+	}
 	expected := extractSpecialCharLiterals(source)
 	got := extractSpecialCharLiterals(translated)
 	if stringSlicesEqual(expected, got) {


### PR DESCRIPTION
Adds dual-string fast paths for extra placeholder parity and special character parity validation in `internal/i18n/segmentvalidate/`. Also adds slice capacity hinting for `extractExtraPlaceholders`. Verified with tests and benchmarks.

---
*PR created automatically by Jules for task [4257088350502192755](https://jules.google.com/task/4257088350502192755) started by @cungminh2710*