### PR TITLE
feat(jobs): restyle create job dialog as a composer

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog-msw-handlers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog-msw-handlers.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { http, HttpResponse } from "msw";
+
+import { createProjectFileRecord } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files.fixture";
+
+export const createJobDialogOrganizationSlug = "acme";
+export const createJobDialogNativeProjectId = "project_website";
+export const createJobDialogCrowdinProjectId = "ext:crowdin:902807";
+
+export const createJobDialogNativeFiles = [
+  createProjectFileRecord(),
+  createProjectFileRecord({
+    sourcePath: "marketing/pricing.json",
+    storedFileId: "file_pricing_json",
+    filename: "pricing.json",
+  }),
+];
+
+export const createJobDialogNativeMembers = [
+  {
+    workosUserId: "user_mina",
+    displayName: "Mina Chen",
+    email: "mina@example.com",
+    status: "active",
+  },
+  {
+    workosUserId: "user_otto",
+    displayName: "Otto Berg",
+    email: "otto@example.com",
+    status: "active",
+  },
+];
+
+export const createJobDialogProviderFiles = [
+  {
+    sourcePath: "locales/home.json",
+    filename: "home.json",
+    provider: { externalResourceId: "crowdin_file_home", resourceType: "file" },
+  },
+  {
+    sourcePath: "locales/pricing.json",
+    filename: "pricing.json",
+    provider: { externalResourceId: "crowdin_file_pricing", resourceType: "file" },
+  },
+];
+
+export const createJobDialogProviderMembers = [
+  {
+    externalUserId: "crowdin_mina",
+    username: "mina",
+    displayName: "Mina Chen",
+    role: "translator",
+  },
+  {
+    externalUserId: "crowdin_otto",
+    username: "otto",
+    displayName: "Otto Berg",
+    role: "proofreader",
+  },
+];
+
+export const createJobDialogMswHandlers = [
+  http.get("/api/orgs/:organizationSlug/projects/:projectId/files", () =>
+    HttpResponse.json({ files: createJobDialogNativeFiles }),
+  ),
+  http.get("/api/orgs/:organizationSlug/members", () =>
+    HttpResponse.json({ members: createJobDialogNativeMembers }),
+  ),
+  http.post("/api/orgs/:organizationSlug/projects/:projectId/jobs", () =>
+    HttpResponse.json({ job: { id: "job_native_1" } }, { status: 201 }),
+  ),
+  http.get("/api/orgs/:organizationSlug/tms-provider/projects/:externalProjectId/files", () =>
+    HttpResponse.json({ files: createJobDialogProviderFiles }),
+  ),
+  http.get("/api/orgs/:organizationSlug/tms-provider/projects/:externalProjectId/members", () =>
+    HttpResponse.json({ members: createJobDialogProviderMembers }),
+  ),
+  http.post("/api/orgs/:organizationSlug/tms-provider/projects/:externalProjectId/jobs", () =>
+    HttpResponse.json(
+      { jobs: [{ id: "job_crowdin_fr" }, { id: "job_crowdin_de" }] },
+      { status: 201 },
+    ),
+  ),
+];

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog-msw-handlers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog-msw-handlers.ts
@@ -25,6 +25,16 @@ export const createJobDialogNativeFiles = [
     storedFileId: "file_pricing_json",
     filename: "pricing.json",
   }),
