### PR TITLE
feat(chat): support image/video jobs and project selector

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.test.ts
@@ -212,6 +212,38 @@ describe("conversation creation", () => {
         url: `/api/orgs/${encodeURIComponent(identity.organization.slug)}/files/${body.files[0]!.id}`,
       }),
     ]);
+    expect(message?.text).toContain(`sourceFileId=${body.files[0]!.id}`);
+    expect(message?.text).toContain("fileFormat=json");
+  });
+
+  it("appends image sourceFileId markers so chat can create localization jobs", async () => {
+    const identity = createWorkosIdentity();
+    const headers = await authHeadersFor(identity);
+    const formData = new FormData();
+    formData.set("text", "Localize the attached image to ja-JP");
+    formData.append(
+      "files",
+      new File([Uint8Array.from([137, 80, 78, 71])], "banner.png", {
+        type: "image/png",
+      }),
+    );
+
+    const response = await app.request(`/api/orgs/${identity.organization.slug}/conversations`, {
+      method: "POST",
+      headers,
+      body: formData,
+    });
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as {
+      conversation: { id: string };
+      files: Array<{ id: string; filename: string }>;
+      message: { text: string };
+    };
+    expect(body.files[0]).toMatchObject({ filename: "banner.png" });
+    expect(body.message.text).toContain("Localize the attached image to ja-JP");
+    expect(body.message.text).toContain(`sourceFileId=${body.files[0]!.id}`);
+    expect(body.message.text).toContain("fileFormat=png");
   });
 
   it("seeds selected GitHub repository context when creating a chat UI conversation", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
@@ -26,6 +26,10 @@ import { getFileStorageAdapter } from "@/lib/file-storage";
 import { createStoredFile } from "@/lib/file-storage/records";
 import { getOwnedProject } from "@/api/routes/project/project.shared";
 import { addInteractionMessage, createInteraction } from "@/lib/conversations/interactions";
+import {
+  appendStoredFileContext,
+  toStoredTranslationFileRef,
+} from "@/lib/conversations/stored-file-context";
 import { inferSupportedSourceUploadFormat } from "@/lib/translation/file-formats";
 import type { RepositoryAgentGitHubContext } from "@/lib/agent-contracts/repository-task";
 import {
@@ -373,7 +377,6 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
       if (!parsed.data.text && files.length === 0) {
         return badRequestResponse(c, "invalid_conversation_payload");
       }
-      const messageText = parsed.data.text || "Please translate the attached source file.";
 
       if (files.length > maxMessageUploadFiles) {
         return tooManyFilesResponse(c);
@@ -456,6 +459,12 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
           : new Error("failed to store uploaded file");
       }
 
+      const translationFileRefs = storedFiles
+        .map((file) => toStoredTranslationFileRef(file))
+        .filter((file): file is NonNullable<typeof file> => file !== null);
+      const userFacingText = parsed.data.text || "Please translate the attached source file.";
+      const messageText = appendStoredFileContext(userFacingText, translationFileRefs);
+
       let conversation: Awaited<ReturnType<typeof createInteraction>> | undefined;
       let responseFiles = storedFiles;
       let message;
@@ -463,7 +472,7 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
         const createdConversation = await createInteraction({
           organizationId: orgId,
           source: "chat_ui",
-          title: messageText.slice(0, 120),
+          title: userFacingText.slice(0, 120),
           projectId,
         });
         conversation = createdConversation;
@@ -590,6 +599,14 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
           return tooManyFilesResponse(c);
         }
 
+        for (const file of files) {
+          if (!inferSupportedSourceUploadFormat(file.name)) {
+            return badRequestResponse(c, "unsupported_translation_source_file", undefined, {
+              filename: file.name,
+            });
+          }
+        }
+
         if (conversation.source !== "chat_ui") {
           return c.json({ error: "conversation_not_replyable" }, 400);
         }
@@ -663,6 +680,14 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
             : new Error("failed to store uploaded file");
         }
 
