### PR TITLE
feat(cat): support Crowdin bulk hide in CAT

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -45,6 +45,7 @@ const {
   getTmsProviderLiveCatFileMock,
   getTmsProviderLiveCatAllFilesMock,
   saveTmsProviderLiveCatTranslationMock,
+  setTmsProviderLiveCatStringsHiddenMock,
   saveTmsProviderLiveCatCommentMock,
   resolveTmsProviderLiveCatCommentMock,
   loadCatSegmentConcordanceMock,
@@ -59,6 +60,7 @@ const {
   getTmsProviderLiveCatFileMock: vi.fn(),
   getTmsProviderLiveCatAllFilesMock: vi.fn(),
   saveTmsProviderLiveCatTranslationMock: vi.fn(),
+  setTmsProviderLiveCatStringsHiddenMock: vi.fn(),
   saveTmsProviderLiveCatCommentMock: vi.fn(),
   resolveTmsProviderLiveCatCommentMock: vi.fn(),
   loadCatSegmentConcordanceMock: vi.fn(),
@@ -105,6 +107,8 @@ vi.mock("@/lib/providers/jobs/tms-provider-live", async (importOriginal) => {
       getTmsProviderLiveCatAllFilesMock(...args),
     saveTmsProviderLiveCatTranslation: (...args: unknown[]) =>
       saveTmsProviderLiveCatTranslationMock(...args),
+    setTmsProviderLiveCatStringsHidden: (...args: unknown[]) =>
+      setTmsProviderLiveCatStringsHiddenMock(...args),
     saveTmsProviderLiveCatComment: (...args: unknown[]) =>
       saveTmsProviderLiveCatCommentMock(...args),
     resolveTmsProviderLiveCatComment: (...args: unknown[]) =>
@@ -2206,13 +2210,17 @@ describe("project file CAT routes", () => {
     ]);
   });
 
-  it("rejects hidden-string updates for external TMS projects", async () => {
+  it("hides Crowdin CAT strings for users with write-back permission", async () => {
     const translator = projectFixture.createWorkosIdentityWithRole("translator");
     getTmsProviderConnectionMock.mockResolvedValue({
       providerKind: "crowdin",
       displayName: "Crowdin",
       validationStatus: "valid",
       validationMessage: null,
+    });
+    setTmsProviderLiveCatStringsHiddenMock.mockResolvedValue({
+      updatedCount: 2,
+      isHidden: true,
     });
 
     const response = await client.api.orgs[":organizationSlug"].projects[
@@ -2225,6 +2233,66 @@ describe("project file CAT routes", () => {
         },
         json: {
           sourcePath: "crowdin/home.json",
+          externalStringIds: ["1001", "1002"],
+          isHidden: true,
+        },
+      },
+      { headers: await projectFixture.authHeadersFor(translator) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ updatedCount: 2, isHidden: true });
+    expect(setTmsProviderLiveCatStringsHiddenMock).toHaveBeenCalledWith(
+      expect.any(String),
+      "42",
+      { externalStringIds: ["1001", "1002"], isHidden: true },
+      expect.objectContaining({ actorUserId: expect.any(String) }),
+    );
+  });
+
+  it("denies CAT hidden-string updates without write-back permission", async () => {
+    const member = projectFixture.createWorkosIdentityWithRole("member");
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.strings.hidden.$post(
+      {
+        param: {
+          organizationSlug: member.organization.slug ?? "missing-slug",
+          projectId: "ext:crowdin:42",
+        },
+        json: {
+          sourcePath: "crowdin/home.json",
+          externalStringIds: ["1001"],
+          isHidden: true,
+        },
+      },
+      { headers: await projectFixture.authHeadersFor(member) },
+    );
+
+    expect(response.status).toBe(403);
+    expect(setTmsProviderLiveCatStringsHiddenMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects CAT hidden-string updates for non-Crowdin providers", async () => {
+    const translator = projectFixture.createWorkosIdentityWithRole("translator");
+    getTmsProviderConnectionMock.mockResolvedValue({
+      providerKind: "phrase",
+      displayName: "Phrase",
+      validationStatus: "valid",
+      validationMessage: null,
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.strings.hidden.$post(
+      {
+        param: {
+          organizationSlug: translator.organization.slug ?? "missing-slug",
+          projectId: "ext:phrase:42",
+        },
+        json: {
+          sourcePath: "phrase/home.json",
           externalStringIds: ["1001"],
           isHidden: true,
         },
@@ -2234,5 +2302,6 @@ describe("project file CAT routes", () => {
 
     expect(response.status).toBe(400);
     expect(await response.json()).toMatchObject({ error: "provider_cat_unsupported" });
+    expect(setTmsProviderLiveCatStringsHiddenMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -60,6 +60,7 @@ import {
   listTmsProviderLiveProjectBranches,
   saveTmsProviderLiveCatTranslation,
   saveTmsProviderLiveCatComment,
+  setTmsProviderLiveCatStringsHidden,
   resolveTmsProviderLiveCatComment,
 } from "@/lib/providers/jobs/tms-provider-live";
 import { listOrganizationProjects } from "@/lib/projects/organization/organization-project-service";
@@ -1627,11 +1628,35 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         }
 
         if (target.kind === "provider") {
-          return badRequestResponse(
-            c,
-            "provider_cat_unsupported",
-            "Hidden strings can only be updated for workspace files.",
-          );
+          if (target.providerKind !== "crowdin") {
+            return badRequestResponse(
+              c,
+              "provider_cat_unsupported",
+              "Hidden strings can only be updated for Crowdin CAT.",
+            );
+          }
+
+          try {
+            const result = await setTmsProviderLiveCatStringsHidden(
+              c.var.auth.organization.localOrganizationId,
+              target.externalProjectId,
+              {
+                externalStringIds: body.externalStringIds,
+                isHidden: body.isHidden,
+              },
+              { actorUserId: c.var.auth.user.localUserId },
+            );
+
+            return c.json(
+              {
+                updatedCount: result.updatedCount,
+                isHidden: result.isHidden,
+              },
+              200,
+            );
+          } catch (error) {
+            return tmsProviderLiveErrorResponse(c, error);
+          }
         }
 
         const project = await getOwnedProject(c.var.auth, params.projectId);

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -321,7 +321,10 @@ export const maxCatHiddenStringBatch = maxNativeCatHiddenStringBatch;
 
 export const projectFileCatHiddenStringsBodySchema = z.object({
   sourcePath: z.string().trim().min(1).max(2048),
-  externalStringIds: z.array(z.string().trim().min(1).max(128)).min(1).max(maxNativeCatHiddenStringBatch),
+  externalStringIds: z
+    .array(z.string().trim().min(1).max(128))
+    .min(1)
+    .max(maxNativeCatHiddenStringBatch),
   isHidden: z.boolean(),
 });
 

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -317,6 +317,7 @@ export const projectFileCatStatusBodySchema = z.object({
 });
 
 export const maxNativeCatHiddenStringBatch = 200;
+export const maxCatHiddenStringBatch = maxNativeCatHiddenStringBatch;
 
 export const projectFileCatHiddenStringsBodySchema = z.object({
   sourcePath: z.string().trim().min(1).max(2048),

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -321,10 +321,7 @@ export const maxCatHiddenStringBatch = maxNativeCatHiddenStringBatch;
 
 export const projectFileCatHiddenStringsBodySchema = z.object({
   sourcePath: z.string().trim().min(1).max(2048),
-  externalStringIds: z
-    .array(z.string().trim().min(1).max(128))
-    .min(1)
-    .max(maxNativeCatHiddenStringBatch),
+  externalStringIds: z.array(z.string().trim().min(1).max(128)).min(1).max(maxNativeCatHiddenStringBatch),
   isHidden: z.boolean(),
 });
 

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
@@ -443,26 +443,28 @@ export function ProjectFileCatWorkspace({
         );
       }
 
-      const translationKeyIds = segmentIds.filter((segmentId) => {
-        const segment = catFile.segments.find((item) => item.externalStringId === segmentId);
-        return (
-          resolveCatLinkedIssueTranslationKeyId({
-            isNativeProject: true,
-            segmentId,
-            contentKind: segment?.contentKind,
-          }) != null
-        );
-      });
-      if (translationKeyIds.length === 0) {
+      const externalStringIds = isNativeProject
+        ? segmentIds.filter((segmentId) => {
+            const segment = catFile.segments.find((item) => item.externalStringId === segmentId);
+            return (
+              resolveCatLinkedIssueTranslationKeyId({
+                isNativeProject: true,
+                segmentId,
+                contentKind: segment?.contentKind,
+              }) != null
+            );
+          })
+        : segmentIds;
+      if (externalStringIds.length === 0) {
         return;
       }
 
       await setStringsHidden({
-        externalStringIds: translationKeyIds,
+        externalStringIds,
         isHidden,
       });
     },
-    [catFile?.canEditTranslations, catFile?.segments, intl, setStringsHidden],
+    [catFile?.canEditTranslations, catFile?.segments, intl, isNativeProject, setStringsHidden],
   );
 
   const handleAddToIssueSheet = useCallback(
@@ -798,7 +800,7 @@ export function ProjectFileCatWorkspace({
           onAddToIssueSheet: handleAddToIssueSheet,
           onResolveComment:
             catFile?.provider?.kind === "crowdin" ? handleResolveComment : undefined,
-          ...(canHideNativeStrings
+          ...(canHideNativeStrings || catFile?.provider?.kind === "crowdin"
             ? {
                 onBulkHide: (segmentIds: string[]) => handleSetStringsHidden(segmentIds, true),
                 onBulkUnhide: (segmentIds: string[]) => handleSetStringsHidden(segmentIds, false),

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.test.tsx
@@ -262,6 +262,51 @@ describe("useCatMutations", () => {
     expect(invalidateSegmentCommentsMock).toHaveBeenCalled();
   });
 
+  it("hides strings and invalidates the queue on success", async () => {
+    catStringsHiddenPostMock.mockResolvedValue(jsonResponse({ updatedCount: 2, isHidden: true }));
+
+    const { result } = renderCatMutations();
+
+    await act(async () => {
+      const saved = await result.current.setStringsHidden({
+        externalStringIds: ["segment-1", "segment-2"],
+        isHidden: true,
+      });
+      expect(saved).toEqual({ updatedCount: 2, isHidden: true });
+    });
+
+    expect(catStringsHiddenPostMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        json: expect.objectContaining({
+          sourcePath: catApiTestContext.sourcePath,
+          externalStringIds: ["segment-1", "segment-2"],
+          isHidden: true,
+        }),
+      }),
+    );
+    expect(invalidateQueue).toHaveBeenCalled();
+  });
+
+  it("surfaces API errors when hiding strings fails", async () => {
+    catStringsHiddenPostMock.mockResolvedValue(
+      errorResponse(
+        "crowdin_hidden_strings_forbidden",
+        "Crowdin did not allow updating hidden strings.",
+        400,
+      ),
+    );
+
+    const { result } = renderCatMutations();
+
+    await expect(
+      result.current.setStringsHidden({
+        externalStringIds: ["segment-1"],
+        isHidden: true,
+      }),
+    ).rejects.toThrow("Crowdin did not allow updating hidden strings.");
+    expect(invalidateQueue).not.toHaveBeenCalled();
+  });
+
   it("omits externalResourceId for native projects without a provider", async () => {
     const translation = createCatTranslation();
     catTranslationsPostMock.mockResolvedValue(jsonResponse({ translation }));

--- a/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-filter.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-filter.test.ts
@@ -124,12 +124,20 @@ describe("segmentMatchesQueueFilter", () => {
 
     expect(filterCatQueueSegments(segments, "hidden").map((segment) => segment.id)).toEqual(["a"]);
   });
+
+  it("matches hidden source strings", () => {
+    expect(segmentMatchesQueueFilter(createSegment({ isHidden: true }), "hidden")).toBe(true);
+    expect(segmentMatchesQueueFilter(createSegment(), "hidden")).toBe(false);
+  });
 });
 
 describe("resolveAvailableCatQueueFilters", () => {
-  it("includes hidden for native projects only", () => {
+  it("includes hidden for native and Crowdin projects", () => {
     expect(resolveAvailableCatQueueFilters(null)).toContain("hidden");
-    expect(resolveAvailableCatQueueFilters("crowdin")).not.toContain("hidden");
+    expect(resolveAvailableCatQueueFilters("crowdin")).toContain("hidden");
+    expect(resolveAvailableCatQueueFilters("phrase")).not.toContain("hidden");
+    expect(resolveAvailableCatQueueFilters("lokalise")).not.toContain("hidden");
+    expect(resolveAvailableCatQueueFilters("smartling")).not.toContain("hidden");
   });
 
   it("includes has issues for Crowdin projects", () => {

--- a/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-filter.ts
+++ b/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-filter.ts
@@ -41,7 +41,7 @@ export function isQueueFilterSupportedForProvider(
   providerKind: string | null | undefined,
 ) {
   if (filter === "hidden") {
-    return providerKind == null || providerKind === "native";
+    return providerKind == null || providerKind === "native" || providerKind === "crowdin";
   }
 
   if (filter === "has_issues") {

--- a/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-panel.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-panel.test.tsx
@@ -49,3 +49,52 @@ describe("CatQueuePanel pagination", () => {
     expect(onLoadMoreQueue).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("CatQueuePanel bulk hide", () => {
+  it("offers Hide and Unhide when those bulk handlers are provided", async () => {
+    window.localStorage.setItem("cat-queue:selection-mode:v1", "false");
+    const user = userEvent.setup();
+    const onBulkHide = vi.fn();
+    const onBulkUnhide = vi.fn();
+    const segments = catSegmentsFixture.slice(0, 3);
+
+    renderWithCatProviders(
+      <CatQueuePanel
+        segments={segments}
+        selectedSegmentId={segments[0]!.id}
+        onSelectSegment={vi.fn()}
+        onToggleSegmentChecked={vi.fn()}
+        onBulkHide={onBulkHide}
+        onBulkUnhide={onBulkUnhide}
+      />,
+    );
+
+    await user.click(screen.getByRole("checkbox", { name: "Show bulk selection checkboxes" }));
+    await user.click(screen.getByRole("button", { name: "Queue actions" }));
+
+    expect(screen.getByRole("menuitem", { name: "Hide selected" })).toBeDisabled();
+    expect(screen.getByRole("menuitem", { name: "Unhide selected" })).toBeDisabled();
+  });
+
+  it("includes Hidden in the Crowdin queue filter menu", async () => {
+    const user = userEvent.setup();
+    const onQueueFilterChange = vi.fn();
+    const segments = catSegmentsFixture.slice(0, 3);
+
+    renderWithCatProviders(
+      <CatQueuePanel
+        segments={segments}
+        selectedSegmentId={segments[0]!.id}
+        onSelectSegment={vi.fn()}
+        queueFilter="all"
+        onQueueFilterChange={onQueueFilterChange}
+        availableQueueFilters={["all", "hidden"]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Filter queue" }));
+    await user.click(screen.getByRole("menuitemradio", { name: "Hidden" }));
+
+    expect(onQueueFilterChange).toHaveBeenCalledWith("hidden");
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-panel.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-panel.test.tsx
@@ -72,8 +72,14 @@ describe("CatQueuePanel bulk hide", () => {
     await user.click(screen.getByRole("checkbox", { name: "Show bulk selection checkboxes" }));
     await user.click(screen.getByRole("button", { name: "Queue actions" }));
 
-    expect(screen.getByRole("menuitem", { name: "Hide selected" })).toBeDisabled();
-    expect(screen.getByRole("menuitem", { name: "Unhide selected" })).toBeDisabled();
+    expect(screen.getByRole("menuitem", { name: "Hide selected" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+    expect(screen.getByRole("menuitem", { name: "Unhide selected" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
   });
 
   it("includes Hidden in the Crowdin queue filter menu", async () => {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
@@ -536,6 +536,7 @@ export class CatWorkspaceOrchestrator {
       {
         status: draft?.status ?? "pending",
         hasOpenIssues: this.segmentHasOpenIssues(segmentId),
+        isHidden: this.segmentMeta.get(segmentId)?.isHidden,
       },
       filter,
     );

--- a/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-review-controller.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/controllers/cat-review-controller.test.ts
@@ -663,11 +663,12 @@ describe("CatReviewController", () => {
   describe("bulkHide", () => {
     it("delegates to onBulkHide and marks selected segments hidden", async () => {
       const onBulkHide = vi.fn().mockResolvedValue(undefined);
-      const { controller, workspace } = createController(undefined, {
-        review: { onBulkHide },
-      });
+      const workspace = createTestWorkspace();
       workspace.toggleSegmentChecked("seg-02", true);
       workspace.toggleSegmentChecked("seg-03", true);
+      const { controller } = createController(workspace, {
+        review: { onBulkHide },
+      });
 
       await controller.bulkHide();
 
@@ -685,6 +686,18 @@ describe("CatReviewController", () => {
       await controller.bulkHide();
 
       expect(workspace.getSegmentView("seg-02")?.isHidden).toBeUndefined();
+      expect(workspace.isBulkActionPending).toBe(false);
+    });
+
+    it("no-ops when no segments are checked", async () => {
+      const onBulkHide = vi.fn();
+      const { controller, workspace } = createController(undefined, {
+        review: { onBulkHide },
+      });
+
+      await controller.bulkHide();
+
+      expect(onBulkHide).not.toHaveBeenCalled();
       expect(workspace.isBulkActionPending).toBe(false);
     });
   });
@@ -707,10 +720,10 @@ describe("CatReviewController", () => {
           },
         ],
       });
+      workspace.toggleSegmentChecked("seg-02", true);
       const { controller } = createController(workspace, {
         review: { onBulkUnhide },
       });
-      workspace.toggleSegmentChecked("seg-02", true);
 
       await controller.bulkUnhide();
 

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-domain-stores.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-domain-stores.test.ts
@@ -78,6 +78,17 @@ describe("CatQueueStore", () => {
     expect(queue.checkedSegmentIds.size).toBe(0);
   });
 
+  it("toggles hidden metadata on queue segments", () => {
+    const queue = new CatQueueStore();
+    queue.replace([...queueSegments]);
+
+    queue.setHidden(["seg-02"], true);
+    expect(queue.segments.find((segment) => segment.id === "seg-02")?.isHidden).toBe(true);
+
+    queue.setHidden(["seg-02"], false);
+    expect(queue.segments.find((segment) => segment.id === "seg-02")?.isHidden).toBeUndefined();
+  });
+
   it("falls back to the first visible segment when the selected segment disappears", () => {
     const queue = new CatQueueStore();
     queue.replace([...queueSegments]);

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-segment-view.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-segment-view.test.ts
@@ -61,6 +61,24 @@ describe("toQueueSegment", () => {
       sourcePath: "locales/en.json",
     });
   });
+
+  it("preserves hidden source-string state", () => {
+    expect(
+      toQueueSegment({
+        id: "seg-01",
+        index: 1,
+        key: "hero.title",
+        sourceText: "Hello",
+        isHidden: true,
+      }),
+    ).toEqual({
+      id: "seg-01",
+      index: 1,
+      key: "hero.title",
+      sourceText: "Hello",
+      isHidden: true,
+    });
+  });
 });
 
 describe("composeSegmentView", () => {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -622,11 +622,15 @@ describe("CrowdinApiClient", () => {
   });
 
   it("chunks source-string batch patches at the Crowdin limit", async () => {
-    const fetchMock = vi.fn(async () => {
+    const patchBodies: unknown[] = [];
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (typeof init?.body === "string") {
+        patchBodies.push(JSON.parse(init.body));
+      }
       return new Response(JSON.stringify({ data: [] }), { status: 200 });
-    }) as unknown as typeof fetch;
+    });
 
-    const client = createClient(fetchMock);
+    const client = createClient(fetchMock as unknown as typeof fetch);
     const stringIds = Array.from(
       { length: CROWDIN_SOURCE_STRING_BATCH_PATCH_LIMIT + 1 },
       (_, index) => index + 1,
@@ -635,10 +639,8 @@ describe("CrowdinApiClient", () => {
     await client.batchSetSourceStringsHidden(1, stringIds, false);
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    const firstBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
-    const secondBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
-    expect(firstBody).toHaveLength(CROWDIN_SOURCE_STRING_BATCH_PATCH_LIMIT);
-    expect(secondBody).toEqual([{ op: "replace", path: "/501/isHidden", value: false }]);
+    expect(patchBodies[0]).toHaveLength(CROWDIN_SOURCE_STRING_BATCH_PATCH_LIMIT);
+    expect(patchBodies[1]).toEqual([{ op: "replace", path: "/501/isHidden", value: false }]);
   });
 
   it("lists source strings by taskId", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -26,7 +26,11 @@ vi.mock("@/lib/log", () => ({
   })),
 }));
 
-import { CrowdinApiClient, CrowdinApiError } from "./crowdin-api";
+import {
+  CrowdinApiClient,
+  CrowdinApiError,
+  CROWDIN_SOURCE_STRING_BATCH_PATCH_LIMIT,
+} from "./crowdin-api";
 
 describe("CrowdinApiClient", () => {
   beforeEach(() => {
@@ -565,6 +569,76 @@ describe("CrowdinApiClient", () => {
       fileId: 101,
       isHidden: false,
     });
+  });
+
+  it("batch-hides source strings with JSON Patch replace on isHidden", async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      expect(String(url)).toBe("https://api.crowdin.test/api/v2/projects/1/strings");
+      expect(init?.method).toBe("PATCH");
+      expect(JSON.parse(String(init?.body))).toEqual([
+        { op: "replace", path: "/1001/isHidden", value: true },
+        { op: "replace", path: "/1002/isHidden", value: true },
+      ]);
+      return new Response(
+        JSON.stringify({
+          data: [
+            {
+              data: {
+                id: 1001,
+                projectId: 1,
+                fileId: 101,
+                identifier: "hello",
+                text: "Hello",
+                type: "text",
+                context: null,
+                isHidden: true,
+                labelIds: null,
+              },
+            },
+            {
+              data: {
+                id: 1002,
+                projectId: 1,
+                fileId: 101,
+                identifier: "bye",
+                text: "Bye",
+                type: "text",
+                context: null,
+                isHidden: true,
+                labelIds: null,
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const strings = await client.batchSetSourceStringsHidden(1, [1001, 1002, 1001], true);
+
+    expect(strings).toHaveLength(2);
+    expect(strings.map((string) => string.isHidden)).toEqual([true, true]);
+  });
+
+  it("chunks source-string batch patches at the Crowdin limit", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const stringIds = Array.from(
+      { length: CROWDIN_SOURCE_STRING_BATCH_PATCH_LIMIT + 1 },
+      (_, index) => index + 1,
+    );
+
+    await client.batchSetSourceStringsHidden(1, stringIds, false);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const firstBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    const secondBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
+    expect(firstBody).toHaveLength(CROWDIN_SOURCE_STRING_BATCH_PATCH_LIMIT);
+    expect(secondBody).toEqual([{ op: "replace", path: "/501/isHidden", value: false }]);
   });
 
   it("lists source strings by taskId", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -124,6 +124,9 @@ export function buildCrowdinFileQueueCroql(input: {
     case "has_issues":
       parts.push("count of comments where (has unresolved issue) > 0");
       break;
+    case "hidden":
+      parts.push("is hidden");
+      break;
     case "all":
     default:
       break;
@@ -136,6 +139,8 @@ export function buildCrowdinFileSearchCroql(fileId: number, search: string) {
   const escaped = escapeCrowdinCroqlString(search.trim());
   return `id of file = ${fileId} and (identifier contains "${escaped}" or text contains "${escaped}")`;
 }
+
+export const CROWDIN_SOURCE_STRING_BATCH_PATCH_LIMIT = 500;
 
 export const CROWDIN_LIVE_TASK_LIST_LIMIT = 50;
 export const CROWDIN_LIVE_TASK_LIST_ORDER_BY = "createdAt desc";
@@ -955,6 +960,59 @@ export class CrowdinApiClient {
       }
       throw error;
     }
+  }
+
+  /**
+   * Bulk-update source string fields via JSON Patch.
+   *
+   * Crowdin documents replace on `/{stringId}/isHidden`. Requests larger than
+   * {@link CROWDIN_SOURCE_STRING_BATCH_PATCH_LIMIT} are sent in chunks.
+   *
+   * @see https://support.crowdin.com/developer/api/v2/#operation/api.projects.strings.batchPatch
+   */
+  async batchUpdateSourceStrings(
+    projectId: number,
+    operations: CrowdinPatchOperation[],
+  ): Promise<CrowdinSourceString[]> {
+    if (operations.length === 0) {
+      return [];
+    }
+
+    const updated: CrowdinSourceString[] = [];
+    for (
+      let index = 0;
+      index < operations.length;
+      index += CROWDIN_SOURCE_STRING_BATCH_PATCH_LIMIT
+    ) {
+      const chunk = operations.slice(index, index + CROWDIN_SOURCE_STRING_BATCH_PATCH_LIMIT);
+      const response = await this.patch<CrowdinListResponse<CrowdinSourceString>>(
+        `/projects/${projectId}/strings`,
+        chunk,
+      );
+      updated.push(...(response.data ?? []).map((item) => item.data));
+    }
+
+    return updated;
+  }
+
+  async batchSetSourceStringsHidden(
+    projectId: number,
+    stringIds: number[],
+    isHidden: boolean,
+  ): Promise<CrowdinSourceString[]> {
+    const uniqueIds = [...new Set(stringIds)];
+    if (uniqueIds.length === 0) {
+      return [];
+    }
+
+    return this.batchUpdateSourceStrings(
+      projectId,
+      uniqueIds.map((stringId) => ({
+        op: "replace" as const,
+        path: `/${stringId}/isHidden`,
+        value: isHidden,
+      })),
+    );
   }
 
   async getSourceStringsByIds(

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-croql.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-croql.test.ts
@@ -88,6 +88,16 @@ describe("buildCrowdinFileQueueCroql", () => {
       }),
     ).toBeUndefined();
   });
+
+  it("filters hidden strings with is hidden", () => {
+    expect(
+      buildCrowdinFileQueueCroql({
+        fileId: 101,
+        targetLocale: "fr",
+        queueFilter: "hidden",
+      }),
+    ).toBe("id of file = 101 and is hidden");
+  });
 });
 
 describe("Crowdin CROQL size limits", () => {

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-cat.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-cat.test.ts
@@ -26,6 +26,7 @@ import {
   getTmsProviderLiveCatSegmentComments,
   getTmsProviderLiveCatSegmentTarget,
   saveTmsProviderLiveCatTranslation,
+  setTmsProviderLiveCatStringsHidden,
 } from "./tms-provider-live";
 
 const fixture = createAuthTestFixture();
@@ -2002,6 +2003,145 @@ describe("getTmsProviderLiveCatAllFiles", () => {
       name: "TmsProviderLiveError",
       code: "crowdin_cat_all_files_query_too_large",
       message: CROWDIN_CAT_ALL_FILES_QUERY_TOO_LARGE_MESSAGE,
+    });
+  });
+});
+
+describe("setTmsProviderLiveCatStringsHidden", () => {
+  let originalFetch: typeof fetch;
+
+  beforeAll(async () => {
+    await db.$client.query("select 1");
+  });
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    vi.clearAllMocks();
+    await fixture.cleanup();
+  });
+
+  it("hides Crowdin strings with JSON Patch replace on isHidden", async () => {
+    const { organization, user } = await fixture.createLocalWorkosIdentity(
+      fixture.createWorkosIdentityWithRole("admin"),
+    );
+    await setupCrowdinPatCredential({
+      organizationId: organization.id,
+      userId: user.id,
+    });
+
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+      if (path.endsWith("/projects/42/strings") && init?.method === "PATCH") {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 1001,
+                  projectId: 42,
+                  fileId: 101,
+                  identifier: "hello",
+                  text: "Hello",
+                  type: "text",
+                  context: null,
+                  isHidden: true,
+                  labelIds: null,
+                },
+              },
+              {
+                data: {
+                  id: 1002,
+                  projectId: 42,
+                  fileId: 101,
+                  identifier: "bye",
+                  text: "Bye",
+                  type: "text",
+                  context: null,
+                  isHidden: true,
+                  labelIds: null,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ error: { message: path } }), { status: 404 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await setTmsProviderLiveCatStringsHidden(
+      organization.id,
+      "42",
+      { externalStringIds: ["1001", "1002", "1001"], isHidden: true },
+      { actorUserId: user.id },
+    );
+
+    expect(result).toEqual({ updatedCount: 2, isHidden: true });
+    const patchCall = fetchMock.mock.calls.find(
+      ([url, init]) => String(url).endsWith("/projects/42/strings") && init?.method === "PATCH",
+    );
+    expect(JSON.parse(String(patchCall?.[1]?.body))).toEqual([
+      { op: "replace", path: "/1001/isHidden", value: true },
+      { op: "replace", path: "/1002/isHidden", value: true },
+    ]);
+  });
+
+  it("maps Crowdin 403 hide failures to a forbidden error", async () => {
+    const { organization, user } = await fixture.createLocalWorkosIdentity(
+      fixture.createWorkosIdentityWithRole("admin"),
+    );
+    await setupCrowdinPatCredential({
+      organizationId: organization.id,
+      userId: user.id,
+    });
+
+    const fetchMock = vi.fn(async (url, init) => {
+      if (String(url).endsWith("/projects/42/strings") && init?.method === "PATCH") {
+        return new Response(JSON.stringify({ error: { message: "Forbidden" } }), { status: 403 });
+      }
+
+      return new Response(JSON.stringify({ error: { message: String(url) } }), { status: 404 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(
+      setTmsProviderLiveCatStringsHidden(
+        organization.id,
+        "42",
+        { externalStringIds: ["1001"], isHidden: true },
+        { actorUserId: user.id },
+      ),
+    ).rejects.toMatchObject({
+      name: "TmsProviderLiveError",
+      code: "crowdin_hidden_strings_forbidden",
+    });
+  });
+
+  it("rejects non-numeric Crowdin string ids", async () => {
+    const { organization, user } = await fixture.createLocalWorkosIdentity(
+      fixture.createWorkosIdentityWithRole("admin"),
+    );
+    await setupCrowdinPatCredential({
+      organizationId: organization.id,
+      userId: user.id,
+    });
+
+    await expect(
+      setTmsProviderLiveCatStringsHidden(
+        organization.id,
+        "42",
+        { externalStringIds: ["not-a-number"], isHidden: true },
+        { actorUserId: user.id },
+      ),
+    ).rejects.toMatchObject({
+      name: "TmsProviderLiveError",
+      code: "invalid_crowdin_project_or_string_id",
     });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.test.ts
@@ -30,6 +30,7 @@ describe("getTmsProviderLiveErrorStatus", () => {
     ["invalid_encoded_job_id", 400],
     ["invalid_crowdin_assignee_id", 400],
     ["crowdin_cat_all_files_query_too_large", 400],
+    ["crowdin_hidden_strings_forbidden", 400],
     ["invalid_smartling_project_id", 400],
     ["invalid_smartling_string_id", 400],
     ["smartling_auth_invalid", 401],

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.ts
@@ -51,6 +51,7 @@ export function getTmsProviderLiveErrorStatus(code: string): TmsProviderLiveErro
     case "invalid_encoded_job_id":
     case "invalid_crowdin_project_or_file_id":
     case "invalid_crowdin_project_or_string_id":
+    case "crowdin_hidden_strings_forbidden":
     case "crowdin_cat_all_files_query_too_large":
     case "invalid_phrase_project_id":
     case "invalid_smartling_project_id":

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -1345,11 +1345,7 @@ async function setCrowdinLiveCatStringsHidden(input: {
   });
 
   try {
-    const updated = await client.batchSetSourceStringsHidden(
-      projectId,
-      stringIds,
-      input.isHidden,
-    );
+    const updated = await client.batchSetSourceStringsHidden(projectId, stringIds, input.isHidden);
     return {
       updatedCount: updated.length > 0 ? updated.length : stringIds.length,
       isHidden: input.isHidden,

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -1296,6 +1296,69 @@ async function saveCrowdinLiveCatTranslation(input: {
   }
 }
 
+function mapCrowdinHiddenStringError(error: unknown): never {
+  if (error instanceof CrowdinApiError && error.status === 401) {
+    throw new TmsProviderLiveError("crowdin_auth_invalid", "Crowdin credentials are invalid.");
+  }
+
+  if (error instanceof CrowdinApiError && (error.status === 403 || error.status === 400)) {
+    throw new TmsProviderLiveError(
+      "crowdin_hidden_strings_forbidden",
+      "Crowdin did not allow updating hidden strings. Managers can hide strings.",
+    );
+  }
+
+  throw error;
+}
+
+async function setCrowdinLiveCatStringsHidden(input: {
+  context: ActiveTmsProviderContext;
+  externalProjectId: string;
+  externalStringIds: string[];
+  isHidden: boolean;
+}): Promise<{ updatedCount: number; isHidden: boolean }> {
+  const projectId = Number(input.externalProjectId);
+  if (Number.isNaN(projectId)) {
+    throw new TmsProviderLiveError(
+      "invalid_crowdin_project_or_string_id",
+      "Crowdin project or string identifier is invalid.",
+    );
+  }
+
+  const stringIds = [
+    ...new Set(
+      input.externalStringIds
+        .map((externalStringId) => Number(externalStringId))
+        .filter((stringId) => Number.isInteger(stringId) && stringId > 0),
+    ),
+  ];
+  if (stringIds.length === 0) {
+    throw new TmsProviderLiveError(
+      "invalid_crowdin_project_or_string_id",
+      "Crowdin project or string identifier is invalid.",
+    );
+  }
+
+  const client = new CrowdinApiClient({
+    token: input.context.secretMaterial,
+    baseUrl: input.context.credential.baseUrl ?? undefined,
+  });
+
+  try {
+    const updated = await client.batchSetSourceStringsHidden(
+      projectId,
+      stringIds,
+      input.isHidden,
+    );
+    return {
+      updatedCount: updated.length > 0 ? updated.length : stringIds.length,
+      isHidden: input.isHidden,
+    };
+  } catch (error) {
+    mapCrowdinHiddenStringError(error);
+  }
+}
+
 async function buildCrowdinLiveCatSegmentComments(input: {
   context: ActiveTmsProviderContext;
   file: TmsProviderLiveFile;
@@ -2722,6 +2785,34 @@ export async function saveTmsProviderLiveCatTranslation(
     targetLocale: input.targetLocale,
     externalStringId: input.externalStringId,
     text: input.text,
+  });
+}
+
+export async function setTmsProviderLiveCatStringsHidden(
+  organizationId: string,
+  externalProjectId: string,
+  input: {
+    externalStringIds: string[];
+    isHidden: boolean;
+  },
+  options?: { actorUserId?: string | null },
+): Promise<{ updatedCount: number; isHidden: boolean }> {
+  const context = await loadActiveTmsProviderContext(organizationId, {
+    actorUserId: options?.actorUserId,
+  });
+
+  if (context.providerKind !== "crowdin") {
+    throw new TmsProviderLiveError(
+      "provider_cat_unsupported",
+      "Hidden strings can only be updated for Crowdin CAT.",
+    );
+  }
+
+  return setCrowdinLiveCatStringsHidden({
+    context,
+    externalProjectId,
+    externalStringIds: input.externalStringIds,
+    isHidden: input.isHidden,
   });
 }
 

--- a/docs/adr/2026-08-17-crowdin-cat-bulk-hide-design.md
+++ b/docs/adr/2026-08-17-crowdin-cat-bulk-hide-design.md
@@ -1,0 +1,30 @@
+# Crowdin CAT Bulk Hide
+
+## Context
+
+Crowdin source strings expose `isHidden`. Managers hide strings so translators do not see them, then unhide later. Our CAT already shows a Hidden badge for Crowdin segments. The queue bulk menu only offered approve and skip, so managers still had to hide strings in Crowdin.
+
+## Decision
+
+Add Hide selected / Unhide selected as Crowdin CAT bulk actions, and a Hidden queue filter.
+
+1. Call Crowdin `PATCH /projects/{id}/strings` with `replace` on `/{stringId}/isHidden`.
+2. Expose `POST .../files/detail/cat/strings/hidden` for Crowdin live CAT. Other TMS providers stay unsupported.
+3. Show Hide / Unhide in the CAT bulk menu when the file is Crowdin and the user can edit translations.
+4. Keep hidden strings visible in the manager CAT. Add a Hidden filter via Crowdin CROQL `is hidden`.
+5. Hidden remains a source-string property, not per locale.
+
+Do not block editing hidden strings. Managers using CAT with Crowdin credentials should still translate them; the badge stays informational.
+
+## Alternatives considered
+
+- Filter hidden strings out of the default CAT queue: wrong for manager workflows that need to see them.
+- Per-segment hide in the editor header only: bulk hide is the Crowdin manager workflow we are matching.
+- Native TMS hide in this change: originally out of scope. Native keys now live on main (`feat(native-tms): add hidden strings and CAT bulk hide`); this work adds Crowdin live CAT beside that path.
+
+## Testing
+
+- Crowdin API client coverage for batch `isHidden` replace, including chunking.
+- Live CAT coverage that hide/unhide PATCHes Crowdin string IDs.
+- Route coverage for Crowdin success and unsupported providers/native projects.
+- CAT bulk menu and Hidden filter coverage for Crowdin.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Crowdin CAT now supports bulk hide/unhide and a Hidden queue filter, beside native TMS hide from #1878.

Managers can hide or unhide selected Crowdin source strings from the CAT bulk menu. The change calls Crowdin `PATCH /projects/{id}/strings` with `replace` on `/{stringId}/isHidden`, through `POST .../files/detail/cat/strings/hidden`. Native files keep the workspace hide path. Phrase, Lokalise, and Smartling stay unsupported.

Hidden strings stay visible in the manager CAT. The Hidden filter works for native and Crowdin (Crowdin uses CROQL `is hidden`). Hidden remains a source-string property, not per locale.

Rebased onto `main` after #1878 landed. The CAT route now serves both native and Crowdin hide.

## How to test

- Open a Crowdin CAT file as a translator or manager.
- Select strings and choose Hide selected / Unhide selected in the queue actions menu.
- Confirm Crowdin marks those strings hidden/visible and the CAT Hidden badge updates.
- Filter the queue to Hidden and confirm only hidden strings appear.
- Confirm native CAT hide still works, and Phrase/Lokalise/Smartling CAT files do not offer Crowdin hide.

Automated:

```
cd apps/hyperlocalise-web
vp test
vp check --fix
```

`vp test`: 671 files, 4421 tests passed after rebase.
`vp check --fix`: 0 errors (4 existing warnings unrelated to this change).

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-289f5f2c-60cf-4818-b689-d560a900daf5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-289f5f2c-60cf-4818-b689-d560a900daf5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

