### PR TITLE
chore(cli): bump pinned hyperlocalise CLI to 1.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Install Hyperlocalise
         uses: ./install
         with:
-          version: 1.8.28
+          version: 1.9.0
 
       - name: Dry-run sync push
         run: hl sync push --dry-run

--- a/.github/workflows/hyperlocalise-web-localize.yml
+++ b/.github/workflows/hyperlocalise-web-localize.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Hyperlocalise
         uses: ./install
         with:
-          version: 1.8.28
+          version: 1.9.0
 
       - name: Extract source catalog
         run: |
@@ -102,7 +102,7 @@ jobs:
       - name: Install Hyperlocalise
         uses: ./install
         with:
-          version: 1.8.28
+          version: 1.9.0
 
       - name: Extract source catalog
         run: |

--- a/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
+++ b/apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
@@ -19,7 +19,7 @@ import { isReleaseSandboxVcrImageEnabled } from "@/lib/flags/release-flags";
 export const sandboxRipgrepReleaseVersion = "14.1.1";
 
 /** Pinned hyperlocalise CLI release installed into every sandbox. */
-export const sandboxHyperlocaliseReleaseVersion = "1.8.28";
+export const sandboxHyperlocaliseReleaseVersion = "1.9.0";
 
 /**
  * Pinned Playwright release used for Debian/Ubuntu `install-deps` fallback.

--- a/apps/sandbox-image/Dockerfile
+++ b/apps/sandbox-image/Dockerfile
@@ -22,7 +22,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Keep in sync with apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts
 ARG NODE_MAJOR=24
-ARG HYPERLOCALISE_VERSION=1.8.28
+ARG HYPERLOCALISE_VERSION=1.9.0
 ARG PLAYWRIGHT_VERSION=1.61.1
 # Optional pin; omit / leave empty to install the latest Volta release.
 ARG VOLTA_VERSION=


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Bump the pinned hyperlocalise CLI release from **1.8.28** to **1.9.0** in every consumer:

- `.github/workflows/ci.yml` — CI install action
- `.github/workflows/hyperlocalise-web-localize.yml` — localize + sync jobs
- `apps/hyperlocalise-web/src/lib/vercel-sandbox-config.ts` — Vercel sandbox install
- `apps/sandbox-image/Dockerfile` — sandbox image `HYPERLOCALISE_VERSION`

[v1.9.0](https://github.com/hyperlocalise/hyperlocalise/releases/tag/v1.9.0) adds OpenRouter and Vercel AI Gateway providers. No breaking changes.

## How to test

- Confirmed no remaining `1.8.28` pins
- Installed the `1.9.0` Linux amd64 release via `install-hyperlocalise.sh`; `hyperlocalise version` prints `hyperlocalise: 1.9.0`
- `vp test src/lib/vercel-sandbox-config.test.ts` — 9 passed
- `vp check --fix` — pass (4 pre-existing unrelated warnings)
- CI on this PR installs CLI 1.9.0

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb1e39ca-e199-4d6d-a491-1be33ea921d2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb1e39ca-e199-4d6d-a491-1be33ea921d2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