+        const translationFileRefs = storedFiles
+          .map((file) => toStoredTranslationFileRef(file))
+          .filter((file): file is NonNullable<typeof file> => file !== null);
+        const messageText = appendStoredFileContext(
+          text.trim() || (files.length > 0 ? "Please translate the attached source file." : ""),
+          translationFileRefs,
+        );
+
         if (repositoryGitHubContext) {
           await seedConversationRepositorySession({
             conversationId,
@@ -677,7 +702,7 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
             interactionId: conversationId,
             senderType: "user",
             senderEmail: c.var.auth.user.email,
-            text,
+            text: messageText,
             attachments: storedFiles.map((file) => ({
               id: file.id,
               filename: file.filename,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/project-selector-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/project-selector-model.test.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildChatProjectOptions,
+  resolveChatProjectLabel,
+  resolveChatProjectSelection,
+} from "./project-selector-model";
+
+describe("project selector model", () => {
+  it("merges live TMS projects ahead of native projects", () => {
+    expect(
+      buildChatProjectOptions({
+        nativeProjects: [
+          { id: "proj_native", name: "Mobile", source: "native" },
+          { id: "proj_synced", name: "Synced Crowdin", source: "external_tms" },
+        ],
+        tmsProjects: [
+          {
+            id: "ext:crowdin:42",
+            name: "Crowdin App",
+            source: "external_tms",
+            externalProviderKind: "crowdin",
+          },
+          {
+            id: "ext:crowdin:99",
+            name: "Inactive",
+            source: "external_tms",
+            isActive: false,
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        id: "ext:crowdin:42",
+        name: "Crowdin App",
+        source: "external_tms",
+        externalProviderKind: "crowdin",
+      },
+      {
+        id: "proj_native",
+        name: "Mobile",
+        source: "native",
+        externalProviderKind: null,
+      },
+    ]);
+  });
+
+  it("prefers locked, selected, initial, then single-project auto-select", () => {
+    const projects = buildChatProjectOptions({
+      nativeProjects: [
+        { id: "proj_a", name: "A", source: "native" },
+        { id: "proj_b", name: "B", source: "native" },
+      ],
+      tmsProjects: [],
+    });
+
+    expect(
+      resolveChatProjectSelection({
+        projects,
+        selectedProjectId: "proj_b",
+        lockedProjectId: "proj_a",
+        initialProjectId: "proj_b",
+      }),
+    ).toBe("proj_a");
+
+    expect(
+      resolveChatProjectSelection({
+        projects,
+        selectedProjectId: "proj_b",
+        initialProjectId: "proj_a",
+      }),
+    ).toBe("proj_b");
+
+    expect(
+      resolveChatProjectSelection({
+        projects,
+        selectedProjectId: "",
+        initialProjectId: "proj_b",
+      }),
+    ).toBe("proj_b");
+
+    expect(
+      resolveChatProjectSelection({
+        projects: [],
+        selectedProjectId: "",
+        initialProjectId: "cat-project",
+      }),
+    ).toBe("cat-project");
+
+    expect(
+      resolveChatProjectSelection({
+        projects: projects.slice(0, 1),
+        selectedProjectId: "",
+      }),
+    ).toBe("proj_a");
+  });
+
+  it("resolves labels from the project list or locked fallback name", () => {
+    const projects = buildChatProjectOptions({
+      nativeProjects: [{ id: "proj_a", name: "Mobile", source: "native" }],
+      tmsProjects: [],
+    });
+
+    expect(
+      resolveChatProjectLabel({
+        projects,
+        projectId: "proj_a",
+        placeholder: "Project",
+      }),
+    ).toBe("Mobile");
+
+    expect(
+      resolveChatProjectLabel({
+        projects,
+        projectId: "ext:crowdin:42",
+        fallbackName: "CAT Project",
+        placeholder: "Project",
+      }),
+    ).toBe("CAT Project");
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/project-selector-model.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/project-selector-model.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+export type ChatProjectOption = {
+  id: string;
+  name: string;
+  source: "native" | "external_tms";
+  externalProviderKind?: string | null;
+};
+
+type ProjectLike = {
+  id: string;
+  name: string;
+  source?: "native" | "external_tms" | null;
+  externalProviderKind?: string | null;
+  isActive?: boolean;
+};
+
+export function buildChatProjectOptions(input: {
+  nativeProjects: ProjectLike[];
+  tmsProjects: ProjectLike[];
+}): ChatProjectOption[] {
+  const tms = input.tmsProjects
+    .filter((project) => project.isActive !== false && project.id.trim().length > 0)
+    .map((project) => ({
+      id: project.id,
+      name: project.name,
+      source: "external_tms" as const,
+      externalProviderKind: project.externalProviderKind ?? null,
+    }));
+
+  const native = input.nativeProjects
+    .filter((project) => (project.source ?? "native") === "native" && project.id.trim().length > 0)
+    .map((project) => ({
+      id: project.id,
+      name: project.name,
+      source: "native" as const,
+      externalProviderKind: null,
+    }));
+
+  return [...tms, ...native];
+}
+
+export function resolveChatProjectSelection(input: {
+  projects: ChatProjectOption[];
+  selectedProjectId: string;
+  lockedProjectId?: string | null;
+  initialProjectId?: string | null;
+}) {
+  if (input.lockedProjectId) {
+    return input.lockedProjectId;
+  }
+
+  if (
+    input.selectedProjectId &&
+    input.projects.some((project) => project.id === input.selectedProjectId)
+  ) {
+    return input.selectedProjectId;
+  }
+
+  // Trust page context (e.g. CAT) even before the project appears in the list.
+  if (input.initialProjectId) {
+    return input.initialProjectId;
+  }
+
+  if (input.projects.length === 1) {
+    return input.projects[0]!.id;
+  }
+
+  return "";
+}
+
+export function resolveChatProjectLabel(input: {
+  projects: ChatProjectOption[];
+  projectId: string;
+  fallbackName?: string | null;
+  placeholder: string;
+}) {
+  if (!input.projectId) {
+    return input.placeholder;
+  }
+
+  const match = input.projects.find((project) => project.id === input.projectId);
+  if (match?.name.trim()) {
+    return match.name;
+  }
+
+  if (input.fallbackName?.trim()) {
+    return input.fallbackName.trim();
+  }
+
+  return input.projectId;
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/project-selector.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/project-selector.messages.ts
@@ -1,0 +1,43 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { defineMessages } from "react-intl";
+
+export const projectSelectorMessages = defineMessages({
+  projectsUnavailable: {
+    defaultMessage: "Projects unavailable",
+    id: "chatProjectSelUnavailable",
+    description: "Project selector label when workspace projects failed to load",
+  },
+  noProjects: {
+    defaultMessage: "No projects",
+    id: "chatProjectSelEmpty",
+    description: "Project selector label when the workspace has no selectable projects",
+  },
+  projectPlaceholder: {
+    defaultMessage: "Project",
+    id: "chatProjectSelPlaceholder",
+    description: "Project selector placeholder when no project is selected yet",
+  },
+  nativeGroup: {
+    defaultMessage: "Hyperlocalise",
+    id: "chatProjectSelNativeGroup",
+    description: "Dropdown group label for native Hyperlocalise projects",
+  },
+  tmsGroup: {
+    defaultMessage: "TMS",
+    id: "chatProjectSelTmsGroup",
+    description: "Dropdown group label for live TMS provider projects",
+  },
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/project-selector.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/project-selector.messages.ts
@@ -17,27 +17,27 @@ import { defineMessages } from "react-intl";
 export const projectSelectorMessages = defineMessages({
   projectsUnavailable: {
     defaultMessage: "Projects unavailable",
-    id: "chatProjectSelUnavailable",
+    id: "cv2g6Sf3ye",
     description: "Project selector label when workspace projects failed to load",
   },
   noProjects: {
     defaultMessage: "No projects",
-    id: "chatProjectSelEmpty",
+    id: "h1hScUfLYO",
     description: "Project selector label when the workspace has no selectable projects",
   },
   projectPlaceholder: {
     defaultMessage: "Project",
-    id: "chatProjectSelPlaceholder",
+    id: "3qpoJUP9OU",
     description: "Project selector placeholder when no project is selected yet",
   },
   nativeGroup: {
     defaultMessage: "Hyperlocalise",
-    id: "chatProjectSelNativeGroup",
+    id: "OQ8wr0lFpw",
     description: "Dropdown group label for native Hyperlocalise projects",
   },
   tmsGroup: {
     defaultMessage: "TMS",
-    id: "chatProjectSelTmsGroup",
+    id: "cgUwgiYYdC",
     description: "Dropdown group label for live TMS provider projects",
   },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/project-selector.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/project-selector.test.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import type { ReactElement } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IntlProvider } from "react-intl";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import type { ChatProjectOption } from "./project-selector-model";
+import { ProjectSelector } from "./project-selector";
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <IntlProvider locale="en" messages={{}}>
+      {ui}
+    </IntlProvider>,
+  );
+}
+
+function createProject(overrides: Partial<ChatProjectOption> = {}): ChatProjectOption {
+  return {
+    id: "proj_web",
+    name: "Website",
+    source: "native",
+    externalProviderKind: null,
+    ...overrides,
+  };
+}
+
+describe("ProjectSelector", () => {
+  it("opens the project menu and selects a project", async () => {
+    const user = userEvent.setup();
+    const onSelectProject = vi.fn();
+
+    renderWithIntl(
+      <ProjectSelector
+        projects={[
+          createProject({ id: "proj_web", name: "Website" }),
+          createProject({
+            id: "ext:crowdin:42",
+            name: "Crowdin App",
+            source: "external_tms",
+            externalProviderKind: "crowdin",
+          }),
+        ]}
+        projectsIsError={false}
+        projectsIsLoading={false}
+        selectedProjectId=""
+        onSelectProject={onSelectProject}
+        triggerStyle="button"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /project/i }));
+    await user.click(await screen.findByText("Crowdin App"));
+
+    expect(onSelectProject).toHaveBeenCalledWith("ext:crowdin:42");
+  });
+
+  it("locks the selected project chip when the conversation is already scoped", () => {
+    renderWithIntl(
+      <ProjectSelector
+        projects={[
+          createProject({ id: "proj_web", name: "Website" }),
+          createProject({ id: "proj_mobile", name: "Mobile" }),
+        ]}
+        projectsIsError={false}
+        projectsIsLoading={false}
+        selectedProjectId="proj_web"
+        locked
+        onSelectProject={vi.fn()}
+        triggerStyle="button"
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /website/i })).toBeDisabled();
+    expect(screen.queryByText("Mobile")).toBeNull();
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/project-selector.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/project-selector.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import { ArrowDown01Icon, FolderLibraryIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { PromptInputButton } from "@/components/ai-elements/prompt-input";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Skeleton } from "@/components/ui/skeleton";
+
+import {
+  resolveChatProjectLabel,
+  type ChatProjectOption,
+} from "./project-selector-model";
+import { projectSelectorMessages as messages } from "./project-selector.messages";
+
+type ProjectSelectorTriggerStyle = "button" | "prompt-input";
+
+type ProjectSelectorTriggerProps = Omit<
+  ComponentPropsWithoutRef<"button">,
+  "children" | "className" | "disabled" | "style"
+> & {
+  children: ReactNode;
+  className?: string;
+  disabled?: boolean;
+  triggerStyle: ProjectSelectorTriggerStyle;
+};
+
+function ProjectSelectorTrigger({
+  children,
+  className,
+  disabled,
+  triggerStyle,
+  ...props
+}: ProjectSelectorTriggerProps) {
+  if (triggerStyle === "prompt-input") {
+    return (
+      <PromptInputButton className={className} size="sm" disabled={disabled} {...props}>
+        {children}
+      </PromptInputButton>
+    );
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      className={className}
+      disabled={disabled}
+      {...props}
+    >
+      {children}
+    </Button>
+  );
+}
+
+export function ProjectSelector({
+  locked = false,
+  lockedProjectName = null,
+  onSelectProject,
+  projects,
+  projectsIsError,
+  projectsIsLoading,
+  selectedProjectId,
+  triggerStyle,
+}: {
+  locked?: boolean;
+  lockedProjectName?: string | null;
+  onSelectProject: (projectId: string) => void;
+  projects: ChatProjectOption[];
+  projectsIsError: boolean;
+  projectsIsLoading: boolean;
+  selectedProjectId: string;
+  triggerStyle: ProjectSelectorTriggerStyle;
+}) {
+  const intl = useIntl();
+  const disabledTriggerClassName =
+    triggerStyle === "prompt-input"
+      ? "inline-flex h-8 items-center gap-1 rounded-full px-2.5 text-sm font-medium text-muted-foreground"
+      : "rounded-full px-2.5 text-muted-foreground";
+  const interactiveTriggerClassName =
+    triggerStyle === "prompt-input"
+      ? "inline-flex h-8 max-w-56 items-center gap-1 rounded-full px-2.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent/20 hover:text-foreground"
+      : "rounded-full px-2.5 text-muted-foreground hover:bg-accent/20 hover:text-foreground";
+  const singleProjectTriggerClassName =
+    triggerStyle === "prompt-input"
+      ? "inline-flex h-8 max-w-56 items-center gap-1 rounded-full px-2.5 text-sm font-medium text-muted-foreground"
+      : "max-w-56 rounded-full px-2.5 text-muted-foreground";
+
+  const selectedLabel = resolveChatProjectLabel({
+    projects,
+    projectId: selectedProjectId,
+    fallbackName: lockedProjectName,
+    placeholder: intl.formatMessage(messages.projectPlaceholder),
+  });
+
+  if (projectsIsLoading) {
+    return (
+      <ProjectSelectorTrigger
+        triggerStyle={triggerStyle}
+        className={disabledTriggerClassName}
+        disabled
+      >
+        <HugeiconsIcon icon={FolderLibraryIcon} strokeWidth={1.8} className="size-4" />
+        <Skeleton className="h-3.5 w-24 rounded-full bg-muted" />
+      </ProjectSelectorTrigger>
+    );
+  }
+
+  if (projectsIsError) {
+    return (
+      <ProjectSelectorTrigger
+        triggerStyle={triggerStyle}
+        className={disabledTriggerClassName}
+        disabled
+      >
+        <HugeiconsIcon icon={FolderLibraryIcon} strokeWidth={1.8} className="size-4" />
+        <FormattedMessage {...messages.projectsUnavailable} />
+      </ProjectSelectorTrigger>
+    );
+  }
+
+  if (projects.length === 0 && !selectedProjectId) {
+    return (
+      <ProjectSelectorTrigger
+        triggerStyle={triggerStyle}
+        className={disabledTriggerClassName}
+        disabled
+      >
+        <HugeiconsIcon icon={FolderLibraryIcon} strokeWidth={1.8} className="size-4" />
+        <FormattedMessage {...messages.noProjects} />
+      </ProjectSelectorTrigger>
+    );
+  }
+
+  if (locked || projects.length === 1) {
+    return (
+      <ProjectSelectorTrigger
+        triggerStyle={triggerStyle}
+        className={singleProjectTriggerClassName}
+        disabled
+      >
+        <HugeiconsIcon icon={FolderLibraryIcon} strokeWidth={1.8} className="size-4 shrink-0" />
+        <span className="truncate">{selectedLabel}</span>
+      </ProjectSelectorTrigger>
+    );
+  }
+
+  const tmsProjects = projects.filter((project) => project.source === "external_tms");
+  const nativeProjects = projects.filter((project) => project.source === "native");
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <ProjectSelectorTrigger
+            triggerStyle={triggerStyle}
+            className={interactiveTriggerClassName}
+          >
+            <HugeiconsIcon icon={FolderLibraryIcon} strokeWidth={1.8} className="size-4 shrink-0" />
+            <span className="max-w-44 truncate">{selectedLabel}</span>
+            <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={1.8} className="size-3.5 shrink-0" />
+          </ProjectSelectorTrigger>
+        }
+      />
+      <DropdownMenuContent className="min-w-64" align="end">
+        {tmsProjects.length > 0 ? (
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>
+              <FormattedMessage {...messages.tmsGroup} />
+            </DropdownMenuLabel>
+            {tmsProjects.map((project) => (
+              <DropdownMenuItem key={project.id} onClick={() => onSelectProject(project.id)}>
+                <HugeiconsIcon icon={FolderLibraryIcon} strokeWidth={1.8} className="size-4" />
+                <span className="min-w-0 flex-1 truncate">{project.name}</span>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuGroup>
+        ) : null}
+        {nativeProjects.length > 0 ? (
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>
+              <FormattedMessage {...messages.nativeGroup} />
+            </DropdownMenuLabel>
+            {nativeProjects.map((project) => (
+              <DropdownMenuItem key={project.id} onClick={() => onSelectProject(project.id)}>
+                <HugeiconsIcon icon={FolderLibraryIcon} strokeWidth={1.8} className="size-4" />
+                <span className="min-w-0 flex-1 truncate">{project.name}</span>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuGroup>
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/project-selector.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/project-selector.tsx
@@ -29,10 +29,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 
-import {
-  resolveChatProjectLabel,
-  type ChatProjectOption,
-} from "./project-selector-model";
+import { resolveChatProjectLabel, type ChatProjectOption } from "./project-selector-model";
 import { projectSelectorMessages as messages } from "./project-selector.messages";
 
 type ProjectSelectorTriggerStyle = "button" | "prompt-input";

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.tsx
@@ -104,6 +104,7 @@ export function ConversationPanel({
             <ReplyComposer
               disabled={composerDisabled}
               isStreaming={isStreaming}
+              lockedProjectId={conversation.projectId}
               onSend={onSendMessage}
               organizationSlug={organizationSlug}
             />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.stories.tsx
@@ -36,6 +36,9 @@ const meta = {
   args: {
     disabled: false,
     isStreaming: false,
+    projects: [],
+    projectsIsLoading: false,
+    projectsIsError: false,
     repositories: repositoriesFixture,
     repositoriesIsLoading: false,
     repositoriesIsError: false,
@@ -93,5 +96,85 @@ export const NoRepositories: Story = {
 export const SingleRepository: Story = {
   args: {
     repositories: repositoriesFixture.slice(0, 1),
+  },
+};
+
+export const LoadingProjects: Story = {
+  args: {
+    projectsIsLoading: true,
+  },
+};
+
+export const ProjectsLoadError: Story = {
+  args: {
+    projectsIsError: true,
+  },
+};
+
+export const WithProjects: Story = {
+  args: {
+    projects: [
+      {
+        id: "proj_website",
+        name: "Website",
+        source: "native",
+        externalProviderKind: null,
+      },
+      {
+        id: "ext:crowdin:42",
+        name: "Crowdin App",
+        source: "external_tms",
+        externalProviderKind: "crowdin",
+      },
+    ],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Project")).toBeInTheDocument();
+  },
+};
+
+export const CatPreselectedProject: Story = {
+  args: {
+    initialProjectId: "proj_website",
+    projects: [
+      {
+        id: "proj_website",
+        name: "Website",
+        source: "native",
+        externalProviderKind: null,
+      },
+      {
+        id: "proj_mobile",
+        name: "Mobile",
+        source: "native",
+        externalProviderKind: null,
+      },
+    ],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Website")).toBeInTheDocument();
+  },
+};
+
+export const LockedProject: Story = {
+  args: {
+    lockedProjectId: "proj_website",
+    projects: [
+      {
+        id: "proj_website",
+        name: "Website",
+        source: "native",
+        externalProviderKind: null,
+      },
+      {
+        id: "proj_mobile",
+        name: "Mobile",
+        source: "native",
+        externalProviderKind: null,
+      },
+    ],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("button", { name: /website/i })).toBeDisabled();
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.test.tsx
@@ -44,6 +44,9 @@ function DraftBackedComposer({
           onDraftChange?.(next);
         }}
         onSend={vi.fn()}
+        projects={[]}
+        projectsIsError={false}
+        projectsIsLoading={false}
         repositories={repositoriesFixture}
         repositoriesIsError={false}
         repositoriesIsLoading={false}
@@ -94,6 +97,9 @@ describe("ReplyComposerView draft sync", () => {
                 setRerenderCount((count) => count + 1);
               }}
               onSend={vi.fn()}
+              projects={[]}
+              projectsIsError={false}
+              projectsIsLoading={false}
               repositories={repositoriesFixture}
               repositoriesIsError={false}
               repositoriesIsLoading={false}
@@ -122,6 +128,9 @@ describe("ReplyComposerView draft sync", () => {
           disabled={false}
           isStreaming={false}
           onSend={vi.fn()}
+          projects={[]}
+          projectsIsError={false}
+          projectsIsLoading={false}
           repositories={repositoriesFixture}
           repositoriesIsError={false}
           repositoriesIsLoading={false}
@@ -153,6 +162,9 @@ describe("ReplyComposerView draft sync", () => {
               isStreaming={false}
               onDraftChange={setDraft}
               onSend={vi.fn()}
+              projects={[]}
+              projectsIsError={false}
+              projectsIsLoading={false}
               repositories={repositoriesFixture}
               repositoriesIsError={false}
               repositoriesIsLoading={false}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
@@ -39,8 +39,17 @@ import {
   Attachments,
 } from "@/components/ai-elements/attachments";
 import { apiClient } from "@/lib/api-client-instance";
+import { readApiResponseError } from "@/lib/api-error";
 
 import { RepositorySelector } from "../../_components/repository-selector";
+import { ProjectSelector } from "../../_components/project-selector";
+import {
+  buildChatProjectOptions,
+  resolveChatProjectSelection,
+  type ChatProjectOption,
+} from "../../_components/project-selector-model";
+import { useTmsLiveProjects } from "../../_hooks/use-tms-live-projects";
+import type { ApiProject } from "../../projects/_components/project-list";
 import { createInboxApi, type InboxApi, type InboxGithubRepository } from "./inbox-api";
 import { replyComposerMessages } from "./reply-composer.messages";
 
@@ -64,7 +73,10 @@ function dataUrlToFile(dataUrl: string, filename: string, mediaType?: string): F
 type ReplyComposerViewProps = {
   disabled: boolean;
   draft?: string;
+  initialProjectId?: string | null;
   isStreaming: boolean;
+  lockedProjectId?: string | null;
+  lockedProjectName?: string | null;
   onDraftChange?: (draft: string) => void;
   onSend: (
     text: string,
@@ -72,6 +84,9 @@ type ReplyComposerViewProps = {
     options?: { projectId?: string; repositoryFullName?: string },
   ) => void | Promise<void>;
   placeholder?: string;
+  projects: ChatProjectOption[];
+  projectsIsError: boolean;
+  projectsIsLoading: boolean;
   repositories: InboxGithubRepository[];
   repositoriesIsError: boolean;
   repositoriesIsLoading: boolean;
@@ -81,10 +96,16 @@ type ReplyComposerViewProps = {
 export function ReplyComposerView({
   disabled,
   draft = "",
+  initialProjectId = null,
   isStreaming,
+  lockedProjectId = null,
+  lockedProjectName = null,
   onDraftChange,
   onSend,
   placeholder,
+  projects,
+  projectsIsError,
+  projectsIsLoading,
   repositories,
   repositoriesIsError,
   repositoriesIsLoading,
@@ -93,6 +114,7 @@ export function ReplyComposerView({
   const intl = useIntl();
   const [replyText, setReplyText] = useState(draft);
   const [selectedRepositoryFullName, setSelectedRepositoryFullName] = useState("");
+  const [selectedProjectId, setSelectedProjectId] = useState("");
   const promptInputController = usePromptInputController();
   // Stable across keystrokes; the controller object itself is recreated whenever
   // textInput changes, so it must not be an effect dependency.
@@ -117,8 +139,21 @@ export function ReplyComposerView({
     }
   }, [repositories, selectedRepositoryFullName]);
 
+  useEffect(() => {
+    if (selectedProjectId && !projects.some((project) => project.id === selectedProjectId)) {
+      setSelectedProjectId("");
+    }
+  }, [projects, selectedProjectId]);
+
   const resolvedRepositoryFullName =
     selectedRepositoryFullName || (repositories.length === 1 ? repositories[0]?.fullName : "");
+  const resolvedProjectId = resolveChatProjectSelection({
+    projects,
+    selectedProjectId,
+    lockedProjectId,
+    initialProjectId,
+  });
+  const projectLocked = Boolean(lockedProjectId) || projects.length === 1;
 
   const attachments = usePromptInputAttachments();
 
@@ -135,6 +170,7 @@ export function ReplyComposerView({
     );
 
     await onSend(trimmedText, fileObjects, {
+      projectId: resolvedProjectId || undefined,
       repositoryFullName: resolvedRepositoryFullName || undefined,
     });
     setReplyText("");
@@ -217,6 +253,16 @@ export function ReplyComposerView({
             </PromptInputTools>
 
             <PromptInputTools className="flex-wrap justify-end gap-2 text-sm text-muted-foreground">
+              <ProjectSelector
+                projects={projects}
+                projectsIsError={projectsIsError}
+                projectsIsLoading={projectsIsLoading}
+                selectedProjectId={resolvedProjectId}
+                locked={projectLocked}
+                lockedProjectName={lockedProjectName}
+                onSelectProject={setSelectedProjectId}
+                triggerStyle="prompt-input"
+              />
               <RepositorySelector
                 repositories={repositories}
                 repositoriesIsError={repositoriesIsError}
@@ -248,7 +294,12 @@ export function ReplyComposerView({
 
 type ReplyComposerProps = Omit<
   ReplyComposerViewProps,
-  "repositories" | "repositoriesIsError" | "repositoriesIsLoading"
+  | "repositories"
+  | "repositoriesIsError"
+  | "repositoriesIsLoading"
+  | "projects"
+  | "projectsIsError"
+  | "projectsIsLoading"
 > & {
   organizationSlug: string;
   inboxApi?: InboxApi;
@@ -264,12 +315,35 @@ export const ReplyComposer = memo(function ReplyComposer({
     queryKey: ["github-repositories", organizationSlug],
     queryFn: () => injectedInboxApi.listGithubRepositories(organizationSlug),
   });
+  const nativeProjectsQuery = useQuery({
+    queryKey: ["chat-composer-projects", organizationSlug, "native"],
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects.$get({
+        param: { organizationSlug },
+      });
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to load projects");
+      }
+      const body = (await response.json()) as { projects: ApiProject[] };
+      return body.projects;
+    },
+  });
+  const tmsProjectsQuery = useTmsLiveProjects(organizationSlug);
+  const projects = buildChatProjectOptions({
+    nativeProjects: nativeProjectsQuery.data ?? [],
+    tmsProjects: tmsProjectsQuery.data ?? [],
+  });
+  const projectsIsLoading = nativeProjectsQuery.isLoading || tmsProjectsQuery.isLoading;
+  const projectsIsError = nativeProjectsQuery.isError;
 
   return (
     <PromptInputProvider initialInput={draft ?? ""}>
       <ReplyComposerView
         {...viewProps}
         draft={draft}
+        projects={projects}
+        projectsIsError={projectsIsError}
+        projectsIsLoading={projectsIsLoading}
         repositories={repositoriesQuery.data ?? []}
         repositoriesIsError={repositoriesQuery.isError}
         repositoriesIsLoading={repositoriesQuery.isLoading}

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-empty-state.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-empty-state.test.ts
@@ -27,12 +27,20 @@ function formatMessage(descriptor: MessageDescriptor, values?: Record<string, st
 }
 
 describe("buildChatDockSuggestions", () => {
-  it("shows only the find-context chip without page context", () => {
+  it("shows find-context and media localization chips without page context", () => {
     const suggestions = buildChatDockSuggestions(null, formatMessage);
 
-    expect(suggestions.map((suggestion) => suggestion.id)).toEqual(["find-context"]);
+    expect(suggestions.map((suggestion) => suggestion.id)).toEqual([
+      "find-context",
+      "localize-image",
+      "localize-video",
+    ]);
     expect(suggestions[0]?.label).toBe("What's the context of a string");
     expect(suggestions[0]?.prompt).toBe("What's the context of ");
+    expect(suggestions[1]?.label).toBe("Localize an image");
+    expect(suggestions[1]?.prompt).toBe("Localize the attached image to ");
+    expect(suggestions[2]?.label).toBe("Localize a short video");
+    expect(suggestions[2]?.prompt).toBe("Localize the attached video to ");
   });
 
   it("shows only the selected segment chip using the source string", () => {

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-empty-state.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-empty-state.tsx
@@ -13,7 +13,7 @@
  * Version 2.0 or later.
  */
 import type { ComponentProps } from "react";
-import { Chat01Icon, FileSearchIcon } from "@hugeicons/core-free-icons";
+import { Chat01Icon, FileSearchIcon, Image01Icon, FileVideoIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, type MessageDescriptor, useIntl } from "react-intl";
 
@@ -71,6 +71,18 @@ export function buildChatDockSuggestions(
       label: formatMessage(chatDockMessages.suggestionFindContext),
       // Trailing space lets the user finish typing the string.
       prompt: `${formatMessage(chatDockMessages.promptFindContext)} `,
+    },
+    {
+      id: "localize-image",
+      icon: Image01Icon,
+      label: formatMessage(chatDockMessages.suggestionLocalizeImage),
+      prompt: `${formatMessage(chatDockMessages.promptLocalizeImage)} `,
+    },
+    {
+      id: "localize-video",
+      icon: FileVideoIcon,
+      label: formatMessage(chatDockMessages.suggestionLocalizeVideo),
+      prompt: `${formatMessage(chatDockMessages.promptLocalizeVideo)} `,
     },
   ];
 }

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
@@ -399,7 +399,12 @@ export const ChatDockPanel = observer(function ChatDockPanel({
           key={tab.id}
           disabled={isBusy}
           draft={tab.draft}
+          initialProjectId={tab.isPending ? (store.pageContext?.projectId ?? null) : null}
           isStreaming={isTabStreaming}
+          lockedProjectId={!tab.isPending ? (persistedConversation?.projectId ?? null) : null}
+          lockedProjectName={
+            tab.isPending ? (store.pageContext?.projectName ?? null) : null
+          }
           onDraftChange={(nextDraft) => store.setDraft(tab.id, nextDraft)}
           onSend={onSendMessage}
           organizationSlug={organizationSlug}

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
@@ -402,9 +402,7 @@ export const ChatDockPanel = observer(function ChatDockPanel({
           initialProjectId={tab.isPending ? (store.pageContext?.projectId ?? null) : null}
           isStreaming={isTabStreaming}
           lockedProjectId={!tab.isPending ? (persistedConversation?.projectId ?? null) : null}
-          lockedProjectName={
-            tab.isPending ? (store.pageContext?.projectName ?? null) : null
-          }
+          lockedProjectName={tab.isPending ? (store.pageContext?.projectName ?? null) : null}
           onDraftChange={(nextDraft) => store.setDraft(tab.id, nextDraft)}
           onSend={onSendMessage}
           organizationSlug={organizationSlug}

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.messages.ts
@@ -58,13 +58,23 @@ export const chatDockMessages = defineMessages({
   },
   emptySubtitle: {
     id: "w2b0cdIV3S",
-    defaultMessage: "Ask about strings, context, or anything else",
+    defaultMessage: "Ask about strings, localize images or short videos, or anything else",
     description: "Empty state subtitle describing chat capabilities",
   },
   suggestionFindContext: {
     id: "pehDkakH9A",
     defaultMessage: "What's the context of a string",
     description: "Suggested prompt chip to find localisation context",
+  },
+  suggestionLocalizeImage: {
+    defaultMessage: "Localize an image",
+    id: "k2Wm9pQxR7",
+    description: "Suggested prompt chip to localize an attached image via a file translation job",
+  },
+  suggestionLocalizeVideo: {
+    defaultMessage: "Localize a short video",
+    id: "n8Tv4cLmB1",
+    description: "Suggested prompt chip to localize an attached short video via a file translation job",
   },
   suggestionSegmentContext: {
     id: "01h5d0m29X",
@@ -76,6 +86,18 @@ export const chatDockMessages = defineMessages({
     defaultMessage: "What's the context of",
     description:
       "Prefilled prompt stem when choosing the find-context chip without a selected string",
+  },
+  promptLocalizeImage: {
+    defaultMessage: "Localize the attached image to",
+    id: "p5Hs6yKdE3",
+    description:
+      "Prefilled prompt stem when choosing the localize-image chip; trailing space lets the user add a target language",
+  },
+  promptLocalizeVideo: {
+    defaultMessage: "Localize the attached video to",
+    id: "q9Jr2uFaW0",
+    description:
+      "Prefilled prompt stem when choosing the localize-video chip; trailing space lets the user add a target language",
   },
   promptSegmentContext: {
     id: "ERiH8D9Q+l",

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.messages.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock.messages.ts
@@ -57,7 +57,7 @@ export const chatDockMessages = defineMessages({
     description: "Empty state title for a new chat dock conversation",
   },
   emptySubtitle: {
-    id: "w2b0cdIV3S",
+    id: "v3BuukETY6",
     defaultMessage: "Ask about strings, localize images or short videos, or anything else",
     description: "Empty state subtitle describing chat capabilities",
   },
@@ -68,13 +68,14 @@ export const chatDockMessages = defineMessages({
   },
   suggestionLocalizeImage: {
     defaultMessage: "Localize an image",
-    id: "k2Wm9pQxR7",
+    id: "6ofd3aj3i1",
     description: "Suggested prompt chip to localize an attached image via a file translation job",
   },
   suggestionLocalizeVideo: {
     defaultMessage: "Localize a short video",
-    id: "n8Tv4cLmB1",
-    description: "Suggested prompt chip to localize an attached short video via a file translation job",
+    id: "Thq8Nht0hH",
+    description:
+      "Suggested prompt chip to localize an attached short video via a file translation job",
   },
   suggestionSegmentContext: {
     id: "01h5d0m29X",
@@ -89,13 +90,13 @@ export const chatDockMessages = defineMessages({
   },
   promptLocalizeImage: {
     defaultMessage: "Localize the attached image to",
-    id: "p5Hs6yKdE3",
+    id: "9xLYM1kt9j",
     description:
       "Prefilled prompt stem when choosing the localize-image chip; trailing space lets the user add a target language",
   },
   promptLocalizeVideo: {
     defaultMessage: "Localize the attached video to",
-    id: "q9Jr2uFaW0",
+    id: "0w8pdWYmk/",
     description:
       "Prefilled prompt stem when choosing the localize-video chip; trailing space lets the user add a target language",
   },

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
@@ -112,6 +112,7 @@ vi.mock("@/lib/log", () => ({
 }));
 
 import {
+  buildFileTranslationInstructions,
   getOrCreateConversationRepositorySandbox,
   prepareConversationAgentTurn,
   REPOSITORY_ACCESS_CONTENTION_FOLLOW_UP,
@@ -127,6 +128,17 @@ const baseClassification = {
   currentMessageSpecifiesRepository: false,
   confidence: 0.9,
 };
+
+describe("buildFileTranslationInstructions", () => {
+  it("lists image and video formats for chat file translation jobs", () => {
+    const instructions = buildFileTranslationInstructions();
+    expect(instructions).toContain("png");
+    expect(instructions).toContain("jpeg");
+    expect(instructions).toContain("webp");
+    expect(instructions).toContain("mp4");
+    expect(instructions).toContain("localizes the image or video asset");
+  });
+});
 
 describe("conversation repository sandbox reuse", () => {
   const githubContext = {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
@@ -61,7 +61,7 @@ export const REPOSITORY_ACCESS_CONTENTION_FOLLOW_UP =
 
 export function buildFileTranslationInstructions() {
   return [
-    "When a message includes stored source file IDs, create file translation jobs with type \"file\", the provided sourceFileId and fileFormat, targetLocales, and sourceLocale.",
+    'When a message includes stored source file IDs, create file translation jobs with type "file", the provided sourceFileId and fileFormat, targetLocales, and sourceLocale.',
     'Use sourceLocale "auto" if the user did not specify a source locale.',
     `Supported file job formats: ${supportedFileTranslationFileFormats.join(", ")}.`,
     "For png, jpeg, webp, and mp4 attachments, still create a file translation job — the workflow localizes the image or video asset for each target locale.",

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
@@ -60,7 +60,13 @@ export const REPOSITORY_ACCESS_CONTENTION_FOLLOW_UP =
   "I'm still preparing repository access for this conversation. Please send your message again in a moment.";
 
 export function buildFileTranslationInstructions() {
-  return `When a message includes stored source file IDs, create file translation jobs with type "file", the provided sourceFileId and fileFormat, targetLocales, and sourceLocale. Use sourceLocale "auto" if the user did not specify a source locale. Supported file job formats: ${supportedFileTranslationFileFormats.join(", ")}.`;
+  return [
+    "When a message includes stored source file IDs, create file translation jobs with type \"file\", the provided sourceFileId and fileFormat, targetLocales, and sourceLocale.",
+    'Use sourceLocale "auto" if the user did not specify a source locale.',
+    `Supported file job formats: ${supportedFileTranslationFileFormats.join(", ")}.`,
+    "For png, jpeg, webp, and mp4 attachments, still create a file translation job — the workflow localizes the image or video asset for each target locale.",
+    "mp4 clips should typically be short (about 3–10 seconds).",
+  ].join(" ");
 }
 
 /**

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/hyperlocalise-agent.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/hyperlocalise-agent.ts
@@ -85,8 +85,10 @@ export function buildTranslationAttachmentRequiredMessage(surface: Hyperlocalise
     "Attach a file with a target language to create a translation job, or ask me to find text in a repo enabled under Agent → GitHub.",
   ];
 
-  if (surface === "slack") {
-    lines.push("Supported file types include JSON, CSV, XLIFF, and other localization formats.");
+  if (surface === "slack" || surface === "web") {
+    lines.push(
+      "Supported file types include JSON, CSV, XLIFF, images (PNG, JPEG, WebP), short MP4 videos, and other localization formats.",
+    );
   }
 
   return lines.join(" ");

--- a/apps/hyperlocalise-web/src/lib/agents/slack/file-attachments.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/file-attachments.ts
@@ -12,20 +12,20 @@
  */
 import type { Message } from "chat";
 
+import {
+  appendStoredFileContext,
+  buildStoredFileContext,
+  type StoredTranslationFileRef,
+} from "@/lib/conversations/stored-file-context";
 import { createStoredFile } from "@/lib/file-storage/records";
 import {
   inferSupportedFileTranslationFileFormat,
   supportedFileTranslationFileFormats,
-  type SupportedFileTranslationFileFormat,
 } from "@/lib/translation/file-formats";
 
 type SlackAttachment = NonNullable<Message["attachments"]>[number];
 
-export type StoredSlackFileAttachment = {
-  id: string;
-  filename: string;
-  contentType: string;
-  fileFormat: SupportedFileTranslationFileFormat;
+export type StoredSlackFileAttachment = StoredTranslationFileRef & {
   url: string;
 };
 
@@ -131,27 +131,11 @@ export async function storeSlackFileAttachments(input: StoreSlackFileAttachments
 }
 
 export function buildSlackStoredFileContext(files: StoredSlackFileAttachment[]) {
-  if (files.length === 0) {
-    return null;
-  }
-
-  return [
-    "Attached translation source files are already stored and ready for file translation jobs:",
-    ...files.map(
-      (file) =>
-        `- ${file.filename}: sourceFileId=${file.id}, fileFormat=${file.fileFormat}, contentType=${file.contentType}`,
-    ),
-    "Use these sourceFileId values when creating file translation jobs.",
-  ].join("\n");
+  return buildStoredFileContext(files);
 }
 
 export function appendSlackStoredFileContext(text: string, files: StoredSlackFileAttachment[]) {
-  const fileContext = buildSlackStoredFileContext(files);
-  if (!fileContext) {
-    return text;
-  }
-
-  return [text.trim() || "Please translate the attached source file.", "", fileContext].join("\n");
+  return appendStoredFileContext(text, files);
 }
 
 export function buildUnsupportedSlackFilesMessage(attachments: SlackAttachment[]) {

--- a/apps/hyperlocalise-web/src/lib/conversations/stored-file-context.test.ts
+++ b/apps/hyperlocalise-web/src/lib/conversations/stored-file-context.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  appendStoredFileContext,
+  buildStoredFileContext,
+  toStoredTranslationFileRef,
+} from "./stored-file-context";
+
+describe("stored file context", () => {
+  it("maps supported text, image, and video uploads to translation file refs", () => {
+    expect(
+      toStoredTranslationFileRef({
+        id: "file_json",
+        filename: "messages.json",
+        contentType: "application/json",
+      }),
+    ).toEqual({
+      id: "file_json",
+      filename: "messages.json",
+      contentType: "application/json",
+      fileFormat: "json",
+    });
+    expect(
+      toStoredTranslationFileRef({
+        id: "file_png",
+        filename: "banner.png",
+        contentType: "image/png",
+      }),
+    ).toMatchObject({ fileFormat: "png" });
+    expect(
+      toStoredTranslationFileRef({
+        id: "file_mp4",
+        filename: "clip.mp4",
+        contentType: "video/mp4",
+      }),
+    ).toMatchObject({ fileFormat: "mp4" });
+  });
+
+  it("skips office and unsupported uploads that cannot become file translation jobs", () => {
+    expect(
+      toStoredTranslationFileRef({
+        id: "file_docx",
+        filename: "brief.docx",
+        contentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      }),
+    ).toBeNull();
+    expect(
+      toStoredTranslationFileRef({
+        id: "file_pdf",
+        filename: "brief.pdf",
+        contentType: "application/pdf",
+      }),
+    ).toBeNull();
+  });
+
+  it("appends sourceFileId markers the agent can use for file jobs", () => {
+    const files = [
+      {
+        id: "file_png",
+        filename: "banner.png",
+        contentType: "image/png",
+        fileFormat: "png" as const,
+      },
+    ];
+
+    expect(buildStoredFileContext(files)).toContain("sourceFileId=file_png");
+    expect(buildStoredFileContext(files)).toContain("fileFormat=png");
+    expect(appendStoredFileContext("Localize to ja-JP", files)).toBe(
+      [
+        "Localize to ja-JP",
+        "",
+        "Attached translation source files are already stored and ready for file translation jobs:",
+        "- banner.png: sourceFileId=file_png, fileFormat=png, contentType=image/png",
+        "Use these sourceFileId values when creating file translation jobs.",
+      ].join("\n"),
+    );
+    expect(appendStoredFileContext("  ", files)).toContain(
+      "Please translate the attached source file.",
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/conversations/stored-file-context.ts
+++ b/apps/hyperlocalise-web/src/lib/conversations/stored-file-context.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import {
+  inferSupportedFileTranslationFileFormat,
+  type SupportedFileTranslationFileFormat,
+} from "@/lib/translation/file-formats";
+
+export type StoredTranslationFileRef = {
+  id: string;
+  filename: string;
+  contentType: string;
+  fileFormat: SupportedFileTranslationFileFormat;
+};
+
+export function toStoredTranslationFileRef(file: {
+  id: string;
+  filename: string;
+  contentType: string;
+}): StoredTranslationFileRef | null {
+  const fileFormat = inferSupportedFileTranslationFileFormat(file.filename);
+  if (!fileFormat) {
+    return null;
+  }
+
+  return {
+    id: file.id,
+    filename: file.filename,
+    contentType: file.contentType,
+    fileFormat,
+  };
+}
+
+export function buildStoredFileContext(files: StoredTranslationFileRef[]) {
+  if (files.length === 0) {
+    return null;
+  }
+
+  return [
+    "Attached translation source files are already stored and ready for file translation jobs:",
+    ...files.map(
+      (file) =>
+        `- ${file.filename}: sourceFileId=${file.id}, fileFormat=${file.fileFormat}, contentType=${file.contentType}`,
+    ),
+    "Use these sourceFileId values when creating file translation jobs.",
+  ].join("\n");
+}
+
+export function appendStoredFileContext(text: string, files: StoredTranslationFileRef[]) {
+  const fileContext = buildStoredFileContext(files);
+  if (!fileContext) {
+    return text;
+  }
+
+  return [text.trim() || "Please translate the attached source file.", "", fileContext].join("\n");
+}

--- a/apps/hyperlocalise-web/src/lib/translation/file-formats.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-formats.test.ts
@@ -57,7 +57,7 @@ describe("translation file formats", () => {
     expect(inferSupportedTranslationFileFormat("banner.jpg")).toBe("jpeg");
     expect(inferSupportedTranslationFileFormat("banner.jpeg")).toBe("jpeg");
     expect(inferSupportedTranslationFileFormat("banner.webp")).toBe("webp");
-    expect(inferSupportedFileTranslationFileFormat("banner.png")).toBeNull();
+    expect(inferSupportedFileTranslationFileFormat("banner.png")).toBe("png");
     expect(inferSupportedSourceUploadFormat("banner.png")).toBe("png");
     expect(inferSupportedImageTranslationFileFormat("banner.jpg")).toBe("jpeg");
     expect(isSupportedSourceUploadFormat("banner.webp")).toBe(true);
@@ -67,7 +67,7 @@ describe("translation file formats", () => {
 
   it("infers CLI-supported video formats separately", () => {
     expect(inferSupportedTranslationFileFormat("clip.mp4")).toBe("mp4");
-    expect(inferSupportedFileTranslationFileFormat("clip.mp4")).toBeNull();
+    expect(inferSupportedFileTranslationFileFormat("clip.mp4")).toBe("mp4");
     expect(inferSupportedSourceUploadFormat("clip.mp4")).toBe("mp4");
     expect(isSupportedSourceUploadFormat("hero.mp4")).toBe(true);
     expect(isVideoTranslationFileFormat("mp4")).toBe(true);

--- a/apps/hyperlocalise-web/src/lib/translation/file-formats.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-formats.ts
@@ -262,7 +262,7 @@ export function getLocaleScanExtensions(): string[] {
   const extensions = new Set<string>();
 
   for (const [extension, format] of Object.entries(formatsByExtension)) {
-    if (isSupportedFileTranslationFileFormat(format)) {
+    if (isSupportedFileTranslationFileFormat(format) && !isBinaryTranslationFileFormat(format)) {
       extensions.add(extension.slice(1));
     }
   }

--- a/apps/hyperlocalise-web/src/lib/translation/file-formats.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-formats.ts
@@ -50,6 +50,10 @@ export const supportedFileTranslationFileFormats = [
   "stringsdict",
   "xcstrings",
   "csv",
+  "png",
+  "jpeg",
+  "webp",
+  "mp4",
 ] as const;
 
 export type SupportedFileTranslationFileFormat =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Enables **job-based** image and video localisation from chat dock / inbox (New request), and adds a project selector so file jobs can attach a project.

### Image / video file jobs
- Add `png`, `jpeg`, `webp`, and `mp4` to `supportedFileTranslationFileFormats`.
- Append shared `sourceFileId` / `fileFormat` context on web chat uploads (same pattern as Slack).
- Update agent instructions for image/video localisation and short MP4 duration.
- Add New request chips: “Localize an image” / “Localize a short video”.
- Keep binary formats out of locale scan extensions.

### Project selector
- Add a Project chip beside GitHub in the reply composer (native + live TMS).
- Lock once the conversation already has a `projectId`.
- Pre-select from CAT `pageContext.projectId` on pending New request tabs.
- Auto-select when only one project is available.

## How to test

1. Open New request in chat dock; confirm image/video suggestion chips appear.
2. Confirm the Project chip appears next to GitHub; pick a project (or see CAT preselect when opened from CAT).
3. Upload a PNG (or short MP4) and ask to localize to a target locale.
4. Confirm a file translation job is created with the selected project.
5. Open an existing conversation with a project — Project chip should be locked.

Automated:

- `vp test` — 4301 passed
- `vp check --fix` — passed (pre-existing warnings only)

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0090a-acbc-713a-a18c-998feacb035d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0090a-acbc-713a-a18c-998feacb035d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

