### PR TITLE
feat(cli): add Vercel AI Gateway LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Operational notes:
 
 ## Supported integrations
 
-LLM providers are documented in the docs site and currently include `openai`, `azure_openai`, `anthropic`, `lmstudio`, `groq`, `mistral`, `ollama`, `gemini`, `bedrock`, and `openrouter`.
+LLM providers are documented in the docs site and currently include `openai`, `azure_openai`, `anthropic`, `lmstudio`, `groq`, `mistral`, `ollama`, `gemini`, `bedrock`, `openrouter`, and `ai_gateway`.
 
 Storage adapters are documented in the docs site and in `internal/i18n/storage/`, with support for `crowdin`, `lilt`, `lokalise`, `phrase`, `poeditor`, and `smartling`.
 

--- a/apps/cli/cmd/templates/i18n.yml
+++ b/apps/cli/cmd/templates/i18n.yml
@@ -28,11 +28,11 @@ buckets:
 llm:
   # Profiles define provider/model and optional prompt behavior.
   # A default profile is required.
-  # Supported providers: openai, azure_openai, anthropic, gemini, bedrock, lmstudio, groq, mistral, ollama, openrouter.
+  # Supported providers: openai, azure_openai, anthropic, gemini, bedrock, lmstudio, groq, mistral, ollama, openrouter, ai_gateway.
   # Available vars: {{source}}, {{target}}, {{input}}.
   profiles:
     default:
-      # Provider: openai, azure_openai, anthropic, gemini, bedrock, lmstudio, groq, mistral, ollama, or openrouter.
+      # Provider: openai, azure_openai, anthropic, gemini, bedrock, lmstudio, groq, mistral, ollama, openrouter, or ai_gateway.
       provider: openai
       model: gpt-5.2
       # Optional explicit system message template.

--- a/docs/adr/2026-08-16-cli-ai-gateway-provider-design.md
+++ b/docs/adr/2026-08-16-cli-ai-gateway-provider-design.md
@@ -1,0 +1,37 @@
+# CLI Vercel AI Gateway provider
+
+## Date
+
+2026-08-16
+
+## Context
+
+The Go CLI already talks to OpenAI-compatible hosts through a shared chat
+completions client. OpenRouter, Groq, Gemini, Mistral, Ollama, and LM Studio
+all use that path. The web app now defaults managed translation and the agent
+to Vercel AI Gateway (`AI_GATEWAY_API_KEY`). The CLI still has no Gateway
+provider, so local `run` and `eval` cannot use the same key and model IDs.
+
+## Decision
+
+Add `ai_gateway` as a built-in LLM provider.
+
+| Item | Value |
+|------|--------|
+| Config value | `ai_gateway` |
+| Required env | `AI_GATEWAY_API_KEY` |
+| Optional env | `AI_GATEWAY_BASE_URL` |
+| Default base URL | `https://ai-gateway.vercel.sh/v1` |
+| Client | Existing OpenAI-compatible chat completions helper |
+| Model IDs | Passed through unchanged (`openai/gpt-5.6-luna`, `anthropic/claude-opus-5`) |
+
+Auth is the Gateway API key only. The CLI does not read `VERCEL_OIDC_TOKEN`.
+Image localization stays OpenAI-only; this change covers text translation and
+eval.
+
+## Consequences
+
+- Users can set `llm.profiles.<name>.provider` to `ai_gateway` and reuse the
+  same `AI_GATEWAY_API_KEY` as the web app.
+- Docs, the `init` template, and config validation list `ai_gateway` with the
+  other providers.

--- a/docs/configuration/i18n-config.mdx
+++ b/docs/configuration/i18n-config.mdx
@@ -208,7 +208,7 @@ Supported entries are flat Java properties keys with string values. Hyperlocalis
 
 `llm.profiles.<name>` fields:
 
-- `provider`: `openai`, `azure_openai`, `anthropic`, `gemini`, `bedrock`, `lmstudio`, `groq`, `mistral`, `ollama`, or `openrouter`
+- `provider`: `openai`, `azure_openai`, `anthropic`, `gemini`, `bedrock`, `lmstudio`, `groq`, `mistral`, `ollama`, `openrouter`, or `ai_gateway`
 - `model`: provider model id
 - `system_prompt` (optional): explicit system-message template
 - `user_prompt` (optional): explicit user-message template

