### PR TITLE
feat(web): gate workspace domains behind WorkOS flag

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/linked-domain/linked-domain.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/linked-domain/linked-domain.route.test.ts
@@ -14,7 +14,7 @@ import "dotenv/config";
 
 import { eq } from "drizzle-orm";
 import { testClient } from "hono/testing";
-import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const mocks = vi.hoisted(() => ({
   resolveApiAuthContextFromSessionMock: vi.fn(
@@ -24,6 +24,7 @@ const mocks = vi.hoisted(() => ({
       null,
   ),
   verifyLinkedDomainChallengeMock: vi.fn(),
+  workspaceDomainsFlagRunMock: vi.fn(async () => true),
 }));
 
 vi.mock("@/api/auth/workos-session", async (importOriginal) => {
@@ -39,6 +40,14 @@ vi.mock("@/lib/linked-domains/verify", async (importOriginal) => {
   return {
     ...actual,
     verifyLinkedDomainChallenge: mocks.verifyLinkedDomainChallengeMock,
+  };
+});
+
+vi.mock("@/lib/flags/workspace-flags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/flags/workspace-flags")>();
+  return {
+    ...actual,
+    workspaceDomainsFlag: { run: mocks.workspaceDomainsFlagRunMock },
   };
 });
 
@@ -96,9 +105,30 @@ describe("linkedDomainRoutes", () => {
     await db.$client.query("select 1");
   });
 
+  beforeEach(() => {
+    mocks.workspaceDomainsFlagRunMock.mockResolvedValue(true);
+  });
+
   afterEach(async () => {
     vi.clearAllMocks();
     await fixture.cleanup();
+  });
+
+  it("denies linked domain access when the feature flag is disabled", async () => {
+    mocks.workspaceDomainsFlagRunMock.mockResolvedValue(false);
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const organizationSlug = identity.organization.slug ?? "missing-slug";
+
+    const response = await client.api.orgs[":organizationSlug"]["linked-domains"].$get(
+      { param: { organizationSlug } },
+      { headers },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "feature_unavailable",
+    });
   });
 
   it("starts verifies and lists a linked domain claim", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/linked-domain/linked-domain.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/linked-domain/linked-domain.route.ts
@@ -15,12 +15,16 @@ import { validator } from "hono/validator";
 
 import { hasCapability } from "@/api/auth/policy";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
+import { createWorkspaceFeatureFlagMiddleware } from "@/api/middleware/workspace-feature-flag";
 import {
   badRequestResponse,
   conflictResponse,
   forbiddenResponse,
   notFoundResponse,
 } from "@/api/response.schema";
+import { LOCALISATION_AUDIT_ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { serverAnalytics } from "@/lib/analytics/server";
+import { workspaceDomainsFlag } from "@/lib/flags/workspace-flags";
 import {
   cancelPendingLinkedDomainClaim,
   getLinkedDomain,
@@ -30,8 +34,6 @@ import {
   verifyAndClaimLinkedDomain,
 } from "@/lib/linked-domains/claims";
 import type { LinkedDomainError } from "@/lib/linked-domains/types";
-import { LOCALISATION_AUDIT_ANALYTICS_EVENTS } from "@/lib/analytics/events";
-import { serverAnalytics } from "@/lib/analytics/server";
 import { isErr } from "@/lib/primitives/result/results";
 
 import {
@@ -82,6 +84,11 @@ function canWriteLinkedDomains(role: AuthVariables["auth"]["membership"]["role"]
   return hasCapability(role, "projects:create");
 }
 
+const requireWorkspaceDomainsFeature = createWorkspaceFeatureFlagMiddleware(
+  workspaceDomainsFlag,
+  "Workspace domains is not enabled for this organization",
+);
+
 function mapLinkedDomainError(
   c: Parameters<typeof badRequestResponse>[0],
   error: LinkedDomainError,
@@ -102,6 +109,7 @@ function mapLinkedDomainError(
 export function createLinkedDomainRoutes() {
   return new Hono<{ Variables: AuthVariables }>()
     .use("*", workosAuthMiddleware)
+    .use("*", requireWorkspaceDomainsFeature)
     .get("/", async (c) => {
       if (!canReadLinkedDomains(c.var.auth.membership.role)) {
         return forbiddenResponse(c);

--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -77,9 +77,13 @@ vi.mock("@/lib/flags/release-flags", () => ({
   RELEASE_CAT_ALL_FILES_FLAG: "release-cat-all-files",
 }));
 
-vi.mock("@/lib/flags/workspace-flags", () => ({
-  workspaceIssuesFlag: { run: workspaceIssuesFlagRunMock },
-}));
+vi.mock("@/lib/flags/workspace-flags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/flags/workspace-flags")>();
+  return {
+    ...actual,
+    workspaceIssuesFlag: { run: workspaceIssuesFlagRunMock },
+  };
+});
 
 vi.mock("@/lib/translation/cat", () => ({
   loadCatSegmentConcordance: (...args: unknown[]) => loadCatSegmentConcordanceMock(...args),

--- a/apps/hyperlocalise-web/src/app/.well-known/vercel/flags/route.ts
+++ b/apps/hyperlocalise-web/src/app/.well-known/vercel/flags/route.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../../lib/flags/release-flags";
 import {
   workspaceAutomationsFlag,
+  workspaceDomainsFlag,
   workspaceIssuesFlag,
   workspaceKnowledgeFlag,
 } from "../../../../lib/flags/workspace-flags";
@@ -13,6 +14,7 @@ import {
 export const GET = createFlagsDiscoveryEndpoint(async () =>
   getProviderData({
     workspaceAutomationsFlag,
+    workspaceDomainsFlag,
     workspaceIssuesFlag,
     workspaceKnowledgeFlag,
     releaseCatAllFilesFlag,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/claim-domain/[domainSlug]/route.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/claim-domain/[domainSlug]/route.ts
@@ -12,12 +12,13 @@
  */
 import { NextResponse } from "next/server";
 
-import { isValidDomainSlug } from "@/lib/localisation-audit/domain-slug";
+import { requireWorkspaceFeatureFlag, workspaceDomainsFlag } from "@/lib/flags/workspace-flags";
 import {
   claimDomainPathForOrg,
   clearClaimDomainIntent,
   setClaimDomainIntent,
 } from "@/lib/linked-domains/claim-intent";
+import { isValidDomainSlug } from "@/lib/localisation-audit/domain-slug";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 export async function GET(request: Request, context: { params: Promise<{ domainSlug: string }> }) {
@@ -41,6 +42,7 @@ export async function GET(request: Request, context: { params: Promise<{ domainS
   }
 
   await clearClaimDomainIntent();
+  await requireWorkspaceFeatureFlag(workspaceDomainsFlag, auth);
   const path = claimDomainPathForOrg(organizationSlug, domainSlug);
   return NextResponse.redirect(new URL(path, requestUrl.origin));
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/[linkedDomainId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/[linkedDomainId]/page.tsx
@@ -10,6 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { requireWorkspaceFeatureFlag, workspaceDomainsFlag } from "@/lib/flags/workspace-flags";
 import { requireAppCapability } from "@/lib/workos/app-auth";
 
 import { DomainDetailPageContent } from "./_components/domain-detail-page-content";
@@ -20,7 +21,8 @@ export default async function DomainDetailPage({
   params: Promise<{ organizationSlug: string; linkedDomainId: string }>;
 }) {
   const { organizationSlug, linkedDomainId } = await params;
-  await requireAppCapability("projects:read", { organizationSlug });
+  const auth = await requireAppCapability("projects:read", { organizationSlug });
+  await requireWorkspaceFeatureFlag(workspaceDomainsFlag, auth);
 
   return (
     <DomainDetailPageContent organizationSlug={organizationSlug} linkedDomainId={linkedDomainId} />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/domains/page.tsx
@@ -10,6 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { requireWorkspaceFeatureFlag, workspaceDomainsFlag } from "@/lib/flags/workspace-flags";
 import { requireAppCapability } from "@/lib/workos/app-auth";
 
 import { DomainsPageContent } from "./_components/domains-page-content";
@@ -20,7 +21,8 @@ export default async function DomainsPage({
   params: Promise<{ organizationSlug: string }>;
 }) {
   const { organizationSlug } = await params;
-  await requireAppCapability("projects:read", { organizationSlug });
+  const auth = await requireAppCapability("projects:read", { organizationSlug });
+  await requireWorkspaceFeatureFlag(workspaceDomainsFlag, auth);
 
   return <DomainsPageContent organizationSlug={organizationSlug} />;
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/link-domain/[domainSlug]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/link-domain/[domainSlug]/page.tsx
@@ -10,6 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { requireWorkspaceFeatureFlag, workspaceDomainsFlag } from "@/lib/flags/workspace-flags";
 import { requireAppCapability } from "@/lib/workos/app-auth";
 
 import { LinkDomainPageContent } from "./_components/link-domain-page-content";
@@ -20,7 +21,8 @@ export default async function LinkDomainPage({
   params: Promise<{ organizationSlug: string; domainSlug: string }>;
 }) {
   const { organizationSlug, domainSlug } = await params;
-  await requireAppCapability("projects:create", { organizationSlug });
+  const auth = await requireAppCapability("projects:create", { organizationSlug });
+  await requireWorkspaceFeatureFlag(workspaceDomainsFlag, auth);
 
   return <LinkDomainPageContent organizationSlug={organizationSlug} domainSlug={domainSlug} />;
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/settings-pages.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/settings-pages.tsx
@@ -39,6 +39,7 @@ import { NotificationPreferencesSection } from "./notification-preferences-secti
 type SettingsPageProps = {
   organizationSlug: string;
   capabilities: OrganizationCapability[];
+  domainsEnabled: boolean;
 };
 
 type AccountPageProps = {
@@ -65,6 +66,7 @@ type SettingsRowConfig = {
   label: string;
   requiredCapability?: OrganizationCapability;
   absoluteHref?: boolean;
+  requiresDomainsFeature?: boolean;
 };
 
 function buildSettingsRows(
@@ -117,6 +119,7 @@ function buildSettingsRows(
       absoluteHref: true,
       icon: LinkSquare02Icon,
       requiredCapability: "projects:read",
+      requiresDomainsFeature: true,
     },
     {
       label: intl.formatMessage({
@@ -213,13 +216,23 @@ function ReadonlyField({ label, value }: { label: string; value: string }) {
   );
 }
 
-export async function SettingsPageContent({ organizationSlug, capabilities }: SettingsPageProps) {
+export async function SettingsPageContent({
+  organizationSlug,
+  capabilities,
+  domainsEnabled,
+}: SettingsPageProps) {
   const intl = getIntlShape(await getAppLocale());
   const baseHref = `/org/${organizationSlug}/settings`;
   const settingsRows = buildSettingsRows(intl, organizationSlug);
-  const visibleRows = settingsRows.filter(
-    (row) => !row.requiredCapability || capabilities.includes(row.requiredCapability),
-  );
+  const visibleRows = settingsRows.filter((row) => {
+    if (row.requiredCapability && !capabilities.includes(row.requiredCapability)) {
+      return false;
+    }
+    if (row.requiresDomainsFeature && !domainsEnabled) {
+      return false;
+    }
+    return true;
+  });
   const openLabel = intl.formatMessage({
     defaultMessage: "Open",
     id: "PEy6fPw+25",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/page.tsx
@@ -10,6 +10,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { evaluateWorkspaceFeatureFlags } from "@/lib/flags/workspace-flags";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 import { SettingsPageContent } from "./_components/settings-pages";
 
@@ -20,8 +21,13 @@ export default async function SettingsPage({
 }) {
   const { organizationSlug } = await params;
   const auth = await requireAppAuthContext({ organizationSlug });
+  const flags = await evaluateWorkspaceFeatureFlags(auth);
 
   return (
-    <SettingsPageContent organizationSlug={organizationSlug} capabilities={auth.capabilities} />
+    <SettingsPageContent
+      organizationSlug={organizationSlug}
+      capabilities={auth.capabilities}
+      domainsEnabled={flags.domains}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -17,6 +17,7 @@ import { getIntlShape } from "@/lib/app-i18n/intl";
 
 import {
   WORKSPACE_AUTOMATIONS_FLAG,
+  WORKSPACE_DOMAINS_FLAG,
   WORKSPACE_ISSUES_FLAG,
   WORKSPACE_KNOWLEDGE_FLAG,
 } from "@/lib/flags/workos-flag-entities";
@@ -178,6 +179,7 @@ describe("path builders", () => {
     expect(byLabel.get("Automations")?.featureFlagKey).toBe(WORKSPACE_AUTOMATIONS_FLAG);
     expect(byLabel.get("Knowledge")?.featureFlagKey).toBe(WORKSPACE_KNOWLEDGE_FLAG);
     expect(byLabel.get("Issues")?.featureFlagKey).toBe(WORKSPACE_ISSUES_FLAG);
+    expect(byLabel.get("Domains")?.featureFlagKey).toBe(WORKSPACE_DOMAINS_FLAG);
   });
 
   it("builds project navigation items scoped to the project", () => {

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -17,6 +17,7 @@ import { normalizeAppLocale } from "@/lib/app-i18n/locales";
 import { RELEASE_CAT_ALL_FILES_FLAG } from "@/lib/flags/release-flag-keys";
 import {
   WORKSPACE_AUTOMATIONS_FLAG,
+  WORKSPACE_DOMAINS_FLAG,
   WORKSPACE_ISSUES_FLAG,
   WORKSPACE_KNOWLEDGE_FLAG,
 } from "@/lib/flags/workos-flag-entities";
@@ -58,6 +59,7 @@ export type NavigationItem = {
     | typeof WORKSPACE_AUTOMATIONS_FLAG
     | typeof WORKSPACE_KNOWLEDGE_FLAG
     | typeof WORKSPACE_ISSUES_FLAG
+    | typeof WORKSPACE_DOMAINS_FLAG
     | typeof RELEASE_CAT_ALL_FILES_FLAG;
 };
 
@@ -190,6 +192,7 @@ export function buildGlobalNavigationGroups(
             id: "B3yFCBQLDF",
             description: "Sidebar description for the Domains navigation item",
           }),
+          featureFlagKey: WORKSPACE_DOMAINS_FLAG,
         },
         {
           label: intl.formatMessage({

--- a/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
@@ -151,13 +151,14 @@ describe("workosAdapter", () => {
 const intl = getIntlShape("en") as IntlShape;
 
 describe("filterNavigationByWorkspaceFlags", () => {
-  it("removes Automations, Knowledge, and Issues when workspace flags are disabled", () => {
+  it("removes Automations, Knowledge, Issues, and Domains when workspace flags are disabled", () => {
     const groups = buildGlobalNavigationGroups("acme", intl);
     const filtered = filterNavigationByWorkspaceFlags(groups, {
       automations: false,
       knowledge: false,
       visualMock: false,
       issues: false,
+      domains: false,
       glossarySearch: false,
     });
 
@@ -166,16 +167,18 @@ describe("filterNavigationByWorkspaceFlags", () => {
     expect(itemLabels).not.toContain("Automations");
     expect(itemLabels).not.toContain("Knowledge");
     expect(itemLabels).not.toContain("Issues");
+    expect(itemLabels).not.toContain("Domains");
     expect(itemLabels).toContain("Projects");
   });
 
-  it("keeps Automations, Knowledge, and Issues when workspace flags are enabled", () => {
+  it("keeps Automations, Knowledge, Issues, and Domains when workspace flags are enabled", () => {
     const groups = buildGlobalNavigationGroups("acme", intl);
     const filtered = filterNavigationByWorkspaceFlags(groups, {
       automations: true,
       knowledge: true,
       visualMock: true,
       issues: true,
+      domains: true,
       glossarySearch: true,
     });
 
@@ -184,5 +187,6 @@ describe("filterNavigationByWorkspaceFlags", () => {
     expect(itemLabels).toContain("Automations");
     expect(itemLabels).toContain("Knowledge");
     expect(itemLabels).toContain("Issues");
+    expect(itemLabels).toContain("Domains");
   });
 });

--- a/apps/hyperlocalise-web/src/lib/flags/workos-flag-entities.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-flag-entities.ts
@@ -14,6 +14,7 @@ export const WORKSPACE_AUTOMATIONS_FLAG = "workspace-automations";
 export const WORKSPACE_KNOWLEDGE_FLAG = "workspace-knowledge";
 export const WORKSPACE_VISUAL_MOCK_FLAG = "workspace-visual-mock";
 export const WORKSPACE_ISSUES_FLAG = "workspace-issues";
+export const WORKSPACE_DOMAINS_FLAG = "workspace-domains";
 export const WORKSPACE_GLOSSARY_SEARCH_FLAG = "workspace-glossary-search";
 export const WORKSPACE_FEATURE_UNAVAILABLE_REASON = "feature-unavailable";
 
@@ -27,6 +28,7 @@ export type WorkspaceFeatureFlagState = {
   knowledge: boolean;
   visualMock: boolean;
   issues: boolean;
+  domains: boolean;
   glossarySearch: boolean;
 };
 
@@ -35,5 +37,6 @@ export const DISABLED_WORKSPACE_FEATURE_FLAGS: WorkspaceFeatureFlagState = {
   knowledge: false,
   visualMock: false,
   issues: false,
+  domains: false,
   glossarySearch: false,
 };

--- a/apps/hyperlocalise-web/src/lib/flags/workspace-flag-navigation.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workspace-flag-navigation.ts
@@ -14,6 +14,7 @@ import type { NavigationGroup, NavigationItem } from "@/components/app-shell/nav
 
 import {
   WORKSPACE_AUTOMATIONS_FLAG,
+  WORKSPACE_DOMAINS_FLAG,
   WORKSPACE_GLOSSARY_SEARCH_FLAG,
   WORKSPACE_ISSUES_FLAG,
   WORKSPACE_KNOWLEDGE_FLAG,
@@ -27,6 +28,7 @@ function workspaceFlagEnabledByKey(flags: WorkspaceFeatureFlagState): Record<str
     [WORKSPACE_KNOWLEDGE_FLAG]: flags.knowledge,
     [WORKSPACE_VISUAL_MOCK_FLAG]: flags.visualMock,
     [WORKSPACE_ISSUES_FLAG]: flags.issues,
+    [WORKSPACE_DOMAINS_FLAG]: flags.domains,
     [WORKSPACE_GLOSSARY_SEARCH_FLAG]: flags.glossarySearch,
   };
 }

--- a/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
@@ -21,6 +21,7 @@ import { createWorkosIdentify } from "./identify-workos-context";
 import { workosAdapter } from "./workos-adapter";
 import {
   WORKSPACE_AUTOMATIONS_FLAG,
+  WORKSPACE_DOMAINS_FLAG,
   WORKSPACE_FEATURE_UNAVAILABLE_REASON,
   WORKSPACE_GLOSSARY_SEARCH_FLAG,
   WORKSPACE_ISSUES_FLAG,
@@ -63,6 +64,13 @@ export const workspaceIssuesFlag = flag<boolean, WorkosFlagEntities>({
   adapter: workosAdapter(),
 });
 
+export const workspaceDomainsFlag = flag<boolean, WorkosFlagEntities>({
+  key: WORKSPACE_DOMAINS_FLAG,
+  defaultValue: false,
+  description: "Workspace domains for claimed sites and localisation audit reports.",
+  adapter: workosAdapter(),
+});
+
 export const workspaceGlossarySearchFlag = flag<boolean, WorkosFlagEntities>({
   key: WORKSPACE_GLOSSARY_SEARCH_FLAG,
   defaultValue: false,
@@ -76,15 +84,16 @@ export async function evaluateWorkspaceFeatureFlags(
 ): Promise<WorkspaceFeatureFlagState> {
   const identify = () => createWorkosIdentify(auth);
 
-  const [automations, knowledge, visualMock, issues, glossarySearch] = await Promise.all([
+  const [automations, knowledge, visualMock, issues, domains, glossarySearch] = await Promise.all([
     workspaceAutomationsFlag.run({ identify }),
     workspaceKnowledgeFlag.run({ identify }),
     workspaceVisualMockFlag.run({ identify }),
     workspaceIssuesFlag.run({ identify }),
+    workspaceDomainsFlag.run({ identify }),
     workspaceGlossarySearchFlag.run({ identify }),
   ]);
 
-  return { automations, knowledge, visualMock, issues, glossarySearch };
+  return { automations, knowledge, visualMock, issues, domains, glossarySearch };
 }
 
 export async function resolveWorkspaceVisualMockFlag(input: {


### PR DESCRIPTION
## What changed

Add WorkOS flag `workspace-domains` (default off) so the Domains product ships the same way as Issues.

When the flag is off:

- Sidebar **Domains** is hidden
- Settings hub **Domains** is hidden
- `/org/.../domains`, domain detail, and link-domain pages redirect to the dashboard (`?reason=feature-unavailable`)
- Linked-domain APIs return `403 feature_unavailable`
- Claim-domain after sign-in is blocked

Enable the flag per organization in the WorkOS dashboard. Create the `workspace-domains` key there before turning it on.

## How to test

- Create `workspace-domains` in WorkOS and leave it off for a test org
- Confirm sidebar and Settings hide Domains
- Visit `/org/<slug>/domains` and confirm the dashboard redirect
- Call `GET /api/orgs/<slug>/linked-domains` and confirm `403` / `feature_unavailable`
- Enable the flag and confirm nav, pages, and claim flow work
- `vp test src/lib/flags/workos-adapter.test.ts src/components/app-shell/navigation-config.test.ts` in `apps/hyperlocalise-web` — passed
- `vp check --fix` in `apps/hyperlocalise-web` — passed (0 errors; 4 pre-existing unrelated warnings)

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review