### PR TITLE
fix(cat): show Hidden instead of Untranslated for hidden strings

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-header.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/editor/cat-editor-header.tsx
@@ -20,7 +20,10 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
 import { CatHiddenStringBadge } from "@/components/cat/segment/cat-hidden-string-badge";
-import { SegmentStatusBadge } from "@/components/cat/segment/cat-segment-status";
+import {
+  SegmentStatusBadge,
+  shouldShowSegmentStatusBadge,
+} from "@/components/cat/segment/cat-segment-status";
 import { CatShareSegmentButton } from "@/components/cat/segment/cat-share-segment-button";
 import { catEditorPanelMessages } from "@/components/cat/shared/cat.messages";
 import type { CatSegment } from "@/components/cat/shared/types";
@@ -64,7 +67,9 @@ export function CatEditorHeader({
             }}
           />
         </span>
-        <SegmentStatusBadge status={segment.status} />
+        {shouldShowSegmentStatusBadge(segment.status, segment.isHidden) ? (
+          <SegmentStatusBadge status={segment.status} />
+        ) : null}
         {segment.isHidden ? <CatHiddenStringBadge /> : null}
         {isTargetDirty ? (
           <Badge variant="outline" className="border-bud-500/40 bg-bud-500/10 text-bud-300">

--- a/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/file-view/cat-file-view-panel.tsx
@@ -20,7 +20,11 @@ import { Loader2, RefreshCw, Upload } from "lucide-react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { CatWorkspaceViewSwitcherConnected } from "@/components/cat/workspace/cat-workspace-view-switcher-connected";
-import { SegmentStatusBadge } from "@/components/cat/segment/cat-segment-status";
+import { CatHiddenStringBadge } from "@/components/cat/segment/cat-hidden-string-badge";
+import {
+  SegmentStatusBadge,
+  shouldShowSegmentStatusBadge,
+} from "@/components/cat/segment/cat-segment-status";
 import type { CatSegment } from "@/components/cat/shared/types";
 import type { CatFileViewerId } from "@/components/cat/workspace/cat-file-view-capabilities";
 import { Button } from "@/components/ui/button";
@@ -116,7 +120,10 @@ export function CatFileViewPanel({
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-4 py-3 lg:px-5">
         <div className="min-w-0 space-y-1">
           <div className="flex flex-wrap items-center gap-2">
-            <SegmentStatusBadge status={segment.status} />
+            {shouldShowSegmentStatusBadge(segment.status, segment.isHidden) ? (
+              <SegmentStatusBadge status={segment.status} />
+            ) : null}
+            {segment.isHidden ? <CatHiddenStringBadge /> : null}
             <p className="truncate font-mono text-xs text-muted-foreground">{displayName}</p>
           </div>
           <p className="text-sm text-muted-foreground">

--- a/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-filter.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-filter.test.ts
@@ -46,6 +46,18 @@ describe("segmentMatchesQueueFilter", () => {
     ).toBe(false);
   });
 
+  it("does not treat hidden pending segments as untranslated work", () => {
+    expect(
+      segmentMatchesQueueFilter(
+        createSegment({ status: "pending", isHidden: true }),
+        "untranslated",
+      ),
+    ).toBe(false);
+    expect(
+      segmentMatchesQueueFilter(createSegment({ status: "pending", isHidden: true }), "all"),
+    ).toBe(true);
+  });
+
   it("matches reviewed segments", () => {
     expect(segmentMatchesQueueFilter(createSegment({ status: "reviewed" }), "reviewed")).toBe(true);
   });

--- a/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-filter.ts
+++ b/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-filter.ts
@@ -19,6 +19,7 @@ export type CatQueueFilter = ProjectFileCatQueueFilter | "skipped";
 export type CatSegmentFilterInput = {
   status: CatSegment["status"];
   hasOpenIssues?: boolean;
+  isHidden?: boolean;
 };
 
 export const catQueueFilterValues: CatQueueFilter[] = [
@@ -119,7 +120,8 @@ export function segmentMatchesQueueFilterFromInput(
     case "all":
       return true;
     case "untranslated":
-      return input.status === "pending";
+      // Hidden TMS strings are not translator queue work.
+      return input.status === "pending" && !input.isHidden;
     case "needs_review":
       return input.status === "needs_review" && !segmentHasOpenIssuesFromInput(input);
     case "reviewed":
@@ -138,6 +140,7 @@ export function segmentMatchesQueueFilter(segment: CatSegment, filter: CatQueueF
     {
       status: segment.status,
       hasOpenIssues: segmentHasOpenIssues(segment),
+      isHidden: segment.isHidden,
     },
     filter,
   );

--- a/apps/hyperlocalise-web/src/components/cat/segment/cat-segment-status.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/segment/cat-segment-status.test.tsx
@@ -17,13 +17,25 @@ import { describe, expect, it } from "vite-plus/test";
 
 import { renderWithCatProviders } from "@/components/cat/shared/cat-test-utils";
 
-import { QueueStatusDot, SegmentStatusBadge } from "./cat-segment-status";
+import {
+  QueueStatusDot,
+  SegmentStatusBadge,
+  shouldShowSegmentStatusBadge,
+} from "./cat-segment-status";
 
 describe("QueueStatusDot", () => {
   it("uses yellow for segments that need review", () => {
     renderWithCatProviders(<QueueStatusDot status="needs_review" />);
 
     expect(screen.getByRole("img", { name: /Needs review/i })).toHaveClass("bg-beam-700");
+  });
+});
+
+describe("shouldShowSegmentStatusBadge", () => {
+  it("hides the Untranslated status when the string is hidden", () => {
+    expect(shouldShowSegmentStatusBadge("pending", true)).toBe(false);
+    expect(shouldShowSegmentStatusBadge("pending", false)).toBe(true);
+    expect(shouldShowSegmentStatusBadge("needs_review", true)).toBe(true);
   });
 });
 

--- a/apps/hyperlocalise-web/src/components/cat/segment/cat-segment-status.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/segment/cat-segment-status.tsx
@@ -56,6 +56,14 @@ function segmentStatusBadgeVariant(status: CatSegmentStatus) {
   return "outline" as const;
 }
 
+/**
+ * Hidden TMS strings are not translator work. Prefer the Hidden badge over
+ * the Untranslated (pending) status label so they are not confused.
+ */
+export function shouldShowSegmentStatusBadge(status: CatSegmentStatus, isHidden?: boolean) {
+  return !(isHidden === true && status === "pending");
+}
+
 export function QueueStatusDot({ status }: { status: CatSegmentStatus }) {
   const intl = useIntl();
   const statusLabel = intl.formatMessage(getSegmentStatusMessage(status));

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.test.tsx
@@ -85,6 +85,21 @@ describe("CatSideBySideRow", () => {
     expect(screen.queryByText("Needs review")).not.toBeInTheDocument();
   });
 
+  it("shows Hidden instead of Untranslated for hidden pending segments", () => {
+    const state = createCatWorkspaceState({ selectedSegmentId: "seg-02" });
+    const segment = {
+      ...state.segments!.find((item) => item.id === "seg-02")!,
+      status: "pending" as const,
+      targetText: "",
+      isHidden: true,
+    };
+
+    renderRow({ segment, isDirty: false });
+
+    expect(screen.getByText("Hidden")).toBeInTheDocument();
+    expect(screen.queryByText("Untranslated")).not.toBeInTheDocument();
+  });
+
   it("shows the share link button when focused with a share url", async () => {
     const user = userEvent.setup();
     const writeText = vi.fn().mockResolvedValue(undefined);

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-row.tsx
@@ -42,7 +42,10 @@ import {
 } from "@/components/cat/editor/cat-target-editor";
 import { analyzeCatMessageFormat } from "@/components/cat/message-format/cat-message-format";
 import { CatHiddenStringBadge } from "@/components/cat/segment/cat-hidden-string-badge";
-import { SegmentStatusBadge } from "@/components/cat/segment/cat-segment-status";
+import {
+  SegmentStatusBadge,
+  shouldShowSegmentStatusBadge,
+} from "@/components/cat/segment/cat-segment-status";
 import { CatSegmentKeyMeta } from "@/components/cat/segment/cat-segment-key-meta";
 import { CatSegmentTags } from "@/components/cat/segment/cat-segment-tags";
 import { CatShareSegmentButton } from "@/components/cat/segment/cat-share-segment-button";
@@ -219,7 +222,9 @@ export function CatSideBySideRow({
     ) : null;
   const statusAndTags = (
     <div className="flex flex-wrap items-center gap-1.5">
-      {isTargetLoading ? null : <SegmentStatusBadge status={segment.status} />}
+      {isTargetLoading || !shouldShowSegmentStatusBadge(segment.status, segment.isHidden) ? null : (
+        <SegmentStatusBadge status={segment.status} />
+      )}
       {segment.isHidden ? <CatHiddenStringBadge /> : null}
       {segmentTags.length > 0 ? <CatSegmentTags tags={segmentTags} /> : null}
     </div>

--- a/apps/hyperlocalise-web/src/components/cat/visual-editor/cat-visual-editor-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/visual-editor/cat-visual-editor-detail-panel.tsx
@@ -22,7 +22,11 @@ import { CatEditorShortcutKbd } from "@/components/cat/editor/cat-editor-shortcu
 import { CatEditorSourceSection } from "@/components/cat/editor/cat-editor-source-section";
 import { CatEditorTargetSection } from "@/components/cat/editor/cat-editor-target-section";
 import { CatIntelligencePanel } from "@/components/cat/intelligence/cat-intelligence-panel";
-import { SegmentStatusBadge } from "@/components/cat/segment/cat-segment-status";
+import { CatHiddenStringBadge } from "@/components/cat/segment/cat-hidden-string-badge";
+import {
+  SegmentStatusBadge,
+  shouldShowSegmentStatusBadge,
+} from "@/components/cat/segment/cat-segment-status";
 import { catEditorPanelMessages } from "@/components/cat/shared/cat.messages";
 import type {
   CatSegmentCommentInput,
@@ -114,7 +118,10 @@ export function CatVisualEditorDetailPanel({
         <div className="min-w-0 space-y-1.5">
           <h2 className="truncate text-sm font-semibold text-foreground">{heading}</h2>
           <div className="flex flex-wrap items-center gap-1.5">
-            <SegmentStatusBadge status={segment.status} />
+            {shouldShowSegmentStatusBadge(segment.status, segment.isHidden) ? (
+              <SegmentStatusBadge status={segment.status} />
+            ) : null}
+            {segment.isHidden ? <CatHiddenStringBadge /> : null}
             {isTargetDirty ? (
               <Badge variant="outline" className="border-bud-500/40 bg-bud-500/10 text-bud-300">
                 <FormattedMessage {...catEditorPanelMessages.unsavedChanges} />

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -107,7 +107,10 @@ export function buildCrowdinFileQueueCroql(input: {
 
   switch (input.queueFilter) {
     case "untranslated":
+      // Hidden strings are withheld from translators; do not list them as
+      // untranslated work (Crowdin's editor keeps Hidden as its own filter).
       parts.push(`count of languages summary where (${languageSummary} and is translated) = 0`);
+      parts.push("not is hidden");
       break;
     case "needs_review":
       parts.push(

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-croql.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-croql.test.ts
@@ -30,7 +30,7 @@ describe("buildCrowdinFileQueueCroql", () => {
         queueFilter: "untranslated",
       }),
     ).toBe(
-      'id of file = 101 and count of languages summary where (language = @language:"fr" and is translated) = 0',
+      'id of file = 101 and count of languages summary where (language = @language:"fr" and is translated) = 0 and not is hidden',
     );
   });
 
@@ -65,7 +65,9 @@ describe("buildCrowdinFileQueueCroql", () => {
         targetLocale: "fr",
         queueFilter: "untranslated",
       }),
-    ).toBe('count of languages summary where (language = @language:"fr" and is translated) = 0');
+    ).toBe(
+      'count of languages summary where (language = @language:"fr" and is translated) = 0 and not is hidden',
+    );
   });
 
   it("scopes to multiple file ids with or", () => {

--- a/docs/adr/2026-08-12-crowdin-hidden-string-cat-ui-design.md
+++ b/docs/adr/2026-08-12-crowdin-hidden-string-cat-ui-design.md
@@ -12,6 +12,8 @@ Treat hidden as a first-class optional CAT segment flag and show a clear indicat
 2. Pass `isHidden` through `projectFileCatSegmentSchema` and into `CatQueueSegment` / `CatSegment`.
 3. Map it from Crowdin live CAT (single-file and all-files).
 4. Show a compact "Hidden" badge in the editor header, queue row, and side-by-side status row.
+5. Do not label hidden pending strings as **Untranslated**. Suppress the pending status badge when `isHidden` is true so the Hidden badge is the status signal.
+6. Exclude hidden strings from the Crowdin and client **Untranslated** queue filters (`not is hidden` in CroQL). They remain visible under **All**.
 
 Do not block editing. Managers using CAT with Crowdin credentials should still translate hidden strings; the badge is informational, matching Crowdin's manager editor.
 
@@ -19,9 +21,12 @@ Do not block editing. Managers using CAT with Crowdin credentials should still t
 
 - Filter hidden strings out of the queue: wrong for manager workflows that need to see them.
 - Crowdin-only UI branch: rejected; a shared `isHidden` field keeps the CAT UI provider-agnostic if other TMS adapters later map the same concept.
+- Keep Untranslated + Hidden badges together: rejected; dual labels made hidden strings look like open translator work.
 
 ## Testing
 
 - Unit coverage for Crowdin → CAT segment mapping of `isHidden: true`.
 - Mapper coverage that queue/workspace state carries the flag.
 - Light UI assertion that the badge renders when `segment.isHidden` is set.
+- Assert pending + hidden does not render the Untranslated status badge.
+- Assert untranslated CroQL and client queue filters exclude hidden strings.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Crowdin hidden strings still showed the **Untranslated** status badge next to (or instead of feeling like) the **Hidden** badge, which made them look like open translator work.

- Suppress the pending/`Untranslated` status badge when `isHidden` is set; keep showing **Hidden**
- Exclude hidden strings from Crowdin untranslated CroQL (`not is hidden`) and the client untranslated queue filter
- Hidden strings remain available under **All** (and keep translation status badges when not pending)

## How to test

- `vp test` on CAT status, queue filter, side-by-side, Crowdin CroQL, and Hidden badge tests (79 passed)
- `vp check --fix` (no new errors; existing unrelated warnings only)

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00ef6-c190-719f-9627-772bc1cdf6c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00ef6-c190-719f-9627-772bc1cdf6c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

