### PR TITLE
fix(localisation-audit): ignore CSS leaked into CTA overlap

### DIFF
--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics.test.ts
@@ -658,10 +658,10 @@ describe("linguistic heuristic credits", () => {
     );
 
     expect(outcome.status).toBe("inconclusive");
-    if (outcome.status === "na") return;
-    expect(outcome.findings.some((finding) => finding.title === "Untranslated call to action")).toBe(
-      false,
-    );
+    if (outcome.status !== "inconclusive") return;
+    expect(
+      (outcome.findings ?? []).some((finding) => finding.title === "Untranslated call to action"),
+    ).toBe(false);
   });
 
   it("still flags leftover source-language CTA copy on Latin-script locale pages", () => {
@@ -670,19 +670,13 @@ describe("linguistic heuristic credits", () => {
         emptyCrawledPage({
           url: "https://example.com/en/pricing",
           htmlLang: "en",
-          buttons: [
-            "@keyframes shimmer { 0% { background-position: 250% 0; } }",
-            "Get started",
-          ],
+          buttons: ["@keyframes shimmer { 0% { background-position: 250% 0; } }", "Get started"],
           textSample: "Welcome to our pricing page for growing product teams worldwide.",
         }),
         emptyCrawledPage({
           url: "https://example.com/vi/pricing",
           htmlLang: "vi",
-          buttons: [
-            "@keyframes shimmer { 0% { background-position: 250% 0; } }",
-            "Get started",
-          ],
+          buttons: ["@keyframes shimmer { 0% { background-position: 250% 0; } }", "Get started"],
           textSample: "Chào mừng đến trang giá dành cho các nhóm sản phẩm đang phát triển.",
         }),
       ]),

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics.test.ts
@@ -630,6 +630,71 @@ describe("linguistic heuristic credits", () => {
 
     expect(outcome.status).toBe("inconclusive");
   });
+
+  it("does not treat shared CSS leaked into buttons as an untranslated CTA", () => {
+    const shimmer =
+      "@keyframes shimmer { 0% { background-position: 250% 0; } 100% { background-position: -250% 0; } }";
+    const outcome = linguisticHeuristicScorers["translation-completeness"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://www.weex.com/",
+          htmlLang: "en",
+          buttons: [shimmer, "Get started"],
+          textSample: "Trade crypto with a global exchange built for growing teams worldwide.",
+        }),
+        emptyCrawledPage({
+          url: "https://www.weex.com/vi",
+          htmlLang: "vi",
+          buttons: [shimmer, "Bắt đầu ngay"],
+          textSample: "Giao dịch tiền mã hóa trên sàn toàn cầu dành cho các nhóm đang phát triển.",
+        }),
+        emptyCrawledPage({
+          url: "https://www.weex.com/de",
+          htmlLang: "de",
+          buttons: [shimmer, "Jetzt starten"],
+          textSample: "Handle Krypto auf einer globalen Börse für wachsende Teams weltweit.",
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("inconclusive");
+    if (outcome.status === "na") return;
+    expect(outcome.findings.some((finding) => finding.title === "Untranslated call to action")).toBe(
+      false,
+    );
+  });
+
+  it("still flags leftover source-language CTA copy on Latin-script locale pages", () => {
+    const outcome = linguisticHeuristicScorers["translation-completeness"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://example.com/en/pricing",
+          htmlLang: "en",
+          buttons: [
+            "@keyframes shimmer { 0% { background-position: 250% 0; } }",
+            "Get started",
+          ],
+          textSample: "Welcome to our pricing page for growing product teams worldwide.",
+        }),
+        emptyCrawledPage({
+          url: "https://example.com/vi/pricing",
+          htmlLang: "vi",
+          buttons: [
+            "@keyframes shimmer { 0% { background-position: 250% 0; } }",
+            "Get started",
+          ],
+          textSample: "Chào mừng đến trang giá dành cho các nhóm sản phẩm đang phát triển.",
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("scored");
+    if (outcome.status !== "scored") return;
+    const cta = outcome.findings.find((finding) => finding.title === "Untranslated call to action");
+    expect(cta?.evidence).toBe('Primary CTA: "Get started"');
+    expect(cta?.where).toBe("Primary action · <button>");
+    expect(cta?.evidence).not.toContain("@keyframes");
+  });
 });
 
 describe("contextual heuristic credits", () => {

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/linguistic.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/linguistic.ts
@@ -20,6 +20,7 @@ import {
   groupPagesByLanguage,
   isCjkLanguage,
   isLatinScriptLanguage,
+  isPlausibleCtaCopy,
   isRtlLanguage,
   languageOf,
   looksLikeUrlOrEmail,
@@ -31,6 +32,28 @@ import type { HeuristicCreditOutcome, HeuristicScorer } from "../types";
 
 function scored(score: number, findings: LocalisationAuditFinding[]): HeuristicCreditOutcome {
   return { status: "scored", score: clampScore(score), findings };
+}
+
+function ctaCandidates(page: { buttons: string[]; anchors: Array<{ text: string }> }): Array<{
+  text: string;
+  tag: "<button>" | "<a>";
+}> {
+  const seen = new Set<string>();
+  const candidates: Array<{ text: string; tag: "<button>" | "<a>" }> = [];
+  const push = (text: string, tag: "<button>" | "<a>") => {
+    if (!isPlausibleCtaCopy(text) || seen.has(text)) {
+      return;
+    }
+    seen.add(text);
+    candidates.push({ text, tag });
+  };
+  for (const text of page.buttons) {
+    push(text, "<button>");
+  }
+  for (const anchor of page.anchors) {
+    push(anchor.text, "<a>");
+  }
+  return candidates;
 }
 
 const scoreTranslationCompleteness: HeuristicScorer = (context) => {
@@ -100,17 +123,12 @@ const scoreTranslationCompleteness: HeuristicScorer = (context) => {
 
     if (isLatinScriptLanguage(locale)) {
       const sourcePages = groupPagesByLanguage(context.pages).get(source) ?? [];
-      const sourceCtas = sourcePages.flatMap((item) => [
-        ...item.buttons,
-        ...item.anchors.map((a) => a.text),
-      ]);
-      const overlap = [...page.buttons, ...page.anchors.map((anchor) => anchor.text)].filter(
-        (textValue) =>
-          textValue.length >= 8 &&
-          sourceCtas.includes(textValue) &&
-          !looksLikeUrlOrEmail(textValue),
+      const sourceCtas = new Set(
+        sourcePages.flatMap((item) => ctaCandidates(item).map((cta) => cta.text)),
       );
+      const overlap = ctaCandidates(page).filter((cta) => sourceCtas.has(cta.text));
       if (overlap.length > 0) {
+        const primary = overlap[0]!;
         score -= 22;
         findings.push(
           creditFinding({
@@ -120,9 +138,12 @@ const scoreTranslationCompleteness: HeuristicScorer = (context) => {
             severity: "high",
             title: "Untranslated call to action",
             summary: `A ${locale} page still uses source-language CTA copy.`,
-            where: formatFindingWhere({ section: "Pricing hero", tag: "<button>" }),
+            where: formatFindingWhere({
+              section: primary.tag === "<button>" ? "Primary action" : "Link",
+              tag: primary.tag,
+            }),
             url: page.url,
-            evidence: `Primary CTA: "${overlap[0]}"`,
+            evidence: clipFindingEvidence(`Primary CTA: "${primary.text}"`),
             advice: "Translate leftover source-language CTAs to match the surrounding locale copy.",
             confidence: 92,
           }),

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared-locale.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared-locale.test.ts
@@ -18,8 +18,10 @@ import {
   htmlLangMatchesPathLocale,
   htmlLangSuggestionForPathLocale,
   isCjkLanguage,
+  isPlausibleCtaCopy,
   isRtlLanguage,
   isWellFormedHtmlLang,
+  looksLikeCssOrCode,
   pageLocale,
   pathLocaleFromUrl,
   textHasEasternArabicDigits,
@@ -129,5 +131,23 @@ describe("script and calendar helpers", () => {
     expect(textHasGregorianCalendarSignals("15 يناير 2024")).toBe(true);
     expect(textHasGregorianCalendarSignals("January 2024")).toBe(true);
     expect(textHasGregorianCalendarSignals("1 رمضان 1446")).toBe(false);
+  });
+});
+
+describe("CTA copy filters", () => {
+  it("rejects CSS keyframes and other non-copy leaked into controls", () => {
+    const shimmer =
+      "@keyframes shimmer { 0% { background-position: 250% 0; } 100% { background-position: -250% 0; } }";
+    expect(looksLikeCssOrCode(shimmer)).toBe(true);
+    expect(isPlausibleCtaCopy(shimmer)).toBe(false);
+    expect(isPlausibleCtaCopy("color: red; width: 12px;")).toBe(false);
+    expect(isPlausibleCtaCopy("https://example.com/signup")).toBe(false);
+  });
+
+  it("accepts short human CTA labels", () => {
+    expect(isPlausibleCtaCopy("Get started")).toBe(true);
+    expect(isPlausibleCtaCopy("Start free trial")).toBe(true);
+    expect(isPlausibleCtaCopy("Bắt đầu ngay")).toBe(true);
+    expect(isPlausibleCtaCopy("OK")).toBe(false);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared.ts
@@ -288,6 +288,35 @@ export function looksLikeUrlOrEmail(text: string): boolean {
   return /https?:\/\/|www\.|@[\w.-]+\.\w{2,}/i.test(text);
 }
 
+const CTA_COPY_MIN_CHARS = 8;
+const CTA_COPY_MAX_CHARS = 72;
+const CSS_AT_RULE_RE = /@(?:keyframes|media|font-face|import|supports|layer)\b/i;
+const CSS_DECLARATION_RE = /[a-z-]+\s*:\s*[^:;{}]+;/i;
+const CSS_VALUE_HINT_RE = /--|px|%|rgb|hsl|#[0-9a-f]{3,8}/i;
+
+/** Inline CSS, keyframes, or other non-copy leaked into button/anchor text. */
+export function looksLikeCssOrCode(text: string): boolean {
+  if (CSS_AT_RULE_RE.test(text) || /[{}]/.test(text)) {
+    return true;
+  }
+  return CSS_DECLARATION_RE.test(text) && CSS_VALUE_HINT_RE.test(text);
+}
+
+/**
+ * Whether a button or link label is short human copy that can be compared
+ * across locales. Rejects CSS, URLs, and other non-CTA noise.
+ */
+export function isPlausibleCtaCopy(text: string): boolean {
+  const trimmed = text.replace(/\s+/g, " ").trim();
+  if (trimmed.length < CTA_COPY_MIN_CHARS || trimmed.length > CTA_COPY_MAX_CHARS) {
+    return false;
+  }
+  if (looksLikeUrlOrEmail(trimmed) || looksLikeCssOrCode(trimmed)) {
+    return false;
+  }
+  return /\p{L}/u.test(trimmed);
+}
+
 export function looksPrimarilyEnglish(text: string): boolean {
   const sample = text.slice(0, 800);
   if (sample.length < 40) return false;

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/html-parse.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/html-parse.test.ts
@@ -170,4 +170,29 @@ describe("parsePageSignals", () => {
     expect(signals.anchors[0]).toEqual({ href: "/p/0", text: "P0" });
     expect(signals.anchors[79]).toEqual({ href: "/p/79", text: "P79" });
   });
+
+  it("does not treat style or script text inside buttons as the button label", () => {
+    const signals = parsePageSignals(`
+      <html lang="vi">
+        <body>
+          <button>
+            Đăng ký
+            <style>@keyframes shimmer { 0% { background-position: 250% 0; } 100% { background-position: -250% 0; } }</style>
+          </button>
+          <button>
+            <style>@keyframes pulse { from { opacity: 0; } to { opacity: 1; } }</style>
+          </button>
+          <a href="/signup">
+            Bắt đầu
+            <script>window.__cta = true</script>
+          </a>
+        </body>
+      </html>
+    `);
+
+    expect(signals.buttons).toEqual(["Đăng ký"]);
+    expect(signals.anchors).toEqual([{ href: "/signup", text: "Bắt đầu" }]);
+    expect(signals.buttons.join(" ")).not.toContain("@keyframes");
+    expect(signals.anchors.map((anchor) => anchor.text).join(" ")).not.toContain("__cta");
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/html-parse.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/html-parse.ts
@@ -358,17 +358,19 @@ export function parsePageSignals(html: string): ParsedPageSignals {
         if (inStyle) {
           styleBuffer += text;
         }
-        if (currentAnchor) {
-          currentAnchor.textParts.push(text);
-        }
-        if (inButton) {
-          buttonBuffer += text;
-        }
-        if (inLabel) {
-          labelBuffer += text;
-        }
-        if (headingTag) {
-          headingBuffer += text;
+        if (!inScriptOrStyle) {
+          if (currentAnchor) {
+            currentAnchor.textParts.push(text);
+          }
+          if (inButton) {
+            buttonBuffer += text;
+          }
+          if (inLabel) {
+            labelBuffer += text;
+          }
+          if (headingTag) {
+            headingBuffer += text;
+          }
         }
         if (!inScriptOrStyle && !inTitle && !inJsonLd) {
           const cleaned = text.replace(/\s+/g, " ").trim();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The translation-completeness CTA check treated any shared 8+ character button or link string as leftover source-language copy. Sites that inject `<style>` (for example `@keyframes shimmer`) inside buttons produced false “Untranslated call to action” findings, as on weex.com locale homepages.

This change:

- Skips `style`/`script` text when collecting button, link, heading, and label copy
- Compares only short human CTA labels (rejects CSS, URLs, and other non-copy)
- Reports the control as a primary action or link instead of a hardcoded “Pricing hero”

## How to test

- `vp test src/lib/localisation-audit` — 16 files, 142 tests passed
- `vp test` — 648 files, 4254 tests passed
- `vp check --fix` — 0 errors (4 pre-existing warnings in unrelated storybook/email files)

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2cdbc86-9296-4d22-85b7-5efdf648ea1d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2cdbc86-9296-4d22-85b7-5efdf648ea1d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

