### PR TITLE
fix(agent): drop AI_GATEWAY_API_KEY for Vercel OIDC

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -86,7 +86,6 @@ jobs:
     env:
       DATABASE_URL: postgres://hyperlocalise:hyperlocalise@127.0.0.1:5432/hyperlocalise?sslmode=disable
       OPENAI_API_KEY: test-openai-api-key
-      AI_GATEWAY_API_KEY: test-ai-gateway-api-key
       NEXT_PUBLIC_WAITLIST_URL: https://example.com/waitlist
       NEXT_PUBLIC_WORKOS_REDIRECT_URI: http://localhost:3000/auth/callback
       GITHUB_APP_WEBHOOK_SECRET: your-github-app-webhook-secret

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,9 +57,8 @@ go build -o $(go env GOPATH)/bin/golangci-lint github.com/golangci/golangci-lint
   WORKOS_CLIENT_ID=client_placeholder
   WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
   NEXT_PUBLIC_WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
- WORKOS_COOKIE_PASSWORD=this-is-a-test-cookie-password-at-least-32-characters
+  WORKOS_COOKIE_PASSWORD=this-is-a-test-cookie-password-at-least-32-characters
   AUTUMN_API_KEY=am_sk_test_placeholder
-  AI_GATEWAY_API_KEY=test-ai-gateway-api-key
   # Optional. Enables server-side GA4 custom events via Measurement Protocol.
   # GA_MEASUREMENT_PROTOCOL_API_SECRET=
  ```

--- a/apps/hyperlocalise-web/.env.e2e.example
+++ b/apps/hyperlocalise-web/.env.e2e.example
@@ -19,4 +19,3 @@ WORKOS_WEBHOOK_SECRET=whsec_e2e_local
 E2E_BASE_URL=http://localhost:3000
 
 AUTUMN_API_KEY=am_sk_test_placeholder
-AI_GATEWAY_API_KEY=test-ai-gateway-api-key

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
@@ -45,7 +45,6 @@ const {
 vi.mock("@/lib/env", () => ({
   env: {
     OPENAI_API_KEY: "test-openai-key",
-    AI_GATEWAY_API_KEY: "test-ai-gateway-key",
   },
 }));
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/hyperlocalise-agent.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/hyperlocalise-agent.test.ts
@@ -12,8 +12,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-const { createGatewayMock, isStepCountMock, toolLoopAgentMock } = vi.hoisted(() => ({
-  createGatewayMock: vi.fn(() => (modelId: string) => `gateway:${modelId}`),
+const { isStepCountMock, toolLoopAgentMock } = vi.hoisted(() => ({
   isStepCountMock: vi.fn((count: number) => ({ stepLimit: count })),
   toolLoopAgentMock: vi.fn(function ToolLoopAgent(settings: unknown) {
     return { settings };
@@ -25,17 +24,10 @@ vi.mock("ai", async () => {
 
   return {
     ...actual,
-    createGateway: createGatewayMock,
     isStepCount: isStepCountMock,
     ToolLoopAgent: toolLoopAgentMock,
   };
 });
-
-vi.mock("@/lib/env", () => ({
-  env: {
-    AI_GATEWAY_API_KEY: "test-ai-gateway-key",
-  },
-}));
 
 vi.mock("@/lib/database", () => ({
   db: {},
@@ -122,11 +114,10 @@ describe("hyperlocalise agent core", () => {
       activeTools: ["example"],
     });
 
-    expect(createGatewayMock).toHaveBeenCalledWith({ apiKey: "test-ai-gateway-key" });
     expect(isStepCountMock).toHaveBeenCalledWith(hyperlocaliseAgentStepLimit);
     expect(toolLoopAgentMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        model: `gateway:${hyperlocaliseManagedGatewayModelId}`,
+        model: hyperlocaliseManagedGatewayModelId,
         tools,
         activeTools: ["example"],
         timeout: DEFAULT_AGENT_TIMEOUT,

--- a/apps/hyperlocalise-web/src/lib/agents/email/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/email/bot.test.ts
@@ -24,7 +24,6 @@ vi.mock("@/lib/env", () => ({
     RESEND_FROM_ADDRESS: "agent@example.com",
     RESEND_FROM_NAME: "Hyperlocalise",
     OPENAI_API_KEY: "test-openai-api-key",
-    AI_GATEWAY_API_KEY: "test-ai-gateway-api-key",
   },
 }));
 

--- a/apps/hyperlocalise-web/src/lib/agents/email/intent.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/email/intent.test.ts
@@ -30,9 +30,7 @@ vi.mock("ai", async () => {
 });
 
 vi.mock("@/lib/env", () => ({
-  env: {
-    AI_GATEWAY_API_KEY: "test-ai-gateway-api-key",
-  },
+  env: {},
 }));
 
 function expectGenerateTextUsesInstructions(expectedInstructions: string) {

--- a/apps/hyperlocalise-web/src/lib/agents/github/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/bot.test.ts
@@ -114,7 +114,6 @@ vi.mock("@/lib/env", () => ({
     GITHUB_APP_PRIVATE_KEY: "private-key",
     GITHUB_APP_WEBHOOK_SECRET: "secret",
     OPENAI_API_KEY: "openai-key",
-    AI_GATEWAY_API_KEY: "test-ai-gateway-key",
   },
 }));
 

--- a/apps/hyperlocalise-web/src/lib/agents/image-generation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/image-generation.test.ts
@@ -12,12 +12,10 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-const { generateImageMock, getManagedImageModelMock, isManagedLanguageModelAvailableMock } =
-  vi.hoisted(() => ({
-    generateImageMock: vi.fn(),
-    getManagedImageModelMock: vi.fn(() => ({ id: "openai/gpt-image-2" })),
-    isManagedLanguageModelAvailableMock: vi.fn(() => true),
-  }));
+const { generateImageMock, getManagedImageModelMock } = vi.hoisted(() => ({
+  generateImageMock: vi.fn(),
+  getManagedImageModelMock: vi.fn(() => "openai/gpt-image-2"),
+}));
 
 vi.mock("ai", async () => {
   const actual = await vi.importActual<typeof import("ai")>("ai");
@@ -29,7 +27,6 @@ vi.mock("ai", async () => {
 
 vi.mock("@/lib/providers/language-model", () => ({
   getManagedImageModel: getManagedImageModelMock,
-  isManagedLanguageModelAvailable: isManagedLanguageModelAvailableMock,
 }));
 
 vi.mock("@/lib/billing/agent-runtime-usage", () => ({
@@ -41,7 +38,6 @@ import { regenerateImageFromAttachment } from "./image-generation";
 describe("image generation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    isManagedLanguageModelAvailableMock.mockReturnValue(true);
     generateImageMock.mockResolvedValue({
       images: [{ uint8Array: new Uint8Array([1, 2, 3]), mediaType: "image/png" }],
     });
@@ -57,7 +53,7 @@ describe("image generation", () => {
     expect(getManagedImageModelMock).toHaveBeenCalledOnce();
     expect(generateImageMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        model: { id: "openai/gpt-image-2" },
+        model: "openai/gpt-image-2",
         prompt: {
           images: [Buffer.from("source")],
           text: "Localize this screenshot into Japanese",
@@ -69,14 +65,5 @@ describe("image generation", () => {
       mimeType: "image/png",
       prompt: "Localize this screenshot into Japanese",
     });
-  });
-
-  it("requires the managed Gateway key instead of an org BYOK key", async () => {
-    isManagedLanguageModelAvailableMock.mockReturnValue(false);
-
-    await expect(
-      regenerateImageFromAttachment(Buffer.from("source"), "image/png", "Translate this"),
-    ).rejects.toThrow("AI_GATEWAY_API_KEY is not configured");
-    expect(getManagedImageModelMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agents/image-generation.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/image-generation.ts
@@ -13,10 +13,7 @@
 import { generateImage } from "ai";
 
 import { withAgentRuntimeUsageMetering } from "@/lib/billing/agent-runtime-usage";
-import {
-  getManagedImageModel,
-  isManagedLanguageModelAvailable,
-} from "@/lib/providers/language-model";
+import { getManagedImageModel } from "@/lib/providers/language-model";
 
 export type ImageGenerationResult = {
   image: Buffer;
@@ -33,9 +30,6 @@ export type ImageGenerationBilling = {
 };
 
 function getImageModel() {
-  if (!isManagedLanguageModelAvailable()) {
-    throw new Error("AI_GATEWAY_API_KEY is not configured");
-  }
   return getManagedImageModel();
 }
 

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
@@ -90,7 +90,6 @@ vi.mock("@/lib/env", () => ({
     SLACK_CLIENT_ID: "test-client-id",
     SLACK_CLIENT_SECRET: "test-client-secret",
     OPENAI_API_KEY: "test-openai-key",
-    AI_GATEWAY_API_KEY: "test-ai-gateway-key",
   },
 }));
 

--- a/apps/hyperlocalise-web/src/lib/agents/slack/image-attachments.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/image-attachments.ts
@@ -20,7 +20,6 @@ import {
   type ImageLocalizationAttachment,
 } from "@/lib/agents/image-localization";
 import { getHyperlocaliseAgentModel } from "@/lib/agent-runtime/loops/model";
-import { isManagedLanguageModelAvailable } from "@/lib/providers/language-model";
 
 import {
   createStoredSlackImageAttachment,
@@ -64,9 +63,6 @@ type SlackImageStorageContext = {
 };
 
 function getSlackImageIntentModel() {
-  if (!isManagedLanguageModelAvailable()) {
-    throw new Error("AI_GATEWAY_API_KEY is not configured");
-  }
   return getHyperlocaliseAgentModel();
 }
 

--- a/apps/hyperlocalise-web/src/lib/agents/video-generation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/video-generation.test.ts
@@ -12,12 +12,10 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-const { generateVideoMock, getManagedVideoModelMock, isManagedLanguageModelAvailableMock } =
-  vi.hoisted(() => ({
-    generateVideoMock: vi.fn(),
-    getManagedVideoModelMock: vi.fn(() => ({ id: "google/gemini-omni-flash-preview" })),
-    isManagedLanguageModelAvailableMock: vi.fn(() => true),
-  }));
+const { generateVideoMock, getManagedVideoModelMock } = vi.hoisted(() => ({
+  generateVideoMock: vi.fn(),
+  getManagedVideoModelMock: vi.fn(() => "google/gemini-omni-flash-preview"),
+}));
 
 vi.mock("ai", async () => {
   const actual = await vi.importActual<typeof import("ai")>("ai");
@@ -29,7 +27,6 @@ vi.mock("ai", async () => {
 
 vi.mock("@/lib/providers/language-model", () => ({
   getManagedVideoModel: getManagedVideoModelMock,
-  isManagedLanguageModelAvailable: isManagedLanguageModelAvailableMock,
   hyperlocaliseVideoModelId: "google/gemini-omni-flash-preview",
 }));
 
@@ -37,12 +34,11 @@ vi.mock("@/lib/billing/agent-runtime-usage", () => ({
   withAgentRuntimeUsageMetering: vi.fn(async ({ run }: { run: () => Promise<unknown> }) => run()),
 }));
 
-import { regenerateVideoFromAttachment, VideoLocalizationError } from "./video-generation";
+import { regenerateVideoFromAttachment } from "./video-generation";
 
 describe("video generation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    isManagedLanguageModelAvailableMock.mockReturnValue(true);
     generateVideoMock.mockResolvedValue({
       video: { uint8Array: new Uint8Array([9, 8, 7]), mediaType: "video/mp4" },
     });
@@ -58,7 +54,7 @@ describe("video generation", () => {
     expect(getManagedVideoModelMock).toHaveBeenCalledOnce();
     expect(generateVideoMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        model: { id: "google/gemini-omni-flash-preview" },
+        model: "google/gemini-omni-flash-preview",
         prompt: "Localize this clip into Spanish",
       }),
     );
@@ -67,21 +63,5 @@ describe("video generation", () => {
       mimeType: "video/mp4",
       prompt: "Localize this clip into Spanish",
     });
-  });
-
-  it("requires the managed Gateway key instead of an org BYOK key", async () => {
-    isManagedLanguageModelAvailableMock.mockReturnValue(false);
-
-    await expect(
-      regenerateVideoFromAttachment(Buffer.from("source-video"), "video/mp4", "Translate this"),
-    ).rejects.toEqual(
-      expect.objectContaining({
-        name: "VideoLocalizationError",
-        code: "video_model_unavailable",
-        message: "AI_GATEWAY_API_KEY is not configured",
-      }),
-    );
-    expect(getManagedVideoModelMock).not.toHaveBeenCalled();
-    expect(VideoLocalizationError).toBeDefined();
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agents/video-generation.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/video-generation.ts
@@ -13,11 +13,7 @@
 import { experimental_generateVideo as generateVideo } from "ai";
 
 import { withAgentRuntimeUsageMetering } from "@/lib/billing/agent-runtime-usage";
-import {
-  getManagedVideoModel,
-  hyperlocaliseVideoModelId,
-  isManagedLanguageModelAvailable,
-} from "@/lib/providers/language-model";
+import { getManagedVideoModel, hyperlocaliseVideoModelId } from "@/lib/providers/language-model";
 
 export { hyperlocaliseVideoModelId };
 
@@ -51,12 +47,6 @@ export class VideoLocalizationError extends Error {
 }
 
 function getVideoModel() {
-  if (!isManagedLanguageModelAvailable()) {
-    throw new VideoLocalizationError(
-      "video_model_unavailable",
-      "AI_GATEWAY_API_KEY is not configured",
-    );
-  }
   return getManagedVideoModel();
 }
 

--- a/apps/hyperlocalise-web/src/lib/env.ts
+++ b/apps/hyperlocalise-web/src/lib/env.ts
@@ -30,9 +30,6 @@ export const env = createEnv({
     /** OpenAI API key used for CLI sandbox translation. Optional when that feature is disabled. */
     OPENAI_API_KEY: z.string().min(1).optional(),
 
-    /** Vercel AI Gateway key for the managed agent, translation, image, and video localization. Optional when AI features are disabled. */
-    AI_GATEWAY_API_KEY: z.string().min(1).optional(),
-
     /** Master encryption key for provider credentials. Must be a high-entropy 32-byte base64 value. */
     PROVIDER_CREDENTIALS_MASTER_KEY: z.string().min(1),
 
@@ -251,8 +248,6 @@ export const env = createEnv({
     NEXT_PUBLIC_APP_ENV: process.env.NEXT_PUBLIC_APP_ENV,
     DATABASE_URL: process.env.DATABASE_URL,
     OPENAI_API_KEY: process.env.OPENAI_API_KEY ?? (isTestEnv ? "test-openai-api-key" : undefined),
-    AI_GATEWAY_API_KEY:
-      process.env.AI_GATEWAY_API_KEY ?? (isTestEnv ? "test-ai-gateway-api-key" : undefined),
     PROVIDER_CREDENTIALS_MASTER_KEY:
       process.env.PROVIDER_CREDENTIALS_MASTER_KEY ??
       (isTestEnv ? "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=" : undefined),

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/company-profile.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/company-profile.ts
@@ -14,7 +14,6 @@ import { generateText, Output } from "ai";
 import { z } from "zod";
 
 import { getHyperlocaliseAgentModel } from "@/lib/agent-runtime/loops/model";
-import { isManagedLanguageModelAvailable } from "@/lib/providers/language-model";
 import { createLogger } from "@/lib/log";
 
 import type { LocalisationAuditCompanyProfile, LocalisationAuditCrawledPage } from "./types";
@@ -192,10 +191,6 @@ export async function inferCompanyProfileWithLuna(
     page: homepage,
   });
   heuristic.logoUrl = evidence.logoUrl;
-
-  if (!isManagedLanguageModelAvailable()) {
-    return heuristic;
-  }
 
   try {
     const { output } = await generateText({

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/luna.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/luna.ts
@@ -14,7 +14,6 @@ import { generateText, Output } from "ai";
 import { z } from "zod";
 
 import { getHyperlocaliseAgentModel } from "@/lib/agent-runtime/loops/model";
-import { isManagedLanguageModelAvailable } from "@/lib/providers/language-model";
 import { createLogger } from "@/lib/log";
 
 import type { LocalisationAuditFinding, LocalisationAuditFindingSeverity } from "../types";
@@ -86,7 +85,7 @@ function compactEvidence(evidence: Record<string, unknown>): Record<string, unkn
 export async function scoreCreditsWithLuna(input: {
   credits: LunaCreditInput[];
 }): Promise<LunaBatchResult> {
-  if (input.credits.length === 0 || !isManagedLanguageModelAvailable()) {
+  if (input.credits.length === 0) {
     return { credits: [], linguisticNotes: [] };
   }
 

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/runner.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/runner.test.ts
@@ -98,7 +98,7 @@ describe("runLocalisationAuditCredits", () => {
       focusLocales: ["fr"],
     });
 
-    expect(generateTextMock).not.toHaveBeenCalled();
+    expect(generateTextMock).toHaveBeenCalledOnce();
     expect(result.credits.find((credit) => credit.id === "fluency")?.method).toBe("na");
     expect(result.credits.find((credit) => credit.id === "fluency")?.score).toBeNull();
     expect(result.credits.find((credit) => credit.id === "glossary-compliance")?.method).toBe("na");

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/runner.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/runner.test.ts
@@ -12,10 +12,9 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-const { generateTextMock, envState, getHyperlocaliseAgentModelMock } = vi.hoisted(() => ({
+const { generateTextMock, getHyperlocaliseAgentModelMock } = vi.hoisted(() => ({
   generateTextMock: vi.fn(),
   getHyperlocaliseAgentModelMock: vi.fn(() => ({ modelId: "test-model" })),
-  envState: { AI_GATEWAY_API_KEY: "test-ai-gateway-api-key" as string | undefined },
 }));
 
 vi.mock("ai", async (importOriginal) => {
@@ -25,10 +24,6 @@ vi.mock("ai", async (importOriginal) => {
     generateText: (...args: unknown[]) => generateTextMock(...args),
   };
 });
-
-vi.mock("@/lib/env", () => ({
-  env: envState,
-}));
 
 vi.mock("@/lib/agent-runtime/loops/model", () => ({
   getHyperlocaliseAgentModel: () => getHyperlocaliseAgentModelMock(),
@@ -50,7 +45,6 @@ import { emptyCrawledPage } from "../types";
 describe("runLocalisationAuditCredits", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    envState.AI_GATEWAY_API_KEY = "test-ai-gateway-api-key";
   });
 
   it("does not call Luna for credits the heuristic already scored", async () => {
@@ -83,8 +77,8 @@ describe("runLocalisationAuditCredits", () => {
     }
   });
 
-  it("batches remaining credits to Luna and marks them N/A when the API key is missing", async () => {
-    envState.AI_GATEWAY_API_KEY = undefined;
+  it("batches remaining credits to Luna and marks them N/A when scoring fails", async () => {
+    generateTextMock.mockRejectedValue(new Error("gateway unavailable"));
 
     const result = await runLocalisationAuditCredits({
       pages: [

--- a/apps/hyperlocalise-web/src/lib/providers/language-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/language-model.test.ts
@@ -12,30 +12,14 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-const { createGatewayMock, createOpenAIMock, createAnthropicMock, envState } = vi.hoisted(() => ({
-  createGatewayMock: vi.fn(() => {
-    const gateway = Object.assign((modelId: string) => ({ kind: "gateway", modelId }), {
-      image: (modelId: string) => ({ kind: "gateway-image", modelId }),
-      video: (modelId: string) => ({ kind: "gateway-video", modelId }),
-    });
-    return gateway;
-  }),
+const { createOpenAIMock, createAnthropicMock } = vi.hoisted(() => ({
   createOpenAIMock: vi.fn((options: { apiKey: string; baseURL?: string }) => {
     return (modelId: string) => ({ kind: "openai", modelId, options });
   }),
   createAnthropicMock: vi.fn((options: { apiKey: string }) => {
     return (modelId: string) => ({ kind: "anthropic", modelId, options });
   }),
-  envState: { AI_GATEWAY_API_KEY: "gw-key" as string | undefined },
 }));
-
-vi.mock("ai", async () => {
-  const actual = await vi.importActual<typeof import("ai")>("ai");
-  return {
-    ...actual,
-    createGateway: createGatewayMock,
-  };
-});
 
 vi.mock("@ai-sdk/openai", () => ({
   createOpenAI: createOpenAIMock,
@@ -43,10 +27,6 @@ vi.mock("@ai-sdk/openai", () => ({
 
 vi.mock("@ai-sdk/anthropic", () => ({
   createAnthropic: createAnthropicMock,
-}));
-
-vi.mock("@/lib/env", () => ({
-  env: envState,
 }));
 
 import {
@@ -57,44 +37,19 @@ import {
   hyperlocaliseImageModelId,
   hyperlocaliseManagedGatewayModelId,
   hyperlocaliseVideoModelId,
-  isManagedLanguageModelAvailable,
   resolveProviderLanguageModel,
 } from "./language-model";
 
 describe("managed language model", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    envState.AI_GATEWAY_API_KEY = "gw-key";
-  });
-
-  it("uses Vercel AI Gateway when the platform key is configured", () => {
-    expect(isManagedLanguageModelAvailable()).toBe(true);
-    expect(getManagedLanguageModel()).toEqual({
-      kind: "gateway",
-      modelId: hyperlocaliseManagedGatewayModelId,
-    });
-    expect(createGatewayMock).toHaveBeenCalledWith({ apiKey: "gw-key" });
-  });
-
-  it("throws when the Gateway key is missing", () => {
-    envState.AI_GATEWAY_API_KEY = undefined;
-    expect(isManagedLanguageModelAvailable()).toBe(false);
-    expect(() => getManagedLanguageModel()).toThrow("AI_GATEWAY_API_KEY is not configured");
-  });
-
-  it("routes image and video localization through the managed Gateway", () => {
-    expect(getManagedImageModel()).toEqual({
-      kind: "gateway-image",
-      modelId: hyperlocaliseImageModelId,
-    });
-    expect(getManagedVideoModel()).toEqual({
-      kind: "gateway-video",
-      modelId: hyperlocaliseVideoModelId,
-    });
+  it("uses Vercel AI Gateway model strings", () => {
+    expect(getManagedLanguageModel()).toBe(hyperlocaliseManagedGatewayModelId);
+    expect(getManagedImageModel()).toBe(hyperlocaliseImageModelId);
+    expect(getManagedVideoModel()).toBe(hyperlocaliseVideoModelId);
+    expect(hyperlocaliseManagedGatewayModelId).toBe("openai/gpt-5.6-luna");
     expect(hyperlocaliseImageModelId).toBe("openai/gpt-image-2");
     expect(hyperlocaliseVideoModelId).toBe("google/gemini-omni-flash-preview");
-    expect(createGatewayMock).toHaveBeenCalledWith({ apiKey: "gw-key" });
     expect(createOpenAIMock).not.toHaveBeenCalled();
+    expect(createAnthropicMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/providers/language-model.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/language-model.ts
@@ -12,11 +12,10 @@
  */
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { createOpenAI } from "@ai-sdk/openai";
-import { createGateway, type LanguageModel } from "ai";
+import type { LanguageModel } from "ai";
 
 import { hyperlocaliseAgentModelId } from "@/lib/agent-runtime/loops/model-id";
 import type { LlmProvider } from "@/lib/database/types";
-import { env } from "@/lib/env";
 
 export const hyperlocaliseManagedGatewayModelId = `openai/${hyperlocaliseAgentModelId}`;
 export const hyperlocaliseImageModelId = "openai/gpt-image-2";
@@ -36,32 +35,16 @@ const openAiCompatibleBaseUrlByProvider = {
   mistral: "https://api.mistral.ai/v1",
 } as const satisfies Partial<Record<LlmProvider, string>>;
 
-export const managedLanguageModelDeps = {
-  isAvailable: (): boolean => Boolean(env.AI_GATEWAY_API_KEY),
-};
-
-export function isManagedLanguageModelAvailable() {
-  return managedLanguageModelDeps.isAvailable();
-}
-
-export function getManagedGateway() {
-  if (!env.AI_GATEWAY_API_KEY) {
-    throw new Error("AI_GATEWAY_API_KEY is not configured");
-  }
-
-  return createGateway({ apiKey: env.AI_GATEWAY_API_KEY });
-}
-
 export function getManagedLanguageModel(): LanguageModel {
-  return getManagedGateway()(hyperlocaliseManagedGatewayModelId);
+  return hyperlocaliseManagedGatewayModelId;
 }
 
 export function getManagedImageModel() {
-  return getManagedGateway().image(hyperlocaliseImageModelId);
+  return hyperlocaliseImageModelId;
 }
 
 export function getManagedVideoModel() {
-  return getManagedGateway().video(hyperlocaliseVideoModelId);
+  return hyperlocaliseVideoModelId;
 }
 
 export function resolveProviderLanguageModel(input: {

--- a/apps/hyperlocalise-web/src/lib/providers/organization-language-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/organization-language-model.test.ts
@@ -32,7 +32,6 @@ const {
 
 vi.mock("@/lib/env", () => ({
   env: {
-    AI_GATEWAY_API_KEY: "gw-key",
     DATABASE_URL: "postgresql://hyperlocalise:hyperlocalise@localhost:5432/hyperlocalise",
     PROVIDER_CREDENTIALS_MASTER_KEY: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
     NEXT_PUBLIC_WAITLIST_URL: "https://example.com/waitlist",

--- a/apps/hyperlocalise-web/src/lib/translation/generate-cat-ai-recommendation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/generate-cat-ai-recommendation.test.ts
@@ -169,8 +169,8 @@ describe("generateCatAiRecommendation", () => {
   it("maps model setup failures to a result error", async () => {
     loadOrganizationTranslationModelMock.mockResolvedValue({
       ok: false,
-      code: "provider_credential_missing",
-      message: "no organization provider credential or managed translation model is configured",
+      code: "translation_project_not_found",
+      message: "translation project proj_1 was not found",
     });
 
     const result = await generateCatAiRecommendation({
@@ -187,8 +187,8 @@ describe("generateCatAiRecommendation", () => {
     expect(result).toEqual({
       ok: false,
       error: {
-        code: "provider_credential_missing",
-        message: "no organization provider credential or managed translation model is configured",
+        code: "translation_project_not_found",
+        message: "translation project proj_1 was not found",
       },
     });
   });

--- a/apps/hyperlocalise-web/src/lib/translation/generation.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/generation.ts
@@ -19,7 +19,6 @@ import { db, schema } from "@/lib/database";
 import type { LlmProvider } from "@/lib/database/types";
 import {
   getManagedLanguageModel,
-  isManagedLanguageModelAvailable,
   resolveProviderLanguageModel,
 } from "@/lib/providers/language-model";
 import { loadLatestOrganizationProviderCredential } from "@/lib/providers/organization-language-model";
@@ -325,14 +324,6 @@ function normalizeAiSdkTokenUsage(
 
 export { resolveProviderLanguageModel } from "@/lib/providers/language-model";
 
-export const organizationTranslationGeneratorDeps = {
-  isManagedTranslationModelAvailable: (): boolean => isManagedLanguageModelAvailable(),
-};
-
-export function isManagedTranslationModelAvailable() {
-  return organizationTranslationGeneratorDeps.isManagedTranslationModelAvailable();
-}
-
 export class OrganizationModelResolver {
   async resolve(projectId: string) {
     const [project] = await db
@@ -379,14 +370,6 @@ export class OrganizationModelResolver {
         project: projectContext,
         model,
         translateStringJob: createStringTranslationGenerator({ model }),
-      };
-    }
-
-    if (!organizationTranslationGeneratorDeps.isManagedTranslationModelAvailable()) {
-      return {
-        ok: false as const,
-        code: "provider_credential_missing" as const,
-        message: "no organization provider credential or managed translation model is configured",
       };
     }
 

--- a/apps/hyperlocalise-web/src/lib/translation/load-organization-translation-generator.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-organization-translation-generator.test.ts
@@ -23,10 +23,7 @@ import {
 } from "@/lib/security/provider-credential-crypto";
 
 import { createProjectTestFixture } from "../../api/routes/project/project.fixture";
-import {
-  loadOrganizationTranslationGenerator,
-  organizationTranslationGeneratorDeps,
-} from "./generation";
+import { loadOrganizationTranslationGenerator } from "./generation";
 
 const projectFixture = createProjectTestFixture();
 
@@ -97,22 +94,6 @@ describe("loadOrganizationTranslationGenerator", () => {
     }
 
     expect(typeof result.translateStringJob).toBe("function");
-  });
-
-  it("fails when neither BYOK nor managed translation is available", async () => {
-    vi.spyOn(
-      organizationTranslationGeneratorDeps,
-      "isManagedTranslationModelAvailable",
-    ).mockReturnValue(false);
-    const { project } = await projectFixture.createStoredProjectFixture();
-
-    const result = await loadOrganizationTranslationGenerator(project.id);
-
-    expect(result).toEqual({
-      ok: false,
-      code: "provider_credential_missing",
-      message: "no organization provider credential or managed translation model is configured",
-    });
   });
 
   it("fails when the project does not exist", async () => {

--- a/docs/adr/2026-08-13-video-omni-localization-design.md
+++ b/docs/adr/2026-08-13-video-omni-localization-design.md
@@ -17,8 +17,9 @@ supported; other languages are unevaluated. Uploaded-video edit is unavailable
 in the EEA, Switzerland, and the United Kingdom. Voice editing is not
 supported. Captions, CLI sync, Slack, email, Contentful, YouTube, and webm wait.
 
-The app does not use AI Gateway today. Image regen uses a platform
-`OPENAI_API_KEY`. Video follows that shape with a platform `AI_GATEWAY_API_KEY`.
+Image regen and video both use Vercel AI Gateway model strings. Vercel
+authenticates those calls with OIDC. File-translation sandboxes still use
+`OPENAI_API_KEY`.
 
 ## Decision
 
@@ -63,7 +64,8 @@ does.
 File jobs add a video branch next to images. Approved variants stay locked
 without force. Usage metering source is `video_localization`.
 
-The model id is `google/gemini-omni-flash-preview` through `createGateway`. The
+The model id is `google/gemini-omni-flash-preview` through the AI SDK Gateway
+default provider. The
 prompt keeps composition and localizes on-screen text and speech. Generation
 runs in workflow steps, not the HTTP handler.
 

--- a/docs/adr/2026-08-16-agent-ai-gateway-default-design.md
+++ b/docs/adr/2026-08-16-agent-ai-gateway-default-design.md
@@ -22,11 +22,13 @@ Resolve language models in `src/lib/providers/language-model.ts` and
 
 | Path | When | Client | Auth |
 |------|------|--------|------|
-| Managed | No org BYOK credential | `createGateway` from the AI SDK | Platform `AI_GATEWAY_API_KEY` |
+| Managed | No org BYOK credential | AI SDK Gateway model string | Vercel OIDC on deploy |
 | BYOK | Latest org credential | `createAnthropic`, `createOpenAI`, or OpenAI-compatible | Decrypted org key |
 
-Managed model id is `openai/gpt-5.6-luna` (`hyperlocaliseManagedGatewayModelId`).
-BYOK keeps the catalog model name the org selected.
+Managed calls pass a Gateway model id, for example `openai/gpt-5.6-luna`
+(`hyperlocaliseManagedGatewayModelId`). The AI SDK default provider is Vercel
+AI Gateway, so no `AI_GATEWAY_API_KEY` or `createGateway({ apiKey })` is
+required on Vercel. BYOK keeps the catalog model name the org selected.
 
 The conversation agent resolves this per organization and reuses that model for
 conversation classification. Managed string translation uses the same Gateway
@@ -46,8 +48,8 @@ OpenAI `reasoningSummary` options apply only for Gateway and OpenAI BYOK.
 
 ## Consequences
 
-- Deployments that run the agent, managed translation, image localization, or
-  video localization need `AI_GATEWAY_API_KEY`.
+- Vercel deployments authenticate Gateway with OIDC. Do not set
+  `AI_GATEWAY_API_KEY` in the app, CI, or local env files.
 - BYOK orgs keep conversational agent and classification traffic on their own
   provider accounts. Image and video jobs still go through the platform Gateway.
 - Subagents and automations that call `getHyperlocaliseAgentModel()` use Gateway


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Vercel AI Gateway is the default AI SDK provider. On Vercel, OIDC authenticates those calls, so a platform `AI_GATEWAY_API_KEY` is unused.

Managed language, image, and video models now pass Gateway model strings:

```ts
model: "openai/gpt-5.6-luna"
```

Removed the env from `env.ts`, Web CI, local `.env` examples, and the availability gates that treated a missing key as "AI disabled". Org BYOK still uses `createOpenAI` / `createAnthropic` with the decrypted org key.

## How to test

- `vp check --fix` in `apps/hyperlocalise-web` — passed (existing storybook warnings only)
- `vp test` in `apps/hyperlocalise-web` — 4263 passed after fixing the Luna failure assertion; targeted re-run of 7 files / 23 tests passed
- Confirm Web CI no longer sets `AI_GATEWAY_API_KEY`
- On Vercel, agent / translation / image / video calls should keep using Gateway without a gateway API key

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c523989e-c584-4f15-bee3-b6de1f9641b1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c523989e-c584-4f15-bee3-b6de1f9641b1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

