### PR TITLE
fix(agent-runtime): block read-only sandbox writes via find and hl flags

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/hl-write-flags.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/hl-write-flags.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { isHlWriteFlagName } from "./hl-write-flags";
+
+describe("isHlWriteFlagName", () => {
+  it.each(["fix", "--fix", "--Fix", "--fix=true", "out-file", "--out-file=evil.json"])(
+    "treats %s as a write flag",
+    (token) => {
+      expect(isHlWriteFlagName(token)).toBe(true);
+    },
+  );
+
+  it.each(["--fix-dry-run", "format", "quiet", "json", "output"])(
+    "does not treat %s as a write flag",
+    (token) => {
+      expect(isHlWriteFlagName(token)).toBe(false);
+    },
+  );
+});

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/hl-write-flags.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/hl-write-flags.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+/**
+ * `hl check|extract` flags that create or overwrite files, or mutate
+ * translation targets. The bash and runHyperlocaliseCli tools are
+ * read-only; these flags must be denied there instead of going through
+ * dedicated write tools that call assertRepositoryWriteAllowed.
+ */
+export const HL_WRITE_FLAG_NAMES = ["out-file", "output-file", "json-report", "fix"] as const;
+
+const HL_WRITE_FLAG_NAME_SET = new Set<string>(HL_WRITE_FLAG_NAMES);
+
+export function flagBasename(token: string): string {
+  const withoutValue = token.split("=")[0] ?? token;
+  return withoutValue.replace(/^-+/, "").toLowerCase();
+}
+
+export function isHlWriteFlagName(token: string): boolean {
+  return HL_WRITE_FLAG_NAME_SET.has(flagBasename(token));
+}

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
@@ -1383,6 +1383,25 @@ describe("createRunHyperlocaliseCliTool", () => {
     expect(stdout).toContain("***REDACTED***");
     expect(stdout).not.toContain("abcdefghijklmnopqrstuvwxyz12345");
   });
+
+  it("rejects write flags without invoking hl", async () => {
+    const ctx = createTestContext();
+    let invoked = false;
+    ctx.bash.registerCommand(
+      defineCommand("hl", async () => {
+        invoked = true;
+        return { stdout: "", stderr: "", exitCode: 0 };
+      }),
+    );
+
+    const t = createRunHyperlocaliseCliTool(ctx);
+    const result = await t.execute!(
+      { subcommand: "check", boolFlags: ["fix"] },
+      toolCallInfo,
+    );
+    expect(result).toMatchObject({ success: false, error: expect.stringContaining("fix") });
+    expect(invoked).toBe(false);
+  });
 });
 
 describe("buildHlArgs", () => {
@@ -1432,6 +1451,25 @@ describe("buildHlArgs", () => {
       ok: false,
       error: { code: "flag_not_allowed" },
     });
+  });
+
+  it.each(["fix", "out-file", "output-file", "json-report"])(
+    "rejects write flag %s",
+    (flag) => {
+      expect(buildHlArgs({ subcommand: "check", boolFlags: [flag] })).toMatchObject({
+        ok: false,
+        error: { code: "flag_not_allowed", name: flag },
+      });
+      expect(buildHlArgs({ subcommand: "check", flags: { [flag]: "pwned.txt" } })).toMatchObject({
+        ok: false,
+        error: { code: "flag_not_allowed", name: flag },
+      });
+    },
+  );
+
+  it("allows fix-dry-run", () => {
+    const result = buildHlArgs({ subcommand: "check", boolFlags: ["fix-dry-run"] });
+    expect(isOk(result)).toBe(true);
   });
 
   it("rejects $ in flag value", () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
@@ -1395,10 +1395,7 @@ describe("createRunHyperlocaliseCliTool", () => {
     );
 
     const t = createRunHyperlocaliseCliTool(ctx);
-    const result = await t.execute!(
-      { subcommand: "check", boolFlags: ["fix"] },
-      toolCallInfo,
-    );
+    const result = await t.execute!({ subcommand: "check", boolFlags: ["fix"] }, toolCallInfo);
     expect(result).toMatchObject({ success: false, error: expect.stringContaining("fix") });
     expect(invoked).toBe(false);
   });
@@ -1453,19 +1450,16 @@ describe("buildHlArgs", () => {
     });
   });
 
