### PR TITLE
feat(web): red 9+ unread badge on Inbox sidebar

### DIFF
--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
@@ -40,6 +40,10 @@ import {
 
 import { appShellNavigationMessages } from "./app-shell-navigation.messages";
 import { filterNavigationItemsByWorkspaceFlags } from "@/lib/flags/workspace-flag-navigation";
+import {
+  formatInboxUnreadBadgeLabel,
+  inboxUnreadBadgeClassName,
+} from "./inbox-unread-badge";
 
 import {
   buildOrganizationPath,
@@ -262,7 +266,7 @@ function NavigationGroupItems({
     refetchInterval: 45_000,
   });
   const unreadCount = unreadCountQuery.data ?? 0;
-  const unreadBadgeLabel = unreadCount > 99 ? "99+" : unreadCount > 0 ? String(unreadCount) : null;
+  const unreadBadgeLabel = formatInboxUnreadBadgeLabel(unreadCount);
 
   return (
     <SidebarGroupContent>
@@ -303,7 +307,7 @@ function NavigationGroupItems({
                 ) : null}
               </SidebarMenuButton>
               {dynamicBadge ? (
-                <SidebarMenuBadge className="pointer-events-none peer-hover/menu-button:text-sidebar-accent-foreground">
+                <SidebarMenuBadge className={inboxUnreadBadgeClassName}>
                   {dynamicBadge}
                 </SidebarMenuBadge>
               ) : null}

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
@@ -40,10 +40,7 @@ import {
 
 import { appShellNavigationMessages } from "./app-shell-navigation.messages";
 import { filterNavigationItemsByWorkspaceFlags } from "@/lib/flags/workspace-flag-navigation";
-import {
-  formatInboxUnreadBadgeLabel,
-  inboxUnreadBadgeClassName,
-} from "./inbox-unread-badge";
+import { formatInboxUnreadBadgeLabel, inboxUnreadBadgeClassName } from "./inbox-unread-badge";
 
 import {
   buildOrganizationPath,

--- a/apps/hyperlocalise-web/src/components/app-shell/inbox-unread-badge.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/inbox-unread-badge.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { formatInboxUnreadBadgeLabel } from "./inbox-unread-badge";
+
+describe("formatInboxUnreadBadgeLabel", () => {
+  it("hides the badge when there are no unread items", () => {
+    expect(formatInboxUnreadBadgeLabel(0)).toBeNull();
+    expect(formatInboxUnreadBadgeLabel(-1)).toBeNull();
+  });
+
+  it("shows exact counts from 1 through 9", () => {
+    expect(formatInboxUnreadBadgeLabel(1)).toBe("1");
+    expect(formatInboxUnreadBadgeLabel(9)).toBe("9");
+  });
+
+  it("caps counts above 9 as 9+", () => {
+    expect(formatInboxUnreadBadgeLabel(10)).toBe("9+");
+    expect(formatInboxUnreadBadgeLabel(99)).toBe("9+");
+  });
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/inbox-unread-badge.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/inbox-unread-badge.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+/** Cap an inbox unread count for sidebar badge display (`9+` above nine). */
+export function formatInboxUnreadBadgeLabel(count: number): string | null {
+  if (count <= 0) {
+    return null;
+  }
+
+  if (count > 9) {
+    return "9+";
+  }
+
+  return String(count);
+}
+
+/** Solid red unread badge styles with readable contrast in light and dark mode. */
+export const inboxUnreadBadgeClassName =
+  "bg-destructive-solid text-[0.625rem] leading-none font-semibold text-destructive-foreground peer-hover/menu-button:text-destructive-foreground peer-data-active/menu-button:text-destructive-foreground";

--- a/apps/hyperlocalise-web/src/components/ui/sidebar.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/sidebar.stories.tsx
@@ -13,6 +13,8 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { expect } from "storybook/test";
 
+import { inboxUnreadBadgeClassName } from "@/components/app-shell/inbox-unread-badge";
+
 import {
   Sidebar,
   SidebarContent,
@@ -57,8 +59,11 @@ export const Overview: Story = {
             <SidebarGroupContent>
               <SidebarMenu>
                 <SidebarMenuItem>
-                  <SidebarMenuButton isActive>Mobile checkout</SidebarMenuButton>
-                  <SidebarMenuBadge>8</SidebarMenuBadge>
+                  <SidebarMenuButton isActive>Inbox</SidebarMenuButton>
+                  <SidebarMenuBadge className={inboxUnreadBadgeClassName}>9+</SidebarMenuBadge>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton>Projects</SidebarMenuButton>
                 </SidebarMenuItem>
                 <SidebarMenuItem>
                   <SidebarMenuButton variant="outline" size="sm">
@@ -91,6 +96,7 @@ export const Overview: Story = {
     </SidebarProvider>
   ),
   play: async ({ canvas }) => {
-    await expect(canvas.getByText("Mobile checkout")).toBeInTheDocument();
+    await expect(canvas.getByText("Inbox")).toBeInTheDocument();
+    await expect(canvas.getByText("9+")).toBeInTheDocument();
   },
 };

--- a/docs/plans/2026-08-16-inbox-sidebar-unread-badge-design.md
+++ b/docs/plans/2026-08-16-inbox-sidebar-unread-badge-design.md
@@ -1,0 +1,33 @@
+# Inbox sidebar unread badge
+
+## Problem
+
+The sidebar Inbox item already fetches unread notification count, but the badge
+caps at `99+` and uses default sidebar text color. Unread state is easy to miss,
+especially across light and dark themes.
+
+## Decision
+
+Keep the existing unread-count query on Inbox. Change only display:
+
+1. Cap the label at `9+` when count is greater than 9 (same rule as overview
+   attention badges).
+2. Hide the badge when count is 0 or still loading with no data.
+3. Style the badge as a solid red pill using `destructive-solid` background and
+   `destructive-foreground` text so contrast stays readable in light and dark
+   mode.
+4. Keep white/red colors on hover and active menu states so peer text overrides
+   do not wash out the badge.
+
+## Behavior
+
+| Unread count | Badge |
+| --- | --- |
+| 0 / unknown | none |
+| 1–9 | exact number |
+| 10+ | `9+` |
+
+## Out of scope
+
+Collapsed icon-mode badge placement, unread conversation counts (non-notification
+inbox threads), and toast/dot alternatives.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Cap the sidebar **Inbox** unread notification badge at `9+` (was `99+`).
- Style the badge with `destructive-solid` red + white text for readable contrast in light and dark mode.
- Extract `formatInboxUnreadBadgeLabel` with unit coverage; update Sidebar Storybook Overview to show the badge.

## How to test

- Unit: `vp test src/components/app-shell/inbox-unread-badge.test.ts`
- Full web suite: `vp test` (4294 passed) and `vp check --fix`
- Storybook: `UI/Sidebar` → Overview — Inbox shows red `9+` in light and dark themes

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0090b-b0ac-7356-a81c-666ba06759e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0090b-b0ac-7356-a81c-666ba06759e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

