### PR TITLE
feat(automations): add AI Gateway web search tool

### DIFF
--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/build-workspace-orchestrator-tools.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/build-workspace-orchestrator-tools.ts
@@ -27,6 +27,7 @@ import { createSaveMemoryTool } from "./tools/save_memory";
 import { createUseAhrefsTool } from "./tools/use_ahrefs";
 import { createUseGithubRepositoryTool } from "./tools/use_github_repository";
 import { createUseSemrushTool } from "./tools/use_semrush";
+import { createUseWebSearchTool } from "./tools/use_web_search";
 
 const TOOL_BUILDERS: Record<
   WorkspaceOrchestratorToolName,
@@ -41,6 +42,7 @@ const TOOL_BUILDERS: Record<
   create_issue: createCreateIssueTool,
   use_semrush: createUseSemrushTool,
   use_ahrefs: createUseAhrefsTool,
+  use_web_search: createUseWebSearchTool,
   notify_slack: createNotifySlackTool,
   notify_email: createNotifyEmailTool,
   recall_memory: createRecallMemoryTool,

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.test.ts
@@ -179,6 +179,19 @@ describe("buildWorkspaceOrchestratorPlan", () => {
     expect(plan.tools).toEqual(["use_ahrefs", "notify_slack"]);
   });
 
