### PR TITLE
feat(web): swap homepage and startups hero images

### DIFF
--- a/apps/hyperlocalise-web/src/components/marketing/hero-section.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/hero-section.tsx
@@ -26,7 +26,7 @@ import { TypographyH1, TypographyP } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
 
 const dashboardHref = "/dashboard";
-const HERO_IMAGE_SRC = "/images/nasa-Q1p7bh3SHj8-unsplash.jpg";
+const HERO_IMAGE_SRC = "/images/vimal-s-GBg3jyGS-Ug-unsplash.jpg";
 
 const TRUSTED_BY_LOGOS = [
   {
@@ -89,7 +89,7 @@ export function HeroSection() {
         fill
         priority
         sizes="100vw"
-        className="object-cover object-[center_35%]"
+        className="object-cover object-[center_40%]"
       />
       <div
         className="absolute inset-0 bg-gradient-to-b from-black/55 via-black/40 to-black/80"

--- a/apps/hyperlocalise-web/src/components/marketing/startups/startups-page-content.test.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/startups/startups-page-content.test.ts
@@ -25,7 +25,7 @@ import {
 
 describe("startups page content", () => {
   it("exposes program assets and customer destinations", () => {
-    expect(startupsHeroImageSrc).toBe("/images/vimal-s-GBg3jyGS-Ug-unsplash.jpg");
+    expect(startupsHeroImageSrc).toBe("/images/nasa-Q1p7bh3SHj8-unsplash.jpg");
     expect(startmateUrl).toBe("https://www.startmate.com");
     expect(startmateLogoSrc).toBe("/images/startmate-logo.svg");
     expect(slatorUrl).toBe("https://slator.com/2026-slator-language-ai-50-under-50/");

--- a/apps/hyperlocalise-web/src/components/marketing/startups/startups-page-content.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/startups/startups-page-content.ts
@@ -13,7 +13,7 @@
 import type { HomepageFaqItem } from "@/components/marketing/homepage-faq-content";
 import { getIntlShape } from "@/lib/app-i18n/intl";
 
-export const startupsHeroImageSrc = "/images/vimal-s-GBg3jyGS-Ug-unsplash.jpg";
+export const startupsHeroImageSrc = "/images/nasa-Q1p7bh3SHj8-unsplash.jpg";
 export const startmateUrl = "https://www.startmate.com";
 export const startmateLogoSrc = "/images/startmate-logo.svg";
 export const slatorUrl = "https://slator.com/2026-slator-language-ai-50-under-50/";

--- a/apps/hyperlocalise-web/src/components/marketing/startups/startups-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/startups/startups-page.tsx
@@ -65,7 +65,7 @@ export function StartupsPage({ locale }: StartupsPageProps) {
           fill
           priority
           sizes="100vw"
-          className="object-cover object-[center_40%]"
+          className="object-cover object-[center_35%]"
         />
         <div
           className="absolute inset-0 bg-gradient-to-b from-black/50 via-black/45 to-black/85"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The homepage and startups marketing heroes now use each other's photos.

- Homepage hero uses `/images/vimal-s-GBg3jyGS-Ug-unsplash.jpg` (previously on startups)
- Startups hero uses `/images/nasa-Q1p7bh3SHj8-unsplash.jpg` (previously on homepage)
- Each photo keeps the crop position that was already tuned for it

[Homepage hero now uses the daylight Earth photo](https://cursor.com/agents/bc-1fd8fde7-fe8a-47af-808e-b2af311bab94/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_hero_daylight_earth.webp)
[Startups hero now uses the night Earth photo](https://cursor.com/agents/bc-1fd8fde7-fe8a-47af-808e-b2af311bab94/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstartups_hero_night_earth.webp)

[homepage_and_startups_hero_swap.mp4](https://cursor.com/agents/bc-1fd8fde7-fe8a-47af-808e-b2af311bab94/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_and_startups_hero_swap.mp4)

## How to test

- Open `/` and confirm the hero is the daylight Earth photo
- Open `/startups` and confirm the hero is the night city-lights Earth photo
- `vp test src/components/marketing/startups/startups-page-content.test.ts` in `apps/hyperlocalise-web`
- `vp check --fix` in `apps/hyperlocalise-web`

## Checklist

- [x] I ran relevant checks locally (`vp test` for the startups content file, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fd8fde7-fe8a-47af-808e-b2af311bab94?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fd8fde7-fe8a-47af-808e-b2af311bab94&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

