### PR TITLE
feat(localisation-audit): mark bot-blocked crawls as terminal

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/localisation-audit/localisation-audit.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/localisation-audit/localisation-audit.route.test.ts
@@ -292,6 +292,30 @@ describe("localisation audit routes", () => {
     expect(body.audit.report).toEqual(expect.objectContaining({ score: 82 }));
   });
 
+  it("does not expose a prior score while an audit is blocked", async () => {
+    findBySlugMock.mockResolvedValue(
+      succeededAudit({
+        status: "blocked",
+        progressStage: "blocked",
+        errorCode: "crawl_blocked",
+        errorMessage: "This domain blocked HyperlocaliseAuditBot/1.0.",
+      }),
+    );
+    const { createLocalisationAuditRoutes } = await import("./localisation-audit.route");
+    const routes = createLocalisationAuditRoutes();
+
+    const response = await routes.request("/example-com");
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.audit.status).toBe("blocked");
+    expect(body.audit.score).toBeNull();
+    expect(body.audit.teaser).toBeNull();
+    expect(body.audit.unlocked).toBe(false);
+    expect(body.audit.report).toBeNull();
+    expect(body.audit.retryable).toBe(false);
+  });
+
   it("queues report email instead of unlocking immediately", async () => {
     findBySlugMock.mockResolvedValue(succeededAudit());
     upsertLeadMock.mockResolvedValue({
@@ -328,6 +352,32 @@ describe("localisation audit routes", () => {
       token: "opaque-token",
     });
     expect(app).toBeTruthy();
+  });
+
+  it("does not accept report email requests for blocked audits", async () => {
+    findBySlugMock.mockResolvedValue(
+      succeededAudit({
+        status: "blocked",
+        progressStage: "blocked",
+        score: 82,
+        teaser: { score: 82, headlineFindings: [], findingsCount: 0 },
+        errorCode: "crawl_blocked",
+        errorMessage: "This domain blocked HyperlocaliseAuditBot/1.0.",
+      }),
+    );
+    const { createLocalisationAuditRoutes } = await import("./localisation-audit.route");
+    const routes = createLocalisationAuditRoutes();
+
+    const response = await routes.request("/example-com/unlock", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "lead@example.com", locale: "en" }),
+    });
+
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.error).toBe("localisation_audit_blocked");
+    expect(upsertLeadMock).not.toHaveBeenCalled();
   });
 
   it("stores pending lead while audit is still running", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/localisation-audit/localisation-audit.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/localisation-audit/localisation-audit.route.ts
@@ -25,6 +25,7 @@ import { DEFAULT_APP_LOCALE, normalizeAppLocale } from "@/lib/app-i18n/locales";
 import { rejectLocalisationAuditBot } from "@/lib/localisation-audit/bot-protection";
 import { LocalisationAuditDailyQuotaExceededError } from "@/lib/localisation-audit/daily-quota";
 import { resolveDomainIdentity, isValidDomainSlug } from "@/lib/localisation-audit/domain-slug";
+import { LOCALISATION_AUDIT_USER_AGENT_NAME } from "@/lib/localisation-audit/user-agent";
 import {
   attachLocalisationAuditWorkflowRun,
   claimOrReuseLocalisationAudit,
@@ -63,6 +64,7 @@ type LocalisationAuditRouteOptions = {
 
 function publicAuditView(audit: LocalisationAuditRow) {
   const retryable = isLocalisationAuditRetryable(audit);
+  const blocked = audit.status === "blocked";
   return {
     id: audit.id,
     domainKey: audit.domainKey,
@@ -71,9 +73,9 @@ function publicAuditView(audit: LocalisationAuditRow) {
     status: audit.status,
     attemptNumber: audit.attemptNumber,
     progressStage: audit.progressStage,
-    score: audit.score,
+    score: blocked ? null : audit.score,
     focusLocales: audit.focusLocales,
-    teaser: audit.teaser,
+    teaser: blocked ? null : audit.teaser,
     errorCode: audit.errorCode,
     errorMessage: audit.errorMessage,
     retryable,
@@ -249,6 +251,13 @@ export function createLocalisationAuditRoutes(options: LocalisationAuditRouteOpt
           c,
           "localisation_audit_failed",
           "This audit failed. Retry the audit before requesting a report email.",
+        );
+      }
+      if (audit.status === "blocked") {
+        return conflictResponse(
+          c,
+          "localisation_audit_blocked",
+          `This audit was blocked by the domain. Allow ${LOCALISATION_AUDIT_USER_AGENT_NAME}, then start a new audit before requesting a report email.`,
         );
       }
 

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page-content.test.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page-content.test.ts
@@ -28,6 +28,9 @@ describe("localisation audit page content", () => {
 
     expect(copy.headline).toBe("See how your brand travels.");
     expect(copy.submit).toBe("See my score");
+    expect(copy.crawlAccessNoteHeading).toBe("Site owner note");
+    expect(copy.crawlAccessNoteBody).toContain("firewall");
+    expect(copy.crawlAccessNoteUserAgent).toBe("User agent");
     expect(copy.methodologyHeading).toBe("What we notice");
     expect(copy.notices).toHaveLength(3);
     expect(copy.notices[0]?.title).toBe("Voice");

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page-content.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page-content.ts
@@ -63,6 +63,22 @@ export function getLocalisationAuditPageCopy(locale: string) {
       id: "KigHdi8k7w",
       description: "Hint under the optional focus languages field on the localisation audit form",
     }),
+    crawlAccessNoteHeading: intl.formatMessage({
+      defaultMessage: "Site owner note",
+      id: "9/2rO3b/i4",
+      description: "Heading for the crawl access note on the localisation audit form",
+    }),
+    crawlAccessNoteBody: intl.formatMessage({
+      defaultMessage:
+        "If your site uses a firewall, CDN, bot check, or login wall, allow this user agent to access public pages so we can complete the audit.",
+      id: "ndyP1whnV+",
+      description: "Guidance for site owners to allow the localisation audit crawler",
+    }),
+    crawlAccessNoteUserAgent: intl.formatMessage({
+      defaultMessage: "User agent",
+      id: "gyNaN2JbUy",
+      description: "Label for the localisation audit crawler user agent",
+    }),
     submit: intl.formatMessage({
       defaultMessage: "See my score",
       id: "fZ/p4nukUo",
@@ -327,6 +343,32 @@ export function getLocalisationAuditResultCopy(locale: string) {
       defaultMessage: "The audit could not finish for this domain.",
       id: "dIHTtzU056",
       description: "Fallback error when a failed localisation audit has no error message",
+    }),
+    blockedTitle: intl.formatMessage({
+      defaultMessage: "Audit blocked",
+      id: "fU9GF3etrw",
+      description: "Title when a domain blocks the public localisation audit crawler",
+    }),
+    blockedBody: intl.formatMessage({
+      defaultMessage: "This domain blocked the crawler, so we did not score the site.",
+      id: "i/10E+WnLM",
+      description: "Body explaining that a blocked crawl did not produce a localisation score",
+    }),
+    blockedGuidance: intl.formatMessage({
+      defaultMessage:
+        "Allow the user agent below through your firewall, CDN, bot protection, or login wall, then start a new audit.",
+      id: "FvGsFbmiod",
+      description: "Guidance for a site owner whose domain blocked the localisation audit crawler",
+    }),
+    blockedUserAgent: intl.formatMessage({
+      defaultMessage: "User agent",
+      id: "ryGOjbG4Wd",
+      description: "Label for the blocked localisation audit crawler user agent",
+    }),
+    startNewAudit: intl.formatMessage({
+      defaultMessage: "Start a new audit",
+      id: "k3eu1T7STw",
+      description: "Button to start a fresh localisation audit after a domain block",
     }),
     retry: intl.formatMessage({
       defaultMessage: "Retry audit",

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page.stories.tsx
@@ -43,6 +43,12 @@ export const Default: Story = {
       canvas.getByRole("heading", { name: "See how your brand travels." }),
     ).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "See my score" })).toBeInTheDocument();
+    const crawlNote = canvas.getByRole("complementary", { name: "Site owner note" });
+    await expect(crawlNote).toBeInTheDocument();
+    await expect(crawlNote.closest("section")?.textContent).toContain("What we notice");
+    await expect(
+      canvas.getByText("HyperlocaliseAuditBot/1.0 (+https://hyperlocalise.com)"),
+    ).toBeInTheDocument();
     await expect(canvas.getByRole("heading", { name: "What we notice" })).toBeInTheDocument();
     await expect(
       canvas.getByRole("heading", { name: "How other sites score" }),

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-page.tsx
@@ -15,6 +15,7 @@ import { MarketingFooter } from "@/components/marketing/marketing-footer";
 import { footerColumns } from "@/components/marketing/marketing-page-content";
 import { TypographyH1, TypographyH2, TypographyH3, TypographyP } from "@/components/ui/typography";
 import type { LocalisationAuditLeaderboardEntry } from "@/lib/localisation-audit/store";
+import { LOCALISATION_AUDIT_USER_AGENT } from "@/lib/localisation-audit/user-agent";
 
 import { LocalisationAuditForm } from "./localisation-audit-form";
 import { LocalisationAuditLeaderboard } from "./localisation-audit-leaderboard";
@@ -70,6 +71,24 @@ export function LocalisationAuditPage({ locale, leaderboard }: LocalisationAudit
               </div>
             ))}
           </div>
+          <aside
+            aria-labelledby="localisation-audit-crawl-note"
+            className="mt-12 max-w-2xl space-y-2 rounded-xl border border-border bg-muted/30 p-6 text-sm text-muted-foreground"
+          >
+            <h3
+              id="localisation-audit-crawl-note"
+              className="text-balance font-medium text-foreground"
+            >
+              {copy.crawlAccessNoteHeading}
+            </h3>
+            <p className="text-pretty">{copy.crawlAccessNoteBody}</p>
+            <p className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+              <span>{copy.crawlAccessNoteUserAgent}:</span>
+              <code className="break-all rounded bg-black/10 px-1.5 py-0.5 text-xs text-foreground">
+                {LOCALISATION_AUDIT_USER_AGENT}
+              </code>
+            </p>
+          </aside>
           <TypographyP className="mt-12 max-w-2xl text-muted-foreground">
             {copy.scopeNote}
           </TypographyP>

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-result-page.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-result-page.stories.tsx
@@ -22,6 +22,7 @@ import {
 } from "./localisation-audit-msw-handlers";
 import { LocalisationAuditResultPage } from "./localisation-audit-result-page";
 import {
+  createBlockedAudit,
   createFailedAudit,
   createRunningAudit,
   createSucceededAudit,
@@ -34,6 +35,7 @@ const excellentAudit = createSucceededAudit({ scoreBand: "excellent" });
 const criticalAudit = createSucceededAudit({ scoreBand: "critical" });
 const crawlingAudit = createRunningAudit({ progressStage: "crawling" });
 const failedAudit = createFailedAudit();
+const blockedAudit = createBlockedAudit();
 
 const meta = {
   title: "Marketing/LocalisationAudit/Result",
@@ -172,5 +174,18 @@ export const FailedRetryable: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("heading", { name: "Audit failed" })).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Retry audit" })).toBeInTheDocument();
+  },
+};
+
+export const BlockedByDomain: Story = {
+  args: {
+    audit: blockedAudit,
+    standing: null,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Audit blocked" })).toBeInTheDocument();
+    await expect(canvas.getByText(/HyperlocaliseAuditBot\/1\.0/)).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: "Start a new audit" })).toBeInTheDocument();
+    await expect(canvas.queryByRole("button", { name: "Retry audit" })).not.toBeInTheDocument();
   },
 };

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-result.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-result.tsx
@@ -34,6 +34,7 @@ import {
   type LocalisationAuditCriterion,
 } from "@/lib/localisation-audit/criteria";
 import { sanitizeLocalisationAuditFindingUrl } from "@/lib/localisation-audit/finding-url";
+import { LOCALISATION_AUDIT_USER_AGENT } from "@/lib/localisation-audit/user-agent";
 import {
   formatDimensionScore,
   scoreTone,
@@ -653,7 +654,7 @@ export function LocalisationAuditResult({
   }, [audit.score, audit.status]);
 
   useEffect(() => {
-    if (audit.status === "succeeded" || audit.status === "failed") {
+    if (audit.status === "succeeded" || audit.status === "failed" || audit.status === "blocked") {
       return;
     }
 
@@ -828,6 +829,30 @@ export function LocalisationAuditResult({
           disabled={rerunPending}
         >
           {rerunPending ? copy.retrying : copy.retry}
+        </Button>
+      </MeshWash>
+    );
+  }
+
+  if (audit.status === "blocked") {
+    return (
+      <MeshWash>
+        <TypographyH1 className="border-none text-white">{copy.blockedTitle}</TypographyH1>
+        <TypographyP className="mt-4 max-w-2xl text-lg text-white/80">
+          {copy.blockedBody}
+        </TypographyP>
+        <TypographyP className="mt-2 max-w-2xl text-white/70">{copy.blockedGuidance}</TypographyP>
+        <p className="mt-5 max-w-2xl text-sm text-white/75">
+          <span className="text-white/55">{copy.blockedUserAgent}: </span>
+          <code className="break-all text-white">{LOCALISATION_AUDIT_USER_AGENT}</code>
+        </p>
+        {error ? <p className="mt-4 text-sm text-red-200">{error}</p> : null}
+        <Button
+          nativeButton={false}
+          render={<Link href={`/${locale}/localisation-audit`} />}
+          className="mt-8 bg-white text-black hover:bg-white/90"
+        >
+          {copy.startNewAudit}
         </Button>
       </MeshWash>
     );

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit.fixture.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit.fixture.ts
@@ -502,3 +502,24 @@ export function createFailedAudit({
     completedAt: null,
   };
 }
+
+export function createBlockedAudit(): LocalisationAuditStoryAudit {
+  return {
+    id: localisationAuditId,
+    domainKey: localisationAuditDomainKey,
+    domainSlug: localisationAuditDomainSlug,
+    sourceUrl: localisationAuditSourceUrl,
+    status: "blocked",
+    attemptNumber: 2,
+    progressStage: "blocked",
+    score: null,
+    teaser: null,
+    report: null,
+    unlocked: false,
+    retryable: false,
+    rerunnable: false,
+    errorCode: "crawl_blocked",
+    errorMessage: "This domain blocked HyperlocaliseAuditBot/1.0.",
+    completedAt: null,
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/analytics/events.ts
+++ b/apps/hyperlocalise-web/src/lib/analytics/events.ts
@@ -20,6 +20,7 @@ export const LOCALISATION_AUDIT_ANALYTICS_EVENTS = {
   retry: "localisation_audit_retry",
   completed: "localisation_audit_completed",
   failed: "localisation_audit_failed",
+  blocked: "localisation_audit_blocked",
   teaserView: "localisation_audit_teaser_view",
   reportEmailRequest: "localisation_audit_report_email_request",
   reportEmailSent: "localisation_audit_report_email_sent",

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/crawl-block.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/crawl-block.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { detectLocalisationAuditCrawlBlock } from "./crawl-block";
+
+describe("detectLocalisationAuditCrawlBlock", () => {
+  it.each([
+    [401, "<html><body>Unauthorized</body></html>"],
+    [403, "<html><body>Forbidden</body></html>"],
+    [429, "<html><body>Too many requests</body></html>"],
+  ])("detects access-denied status %s", (status, html) => {
+    expect(detectLocalisationAuditCrawlBlock(status, html)).toBe("bot_protection");
+  });
+
+  it("detects a bot challenge served with a successful status", () => {
+    expect(
+      detectLocalisationAuditCrawlBlock(
+        200,
+        "<html><title>Just a moment...</title><body>Checking your browser before accessing.</body></html>",
+      ),
+    ).toBe("bot_protection");
+  });
+
+  it("does not classify normal content or generic server errors as bot protection", () => {
+    expect(
+      detectLocalisationAuditCrawlBlock(
+        200,
+        "<html><title>Welcome</title><body>Our global product helps teams localize.</body></html>",
+      ),
+    ).toBeNull();
+    expect(
+      detectLocalisationAuditCrawlBlock(503, "<html><body>Temporarily unavailable</body></html>"),
+    ).toBeNull();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/crawl-block.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/crawl-block.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { LocalisationAuditCrawlBlockReason } from "./types";
+
+const ACCESS_DENIED_STATUS_CODES = new Set([401, 403, 429]);
+const BOT_CHALLENGE_MARKERS = [
+  /access\s+denied/i,
+  /request\s+blocked/i,
+  /bot\s+(?:detected|traffic)/i,
+  /(?:verify|confirm)\s+you(?:'re| are)\s+(?:a\s+)?human/i,
+  /checking\s+your\s+browser/i,
+  /enable\s+(?:javascript|js)\s+and\s+cookies/i,
+  /unusual\s+traffic/i,
+  /security\s+(?:check|challenge)\s+(?:required|in\s+progress|to\s+continue)/i,
+  /(?:solve|complete|verify).{0,40}captcha/i,
+  /captcha.{0,40}(?:challenge|verify|human)/i,
+  /(?:challenge-platform|cf-chl-)/i,
+  /just\s+a\s+moment/i,
+];
+
+export function detectLocalisationAuditCrawlBlock(
+  status: number,
+  html: string,
+): LocalisationAuditCrawlBlockReason | null {
+  if (ACCESS_DENIED_STATUS_CODES.has(status)) {
+    return "bot_protection";
+  }
+
+  if (BOT_CHALLENGE_MARKERS.some((marker) => marker.test(html))) {
+    return "bot_protection";
+  }
+
+  return null;
+}

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.test.ts
@@ -103,6 +103,24 @@ describe("crawlLocalisationAuditSample", () => {
     ).toBe(true);
   });
 
+  it("returns a blocked result when the homepage denies the crawler", async () => {
+    const { createRenderer } = mockBrowser([
+      htmlPage(
+        "https://example.com/",
+        "<html><title>Access denied</title><body>Request blocked.</body></html>",
+        { status: 403 },
+      ),
+    ]);
+
+    const result = await crawlLocalisationAuditSample(
+      { origin: "https://example.com", sourceUrl: "https://example.com/" },
+      { createRenderer },
+    );
+
+    expect(result.pages).toEqual([]);
+    expect(result.blockedReason).toBe("bot_protection");
+  });
+
   it("follows a rendered homepage redirect and crawls the final URL", async () => {
     const { createRenderer } = mockBrowser([
       htmlPage(

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/crawl.ts
@@ -14,8 +14,10 @@ import { readBoundedResponseBody, withPublicHttpFetch } from "@/lib/security/pub
 
 import type { CrawlLocalisationAuditSampleOptions, HtmlPageRenderer } from "./crawl-renderer";
 import { LOCALE_PREFIX, pathLocaleFromUrl, resolveFocusLocaleCode } from "./credits/shared";
+import { detectLocalisationAuditCrawlBlock } from "./crawl-block";
 import { crawledPageFromSignals, parsePageSignals } from "./html-parse";
 import { AuditBrowserSetupError } from "./sandbox-browser-error";
+import { LOCALISATION_AUDIT_USER_AGENT } from "./user-agent";
 import type {
   LocalisationAuditCrawledPage,
   LocalisationAuditCrawlResult,
@@ -29,14 +31,13 @@ export type {
   RenderedHtmlPage,
 } from "./crawl-renderer";
 
-const USER_AGENT = "HyperlocaliseLocalisationAudit/1.0 (+https://hyperlocalise.com)";
 const MAX_PAGES = 15;
 const FETCH_TIMEOUT_MS = 12_000;
 const MAX_REDIRECTS = 5;
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
 const FETCH_TEXT_HEADERS: Record<string, string> = {
-  "User-Agent": USER_AGENT,
+  "User-Agent": LOCALISATION_AUDIT_USER_AGENT,
   Accept: "text/plain,application/xml,text/xml,application/xhtml+xml;q=0.9,*/*;q=0.1",
 };
 
@@ -303,6 +304,18 @@ async function crawlLocalisationAuditSampleInner(
       return { pages: [], sitemap: EMPTY_SITEMAP_SIGNAL };
     }
 
+    const homeBlockedReason = detectLocalisationAuditCrawlBlock(
+      homeRendered.status,
+      homeRendered.html,
+    );
+    if (homeBlockedReason) {
+      return {
+        pages: [],
+        sitemap: EMPTY_SITEMAP_SIGNAL,
+        blockedReason: homeBlockedReason,
+      };
+    }
+
     const homePage = pageFromRendered(homeRendered.html, homeRendered.url, homeRendered.status);
     const signals = parsePageSignals(homeRendered.html);
     const originHost = new URL(input.origin).hostname;
@@ -339,6 +352,16 @@ async function crawlLocalisationAuditSampleInner(
       otherUrls.length > 0 ? renderer.render(otherUrls) : Promise.resolve([]),
       fetchSitemapSignals(input.origin),
     ]);
+
+    const blockedReason = otherRendered
+      .map((rendered) => detectLocalisationAuditCrawlBlock(rendered.status, rendered.html))
+      .find(
+        (reason): reason is NonNullable<LocalisationAuditCrawlResult["blockedReason"]> =>
+          reason != null,
+      );
+    if (blockedReason) {
+      return { pages: [], sitemap, blockedReason };
+    }
 
     const pagesByUrl = new Map<string, LocalisationAuditCrawledPage>();
     pagesByUrl.set(homePage.url, homePage);

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/sandbox-browser.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/sandbox-browser.test.ts
@@ -87,7 +87,7 @@ describe("audit Playwright script", () => {
     expect(script).toContain('waitForLoadState("networkidle"');
     expect(script).toContain("page.route");
     expect(script).toContain("isBlockedNavigationUrl");
-    expect(script).toContain("HyperlocaliseLocalisationAudit/1.0");
+    expect(script).toContain("HyperlocaliseAuditBot/1.0 (+https://hyperlocalise.com)");
     expect(script).toContain("isBlockedIpv4Address");
     expect(script).toContain("isBlockedIpv6Address");
     expect(script).toContain('hostname.startsWith("::ffff:")');

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/sandbox-browser.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/sandbox-browser.ts
@@ -22,12 +22,12 @@ import { createConfiguredVercelSandbox } from "@/lib/vercel-sandbox-config";
 
 import type { HtmlPageRenderer, RenderedHtmlPage } from "./crawl-renderer";
 import { AuditBrowserSetupError } from "./sandbox-browser-error";
+import { LOCALISATION_AUDIT_USER_AGENT } from "./user-agent";
 
 export { AuditBrowserSetupError } from "./sandbox-browser-error";
 
 export const AUDIT_BROWSER_SANDBOX_TIMEOUT_MS = 10 * 60 * 1000;
-export const AUDIT_BROWSER_USER_AGENT =
-  "HyperlocaliseLocalisationAudit/1.0 (+https://hyperlocalise.com)";
+export const AUDIT_BROWSER_USER_AGENT = LOCALISATION_AUDIT_USER_AGENT;
 export const AUDIT_BROWSER_NAV_TIMEOUT_MS = 20_000;
 export const AUDIT_BROWSER_NETWORKIDLE_TIMEOUT_MS = 4_000;
 export const AUDIT_BROWSER_SETTLE_MS = 400;

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/store.retry-window.test.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/store.retry-window.test.ts
@@ -77,6 +77,20 @@ describe("localisation audit daily re-run window", () => {
     expect(localisationAuditRerunAvailableAt(audit({ status: "failed", report: null }))).toBeNull();
   });
 
+  it("keeps blocked audits terminal until a new audit is claimed", () => {
+    const blocked = audit({
+      status: "blocked",
+      progressStage: "blocked",
+      score: null,
+      teaser: null,
+      report: null,
+    });
+
+    expect(isLocalisationAuditRetryable(blocked)).toBe(false);
+    expect(isLocalisationAuditRerunnable(blocked)).toBe(false);
+    expect(localisationAuditRerunAvailableAt(blocked)).toBeNull();
+  });
+
   it("counts first runs and aged re-runs toward the daily cap, not same-day retries", () => {
     expect(localisationAuditRunConsumesDailyQuota(null)).toBe(true);
     expect(localisationAuditRunConsumesDailyQuota(new Date())).toBe(false);

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/store.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/store.ts
@@ -403,6 +403,7 @@ export async function claimOrReuseLocalisationAudit(input: {
                   dailyRerunCutoff,
                 ),
               ),
+              eq(schema.localisationAudits.status, "blocked"),
               and(
                 inArray(schema.localisationAudits.status, ["queued", "running"]),
                 lt(schema.localisationAudits.statusUpdatedAt, staleCutoff),
@@ -547,6 +548,33 @@ export async function completeLocalisationAudit(input: {
       statusUpdatedAt: timestamp,
       errorCode: null,
       errorMessage: null,
+    })
+    .where(
+      and(
+        eq(schema.localisationAudits.id, input.auditId),
+        eq(schema.localisationAudits.attemptNumber, input.attemptNumber),
+      ),
+    )
+    .returning();
+  return row ?? null;
+}
+
+export async function blockLocalisationAudit(input: {
+  auditId: string;
+  attemptNumber: number;
+  errorCode: string;
+  errorMessage: string;
+}) {
+  const timestamp = now();
+  const [row] = await db
+    .update(schema.localisationAudits)
+    .set({
+      status: "blocked" satisfies LocalisationAuditStatus,
+      progressStage: "blocked" satisfies LocalisationAuditProgressStage,
+      errorCode: input.errorCode,
+      errorMessage: input.errorMessage,
+      completedAt: timestamp,
+      statusUpdatedAt: timestamp,
     })
     .where(
       and(

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/types.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/types.ts
@@ -11,7 +11,7 @@
  * Version 2.0 or later.
  */
 
-export type LocalisationAuditStatus = "queued" | "running" | "succeeded" | "failed";
+export type LocalisationAuditStatus = "queued" | "running" | "succeeded" | "failed" | "blocked";
 
 export type LocalisationAuditProgressStage =
   | "queued"
@@ -20,7 +20,8 @@ export type LocalisationAuditProgressStage =
   | "analyzing"
   | "scoring"
   | "completed"
-  | "failed";
+  | "failed"
+  | "blocked";
 
 /** `warning` is a legacy stored-report value; treat it as `high`. */
 export type LocalisationAuditFindingSeverity =
@@ -116,9 +117,12 @@ export type LocalisationAuditSitemapSignal = {
   localizedUrls: string[];
 };
 
+export type LocalisationAuditCrawlBlockReason = "bot_protection";
+
 export type LocalisationAuditCrawlResult = {
   pages: LocalisationAuditCrawledPage[];
   sitemap: LocalisationAuditSitemapSignal;
+  blockedReason?: LocalisationAuditCrawlBlockReason;
 };
 
 export type LocalisationAuditCreditMethod = "heuristic" | "luna" | "na";

--- a/apps/hyperlocalise-web/src/lib/localisation-audit/user-agent.ts
+++ b/apps/hyperlocalise-web/src/lib/localisation-audit/user-agent.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+export const LOCALISATION_AUDIT_USER_AGENT_NAME = "HyperlocaliseAuditBot/1.0";
+export const LOCALISATION_AUDIT_USER_AGENT = `${LOCALISATION_AUDIT_USER_AGENT_NAME} (+https://hyperlocalise.com)`;

--- a/apps/hyperlocalise-web/src/workflows/localisation-audit.ts
+++ b/apps/hyperlocalise-web/src/workflows/localisation-audit.ts
@@ -79,6 +79,7 @@ export async function localisationAuditWorkflow(event: LocalisationAuditEventDat
         focusLocales: prepared.focusLocales,
         pages: crawl.pages,
         sitemap: crawl.sitemap,
+        blockedReason: crawl.blockedReason,
       });
 
       if (!analyzedResult.ok) {

--- a/apps/hyperlocalise-web/src/workflows/steps/localisation-audit.analyze.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/localisation-audit.analyze.test.ts
@@ -14,6 +14,7 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const {
   buildProfileMock,
+  blockMock,
   completeMock,
   creditsMock,
   failMock,
@@ -23,6 +24,7 @@ const {
   trackMock,
 } = vi.hoisted(() => ({
   buildProfileMock: vi.fn(),
+  blockMock: vi.fn(),
   completeMock: vi.fn(),
   creditsMock: vi.fn(),
   failMock: vi.fn(),
@@ -49,6 +51,7 @@ vi.mock("@/lib/localisation-audit/credits/runner", () => ({
 }));
 
 vi.mock("@/lib/localisation-audit/store", () => ({
+  blockLocalisationAudit: blockMock,
   completeLocalisationAudit: completeMock,
   failLocalisationAudit: failMock,
   findLocalisationAuditById: findAuditMock,
@@ -86,6 +89,7 @@ const pages = [
 describe("analyzeLocalisationAuditStep company profile", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    blockMock.mockResolvedValue({ id: "audit-1", status: "blocked" });
     buildProfileMock.mockResolvedValue(inferredProfile);
     completeMock.mockResolvedValue({ id: "audit-1" });
     creditsMock.mockResolvedValue({
@@ -227,5 +231,30 @@ describe("analyzeLocalisationAuditStep company profile", () => {
 
     expect(patchProfileMock).not.toHaveBeenCalled();
     expect(completeMock.mock.calls[0]?.[0].report.companyProfile).toEqual(inferredProfile);
+  });
+
+  it("blocks the audit before profile inference or scoring when the domain blocks the crawl", async () => {
+    const result = await analyzeLocalisationAuditStep({
+      auditId: "audit-1",
+      attemptNumber: 2,
+      domainKey: "acme.example",
+      domainSlug: "acme-example",
+      sourceUrl: "https://acme.example/",
+      focusLocales: [],
+      pages: [],
+      sitemap: EMPTY_SITEMAP_SIGNAL,
+      blockedReason: "bot_protection",
+    });
+
+    expect(result).toEqual({ ok: false, code: "localisation_audit_blocked" });
+    expect(blockMock).toHaveBeenCalledWith({
+      auditId: "audit-1",
+      attemptNumber: 2,
+      errorCode: "crawl_blocked",
+      errorMessage: expect.stringContaining("HyperlocaliseAuditBot/1.0"),
+    });
+    expect(buildProfileMock).not.toHaveBeenCalled();
+    expect(creditsMock).not.toHaveBeenCalled();
+    expect(completeMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/hyperlocalise-web/src/workflows/steps/localisation-audit.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/localisation-audit.ts
@@ -23,7 +23,9 @@ import {
   aggregateLocalisationAuditCredits,
   pickHeadlineFindings,
 } from "@/lib/localisation-audit/score";
+import { LOCALISATION_AUDIT_USER_AGENT_NAME } from "@/lib/localisation-audit/user-agent";
 import {
+  blockLocalisationAudit,
   completeLocalisationAudit,
   failLocalisationAudit,
   findLocalisationAuditById,
@@ -128,8 +130,26 @@ export async function analyzeLocalisationAuditStep(input: {
   focusLocales: string[];
   pages: LocalisationAuditCrawlResult["pages"];
   sitemap: LocalisationAuditCrawlResult["sitemap"];
+  blockedReason?: LocalisationAuditCrawlResult["blockedReason"];
 }) {
   "use step";
+
+  if (input.blockedReason) {
+    const blocked = await blockLocalisationAudit({
+      auditId: input.auditId,
+      attemptNumber: input.attemptNumber,
+      errorCode: "crawl_blocked",
+      errorMessage: `This domain blocked ${LOCALISATION_AUDIT_USER_AGENT_NAME}. Allow it through your firewall, CDN, bot protection, or login wall, then start a new audit.`,
+    });
+    if (!blocked) {
+      return { ok: false as const, code: "stale_attempt" as const };
+    }
+    serverAnalytics.track(LOCALISATION_AUDIT_ANALYTICS_EVENTS.blocked, {
+      status: "blocked",
+      outcome: input.blockedReason,
+    });
+    return { ok: false as const, code: "localisation_audit_blocked" as const };
+  }
 
   if (input.pages.length === 0) {
     await failLocalisationAudit({

--- a/docs/adr/2026-08-17-localisation-audit-blocked-domain-design.md
+++ b/docs/adr/2026-08-17-localisation-audit-blocked-domain-design.md
@@ -1,0 +1,51 @@
+# Block localisation audits when domains reject the crawler
+
+## Summary
+
+Detect common bot-protection responses during the homepage crawl and persist a
+terminal `blocked` audit instead of scoring a challenge or access-denied page.
+The result tells the site owner to allow `HyperlocaliseAuditBot/1.0`, and a new
+audit submission can start a fresh attempt after the owner changes the site
+rules.
+
+## Decision
+
+Add `blocked` to the localisation audit status and `blocked` to the progress
+stage. A blocked attempt is not retryable and never enters the scoring,
+completion, leaderboard, or report-email paths.
+
+Use conservative detection at the homepage boundary:
+
+- Treat HTTP `401`, `403`, and `429` responses as blocked.
+- Treat challenge pages as blocked when their HTML contains recognizable
+  access-control or bot-challenge language, including CAPTCHA, Cloudflare
+  challenge markers, “verify you are human”, “access denied”, and “request
+  blocked”.
+- Leave ordinary timeouts, connection failures, and unrelated `5xx` responses
+  as failed so they retain the existing retry behavior.
+
+## Flow
+
+1. The crawl returns an optional `blockedReason` before parsing pages for
+   scoring.
+2. The analysis step calls `blockLocalisationAudit` and returns a non-success
+   result without building a company profile or running credits.
+3. The workflow stops without queueing pending report emails.
+4. Public API responses expose `status: "blocked"`, no retryable flag, and the
+   stored owner-facing message. Unlock requests for blocked audits are rejected.
+5. A new POST for the same domain may reclaim the blocked row and create a new
+   attempt; a blocked audit is never automatically retried.
+
+## UI
+
+Render a dedicated blocked state instead of the score report or failed-retry
+state. Explain that the domain blocked Hyperlocalise's crawler, show the
+allow-list identity, and provide a link to start a new audit. Do not offer a
+retry button on the blocked result.
+
+## Verification
+
+Cover status and challenge-content detection, crawl propagation, analysis
+short-circuiting, blocked persistence, blocked email rejection, reclaiming only
+through a new submission, and the blocked result Storybook state. Run the
+focused audit tests and the web app's `vp check --fix` command.

--- a/docs/adr/2026-08-17-localisation-audit-crawl-note-design.md
+++ b/docs/adr/2026-08-17-localisation-audit-crawl-note-design.md
@@ -1,0 +1,45 @@
+# Localisation audit crawl access note
+
+## Summary
+
+Show a short owner-facing note in the public localisation audit page's “What we
+notice” section so a site owner can allow Hyperlocalise through a firewall, CDN,
+bot check, or login wall. Rename the crawler identity to the product-ready
+`HyperlocaliseAuditBot/1.0 (+https://hyperlocalise.com)` and use the same value in
+the note.
+
+## Decision
+
+Place a semantic note directly below the three methodology cards in the “What
+we notice” section. The note is informational and does not add a step, change
+the audit API, or change crawl permissions. The form remains focused on URL and
+language inputs and submission.
+
+The note will use concise localized copy:
+
+- Heading: `Site owner note`
+- Body: `If your site is behind a firewall, CDN, bot check, or login wall, allow
+  HyperlocaliseAuditBot/1.0 to access public pages so we can complete the
+  audit.`
+
+The existing scope copy remains the source of truth for the audit boundary: only
+public pages are read, and the crawler never signs in or fills in forms.
+
+## Implementation
+
+1. Change the crawl module's shared `User-Agent` value to
+   `HyperlocaliseAuditBot/1.0 (+https://hyperlocalise.com)`.
+2. Add localized messages for the owner-note heading, body, and user-agent label.
+3. Render the messages in an accessible `<aside>` below the methodology cards,
+   using existing Tailwind theme tokens.
+4. Update the landing-page Storybook interaction to assert that the note and
+   product-ready user-agent name are visible in the methodology section.
+
+No database, API, auth, robots, or crawler control-flow changes are required.
+
+## Verification
+
+Run the localisation-audit component tests and Storybook checks through the
+web app's required `vp test` and `vp check --fix` commands. Also search the
+repository to confirm the old crawler identity is gone and the new identity is
+used consistently in the crawl implementation and owner-facing copy.


### PR DESCRIPTION
## Summary

- Use the product-ready HyperlocaliseAuditBot/1.0 user agent for browser and text crawls.
- Show site-owner crawl access guidance in the landing page's What we notice section.
- Detect bot protection, persist blocked as a terminal audit state, and skip profile inference, credits, scoring, reports, emails, and leaderboard publication.
- Provide a blocked result with exact user-agent guidance and a Start a new audit CTA.

## Validation

- Focused web tests: 43 passed.
- vp check --fix: 0 errors; 4 existing warnings remain outside this change.
- Full vp test: local Postgres and app services were unavailable in this environment, causing unrelated integration failures.