### PR TITLE
feat(web): roll out Issues and remove workspace-issues flag

### DIFF
--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_issue.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_issue.test.ts
@@ -23,7 +23,6 @@ import { createCreateIssueTool } from "./create_issue";
 const mocks = vi.hoisted(() => ({
   createIssue: vi.fn(),
   updateWorkspaceAutomationRun: vi.fn(),
-  resolveWorkspaceIssuesFlag: vi.fn(),
 }));
 
 vi.mock("@/lib/projects/issue-sheet/issue-sheet-service", () => ({
@@ -34,10 +33,6 @@ vi.mock("@/lib/projects/issue-sheet/issue-sheet-service", () => ({
 
 vi.mock("@/lib/agents/workspace-automations", () => ({
   updateWorkspaceAutomationRun: (...args: unknown[]) => mocks.updateWorkspaceAutomationRun(...args),
-}));
-
-vi.mock("@/lib/flags/workspace-flags", () => ({
-  resolveWorkspaceIssuesFlag: (...args: unknown[]) => mocks.resolveWorkspaceIssuesFlag(...args),
 }));
 
 function session(
@@ -98,7 +93,6 @@ function session(
 describe("createCreateIssueTool", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.resolveWorkspaceIssuesFlag.mockResolvedValue(true);
     mocks.createIssue.mockResolvedValue({
       id: "issue-1",
       key: "ISS-1",
@@ -252,16 +246,5 @@ describe("createCreateIssueTool", () => {
       completed: true,
       issues: [{ id: "issue-1" }, { id: "issue-2" }],
     });
-  });
-
-  it("rejects when workspace Issues is disabled", async () => {
-    mocks.resolveWorkspaceIssuesFlag.mockResolvedValue(false);
-    const tool = createCreateIssueTool(session());
-    await expect(
-      tool.execute!(
-        { issues: [{ title: "Nope" }] },
-        { toolCallId: "call-1", messages: [], context: {} },
-      ),
-    ).rejects.toThrow("issues_feature_unavailable");
   });
 });

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_issue.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/create_issue.ts
@@ -18,7 +18,6 @@ import {
   issueSheetIssueTypeSchema,
 } from "@/api/routes/project/issue-sheet.schema";
 import { updateWorkspaceAutomationRun } from "@/lib/agents/workspace-automations";
-import { resolveWorkspaceIssuesFlag } from "@/lib/flags/workspace-flags";
 import { IssueSheetService } from "@/lib/projects/issue-sheet/issue-sheet-service";
 
 import type { WorkspaceOrchestratorSession } from "../context";
@@ -86,13 +85,6 @@ export function createCreateIssueTool(session: WorkspaceOrchestratorSession) {
       const createConfig = session.automation.toolConfig.createIssue;
       if (!createConfig?.enabled) {
         throw new Error("create_issue_not_configured");
-      }
-
-      const issuesFeatureEnabled = await resolveWorkspaceIssuesFlag({
-        organizationId: session.organizationId,
-      });
-      if (!issuesFeatureEnabled) {
-        throw new Error("issues_feature_unavailable");
       }
 
       const existingOutput = readCreateIssue(session.run.outputSummary, session.stepResults);

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/list_issues.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/list_issues.test.ts
@@ -22,17 +22,12 @@ import { createListIssuesTool } from "./list_issues";
 
 const mocks = vi.hoisted(() => ({
   listIssues: vi.fn(),
-  resolveWorkspaceIssuesFlag: vi.fn(),
 }));
 
 vi.mock("@/lib/projects/issue-sheet/issue-sheet-service", () => ({
   IssueSheetService: class {
     listIssues = mocks.listIssues;
   },
-}));
-
-vi.mock("@/lib/flags/workspace-flags", () => ({
-  resolveWorkspaceIssuesFlag: (...args: unknown[]) => mocks.resolveWorkspaceIssuesFlag(...args),
 }));
 
 function session(
@@ -92,7 +87,6 @@ function session(
 describe("createListIssuesTool", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.resolveWorkspaceIssuesFlag.mockResolvedValue(true);
     mocks.listIssues.mockResolvedValue({
       total: 1,
       summary: { total: 1, open: 1, inProgress: 0, resolved: 0, wontFix: 0 },
@@ -174,13 +168,5 @@ describe("createListIssuesTool", () => {
     await expect(
       tool.execute!({}, { toolCallId: "call-1", messages: [], context: {} }),
     ).rejects.toThrow("automation_author_required");
-  });
-
-  it("rejects when workspace Issues is disabled", async () => {
-    mocks.resolveWorkspaceIssuesFlag.mockResolvedValue(false);
-    const tool = createListIssuesTool(session());
-    await expect(
-      tool.execute!({}, { toolCallId: "call-1", messages: [], context: {} }),
-    ).rejects.toThrow("issues_feature_unavailable");
   });
 });

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/list_issues.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/list_issues.ts
@@ -18,7 +18,6 @@ import {
   issueSheetIssueTypeSchema,
   issueSheetPrioritySchema,
 } from "@/api/routes/project/issue-sheet.schema";
-import { resolveWorkspaceIssuesFlag } from "@/lib/flags/workspace-flags";
 import { IssueSheetService } from "@/lib/projects/issue-sheet/issue-sheet-service";
 
 import type { WorkspaceOrchestratorSession } from "../context";
@@ -72,13 +71,6 @@ export function createListIssuesTool(session: WorkspaceOrchestratorSession) {
       const listConfig = session.automation.toolConfig.listIssues;
       if (!listConfig?.enabled) {
         throw new Error("list_issues_not_configured");
-      }
-
-      const issuesFeatureEnabled = await resolveWorkspaceIssuesFlag({
-        organizationId: session.organizationId,
-      });
-      if (!issuesFeatureEnabled) {
-        throw new Error("issues_feature_unavailable");
       }
 
       const projectId = session.automation.projectId?.trim() || null;

--- a/apps/hyperlocalise-web/src/api/routes/issues/issues.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/issues/issues.route.test.ts
@@ -12,21 +12,20 @@
  */
 import "dotenv/config";
 
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
 import { app } from "@/api/app";
 import { db } from "@/lib/database";
 
 import { createProjectTestFixture } from "../project/project.fixture";
 
-const { resolveApiAuthContextFromSessionMock, workspaceIssuesFlagRunMock } = vi.hoisted(() => ({
+const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
   resolveApiAuthContextFromSessionMock: vi.fn(
     (options) =>
       globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
       globalThis.__testApiAuthContext ??
       null,
   ),
-  workspaceIssuesFlagRunMock: vi.fn(async () => true),
 }));
 
 vi.mock("@/api/auth/workos-session", async (importOriginal) => {
@@ -37,22 +36,10 @@ vi.mock("@/api/auth/workos-session", async (importOriginal) => {
   };
 });
 
-vi.mock("@/lib/flags/workspace-flags", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/flags/workspace-flags")>();
-  return {
-    ...actual,
-    workspaceIssuesFlag: { run: workspaceIssuesFlagRunMock },
-  };
-});
-
 const projectFixture = createProjectTestFixture();
 
 beforeAll(async () => {
   await db.$client.query("select 1");
-});
-
-beforeEach(() => {
-  workspaceIssuesFlagRunMock.mockResolvedValue(true);
 });
 
 afterEach(async () => {
@@ -103,23 +90,6 @@ type ListBody = {
 };
 
 describe("Organization issues routes", () => {
-  it("denies organization issues access when the feature flag is disabled", async () => {
-    workspaceIssuesFlagRunMock.mockResolvedValue(false);
-    const { identity } = await projectFixture.createStoredProjectFixture();
-    const headers = await projectFixture.authHeadersFor(identity);
-    const organizationSlug = identity.organization.slug ?? "missing-slug";
-
-    const response = await requestJson(organizationIssuesUrl(organizationSlug), {
-      headers,
-      query: { view: "all_open" },
-    });
-
-    expect(response.status).toBe(403);
-    await expect(response.json()).resolves.toMatchObject({
-      error: "feature_unavailable",
-    });
-  });
-
   it("lists issues across accessible projects", async () => {
     const { identity, project } = await projectFixture.createStoredProjectFixture();
     const headers = await projectFixture.authHeadersFor(identity);

--- a/apps/hyperlocalise-web/src/api/routes/issues/issues.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/issues/issues.route.ts
@@ -14,10 +14,8 @@ import { Hono } from "hono";
 
 import { hasCapability } from "@/api/auth/policy";
 import { createZodValidator } from "@/api/errors";
-import { createWorkspaceFeatureFlagMiddleware } from "@/api/middleware/workspace-feature-flag";
 import { forbiddenResponse } from "@/api/response.schema";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
-import { workspaceIssuesFlag } from "@/lib/flags/workspace-flags";
 import { organizationIssueService } from "@/lib/projects/issue-sheet/organization-issue-service";
 
 import { organizationIssuesQuerySchema } from "./issues.schema";
@@ -28,15 +26,9 @@ const validateOrganizationIssuesQuery = createZodValidator(
   "invalid_organization_issues_query",
 );
 
-const requireWorkspaceIssuesFeature = createWorkspaceFeatureFlagMiddleware(
-  workspaceIssuesFlag,
-  "Workspace issues is not enabled for this organization",
-);
-
 export function createOrganizationIssuesRoutes() {
   return new Hono<{ Variables: AuthVariables }>()
     .use("*", workosAuthMiddleware)
-    .use("*", requireWorkspaceIssuesFeature)
     .get("/", validateOrganizationIssuesQuery, async (c) => {
       if (!hasCapability(c.var.auth.membership.role, "projects:read")) {
         return forbiddenResponse(c, "forbidden");

--- a/apps/hyperlocalise-web/src/api/routes/issues/organization-issue-sheet.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/issues/organization-issue-sheet.route.ts
@@ -14,10 +14,8 @@ import { Hono } from "hono";
 
 import { hasCapability } from "@/api/auth/policy";
 import { createZodValidator } from "@/api/errors";
-import { createWorkspaceFeatureFlagMiddleware } from "@/api/middleware/workspace-feature-flag";
 import { forbiddenResponse, notFoundResponse } from "@/api/response.schema";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
-import { workspaceIssuesFlag } from "@/lib/flags/workspace-flags";
 import { organizationIssueService } from "@/lib/projects/issue-sheet/organization-issue-service";
 
 import { organizationIssueSheetIssueParamsSchema } from "./issues.schema";
@@ -28,15 +26,9 @@ const validateIssueParams = createZodValidator(
   "invalid_issue_sheet_params",
 );
 
-const requireWorkspaceIssuesFeature = createWorkspaceFeatureFlagMiddleware(
-  workspaceIssuesFlag,
-  "Workspace issues is not enabled for this organization",
-);
-
 export function createOrganizationIssueSheetRoutes() {
   return new Hono<{ Variables: AuthVariables }>()
     .use("*", workosAuthMiddleware)
-    .use("*", requireWorkspaceIssuesFeature)
     .get("/:issueId", validateIssueParams, async (c) => {
       if (!hasCapability(c.var.auth.membership.role, "projects:read")) {
         return forbiddenResponse(c, "forbidden");

--- a/apps/hyperlocalise-web/src/api/routes/mentions/mention-suggestions.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mentions/mention-suggestions.route.test.ts
@@ -12,21 +12,20 @@
  */
 import "dotenv/config";
 
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
 import { app } from "@/api/app";
 import { db } from "@/lib/database";
 
 import { createProjectTestFixture } from "../project/project.fixture";
 
-const { resolveApiAuthContextFromSessionMock, workspaceIssuesFlagRunMock } = vi.hoisted(() => ({
+const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
   resolveApiAuthContextFromSessionMock: vi.fn(
     (options) =>
       globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
       globalThis.__testApiAuthContext ??
       null,
   ),
-  workspaceIssuesFlagRunMock: vi.fn(async () => true),
 }));
 
 vi.mock("@/api/auth/workos-session", async (importOriginal) => {
@@ -37,22 +36,10 @@ vi.mock("@/api/auth/workos-session", async (importOriginal) => {
   };
 });
 
-vi.mock("@/lib/flags/workspace-flags", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/flags/workspace-flags")>();
-  return {
-    ...actual,
-    workspaceIssuesFlag: { run: workspaceIssuesFlagRunMock },
-  };
-});
-
 const projectFixture = createProjectTestFixture();
 
 beforeAll(async () => {
   await db.$client.query("select 1");
-});
-
-beforeEach(() => {
-  workspaceIssuesFlagRunMock.mockResolvedValue(true);
 });
 
 afterEach(async () => {

--- a/apps/hyperlocalise-web/src/api/routes/mentions/mention-suggestions.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mentions/mention-suggestions.route.ts
@@ -17,17 +17,10 @@ import { createZodValidator } from "@/api/errors";
 import { hasCapability } from "@/api/auth/policy";
 import { buildAccessibleProjectsWhere } from "@/api/auth/team-access";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
-import { createWorkspaceFeatureFlagMiddleware } from "@/api/middleware/workspace-feature-flag";
 import { forbiddenResponse } from "@/api/response.schema";
 import { db, schema } from "@/lib/database";
-import { workspaceIssuesFlag } from "@/lib/flags/workspace-flags";
 
 import { mentionSuggestionsQuerySchema } from "./mention-suggestions.schema";
-
-const requireWorkspaceIssuesFeature = createWorkspaceFeatureFlagMiddleware(
-  workspaceIssuesFlag,
-  "Workspace issues is not enabled for this organization",
-);
 
 const validateMentionSuggestionsQuery = createZodValidator(
   "query",
@@ -54,7 +47,6 @@ function issueDisplayKey(input: { issueId: string; externalRef: string | null })
 export function createMentionSuggestionsRoutes() {
   return new Hono<{ Variables: AuthVariables }>()
     .use("*", workosAuthMiddleware)
-    .use("*", requireWorkspaceIssuesFeature)
     .get("/", validateMentionSuggestionsQuery, async (c) => {
       if (!hasCapability(c.var.auth.membership.role, "projects:read")) {
         return forbiddenResponse(c, "forbidden");

--- a/apps/hyperlocalise-web/src/api/routes/notifications/notifications.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/notifications/notifications.route.test.ts
@@ -15,7 +15,7 @@ import "dotenv/config";
 import { randomUUID } from "node:crypto";
 
 import { eq } from "drizzle-orm";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
 import { app } from "@/api/app";
 import { db, schema } from "@/lib/database";
@@ -25,14 +25,13 @@ import { ensureDefaultWorkspaceTeam } from "@/lib/teams/default-workspace-team";
 
 import { createProjectTestFixture } from "../project/project.fixture";
 
-const { resolveApiAuthContextFromSessionMock, workspaceIssuesFlagRunMock } = vi.hoisted(() => ({
+const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
   resolveApiAuthContextFromSessionMock: vi.fn(
     (options) =>
       globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
       globalThis.__testApiAuthContext ??
       null,
   ),
-  workspaceIssuesFlagRunMock: vi.fn(async () => true),
 }));
 
 vi.mock("@/api/auth/workos-session", async (importOriginal) => {
@@ -43,24 +42,12 @@ vi.mock("@/api/auth/workos-session", async (importOriginal) => {
   };
 });
 
-vi.mock("@/lib/flags/workspace-flags", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/flags/workspace-flags")>();
-  return {
-    ...actual,
-    workspaceIssuesFlag: { run: workspaceIssuesFlagRunMock },
-  };
-});
-
 const projectFixture = createProjectTestFixture();
 const issueSheetService = new IssueSheetService();
 const notificationService = new IssueNotificationService();
 
 beforeAll(async () => {
   await db.$client.query("select 1");
-});
-
-beforeEach(() => {
-  workspaceIssuesFlagRunMock.mockResolvedValue(true);
 });
 
 afterEach(async () => {
@@ -93,16 +80,6 @@ async function requestJson(
 }
 
 describe("Issue notifications routes", () => {
-  it("denies access when the workspace issues feature flag is disabled", async () => {
-    workspaceIssuesFlagRunMock.mockResolvedValue(false);
-    const { identity } = await projectFixture.createStoredProjectFixture();
-    const headers = await projectFixture.authHeadersFor(identity);
-    const organizationSlug = identity.organization.slug ?? "missing-slug";
-
-    const response = await requestJson(notificationsUrl(organizationSlug), { headers });
-    expect(response.status).toBe(403);
-  });
-
   it("lists, counts, marks one, and marks all notifications as read", async () => {
     const { identity, organization, user, project } =
       await projectFixture.createStoredProjectFixture();

--- a/apps/hyperlocalise-web/src/api/routes/notifications/notifications.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/notifications/notifications.route.ts
@@ -15,9 +15,7 @@ import { Hono } from "hono";
 import { hasCapability } from "@/api/auth/policy";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
 import { createZodValidator } from "@/api/errors";
-import { createWorkspaceFeatureFlagMiddleware } from "@/api/middleware/workspace-feature-flag";
 import { forbiddenResponse, notFoundResponse } from "@/api/response.schema";
-import { workspaceIssuesFlag } from "@/lib/flags/workspace-flags";
 import { issueNotificationService } from "@/lib/projects/issue-sheet/issue-notification-service";
 
 import {
@@ -37,15 +35,9 @@ const validateIssueNotificationIdParams = createZodValidator(
   "invalid_issue_notification_id",
 );
 
-const requireWorkspaceIssuesFeature = createWorkspaceFeatureFlagMiddleware(
-  workspaceIssuesFlag,
-  "Workspace issues is not enabled for this organization",
-);
-
 export function createIssueNotificationsRoutes() {
   return new Hono<{ Variables: AuthVariables }>()
     .use("*", workosAuthMiddleware)
-    .use("*", requireWorkspaceIssuesFeature)
     .get("/", validateIssueNotificationsQuery, async (c) => {
       if (!hasCapability(c.var.auth.membership.role, "projects:read")) {
         return forbiddenResponse(c, "forbidden");

--- a/apps/hyperlocalise-web/src/api/routes/project/issue-sheet-comments.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/issue-sheet-comments.route.test.ts
@@ -12,7 +12,7 @@
  */
 import "dotenv/config";
 
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
 import { app } from "@/api/app";
 import { db, schema } from "@/lib/database";
@@ -20,14 +20,13 @@ import { eq } from "drizzle-orm";
 
 import { createProjectTestFixture } from "./project.fixture";
 
-const { resolveApiAuthContextFromSessionMock, workspaceIssuesFlagRunMock } = vi.hoisted(() => ({
+const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
   resolveApiAuthContextFromSessionMock: vi.fn(
     (options) =>
       globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
       globalThis.__testApiAuthContext ??
       null,
   ),
-  workspaceIssuesFlagRunMock: vi.fn(async () => true),
 }));
 
 vi.mock("@/api/auth/workos-session", async (importOriginal) => {
@@ -35,14 +34,6 @@ vi.mock("@/api/auth/workos-session", async (importOriginal) => {
   return {
     ...actual,
     resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
-  };
-});
-
-vi.mock("@/lib/flags/workspace-flags", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/flags/workspace-flags")>();
-  return {
-    ...actual,
-    workspaceIssuesFlag: { run: workspaceIssuesFlagRunMock },
   };
 });
 
@@ -65,10 +56,6 @@ type CommentResponse = {
 
 beforeAll(async () => {
   await db.$client.query("select 1");
-});
-
-beforeEach(() => {
-  workspaceIssuesFlagRunMock.mockResolvedValue(true);
 });
 
 afterEach(async () => {
@@ -119,27 +106,6 @@ async function createIssue(organizationSlug: string, projectId: string, headers:
 }
 
 describe("Issue sheet comment routes", () => {
-  it("denies comment access when the feature flag is disabled", async () => {
-    workspaceIssuesFlagRunMock.mockResolvedValue(false);
-    const { identity, project } = await projectFixture.createStoredProjectFixture();
-    const headers = await projectFixture.authHeadersFor(identity);
-    const organizationSlug = identity.organization.slug ?? "missing-slug";
-
-    const response = await requestJson(
-      commentsUrl(organizationSlug, project.id, "00000000-0000-4000-8000-000000000000"),
-      {
-        method: "POST",
-        headers,
-        body: { body: "Blocked" },
-      },
-    );
-
-    expect(response.status).toBe(403);
-    await expect(response.json()).resolves.toMatchObject({
-      error: "feature_unavailable",
-    });
-  });
-
   it("creates, updates, replies, and deletes comments", async () => {
     const { identity, project } = await projectFixture.createStoredProjectFixture();
     const headers = await projectFixture.authHeadersFor(identity);

--- a/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.test.ts
@@ -14,7 +14,7 @@ import "dotenv/config";
 
 import { and, eq } from "drizzle-orm";
 import { testClient } from "hono/testing";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
 import { app } from "@/api/app";
 import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
@@ -23,14 +23,13 @@ import { db, schema } from "@/lib/database";
 
 import { createProjectTestFixture } from "./project.fixture";
 
-const { resolveApiAuthContextFromSessionMock, workspaceIssuesFlagRunMock } = vi.hoisted(() => ({
+const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
   resolveApiAuthContextFromSessionMock: vi.fn(
     (options) =>
       globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
       globalThis.__testApiAuthContext ??
       null,
   ),
-  workspaceIssuesFlagRunMock: vi.fn(async () => true),
 }));
 
 vi.mock("@/api/auth/workos-session", async (importOriginal) => {
@@ -38,14 +37,6 @@ vi.mock("@/api/auth/workos-session", async (importOriginal) => {
   return {
     ...actual,
     resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
-  };
-});
-
-vi.mock("@/lib/flags/workspace-flags", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/flags/workspace-flags")>();
-  return {
-    ...actual,
-    workspaceIssuesFlag: { run: workspaceIssuesFlagRunMock },
   };
 });
 
@@ -97,33 +88,12 @@ beforeAll(async () => {
   await db.$client.query("select 1");
 });
 
-beforeEach(() => {
-  workspaceIssuesFlagRunMock.mockResolvedValue(true);
-});
-
 afterEach(async () => {
   vi.clearAllMocks();
   await projectFixture.cleanup();
 });
 
 describe("Issue Sheet routes", () => {
-  it("denies issue sheet access when the feature flag is disabled", async () => {
-    workspaceIssuesFlagRunMock.mockResolvedValue(false);
-    const { identity, project } = await projectFixture.createStoredProjectFixture();
-    const headers = await projectFixture.authHeadersFor(identity);
-    const organizationSlug = identity.organization.slug ?? "missing-slug";
-
-    const response = await issueSheet().$get(
-      { param: { organizationSlug: organizationSlug, projectId: project.id } } as never,
-      { headers: headers },
-    );
-
-    expect(response.status).toBe(403);
-    await expect(response.json()).resolves.toMatchObject({
-      error: "feature_unavailable",
-    });
-  });
-
   it("creates, lists, updates, and enriches generic issue rows", async () => {
     const { identity, project } = await projectFixture.createStoredProjectFixture();
     const headers = await projectFixture.authHeadersFor(identity);

--- a/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/issue-sheet.route.ts
@@ -19,8 +19,6 @@ import {
   isWriteBackTranslationAllowed,
 } from "@/api/auth/capability-guards";
 import { badRequestResponse, conflictResponse, notFoundResponse } from "@/api/response.schema";
-import { createWorkspaceFeatureFlagMiddleware } from "@/api/middleware/workspace-feature-flag";
-import { workspaceIssuesFlag } from "@/lib/flags/workspace-flags";
 import { IssueSheetService } from "@/lib/projects/issue-sheet/issue-sheet-service";
 
 import { createIssueSheetCommentRoutes } from "./issue-sheet-comments.route";
@@ -113,11 +111,6 @@ const validateFeedQuery = createZodValidator(
   "invalid_issue_sheet_feed_query",
 );
 
-const requireWorkspaceIssuesFeature = createWorkspaceFeatureFlagMiddleware(
-  workspaceIssuesFlag,
-  "Workspace issues is not enabled for this organization",
-);
-
 async function requireProject(c: { var: { auth: AuthVariables["auth"] } }, projectId: string) {
   const project = await getOwnedProject(c.var.auth, projectId);
   if (!project) {
@@ -129,7 +122,6 @@ async function requireProject(c: { var: { auth: AuthVariables["auth"] } }, proje
 export function createIssueSheetRoutes() {
   return (
     new Hono<{ Variables: AuthVariables }>()
-      .use("*", requireWorkspaceIssuesFeature)
       .route("/:issueId/comments", createIssueSheetCommentRoutes())
       .get("/", validateIssueSheetParams, validateIssueSheetQuery, async (c) => {
         const params = c.req.valid("param");

--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -54,7 +54,6 @@ const {
   createStoredFileMock,
   deleteStoredFileMock,
   isReleaseCatAllFilesEnabledMock,
-  workspaceIssuesFlagRunMock,
 } = vi.hoisted(() => ({
   getTmsProviderConnectionMock: vi.fn(),
   getTmsProviderLiveCatFileMock: vi.fn(),
@@ -69,21 +68,12 @@ const {
   createStoredFileMock: vi.fn(),
   deleteStoredFileMock: vi.fn(),
   isReleaseCatAllFilesEnabledMock: vi.fn(async () => false),
-  workspaceIssuesFlagRunMock: vi.fn(async () => true),
 }));
 
 vi.mock("@/lib/flags/release-flags", () => ({
   isReleaseCatAllFilesEnabled: isReleaseCatAllFilesEnabledMock,
   RELEASE_CAT_ALL_FILES_FLAG: "release-cat-all-files",
 }));
-
-vi.mock("@/lib/flags/workspace-flags", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/flags/workspace-flags")>();
-  return {
-    ...actual,
-    workspaceIssuesFlag: { run: workspaceIssuesFlagRunMock },
-  };
-});
 
 vi.mock("@/lib/translation/cat", () => ({
   loadCatSegmentConcordance: (...args: unknown[]) => loadCatSegmentConcordanceMock(...args),
@@ -149,7 +139,6 @@ beforeAll(async () => {
 afterEach(async () => {
   vi.clearAllMocks();
   isReleaseCatAllFilesEnabledMock.mockResolvedValue(false);
-  workspaceIssuesFlagRunMock.mockResolvedValue(true);
   await projectFixture.cleanup();
 });
 
@@ -1503,57 +1492,6 @@ describe("project file CAT routes", () => {
       comment: { externalCommentId: legacyIssue!.id, status: "resolved" },
     });
     expect(resolveTmsProviderLiveCatCommentMock).not.toHaveBeenCalled();
-  });
-
-  it("still rejects native CAT issue posts when the workspace flag is off", async () => {
-    workspaceIssuesFlagRunMock.mockResolvedValue(false);
-    const { identity, project, organization } = await projectFixture.createStoredProjectFixture();
-    const headers = await projectFixture.authHeadersFor(identity);
-    const sourcePath = "locales/en.json";
-    const sourceFile = await ensureRepositorySourceFile({
-      organizationId: organization.id,
-      projectId: project.id,
-      sourcePath,
-    });
-
-    await upsertProjectTranslationKeysFromEntries({
-      organizationId: organization.id,
-      projectId: project.id,
-      repositorySourceFileId: sourceFile.id,
-      entries: [{ key: "greeting", text: "Hello", context: null }],
-    });
-
-    const keys = await db
-      .select({ id: schema.projectTranslationKeys.id })
-      .from(schema.projectTranslationKeys)
-      .where(eq(schema.projectTranslationKeys.repositorySourceFileId, sourceFile.id))
-      .limit(1);
-    const translationKeyId = keys[0]!.id;
-
-    const postResponse = await client.api.orgs[":organizationSlug"].projects[
-      ":projectId"
-    ].files.detail.cat.comments.$post(
-      {
-        param: {
-          organizationSlug: identity.organization.slug ?? "missing-slug",
-          projectId: project.id,
-        },
-        json: {
-          sourcePath,
-          targetLocale: "fr-FR",
-          externalStringId: translationKeyId,
-          text: "Still wrong tone.",
-          type: "issue",
-          issueType: "translation_mistake",
-        },
-      },
-      { headers },
-    );
-
-    expect(postResponse.status).toBe(400);
-    expect(await postResponse.json()).toMatchObject({
-      error: "native_cat_issue_unsupported",
-    });
   });
 
   it("returns Crowdin CAT content for an encoded provider project", async () => {

--- a/apps/hyperlocalise-web/src/app/.well-known/vercel/flags/route.ts
+++ b/apps/hyperlocalise-web/src/app/.well-known/vercel/flags/route.ts
@@ -7,7 +7,6 @@ import {
 import {
   workspaceAutomationsFlag,
   workspaceDomainsFlag,
-  workspaceIssuesFlag,
   workspaceKnowledgeFlag,
 } from "../../../../lib/flags/workspace-flags";
 
@@ -15,7 +14,6 @@ export const GET = createFlagsDiscoveryEndpoint(async () =>
   getProviderData({
     workspaceAutomationsFlag,
     workspaceDomainsFlag,
-    workspaceIssuesFlag,
     workspaceKnowledgeFlag,
     releaseCatAllFilesFlag,
     releaseSandboxVcrImageFlag,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/[automationId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/[automationId]/page.tsx
@@ -37,7 +37,6 @@ export default async function AutomationDetailPage({
       <AutomationDetailPageContent
         organizationSlug={organizationSlug}
         automationId={automationId}
-        issuesAvailable={flags.issues}
         knowledgeAvailable={flags.knowledge}
         canUpdateKnowledgeMemory={hasCapability(auth.membership.role, "workspace:update")}
       />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.tsx
@@ -33,13 +33,11 @@ import { WorkspaceAutomationEditor } from "./workspace-automation-form";
 export function AutomationDetailPageContent({
   organizationSlug,
   automationId,
-  issuesAvailable = false,
   knowledgeAvailable = false,
   canUpdateKnowledgeMemory = false,
 }: {
   organizationSlug: string;
   automationId: string;
-  issuesAvailable?: boolean;
   knowledgeAvailable?: boolean;
   canUpdateKnowledgeMemory?: boolean;
 }) {
@@ -166,7 +164,6 @@ export function AutomationDetailPageContent({
         organizationSlug={organizationSlug}
         form={form}
         errors={errors}
-        issuesAvailable={issuesAvailable}
         knowledgeAvailable={knowledgeAvailable}
         canUpdateKnowledgeMemory={canUpdateKnowledgeMemory}
         onChange={setForm}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-new-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-new-page-content.tsx
@@ -35,13 +35,11 @@ import { WorkspaceAutomationEditor } from "./workspace-automation-form";
 export function AutomationsNewPageContent({
   organizationSlug,
   initialForm = createDefaultWorkspaceAutomationFormState(),
-  issuesAvailable = false,
   knowledgeAvailable = false,
   canUpdateKnowledgeMemory = false,
 }: {
   organizationSlug: string;
   initialForm?: WorkspaceAutomationFormState;
-  issuesAvailable?: boolean;
   knowledgeAvailable?: boolean;
   canUpdateKnowledgeMemory?: boolean;
 }) {
@@ -98,7 +96,6 @@ export function AutomationsNewPageContent({
         organizationSlug={organizationSlug}
         form={form}
         errors={errors}
-        issuesAvailable={issuesAvailable}
         knowledgeAvailable={knowledgeAvailable}
         canUpdateKnowledgeMemory={canUpdateKnowledgeMemory}
         onChange={setForm}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -402,16 +402,6 @@ export const workspaceAutomationFormMessages = defineMessages({
     id: "MweQRnF9MU",
     description: "Description for the Create issue automation tool",
   },
-  issuesUnavailableDescription: {
-    defaultMessage: "Enable workspace Issues before using Issue Sheet tools in automations.",
-    id: "uyibAnXll7",
-    description: "Description when workspace Issues feature flag is off",
-  },
-  enableIssuesFirstShortcut: {
-    defaultMessage: "Enable first",
-    id: "SCwFU6O6EH",
-    description: "Shortcut shown when workspace Issues is not enabled for the organization",
-  },
   removeListIssues: {
     defaultMessage: "Remove List issues tool",
     id: "N7Y/6FnTVv",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -1091,7 +1091,6 @@ function AddToolMenu({
   emailConnected,
   form,
   githubConnected,
-  issuesAvailable,
   knowledgeAvailable,
   mcpConnected,
   onChange,
@@ -1105,7 +1104,6 @@ function AddToolMenu({
   emailConnected: boolean;
   form: WorkspaceAutomationFormState;
   githubConnected: boolean;
-  issuesAvailable: boolean;
   knowledgeAvailable: boolean;
   mcpConnected: boolean;
   onChange: (next: WorkspaceAutomationFormState) => void;
@@ -1357,7 +1355,7 @@ function AddToolMenu({
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent className="min-w-56">
                 <DropdownMenuItem
-                  disabled={form.listIssuesEnabled || !issuesAvailable}
+                  disabled={form.listIssuesEnabled}
                   onClick={() => onChange({ ...form, listIssuesEnabled: true })}
                 >
                   <HugeiconsIcon icon={Task01Icon} strokeWidth={1.8} className="size-4" />
@@ -1366,16 +1364,10 @@ function AddToolMenu({
                     <DropdownMenuShortcut>
                       <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
                     </DropdownMenuShortcut>
-                  ) : !issuesAvailable ? (
-                    <DropdownMenuShortcut>
-                      <FormattedMessage
-                        {...workspaceAutomationFormMessages.enableIssuesFirstShortcut}
-                      />
-                    </DropdownMenuShortcut>
                   ) : null}
                 </DropdownMenuItem>
                 <DropdownMenuItem
-                  disabled={form.createIssueEnabled || !issuesAvailable}
+                  disabled={form.createIssueEnabled}
                   onClick={() => onChange({ ...form, createIssueEnabled: true })}
                 >
                   <HugeiconsIcon icon={Task01Icon} strokeWidth={1.8} className="size-4" />
@@ -1383,12 +1375,6 @@ function AddToolMenu({
                   {form.createIssueEnabled ? (
                     <DropdownMenuShortcut>
                       <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                    </DropdownMenuShortcut>
-                  ) : !issuesAvailable ? (
-                    <DropdownMenuShortcut>
-                      <FormattedMessage
-                        {...workspaceAutomationFormMessages.enableIssuesFirstShortcut}
-                      />
                     </DropdownMenuShortcut>
                   ) : null}
                 </DropdownMenuItem>
@@ -1554,7 +1540,6 @@ function ToolsSettings({
   errors,
   form,
   githubConnected,
-  issuesAvailable,
   knowledgeAvailable,
   mcpServerConnections,
   onChange,
@@ -1574,7 +1559,6 @@ function ToolsSettings({
   errors: Record<string, string | undefined>;
   form: WorkspaceAutomationFormState;
   githubConnected: boolean;
-  issuesAvailable: boolean;
   knowledgeAvailable: boolean;
   mcpServerConnections: McpServerConnectionOption[];
   onChange: (next: WorkspaceAutomationFormState) => void;
@@ -2184,13 +2168,7 @@ function ToolsSettings({
             icon={<HugeiconsIcon icon={Task01Icon} strokeWidth={1.8} className="size-4" />}
             title={<FormattedMessage {...workspaceAutomationFormMessages.listIssues} />}
             description={
-              issuesAvailable ? (
-                <FormattedMessage {...workspaceAutomationFormMessages.listIssuesDescription} />
-              ) : (
-                <FormattedMessage
-                  {...workspaceAutomationFormMessages.issuesUnavailableDescription}
-                />
-              )
+              <FormattedMessage {...workspaceAutomationFormMessages.listIssuesDescription} />
             }
             action={
               <DeleteToolButton
@@ -2207,13 +2185,7 @@ function ToolsSettings({
             icon={<HugeiconsIcon icon={Task01Icon} strokeWidth={1.8} className="size-4" />}
             title={<FormattedMessage {...workspaceAutomationFormMessages.createIssue} />}
             description={
-              issuesAvailable ? (
-                <FormattedMessage {...workspaceAutomationFormMessages.createIssueDescription} />
-              ) : (
-                <FormattedMessage
-                  {...workspaceAutomationFormMessages.issuesUnavailableDescription}
-                />
-              )
+              <FormattedMessage {...workspaceAutomationFormMessages.createIssueDescription} />
             }
             action={
               <DeleteToolButton
@@ -2419,7 +2391,6 @@ function ToolsSettings({
           emailConnected={emailConnected}
           form={form}
           githubConnected={githubConnected}
-          issuesAvailable={issuesAvailable}
           knowledgeAvailable={knowledgeAvailable}
           mcpConnected={mcpConnected}
           onChange={onChange}
@@ -2537,7 +2508,6 @@ export function WorkspaceAutomationEditor({
   disabled,
   errors,
   form,
-  issuesAvailable = false,
   knowledgeAvailable = false,
   mode,
   onChange,
@@ -2549,7 +2519,6 @@ export function WorkspaceAutomationEditor({
   disabled?: boolean;
   errors: Record<string, string | undefined>;
   form: WorkspaceAutomationFormState;
-  issuesAvailable?: boolean;
   knowledgeAvailable?: boolean;
   mode: "create" | "detail";
   onChange: (next: WorkspaceAutomationFormState) => void;
@@ -2857,7 +2826,6 @@ export function WorkspaceAutomationEditor({
             errors={errors}
             form={form}
             githubConnected={githubConnected}
-            issuesAvailable={issuesAvailable}
             knowledgeAvailable={knowledgeAvailable}
             mcpServerConnections={mcpServerConnections}
             onChange={onChange}
@@ -2887,7 +2855,6 @@ export function WorkspaceAutomationForm(props: {
   form: WorkspaceAutomationFormState;
   errors: Record<string, string | undefined>;
   disabled?: boolean;
-  issuesAvailable?: boolean;
   knowledgeAvailable?: boolean;
   canUpdateKnowledgeMemory?: boolean;
   onChange: (next: WorkspaceAutomationFormState) => void;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/new/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/new/page.tsx
@@ -50,7 +50,6 @@ export default async function NewAutomationPage({
       <AutomationsNewPageContent
         organizationSlug={organizationSlug}
         initialForm={initialForm}
-        issuesAvailable={flags.issues}
         knowledgeAvailable={flags.knowledge}
         canUpdateKnowledgeMemory={hasCapability(auth.membership.role, "workspace:update")}
       />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-content.tsx
@@ -69,8 +69,7 @@ export const InboxPageContent = observer(function InboxPageContent({
   const queryClient = useQueryClient();
   const urlConversationId = params?.conversationId as string | undefined;
   const urlNotificationId = params?.notificationId as string | undefined;
-  const { chatDock, workspaceFeatureFlags } = useAppShellStore();
-  const issuesEnabled = workspaceFeatureFlags.issues;
+  const { chatDock } = useAppShellStore();
   const streamManager = getChatStreamManager(organizationSlug, chatDock);
 
   const conversationsQuery = useQuery({
@@ -80,7 +79,6 @@ export const InboxPageContent = observer(function InboxPageContent({
 
   const notificationsQuery = useInfiniteQuery({
     queryKey: notificationsQueryKey(organizationSlug),
-    enabled: issuesEnabled,
     initialPageParam: 0,
     queryFn: async ({ pageParam }) => {
       const result = await injectedNotificationsApi.list(organizationSlug, {
@@ -98,7 +96,6 @@ export const InboxPageContent = observer(function InboxPageContent({
   const unreadCountQuery = useQuery({
     queryKey: notificationsUnreadCountQueryKey(organizationSlug),
     queryFn: () => injectedNotificationsApi.unreadCount(organizationSlug),
-    enabled: issuesEnabled,
     refetchInterval: 45_000,
   });
 
@@ -140,7 +137,6 @@ export const InboxPageContent = observer(function InboxPageContent({
     queryKey: notificationDetailQueryKey(organizationSlug, selectedNotificationId),
     queryFn: () => injectedNotificationsApi.getById(organizationSlug, selectedNotificationId),
     enabled:
-      issuesEnabled &&
       selection?.kind === "notification" &&
       !!selectedNotificationId &&
       !selectedNotificationFromList,
@@ -267,7 +263,7 @@ export const InboxPageContent = observer(function InboxPageContent({
     !notificationsQuery.isLoading &&
     conversations.length + notifications.length <= 1;
   const hasMoreNotifications =
-    issuesEnabled && notifications.length < notificationsTotal && notificationsQuery.hasNextPage;
+    notifications.length < notificationsTotal && notificationsQuery.hasNextPage;
 
   useEffect(() => {
     if (
@@ -322,8 +318,8 @@ export const InboxPageContent = observer(function InboxPageContent({
       messages={messages}
       messagesIsLoading={messagesQuery.isLoading}
       notifications={notifications}
-      notificationsIsError={issuesEnabled && notificationsQuery.isError}
-      notificationsIsLoading={issuesEnabled && notificationsQuery.isLoading}
+      notificationsIsError={notificationsQuery.isError}
+      notificationsIsLoading={notificationsQuery.isLoading}
       onLoadMoreNotifications={onLoadMoreNotifications}
       onMarkAllRead={onMarkAllRead}
       onSelectConversation={onSelectConversation}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/issues/page.tsx
@@ -15,7 +15,6 @@ import { Suspense } from "react";
 import { TypographyP } from "@/components/ui/typography";
 import { getIntlShape } from "@/lib/app-i18n/intl";
 import { getAppLocale } from "@/lib/app-i18n/server-locale";
-import { requireWorkspaceFeatureFlag, workspaceIssuesFlag } from "@/lib/flags/workspace-flags";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { IssuesPageContent } from "./_components/issues-page-content";
@@ -26,8 +25,7 @@ export default async function IssuesPage({
   params: Promise<{ organizationSlug: string }>;
 }) {
   const { organizationSlug } = await params;
-  const auth = await requireAppAuthContext({ organizationSlug });
-  await requireWorkspaceFeatureFlag(workspaceIssuesFlag, auth);
+  await requireAppAuthContext({ organizationSlug });
   const intl = getIntlShape(await getAppLocale());
 
   return (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/[issueId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/[issueId]/page.tsx
@@ -15,7 +15,6 @@ import { Suspense } from "react";
 import { TypographyP } from "@/components/ui/typography";
 import { getIntlShape } from "@/lib/app-i18n/intl";
 import { getAppLocale } from "@/lib/app-i18n/server-locale";
-import { requireWorkspaceFeatureFlag, workspaceIssuesFlag } from "@/lib/flags/workspace-flags";
 import { normalizeProjectId } from "@/lib/projects/identity/project-id";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
@@ -28,8 +27,7 @@ export default async function IssueDetailPage({
 }) {
   const { organizationSlug, projectId: rawProjectId, issueId } = await params;
   const projectId = normalizeProjectId(rawProjectId);
-  const auth = await requireAppAuthContext({ organizationSlug });
-  await requireWorkspaceFeatureFlag(workspaceIssuesFlag, auth);
+  await requireAppAuthContext({ organizationSlug });
   const intl = getIntlShape(await getAppLocale());
 
   return (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/issue-sheet/page.tsx
@@ -15,7 +15,6 @@ import { Suspense } from "react";
 import { TypographyP } from "@/components/ui/typography";
 import { getIntlShape } from "@/lib/app-i18n/intl";
 import { getAppLocale } from "@/lib/app-i18n/server-locale";
-import { requireWorkspaceFeatureFlag, workspaceIssuesFlag } from "@/lib/flags/workspace-flags";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { IssueSheetPageContent } from "./_components/issue-sheet-page-content";
@@ -26,8 +25,7 @@ export default async function IssueSheetPage({
   params: Promise<{ organizationSlug: string; projectId: string }>;
 }) {
   const { organizationSlug, projectId } = await params;
-  const auth = await requireAppAuthContext({ organizationSlug });
-  await requireWorkspaceFeatureFlag(workspaceIssuesFlag, auth);
+  await requireAppAuthContext({ organizationSlug });
   const intl = getIntlShape(await getAppLocale());
 
   return (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-issue-templates-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-issue-templates-panel.tsx
@@ -121,8 +121,6 @@ export function ProjectIssueTemplatesPanel({
     },
   });
 
-  // No feature flag on this page to check directly; a config load failure (most commonly the
-  // workspace issues flag being off for this org) just means there is nothing to configure here.
   if (configQuery.isError) {
     return null;
   }

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
@@ -253,13 +253,12 @@ function NavigationGroupItems({
   projectId?: string;
 }) {
   const intl = useIntl();
-  const { chatDock, workspaceFeatureFlags } = useAppShellStore();
+  const { chatDock } = useAppShellStore();
   const inboxHref = buildOrganizationPath(organizationSlug, "inbox");
-  const issuesEnabled = workspaceFeatureFlags.issues;
   const unreadCountQuery = useQuery({
     queryKey: notificationsUnreadCountQueryKey(organizationSlug),
     queryFn: () => inboxNotificationsApi.unreadCount(organizationSlug),
-    enabled: Boolean(organizationSlug) && issuesEnabled,
+    enabled: Boolean(organizationSlug),
     refetchInterval: 45_000,
   });
   const unreadCount = unreadCountQuery.data ?? 0;

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -18,7 +18,6 @@ import { getIntlShape } from "@/lib/app-i18n/intl";
 import {
   WORKSPACE_AUTOMATIONS_FLAG,
   WORKSPACE_DOMAINS_FLAG,
-  WORKSPACE_ISSUES_FLAG,
   WORKSPACE_KNOWLEDGE_FLAG,
 } from "@/lib/flags/workos-flag-entities";
 import { RELEASE_CAT_ALL_FILES_FLAG } from "@/lib/flags/release-flag-keys";
@@ -178,7 +177,7 @@ describe("path builders", () => {
     });
     expect(byLabel.get("Automations")?.featureFlagKey).toBe(WORKSPACE_AUTOMATIONS_FLAG);
     expect(byLabel.get("Knowledge")?.featureFlagKey).toBe(WORKSPACE_KNOWLEDGE_FLAG);
-    expect(byLabel.get("Issues")?.featureFlagKey).toBe(WORKSPACE_ISSUES_FLAG);
+    expect(byLabel.get("Issues")?.featureFlagKey).toBeUndefined();
     expect(byLabel.get("Domains")?.featureFlagKey).toBe(WORKSPACE_DOMAINS_FLAG);
   });
 
@@ -193,9 +192,7 @@ describe("path builders", () => {
       ["Issues", "/org/acme/projects/proj_1/issue-sheet"],
       ["Settings", "/org/acme/projects/proj_1/settings"],
     ]);
-    expect(items.find((item) => item.label === "Issues")?.featureFlagKey).toBe(
-      WORKSPACE_ISSUES_FLAG,
-    );
+    expect(items.find((item) => item.label === "Issues")?.featureFlagKey).toBeUndefined();
   });
 });
 

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -18,7 +18,6 @@ import { RELEASE_CAT_ALL_FILES_FLAG } from "@/lib/flags/release-flag-keys";
 import {
   WORKSPACE_AUTOMATIONS_FLAG,
   WORKSPACE_DOMAINS_FLAG,
-  WORKSPACE_ISSUES_FLAG,
   WORKSPACE_KNOWLEDGE_FLAG,
 } from "@/lib/flags/workos-flag-entities";
 import { supportsCatAllFilesProvider } from "@/lib/projects/cat-all-files";
@@ -58,7 +57,6 @@ export type NavigationItem = {
   featureFlagKey?:
     | typeof WORKSPACE_AUTOMATIONS_FLAG
     | typeof WORKSPACE_KNOWLEDGE_FLAG
-    | typeof WORKSPACE_ISSUES_FLAG
     | typeof WORKSPACE_DOMAINS_FLAG
     | typeof RELEASE_CAT_ALL_FILES_FLAG;
 };
@@ -130,7 +128,6 @@ export function buildGlobalNavigationGroups(
           }),
           href: org("issues"),
           icon: ClipboardListIcon,
-          featureFlagKey: WORKSPACE_ISSUES_FLAG,
         },
         {
           label: intl.formatMessage({
@@ -325,7 +322,6 @@ export function buildProjectNavigationItems(
       }),
       href: project("issue-sheet"),
       icon: ClipboardListIcon,
-      featureFlagKey: WORKSPACE_ISSUES_FLAG,
     },
     {
       label: intl.formatMessage({

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
@@ -62,7 +62,6 @@ import {
   readCatWorkspaceViewMode,
 } from "@/components/cat/workspace/cat-workspace-view-mode";
 
-import { useOptionalAppShellStore } from "@/components/app-shell/store/app-shell-store-context";
 import { resolveCatLinkedIssueTranslationKeyId } from "@/components/cat/issues/cat-linked-issue-translation-key";
 import {
   CatLinkedIssuesDialog,
@@ -121,8 +120,6 @@ export function ProjectFileCatWorkspace({
   pageNavigationGuardRef?: CatPageNavigationGuardRef;
 }) {
   const intl = useIntl();
-  const appShellStore = useOptionalAppShellStore();
-  const issuesEnabled = appShellStore?.workspaceFeatureFlags.issues ?? false;
   const [linkedIssuesOpen, setLinkedIssuesOpen] = useState(false);
   const [linkedIssuesSegment, setLinkedIssuesSegment] =
     useState<CatLinkedIssueSegmentContext | null>(null);
@@ -697,7 +694,7 @@ export function ProjectFileCatWorkspace({
           onApprove: handleApprove,
           onSaveDraft: isNativeProject ? handleSaveDraft : undefined,
           onAddComment: handleAddComment,
-          onAddToIssueSheet: issuesEnabled ? handleAddToIssueSheet : undefined,
+          onAddToIssueSheet: handleAddToIssueSheet,
           onResolveComment:
             catFile?.provider?.kind === "crowdin" ? handleResolveComment : undefined,
         }}
@@ -717,17 +714,15 @@ export function ProjectFileCatWorkspace({
         hasMoreQueue={pagination?.hasMore ?? false}
         canLookupFreshContext={canLookupFreshContext}
         onPageLimitChange={setPageLimit}
-        nativeIssuesEnabled={issuesEnabled && isNativeProject}
+        nativeIssuesEnabled={isNativeProject}
       />
-      {issuesEnabled ? (
-        <CatLinkedIssuesDialog
-          open={linkedIssuesOpen}
-          onOpenChange={setLinkedIssuesOpen}
-          organizationSlug={organizationSlug}
-          projectId={projectId}
-          segment={linkedIssuesSegment}
-        />
-      ) : null}
+      <CatLinkedIssuesDialog
+        open={linkedIssuesOpen}
+        onOpenChange={setLinkedIssuesOpen}
+        organizationSlug={organizationSlug}
+        projectId={projectId}
+        segment={linkedIssuesSegment}
+      />
     </div>
   );
 }

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
@@ -150,7 +150,6 @@ export const WORKSPACE_AUTOMATION_API_ERROR_MESSAGES: Record<string, string> = {
   ahrefs_connection_not_found:
     "The selected Ahrefs connection was not found. Choose another connection.",
   ahrefs_not_connected: "Enable the selected Ahrefs connection in Integrations before using it.",
-  issues_feature_unavailable: "Enable workspace Issues before using Issue Sheet automation tools.",
   github_repository_not_enabled: "Enable this repository before configuring automation.",
   github_repository_archived: "Archived repositories cannot use automations.",
   project_not_found: "The selected project could not be found.",
@@ -651,8 +650,6 @@ export function mapWorkspaceAutomationApiErrorToFieldErrors(
     case "ahrefs_connection_not_found":
     case "ahrefs_not_connected":
       return { ahrefsConnectionId: message };
-    case "issues_feature_unavailable":
-      return { form: message };
     default:
       return { form: message };
   }

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -14,7 +14,6 @@ import { and, asc, desc, eq, isNotNull, isNull, lte, or, sql } from "drizzle-orm
 import { z } from "zod";
 
 import { db, schema, type DatabaseClient } from "@/lib/database";
-import { resolveWorkspaceIssuesFlag } from "@/lib/flags/workspace-flags";
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 import { optionalProjectIdSchema } from "@/lib/projects/identity/project-id";
 import { lockAhrefsConnectionForUpdate } from "@/lib/ahrefs/connections";
@@ -384,10 +383,6 @@ export type WorkspaceAutomationConfigValidationError =
   | {
       code: "ahrefs_not_connected";
       message: "Enable the selected Ahrefs connection in Integrations before using it.";
-    }
-  | {
-      code: "issues_feature_unavailable";
-      message: "Enable workspace Issues before using Issue Sheet automation tools.";
     };
 
 type AutomationRow = typeof schema.workspaceAutomations.$inferSelect;
@@ -905,22 +900,6 @@ export async function validateWorkspaceAutomationIntegrations(input: {
       return err({
         code: "ahrefs_not_connected",
         message: "Enable the selected Ahrefs connection in Integrations before using it.",
-      });
-    }
-  }
-
-  if (
-    hasWorkspaceAutomationListIssuesTool(input.toolConfig) ||
-    hasWorkspaceAutomationCreateIssueTool(input.toolConfig)
-  ) {
-    const issuesEnabled = await resolveWorkspaceIssuesFlag({
-      organizationId: input.organizationId,
-      dbClient: database,
-    });
-    if (!issuesEnabled) {
-      return err({
-        code: "issues_feature_unavailable",
-        message: "Enable workspace Issues before using Issue Sheet automation tools.",
       });
     }
   }

--- a/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
@@ -151,13 +151,12 @@ describe("workosAdapter", () => {
 const intl = getIntlShape("en") as IntlShape;
 
 describe("filterNavigationByWorkspaceFlags", () => {
-  it("removes Automations, Knowledge, Issues, and Domains when workspace flags are disabled", () => {
+  it("removes Automations, Knowledge, and Domains when workspace flags are disabled", () => {
     const groups = buildGlobalNavigationGroups("acme", intl);
     const filtered = filterNavigationByWorkspaceFlags(groups, {
       automations: false,
       knowledge: false,
       visualMock: false,
-      issues: false,
       domains: false,
       glossarySearch: false,
     });
@@ -166,7 +165,7 @@ describe("filterNavigationByWorkspaceFlags", () => {
 
     expect(itemLabels).not.toContain("Automations");
     expect(itemLabels).not.toContain("Knowledge");
-    expect(itemLabels).not.toContain("Issues");
+    expect(itemLabels).toContain("Issues");
     expect(itemLabels).not.toContain("Domains");
     expect(itemLabels).toContain("Projects");
   });
@@ -177,7 +176,6 @@ describe("filterNavigationByWorkspaceFlags", () => {
       automations: true,
       knowledge: true,
       visualMock: true,
-      issues: true,
       domains: true,
       glossarySearch: true,
     });

--- a/apps/hyperlocalise-web/src/lib/flags/workos-flag-entities.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-flag-entities.ts
@@ -13,7 +13,6 @@
 export const WORKSPACE_AUTOMATIONS_FLAG = "workspace-automations";
 export const WORKSPACE_KNOWLEDGE_FLAG = "workspace-knowledge";
 export const WORKSPACE_VISUAL_MOCK_FLAG = "workspace-visual-mock";
-export const WORKSPACE_ISSUES_FLAG = "workspace-issues";
 export const WORKSPACE_DOMAINS_FLAG = "workspace-domains";
 export const WORKSPACE_GLOSSARY_SEARCH_FLAG = "workspace-glossary-search";
 export const WORKSPACE_FEATURE_UNAVAILABLE_REASON = "feature-unavailable";
@@ -27,7 +26,6 @@ export type WorkspaceFeatureFlagState = {
   automations: boolean;
   knowledge: boolean;
   visualMock: boolean;
-  issues: boolean;
   domains: boolean;
   glossarySearch: boolean;
 };
@@ -36,7 +34,6 @@ export const DISABLED_WORKSPACE_FEATURE_FLAGS: WorkspaceFeatureFlagState = {
   automations: false,
   knowledge: false,
   visualMock: false,
-  issues: false,
   domains: false,
   glossarySearch: false,
 };

--- a/apps/hyperlocalise-web/src/lib/flags/workspace-flag-navigation.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workspace-flag-navigation.ts
@@ -16,7 +16,6 @@ import {
   WORKSPACE_AUTOMATIONS_FLAG,
   WORKSPACE_DOMAINS_FLAG,
   WORKSPACE_GLOSSARY_SEARCH_FLAG,
-  WORKSPACE_ISSUES_FLAG,
   WORKSPACE_KNOWLEDGE_FLAG,
   WORKSPACE_VISUAL_MOCK_FLAG,
   type WorkspaceFeatureFlagState,
@@ -27,7 +26,6 @@ function workspaceFlagEnabledByKey(flags: WorkspaceFeatureFlagState): Record<str
     [WORKSPACE_AUTOMATIONS_FLAG]: flags.automations,
     [WORKSPACE_KNOWLEDGE_FLAG]: flags.knowledge,
     [WORKSPACE_VISUAL_MOCK_FLAG]: flags.visualMock,
-    [WORKSPACE_ISSUES_FLAG]: flags.issues,
     [WORKSPACE_DOMAINS_FLAG]: flags.domains,
     [WORKSPACE_GLOSSARY_SEARCH_FLAG]: flags.glossarySearch,
   };

--- a/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
@@ -24,7 +24,6 @@ import {
   WORKSPACE_DOMAINS_FLAG,
   WORKSPACE_FEATURE_UNAVAILABLE_REASON,
   WORKSPACE_GLOSSARY_SEARCH_FLAG,
-  WORKSPACE_ISSUES_FLAG,
   WORKSPACE_KNOWLEDGE_FLAG,
   WORKSPACE_VISUAL_MOCK_FLAG,
   type WorkosFlagEntities,
@@ -57,13 +56,6 @@ export const workspaceVisualMockFlag = flag<boolean, WorkosFlagEntities>({
   adapter: workosAdapter(),
 });
 
-export const workspaceIssuesFlag = flag<boolean, WorkosFlagEntities>({
-  key: WORKSPACE_ISSUES_FLAG,
-  defaultValue: false,
-  description: "Workspace issues and project Issue Sheet for localization issue tracking.",
-  adapter: workosAdapter(),
-});
-
 export const workspaceDomainsFlag = flag<boolean, WorkosFlagEntities>({
   key: WORKSPACE_DOMAINS_FLAG,
   defaultValue: false,
@@ -84,16 +76,15 @@ export async function evaluateWorkspaceFeatureFlags(
 ): Promise<WorkspaceFeatureFlagState> {
   const identify = () => createWorkosIdentify(auth);
 
-  const [automations, knowledge, visualMock, issues, domains, glossarySearch] = await Promise.all([
+  const [automations, knowledge, visualMock, domains, glossarySearch] = await Promise.all([
     workspaceAutomationsFlag.run({ identify }),
     workspaceKnowledgeFlag.run({ identify }),
     workspaceVisualMockFlag.run({ identify }),
-    workspaceIssuesFlag.run({ identify }),
     workspaceDomainsFlag.run({ identify }),
     workspaceGlossarySearchFlag.run({ identify }),
   ]);
 
-  return { automations, knowledge, visualMock, issues, domains, glossarySearch };
+  return { automations, knowledge, visualMock, domains, glossarySearch };
 }
 
 export async function resolveWorkspaceVisualMockFlag(input: {
@@ -176,43 +167,6 @@ export async function resolveWorkspaceKnowledgeFlag(input: {
 
     return (
       (await workspaceKnowledgeFlag.run({
-        identify: () => ({ organization: { id: organization.workosOrganizationId } }),
-      })) === true
-    );
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Resolves workspaceIssuesFlag from an internal organizationId for callers without a live HTTP
- * auth context — workspace-automation tool execution and config validation. Mirrors
- * resolveWorkspaceKnowledgeFlag: Issue Sheet HTTP routes already reject when the flag is off, but
- * automation create/update and orchestrator tools can still reach IssueSheetService unless we
- * re-check here.
- */
-export async function resolveWorkspaceIssuesFlag(input: {
-  organizationId: string;
-  dbClient?: Pick<typeof db, "select">;
-}): Promise<boolean> {
-  const dbClient = input.dbClient ?? db;
-  if (typeof dbClient.select !== "function") {
-    return false;
-  }
-
-  try {
-    const [organization] = await dbClient
-      .select({ workosOrganizationId: schema.organizations.workosOrganizationId })
-      .from(schema.organizations)
-      .where(eq(schema.organizations.id, input.organizationId))
-      .limit(1);
-
-    if (!organization) {
-      return false;
-    }
-
-    return (
-      (await workspaceIssuesFlag.run({
         identify: () => ({ organization: { id: organization.workosOrganizationId } }),
       })) === true
     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Issues is generally available. This removes the `workspace-issues` WorkOS feature flag so every workspace sees and can use Issues.

- Drop the flag from WorkOS flag entities, evaluation, navigation filtering, and the Vercel flags discovery endpoint
- Always show Issues in org and project nav; pages no longer redirect when the flag is off
- Always expose CAT Issue Sheet actions, inbox unread counts, and automation List/Create issue tools
- Remove API middleware and runtime re-checks that returned 403 / `issues_feature_unavailable` when the flag was off
- Update tests that mocked or asserted the flag

Other workspace flags (`workspace-automations`, `workspace-knowledge`, `workspace-visual-mock`, `workspace-domains`, `workspace-glossary-search`) are unchanged. Historical design docs that describe the old flag are left as-is.

## How to test

- `vp test` and `vp check --fix` in `apps/hyperlocalise-web`
- Confirm org Issues and project Issue Sheet appear in the sidebar without enabling a WorkOS flag
- Confirm CAT can add to Issue Sheet and automation issue tools save without an Issues flag

Verified in this environment after Postgres was up:

- Targeted tests for the changed files: 11 files, 140 tests passed
- Full suite: 654 files, 4277 tests passed
- `vp check --fix`: 0 errors (4 pre-existing warnings)

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f55cd450-6647-4538-8c3b-42770fb9cf6d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f55cd450-6647-4538-8c3b-42770fb9cf6d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

