### PR TITLE
feat(localisation-audit): raise daily run limit to 20

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/localisation-audit/localisation-audit.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/localisation-audit/localisation-audit.route.test.ts
@@ -14,6 +14,7 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { createApp } from "@/api/app";
 import { LocalisationAuditDailyQuotaExceededError } from "@/lib/localisation-audit/daily-quota";
+import { LOCALISATION_AUDIT_DAILY_RUN_LIMIT } from "@/lib/localisation-audit/types";
 import { ok } from "@/lib/primitives/result/results";
 
 const {
@@ -220,7 +221,9 @@ describe("localisation audit routes", () => {
   });
 
   it("rejects new runs when the daily quota is exhausted", async () => {
-    claimOrReuseMock.mockRejectedValue(new LocalisationAuditDailyQuotaExceededError("user", 10));
+    claimOrReuseMock.mockRejectedValue(
+      new LocalisationAuditDailyQuotaExceededError("user", LOCALISATION_AUDIT_DAILY_RUN_LIMIT),
+    );
 
     const app = createApp({
       localisationAuditQueue: {
@@ -237,7 +240,7 @@ describe("localisation audit routes", () => {
     expect(response.status).toBe(429);
     const body = await response.json();
     expect(body.error).toBe("localisation_audit_daily_quota");
-    expect(body.message).toContain("10 visitor audits");
+    expect(body.message).toContain(`${LOCALISATION_AUDIT_DAILY_RUN_LIMIT} visitor audits`);
   });
 
   it("marks enqueue failures as retryable failed audits", async () => {

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-form.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-form.tsx
@@ -18,6 +18,7 @@ import { useState, type FormEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { LOCALISATION_AUDIT_DAILY_RUN_LIMIT } from "@/lib/localisation-audit/types";
 import { cn } from "@/lib/primitives/cn";
 
 import { getLocalisationAuditPageCopy } from "./localisation-audit-page-content";
@@ -131,7 +132,7 @@ export function LocalisationAuditForm({ locale, tone = "default" }: Localisation
           {pending ? copy.submitting : copy.submit}
         </Button>
         <p className={cn("text-sm", onMesh ? "text-white/70" : "text-muted-foreground")}>
-          {copy.onePerDomain}
+          {copy.onePerDomain({ limit: LOCALISATION_AUDIT_DAILY_RUN_LIMIT })}
         </p>
       </div>
     </form>

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page-content.test.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page-content.test.ts
@@ -12,6 +12,8 @@
  */
 import { describe, expect, it } from "vite-plus/test";
 
+import { LOCALISATION_AUDIT_DAILY_RUN_LIMIT } from "@/lib/localisation-audit/types";
+
 import {
   getLocalisationAuditGuideHref,
   getLocalisationAuditPageCopy,
@@ -31,6 +33,9 @@ describe("localisation audit page content", () => {
     expect(copy.notices[0]?.title).toBe("Voice");
     expect(copy.leaderboardHeading).toBe("How other sites score");
     expect(copy.startError).toContain("Check the URL");
+    expect(copy.onePerDomain({ limit: LOCALISATION_AUDIT_DAILY_RUN_LIMIT })).toBe(
+      `One free look per site. ${LOCALISATION_AUDIT_DAILY_RUN_LIMIT} a day across all sites.`,
+    );
   });
 
   it("returns result copy and interpolates ICU values", () => {

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page-content.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page-content.ts
@@ -73,11 +73,15 @@ export function getLocalisationAuditPageCopy(locale: string) {
       id: "PHgeGQnTFw",
       description: "Submit button label while the localisation audit is starting",
     }),
-    onePerDomain: intl.formatMessage({
-      defaultMessage: "One free look per site. Ten a day across all sites.",
-      id: "Pk/NpM4S0S",
-      description: "Rate-limit note under the localisation audit landing form",
-    }),
+    onePerDomain: (values: { limit: number }) =>
+      intl.formatMessage(
+        {
+          defaultMessage: "One free look per site. {limit} a day across all sites.",
+          id: "PX+2a63Sck",
+          description: "Rate-limit note under the localisation audit landing form",
+        },
+        values,
+      ),
     startError: intl.formatMessage({
       defaultMessage: "Could not start the audit. Check the URL and try again.",
       id: "tBmWE9rsb2",

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/daily-quota.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/daily-quota.ts
@@ -10,6 +10,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { getIntlShape } from "@/lib/app-i18n/intl";
+
 import {
   LOCALISATION_AUDIT_DAILY_RUN_LIMIT,
   LOCALISATION_AUDIT_RERUN_MS,
@@ -48,8 +50,28 @@ export class LocalisationAuditDailyQuotaExceededError extends Error {
     runSource: LocalisationAuditRunSource = "user",
     limit = localisationAuditDailyRunLimit(runSource),
   ) {
-    const audience = runSource === "scheduled" ? "scheduled" : "visitor";
-    super(`We've reached today's limit of ${limit} ${audience} audits. Try again tomorrow.`);
+    const intl = getIntlShape();
+    const message =
+      runSource === "scheduled"
+        ? intl.formatMessage(
+            {
+              defaultMessage:
+                "We've reached today's limit of {limit} scheduled audits. Try again tomorrow.",
+              id: "RYfCDsRyCY",
+              description: "Error when the scheduled localisation audit daily quota is exhausted",
+            },
+            { limit },
+          )
+        : intl.formatMessage(
+            {
+              defaultMessage:
+                "We've reached today's limit of {limit} visitor audits. Try again tomorrow.",
+              id: "nCmj3mv2tP",
+              description: "Error when the public localisation audit daily quota is exhausted",
+            },
+            { limit },
+          );
+    super(message);
     this.name = "LocalisationAuditDailyQuotaExceededError";
     this.runSource = runSource;
   }

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/types.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/types.ts
@@ -217,7 +217,7 @@ export type LocalisationAuditRunSource = "user" | "scheduled";
  * Rolling 24h cap on new runs and daily re-runs, per run source.
  * User submissions and scheduled audits each get their own bucket of this size.
  */
-export const LOCALISATION_AUDIT_DAILY_RUN_LIMIT = 10;
+export const LOCALISATION_AUDIT_DAILY_RUN_LIMIT = 20;
 export const LOCALISATION_AUDIT_EMAIL_RESEND_COOLDOWN_MS = 60 * 1000;
 export const LOCALISATION_AUDIT_REPORT_TOKEN_TTL_MS = 24 * 60 * 60 * 1000;
 

--- a/docs/adr/2026-08-15-localisation-audit-split-daily-quota-design.md
+++ b/docs/adr/2026-08-15-localisation-audit-split-daily-quota-design.md
@@ -13,13 +13,13 @@ seed day can block users and a busy visitor day can block the schedule.
 
 ## Decision
 
-Keep the same per-bucket size of **10**, but count **user** and
-**scheduled** runs separately.
+Keep a shared per-bucket size via `LOCALISATION_AUDIT_DAILY_RUN_LIMIT`,
+but count **user** and **scheduled** runs separately.
 
 | Bucket | Cap | Who consumes it |
 |--------|-----|-----------------|
-| `user` | 10 | `POST /api/localisation-audit` and other visitor starts |
-| `scheduled` | 10 | Cron / internal starts that pass `runSource: "scheduled"` |
+| `user` | `LOCALISATION_AUDIT_DAILY_RUN_LIMIT` | `POST /api/localisation-audit` and other visitor starts |
+| `scheduled` | `LOCALISATION_AUDIT_DAILY_RUN_LIMIT` | Cron / internal starts that pass `runSource: "scheduled"` |
 
 Rules:
 
@@ -45,3 +45,9 @@ Rules:
 - Exhausting the user bucket does not block a scheduled claim, and the
   reverse.
 - Same-day retry after a failed user run still skips another user slot.
+
+## Update
+
+2026-08-16: raised `LOCALISATION_AUDIT_DAILY_RUN_LIMIT` from 10 to 20.
+User and scheduled buckets still split; each now allows 20 quota-consuming
+runs per rolling 24h.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Raise the localisation audit rolling 24h cap from 10 to 20 per run source, and pass that cap as an ICU `{limit}` parameter instead of hardcoding “Twenty” / “10” in copy.

- `LOCALISATION_AUDIT_DAILY_RUN_LIMIT` is now 20. User submissions and scheduled audits still use separate buckets.
- Landing note: `One free look per site. {limit} a day across all sites.`
- Quota 429 messages: `We've reached today's limit of {limit} visitor|scheduled audits. Try again tomorrow.`
- Rebased onto latest `main` (includes the formatMessage conversion of audit page copy).

## How to test

- `vp test src/components/marketing/localisation-audit/localisation-audit-page-content.test.ts src/api/routes/localisation-audit/localisation-audit.route.test.ts src/lib/localisation-audit/store.retry.test.ts` — 27 passed
- `vp test` — 4238 passed
- `vp check --fix` — 0 errors on changed files
- Confirm the audit form helper text says “20 a day”, and a 429 reports “20 visitor audits”.

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe3c48b3-8637-4452-8ec6-888d5ea3fb0f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe3c48b3-8637-4452-8ec6-888d5ea3fb0f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

