### PR TITLE
feat(inbox): open New Request as a dedicated inbox chat

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/chat/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/chat/page.tsx
@@ -18,5 +18,5 @@ export default async function ChatPage({
   params: Promise<{ organizationSlug: string }>;
 }) {
   const { organizationSlug } = await params;
-  redirect(`/org/${organizationSlug}/dashboard?newRequest=1`);
+  redirect(`/org/${organizationSlug}/inbox/new`);
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.messages.ts
@@ -20,6 +20,21 @@ export const conversationPanelMessages = defineMessages({
     id: "iUA2MassCX",
     description: "Empty state when no inbox conversation is selected",
   },
+  newRequestTitle: {
+    defaultMessage: "New Request",
+    id: "nR4q2mLw8K",
+    description: "Header title for a dedicated new localisation request chat",
+  },
+  newRequestSubtitle: {
+    defaultMessage: "Ask the localisation agent to prepare work",
+    id: "sT7p1cVn3D",
+    description: "Header subtitle for a dedicated new localisation request chat",
+  },
+  createFailed: {
+    defaultMessage: "Could not start this chat. Try again.",
+    id: "bH6w9fQr2M",
+    description: "Error when creating a conversation from the inbox New Request page fails",
+  },
   createdAt: {
     defaultMessage: "Created {relativeTime}",
     id: "oKnUPzABxE",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.messages.ts
@@ -22,17 +22,17 @@ export const conversationPanelMessages = defineMessages({
   },
   newRequestTitle: {
     defaultMessage: "New Request",
-    id: "nR4q2mLw8K",
+    id: "XJxHCpyMN1",
     description: "Header title for a dedicated new localisation request chat",
   },
   newRequestSubtitle: {
     defaultMessage: "Ask the localisation agent to prepare work",
-    id: "sT7p1cVn3D",
+    id: "DSb2QBD50S",
     description: "Header subtitle for a dedicated new localisation request chat",
   },
   createFailed: {
     defaultMessage: "Could not start this chat. Try again.",
-    id: "bH6w9fQr2M",
+    id: "kFMJ/YkEV9",
     description: "Error when creating a conversation from the inbox New Request page fails",
   },
   createdAt: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.stories.tsx
@@ -59,6 +59,7 @@ export const ChatConversation: Story = {
       canvas.getByRole("heading", { name: "Translate homepage hero copy" }),
     ).toBeInTheDocument();
     await expect(canvas.getByPlaceholderText("Ask Hyperlocalise…")).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Send reply" })).toBeInTheDocument();
   },
 };
 
@@ -80,6 +81,7 @@ export const NewRequest: Story = {
     await expect(canvas.getByRole("heading", { name: "New Request" })).toBeInTheDocument();
     await expect(canvas.getByText("Welcome to Hyperlocalise")).toBeInTheDocument();
     await expect(canvas.getByPlaceholderText("Ask Hyperlocalise…")).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Send reply" })).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.stories.tsx
@@ -71,6 +71,18 @@ export const NoSelection: Story = {
   },
 };
 
+export const NewRequest: Story = {
+  args: {
+    conversation: undefined,
+    isComposingNew: true,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "New Request" })).toBeInTheDocument();
+    await expect(canvas.getByText("Welcome to Hyperlocalise")).toBeInTheDocument();
+    await expect(canvas.getByPlaceholderText("Ask Hyperlocalise…")).toBeInTheDocument();
+  },
+};
+
 export const LoadingMessages: Story = {
   args: {
     messages: [],

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.tsx
@@ -12,10 +12,13 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { BubbleChatNotificationIcon } from "@hugeicons/core-free-icons";
+import { useRef } from "react";
+import { BubbleChatNotificationIcon, Chat01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
 
+import { ChatDockEmptyState } from "@/components/app-shell/chat-dock/chat-dock-empty-state";
+import { chatDockMessages } from "@/components/app-shell/chat-dock/chat-dock.messages";
 import { Badge } from "@/components/ui/badge";
 import { TypographyH4, TypographyMuted } from "@/components/ui/typography";
 
@@ -38,24 +41,30 @@ import { ReplyComposer } from "./reply-composer";
 export function ConversationPanel({
   conversation,
   currentUser,
+  draft = "",
+  isComposingNew = false,
   isSending,
   isStreaming,
   jobs,
   jobsIsLoading,
   messages,
   messagesIsLoading,
+  onDraftChange,
   onSendMessage,
   organizationSlug,
   streamedAssistant,
 }: {
   conversation: Conversation | undefined;
   currentUser: InboxCurrentUser;
+  draft?: string;
+  isComposingNew?: boolean;
   isSending: boolean;
   isStreaming: boolean;
   jobs: LinkedJob[];
   jobsIsLoading: boolean;
   messages: ConversationMessage[];
   messagesIsLoading: boolean;
+  onDraftChange?: (draft: string) => void;
   onSendMessage: (
     text: string,
     files: File[],
@@ -64,6 +73,66 @@ export function ConversationPanel({
   organizationSlug: string;
   streamedAssistant: StreamedAssistantMessage | null;
 }) {
+  const intl = useIntl();
+  const panelRef = useRef<HTMLElement>(null);
+
+  if (isComposingNew) {
+    const composerDisabled = isSending || isStreaming;
+
+    return (
+      <section
+        ref={panelRef}
+        className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background"
+      >
+        <header className="flex min-h-16 items-center border-b border-border px-4 py-3 sm:px-6">
+          <div className="flex min-w-0 flex-1 items-start gap-3">
+            <HugeiconsIcon
+              icon={Chat01Icon}
+              strokeWidth={1.8}
+              className="mt-0.5 size-5 shrink-0 text-muted-foreground"
+            />
+            <div className="min-w-0">
+              <TypographyH4 className="truncate text-base">
+                <FormattedMessage {...conversationPanelMessages.newRequestTitle} />
+              </TypographyH4>
+              <TypographyMuted className="mt-1.5 text-xs">
+                <FormattedMessage {...conversationPanelMessages.newRequestSubtitle} />
+              </TypographyMuted>
+            </div>
+          </div>
+        </header>
+
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <ChatDockEmptyState
+            onSelectSuggestion={(prompt) => {
+              onDraftChange?.(prompt);
+              requestAnimationFrame(() => {
+                const textarea = panelRef.current?.querySelector("textarea");
+                if (!textarea) {
+                  return;
+                }
+                textarea.focus();
+                const cursor = textarea.value.length;
+                textarea.setSelectionRange(cursor, cursor);
+              });
+            }}
+          />
+          <InboxPanelErrorBoundary scope="composer" resetKeys={[composerDisabled, draft]}>
+            <ReplyComposer
+              disabled={composerDisabled}
+              draft={draft}
+              isStreaming={isStreaming}
+              onDraftChange={onDraftChange}
+              onSend={onSendMessage}
+              organizationSlug={organizationSlug}
+              placeholder={intl.formatMessage(chatDockMessages.emptyComposer)}
+            />
+          </InboxPanelErrorBoundary>
+        </div>
+      </section>
+    );
+  }
+
   if (!conversation) {
     return (
       <section className="flex min-h-0 min-w-0 flex-col overflow-hidden bg-background">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.ts
@@ -33,7 +33,10 @@ export type InboxApi = {
   createConversation(
     organizationSlug: string,
     input: SendConversationMessageInput,
-  ): Promise<{ conversation: { id: string; title?: string }; message?: { id: string; text: string } }>;
+  ): Promise<{
+    conversation: { id: string; title?: string };
+    message?: { id: string; text: string };
+  }>;
   sendMessage(
     organizationSlug: string,
     conversationId: string,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.ts
@@ -30,6 +30,10 @@ export type InboxApi = {
   listMessages(organizationSlug: string, conversationId: string): Promise<ConversationMessage[]>;
   listLinkedJobs(organizationSlug: string, conversationId: string): Promise<LinkedJob[]>;
   listGithubRepositories(organizationSlug: string): Promise<InboxGithubRepository[]>;
+  createConversation(
+    organizationSlug: string,
+    input: SendConversationMessageInput,
+  ): Promise<{ conversation: { id: string; title?: string }; message?: { id: string; text: string } }>;
   sendMessage(
     organizationSlug: string,
     conversationId: string,
@@ -38,6 +42,21 @@ export type InboxApi = {
 };
 
 type ApiClient = ReturnType<typeof createApiClient>;
+
+const FILE_ONLY_CONVERSATION_TEXT = "Please translate the attached source file.";
+
+function appendConversationFormData(formData: FormData, input: SendConversationMessageInput) {
+  formData.set("text", input.text.trim() || FILE_ONLY_CONVERSATION_TEXT);
+  if (input.projectId) {
+    formData.set("projectId", input.projectId);
+  }
+  if (input.repositoryFullName) {
+    formData.set("repositoryFullName", input.repositoryFullName);
+  }
+  for (const file of input.files) {
+    formData.append("files", file);
+  }
+}
 
 export function createInboxApi(client: ApiClient): InboxApi {
   const conversations = client.api.orgs[":organizationSlug"].conversations;
@@ -89,6 +108,26 @@ export function createInboxApi(client: ApiClient): InboxApi {
       }
       const body = (await response.json()) as { repositories: InboxGithubRepository[] };
       return body.repositories.filter((repository) => repository.enabled && !repository.archived);
+    },
+
+    async createConversation(organizationSlug, input) {
+      const formData = new FormData();
+      appendConversationFormData(formData, input);
+
+      const response = await fetch(
+        `/api/orgs/${encodeURIComponent(organizationSlug)}/conversations`,
+        {
+          method: "POST",
+          body: formData,
+        },
+      );
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to create conversation");
+      }
+      return response.json() as Promise<{
+        conversation: { id: string; title?: string };
+        message?: { id: string; text: string };
+      }>;
     },
 
     async sendMessage(organizationSlug, conversationId, input) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.messages.ts
@@ -32,12 +32,12 @@ export const inboxListMessages = defineMessages({
   },
   newRequestTitle: {
     defaultMessage: "New Request",
-    id: "k3nR8qLw2P",
+    id: "sHACVcApZT",
     description: "Inbox list row title for a dedicated new localisation request chat",
   },
   newRequestPreview: {
     defaultMessage: "Start a localisation request",
-    id: "p9mT4vHc1B",
+    id: "Leoig5Z0u9",
     description: "Inbox list row preview for a dedicated new localisation request chat",
   },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.messages.ts
@@ -30,4 +30,14 @@ export const inboxListMessages = defineMessages({
     id: "k9uRw1QXC6",
     description: "Preview text when a conversation in the inbox list has no messages",
   },
+  newRequestTitle: {
+    defaultMessage: "New Request",
+    id: "k3nR8qLw2P",
+    description: "Inbox list row title for a dedicated new localisation request chat",
+  },
+  newRequestPreview: {
+    defaultMessage: "Start a localisation request",
+    id: "p9mT4vHc1B",
+    description: "Inbox list row preview for a dedicated new localisation request chat",
+  },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.stories.tsx
@@ -144,6 +144,17 @@ export const Empty: Story = {
   },
 };
 
+export const NewRequest: Story = {
+  args: {
+    selection: { kind: "new" },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("New Request")).toBeInTheDocument();
+    await expect(canvas.getByText("Start a localisation request")).toBeInTheDocument();
+    await expect(canvas.getByText("Translate homepage hero copy")).toBeInTheDocument();
+  },
+};
+
 export const Error: Story = {
   args: {
     conversations: [],

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.test.ts
@@ -12,7 +12,11 @@
  */
 import { describe, expect, it } from "vite-plus/test";
 
-import { buildInboxIndexItems, notificationSecondaryText, resolveInboxSelection } from "./inbox-list";
+import {
+  buildInboxIndexItems,
+  notificationSecondaryText,
+  resolveInboxSelection,
+} from "./inbox-list";
 import type { InboxIssueNotification } from "./inbox-notifications-api";
 import type { Conversation } from "./inbox-types";
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.test.ts
@@ -12,7 +12,7 @@
  */
 import { describe, expect, it } from "vite-plus/test";
 
-import { buildInboxIndexItems, notificationSecondaryText } from "./inbox-list";
+import { buildInboxIndexItems, notificationSecondaryText, resolveInboxSelection } from "./inbox-list";
 import type { InboxIssueNotification } from "./inbox-notifications-api";
 import type { Conversation } from "./inbox-types";
 
@@ -58,6 +58,40 @@ describe("notificationSecondaryText", () => {
 
   it("falls back to the preview when the excerpt is empty", () => {
     expect(notificationSecondaryText("  ", "Someone mentioned you")).toBe("Someone mentioned you");
+  });
+});
+
+describe("resolveInboxSelection", () => {
+  it("prefers the dedicated compose route over existing inbox items", () => {
+    expect(
+      resolveInboxSelection({
+        composeNew: true,
+        urlConversationId: "c-1",
+        urlNotificationId: "n-1",
+        firstConversationId: "c-2",
+        firstNotificationId: "n-2",
+      }),
+    ).toEqual({ kind: "new" });
+  });
+
+  it("selects the URL conversation when not composing", () => {
+    expect(
+      resolveInboxSelection({
+        composeNew: false,
+        urlConversationId: "c-1",
+        firstConversationId: "c-2",
+      }),
+    ).toEqual({ kind: "conversation", id: "c-1" });
+  });
+
+  it("falls back to the first conversation when the inbox index has no URL selection", () => {
+    expect(
+      resolveInboxSelection({
+        composeNew: false,
+        firstConversationId: "c-2",
+        firstNotificationId: "n-2",
+      }),
+    ).toEqual({ kind: "conversation", id: "c-2" });
   });
 });
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.tsx
@@ -13,6 +13,8 @@
  * Version 2.0 or later.
  */
 import { memo, useMemo } from "react";
+import { Chat01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl, type MessageDescriptor } from "react-intl";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -40,7 +42,33 @@ export type InboxIndexItem =
 export type InboxSelection =
   | { kind: "conversation"; id: string }
   | { kind: "notification"; id: string }
+  | { kind: "new" }
   | null;
+
+export function resolveInboxSelection(input: {
+  composeNew: boolean;
+  urlConversationId?: string;
+  urlNotificationId?: string;
+  firstConversationId?: string;
+  firstNotificationId?: string;
+}): InboxSelection {
+  if (input.composeNew) {
+    return { kind: "new" };
+  }
+  if (input.urlNotificationId) {
+    return { kind: "notification", id: input.urlNotificationId };
+  }
+  if (input.urlConversationId) {
+    return { kind: "conversation", id: input.urlConversationId };
+  }
+  if (input.firstConversationId) {
+    return { kind: "conversation", id: input.firstConversationId };
+  }
+  if (input.firstNotificationId) {
+    return { kind: "notification", id: input.firstNotificationId };
+  }
+  return null;
+}
 
 /** Plain-text secondary line for notification rows (strips mention markdown etc.). */
 export function notificationSecondaryText(excerpt: string | undefined, fallback: string): string {
@@ -127,6 +155,8 @@ export const InboxList = memo(function InboxList({
     [conversations, notifications],
   );
 
+  const isComposingNew = selection?.kind === "new";
+
   return (
     <section className="flex max-h-[40svh] min-h-0 shrink-0 flex-col overflow-hidden border-border lg:h-full lg:max-h-none lg:shrink lg:border-r">
       {unreadNotificationCount > 0 && onMarkAllRead ? (
@@ -143,12 +173,13 @@ export const InboxList = memo(function InboxList({
           <TypographyMuted className="px-3 py-4">
             <FormattedMessage {...inboxNotificationsMessages.loadError} />
           </TypographyMuted>
-        ) : items.length === 0 ? (
+        ) : items.length === 0 && !isComposingNew ? (
           <TypographyMuted className="px-3 py-4">
             <FormattedMessage {...inboxNotificationsMessages.empty} />
           </TypographyMuted>
         ) : (
           <div className="flex flex-col gap-1">
+            {isComposingNew ? <NewRequestListItem /> : null}
             {items.map((item) =>
               item.kind === "conversation" ? (
                 <ConversationListItem
@@ -189,6 +220,34 @@ export const InboxList = memo(function InboxList({
         )}
       </div>
     </section>
+  );
+});
+
+function listItemClassName(isSelected: boolean) {
+  return cn(
+    "grid w-full text-left transition-colors",
+    "grid-cols-[2rem_minmax(0,1fr)] gap-2 rounded-md px-2 py-2.5",
+    isSelected
+      ? "bg-accent text-foreground"
+      : "text-foreground hover:bg-muted hover:text-foreground",
+  );
+}
+
+const NewRequestListItem = memo(function NewRequestListItem() {
+  return (
+    <div aria-current="page" className={listItemClassName(true)}>
+      <div className="flex size-8 items-center justify-center rounded-full bg-muted text-muted-foreground">
+        <HugeiconsIcon icon={Chat01Icon} strokeWidth={2} className="size-4" />
+      </div>
+      <div className="min-w-0">
+        <TypographySmall className="truncate">
+          <FormattedMessage {...inboxListMessages.newRequestTitle} />
+        </TypographySmall>
+        <TypographyMuted className="mt-1 truncate">
+          <FormattedMessage {...inboxListMessages.newRequestPreview} />
+        </TypographyMuted>
+      </div>
+    </div>
   );
 });
 
@@ -234,13 +293,7 @@ const ConversationListItem = memo(function ConversationListItem({
       type="button"
       aria-pressed={isSelected}
       onClick={() => onSelect(conversation.id)}
-      className={cn(
-        "grid w-full text-left transition-colors",
-        "grid-cols-[2rem_minmax(0,1fr)] gap-2 rounded-md px-2 py-2.5",
-        isSelected
-          ? "bg-accent text-foreground"
-          : "text-foreground hover:bg-muted hover:text-foreground",
-      )}
+      className={listItemClassName(isSelected)}
     >
       <Avatar className="size-8 bg-muted">
         {participantAvatar.imageUrl ? (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-content.tsx
@@ -12,17 +12,21 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useParams, useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo } from "react";
+import { useParams, usePathname, useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useMutation, useInfiniteQuery, useQuery, useQueryClient } from "@tanstack/react-query";
 import { observer } from "mobx-react-lite";
+import { useIntl } from "react-intl";
+import { toast } from "sonner";
 
 import { useAppShellStore } from "@/components/app-shell/store/app-shell-store-context";
 import { getChatStreamManager } from "@/components/app-shell/chat-dock/chat-stream-manager";
+import { isInboxNewRequestPath } from "@/components/app-shell/navigation-config";
 import { apiClient } from "@/lib/api-client-instance";
 
 import { createInboxApi, type InboxApi } from "./inbox-api";
-import type { InboxSelection } from "./inbox-list";
+import { conversationPanelMessages } from "./conversation-panel.messages";
+import { resolveInboxSelection, type InboxSelection } from "./inbox-list";
 import {
   createInboxNotificationsApi,
   notificationsQueryKey,
@@ -65,10 +69,14 @@ export const InboxPageContent = observer(function InboxPageContent({
   notificationsApi?: InboxNotificationsApi;
 }) {
   const router = useRouter();
+  const pathname = usePathname();
   const params = useParams();
+  const intl = useIntl();
   const queryClient = useQueryClient();
   const urlConversationId = params?.conversationId as string | undefined;
   const urlNotificationId = params?.notificationId as string | undefined;
+  const composeNew = isInboxNewRequestPath(pathname);
+  const [composeDraft, setComposeDraft] = useState("");
   const { chatDock } = useAppShellStore();
   const streamManager = getChatStreamManager(organizationSlug, chatDock);
 
@@ -106,21 +114,17 @@ export const InboxPageContent = observer(function InboxPageContent({
   );
   const notificationsTotal = notificationsQuery.data?.pages[0]?.total ?? notifications.length;
 
-  const selection: InboxSelection = useMemo(() => {
-    if (urlNotificationId) {
-      return { kind: "notification", id: urlNotificationId };
-    }
-    if (urlConversationId) {
-      return { kind: "conversation", id: urlConversationId };
-    }
-    if (conversations[0]) {
-      return { kind: "conversation", id: conversations[0].id };
-    }
-    if (notifications[0]) {
-      return { kind: "notification", id: notifications[0].id };
-    }
-    return null;
-  }, [conversations, notifications, urlConversationId, urlNotificationId]);
+  const selection: InboxSelection = useMemo(
+    () =>
+      resolveInboxSelection({
+        composeNew,
+        urlConversationId,
+        urlNotificationId,
+        firstConversationId: conversations[0]?.id,
+        firstNotificationId: notifications[0]?.id,
+      }),
+    [composeNew, conversations, notifications, urlConversationId, urlNotificationId],
+  );
 
   const selectedConversationId = selection?.kind === "conversation" ? selection.id : "";
   const selectedNotificationId = selection?.kind === "notification" ? selection.id : "";
@@ -186,6 +190,15 @@ export const InboxPageContent = observer(function InboxPageContent({
     },
   });
 
+  const createConversationMutation = useMutation({
+    mutationFn: (input: {
+      text: string;
+      files: File[];
+      projectId?: string;
+      repositoryFullName?: string;
+    }) => injectedInboxApi.createConversation(organizationSlug, input),
+  });
+
   const markReadMutation = useMutation({
     mutationFn: (notificationId: string) =>
       injectedNotificationsApi.markRead(organizationSlug, notificationId),
@@ -218,15 +231,39 @@ export const InboxPageContent = observer(function InboxPageContent({
   });
 
   const mutateAsync = sendMessageMutation.mutateAsync;
+  const createConversationAsync = createConversationMutation.mutateAsync;
   const onSendMessage = useCallback(
     async (
       text: string,
       files: File[],
       options?: { projectId?: string; repositoryFullName?: string },
     ) => {
+      if (composeNew) {
+        try {
+          const result = await createConversationAsync({ text, files, ...options });
+          setComposeDraft("");
+          await queryClient.invalidateQueries({
+            queryKey: conversationsQueryKey(organizationSlug),
+          });
+          router.push(`/org/${organizationSlug}/inbox/${result.conversation.id}`);
+        } catch (error) {
+          toast.error(intl.formatMessage(conversationPanelMessages.createFailed));
+          throw error;
+        }
+        return;
+      }
+
       await mutateAsync({ text, files, ...options });
     },
-    [mutateAsync],
+    [
+      composeNew,
+      createConversationAsync,
+      intl,
+      mutateAsync,
+      organizationSlug,
+      queryClient,
+      router,
+    ],
   );
 
   const onSelectConversation = useCallback(
@@ -308,9 +345,10 @@ export const InboxPageContent = observer(function InboxPageContent({
       conversationsIsError={conversationsQuery.isError}
       conversationsIsLoading={conversationsQuery.isLoading}
       currentUser={currentUser}
+      draft={composeDraft}
       hasMoreNotifications={hasMoreNotifications}
       isLoadingMoreNotifications={notificationsQuery.isFetchingNextPage}
-      isSending={sendMessageMutation.isPending}
+      isSending={sendMessageMutation.isPending || createConversationMutation.isPending}
       isSparseInbox={isSparseInbox}
       isStreaming={isStreaming}
       jobs={jobs}
@@ -320,6 +358,7 @@ export const InboxPageContent = observer(function InboxPageContent({
       notifications={notifications}
       notificationsIsError={notificationsQuery.isError}
       notificationsIsLoading={notificationsQuery.isLoading}
+      onDraftChange={setComposeDraft}
       onLoadMoreNotifications={onLoadMoreNotifications}
       onMarkAllRead={onMarkAllRead}
       onSelectConversation={onSelectConversation}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-content.tsx
@@ -255,15 +255,7 @@ export const InboxPageContent = observer(function InboxPageContent({
 
       await mutateAsync({ text, files, ...options });
     },
-    [
-      composeNew,
-      createConversationAsync,
-      intl,
-      mutateAsync,
-      organizationSlug,
-      queryClient,
-      router,
-    ],
+    [composeNew, createConversationAsync, intl, mutateAsync, organizationSlug, queryClient, router],
   );
 
   const onSelectConversation = useCallback(

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-view.stories.tsx
@@ -237,5 +237,6 @@ export const NewRequest: Story = {
     await expect(canvas.getByText("Start a localisation request")).toBeInTheDocument();
     await expect(canvas.getByText("Welcome to Hyperlocalise")).toBeInTheDocument();
     await expect(canvas.getByPlaceholderText("Ask Hyperlocalise…")).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Send reply" })).toBeInTheDocument();
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-view.stories.tsx
@@ -224,3 +224,18 @@ export const IssueNotificationLoading: Story = {
     await expect(canvas.getByText("Loading issue")).toBeInTheDocument();
   },
 };
+
+export const NewRequest: Story = {
+  args: {
+    selectedConversation: undefined,
+    selection: { kind: "new" },
+    messages: [],
+    jobs: [],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "New Request" })).toBeInTheDocument();
+    await expect(canvas.getByText("Start a localisation request")).toBeInTheDocument();
+    await expect(canvas.getByText("Welcome to Hyperlocalise")).toBeInTheDocument();
+    await expect(canvas.getByPlaceholderText("Ask Hyperlocalise…")).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-view.tsx
@@ -35,6 +35,7 @@ export function InboxPageView({
   conversationsIsError,
   conversationsIsLoading,
   currentUser,
+  draft = "",
   hasMoreNotifications,
   isLoadingMoreNotifications,
   isSending,
@@ -47,6 +48,7 @@ export function InboxPageView({
   notifications,
   notificationsIsError,
   notificationsIsLoading,
+  onDraftChange,
   onLoadMoreNotifications,
   onMarkAllRead,
   onSelectConversation,
@@ -64,6 +66,7 @@ export function InboxPageView({
   conversationsIsError: boolean;
   conversationsIsLoading: boolean;
   currentUser: InboxCurrentUser;
+  draft?: string;
   hasMoreNotifications: boolean;
   isLoadingMoreNotifications: boolean;
   isSending: boolean;
@@ -76,6 +79,7 @@ export function InboxPageView({
   notifications: InboxIssueNotification[];
   notificationsIsError: boolean;
   notificationsIsLoading: boolean;
+  onDraftChange?: (draft: string) => void;
   onLoadMoreNotifications: () => void;
   onMarkAllRead: () => void;
   onSelectConversation: (conversationId: string) => void;
@@ -100,7 +104,9 @@ export function InboxPageView({
       ? `conversation:${selection.id}`
       : selection?.kind === "notification"
         ? `notification:${selection.id}`
-        : "none";
+        : selection?.kind === "new"
+          ? "new"
+          : "none";
 
   return (
     <main
@@ -165,12 +171,15 @@ export function InboxPageView({
           <ConversationPanel
             conversation={selectedConversation}
             currentUser={currentUser}
+            draft={draft}
+            isComposingNew={selection?.kind === "new"}
             isSending={isSending}
             isStreaming={isStreaming}
             jobs={jobs}
             jobsIsLoading={jobsIsLoading}
             messages={messages}
             messagesIsLoading={messagesIsLoading}
+            onDraftChange={onDraftChange}
             onSendMessage={onSendMessage}
             organizationSlug={organizationSlug}
             streamedAssistant={streamedAssistant}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.test.tsx
@@ -63,6 +63,40 @@ function renderComposer(ui: ReactNode) {
   );
 }
 
+describe("ReplyComposerView toolbar", () => {
+  it("shows the dock toolbar with send, github, and attachments", () => {
+    renderComposer(
+      <PromptInputProvider>
+        <ReplyComposerView
+          disabled={false}
+          initialProjectId="proj_website"
+          isStreaming={false}
+          onSend={vi.fn()}
+          projects={[
+            {
+              id: "proj_website",
+              name: "Hyperlocalise Website Localisation",
+              source: "native",
+              externalProviderKind: null,
+            },
+          ]}
+          projectsIsError={false}
+          projectsIsLoading={false}
+          repositories={repositoriesFixture}
+          repositoriesIsError={false}
+          repositoriesIsLoading={false}
+        />
+      </PromptInputProvider>,
+    );
+
+    expect(screen.getByRole("button", { name: "Send reply" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send reply" })).toHaveTextContent("Send");
+    expect(screen.getByRole("button", { name: "Add photos and files" })).toBeInTheDocument();
+    expect(screen.getByText("GitHub repo")).toBeInTheDocument();
+    expect(screen.getByText("Hyperlocalise Website Localisation")).toBeInTheDocument();
+  });
+});
+
 describe("ReplyComposerView draft sync", () => {
   it("keeps typed characters when draft is lifted to parent state", async () => {
     const user = userEvent.setup();

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
@@ -90,7 +90,6 @@ type ReplyComposerViewProps = {
   repositories: InboxGithubRepository[];
   repositoriesIsError: boolean;
   repositoriesIsLoading: boolean;
-  variant?: "default" | "compact";
 };
 
 export function ReplyComposerView({
@@ -109,7 +108,6 @@ export function ReplyComposerView({
   repositories,
   repositoriesIsError,
   repositoriesIsLoading,
-  variant = "default",
 }: ReplyComposerViewProps) {
   const intl = useIntl();
   const [replyText, setReplyText] = useState(draft);
@@ -179,25 +177,15 @@ export function ReplyComposerView({
   };
 
   return (
-    <section
-      className={
-        variant === "compact"
-          ? "sticky bottom-0 z-20 shrink-0 border-t border-border bg-background p-3"
-          : "sticky bottom-0 z-20 shrink-0 border-t border-border bg-background/95 px-4 py-4 backdrop-blur sm:px-6"
-      }
-    >
+    <section className="sticky bottom-0 z-20 shrink-0 border-t border-border bg-background p-3">
       <div className="mx-auto w-full max-w-4xl">
         <PromptInput
           onSubmit={({ text, files }) => sendReply(text, files)}
-          className={
-            variant === "compact"
-              ? "overflow-hidden rounded-xl border border-border bg-muted/30 text-foreground shadow-sm [&_[data-slot=input-group]]:h-auto [&_[data-slot=input-group]]:rounded-xl [&_[data-slot=input-group]]:border-0 [&_[data-slot=input-group]]:bg-transparent"
-              : "overflow-hidden rounded-[1.35rem] border border-border bg-background text-foreground shadow-2xl shadow-black/10 [&_[data-slot=input-group]]:h-auto [&_[data-slot=input-group]]:rounded-[1.35rem] [&_[data-slot=input-group]]:border-0 [&_[data-slot=input-group]]:bg-transparent"
-          }
+          className="overflow-hidden rounded-xl border border-border bg-muted/30 text-foreground shadow-sm [&_[data-slot=input-group]]:h-auto [&_[data-slot=input-group]]:rounded-xl [&_[data-slot=input-group]]:border-0 [&_[data-slot=input-group]]:bg-transparent"
         >
           <PromptInputBody>
             {attachments.files.length > 0 && (
-              <div className="px-4 pt-3 sm:px-6">
+              <div className="px-3 pt-3">
                 <Attachments variant="inline">
                   {attachments.files.map((file) => (
                     <Attachment
@@ -220,11 +208,7 @@ export function ReplyComposerView({
                 setReplyText(next);
                 onDraftChange?.(next);
               }}
-              className={
-                variant === "compact"
-                  ? "min-h-12 max-h-28 px-3 py-3 text-sm leading-5"
-                  : "min-h-24 px-4 py-4 text-base leading-6 sm:px-6 sm:py-5"
-              }
+              className="min-h-12 max-h-28 px-3 py-3 text-sm leading-5"
               placeholder={
                 isStreaming
                   ? intl.formatMessage(replyComposerMessages.streamingPlaceholder)
@@ -233,14 +217,8 @@ export function ReplyComposerView({
               rows={1}
             />
           </PromptInputBody>
-          <PromptInputFooter
-            className={
-              variant === "compact"
-                ? "min-h-10 flex-wrap gap-2 border-0 bg-transparent px-2 pb-2 sm:flex-nowrap"
-                : "flex-wrap gap-3 border-t border-border bg-muted px-4 py-3 sm:px-5"
-            }
-          >
-            <PromptInputTools className="flex-wrap gap-2 text-sm text-muted-foreground">
+          <PromptInputFooter className="min-h-10 flex-wrap gap-2 border-0 bg-transparent px-2 pb-2 sm:flex-nowrap">
+            <PromptInputTools className="gap-2 text-sm text-muted-foreground">
               <PromptInputButton
                 className="inline-flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent/20 hover:text-foreground"
                 size="icon-sm"
@@ -252,7 +230,7 @@ export function ReplyComposerView({
               </PromptInputButton>
             </PromptInputTools>
 
-            <PromptInputTools className="flex-wrap justify-end gap-2 text-sm text-muted-foreground">
+            <PromptInputTools className="min-w-0 flex-1 flex-wrap justify-end gap-2 text-sm text-muted-foreground sm:flex-nowrap">
               <ProjectSelector
                 projects={projects}
                 projectsIsError={projectsIsError}
@@ -274,7 +252,7 @@ export function ReplyComposerView({
               <PromptInputSubmit
                 size="sm"
                 disabled={(!replyText.trim() && attachments.files.length === 0) || disabled}
-                className="rounded-full bg-primary text-primary-foreground hover:bg-primary/90"
+                className="shrink-0 rounded-full bg-primary text-primary-foreground hover:bg-primary/90"
                 aria-label={sendReplyLabel}
                 tooltip={{
                   content: sendReplyLabel,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/new/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/new/page.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
+
+import { InboxPageContent } from "../_components/inbox-page-content";
+
+export default async function InboxNewRequestPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  const { organizationSlug } = await params;
+  const auth = await requireAppAuthContext({ organizationSlug });
+  const currentUserName =
+    [auth.sessionUser.firstName, auth.sessionUser.lastName].filter(Boolean).join(" ") ||
+    auth.sessionUser.email;
+
+  return (
+    <InboxPageContent
+      currentUser={{
+        avatarUrl: auth.sessionUser.profilePictureUrl ?? null,
+        email: auth.sessionUser.email,
+        name: currentUserName,
+      }}
+      organizationSlug={organizationSlug}
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
@@ -254,7 +254,6 @@ function NavigationGroupItems({
   projectId?: string;
 }) {
   const intl = useIntl();
-  const { chatDock } = useAppShellStore();
   const inboxHref = buildOrganizationPath(organizationSlug, "inbox");
   const unreadCountQuery = useQuery({
     queryKey: notificationsUnreadCountQueryKey(organizationSlug),
@@ -269,13 +268,11 @@ function NavigationGroupItems({
     <SidebarGroupContent>
       <SidebarMenu className="gap-1">
         {group.items.map((item) => {
-          const isActionItem = item.action === "open-chat-dock";
-          const isActive = isActionItem
-            ? false
-            : isNavigationItemActive(pathname, item.href, {
-                projectId,
-                organizationSlug,
-              });
+          const isActive = isNavigationItemActive(pathname, item.href, {
+            exact: item.exact,
+            projectId,
+            organizationSlug,
+          });
           const isInboxItem = item.href === inboxHref;
           const dynamicBadge = isInboxItem ? unreadBadgeLabel : null;
           const badge = dynamicBadge ?? item.badge;
@@ -289,11 +286,10 @@ function NavigationGroupItems({
           return (
             <SidebarMenuItem key={item.href}>
               <SidebarMenuButton
-                render={isActionItem ? undefined : <Link href={item.href} />}
+                render={<Link href={item.href} />}
                 isActive={isActive}
                 tooltip={tooltip}
                 className={navigationButtonClass(isActive)}
-                onClick={isActionItem ? () => chatDock.openNewTab() : undefined}
               >
                 <HugeiconsIcon icon={item.icon} strokeWidth={2} className="size-4" />
                 <span className="min-w-0 flex-1 truncate">{item.label}</span>

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
@@ -23,6 +23,7 @@ describe("getAppShellTitle", () => {
   it.each([
     ["/org/acme/dashboard", "Overview"],
     ["/org/acme/inbox", "Inbox"],
+    ["/org/acme/inbox/new", "New Request"],
     ["/org/acme/projects", "Projects"],
     ["/org/acme/projects/proj_1", "proj_1"],
     ["/org/acme/projects/proj_1/files", "Files"],
@@ -79,6 +80,17 @@ describe("getAppShellTitle", () => {
 describe("getAppShellBreadcrumbs", () => {
   it("returns a single crumb for top-level routes", () => {
     expect(getAppShellBreadcrumbs("/org/acme/inbox", intl)).toEqual([{ label: "Inbox" }]);
+  });
+
+  it("returns New Request breadcrumbs for the inbox compose page", () => {
+    expect(getAppShellBreadcrumbs("/org/acme/inbox/new", intl)).toEqual([
+      { label: "Inbox", href: "/org/acme/inbox" },
+      { label: "New Request" },
+    ]);
+    expect(getAppShellBreadcrumbs("/en/org/acme/inbox/new", intl)).toEqual([
+      { label: "Inbox", href: "/org/acme/inbox" },
+      { label: "New Request" },
+    ]);
   });
 
   it("returns settings breadcrumbs for settings subpages", () => {

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
@@ -316,6 +316,22 @@ export function getAppShellBreadcrumbs(
   const { organizationSlug, routeSegments } = orgRoute;
   const [section, subsection, projectSection] = routeSegments;
 
+  if (section === "inbox" && subsection === "new") {
+    return [
+      {
+        label: formatRouteTitle(intl, "inbox"),
+        href: buildOrgPath(organizationSlug, "inbox"),
+      },
+      {
+        label: intl.formatMessage({
+          defaultMessage: "New Request",
+          id: "qL8n2wPk5R",
+          description: "App shell breadcrumb title for the inbox New Request compose page",
+        }),
+      },
+    ];
+  }
+
   if (section === "settings") {
     if (!subsection) {
       return [{ label: formatRouteTitle(intl, "settings") }];

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
@@ -325,7 +325,7 @@ export function getAppShellBreadcrumbs(
       {
         label: intl.formatMessage({
           defaultMessage: "New Request",
-          id: "qL8n2wPk5R",
+          id: "dKBR5NGh7M",
           description: "App shell breadcrumb title for the inbox New Request compose page",
         }),
       },

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
@@ -378,7 +378,6 @@ export const ChatDockPanel = observer(function ChatDockPanel({
           onSend={onSendMessage}
           organizationSlug={organizationSlug}
           placeholder={intl.formatMessage(chatDockMessages.emptyComposer)}
-          variant="compact"
         />
       </div>
     </section>

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-panel.tsx
@@ -33,7 +33,6 @@ import { ReplyComposer } from "@/app/[lang]/(authenticated)/org/[organizationSlu
 import { Button } from "@/components/ui/button";
 import { TypographyMuted } from "@/components/ui/typography";
 import { apiClient } from "@/lib/api-client-instance";
-import { readApiResponseError } from "@/lib/api-error";
 
 import { ChatDockEmptyState } from "./chat-dock-empty-state";
 import { chatDockMessages } from "./chat-dock.messages";
@@ -171,40 +170,12 @@ export const ChatDockPanel = observer(function ChatDockPanel({
   ]);
 
   const createConversationMutation = useMutation({
-    mutationFn: async (input: {
+    mutationFn: (input: {
       text: string;
       files: File[];
       projectId?: string;
       repositoryFullName?: string;
-    }) => {
-      const formData = new FormData();
-      formData.set("text", input.text.trim() || "Please translate the attached source file.");
-      if (input.projectId) {
-        formData.set("projectId", input.projectId);
-      }
-      if (input.repositoryFullName) {
-        formData.set("repositoryFullName", input.repositoryFullName);
-      }
-      for (const file of input.files) {
-        formData.append("files", file);
-      }
-
-      const response = await fetch(
-        `/api/orgs/${encodeURIComponent(organizationSlug)}/conversations`,
-        {
-          method: "POST",
-          body: formData,
-        },
-      );
-      if (!response.ok) {
-        throw await readApiResponseError(response, "Failed to create conversation");
-      }
-
-      return response.json() as Promise<{
-        conversation: { id: string; title?: string };
-        message?: { id: string; text: string };
-      }>;
-    },
+    }) => inboxApi.createConversation(organizationSlug, input),
   });
 
   const sendMessageMutation = useMutation({

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -28,6 +28,7 @@ import {
   buildOrganizationPath,
   buildProjectNavigationItems,
   buildProjectPath,
+  isInboxNewRequestPath,
   isNavigationItemActive,
   parseProjectRoute,
   stripAppLocalePrefix,
@@ -172,8 +173,8 @@ describe("path builders", () => {
     expect(byLabel.get("Inbox")?.href).toBe("/org/acme/inbox");
     expect(byLabel.get("Projects")?.href).toBe("/org/acme/projects");
     expect(byLabel.get("New Request")).toMatchObject({
-      href: "#open-chat-dock",
-      action: "open-chat-dock",
+      href: "/org/acme/inbox/new",
+      exact: true,
     });
     expect(byLabel.get("Automations")?.featureFlagKey).toBe(WORKSPACE_AUTOMATIONS_FLAG);
     expect(byLabel.get("Knowledge")?.featureFlagKey).toBe(WORKSPACE_KNOWLEDGE_FLAG);
@@ -289,6 +290,14 @@ describe("isNavigationItemActive", () => {
     expect(isNavigationItemActive("/org/acme/inbox/thread_1", "/org/acme/inbox")).toBe(true);
   });
 
+  it("keeps Inbox inactive on the dedicated New Request compose route", () => {
+    expect(isNavigationItemActive("/org/acme/inbox/new", "/org/acme/inbox")).toBe(false);
+    expect(isNavigationItemActive("/en/org/acme/inbox/new", "/org/acme/inbox")).toBe(false);
+    expect(isNavigationItemActive("/org/acme/inbox/new", "/org/acme/inbox/new", { exact: true })).toBe(
+      true,
+    );
+  });
+
   it("ignores the hash fragment on the item href", () => {
     expect(isNavigationItemActive("/org/acme/settings", "/org/acme/settings#profile")).toBe(true);
   });
@@ -309,5 +318,14 @@ describe("isNavigationItemActive", () => {
     expect(isNavigationItemActive("/org/acme/my-jobs/job_1", myWorkHref)).toBe(true);
     expect(isNavigationItemActive("/en/org/acme/my-jobs", myWorkHref)).toBe(true);
     expect(isNavigationItemActive("/org/acme/inbox", myWorkHref)).toBe(false);
+  });
+});
+
+describe("isInboxNewRequestPath", () => {
+  it("matches locale-prefixed and bare inbox compose paths", () => {
+    expect(isInboxNewRequestPath("/org/acme/inbox/new")).toBe(true);
+    expect(isInboxNewRequestPath("/en/org/acme/inbox/new")).toBe(true);
+    expect(isInboxNewRequestPath("/org/acme/inbox")).toBe(false);
+    expect(isInboxNewRequestPath("/org/acme/inbox/thread_1")).toBe(false);
   });
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -293,9 +293,9 @@ describe("isNavigationItemActive", () => {
   it("keeps Inbox inactive on the dedicated New Request compose route", () => {
     expect(isNavigationItemActive("/org/acme/inbox/new", "/org/acme/inbox")).toBe(false);
     expect(isNavigationItemActive("/en/org/acme/inbox/new", "/org/acme/inbox")).toBe(false);
-    expect(isNavigationItemActive("/org/acme/inbox/new", "/org/acme/inbox/new", { exact: true })).toBe(
-      true,
-    );
+    expect(
+      isNavigationItemActive("/org/acme/inbox/new", "/org/acme/inbox/new", { exact: true }),
+    ).toBe(true);
   });
 
   it("ignores the hash fragment on the item href", () => {

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -44,25 +44,20 @@ import type { HugeiconsIcon } from "@hugeicons/react";
 
 export type NavigationIcon = ComponentProps<typeof HugeiconsIcon>["icon"];
 
-export type NavigationItemAction = "open-chat-dock";
-
 export type NavigationItem = {
   label: string;
   href: string;
   icon: NavigationIcon;
   description?: string;
   badge?: string;
-  /** Non-route action; when set, the sidebar renders a button instead of a link. */
-  action?: NavigationItemAction;
+  /** When true, only the exact href is active (not nested paths). */
+  exact?: boolean;
   featureFlagKey?:
     | typeof WORKSPACE_AUTOMATIONS_FLAG
     | typeof WORKSPACE_KNOWLEDGE_FLAG
     | typeof WORKSPACE_DOMAINS_FLAG
     | typeof RELEASE_CAT_ALL_FILES_FLAG;
 };
-
-/** Sentinel href for the New Request sidebar action (never navigated). */
-export const OPEN_CHAT_DOCK_HREF = "#open-chat-dock";
 
 export type NavigationGroup = {
   label?: string;
@@ -93,8 +88,8 @@ export function buildGlobalNavigationGroups(
             id: "VtO24sqmBM",
             description: "Sidebar navigation item to start a new localisation request",
           }),
-          href: OPEN_CHAT_DOCK_HREF,
-          action: "open-chat-dock",
+          href: org("inbox/new"),
+          exact: true,
           icon: Chat01Icon,
           description: intl.formatMessage({
             defaultMessage: "Ask the localisation agent to prepare work",
@@ -378,6 +373,18 @@ function decodePathSegment(value: string) {
   }
 }
 
+export function isInboxNewRequestPath(pathname: string | null | undefined, inboxHref?: string) {
+  const normalizedPathname = stripAppLocalePrefix(pathname ?? "");
+  if (inboxHref) {
+    const inboxNewHref = `${inboxHref.replace(/\/+$/, "")}/new`;
+    return (
+      normalizedPathname === inboxNewHref || normalizedPathname.startsWith(`${inboxNewHref}/`)
+    );
+  }
+
+  return /\/org\/[^/]+\/inbox\/new\/?$/.test(normalizedPathname);
+}
+
 export function isNavigationItemActive(
   pathname: string | null | undefined,
   href: string,
@@ -407,6 +414,11 @@ export function isNavigationItemActive(
 
   if (normalizedPathname === itemPathname) {
     return true;
+  }
+
+  // New Request lives under /inbox/new; keep the Inbox item inactive there.
+  if (itemPathname.endsWith("/inbox") && isInboxNewRequestPath(normalizedPathname, itemPathname)) {
+    return false;
   }
 
   if (itemPathname.endsWith("/projects")) {

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -377,9 +377,7 @@ export function isInboxNewRequestPath(pathname: string | null | undefined, inbox
   const normalizedPathname = stripAppLocalePrefix(pathname ?? "");
   if (inboxHref) {
     const inboxNewHref = `${inboxHref.replace(/\/+$/, "")}/new`;
-    return (
-      normalizedPathname === inboxNewHref || normalizedPathname.startsWith(`${inboxNewHref}/`)
-    );
+    return normalizedPathname === inboxNewHref || normalizedPathname.startsWith(`${inboxNewHref}/`);
   }
 
   return /\/org\/[^/]+\/inbox\/new\/?$/.test(normalizedPathname);

--- a/docs/plans/2026-08-17-inbox-new-request-compose-design.md
+++ b/docs/plans/2026-08-17-inbox-new-request-compose-design.md
@@ -1,0 +1,21 @@
+# Inbox New Request compose page
+
+## Goal
+
+Sidebar **New Request** opens a full inbox page with a dedicated empty chat, instead of the floating chat dock.
+
+## Decisions
+
+- Navigate to `/org/:slug/inbox/new`.
+- Reuse the inbox list + detail layout.
+- Show a pending chat (empty state, suggestion chips, composer) until the first send.
+- Create the conversation with `POST /api/orgs/:slug/conversations`, then go to `/inbox/:conversationId`.
+- Keep Inbox inactive on `/inbox/new`; New Request is exact-active there.
+- Redirect `/org/:slug/chat` to `/inbox/new`.
+- Leave the footer dock and dashboard CTAs on `ChatDockStore.openNewTab()`.
+
+## Out of scope
+
+- Removing the chat dock.
+- Syncing dock tabs with inbox selection.
+- Crowdin embed New conversation flow.

--- a/docs/plans/2026-08-17-unify-inbox-chat-composer-design.md
+++ b/docs/plans/2026-08-17-unify-inbox-chat-composer-design.md
@@ -1,0 +1,17 @@
+# Unify inbox and chat-dock composers
+
+## Goal
+
+Inbox chat uses the same input chrome as the floating chat dock: compact rounded field, attachment, project, GitHub repo, and a visible Send button.
+
+## Decisions
+
+- Keep a single `ReplyComposer` implementation.
+- Drop the large `default` variant. Dock compact chrome is the only look.
+- Inbox conversation panel (new request and existing chat_ui threads) uses that look automatically.
+- Keep Send in the toolbar and do not let the project/repo labels clip it away.
+
+## Out of scope
+
+- Changing composer behavior (attachments, project lock, streaming).
+- Removing the floating dock.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Sidebar **New Request** now navigates to `/org/:slug/inbox/new` instead of opening the floating chat dock.

That page reuses the inbox list + detail layout and shows a dedicated compose chat. The first send creates a conversation via `POST /api/orgs/:slug/conversations`, then navigates to `/inbox/:conversationId`.

Inbox and the floating chat dock now share one composer chrome: compact rounded field, attachments, project, GitHub repo, and a visible Send button. The larger inbox-only input is gone.

`/org/:slug/chat` redirects to `/inbox/new`. The Inbox nav item stays inactive on the compose route. Footer dock and dashboard New Request CTAs still open the floating dock.

[Unified dock-style composer](https://cursor.com/agents/bc-702fd6fc-684d-4004-bd6c-77808614345f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Funified_composer_dock_style.webp)
[Inbox New Request with unified composer](https://cursor.com/agents/bc-702fd6fc-684d-4004-bd6c-77808614345f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finbox_new_request_unified_composer.webp)

## How to test

1. Click **New Request** in the sidebar. Confirm it opens `/inbox/new` with a compose chat, not the floating dock.
2. Confirm the composer matches the chat dock: Send button, GitHub repo, project, attachments.
3. Confirm the **Inbox** nav item is not marked active on that page.
4. Send a first message. Confirm a conversation is created and the URL becomes `/inbox/:conversationId`.
5. Confirm footer dock / dashboard New Request still open the floating chat dock.
6. Automated: `vp check --fix` (pass) and `vp test` (671 files / 4395 tests passed).

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-702fd6fc-684d-4004-bd6c-77808614345f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-702fd6fc-684d-4004-bd6c-77808614345f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