+  createProjectFileRecord({
+    sourcePath: "marketing/campaigns/spring.json",
+    storedFileId: "file_spring_json",
+    filename: "spring.json",
+  }),
+  createProjectFileRecord({
+    sourcePath: "legal/terms.json",
+    storedFileId: "file_terms_json",
+    filename: "terms.json",
+  }),
 ];
 
 export const createJobDialogNativeMembers = [
@@ -52,6 +62,16 @@ export const createJobDialogProviderFiles = [
     sourcePath: "locales/pricing.json",
     filename: "pricing.json",
     provider: { externalResourceId: "crowdin_file_pricing", resourceType: "file" },
+  },
+  {
+    sourcePath: "locales/emails/welcome.json",
+    filename: "welcome.json",
+    provider: { externalResourceId: "crowdin_file_welcome", resourceType: "file" },
+  },
+  {
+    sourcePath: "legal/terms.json",
+    filename: "terms.json",
+    provider: { externalResourceId: "crowdin_file_terms", resourceType: "file" },
   },
 ];
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.messages.ts
@@ -16,8 +16,8 @@ import { defineMessages } from "react-intl";
 
 export const createJobDialogMessages = defineMessages({
   title: {
-    defaultMessage: "Create job",
-    id: "RQv/LERmVL",
+    defaultMessage: "New job",
+    id: "yRg4x8kKbX",
     description: "Create job dialog title",
   },
   descriptionProvider: {
@@ -61,19 +61,44 @@ export const createJobDialogMessages = defineMessages({
     description: "Label for the optional job description field",
   },
   descriptionPlaceholder: {
-    defaultMessage: "Optional notes for translators",
-    id: "W87BMcVF5T",
+    defaultMessage: "Add context for translators…",
+    id: "Ml4FXbhH7X",
     description: "Placeholder for the optional job description field",
   },
   sourceLocale: {
-    defaultMessage: "Source locale: {locale}",
-    id: "jvDZaWTAOJ",
+    defaultMessage: "Source {locale}",
+    id: "bYcr+0cE/T",
     description: "Shows the project source locale in the create job dialog",
+  },
+  sourceLocaleAria: {
+    defaultMessage: "Source locale",
+    id: "mBvpGTXpPk",
+    description: "Accessible label for the read-only source locale chip",
   },
   targetLocalesLabel: {
     defaultMessage: "Target locales",
     id: "zedkthWR8N",
     description: "Label for the target locales selection list",
+  },
+  allLocales: {
+    defaultMessage: "All locales",
+    id: "mFzR+186UW",
+    description: "Chip label when every target locale is selected",
+  },
+  localeCount: {
+    defaultMessage: "{count, plural, one {# locale} other {# locales}}",
+    id: "FjJpQAXPiH",
+    description: "Chip label for a partial target locale selection",
+  },
+  localesPlaceholder: {
+    defaultMessage: "Locales",
+    id: "iVnVwwFFdq",
+    description: "Chip placeholder when no target locales are selected",
+  },
+  searchLocales: {
+    defaultMessage: "Search locales…",
+    id: "AKyH88ZuDN",
+    description: "Search placeholder in the target locale picker",
   },
   selectAll: {
     defaultMessage: "Select all",
@@ -101,9 +126,14 @@ export const createJobDialogMessages = defineMessages({
     description: "Label for the files selection list",
   },
   filesSelectedCount: {
-    defaultMessage: "{count, plural, one {# file selected} other {# files selected}}",
-    id: "pckObbKjS/",
+    defaultMessage: "{count, plural, one {# file} other {# files}}",
+    id: "e/0aPM+6Iw",
     description: "Count of files selected for the new job",
+  },
+  searchFiles: {
+    defaultMessage: "Search files…",
+    id: "hZtUjyTrTe",
+    description: "Search placeholder in the files picker",
   },
   noFilesAvailable: {
     defaultMessage: "No files available in this project.",
@@ -120,6 +150,21 @@ export const createJobDialogMessages = defineMessages({
     id: "2VWwjqjclF",
     description: "Label for single-assignee selection on native jobs",
   },
+  unassigned: {
+    defaultMessage: "Unassigned",
+    id: "vuk3bDm+PN",
+    description: "Chip and picker label when no assignee is selected",
+  },
+  assigneeCount: {
+    defaultMessage: "{count, plural, one {# assignee} other {# assignees}}",
+    id: "hTvi2pxcky",
+    description: "Chip label for a multi-assignee selection",
+  },
+  searchAssignees: {
+    defaultMessage: "Search people…",
+    id: "AlWYFrRq+B",
+    description: "Search placeholder in the assignee picker",
+  },
   noCrowdinMembers: {
     defaultMessage: "No Crowdin project members found.",
     id: "Qao/O64dbg",
@@ -130,10 +175,10 @@ export const createJobDialogMessages = defineMessages({
     id: "vvT35LUoRE",
     description: "Empty state when organization members cannot be listed",
   },
-  assigneeHintNative: {
-    defaultMessage: "Optional. Native jobs currently support one assignee.",
-    id: "+WPReqq8Dt",
-    description: "Hint under the native job assignee picker",
+  loading: {
+    defaultMessage: "Loading…",
+    id: "iD0GLTqlIQ",
+    description: "Loading label inside create job property pickers",
   },
   cancel: {
     defaultMessage: "Cancel",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.messages.ts
@@ -65,16 +65,6 @@ export const createJobDialogMessages = defineMessages({
     id: "Ml4FXbhH7X",
     description: "Placeholder for the optional job description field",
   },
-  sourceLocale: {
-    defaultMessage: "Source {locale}",
-    id: "bYcr+0cE/T",
-    description: "Shows the project source locale in the create job dialog",
-  },
-  sourceLocaleAria: {
-    defaultMessage: "Source locale",
-    id: "mBvpGTXpPk",
-    description: "Accessible label for the read-only source locale chip",
-  },
   targetLocalesLabel: {
     defaultMessage: "Target locales",
     id: "zedkthWR8N",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.messages.ts
@@ -137,22 +137,22 @@ export const createJobDialogMessages = defineMessages({
   },
   filesSearchEmpty: {
     defaultMessage: "No files match this search.",
-    id: "nF4kG8pW2c",
+    id: "q0vQCpRAVI",
     description: "Empty state when the create job file tree search has no matches",
   },
   expandFolder: {
     defaultMessage: "Expand {folder}",
-    id: "pH6mJ1rY4d",
+    id: "lwgrrpA8Lf",
     description: "Accessible label to expand a folder in the create job file tree",
   },
   collapseFolder: {
     defaultMessage: "Collapse {folder}",
-    id: "qK7nL2sZ5e",
+    id: "b7iFjKUEa6",
     description: "Accessible label to collapse a folder in the create job file tree",
   },
   selectFolder: {
     defaultMessage: "Select all files in {folder}",
-    id: "rM8oN3tA6f",
+    id: "8HnJuAO7Ry",
     description: "Accessible label to select every file in a folder",
   },
   noFilesAvailable: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.messages.ts
@@ -135,6 +135,26 @@ export const createJobDialogMessages = defineMessages({
     id: "hZtUjyTrTe",
     description: "Search placeholder in the files picker",
   },
+  filesSearchEmpty: {
+    defaultMessage: "No files match this search.",
+    id: "nF4kG8pW2c",
+    description: "Empty state when the create job file tree search has no matches",
+  },
+  expandFolder: {
+    defaultMessage: "Expand {folder}",
+    id: "pH6mJ1rY4d",
+    description: "Accessible label to expand a folder in the create job file tree",
+  },
+  collapseFolder: {
+    defaultMessage: "Collapse {folder}",
+    id: "qK7nL2sZ5e",
+    description: "Accessible label to collapse a folder in the create job file tree",
+  },
+  selectFolder: {
+    defaultMessage: "Select all files in {folder}",
+    id: "rM8oN3tA6f",
+    description: "Accessible label to select every file in a folder",
+  },
   noFilesAvailable: {
     defaultMessage: "No files available in this project.",
     id: "izy21loiHb",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.stories.tsx
@@ -58,7 +58,9 @@ export const Native: Story = {
     const files = await canvas.findByRole("group", { name: "Files" });
     await expect(files).toBeInTheDocument();
     await expect(canvas.getByRole("checkbox", { name: "marketing/home.json" })).not.toBeChecked();
-    await expect(canvas.getByRole("checkbox", { name: "marketing/pricing.json" })).not.toBeChecked();
+    await expect(
+      canvas.getByRole("checkbox", { name: "marketing/pricing.json" }),
+    ).not.toBeChecked();
     await expect(canvas.getByRole("button", { name: "Collapse marketing" })).toBeInTheDocument();
     await expect(
       canvas.queryByRole("checkbox", { name: "marketing/campaigns/spring.json" }),

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.stories.tsx
@@ -58,12 +58,16 @@ export const Native: Story = {
     await expect(canvas.getByRole("button", { name: "Create job" })).toBeInTheDocument();
 
     await userEvent.click(canvas.getByLabelText("Files"));
-    await expect(
-      await body.findByRole("option", { name: /marketing\/home\.json/ }),
-    ).toBeInTheDocument();
-    await expect(
-      body.getByRole("option", { name: /marketing\/pricing\.json/ }),
-    ).toBeInTheDocument();
+    const homeFile = await body.findByRole("option", { name: /marketing\/home\.json/ });
+    await expect(homeFile).toHaveAttribute("aria-checked", "false");
+    await expect(body.getByRole("option", { name: /marketing\/pricing\.json/ })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+    await expect(body.getByRole("listbox", { name: "Files" })).toHaveAttribute(
+      "aria-multiselectable",
+      "true",
+    );
   },
 };
 
@@ -82,14 +86,24 @@ export const Crowdin: Story = {
     await expect(canvas.queryByLabelText("Source locale")).not.toBeInTheDocument();
 
     await userEvent.click(canvas.getByLabelText("Files"));
-    await expect(
-      await body.findByRole("option", { name: /locales\/home\.json/ }),
-    ).toBeInTheDocument();
-    await expect(body.getByRole("option", { name: /locales\/pricing\.json/ })).toBeInTheDocument();
+    const homeFile = await body.findByRole("option", { name: /locales\/home\.json/ });
+    await expect(homeFile).toHaveAttribute("aria-checked", "false");
+    await expect(body.getByRole("option", { name: /locales\/pricing\.json/ })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
     await userEvent.keyboard("{Escape}");
 
     await userEvent.click(canvas.getByLabelText("Assignees"));
-    await expect(await body.findByRole("option", { name: /Mina Chen/ })).toBeInTheDocument();
-    await expect(body.getByRole("option", { name: /Otto Berg/ })).toBeInTheDocument();
+    const mina = await body.findByRole("option", { name: /Mina Chen/ });
+    await expect(mina).toHaveAttribute("aria-checked", "false");
+    await expect(body.getByRole("option", { name: /Otto Berg/ })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+    await expect(body.getByRole("listbox", { name: "Assignees" })).toHaveAttribute(
+      "aria-multiselectable",
+      "true",
+    );
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.stories.tsx
@@ -48,7 +48,7 @@ export const Native: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("dialog", { name: "New job" })).toBeInTheDocument();
     await expect(canvas.getByLabelText("Title")).toBeInTheDocument();
-    await expect(canvas.getByLabelText("Source locale")).toHaveTextContent(/English/);
+    await expect(canvas.queryByLabelText("Source locale")).not.toBeInTheDocument();
     await expect(canvas.getByLabelText("Target locales")).toHaveTextContent("All locales");
     await expect(canvas.getByLabelText("Assignee")).toHaveTextContent("Unassigned");
     await expect(canvas.queryByLabelText("Task type")).not.toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.stories.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { CreateJobDialog } from "./create-job-dialog";
+import {
+  createJobDialogCrowdinProjectId,
+  createJobDialogMswHandlers,
+  createJobDialogNativeProjectId,
+  createJobDialogOrganizationSlug,
+} from "./create-job-dialog-msw-handlers";
+
+const meta = {
+  title: "App/Jobs/Create Dialog",
+  component: CreateJobDialog,
+  parameters: {
+    layout: "centered",
+    msw: {
+      handlers: createJobDialogMswHandlers,
+    },
+  },
+  args: {
+    open: true,
+    organizationSlug: createJobDialogOrganizationSlug,
+    projectId: createJobDialogNativeProjectId,
+    sourceLocale: "en-US",
+    targetLocales: ["fr-FR", "de-DE", "ja-JP"],
+    onOpenChange: fn(),
+    onCreated: fn(),
+  },
+} satisfies Meta<typeof CreateJobDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Native: Story = {
+  play: async ({ canvas, canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await expect(canvas.getByRole("dialog", { name: "New job" })).toBeInTheDocument();
+    await expect(canvas.getByLabelText("Title")).toBeInTheDocument();
+    await expect(canvas.getByLabelText("Source locale")).toHaveTextContent(/English/);
+    await expect(canvas.getByLabelText("Target locales")).toHaveTextContent("All locales");
+    await expect(canvas.getByLabelText("Files")).toBeInTheDocument();
+    await expect(canvas.getByLabelText("Assignee")).toHaveTextContent("Unassigned");
+    await expect(canvas.queryByLabelText("Task type")).not.toBeInTheDocument();
+    await expect(canvas.queryByLabelText("Description")).not.toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Create job" })).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByLabelText("Files"));
+    await expect(
+      await body.findByRole("option", { name: /marketing\/home\.json/ }),
+    ).toBeInTheDocument();
+    await expect(
+      body.getByRole("option", { name: /marketing\/pricing\.json/ }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const Crowdin: Story = {
+  args: {
+    projectId: createJobDialogCrowdinProjectId,
+  },
+  play: async ({ canvas, canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await expect(canvas.getByRole("dialog", { name: "New job" })).toBeInTheDocument();
+    await expect(canvas.getByLabelText("Title")).toBeInTheDocument();
+    await expect(canvas.getByLabelText("Description")).toBeInTheDocument();
+    await expect(canvas.getByLabelText("Task type")).toHaveTextContent("Translation");
+    await expect(canvas.getByLabelText("Target locales")).toHaveTextContent("All locales");
+    await expect(canvas.getByLabelText("Assignees")).toHaveTextContent("Unassigned");
+    await expect(canvas.queryByLabelText("Source locale")).not.toBeInTheDocument();
+
+    await userEvent.click(canvas.getByLabelText("Files"));
+    await expect(
+      await body.findByRole("option", { name: /locales\/home\.json/ }),
+    ).toBeInTheDocument();
+    await expect(body.getByRole("option", { name: /locales\/pricing\.json/ })).toBeInTheDocument();
+    await userEvent.keyboard("{Escape}");
+
+    await userEvent.click(canvas.getByLabelText("Assignees"));
+    await expect(await body.findByRole("option", { name: /Mina Chen/ })).toBeInTheDocument();
+    await expect(body.getByRole("option", { name: /Otto Berg/ })).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.stories.tsx
@@ -45,29 +45,24 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Native: Story = {
-  play: async ({ canvas, canvasElement }) => {
-    const body = within(canvasElement.ownerDocument.body);
+  play: async ({ canvas }) => {
     await expect(canvas.getByRole("dialog", { name: "New job" })).toBeInTheDocument();
     await expect(canvas.getByLabelText("Title")).toBeInTheDocument();
     await expect(canvas.getByLabelText("Source locale")).toHaveTextContent(/English/);
     await expect(canvas.getByLabelText("Target locales")).toHaveTextContent("All locales");
-    await expect(canvas.getByLabelText("Files")).toBeInTheDocument();
     await expect(canvas.getByLabelText("Assignee")).toHaveTextContent("Unassigned");
     await expect(canvas.queryByLabelText("Task type")).not.toBeInTheDocument();
     await expect(canvas.queryByLabelText("Description")).not.toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Create job" })).toBeInTheDocument();
 
-    await userEvent.click(canvas.getByLabelText("Files"));
-    const homeFile = await body.findByRole("option", { name: /marketing\/home\.json/ });
-    await expect(homeFile).toHaveAttribute("aria-checked", "false");
-    await expect(body.getByRole("option", { name: /marketing\/pricing\.json/ })).toHaveAttribute(
-      "aria-checked",
-      "false",
-    );
-    await expect(body.getByRole("listbox", { name: "Files" })).toHaveAttribute(
-      "aria-multiselectable",
-      "true",
-    );
+    const files = await canvas.findByRole("group", { name: "Files" });
+    await expect(files).toBeInTheDocument();
+    await expect(canvas.getByRole("checkbox", { name: "marketing/home.json" })).not.toBeChecked();
+    await expect(canvas.getByRole("checkbox", { name: "marketing/pricing.json" })).not.toBeChecked();
+    await expect(canvas.getByRole("button", { name: "Collapse marketing" })).toBeInTheDocument();
+    await expect(
+      canvas.queryByRole("checkbox", { name: "marketing/campaigns/spring.json" }),
+    ).not.toBeInTheDocument();
   },
 };
 
@@ -85,14 +80,12 @@ export const Crowdin: Story = {
     await expect(canvas.getByLabelText("Assignees")).toHaveTextContent("Unassigned");
     await expect(canvas.queryByLabelText("Source locale")).not.toBeInTheDocument();
 
-    await userEvent.click(canvas.getByLabelText("Files"));
-    const homeFile = await body.findByRole("option", { name: /locales\/home\.json/ });
-    await expect(homeFile).toHaveAttribute("aria-checked", "false");
-    await expect(body.getByRole("option", { name: /locales\/pricing\.json/ })).toHaveAttribute(
-      "aria-checked",
-      "false",
-    );
-    await userEvent.keyboard("{Escape}");
+    await expect(await canvas.findByRole("group", { name: "Files" })).toBeInTheDocument();
+    await expect(canvas.getByRole("checkbox", { name: "locales/home.json" })).not.toBeChecked();
+    await expect(canvas.getByRole("checkbox", { name: "locales/pricing.json" })).not.toBeChecked();
+    await expect(
+      canvas.queryByRole("checkbox", { name: "locales/emails/welcome.json" }),
+    ).not.toBeInTheDocument();
 
     await userEvent.click(canvas.getByLabelText("Assignees"));
     const mina = await body.findByRole("option", { name: /Mina Chen/ });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.test.tsx
@@ -102,6 +102,11 @@ const nativeFiles = [
     storedFileId: "file_pricing_json",
     filename: "pricing.json",
   }),
+  createProjectFileRecord({
+    sourcePath: "marketing/campaigns/spring.json",
+    storedFileId: "file_spring_json",
+    filename: "spring.json",
+  }),
 ];
 
 const nativeMembers = [
@@ -183,13 +188,15 @@ describe("CreateJobDialog", () => {
     expect(screen.getByLabelText("Title")).toBeInTheDocument();
     expect(screen.getByLabelText("Source locale")).toHaveTextContent(/English/);
     expect(screen.getByLabelText("Target locales")).toHaveTextContent("All locales");
-    expect(screen.getByLabelText("Files")).toBeInTheDocument();
     expect(screen.getByLabelText("Assignee")).toHaveTextContent("Unassigned");
     expect(screen.queryByLabelText("Task type")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Description")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Create job" })).toBeDisabled();
 
-    await waitFor(() => expect(apiMocks.nativeFilesGet).toHaveBeenCalled());
+    expect(await screen.findByRole("group", { name: "Files" })).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "marketing/home.json" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Collapse marketing" })).toBeInTheDocument();
+    expect(screen.queryByRole("checkbox", { name: "marketing/campaigns/spring.json" })).not.toBeInTheDocument();
   });
 
   it("exposes locale and file membership to assistive technologies", async () => {
@@ -230,28 +237,47 @@ describe("CreateJobDialog", () => {
     );
     await user.keyboard("{Escape}");
 
-    await user.click(screen.getByLabelText("Files"));
-    const fileList = await screen.findByRole("listbox", { name: "Files" });
-    expect(fileList).toHaveAttribute("aria-multiselectable", "true");
-    const homeFile = await screen.findByRole("option", { name: /marketing\/home\.json/ });
-    const pricingFile = screen.getByRole("option", { name: /marketing\/pricing\.json/ });
-    expect(homeFile).toHaveAttribute("aria-checked", "false");
-    expect(pricingFile).toHaveAttribute("aria-checked", "false");
+    const files = await screen.findByRole("group", { name: "Files" });
+    const homeFile = within(files).getByRole("checkbox", { name: "marketing/home.json" });
+    const pricingFile = within(files).getByRole("checkbox", { name: "marketing/pricing.json" });
+    const marketingFolder = screen.getByRole("checkbox", { name: "Select all files in marketing" });
+    expect(homeFile).not.toBeChecked();
+    expect(pricingFile).not.toBeChecked();
+    expect(marketingFolder).not.toBeChecked();
 
     await user.click(homeFile);
-    expect(homeFile).toHaveAttribute("aria-checked", "true");
-    expect(pricingFile).toHaveAttribute("aria-checked", "false");
-    await user.keyboard("{Escape}");
+    expect(homeFile).toBeChecked();
+    expect(pricingFile).not.toBeChecked();
+    expect(marketingFolder).toHaveProperty("indeterminate", true);
+  });
 
-    await user.click(screen.getByLabelText("Files"));
-    expect(await screen.findByRole("option", { name: /marketing\/home\.json/ })).toHaveAttribute(
-      "aria-checked",
-      "true",
-    );
-    expect(screen.getByRole("option", { name: /marketing\/pricing\.json/ })).toHaveAttribute(
-      "aria-checked",
-      "false",
-    );
+  it("selects a folder, collapses nested files, and filters the tree by search", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    const files = await screen.findByRole("group", { name: "Files" });
+    expect(within(files).queryByRole("checkbox", { name: "marketing/campaigns/spring.json" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Expand campaigns" }));
+    const springFile = await screen.findByRole("checkbox", {
+      name: "marketing/campaigns/spring.json",
+    });
+    expect(springFile).toBeInTheDocument();
+
+    await user.click(screen.getByRole("checkbox", { name: "Select all files in marketing" }));
+    expect(within(files).getByRole("checkbox", { name: "marketing/home.json" })).toBeChecked();
+    expect(within(files).getByRole("checkbox", { name: "marketing/pricing.json" })).toBeChecked();
+    expect(springFile).toBeChecked();
+    expect(screen.getByText("3 files")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Collapse marketing" }));
+    expect(screen.queryByRole("checkbox", { name: "marketing/home.json" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Expand marketing" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Expand marketing" }));
+    await user.type(screen.getByLabelText("Search files…"), "pricing");
+    expect(screen.getByRole("checkbox", { name: "marketing/pricing.json" })).toBeInTheDocument();
+    expect(screen.queryByRole("checkbox", { name: "marketing/home.json" })).not.toBeInTheDocument();
   });
 
   it("exposes Crowdin assignee multi-select state when the picker is reopened", async () => {
@@ -287,9 +313,7 @@ describe("CreateJobDialog", () => {
     renderDialog({ onOpenChange, onCreated });
 
     await user.type(screen.getByLabelText("Title"), "Release notes");
-    await user.click(screen.getByLabelText("Files"));
-    await user.click(await screen.findByRole("option", { name: /marketing\/home\.json/ }));
-    await user.keyboard("{Escape}");
+    await user.click(await screen.findByRole("checkbox", { name: "marketing/home.json" }));
     await user.click(screen.getByRole("button", { name: "Create job" }));
 
     await waitFor(() => expect(apiMocks.nativeJobsPost).toHaveBeenCalledTimes(1));
@@ -342,9 +366,7 @@ describe("CreateJobDialog", () => {
 
     await user.type(screen.getByLabelText("Title"), "Homepage");
     await user.type(screen.getByLabelText("Description"), "Ship the homepage first.");
-    await user.click(screen.getByLabelText("Files"));
-    await user.click(await screen.findByRole("option", { name: /locales\/home\.json/ }));
-    await user.keyboard("{Escape}");
+    await user.click(await screen.findByRole("checkbox", { name: "locales/home.json" }));
     await user.click(screen.getByRole("button", { name: "Create job" }));
 
     await waitFor(() => expect(apiMocks.providerJobsPost).toHaveBeenCalledTimes(1));

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.test.tsx
@@ -192,6 +192,94 @@ describe("CreateJobDialog", () => {
     await waitFor(() => expect(apiMocks.nativeFilesGet).toHaveBeenCalled());
   });
 
+  it("exposes locale and file membership to assistive technologies", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByLabelText("Target locales"));
+    const localeList = await screen.findByRole("listbox", { name: "Target locales" });
+    expect(localeList).toHaveAttribute("aria-multiselectable", "true");
+    expect(screen.getByRole("option", { name: /French \(France\)/ })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect(screen.getByRole("option", { name: /German \(Germany\)/ })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+
+    await user.click(screen.getByRole("option", { name: /French \(France\)/ }));
+    expect(screen.getByRole("option", { name: /French \(France\)/ })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+    expect(screen.getByRole("option", { name: /German \(Germany\)/ })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    await user.keyboard("{Escape}");
+
+    await user.click(screen.getByLabelText("Target locales"));
+    expect(screen.getByRole("option", { name: /French \(France\)/ })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+    expect(screen.getByRole("option", { name: /German \(Germany\)/ })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    await user.keyboard("{Escape}");
+
+    await user.click(screen.getByLabelText("Files"));
+    const fileList = await screen.findByRole("listbox", { name: "Files" });
+    expect(fileList).toHaveAttribute("aria-multiselectable", "true");
+    const homeFile = await screen.findByRole("option", { name: /marketing\/home\.json/ });
+    const pricingFile = screen.getByRole("option", { name: /marketing\/pricing\.json/ });
+    expect(homeFile).toHaveAttribute("aria-checked", "false");
+    expect(pricingFile).toHaveAttribute("aria-checked", "false");
+
+    await user.click(homeFile);
+    expect(homeFile).toHaveAttribute("aria-checked", "true");
+    expect(pricingFile).toHaveAttribute("aria-checked", "false");
+    await user.keyboard("{Escape}");
+
+    await user.click(screen.getByLabelText("Files"));
+    expect(await screen.findByRole("option", { name: /marketing\/home\.json/ })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect(screen.getByRole("option", { name: /marketing\/pricing\.json/ })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+  });
+
+  it("exposes Crowdin assignee multi-select state when the picker is reopened", async () => {
+    const user = userEvent.setup();
+    renderDialog({
+      projectId: encodeProviderProjectId({
+        providerKind: "crowdin",
+        externalProjectId: "902807",
+      }),
+    });
+
+    await user.click(screen.getByLabelText("Assignees"));
+    const assigneeList = await screen.findByRole("listbox", { name: "Assignees" });
+    expect(assigneeList).toHaveAttribute("aria-multiselectable", "true");
+    const mina = await screen.findByRole("option", { name: /Mina Chen/ });
+    expect(mina).toHaveAttribute("aria-checked", "false");
+
+    await user.click(mina);
+    expect(mina).toHaveAttribute("aria-checked", "true");
+    await user.keyboard("{Escape}");
+
+    await user.click(screen.getByLabelText("Assignees"));
+    expect(await screen.findByRole("option", { name: /Mina Chen/ })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+  });
+
   it("creates a native job from the composer", async () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.test.tsx
@@ -196,7 +196,9 @@ describe("CreateJobDialog", () => {
     expect(await screen.findByRole("group", { name: "Files" })).toBeInTheDocument();
     expect(screen.getByRole("checkbox", { name: "marketing/home.json" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Collapse marketing" })).toBeInTheDocument();
-    expect(screen.queryByRole("checkbox", { name: "marketing/campaigns/spring.json" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("checkbox", { name: "marketing/campaigns/spring.json" }),
+    ).not.toBeInTheDocument();
   });
 
   it("exposes locale and file membership to assistive technologies", async () => {
@@ -256,7 +258,9 @@ describe("CreateJobDialog", () => {
     renderDialog();
 
     const files = await screen.findByRole("group", { name: "Files" });
-    expect(within(files).queryByRole("checkbox", { name: "marketing/campaigns/spring.json" })).not.toBeInTheDocument();
+    expect(
+      within(files).queryByRole("checkbox", { name: "marketing/campaigns/spring.json" }),
+    ).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Expand campaigns" }));
     const springFile = await screen.findByRole("checkbox", {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.test.tsx
@@ -186,7 +186,7 @@ describe("CreateJobDialog", () => {
 
     expect(screen.getByRole("dialog", { name: "New job" })).toBeInTheDocument();
     expect(screen.getByLabelText("Title")).toBeInTheDocument();
-    expect(screen.getByLabelText("Source locale")).toHaveTextContent(/English/);
+    expect(screen.queryByLabelText("Source locale")).not.toBeInTheDocument();
     expect(screen.getByLabelText("Target locales")).toHaveTextContent("All locales");
     expect(screen.getByLabelText("Assignee")).toHaveTextContent("Unassigned");
     expect(screen.queryByLabelText("Task type")).not.toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.test.tsx
@@ -284,6 +284,60 @@ describe("CreateJobDialog", () => {
     expect(screen.queryByRole("checkbox", { name: "marketing/home.json" })).not.toBeInTheDocument();
   });
 
+  it("selects every file in a folder even when search hides some of them", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await screen.findByRole("group", { name: "Files" });
+    await user.type(screen.getByLabelText("Search files…"), "pricing");
+    const marketingFolder = screen.getByRole("checkbox", { name: "Select all files in marketing" });
+    const pricingFile = screen.getByRole("checkbox", { name: "marketing/pricing.json" });
+
+    await user.click(pricingFile);
+    expect(pricingFile).toBeChecked();
+    expect(marketingFolder).not.toBeChecked();
+    expect(marketingFolder).toHaveProperty("indeterminate", true);
+    expect(screen.getByText("1 file")).toBeInTheDocument();
+
+    await user.click(marketingFolder);
+    expect(pricingFile).toBeChecked();
+    expect(marketingFolder).toBeChecked();
+    expect(screen.getByText("3 files")).toBeInTheDocument();
+
+    await user.clear(screen.getByLabelText("Search files…"));
+    expect(screen.getByRole("checkbox", { name: "marketing/home.json" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "marketing/pricing.json" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Select all files in marketing" })).toBeChecked();
+  });
+
+  it("exposes the native assignee selection when the picker is reopened", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByLabelText("Assignee"));
+    const assigneeList = await screen.findByRole("listbox", { name: "Assignee" });
+    expect(assigneeList).not.toHaveAttribute("aria-multiselectable");
+    expect(screen.getByRole("option", { name: "Unassigned" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    const mina = await screen.findByRole("option", { name: /Mina Chen/ });
+    expect(mina).toHaveAttribute("aria-checked", "false");
+
+    await user.click(mina);
+    expect(screen.getByLabelText("Assignee")).toHaveTextContent("Mina Chen");
+
+    await user.click(screen.getByLabelText("Assignee"));
+    expect(await screen.findByRole("option", { name: /Mina Chen/ })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect(screen.getByRole("option", { name: "Unassigned" })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+  });
+
   it("exposes Crowdin assignee multi-select state when the picker is reopened", async () => {
     const user = userEvent.setup();
     renderDialog({

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.test.tsx
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IntlProvider } from "react-intl";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { createProjectFileRecord } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files.fixture";
+import { encodeProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
+
+import { CreateJobDialog } from "./create-job-dialog";
+
+const apiMocks = vi.hoisted(() => ({
+  nativeFilesGet: vi.fn(),
+  nativeMembersGet: vi.fn(),
+  nativeJobsPost: vi.fn(),
+  providerFilesGet: vi.fn(),
+  providerMembersGet: vi.fn(),
+  providerJobsPost: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+  toastWarning: vi.fn(),
+}));
+
+vi.mock("@/lib/api-client-instance", () => ({
+  apiClient: {
+    api: {
+      orgs: {
+        ":organizationSlug": {
+          projects: {
+            ":projectId": {
+              files: { $get: apiMocks.nativeFilesGet },
+              jobs: { $post: apiMocks.nativeJobsPost },
+            },
+          },
+          members: { $get: apiMocks.nativeMembersGet },
+          "tms-provider": {
+            projects: {
+              ":externalProjectId": {
+                files: { $get: apiMocks.providerFilesGet },
+                members: { $get: apiMocks.providerMembersGet },
+                jobs: { $post: apiMocks.providerJobsPost },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}));
+
+vi.mock("@/components/markdown-editor/markdown-editor", () => ({
+  MarkdownEditor: ({
+    value,
+    onChange,
+    ariaLabel,
+  }: {
+    value: string;
+    onChange: (next: string) => void;
+    ariaLabel?: string;
+  }) => (
+    <textarea
+      aria-label={ariaLabel}
+      value={value}
+      onChange={(event) => onChange(event.currentTarget.value)}
+    />
+  ),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: apiMocks.toastSuccess,
+    error: apiMocks.toastError,
+    warning: apiMocks.toastWarning,
+  },
+}));
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const nativeFiles = [
+  createProjectFileRecord(),
+  createProjectFileRecord({
+    sourcePath: "marketing/pricing.json",
+    storedFileId: "file_pricing_json",
+    filename: "pricing.json",
+  }),
+];
+
+const nativeMembers = [
+  {
+    workosUserId: "user_mina",
+    displayName: "Mina Chen",
+    email: "mina@example.com",
+    status: "active",
+  },
+];
+
+const providerFiles = [
+  {
+    sourcePath: "locales/home.json",
+    filename: "home.json",
+    provider: { externalResourceId: "crowdin_file_home", resourceType: "file" },
+  },
+];
+
+const providerMembers = [
+  {
+    externalUserId: "crowdin_mina",
+    username: "mina",
+    displayName: "Mina Chen",
+    role: "translator",
+  },
+];
+
+function renderDialog({
+  projectId = "project_website",
+  onOpenChange = vi.fn(),
+  onCreated = vi.fn(),
+}: {
+  projectId?: string;
+  onOpenChange?: (open: boolean) => void;
+  onCreated?: () => void;
+} = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en" messages={{}}>
+        <CreateJobDialog
+          open
+          onOpenChange={onOpenChange}
+          organizationSlug="acme"
+          projectId={projectId}
+          sourceLocale="en-US"
+          targetLocales={["fr-FR", "de-DE"]}
+          onCreated={onCreated}
+        />
+      </IntlProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("CreateJobDialog", () => {
+  beforeEach(() => {
+    apiMocks.nativeFilesGet.mockResolvedValue(jsonResponse({ files: nativeFiles }));
+    apiMocks.nativeMembersGet.mockResolvedValue(jsonResponse({ members: nativeMembers }));
+    apiMocks.nativeJobsPost.mockResolvedValue(jsonResponse({ job: { id: "job_native_1" } }, 201));
+    apiMocks.providerFilesGet.mockResolvedValue(jsonResponse({ files: providerFiles }));
+    apiMocks.providerMembersGet.mockResolvedValue(jsonResponse({ members: providerMembers }));
+    apiMocks.providerJobsPost.mockResolvedValue(
+      jsonResponse({ jobs: [{ id: "job_crowdin_fr" }, { id: "job_crowdin_de" }] }, 201),
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the native composer with compact property chips", async () => {
+    renderDialog();
+
+    expect(screen.getByRole("dialog", { name: "New job" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Title")).toBeInTheDocument();
+    expect(screen.getByLabelText("Source locale")).toHaveTextContent(/English/);
+    expect(screen.getByLabelText("Target locales")).toHaveTextContent("All locales");
+    expect(screen.getByLabelText("Files")).toBeInTheDocument();
+    expect(screen.getByLabelText("Assignee")).toHaveTextContent("Unassigned");
+    expect(screen.queryByLabelText("Task type")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Description")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Create job" })).toBeDisabled();
+
+    await waitFor(() => expect(apiMocks.nativeFilesGet).toHaveBeenCalled());
+  });
+
+  it("creates a native job from the composer", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onCreated = vi.fn();
+    renderDialog({ onOpenChange, onCreated });
+
+    await user.type(screen.getByLabelText("Title"), "Release notes");
+    await user.click(screen.getByLabelText("Files"));
+    await user.click(await screen.findByRole("option", { name: /marketing\/home\.json/ }));
+    await user.keyboard("{Escape}");
+    await user.click(screen.getByRole("button", { name: "Create job" }));
+
+    await waitFor(() => expect(apiMocks.nativeJobsPost).toHaveBeenCalledTimes(1));
+    expect(apiMocks.nativeJobsPost.mock.calls[0]?.[0]).toMatchObject({
+      param: { organizationSlug: "acme", projectId: "project_website" },
+      json: {
+        type: "file",
+        title: "Release notes",
+        fileInput: {
+          sourceFileId: "file_home_json",
+          fileFormat: "json",
+          sourceLocale: "en-US",
+          targetLocales: ["fr-FR", "de-DE"],
+        },
+      },
+    });
+    await waitFor(() => expect(onCreated).toHaveBeenCalled());
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(apiMocks.toastSuccess).toHaveBeenCalledWith("Job created");
+  });
+
+  it("renders Crowdin task type and description in the composer", async () => {
+    const user = userEvent.setup();
+    renderDialog({
+      projectId: encodeProviderProjectId({
+        providerKind: "crowdin",
+        externalProjectId: "902807",
+      }),
+    });
+
+    expect(screen.getByLabelText("Task type")).toHaveTextContent("Translation");
+    expect(screen.getByLabelText("Description")).toBeInTheDocument();
+    expect(screen.getByLabelText("Assignees")).toHaveTextContent("Unassigned");
+    expect(screen.queryByLabelText("Source locale")).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Task type"));
+    const listbox = await screen.findByRole("listbox");
+    await user.click(within(listbox).getByRole("option", { name: "Proofread" }));
+    expect(screen.getByLabelText("Task type")).toHaveTextContent("Proofread");
+  });
+
+  it("creates Crowdin jobs with selected files, locales, and description", async () => {
+    const user = userEvent.setup();
+    renderDialog({
+      projectId: encodeProviderProjectId({
+        providerKind: "crowdin",
+        externalProjectId: "902807",
+      }),
+    });
+
+    await user.type(screen.getByLabelText("Title"), "Homepage");
+    await user.type(screen.getByLabelText("Description"), "Ship the homepage first.");
+    await user.click(screen.getByLabelText("Files"));
+    await user.click(await screen.findByRole("option", { name: /locales\/home\.json/ }));
+    await user.keyboard("{Escape}");
+    await user.click(screen.getByRole("button", { name: "Create job" }));
+
+    await waitFor(() => expect(apiMocks.providerJobsPost).toHaveBeenCalledTimes(1));
+    expect(apiMocks.providerJobsPost.mock.calls[0]?.[0]).toMatchObject({
+      param: { organizationSlug: "acme", externalProjectId: "902807" },
+      json: {
+        title: "Homepage",
+        targetLocales: ["fr-FR", "de-DE"],
+        fileIds: ["crowdin_file_home"],
+        kind: "translation",
+        description: "Ship the homepage first.",
+      },
+    });
+    await waitFor(() => expect(apiMocks.toastSuccess).toHaveBeenCalledWith("2 jobs created"));
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
@@ -182,7 +182,7 @@ function CreateJobPropertyPicker({
       <PopoverContent align="start" className="w-80 p-0" sideOffset={6}>
         <Command>
           <CommandInput placeholder={searchPlaceholder} />
-          <CommandList>
+          <CommandList label={ariaLabel} aria-multiselectable={multiple ? true : undefined}>
             <CommandEmpty>
               {isLoading ? <FormattedMessage {...createJobDialogMessages.loading} /> : emptyLabel}
             </CommandEmpty>
@@ -238,6 +238,7 @@ function CreateJobPropertyPicker({
                     key={item.id}
                     value={item.searchValue ?? `${item.id} ${item.label} ${item.secondary ?? ""}`}
                     data-checked={checked || undefined}
+                    aria-checked={multiple ? checked : undefined}
                     onSelect={() => {
                       onToggle(item.id);
                       if (!multiple) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
@@ -219,6 +219,7 @@ function CreateJobPropertyPicker({
                   <CommandItem
                     value={`${intl.formatMessage(createJobDialogMessages.unassigned)} unassigned`}
                     data-checked={selectedIds.length === 0 || undefined}
+                    aria-checked={selectedIds.length === 0}
                     onSelect={() => {
                       onClear?.();
                       setOpen(false);
@@ -238,7 +239,7 @@ function CreateJobPropertyPicker({
                     key={item.id}
                     value={item.searchValue ?? `${item.id} ${item.label} ${item.secondary ?? ""}`}
                     data-checked={checked || undefined}
-                    aria-checked={multiple ? checked : undefined}
+                    aria-checked={checked}
                     onSelect={() => {
                       onToggle(item.id);
                       if (!multiple) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
@@ -24,7 +24,6 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
 import {
   CheckListIcon,
-  File01Icon,
   LanguageCircleIcon,
   TranslateIcon,
   UserIcon,
@@ -76,6 +75,7 @@ import {
 import { cn } from "@/lib/primitives/cn";
 
 import { createJobDialogMessages } from "./create-job-dialog.messages";
+import { CreateJobFileTree } from "./create-job-file-tree";
 
 class PartialCreateJobsError extends Error {
   readonly createdCount: number;
@@ -503,21 +503,6 @@ export function CreateJobDialog({
     });
   }, [intl, selectedLocales, targetLocales.length]);
 
-  const fileTriggerLabel = useMemo(() => {
-    if (selectedFileIds.length === 0) {
-      return intl.formatMessage(createJobDialogMessages.filesLabel);
-    }
-    if (selectedFileIds.length === 1) {
-      return (
-        fileOptions.find((file) => file.id === selectedFileIds[0])?.label ??
-        intl.formatMessage(createJobDialogMessages.filesSelectedCount, { count: 1 })
-      );
-    }
-    return intl.formatMessage(createJobDialogMessages.filesSelectedCount, {
-      count: selectedFileIds.length,
-    });
-  }, [fileOptions, intl, selectedFileIds]);
-
   const assigneeTriggerLabel = useMemo(() => {
     if (selectedAssignees.length === 0) {
       return intl.formatMessage(createJobDialogMessages.unassigned);
@@ -772,6 +757,14 @@ export function CreateJobDialog({
               />
             ) : null}
 
+            <CreateJobFileTree
+              files={fileOptions}
+              selectedIds={selectedFileIds}
+              onSelectedIdsChange={setSelectedFileIds}
+              isLoading={filesLoading}
+              disabled={createJob.isPending}
+            />
+
             <div className="flex flex-wrap items-center gap-0.5 pt-1">
               {isProviderProject ? (
                 <Select
@@ -837,21 +830,6 @@ export function CreateJobDialog({
                     : createJobDialogMessages.noLocalesAvailable,
                 )}
                 searchPlaceholder={intl.formatMessage(createJobDialogMessages.searchLocales)}
-                disabled={createJob.isPending}
-              />
-
-              <CreateJobPropertyPicker
-                icon={File01Icon}
-                ariaLabel={intl.formatMessage(createJobDialogMessages.filesLabel)}
-                triggerLabel={fileTriggerLabel}
-                items={fileOptions.map((file) => ({ id: file.id, label: file.label }))}
-                selectedIds={selectedFileIds}
-                onToggle={(fileId) => setSelectedFileIds((current) => toggleValue(current, fileId))}
-                onSelectAll={() => setSelectedFileIds(fileOptions.map((file) => file.id))}
-                onClear={() => setSelectedFileIds([])}
-                emptyLabel={intl.formatMessage(createJobDialogMessages.noFilesAvailable)}
-                searchPlaceholder={intl.formatMessage(createJobDialogMessages.searchFiles)}
-                isLoading={filesLoading}
                 disabled={createJob.isPending}
               />
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
@@ -12,14 +12,38 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useEffect, useMemo, useState } from "react";
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type FormEvent,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
+import {
+  CheckListIcon,
+  File01Icon,
+  LanguageCircleIcon,
+  TranslateIcon,
+  UserIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
 import { toast } from "sonner";
 
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
 import { MarkdownEditor } from "@/components/markdown-editor/markdown-editor";
 import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
 import {
   Dialog,
   DialogContent,
@@ -29,18 +53,21 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { ScrollArea } from "@/components/ui/scroll-area";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
   SelectTrigger,
-  SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { readApiResponseError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
+import {
+  formatLocaleDisplayName,
+  formatLocaleOptionLabel,
+} from "@/lib/i18n/locale-display-names.messages";
 import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 import {
   inferSupportedTranslationFileFormat,
@@ -83,62 +110,157 @@ type FileOption = {
   fileFormat?: SupportedTranslationFileFormat | null;
 };
 
+type PropertyPickerItem = {
+  id: string;
+  label: string;
+  secondary?: string | null;
+  searchValue?: string;
+};
+
+const propertyTriggerClassName =
+  "h-7 gap-1.5 rounded-md border-0 bg-transparent px-1.5 text-xs font-normal text-muted-foreground shadow-none hover:bg-muted/60 hover:text-foreground";
+
 function toggleValue(values: string[], value: string) {
   return values.includes(value)
     ? values.filter((entry) => entry !== value)
     : [...values, value].toSorted((a, b) => a.localeCompare(b));
 }
 
-function SelectionList({
+function CreateJobPropertyPicker({
+  icon,
+  ariaLabel,
+  triggerLabel,
   items,
-  selected,
+  selectedIds,
   onToggle,
+  onSelectAll,
+  onClear,
   emptyLabel,
+  searchPlaceholder,
+  isLoading,
   disabled,
+  multiple = true,
 }: {
-  items: { id: string; label: string; secondary?: string | null }[];
-  selected: string[];
+  icon: IconSvgElement;
+  ariaLabel: string;
+  triggerLabel: string;
+  items: PropertyPickerItem[];
+  selectedIds: string[];
   onToggle: (id: string) => void;
+  onSelectAll?: () => void;
+  onClear?: () => void;
   emptyLabel: string;
+  searchPlaceholder: string;
+  isLoading?: boolean;
   disabled?: boolean;
+  multiple?: boolean;
 }) {
-  if (items.length === 0) {
-    return <p className="text-sm text-muted-foreground">{emptyLabel}</p>;
-  }
+  const intl = useIntl();
+  const [open, setOpen] = useState(false);
+  const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
 
   return (
-    <ScrollArea className="h-40 rounded-md border border-border">
-      <div className="space-y-1 p-2">
-        {items.map((item) => {
-          const checked = selected.includes(item.id);
-          return (
-            <label
-              key={item.id}
-              className={cn(
-                "flex cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted/60",
-                disabled && "pointer-events-none opacity-60",
-              )}
-            >
-              <input
-                type="checkbox"
-                className="mt-0.5 size-4 rounded border border-input accent-primary"
-                checked={checked}
-                disabled={disabled}
-                onChange={() => onToggle(item.id)}
-              />
-              <span className="min-w-0">
-                <span className="block truncate font-medium text-foreground">{item.label}</span>
-                {item.secondary ? (
-                  <span className="block truncate text-xs text-muted-foreground">
-                    {item.secondary}
-                  </span>
-                ) : null}
-              </span>
-            </label>
-          );
-        })}
-      </div>
-    </ScrollArea>
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={disabled || isLoading}
+            aria-label={ariaLabel}
+            className={cn(propertyTriggerClassName, "max-w-48")}
+          />
+        }
+      >
+        {isLoading ? (
+          <Spinner data-icon="inline-start" />
+        ) : (
+          <HugeiconsIcon icon={icon} strokeWidth={1.8} data-icon="inline-start" />
+        )}
+        <span className="min-w-0 truncate">{triggerLabel}</span>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-80 p-0" sideOffset={6}>
+        <Command>
+          <CommandInput placeholder={searchPlaceholder} />
+          <CommandList>
+            <CommandEmpty>
+              {isLoading ? <FormattedMessage {...createJobDialogMessages.loading} /> : emptyLabel}
+            </CommandEmpty>
+            {multiple && items.length > 0 ? (
+              <>
+                <CommandGroup>
+                  {onSelectAll ? (
+                    <CommandItem
+                      value="select-all"
+                      onSelect={() => {
+                        onSelectAll();
+                      }}
+                    >
+                      <FormattedMessage {...createJobDialogMessages.selectAll} />
+                    </CommandItem>
+                  ) : null}
+                  {onClear && selectedIds.length > 0 ? (
+                    <CommandItem
+                      value="clear-all"
+                      onSelect={() => {
+                        onClear();
+                      }}
+                    >
+                      <FormattedMessage {...createJobDialogMessages.clear} />
+                    </CommandItem>
+                  ) : null}
+                </CommandGroup>
+                <CommandSeparator />
+              </>
+            ) : null}
+            {!multiple ? (
+              <>
+                <CommandGroup>
+                  <CommandItem
+                    value={`${intl.formatMessage(createJobDialogMessages.unassigned)} unassigned`}
+                    data-checked={selectedIds.length === 0 || undefined}
+                    onSelect={() => {
+                      onClear?.();
+                      setOpen(false);
+                    }}
+                  >
+                    <FormattedMessage {...createJobDialogMessages.unassigned} />
+                  </CommandItem>
+                </CommandGroup>
+                <CommandSeparator />
+              </>
+            ) : null}
+            <CommandGroup>
+              {items.map((item) => {
+                const checked = selectedSet.has(item.id);
+                return (
+                  <CommandItem
+                    key={item.id}
+                    value={item.searchValue ?? `${item.id} ${item.label} ${item.secondary ?? ""}`}
+                    data-checked={checked || undefined}
+                    onSelect={() => {
+                      onToggle(item.id);
+                      if (!multiple) {
+                        setOpen(false);
+                      }
+                    }}
+                  >
+                    <span className="min-w-0 flex-1 truncate">
+                      <span className="block truncate">{item.label}</span>
+                      {item.secondary ? (
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {item.secondary}
+                        </span>
+                      ) : null}
+                    </span>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -340,6 +462,76 @@ export function CreateJobDialog({
     ? providerAssigneesQuery.isLoading
     : nativeAssigneesQuery.isLoading;
 
+  const kindItems = useMemo(
+    () => [
+      {
+        value: "translation",
+        label: intl.formatMessage(createJobDialogMessages.taskTypeTranslation),
+      },
+      {
+        value: "proofread",
+        label: intl.formatMessage(createJobDialogMessages.taskTypeProofread),
+      },
+    ],
+    [intl],
+  );
+
+  const localeItems = useMemo(
+    () =>
+      targetLocales.map((locale) => ({
+        id: locale,
+        label: formatLocaleDisplayName(intl, locale),
+        secondary: locale,
+        searchValue: formatLocaleOptionLabel(intl, locale),
+      })),
+    [intl, targetLocales],
+  );
+
+  const localeTriggerLabel = useMemo(() => {
+    if (selectedLocales.length === 0) {
+      return intl.formatMessage(createJobDialogMessages.localesPlaceholder);
+    }
+    if (targetLocales.length > 0 && selectedLocales.length === targetLocales.length) {
+      return intl.formatMessage(createJobDialogMessages.allLocales);
+    }
+    if (selectedLocales.length === 1) {
+      return formatLocaleDisplayName(intl, selectedLocales[0]);
+    }
+    return intl.formatMessage(createJobDialogMessages.localeCount, {
+      count: selectedLocales.length,
+    });
+  }, [intl, selectedLocales, targetLocales.length]);
+
+  const fileTriggerLabel = useMemo(() => {
+    if (selectedFileIds.length === 0) {
+      return intl.formatMessage(createJobDialogMessages.filesLabel);
+    }
+    if (selectedFileIds.length === 1) {
+      return (
+        fileOptions.find((file) => file.id === selectedFileIds[0])?.label ??
+        intl.formatMessage(createJobDialogMessages.filesSelectedCount, { count: 1 })
+      );
+    }
+    return intl.formatMessage(createJobDialogMessages.filesSelectedCount, {
+      count: selectedFileIds.length,
+    });
+  }, [fileOptions, intl, selectedFileIds]);
+
+  const assigneeTriggerLabel = useMemo(() => {
+    if (selectedAssignees.length === 0) {
+      return intl.formatMessage(createJobDialogMessages.unassigned);
+    }
+    if (selectedAssignees.length === 1) {
+      return (
+        assigneeOptions.find((assignee) => assignee.id === selectedAssignees[0])?.label ??
+        intl.formatMessage(createJobDialogMessages.assigneeCount, { count: 1 })
+      );
+    }
+    return intl.formatMessage(createJobDialogMessages.assigneeCount, {
+      count: selectedAssignees.length,
+    });
+  }, [assigneeOptions, intl, selectedAssignees]);
+
   const createJob = useMutation({
     mutationFn: async () => {
       if (!title.trim()) {
@@ -491,178 +683,191 @@ export function CreateJobDialog({
     },
   });
 
+  const canSubmit =
+    !createJob.isPending &&
+    Boolean(title.trim()) &&
+    selectedLocales.length > 0 &&
+    selectedFileIds.length > 0 &&
+    targetLocales.length > 0;
+
+  function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canSubmit) {
+      return;
+    }
+    createJob.mutate();
+  }
+
+  function handleFormKeyDown(event: KeyboardEvent<HTMLFormElement>) {
+    if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+      event.preventDefault();
+      if (canSubmit) {
+        createJob.mutate();
+      }
+    }
+  }
+
+  const sourceLocaleChip: ReactNode = (
+    <span
+      className={cn(
+        propertyTriggerClassName,
+        "inline-flex max-w-48 items-center pointer-events-none hover:bg-transparent",
+      )}
+      aria-label={intl.formatMessage(createJobDialogMessages.sourceLocaleAria)}
+    >
+      <HugeiconsIcon icon={LanguageCircleIcon} strokeWidth={1.8} className="size-3.5" />
+      <FormattedMessage
+        {...createJobDialogMessages.sourceLocale}
+        values={{ locale: formatLocaleDisplayName(intl, sourceLocale) }}
+      />
+    </span>
+  );
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="flex max-h-[90vh] flex-col gap-0 overflow-hidden p-0 sm:max-w-xl">
-        <DialogHeader className="border-b border-border px-6 py-4">
-          <DialogTitle>
-            <FormattedMessage {...createJobDialogMessages.title} />
-          </DialogTitle>
-          <DialogDescription>
-            {isProviderProject ? (
-              <FormattedMessage {...createJobDialogMessages.descriptionProvider} />
-            ) : (
-              <FormattedMessage {...createJobDialogMessages.descriptionNative} />
-            )}
-          </DialogDescription>
-        </DialogHeader>
+        <form
+          onSubmit={submit}
+          onKeyDown={handleFormKeyDown}
+          className="flex min-h-0 flex-1 flex-col"
+        >
+          <DialogHeader className="px-5 pt-4 pb-2">
+            <DialogTitle className="text-sm font-medium text-muted-foreground">
+              <FormattedMessage {...createJobDialogMessages.title} />
+            </DialogTitle>
+            <DialogDescription className="sr-only">
+              {isProviderProject ? (
+                <FormattedMessage {...createJobDialogMessages.descriptionProvider} />
+              ) : (
+                <FormattedMessage {...createJobDialogMessages.descriptionNative} />
+              )}
+            </DialogDescription>
+          </DialogHeader>
 
-        <div className="space-y-5 overflow-y-auto px-6 py-4">
-          <div className="space-y-2">
-            <Label htmlFor="create-job-title">
-              <FormattedMessage {...createJobDialogMessages.titleLabel} />
-            </Label>
+          <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-5 pb-3">
             <Input
               id="create-job-title"
+              name="title"
               value={title}
-              onChange={(event) => setTitle(event.target.value)}
+              onChange={(event) => setTitle(event.currentTarget.value)}
               placeholder={intl.formatMessage(createJobDialogMessages.titlePlaceholder)}
+              aria-label={intl.formatMessage(createJobDialogMessages.titleLabel)}
+              required
+              autoFocus
               maxLength={256}
+              className="h-auto rounded-none border-0 bg-transparent px-0 py-1 text-base font-medium shadow-none focus-visible:ring-0 md:text-lg"
             />
-          </div>
 
-          {isProviderProject ? (
-            <div className="space-y-5">
-              <div className="space-y-2">
-                <Label>
-                  <FormattedMessage {...createJobDialogMessages.taskTypeLabel} />
-                </Label>
+            {isProviderProject ? (
+              <MarkdownEditor
+                value={description}
+                onChange={setDescription}
+                disabled={createJob.isPending}
+                placeholder={intl.formatMessage(createJobDialogMessages.descriptionPlaceholder)}
+                ariaLabel={intl.formatMessage(createJobDialogMessages.descriptionLabel)}
+                chrome="minimal"
+                imageUpload={{ organizationSlug, projectId }}
+                className="min-h-28 bg-transparent px-0"
+              />
+            ) : null}
+
+            <div className="flex flex-wrap items-center gap-0.5 pt-1">
+              {isProviderProject ? (
                 <Select
                   value={kind}
+                  items={kindItems}
                   onValueChange={(value) => {
                     if (value === "translation" || value === "proofread") {
                       setKind(value);
                     }
                   }}
+                  disabled={createJob.isPending}
                 >
-                  <SelectTrigger className="w-full">
-                    <SelectValue>
+                  <SelectTrigger
+                    aria-label={intl.formatMessage(createJobDialogMessages.taskTypeLabel)}
+                    showIcon={false}
+                    className={propertyTriggerClassName}
+                  >
+                    <span className="flex items-center gap-1.5">
+                      <HugeiconsIcon
+                        icon={kind === "proofread" ? CheckListIcon : TranslateIcon}
+                        strokeWidth={1.8}
+                        className="size-3.5"
+                      />
                       {intl.formatMessage(
                         kind === "proofread"
                           ? createJobDialogMessages.taskTypeProofread
                           : createJobDialogMessages.taskTypeTranslation,
                       )}
-                    </SelectValue>
+                    </span>
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem
-                      value="translation"
-                      label={intl.formatMessage(createJobDialogMessages.taskTypeTranslation)}
-                    >
-                      <FormattedMessage {...createJobDialogMessages.taskTypeTranslation} />
-                    </SelectItem>
-                    <SelectItem
-                      value="proofread"
-                      label={intl.formatMessage(createJobDialogMessages.taskTypeProofread)}
-                    >
-                      <FormattedMessage {...createJobDialogMessages.taskTypeProofread} />
-                    </SelectItem>
+                    <SelectGroup>
+                      {kindItems.map((item) => (
+                        <SelectItem key={item.value} value={item.value} label={item.label}>
+                          <span className="flex items-center gap-2">
+                            <HugeiconsIcon
+                              icon={item.value === "proofread" ? CheckListIcon : TranslateIcon}
+                              strokeWidth={1.8}
+                            />
+                            {item.label}
+                          </span>
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
                   </SelectContent>
                 </Select>
-              </div>
-              <div className="space-y-2">
-                <Label>
-                  <FormattedMessage {...createJobDialogMessages.descriptionLabel} />
-                </Label>
-                <MarkdownEditor
-                  value={description}
-                  onChange={setDescription}
-                  disabled={createJob.isPending}
-                  placeholder={intl.formatMessage(createJobDialogMessages.descriptionPlaceholder)}
-                  imageUpload={{ organizationSlug, projectId }}
-                />
-              </div>
-            </div>
-          ) : (
-            <p className="text-sm text-muted-foreground">
-              <FormattedMessage
-                {...createJobDialogMessages.sourceLocale}
-                values={{
-                  locale: <span className="font-medium text-foreground">{sourceLocale}</span>,
-                }}
-              />
-            </p>
-          )}
-
-          <div className="space-y-2">
-            <div className="flex items-center justify-between gap-2">
-              <Label>
-                <FormattedMessage {...createJobDialogMessages.targetLocalesLabel} />
-              </Label>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-7 px-2 text-xs"
-                onClick={() =>
-                  setSelectedLocales(
-                    selectedLocales.length === targetLocales.length ? [] : targetLocales,
-                  )
-                }
-              >
-                {selectedLocales.length === targetLocales.length ? (
-                  <FormattedMessage {...createJobDialogMessages.clear} />
-                ) : (
-                  <FormattedMessage {...createJobDialogMessages.selectAll} />
-                )}
-              </Button>
-            </div>
-            {targetLocales.length === 0 ? (
-              <p className="text-sm text-muted-foreground">
-                <FormattedMessage {...createJobDialogMessages.noTargetLocalesConfigured} />
-              </p>
-            ) : (
-              <SelectionList
-                items={targetLocales.map((locale) => ({ id: locale, label: locale }))}
-                selected={selectedLocales}
-                onToggle={(locale) => setSelectedLocales((current) => toggleValue(current, locale))}
-                emptyLabel={intl.formatMessage(createJobDialogMessages.noLocalesAvailable)}
-              />
-            )}
-          </div>
-
-          <div className="space-y-2">
-            <div className="flex items-center justify-between gap-2">
-              <Label>
-                <FormattedMessage {...createJobDialogMessages.filesLabel} />
-              </Label>
-              <span className="text-xs text-muted-foreground">
-                <FormattedMessage
-                  {...createJobDialogMessages.filesSelectedCount}
-                  values={{ count: selectedFileIds.length }}
-                />
-              </span>
-            </div>
-            {filesLoading ? (
-              <div className="flex h-40 items-center justify-center rounded-md border border-border">
-                <Spinner className="size-4" />
-              </div>
-            ) : (
-              <SelectionList
-                items={fileOptions.map((file) => ({ id: file.id, label: file.label }))}
-                selected={selectedFileIds}
-                onToggle={(fileId) => setSelectedFileIds((current) => toggleValue(current, fileId))}
-                emptyLabel={intl.formatMessage(createJobDialogMessages.noFilesAvailable)}
-              />
-            )}
-          </div>
-
-          <div className="space-y-2">
-            <Label>
-              {isProviderProject ? (
-                <FormattedMessage {...createJobDialogMessages.assigneesLabel} />
               ) : (
-                <FormattedMessage {...createJobDialogMessages.assigneeLabel} />
+                sourceLocaleChip
               )}
-            </Label>
-            {assigneesLoading ? (
-              <div className="flex h-40 items-center justify-center rounded-md border border-border">
-                <Spinner className="size-4" />
-              </div>
-            ) : (
-              <SelectionList
-                items={assigneeOptions}
-                selected={selectedAssignees}
+
+              <CreateJobPropertyPicker
+                icon={LanguageCircleIcon}
+                ariaLabel={intl.formatMessage(createJobDialogMessages.targetLocalesLabel)}
+                triggerLabel={localeTriggerLabel}
+                items={localeItems}
+                selectedIds={selectedLocales}
+                onToggle={(locale) => setSelectedLocales((current) => toggleValue(current, locale))}
+                onSelectAll={() => setSelectedLocales(targetLocales)}
+                onClear={() => setSelectedLocales([])}
+                emptyLabel={intl.formatMessage(
+                  targetLocales.length === 0
+                    ? createJobDialogMessages.noTargetLocalesConfigured
+                    : createJobDialogMessages.noLocalesAvailable,
+                )}
+                searchPlaceholder={intl.formatMessage(createJobDialogMessages.searchLocales)}
+                disabled={createJob.isPending}
+              />
+
+              <CreateJobPropertyPicker
+                icon={File01Icon}
+                ariaLabel={intl.formatMessage(createJobDialogMessages.filesLabel)}
+                triggerLabel={fileTriggerLabel}
+                items={fileOptions.map((file) => ({ id: file.id, label: file.label }))}
+                selectedIds={selectedFileIds}
+                onToggle={(fileId) => setSelectedFileIds((current) => toggleValue(current, fileId))}
+                onSelectAll={() => setSelectedFileIds(fileOptions.map((file) => file.id))}
+                onClear={() => setSelectedFileIds([])}
+                emptyLabel={intl.formatMessage(createJobDialogMessages.noFilesAvailable)}
+                searchPlaceholder={intl.formatMessage(createJobDialogMessages.searchFiles)}
+                isLoading={filesLoading}
+                disabled={createJob.isPending}
+              />
+
+              <CreateJobPropertyPicker
+                icon={UserIcon}
+                ariaLabel={intl.formatMessage(
+                  isProviderProject
+                    ? createJobDialogMessages.assigneesLabel
+                    : createJobDialogMessages.assigneeLabel,
+                )}
+                triggerLabel={assigneeTriggerLabel}
+                items={assigneeOptions.map((assignee) => ({
+                  id: assignee.id,
+                  label: assignee.label,
+                  secondary: assignee.secondary,
+                }))}
+                selectedIds={selectedAssignees}
                 onToggle={(assigneeId) => {
                   if (isProviderProject) {
                     setSelectedAssignees((current) => toggleValue(current, assigneeId));
@@ -672,40 +877,40 @@ export function CreateJobDialog({
                     current.includes(assigneeId) ? [] : [assigneeId],
                   );
                 }}
+                onSelectAll={
+                  isProviderProject
+                    ? () => setSelectedAssignees(assigneeOptions.map((assignee) => assignee.id))
+                    : undefined
+                }
+                onClear={() => setSelectedAssignees([])}
                 emptyLabel={intl.formatMessage(
                   isProviderProject
                     ? createJobDialogMessages.noCrowdinMembers
                     : createJobDialogMessages.noOrgMembers,
                 )}
+                searchPlaceholder={intl.formatMessage(createJobDialogMessages.searchAssignees)}
+                isLoading={assigneesLoading}
+                disabled={createJob.isPending}
+                multiple={isProviderProject}
               />
-            )}
-            {!isProviderProject ? (
-              <p className="text-xs text-muted-foreground">
-                <FormattedMessage {...createJobDialogMessages.assigneeHintNative} />
-              </p>
-            ) : null}
+            </div>
           </div>
-        </div>
 
-        <DialogFooter className="border-t border-border px-6 py-4">
-          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-            <FormattedMessage {...createJobDialogMessages.cancel} />
-          </Button>
-          <Button
-            type="button"
-            disabled={
-              createJob.isPending ||
-              !title.trim() ||
-              selectedLocales.length === 0 ||
-              selectedFileIds.length === 0 ||
-              targetLocales.length === 0
-            }
-            onClick={() => createJob.mutate()}
-          >
-            {createJob.isPending ? <Spinner className="size-4" /> : null}
-            <FormattedMessage {...createJobDialogMessages.submit} />
-          </Button>
-        </DialogFooter>
+          <DialogFooter className="flex-row items-center justify-end gap-2 border-t border-border px-5 py-3 sm:justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={createJob.isPending}
+              onClick={() => onOpenChange(false)}
+            >
+              <FormattedMessage {...createJobDialogMessages.cancel} />
+            </Button>
+            <Button type="submit" disabled={!canSubmit}>
+              {createJob.isPending ? <Spinner data-icon="inline-start" /> : null}
+              <FormattedMessage {...createJobDialogMessages.submit} />
+            </Button>
+          </DialogFooter>
+        </form>
       </DialogContent>
     </Dialog>
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.tsx
@@ -12,14 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import {
-  useEffect,
-  useMemo,
-  useState,
-  type FormEvent,
-  type KeyboardEvent,
-  type ReactNode,
-} from "react";
+import { useEffect, useMemo, useState, type FormEvent, type KeyboardEvent } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
 import {
@@ -694,22 +687,6 @@ export function CreateJobDialog({
     }
   }
 
-  const sourceLocaleChip: ReactNode = (
-    <span
-      className={cn(
-        propertyTriggerClassName,
-        "inline-flex max-w-48 items-center pointer-events-none hover:bg-transparent",
-      )}
-      aria-label={intl.formatMessage(createJobDialogMessages.sourceLocaleAria)}
-    >
-      <HugeiconsIcon icon={LanguageCircleIcon} strokeWidth={1.8} className="size-3.5" />
-      <FormattedMessage
-        {...createJobDialogMessages.sourceLocale}
-        values={{ locale: formatLocaleDisplayName(intl, sourceLocale) }}
-      />
-    </span>
-  );
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="flex max-h-[90vh] flex-col gap-0 overflow-hidden p-0 sm:max-w-xl">
@@ -812,9 +789,7 @@ export function CreateJobDialog({
                     </SelectGroup>
                   </SelectContent>
                 </Select>
-              ) : (
-                sourceLocaleChip
-              )}
+              ) : null}
 
               <CreateJobPropertyPicker
                 icon={LanguageCircleIcon}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-file-tree-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-file-tree-model.test.ts
@@ -17,6 +17,7 @@ import {
   buildCreateJobFileTree,
   collectCreateJobFileIds,
   filterCreateJobFileTree,
+  folderFileIdsByPath,
   folderSelectionState,
   topLevelFolderPaths,
 } from "./create-job-file-tree-model";
@@ -96,6 +97,11 @@ describe("buildCreateJobFileTree", () => {
     expect(collectCreateJobFileIds(marketing!)).toEqual(["spring", "home", "pricing"]);
     expect(topLevelFolderPaths(tree)).toEqual(["legal", "marketing"]);
     expect(allFolderPaths(tree)).toEqual(["legal", "marketing", "marketing/campaigns"]);
+    expect(Object.fromEntries(folderFileIdsByPath(tree))).toEqual({
+      legal: ["terms"],
+      marketing: ["spring", "home", "pricing"],
+      "marketing/campaigns": ["spring"],
+    });
   });
 });
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-file-tree-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-file-tree-model.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  allFolderPaths,
+  buildCreateJobFileTree,
+  collectCreateJobFileIds,
+  filterCreateJobFileTree,
+  folderSelectionState,
+  topLevelFolderPaths,
+} from "./create-job-file-tree-model";
+
+const files = [
+  { id: "home", label: "marketing/home.json" },
+  { id: "pricing", label: "marketing/pricing.json" },
+  { id: "spring", label: "marketing/campaigns/spring.json" },
+  { id: "terms", label: "legal/terms.json" },
+  { id: "readme", label: "README.json" },
+];
+
+describe("buildCreateJobFileTree", () => {
+  it("nests files under collapsible folders and keeps root files at the top level", () => {
+    const tree = buildCreateJobFileTree(files);
+
+    expect(tree).toEqual([
+      {
+        type: "folder",
+        name: "legal",
+        path: "legal",
+        children: [
+          {
+            type: "file",
+            id: "terms",
+            name: "terms.json",
+            path: "legal/terms.json",
+          },
+        ],
+      },
+      {
+        type: "folder",
+        name: "marketing",
+        path: "marketing",
+        children: [
+          {
+            type: "folder",
+            name: "campaigns",
+            path: "marketing/campaigns",
+            children: [
+              {
+                type: "file",
+                id: "spring",
+                name: "spring.json",
+                path: "marketing/campaigns/spring.json",
+              },
+            ],
+          },
+          {
+            type: "file",
+            id: "home",
+            name: "home.json",
+            path: "marketing/home.json",
+          },
+          {
+            type: "file",
+            id: "pricing",
+            name: "pricing.json",
+            path: "marketing/pricing.json",
+          },
+        ],
+      },
+      {
+        type: "file",
+        id: "readme",
+        name: "README.json",
+        path: "README.json",
+      },
+    ]);
+  });
+
+  it("collects descendant file ids and folder paths", () => {
+    const tree = buildCreateJobFileTree(files);
+    const marketing = tree.find((node) => node.type === "folder" && node.path === "marketing");
+
+    expect(marketing).toBeDefined();
+    expect(collectCreateJobFileIds(marketing!)).toEqual(["spring", "home", "pricing"]);
+    expect(topLevelFolderPaths(tree)).toEqual(["legal", "marketing"]);
+    expect(allFolderPaths(tree)).toEqual(["legal", "marketing", "marketing/campaigns"]);
+  });
+});
+
+describe("folderSelectionState", () => {
+  it("reports none, some, and all from the selected id set", () => {
+    const ids = ["home", "pricing", "spring"];
+
+    expect(folderSelectionState(ids, new Set())).toBe("none");
+    expect(folderSelectionState(ids, new Set(["home"]))).toBe("some");
+    expect(folderSelectionState(ids, new Set(ids))).toBe("all");
+  });
+});
+
+describe("filterCreateJobFileTree", () => {
+  it("keeps matching files and ancestor folders", () => {
+    const tree = buildCreateJobFileTree(files);
+    const filtered = filterCreateJobFileTree(tree, "spring");
+
+    expect(filtered).toEqual([
+      {
+        type: "folder",
+        name: "marketing",
+        path: "marketing",
+        children: [
+          {
+            type: "folder",
+            name: "campaigns",
+            path: "marketing/campaigns",
+            children: [
+              {
+                type: "file",
+                id: "spring",
+                name: "spring.json",
+                path: "marketing/campaigns/spring.json",
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("returns the original tree when the query is empty", () => {
+    const tree = buildCreateJobFileTree(files);
+    expect(filterCreateJobFileTree(tree, "  ")).toBe(tree);
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-file-tree-model.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-file-tree-model.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+export type CreateJobFileTreeFile = {
+  type: "file";
+  id: string;
+  name: string;
+  path: string;
+};
+
+export type CreateJobFileTreeFolder = {
+  type: "folder";
+  name: string;
+  path: string;
+  children: CreateJobFileTreeNode[];
+};
+
+export type CreateJobFileTreeNode = CreateJobFileTreeFile | CreateJobFileTreeFolder;
+
+export type CreateJobFileTreeItem = {
+  id: string;
+  label: string;
+};
+
+type DraftFolder = {
+  name: string;
+  path: string;
+  files: CreateJobFileTreeFile[];
+  folders: Map<string, DraftFolder>;
+};
+
+function compareNodes(left: CreateJobFileTreeNode, right: CreateJobFileTreeNode) {
+  if (left.type !== right.type) {
+    return left.type === "folder" ? -1 : 1;
+  }
+  return left.name.localeCompare(right.name);
+}
+
+function freezeFolder(folder: DraftFolder): CreateJobFileTreeFolder {
+  const children: CreateJobFileTreeNode[] = [
+    ...[...folder.folders.values()].map(freezeFolder),
+    ...folder.files,
+  ].toSorted(compareNodes);
+  return {
+    type: "folder",
+    name: folder.name,
+    path: folder.path,
+    children,
+  };
+}
+
+export function buildCreateJobFileTree(files: CreateJobFileTreeItem[]): CreateJobFileTreeNode[] {
+  const rootFolders = new Map<string, DraftFolder>();
+  const rootFiles: CreateJobFileTreeFile[] = [];
+
+  function folderAt(parent: Map<string, DraftFolder>, name: string, path: string) {
+    const existing = parent.get(name);
+    if (existing) {
+      return existing;
+    }
+    const created: DraftFolder = {
+      name,
+      path,
+      files: [],
+      folders: new Map(),
+    };
+    parent.set(name, created);
+    return created;
+  }
+
+  for (const file of files) {
+    const parts = file.label.split("/").filter(Boolean);
+    if (parts.length === 0) {
+      continue;
+    }
+    if (parts.length === 1) {
+      rootFiles.push({
+        type: "file",
+        id: file.id,
+        name: parts[0],
+        path: file.label,
+      });
+      continue;
+    }
+
+    let folders = rootFolders;
+    let path = "";
+    let current: DraftFolder | undefined;
+    for (const folderName of parts.slice(0, -1)) {
+      path = path ? `${path}/${folderName}` : folderName;
+      current = folderAt(folders, folderName, path);
+      folders = current.folders;
+    }
+    current?.files.push({
+      type: "file",
+      id: file.id,
+      name: parts[parts.length - 1],
+      path: file.label,
+    });
+  }
+
+  return [...[...rootFolders.values()].map(freezeFolder), ...rootFiles].toSorted(compareNodes);
+}
+
+export function collectCreateJobFileIds(node: CreateJobFileTreeNode): string[] {
+  if (node.type === "file") {
+    return [node.id];
+  }
+  return node.children.flatMap(collectCreateJobFileIds);
+}
+
+export function folderSelectionState(
+  fileIds: string[],
+  selectedIds: ReadonlySet<string>,
+): "none" | "some" | "all" {
+  if (fileIds.length === 0) {
+    return "none";
+  }
+  let selectedCount = 0;
+  for (const fileId of fileIds) {
+    if (selectedIds.has(fileId)) {
+      selectedCount += 1;
+    }
+  }
+  if (selectedCount === 0) {
+    return "none";
+  }
+  if (selectedCount === fileIds.length) {
+    return "all";
+  }
+  return "some";
+}
+
+export function topLevelFolderPaths(nodes: CreateJobFileTreeNode[]): string[] {
+  return nodes.flatMap((node) => (node.type === "folder" ? [node.path] : []));
+}
+
+export function allFolderPaths(nodes: CreateJobFileTreeNode[]): string[] {
+  return nodes.flatMap((node) =>
+    node.type === "folder" ? [node.path, ...allFolderPaths(node.children)] : [],
+  );
+}
+
+export function filterCreateJobFileTree(
+  nodes: CreateJobFileTreeNode[],
+  query: string,
+): CreateJobFileTreeNode[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    return nodes;
+  }
+
+  function matchNode(node: CreateJobFileTreeNode): CreateJobFileTreeNode | null {
+    if (node.type === "file") {
+      return node.name.toLowerCase().includes(normalized) ||
+        node.path.toLowerCase().includes(normalized)
+        ? node
+        : null;
+    }
+    const children = node.children.flatMap((child) => {
+      const matched = matchNode(child);
+      return matched ? [matched] : [];
+    });
+    if (node.name.toLowerCase().includes(normalized) || children.length > 0) {
+      return { ...node, children };
+    }
+    return null;
+  }
+
+  return nodes.flatMap((node) => {
+    const matched = matchNode(node);
+    return matched ? [matched] : [];
+  });
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-file-tree-model.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-file-tree-model.ts
@@ -119,6 +119,25 @@ export function collectCreateJobFileIds(node: CreateJobFileTreeNode): string[] {
   return node.children.flatMap(collectCreateJobFileIds);
 }
 
+export function folderFileIdsByPath(nodes: CreateJobFileTreeNode[]): Map<string, string[]> {
+  const idsByPath = new Map<string, string[]>();
+
+  function walk(node: CreateJobFileTreeNode) {
+    if (node.type === "file") {
+      return;
+    }
+    idsByPath.set(node.path, collectCreateJobFileIds(node));
+    for (const child of node.children) {
+      walk(child);
+    }
+  }
+
+  for (const node of nodes) {
+    walk(node);
+  }
+  return idsByPath;
+}
+
 export function folderSelectionState(
   fileIds: string[],
   selectedIds: ReadonlySet<string>,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-file-tree.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-file-tree.tsx
@@ -1,0 +1,377 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useEffect, useMemo, useRef, useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+import {
+  ArrowRight01Icon,
+  File01Icon,
+  Folder01Icon,
+  FolderOpenIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/primitives/cn";
+
+import { createJobDialogMessages } from "./create-job-dialog.messages";
+import {
+  allFolderPaths,
+  buildCreateJobFileTree,
+  collectCreateJobFileIds,
+  filterCreateJobFileTree,
+  folderSelectionState,
+  topLevelFolderPaths,
+  type CreateJobFileTreeFolder,
+  type CreateJobFileTreeItem,
+  type CreateJobFileTreeNode,
+} from "./create-job-file-tree-model";
+
+const ROW_CLASS =
+  "flex min-h-7 w-full items-center gap-1.5 rounded-md px-1.5 text-xs hover:bg-muted/60";
+
+function toggleIds(selectedIds: string[], ids: string[], shouldSelect: boolean) {
+  if (shouldSelect) {
+    return [...new Set([...selectedIds, ...ids])].toSorted((left, right) => left.localeCompare(right));
+  }
+  const remove = new Set(ids);
+  return selectedIds.filter((id) => !remove.has(id));
+}
+
+function FolderCheckbox({
+  state,
+  label,
+  disabled,
+  onToggle,
+}: {
+  state: "none" | "some" | "all";
+  label: string;
+  disabled?: boolean;
+  onToggle: () => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.indeterminate = state === "some";
+    }
+  }, [state]);
+
+  return (
+    <input
+      ref={inputRef}
+      type="checkbox"
+      checked={state === "all"}
+      disabled={disabled}
+      aria-label={label}
+      className="size-3.5 shrink-0 rounded border border-input accent-primary"
+      onChange={onToggle}
+      onClick={(event) => event.stopPropagation()}
+    />
+  );
+}
+
+function FileTreeFolder({
+  folder,
+  depth,
+  selectedIds,
+  expandedPaths,
+  disabled,
+  onToggleIds,
+  onExpandedChange,
+}: {
+  folder: CreateJobFileTreeFolder;
+  depth: number;
+  selectedIds: string[];
+  expandedPaths: Set<string>;
+  disabled?: boolean;
+  onToggleIds: (ids: string[], shouldSelect: boolean) => void;
+  onExpandedChange: (path: string, open: boolean) => void;
+}) {
+  const intl = useIntl();
+  const fileIds = useMemo(() => collectCreateJobFileIds(folder), [folder]);
+  const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+  const state = folderSelectionState(fileIds, selectedSet);
+  const open = expandedPaths.has(folder.path);
+  const selectFolderLabel = intl.formatMessage(createJobDialogMessages.selectFolder, {
+    folder: folder.path,
+  });
+
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={(nextOpen) => onExpandedChange(folder.path, nextOpen)}
+    >
+      <div
+        style={{ paddingInlineStart: depth * 12 }}
+        className={ROW_CLASS}
+      >
+        <CollapsibleTrigger
+          render={
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label={intl.formatMessage(
+                open
+                  ? createJobDialogMessages.collapseFolder
+                  : createJobDialogMessages.expandFolder,
+                { folder: folder.name },
+              )}
+              className="size-5 shrink-0 text-muted-foreground"
+            />
+          }
+        >
+          <HugeiconsIcon
+            icon={ArrowRight01Icon}
+            strokeWidth={1.8}
+            data-icon
+            className={cn(
+              "size-3.5 transition-transform rtl:rotate-180",
+              open && "rotate-90 rtl:rotate-90",
+            )}
+          />
+        </CollapsibleTrigger>
+        <FolderCheckbox
+          state={state}
+          label={selectFolderLabel}
+          disabled={disabled}
+          onToggle={() => onToggleIds(fileIds, state !== "all")}
+        />
+        <HugeiconsIcon
+          icon={open ? FolderOpenIcon : Folder01Icon}
+          strokeWidth={1.8}
+          className="size-3.5 shrink-0 text-muted-foreground"
+        />
+        <span className="min-w-0 truncate font-medium">{folder.name}</span>
+      </div>
+      <CollapsibleContent>
+        <div role="group" className="flex flex-col">
+          {folder.children.map((child) => (
+            <FileTreeNode
+              key={child.type === "folder" ? `folder:${child.path}` : child.id}
+              node={child}
+              depth={depth + 1}
+              selectedIds={selectedIds}
+              expandedPaths={expandedPaths}
+              disabled={disabled}
+              onToggleIds={onToggleIds}
+              onExpandedChange={onExpandedChange}
+            />
+          ))}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function FileTreeNode({
+  node,
+  depth,
+  selectedIds,
+  expandedPaths,
+  disabled,
+  onToggleIds,
+  onExpandedChange,
+}: {
+  node: CreateJobFileTreeNode;
+  depth: number;
+  selectedIds: string[];
+  expandedPaths: Set<string>;
+  disabled?: boolean;
+  onToggleIds: (ids: string[], shouldSelect: boolean) => void;
+  onExpandedChange: (path: string, open: boolean) => void;
+}) {
+  if (node.type === "folder") {
+    return (
+      <FileTreeFolder
+        folder={node}
+        depth={depth}
+        selectedIds={selectedIds}
+        expandedPaths={expandedPaths}
+        disabled={disabled}
+        onToggleIds={onToggleIds}
+        onExpandedChange={onExpandedChange}
+      />
+    );
+  }
+
+  const checked = selectedIds.includes(node.id);
+  return (
+    <label
+      style={{ paddingInlineStart: 20 + depth * 12 }}
+      className={cn(ROW_CLASS, "cursor-pointer")}
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        aria-label={node.path}
+        className="size-3.5 shrink-0 rounded border border-input accent-primary"
+        onChange={() => onToggleIds([node.id], !checked)}
+      />
+      <HugeiconsIcon
+        icon={File01Icon}
+        strokeWidth={1.8}
+        className="size-3.5 shrink-0 text-muted-foreground"
+      />
+      <span className="min-w-0 truncate">{node.name}</span>
+    </label>
+  );
+}
+
+export function CreateJobFileTree({
+  files,
+  selectedIds,
+  onSelectedIdsChange,
+  isLoading,
+  disabled,
+}: {
+  files: CreateJobFileTreeItem[];
+  selectedIds: string[];
+  onSelectedIdsChange: (ids: string[]) => void;
+  isLoading?: boolean;
+  disabled?: boolean;
+}) {
+  const intl = useIntl();
+  const [query, setQuery] = useState("");
+  const tree = useMemo(() => buildCreateJobFileTree(files), [files]);
+  const filteredTree = useMemo(() => filterCreateJobFileTree(tree, query), [query, tree]);
+  const defaultExpanded = useMemo(() => topLevelFolderPaths(tree), [tree]);
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => new Set(defaultExpanded));
+  const treeKey = useMemo(() => files.map((file) => file.id).join("\0"), [files]);
+
+  useEffect(() => {
+    setExpandedPaths(new Set(topLevelFolderPaths(tree)));
+  }, [tree, treeKey]);
+
+  const visibleExpandedPaths = useMemo(() => {
+    if (query.trim()) {
+      return new Set(allFolderPaths(filteredTree));
+    }
+    return expandedPaths;
+  }, [expandedPaths, filteredTree, query]);
+
+  function handleToggleIds(ids: string[], shouldSelect: boolean) {
+    onSelectedIdsChange(toggleIds(selectedIds, ids, shouldSelect));
+  }
+
+  function handleExpandedChange(path: string, open: boolean) {
+    setExpandedPaths((current) => {
+      const next = new Set(current);
+      if (open) {
+        next.add(path);
+      } else {
+        next.delete(path);
+      }
+      return next;
+    });
+  }
+
+  const filesLabel = intl.formatMessage(createJobDialogMessages.filesLabel);
+
+  return (
+    <div className="flex min-h-0 flex-col gap-1.5 rounded-lg border border-border/80 bg-muted/20 p-2">
+      <div className="flex items-center justify-between gap-2 px-0.5">
+        <div className="flex min-w-0 items-center gap-2">
+          <p className="text-xs font-medium text-muted-foreground">{filesLabel}</p>
+          {selectedIds.length > 0 ? (
+            <p className="text-xs tabular-nums text-muted-foreground">
+              {intl.formatMessage(createJobDialogMessages.filesSelectedCount, {
+                count: selectedIds.length,
+              })}
+            </p>
+          ) : null}
+        </div>
+        {files.length > 0 ? (
+          <div className="flex items-center gap-1">
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              disabled={disabled || isLoading || selectedIds.length === files.length}
+              onClick={() => onSelectedIdsChange(files.map((file) => file.id))}
+            >
+              <FormattedMessage {...createJobDialogMessages.selectAll} />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              disabled={disabled || isLoading || selectedIds.length === 0}
+              onClick={() => onSelectedIdsChange([])}
+            >
+              <FormattedMessage {...createJobDialogMessages.clear} />
+            </Button>
+          </div>
+        ) : null}
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center gap-2 px-0.5 py-3 text-xs text-muted-foreground">
+          <Spinner />
+          <FormattedMessage {...createJobDialogMessages.loading} />
+        </div>
+      ) : files.length === 0 ? (
+        <p className="px-0.5 py-3 text-xs text-muted-foreground">
+          <FormattedMessage {...createJobDialogMessages.noFilesAvailable} />
+        </p>
+      ) : (
+        <>
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.currentTarget.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+              }
+            }}
+            placeholder={intl.formatMessage(createJobDialogMessages.searchFiles)}
+            aria-label={intl.formatMessage(createJobDialogMessages.searchFiles)}
+            disabled={disabled}
+            autoComplete="off"
+            className="h-8 bg-background/60 text-xs md:text-xs"
+          />
+          {filteredTree.length === 0 ? (
+            <p className="px-0.5 py-3 text-xs text-muted-foreground">
+              <FormattedMessage {...createJobDialogMessages.filesSearchEmpty} />
+            </p>
+          ) : (
+            <div
+              className="flex max-h-52 flex-col overflow-y-auto"
+              role="group"
+              aria-label={filesLabel}
+            >
+              {filteredTree.map((node) => (
+                <FileTreeNode
+                  key={node.type === "folder" ? `folder:${node.path}` : node.id}
+                  node={node}
+                  depth={0}
+                  selectedIds={selectedIds}
+                  expandedPaths={visibleExpandedPaths}
+                  disabled={disabled}
+                  onToggleIds={handleToggleIds}
+                  onExpandedChange={handleExpandedChange}
+                />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-file-tree.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-file-tree.tsx
@@ -34,6 +34,7 @@ import {
   buildCreateJobFileTree,
   collectCreateJobFileIds,
   filterCreateJobFileTree,
+  folderFileIdsByPath,
   folderSelectionState,
   topLevelFolderPaths,
   type CreateJobFileTreeFolder,
@@ -89,23 +90,26 @@ function FolderCheckbox({
 
 function FileTreeFolder({
   folder,
+  fileIds,
   depth,
   selectedIds,
   expandedPaths,
   disabled,
   onToggleIds,
   onExpandedChange,
+  folderIdsByPath,
 }: {
   folder: CreateJobFileTreeFolder;
+  fileIds: string[];
   depth: number;
   selectedIds: string[];
   expandedPaths: Set<string>;
   disabled?: boolean;
   onToggleIds: (ids: string[], shouldSelect: boolean) => void;
   onExpandedChange: (path: string, open: boolean) => void;
+  folderIdsByPath: ReadonlyMap<string, string[]>;
 }) {
   const intl = useIntl();
-  const fileIds = useMemo(() => collectCreateJobFileIds(folder), [folder]);
   const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
   const state = folderSelectionState(fileIds, selectedSet);
   const open = expandedPaths.has(folder.path);
@@ -167,6 +171,7 @@ function FileTreeFolder({
               disabled={disabled}
               onToggleIds={onToggleIds}
               onExpandedChange={onExpandedChange}
+              folderIdsByPath={folderIdsByPath}
             />
           ))}
         </div>
@@ -183,6 +188,7 @@ function FileTreeNode({
   disabled,
   onToggleIds,
   onExpandedChange,
+  folderIdsByPath,
 }: {
   node: CreateJobFileTreeNode;
   depth: number;
@@ -191,17 +197,20 @@ function FileTreeNode({
   disabled?: boolean;
   onToggleIds: (ids: string[], shouldSelect: boolean) => void;
   onExpandedChange: (path: string, open: boolean) => void;
+  folderIdsByPath: ReadonlyMap<string, string[]>;
 }) {
   if (node.type === "folder") {
     return (
       <FileTreeFolder
         folder={node}
+        fileIds={folderIdsByPath.get(node.path) ?? collectCreateJobFileIds(node)}
         depth={depth}
         selectedIds={selectedIds}
         expandedPaths={expandedPaths}
         disabled={disabled}
         onToggleIds={onToggleIds}
         onExpandedChange={onExpandedChange}
+        folderIdsByPath={folderIdsByPath}
       />
     );
   }
@@ -246,6 +255,7 @@ export function CreateJobFileTree({
   const intl = useIntl();
   const [query, setQuery] = useState("");
   const tree = useMemo(() => buildCreateJobFileTree(files), [files]);
+  const folderIdsByPath = useMemo(() => folderFileIdsByPath(tree), [tree]);
   const filteredTree = useMemo(() => filterCreateJobFileTree(tree, query), [query, tree]);
   const defaultExpanded = useMemo(() => topLevelFolderPaths(tree), [tree]);
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => new Set(defaultExpanded));
@@ -362,6 +372,7 @@ export function CreateJobFileTree({
                   disabled={disabled}
                   onToggleIds={handleToggleIds}
                   onExpandedChange={handleExpandedChange}
+                  folderIdsByPath={folderIdsByPath}
                 />
               ))}
             </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-file-tree.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-file-tree.tsx
@@ -46,7 +46,9 @@ const ROW_CLASS =
 
 function toggleIds(selectedIds: string[], ids: string[], shouldSelect: boolean) {
   if (shouldSelect) {
-    return [...new Set([...selectedIds, ...ids])].toSorted((left, right) => left.localeCompare(right));
+    return [...new Set([...selectedIds, ...ids])].toSorted((left, right) =>
+      left.localeCompare(right),
+    );
   }
   const remove = new Set(ids);
   return selectedIds.filter((id) => !remove.has(id));
@@ -112,14 +114,8 @@ function FileTreeFolder({
   });
 
   return (
-    <Collapsible
-      open={open}
-      onOpenChange={(nextOpen) => onExpandedChange(folder.path, nextOpen)}
-    >
-      <div
-        style={{ paddingInlineStart: depth * 12 }}
-        className={ROW_CLASS}
-      >
+    <Collapsible open={open} onOpenChange={(nextOpen) => onExpandedChange(folder.path, nextOpen)}>
+      <div style={{ paddingInlineStart: depth * 12 }} className={ROW_CLASS}>
         <CollapsibleTrigger
           render={
             <Button


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The create-job dialog now uses the same compact composer as the create-issue dialog: muted "New job" title, borderless title field, optional Crowdin description, and ghost chips for task type, locales, and assignees. Native jobs no longer show a read-only source locale chip; the project source locale is still sent in the create payload.

Files are no longer a Select/Command chip. They appear as an inline collapsible tree: folders expand and collapse, a folder checkbox selects every descendant file (indeterminate when mixed), and search filters the tree. Nested folders start collapsed so large projects stay scannable. Folder checkbox state and select-all always use the unfiltered tree, so a search cannot shrink what a folder checkbox selects.

Job-creation behavior is unchanged. Native jobs still create one job per selected file with an optional single assignee. Crowdin jobs still send `kind`, description, file IDs, and assignees, and still handle partial creates.

Locale, Crowdin assignee, and native assignee pickers expose membership with `aria-checked`. File selection uses native checkboxes in the tree.

## How to test

- `vp test src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-dialog.test.tsx src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/create-job-file-tree-model.test.ts`
- `vp check --fix`
- Storybook: `App/Jobs/Create Dialog` (`Native` and `Crowdin`)
- Open Create job. Confirm native has no source locale chip. Search the file tree, select a folder, then clear search and confirm hidden files were selected too.

[Native create job dialog without a source locale chip](https://cursor.com/agents/bc-f3a5c385-590a-49ec-bd76-8e4dc94d3220/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcreate_job_dialog_native_no_source_chip.webp)
[Native create job file tree with nested campaigns expanded](https://cursor.com/agents/bc-f3a5c385-590a-49ec-bd76-8e4dc94d3220/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcreate_job_file_tree_native_expanded.webp)
[Marketing folder selected, three files checked](https://cursor.com/agents/bc-f3a5c385-590a-49ec-bd76-8e4dc94d3220/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcreate_job_file_tree_native_folder_selected.webp)
[create_job_file_tree_walkthrough.mp4](https://cursor.com/agents/bc-f3a5c385-590a-49ec-bd76-8e4dc94d3220/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcreate_job_file_tree_walkthrough.mp4)

## Checklist

- [x] I ran relevant checks locally (`vp test` for the dialog and file-tree model, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3a5c385-590a-49ec-bd76-8e4dc94d3220?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3a5c385-590a-49ec-bd76-8e4dc94d3220&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

