### PR TITLE
test(audit): add leaderboard Storybook coverage for score bars

### DIFF
--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-leaderboard.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-leaderboard.stories.tsx
@@ -13,26 +13,20 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { expect } from "storybook/test";
 
-import { LocalisationAuditPage } from "./localisation-audit-page";
+import { LocalisationAuditLeaderboard } from "./localisation-audit-leaderboard";
 import { localisationAuditLeaderboardEntries } from "./localisation-audit.fixture";
 
 const meta = {
-  title: "Marketing/LocalisationAudit/Landing",
-  component: LocalisationAuditPage,
+  title: "Marketing/LocalisationAudit/Leaderboard",
+  component: LocalisationAuditLeaderboard,
   parameters: {
     layout: "fullscreen",
-    nextjs: {
-      appDirectory: true,
-      navigation: {
-        pathname: "/en/localisation-audit",
-      },
-    },
   },
   args: {
     locale: "en",
-    leaderboard: localisationAuditLeaderboardEntries(),
+    entries: localisationAuditLeaderboardEntries(),
   },
-} satisfies Meta<typeof LocalisationAuditPage>;
+} satisfies Meta<typeof LocalisationAuditLeaderboard>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -40,21 +34,25 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   play: async ({ canvas }) => {
     await expect(
-      canvas.getByRole("heading", { name: "See how your brand travels." }),
-    ).toBeInTheDocument();
-    await expect(canvas.getByRole("button", { name: "See my score" })).toBeInTheDocument();
-    await expect(canvas.getByRole("heading", { name: "What we notice" })).toBeInTheDocument();
-    await expect(
       canvas.getByRole("heading", { name: "How other sites score" }),
     ).toBeInTheDocument();
-    await expect(canvas.getByText("Site")).toBeInTheDocument();
-    await expect(canvas.getByText("Score")).toBeInTheDocument();
-    await expect(canvas.getByRole("meter", { name: "Score 91 out of 100" })).toBeInTheDocument();
+    await expect(canvas.getByRole("meter", { name: "Score 91 out of 100" })).toHaveAttribute(
+      "aria-valuenow",
+      "91",
+    );
     await expect(canvas.getByRole("meter", { name: "Score 72 out of 100" })).toBeInTheDocument();
     await expect(canvas.getByRole("meter", { name: "Score 52 out of 100" })).toBeInTheDocument();
     await expect(canvas.getByText("Northstar")).toBeInTheDocument();
     await expect(canvas.getByText("bramble.example")).toBeInTheDocument();
-    await expect(canvas.queryByText("hreflang")).not.toBeInTheDocument();
-    await expect(canvas.queryByText(/SSRF/)).not.toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    entries: [],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("No public scores yet. Be the first.")).toBeInTheDocument();
+    await expect(canvas.queryByRole("meter")).not.toBeInTheDocument();
   },
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Follow-up to #1866. Adds a dedicated Storybook story for the localisation audit leaderboard (green / yellow / red score bars, logos, empty state) and mounts the landing story with `appDirectory` so the form’s router hook works.

[Localisation audit leaderboard with colored score bars and site logos](https://cursor.com/agents/bc-8ad6216c-147b-45a4-b8c9-d6530f45cf5b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flocalisation_audit_leaderboard_bars_and_logos.webp)

[localisation_audit_leaderboard_color_bars_hover.mp4](https://cursor.com/agents/bc-8ad6216c-147b-45a4-b8c9-d6530f45cf5b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flocalisation_audit_leaderboard_color_bars_hover.mp4)

## How to test

- Storybook `Marketing/LocalisationAudit/Leaderboard`
- Storybook `Marketing/LocalisationAudit/Landing` should render without the app-router invariant

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ad6216c-147b-45a4-b8c9-d6530f45cf5b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ad6216c-147b-45a4-b8c9-d6530f45cf5b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

