### PR TITLE
fix(audit): accept nb_NO og:locale on Norwegian /no/ pages

### DIFF
--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics.test.ts
@@ -70,6 +70,22 @@ describe("technical heuristic credits", () => {
     expect(mismatch?.advice).not.toContain('html lang="au"');
   });
 
+  it("does not flag nb-NO html lang on a /no/ path as a mismatch", () => {
+    const outcome = technicalHeuristicScorers["locale-detection"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://example.com/no/tjenester",
+          htmlLang: "nb-NO",
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("scored");
+    if (outcome.status !== "scored") return;
+    expect(outcome.findings.some((finding) => finding.id.includes("mismatch"))).toBe(false);
+    expect(outcome.score).toBe(100);
+  });
+
   it("does not flag en html lang on an /au/ path as a mismatch", () => {
     const outcome = technicalHeuristicScorers["locale-detection"]!(
       context([
@@ -222,6 +238,75 @@ describe("technical heuristic credits", () => {
     expect(outcome.status).toBe("scored");
     if (outcome.status !== "scored") return;
     expect(outcome.findings.some((finding) => finding.id.startsWith("canonical-locale-"))).toBe(
+      false,
+    );
+    expect(outcome.score).toBe(100);
+  });
+
+  it("accepts og:locale nb_NO on a Norwegian /no/ page", () => {
+    const outcome = technicalHeuristicScorers["localized-seo-metadata"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://example.com/en/pricing",
+          htmlLang: "en",
+          title: "Pricing",
+          metaDescription: "Plans for teams",
+          ogLocale: "en_US",
+        }),
+        emptyCrawledPage({
+          url: "https://example.com/no/pricing",
+          htmlLang: "no",
+          title: "Priser",
+          metaDescription: "Planer for team",
+          ogLocale: "nb_NO",
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("scored");
+    if (outcome.status !== "scored") return;
+    expect(outcome.findings.some((finding) => finding.id.startsWith("seo-og-locale-"))).toBe(false);
+    expect(outcome.score).toBe(100);
+  });
+
+  it("still flags og:locale that is a different language", () => {
+    const outcome = technicalHeuristicScorers["localized-seo-metadata"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://example.com/en/pricing",
+          htmlLang: "en",
+          title: "Pricing",
+          ogLocale: "en_US",
+        }),
+        emptyCrawledPage({
+          url: "https://example.com/no/pricing",
+          htmlLang: "no",
+          title: "Priser",
+          ogLocale: "sv_SE",
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("scored");
+    if (outcome.status !== "scored") return;
+    expect(outcome.findings.some((finding) => finding.id.startsWith("seo-og-locale-"))).toBe(true);
+    expect(outcome.score).toBeLessThan(100);
+  });
+
+  it("accepts JSON-LD inLanguage nb on a /no/ page", () => {
+    const outcome = technicalHeuristicScorers["structured-data"]!(
+      context([
+        emptyCrawledPage({
+          url: "https://example.com/no/pricing",
+          htmlLang: "no",
+          jsonLd: [{ type: "WebPage", inLanguage: "nb" }],
+        }),
+      ]),
+    );
+
+    expect(outcome.status).toBe("scored");
+    if (outcome.status !== "scored") return;
+    expect(outcome.findings.some((finding) => finding.id.startsWith("jsonld-language-"))).toBe(
       false,
     );
     expect(outcome.score).toBe(100);

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/technical.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/heuristics/technical.ts
@@ -21,6 +21,7 @@ import {
   htmlLangSuggestionForPathLocale,
   isWellFormedHtmlLang,
   languageOf,
+  languagesMatch,
   LOCALE_SUBDOMAIN,
   looksPrimarilyEnglish,
   pageLocale,
@@ -247,7 +248,7 @@ const scoreLanguageSwitcher: HeuristicScorer = (context) => {
         LANGUAGE_NAME.test(anchor.text.trim()) ||
         LANGUAGE_NAME.test(anchor.href);
       if (!looksLikeSwitcher || !targetLocale) continue;
-      if (pageLocale(page) && languageOf(targetLocale) === languageOf(pageLocale(page)!)) {
+      if (pageLocale(page) && languagesMatch(targetLocale, pageLocale(page)!)) {
         continue;
       }
       found += 1;
@@ -491,7 +492,7 @@ const scoreCanonicalUrls: HeuristicScorer = (context) => {
     }
     const canonicalPathToken = pathLocaleFromUrl(canonicalUrl.toString());
     const canonicalLocale = canonicalPathToken ? canonicalPathLocale(canonicalPathToken) : null;
-    if (pageLoc && canonicalLocale && languageOf(pageLoc) !== languageOf(canonicalLocale)) {
+    if (pageLoc && canonicalLocale && !languagesMatch(pageLoc, canonicalLocale)) {
       score -= 30;
       findings.push(
         creditFinding({
@@ -575,7 +576,7 @@ const scoreLocalizedSeoMetadata: HeuristicScorer = (context) => {
 
   for (const [language, pages] of byLanguage) {
     const page = pages[0]!;
-    if (page.ogLocale && languageOf(page.ogLocale) !== language) {
+    if (page.ogLocale && !languagesMatch(page.ogLocale, language)) {
       score -= 12;
       findings.push(
         creditFinding({
@@ -761,7 +762,7 @@ const scoreStructuredData: HeuristicScorer = (context) => {
         score -= 8;
         continue;
       }
-      if (locale && languageOf(node.inLanguage) !== languageOf(locale)) {
+      if (locale && !languagesMatch(node.inLanguage, locale)) {
         score -= 18;
         findings.push(
           creditFinding({

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared-locale.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared-locale.test.ts
@@ -18,6 +18,7 @@ import {
   htmlLangMatchesPathLocale,
   htmlLangSuggestionForPathLocale,
   isCjkLanguage,
+  languagesMatch,
   isPlausibleCtaCopy,
   isRtlLanguage,
   isWellFormedHtmlLang,
@@ -64,6 +65,30 @@ describe("htmlLangMatchesPathLocale", () => {
     expect(htmlLangMatchesPathLocale("fr-CA", "fr")).toBe(true);
     expect(htmlLangMatchesPathLocale("es-419", "es")).toBe(true);
     expect(htmlLangMatchesPathLocale("en-AU", "fr")).toBe(false);
+  });
+
+  it("accepts Norwegian Bokmål html lang on a /no/ macrolanguage path", () => {
+    expect(htmlLangMatchesPathLocale("nb", "no")).toBe(true);
+    expect(htmlLangMatchesPathLocale("nb-NO", "no")).toBe(true);
+    expect(htmlLangMatchesPathLocale("nn-NO", "no")).toBe(true);
+    expect(htmlLangMatchesPathLocale("nb-NO", "nn")).toBe(false);
+    expect(htmlLangMatchesPathLocale("sv", "no")).toBe(false);
+  });
+});
+
+describe("languagesMatch", () => {
+  it("treats Norwegian Bokmål and Nynorsk as the no macrolanguage", () => {
+    expect(languagesMatch("nb_NO", "no")).toBe(true);
+    expect(languagesMatch("nn-NO", "no")).toBe(true);
+    expect(languagesMatch("nb", "nb-NO")).toBe(true);
+    expect(languagesMatch("nb", "nn")).toBe(false);
+    expect(languagesMatch("fr_FR", "no")).toBe(false);
+  });
+
+  it("treats deprecated language aliases as the current ISO code", () => {
+    expect(languagesMatch("iw", "he")).toBe(true);
+    expect(languagesMatch("in_ID", "id")).toBe(true);
+    expect(languagesMatch("tl", "fil")).toBe(true);
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/credits/shared.ts
@@ -95,6 +95,53 @@ export function languageOf(locale: string): string {
   return normalizeLocale(locale).split("-")[0] ?? "";
 }
 
+function localeRegion(locale: string): string {
+  return normalizeLocale(locale).split("-").slice(1).join("-");
+}
+
+/**
+ * Deprecated ISO 639-1 aliases still seen in html lang and og:locale.
+ * Mapped to the current preferred language subtag.
+ */
+const LANGUAGE_ALIASES: ReadonlyMap<string, string> = new Map([
+  ["iw", "he"],
+  ["in", "id"],
+  ["ji", "yi"],
+  ["jw", "jv"],
+  ["mo", "ro"],
+  ["tl", "fil"],
+]);
+
+/**
+ * Individual ISO 639 languages → their macrolanguage.
+ * `no` is Norwegian; `nb` is Bokmål and `nn` is Nynorsk. Open Graph uses
+ * `nb_NO` for Norwegian, so a `/no/` page with og:locale=nb_NO is correct.
+ */
+const LANGUAGE_MACROLANGUAGE: ReadonlyMap<string, string> = new Map([
+  ["nb", "no"],
+  ["nn", "no"],
+]);
+
+function canonicalLanguage(locale: string): string {
+  const language = languageOf(locale);
+  return LANGUAGE_ALIASES.get(language) ?? language;
+}
+
+/**
+ * Whether two locale tags refer to the same language family.
+ * Matches `nb`/`nn` to macrolanguage `no`, and deprecated aliases such as
+ * `iw`→`he`. Sibling individual languages (`nb` vs `nn`) do not match.
+ */
+export function languagesMatch(left: string, right: string): boolean {
+  const leftLanguage = canonicalLanguage(left);
+  const rightLanguage = canonicalLanguage(right);
+  if (!leftLanguage || !rightLanguage) return false;
+  if (leftLanguage === rightLanguage) return true;
+  const leftMacro = LANGUAGE_MACROLANGUAGE.get(leftLanguage) ?? leftLanguage;
+  const rightMacro = LANGUAGE_MACROLANGUAGE.get(rightLanguage) ?? rightLanguage;
+  return leftLanguage === rightMacro || rightLanguage === leftMacro;
+}
+
 /**
  * Whether a value is a structurally valid BCP 47 language tag for `html lang`.
  * Accepts UN M.49 regions such as `es-419` (Latin America) and scripts such as `zh-Hans`.
@@ -158,20 +205,18 @@ export function canonicalPathLocale(pathLocale: string): string {
 /**
  * Whether declared html lang agrees with the URL path locale.
  * `en` matches path `/au/` (suggested `en-AU`); `fr` on `/au/` does not.
+ * `nb-NO` matches path `/no/` (Norwegian Bokmål under macrolanguage `no`).
  */
 export function htmlLangMatchesPathLocale(htmlLang: string, pathLocale: string): boolean {
   const html = normalizeLocale(htmlLang);
   const suggested = normalizeLocale(htmlLangSuggestionForPathLocale(pathLocale));
   if (html === suggested) return true;
-  if (languageOf(html) !== languageOf(suggested)) return false;
-  // Bare language tag matches a language-region suggestion for the same language.
-  if (!html.includes("-") && suggested.includes("-")) return true;
-  // Language-region path matches a bare html lang for the same language.
-  if (html.includes("-") && !suggested.includes("-") && languageOf(html) === suggested) {
-    return true;
-  }
-  // Same language-region family (en-AU vs en-au already normalized; en-GB vs en-AU disagree on region)
-  return html === suggested;
+  if (!languagesMatch(html, suggested)) return false;
+  const htmlRegion = localeRegion(html);
+  const suggestedRegion = localeRegion(suggested);
+  // Bare language (or equivalent, e.g. nb vs no) matches a language-region tag.
+  if (!htmlRegion || !suggestedRegion) return true;
+  return htmlRegion === suggestedRegion;
 }
 
 export function isRtlLanguage(locale: string): boolean {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The localisation audit compared `og:locale` to the page language with a strict language-subtag check. `languageOf("nb_NO")` is `nb`, so a `/no/` page was flagged as:

> og:locale is nb_NO on a no page.

That finding is wrong. `no` is the ISO 639 Norwegian macrolanguage; `nb` (Bokmål) and `nn` (Nynorsk) are the individual languages. Facebook Open Graph uses `nb_NO` for Norwegian, so `og:locale=nb_NO` on a `no` page is correct.

This adds `languagesMatch()` that:

- Treats `nb` / `nn` as matching macrolanguage `no`
- Does **not** treat `nb` and `nn` as interchangeable
- Also maps common deprecated aliases (`iw`→`he`, `in`→`id`, `tl`→`fil`)

The helper is used for og:locale, html lang vs path, JSON-LD `inLanguage`, canonical locale, and language-switcher same-language skips.

## How to test

- `vp test src/lib/localisation-audit/credits/shared-locale.test.ts src/lib/localisation-audit/credits/heuristics.test.ts` from `apps/hyperlocalise-web`
- `vp check --fix` in `apps/hyperlocalise-web`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-384b945d-d5a7-4b83-be54-217e17c8cd81?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-384b945d-d5a7-4b83-be54-217e17c8cd81&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

