### PR TITLE
fix(cat): keep queue chrome mounted when filters change

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-page-content.tsx
@@ -23,6 +23,7 @@ import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { TypographyP } from "@/components/ui/typography";
 import { ProjectFileCatWorkspace } from "@/components/cat/project-file/project-file-cat-workspace";
+import { CatQueueToolbarHost } from "@/components/cat/queue/cat-queue-toolbar-host";
 import {
   attemptCatPageNavigation,
   type CatPageNavigationGuardRef,
@@ -582,6 +583,8 @@ export function ProjectFileCatPageContent({
             />
           </TypographyP>
         ) : null}
+
+        <CatQueueToolbarHost />
       </div>
 
       {(repositoriesQuery.isError ||

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -52,6 +52,7 @@ import {
 } from "./select-job-cat-repository";
 import { jobCatPageContentMessages } from "./job-cat-page-content.messages";
 import { ProjectFileCatWorkspace } from "@/components/cat/project-file/project-file-cat-workspace";
+import { CatQueueToolbarHost } from "@/components/cat/queue/cat-queue-toolbar-host";
 import {
   attemptCatPageNavigation,
   type CatPageNavigationGuardRef,
@@ -618,6 +619,8 @@ export function JobCatPageContent({
               onTargetLocaleChange={handleAllFilesLocaleChange}
             />
           ) : null}
+
+          <CatQueueToolbarHost />
         </div>
 
         {repositoryBanner}
@@ -794,6 +797,8 @@ export function JobCatPageContent({
               onRepositoryChange={handleRepositoryChange}
             />
           ) : null}
+
+          <CatQueueToolbarHost />
         </div>
 
         {repositoryBanner}
@@ -942,6 +947,8 @@ export function JobCatPageContent({
               intl.formatMessage(jobCatPageContentMessages.fileFormatFallback),
           })}
         </TypographyP>
+
+        <CatQueueToolbarHost />
       </div>
 
       {repositoryBanner}

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-api.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-api.test.ts
@@ -64,6 +64,7 @@ vi.mock("@/lib/api-client-instance", () => ({
 }));
 
 import {
+  canReuseCatQueuePlaceholderData,
   fetchProjectFileCatQueuePage,
   projectFileCatBaseQueryKey,
   projectFileCatQueryKey,
@@ -316,5 +317,69 @@ describe("projectFileCatBaseQueryKey", () => {
       null,
     ]);
     expect(key).not.toContain(0);
+  });
+});
+
+describe("canReuseCatQueuePlaceholderData", () => {
+  const baseKeyInput = {
+    ...catApiTestContext,
+    search: "",
+    queueFilter: "all" as const,
+    limit: 50,
+  };
+
+  it("reuses previous data when only search, filter, or page size change", () => {
+    const previousKey = projectFileCatBaseQueryKey(baseKeyInput);
+
+    expect(
+      canReuseCatQueuePlaceholderData(
+        previousKey,
+        projectFileCatBaseQueryKey({ ...baseKeyInput, search: "hero" }),
+      ),
+    ).toBe(true);
+    expect(
+      canReuseCatQueuePlaceholderData(
+        previousKey,
+        projectFileCatBaseQueryKey({ ...baseKeyInput, queueFilter: "needs_review" }),
+      ),
+    ).toBe(true);
+    expect(
+      canReuseCatQueuePlaceholderData(
+        previousKey,
+        projectFileCatBaseQueryKey({ ...baseKeyInput, limit: 25 }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not reuse previous data when the target locale or file identity changes", () => {
+    const previousKey = projectFileCatBaseQueryKey(baseKeyInput);
+
+    expect(
+      canReuseCatQueuePlaceholderData(
+        previousKey,
+        projectFileCatBaseQueryKey({ ...baseKeyInput, targetLocale: "de" }),
+      ),
+    ).toBe(false);
+    expect(
+      canReuseCatQueuePlaceholderData(
+        previousKey,
+        projectFileCatBaseQueryKey({ ...baseKeyInput, sourcePath: "locales/other.json" }),
+      ),
+    ).toBe(false);
+    expect(
+      canReuseCatQueuePlaceholderData(
+        previousKey,
+        projectFileCatBaseQueryKey({
+          ...baseKeyInput,
+          sourcePaths: "locales/en.json,locales/de.json",
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      canReuseCatQueuePlaceholderData(
+        previousKey,
+        projectFileCatBaseQueryKey({ ...baseKeyInput, projectId: "project_2" }),
+      ),
+    ).toBe(false);
   });
 });

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-api.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-api.ts
@@ -79,6 +79,29 @@ export function projectFileCatBaseQueryKey(input: {
   ] as const;
 }
 
+const CAT_QUEUE_BASE_QUERY_KEY_LENGTH = 11;
+
+function catQueuePlaceholderIdentity(key: readonly unknown[]) {
+  if (key.length !== CAT_QUEUE_BASE_QUERY_KEY_LENGTH || key[0] !== "project-file-cat-queue") {
+    return null;
+  }
+
+  return [key[0], key[1], key[2], key[3], key[4], key[5], key[6], key[10]] as const;
+}
+
+export function canReuseCatQueuePlaceholderData(
+  previousKey: readonly unknown[],
+  nextKey: readonly unknown[],
+) {
+  const previousIdentity = catQueuePlaceholderIdentity(previousKey);
+  const nextIdentity = catQueuePlaceholderIdentity(nextKey);
+  if (!previousIdentity || !nextIdentity) {
+    return false;
+  }
+
+  return previousIdentity.every((value, index) => Object.is(value, nextIdentity[index]));
+}
+
 export type ProjectFileCatQueuePageParam = {
   offset: number;
   phraseScanPage?: number;

--- a/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/project-file-cat-workspace.tsx
@@ -654,7 +654,8 @@ export function ProjectFileCatWorkspace({
 
   const isFullscreen = layout === "fullscreen";
 
-  const isQueueLoading = isSearchPending || (catQuery.isLoading && !catFile);
+  const isQueueLoading =
+    isSearchPending || (catQuery.isLoading && !catFile) || catQuery.isPlaceholderData;
 
   if (catQuery.isLoading && !catFile) {
     return (

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-segment-query.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-segment-query.ts
@@ -12,7 +12,12 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useInfiniteQuery, useQueryClient, type InfiniteData } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  useInfiniteQuery,
+  useQueryClient,
+  type InfiniteData,
+} from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useIntl } from "react-intl";
 
@@ -118,6 +123,7 @@ export function useCatSegmentQuery(input: {
   >({
     queryKey: baseQueryKey,
     enabled: input.enabled !== false && Boolean(input.targetLocale) && Boolean(input.sourcePath),
+    placeholderData: keepPreviousData,
     initialPageParam: { offset: 0 },
     getNextPageParam: (lastPage) => {
       const pagePagination = lastPage.pagination;

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-segment-query.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-segment-query.ts
@@ -12,12 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import {
-  keepPreviousData,
-  useInfiniteQuery,
-  useQueryClient,
-  type InfiniteData,
-} from "@tanstack/react-query";
+import { useInfiniteQuery, useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useIntl } from "react-intl";
 
@@ -28,6 +23,7 @@ import { isServerQueueFilter, type CatQueueFilter } from "@/components/cat/queue
 import { mergeCatQueuePages } from "@/components/cat/queue/merge-cat-queue-pages";
 
 import {
+  canReuseCatQueuePlaceholderData,
   defaultCatPageLimit,
   fetchProjectFileCatQueuePage,
   projectFileCatBaseQueryKey,
@@ -123,7 +119,17 @@ export function useCatSegmentQuery(input: {
   >({
     queryKey: baseQueryKey,
     enabled: input.enabled !== false && Boolean(input.targetLocale) && Boolean(input.sourcePath),
-    placeholderData: keepPreviousData,
+    placeholderData: (previousData, previousQuery) => {
+      if (
+        previousData === undefined ||
+        previousQuery === undefined ||
+        !canReuseCatQueuePlaceholderData(previousQuery.queryKey, baseQueryKey)
+      ) {
+        return undefined;
+      }
+
+      return previousData;
+    },
     initialPageParam: { offset: 0 },
     getNextPageParam: (lastPage) => {
       const pagePagination = lastPage.pagination;

--- a/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-panel.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-panel.test.tsx
@@ -50,12 +50,8 @@ describe("CatQueuePanel pagination", () => {
   });
 });
 
-describe("CatQueuePanel bulk hide", () => {
-  it("offers Hide and Unhide when those bulk handlers are provided", async () => {
-    window.localStorage.setItem("cat-queue:selection-mode:v1", "false");
-    const user = userEvent.setup();
-    const onBulkHide = vi.fn();
-    const onBulkUnhide = vi.fn();
+describe("CatQueuePanel chrome", () => {
+  it("does not render filter, search, or bulk actions in the queue column", () => {
     const segments = catSegmentsFixture.slice(0, 3);
 
     renderWithCatProviders(
@@ -63,44 +59,11 @@ describe("CatQueuePanel bulk hide", () => {
         segments={segments}
         selectedSegmentId={segments[0]!.id}
         onSelectSegment={vi.fn()}
-        onToggleSegmentChecked={vi.fn()}
-        onBulkHide={onBulkHide}
-        onBulkUnhide={onBulkUnhide}
       />,
     );
 
-    await user.click(screen.getByRole("checkbox", { name: "Show bulk selection checkboxes" }));
-    await user.click(screen.getByRole("button", { name: "Queue actions" }));
-
-    expect(screen.getByRole("menuitem", { name: "Hide selected" })).toHaveAttribute(
-      "aria-disabled",
-      "true",
-    );
-    expect(screen.getByRole("menuitem", { name: "Unhide selected" })).toHaveAttribute(
-      "aria-disabled",
-      "true",
-    );
-  });
-
-  it("includes Hidden in the Crowdin queue filter menu", async () => {
-    const user = userEvent.setup();
-    const onQueueFilterChange = vi.fn();
-    const segments = catSegmentsFixture.slice(0, 3);
-
-    renderWithCatProviders(
-      <CatQueuePanel
-        segments={segments}
-        selectedSegmentId={segments[0]!.id}
-        onSelectSegment={vi.fn()}
-        queueFilter="all"
-        onQueueFilterChange={onQueueFilterChange}
-        availableQueueFilters={["all", "hidden"]}
-      />,
-    );
-
-    await user.click(screen.getByRole("button", { name: "Filter queue" }));
-    await user.click(screen.getByRole("menuitemradio", { name: "Hidden" }));
-
-    expect(onQueueFilterChange).toHaveBeenCalledWith("hidden");
+    expect(screen.queryByRole("button", { name: "Filter queue" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("searchbox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Queue actions" })).not.toBeInTheDocument();
   });
 });

--- a/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-panel.tsx
@@ -12,34 +12,16 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { FilterIcon, MoreHorizontalCircle01Icon, SearchIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
-import { DownloadIcon } from "lucide-react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { FormattedMessage } from "react-intl";
 
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
-import { cn } from "@/lib/primitives/cn";
 
 import { CatQueueSkeletonList } from "./cat-queue-skeleton-list";
 import { CatQueueVirtualList } from "./cat-queue-virtual-list";
-import { catQueueFilterValues, type CatQueueFilter } from "./cat-queue-filter";
-import { useCatQueueSelectionMode } from "./use-cat-queue-selection-mode";
+import type { CatQueueFilter } from "./cat-queue-filter";
 import { catQueuePanelMessages, catWorkspaceMessages } from "@/components/cat/shared/cat.messages";
 import type { CatSegment } from "@/components/cat/shared/types";
-import { CatWorkspaceViewSwitcherConnected } from "@/components/cat/workspace/cat-workspace-view-switcher-connected";
 
 export type CatQueuePagination = {
   offset: number;
@@ -49,82 +31,38 @@ export type CatQueuePagination = {
   hasMore: boolean;
 };
 
-const queueFilterMessageByValue: Record<
-  CatQueueFilter,
-  (typeof catQueuePanelMessages)[keyof typeof catQueuePanelMessages]
-> = {
-  all: catQueuePanelMessages.filterAll,
-  untranslated: catQueuePanelMessages.filterUntranslated,
-  needs_review: catQueuePanelMessages.filterNeedsReview,
-  reviewed: catQueuePanelMessages.filterReviewed,
-  has_issues: catQueuePanelMessages.filterHasIssues,
-  skipped: catQueuePanelMessages.filterSkipped,
-  hidden: catQueuePanelMessages.filterHidden,
-};
-
 export function CatQueuePanel({
   segments,
   selectedSegmentId,
   dirtySegmentIds,
   onSelectSegment,
   search = "",
-  onSearchChange,
-  isSearching = false,
   queueFilter = "all",
-  onQueueFilterChange,
-  availableQueueFilters = catQueueFilterValues,
   checkedSegmentIds,
   onToggleSegmentChecked,
-  onSelectAllVisible,
-  onClearChecked,
-  onBulkApprove,
-  onBulkSkip,
-  onBulkHide,
-  onBulkUnhide,
-  isBulkActionPending = false,
+  showSelection = false,
   isFetchingPage = false,
   isQueueLoading = false,
   pagination = null,
   hasMoreQueue = false,
   onLoadMoreQueue,
-  onDownloadFilteredView,
-  isDownloadingFilteredView = false,
 }: {
   segments: CatSegment[];
   selectedSegmentId: string;
   dirtySegmentIds?: ReadonlySet<string>;
   onSelectSegment: (segmentId: string) => void;
   search?: string;
-  onSearchChange?: (value: string) => void;
-  isSearching?: boolean;
   queueFilter?: CatQueueFilter;
-  onQueueFilterChange?: (filter: CatQueueFilter) => void;
-  availableQueueFilters?: CatQueueFilter[];
   checkedSegmentIds?: ReadonlySet<string>;
   onToggleSegmentChecked?: (segmentId: string, checked: boolean) => void;
-  onSelectAllVisible?: () => void;
-  onClearChecked?: () => void;
-  onBulkApprove?: () => void;
-  onBulkSkip?: () => void;
-  onBulkHide?: () => void;
-  onBulkUnhide?: () => void;
-  isBulkActionPending?: boolean;
+  showSelection?: boolean;
   isFetchingPage?: boolean;
   isQueueLoading?: boolean;
   pagination?: CatQueuePagination | null;
   hasMoreQueue?: boolean;
   onLoadMoreQueue?: () => void;
-  onDownloadFilteredView?: (format: "csv" | "tmx" | "xlf" | "xliff") => void;
-  isDownloadingFilteredView?: boolean;
 }) {
-  const intl = useIntl();
-  const [selectionMode, setSelectionMode] = useCatQueueSelectionMode();
   const loadedCount = segments.length;
-  const selectedCount = checkedSegmentIds?.size ?? 0;
-  const hasBulkActions = Boolean(
-    onToggleSegmentChecked && (onBulkApprove || onBulkSkip || onBulkHide || onBulkUnhide),
-  );
-  const showSelection = selectionMode && Boolean(onToggleSegmentChecked);
   const hasActiveFilter = queueFilter !== "all";
   const hasSearch = search.trim().length > 0;
   const emptyMessage = hasSearch
@@ -135,205 +73,10 @@ export function CatQueuePanel({
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-background lg:border-r lg:border-border">
-      <div className="shrink-0 space-y-3 border-b border-border px-4 py-3">
-        <div className="flex items-center justify-between gap-2">
-          <h2 className="text-sm font-semibold text-foreground">
-            <FormattedMessage {...catQueuePanelMessages.queueTitle} />
-          </h2>
-          <div className="flex items-center gap-1">
-            {onDownloadFilteredView ? (
-              <DropdownMenu>
-                <DropdownMenuTrigger
-                  render={
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="h-8 gap-1.5 font-normal"
-                      disabled={isDownloadingFilteredView}
-                      aria-label={intl.formatMessage(catQueuePanelMessages.downloadFilteredAria)}
-                    />
-                  }
-                >
-                  {isDownloadingFilteredView ? (
-                    <Spinner className="size-3.5" />
-                  ) : (
-                    <DownloadIcon className="size-3.5" />
-                  )}
-                  <span className="text-xs">
-                    <FormattedMessage {...catQueuePanelMessages.downloadFiltered} />
-                  </span>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-40">
-                  <DropdownMenuGroup>
-                    <DropdownMenuLabel>
-                      <FormattedMessage {...catQueuePanelMessages.downloadFilteredFormatLabel} />
-                    </DropdownMenuLabel>
-                    {(["csv", "tmx", "xlf", "xliff"] as const).map((format) => (
-                      <DropdownMenuItem key={format} onClick={() => onDownloadFilteredView(format)}>
-                        {format.toUpperCase()}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuGroup>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            ) : null}
-            <CatWorkspaceViewSwitcherConnected />
-          </div>
-        </div>
-
-        {onSearchChange ? (
-          <div className="relative">
-            <HugeiconsIcon
-              icon={SearchIcon}
-              className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground"
-            />
-            <Input
-              value={search}
-              onChange={(event) => onSearchChange(event.target.value)}
-              placeholder={intl.formatMessage(catQueuePanelMessages.searchPlaceholder)}
-              aria-label={intl.formatMessage(catQueuePanelMessages.searchAria)}
-              className="h-9 pl-9 font-mono text-xs"
-            />
-            {isSearching ? (
-              <Spinner className="absolute top-1/2 right-2.5 size-3.5 -translate-y-1/2" />
-            ) : null}
-          </div>
-        ) : null}
-
-        <div className="flex items-center justify-between gap-2">
-          <div className="flex min-w-0 flex-wrap items-center gap-2">
-            {onQueueFilterChange ? (
-              <DropdownMenu>
-                <DropdownMenuTrigger
-                  render={
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className={cn(
-                        "h-8 gap-1.5 font-normal",
-                        hasActiveFilter && "border-grove-400/40",
-                      )}
-                      aria-label={intl.formatMessage(catQueuePanelMessages.filterQueueAria)}
-                    />
-                  }
-                >
-                  <HugeiconsIcon icon={FilterIcon} className="size-3.5" />
-                  <span className="text-xs">
-                    <FormattedMessage {...queueFilterMessageByValue[queueFilter]} />
-                  </span>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="start" className="w-48">
-                  <DropdownMenuGroup>
-                    <DropdownMenuLabel>
-                      <FormattedMessage {...catQueuePanelMessages.filterQueueAria} />
-                    </DropdownMenuLabel>
-                    <DropdownMenuRadioGroup
-                      value={queueFilter}
-                      onValueChange={(value) => onQueueFilterChange(value as CatQueueFilter)}
-                    >
-                      {availableQueueFilters.map((filterValue) => (
-                        <DropdownMenuRadioItem key={filterValue} value={filterValue}>
-                          <FormattedMessage {...queueFilterMessageByValue[filterValue]} />
-                        </DropdownMenuRadioItem>
-                      ))}
-                    </DropdownMenuRadioGroup>
-                  </DropdownMenuGroup>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            ) : null}
-
-            {hasBulkActions ? (
-              <label className="flex h-8 cursor-pointer items-center gap-1.5 rounded-lg border border-border px-2.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">
-                <input
-                  type="checkbox"
-                  className="size-3.5 rounded border-input accent-foreground"
-                  checked={selectionMode}
-                  aria-label={intl.formatMessage(catQueuePanelMessages.showSelectionAria)}
-                  onChange={(event) => {
-                    const enabled = event.currentTarget.checked;
-                    setSelectionMode(enabled);
-                    if (!enabled) {
-                      onClearChecked?.();
-                    }
-                  }}
-                />
-                <FormattedMessage {...catQueuePanelMessages.showSelection} />
-              </label>
-            ) : null}
-          </div>
-
-          {showSelection && hasBulkActions ? (
-            <DropdownMenu>
-              <DropdownMenuTrigger
-                render={
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon-sm"
-                    className="size-8 shrink-0"
-                    aria-label={intl.formatMessage(catQueuePanelMessages.queueActionsAria)}
-                    disabled={isBulkActionPending}
-                  />
-                }
-              >
-                {isBulkActionPending ? (
-                  <Spinner className="size-3.5" />
-                ) : (
-                  <HugeiconsIcon icon={MoreHorizontalCircle01Icon} className="size-4" />
-                )}
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-52">
-                <DropdownMenuGroup>
-                  <DropdownMenuLabel>
-                    {selectedCount > 0 ? (
-                      <FormattedMessage
-                        {...catQueuePanelMessages.bulkSelectionSummary}
-                        values={{ count: selectedCount }}
-                      />
-                    ) : (
-                      <FormattedMessage {...catQueuePanelMessages.queueActionsAria} />
-                    )}
-                  </DropdownMenuLabel>
-                  {onSelectAllVisible ? (
-                    <DropdownMenuItem onClick={onSelectAllVisible} disabled={segments.length === 0}>
-                      <FormattedMessage {...catQueuePanelMessages.bulkSelectAll} />
-                    </DropdownMenuItem>
-                  ) : null}
-                  {onClearChecked ? (
-                    <DropdownMenuItem onClick={onClearChecked} disabled={selectedCount === 0}>
-                      <FormattedMessage {...catQueuePanelMessages.bulkClearSelection} />
-                    </DropdownMenuItem>
-                  ) : null}
-                </DropdownMenuGroup>
-                <DropdownMenuSeparator />
-                <DropdownMenuGroup>
-                  {onBulkApprove ? (
-                    <DropdownMenuItem onClick={onBulkApprove} disabled={selectedCount === 0}>
-                      <FormattedMessage {...catQueuePanelMessages.bulkApprove} />
-                    </DropdownMenuItem>
-                  ) : null}
-                  {onBulkSkip ? (
-                    <DropdownMenuItem onClick={onBulkSkip} disabled={selectedCount === 0}>
-                      <FormattedMessage {...catQueuePanelMessages.bulkSkip} />
-                    </DropdownMenuItem>
-                  ) : null}
-                  {onBulkHide ? (
-                    <DropdownMenuItem onClick={onBulkHide} disabled={selectedCount === 0}>
-                      <FormattedMessage {...catQueuePanelMessages.bulkHide} />
-                    </DropdownMenuItem>
-                  ) : null}
-                  {onBulkUnhide ? (
-                    <DropdownMenuItem onClick={onBulkUnhide} disabled={selectedCount === 0}>
-                      <FormattedMessage {...catQueuePanelMessages.bulkUnhide} />
-                    </DropdownMenuItem>
-                  ) : null}
-                </DropdownMenuGroup>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          ) : null}
-        </div>
+      <div className="shrink-0 border-b border-border px-4 py-3">
+        <h2 className="text-sm font-semibold text-foreground">
+          <FormattedMessage {...catQueuePanelMessages.queueTitle} />
+        </h2>
       </div>
 
       {isQueueLoading ? (

--- a/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-toolbar-connected.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-toolbar-connected.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { observer } from "mobx-react-lite";
+import { useCallback, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { catQueueFilterValues, type CatQueueFilter } from "./cat-queue-filter";
+import { CatQueueToolbar } from "./cat-queue-toolbar";
+import { CAT_QUEUE_TOOLBAR_HOST_ID } from "./cat-queue-toolbar-host";
+import { useCatWorkspace } from "@/components/cat/workspace/cat-workspace-context";
+
+export const CatQueueToolbarConnected = observer(function CatQueueToolbarConnected({
+  onQueueSearchChange,
+  onQueueFilterChange,
+  availableQueueFilters = catQueueFilterValues,
+  isSearching = false,
+  visibleCount = 0,
+  onSelectAllVisible,
+  onBulkApprove,
+  onBulkSkip,
+  onBulkHide,
+  onBulkUnhide,
+  onDownloadFilteredView,
+  isDownloadingFilteredView = false,
+}: {
+  onQueueSearchChange?: (value: string) => void;
+  onQueueFilterChange?: (filter: CatQueueFilter) => void;
+  availableQueueFilters?: CatQueueFilter[];
+  isSearching?: boolean;
+  visibleCount?: number;
+  onSelectAllVisible?: () => void;
+  onBulkApprove?: () => void;
+  onBulkSkip?: () => void;
+  onBulkHide?: () => void;
+  onBulkUnhide?: () => void;
+  onDownloadFilteredView?: (format: "csv" | "tmx" | "xlf" | "xliff") => void;
+  isDownloadingFilteredView?: boolean;
+}) {
+  const store = useCatWorkspace();
+  const [host, setHost] = useState<HTMLElement | null | undefined>(undefined);
+
+  useEffect(() => {
+    setHost(document.getElementById(CAT_QUEUE_TOOLBAR_HOST_ID));
+  }, []);
+
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      store.setQueueSearch(value);
+      onQueueSearchChange?.(value);
+    },
+    [onQueueSearchChange, store],
+  );
+
+  const handleFilterChange = useCallback(
+    (filter: CatQueueFilter) => {
+      if (onQueueFilterChange) {
+        store.queue.setFilter(filter);
+        onQueueFilterChange(filter);
+        return;
+      }
+
+      store.setQueueFilter(filter);
+    },
+    [onQueueFilterChange, store],
+  );
+
+  const toolbar = (
+    <CatQueueToolbar
+      search={store.queueSearch}
+      onSearchChange={onQueueSearchChange ? handleSearchChange : undefined}
+      isSearching={isSearching}
+      queueFilter={store.queueFilter}
+      onQueueFilterChange={handleFilterChange}
+      availableQueueFilters={availableQueueFilters}
+      selectionMode={store.selectionMode}
+      onSelectionModeChange={(enabled) => store.setSelectionMode(enabled)}
+      selectedCount={store.checkedSegmentIds.size}
+      visibleCount={visibleCount}
+      onSelectAllVisible={onSelectAllVisible}
+      onClearChecked={() => store.clearChecked()}
+      onBulkApprove={onBulkApprove}
+      onBulkSkip={onBulkSkip}
+      onBulkHide={onBulkHide}
+      onBulkUnhide={onBulkUnhide}
+      isBulkActionPending={store.isBulkActionPending}
+      onDownloadFilteredView={onDownloadFilteredView}
+      isDownloadingFilteredView={isDownloadingFilteredView}
+    />
+  );
+
+  if (host === undefined) {
+    return null;
+  }
+
+  if (!host) {
+    return toolbar;
+  }
+
+  return createPortal(toolbar, host);
+});

--- a/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-toolbar-host.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-toolbar-host.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { cn } from "@/lib/primitives/cn";
+
+export const CAT_QUEUE_TOOLBAR_HOST_ID = "cat-queue-toolbar-host";
+
+export function CatQueueToolbarHost({ className }: { className?: string }) {
+  return (
+    <div
+      id={CAT_QUEUE_TOOLBAR_HOST_ID}
+      className={cn(
+        "ms-auto flex min-w-0 flex-1 flex-wrap items-center justify-end gap-2",
+        className,
+      )}
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-toolbar.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-toolbar.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { renderWithCatProviders } from "@/components/cat/shared/cat-test-utils";
+
+import { CatQueueToolbar } from "./cat-queue-toolbar";
+
+describe("CatQueueToolbar", () => {
+  it("includes Hidden in the Crowdin queue filter menu", async () => {
+    const user = userEvent.setup();
+    const onQueueFilterChange = vi.fn();
+
+    renderWithCatProviders(
+      <CatQueueToolbar
+        queueFilter="all"
+        onQueueFilterChange={onQueueFilterChange}
+        availableQueueFilters={["all", "hidden"]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Filter queue" }));
+    await user.click(screen.getByRole("menuitemradio", { name: "Hidden" }));
+
+    expect(onQueueFilterChange).toHaveBeenCalledWith("hidden");
+  });
+
+  it("offers Hide and Unhide when those bulk handlers are provided", async () => {
+    const user = userEvent.setup();
+    const onBulkHide = vi.fn();
+    const onBulkUnhide = vi.fn();
+
+    renderWithCatProviders(
+      <CatQueueToolbar
+        selectionMode
+        onSelectionModeChange={vi.fn()}
+        onBulkHide={onBulkHide}
+        onBulkUnhide={onBulkUnhide}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Queue actions" }));
+
+    expect(screen.getByRole("menuitem", { name: "Hide selected" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+    expect(screen.getByRole("menuitem", { name: "Unhide selected" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-toolbar.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/queue/cat-queue-toolbar.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { FilterIcon, MoreHorizontalCircle01Icon, SearchIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { DownloadIcon } from "lucide-react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/primitives/cn";
+
+import { catQueueFilterValues, type CatQueueFilter } from "./cat-queue-filter";
+import { catQueuePanelMessages } from "@/components/cat/shared/cat.messages";
+import { CatWorkspaceViewSwitcherConnected } from "@/components/cat/workspace/cat-workspace-view-switcher-connected";
+
+export const queueFilterMessageByValue: Record<
+  CatQueueFilter,
+  (typeof catQueuePanelMessages)[keyof typeof catQueuePanelMessages]
+> = {
+  all: catQueuePanelMessages.filterAll,
+  untranslated: catQueuePanelMessages.filterUntranslated,
+  needs_review: catQueuePanelMessages.filterNeedsReview,
+  reviewed: catQueuePanelMessages.filterReviewed,
+  has_issues: catQueuePanelMessages.filterHasIssues,
+  skipped: catQueuePanelMessages.filterSkipped,
+  hidden: catQueuePanelMessages.filterHidden,
+};
+
+export function CatQueueToolbar({
+  search = "",
+  onSearchChange,
+  isSearching = false,
+  queueFilter = "all",
+  onQueueFilterChange,
+  availableQueueFilters = catQueueFilterValues,
+  selectionMode = false,
+  onSelectionModeChange,
+  selectedCount = 0,
+  visibleCount = 0,
+  onSelectAllVisible,
+  onClearChecked,
+  onBulkApprove,
+  onBulkSkip,
+  onBulkHide,
+  onBulkUnhide,
+  isBulkActionPending = false,
+  onDownloadFilteredView,
+  isDownloadingFilteredView = false,
+}: {
+  search?: string;
+  onSearchChange?: (value: string) => void;
+  isSearching?: boolean;
+  queueFilter?: CatQueueFilter;
+  onQueueFilterChange?: (filter: CatQueueFilter) => void;
+  availableQueueFilters?: CatQueueFilter[];
+  selectionMode?: boolean;
+  onSelectionModeChange?: (enabled: boolean) => void;
+  selectedCount?: number;
+  visibleCount?: number;
+  onSelectAllVisible?: () => void;
+  onClearChecked?: () => void;
+  onBulkApprove?: () => void;
+  onBulkSkip?: () => void;
+  onBulkHide?: () => void;
+  onBulkUnhide?: () => void;
+  isBulkActionPending?: boolean;
+  onDownloadFilteredView?: (format: "csv" | "tmx" | "xlf" | "xliff") => void;
+  isDownloadingFilteredView?: boolean;
+}) {
+  const intl = useIntl();
+  const hasBulkActions = Boolean(
+    onSelectionModeChange && (onBulkApprove || onBulkSkip || onBulkHide || onBulkUnhide),
+  );
+  const hasActiveFilter = queueFilter !== "all";
+
+  return (
+    <div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
+      {onSearchChange ? (
+        <div className="relative min-w-0 flex-1 basis-40 sm:max-w-64">
+          <HugeiconsIcon
+            icon={SearchIcon}
+            className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground"
+          />
+          <Input
+            value={search}
+            onChange={(event) => onSearchChange(event.target.value)}
+            placeholder={intl.formatMessage(catQueuePanelMessages.searchPlaceholder)}
+            aria-label={intl.formatMessage(catQueuePanelMessages.searchAria)}
+            className="h-8 pl-9 font-mono text-xs"
+          />
+          {isSearching ? (
+            <Spinner className="absolute top-1/2 right-2.5 size-3.5 -translate-y-1/2" />
+          ) : null}
+        </div>
+      ) : null}
+
+      {onQueueFilterChange ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className={cn("h-8 gap-1.5 font-normal", hasActiveFilter && "border-grove-400/40")}
+                aria-label={intl.formatMessage(catQueuePanelMessages.filterQueueAria)}
+              />
+            }
+          >
+            <HugeiconsIcon icon={FilterIcon} className="size-3.5" />
+            <span className="text-xs">
+              <FormattedMessage {...queueFilterMessageByValue[queueFilter]} />
+            </span>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-48">
+            <DropdownMenuGroup>
+              <DropdownMenuLabel>
+                <FormattedMessage {...catQueuePanelMessages.filterQueueAria} />
+              </DropdownMenuLabel>
+              <DropdownMenuRadioGroup
+                value={queueFilter}
+                onValueChange={(value) => onQueueFilterChange(value as CatQueueFilter)}
+              >
+                {availableQueueFilters.map((filterValue) => (
+                  <DropdownMenuRadioItem key={filterValue} value={filterValue}>
+                    <FormattedMessage {...queueFilterMessageByValue[filterValue]} />
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : null}
+
+      {onDownloadFilteredView ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-8 gap-1.5 font-normal"
+                disabled={isDownloadingFilteredView}
+                aria-label={intl.formatMessage(catQueuePanelMessages.downloadFilteredAria)}
+              />
+            }
+          >
+            {isDownloadingFilteredView ? (
+              <Spinner className="size-3.5" />
+            ) : (
+              <DownloadIcon className="size-3.5" />
+            )}
+            <span className="hidden text-xs sm:inline">
+              <FormattedMessage {...catQueuePanelMessages.downloadFiltered} />
+            </span>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-40">
+            <DropdownMenuGroup>
+              <DropdownMenuLabel>
+                <FormattedMessage {...catQueuePanelMessages.downloadFilteredFormatLabel} />
+              </DropdownMenuLabel>
+              {(["csv", "tmx", "xlf", "xliff"] as const).map((format) => (
+                <DropdownMenuItem key={format} onClick={() => onDownloadFilteredView(format)}>
+                  {format.toUpperCase()}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : null}
+
+      {hasBulkActions ? (
+        <label className="flex h-8 cursor-pointer items-center gap-1.5 rounded-lg border border-border px-2.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">
+          <input
+            type="checkbox"
+            className="size-3.5 rounded border-input accent-foreground"
+            checked={selectionMode}
+            aria-label={intl.formatMessage(catQueuePanelMessages.showSelectionAria)}
+            onChange={(event) => onSelectionModeChange?.(event.currentTarget.checked)}
+          />
+          <span className="hidden sm:inline">
+            <FormattedMessage {...catQueuePanelMessages.showSelection} />
+          </span>
+        </label>
+      ) : null}
+
+      {selectionMode && hasBulkActions ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <Button
+                type="button"
+                variant="outline"
+                size="icon-sm"
+                className="size-8 shrink-0"
+                aria-label={intl.formatMessage(catQueuePanelMessages.queueActionsAria)}
+                disabled={isBulkActionPending}
+              />
+            }
+          >
+            {isBulkActionPending ? (
+              <Spinner className="size-3.5" />
+            ) : (
+              <HugeiconsIcon icon={MoreHorizontalCircle01Icon} className="size-4" />
+            )}
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-52">
+            <DropdownMenuGroup>
+              <DropdownMenuLabel>
+                {selectedCount > 0 ? (
+                  <FormattedMessage
+                    {...catQueuePanelMessages.bulkSelectionSummary}
+                    values={{ count: selectedCount }}
+                  />
+                ) : (
+                  <FormattedMessage {...catQueuePanelMessages.queueActionsAria} />
+                )}
+              </DropdownMenuLabel>
+              {onSelectAllVisible ? (
+                <DropdownMenuItem onClick={onSelectAllVisible} disabled={visibleCount === 0}>
+                  <FormattedMessage {...catQueuePanelMessages.bulkSelectAll} />
+                </DropdownMenuItem>
+              ) : null}
+              {onClearChecked ? (
+                <DropdownMenuItem onClick={onClearChecked} disabled={selectedCount === 0}>
+                  <FormattedMessage {...catQueuePanelMessages.bulkClearSelection} />
+                </DropdownMenuItem>
+              ) : null}
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuGroup>
+              {onBulkApprove ? (
+                <DropdownMenuItem onClick={onBulkApprove} disabled={selectedCount === 0}>
+                  <FormattedMessage {...catQueuePanelMessages.bulkApprove} />
+                </DropdownMenuItem>
+              ) : null}
+              {onBulkSkip ? (
+                <DropdownMenuItem onClick={onBulkSkip} disabled={selectedCount === 0}>
+                  <FormattedMessage {...catQueuePanelMessages.bulkSkip} />
+                </DropdownMenuItem>
+              ) : null}
+              {onBulkHide ? (
+                <DropdownMenuItem onClick={onBulkHide} disabled={selectedCount === 0}>
+                  <FormattedMessage {...catQueuePanelMessages.bulkHide} />
+                </DropdownMenuItem>
+              ) : null}
+              {onBulkUnhide ? (
+                <DropdownMenuItem onClick={onBulkUnhide} disabled={selectedCount === 0}>
+                  <FormattedMessage {...catQueuePanelMessages.bulkUnhide} />
+                </DropdownMenuItem>
+              ) : null}
+            </DropdownMenuGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : null}
+
+      <CatWorkspaceViewSwitcherConnected />
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/cat/queue/use-cat-queue-selection-mode.ts
+++ b/apps/hyperlocalise-web/src/components/cat/queue/use-cat-queue-selection-mode.ts
@@ -1,5 +1,3 @@
-"use client";
-
 /*
  * Copyright (c) 2026 Hyperlocalise Pty Ltd
  *
@@ -12,11 +10,14 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useCallback, useState } from "react";
 
 const STORAGE_KEY = "cat-queue:selection-mode:v1";
 
-function readSelectionModePreference() {
+export function readCatQueueSelectionModePreference() {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
   try {
     return localStorage.getItem(STORAGE_KEY) === "true";
   } catch {
@@ -24,19 +25,10 @@ function readSelectionModePreference() {
   }
 }
 
-export function useCatQueueSelectionMode() {
-  const [selectionMode, setSelectionMode] = useState(() =>
-    typeof window !== "undefined" ? readSelectionModePreference() : false,
-  );
-
-  const setSelectionModePersisted = useCallback((value: boolean) => {
-    setSelectionMode(value);
-    try {
-      localStorage.setItem(STORAGE_KEY, String(value));
-    } catch {
-      // Ignore storage failures in private browsing or restricted contexts.
-    }
-  }, []);
-
-  return [selectionMode, setSelectionModePersisted] as const;
+export function writeCatQueueSelectionModePreference(value: boolean) {
+  try {
+    localStorage.setItem(STORAGE_KEY, String(value));
+  } catch {
+    // Ignore storage failures in private browsing or restricted contexts.
+  }
 }

--- a/apps/hyperlocalise-web/src/components/cat/shared/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/cat/shared/dependencies.ts
@@ -136,8 +136,6 @@ export interface CatWorkspaceViewProps {
   dirtySegmentIds?: ReadonlySet<string>;
   className?: string;
   queueSearch?: string;
-  onQueueSearchChange?: (value: string) => void;
-  isQueueSearchPending?: boolean;
   isQueueFetchingPage?: boolean;
   isQueueLoading?: boolean;
   queuePagination?: {
@@ -153,24 +151,13 @@ export interface CatWorkspaceViewProps {
   isSegmentTargetLoading?: boolean;
   isImageBusy?: boolean;
   queueFilter?: CatQueueFilter;
-  onQueueFilterChange?: (filter: CatQueueFilter) => void;
-  availableQueueFilters?: CatQueueFilter[];
   checkedSegmentIds?: ReadonlySet<string>;
   onToggleSegmentChecked?: (segmentId: string, checked: boolean) => void;
-  onSelectAllVisible?: () => void;
-  onClearChecked?: () => void;
-  onBulkApprove?: () => void;
-  onBulkSkip?: () => void;
-  onBulkHide?: () => void;
-  onBulkUnhide?: () => void;
-  isBulkActionPending?: boolean;
   buildSegmentShareUrl?: (segment: CatSegment) => string | null;
   onIntelligencePanelVisible?: (segmentId: string) => void;
   organizationSlug?: string;
   projectId?: string;
   nativeIssuesEnabled?: boolean;
-  onDownloadFilteredView?: (format: "csv" | "tmx" | "xlf" | "xliff") => void;
-  isDownloadingFilteredView?: boolean;
 }
 
 export const noopCatDependencies: CatWorkspaceDependencies = {

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-panel.tsx
@@ -12,30 +12,16 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { FilterIcon, SearchIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
-import { DownloadIcon } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useCallback, useMemo } from "react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { FormattedMessage } from "react-intl";
 
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/primitives/cn";
 
 import { CatQueueSkeletonList } from "@/components/cat/queue/cat-queue-skeleton-list";
-import { catQueueFilterValues, type CatQueueFilter } from "@/components/cat/queue/cat-queue-filter";
+import type { CatQueueFilter } from "@/components/cat/queue/cat-queue-filter";
 import type { CatQueuePagination } from "@/components/cat/queue/cat-queue-panel";
 import {
   catQueuePanelMessages,
@@ -50,23 +36,9 @@ import type {
   CatTranslationMemoryMatch,
 } from "@/components/cat/shared/types";
 import { useCatWorkspace } from "@/components/cat/workspace/cat-workspace-context";
-import { CatWorkspaceViewSwitcherConnected } from "@/components/cat/workspace/cat-workspace-view-switcher-connected";
 
 import { CatSideBySideIntelligencePanel } from "./cat-side-by-side-intelligence-panel";
 import { CatSideBySideVirtualList } from "./cat-side-by-side-virtual-list";
-
-const queueFilterMessageByValue: Record<
-  CatQueueFilter,
-  (typeof catQueuePanelMessages)[keyof typeof catQueuePanelMessages]
-> = {
-  all: catQueuePanelMessages.filterAll,
-  untranslated: catQueuePanelMessages.filterUntranslated,
-  needs_review: catQueuePanelMessages.filterNeedsReview,
-  reviewed: catQueuePanelMessages.filterReviewed,
-  has_issues: catQueuePanelMessages.filterHasIssues,
-  skipped: catQueuePanelMessages.filterSkipped,
-  hidden: catQueuePanelMessages.filterHidden,
-};
 
 export const CatSideBySidePanel = observer(function CatSideBySidePanel({
   segments,
@@ -101,18 +73,12 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
   showVisualContext,
   canLookupFreshContext,
   search = "",
-  onSearchChange,
-  isSearching = false,
   queueFilter = "all",
-  onQueueFilterChange,
-  availableQueueFilters = catQueueFilterValues,
   isFetchingPage = false,
   isQueueLoading = false,
   pagination = null,
   hasMoreQueue = false,
   onLoadMoreQueue,
-  onDownloadFilteredView,
-  isDownloadingFilteredView = false,
   onFocusSegment,
   onTargetChange,
   onApprove,
@@ -172,18 +138,12 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
   showVisualContext: boolean;
   canLookupFreshContext: boolean;
   search?: string;
-  onSearchChange?: (value: string) => void;
-  isSearching?: boolean;
   queueFilter?: CatQueueFilter;
-  onQueueFilterChange?: (filter: CatQueueFilter) => void;
-  availableQueueFilters?: CatQueueFilter[];
   isFetchingPage?: boolean;
   isQueueLoading?: boolean;
   pagination?: CatQueuePagination | null;
   hasMoreQueue?: boolean;
   onLoadMoreQueue?: () => void;
-  onDownloadFilteredView?: (format: "csv" | "tmx" | "xlf" | "xliff") => void;
-  isDownloadingFilteredView?: boolean;
   onFocusSegment: (segmentId: string) => void;
   onTargetChange: (segmentId: string, value: string) => void;
   onApprove?: (segmentId: string) => void;
@@ -220,7 +180,6 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
   segmentShareUrl?: string | null;
   className?: string;
 }) {
-  const intl = useIntl();
   const store = useCatWorkspace();
   const hoveredSegmentId = store.ui.hoveredSegmentId;
   const intelligenceSegmentId = store.intelligenceSegmentId;
@@ -256,118 +215,7 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
       )}
     >
       <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
-        <div className="shrink-0 space-y-3 border-b border-border px-4 py-3">
-          <div className="flex items-center justify-between gap-3">
-            {onSearchChange ? (
-              <div className="relative min-w-0 flex-1">
-                <HugeiconsIcon
-                  icon={SearchIcon}
-                  className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground"
-                />
-                <Input
-                  value={search}
-                  onChange={(event) => onSearchChange(event.target.value)}
-                  placeholder={intl.formatMessage(catQueuePanelMessages.searchPlaceholder)}
-                  aria-label={intl.formatMessage(catQueuePanelMessages.searchAria)}
-                  className="h-9 pl-9"
-                />
-                {isSearching ? (
-                  <Spinner className="absolute top-1/2 right-2.5 size-4 -translate-y-1/2" />
-                ) : null}
-              </div>
-            ) : (
-              <div className="flex-1" />
-            )}
-
-            <div className="flex shrink-0 items-center gap-2">
-              {onQueueFilterChange ? (
-                <DropdownMenu>
-                  <DropdownMenuTrigger
-                    render={
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="h-9 gap-1.5 px-2.5"
-                        aria-label={intl.formatMessage(catQueuePanelMessages.filterQueueAria)}
-                      />
-                    }
-                  >
-                    <HugeiconsIcon icon={FilterIcon} className="size-4" />
-                    <span className="hidden text-xs sm:inline">
-                      <FormattedMessage {...queueFilterMessageByValue[queueFilter]} />
-                    </span>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="min-w-44">
-                    <DropdownMenuRadioGroup
-                      value={queueFilter}
-                      onValueChange={(value) => {
-                        if (
-                          value === "all" ||
-                          value === "untranslated" ||
-                          value === "needs_review" ||
-                          value === "reviewed" ||
-                          value === "has_issues" ||
-                          value === "skipped"
-                        ) {
-                          onQueueFilterChange(value);
-                        }
-                      }}
-                    >
-                      {availableQueueFilters.map((filter) => (
-                        <DropdownMenuRadioItem key={filter} value={filter}>
-                          <FormattedMessage {...queueFilterMessageByValue[filter]} />
-                        </DropdownMenuRadioItem>
-                      ))}
-                    </DropdownMenuRadioGroup>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              ) : null}
-
-              {onDownloadFilteredView ? (
-                <DropdownMenu>
-                  <DropdownMenuTrigger
-                    render={
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        className="h-9 gap-1.5 px-2.5"
-                        disabled={isDownloadingFilteredView}
-                        aria-label={intl.formatMessage(catQueuePanelMessages.downloadFilteredAria)}
-                      />
-                    }
-                  >
-                    {isDownloadingFilteredView ? (
-                      <Spinner className="size-4" />
-                    ) : (
-                      <DownloadIcon className="size-4" />
-                    )}
-                    <span className="hidden text-xs sm:inline">
-                      <FormattedMessage {...catQueuePanelMessages.downloadFiltered} />
-                    </span>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="w-40">
-                    <DropdownMenuGroup>
-                      <DropdownMenuLabel>
-                        <FormattedMessage {...catQueuePanelMessages.downloadFilteredFormatLabel} />
-                      </DropdownMenuLabel>
-                      {(["csv", "tmx", "xlf", "xliff"] as const).map((format) => (
-                        <DropdownMenuItem
-                          key={format}
-                          onClick={() => onDownloadFilteredView(format)}
-                        >
-                          {format.toUpperCase()}
-                        </DropdownMenuItem>
-                      ))}
-                    </DropdownMenuGroup>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              ) : null}
-
-              <CatWorkspaceViewSwitcherConnected />
-            </div>
-          </div>
-
+        <div className="shrink-0 border-b border-border px-4 py-3">
           <div className="grid grid-cols-2 gap-0 text-xs font-medium tracking-wide text-muted-foreground uppercase">
             <p className="border-r border-border pr-4">
               <FormattedMessage {...catSideBySidePanelMessages.sourceColumn} />

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.navigation.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.navigation.test.tsx
@@ -199,7 +199,7 @@ describe("CatWorkspaceContainer queue navigation", () => {
     const targetEditor = (await waitForTargetEditor()) as HTMLElement;
     await user.click(targetEditor);
     await user.keyboard(" unsaved");
-    await user.click(screen.getByRole("button", { name: "Filter queue" }));
+    await user.click(await screen.findByRole("button", { name: "Filter queue" }));
     await user.click(await screen.findByRole("menuitemradio", { name: "Approved" }));
 
     expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.tsx
@@ -33,9 +33,10 @@ import type {
   CatWorkspaceViewProps,
   PartialCatWorkspaceDependencies,
 } from "@/components/cat/shared/dependencies";
+import type { CatQueueFilter } from "@/components/cat/queue/cat-queue-filter";
+import { CatQueueToolbarConnected } from "@/components/cat/queue/cat-queue-toolbar-connected";
 import { catWorkspaceContainerMessages } from "@/components/cat/shared/cat.messages";
 import type { CatSegment, CatWorkspaceState } from "@/components/cat/shared/types";
-import type { CatQueueFilter } from "@/components/cat/queue/cat-queue-filter";
 
 import { CatQueryBridge } from "./bridge/cat-query-bridge";
 import { CatChatDockPageContextBridge } from "./cat-chat-dock-page-context-bridge";
@@ -137,6 +138,18 @@ const CatWorkspaceContainerObserver = observer(function CatWorkspaceContainerObs
     onLoadMoreQueue,
   });
 
+  useEffect(() => {
+    if (queueFilter !== undefined && store.queue.filter !== queueFilter) {
+      store.queue.setFilter(queueFilter);
+    }
+  }, [queueFilter, store]);
+
+  useEffect(() => {
+    if (queueSearch !== undefined && store.queue.search !== queueSearch) {
+      store.queue.setSearch(queueSearch);
+    }
+  }, [queueSearch, store]);
+
   return (
     <>
       <CatChatDockPageContextBridge projectId={lazySegment?.projectId} />
@@ -148,6 +161,23 @@ const CatWorkspaceContainerObserver = observer(function CatWorkspaceContainerObs
         initialSegmentKeyOrId={initialSegmentKeyOrId}
       />
       {lazySegment ? <CatWorkspaceLazySegmentSync {...lazySegment} /> : null}
+
+      <CatQueueToolbarConnected
+        onQueueSearchChange={onQueueSearchChange}
+        onQueueFilterChange={controller.handleQueueFilterChange}
+        availableQueueFilters={availableQueueFilters}
+        isSearching={isQueueSearchPending}
+        visibleCount={controller.queueSegments.length}
+        onSelectAllVisible={() =>
+          store.selectAllVisible(controller.queueSegments.map((segment) => segment.id))
+        }
+        onBulkApprove={() => void controller.handleBulkApprove()}
+        onBulkSkip={() => void controller.handleBulkSkip()}
+        onBulkHide={review?.onBulkHide ? () => void controller.handleBulkHide() : undefined}
+        onBulkUnhide={review?.onBulkUnhide ? () => void controller.handleBulkUnhide() : undefined}
+        onDownloadFilteredView={onDownloadFilteredView}
+        isDownloadingFilteredView={isDownloadingFilteredView}
+      />
 
       <CatPanelErrorBoundary
         scope="workspace"
@@ -187,8 +217,6 @@ const CatWorkspaceContainerObserver = observer(function CatWorkspaceContainerObs
           canUseAiRecommendation={controller.canUseAiRecommendation}
           className={className}
           queueSearch={queueSearch}
-          onQueueSearchChange={onQueueSearchChange}
-          isQueueSearchPending={isQueueSearchPending}
           isQueueFetchingPage={isQueueFetchingPage}
           isQueueLoading={isQueueLoading}
           isCommentsLoading={store.isCommentsLoading}
@@ -198,28 +226,15 @@ const CatWorkspaceContainerObserver = observer(function CatWorkspaceContainerObs
           hasMoreQueue={hasMoreQueue}
           onLoadMoreQueue={onLoadMoreQueue}
           queueFilter={controller.queueFilter}
-          onQueueFilterChange={controller.handleQueueFilterChange}
-          availableQueueFilters={availableQueueFilters}
           checkedSegmentIds={store.checkedSegmentIds}
           onToggleSegmentChecked={(segmentId, checked) =>
             store.toggleSegmentChecked(segmentId, checked)
           }
-          onSelectAllVisible={() =>
-            store.selectAllVisible(controller.queueSegments.map((segment) => segment.id))
-          }
-          onClearChecked={() => store.clearChecked()}
-          onBulkApprove={() => void controller.handleBulkApprove()}
-          onBulkSkip={() => void controller.handleBulkSkip()}
-          onBulkHide={review?.onBulkHide ? () => void controller.handleBulkHide() : undefined}
-          onBulkUnhide={review?.onBulkUnhide ? () => void controller.handleBulkUnhide() : undefined}
-          isBulkActionPending={store.isBulkActionPending}
           buildSegmentShareUrl={controller.resolvedBuildSegmentShareUrl}
           onIntelligencePanelVisible={controller.handleIntelligencePanelVisible}
           organizationSlug={lazySegment?.organizationSlug}
           projectId={lazySegment?.projectId}
           nativeIssuesEnabled={nativeIssuesEnabled}
-          onDownloadFilteredView={onDownloadFilteredView}
-          isDownloadingFilteredView={isDownloadingFilteredView}
         />
       </CatPanelErrorBoundary>
 
@@ -260,6 +275,8 @@ export function CatWorkspaceContainer({
   initialState,
   initialSegmentKeyOrId,
   initialViewMode,
+  queueFilter,
+  queueSearch,
   ...props
 }: CatWorkspaceContainerProps) {
   return (
@@ -267,11 +284,15 @@ export function CatWorkspaceContainer({
       initialState={initialState}
       initialSegmentKeyOrId={initialSegmentKeyOrId}
       initialViewMode={initialViewMode}
+      initialQueueFilter={queueFilter}
+      initialSearch={queueSearch}
     >
       <CatWorkspaceContainerInner
         initialState={initialState}
         initialSegmentKeyOrId={initialSegmentKeyOrId}
         initialViewMode={initialViewMode}
+        queueFilter={queueFilter}
+        queueSearch={queueSearch}
         {...props}
       />
     </CatWorkspaceProvider>

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-context.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-context.tsx
@@ -14,6 +14,7 @@
  */
 import { createContext, useContext, useMemo, type ReactNode } from "react";
 
+import type { CatQueueFilter } from "@/components/cat/queue/cat-queue-filter";
 import type { CatWorkspaceState } from "@/components/cat/shared/types";
 
 import {
@@ -29,18 +30,27 @@ export function CatWorkspaceProvider({
   initialState,
   initialSegmentKeyOrId,
   initialViewMode,
+  initialQueueFilter,
+  initialSearch,
   children,
 }: {
   initialState: CatWorkspaceState;
   initialSegmentKeyOrId?: string | null;
   initialViewMode?: CatWorkspaceViewMode;
+  initialQueueFilter?: CatQueueFilter;
+  initialSearch?: string;
   children: ReactNode;
 }) {
   const store = useMemo(
     () => {
-      const options: CreateCatWorkspaceOptions | undefined = initialViewMode
-        ? { initialViewMode }
-        : undefined;
+      const options: CreateCatWorkspaceOptions | undefined =
+        initialViewMode || initialQueueFilter || initialSearch
+          ? {
+              ...(initialViewMode ? { initialViewMode } : {}),
+              ...(initialQueueFilter ? { initialQueueFilter } : {}),
+              ...(initialSearch ? { initialSearch } : {}),
+            }
+          : undefined;
       return createCatWorkspace(initialState, initialSegmentKeyOrId, options);
     },
     // Store is scoped to workspace mount; parent key handles remounts.

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-orchestrator.ts
@@ -55,6 +55,8 @@ import {
 
 export type CreateCatWorkspaceOptions = {
   initialViewMode?: CatWorkspaceViewMode;
+  initialQueueFilter?: CatQueueFilter;
+  initialSearch?: string;
 };
 
 type UnsavedNavigationPrompt = {
@@ -212,6 +214,8 @@ export class CatWorkspaceOrchestrator {
 
   constructor(options?: CreateCatWorkspaceOptions) {
     this.ui = new CatWorkspaceUiStore(options?.initialViewMode);
+    this.queue.filter = options?.initialQueueFilter ?? "all";
+    this.queue.search = options?.initialSearch ?? "";
     makeAutoObservable(
       this,
       {
@@ -279,6 +283,18 @@ export class CatWorkspaceOrchestrator {
 
   set queueFilter(value: CatQueueFilter) {
     this.queue.filter = value;
+  }
+
+  get queueSearch() {
+    return this.queue.search;
+  }
+
+  set queueSearch(value: string) {
+    this.queue.search = value;
+  }
+
+  get selectionMode() {
+    return this.queue.selectionMode;
   }
 
   get checkedSegmentIds() {
@@ -1144,6 +1160,14 @@ export class CatWorkspaceOrchestrator {
     if (selectionWillChange) {
       this.setSelectedSegmentId(filtered[0]?.id ?? "");
     }
+  }
+
+  setQueueSearch(search: string) {
+    this.queue.setSearch(search);
+  }
+
+  setSelectionMode(enabled: boolean) {
+    this.queue.setSelectionMode(enabled);
   }
 
   attemptPageNavigation(proceed: () => void) {

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-skeleton.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-skeleton.tsx
@@ -128,13 +128,8 @@ function CatQueuePanelSkeleton() {
       aria-busy="true"
       aria-label={intl.formatMessage(catWorkspaceSkeletonMessages.loadingQueue)}
     >
-      <div className="shrink-0 space-y-3 border-b border-border px-4 py-3">
-        <div className="space-y-2">
-          <Skeleton className="h-4 w-16 rounded-full bg-skeleton" />
-          <Skeleton className="h-3 w-full max-w-48 rounded-full bg-skeleton" />
-        </div>
-        <Skeleton className="h-9 w-full rounded-md bg-skeleton" />
-        <Skeleton className="h-8 w-24 rounded-md bg-skeleton" />
+      <div className="shrink-0 border-b border-border px-4 py-3">
+        <Skeleton className="h-4 w-16 rounded-full bg-skeleton" />
       </div>
 
       <div className="shrink-0 px-4 py-3">

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
@@ -83,8 +83,6 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
   dirtySegmentIds,
   className,
   queueSearch,
-  onQueueSearchChange,
-  isQueueSearchPending = false,
   isQueueFetchingPage = false,
   isQueueLoading = false,
   isCommentsLoading = false,
@@ -94,24 +92,13 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
   hasMoreQueue = false,
   onLoadMoreQueue,
   queueFilter,
-  onQueueFilterChange,
-  availableQueueFilters,
   checkedSegmentIds,
   onToggleSegmentChecked,
-  onSelectAllVisible,
-  onClearChecked,
-  onBulkApprove,
-  onBulkSkip,
-  onBulkHide,
-  onBulkUnhide,
-  isBulkActionPending = false,
   buildSegmentShareUrl,
   onIntelligencePanelVisible,
   organizationSlug,
   projectId,
   nativeIssuesEnabled = false,
-  onDownloadFilteredView,
-  isDownloadingFilteredView = false,
 }: CatWorkspaceViewProps) {
   const store = useCatWorkspace();
   const viewMode = store.ui.viewMode;
@@ -168,18 +155,13 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
             selectedSegmentId=""
             onSelectSegment={() => undefined}
             search={queueSearch}
-            onSearchChange={onQueueSearchChange}
-            isSearching={isQueueSearchPending}
             queueFilter={queueFilter}
-            onQueueFilterChange={onQueueFilterChange}
-            availableQueueFilters={availableQueueFilters}
+            showSelection={store.selectionMode}
             isFetchingPage={isQueueFetchingPage}
             isQueueLoading
             pagination={queuePagination}
             hasMoreQueue={hasMoreQueue}
             onLoadMoreQueue={onLoadMoreQueue}
-            onDownloadFilteredView={onDownloadFilteredView}
-            isDownloadingFilteredView={isDownloadingFilteredView}
           />
         </CatPanelErrorBoundary>
       </div>
@@ -200,27 +182,15 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
             selectedSegmentId=""
             onSelectSegment={dependencies.navigation.onSelectSegment}
             search={queueSearch}
-            onSearchChange={onQueueSearchChange}
-            isSearching={isQueueSearchPending}
             queueFilter={queueFilter}
-            onQueueFilterChange={onQueueFilterChange}
-            availableQueueFilters={availableQueueFilters}
             checkedSegmentIds={checkedSegmentIds}
             onToggleSegmentChecked={onToggleSegmentChecked}
-            onSelectAllVisible={onSelectAllVisible}
-            onClearChecked={onClearChecked}
-            onBulkApprove={onBulkApprove}
-            onBulkSkip={onBulkSkip}
-            onBulkHide={onBulkHide}
-            onBulkUnhide={onBulkUnhide}
-            isBulkActionPending={isBulkActionPending}
+            showSelection={store.selectionMode}
             isFetchingPage={isQueueFetchingPage}
             isQueueLoading={isQueueLoading}
             pagination={queuePagination}
             hasMoreQueue={hasMoreQueue}
             onLoadMoreQueue={onLoadMoreQueue}
-            onDownloadFilteredView={onDownloadFilteredView}
-            isDownloadingFilteredView={isDownloadingFilteredView}
           />
         </CatPanelErrorBoundary>
       </div>
@@ -357,18 +327,12 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
           showVisualContext={showVisualContext}
           canLookupFreshContext={canLookupContext}
           search={queueSearch}
-          onSearchChange={onQueueSearchChange}
-          isSearching={isQueueSearchPending}
           queueFilter={queueFilter}
-          onQueueFilterChange={onQueueFilterChange}
-          availableQueueFilters={availableQueueFilters}
           isFetchingPage={isQueueFetchingPage}
           isQueueLoading={isQueueLoading}
           pagination={queuePagination}
           hasMoreQueue={hasMoreQueue}
           onLoadMoreQueue={onLoadMoreQueue}
-          onDownloadFilteredView={onDownloadFilteredView}
-          isDownloadingFilteredView={isDownloadingFilteredView}
           onFocusSegment={dependencies.navigation.onSelectSegment}
           onTargetChange={(segmentId, value) => editing.onTargetChange(segmentId, value)}
           onApprove={(segmentId) => {
@@ -618,27 +582,15 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
             }
           }}
           search={queueSearch}
-          onSearchChange={onQueueSearchChange}
-          isSearching={isQueueSearchPending}
           queueFilter={queueFilter}
-          onQueueFilterChange={onQueueFilterChange}
-          availableQueueFilters={availableQueueFilters}
           checkedSegmentIds={checkedSegmentIds}
           onToggleSegmentChecked={onToggleSegmentChecked}
-          onSelectAllVisible={onSelectAllVisible}
-          onClearChecked={onClearChecked}
-          onBulkApprove={onBulkApprove}
-          onBulkSkip={onBulkSkip}
-          onBulkHide={onBulkHide}
-          onBulkUnhide={onBulkUnhide}
-          isBulkActionPending={isBulkActionPending}
+          showSelection={store.selectionMode}
           isFetchingPage={isQueueFetchingPage}
           isQueueLoading={isQueueLoading}
           pagination={queuePagination}
           hasMoreQueue={hasMoreQueue}
           onLoadMoreQueue={onLoadMoreQueue}
-          onDownloadFilteredView={onDownloadFilteredView}
-          isDownloadingFilteredView={isDownloadingFilteredView}
         />
       </CatPanelErrorBoundary>
     );

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-domain-stores.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-domain-stores.test.ts
@@ -78,6 +78,26 @@ describe("CatQueueStore", () => {
     expect(queue.checkedSegmentIds.size).toBe(0);
   });
 
+  it("stores queue search independently of the segment list", () => {
+    const queue = new CatQueueStore();
+
+    queue.setSearch("welcome");
+
+    expect(queue.search).toBe("welcome");
+  });
+
+  it("clears checked segments when bulk selection mode is turned off", () => {
+    const queue = new CatQueueStore();
+    queue.replace([...queueSegments]);
+    queue.toggleChecked("seg-02", true);
+
+    queue.setSelectionMode(true);
+    queue.setSelectionMode(false);
+
+    expect(queue.selectionMode).toBe(false);
+    expect(queue.checkedSegmentIds.size).toBe(0);
+  });
+
   it("toggles hidden metadata on queue segments", () => {
     const queue = new CatQueueStore();
     queue.replace([...queueSegments]);

--- a/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-queue-store.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/store/cat-queue-store.ts
@@ -13,11 +13,17 @@
 import { makeAutoObservable } from "mobx";
 
 import type { CatQueueFilter } from "@/components/cat/queue/cat-queue-filter";
+import {
+  readCatQueueSelectionModePreference,
+  writeCatQueueSelectionModePreference,
+} from "@/components/cat/queue/use-cat-queue-selection-mode";
 import type { CatQueueSegment } from "@/components/cat/shared/types";
 
 export class CatQueueStore {
   selectedSegmentId = "";
   filter: CatQueueFilter = "all";
+  search = "";
+  selectionMode = readCatQueueSelectionModePreference();
   checkedSegmentIds = new Set<string>();
   segmentMeta = new Map<string, CatQueueSegment>();
 
@@ -53,6 +59,18 @@ export class CatQueueStore {
   setFilter(filter: CatQueueFilter) {
     this.filter = filter;
     this.clearChecked();
+  }
+
+  setSearch(search: string) {
+    this.search = search;
+  }
+
+  setSelectionMode(enabled: boolean) {
+    this.selectionMode = enabled;
+    writeCatQueueSelectionModePreference(enabled);
+    if (!enabled) {
+      this.clearChecked();
+    }
   }
 
   toggleChecked(segmentId: string, checked: boolean) {


### PR DESCRIPTION
## What changed

Queue search, filter, download, and bulk actions now live in the CAT header next to the GitHub repo and locale pickers, instead of inside the queue catalog.

Changing a filter used to swap the React Query key, empty `catFile`, and replace the whole workspace with a skeleton. The header toolbar stays mounted, MobX owns search/filter/selection chrome, and refetch keeps previous queue pages so only the list skeletons.

## How to test

- [ ] Open a project-file CAT workspace and confirm search, filter, download, selection, and actions sit in the top bar next to locale/GitHub
- [ ] Change the queue filter and confirm the editor stays visible (list may skeleton; the whole CAT should not)
- [ ] Repeat from a job strings CAT page (all-files, native file, and provider file headers)
- [ ] From the web app: `vp check --fix` and `vp test src/components/cat/queue src/components/cat/workspace`

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`; CAT queue/workspace unit tests)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)