+  it("includes use_web_search when Web Search is enabled", () => {
+    const plan = buildWorkspaceOrchestratorPlan(
+      automation({
+        toolConfig: {
+          webSearch: { enabled: true, provider: "auto" },
+          slack: { enabled: true, channelId: "C123" },
+        },
+      }),
+    );
+
+    expect(plan.tools).toEqual(["use_web_search", "notify_slack"]);
+  });
+
   it("does not plan recall_memory when knowledge is enabled", () => {
     const plan = buildWorkspaceOrchestratorPlan(
       automation({

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.ts
@@ -20,6 +20,7 @@ import {
   hasWorkspaceAutomationCreateIssueTool,
   hasWorkspaceAutomationCreateNativeTmsJobTool,
   hasWorkspaceAutomationListIssuesTool,
+  hasWorkspaceAutomationWebSearchTool,
   type WorkspaceAutomationRecord,
   type WorkspaceAutomationToolConfig,
 } from "@/lib/agents/workspace-automations";
@@ -36,6 +37,7 @@ export const WORKSPACE_ORCHESTRATOR_TOOL_NAMES = [
   "create_issue",
   "use_semrush",
   "use_ahrefs",
+  "use_web_search",
   "notify_slack",
   "notify_email",
   "recall_memory",
@@ -62,6 +64,7 @@ const WORKFLOW_TOOLS: WorkspaceOrchestratorToolName[] = [
   "create_issue",
   "use_semrush",
   "use_ahrefs",
+  "use_web_search",
 ];
 
 const NOTIFICATION_TOOLS: WorkspaceOrchestratorToolName[] = ["notify_slack", "notify_email"];
@@ -95,6 +98,8 @@ function workflowToolEnabled(
       return Boolean(toolConfig.semrush?.enabled && toolConfig.semrush.connectionId);
     case "use_ahrefs":
       return Boolean(toolConfig.ahrefs?.enabled && toolConfig.ahrefs.connectionId);
+    case "use_web_search":
+      return hasWorkspaceAutomationWebSearchTool(toolConfig);
     default:
       return false;
   }
@@ -142,6 +147,7 @@ function orderWorkflowTools(input: {
       ...enabled.filter((tool) => tool === "create_issue"),
       ...enabled.filter((tool) => tool === "use_semrush"),
       ...enabled.filter((tool) => tool === "use_ahrefs"),
+      ...enabled.filter((tool) => tool === "use_web_search"),
     ];
   }
 
@@ -155,6 +161,7 @@ function orderWorkflowTools(input: {
     ...enabled.filter((tool) => tool === "create_issue"),
     ...enabled.filter((tool) => tool === "use_semrush"),
     ...enabled.filter((tool) => tool === "use_ahrefs"),
+    ...enabled.filter((tool) => tool === "use_web_search"),
   ];
 }
 

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_web_search.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_web_search.test.ts
@@ -22,8 +22,8 @@ import { createUseWebSearchTool, resolveWorkspaceWebSearchGatewayTools } from ".
 
 const mocks = vi.hoisted(() => ({
   generate: vi.fn(),
-  withAgentRuntimeUsageMetering: vi.fn(
-    async (input: { run: () => Promise<unknown> }) => input.run(),
+  withAgentRuntimeUsageMetering: vi.fn(async (input: { run: () => Promise<unknown> }) =>
+    input.run(),
   ),
 }));
 
@@ -40,8 +40,7 @@ vi.mock("ai", async () => {
 
 vi.mock("@/lib/billing/agent-runtime-usage", () => ({
   extractGenerateResultTokenUsage: vi.fn(),
-  withAgentRuntimeUsageMetering: (...args: unknown[]) =>
-    mocks.withAgentRuntimeUsageMetering(...args),
+  withAgentRuntimeUsageMetering: mocks.withAgentRuntimeUsageMetering,
 }));
 
 function session(

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_web_search.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_web_search.test.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import type {
+  WorkspaceAutomationRecord,
+  WorkspaceAutomationRunRecord,
+} from "@/lib/agents/workspace-automations";
+
+import type { WorkspaceOrchestratorSession } from "../context";
+import { createUseWebSearchTool, resolveWorkspaceWebSearchGatewayTools } from "./use_web_search";
+
+const mocks = vi.hoisted(() => ({
+  generate: vi.fn(),
+  withAgentRuntimeUsageMetering: vi.fn(
+    async (input: { run: () => Promise<unknown> }) => input.run(),
+  ),
+}));
+
+vi.mock("ai", async () => {
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+
+  return {
+    ...actual,
+    ToolLoopAgent: vi.fn(function ToolLoopAgent() {
+      return { generate: mocks.generate };
+    }),
+  };
+});
+
+vi.mock("@/lib/billing/agent-runtime-usage", () => ({
+  extractGenerateResultTokenUsage: vi.fn(),
+  withAgentRuntimeUsageMetering: (...args: unknown[]) =>
+    mocks.withAgentRuntimeUsageMetering(...args),
+}));
+
+function session(
+  toolConfig: WorkspaceAutomationRecord["toolConfig"] = {},
+): WorkspaceOrchestratorSession {
+  const automation = {
+    id: "automation-1",
+    organizationId: "org-1",
+    authorUserId: null,
+    status: "active",
+    name: "Web search automation",
+    instructions: "Research local competitors.",
+    projectId: null,
+    triggerConfig: { mode: "manual" },
+    repositoryTarget: { kind: "none" },
+    toolConfig,
+    configVersion: 1,
+    nextRunAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  } satisfies WorkspaceAutomationRecord;
+
+  const run = {
+    id: "run-1",
+    automationId: automation.id,
+    organizationId: automation.organizationId,
+    triggerSource: "manual",
+    status: "running",
+    inputSnapshot: {},
+    outputSummary: {},
+    error: null,
+    githubRepositoryAutomationJobId: null,
+    idempotencyKey: null,
+    startedAt: null,
+    completedAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  } satisfies WorkspaceAutomationRunRecord;
+
+  return {
+    organizationId: automation.organizationId,
+    automation,
+    run,
+    plan: { tools: ["use_web_search"] },
+    repository: null,
+    composedInstructions: "",
+    stepResults: {},
+    terminalStatus: null,
+    terminalError: null,
+  };
+}
+
+describe("resolveWorkspaceWebSearchGatewayTools", () => {
+  it("exposes both Gateway search tools for auto", () => {
+    expect(Object.keys(resolveWorkspaceWebSearchGatewayTools("auto")).toSorted()).toEqual([
+      "exa_search",
+      "perplexity_search",
+    ]);
+  });
+
+  it("exposes only Perplexity or Exa when that provider is selected", () => {
+    expect(Object.keys(resolveWorkspaceWebSearchGatewayTools("perplexity"))).toEqual([
+      "perplexity_search",
+    ]);
+    expect(Object.keys(resolveWorkspaceWebSearchGatewayTools("exa"))).toEqual(["exa_search"]);
+  });
+});
+
+describe("createUseWebSearchTool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects when Web Search is not enabled on the automation", async () => {
+    await expect(
+      createUseWebSearchTool(session()).execute!(
+        { objective: "Find competitor landing pages" },
+        { toolCallId: "call-1", messages: [], context: {} },
+      ),
+    ).rejects.toThrow("web_search_not_configured");
+
+    expect(mocks.generate).not.toHaveBeenCalled();
+  });
+
+  it("runs a nested search agent and stores the summary", async () => {
+    mocks.generate.mockResolvedValue({ text: "  Found three local competitors.  " });
+    const current = session({
+      webSearch: { enabled: true, provider: "exa" },
+    });
+
+    const result = await createUseWebSearchTool(current).execute!(
+      { objective: "Find competitor landing pages" },
+      { toolCallId: "call-1", messages: [], context: {} },
+    );
+
+    expect(result).toEqual({
+      summary: "Found three local competitors.",
+      provider: "exa",
+      toolNames: ["exa_search"],
+    });
+    expect(current.stepResults.use_web_search).toEqual(result);
+    expect(mocks.generate).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_web_search.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_web_search.test.ts
@@ -141,7 +141,13 @@ describe("createUseWebSearchTool", () => {
       provider: "exa",
       toolNames: ["exa_search"],
     });
-    expect(current.stepResults.use_web_search).toEqual(result);
+    expect(current.stepResults.use_web_search).toEqual({
+      provider: "exa",
+      toolCount: 1,
+      status: "completed",
+    });
+    expect(JSON.stringify(current.stepResults)).not.toContain("Found three local competitors.");
+    expect(current.run.outputSummary.webSearch).toEqual(result);
     expect(mocks.generate).toHaveBeenCalledOnce();
   });
 });

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_web_search.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_web_search.ts
@@ -28,6 +28,7 @@ import type { WorkspaceAutomationWebSearchProvider } from "@/lib/agents/workspac
 import { assertNever } from "@/lib/primitives/assert-never/assert-never";
 
 import type { WorkspaceOrchestratorSession } from "../context";
+import { mergeToolOutputSummaryIntoSessionRun } from "../workspace-orchestrator-output-summary";
 
 const WEB_SEARCH_TOOL_STEP_LIMIT = 8;
 
@@ -143,7 +144,16 @@ export function createUseWebSearchTool(session: WorkspaceOrchestratorSession) {
         provider,
         toolNames,
       };
-      session.stepResults.use_web_search = payload;
+
+      // Record only provider/status/count metadata in stepResults. The summary can echo
+      // customer-identifying details from the search objective or automation instructions,
+      // and run-workspace-orchestrator logs session.stepResults wholesale.
+      session.stepResults.use_web_search = {
+        provider,
+        toolCount: toolNames.length,
+        status: "completed",
+      };
+      mergeToolOutputSummaryIntoSessionRun(session, { webSearch: payload });
       return payload;
     },
   });

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_web_search.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_web_search.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { gateway, isStepCount, ToolLoopAgent, type ToolSet } from "ai";
+import { z } from "zod";
+
+import { defineAgentTool } from "@/agents/_runtime/define-agent-tool";
+import { getHyperlocaliseAgentModel } from "@/lib/agent-runtime/loops/model";
+import {
+  SUBAGENT_NO_QUESTIONS_RULES,
+  SUBAGENT_RESPONSE_FORMAT,
+  WORKFLOW_AGENT_TIMEOUT,
+} from "@/lib/agent-runtime/subagents/constants";
+import {
+  extractGenerateResultTokenUsage,
+  withAgentRuntimeUsageMetering,
+} from "@/lib/billing/agent-runtime-usage";
+import type { WorkspaceAutomationWebSearchProvider } from "@/lib/agents/workspace-automations";
+import { assertNever } from "@/lib/primitives/assert-never/assert-never";
+
+import type { WorkspaceOrchestratorSession } from "../context";
+
+const WEB_SEARCH_TOOL_STEP_LIMIT = 8;
+
+const useWebSearchInputSchema = z.object({
+  objective: z
+    .string()
+    .trim()
+    .min(1)
+    .max(4000)
+    .describe("What to search the live web for, including markets, competitors, or current facts."),
+});
+
+export function resolveWorkspaceWebSearchGatewayTools(
+  provider: WorkspaceAutomationWebSearchProvider,
+): ToolSet {
+  switch (provider) {
+    case "perplexity":
+      return {
+        perplexity_search: gateway.tools.perplexitySearch(),
+      };
+    case "exa":
+      return {
+        exa_search: gateway.tools.exaSearch(),
+      };
+    case "auto":
+      return {
+        perplexity_search: gateway.tools.perplexitySearch(),
+        exa_search: gateway.tools.exaSearch(),
+      };
+    default:
+      return assertNever(provider);
+  }
+}
+
+function webSearchProviderInstructions(provider: WorkspaceAutomationWebSearchProvider): string {
+  switch (provider) {
+    case "perplexity":
+      return "Use perplexity_search for current web results.";
+    case "exa":
+      return "Use exa_search for current web results and extracted excerpts.";
+    case "auto":
+      return [
+        "Choose the search tool that fits the objective.",
+        "Use perplexity_search for news, recency, language, or country filters.",
+        "Use exa_search for domain filters, categories, or token-efficient excerpts.",
+      ].join(" ");
+    default:
+      return assertNever(provider);
+  }
+}
+
+export function createUseWebSearchTool(session: WorkspaceOrchestratorSession) {
+  return defineAgentTool({
+    description:
+      "Search the live web through Vercel AI Gateway. Supports Auto (Perplexity or Exa), Perplexity, or Exa.",
+    inputSchema: useWebSearchInputSchema,
+    execute: async ({ objective }) => {
+      const webSearch = session.automation.toolConfig.webSearch;
+      if (!webSearch?.enabled) {
+        throw new Error("web_search_not_configured");
+      }
+
+      const provider = webSearch.provider;
+      const tools = resolveWorkspaceWebSearchGatewayTools(provider);
+      const toolNames = Object.keys(tools);
+
+      const agent = new ToolLoopAgent({
+        model: getHyperlocaliseAgentModel(),
+        tools,
+        instructions: [
+          "You are gathering current web research for a workspace automation.",
+          webSearchProviderInstructions(provider),
+          "Cite titles and URLs for the sources you rely on.",
+          "Return a concise factual summary with the key findings.",
+          SUBAGENT_NO_QUESTIONS_RULES,
+          SUBAGENT_RESPONSE_FORMAT,
+        ].join("\n"),
+        stopWhen: isStepCount(WEB_SEARCH_TOOL_STEP_LIMIT),
+        timeout: WORKFLOW_AGENT_TIMEOUT,
+      });
+
+      const result = await withAgentRuntimeUsageMetering({
+        organizationId: session.organizationId,
+        operationKey: `workspace-web-search:${session.run.id}:agent_runs`,
+        source: "workspace_web_search_agent",
+        dimensions: {
+          surface: "automation",
+          agent_surface: "web_search",
+          provider,
+        },
+        extractTokenUsage: extractGenerateResultTokenUsage,
+        run: () =>
+          agent.generate({
+            messages: [
+              {
+                role: "user",
+                content: [
+                  `Objective: ${objective}`,
+                  session.automation.instructions.trim()
+                    ? `Automation instructions:\n${session.automation.instructions.trim()}`
+                    : null,
+                ]
+                  .filter((line): line is string => Boolean(line))
+                  .join("\n\n"),
+              },
+            ],
+          }),
+      });
+
+      const summary = result.text.trim() || "Completed web search with no textual summary.";
+      const payload = {
+        summary,
+        provider,
+        toolNames,
+      };
+      session.stepResults.use_web_search = payload;
+      return payload;
+    },
+  });
+}

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-orchestrator-output-summary.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-orchestrator-output-summary.test.ts
@@ -69,6 +69,39 @@ describe("buildWorkspaceOrchestratorOutputSummary", () => {
     });
   });
 
+  it("keeps a persisted web-search summary off logged step results", () => {
+    const outputSummary = buildWorkspaceOrchestratorOutputSummary(
+      {
+        webSearch: {
+          summary: "Acme Corp competitor research for Jane Doe",
+          provider: "exa",
+          toolNames: ["exa_search"],
+        },
+      },
+      {
+        use_web_search: {
+          provider: "exa",
+          toolCount: 1,
+          status: "completed",
+        },
+      },
+    );
+
+    expect(outputSummary.webSearch).toEqual({
+      summary: "Acme Corp competitor research for Jane Doe",
+      provider: "exa",
+      toolNames: ["exa_search"],
+    });
+    expect(outputSummary.orchestratorStepResults).toEqual({
+      use_web_search: {
+        provider: "exa",
+        toolCount: 1,
+        status: "completed",
+      },
+    });
+    expect(JSON.stringify(outputSummary.orchestratorStepResults)).not.toContain("Jane Doe");
+  });
+
   it("falls back to prior orchestrator step results when the stale snapshot omitted tool fields", () => {
     const outputSummary = buildWorkspaceOrchestratorOutputSummary(
       {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -474,38 +474,38 @@ export const workspaceAutomationFormMessages = defineMessages({
   },
   webSearch: {
     defaultMessage: "Web Search",
-    id: "k8Wm2nQp4R",
+    id: "DwaD/cBlPO",
     description: "Menu item and tool title for live web search",
   },
   webSearchDescription: {
     defaultMessage:
       "Search the live web through AI Gateway. Auto lets the agent pick Perplexity or Exa.",
-    id: "pL3x9vBq2T",
+    id: "SnTFQm1KyV",
     description: "Description for the Web Search automation tool",
   },
   removeWebSearchTool: {
     defaultMessage: "Remove Web Search tool",
-    id: "nR7c4hYs1K",
+    id: "YOVFvt60oU",
     description: "Accessible label to remove the Web Search tool",
   },
   webSearchProvider: {
     defaultMessage: "Search provider",
-    id: "aF2d8mQw6E",
+    id: "6Nr6tK1aoh",
     description: "Label for the Web Search provider picker",
   },
   webSearchProviderAuto: {
     defaultMessage: "Auto",
-    id: "bH5t1kZp9C",
+    id: "y6su8h1cH4",
     description: "Web Search provider option that lets the agent choose Perplexity or Exa",
   },
   webSearchProviderPerplexity: {
     defaultMessage: "Perplexity",
-    id: "cJ6u2lXq0D",
+    id: "Uuw7RsxOWd",
     description: "Web Search provider option for Perplexity Search",
   },
   webSearchProviderExa: {
     defaultMessage: "Exa",
-    id: "dK7v3mYr1E",
+    id: "P5KI62Z4os",
     description: "Web Search provider option for Exa Search",
   },
   comingSoon: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -472,6 +472,42 @@ export const workspaceAutomationFormMessages = defineMessages({
     id: "CKjsX01Ql/",
     description: "Accessible label to remove the Ahrefs tool",
   },
+  webSearch: {
+    defaultMessage: "Web Search",
+    id: "k8Wm2nQp4R",
+    description: "Menu item and tool title for live web search",
+  },
+  webSearchDescription: {
+    defaultMessage:
+      "Search the live web through AI Gateway. Auto lets the agent pick Perplexity or Exa.",
+    id: "pL3x9vBq2T",
+    description: "Description for the Web Search automation tool",
+  },
+  removeWebSearchTool: {
+    defaultMessage: "Remove Web Search tool",
+    id: "nR7c4hYs1K",
+    description: "Accessible label to remove the Web Search tool",
+  },
+  webSearchProvider: {
+    defaultMessage: "Search provider",
+    id: "aF2d8mQw6E",
+    description: "Label for the Web Search provider picker",
+  },
+  webSearchProviderAuto: {
+    defaultMessage: "Auto",
+    id: "bH5t1kZp9C",
+    description: "Web Search provider option that lets the agent choose Perplexity or Exa",
+  },
+  webSearchProviderPerplexity: {
+    defaultMessage: "Perplexity",
+    id: "cJ6u2lXq0D",
+    description: "Web Search provider option for Perplexity Search",
+  },
+  webSearchProviderExa: {
+    defaultMessage: "Exa",
+    id: "dK7v3mYr1E",
+    description: "Web Search provider option for Exa Search",
+  },
   comingSoon: {
     defaultMessage: "Coming soon",
     id: "lvwFhMaVAT",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -2434,7 +2434,9 @@ function ToolsSettings({
                 <SelectTrigger className="w-full">
                   <SelectValue>
                     {form.webSearchProvider === "perplexity"
-                      ? intl.formatMessage(workspaceAutomationFormMessages.webSearchProviderPerplexity)
+                      ? intl.formatMessage(
+                          workspaceAutomationFormMessages.webSearchProviderPerplexity,
+                        )
                       : form.webSearchProvider === "exa"
                         ? intl.formatMessage(workspaceAutomationFormMessages.webSearchProviderExa)
                         : intl.formatMessage(workspaceAutomationFormMessages.webSearchProviderAuto)}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -26,7 +26,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useQuery } from "@tanstack/react-query";
-import { ClockIcon, MailIcon, SearchIcon, Trash2Icon } from "lucide-react";
+import { ClockIcon, GlobeIcon, MailIcon, SearchIcon, Trash2Icon } from "lucide-react";
 import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
 import type { SimpleIcon } from "simple-icons";
 import {
@@ -342,7 +342,8 @@ function toolCount(form: WorkspaceAutomationFormState) {
     Number(form.knowledgeEnabled) +
     Number(form.mcpEnabled) +
     Number(form.semrushEnabled) +
-    Number(form.ahrefsEnabled)
+    Number(form.ahrefsEnabled) +
+    Number(form.webSearchEnabled)
   );
 }
 
@@ -1428,6 +1429,18 @@ function AddToolMenu({
                 </DropdownMenuShortcut>
               ) : null}
             </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={form.webSearchEnabled}
+              onClick={() => onChange({ ...form, webSearchEnabled: true })}
+            >
+              <GlobeIcon className="size-4" />
+              <FormattedMessage {...workspaceAutomationFormMessages.webSearch} />
+              {form.webSearchEnabled ? (
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                </DropdownMenuShortcut>
+              ) : null}
+            </DropdownMenuItem>
           </DropdownMenuGroup>
           <DropdownMenuSeparator />
           <DropdownMenuGroup>
@@ -2381,6 +2394,66 @@ function ToolsSettings({
                 </SelectContent>
               </Select>
               <FieldError message={errors.ahrefsConnectionId} />
+            </div>
+          </EditorRow>
+        ) : null}
+
+        {form.webSearchEnabled ? (
+          <EditorRow
+            icon={<GlobeIcon className="size-4" />}
+            title={<FormattedMessage {...workspaceAutomationFormMessages.webSearch} />}
+            description={intl.formatMessage(workspaceAutomationFormMessages.webSearchDescription)}
+            action={
+              <DeleteToolButton
+                disabled={disabled}
+                label={intl.formatMessage(workspaceAutomationFormMessages.removeWebSearchTool)}
+                onClick={() =>
+                  onChange({
+                    ...form,
+                    webSearchEnabled: false,
+                    webSearchProvider: "auto",
+                  })
+                }
+              />
+            }
+          >
+            <div className="grid gap-1.5">
+              <Label className="text-xs text-muted-foreground">
+                <FormattedMessage {...workspaceAutomationFormMessages.webSearchProvider} />
+              </Label>
+              <Select
+                value={form.webSearchProvider}
+                disabled={disabled}
+                onValueChange={(value) => {
+                  if (value !== "auto" && value !== "perplexity" && value !== "exa") {
+                    return;
+                  }
+                  onChange({ ...form, webSearchProvider: value });
+                }}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue>
+                    {form.webSearchProvider === "perplexity"
+                      ? intl.formatMessage(workspaceAutomationFormMessages.webSearchProviderPerplexity)
+                      : form.webSearchProvider === "exa"
+                        ? intl.formatMessage(workspaceAutomationFormMessages.webSearchProviderExa)
+                        : intl.formatMessage(workspaceAutomationFormMessages.webSearchProviderAuto)}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="auto">
+                    <FormattedMessage {...workspaceAutomationFormMessages.webSearchProviderAuto} />
+                  </SelectItem>
+                  <SelectItem value="perplexity">
+                    <FormattedMessage
+                      {...workspaceAutomationFormMessages.webSearchProviderPerplexity}
+                    />
+                  </SelectItem>
+                  <SelectItem value="exa">
+                    <FormattedMessage {...workspaceAutomationFormMessages.webSearchProviderExa} />
+                  </SelectItem>
+                </SelectContent>
+              </Select>
             </div>
           </EditorRow>
         ) : null}

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
@@ -767,6 +767,10 @@ export function getWorkspaceAutomationTemplateFlow(
     tools.push({ id: "contentful", label: "Contentful" });
   }
 
+  if (form.webSearchEnabled) {
+    tools.push({ id: "web-search", label: "Web Search" });
+  }
+
   return { trigger, tools };
 }
 

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
@@ -166,6 +166,16 @@ describe("workspace automation view model", () => {
     expect(state.knowledgeAllowUpdates).toBe(true);
   });
 
+  it("hydrates Web Search provider from an existing automation record", () => {
+    const state = createWorkspaceAutomationFormStateFromRecord({
+      ...createAutomationSummary(),
+      toolConfig: { webSearch: { enabled: true, provider: "exa" } },
+    });
+
+    expect(state.webSearchEnabled).toBe(true);
+    expect(state.webSearchProvider).toBe("exa");
+  });
+
   it("prefills the Contentful translation template", () => {
     const form = createWorkspaceAutomationFormStateFromTemplate(
       "translate-contentful-article",
@@ -374,6 +384,21 @@ describe("workspace automation view model", () => {
 
     expect(validateWorkspaceAutomationFormState(form)).toMatchObject({
       form: "Translate with agent requires Create job to be enabled.",
+    });
+  });
+
+  it("maps Web Search provider into the API payload", () => {
+    const form = {
+      ...createDefaultWorkspaceAutomationFormState(),
+      name: "Market research",
+      instructions: "Search live SERPs for the target market.",
+      webSearchEnabled: true,
+      webSearchProvider: "perplexity" as const,
+    };
+
+    expect(validateWorkspaceAutomationFormState(form)).toEqual({});
+    expect(formStateToWorkspaceAutomationPayload(form).toolConfig).toEqual({
+      webSearch: { enabled: true, provider: "perplexity" },
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
@@ -16,6 +16,7 @@ import type {
   WorkspaceAutomationRepositoryTarget,
   WorkspaceAutomationToolConfig,
   WorkspaceAutomationTriggerConfig,
+  WorkspaceAutomationWebSearchProvider,
 } from "./workspace-automations";
 import {
   getWorkspaceAutomationTemplate,
@@ -75,6 +76,8 @@ export type WorkspaceAutomationFormState = {
   semrushConnectionId: string;
   ahrefsEnabled: boolean;
   ahrefsConnectionId: string;
+  webSearchEnabled: boolean;
+  webSearchProvider: WorkspaceAutomationWebSearchProvider;
 };
 
 function workspaceAutomationFormNeedsProject(form: WorkspaceAutomationFormState): boolean {
@@ -126,7 +129,7 @@ export const WORKSPACE_AUTOMATION_API_ERROR_MESSAGES: Record<string, string> = {
     "Use GitHub repo automations with a scheduled or manual trigger, not GitHub push.",
   github_push_branches_required: "Add at least one branch pattern for GitHub push triggers.",
   scheduled_workflow_required:
-    "Scheduled automations require at least one GitHub, Contentful, or Issues workflow tool.",
+    "Scheduled automations require at least one GitHub, Contentful, Issues, or Web Search workflow tool.",
   slack_not_connected: "Connect Slack in Integrations before enabling Slack notifications.",
   slack_channel_required: "Choose a Slack channel for notifications.",
   email_not_connected: "Enable the email agent in Integrations before using email notifications.",
@@ -202,6 +205,8 @@ export function createDefaultWorkspaceAutomationFormState(): WorkspaceAutomation
     semrushConnectionId: "",
     ahrefsEnabled: false,
     ahrefsConnectionId: "",
+    webSearchEnabled: false,
+    webSearchProvider: "auto",
   };
 }
 
@@ -220,6 +225,7 @@ export function createWorkspaceAutomationFormStateFromRecord(
   const mcp = automation.toolConfig.mcp;
   const semrush = automation.toolConfig.semrush;
   const ahrefs = automation.toolConfig.ahrefs;
+  const webSearch = automation.toolConfig.webSearch;
 
   return {
     name: automation.name,
@@ -285,6 +291,8 @@ export function createWorkspaceAutomationFormStateFromRecord(
     semrushConnectionId: semrush?.connectionId ?? "",
     ahrefsEnabled: Boolean(ahrefs?.enabled),
     ahrefsConnectionId: ahrefs?.connectionId ?? "",
+    webSearchEnabled: Boolean(webSearch?.enabled),
+    webSearchProvider: webSearch?.provider ?? "auto",
   };
 }
 
@@ -491,6 +499,14 @@ export function formStateToWorkspaceAutomationPayload(form: WorkspaceAutomationF
           },
         }
       : {}),
+    ...(form.webSearchEnabled
+      ? {
+          webSearch: {
+            enabled: true,
+            provider: form.webSearchProvider,
+          },
+        }
+      : {}),
   };
 
   const projectId = form.projectId.trim() || undefined;
@@ -667,6 +683,7 @@ export function workspaceAutomationFormCanActivate(form: WorkspaceAutomationForm
     form.createIssueEnabled ||
     form.mcpEnabled ||
     form.semrushEnabled ||
-    form.ahrefsEnabled
+    form.ahrefsEnabled ||
+    form.webSearchEnabled
   );
 }

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
@@ -114,6 +114,28 @@ async function seedWorkspaceAutomationScope() {
   };
 }
 
+describe("workspaceAutomationConfigSchema web search", () => {
+  it("defaults the provider to auto and accepts perplexity or exa", () => {
+    expect(
+      workspaceAutomationConfigSchema.parse({
+        toolConfig: { webSearch: { enabled: true } },
+      }).toolConfig.webSearch,
+    ).toEqual({ enabled: true, provider: "auto" });
+
+    expect(
+      workspaceAutomationConfigSchema.parse({
+        toolConfig: { webSearch: { enabled: true, provider: "perplexity" } },
+      }).toolConfig.webSearch,
+    ).toEqual({ enabled: true, provider: "perplexity" });
+
+    expect(
+      workspaceAutomationConfigSchema.parse({
+        toolConfig: { webSearch: { enabled: true, provider: "exa" } },
+      }).toolConfig.webSearch,
+    ).toEqual({ enabled: true, provider: "exa" });
+  });
+});
+
 describe("workspaceAutomationConfigSchema native TMS tools", () => {
   it("migrates legacy translation toolConfig into create and assign tools", () => {
     const config = workspaceAutomationConfigSchema.parse({
@@ -356,7 +378,28 @@ describe("workspace automations", () => {
     expect(notificationOnlySchedule.error).toMatchObject({
       code: "scheduled_workflow_required",
       message:
-        "Scheduled automations require at least one GitHub, Contentful, or Issues workflow tool.",
+        "Scheduled automations require at least one GitHub, Contentful, Issues, or Web Search workflow tool.",
+    });
+
+    const scheduledWebSearch = expectOk(
+      await createWorkspaceAutomation({
+        organizationId: scope.organizationId,
+        authorUserId: scope.userId,
+        name: "Daily web research",
+        instructions: "Search the live web for competitor changes.",
+        triggerConfig,
+        toolConfig: {
+          webSearch: { enabled: true, provider: "auto" },
+          slack: {
+            enabled: true,
+            channelId: "C123",
+          },
+        },
+      }),
+    );
+    expect(scheduledWebSearch.toolConfig.webSearch).toEqual({
+      enabled: true,
+      provider: "auto",
     });
 
     const manualNotification = expectOk(
@@ -385,7 +428,7 @@ describe("workspace automations", () => {
     expect(scheduledUpdate.error).toMatchObject({
       code: "scheduled_workflow_required",
       message:
-        "Scheduled automations require at least one GitHub, Contentful, or Issues workflow tool.",
+        "Scheduled automations require at least one GitHub, Contentful, Issues, or Web Search workflow tool.",
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -185,11 +185,7 @@ const ahrefsToolConfigSchema = z
   })
   .default({ enabled: false });
 
-export const workspaceAutomationWebSearchProviderSchema = z.enum([
-  "auto",
-  "perplexity",
-  "exa",
-]);
+export const workspaceAutomationWebSearchProviderSchema = z.enum(["auto", "perplexity", "exa"]);
 
 const webSearchToolConfigSchema = z
   .object({

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -185,6 +185,19 @@ const ahrefsToolConfigSchema = z
   })
   .default({ enabled: false });
 
+export const workspaceAutomationWebSearchProviderSchema = z.enum([
+  "auto",
+  "perplexity",
+  "exa",
+]);
+
+const webSearchToolConfigSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+    provider: workspaceAutomationWebSearchProviderSchema.default("auto"),
+  })
+  .default({ enabled: false, provider: "auto" });
+
 function migrateLegacyTranslationToolConfig(
   value: Record<string, unknown>,
 ): Record<string, unknown> {
@@ -242,6 +255,7 @@ const toolConfigObjectSchema = z
     mcp: mcpToolConfigSchema.optional(),
     semrush: semrushToolConfigSchema.optional(),
     ahrefs: ahrefsToolConfigSchema.optional(),
+    webSearch: webSearchToolConfigSchema.optional(),
   })
   .default({});
 
@@ -281,6 +295,10 @@ export type WorkspaceAutomationKnowledgeToolConfig = z.infer<typeof knowledgeToo
 export type WorkspaceAutomationMcpToolConfig = z.infer<typeof mcpToolConfigSchema>;
 export type WorkspaceAutomationSemrushToolConfig = z.infer<typeof semrushToolConfigSchema>;
 export type WorkspaceAutomationAhrefsToolConfig = z.infer<typeof ahrefsToolConfigSchema>;
+export type WorkspaceAutomationWebSearchProvider = z.infer<
+  typeof workspaceAutomationWebSearchProviderSchema
+>;
+export type WorkspaceAutomationWebSearchToolConfig = z.infer<typeof webSearchToolConfigSchema>;
 export type WorkspaceAutomationToolConfig = z.infer<typeof toolConfigObjectSchema>;
 
 export type WorkspaceAutomationConfigValidationError =
@@ -306,7 +324,7 @@ export type WorkspaceAutomationConfigValidationError =
     }
   | {
       code: "scheduled_workflow_required";
-      message: "Scheduled automations require at least one GitHub, Contentful, or Issues workflow tool.";
+      message: "Scheduled automations require at least one GitHub, Contentful, Issues, or Web Search workflow tool.";
     }
   | {
       code: "contentful_connection_required";
@@ -435,6 +453,10 @@ export function hasWorkspaceAutomationSemrushTool(toolConfig: WorkspaceAutomatio
 
 export function hasWorkspaceAutomationAhrefsTool(toolConfig: WorkspaceAutomationToolConfig) {
   return Boolean(toolConfig.ahrefs?.enabled);
+}
+
+export function hasWorkspaceAutomationWebSearchTool(toolConfig: WorkspaceAutomationToolConfig) {
+  return Boolean(toolConfig.webSearch?.enabled);
 }
 
 export type WorkspaceAutomationRecord = {
@@ -606,12 +628,13 @@ function validateWorkspaceAutomationConfig(input: {
     !hasWorkspaceAutomationGithubWorkflow(input.toolConfig) &&
     !hasWorkspaceAutomationContentfulWorkflow(input.toolConfig) &&
     !hasWorkspaceAutomationListIssuesTool(input.toolConfig) &&
-    !hasWorkspaceAutomationCreateIssueTool(input.toolConfig)
+    !hasWorkspaceAutomationCreateIssueTool(input.toolConfig) &&
+    !hasWorkspaceAutomationWebSearchTool(input.toolConfig)
   ) {
     return err({
       code: "scheduled_workflow_required",
       message:
-        "Scheduled automations require at least one GitHub, Contentful, or Issues workflow tool.",
+        "Scheduled automations require at least one GitHub, Contentful, Issues, or Web Search workflow tool.",
     });
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Workspace automations can now add a first-party **Web Search** tool. It searches the live web through Vercel AI Gateway and does not need a separate Perplexity or Exa API key.

The tool config is:

```ts
toolConfig.webSearch = {
  enabled: true,
  provider: "auto" | "perplexity" | "exa",
}
```

- **Auto** gives the nested research agent both `gateway.tools.perplexitySearch()` and `gateway.tools.exaSearch()`, so it can pick the better source.
- **Perplexity** uses only Perplexity Search.
- **Exa** uses only Exa Search (`type: "auto"` by default).

The orchestrator plans `use_web_search` when the tool is enabled. Scheduled automations can use Web Search as their workflow tool (for example, daily research plus Slack).

The generated search summary is kept on the persisted run output (`outputSummary.webSearch`) and returned to the parent agent. Logged `stepResults` only include provider, status, and tool count, so customer-identifying details from the search objective or automation instructions are not echoed through `logger.info({ stepResults })`.

## How to test

- `vp test` in `apps/hyperlocalise-web`: 661 files, 4313 tests passed
- `vp check --fix` in `apps/hyperlocalise-web`: 0 errors (4 pre-existing warnings in unrelated files)
- In the automation editor, add **Web Search**, choose Auto / Perplexity / Exa, save, and run a manual automation that asks for current web facts.

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d29481e-0880-4ff4-be4d-4ee7fe2d6600?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d29481e-0880-4ff4-be4d-4ee7fe2d6600&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

