### PR TITLE
fix(translation): retry needs-review copies of multi-word source

### DIFF
--- a/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.test.ts
@@ -91,6 +91,7 @@ describe("loadProjectTranslationsAsPrefilledEntries", () => {
 
     expect(result).toEqual({
       prefilled: {},
+      retryKeys: [],
       truncated: false,
       loadedKeyCount: 0,
       maxKeyCount: 5_000,
@@ -136,6 +137,7 @@ describe("loadProjectTranslationsAsPrefilledEntries", () => {
         greeting: "Bonjour",
         farewell: "Au revoir",
       },
+      retryKeys: [],
       truncated: false,
       loadedKeyCount: 3,
       maxKeyCount: 5_000,
@@ -195,6 +197,7 @@ describe("loadProjectTranslationsAsPrefilledEntries", () => {
       brand: "Hyperlocalise",
       view_automations: "Xem tự động hóa",
     });
+    expect(result.retryKeys).toEqual(["workspace_knowledge"]);
     expect(result.translatedKeyCount).toBe(2);
     expect(result.loadedKeyCount).toBe(3);
   });
@@ -235,6 +238,7 @@ describe("loadProjectTranslationsAsPrefilledEntries", () => {
     expect(result.prefilled).toEqual({
       view_automations: "View automations",
     });
+    expect(result.retryKeys).toEqual([]);
     expect(result.translatedKeyCount).toBe(1);
   });
 
@@ -270,6 +274,7 @@ describe("loadProjectTranslationsAsPrefilledEntries", () => {
     });
 
     expect(result.prefilled).toEqual({});
+    expect(result.retryKeys).toEqual([]);
     expect(result.truncated).toBe(false);
     expect(result.loadedKeyCount).toBe(1);
     expect(result.translatedKeyCount).toBe(0);
@@ -311,6 +316,7 @@ describe("loadProjectTranslationsAsPrefilledEntries", () => {
       farewell: "Goodbye",
       empty: "Pending",
     });
+    expect(result.retryKeys).toEqual([]);
     expect(result.translatedKeyCount).toBe(1);
   });
 
@@ -351,6 +357,7 @@ describe("loadProjectTranslationsAsPrefilledEntries", () => {
     expect(result.prefilled).toEqual({
       workspace_knowledge: "Enable workspace knowledge",
     });
+    expect(result.retryKeys).toEqual(["workspace_knowledge"]);
     expect(result.translatedKeyCount).toBe(0);
   });
 
@@ -390,6 +397,7 @@ describe("loadProjectTranslationsAsPrefilledEntries", () => {
         greeting: "Hello",
         farewell: "Goodbye",
       },
+      retryKeys: [],
       truncated: false,
       loadedKeyCount: 2,
       maxKeyCount: 5_000,

--- a/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.test.ts
@@ -144,6 +144,100 @@ describe("loadProjectTranslationsAsPrefilledEntries", () => {
     expect(selectMock).toHaveBeenCalledTimes(3);
   });
 
+  it("omits needs-review copies of multi-word source text so translate-with-agent can retry", async () => {
+    repoLimitMock.mockResolvedValueOnce([{ id: "repo_file_1", sourcePath: "locales/en.json" }]);
+    offsetMock.mockResolvedValueOnce([
+      { id: "key_1", key: "workspace_knowledge", sourceText: "Enable workspace knowledge" },
+      { id: "key_2", key: "brand", sourceText: "Hyperlocalise" },
+      { id: "key_3", key: "view_automations", sourceText: "View automations" },
+    ]);
+
+    whereMock.mockImplementationOnce(() => ({
+      limit: repoLimitMock,
+      orderBy: orderByMock,
+    }));
+    whereMock.mockImplementationOnce(() => ({
+      limit: repoLimitMock,
+      orderBy: orderByMock,
+    }));
+    whereMock.mockImplementationOnce(
+      () =>
+        Promise.resolve([
+          {
+            id: "translation_1",
+            translationKeyId: "key_1",
+            text: "Enable workspace knowledge",
+            status: "needs_review",
+          },
+          {
+            id: "translation_2",
+            translationKeyId: "key_2",
+            text: "Hyperlocalise",
+            status: "needs_review",
+          },
+          {
+            id: "translation_3",
+            translationKeyId: "key_3",
+            text: "Xem tự động hóa",
+            status: "needs_review",
+          },
+        ]) as unknown as { limit: typeof repoLimitMock; orderBy: typeof orderByMock },
+    );
+
+    const result = await loadProjectTranslationsAsPrefilledEntries({
+      organizationId: "org_1",
+      projectId: "project_1",
+      sourcePath: "locales/en.json",
+      targetLocale: "vi",
+    });
+
+    expect(result.prefilled).toEqual({
+      brand: "Hyperlocalise",
+      view_automations: "Xem tự động hóa",
+    });
+    expect(result.translatedKeyCount).toBe(2);
+    expect(result.loadedKeyCount).toBe(3);
+  });
+
+  it("keeps approved copies of multi-word source text", async () => {
+    repoLimitMock.mockResolvedValueOnce([{ id: "repo_file_1", sourcePath: "locales/en.json" }]);
+    offsetMock.mockResolvedValueOnce([
+      { id: "key_1", key: "view_automations", sourceText: "View automations" },
+    ]);
+
+    whereMock.mockImplementationOnce(() => ({
+      limit: repoLimitMock,
+      orderBy: orderByMock,
+    }));
+    whereMock.mockImplementationOnce(() => ({
+      limit: repoLimitMock,
+      orderBy: orderByMock,
+    }));
+    whereMock.mockImplementationOnce(
+      () =>
+        Promise.resolve([
+          {
+            id: "translation_1",
+            translationKeyId: "key_1",
+            text: "View automations",
+            status: "approved",
+          },
+        ]) as unknown as { limit: typeof repoLimitMock; orderBy: typeof orderByMock },
+    );
+
+    const result = await loadProjectTranslationsAsPrefilledEntries({
+      organizationId: "org_1",
+      projectId: "project_1",
+      sourcePath: "locales/en.json",
+      targetLocale: "vi",
+    });
+
+    expect(result.prefilled).toEqual({
+      view_automations: "View automations",
+    });
+    expect(result.translatedKeyCount).toBe(1);
+  });
+
   it("excludes rejected translations even when text is present", async () => {
     repoLimitMock.mockResolvedValueOnce([{ id: "repo_file_1", sourcePath: "locales/en.json" }]);
     offsetMock.mockResolvedValueOnce([{ id: "key_1", key: "greeting", sourceText: "Hello" }]);
@@ -218,6 +312,46 @@ describe("loadProjectTranslationsAsPrefilledEntries", () => {
       empty: "Pending",
     });
     expect(result.translatedKeyCount).toBe(1);
+  });
+
+  it("falls back to source text for omitted same-as-source reviews when exporting all keys", async () => {
+    repoLimitMock.mockResolvedValueOnce([{ id: "repo_file_1", sourcePath: "locales/en.json" }]);
+    offsetMock.mockResolvedValueOnce([
+      { id: "key_1", key: "workspace_knowledge", sourceText: "Enable workspace knowledge" },
+    ]);
+
+    whereMock.mockImplementationOnce(() => ({
+      limit: repoLimitMock,
+      orderBy: orderByMock,
+    }));
+    whereMock.mockImplementationOnce(() => ({
+      limit: repoLimitMock,
+      orderBy: orderByMock,
+    }));
+    whereMock.mockImplementationOnce(
+      () =>
+        Promise.resolve([
+          {
+            id: "translation_1",
+            translationKeyId: "key_1",
+            text: "Enable workspace knowledge",
+            status: "needs_review",
+          },
+        ]) as unknown as { limit: typeof repoLimitMock; orderBy: typeof orderByMock },
+    );
+
+    const result = await loadProjectTranslationsAsPrefilledEntries({
+      organizationId: "org_1",
+      projectId: "project_1",
+      sourcePath: "locales/en.json",
+      targetLocale: "vi",
+      includeAllSourceKeys: true,
+    });
+
+    expect(result.prefilled).toEqual({
+      workspace_knowledge: "Enable workspace knowledge",
+    });
+    expect(result.translatedKeyCount).toBe(0);
   });
 
   it("exports source fallback entries when no target translations exist", async () => {

--- a/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
@@ -499,6 +499,7 @@ export class ProjectTranslationService extends ProjectServiceBase {
     includeAllSourceKeys?: boolean;
   }): Promise<{
     prefilled: Record<string, string>;
+    retryKeys: string[];
     truncated: boolean;
     loadedKeyCount: number;
     maxKeyCount: number;
@@ -513,6 +514,7 @@ export class ProjectTranslationService extends ProjectServiceBase {
     if (!sourceFile) {
       return {
         prefilled: {},
+        retryKeys: [],
         truncated: false,
         loadedKeyCount: 0,
         maxKeyCount: maxKeysPerImport,
@@ -521,6 +523,7 @@ export class ProjectTranslationService extends ProjectServiceBase {
     }
 
     const prefilled: Record<string, string> = {};
+    const retryKeys: string[] = [];
     let loadedKeyCount = 0;
     let translatedKeyCount = 0;
     let offset = 0;
@@ -562,6 +565,10 @@ export class ProjectTranslationService extends ProjectServiceBase {
             status: translation!.status,
           });
 
+        if (retrySameAsSource) {
+          retryKeys.push(key.key);
+        }
+
         if (hasValidTranslation && !retrySameAsSource) {
           prefilled[key.key] = translation!.text;
           translatedKeyCount += 1;
@@ -583,6 +590,7 @@ export class ProjectTranslationService extends ProjectServiceBase {
 
     return {
       prefilled,
+      retryKeys,
       truncated: false,
       loadedKeyCount,
       maxKeyCount: maxKeysPerImport,

--- a/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
@@ -19,6 +19,7 @@ import type {
 } from "@/api/routes/project/project.schema";
 import { db, schema } from "@/lib/database";
 import { ProjectServiceBase } from "@/lib/projects/project-service-base";
+import { shouldRetrySameAsSourcePrefill } from "@/lib/projects/translations/should-retry-same-as-source-prefill";
 import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
 
 type ProjectKeysScopeInput = {
@@ -551,8 +552,17 @@ export class ProjectTranslationService extends ProjectServiceBase {
         const translation = translationByKeyId.get(key.id);
         const hasValidTranslation =
           Boolean(translation?.text?.trim()) && translation?.status !== "rejected";
+        // Leave multi-word needs-review copies out of prefill so a later
+        // translate-with-agent run can try them again. Single-word copies stay.
+        const retrySameAsSource =
+          hasValidTranslation &&
+          shouldRetrySameAsSourcePrefill({
+            sourceText: key.sourceText,
+            targetText: translation!.text,
+            status: translation!.status,
+          });
 
-        if (hasValidTranslation) {
+        if (hasValidTranslation && !retrySameAsSource) {
           prefilled[key.key] = translation!.text;
           translatedKeyCount += 1;
           continue;

--- a/apps/hyperlocalise-web/src/lib/projects/translations/should-retry-same-as-source-prefill.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/should-retry-same-as-source-prefill.test.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { shouldRetrySameAsSourcePrefill } from "./should-retry-same-as-source-prefill";
+
+describe("shouldRetrySameAsSourcePrefill", () => {
+  it("retries needs-review copies of multi-word source text", () => {
+    expect(
+      shouldRetrySameAsSourcePrefill({
+        sourceText: "Enable workspace knowledge for this organization.",
+        targetText: "Enable workspace knowledge for this organization.",
+        status: "needs_review",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps single-word needs-review copies", () => {
+    expect(
+      shouldRetrySameAsSourcePrefill({
+        sourceText: "Hyperlocalise",
+        targetText: "Hyperlocalise",
+        status: "needs_review",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps approved copies even when the source has multiple words", () => {
+    expect(
+      shouldRetrySameAsSourcePrefill({
+        sourceText: "View automations",
+        targetText: "View automations",
+        status: "approved",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps draft copies even when the source has multiple words", () => {
+    expect(
+      shouldRetrySameAsSourcePrefill({
+        sourceText: "View automations",
+        targetText: "View automations",
+        status: "draft",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps needs-review rows that already differ from the source", () => {
+    expect(
+      shouldRetrySameAsSourcePrefill({
+        sourceText: "View automations",
+        targetText: "Xem tự động hóa",
+        status: "needs_review",
+      }),
+    ).toBe(false);
+  });
+
+  it("trims whitespace before comparing text and counting words", () => {
+    expect(
+      shouldRetrySameAsSourcePrefill({
+        sourceText: "  View automations  ",
+        targetText: "View automations",
+        status: "needs_review",
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/projects/translations/should-retry-same-as-source-prefill.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/should-retry-same-as-source-prefill.test.ts
@@ -12,7 +12,10 @@
  */
 import { describe, expect, it } from "vite-plus/test";
 
-import { shouldRetrySameAsSourcePrefill } from "./should-retry-same-as-source-prefill";
+import {
+  mergeTranslationPrefills,
+  shouldRetrySameAsSourcePrefill,
+} from "./should-retry-same-as-source-prefill";
 
 describe("shouldRetrySameAsSourcePrefill", () => {
   it("retries needs-review copies of multi-word source text", () => {
@@ -73,5 +76,41 @@ describe("shouldRetrySameAsSourcePrefill", () => {
         status: "needs_review",
       }),
     ).toBe(true);
+  });
+});
+
+describe("mergeTranslationPrefills", () => {
+  it("lets project translations override matching TM values", () => {
+    expect(
+      mergeTranslationPrefills({
+        tmPrefilled: {
+          greeting: "Bonjour",
+          farewell: "Au revoir",
+        },
+        projectPrefilled: {
+          greeting: "Salut",
+        },
+      }),
+    ).toEqual({
+      greeting: "Salut",
+      farewell: "Au revoir",
+    });
+  });
+
+  it("drops TM copies for keys marked for same-as-source retry", () => {
+    expect(
+      mergeTranslationPrefills({
+        tmPrefilled: {
+          workspace_knowledge: "Enable workspace knowledge",
+          brand: "Hyperlocalise",
+        },
+        projectPrefilled: {
+          brand: "Hyperlocalise",
+        },
+        retryKeys: ["workspace_knowledge"],
+      }),
+    ).toEqual({
+      brand: "Hyperlocalise",
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/projects/translations/should-retry-same-as-source-prefill.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/should-retry-same-as-source-prefill.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+const MIN_SOURCE_WORDS_FOR_SAME_AS_SOURCE_RETRY = 2;
+
+function countSourceWords(sourceText: string): number {
+  const trimmed = sourceText.trim();
+  if (!trimmed) {
+    return 0;
+  }
+
+  return trimmed.split(/\s+/).length;
+}
+
+/**
+ * Prefill skips these rows so translate-with-agent can try again.
+ * Single-word copies often stay untranslated on purpose (brands, codes).
+ */
+export function shouldRetrySameAsSourcePrefill(input: {
+  sourceText: string;
+  targetText: string;
+  status: string | null | undefined;
+}): boolean {
+  if (input.status !== "needs_review") {
+    return false;
+  }
+
+  const sourceText = input.sourceText.trim();
+  const targetText = input.targetText.trim();
+  if (!sourceText || sourceText !== targetText) {
+    return false;
+  }
+
+  return countSourceWords(sourceText) >= MIN_SOURCE_WORDS_FOR_SAME_AS_SOURCE_RETRY;
+}

--- a/apps/hyperlocalise-web/src/lib/projects/translations/should-retry-same-as-source-prefill.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/should-retry-same-as-source-prefill.ts
@@ -43,3 +43,23 @@ export function shouldRetrySameAsSourcePrefill(input: {
 
   return countSourceWords(sourceText) >= MIN_SOURCE_WORDS_FOR_SAME_AS_SOURCE_RETRY;
 }
+
+export function mergeTranslationPrefills(input: {
+  tmPrefilled: Record<string, string>;
+  projectPrefilled: Record<string, string>;
+  retryKeys?: Iterable<string>;
+}): Record<string, string> {
+  const retryKeys = new Set(input.retryKeys ?? []);
+  const merged = { ...input.tmPrefilled, ...input.projectPrefilled };
+  if (retryKeys.size === 0) {
+    return merged;
+  }
+
+  const next: Record<string, string> = {};
+  for (const [key, value] of Object.entries(merged)) {
+    if (!retryKeys.has(key)) {
+      next[key] = value;
+    }
+  }
+  return next;
+}

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -16,6 +16,7 @@ import {
   sourceContainsTerm,
   validateGlossaryTermsInTranslation,
 } from "@/lib/glossary/validate-glossary-terms-in-translation";
+import { mergeTranslationPrefills } from "@/lib/projects/translations/should-retry-same-as-source-prefill";
 import {
   inferSupportedFileTranslationFileFormat,
   isImageTranslationFileFormat,
@@ -826,6 +827,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
       }
 
       let existingPrefilled: Record<string, string> = {};
+      let retryKeys: string[] = [];
       if (repositorySourcePath) {
         const projectPrefill = await loadProjectTranslationsAsPrefilledEntriesStep({
           organizationId,
@@ -834,6 +836,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
           targetLocale,
         });
         existingPrefilled = projectPrefill.prefilled;
+        retryKeys = projectPrefill.retryKeys;
         if (projectPrefill.truncated) {
           console.warn("[file-translation-workflow] project translation prefill truncated", {
             jobId: claim.job.id,
@@ -851,9 +854,21 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
             prefilledEntryCount: Object.keys(existingPrefilled).length,
           });
         }
+        if (retryKeys.length > 0) {
+          console.info("[file-translation-workflow] omitted same-as-source review prefills", {
+            jobId: claim.job.id,
+            projectId: claim.job.projectId,
+            targetLocale,
+            omittedKeyCount: retryKeys.length,
+          });
+        }
       }
 
-      const merged = { ...tmPrefilled, ...existingPrefilled };
+      const merged = mergeTranslationPrefills({
+        tmPrefilled,
+        projectPrefilled: existingPrefilled,
+        retryKeys,
+      });
       if (Object.keys(merged).length > 0) {
         prefilledByLocale[targetLocale] = merged;
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Translate-with-agent prefills existing project translations so `hl run` can skip work that already has a target. That also reused `needs_review` rows whose text still matched the source, so a failed copy-through never got a second attempt.

Prefill now omits those rows when the source has two or more words. Single-word copies stay prefilled (brands, codes, and other strings that often stay untranslated on purpose). Approved copies stay prefilled even when they match a multi-word source.

File jobs also persist those copied targets into attached translation memory as approved. The next run merged that TM value back in after project prefill omitted the needs-review row. The same retry keys are now dropped from the merged TM + project prefill so `hl run` translates them again.

## How to test

- `vp test src/lib/projects/translations/should-retry-same-as-source-prefill.test.ts src/lib/projects/translations/project-translation-service.test.ts`
- `vp check --fix`
- Re-run Translate with agent on a file that has a `needs_review` multi-word string still equal to the source, including on a project with attached translation memory. That string should be translated again instead of being skipped.

## Checklist

- [x] I ran relevant checks locally (`vp test` on the translation prefill files, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13272703-3122-428e-a795-4ad0fa08d677?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13272703-3122-428e-a795-4ad0fa08d677&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

