### PR TITLE
feat(cat): download filtered view and preserve search across locales

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -933,7 +933,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           if (target.kind === "provider") {
             sourceLocale = "en";
           } else {
-            const project = await getOwnedProject(c.var.auth, params.projectId);
+            const project = await getOwnedProjectRecord(c.var.auth, params.projectId);
             if (!project) {
               return projectNotFoundResponse(c);
             }

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -82,6 +82,11 @@ import {
 } from "@/lib/projects/cat/external-cat-string-overlay-service";
 import { resolveProjectFileCatPagination } from "@/lib/projects/cat/project-file-cat-pagination";
 import {
+  buildCatFilteredExportPayload,
+  collectCatFilteredExportRows,
+} from "@/lib/projects/cat/cat-filtered-export-service";
+import { maxCatFilteredExportSegments } from "@/lib/projects/cat/cat-filtered-export";
+import {
   getProjectFileDetail,
   listFilteredProjectFiles,
 } from "@/lib/projects/files/project-file-service";
@@ -135,6 +140,7 @@ import {
   projectFileCatSegmentParamsSchema,
   projectFileCatSegmentQuerySchema,
   projectFileCatQuerySchema,
+  projectFileCatExportQuerySchema,
   projectFileCatConcordanceBodySchema,
   projectFileCatCommentBodySchema,
   projectFileCatCommentResolveBodySchema,
@@ -493,6 +499,16 @@ const validateProjectFileCatQuery = validator("query", (value, c) => {
   return parsed.data;
 });
 
+const validateProjectFileCatExportQuery = validator("query", (value, c) => {
+  const parsed = projectFileCatExportQuerySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidProjectPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
 const validateProjectFileCatTranslationBody = validator("json", (value, c) => {
   const parsed = projectFileCatTranslationBodySchema.safeParse(value);
 
@@ -715,7 +731,7 @@ type CreateProjectRoutesOptions = {
   translationFileImportQueue?: TranslationFileImportQueue;
 };
 
-async function loadProjectFileCatQueue(
+export async function loadProjectFileCatQueue(
   auth: AuthVariables["auth"],
   projectId: string,
   query: ProjectFileCatQuery,
@@ -898,6 +914,87 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         }
 
         return c.json({ catQueue: result.catQueue }, 200);
+      },
+    )
+    .get(
+      "/:projectId/files/detail/cat/export",
+      validateProjectParams,
+      validateProjectFileCatExportQuery,
+      async (c) => {
+        const params = c.req.valid("param");
+        const query = c.req.valid("query");
+        const target = await resolveProjectResourceTarget(c.var.auth, params.projectId);
+        if (target.kind === "provider_unavailable") {
+          return providerProjectUnavailableResponse(c, target);
+        }
+
+        let sourceLocale = query.sourceLocale?.trim() || "";
+        if (!sourceLocale) {
+          if (target.kind === "provider") {
+            sourceLocale = "en";
+          } else {
+            const project = await getOwnedProject(c.var.auth, params.projectId);
+            if (!project) {
+              return projectNotFoundResponse(c);
+            }
+            sourceLocale = project.sourceLocale?.trim() || "en";
+          }
+        }
+
+        const { format, sourceLocale: _sourceLocale, ...catQuery } = query;
+        const collected = await collectCatFilteredExportRows({
+          auth: c.var.auth,
+          projectId: params.projectId,
+          query: catQuery,
+          sourceLocale,
+          loadCatQueue: loadProjectFileCatQueue,
+          externalProjectId: target.kind === "provider" ? target.externalProjectId : null,
+        });
+
+        if (collected.kind === "feature_unavailable") {
+          return sharedForbiddenResponse(
+            c,
+            "feature_unavailable",
+            "All Files CAT is not enabled for this organization",
+          );
+        }
+        if (collected.kind === "provider_unavailable") {
+          return providerProjectUnavailableResponse(c, collected.target);
+        }
+        if (collected.kind === "project_not_found") {
+          return projectNotFoundResponse(c);
+        }
+        if (collected.kind === "source_file_not_found") {
+          return badRequestResponse(
+            c,
+            "source_file_not_found",
+            "Source file not found for the given path",
+          );
+        }
+        if (collected.kind === "provider_error") {
+          return tmsProviderLiveErrorResponse(c, collected.error);
+        }
+        if (collected.kind === "empty") {
+          return notFoundResponse(c, "cat_export_empty", "No segments match the current filters.");
+        }
+
+        const payload = buildCatFilteredExportPayload({
+          format,
+          rows: collected.rows,
+          sourcePath: query.sourcePath,
+          targetLocale: query.targetLocale,
+        });
+
+        return c.body(payload.body, 200, {
+          "Content-Type": payload.contentType,
+          "Content-Disposition": `attachment; filename*=UTF-8''${encodeURIComponent(payload.filename)}`,
+          ...(collected.truncated
+            ? {
+                "X-Hyperlocalise-Export-Truncated": "true",
+                "X-Hyperlocalise-Export-Limit": String(maxCatFilteredExportSegments),
+              }
+            : {}),
+        });
       },
     )
     .get(

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -274,6 +274,15 @@ export const projectFileCatQuerySchema = z.object({
   phraseScanSkip: z.coerce.number().int().min(0).optional(),
 });
 
+export const projectFileCatExportFormatSchema = z.enum(["csv", "tmx", "xlf", "xliff"]);
+
+export const projectFileCatExportQuerySchema = projectFileCatQuerySchema
+  .omit({ offset: true, limit: true, phraseScanPage: true, phraseScanSkip: true })
+  .extend({
+    format: projectFileCatExportFormatSchema,
+    sourceLocale: z.string().trim().min(1).max(32).optional(),
+  });
+
 export const projectFileCatPaginationSchema = z.object({
   offset: z.number().int().min(0),
   limit: z.number().int().min(1),
@@ -702,6 +711,7 @@ export type ProjectFilesQuery = z.infer<typeof projectFilesQuerySchema>;
 export type ProjectProviderBranchesResponse = z.infer<typeof projectProviderBranchesResponseSchema>;
 export type ProjectFileDetailQuery = z.infer<typeof projectFileDetailQuerySchema>;
 export type ProjectFileCatQuery = z.infer<typeof projectFileCatQuerySchema>;
+export type ProjectFileCatExportQuery = z.infer<typeof projectFileCatExportQuerySchema>;
 export type ProjectFileCatQueueFilter = z.infer<typeof projectFileCatQueueFilterSchema>;
 export type ProjectFileCatTranslationBody = z.infer<typeof projectFileCatTranslationBodySchema>;
 export type ProjectFileCatImageRegenerateBody = z.infer<

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
@@ -40,9 +40,7 @@ import {
   resolveProjectFileCatTargetLocaleResolution,
   resolveProjectFileCatTargetLocales,
 } from "@/lib/projects/project-file-cat-routing";
-import {
-  buildCatNavigationSearchParams,
-} from "@/lib/projects/cat/cat-workspace-query-params";
+import { buildCatNavigationSearchParams } from "@/lib/projects/cat/cat-workspace-query-params";
 import type { CatQueueFilter } from "@/components/cat/queue/cat-queue-filter";
 
 import { ProjectPageShell, useProjectPageQuery } from "../../_components/project-page-shell";

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
@@ -40,6 +40,10 @@ import {
   resolveProjectFileCatTargetLocaleResolution,
   resolveProjectFileCatTargetLocales,
 } from "@/lib/projects/project-file-cat-routing";
+import {
+  buildCatNavigationSearchParams,
+} from "@/lib/projects/cat/cat-workspace-query-params";
+import type { CatQueueFilter } from "@/components/cat/queue/cat-queue-filter";
 
 import { ProjectPageShell, useProjectPageQuery } from "../../_components/project-page-shell";
 import {
@@ -83,6 +87,8 @@ export function ProjectFileCatPageContent({
   catAllFilesEnabled = false,
   highlightLocale,
   initialSegmentKey = null,
+  initialQueueFilter = "all",
+  initialSearch = "",
   externalResourceId = null,
   resourceType = null,
   branch = null,
@@ -95,6 +101,8 @@ export function ProjectFileCatPageContent({
   catAllFilesEnabled?: boolean;
   highlightLocale: string | null;
   initialSegmentKey?: string | null;
+  initialQueueFilter?: CatQueueFilter;
+  initialSearch?: string;
   externalResourceId?: string | null;
   resourceType?: "file" | "key" | null;
   branch?: string | null;
@@ -491,12 +499,13 @@ export function ProjectFileCatPageContent({
 
     const navigate = () => {
       if (allFiles) {
+        const params = buildCatNavigationSearchParams(window.location.search, {
+          locale: nextLocale,
+          sourcePath: CAT_ALL_FILES_SOURCE_PATH,
+        });
+        const section = "strings";
         router.push(
-          buildProjectFileCatAllFilesHref(organizationSlug, projectId, nextLocale, {
-            branch,
-            sourcePaths: sourcePaths ? sourcePaths.split(",") : null,
-            basePath: "strings",
-          }),
+          `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/${section}?${params.toString()}`,
         );
         return;
       }
@@ -505,22 +514,14 @@ export function ProjectFileCatPageContent({
         return;
       }
 
-      const params = new URLSearchParams({
+      const params = buildCatNavigationSearchParams(window.location.search, {
         sourcePath,
         locale: nextLocale,
+        externalResourceId: resolvedExternalResourceId,
+        resourceType:
+          resolvedResourceType && resolvedResourceType !== "file" ? resolvedResourceType : null,
+        branch,
       });
-
-      if (resolvedExternalResourceId) {
-        params.set("externalResourceId", resolvedExternalResourceId);
-      }
-
-      if (resolvedResourceType && resolvedResourceType !== "file") {
-        params.set("resourceType", resolvedResourceType);
-      }
-
-      if (branch) {
-        params.set("branch", branch);
-      }
 
       router.push(
         `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/files/cat?${params.toString()}`,
@@ -626,6 +627,8 @@ export function ProjectFileCatPageContent({
             selectedRepositoryFullName,
           )}
           initialSegmentKey={initialSegmentKey}
+          initialQueueFilter={initialQueueFilter}
+          initialSearch={initialSearch}
           sourcePathsFilter={sourcePaths}
           layout="fullscreen"
           className="min-h-0 flex-1"

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/cat/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/cat/page.tsx
@@ -12,6 +12,10 @@
  */
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 import { isReleaseCatAllFilesEnabled } from "@/lib/flags/release-flags";
+import {
+  parseCatWorkspaceQueueFilterParam,
+  parseCatWorkspaceSearchParam,
+} from "@/lib/projects/cat/cat-workspace-query-params";
 import { parseProjectFileCatSearchParams } from "@/lib/projects/project-file-cat-routing";
 import {
   catAllFilesProviderKindFromTarget,
@@ -33,10 +37,13 @@ export default async function ProjectFileCatPage({
     resourceType?: string;
     branch?: string;
     sourcePaths?: string;
+    queueFilter?: string;
+    search?: string;
   }>;
 }) {
   const { organizationSlug, projectId } = await params;
-  const parsedSearchParams = parseProjectFileCatSearchParams(await searchParams);
+  const rawSearchParams = await searchParams;
+  const parsedSearchParams = parseProjectFileCatSearchParams(rawSearchParams);
   const auth = await requireAppAuthContext({ organizationSlug });
   const target = await resolveProjectResourceTarget(auth, projectId);
   const catAllFilesEnabled = await isReleaseCatAllFilesEnabled(
@@ -52,6 +59,8 @@ export default async function ProjectFileCatPage({
       catAllFilesEnabled={catAllFilesEnabled}
       highlightLocale={parsedSearchParams.highlightLocale}
       initialSegmentKey={parsedSearchParams.initialSegmentKey}
+      initialQueueFilter={parseCatWorkspaceQueueFilterParam(rawSearchParams.queueFilter) ?? "all"}
+      initialSearch={parseCatWorkspaceSearchParam(rawSearchParams.search)}
       externalResourceId={parsedSearchParams.externalResourceId}
       resourceType={parsedSearchParams.resourceType}
       branch={parsedSearchParams.branch}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -57,7 +57,8 @@ import {
   type CatPageNavigationGuardRef,
 } from "@/components/cat/workspace/cat-page-navigation-guard";
 import type { CatQueueFilter } from "@/components/cat/queue/cat-queue-filter";
-import { jobCatQueueFilterParam } from "@/lib/projects/job-cat-routing";
+import { jobCatQueueFilterParam, jobCatSearchParam } from "@/lib/projects/job-cat-routing";
+import { buildCatNavigationSearchParams } from "@/lib/projects/cat/cat-workspace-query-params";
 import {
   CAT_ALL_FILES_SOURCE_PATH,
   isCatAllFilesSourcePath,
@@ -130,6 +131,7 @@ function stringsPageHref(input: {
   targetLocale: string;
   segment?: string | null;
   queueFilter?: CatQueueFilter;
+  search?: string | null;
 }) {
   const params = new URLSearchParams({
     targetLocale: input.targetLocale,
@@ -155,6 +157,10 @@ function stringsPageHref(input: {
     params.set(jobCatQueueFilterParam, input.queueFilter);
   }
 
+  if (input.search?.trim()) {
+    params.set(jobCatSearchParam, input.search.trim());
+  }
+
   return `/org/${input.organizationSlug}/projects/${encodeURIComponent(input.projectId)}/jobs/${encodeURIComponent(input.jobId)}/strings?${params.toString()}`;
 }
 
@@ -168,6 +174,7 @@ export function JobCatPageContent({
   targetLocale,
   initialSegmentKey = null,
   initialQueueFilter = "untranslated",
+  initialSearch = "",
   catAllFilesEnabled = false,
 }: {
   organizationSlug: string;
@@ -179,6 +186,7 @@ export function JobCatPageContent({
   targetLocale: string | null;
   initialSegmentKey?: string | null;
   initialQueueFilter?: CatQueueFilter;
+  initialSearch?: string;
   catAllFilesEnabled?: boolean;
 }) {
   const intl = useIntl();
@@ -343,17 +351,11 @@ export function JobCatPageContent({
     }
 
     const navigate = () => {
+      const params = buildCatNavigationSearchParams(window.location.search, {
+        targetLocale: nextLocale,
+      });
       router.push(
-        stringsPageHref({
-          organizationSlug,
-          projectId,
-          jobId,
-          sourcePath: sourcePath ?? undefined,
-          storedFileId: storedFileId ?? undefined,
-          targetLocale: nextLocale,
-          segment: initialSegmentKey,
-          queueFilter: initialQueueFilter,
-        }),
+        `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(jobId)}/strings?${params.toString()}`,
       );
     };
 
@@ -539,17 +541,14 @@ export function JobCatPageContent({
         return;
       }
       attemptCatPageNavigation(pageNavigationGuardRef, () => {
+        const params = buildCatNavigationSearchParams(window.location.search, {
+          targetLocale: nextLocale,
+          sourcePath: CAT_ALL_FILES_SOURCE_PATH,
+          sourcePaths: serializeCatSourcePathsFilter(jobSourcePaths),
+          storedFileId: null,
+        });
         router.push(
-          stringsPageHref({
-            organizationSlug,
-            projectId,
-            jobId,
-            sourcePath: CAT_ALL_FILES_SOURCE_PATH,
-            sourcePaths: jobSourcePaths,
-            targetLocale: nextLocale,
-            segment: initialSegmentKey,
-            queueFilter: initialQueueFilter,
-          }),
+          `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(jobId)}/strings?${params.toString()}`,
         );
       });
     };
@@ -639,6 +638,7 @@ export function JobCatPageContent({
             )}
             initialSegmentKey={initialSegmentKey}
             initialQueueFilter={initialQueueFilter}
+            initialSearch={initialSearch}
             sourcePathsFilter={serializeCatSourcePathsFilter(jobSourcePaths)}
             layout="fullscreen"
             className="min-h-0 flex-1"
@@ -814,6 +814,7 @@ export function JobCatPageContent({
             )}
             initialSegmentKey={initialSegmentKey}
             initialQueueFilter={initialQueueFilter}
+            initialSearch={initialSearch}
             layout="fullscreen"
             className="min-h-0 flex-1"
             pageNavigationGuardRef={pageNavigationGuardRef}
@@ -962,6 +963,7 @@ export function JobCatPageContent({
           )}
           initialSegmentKey={initialSegmentKey}
           initialQueueFilter={initialQueueFilter}
+          initialSearch={initialSearch}
           layout="fullscreen"
           className="min-h-0 flex-1"
           pageNavigationGuardRef={pageNavigationGuardRef}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
@@ -37,15 +37,8 @@ export default async function ProjectJobStringsPage({
   }>;
 }) {
   const { organizationSlug, projectId, jobId } = await params;
-  const {
-    sourcePath,
-    storedFileId,
-    sourcePaths,
-    targetLocale,
-    segment,
-    queueFilter,
-    search,
-  } = await searchParams;
+  const { sourcePath, storedFileId, sourcePaths, targetLocale, segment, queueFilter, search } =
+    await searchParams;
   const auth = await requireAppAuthContext({ organizationSlug });
   const target = await resolveProjectResourceTarget(auth, projectId);
   const catAllFilesEnabled = await isReleaseCatAllFilesEnabled(

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
@@ -12,6 +12,7 @@
  */
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 import { isReleaseCatAllFilesEnabled } from "@/lib/flags/release-flags";
+import { parseCatWorkspaceSearchParam } from "@/lib/projects/cat/cat-workspace-query-params";
 import { resolveJobCatInitialQueueFilter } from "@/lib/projects/resolve-job-cat-initial-queue-filter";
 import {
   catAllFilesProviderKindFromTarget,
@@ -32,11 +33,19 @@ export default async function ProjectJobStringsPage({
     targetLocale?: string;
     segment?: string;
     queueFilter?: string;
+    search?: string;
   }>;
 }) {
   const { organizationSlug, projectId, jobId } = await params;
-  const { sourcePath, storedFileId, sourcePaths, targetLocale, segment, queueFilter } =
-    await searchParams;
+  const {
+    sourcePath,
+    storedFileId,
+    sourcePaths,
+    targetLocale,
+    segment,
+    queueFilter,
+    search,
+  } = await searchParams;
   const auth = await requireAppAuthContext({ organizationSlug });
   const target = await resolveProjectResourceTarget(auth, projectId);
   const catAllFilesEnabled = await isReleaseCatAllFilesEnabled(
@@ -60,6 +69,7 @@ export default async function ProjectJobStringsPage({
       targetLocale={targetLocale ?? null}
       initialSegmentKey={segment ?? null}
       initialQueueFilter={initialQueueFilter}
+      initialSearch={parseCatWorkspaceSearchParam(search)}
       catAllFilesEnabled={catAllFilesEnabled}
     />
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/strings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/strings/page.tsx
@@ -15,6 +15,10 @@ import { isReleaseCatAllFilesEnabled } from "@/lib/flags/release-flags";
 import { CAT_ALL_FILES_SOURCE_PATH } from "@/lib/projects/cat-all-files";
 import { parseProjectFileCatSearchParams } from "@/lib/projects/project-file-cat-routing";
 import {
+  parseCatWorkspaceQueueFilterParam,
+  parseCatWorkspaceSearchParam,
+} from "@/lib/projects/cat/cat-workspace-query-params";
+import {
   catAllFilesProviderKindFromTarget,
   resolveProjectResourceTarget,
 } from "@/api/routes/project/project.shared";
@@ -34,6 +38,8 @@ export default async function ProjectStringsPage({
     resourceType?: string;
     branch?: string;
     sourcePaths?: string;
+    queueFilter?: string;
+    search?: string;
   }>;
 }) {
   const { organizationSlug, projectId } = await params;
@@ -66,6 +72,8 @@ export default async function ProjectStringsPage({
       catAllFilesEnabled={catAllFilesEnabled}
       highlightLocale={parsedSearchParams.highlightLocale}
       initialSegmentKey={parsedSearchParams.initialSegmentKey}
+      initialQueueFilter={parseCatWorkspaceQueueFilterParam(rawSearchParams.queueFilter) ?? "all"}
+      initialSearch={parseCatWorkspaceSearchParam(rawSearchParams.search)}
       externalResourceId={parsedSearchParams.externalResourceId}
       resourceType={parsedSearchParams.resourceType}
       branch={parsedSearchParams.branch}

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-api.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-api.messages.ts
@@ -30,4 +30,9 @@ export const projectFileCatApiMessages = defineMessages({
     id: "4MUAkFDjce",
     description: "Fallback error when loading a CAT segment target translation fails",
   },
+  failedToExportQueue: {
+    defaultMessage: "Failed to download filtered view",
+    id: "catExportFail1",
+    description: "Fallback error when downloading the filtered CAT queue export fails",
+  },
 });

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-api.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-api.messages.ts
@@ -32,7 +32,7 @@ export const projectFileCatApiMessages = defineMessages({
   },
   failedToExportQueue: {
     defaultMessage: "Failed to download filtered view",
-    id: "catExportFail1",
+    id: "0tcV3U/r5g",
     description: "Fallback error when downloading the filtered CAT queue export fails",
   },
 });

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-export.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-export.ts
@@ -1,0 +1,95 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ProjectFileCatQueueFilter } from "@/api/routes/project/project.schema";
+import type { CatFormatMessageIntl } from "@/components/cat/message-format/cat-message-format-i18n";
+import { readApiError } from "@/lib/api-error";
+import { apiClient } from "@/lib/api-client-instance";
+import type { CatFilteredExportFormat } from "@/lib/projects/cat/cat-filtered-export";
+
+import { projectFileCatApiMessages } from "./project-file-cat-api.messages";
+
+function parseContentDispositionFilename(header: string | null) {
+  if (!header) {
+    return null;
+  }
+
+  const utfMatch = header.match(/filename\*=UTF-8''([^;]+)/i);
+  if (utfMatch?.[1]) {
+    try {
+      return decodeURIComponent(utfMatch[1]);
+    } catch {
+      return utfMatch[1];
+    }
+  }
+
+  const plainMatch = header.match(/filename="?([^";]+)"?/i);
+  return plainMatch?.[1] ?? null;
+}
+
+export async function downloadProjectFileCatExport(input: {
+  organizationSlug: string;
+  projectId: string;
+  sourcePath: string;
+  targetLocale: string;
+  sourceLocale: string;
+  format: CatFilteredExportFormat;
+  search: string;
+  queueFilter: ProjectFileCatQueueFilter;
+  externalResourceId?: string | null;
+  resourceType?: "file" | "key";
+  sourcePaths?: string | null;
+  intl: CatFormatMessageIntl;
+}) {
+  const response = await apiClient.api.orgs[":organizationSlug"].projects[
+    ":projectId"
+  ].files.detail.cat.export.$get({
+    param: { organizationSlug: input.organizationSlug, projectId: input.projectId },
+    query: {
+      sourcePath: input.sourcePath,
+      targetLocale: input.targetLocale,
+      sourceLocale: input.sourceLocale,
+      format: input.format,
+      ...(input.externalResourceId ? { externalResourceId: input.externalResourceId } : {}),
+      ...(input.resourceType ? { resourceType: input.resourceType } : {}),
+      ...(input.sourcePaths ? { sourcePaths: input.sourcePaths } : {}),
+      ...(input.search ? { search: input.search } : {}),
+      ...(input.queueFilter !== "all" ? { queueFilter: input.queueFilter } : {}),
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      await readApiError(
+        response,
+        input.intl.formatMessage(projectFileCatApiMessages.failedToExportQueue),
+      ),
+    );
+  }
+
+  const blob = await response.blob();
+  const filename =
+    parseContentDispositionFilename(response.headers.get("Content-Disposition")) ??
+    `cat-export-${input.targetLocale}.${input.format === "xliff" ? "xliff" : input.format}`;
+
+  const objectUrl = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = objectUrl;
+  anchor.download = filename;
+  anchor.rel = "noopener";
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(objectUrl);
+}

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
@@ -40,6 +40,7 @@ import { cn } from "@/lib/primitives/cn";
 
 import {
   resolveAvailableCatQueueFilters,
+  isServerQueueFilter,
   type CatQueueFilter,
 } from "@/components/cat/queue/cat-queue-filter";
 import { glossaryFormatChecksForSegment } from "@/components/cat/intelligence/cat-glossary-checks";
@@ -73,6 +74,9 @@ import { projectFileCatWorkspaceMessages } from "./project-file-cat-workspace.me
 import { fetchCatSegmentValidation } from "./project-file-cat-validation";
 import { useCatMutations } from "./use-cat-mutations";
 import { useCatSegmentQuery } from "./use-cat-segment-query";
+import { useCatWorkspaceQuerySync } from "./use-cat-workspace-query-sync";
+import { downloadProjectFileCatExport } from "./project-file-cat-export";
+import type { CatFilteredExportFormat } from "@/lib/projects/cat/cat-filtered-export";
 
 function initialTargetLocale(targetLocales: string[], highlightLocale: string | null) {
   if (highlightLocale && targetLocales.includes(highlightLocale)) {
@@ -80,6 +84,10 @@ function initialTargetLocale(targetLocales: string[], highlightLocale: string | 
   }
 
   return targetLocales[0] ?? "";
+}
+
+function toServerQueueFilterForExport(filter: CatQueueFilter) {
+  return isServerQueueFilter(filter) ? filter : "all";
 }
 
 export function ProjectFileCatWorkspace({
@@ -96,6 +104,7 @@ export function ProjectFileCatWorkspace({
   canLookupFreshContext = true,
   initialSegmentKey = null,
   initialQueueFilter = "all",
+  initialSearch = "",
   sourcePathsFilter = null,
   layout = "default",
   className,
@@ -114,6 +123,7 @@ export function ProjectFileCatWorkspace({
   canLookupFreshContext?: boolean;
   initialSegmentKey?: string | null;
   initialQueueFilter?: CatQueueFilter;
+  initialSearch?: string;
   sourcePathsFilter?: string | null;
   layout?: "default" | "fullscreen";
   className?: string;
@@ -158,6 +168,7 @@ export function ProjectFileCatWorkspace({
     setSearch,
     queueFilter,
     setQueueFilter,
+    debouncedSearch,
     isSearchPending,
     pagination,
     loadNextPage,
@@ -172,10 +183,63 @@ export function ProjectFileCatWorkspace({
     targetLocale,
     enabled: Boolean(targetLocale),
     initialQueueFilter,
+    initialSearch,
     pageLimit,
     sourcePaths: sourcePathsFilter,
   });
 
+  useCatWorkspaceQuerySync({
+    queueFilter,
+    search,
+    debouncedSearch,
+  });
+
+  const [isExporting, setIsExporting] = useState(false);
+
+  const handleDownloadFilteredView = useCallback(
+    async (format: CatFilteredExportFormat) => {
+      if (!targetLocale || isExporting) {
+        return;
+      }
+
+      setIsExporting(true);
+      try {
+        await downloadProjectFileCatExport({
+          organizationSlug,
+          projectId,
+          sourcePath,
+          targetLocale,
+          sourceLocale,
+          format,
+          search: debouncedSearch,
+          queueFilter: toServerQueueFilterForExport(queueFilter),
+          externalResourceId,
+          resourceType,
+          sourcePaths: sourcePathsFilter,
+          intl,
+        });
+      } catch (error) {
+        // Surface via console; queue UI already has empty/error states for load failures.
+        console.error(error);
+      } finally {
+        setIsExporting(false);
+      }
+    },
+    [
+      debouncedSearch,
+      externalResourceId,
+      intl,
+      isExporting,
+      organizationSlug,
+      projectId,
+      queueFilter,
+      resourceType,
+      sourceLocale,
+      sourcePath,
+      sourcePathsFilter,
+      targetLocale,
+    ],
+  );
   const availableQueueFilters = useMemo(
     () => resolveAvailableCatQueueFilters(catFile?.provider?.kind),
     [catFile?.provider?.kind],
@@ -715,6 +779,8 @@ export function ProjectFileCatWorkspace({
         canLookupFreshContext={canLookupFreshContext}
         onPageLimitChange={setPageLimit}
         nativeIssuesEnabled={isNativeProject}
+        onDownloadFilteredView={handleDownloadFilteredView}
+        isDownloadingFilteredView={isExporting}
       />
       <CatLinkedIssuesDialog
         open={linkedIssuesOpen}

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-segment-query.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-segment-query.ts
@@ -57,12 +57,13 @@ export function useCatSegmentQuery(input: {
   targetLocale: string;
   enabled?: boolean;
   initialQueueFilter?: CatQueueFilter;
+  initialSearch?: string;
   pageLimit?: number;
   sourcePaths?: string | null;
 }) {
   const intl = useIntl();
   const queryClient = useQueryClient();
-  const [search, setSearch] = useState("");
+  const [search, setSearch] = useState(() => input.initialSearch ?? "");
   const [queueFilter, setQueueFilter] = useState<CatQueueFilter>(
     () => input.initialQueueFilter ?? "all",
   );

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-workspace-query-sync.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-workspace-query-sync.ts
@@ -1,0 +1,58 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useRef } from "react";
+
+import type { CatQueueFilter } from "@/components/cat/queue/cat-queue-filter";
+import { applyCatWorkspaceQueryParams } from "@/lib/projects/cat/cat-workspace-query-params";
+
+/**
+ * Keeps queueFilter + search in the URL so locale/file remounts restore them.
+ */
+export function useCatWorkspaceQuerySync(input: {
+  queueFilter: CatQueueFilter;
+  search: string;
+  debouncedSearch: string;
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const searchParamsString = searchParams.toString();
+  const didMountRef = useRef(false);
+
+  useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
+
+    const next = applyCatWorkspaceQueryParams(new URLSearchParams(searchParamsString), {
+      queueFilter: input.queueFilter,
+      search: input.debouncedSearch,
+    });
+    const nextString = next.toString();
+    if (nextString === searchParamsString) {
+      return;
+    }
+
+    router.replace(nextString ? `${pathname}?${nextString}` : pathname, { scroll: false });
+  }, [
+    input.debouncedSearch,
+    input.queueFilter,
+    pathname,
+    router,
+    searchParamsString,
+  ]);
+}

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-workspace-query-sync.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-workspace-query-sync.ts
@@ -48,11 +48,5 @@ export function useCatWorkspaceQuerySync(input: {
     }
 
     router.replace(nextString ? `${pathname}?${nextString}` : pathname, { scroll: false });
-  }, [
-    input.debouncedSearch,
-    input.queueFilter,
-    pathname,
-    router,
-    searchParamsString,
-  ]);
+  }, [input.debouncedSearch, input.queueFilter, pathname, router, searchParamsString]);
 }

--- a/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-panel.tsx
@@ -14,6 +14,7 @@
  */
 import { FilterIcon, MoreHorizontalCircle01Icon, SearchIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { DownloadIcon } from "lucide-react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
@@ -83,6 +84,8 @@ export function CatQueuePanel({
   pagination = null,
   hasMoreQueue = false,
   onLoadMoreQueue,
+  onDownloadFilteredView,
+  isDownloadingFilteredView = false,
 }: {
   segments: CatSegment[];
   selectedSegmentId: string;
@@ -106,6 +109,8 @@ export function CatQueuePanel({
   pagination?: CatQueuePagination | null;
   hasMoreQueue?: boolean;
   onLoadMoreQueue?: () => void;
+  onDownloadFilteredView?: (format: "csv" | "tmx" | "xlf" | "xliff") => void;
+  isDownloadingFilteredView?: boolean;
 }) {
   const intl = useIntl();
   const [selectionMode, setSelectionMode] = useCatQueueSelectionMode();
@@ -128,7 +133,49 @@ export function CatQueuePanel({
           <h2 className="text-sm font-semibold text-foreground">
             <FormattedMessage {...catQueuePanelMessages.queueTitle} />
           </h2>
-          <CatWorkspaceViewSwitcherConnected />
+          <div className="flex items-center gap-1">
+            {onDownloadFilteredView ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  render={
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-8 gap-1.5 font-normal"
+                      disabled={isDownloadingFilteredView}
+                      aria-label={intl.formatMessage(catQueuePanelMessages.downloadFilteredAria)}
+                    />
+                  }
+                >
+                  {isDownloadingFilteredView ? (
+                    <Spinner className="size-3.5" />
+                  ) : (
+                    <DownloadIcon className="size-3.5" />
+                  )}
+                  <span className="text-xs">
+                    <FormattedMessage {...catQueuePanelMessages.downloadFiltered} />
+                  </span>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-40">
+                  <DropdownMenuGroup>
+                    <DropdownMenuLabel>
+                      <FormattedMessage {...catQueuePanelMessages.downloadFilteredFormatLabel} />
+                    </DropdownMenuLabel>
+                    {(["csv", "tmx", "xlf", "xliff"] as const).map((format) => (
+                      <DropdownMenuItem
+                        key={format}
+                        onClick={() => onDownloadFilteredView(format)}
+                      >
+                        {format.toUpperCase()}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : null}
+            <CatWorkspaceViewSwitcherConnected />
+          </div>
         </div>
 
         {onSearchChange ? (

--- a/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-panel.tsx
@@ -163,10 +163,7 @@ export function CatQueuePanel({
                       <FormattedMessage {...catQueuePanelMessages.downloadFilteredFormatLabel} />
                     </DropdownMenuLabel>
                     {(["csv", "tmx", "xlf", "xliff"] as const).map((format) => (
-                      <DropdownMenuItem
-                        key={format}
-                        onClick={() => onDownloadFilteredView(format)}
-                      >
+                      <DropdownMenuItem key={format} onClick={() => onDownloadFilteredView(format)}>
                         {format.toUpperCase()}
                       </DropdownMenuItem>
                     ))}

--- a/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
@@ -69,6 +69,21 @@ export const catQueuePanelMessages = defineMessages({
     id: "Kjim0yzISM",
     description: "Accessible label for CAT queue search input",
   },
+  downloadFiltered: {
+    defaultMessage: "Download",
+    id: "catDlBtn01",
+    description: "Button label to download the filtered CAT queue view",
+  },
+  downloadFilteredAria: {
+    defaultMessage: "Download filtered view",
+    id: "catDlAria1",
+    description: "Accessible label for downloading the filtered CAT queue",
+  },
+  downloadFilteredFormatLabel: {
+    defaultMessage: "Format",
+    id: "catDlFmt01",
+    description: "Label above download format options in the CAT queue",
+  },
   emptySearchResults: {
     defaultMessage: "No segments match your search.",
     id: "ypyJIGOXrt",

--- a/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/cat.messages.ts
@@ -71,17 +71,17 @@ export const catQueuePanelMessages = defineMessages({
   },
   downloadFiltered: {
     defaultMessage: "Download",
-    id: "catDlBtn01",
+    id: "kUl1Jpz/6B",
     description: "Button label to download the filtered CAT queue view",
   },
   downloadFilteredAria: {
     defaultMessage: "Download filtered view",
-    id: "catDlAria1",
+    id: "2B2vocYfiC",
     description: "Accessible label for downloading the filtered CAT queue",
   },
   downloadFilteredFormatLabel: {
     defaultMessage: "Format",
-    id: "catDlFmt01",
+    id: "D/arw4JcTP",
     description: "Label above download format options in the CAT queue",
   },
   emptySearchResults: {

--- a/apps/hyperlocalise-web/src/components/cat/shared/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/dependencies.ts
@@ -165,6 +165,8 @@ export interface CatWorkspaceViewProps {
   organizationSlug?: string;
   projectId?: string;
   nativeIssuesEnabled?: boolean;
+  onDownloadFilteredView?: (format: "csv" | "tmx" | "xlf" | "xliff") => void;
+  isDownloadingFilteredView?: boolean;
 }
 
 export const noopCatDependencies: CatWorkspaceDependencies = {

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-panel.tsx
@@ -14,6 +14,7 @@
  */
 import { FilterIcon, SearchIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { DownloadIcon } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useCallback, useMemo } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -22,6 +23,9 @@ import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
@@ -106,6 +110,8 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
   pagination = null,
   hasMoreQueue = false,
   onLoadMoreQueue,
+  onDownloadFilteredView,
+  isDownloadingFilteredView = false,
   onFocusSegment,
   onTargetChange,
   onApprove,
@@ -175,6 +181,8 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
   pagination?: CatQueuePagination | null;
   hasMoreQueue?: boolean;
   onLoadMoreQueue?: () => void;
+  onDownloadFilteredView?: (format: "csv" | "tmx" | "xlf" | "xliff") => void;
+  isDownloadingFilteredView?: boolean;
   onFocusSegment: (segmentId: string) => void;
   onTargetChange: (segmentId: string, value: string) => void;
   onApprove?: (segmentId: string) => void;
@@ -310,6 +318,47 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
                         </DropdownMenuRadioItem>
                       ))}
                     </DropdownMenuRadioGroup>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              ) : null}
+
+              {onDownloadFilteredView ? (
+                <DropdownMenu>
+                  <DropdownMenuTrigger
+                    render={
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="h-9 gap-1.5 px-2.5"
+                        disabled={isDownloadingFilteredView}
+                        aria-label={intl.formatMessage(catQueuePanelMessages.downloadFilteredAria)}
+                      />
+                    }
+                  >
+                    {isDownloadingFilteredView ? (
+                      <Spinner className="size-4" />
+                    ) : (
+                      <DownloadIcon className="size-4" />
+                    )}
+                    <span className="hidden text-xs sm:inline">
+                      <FormattedMessage {...catQueuePanelMessages.downloadFiltered} />
+                    </span>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-40">
+                    <DropdownMenuGroup>
+                      <DropdownMenuLabel>
+                        <FormattedMessage {...catQueuePanelMessages.downloadFilteredFormatLabel} />
+                      </DropdownMenuLabel>
+                      {(["csv", "tmx", "xlf", "xliff"] as const).map((format) => (
+                        <DropdownMenuItem
+                          key={format}
+                          onClick={() => onDownloadFilteredView(format)}
+                        >
+                          {format.toUpperCase()}
+                        </DropdownMenuItem>
+                      ))}
+                    </DropdownMenuGroup>
                   </DropdownMenuContent>
                 </DropdownMenu>
               ) : null}

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
@@ -88,6 +88,8 @@ export interface CatWorkspaceContainerProps {
   onPageLimitChange?: (pageLimit: number) => void;
   pageNavigationGuardRef?: CatPageNavigationGuardRef;
   nativeIssuesEnabled?: boolean;
+  onDownloadFilteredView?: (format: "csv" | "tmx" | "xlf" | "xliff") => void;
+  isDownloadingFilteredView?: boolean;
 }
 
 const CatWorkspaceContainerObserver = observer(function CatWorkspaceContainerObserver({
@@ -117,6 +119,8 @@ const CatWorkspaceContainerObserver = observer(function CatWorkspaceContainerObs
   canLookupFreshContext,
   onPageLimitChange,
   nativeIssuesEnabled = false,
+  onDownloadFilteredView,
+  isDownloadingFilteredView = false,
 }: CatWorkspaceContainerProps & { store: CatWorkspaceOrchestrator }) {
   const controller = useCatWorkspaceRuntime({
     store,
@@ -212,6 +216,8 @@ const CatWorkspaceContainerObserver = observer(function CatWorkspaceContainerObs
           organizationSlug={lazySegment?.organizationSlug}
           projectId={lazySegment?.projectId}
           nativeIssuesEnabled={nativeIssuesEnabled}
+          onDownloadFilteredView={onDownloadFilteredView}
+          isDownloadingFilteredView={isDownloadingFilteredView}
         />
       </CatPanelErrorBoundary>
 

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
@@ -108,6 +108,8 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
   organizationSlug,
   projectId,
   nativeIssuesEnabled = false,
+  onDownloadFilteredView,
+  isDownloadingFilteredView = false,
 }: CatWorkspaceViewProps) {
   const store = useCatWorkspace();
   const viewMode = store.ui.viewMode;
@@ -174,6 +176,8 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
             pagination={queuePagination}
             hasMoreQueue={hasMoreQueue}
             onLoadMoreQueue={onLoadMoreQueue}
+            onDownloadFilteredView={onDownloadFilteredView}
+            isDownloadingFilteredView={isDownloadingFilteredView}
           />
         </CatPanelErrorBoundary>
       </div>
@@ -211,6 +215,8 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
             pagination={queuePagination}
             hasMoreQueue={hasMoreQueue}
             onLoadMoreQueue={onLoadMoreQueue}
+            onDownloadFilteredView={onDownloadFilteredView}
+            isDownloadingFilteredView={isDownloadingFilteredView}
           />
         </CatPanelErrorBoundary>
       </div>
@@ -357,6 +363,8 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
           pagination={queuePagination}
           hasMoreQueue={hasMoreQueue}
           onLoadMoreQueue={onLoadMoreQueue}
+          onDownloadFilteredView={onDownloadFilteredView}
+          isDownloadingFilteredView={isDownloadingFilteredView}
           onFocusSegment={dependencies.navigation.onSelectSegment}
           onTargetChange={(segmentId, value) => editing.onTargetChange(segmentId, value)}
           onApprove={(segmentId) => {
@@ -623,6 +631,8 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
           pagination={queuePagination}
           hasMoreQueue={hasMoreQueue}
           onLoadMoreQueue={onLoadMoreQueue}
+          onDownloadFilteredView={onDownloadFilteredView}
+          isDownloadingFilteredView={isDownloadingFilteredView}
         />
       </CatPanelErrorBoundary>
     );

--- a/apps/hyperlocalise-web/src/lib/projects/cat/cat-filtered-export-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/cat-filtered-export-service.ts
@@ -10,12 +10,13 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import type { AuthVariables } from "@/api/middleware/auth-variables";
+import type { AuthVariables } from "@/api/auth/workos";
 import type {
   ProjectFileCatQuery,
   ProjectFileCatQueueFile,
   ProjectFileCatSegment,
 } from "@/api/routes/project/project.schema";
+import type { ProjectResourceTarget } from "@/api/routes/project/project.shared";
 import { maxProjectFileCatPageLimit } from "@/api/routes/project/project.schema";
 import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-with-concurrency";
 import { getProjectTranslationsByKeyIds } from "@/lib/projects/translations/project-translation-service";
@@ -32,7 +33,10 @@ import {
 export type CatQueueLoaderResult =
   | { kind: "ok"; catQueue: ProjectFileCatQueueFile }
   | { kind: "feature_unavailable" }
-  | { kind: "provider_unavailable"; target: unknown }
+  | {
+      kind: "provider_unavailable";
+      target: Extract<ProjectResourceTarget, { kind: "provider_unavailable" }>;
+    }
   | { kind: "project_not_found" }
   | { kind: "source_file_not_found" }
   | { kind: "provider_error"; error: unknown };
@@ -69,22 +73,26 @@ async function loadProviderTargets(input: {
   actorUserId?: string | null;
   segments: ProjectFileCatSegment[];
 }) {
-  const targets = await mapWithConcurrency(input.segments, PROVIDER_TARGET_CONCURRENCY, async (segment) => {
-    const target = await getTmsProviderLiveCatSegmentTarget(
-      input.organizationId,
-      input.externalProjectId,
-      segment.sourcePath ?? input.sourcePath,
-      input.targetLocale,
-      segment.externalStringId,
-      {
-        actorUserId: input.actorUserId,
-        externalResourceId: segment.externalResourceId,
-        resourceType: segment.resourceType,
-      },
-    );
-    const text = target && target !== "not_found" ? (target.text ?? "") : "";
-    return [segment.externalStringId, text] as const;
-  });
+  const targets = await mapWithConcurrency(
+    input.segments,
+    PROVIDER_TARGET_CONCURRENCY,
+    async (segment) => {
+      const target = await getTmsProviderLiveCatSegmentTarget(
+        input.organizationId,
+        input.externalProjectId,
+        segment.sourcePath ?? input.sourcePath,
+        input.targetLocale,
+        segment.externalStringId,
+        {
+          actorUserId: input.actorUserId,
+          externalResourceId: segment.externalResourceId,
+          resourceType: segment.resourceType,
+        },
+      );
+      const text = target && target !== "not_found" ? (target.text ?? "") : "";
+      return [segment.externalStringId, text] as const;
+    },
+  );
 
   return new Map(targets);
 }

--- a/apps/hyperlocalise-web/src/lib/projects/cat/cat-filtered-export-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/cat-filtered-export-service.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { AuthVariables } from "@/api/middleware/auth-variables";
+import type {
+  ProjectFileCatQuery,
+  ProjectFileCatQueueFile,
+  ProjectFileCatSegment,
+} from "@/api/routes/project/project.schema";
+import { maxProjectFileCatPageLimit } from "@/api/routes/project/project.schema";
+import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-with-concurrency";
+import { getProjectTranslationsByKeyIds } from "@/lib/projects/translations/project-translation-service";
+import { getTmsProviderLiveCatSegmentTarget } from "@/lib/providers/jobs/tms-provider-live";
+
+import {
+  buildCatFilteredExportFilename,
+  maxCatFilteredExportSegments,
+  serializeCatFilteredExport,
+  type CatFilteredExportFormat,
+  type CatFilteredExportRow,
+} from "./cat-filtered-export";
+
+export type CatQueueLoaderResult =
+  | { kind: "ok"; catQueue: ProjectFileCatQueueFile }
+  | { kind: "feature_unavailable" }
+  | { kind: "provider_unavailable"; target: unknown }
+  | { kind: "project_not_found" }
+  | { kind: "source_file_not_found" }
+  | { kind: "provider_error"; error: unknown };
+
+export type CatQueueLoader = (
+  auth: AuthVariables["auth"],
+  projectId: string,
+  query: ProjectFileCatQuery,
+) => Promise<CatQueueLoaderResult>;
+
+const PROVIDER_TARGET_CONCURRENCY = 8;
+
+async function loadNativeTargets(input: {
+  organizationId: string;
+  projectId: string;
+  targetLocale: string;
+  segments: ProjectFileCatSegment[];
+}) {
+  const keyIds = input.segments.map((segment) => segment.externalStringId);
+  const translations = await getProjectTranslationsByKeyIds({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    translationKeyIds: keyIds,
+    targetLocale: input.targetLocale,
+  });
+  return new Map(translations.map((row) => [row.translationKeyId, row.text ?? ""]));
+}
+
+async function loadProviderTargets(input: {
+  organizationId: string;
+  externalProjectId: string;
+  sourcePath: string;
+  targetLocale: string;
+  actorUserId?: string | null;
+  segments: ProjectFileCatSegment[];
+}) {
+  const targets = await mapWithConcurrency(input.segments, PROVIDER_TARGET_CONCURRENCY, async (segment) => {
+    const target = await getTmsProviderLiveCatSegmentTarget(
+      input.organizationId,
+      input.externalProjectId,
+      segment.sourcePath ?? input.sourcePath,
+      input.targetLocale,
+      segment.externalStringId,
+      {
+        actorUserId: input.actorUserId,
+        externalResourceId: segment.externalResourceId,
+        resourceType: segment.resourceType,
+      },
+    );
+    const text = target && target !== "not_found" ? (target.text ?? "") : "";
+    return [segment.externalStringId, text] as const;
+  });
+
+  return new Map(targets);
+}
+
+export async function collectCatFilteredExportRows(input: {
+  auth: AuthVariables["auth"];
+  projectId: string;
+  query: ProjectFileCatQuery;
+  sourceLocale: string;
+  loadCatQueue: CatQueueLoader;
+  externalProjectId?: string | null;
+}): Promise<
+  | { kind: "ok"; rows: CatFilteredExportRow[]; truncated: boolean }
+  | { kind: "empty" }
+  | Exclude<CatQueueLoaderResult, { kind: "ok" }>
+> {
+  const rows: CatFilteredExportRow[] = [];
+  let offset = 0;
+  let phraseScanPage = input.query.phraseScanPage;
+  let phraseScanSkip = input.query.phraseScanSkip;
+  let truncated = false;
+  const isProvider = Boolean(input.externalProjectId);
+
+  while (rows.length < maxCatFilteredExportSegments) {
+    const remaining = maxCatFilteredExportSegments - rows.length;
+    const limit = Math.min(maxProjectFileCatPageLimit, remaining);
+    const pageResult = await input.loadCatQueue(input.auth, input.projectId, {
+      ...input.query,
+      offset,
+      limit,
+      phraseScanPage,
+      phraseScanSkip,
+    });
+
+    if (pageResult.kind !== "ok") {
+      return pageResult;
+    }
+
+    const { catQueue } = pageResult;
+    if (catQueue.segments.length === 0) {
+      break;
+    }
+
+    const targetById = isProvider
+      ? await loadProviderTargets({
+          organizationId: input.auth.organization.localOrganizationId,
+          externalProjectId: input.externalProjectId!,
+          sourcePath: input.query.sourcePath,
+          targetLocale: input.query.targetLocale,
+          actorUserId: input.auth.user.localUserId,
+          segments: catQueue.segments,
+        })
+      : await loadNativeTargets({
+          organizationId: input.auth.organization.localOrganizationId,
+          projectId: input.projectId,
+          targetLocale: input.query.targetLocale,
+          segments: catQueue.segments,
+        });
+
+    for (const segment of catQueue.segments) {
+      rows.push({
+        key: segment.key,
+        sourceText: segment.sourceText,
+        targetText: targetById.get(segment.externalStringId) ?? "",
+        sourceLocale: input.sourceLocale,
+        targetLocale: input.query.targetLocale,
+        sourcePath: segment.sourcePath ?? input.query.sourcePath,
+      });
+    }
+
+    const pagination = catQueue.pagination;
+    if (!pagination?.hasMore) {
+      break;
+    }
+
+    offset = pagination.offset + pagination.returnedCount;
+    phraseScanPage = pagination.nextPhraseScanPage;
+    phraseScanSkip = pagination.nextPhraseScanSkip;
+
+    if (rows.length >= maxCatFilteredExportSegments && pagination.hasMore) {
+      truncated = true;
+      break;
+    }
+  }
+
+  if (rows.length === 0) {
+    return { kind: "empty" };
+  }
+
+  return { kind: "ok", rows, truncated };
+}
+
+export function buildCatFilteredExportPayload(input: {
+  format: CatFilteredExportFormat;
+  rows: CatFilteredExportRow[];
+  sourcePath: string;
+  targetLocale: string;
+}) {
+  const serialized = serializeCatFilteredExport(input.format, input.rows);
+  return {
+    ...serialized,
+    filename: buildCatFilteredExportFilename({
+      sourcePath: input.sourcePath,
+      targetLocale: input.targetLocale,
+      extension: serialized.extension,
+    }),
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/projects/cat/cat-filtered-export.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/cat-filtered-export.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildCatFilteredExportFilename,
+  serializeCatFilteredExport,
+  serializeCatFilteredExportCsv,
+  serializeCatFilteredExportTmx,
+  serializeCatFilteredExportXliff,
+  type CatFilteredExportRow,
+} from "./cat-filtered-export";
+
+const sampleRows: CatFilteredExportRow[] = [
+  {
+    key: 'greet,"user"',
+    sourceText: "Hello\nworld",
+    targetText: "Xin chào",
+    sourceLocale: "en",
+    targetLocale: "vi",
+    sourcePath: "locales/en.json",
+  },
+];
+
+describe("serializeCatFilteredExportCsv", () => {
+  it("escapes commas, quotes, and newlines", () => {
+    const csv = serializeCatFilteredExportCsv(sampleRows);
+    expect(csv).toContain('"greet,""user"""');
+    expect(csv).toContain('"Hello\nworld"');
+    expect(csv.startsWith("key,source_locale,")).toBe(true);
+  });
+});
+
+describe("serializeCatFilteredExportTmx", () => {
+  it("emits TMX translation units", () => {
+    const tmx = serializeCatFilteredExportTmx(sampleRows);
+    expect(tmx).toContain('<tmx version="1.4">');
+    expect(tmx).toContain('tuid="greet,&quot;user&quot;"');
+    expect(tmx).toContain("<seg>Xin chào</seg>");
+  });
+});
+
+describe("serializeCatFilteredExportXliff", () => {
+  it("emits XLIFF 1.2 units for both xlf and xliff", () => {
+    const xliff = serializeCatFilteredExportXliff(sampleRows);
+    expect(xliff).toContain('<xliff version="1.2"');
+    expect(xliff).toContain("<seg>".replace("seg", "source"));
+    expect(xliff).toContain("Xin chào");
+    expect(serializeCatFilteredExport("xlf", sampleRows).extension).toBe("xlf");
+    expect(serializeCatFilteredExport("xliff", sampleRows).extension).toBe("xliff");
+  });
+});
+
+describe("buildCatFilteredExportFilename", () => {
+  it("uses all-files for wildcard source paths", () => {
+    expect(
+      buildCatFilteredExportFilename({
+        sourcePath: "*",
+        targetLocale: "vi",
+        extension: "csv",
+      }),
+    ).toBe("all-files-vi.csv");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/projects/cat/cat-filtered-export.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/cat-filtered-export.test.ts
@@ -54,7 +54,7 @@ describe("serializeCatFilteredExportXliff", () => {
   it("emits XLIFF 1.2 units for both xlf and xliff", () => {
     const xliff = serializeCatFilteredExportXliff(sampleRows);
     expect(xliff).toContain('<xliff version="1.2"');
-    expect(xliff).toContain("<seg>".replace("seg", "source"));
+    expect(xliff).toContain('source-language="en"');
     expect(xliff).toContain("Xin chào");
     expect(serializeCatFilteredExport("xlf", sampleRows).extension).toBe("xlf");
     expect(serializeCatFilteredExport("xliff", sampleRows).extension).toBe("xliff");

--- a/apps/hyperlocalise-web/src/lib/projects/cat/cat-filtered-export.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/cat-filtered-export.ts
@@ -43,7 +43,14 @@ function escapeXml(value: string) {
 }
 
 export function serializeCatFilteredExportCsv(rows: readonly CatFilteredExportRow[]) {
-  const header = ["key", "source_locale", "target_locale", "source_text", "target_text", "source_path"];
+  const header = [
+    "key",
+    "source_locale",
+    "target_locale",
+    "source_text",
+    "target_text",
+    "source_path",
+  ];
   const lines = [
     header.join(","),
     ...rows.map((row) =>
@@ -157,6 +164,9 @@ export function buildCatFilteredExportFilename(input: {
   const base =
     input.sourcePath === "*"
       ? "all-files"
-      : (input.sourcePath.split("/").pop()?.replace(/\.[^.]+$/, "") ?? "cat-export");
+      : (input.sourcePath
+          .split("/")
+          .pop()
+          ?.replace(/\.[^.]+$/, "") ?? "cat-export");
   return `${base}-${input.targetLocale}.${input.extension}`;
 }

--- a/apps/hyperlocalise-web/src/lib/projects/cat/cat-filtered-export.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/cat-filtered-export.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+export const catFilteredExportFormats = ["csv", "tmx", "xlf", "xliff"] as const;
+
+export type CatFilteredExportFormat = (typeof catFilteredExportFormats)[number];
+
+export type CatFilteredExportRow = {
+  key: string;
+  sourceText: string;
+  targetText: string;
+  sourceLocale: string;
+  targetLocale: string;
+  sourcePath?: string;
+};
+
+export const maxCatFilteredExportSegments = 5_000;
+
+function escapeCsvCell(value: string) {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function escapeXml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export function serializeCatFilteredExportCsv(rows: readonly CatFilteredExportRow[]) {
+  const header = ["key", "source_locale", "target_locale", "source_text", "target_text", "source_path"];
+  const lines = [
+    header.join(","),
+    ...rows.map((row) =>
+      [
+        row.key,
+        row.sourceLocale,
+        row.targetLocale,
+        row.sourceText,
+        row.targetText,
+        row.sourcePath ?? "",
+      ]
+        .map(escapeCsvCell)
+        .join(","),
+    ),
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+export function serializeCatFilteredExportTmx(rows: readonly CatFilteredExportRow[]) {
+  const body = rows
+    .map((row) => {
+      const tuid = escapeXml(row.key);
+      return [
+        `  <tu tuid="${tuid}">`,
+        `    <tuv xml:lang="${escapeXml(row.sourceLocale)}"><seg>${escapeXml(row.sourceText)}</seg></tuv>`,
+        `    <tuv xml:lang="${escapeXml(row.targetLocale)}"><seg>${escapeXml(row.targetText)}</seg></tuv>`,
+        `  </tu>`,
+      ].join("\n");
+    })
+    .join("\n");
+
+  return [
+    `<?xml version="1.0" encoding="UTF-8"?>`,
+    `<tmx version="1.4">`,
+    `  <header creationtool="Hyperlocalise" creationtoolversion="1" segtype="sentence" o-tmf="Hyperlocalise" adminlang="en" srclang="${escapeXml(rows[0]?.sourceLocale ?? "en")}" datatype="plaintext"/>`,
+    `  <body>`,
+    body,
+    `  </body>`,
+    `</tmx>`,
+    ``,
+  ].join("\n");
+}
+
+export function serializeCatFilteredExportXliff(rows: readonly CatFilteredExportRow[]) {
+  const sourceLocale = rows[0]?.sourceLocale ?? "en";
+  const targetLocale = rows[0]?.targetLocale ?? "und";
+  const original = rows[0]?.sourcePath ?? "cat-export";
+
+  const units = rows
+    .map((row, index) => {
+      const id = escapeXml(row.key || `unit-${index + 1}`);
+      return [
+        `    <trans-unit id="${id}">`,
+        `      <source xml:lang="${escapeXml(row.sourceLocale)}">${escapeXml(row.sourceText)}</source>`,
+        `      <target xml:lang="${escapeXml(row.targetLocale)}">${escapeXml(row.targetText)}</target>`,
+        `    </trans-unit>`,
+      ].join("\n");
+    })
+    .join("\n");
+
+  return [
+    `<?xml version="1.0" encoding="UTF-8"?>`,
+    `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
+    `  <file original="${escapeXml(original)}" source-language="${escapeXml(sourceLocale)}" target-language="${escapeXml(targetLocale)}" datatype="plaintext">`,
+    `    <body>`,
+    units,
+    `    </body>`,
+    `  </file>`,
+    `</xliff>`,
+    ``,
+  ].join("\n");
+}
+
+export function serializeCatFilteredExport(
+  format: CatFilteredExportFormat,
+  rows: readonly CatFilteredExportRow[],
+) {
+  switch (format) {
+    case "csv":
+      return {
+        body: serializeCatFilteredExportCsv(rows),
+        contentType: "text/csv; charset=utf-8",
+        extension: "csv",
+      };
+    case "tmx":
+      return {
+        body: serializeCatFilteredExportTmx(rows),
+        contentType: "application/x-tmx+xml; charset=utf-8",
+        extension: "tmx",
+      };
+    case "xlf":
+      return {
+        body: serializeCatFilteredExportXliff(rows),
+        contentType: "application/x-xliff+xml; charset=utf-8",
+        extension: "xlf",
+      };
+    case "xliff":
+      return {
+        body: serializeCatFilteredExportXliff(rows),
+        contentType: "application/xliff+xml; charset=utf-8",
+        extension: "xliff",
+      };
+  }
+}
+
+export function buildCatFilteredExportFilename(input: {
+  sourcePath: string;
+  targetLocale: string;
+  extension: string;
+}) {
+  const base =
+    input.sourcePath === "*"
+      ? "all-files"
+      : (input.sourcePath.split("/").pop()?.replace(/\.[^.]+$/, "") ?? "cat-export");
+  return `${base}-${input.targetLocale}.${input.extension}`;
+}

--- a/apps/hyperlocalise-web/src/lib/projects/cat/cat-workspace-query-params.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/cat-workspace-query-params.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  applyCatWorkspaceQueryParams,
+  buildCatNavigationSearchParams,
+  parseCatWorkspaceQueueFilterParam,
+  parseCatWorkspaceSearchParam,
+} from "./cat-workspace-query-params";
+
+describe("parseCatWorkspaceQueueFilterParam", () => {
+  it("accepts known filters and rejects unknown values", () => {
+    expect(parseCatWorkspaceQueueFilterParam("needs_review")).toBe("needs_review");
+    expect(parseCatWorkspaceQueueFilterParam("skipped")).toBeUndefined();
+    expect(parseCatWorkspaceQueueFilterParam(undefined)).toBeUndefined();
+  });
+});
+
+describe("parseCatWorkspaceSearchParam", () => {
+  it("trims search text", () => {
+    expect(parseCatWorkspaceSearchParam("  hello  ")).toBe("hello");
+    expect(parseCatWorkspaceSearchParam("   ")).toBe("");
+  });
+});
+
+describe("applyCatWorkspaceQueryParams", () => {
+  it("writes non-default filter and search, and clears defaults", () => {
+    const params = new URLSearchParams("locale=vi&queueFilter=untranslated&search=old");
+    const next = applyCatWorkspaceQueryParams(params, {
+      queueFilter: "all",
+      search: "",
+    });
+    expect(next.get("locale")).toBe("vi");
+    expect(next.get("queueFilter")).toBeNull();
+    expect(next.get("search")).toBeNull();
+
+    const withValues = applyCatWorkspaceQueryParams(params, {
+      queueFilter: "needs_review",
+      search: "checkout",
+    });
+    expect(withValues.get("queueFilter")).toBe("needs_review");
+    expect(withValues.get("search")).toBe("checkout");
+  });
+});
+
+describe("buildCatNavigationSearchParams", () => {
+  it("preserves filter and search when only locale changes", () => {
+    const next = buildCatNavigationSearchParams(
+      "locale=fr&queueFilter=untranslated&search=save&sourcePath=a.json",
+      { locale: "vi" },
+    );
+    expect(next.get("locale")).toBe("vi");
+    expect(next.get("queueFilter")).toBe("untranslated");
+    expect(next.get("search")).toBe("save");
+    expect(next.get("sourcePath")).toBe("a.json");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/projects/cat/cat-workspace-query-params.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/cat-workspace-query-params.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ProjectFileCatQueueFilter } from "@/api/routes/project/project.schema";
+import { projectFileCatQueueFilterSchema } from "@/api/routes/project/project.schema";
+import type { CatQueueFilter } from "@/components/cat/queue/cat-queue-filter";
+import { isServerQueueFilter } from "@/components/cat/queue/cat-queue-filter";
+
+/** Shared CAT workspace query keys for filter + segment search. */
+export const catWorkspaceQueueFilterParam = "queueFilter";
+export const catWorkspaceSearchParam = "search";
+
+export function parseCatWorkspaceQueueFilterParam(
+  value: string | undefined | null,
+): ProjectFileCatQueueFilter | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const result = projectFileCatQueueFilterSchema.safeParse(value);
+  return result.success ? result.data : undefined;
+}
+
+export function parseCatWorkspaceSearchParam(value: string | undefined | null): string {
+  return value?.trim() ? value.trim() : "";
+}
+
+export function applyCatWorkspaceQueryParams(
+  params: URLSearchParams,
+  input: {
+    queueFilter?: CatQueueFilter | null;
+    search?: string | null;
+  },
+) {
+  const next = new URLSearchParams(params);
+
+  if (input.queueFilter != null) {
+    if (input.queueFilter === "all" || !isServerQueueFilter(input.queueFilter)) {
+      next.delete(catWorkspaceQueueFilterParam);
+    } else {
+      next.set(catWorkspaceQueueFilterParam, input.queueFilter);
+    }
+  }
+
+  if (input.search !== undefined) {
+    const trimmed = input.search?.trim() ?? "";
+    if (!trimmed) {
+      next.delete(catWorkspaceSearchParam);
+    } else {
+      next.set(catWorkspaceSearchParam, trimmed);
+    }
+  }
+
+  return next;
+}
+
+/**
+ * Clone the current browser search params and apply locale/file updates while
+ * preserving queueFilter + search (and any other unrelated params).
+ */
+export function buildCatNavigationSearchParams(
+  currentSearch: string | URLSearchParams,
+  updates: Record<string, string | null | undefined>,
+) {
+  const params =
+    typeof currentSearch === "string"
+      ? new URLSearchParams(currentSearch.startsWith("?") ? currentSearch.slice(1) : currentSearch)
+      : new URLSearchParams(currentSearch);
+
+  for (const [key, value] of Object.entries(updates)) {
+    if (value == null || value === "") {
+      params.delete(key);
+    } else {
+      params.set(key, value);
+    }
+  }
+
+  return params;
+}

--- a/apps/hyperlocalise-web/src/lib/projects/job-cat-routing.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/job-cat-routing.ts
@@ -19,6 +19,7 @@ import {
 import { resolveJobProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 
 export const jobCatQueueFilterParam = "queueFilter";
+export const jobCatSearchParam = "search";
 
 export type JobCatTarget = {
   id: string;

--- a/docs/plans/2026-08-17-cat-filtered-export-and-search-preserve-design.md
+++ b/docs/plans/2026-08-17-cat-filtered-export-and-search-preserve-design.md
@@ -1,0 +1,29 @@
+# CAT filtered export and search preserve
+
+## Problem
+
+1. Changing target locale remounts the CAT workspace (key includes locale), which resets local `queueFilter` and segment `search` state.
+2. Job CAT already puts `queueFilter` in the URL for the initial load, but UI changes do not write back to the URL, and `search` is never URL-backed.
+3. Users need to download the current filtered queue as CSV, TMX, XLF, or XLIFF.
+
+## Decision
+
+### Preserve filter and search in the URL
+
+- Treat `queueFilter` and `search` as first-class CAT query params (same idea as `locale` / `targetLocale`).
+- Sync UI changes into the URL with `router.replace`.
+- When changing locale (or file), clone the current search params and only update the locale (or file) fields so filter and search survive navigation and remount.
+- Pass `initialSearch` and `initialQueueFilter` from the page into `useCatSegmentQuery`.
+
+### Download filtered view
+
+- Add a **Download** button (dropdown) on the queue toolbar.
+- Add `GET .../files/detail/cat/export?format=csv|tmx|xlf|xliff` with the same filter/search/sourcePath/locale query as the queue.
+- Server pages through the filtered queue, loads targets (native batch; provider concurrent), and returns a file attachment.
+- Cap export size (5_000 segments) consistent with other project translation exports.
+- `xlf` and `xliff` share XLIFF 1.2 content; only the filename extension differs.
+
+## Verification
+
+- Unit tests for URL helpers, serializers, and export route behavior.
+- `vp test` and `vp check --fix` in `apps/hyperlocalise-web`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Persist CAT queue filter and segment search in the URL so they survive locale changes (same idea as locale itself). Add a **Download** button on the queue / side-by-side toolbar that exports the current filtered view as CSV, TMX, XLF, or XLIFF via `GET .../files/detail/cat/export`.

## How to test

1. Open CAT, set a filter and segment search, change locale — both remain.
2. Click **Download** and pick CSV / TMX / XLF / XLIFF; confirm the file contains filtered segments.
3. `vp test` (new export/query-param unit tests) and `vp check --fix` in `apps/hyperlocalise-web`.

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, focused `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00ef8-5ec8-7f70-9d0f-e8804e962664?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00ef8-5ec8-7f70-9d0f-e8804e962664&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