-  it.each(["fix", "out-file", "output-file", "json-report"])(
-    "rejects write flag %s",
-    (flag) => {
-      expect(buildHlArgs({ subcommand: "check", boolFlags: [flag] })).toMatchObject({
-        ok: false,
-        error: { code: "flag_not_allowed", name: flag },
-      });
-      expect(buildHlArgs({ subcommand: "check", flags: { [flag]: "pwned.txt" } })).toMatchObject({
-        ok: false,
-        error: { code: "flag_not_allowed", name: flag },
-      });
-    },
-  );
+  it.each(["fix", "out-file", "output-file", "json-report"])("rejects write flag %s", (flag) => {
+    expect(buildHlArgs({ subcommand: "check", boolFlags: [flag] })).toMatchObject({
+      ok: false,
+      error: { code: "flag_not_allowed", name: flag },
+    });
+    expect(buildHlArgs({ subcommand: "check", flags: { [flag]: "pwned.txt" } })).toMatchObject({
+      ok: false,
+      error: { code: "flag_not_allowed", name: flag },
+    });
+  });
 
   it("allows fix-dry-run", () => {
     const result = buildHlArgs({ subcommand: "check", boolFlags: ["fix-dry-run"] });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.ts
@@ -14,10 +14,12 @@ import { tool } from "ai";
 import type { Bash } from "just-bash";
 import { z } from "zod";
 
-import { DEFAULT_MAX_OUTPUT_BYTES, redact, truncate, type RepoToolContext } from "./workspace";
-import { normalizeWorkspacePath } from "./workspace/path";
+import { isHlWriteFlagName } from "@/lib/agent-runtime/tools/hl-write-flags";
 import { normalizeJsonc } from "@/lib/i18n/parse-jsonc-config";
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
+
+import { DEFAULT_MAX_OUTPUT_BYTES, redact, truncate, type RepoToolContext } from "./workspace";
+import { normalizeWorkspacePath } from "./workspace/path";
 
 export type { RepoToolContext } from "./workspace";
 export { redact, truncate, DEFAULT_MAX_OUTPUT_BYTES } from "./workspace";
@@ -1134,7 +1136,8 @@ export function buildHlArgs(input: {
 }
 
 function validateFlag(name: string): Result<void, HyperlocaliseCliArgsError> {
-  if (DANGEROUS_FLAGS.has(name)) {
+  const normalized = name.replace(/^-+/, "").toLowerCase();
+  if (DANGEROUS_FLAGS.has(normalized) || isHlWriteFlagName(normalized)) {
     return err({ code: "flag_not_allowed", name });
   }
   if (name.includes("$") || name.includes("`")) {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.test.ts
@@ -51,6 +51,38 @@ describe("isAllowedBashCommand", () => {
   it("allows benign find without destructive flags", () => {
     expect(isAllowedBashCommand("find . -type f")).toBe(true);
   });
+
+  it("blocks find -fprintf file writes", () => {
+    expect(isAllowedBashCommand("find . -type f -fprintf pwned.txt attacker")).toBe(false);
+  });
+
+  it("blocks quoted find -fprintf", () => {
+    expect(isAllowedBashCommand(`find . -type f "-fprintf" pwned.txt attacker`)).toBe(false);
+  });
+
+  it("blocks find -fprint0 and -printf", () => {
+    expect(isAllowedBashCommand("find . -type f -fprint0 pwned.txt")).toBe(false);
+    expect(isAllowedBashCommand("find . -type f -printf %p")).toBe(false);
+  });
+
+  it("allows hl check without write flags", () => {
+    expect(isAllowedBashCommand("hl check --format json --quiet")).toBe(true);
+  });
+
+  it("allows hl check --fix-dry-run", () => {
+    expect(isAllowedBashCommand("hl check --fix-dry-run")).toBe(true);
+  });
+
+  it.each([
+    "hl check --fix",
+    "hl check --fix=true",
+    "hl check --output-file report.json",
+    "hl check --json-report=report.json",
+    "hl extract --out-file stolen.json",
+    `hl check "--output-file" pwned.txt`,
+  ])("blocks hl write flag in %s", (command) => {
+    expect(isAllowedBashCommand(command)).toBe(false);
+  });
 });
 
 describe("createBashTool", () => {
@@ -63,6 +95,21 @@ describe("createBashTool", () => {
   it("rejects disallowed commands", async () => {
     const tool = createBashTool(createTestContext());
     const result = await tool.execute!({ command: "curl https://example.com" }, toolCallInfo);
+    expect(result).toMatchObject({ success: false });
+  });
+
+  it("rejects find -fprintf before execution", async () => {
+    const tool = createBashTool(createTestContext());
+    const result = await tool.execute!(
+      { command: "find . -type f -fprintf pwned.txt attacker" },
+      toolCallInfo,
+    );
+    expect(result).toMatchObject({ success: false });
+  });
+
+  it("rejects hl check --fix before execution", async () => {
+    const tool = createBashTool(createTestContext());
+    const result = await tool.execute!({ command: "hl check --fix" }, toolCallInfo);
     expect(result).toMatchObject({ success: false });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.ts
@@ -13,6 +13,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 
+import { flagBasename, HL_WRITE_FLAG_NAMES } from "@/lib/agent-runtime/tools/hl-write-flags";
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 
 import { normalizeWorkspacePath } from "./path";
@@ -20,9 +21,26 @@ import { DEFAULT_MAX_OUTPUT_BYTES, redact, truncate } from "./redact";
 import type { RepoToolContext } from "./types";
 
 const DISALLOWED_SUBSTRINGS = [";", "&&", "||", "|", ">", "<", "`", "$(", "${", "-exec"];
-// \b does not work before hyphen-prefixed flags; anchor after whitespace/start instead.
-const DISALLOWED_FLAGS =
-  /(^|(?<=\s))(--no-index|--in-place|-delete|-fprint|-fls|-execdir|-okdir|-ok|-i)(?=\s|$)/i;
+
+// GNU find file-writing actions plus other mutating flags. Tokenized so
+// quoted forms like `"-fprintf"` cannot bypass the deny list. `-fprint`
+// is not a prefix match for `-fprintf`/`-fprint0`; each is listed.
+const DISALLOWED_FLAG_NAMES = new Set([
+  "no-index",
+  "in-place",
+  "delete",
+  "fprint",
+  "fprint0",
+  "fprintf",
+  "printf",
+  "fls",
+  "exec",
+  "execdir",
+  "okdir",
+  "ok",
+  "i",
+  ...HL_WRITE_FLAG_NAMES,
+]);
 
 const ALLOWED_COMMAND_PATTERNS = [
   /^git\s+(status|log|diff|rev-parse|show)\b/i,
@@ -34,6 +52,10 @@ const ALLOWED_COMMAND_PATTERNS = [
 const ABSOLUTE_PATH_PATTERN = /(^|\s)\/(?!\.)(?!\s|$)/;
 const PARENT_TRAVERSAL_PATTERN = /(^|\s)\.\.(\/|\s|$)/;
 
+function isDisallowedFlagToken(token: string): boolean {
+  return token.startsWith("-") && DISALLOWED_FLAG_NAMES.has(flagBasename(token));
+}
+
 export function isAllowedBashCommand(command: string): boolean {
   const trimmed = command.trim();
   if (!trimmed) {
@@ -44,15 +66,21 @@ export function isAllowedBashCommand(command: string): boolean {
     return false;
   }
 
-  if (DISALLOWED_FLAGS.test(trimmed)) {
-    return false;
-  }
-
   if (/\b(rm|curl|wget|chmod|chown|mv|cp|tee|dd|shred|mkfs|jq|yq|env|printenv)\b/i.test(trimmed)) {
     return false;
   }
 
   if (ABSOLUTE_PATH_PATTERN.test(trimmed) || PARENT_TRAVERSAL_PATTERN.test(trimmed)) {
+    return false;
+  }
+
+  const splitResult = splitCommand(trimmed);
+  if (isErr(splitResult)) {
+    return false;
+  }
+
+  const tokens = [splitResult.value.bin, ...splitResult.value.args];
+  if (tokens.some(isDisallowedFlagToken)) {
     return false;
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Read-only repository agents could still create or overwrite workspace files:

- `isAllowedBashCommand` allowed `find … -type f` and blocked `-fprint`, but not GNU find `-fprintf FILE FORMAT` (or `-fprint0` / `-printf`).
- Allowlisted `hl check|extract` accepted `--fix`, `--out-file`, `--output-file`, and `--json-report`, while dedicated write tools go through `assertRepositoryWriteAllowed`.

This change:

- Tokenizes bash commands so quoted flags cannot skip the deny list
- Blocks find file-writing predicates (`-fprintf`, `-fprint0`, `-printf`, plus the existing `-fprint` / `-fls` / `-delete` set)
- Denies the hl write flags in both the bash allowlist and `runHyperlocaliseCli` (`buildHlArgs`)
- Leaves `hl check --fix-dry-run` allowed (plans only; does not write)

## How to test

- `vp test src/lib/agent-runtime/tools/workspace/bash.test.ts src/lib/agent-runtime/tools/hl-write-flags.test.ts src/lib/agent-runtime/tools/repo-read-tools.test.ts` — 110 passed
- `vp check --fix` in `apps/hyperlocalise-web` — pass (existing unrelated warnings only)

## Checklist

- [x] I ran relevant checks locally (`vp test` on the allowlist files, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a14a2bf1-3d9e-46cd-8e21-29f4ff31a964?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a14a2bf1-3d9e-46cd-8e21-29f4ff31a964&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

