### PR TITLE
feat(web): use Seedance 2.5 for video localization

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
@@ -137,6 +137,7 @@ describe("buildFileTranslationInstructions", () => {
     expect(instructions).toContain("webp");
     expect(instructions).toContain("mp4");
     expect(instructions).toContain("localizes the image or video asset");
+    expect(instructions).toContain("3–30 seconds");
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
@@ -34,6 +34,10 @@ import {
 } from "@/lib/agent-runtime/workspaces/repository-sandbox";
 import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 import { supportedFileTranslationFileFormats } from "@/lib/translation/file-formats";
+import {
+  VIDEO_LOCALIZATION_MAX_DURATION_SECONDS,
+  VIDEO_LOCALIZATION_MIN_DURATION_SECONDS,
+} from "@/lib/translation/mp4-duration";
 import { createLogger, serializeErrorForLog } from "@/lib/log";
 
 import {
@@ -65,7 +69,7 @@ export function buildFileTranslationInstructions() {
     'Use sourceLocale "auto" if the user did not specify a source locale.',
     `Supported file job formats: ${supportedFileTranslationFileFormats.join(", ")}.`,
     "For png, jpeg, webp, and mp4 attachments, still create a file translation job — the workflow localizes the image or video asset for each target locale.",
-    "mp4 clips should typically be short (about 3–10 seconds).",
+    `mp4 clips should typically be ${VIDEO_LOCALIZATION_MIN_DURATION_SECONDS}–${VIDEO_LOCALIZATION_MAX_DURATION_SECONDS} seconds.`,
   ].join(" ");
 }
 

--- a/apps/hyperlocalise-web/src/lib/agents/video-generation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/video-generation.test.ts
@@ -14,7 +14,7 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const { generateVideoMock, getManagedVideoModelMock } = vi.hoisted(() => ({
   generateVideoMock: vi.fn(),
-  getManagedVideoModelMock: vi.fn(() => "google/gemini-omni-flash-preview"),
+  getManagedVideoModelMock: vi.fn(() => "bytedance/seedance-2.5"),
 }));
 
 vi.mock("ai", async () => {
@@ -27,7 +27,7 @@ vi.mock("ai", async () => {
 
 vi.mock("@/lib/providers/language-model", () => ({
   getManagedVideoModel: getManagedVideoModelMock,
-  hyperlocaliseVideoModelId: "google/gemini-omni-flash-preview",
+  hyperlocaliseVideoModelId: "bytedance/seedance-2.5",
 }));
 
 vi.mock("@/lib/billing/agent-runtime-usage", () => ({
@@ -44,7 +44,7 @@ describe("video generation", () => {
     });
   });
 
-  it("generates localized videos through the managed Omni Gateway model", async () => {
+  it("generates localized videos through the managed Seedance Gateway model", async () => {
     const result = await regenerateVideoFromAttachment(
       Buffer.from("source-video"),
       "video/mp4",
@@ -54,8 +54,14 @@ describe("video generation", () => {
     expect(getManagedVideoModelMock).toHaveBeenCalledOnce();
     expect(generateVideoMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        model: "google/gemini-omni-flash-preview",
+        model: "bytedance/seedance-2.5",
         prompt: "Localize this clip into Spanish",
+        generateAudio: true,
+        providerOptions: {
+          bytedance: {
+            pollTimeoutMs: 600_000,
+          },
+        },
       }),
     );
     expect(result).toEqual({

--- a/apps/hyperlocalise-web/src/lib/agents/video-generation.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/video-generation.ts
@@ -87,6 +87,11 @@ async function generateVideoFromPrompt(
     aspectRatio: "adaptive",
     generateAudio: true,
     ...(durationSeconds != null ? { duration: durationSeconds } : {}),
+    providerOptions: {
+      bytedance: {
+        pollTimeoutMs: 600_000,
+      },
+    },
   });
 
   const generatedVideo = result.video;
@@ -102,7 +107,7 @@ async function generateVideoFromPrompt(
 
 /**
  * End-to-end video regeneration pipeline:
- * 1. Send the source video and localization prompt to Gemini Omni via AI Gateway
+ * 1. Send the source video and localization prompt to Seedance 2.5 via AI Gateway
  * 2. Return the generated video buffer and the prompt used
  */
 export async function regenerateVideoFromAttachment(

--- a/apps/hyperlocalise-web/src/lib/agents/video-localization.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/video-localization.test.ts
@@ -21,7 +21,7 @@ describe("video localization helpers", () => {
     expect(localizedVideoOutputFilename(undefined, "de")).toBe("video-de.mp4");
   });
 
-  it("includes source and target locale in the Omni prompt", () => {
+  it("includes source and target locale in the Seedance prompt", () => {
     const prompt = buildVideoLocalizationPrompt({
       filename: "hero.mp4",
       sourceLocale: "en-US",
@@ -29,6 +29,7 @@ describe("video localization helpers", () => {
       instructions: "Keep the logo.",
     });
 
+    expect(prompt).toContain("Use [Video 1] as the source");
     expect(prompt).toContain("Source locale: en-US");
     expect(prompt).toContain("Target locale: fr-FR");
     expect(prompt).toContain("User instructions: Keep the logo.");

--- a/apps/hyperlocalise-web/src/lib/agents/video-localization.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/video-localization.ts
@@ -57,7 +57,7 @@ export function buildVideoLocalizationPrompt(input: {
   contextLines?: Array<string | null | undefined>;
 }) {
   return [
-    "Use the attached video as the source and generate a localized version.",
+    "Use [Video 1] as the source and generate a localized version.",
     "Preserve the original layout, style, composition, motion, brand treatment, and visual hierarchy unless the user explicitly asks for a change.",
     "Localize on-screen text and spoken audio into the target locale. Keep everything else the same.",
     input.sourceLocale ? `Source locale: ${input.sourceLocale}` : "Source locale: auto-detect",

--- a/apps/hyperlocalise-web/src/lib/providers/language-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/language-model.test.ts
@@ -47,7 +47,7 @@ describe("managed language model", () => {
     expect(getManagedVideoModel()).toBe(hyperlocaliseVideoModelId);
     expect(hyperlocaliseManagedGatewayModelId).toBe("openai/gpt-5.6-luna");
     expect(hyperlocaliseImageModelId).toBe("openai/gpt-image-2");
-    expect(hyperlocaliseVideoModelId).toBe("google/gemini-omni-flash-preview");
+    expect(hyperlocaliseVideoModelId).toBe("bytedance/seedance-2.5");
     expect(createOpenAIMock).not.toHaveBeenCalled();
     expect(createAnthropicMock).not.toHaveBeenCalled();
   });

--- a/apps/hyperlocalise-web/src/lib/providers/language-model.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/language-model.ts
@@ -19,7 +19,7 @@ import type { LlmProvider } from "@/lib/database/types";
 
 export const hyperlocaliseManagedGatewayModelId = `openai/${hyperlocaliseAgentModelId}`;
 export const hyperlocaliseImageModelId = "openai/gpt-image-2";
-export const hyperlocaliseVideoModelId = "google/gemini-omni-flash-preview";
+export const hyperlocaliseVideoModelId = "bytedance/seedance-2.5";
 
 export type AgentLanguageModelSource = LlmProvider | "gateway";
 

--- a/apps/hyperlocalise-web/src/lib/translation/mp4-duration.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/mp4-duration.test.ts
@@ -59,13 +59,20 @@ describe("mp4 duration probe", () => {
     expect(readMp4DurationSeconds(bytes)).toBeNull();
   });
 
-  it("accepts clips between 3 and 10 seconds", () => {
-    const result = assertMp4DurationSupported(buildMp4WithDuration(5));
-    expect(isOk(result)).toBe(true);
-    if (isErr(result)) {
+  it("accepts clips between 3 and 30 seconds", () => {
+    const shortResult = assertMp4DurationSupported(buildMp4WithDuration(5));
+    expect(isOk(shortResult)).toBe(true);
+    if (isErr(shortResult)) {
       throw new Error("expected 5s clip to be supported");
     }
-    expect(result.value.durationSeconds).toBe(5);
+    expect(shortResult.value.durationSeconds).toBe(5);
+
+    const longResult = assertMp4DurationSupported(buildMp4WithDuration(30));
+    expect(isOk(longResult)).toBe(true);
+    if (isErr(longResult)) {
+      throw new Error("expected 30s clip to be supported");
+    }
+    expect(longResult.value.durationSeconds).toBe(30);
   });
 
   it("rejects clips shorter than 3 seconds", () => {
@@ -77,13 +84,13 @@ describe("mp4 duration probe", () => {
     expect(result.error).toEqual({ code: "video_duration_unsupported", durationSeconds: 2 });
   });
 
-  it("rejects clips longer than 10 seconds", () => {
-    const result = assertMp4DurationSupported(buildMp4WithDuration(11));
+  it("rejects clips longer than 30 seconds", () => {
+    const result = assertMp4DurationSupported(buildMp4WithDuration(31));
     expect(isErr(result)).toBe(true);
     if (isOk(result)) {
-      throw new Error("expected 11s clip to be rejected");
+      throw new Error("expected 31s clip to be rejected");
     }
-    expect(result.error).toEqual({ code: "video_duration_unsupported", durationSeconds: 11 });
+    expect(result.error).toEqual({ code: "video_duration_unsupported", durationSeconds: 31 });
   });
 
   it("rejects unreadable mp4 buffers", () => {

--- a/apps/hyperlocalise-web/src/lib/translation/mp4-duration.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/mp4-duration.ts
@@ -13,7 +13,7 @@
 import { err, ok, type Result } from "@/lib/primitives/result/results";
 
 export const VIDEO_LOCALIZATION_MIN_DURATION_SECONDS = 3;
-export const VIDEO_LOCALIZATION_MAX_DURATION_SECONDS = 10;
+export const VIDEO_LOCALIZATION_MAX_DURATION_SECONDS = 30;
 
 export type Mp4DurationError =
   | { code: "video_duration_unreadable" }

--- a/docs/adr/2026-08-13-video-omni-localization-design.md
+++ b/docs/adr/2026-08-13-video-omni-localization-design.md
@@ -2,8 +2,8 @@
 
 Superseded for the model id by
 [2026-08-16-video-seedance-model-design.md](./2026-08-16-video-seedance-model-design.md).
-The dual-entry CAT paths, duration gates, and error codes in this note still
-apply.
+The dual-entry CAT paths and error codes in this note still apply. Duration
+gates are now 3–30 seconds; see the Seedance note.
 
 ## Date
 
@@ -91,5 +91,5 @@ No live Omni calls in `vp test`.
 
 ## Follow-ups
 
-webm, captions/SRT, CLI sync, Slack/email/Contentful, YouTube/Vimeo, clips over
-10s, org BYOK for video, Gateway cutover for images.
+webm, captions/SRT, CLI sync, Slack/email/Contentful, YouTube/Vimeo, org BYOK
+for video, Gateway cutover for images.

--- a/docs/adr/2026-08-13-video-omni-localization-design.md
+++ b/docs/adr/2026-08-13-video-omni-localization-design.md
@@ -1,5 +1,10 @@
 # Video localization with Gemini Omni Flash
 
+Superseded for the model id by
+[2026-08-16-video-seedance-model-design.md](./2026-08-16-video-seedance-model-design.md).
+The dual-entry CAT paths, duration gates, and error codes in this note still
+apply.
+
 ## Date
 
 2026-08-13
@@ -87,4 +92,4 @@ No live Omni calls in `vp test`.
 ## Follow-ups
 
 webm, captions/SRT, CLI sync, Slack/email/Contentful, YouTube/Vimeo, clips over
-10s, org BYOK for Omni, Gateway cutover for images.
+10s, org BYOK for video, Gateway cutover for images.

--- a/docs/adr/2026-08-16-agent-ai-gateway-default-design.md
+++ b/docs/adr/2026-08-16-agent-ai-gateway-default-design.md
@@ -40,7 +40,7 @@ BYOK:
 | Media | Gateway model | Why |
 |-------|---------------|-----|
 | Image translation | `openai/gpt-image-2` | OpenAI image model through Vercel AI Gateway |
-| Video translation | `google/gemini-omni-flash-preview` | Gemini Omni through the same Gateway |
+| Video translation | `bytedance/seedance-2.5` | Seedance 2.5 through the same Gateway |
 
 File-translation sandboxes follow the same BYOK-then-managed order as string
 jobs. When the organization has a stored provider credential, the sandbox CLI

--- a/docs/adr/2026-08-16-video-seedance-model-design.md
+++ b/docs/adr/2026-08-16-video-seedance-model-design.md
@@ -1,0 +1,43 @@
+# Video localization uses Seedance 2.5
+
+## Date
+
+2026-08-16
+
+## Context
+
+Video localization called `google/gemini-omni-flash-preview` through Vercel AI
+Gateway. ByteDance Seedance 2.5 is now on the same Gateway as
+`bytedance/seedance-2.5`. It edits a source clip from `inputReferences`,
+returns MP4 with audio, and accepts the same `experimental_generateVideo`
+shape already used for Omni.
+
+Seedance asks the prompt to name the first video reference as `[Video 1]`.
+Generation can take several minutes, so the ByteDance poll timeout is 10
+minutes.
+
+## Decision
+
+Point `hyperlocaliseVideoModelId` at `bytedance/seedance-2.5`. Keep the
+existing Gateway call: source MP4 bytes in `inputReferences`,
+`aspectRatio: "adaptive"`, `generateAudio: true`, and the source clip
+duration. Name the source as `[Video 1]` in the localization prompt.
+
+Duration gates stay 3–10 seconds. File-backed and URL-backed CAT paths do
+not change. Image and video jobs stay on the managed Gateway and do not
+use org BYOK.
+
+## Consequences
+
+- Tests mock Seedance. `vp test` still makes no live video calls.
+- Omni-specific EEA/UK region-block mapping remains. Seedance may return
+  different geo errors; those fall through to `video_localization_failed`.
+- Seedance documents URL references. Gateway still accepts the current
+  buffer `inputReferences` used for Omni. Switch to hosted URLs only if
+  buffer uploads fail in production.
+- Seedance can generate up to 30 seconds. Raising the 10s ingest cap is a
+  follow-up.
+
+## Follow-ups
+
+Clips over 10s, hosted URL references if buffers fail, org BYOK for video.

--- a/docs/adr/2026-08-16-video-seedance-model-design.md
+++ b/docs/adr/2026-08-16-video-seedance-model-design.md
@@ -23,9 +23,9 @@ existing Gateway call: source MP4 bytes in `inputReferences`,
 `aspectRatio: "adaptive"`, `generateAudio: true`, and the source clip
 duration. Name the source as `[Video 1]` in the localization prompt.
 
-Duration gates stay 3–10 seconds. File-backed and URL-backed CAT paths do
-not change. Image and video jobs stay on the managed Gateway and do not
-use org BYOK.
+Duration gates are 3–30 seconds, matching Seedance's clip length. File-backed
+and URL-backed CAT paths do not change. Image and video jobs stay on the
+managed Gateway and do not use org BYOK.
 
 ## Consequences
 
@@ -35,9 +35,7 @@ use org BYOK.
 - Seedance documents URL references. Gateway still accepts the current
   buffer `inputReferences` used for Omni. Switch to hosted URLs only if
   buffer uploads fail in production.
-- Seedance can generate up to 30 seconds. Raising the 10s ingest cap is a
-  follow-up.
 
 ## Follow-ups
 
-Clips over 10s, hosted URL references if buffers fail, org BYOK for video.
+Hosted URL references if buffers fail, org BYOK for video.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Video localization now calls `bytedance/seedance-2.5` on Vercel AI Gateway instead of `google/gemini-omni-flash-preview`.

The CAT paths and `experimental_generateVideo` shape stay the same. The localization prompt names the source clip as `[Video 1]`, which Seedance uses for video references. The ByteDance poll timeout is 10 minutes because Seedance generations can run long.

Ingest duration is now **3–30 seconds**, matching Seedance's clip length. The old Omni 10s cap is gone.

## How to test

- `vp test` for video and duration files (no live video calls)
- `vp check --fix` on the touched files
- Confirm `hyperlocaliseVideoModelId` is `bytedance/seedance-2.5`
- Confirm a 30s MP4 passes `assertMp4DurationSupported` and a 31s clip is rejected
- Confirm generateVideo is called with `[Video 1]` in the prompt and `providerOptions.bytedance.pollTimeoutMs`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a5e79f6-5469-4de1-8182-798c79fbdcfb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a5e79f6-5469-4de1-8182-798c79fbdcfb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