--- a/docs/configuration/provider-credentials.mdx
+++ b/docs/configuration/provider-credentials.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Provider credentials"
-description: "Set credentials for OpenAI, Azure OpenAI, Anthropic, Gemini, Bedrock, LM Studio, Ollama, Groq, and remote TMS adapters."
+description: "Set credentials for OpenAI, Azure OpenAI, Anthropic, Gemini, Bedrock, LM Studio, Ollama, Groq, OpenRouter, Vercel AI Gateway, and remote TMS adapters."
 ---
 
 `hyperlocalise` reads provider credentials from:
@@ -148,6 +148,34 @@ GROQ_BASE_URL="https://api.groq.com/openai/v1"
 GROQ_API_KEY="your-groq-api-key"
 ```
 </CodeGroup>
+
+### OpenRouter
+
+<CodeGroup>
+```bash Export
+export OPENROUTER_API_KEY="your-openrouter-api-key"
+```
+
+```bash .env.local
+OPENROUTER_API_KEY="your-openrouter-api-key"
+```
+</CodeGroup>
+
+`OPENROUTER_BASE_URL` defaults to `https://openrouter.ai/api/v1`.
+
+### Vercel AI Gateway
+
+<CodeGroup>
+```bash Export
+export AI_GATEWAY_API_KEY="your-ai-gateway-api-key"
+```
+
+```bash .env.local
+AI_GATEWAY_API_KEY="your-ai-gateway-api-key"
+```
+</CodeGroup>
+
+`AI_GATEWAY_BASE_URL` defaults to `https://ai-gateway.vercel.sh/v1`.
 
 ## Storage adapters
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -87,7 +87,8 @@
               "providers/lmstudio",
               "providers/groq",
               "providers/ollama",
