### PR TITLE
feat(web): pass AI Gateway and org BYOK into sandbox translation jobs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,8 @@ go build -o $(go env GOPATH)/bin/golangci-lint github.com/golangci/golangci-lint
   NEXT_PUBLIC_WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
   WORKOS_COOKIE_PASSWORD=this-is-a-test-cookie-password-at-least-32-characters
   AUTUMN_API_KEY=am_sk_test_placeholder
+  # Optional. Routes file/email sandbox translation through Vercel AI Gateway.
+  # AI_GATEWAY_API_KEY=
   # Optional. Enables server-side GA4 custom events via Measurement Protocol.
   # GA_MEASUREMENT_PROTOCOL_API_SECRET=
  ```

--- a/apps/hyperlocalise-web/src/lib/env.ts
+++ b/apps/hyperlocalise-web/src/lib/env.ts
@@ -27,8 +27,14 @@ export const env = createEnv({
     /** Postgres connection string for Drizzle ORM. */
     DATABASE_URL: z.string().min(1),
 
-    /** OpenAI API key used for CLI sandbox translation. Optional when that feature is disabled. */
+    /** OpenAI API key used for CLI sandbox translation. Optional when AI Gateway or that feature is unused. */
     OPENAI_API_KEY: z.string().min(1).optional(),
+
+    /** Vercel AI Gateway API key used for CLI sandbox translation. Optional when OpenAI is configured. */
+    AI_GATEWAY_API_KEY: z.string().min(1).optional(),
+
+    /** Optional Vercel AI Gateway base URL override for CLI sandbox translation. */
+    AI_GATEWAY_BASE_URL: z.string().min(1).optional(),
 
     /** Master encryption key for provider credentials. Must be a high-entropy 32-byte base64 value. */
     PROVIDER_CREDENTIALS_MASTER_KEY: z.string().min(1),
@@ -248,6 +254,8 @@ export const env = createEnv({
     NEXT_PUBLIC_APP_ENV: process.env.NEXT_PUBLIC_APP_ENV,
     DATABASE_URL: process.env.DATABASE_URL,
     OPENAI_API_KEY: process.env.OPENAI_API_KEY ?? (isTestEnv ? "test-openai-api-key" : undefined),
+    AI_GATEWAY_API_KEY: process.env.AI_GATEWAY_API_KEY,
+    AI_GATEWAY_BASE_URL: process.env.AI_GATEWAY_BASE_URL,
     PROVIDER_CREDENTIALS_MASTER_KEY:
       process.env.PROVIDER_CREDENTIALS_MASTER_KEY ??
       (isTestEnv ? "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=" : undefined),

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.test.ts
@@ -102,6 +102,11 @@ vi.mock("@/lib/database", () => ({
   },
 }));
 
+vi.mock("@/lib/translation/sandbox-byok", () => ({
+  loadSandboxByokCredential: vi.fn(async () => null),
+  loadSandboxByokCredentialForJob: vi.fn(async () => null),
+}));
+
 vi.mock("@/lib/translation/sandbox", () => ({
   createTranslationSandbox: (...args: unknown[]) => createTranslationSandboxMock(...args),
   prepareSandbox: (...args: unknown[]) => prepareSandboxMock(...args),
@@ -483,6 +488,7 @@ describe("translateProviderJobFiles", () => {
       ["fr"],
       null,
       expect.objectContaining({ projectName: "Demo" }),
+      null,
     );
     expect(runSandboxCommandMock).toHaveBeenCalledTimes(1);
     expect(result.filesProcessed).toBe(2);
@@ -713,6 +719,7 @@ describe("translateProviderJobFiles", () => {
       ["fr"],
       null,
       expect.any(Object),
+      null,
     );
     expect(result.filesProcessed).toBe(1);
     expect(result.skippedExistingLocales).toBe(1);
@@ -868,6 +875,7 @@ describe("translateProviderJobFiles", () => {
       ["fr"],
       null,
       expect.any(Object),
+      null,
     );
     expect(result.warnings.some((warning) => warning.includes("Skipped file a.json"))).toBe(true);
     expect(result.changedItems).toEqual([expect.objectContaining({ key: "bye", to: "Au revoir" })]);

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
@@ -264,6 +264,7 @@ async function runMultiFileTranslationInSandbox(input: {
   targetLocales: string[];
   context: SandboxTranslationContext;
   prefilledByLocale: Record<string, Record<string, string>>;
+  organizationId: string;
 }) {
   const {
     buildMultiFileMultiLocaleTempConfig,
@@ -273,6 +274,8 @@ async function runMultiFileTranslationInSandbox(input: {
     writeFileToSandbox,
     writeTempConfig,
   } = await import("@/lib/translation/sandbox");
+  const { loadSandboxByokCredential } = await import("@/lib/translation/sandbox-byok");
+  const byok = await loadSandboxByokCredential(input.organizationId);
 
   const config = buildMultiFileMultiLocaleTempConfig(
     input.files,
@@ -280,6 +283,7 @@ async function runMultiFileTranslationInSandbox(input: {
     input.targetLocales,
     null,
     input.context,
+    byok,
   );
   await writeTempConfig(input.sandboxId, config, sandboxI18nConfigPath);
 
@@ -312,7 +316,7 @@ async function runMultiFileTranslationInSandbox(input: {
       "-lc",
       `hl run --config '${shellSingleQuote(sandboxI18nConfigPath)}' ${localeFlags} --force --progress off${prefilledFlags}`,
     ],
-    { env: getSandboxTranslationEnv() },
+    { env: getSandboxTranslationEnv(byok) },
   );
 
   if (translation.exitCode !== 0) {
@@ -780,6 +784,7 @@ export async function translateProviderJobFiles(input: {
             targetLocales: localesToRun,
             context: batchContext,
             prefilledByLocale,
+            organizationId: input.organizationId,
           });
         } catch (error) {
           warnings.push(

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-byok.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-byok.test.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { loadLatestOrganizationProviderCredentialMock, selectMock } = vi.hoisted(() => ({
+  loadLatestOrganizationProviderCredentialMock: vi.fn(),
+  selectMock: vi.fn(),
+}));
+
+vi.mock("@/lib/providers/organization-language-model", () => ({
+  loadLatestOrganizationProviderCredential: loadLatestOrganizationProviderCredentialMock,
+}));
+
+vi.mock("@/lib/database", () => ({
+  db: {
+    select: (...args: unknown[]) => selectMock(...args),
+  },
+  schema: {
+    jobs: {
+      id: "jobs.id",
+      organizationId: "jobs.organization_id",
+    },
+  },
+}));
+
+import { loadSandboxByokCredential, loadSandboxByokCredentialForJob } from "./sandbox-byok";
+
+describe("loadSandboxByokCredential", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the organization credential when BYOK is configured", async () => {
+    loadLatestOrganizationProviderCredentialMock.mockResolvedValueOnce({
+      ok: true,
+      credential: {
+        provider: "anthropic",
+        apiKey: "sk-ant-org",
+        model: "claude-sonnet-4-6",
+      },
+    });
+
+    await expect(loadSandboxByokCredential("org_123")).resolves.toEqual({
+      provider: "anthropic",
+      apiKey: "sk-ant-org",
+      model: "claude-sonnet-4-6",
+    });
+  });
+
+  it("returns null when the organization has no stored credential", async () => {
+    loadLatestOrganizationProviderCredentialMock.mockResolvedValueOnce({
+      ok: true,
+      credential: null,
+    });
+
+    await expect(loadSandboxByokCredential("org_123")).resolves.toBeNull();
+  });
+
+  it("throws when the stored credential is invalid", async () => {
+    loadLatestOrganizationProviderCredentialMock.mockResolvedValueOnce({
+      ok: false,
+      code: "provider_credential_invalid",
+      message: "organization provider credential is incomplete",
+    });
+
+    await expect(loadSandboxByokCredential("org_123")).rejects.toThrow(
+      "organization provider credential is incomplete",
+    );
+  });
+});
+
+describe("loadSandboxByokCredentialForJob", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads BYOK from the job organization", async () => {
+    selectMock.mockReturnValue({
+      from: () => ({
+        where: () => ({
+          limit: async () => [{ organizationId: "org_123" }],
+        }),
+      }),
+    });
+    loadLatestOrganizationProviderCredentialMock.mockResolvedValueOnce({
+      ok: true,
+      credential: {
+        provider: "openai",
+        apiKey: "sk-org",
+        model: "gpt-5.6-luna",
+      },
+    });
+
+    await expect(loadSandboxByokCredentialForJob("job_123")).resolves.toEqual({
+      provider: "openai",
+      apiKey: "sk-org",
+      model: "gpt-5.6-luna",
+    });
+  });
+
+  it("returns null when the job has no organization", async () => {
+    selectMock.mockReturnValue({
+      from: () => ({
+        where: () => ({
+          limit: async () => [{ organizationId: null }],
+        }),
+      }),
+    });
+
+    await expect(loadSandboxByokCredentialForJob("job_123")).resolves.toBeNull();
+    expect(loadLatestOrganizationProviderCredentialMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-byok.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-byok.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import { loadLatestOrganizationProviderCredential } from "@/lib/providers/organization-language-model";
+
+import type { SandboxByokCredential } from "./sandbox-llm";
+
+export async function loadSandboxByokCredential(
+  organizationId: string,
+): Promise<SandboxByokCredential | null> {
+  const loaded = await loadLatestOrganizationProviderCredential(organizationId);
+  if (!loaded.ok) {
+    throw new Error(loaded.message);
+  }
+
+  return loaded.credential;
+}
+
+export async function loadSandboxByokCredentialForJob(
+  jobId: string,
+): Promise<SandboxByokCredential | null> {
+  const [job] = await db
+    .select({ organizationId: schema.jobs.organizationId })
+    .from(schema.jobs)
+    .where(eq(schema.jobs.id, jobId))
+    .limit(1);
+
+  if (!job?.organizationId) {
+    return null;
+  }
+
+  return loadSandboxByokCredential(job.organizationId);
+}

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-llm.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-llm.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { hyperlocaliseAgentModelId } from "@/lib/agent-runtime/loops/model-id";
+
+import { resolveSandboxLlmProfile, resolveSandboxTranslationEnv } from "./sandbox-llm";
+
+describe("resolveSandboxTranslationEnv", () => {
+  it("passes OpenAI when only that key is set", () => {
+    expect(resolveSandboxTranslationEnv({ OPENAI_API_KEY: "sk-openai" })).toEqual({
+      OPENAI_API_KEY: "sk-openai",
+    });
+  });
+
+  it("passes the AI Gateway key when that env var is set", () => {
+    expect(resolveSandboxTranslationEnv({ AI_GATEWAY_API_KEY: "vck_test" })).toEqual({
+      AI_GATEWAY_API_KEY: "vck_test",
+    });
+  });
+
+  it("passes both keys and an optional Gateway base URL when present", () => {
+    expect(
+      resolveSandboxTranslationEnv({
+        OPENAI_API_KEY: "sk-openai",
+        AI_GATEWAY_API_KEY: "vck_test",
+        AI_GATEWAY_BASE_URL: "https://ai-gateway.example.test/v1",
+      }),
+    ).toEqual({
+      OPENAI_API_KEY: "sk-openai",
+      AI_GATEWAY_API_KEY: "vck_test",
+      AI_GATEWAY_BASE_URL: "https://ai-gateway.example.test/v1",
+    });
+  });
+
+  it("ignores blank Gateway values", () => {
+    expect(
+      resolveSandboxTranslationEnv({
+        OPENAI_API_KEY: "sk-openai",
+        AI_GATEWAY_API_KEY: "   ",
+        AI_GATEWAY_BASE_URL: "",
+      }),
+    ).toEqual({
+      OPENAI_API_KEY: "sk-openai",
+    });
+  });
+
+  it("requires OpenAI or AI Gateway credentials", () => {
+    expect(() => resolveSandboxTranslationEnv({})).toThrow(
+      "OPENAI_API_KEY or AI_GATEWAY_API_KEY is not configured",
+    );
+  });
+});
+
+describe("resolveSandboxLlmProfile", () => {
+  it("uses ai_gateway and the managed Gateway model when the key is set", () => {
+    expect(resolveSandboxLlmProfile({ AI_GATEWAY_API_KEY: "vck_test" })).toEqual({
+      provider: "ai_gateway",
+      model: `openai/${hyperlocaliseAgentModelId}`,
+    });
+  });
+
+  it("keeps the OpenAI profile when only OPENAI_API_KEY is set", () => {
+    expect(resolveSandboxLlmProfile({ OPENAI_API_KEY: "sk-openai" })).toEqual({
+      provider: "openai",
+      model: hyperlocaliseAgentModelId,
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-llm.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-llm.test.ts
@@ -60,6 +60,24 @@ describe("resolveSandboxTranslationEnv", () => {
       "OPENAI_API_KEY or AI_GATEWAY_API_KEY is not configured",
     );
   });
+
+  it("passes only the BYOK provider key when an organization credential is present", () => {
+    expect(
+      resolveSandboxTranslationEnv(
+        {
+          OPENAI_API_KEY: "sk-platform",
+          AI_GATEWAY_API_KEY: "vck_platform",
+        },
+        {
+          provider: "anthropic",
+          apiKey: "sk-ant-org",
+          model: "claude-sonnet-4-6",
+        },
+      ),
+    ).toEqual({
+      ANTHROPIC_API_KEY: "sk-ant-org",
+    });
+  });
 });
 
 describe("resolveSandboxLlmProfile", () => {
@@ -74,6 +92,22 @@ describe("resolveSandboxLlmProfile", () => {
     expect(resolveSandboxLlmProfile({ OPENAI_API_KEY: "sk-openai" })).toEqual({
       provider: "openai",
       model: hyperlocaliseAgentModelId,
+    });
+  });
+
+  it("uses the organization BYOK provider and model when a credential is present", () => {
+    expect(
+      resolveSandboxLlmProfile(
+        { AI_GATEWAY_API_KEY: "vck_test" },
+        {
+          provider: "gemini",
+          apiKey: "gem-org",
+          model: "gemini-3.5-flash",
+        },
+      ),
+    ).toEqual({
+      provider: "gemini",
+      model: "gemini-3.5-flash",
     });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-llm.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-llm.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { hyperlocaliseAgentModelId } from "@/lib/agent-runtime/loops/model-id";
+
+export const sandboxOpenAiApiKeyEnv = "OPENAI_API_KEY";
+export const sandboxAiGatewayApiKeyEnv = "AI_GATEWAY_API_KEY";
+export const sandboxAiGatewayBaseUrlEnv = "AI_GATEWAY_BASE_URL";
+
+export type SandboxLlmProvider = "ai_gateway" | "openai";
+
+export type SandboxTranslationEnvSource = {
+  OPENAI_API_KEY?: string;
+  AI_GATEWAY_API_KEY?: string;
+  AI_GATEWAY_BASE_URL?: string;
+};
+
+export type SandboxLlmProfile = {
+  provider: SandboxLlmProvider;
+  model: string;
+};
+
+function trimEnvValue(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function resolveSandboxLlmProfile(
+  source: SandboxTranslationEnvSource,
+): SandboxLlmProfile {
+  if (trimEnvValue(source.AI_GATEWAY_API_KEY)) {
+    return {
+      provider: "ai_gateway",
+      model: `openai/${hyperlocaliseAgentModelId}`,
+    };
+  }
+
+  return {
+    provider: "openai",
+    model: hyperlocaliseAgentModelId,
+  };
+}
+
+export function resolveSandboxTranslationEnv(
+  source: SandboxTranslationEnvSource,
+): Record<string, string> {
+  const openaiApiKey = trimEnvValue(source.OPENAI_API_KEY);
+  const aiGatewayApiKey = trimEnvValue(source.AI_GATEWAY_API_KEY);
+  const aiGatewayBaseUrl = trimEnvValue(source.AI_GATEWAY_BASE_URL);
+
+  if (!openaiApiKey && !aiGatewayApiKey) {
+    throw new Error("OPENAI_API_KEY or AI_GATEWAY_API_KEY is not configured");
+  }
+
+  return {
+    ...(openaiApiKey ? { [sandboxOpenAiApiKeyEnv]: openaiApiKey } : {}),
+    ...(aiGatewayApiKey ? { [sandboxAiGatewayApiKeyEnv]: aiGatewayApiKey } : {}),
+    ...(aiGatewayBaseUrl ? { [sandboxAiGatewayBaseUrlEnv]: aiGatewayBaseUrl } : {}),
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-llm.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-llm.ts
@@ -16,12 +16,21 @@ export const sandboxOpenAiApiKeyEnv = "OPENAI_API_KEY";
 export const sandboxAiGatewayApiKeyEnv = "AI_GATEWAY_API_KEY";
 export const sandboxAiGatewayBaseUrlEnv = "AI_GATEWAY_BASE_URL";
 
-export type SandboxLlmProvider = "ai_gateway" | "openai";
+export const sandboxByokProviders = ["openai", "anthropic", "gemini", "groq", "mistral"] as const;
+
+export type SandboxByokProvider = (typeof sandboxByokProviders)[number];
+export type SandboxLlmProvider = SandboxByokProvider | "ai_gateway";
 
 export type SandboxTranslationEnvSource = {
-  OPENAI_API_KEY?: string;
-  AI_GATEWAY_API_KEY?: string;
-  AI_GATEWAY_BASE_URL?: string;
+  OPENAI_API_KEY?: string | undefined;
+  AI_GATEWAY_API_KEY?: string | undefined;
+  AI_GATEWAY_BASE_URL?: string | undefined;
+};
+
+export type SandboxByokCredential = {
+  provider: SandboxByokProvider;
+  apiKey: string;
+  model: string;
 };
 
 export type SandboxLlmProfile = {
@@ -29,15 +38,36 @@ export type SandboxLlmProfile = {
   model: string;
 };
 
+export const sandboxApiKeyEnvByByokProvider = {
+  openai: "OPENAI_API_KEY",
+  anthropic: "ANTHROPIC_API_KEY",
+  gemini: "GEMINI_API_KEY",
+  groq: "GROQ_API_KEY",
+  mistral: "MISTRAL_API_KEY",
+} as const satisfies Record<SandboxByokProvider, string>;
+
+function readEnvValue(source: object, key: keyof SandboxTranslationEnvSource): string | undefined {
+  const value = (source as SandboxTranslationEnvSource)[key];
+  return typeof value === "string" ? value : undefined;
+}
+
 function trimEnvValue(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   return trimmed ? trimmed : undefined;
 }
 
 export function resolveSandboxLlmProfile(
-  source: SandboxTranslationEnvSource,
+  source: object,
+  byok?: SandboxByokCredential | null,
 ): SandboxLlmProfile {
-  if (trimEnvValue(source.AI_GATEWAY_API_KEY)) {
+  if (byok) {
+    return {
+      provider: byok.provider,
+      model: byok.model,
+    };
+  }
+
+  if (trimEnvValue(readEnvValue(source, "AI_GATEWAY_API_KEY"))) {
     return {
       provider: "ai_gateway",
       model: `openai/${hyperlocaliseAgentModelId}`,
@@ -51,11 +81,23 @@ export function resolveSandboxLlmProfile(
 }
 
 export function resolveSandboxTranslationEnv(
-  source: SandboxTranslationEnvSource,
+  source: object,
+  byok?: SandboxByokCredential | null,
 ): Record<string, string> {
-  const openaiApiKey = trimEnvValue(source.OPENAI_API_KEY);
-  const aiGatewayApiKey = trimEnvValue(source.AI_GATEWAY_API_KEY);
-  const aiGatewayBaseUrl = trimEnvValue(source.AI_GATEWAY_BASE_URL);
+  if (byok) {
+    const apiKey = trimEnvValue(byok.apiKey);
+    if (!apiKey) {
+      throw new Error("organization provider credential is incomplete");
+    }
+
+    return {
+      [sandboxApiKeyEnvByByokProvider[byok.provider]]: apiKey,
+    };
+  }
+
+  const openaiApiKey = trimEnvValue(readEnvValue(source, "OPENAI_API_KEY"));
+  const aiGatewayApiKey = trimEnvValue(readEnvValue(source, "AI_GATEWAY_API_KEY"));
+  const aiGatewayBaseUrl = trimEnvValue(readEnvValue(source, "AI_GATEWAY_BASE_URL"));
 
   if (!openaiApiKey && !aiGatewayApiKey) {
     throw new Error("OPENAI_API_KEY or AI_GATEWAY_API_KEY is not configured");

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
@@ -24,6 +24,8 @@ const sandboxMocks = vi.hoisted(() => {
 vi.mock("@/lib/env", () => ({
   env: {
     OPENAI_API_KEY: "test-openai-api-key",
+    AI_GATEWAY_API_KEY: undefined as string | undefined,
+    AI_GATEWAY_BASE_URL: undefined as string | undefined,
     FILE_STORAGE_PROVIDER: "vercel_blob",
     FILE_STORAGE_ACCESS: "private",
   },
@@ -46,6 +48,7 @@ vi.mock("@vercel/sandbox", () => ({
   },
 }));
 
+import { env } from "@/lib/env";
 import {
   buildCrowdinFileSandboxConfig,
   buildCrowdinTranslationPath,
@@ -54,6 +57,7 @@ import {
   createTranslationSandbox,
   extractSandboxEntries,
   getOutputFilenamePattern,
+  getSandboxTranslationEnv,
   isSandboxDisconnectError,
   isSandboxStreamClosedError,
   isSandboxTransientNetworkError,
@@ -459,6 +463,8 @@ describe("sandbox translation temporary config", () => {
     const config = buildTempConfig("source.md", "source-de-DE.md", "en-US", "de-DE", null);
     expect(config).toContain("  file:");
     expect(config).not.toContain("  email:");
+    expect(config).toContain("provider: openai");
+    expect(config).toContain("model: gpt-5.6-luna");
     expect(config).toContain('from: "source.md"');
     expect(config).toContain('to: "source-de-DE.md"');
   });
@@ -558,6 +564,27 @@ describe("sandbox translation temporary config", () => {
     expect(config).toContain('from: "work_b_labels.json"');
     expect(config).toContain('to: "work_b_labels-{{target}}.json"');
     expect(config).toContain('- "fr-FR"');
+  });
+
+  it("writes an ai_gateway profile and passes the Gateway key when that env var is set", () => {
+    const previousKey = env.AI_GATEWAY_API_KEY;
+    const previousBaseUrl = env.AI_GATEWAY_BASE_URL;
+    env.AI_GATEWAY_API_KEY = "vck_test_key";
+    env.AI_GATEWAY_BASE_URL = "https://ai-gateway.example.test/v1";
+    try {
+      const config = buildTempConfig("source.json", "target.json", "en-US", "fr-FR", null);
+
+      expect(config).toContain("provider: ai_gateway");
+      expect(config).toContain("model: openai/gpt-5.6-luna");
+      expect(getSandboxTranslationEnv()).toEqual({
+        OPENAI_API_KEY: "test-openai-api-key",
+        AI_GATEWAY_API_KEY: "vck_test_key",
+        AI_GATEWAY_BASE_URL: "https://ai-gateway.example.test/v1",
+      });
+    } finally {
+      env.AI_GATEWAY_API_KEY = previousKey;
+      env.AI_GATEWAY_BASE_URL = previousBaseUrl;
+    }
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
@@ -12,23 +12,26 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-const sandboxMocks = vi.hoisted(() => {
+const { envMock, sandboxMocks } = vi.hoisted(() => {
   const create = vi.fn();
   const output = vi.fn();
   const runCommand = vi.fn();
   const get = vi.fn();
 
-  return { create, get, output, runCommand };
+  return {
+    envMock: {
+      OPENAI_API_KEY: "test-openai-api-key" as string | undefined,
+      AI_GATEWAY_API_KEY: undefined as string | undefined,
+      AI_GATEWAY_BASE_URL: undefined as string | undefined,
+      FILE_STORAGE_PROVIDER: "vercel_blob",
+      FILE_STORAGE_ACCESS: "private",
+    },
+    sandboxMocks: { create, get, output, runCommand },
+  };
 });
 
 vi.mock("@/lib/env", () => ({
-  env: {
-    OPENAI_API_KEY: "test-openai-api-key",
-    AI_GATEWAY_API_KEY: undefined as string | undefined,
-    AI_GATEWAY_BASE_URL: undefined as string | undefined,
-    FILE_STORAGE_PROVIDER: "vercel_blob",
-    FILE_STORAGE_ACCESS: "private",
-  },
+  env: envMock,
 }));
 
 vi.mock("@vercel/sandbox", () => ({
@@ -48,7 +51,6 @@ vi.mock("@vercel/sandbox", () => ({
   },
 }));
 
-import { env } from "@/lib/env";
 import {
   buildCrowdinFileSandboxConfig,
   buildCrowdinTranslationPath,
@@ -566,11 +568,34 @@ describe("sandbox translation temporary config", () => {
     expect(config).toContain('- "fr-FR"');
   });
 
+  it("writes the organization BYOK profile when a credential is provided", () => {
+    const byok = {
+      provider: "gemini" as const,
+      apiKey: "gem-org",
+      model: "gemini-3.5-flash",
+    };
+    const config = buildTempConfig(
+      "source.json",
+      "target.json",
+      "en-US",
+      "fr-FR",
+      null,
+      null,
+      byok,
+    );
+
+    expect(config).toContain("provider: gemini");
+    expect(config).toContain("model: gemini-3.5-flash");
+    expect(getSandboxTranslationEnv(byok)).toEqual({
+      GEMINI_API_KEY: "gem-org",
+    });
+  });
+
   it("writes an ai_gateway profile and passes the Gateway key when that env var is set", () => {
-    const previousKey = env.AI_GATEWAY_API_KEY;
-    const previousBaseUrl = env.AI_GATEWAY_BASE_URL;
-    env.AI_GATEWAY_API_KEY = "vck_test_key";
-    env.AI_GATEWAY_BASE_URL = "https://ai-gateway.example.test/v1";
+    const previousKey = envMock.AI_GATEWAY_API_KEY;
+    const previousBaseUrl = envMock.AI_GATEWAY_BASE_URL;
+    envMock.AI_GATEWAY_API_KEY = "vck_test_key";
+    envMock.AI_GATEWAY_BASE_URL = "https://ai-gateway.example.test/v1";
     try {
       const config = buildTempConfig("source.json", "target.json", "en-US", "fr-FR", null);
 
@@ -582,8 +607,8 @@ describe("sandbox translation temporary config", () => {
         AI_GATEWAY_BASE_URL: "https://ai-gateway.example.test/v1",
       });
     } finally {
-      env.AI_GATEWAY_API_KEY = previousKey;
-      env.AI_GATEWAY_BASE_URL = previousBaseUrl;
+      envMock.AI_GATEWAY_API_KEY = previousKey;
+      envMock.AI_GATEWAY_BASE_URL = previousBaseUrl;
     }
   });
 });

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
@@ -14,8 +14,11 @@ import { randomUUID } from "node:crypto";
 
 import { Sandbox, StreamError } from "@vercel/sandbox";
 
-import { hyperlocaliseAgentModelId } from "@/lib/agent-runtime/loops/model-id";
 import { env } from "@/lib/env";
+import {
+  resolveSandboxLlmProfile,
+  resolveSandboxTranslationEnv,
+} from "@/lib/translation/sandbox-llm";
 import { createConfiguredVercelSandbox } from "@/lib/vercel-sandbox-config";
 import {
   inferSupportedFileTranslationFileFormat,
@@ -470,6 +473,7 @@ export class HyperlocaliseCliConfigBuilder {
       `      - from: ${yamlString(file.from)}`,
       `        to: ${yamlString(file.to)}`,
     ]);
+    const llmProfile = resolveSandboxLlmProfile(env);
 
     return [
       "locales:",
@@ -485,8 +489,8 @@ export class HyperlocaliseCliConfigBuilder {
       "llm:",
       "  profiles:",
       "    default:",
-      "      provider: openai",
-      `      model: ${hyperlocaliseAgentModelId}`,
+      `      provider: ${llmProfile.provider}`,
+      `      model: ${llmProfile.model}`,
       `      system_prompt: ${yamlString(systemPrompt)}`,
       `      user_prompt: ${yamlString(userPrompt)}`,
     ].join("\n");
@@ -819,11 +823,7 @@ const defaultLifecycle = new SandboxLifecycle();
 const defaultRunner = new HyperlocaliseCliRunner(defaultLifecycle);
 
 export function getSandboxTranslationEnv(): Record<string, string> {
-  if (!env.OPENAI_API_KEY) {
-    throw new Error("OPENAI_API_KEY is not configured");
-  }
-
-  return { OPENAI_API_KEY: env.OPENAI_API_KEY };
+  return resolveSandboxTranslationEnv(env);
 }
 
 export function getOutputFilename(inputFilename: string, targetLocale: string): string {

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox.ts
@@ -18,6 +18,7 @@ import { env } from "@/lib/env";
 import {
   resolveSandboxLlmProfile,
   resolveSandboxTranslationEnv,
+  type SandboxByokCredential,
 } from "@/lib/translation/sandbox-llm";
 import { createConfiguredVercelSandbox } from "@/lib/vercel-sandbox-config";
 import {
@@ -425,6 +426,7 @@ export class HyperlocaliseCliConfigBuilder {
     targetLocale: string,
     instructions: string | null = null,
     context: SandboxTranslationContext | null = null,
+    byok?: SandboxByokCredential | null,
   ): string {
     return this.buildMultiLocale(
       inputFile,
@@ -433,6 +435,7 @@ export class HyperlocaliseCliConfigBuilder {
       [targetLocale],
       instructions,
       context,
+      byok,
     );
   }
 
@@ -443,6 +446,7 @@ export class HyperlocaliseCliConfigBuilder {
     targetLocales: string[],
     instructions: string | null = null,
     context: SandboxTranslationContext | null = null,
+    byok?: SandboxByokCredential | null,
   ): string {
     return this.buildMultiFileMultiLocale(
       [{ from: inputFile, to: outputPattern }],
@@ -450,6 +454,7 @@ export class HyperlocaliseCliConfigBuilder {
       targetLocales,
       instructions,
       context,
+      byok,
     );
   }
 
@@ -460,6 +465,7 @@ export class HyperlocaliseCliConfigBuilder {
     targetLocales: string[],
     instructions: string | null = null,
     context: SandboxTranslationContext | null = null,
+    byok?: SandboxByokCredential | null,
   ): string {
     if (files.length === 0) {
       throw new Error("buildMultiFileMultiLocale requires at least one file mapping");
@@ -473,7 +479,7 @@ export class HyperlocaliseCliConfigBuilder {
       `      - from: ${yamlString(file.from)}`,
       `        to: ${yamlString(file.to)}`,
     ]);
-    const llmProfile = resolveSandboxLlmProfile(env);
+    const llmProfile = resolveSandboxLlmProfile(env, byok);
 
     return [
       "locales:",
@@ -683,6 +689,7 @@ export class HyperlocaliseCliRunner {
     targetLocale: string,
     instructions: string | null = null,
     context: SandboxTranslationContext | null = null,
+    byok?: SandboxByokCredential | null,
   ): string {
     return this.configBuilder.build(
       inputFile,
@@ -691,6 +698,7 @@ export class HyperlocaliseCliRunner {
       targetLocale,
       instructions,
       context,
+      byok,
     );
   }
 
@@ -701,6 +709,7 @@ export class HyperlocaliseCliRunner {
     targetLocales: string[],
     instructions: string | null = null,
     context: SandboxTranslationContext | null = null,
+    byok?: SandboxByokCredential | null,
   ): string {
     return this.configBuilder.buildMultiLocale(
       inputFile,
@@ -709,6 +718,7 @@ export class HyperlocaliseCliRunner {
       targetLocales,
       instructions,
       context,
+      byok,
     );
   }
 
@@ -718,6 +728,7 @@ export class HyperlocaliseCliRunner {
     targetLocales: string[],
     instructions: string | null = null,
     context: SandboxTranslationContext | null = null,
+    byok?: SandboxByokCredential | null,
   ): string {
     return this.configBuilder.buildMultiFileMultiLocale(
       files,
@@ -725,6 +736,7 @@ export class HyperlocaliseCliRunner {
       targetLocales,
       instructions,
       context,
+      byok,
     );
   }
 
@@ -822,8 +834,10 @@ export class HyperlocaliseCliRunner {
 const defaultLifecycle = new SandboxLifecycle();
 const defaultRunner = new HyperlocaliseCliRunner(defaultLifecycle);
 
-export function getSandboxTranslationEnv(): Record<string, string> {
-  return resolveSandboxTranslationEnv(env);
+export function getSandboxTranslationEnv(
+  byok?: SandboxByokCredential | null,
+): Record<string, string> {
+  return resolveSandboxTranslationEnv(env, byok);
 }
 
 export function getOutputFilename(inputFilename: string, targetLocale: string): string {
@@ -906,6 +920,7 @@ export function buildTempConfig(
   targetLocale: string,
   instructions: string | null = null,
   context: SandboxTranslationContext | null = null,
+  byok?: SandboxByokCredential | null,
 ) {
   return defaultRunner.buildConfig(
     inputFile,
@@ -914,6 +929,7 @@ export function buildTempConfig(
     targetLocale,
     instructions,
     context,
+    byok,
   );
 }
 
@@ -924,6 +940,7 @@ export function buildMultiLocaleTempConfig(
   targetLocales: string[],
   instructions: string | null = null,
   context: SandboxTranslationContext | null = null,
+  byok?: SandboxByokCredential | null,
 ) {
   return defaultRunner.buildMultiLocaleConfig(
     inputFile,
@@ -932,6 +949,7 @@ export function buildMultiLocaleTempConfig(
     targetLocales,
     instructions,
     context,
+    byok,
   );
 }
 
@@ -941,6 +959,7 @@ export function buildMultiFileMultiLocaleTempConfig(
   targetLocales: string[],
   instructions: string | null = null,
   context: SandboxTranslationContext | null = null,
+  byok?: SandboxByokCredential | null,
 ) {
   return defaultRunner.buildMultiFileMultiLocaleConfig(
     files,
@@ -948,6 +967,7 @@ export function buildMultiFileMultiLocaleTempConfig(
     targetLocales,
     instructions,
     context,
+    byok,
   );
 }
 

--- a/apps/hyperlocalise-web/src/workflows/email-translation.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/email-translation.test.ts
@@ -121,6 +121,26 @@ describe("email translation temporary config", () => {
       expect(config).toContain("model: openai/gpt-5.6-luna");
     });
   });
+
+  it("writes the organization BYOK profile when a credential is provided", () => {
+    withSandboxLlmEnv({ AI_GATEWAY_API_KEY: "vck_test_key" }, () => {
+      const byok = {
+        provider: "anthropic" as const,
+        apiKey: "sk-ant-org",
+        model: "claude-sonnet-4-6",
+      };
+
+      expect(buildTempConfig("source.json", "target.json", "en", "fr", null, byok)).toContain(
+        "provider: anthropic",
+      );
+      expect(buildTempConfig("source.json", "target.json", "en", "fr", null, byok)).toContain(
+        "model: claude-sonnet-4-6",
+      );
+      expect(getSandboxTranslationEnv(byok)).toEqual({
+        ANTHROPIC_API_KEY: "sk-ant-org",
+      });
+    });
+  });
 });
 
 describe("translated file diagnostics", () => {

--- a/apps/hyperlocalise-web/src/workflows/email-translation.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/email-translation.test.ts
@@ -21,6 +21,41 @@ import {
   getSandboxTranslationEnv,
 } from "./email-translation";
 
+function withSandboxLlmEnv(
+  values: {
+    OPENAI_API_KEY?: string;
+    AI_GATEWAY_API_KEY?: string;
+    AI_GATEWAY_BASE_URL?: string;
+  },
+  run: () => void,
+) {
+  const previous = {
+    OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+    AI_GATEWAY_API_KEY: process.env.AI_GATEWAY_API_KEY,
+    AI_GATEWAY_BASE_URL: process.env.AI_GATEWAY_BASE_URL,
+  };
+
+  for (const key of ["OPENAI_API_KEY", "AI_GATEWAY_API_KEY", "AI_GATEWAY_BASE_URL"] as const) {
+    if (values[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = values[key];
+    }
+  }
+
+  try {
+    run();
+  } finally {
+    for (const key of ["OPENAI_API_KEY", "AI_GATEWAY_API_KEY", "AI_GATEWAY_BASE_URL"] as const) {
+      if (previous[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous[key];
+      }
+    }
+  }
+}
+
 describe("email translation workflow filenames", () => {
   it("preserves the attachment extension for sandbox input and output files", () => {
     expect(getSandboxInputFilename("en-US.json")).toBe("en-US.json");
@@ -38,19 +73,26 @@ describe("email translation workflow filenames", () => {
   });
 
   it("passes provider credentials to the sandbox translation command", () => {
-    const previous = process.env.OPENAI_API_KEY;
-    process.env.OPENAI_API_KEY = "test-openai-api-key";
-    try {
+    withSandboxLlmEnv({ OPENAI_API_KEY: "test-openai-api-key" }, () => {
       expect(getSandboxTranslationEnv()).toEqual({
         OPENAI_API_KEY: "test-openai-api-key",
       });
-    } finally {
-      if (previous === undefined) {
-        delete process.env.OPENAI_API_KEY;
-      } else {
-        process.env.OPENAI_API_KEY = previous;
-      }
-    }
+    });
+  });
+
+  it("passes the AI Gateway key to the sandbox when that env var is set", () => {
+    withSandboxLlmEnv(
+      {
+        AI_GATEWAY_API_KEY: "vck_test_key",
+        AI_GATEWAY_BASE_URL: "https://ai-gateway.example.test/v1",
+      },
+      () => {
+        expect(getSandboxTranslationEnv()).toEqual({
+          AI_GATEWAY_API_KEY: "vck_test_key",
+          AI_GATEWAY_BASE_URL: "https://ai-gateway.example.test/v1",
+        });
+      },
+    );
   });
 });
 
@@ -69,6 +111,15 @@ describe("email translation temporary config", () => {
 
     expect(config).toContain("system_prompt:");
     expect(config).not.toContain("User style instructions:");
+  });
+
+  it("writes an ai_gateway profile when AI_GATEWAY_API_KEY is set", () => {
+    withSandboxLlmEnv({ AI_GATEWAY_API_KEY: "vck_test_key" }, () => {
+      const config = buildTempConfig("source.json", "target.json", "en", "fr", null);
+
+      expect(config).toContain("provider: ai_gateway");
+      expect(config).toContain("model: openai/gpt-5.6-luna");
+    });
   });
 });
 

--- a/apps/hyperlocalise-web/src/workflows/email-translation.ts
+++ b/apps/hyperlocalise-web/src/workflows/email-translation.ts
@@ -12,7 +12,10 @@
  */
 import { getWorkflowMetadata } from "workflow";
 
-import { hyperlocaliseAgentModelId } from "@/lib/agent-runtime/loops/model-id";
+import {
+  resolveSandboxLlmProfile,
+  resolveSandboxTranslationEnv,
+} from "@/lib/translation/sandbox-llm";
 import type { EmailAgentTask, EmailAgentTaskAttachment } from "@/lib/workflow/types";
 import {
   markEmailTranslationJobFailed,
@@ -99,6 +102,7 @@ export function buildTempConfig(
     .filter((line): line is string => line !== null)
     .join("\n");
   const userPrompt = ["Translate from {{source}} to {{target}}.", "", "{{input}}"].join("\n");
+  const llmProfile = resolveSandboxLlmProfile(process.env);
 
   return [
     "locales:",
@@ -115,8 +119,8 @@ export function buildTempConfig(
     "llm:",
     "  profiles:",
     "    default:",
-    "      provider: openai",
-    `      model: ${hyperlocaliseAgentModelId}`,
+    `      provider: ${llmProfile.provider}`,
+    `      model: ${llmProfile.model}`,
     `      system_prompt: ${yamlString(systemPrompt)}`,
     `      user_prompt: ${yamlString(userPrompt)}`,
   ].join("\n");
@@ -200,14 +204,7 @@ function shellQuote(value: string): string {
 export function getSandboxTranslationEnv(): Record<string, string> {
   // Read process.env directly so this workflow module never static-imports `@/lib/env`
   // (t3 env + Next helpers are unsafe in the Workflow DevKit sandbox).
-  const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) {
-    throw new Error("OPENAI_API_KEY is not configured");
-  }
-
-  return {
-    OPENAI_API_KEY: apiKey,
-  };
+  return resolveSandboxTranslationEnv(process.env);
 }
 
 async function sendReplyEmail(

--- a/apps/hyperlocalise-web/src/workflows/email-translation.ts
+++ b/apps/hyperlocalise-web/src/workflows/email-translation.ts
@@ -15,6 +15,7 @@ import { getWorkflowMetadata } from "workflow";
 import {
   resolveSandboxLlmProfile,
   resolveSandboxTranslationEnv,
+  type SandboxByokCredential,
 } from "@/lib/translation/sandbox-llm";
 import type { EmailAgentTask, EmailAgentTaskAttachment } from "@/lib/workflow/types";
 import {
@@ -89,6 +90,7 @@ export function buildTempConfig(
   sourceLocale: string | null,
   targetLocale: string,
   instructions: string | null = null,
+  byok?: SandboxByokCredential | null,
 ): string {
   const yamlString = (value: string) => JSON.stringify(value);
   const normalizedInstructions = instructions?.trim();
@@ -102,7 +104,7 @@ export function buildTempConfig(
     .filter((line): line is string => line !== null)
     .join("\n");
   const userPrompt = ["Translate from {{source}} to {{target}}.", "", "{{input}}"].join("\n");
-  const llmProfile = resolveSandboxLlmProfile(process.env);
+  const llmProfile = resolveSandboxLlmProfile(process.env, byok);
 
   return [
     "locales:",
@@ -145,11 +147,21 @@ async function runTranslationCommand(
   sourceLocale: string | null,
   targetLocale: string,
   instructions: string | null,
+  jobId: string,
 ): Promise<{ exitCode: number; output: string }> {
   "use step";
 
   const { sandboxI18nConfigPath } = await import("@/lib/translation/sandbox");
-  const config = buildTempConfig(inputFile, outputFile, sourceLocale, targetLocale, instructions);
+  const { loadSandboxByokCredentialForJob } = await import("@/lib/translation/sandbox-byok");
+  const byok = await loadSandboxByokCredentialForJob(jobId);
+  const config = buildTempConfig(
+    inputFile,
+    outputFile,
+    sourceLocale,
+    targetLocale,
+    instructions,
+    byok,
+  );
   await writeTempConfig(sandboxId, config, sandboxI18nConfigPath);
 
   return runSandboxCommand(
@@ -160,7 +172,7 @@ async function runTranslationCommand(
       `hl run --config ${shellQuote(sandboxI18nConfigPath)} --locale ${shellQuote(targetLocale)} --force --progress off`,
     ],
     {
-      env: getSandboxTranslationEnv(),
+      env: getSandboxTranslationEnv(byok),
     },
   );
 }
@@ -201,10 +213,12 @@ function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
-export function getSandboxTranslationEnv(): Record<string, string> {
+export function getSandboxTranslationEnv(
+  byok?: SandboxByokCredential | null,
+): Record<string, string> {
   // Read process.env directly so this workflow module never static-imports `@/lib/env`
   // (t3 env + Next helpers are unsafe in the Workflow DevKit sandbox).
-  return resolveSandboxTranslationEnv(process.env);
+  return resolveSandboxTranslationEnv(process.env, byok);
 }
 
 async function sendReplyEmail(
@@ -381,6 +395,7 @@ export async function emailTranslationWorkflow(task: EmailAgentTask) {
       sourceLocale,
       targetLocale,
       instructions,
+      task.jobId,
     );
 
     if (translation.exitCode !== 0) {

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -107,7 +107,7 @@ function classifyCliFailureKind(output: string): string {
   if (output.includes("escapes root")) {
     return "path_escapes_root";
   }
-  if (output.includes("OPENAI_API_KEY")) {
+  if (output.includes("OPENAI_API_KEY") || output.includes("AI_GATEWAY_API_KEY")) {
     return "missing_openai_api_key";
   }
   if (output.includes("planning tasks")) {

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -107,7 +107,14 @@ function classifyCliFailureKind(output: string): string {
   if (output.includes("escapes root")) {
     return "path_escapes_root";
   }
-  if (output.includes("OPENAI_API_KEY") || output.includes("AI_GATEWAY_API_KEY")) {
+  if (
+    output.includes("OPENAI_API_KEY") ||
+    output.includes("AI_GATEWAY_API_KEY") ||
+    output.includes("ANTHROPIC_API_KEY") ||
+    output.includes("GEMINI_API_KEY") ||
+    output.includes("GROQ_API_KEY") ||
+    output.includes("MISTRAL_API_KEY")
+  ) {
     return "missing_openai_api_key";
   }
   if (output.includes("planning tasks")) {
@@ -308,7 +315,7 @@ async function runTranslationStep(
   instructions: string | null,
   context: SandboxTranslationContext,
   prefilledByLocale: Record<string, Record<string, string>>,
-  options?: { force?: boolean; maxTranslations?: number },
+  options?: { force?: boolean; maxTranslations?: number; organizationId?: string },
 ) {
   "use step";
 
@@ -322,6 +329,10 @@ async function runTranslationStep(
     writeFileToSandbox,
     writeTempConfig,
   } = await import("@/lib/translation/sandbox");
+  const { loadSandboxByokCredential } = await import("@/lib/translation/sandbox-byok");
+  const byok = options?.organizationId
+    ? await loadSandboxByokCredential(options.organizationId)
+    : null;
 
   const config = buildMultiLocaleTempConfig(
     inputFile,
@@ -330,6 +341,7 @@ async function runTranslationStep(
     targetLocales,
     instructions,
     context,
+    byok,
   );
   await writeTempConfig(sandboxId, config, sandboxI18nConfigPath);
 
@@ -370,7 +382,7 @@ async function runTranslationStep(
         `hl run --config '${shellSingleQuote(sandboxI18nConfigPath)}'${localeArg}${forceFlag}${maxTranslationsFlag} --progress off${prefilledFlags}`,
       ],
       {
-        env: getSandboxTranslationEnv(),
+        env: getSandboxTranslationEnv(byok),
       },
     );
   } catch (error) {
@@ -982,7 +994,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
               .filter((locale) => prefilledByLocale[locale])
               .map((locale) => [locale, prefilledByLocale[locale]]),
           ),
-          { force: runForce, maxTranslations },
+          { force: runForce, maxTranslations, organizationId },
         );
 
       let translation: Awaited<ReturnType<typeof runTranslationStep>>;

--- a/docs/adr/2026-08-16-agent-ai-gateway-default-design.md
+++ b/docs/adr/2026-08-16-agent-ai-gateway-default-design.md
@@ -42,9 +42,11 @@ BYOK:
 | Image translation | `openai/gpt-image-2` | OpenAI image model through Vercel AI Gateway |
 | Video translation | `google/gemini-omni-flash-preview` | Gemini Omni through the same Gateway |
 
-File-translation sandboxes use `ai_gateway` and pass `AI_GATEWAY_API_KEY` when
-that env var is set. Otherwise they keep `openai` and `OPENAI_API_KEY`. The Go
-CLI supports both providers.
+File-translation sandboxes follow the same BYOK-then-managed order as string
+jobs. When the organization has a stored provider credential, the sandbox CLI
+profile uses that provider, model, and decrypted key. Otherwise they use
+`ai_gateway` and `AI_GATEWAY_API_KEY` when that env var is set, or `openai` and
+`OPENAI_API_KEY`. The Go CLI supports those providers.
 
 OpenAI `reasoningSummary` options apply only for Gateway and OpenAI BYOK.
 

--- a/docs/adr/2026-08-16-agent-ai-gateway-default-design.md
+++ b/docs/adr/2026-08-16-agent-ai-gateway-default-design.md
@@ -42,7 +42,9 @@ BYOK:
 | Image translation | `openai/gpt-image-2` | OpenAI image model through Vercel AI Gateway |
 | Video translation | `google/gemini-omni-flash-preview` | Gemini Omni through the same Gateway |
 
-File-translation sandboxes and the Go CLI still use `OPENAI_API_KEY`.
+File-translation sandboxes use `ai_gateway` and pass `AI_GATEWAY_API_KEY` when
+that env var is set. Otherwise they keep `openai` and `OPENAI_API_KEY`. The Go
+CLI supports both providers.
 
 OpenAI `reasoningSummary` options apply only for Gateway and OpenAI BYOK.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

File, email, and provider-agent translation jobs run `hl` in a Vercel sandbox. Those sandboxes used to hardcode `provider: openai` and only forward `OPENAI_API_KEY`.

They now follow the same credential order as string translation and the agent:

1. **Org BYOK** — if the organization has a stored provider credential, the sandbox uses that provider, model, and decrypted key (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `GROQ_API_KEY`, or `MISTRAL_API_KEY`).
2. **Managed AI Gateway** — if `AI_GATEWAY_API_KEY` is set, the CLI profile is `ai_gateway` with `openai/gpt-5.6-luna`.
3. **Managed OpenAI** — otherwise `openai` and `OPENAI_API_KEY`.

At least one managed key is still required when the org has no BYOK credential.

## How to test

- `vp test src/lib/translation/sandbox-llm.test.ts src/lib/translation/sandbox-byok.test.ts src/lib/translation/sandbox-translation.test.ts src/workflows/email-translation.test.ts src/lib/providers/agent-runs/provider-agent-file-translate.test.ts`
- `vp check --fix`
- Store an org provider key, then run a file or email translation job. The sandbox `hl` config should use that provider/model, and the command env should include only the matching BYOK key.
- With no org key and `AI_GATEWAY_API_KEY` set, the config should use `provider: ai_gateway`.

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4aaa206-3924-4b7d-8c06-76d34e91a314?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4aaa206-3924-4b7d-8c06-76d34e91a314&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

