### PR TITLE
fix(crowdin): add Force option to InstallApplicationRequest

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -1,5 +1,11 @@
 # Crowdin Steward's Journal
 
+## 2026-12-29 - Add Force option to InstallApplicationRequest
+
+**Learning:** In Crowdin API v2, installing applications (`POST /api/v2/applications/installations`) supports an optional `force` boolean flag (`force: true`) to force re-installing an application if it is already installed. The SDK previously omitted `Force` from `InstallApplicationRequest`, preventing callers from specifying force installation behavior.
+
+**Action:** Added `Force *bool json:"force,omitempty"` to `InstallApplicationRequest` in `crowdin/model/applications.go`. Added unit test assertions for JSON serialization with `Force` set or omitted in `crowdin/applications_test.go` and `crowdin/model/applications_test.go`.
+
 ## 2026-12-28 - Use pointer representation for FieldAddRequest Config field
 
 **Learning:** In Crowdin API v2, the `config` field in `POST /api/v2/fields` requests is optional. When typed as a non-pointer struct (`FieldConfig`), Go's standard `json.Marshal` serializes an uninitialized struct as `{}` even with `json:"config,omitempty"`, sending an empty object payload to Crowdin instead of omitting the parameter. Typing `Config` as `*FieldConfig` ensures proper parameter omission when `nil`.

--- a/third_party/crowdin-api-client-go/crowdin/applications_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/applications_test.go
@@ -202,6 +202,14 @@ func TestApplicationsService_Install(t *testing.T) {
 			body: `{"url":"https://localhost.dev"}` + "\n",
 		},
 		{
+			name: "with force flag",
+			req: &model.InstallApplicationRequest{
+				URL:   "https://localhost.dev",
+				Force: ToPtr(true),
+			},
+			body: `{"url":"https://localhost.dev","force":true}` + "\n",
+		},
+		{
 			name: "with own permissions",
 			req: &model.InstallApplicationRequest{
 				URL: "https://localhost.dev",

--- a/third_party/crowdin-api-client-go/crowdin/model/applications.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/applications.go
@@ -93,6 +93,9 @@ type InstallApplicationRequest struct {
 	Permissions *ProjectPermission `json:"permissions,omitempty"`
 	// Modules with permissions to set for the application.
 	Modules []*InstallationModule `json:"modules,omitempty"`
+	// Force install application even if it is already installed.
+	// Default: false.
+	Force *bool `json:"force,omitempty"`
 }
 
 // InstallationReplaceValue represents the structure of the values to be replaced.

--- a/third_party/crowdin-api-client-go/crowdin/model/applications_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/applications_test.go
@@ -29,6 +29,11 @@ func TestInstallApplicationRequestValidate(t *testing.T) {
 			req:   &InstallApplicationRequest{URL: "https://example.com/app/install"},
 			valid: true,
 		},
+		{
+			name:  "valid request with force",
+			req:   &InstallApplicationRequest{URL: "https://example.com/app/install", Force: toPtr(true)},
+			valid: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- What: Added optional Force *bool field to InstallApplicationRequest in crowdin/model/applications.go.
- Why: Aligns Install Application endpoint request model with Crowdin API v2 specifications (POST /api/v2/applications/installations), allowing callers to force reinstall applications.
- Docs: https://developer.crowdin.com/api/v2/#operation/api.applications.installations.post
- Scope: third_party/crowdin-api-client-go/crowdin/model/applications.go and test files.
- Tests: Ran go test ./crowdin ./crowdin/model.
- Confidence: Clean model addition with omitempty and unit test assertions.

---
*PR created automatically by Jules for task [3829777422408978801](https://jules.google.com/task/3829777422408978801) started by @cungminh2710*