-              "providers/openrouter"
+              "providers/openrouter",
+              "providers/ai-gateway"
             ]
           },
           {

--- a/docs/providers/ai-gateway.mdx
+++ b/docs/providers/ai-gateway.mdx
@@ -1,0 +1,54 @@
+---
+title: "Vercel AI Gateway"
+description: "Configure Vercel AI Gateway as an LLM provider for translation generation."
+---
+
+## Provider value
+
+Use `ai_gateway` in `llm.profiles.<name>.provider`.
+
+## Model IDs
+
+`model` is passed through to Vercel AI Gateway unchanged, for example
+`openai/gpt-5.6-luna`, `anthropic/claude-opus-5`, or
+`google/gemini-2.5-flash`. Hyperlocalise does not maintain its own catalogue of
+Gateway models; any model ID your Gateway account can access will work.
+
+## Example profile
+
+```json
+{
+  "llm": {
+    "profiles": {
+      "default": {
+        "provider": "ai_gateway",
+        "model": "openai/gpt-5.6-luna",
+        "prompt": "Translate from {{source}} to {{target}}:\n\n{{input}}"
+      }
+    }
+  }
+}
+```
+
+## Required environment variable
+
+<CodeGroup>
+```bash Export
+export AI_GATEWAY_API_KEY="your-ai-gateway-api-key"
+```
+
+```bash .env.local
+AI_GATEWAY_API_KEY="your-ai-gateway-api-key"
+```
+</CodeGroup>
+
+Create a key in the [AI Gateway API Keys](https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai-gateway%2Fapi-keys&title=AI+Gateway+API+Keys) page.
+
+## Optional environment variable
+
+`AI_GATEWAY_BASE_URL` defaults to `https://ai-gateway.vercel.sh/v1`.
+
+## Authentication
+
+The CLI sends `Authorization: Bearer $AI_GATEWAY_API_KEY`. It does not use
+Vercel OIDC tokens.

--- a/docs/providers/overview.mdx
+++ b/docs/providers/overview.mdx
@@ -15,6 +15,7 @@ Use one provider page below for exact setup and examples:
 - [Mistral](/providers/mistral)
 - [Ollama](/providers/ollama)
 - [OpenRouter](/providers/openrouter)
+- [Vercel AI Gateway](/providers/ai-gateway)
 
 ## Supported provider values
 
@@ -28,6 +29,7 @@ Use one provider page below for exact setup and examples:
 - `mistral`
 - `ollama`
 - `openrouter`
+- `ai_gateway`
 
 ## Required profile fields
 

--- a/docs/reference/config-schema.mdx
+++ b/docs/reference/config-schema.mdx
@@ -33,7 +33,7 @@ description: "Concise reference for the hyperlocalise i18n config schema."
 
 - `profiles` map of profile name -> provider/model/prompt
 - optional `context_memory` object with `provider` and `model` for context-building overrides
-- supported providers: `openai` | `azure_openai` | `anthropic` | `gemini` | `bedrock` | `lmstudio` | `groq` | `mistral` | `ollama` | `openrouter`
+- supported providers: `openai` | `azure_openai` | `anthropic` | `gemini` | `bedrock` | `lmstudio` | `groq` | `mistral` | `ollama` | `openrouter` | `ai_gateway`
 - `rules` array with `priority`, `group`, `profile`
 
 ## `storage`

--- a/internal/i18n/translator/bootstrap.go
+++ b/internal/i18n/translator/bootstrap.go
@@ -19,6 +19,7 @@ func RegisterBuiltins(t *Tool) error {
 		NewGeminiProvider(),
 		NewBedrockProvider(),
 		NewOpenRouterProvider(),
+		NewAIGatewayProvider(),
 	}
 
 	for _, provider := range providers {

--- a/internal/i18n/translator/bootstrap_test.go
+++ b/internal/i18n/translator/bootstrap_test.go
@@ -22,6 +22,7 @@ func TestRegisterBuiltinsRegistersExpectedProviders(t *testing.T) {
 	}
 	slices.Sort(got)
 	want := []string{
+		ProviderAIGateway,
 		ProviderAnthropic,
 		ProviderAzureOpenAI,
 		ProviderBedrock,

--- a/internal/i18n/translator/provider_ai_gateway.go
+++ b/internal/i18n/translator/provider_ai_gateway.go
@@ -1,0 +1,42 @@
+package translator
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/openai/openai-go/v3/option"
+)
+
+const (
+	defaultAIGatewayBaseURL    = "https://ai-gateway.vercel.sh/v1"
+	defaultAIGatewayBaseURLEnv = "AI_GATEWAY_BASE_URL"
+	defaultAIGatewayAPIKeyEnv  = "AI_GATEWAY_API_KEY"
+)
+
+type AIGatewayProvider struct{}
+
+func NewAIGatewayProvider() *AIGatewayProvider { return &AIGatewayProvider{} }
+
+func (p *AIGatewayProvider) Name() string { return ProviderAIGateway }
+
+func (p *AIGatewayProvider) Translate(ctx context.Context, req Request) (string, error) {
+	baseURL := strings.TrimSpace(os.Getenv(defaultAIGatewayBaseURLEnv))
+	if baseURL == "" {
+		baseURL = defaultAIGatewayBaseURL
+	}
+
+	apiKey := strings.TrimSpace(os.Getenv(defaultAIGatewayAPIKeyEnv))
+	if apiKey == "" {
+		return "", fmt.Errorf("ai_gateway provider: API key is required (%s)", defaultAIGatewayAPIKeyEnv)
+	}
+
+	return translateWithOpenAICompatibleClient(
+		ctx,
+		ProviderAIGateway,
+		req,
+		option.WithBaseURL(baseURL),
+		option.WithAPIKey(apiKey),
+	)
+}

--- a/internal/i18n/translator/provider_ai_gateway_test.go
+++ b/internal/i18n/translator/provider_ai_gateway_test.go
@@ -1,0 +1,152 @@
+package translator
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAIGatewayProviderTranslateRequiresAPIKey(t *testing.T) {
+	t.Setenv(defaultAIGatewayAPIKeyEnv, "")
+
+	_, err := NewAIGatewayProvider().Translate(context.Background(), Request{
+		Source:         "hello",
+		TargetLanguage: "fr",
+		Model:          "openai/gpt-5.6-luna",
+		SystemPrompt:   "system",
+		UserPrompt:     "user",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "AI_GATEWAY_API_KEY") {
+		t.Fatalf("expected API key error, got %v", err)
+	}
+}
+
+func TestAIGatewayProviderTranslateSendsBearerAuthAndUnchangedModel(t *testing.T) {
+	var gotAuth string
+	var gotModel string
+	var gotPath string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+
+		var body struct {
+			Model string `json:"model"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		gotModel = body.Model
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "chatcmpl-1",
+			"object": "chat.completion",
+			"model": "anthropic/claude-opus-5",
+			"choices": [{"index": 0, "message": {"role": "assistant", "content": "bonjour"}, "finish_reason": "stop"}]
+		}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv(defaultAIGatewayBaseURLEnv, srv.URL)
+	t.Setenv(defaultAIGatewayAPIKeyEnv, "vck_test_key")
+
+	got, err := NewAIGatewayProvider().Translate(context.Background(), Request{
+		Source:         "hello",
+		TargetLanguage: "fr",
+		Model:          "anthropic/claude-opus-5",
+		SystemPrompt:   "system",
+		UserPrompt:     "user",
+	})
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	if got != "bonjour" {
+		t.Fatalf("translate result = %q, want %q", got, "bonjour")
+	}
+	if gotAuth != "Bearer vck_test_key" {
+		t.Fatalf("Authorization header = %q, want %q", gotAuth, "Bearer vck_test_key")
+	}
+	// Gateway model IDs (e.g. "anthropic/claude-opus-5") must pass through unchanged.
+	if gotModel != "anthropic/claude-opus-5" {
+		t.Fatalf("request model = %q, want unchanged %q", gotModel, "anthropic/claude-opus-5")
+	}
+	if gotPath != "/chat/completions" {
+		t.Fatalf("request path = %q, want %q", gotPath, "/chat/completions")
+	}
+}
+
+func TestAIGatewayProviderDefaultBaseURL(t *testing.T) {
+	const want = "https://ai-gateway.vercel.sh/v1"
+	if defaultAIGatewayBaseURL != want {
+		t.Fatalf("defaultAIGatewayBaseURL = %q, want %q", defaultAIGatewayBaseURL, want)
+	}
+}
+
+func TestAIGatewayProviderTranslatePreservesUpstreamErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      int
+		body        string
+		wantStatus  string
+		wantMessage string
+	}{
+		{
+			name:        "401 invalid api key",
+			status:      http.StatusUnauthorized,
+			body:        `{"error":{"message":"Invalid API key","type":"invalid_request_error","code":"invalid_api_key"}}`,
+			wantStatus:  "401",
+			wantMessage: "Invalid API key",
+		},
+		{
+			name:        "400 invalid model",
+			status:      http.StatusBadRequest,
+			body:        `{"error":{"message":"not-a-real-model is not a valid model ID","type":"invalid_request_error","code":"model_not_found"}}`,
+			wantStatus:  "400",
+			wantMessage: "not a valid model ID",
+		},
+		{
+			name:        "429 rate limited",
+			status:      http.StatusTooManyRequests,
+			body:        `{"error":{"message":"Rate limit exceeded","type":"rate_limit_error","code":"rate_limit_exceeded"}}`,
+			wantStatus:  "429",
+			wantMessage: "Rate limit exceeded",
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			t.Setenv(defaultAIGatewayBaseURLEnv, srv.URL)
+			t.Setenv(defaultAIGatewayAPIKeyEnv, "vck_test_key")
+
+			_, err := NewAIGatewayProvider().Translate(context.Background(), Request{
+				Source:         "hello",
+				TargetLanguage: "fr",
+				Model:          "not-a-real-model",
+			})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.wantStatus) {
+				t.Fatalf("error %q does not contain status %q", err.Error(), tc.wantStatus)
+			}
+			if !strings.Contains(err.Error(), tc.wantMessage) {
+				t.Fatalf("error %q does not contain message %q", err.Error(), tc.wantMessage)
+			}
+		})
+	}
+}

--- a/internal/i18n/translator/translator_test.go
+++ b/internal/i18n/translator/translator_test.go
@@ -205,6 +205,14 @@ func TestNewRegistersDefaultProviders(t *testing.T) {
 	if _, ok := tool.providers[ProviderBedrock]; !ok {
 		t.Fatalf("expected %q provider to be registered", ProviderBedrock)
 	}
+
+	if _, ok := tool.providers[ProviderOpenRouter]; !ok {
+		t.Fatalf("expected %q provider to be registered", ProviderOpenRouter)
+	}
+
+	if _, ok := tool.providers[ProviderAIGateway]; !ok {
+		t.Fatalf("expected %q provider to be registered", ProviderAIGateway)
+	}
 }
 
 func TestResponseText(t *testing.T) {

--- a/internal/i18n/translator/types.go
+++ b/internal/i18n/translator/types.go
@@ -17,6 +17,7 @@ const (
 	ProviderGemini      = "gemini"
 	ProviderBedrock     = "bedrock"
 	ProviderOpenRouter  = "openrouter"
+	ProviderAIGateway   = "ai_gateway"
 )
 
 const OpenAIImageModel = "gpt-image-2-2026-04-21"

--- a/pkg/i18nconfig/i18n.go
+++ b/pkg/i18nconfig/i18n.go
@@ -30,6 +30,7 @@ const (
 	llmProviderGemini      = "gemini"
 	llmProviderBedrock     = "bedrock"
 	llmProviderOpenRouter  = "openrouter"
+	llmProviderAIGateway   = "ai_gateway"
 	llmDefaultProfile      = "default"
 	defaultGroupName       = "default"
 )
@@ -742,7 +743,7 @@ func validateProfile(fieldPrefix string, profile LLMProfile) error {
 	}
 
 	switch provider {
-	case llmProviderOpenAI, llmProviderAzureOpenAI, llmProviderAnthropic, llmProviderLMStudio, llmProviderGroq, llmProviderMistral, llmProviderOllama, llmProviderGemini, llmProviderBedrock, llmProviderOpenRouter:
+	case llmProviderOpenAI, llmProviderAzureOpenAI, llmProviderAnthropic, llmProviderLMStudio, llmProviderGroq, llmProviderMistral, llmProviderOllama, llmProviderGemini, llmProviderBedrock, llmProviderOpenRouter, llmProviderAIGateway:
 	default:
 		return fmt.Errorf("%s.provider: unsupported provider %q", fieldPrefix, profile.Provider)
 	}

--- a/pkg/i18nconfig/i18n_test.go
+++ b/pkg/i18nconfig/i18n_test.go
@@ -155,6 +155,15 @@ func TestLoad(t *testing.T) {
 			}`,
 		},
 		{
+			name: "valid llm provider ai_gateway",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "a", "to": "b"}]}},
+			  "groups": {"g": {"targets": ["es-ES"], "buckets": ["ui"]}},
+			  "llm": {"profiles": {"default": {"provider": "ai_gateway", "model": "x", "prompt": "p"}}}
+			}`,
+		},
+		{
 			name: "valid llm provider ollama",
 			content: `{
 			  "locales": {"source": "en-US", "targets": ["es-ES"]},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The Go CLI can now use Vercel AI Gateway as an LLM provider for `run` and `eval`.

Set `llm.profiles.<name>.provider` to `ai_gateway` and export `AI_GATEWAY_API_KEY`. Model IDs such as `openai/gpt-5.6-luna` or `anthropic/claude-opus-5` pass through unchanged to `https://ai-gateway.vercel.sh/v1`.

This matches the existing OpenRouter-style OpenAI-compatible provider path. Image localization stays OpenAI-only. The CLI does not use Vercel OIDC tokens.

## How to test

```bash
export AI_GATEWAY_API_KEY="your-key"
# in i18n.yml:
# llm.profiles.default.provider: ai_gateway
# llm.profiles.default.model: openai/gpt-5.6-luna
hyperlocalise run
```

Automated (all passed):

```bash
make fmt
make lint
go test ./internal/i18n/translator ./pkg/i18nconfig
go test ./...
make check-build
```

`make test` still exits 1 on the known missing `covdata` tool. Every package test passed.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `go test ./...`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23583db2-5bcb-4e0d-bb62-40425adb09fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23583db2-5bcb-4e0d-bb62-40425adb09fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

