### PR TITLE
fix(crowdin): use pointer representation for FieldAddRequest Config field

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -1,5 +1,11 @@
 # Crowdin Steward's Journal
 
+## 2026-12-28 - Use pointer representation for FieldAddRequest Config field
+
+**Learning:** In Crowdin API v2, the `config` field in `POST /api/v2/fields` requests is optional. When typed as a non-pointer struct (`FieldConfig`), Go's standard `json.Marshal` serializes an uninitialized struct as `{}` even with `json:"config,omitempty"`, sending an empty object payload to Crowdin instead of omitting the parameter. Typing `Config` as `*FieldConfig` ensures proper parameter omission when `nil`.
+
+**Action:** Updated `FieldAddRequest.Config` in `crowdin/model/fields.go` to `*FieldConfig` with `json:"config,omitempty"`. Updated call sites and test assertions in `fields_test.go` and `model/fields_test.go`, including a unit test asserting JSON omission behavior when `Config` is `nil`.
+
 ## 2026-12-27 - Preserve exact Crowdin-API-FileName header without query escaping
 
 **Learning:** In Crowdin API v2, uploading files to storage (`POST /api/v2/storages`) passes the filename via the `Crowdin-API-FileName` HTTP header. The Go SDK previously wrapped the filename in `url.QueryEscape`, which incorrectly modified filenames containing spaces (converting spaces to `+` signs) or other special characters, resulting in mangled filenames stored in Crowdin storage.

--- a/third_party/crowdin-api-client-go/crowdin/fields_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/fields_test.go
@@ -232,7 +232,7 @@ func TestFieldsService_Add(t *testing.T) {
 		Description: "Custom field description",
 		Type:        model.TypeSelect,
 		Entities:    []model.FieldEntity{model.EntityTask},
-		Config: model.FieldConfig{
+		Config: &model.FieldConfig{
 			Options: []model.FieldOption{
 				{
 					Value: "option1",

--- a/third_party/crowdin-api-client-go/crowdin/model/fields.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/fields.go
@@ -174,7 +174,7 @@ type FieldAddRequest struct {
 	//  - Locations
 	// For other type field config:
 	//  - Locations
-	Config FieldConfig `json:"config,omitempty"`
+	Config *FieldConfig `json:"config,omitempty"`
 }
 
 // Validate checks if the request is valid.

--- a/third_party/crowdin-api-client-go/crowdin/model/fields_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/fields_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -92,7 +93,7 @@ func TestFieldAddRequestValidate(t *testing.T) {
 			name: "valid request",
 			req: &FieldAddRequest{
 				Name: "Custom field", Slug: "custom-field", Type: TypeSelect,
-				Entities: []FieldEntity{EntityTask}, Description: "Custom field description", Config: FieldConfig{},
+				Entities: []FieldEntity{EntityTask}, Description: "Custom field description", Config: &FieldConfig{},
 			},
 			valid: true,
 		},
@@ -107,4 +108,31 @@ func TestFieldAddRequestValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFieldAddRequest_MarshalJSON(t *testing.T) {
+	t.Run("omits config when nil", func(t *testing.T) {
+		req := &FieldAddRequest{
+			Name:     "Custom field",
+			Slug:     "custom-field",
+			Type:     TypeText,
+			Entities: []FieldEntity{EntityProject},
+		}
+		data, err := json.Marshal(req)
+		assert.NoError(t, err)
+		assert.NotContains(t, string(data), `"config"`)
+	})
+
+	t.Run("includes config when non-nil", func(t *testing.T) {
+		req := &FieldAddRequest{
+			Name:     "Custom field",
+			Slug:     "custom-field",
+			Type:     TypeText,
+			Entities: []FieldEntity{EntityProject},
+			Config:   &FieldConfig{Units: "px"},
+		}
+		data, err := json.Marshal(req)
+		assert.NoError(t, err)
+		assert.Contains(t, string(data), `"config":{"units":"px"}`)
+	})
 }


### PR DESCRIPTION
Fix FieldAddRequest.Config in the Crowdin Go SDK to use *FieldConfig with `json:"config,omitempty"`. This ensures uninitialized Config structs are omitted from JSON payloads during POST /api/v2/fields requests rather than serializing as empty objects `{}`.

---
*PR created automatically by Jules for task [6713172030072598933](https://jules.google.com/task/6713172030072598933) started by @cungminh2710*