### PR TITLE
feat(audit): show leaderboard scores as colored bars with logos

### DIFF
--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-leaderboard.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-leaderboard.tsx
@@ -13,14 +13,40 @@
 import Link from "next/link";
 
 import { TypographyH2, TypographyP } from "@/components/ui/typography";
+import { leaderboardScoreTone } from "@/lib/localisation-audit/score-tone";
 import type { LocalisationAuditLeaderboardEntry } from "@/lib/localisation-audit/store";
+import { cn } from "@/lib/primitives/cn";
 
 import { getLocalisationAuditPageCopy } from "./localisation-audit-page-content";
+import { LocalisationAuditSiteMark } from "./localisation-audit-site-mark";
 
 type LocalisationAuditLeaderboardProps = {
   locale: string;
   entries: LocalisationAuditLeaderboardEntry[];
 };
+
+const LEADERBOARD_GRID =
+  "grid grid-cols-[1.75rem_minmax(0,11rem)_minmax(4.5rem,1fr)_2.75rem] items-center gap-x-3 sm:grid-cols-[2.25rem_minmax(12rem,18rem)_minmax(8rem,1fr)_3.5rem] sm:gap-x-5";
+
+const SCORE_TICKS = [0, 25, 50, 75, 100] as const;
+
+function scoreBarClass(score: number) {
+  const tone = leaderboardScoreTone(score);
+  if (tone === "safe") return "bg-success";
+  if (tone === "watch") return "bg-warning";
+  return "bg-destructive";
+}
+
+function scoreTextClass(score: number) {
+  const tone = leaderboardScoreTone(score);
+  if (tone === "safe") return "text-success";
+  if (tone === "watch") return "text-warning";
+  return "text-destructive";
+}
+
+function siteLabel(entry: LocalisationAuditLeaderboardEntry) {
+  return entry.companyName ?? entry.domainKey;
+}
 
 export function LocalisationAuditLeaderboard({
   locale,
@@ -46,27 +72,84 @@ export function LocalisationAuditLeaderboard({
         {copy.leaderboardSubcopy}
       </TypographyP>
 
-      <ol className="mt-10 divide-y divide-border border-y border-border">
-        {entries.map((entry) => (
-          <li key={entry.domainSlug}>
-            <Link
-              href={`/${locale}/localisation-audit/${entry.domainSlug}`}
-              className="flex items-baseline justify-between gap-6 py-4 transition-colors hover:bg-muted/40"
-            >
-              <span className="flex min-w-0 items-baseline gap-4">
-                <span className="w-8 shrink-0 text-sm tabular-nums text-muted-foreground">
-                  #{entry.rank}
+      <div className="mt-10">
+        <div
+          className={cn(
+            LEADERBOARD_GRID,
+            "border-b border-border pb-3 text-xs font-medium text-muted-foreground uppercase",
+          )}
+        >
+          <span className="col-span-2">{copy.leaderboardSiteColumn}</span>
+          <span className="col-start-3 col-span-2">{copy.leaderboardScoreColumn}</span>
+        </div>
+
+        <ol className="divide-y divide-border">
+          {entries.map((entry) => (
+            <li key={entry.domainSlug}>
+              <Link
+                href={`/${locale}/localisation-audit/${entry.domainSlug}`}
+                className={cn(
+                  LEADERBOARD_GRID,
+                  "py-3.5 transition-colors hover:bg-muted/40 sm:py-4",
+                )}
+              >
+                <span className="text-sm tabular-nums text-muted-foreground">#{entry.rank}</span>
+                <span className="flex min-w-0 items-center gap-3">
+                  <LocalisationAuditSiteMark
+                    domainKey={entry.domainKey}
+                    companyName={entry.companyName}
+                    logoUrl={entry.logoUrl}
+                  />
+                  <span className="min-w-0">
+                    <span className="block truncate font-medium">{siteLabel(entry)}</span>
+                    {entry.companyName ? (
+                      <span className="block truncate text-xs text-muted-foreground">
+                        {entry.domainKey}
+                      </span>
+                    ) : null}
+                  </span>
                 </span>
-                <span className="truncate font-medium">{entry.domainKey}</span>
-              </span>
-              <span className="shrink-0 text-sm tabular-nums text-muted-foreground">
-                {entry.score}
-                <span className="text-muted-foreground/70">/100</span>
-              </span>
-            </Link>
-          </li>
-        ))}
-      </ol>
+                <span className="min-w-0">
+                  <span
+                    className="relative block h-3 overflow-hidden rounded-sm bg-muted"
+                    role="meter"
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-valuenow={entry.score}
+                    aria-label={copy.leaderboardScoreLabel({ score: entry.score })}
+                  >
+                    <span
+                      className={cn(
+                        "block h-full w-full origin-left rounded-sm",
+                        scoreBarClass(entry.score),
+                      )}
+                      style={{
+                        transform: `scaleX(${Math.min(Math.max(entry.score, 0), 100) / 100})`,
+                      }}
+                    />
+                  </span>
+                </span>
+                <span
+                  className={cn(
+                    "text-right text-sm font-semibold tabular-nums",
+                    scoreTextClass(entry.score),
+                  )}
+                >
+                  {entry.score}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ol>
+
+        <div className={cn(LEADERBOARD_GRID, "pt-2")} aria-hidden>
+          <div className="col-start-3 flex justify-between text-xs tabular-nums text-muted-foreground">
+            {SCORE_TICKS.map((tick) => (
+              <span key={tick}>{tick}</span>
+            ))}
+          </div>
+        </div>
+      </div>
     </section>
   );
 }

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page-content.test.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page-content.test.ts
@@ -32,6 +32,9 @@ describe("localisation audit page content", () => {
     expect(copy.notices).toHaveLength(3);
     expect(copy.notices[0]?.title).toBe("Voice");
     expect(copy.leaderboardHeading).toBe("How other sites score");
+    expect(copy.leaderboardSiteColumn).toBe("Site");
+    expect(copy.leaderboardScoreColumn).toBe("Score");
+    expect(copy.leaderboardScoreLabel({ score: 86 })).toBe("Score 86 out of 100");
     expect(copy.startError).toContain("Check the URL");
     expect(copy.onePerDomain({ limit: LOCALISATION_AUDIT_DAILY_RUN_LIMIT })).toBe(
       `One free look per site. ${LOCALISATION_AUDIT_DAILY_RUN_LIMIT} a day across all sites.`,

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page-content.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page-content.ts
@@ -172,19 +172,19 @@ export function getLocalisationAuditPageCopy(locale: string) {
     }),
     leaderboardSiteColumn: intl.formatMessage({
       defaultMessage: "Site",
-      id: "rK9mQ2nL8x",
+      id: "mHZZxFedL8",
       description: "Column heading for site names on the localisation audit leaderboard",
     }),
     leaderboardScoreColumn: intl.formatMessage({
       defaultMessage: "Score",
-      id: "tB4pW7cH1z",
+      id: "MrZ8+8I97E",
       description: "Column heading for scores on the localisation audit leaderboard",
     }),
     leaderboardScoreLabel: (values: { score: number }) =>
       intl.formatMessage(
         {
           defaultMessage: "Score {score} out of 100",
-          id: "uN6dF3sJ5q",
+          id: "dbtTNEaJX2",
           description: "Accessible label for a localisation audit leaderboard score bar",
         },
         values,

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page-content.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page-content.ts
@@ -170,6 +170,25 @@ export function getLocalisationAuditPageCopy(locale: string) {
       id: "4XzQKxM2MY",
       description: "Empty state for the public localisation audit leaderboard",
     }),
+    leaderboardSiteColumn: intl.formatMessage({
+      defaultMessage: "Site",
+      id: "rK9mQ2nL8x",
+      description: "Column heading for site names on the localisation audit leaderboard",
+    }),
+    leaderboardScoreColumn: intl.formatMessage({
+      defaultMessage: "Score",
+      id: "tB4pW7cH1z",
+      description: "Column heading for scores on the localisation audit leaderboard",
+    }),
+    leaderboardScoreLabel: (values: { score: number }) =>
+      intl.formatMessage(
+        {
+          defaultMessage: "Score {score} out of 100",
+          id: "uN6dF3sJ5q",
+          description: "Accessible label for a localisation audit leaderboard score bar",
+        },
+        values,
+      ),
   };
 }
 

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page.stories.tsx
@@ -14,7 +14,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { expect } from "storybook/test";
 
 import { LocalisationAuditPage } from "./localisation-audit-page";
-import { localisationAuditDomainSlug } from "./localisation-audit.fixture";
+import { localisationAuditLeaderboardEntries } from "./localisation-audit.fixture";
 
 const meta = {
   title: "Marketing/LocalisationAudit/Landing",
@@ -24,15 +24,7 @@ const meta = {
   },
   args: {
     locale: "en",
-    leaderboard: [
-      {
-        rank: 1,
-        domainKey: "acme.example",
-        domainSlug: localisationAuditDomainSlug,
-        score: 86,
-        completedAt: new Date("2026-08-01T12:00:00.000Z"),
-      },
-    ],
+    leaderboard: localisationAuditLeaderboardEntries(),
   },
 } satisfies Meta<typeof LocalisationAuditPage>;
 
@@ -49,6 +41,13 @@ export const Default: Story = {
     await expect(
       canvas.getByRole("heading", { name: "How other sites score" }),
     ).toBeInTheDocument();
+    await expect(canvas.getByText("Site")).toBeInTheDocument();
+    await expect(canvas.getByText("Score")).toBeInTheDocument();
+    await expect(canvas.getByRole("meter", { name: "Score 91 out of 100" })).toBeInTheDocument();
+    await expect(canvas.getByRole("meter", { name: "Score 72 out of 100" })).toBeInTheDocument();
+    await expect(canvas.getByRole("meter", { name: "Score 52 out of 100" })).toBeInTheDocument();
+    await expect(canvas.getByText("Northstar")).toBeInTheDocument();
+    await expect(canvas.getByText("bramble.example")).toBeInTheDocument();
     await expect(canvas.queryByText("hreflang")).not.toBeInTheDocument();
     await expect(canvas.queryByText(/SSRF/)).not.toBeInTheDocument();
   },

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-site-mark.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-site-mark.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useState } from "react";
+
+import { cn } from "@/lib/primitives/cn";
+
+const MARK_TONES = [
+  "bg-grove-100 text-grove-900",
+  "bg-spruce-100 text-spruce-900",
+  "bg-clay-100 text-clay-900",
+  "bg-beam-100 text-beam-900",
+  "bg-dew-100 text-dew-900",
+] as const;
+
+type LocalisationAuditSiteMarkProps = {
+  domainKey: string;
+  companyName: string | null;
+  logoUrl: string | null;
+};
+
+function companyMonogram(name: string | null, domainKey: string) {
+  const source = (name ?? domainKey).trim();
+  const letter = source.charAt(0).toUpperCase();
+  return letter || "H";
+}
+
+function markToneClass(seed: string) {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i += 1) {
+    hash = (hash * 31 + seed.charCodeAt(i)) >>> 0;
+  }
+  return MARK_TONES[hash % MARK_TONES.length];
+}
+
+export function LocalisationAuditSiteMark({
+  domainKey,
+  companyName,
+  logoUrl,
+}: LocalisationAuditSiteMarkProps) {
+  const [logoFailed, setLogoFailed] = useState(false);
+  const showLogo = Boolean(logoUrl) && !logoFailed;
+  const imageSrc = showLogo ? logoUrl : null;
+
+  return (
+    <span
+      className={cn(
+        "flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-md border border-border",
+        imageSrc ? "bg-background" : markToneClass(domainKey),
+      )}
+    >
+      {imageSrc ? (
+        // Arbitrary audited-site logos; next/image host allowlist cannot cover them.
+        <img
+          src={imageSrc}
+          alt=""
+          width={32}
+          height={32}
+          loading="lazy"
+          referrerPolicy="no-referrer"
+          className="size-full object-contain p-0.5"
+          onError={() => setLogoFailed(true)}
+        />
+      ) : (
+        <span className="text-sm font-semibold">{companyMonogram(companyName, domainKey)}</span>
+      )}
+    </span>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit.fixture.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit.fixture.ts
@@ -15,7 +15,10 @@ import {
   aggregateLocalisationAuditCredits,
   pickHeadlineFindings,
 } from "@/lib/localisation-audit/score";
-import type { LocalisationAuditStanding } from "@/lib/localisation-audit/store";
+import type {
+  LocalisationAuditLeaderboardEntry,
+  LocalisationAuditStanding,
+} from "@/lib/localisation-audit/store";
 import type {
   LocalisationAuditCreditMethod,
   LocalisationAuditCreditResult,
@@ -368,6 +371,57 @@ export function localisationAuditStanding(score: number): LocalisationAuditStand
     percentile: 14,
     averageScore: 61,
   };
+}
+
+export function localisationAuditLeaderboardEntries(): LocalisationAuditLeaderboardEntry[] {
+  const completedAt = new Date(localisationAuditCompletedAt);
+  return [
+    {
+      rank: 1,
+      domainKey: "northstar.example",
+      domainSlug: "northstar-example",
+      score: 91,
+      completedAt,
+      companyName: "Northstar",
+      logoUrl: "/images/logo.png",
+    },
+    {
+      rank: 2,
+      domainKey: localisationAuditDomainKey,
+      domainSlug: localisationAuditDomainSlug,
+      score: 86,
+      completedAt,
+      companyName: "Acme",
+      logoUrl: "/images/logo.png",
+    },
+    {
+      rank: 3,
+      domainKey: "atlas.example",
+      domainSlug: "atlas-example",
+      score: 72,
+      completedAt,
+      companyName: "Atlas",
+      logoUrl: "/images/logo.png",
+    },
+    {
+      rank: 4,
+      domainKey: "harbor.example",
+      domainSlug: "harbor-example",
+      score: 68,
+      completedAt,
+      companyName: "Harbor",
+      logoUrl: null,
+    },
+    {
+      rank: 5,
+      domainKey: "bramble.example",
+      domainSlug: "bramble-example",
+      score: 52,
+      completedAt,
+      companyName: null,
+      logoUrl: null,
+    },
+  ];
 }
 
 export function createSucceededAudit({

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/score-tone.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/score-tone.test.ts
@@ -16,6 +16,7 @@ import {
   emailAuditToneColor,
   emailAuditToneFill,
   formatDimensionScore,
+  leaderboardScoreTone,
   scoreTone,
   severityTone,
 } from "./score-tone";
@@ -29,6 +30,17 @@ describe("scoreTone", () => {
     expect(scoreTone(49)).toBe("risk");
     expect(scoreTone(12)).toBe("risk");
     expect(scoreTone(null)).toBe("neutral");
+  });
+});
+
+describe("leaderboardScoreTone", () => {
+  it("colors bars green above 75, yellow above 65, and red otherwise", () => {
+    expect(leaderboardScoreTone(100)).toBe("safe");
+    expect(leaderboardScoreTone(76)).toBe("safe");
+    expect(leaderboardScoreTone(75)).toBe("watch");
+    expect(leaderboardScoreTone(66)).toBe("watch");
+    expect(leaderboardScoreTone(65)).toBe("risk");
+    expect(leaderboardScoreTone(12)).toBe("risk");
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/score-tone.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/score-tone.ts
@@ -22,6 +22,15 @@ export function scoreTone(score: number | null | undefined): LocalisationAuditTo
   return "risk";
 }
 
+/** Leaderboard bar colors: green above 75, yellow above 65, red otherwise. */
+export function leaderboardScoreTone(
+  score: number,
+): Extract<LocalisationAuditTone, "safe" | "watch" | "risk"> {
+  if (score > 75) return "safe";
+  if (score > 65) return "watch";
+  return "risk";
+}
+
 export function formatDimensionScore(score: number | null | undefined): string {
   return score == null ? "N/A" : String(score);
 }

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/store.retry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/store.retry.test.ts
@@ -765,6 +765,14 @@ describe("localisation audit leaderboard", () => {
         findingsCount: 2,
         pagesCrawled: 8,
         completedAt: new Date().toISOString(),
+        companyProfile: {
+          name: "Northstar",
+          logoUrl: "https://northstar.example/logo.png",
+          productSummary: "Ops software",
+          brandVoice: "Direct",
+          industry: "SaaS",
+          confidence: 80,
+        },
       },
       report: {
         score: 91,
@@ -793,6 +801,14 @@ describe("localisation audit leaderboard", () => {
         findingsCount: 4,
         pagesCrawled: 8,
         completedAt: new Date().toISOString(),
+        companyProfile: {
+          name: "  ",
+          logoUrl: "javascript:alert(1)",
+          productSummary: null,
+          brandVoice: null,
+          industry: null,
+          confidence: 10,
+        },
       },
       report: {
         score: 62,
@@ -813,7 +829,11 @@ describe("localisation audit leaderboard", () => {
     const ranks = leaderboard.filter((entry) => keys.includes(entry.domainKey));
     expect(ranks[0]?.domainKey).toBe(keys[0]);
     expect(ranks[0]?.score).toBe(91);
+    expect(ranks[0]?.companyName).toBe("Northstar");
+    expect(ranks[0]?.logoUrl).toBe("https://northstar.example/logo.png");
     expect(ranks[1]?.domainKey).toBe(keys[1]);
+    expect(ranks[1]?.companyName).toBeNull();
+    expect(ranks[1]?.logoUrl).toBeNull();
 
     const standing = await getLocalisationAuditStanding({
       domainSlug: second.audit.domainSlug,

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/store.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/store.ts
@@ -49,6 +49,25 @@ function now() {
   return new Date();
 }
 
+function jsonText(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function httpUrl(value: string | null | undefined): string | null {
+  const candidate = jsonText(value);
+  if (!candidate) return null;
+  try {
+    const parsed = new URL(candidate);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return candidate;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
 function isActiveAudit(audit: LocalisationAuditRow, staleMs = LOCALISATION_AUDIT_STALE_MS) {
   if (audit.status !== "queued" && audit.status !== "running") {
     return false;
@@ -137,11 +156,13 @@ export type LocalisationAuditLeaderboardEntry = {
   domainSlug: string;
   score: number;
   completedAt: Date | null;
+  companyName: string | null;
+  logoUrl: string | null;
 };
 
 /**
  * Public leaderboard of succeeded teaser scores (highest first).
- * Only exposes domain identity + score — never emails or full reports.
+ * Only exposes domain identity, logo, and score — never emails or full reports.
  */
 export async function listLocalisationAuditLeaderboard(limit = 25) {
   const rows = await db
@@ -150,6 +171,8 @@ export async function listLocalisationAuditLeaderboard(limit = 25) {
       domainSlug: schema.localisationAudits.domainSlug,
       score: schema.localisationAudits.score,
       completedAt: schema.localisationAudits.completedAt,
+      companyName: sql<string | null>`nullif(${schema.localisationAudits.teaser}->'companyProfile'->>'name', '')`,
+      logoUrl: sql<string | null>`nullif(${schema.localisationAudits.teaser}->'companyProfile'->>'logoUrl', '')`,
     })
     .from(schema.localisationAudits)
     .where(
@@ -175,6 +198,8 @@ export async function listLocalisationAuditLeaderboard(limit = 25) {
         domainSlug: row.domainSlug,
         score: row.score,
         completedAt: row.completedAt,
+        companyName: jsonText(row.companyName),
+        logoUrl: httpUrl(row.logoUrl),
       } satisfies LocalisationAuditLeaderboardEntry,
     ];
   });

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/store.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/store.ts
@@ -171,8 +171,12 @@ export async function listLocalisationAuditLeaderboard(limit = 25) {
       domainSlug: schema.localisationAudits.domainSlug,
       score: schema.localisationAudits.score,
       completedAt: schema.localisationAudits.completedAt,
-      companyName: sql<string | null>`nullif(${schema.localisationAudits.teaser}->'companyProfile'->>'name', '')`,
-      logoUrl: sql<string | null>`nullif(${schema.localisationAudits.teaser}->'companyProfile'->>'logoUrl', '')`,
+      companyName: sql<
+        string | null
+      >`nullif(${schema.localisationAudits.teaser}->'companyProfile'->>'name', '')`,
+      logoUrl: sql<
+        string | null
+      >`nullif(${schema.localisationAudits.teaser}->'companyProfile'->>'logoUrl', '')`,
     })
     .from(schema.localisationAudits)
     .where(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The public localisation audit leaderboard now reads more like a benchmark table:

- Each site shows its crawled logo (with a monogram fallback)
- Average/overall score is a horizontal bar
- Bar color is green above 75, yellow above 65, and red otherwise
- Numeric score stays beside the bar, with a 0–100 scale under the column

Company name and logo come from the stored teaser profile. Non-http logo URLs are dropped.

## How to test

- Open Storybook `Marketing/LocalisationAudit/Landing` and confirm green / yellow / red bars plus logos
- `cd apps/hyperlocalise-web && vp test` and `vp check --fix`
- On a local landing page with succeeded audits, confirm logos and score colors match the thresholds

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ad6216c-147b-45a4-b8c9-d6530f45cf5b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ad6216c-147b-45a4-b8c9-d6530f45cf5b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

