### PR TITLE
refactor(web): migrate remaining Lucide icons to Hugeicons

### DIFF
--- a/apps/hyperlocalise-web/package.json
+++ b/apps/hyperlocalise-web/package.json
@@ -107,7 +107,6 @@
     "jszip": "^3.10.1",
     "just-bash": "^3.0.2",
     "jwks-rsa": "^4.1.0",
-    "lucide-react": "^1.23.0",
     "mammoth": "^1.12.0",
     "media-chrome": "^4.19.0",
     "mobx": "^7.0.0",

--- a/apps/hyperlocalise-web/pnpm-lock.yaml
+++ b/apps/hyperlocalise-web/pnpm-lock.yaml
@@ -289,9 +289,6 @@ importers:
       jwks-rsa:
         specifier: ^4.1.0
         version: 4.1.0(supports-color@8.1.1)
-      lucide-react:
-        specifier: ^1.23.0
-        version: 1.31.0(react@19.2.8)
       mammoth:
         specifier: ^1.12.0
         version: 1.12.1
@@ -8451,11 +8448,6 @@ packages:
 
   lru_map@0.4.1:
     resolution: {integrity: sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==}
-
-  lucide-react@1.31.0:
-    resolution: {integrity: sha512-G8u2eEtoHUnUa9f8lbvqDhCiORMnYLdUEo06EEG9MQvHQrInKcX3Pa2TH39MM5qyzRcWETxB0+aOwAPI1g1kEg==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -19412,10 +19404,6 @@ snapshots:
       lru-cache: 11.5.1
 
   lru_map@0.4.1: {}
-
-  lucide-react@1.31.0(react@19.2.8):
-    dependencies:
-      react: 19.2.8
 
   lz-string@1.5.0: {}
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-template-flow.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-template-flow.tsx
@@ -13,7 +13,8 @@
  * Version 2.0 or later.
  */
 
-import { ClockIcon, MailIcon } from "lucide-react";
+import { Clock01Icon, Mail01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { siGithub } from "simple-icons";
 import Image from "next/image";
 
@@ -58,7 +59,7 @@ function FlowIcon({ bucket }: { bucket: IconBucket }) {
         <Image src="/images/slack-logo.svg" alt="Slack" width={16} height={16} className="size-4" />
       );
     case "email":
-      return <MailIcon className="size-4" />;
+      return <HugeiconsIcon icon={Mail01Icon} className="size-4" />;
     case "contentful":
       return (
         <Image
@@ -70,7 +71,7 @@ function FlowIcon({ bucket }: { bucket: IconBucket }) {
         />
       );
     case "schedule":
-      return <ClockIcon className="size-4" strokeWidth={1.8} />;
+      return <HugeiconsIcon icon={Clock01Icon} className="size-4" strokeWidth={1.8} />;
   }
 }
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -18,15 +18,19 @@ import {
   Add01Icon,
   ArrowDown01Icon,
   BrainCircuitIcon,
+  Clock01Icon,
+  Delete02Icon,
   FolderLibraryIcon,
   GitBranchIcon,
+  Globe02Icon,
+  Mail01Icon,
+  SearchIcon,
   SlackIcon,
   Task01Icon,
   Upload01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useQuery } from "@tanstack/react-query";
-import { ClockIcon, GlobeIcon, MailIcon, SearchIcon, Trash2Icon } from "lucide-react";
 import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
 import type { SimpleIcon } from "simple-icons";
 import {
@@ -166,7 +170,7 @@ function AutomationToolMenuIcon({ icon }: { icon?: SimpleIcon }) {
     return <SimpleBrandIcon icon={icon} colored={false} className="size-4" />;
   }
 
-  return <SearchIcon className="size-4" />;
+  return <HugeiconsIcon icon={SearchIcon} className="size-4" />;
 }
 
 function FieldError({ message }: { message?: string }) {
@@ -254,7 +258,7 @@ function DeleteToolButton({
       onClick={onClick}
       className="size-8 rounded-lg text-muted-foreground hover:text-foreground"
     >
-      <Trash2Icon className="size-4" />
+      <HugeiconsIcon icon={Delete02Icon} className="size-4" />
     </Button>
   );
 }
@@ -744,7 +748,7 @@ function AddTriggerMenu({
               disabled={form.triggerMode === "manual"}
               onClick={() => onChange({ ...form, triggerMode: "manual" })}
             >
-              <ClockIcon className="size-4" />
+              <HugeiconsIcon icon={Clock01Icon} className="size-4" />
               <FormattedMessage {...workspaceAutomationFormMessages.manualRun} />
               {form.triggerMode === "manual" ? (
                 <DropdownMenuShortcut>
@@ -756,7 +760,7 @@ function AddTriggerMenu({
               disabled={form.triggerMode === "scheduled"}
               onClick={() => onChange({ ...form, triggerMode: "scheduled" })}
             >
-              <ClockIcon className="size-4" />
+              <HugeiconsIcon icon={Clock01Icon} className="size-4" />
               <FormattedMessage {...workspaceAutomationFormMessages.scheduled} />
               {form.triggerMode === "scheduled" ? (
                 <DropdownMenuShortcut>
@@ -816,7 +820,7 @@ function AddTriggerMenu({
                 })
               }
             >
-              <SearchIcon className="size-4" />
+              <HugeiconsIcon icon={SearchIcon} className="size-4" />
               <FormattedMessage {...workspaceAutomationFormMessages.contentfulWebhook} />
               {form.triggerMode === "contentful" ? (
                 <DropdownMenuShortcut>
@@ -879,7 +883,7 @@ function TriggerSettings({
       <EditorPanel>
         {form.triggerMode === "scheduled" ? (
           <EditorRow
-            icon={<ClockIcon className="size-4" />}
+            icon={<HugeiconsIcon icon={Clock01Icon} className="size-4" />}
             title={
               <>
                 <span>
@@ -1036,7 +1040,7 @@ function TriggerSettings({
 
         {form.triggerMode === "manual" ? (
           <EditorRow
-            icon={<ClockIcon className="size-4" />}
+            icon={<HugeiconsIcon icon={Clock01Icon} className="size-4" />}
             title={<FormattedMessage {...workspaceAutomationFormMessages.manualOnlyTitle} />}
             description={
               <FormattedMessage {...workspaceAutomationFormMessages.manualOnlyDescription} />
@@ -1046,7 +1050,7 @@ function TriggerSettings({
 
         {form.triggerMode === "contentful" ? (
           <EditorRow
-            icon={<SearchIcon className="size-4" />}
+            icon={<HugeiconsIcon icon={SearchIcon} className="size-4" />}
             title={<FormattedMessage {...workspaceAutomationFormMessages.contentfulWebhook} />}
             description={
               contentfulConnected ? (
@@ -1258,7 +1262,7 @@ function AddToolMenu({
               disabled={form.emailEnabled || !emailConnected}
               onClick={() => onChange({ ...form, emailEnabled: true })}
             >
-              <MailIcon className="size-4" />
+              <HugeiconsIcon icon={Mail01Icon} className="size-4" />
               <FormattedMessage {...workspaceAutomationFormMessages.sendEmail} />
               {form.emailEnabled ? (
                 <DropdownMenuShortcut>
@@ -1282,7 +1286,7 @@ function AddToolMenu({
                 })
               }
             >
-              <SearchIcon className="size-4" />
+              <HugeiconsIcon icon={SearchIcon} className="size-4" />
               <FormattedMessage {...workspaceAutomationFormMessages.contentfulTranslate} />
               {form.contentfulEnabled ? (
                 <DropdownMenuShortcut>
@@ -1433,7 +1437,7 @@ function AddToolMenu({
               disabled={form.webSearchEnabled}
               onClick={() => onChange({ ...form, webSearchEnabled: true })}
             >
-              <GlobeIcon className="size-4" />
+              <HugeiconsIcon icon={Globe02Icon} className="size-4" />
               <FormattedMessage {...workspaceAutomationFormMessages.webSearch} />
               {form.webSearchEnabled ? (
                 <DropdownMenuShortcut>
@@ -1852,7 +1856,7 @@ function ToolsSettings({
 
         {form.emailEnabled ? (
           <EditorRow
-            icon={<MailIcon className="size-4" />}
+            icon={<HugeiconsIcon icon={Mail01Icon} className="size-4" />}
             title={
               <>
                 <span>
@@ -1911,7 +1915,7 @@ function ToolsSettings({
 
         {form.contentfulEnabled ? (
           <EditorRow
-            icon={<SearchIcon className="size-4" />}
+            icon={<HugeiconsIcon icon={SearchIcon} className="size-4" />}
             title={
               <>
                 <span>
@@ -2400,7 +2404,7 @@ function ToolsSettings({
 
         {form.webSearchEnabled ? (
           <EditorRow
-            icon={<GlobeIcon className="size-4" />}
+            icon={<HugeiconsIcon icon={Globe02Icon} className="size-4" />}
             title={<FormattedMessage {...workspaceAutomationFormMessages.webSearch} />}
             description={intl.formatMessage(workspaceAutomationFormMessages.webSearchDescription)}
             action={

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
@@ -12,6 +12,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { Download01Icon, File01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import type {
   DynamicToolUIPart,
   ReasoningUIPart,
@@ -20,7 +22,6 @@ import type {
   ToolUIPart,
   UIMessage,
 } from "ai";
-import { DownloadIcon, FileTextIcon } from "lucide-react";
 import { memo, useState, type ReactNode } from "react";
 import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
 
@@ -274,9 +275,9 @@ function MessageAttachments({ attachments }: { attachments: ConversationMessage[
           rel="noreferrer"
           className="flex max-w-full items-center gap-2 rounded-md border border-border bg-muted/35 px-3 py-2 text-sm text-foreground hover:bg-muted"
         >
-          <FileTextIcon className="size-4 shrink-0 text-muted-foreground" />
+          <HugeiconsIcon icon={File01Icon} className="size-4 shrink-0 text-muted-foreground" />
           <span className="min-w-0 flex-1 truncate">{attachment.filename}</span>
-          <DownloadIcon className="size-4 shrink-0 text-muted-foreground" />
+          <HugeiconsIcon icon={Download01Icon} className="size-4 shrink-0 text-muted-foreground" />
         </a>
       ))}
     </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-panel-error-boundary.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-panel-error-boundary.tsx
@@ -12,7 +12,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { AlertCircleIcon } from "lucide-react";
+import { AlertCircleIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { type ErrorInfo, type ReactNode } from "react";
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 import { FormattedMessage } from "react-intl";
@@ -65,7 +66,7 @@ function InboxPanelErrorFallback({
       data-inbox-panel-error={scope}
     >
       <Alert variant="destructive" className="max-w-md">
-        <AlertCircleIcon />
+        <HugeiconsIcon icon={AlertCircleIcon} />
         <AlertTitle>
           <FormattedMessage {...panelTitleMessageByScope[scope]} />
         </AlertTitle>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integration-row.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integration-row.tsx
@@ -12,8 +12,9 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { ArrowDown01Icon, ArrowUpRight01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import type { ReactNode } from "react";
-import { ArrowUpRightIcon, ChevronDownIcon } from "lucide-react";
 import { FormattedMessage } from "react-intl";
 
 import { integrationRowMessages } from "./integration-row.messages";
@@ -144,14 +145,15 @@ export function IntegrationRow({
               ) : (
                 <FormattedMessage {...integrationRowMessages.connect} />
               )}
-              <ArrowUpRightIcon className="size-3.5" strokeWidth={2} />
+              <HugeiconsIcon icon={ArrowUpRight01Icon} className="size-3.5" strokeWidth={2} />
             </Button>
           ) : showPanel ? (
             <CollapsibleTrigger
               render={
                 <Button type="button" variant="outline" size="sm">
                   <FormattedMessage {...integrationRowMessages.manage} />
-                  <ChevronDownIcon
+                  <HugeiconsIcon
+                    icon={ArrowDown01Icon}
                     className={cn("size-3.5 transition-transform", expanded && "rotate-180")}
                     strokeWidth={2}
                   />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
@@ -15,8 +15,15 @@
 import { useEffect, useId, useMemo, useState, type ReactNode } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { Alert02Icon, Delete02Icon, Key01Icon, SaveIcon } from "@hugeicons/core-free-icons";
-import { ChevronDownIcon, EyeIcon, EyeOffIcon } from "lucide-react";
+import {
+  Alert02Icon,
+  ArrowDown01Icon,
+  Delete02Icon,
+  Key01Icon,
+  SaveIcon,
+  ViewIcon,
+  ViewOffSlashIcon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { SimpleIcon } from "simple-icons";
 import { siAnthropic, siContentful, siCrowdin, siGooglegemini } from "simple-icons";
@@ -743,7 +750,8 @@ function TmsIntegrationRow({
                   ) : (
                     <FormattedMessage {...integrationRowMessages.connect} />
                   )}
-                  <ChevronDownIcon
+                  <HugeiconsIcon
+                    icon={ArrowDown01Icon}
                     className={cn("size-3.5 transition-transform", expanded && "rotate-180")}
                     strokeWidth={2}
                   />
@@ -834,7 +842,8 @@ function CmsIntegrationRow({
                   ) : (
                     <FormattedMessage {...integrationRowMessages.connect} />
                   )}
-                  <ChevronDownIcon
+                  <HugeiconsIcon
+                    icon={ArrowDown01Icon}
                     className={cn("size-3.5 transition-transform", expanded && "rotate-180")}
                     strokeWidth={2}
                   />
@@ -1597,7 +1606,11 @@ export function IntegrationsPageContent({
                             : integrationsPageContentMessages.showApiKeyAriaLabel,
                         )}
                       >
-                        {showApiKey ? <EyeOffIcon size={16} /> : <EyeIcon size={16} />}
+                        {showApiKey ? (
+                          <HugeiconsIcon icon={ViewOffSlashIcon} size={16} />
+                        ) : (
+                          <HugeiconsIcon icon={ViewIcon} size={16} />
+                        )}
                       </button>
                     </div>
                   </Field>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/tms-provider-credential-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/tms-provider-credential-panel.tsx
@@ -14,14 +14,16 @@
  */
 import { useEffect, useRef, useState } from "react";
 import {
+  ArrowDown01Icon,
   Copy01Icon,
   Delete02Icon,
   Key01Icon,
   SaveIcon,
   Tick02Icon,
+  ViewIcon,
+  ViewOffSlashIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ChevronDownIcon, EyeIcon, EyeOffIcon } from "lucide-react";
 import { FormattedMessage, useIntl, type IntlShape, type MessageDescriptor } from "react-intl";
 import { toast } from "sonner";
 
@@ -244,7 +246,11 @@ function CrowdinOAuthSetupFields({
                 : tmsProviderCredentialPanelMessages.showSecretAriaLabel,
             )}
           >
-            {showSecret ? <EyeOffIcon size={16} /> : <EyeIcon size={16} />}
+            {showSecret ? (
+              <HugeiconsIcon icon={ViewOffSlashIcon} size={16} />
+            ) : (
+              <HugeiconsIcon icon={ViewIcon} size={16} />
+            )}
           </button>
         </div>
       </Field>
@@ -522,7 +528,8 @@ export function TmsProviderCredentialPanel({
                 className="h-8 w-full justify-between px-2 text-muted-foreground hover:text-foreground"
               >
                 {intl.formatMessage(tmsProviderCredentialPanelMessages.reconnectOAuthApp)}
-                <ChevronDownIcon
+                <HugeiconsIcon
+                  icon={ArrowDown01Icon}
                   className={cn(
                     "size-3.5 shrink-0 transition-transform",
                     oauthReconnectOpen && "rotate-180",
@@ -609,7 +616,11 @@ export function TmsProviderCredentialPanel({
                   : tmsProviderCredentialPanelMessages.showSecretAriaLabel,
               )}
             >
-              {showSecret ? <EyeOffIcon size={16} /> : <EyeIcon size={16} />}
+              {showSecret ? (
+                <HugeiconsIcon icon={ViewOffSlashIcon} size={16} />
+              ) : (
+                <HugeiconsIcon icon={ViewIcon} size={16} />
+              )}
             </button>
           </div>
         </Field>
@@ -626,7 +637,8 @@ export function TmsProviderCredentialPanel({
                 className="h-8 w-full justify-between px-2 text-muted-foreground hover:text-foreground"
               >
                 {intl.formatMessage(tmsProviderCredentialPanelMessages.advancedSettings)}
-                <ChevronDownIcon
+                <HugeiconsIcon
+                  icon={ArrowDown01Icon}
                   className={cn(
                     "size-3.5 shrink-0 transition-transform",
                     advancedSettingsOpen && "rotate-180",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/knowledge/_components/knowledge-memory-editor-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/knowledge/_components/knowledge-memory-editor-view.tsx
@@ -13,9 +13,8 @@
  * Version 2.0 or later.
  */
 import { useState } from "react";
-import { FloppyDiskIcon } from "@hugeicons/core-free-icons";
+import { FloppyDiskIcon, HistoryIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { HistoryIcon } from "lucide-react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import type { KnowledgeMemoryRecord } from "@/api/routes/knowledge-memory/knowledge-memory.schema";
@@ -171,7 +170,7 @@ export function KnowledgeMemoryEditorView({
             </div>
             <div className="flex items-center gap-2">
               <Button type="button" variant="ghost" onClick={onOpenHistory}>
-                <HistoryIcon data-icon="inline-start" />
+                <HugeiconsIcon icon={HistoryIcon} data-icon="inline-start" />
                 <FormattedMessage {...knowledgeMemoryEditorMessages.history} />
               </Button>
               {canUpdateKnowledgeMemory ? (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/knowledge/_components/knowledge-memory-history-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/knowledge/_components/knowledge-memory-history-dialog.tsx
@@ -12,8 +12,9 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { HistoryIcon, ReloadIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { useMemo, useState } from "react";
-import { HistoryIcon, RotateCcwIcon } from "lucide-react";
 import { MultiFileDiff, type FileContents } from "@pierre/diffs/react";
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTheme } from "next-themes";
@@ -313,7 +314,7 @@ export function KnowledgeMemoryHistoryDialog({
         <DialogContent className="flex h-[min(85dvh,52rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-6xl">
           <DialogHeader className="border-b border-border px-6 py-5 pe-14">
             <DialogTitle className="flex items-center gap-2">
-              <HistoryIcon className="size-4" />
+              <HugeiconsIcon icon={HistoryIcon} className="size-4" />
               Global guidance history
             </DialogTitle>
             <DialogDescription>
@@ -414,7 +415,7 @@ export function KnowledgeMemoryHistoryDialog({
                           }
                           onClick={() => setRestoreRevision(selectedDetail)}
                         >
-                          <RotateCcwIcon className="size-4" />
+                          <HugeiconsIcon icon={ReloadIcon} className="size-4" />
                           Restore
                         </Button>
                       ) : null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-selection-actions.tsx
@@ -14,9 +14,13 @@
  */
 import Link from "next/link";
 import { forwardRef, useImperativeHandle } from "react";
-import { Download01Icon, TranslateIcon, Upload01Icon } from "@hugeicons/core-free-icons";
+import {
+  Download01Icon,
+  LeftToRightListBulletIcon,
+  TranslateIcon,
+  Upload01Icon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ListIcon } from "lucide-react";
 import { FormattedMessage } from "react-intl";
 
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
@@ -92,7 +96,7 @@ export const ProjectFileSelectionActions = forwardRef<
         disabled={!actions.canOpenCat || !actions.catHref}
         render={actions.canOpenCat && actions.catHref ? <Link href={actions.catHref} /> : undefined}
       >
-        <ListIcon />
+        <HugeiconsIcon icon={LeftToRightListBulletIcon} />
         <FormattedMessage {...messages.viewStrings} />
       </Button>
       {actions.isNativeFile ? (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-tree-context-menu.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-tree-context-menu.tsx
@@ -14,9 +14,13 @@
  */
 import { useEffect, useLayoutEffect, useState, type CSSProperties } from "react";
 import { createPortal } from "react-dom";
-import { Download01Icon, TranslateIcon, Upload01Icon } from "@hugeicons/core-free-icons";
+import {
+  Download01Icon,
+  LeftToRightListBulletIcon,
+  TranslateIcon,
+  Upload01Icon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ListIcon } from "lucide-react";
 
 import { FormattedMessage } from "react-intl";
 
@@ -144,7 +148,7 @@ export function ProjectFileTreeContextMenu({
           }
         }}
       >
-        <ListIcon />
+        <HugeiconsIcon icon={LeftToRightListBulletIcon} />
         <FormattedMessage {...messages.viewStrings} />
       </Button>
       {capabilities.isNativeFile ? (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-error-boundary.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-error-boundary.tsx
@@ -12,7 +12,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { AlertCircleIcon } from "lucide-react";
+import { AlertCircleIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { type ErrorInfo, type ReactNode } from "react";
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -65,7 +66,11 @@ function ProjectFilesPanelFallback({
   return (
     <div className={cn("flex min-h-48 flex-col justify-center gap-3 p-4", className)} role="alert">
       <div className="flex items-start gap-2">
-        <AlertCircleIcon className="mt-0.5 size-4 shrink-0 text-flame-100" aria-hidden />
+        <HugeiconsIcon
+          icon={AlertCircleIcon}
+          className="mt-0.5 size-4 shrink-0 text-flame-100"
+          aria-hidden
+        />
         <div className="space-y-1">
           <TypographyP className="text-sm font-medium text-flame-100">
             {scope === "tree" ? (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-view.stories.tsx
@@ -13,9 +13,12 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import Link from "next/link";
 import { expect, userEvent } from "storybook/test";
-import { LinkSquare02Icon, RefreshIcon } from "@hugeicons/core-free-icons";
+import {
+  LeftToRightListBulletIcon,
+  LinkSquare02Icon,
+  RefreshIcon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ListIcon } from "lucide-react";
 
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
 import { Button } from "@/components/ui/button";
@@ -171,7 +174,7 @@ function liveCrowdinHeaderActions() {
       </Button>
       {liveJobCatHref ? (
         <Button size="sm" render={<Link href={liveJobCatHref} />}>
-          <ListIcon />
+          <HugeiconsIcon icon={LeftToRightListBulletIcon} />
           View strings
         </Button>
       ) : null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-content.tsx
@@ -15,9 +15,13 @@
 import Link from "next/link";
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { LinkSquare02Icon, RefreshIcon, StopCircleIcon } from "@hugeicons/core-free-icons";
+import {
+  LeftToRightListBulletIcon,
+  LinkSquare02Icon,
+  RefreshIcon,
+  StopCircleIcon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ListIcon } from "lucide-react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
 
@@ -311,7 +315,7 @@ export function NativeJobDetailContent({
       ) : null}
       {showCatAction && catHref ? (
         <Button size="sm" render={<Link href={catHref} />}>
-          <ListIcon />
+          <HugeiconsIcon icon={LeftToRightListBulletIcon} />
           <FormattedMessage {...messages.viewStrings} />
         </Button>
       ) : null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-view.tsx
@@ -15,9 +15,12 @@
 import Link from "next/link";
 import { type ReactNode } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { LinkSquare02Icon, RefreshIcon } from "@hugeicons/core-free-icons";
+import {
+  LeftToRightListBulletIcon,
+  LinkSquare02Icon,
+  RefreshIcon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ListIcon } from "lucide-react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
 
@@ -236,7 +239,7 @@ export function ProviderLiveJobDetailView({
       ) : null}
       {showViewStrings && catHref ? (
         <Button size="sm" render={<Link href={catHref} />}>
-          <ListIcon />
+          <HugeiconsIcon icon={LeftToRightListBulletIcon} />
           <FormattedMessage {...messages.viewStrings} />
         </Button>
       ) : null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.tsx
@@ -12,10 +12,11 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { LeftToRightListBulletIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { useCallback, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { ListIcon } from "lucide-react";
 import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
 import { toast } from "sonner";
 
@@ -252,7 +253,7 @@ export function JobSourceFilesPanel({
                 disabled={!stringsHrefForSelected}
                 render={stringsHrefForSelected ? <Link href={stringsHrefForSelected} /> : undefined}
               >
-                <ListIcon />
+                <HugeiconsIcon icon={LeftToRightListBulletIcon} />
                 <FormattedMessage {...messages.viewStrings} />
               </Button>
             </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-native-connect-cli-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-native-connect-cli-panel.tsx
@@ -12,8 +12,9 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { Copy01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { useState } from "react";
-import { CopyIcon } from "lucide-react";
 import { FormattedMessage } from "react-intl";
 import { toast } from "sonner";
 
@@ -77,7 +78,7 @@ export function ProjectNativeConnectCliPanel({
             size="sm"
             onClick={() => copyValue(projectId, "projectId")}
           >
-            <CopyIcon className="size-3.5" />
+            <HugeiconsIcon icon={Copy01Icon} className="size-3.5" />
             {copiedField === "projectId" ? (
               <FormattedMessage {...projectNativeConnectCliPanelMessages.copied} />
             ) : (
@@ -98,7 +99,7 @@ export function ProjectNativeConnectCliPanel({
             size="sm"
             onClick={() => copyValue(sampleConfig, "config")}
           >
-            <CopyIcon className="size-3.5" />
+            <HugeiconsIcon icon={Copy01Icon} className="size-3.5" />
             {copiedField === "config" ? (
               <FormattedMessage {...projectNativeConnectCliPanelMessages.copied} />
             ) : (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.tsx
@@ -12,9 +12,9 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { HugeiconsIcon } from "@hugeicons/react";
 import { type FormEvent, useEffect, useState } from "react";
-import { Settings01Icon } from "@hugeicons/core-free-icons";
-import { SaveIcon } from "lucide-react";
+import { SaveIcon, Settings01Icon } from "@hugeicons/core-free-icons";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
@@ -204,7 +204,11 @@ export function ProjectSettingsPageContent({
     visible: Boolean(settingsEditable),
     render: () => (
       <Button type="submit" form="project-settings-form" disabled={isSaving}>
-        {isSaving ? <Spinner /> : <SaveIcon className="size-4" strokeWidth={2} />}
+        {isSaving ? (
+          <Spinner />
+        ) : (
+          <HugeiconsIcon icon={SaveIcon} className="size-4" strokeWidth={2} />
+        )}
         {isSaving ? (
           <FormattedMessage {...projectSettingsPageContentMessages.saving} />
         ) : (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-dialog.tsx
@@ -13,8 +13,7 @@
  * Version 2.0 or later.
  */
 import { type FormEvent, useEffect, useId, useState } from "react";
-import { ChevronDownIcon } from "lucide-react";
-import { SaveIcon } from "@hugeicons/core-free-icons";
+import { ArrowDown01Icon, SaveIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -185,7 +184,8 @@ export function ProjectDialog({
                     className="h-9 w-full justify-between px-3 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
                   >
                     <FormattedMessage {...projectDialogMessages.settings} />
-                    <ChevronDownIcon
+                    <HugeiconsIcon
+                      icon={ArrowDown01Icon}
                       className={cn(
                         "size-4 shrink-0 transition-transform",
                         settingsOpen && "rotate-180",

--- a/apps/hyperlocalise-web/src/components/ai-elements/agent-todo-progress.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/agent-todo-progress.tsx
@@ -12,7 +12,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { CheckCircle2Icon, CircleIcon } from "lucide-react";
+import { CheckmarkCircle02Icon, CircleIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage } from "react-intl";
 
 import { Spinner } from "@/components/ui/spinner";
@@ -52,7 +53,7 @@ export function getAgentTodoItems(value: unknown): AgentTodoItem[] | null {
 
 function TodoStatusIcon({ status }: { status: AgentTodoItem["status"] }) {
   if (status === "completed") {
-    return <CheckCircle2Icon className="size-4 text-green-600" />;
+    return <HugeiconsIcon icon={CheckmarkCircle02Icon} className="size-4 text-green-600" />;
   }
   if (status === "in-progress") {
     return (
@@ -61,7 +62,7 @@ function TodoStatusIcon({ status }: { status: AgentTodoItem["status"] }) {
       </span>
     );
   }
-  return <CircleIcon className="size-4 text-muted-foreground/60" />;
+  return <HugeiconsIcon icon={CircleIcon} className="size-4 text-muted-foreground/60" />;
 }
 
 export function AgentTodoProgress({ items }: { items: AgentTodoItem[] }) {

--- a/apps/hyperlocalise-web/src/components/ai-elements/agent.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/agent.tsx
@@ -12,6 +12,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { Robot01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import {
   Accordion,
   AccordionContent,
@@ -21,7 +23,6 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/primitives/cn";
 import type { Tool } from "ai";
-import { BotIcon } from "lucide-react";
 import type { ComponentProps } from "react";
 import { memo } from "react";
 import { FormattedMessage } from "react-intl";
@@ -44,7 +45,7 @@ export type AgentHeaderProps = ComponentProps<"div"> & {
 export const AgentHeader = memo(({ className, name, model, ...props }: AgentHeaderProps) => (
   <div className={cn("flex w-full items-center justify-between gap-4 p-3", className)} {...props}>
     <div className="flex items-center gap-2">
-      <BotIcon className="size-4 text-muted-foreground" />
+      <HugeiconsIcon icon={Robot01Icon} className="size-4 text-muted-foreground" />
       <span className="font-medium text-sm">{name}</span>
       {model && (
         <Badge className="font-mono text-xs" variant="secondary">

--- a/apps/hyperlocalise-web/src/components/ai-elements/ai-element-error-boundary.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/ai-element-error-boundary.tsx
@@ -12,7 +12,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { AlertCircleIcon } from "lucide-react";
+import { AlertCircleIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { type ErrorInfo, type ReactNode } from "react";
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 import { FormattedMessage } from "react-intl";
@@ -69,7 +70,7 @@ function AiElementErrorFallback({
       data-ai-element-error={scope}
     >
       <Alert variant="destructive" className="max-w-full">
-        <AlertCircleIcon />
+        <HugeiconsIcon icon={AlertCircleIcon} />
         <AlertTitle>
           <FormattedMessage {...panelTitleMessageByScope[scope]} />
         </AlertTitle>

--- a/apps/hyperlocalise-web/src/components/ai-elements/artifact.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/artifact.tsx
@@ -12,11 +12,11 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { Cancel01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/primitives/cn";
-import type { LucideIcon } from "lucide-react";
-import { XIcon } from "lucide-react";
 import type { ComponentProps, HTMLAttributes } from "react";
 import { FormattedMessage } from "react-intl";
 import { TypographyP } from "@/components/ui/typography";
@@ -63,7 +63,7 @@ export const ArtifactClose = ({
           variant={variant}
           {...props}
         >
-          {children ?? <XIcon className="size-4" />}
+          {children ?? <HugeiconsIcon icon={Cancel01Icon} className="size-4" />}
           <span className="sr-only">
             <FormattedMessage {...artifactMessages.close} />
           </span>
@@ -97,7 +97,7 @@ export const ArtifactActions = ({ className, ...props }: ArtifactActionsProps) =
 export type ArtifactActionProps = ComponentProps<typeof Button> & {
   tooltip?: string;
   label?: string;
-  icon?: LucideIcon;
+  icon?: IconSvgElement;
 };
 
 export const ArtifactAction = ({
@@ -127,7 +127,7 @@ export const ArtifactAction = ({
               variant={variant}
               {...props}
             >
-              {Icon ? <Icon className="size-4" /> : children}
+              {Icon ? <HugeiconsIcon icon={Icon} className="size-4" /> : children}
               <span className="sr-only">{label || tooltip}</span>
             </Button>
           }
@@ -145,7 +145,7 @@ export const ArtifactAction = ({
       variant={variant}
       {...props}
     >
-      {Icon ? <Icon className="size-4" /> : children}
+      {Icon ? <HugeiconsIcon icon={Icon} className="size-4" /> : children}
       <span className="sr-only">{label || tooltip}</span>
     </Button>
   );

--- a/apps/hyperlocalise-web/src/components/ai-elements/attachments.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/attachments.tsx
@@ -12,19 +12,20 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import {
+  AttachmentIcon,
+  Cancel01Icon,
+  File01Icon,
+  Globe02Icon,
+  Image01Icon,
+  MusicNote01Icon,
+  Video01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
 import { Button } from "@/components/ui/button";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import { cn } from "@/lib/primitives/cn";
 import type { FileUIPart, SourceDocumentUIPart } from "ai";
-import {
-  FileTextIcon,
-  GlobeIcon,
-  ImageIcon,
-  Music2Icon,
-  PaperclipIcon,
-  VideoIcon,
-  XIcon,
-} from "lucide-react";
 import type { ComponentProps, HTMLAttributes, ReactNode } from "react";
 import { createContext, useCallback, useContext, useMemo } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -51,13 +52,13 @@ export type AttachmentMediaCategory =
 
 export type AttachmentVariant = "grid" | "inline" | "list";
 
-const mediaCategoryIcons: Record<AttachmentMediaCategory, typeof ImageIcon> = {
-  audio: Music2Icon,
-  document: FileTextIcon,
-  image: ImageIcon,
-  source: GlobeIcon,
-  unknown: PaperclipIcon,
-  video: VideoIcon,
+const mediaCategoryIcons: Record<AttachmentMediaCategory, IconSvgElement> = {
+  audio: MusicNote01Icon,
+  document: File01Icon,
+  image: Image01Icon,
+  source: Globe02Icon,
+  unknown: AttachmentIcon,
+  video: Video01Icon,
 };
 
 // ============================================================================
@@ -254,8 +255,8 @@ export const AttachmentPreview = ({
 
   const iconSize = variant === "inline" ? "size-3" : "size-4";
 
-  const renderIcon = (Icon: typeof ImageIcon) => (
-    <Icon className={cn(iconSize, "text-muted-foreground")} />
+  const renderIcon = (Icon: IconSvgElement) => (
+    <HugeiconsIcon icon={Icon} className={cn(iconSize, "text-muted-foreground")} />
   );
 
   const renderContent = () => {
@@ -372,7 +373,7 @@ export const AttachmentRemove = ({
       variant="ghost"
       {...props}
     >
-      {children ?? <XIcon />}
+      {children ?? <HugeiconsIcon icon={Cancel01Icon} />}
       <span className="sr-only">{resolvedLabel}</span>
     </Button>
   );

--- a/apps/hyperlocalise-web/src/components/ai-elements/chain-of-thought.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/chain-of-thought.tsx
@@ -12,12 +12,12 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { ArrowDown01Icon, BrainIcon, DotIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import { Badge } from "@/components/ui/badge";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { cn } from "@/lib/primitives/cn";
-import type { LucideIcon } from "lucide-react";
-import { BrainIcon, ChevronDownIcon, DotIcon } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
 import { createContext, memo, useContext, useMemo } from "react";
 import { FormattedMessage } from "react-intl";
@@ -88,11 +88,12 @@ export const ChainOfThoughtHeader = memo(
           )}
           {...props}
         >
-          <BrainIcon className="size-4" />
+          <HugeiconsIcon icon={BrainIcon} className="size-4" />
           <span className="flex-1 text-start">
             {children ?? <FormattedMessage {...chainOfThoughtMessages.header} />}
           </span>
-          <ChevronDownIcon
+          <HugeiconsIcon
+            icon={ArrowDown01Icon}
             className={cn("size-4 transition-transform", isOpen ? "rotate-180" : "rotate-0")}
           />
         </CollapsibleTrigger>
@@ -102,7 +103,7 @@ export const ChainOfThoughtHeader = memo(
 );
 
 export type ChainOfThoughtStepProps = ComponentProps<"div"> & {
-  icon?: LucideIcon;
+  icon?: IconSvgElement;
   label: ReactNode;
   description?: ReactNode;
   status?: "complete" | "active" | "pending";
@@ -134,7 +135,7 @@ export const ChainOfThoughtStep = memo(
       {...props}
     >
       <div className="relative mt-0.5">
-        <Icon className="size-4" />
+        <HugeiconsIcon icon={Icon} className="size-4" />
         <div className="absolute top-7 bottom-0 start-1/2 -mx-px w-px bg-border" />
       </div>
       <div className="flex-1 space-y-2 overflow-hidden">

--- a/apps/hyperlocalise-web/src/components/ai-elements/checkpoint.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/checkpoint.tsx
@@ -12,12 +12,12 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { Bookmark01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon, type HugeiconsProps } from "@hugeicons/react";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/primitives/cn";
-import type { LucideProps } from "lucide-react";
-import { BookmarkIcon } from "lucide-react";
 import type { ComponentProps, HTMLAttributes } from "react";
 
 export type CheckpointProps = HTMLAttributes<HTMLDivElement>;
@@ -32,10 +32,12 @@ export const Checkpoint = ({ className, children, ...props }: CheckpointProps) =
   </div>
 );
 
-export type CheckpointIconProps = LucideProps;
+export type CheckpointIconProps = Omit<HugeiconsProps, "icon">;
 
 export const CheckpointIcon = ({ className, children, ...props }: CheckpointIconProps) =>
-  children ?? <BookmarkIcon className={cn("size-4 shrink-0", className)} {...props} />;
+  children ?? (
+    <HugeiconsIcon icon={Bookmark01Icon} className={cn("size-4 shrink-0", className)} {...props} />
+  );
 
 export type CheckpointTriggerProps = ComponentProps<typeof Button> & {
   tooltip?: string;

--- a/apps/hyperlocalise-web/src/components/ai-elements/code-block.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/code-block.tsx
@@ -12,6 +12,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { Copy01Icon, Tick02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -22,7 +24,6 @@ import {
 } from "@/components/ui/select";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/primitives/cn";
-import { CheckIcon, CopyIcon } from "lucide-react";
 import type { ComponentProps, CSSProperties, HTMLAttributes } from "react";
 import {
   createContext,
@@ -494,7 +495,7 @@ export const CodeBlockCopyButton = ({
     [],
   );
 
-  const Icon = isCopied ? CheckIcon : CopyIcon;
+  const Icon = isCopied ? Tick02Icon : Copy01Icon;
   const tooltipText = isCopied
     ? intl.formatMessage(codeBlockMessages.copied)
     : intl.formatMessage(codeBlockMessages.copyCode);
@@ -511,7 +512,7 @@ export const CodeBlockCopyButton = ({
             variant="ghost"
             {...props}
           >
-            {children ?? <Icon size={14} />}
+            {children ?? <HugeiconsIcon icon={Icon} size={14} />}
           </Button>
         }
       />

--- a/apps/hyperlocalise-web/src/components/ai-elements/commit.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/commit.tsx
@@ -12,12 +12,20 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import {
+  Copy01Icon,
+  File01Icon,
+  GitCommitIcon,
+  MinusSignIcon,
+  PlusSignIcon,
+  Tick02Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon, type HugeiconsProps } from "@hugeicons/react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/primitives/cn";
-import { CheckIcon, CopyIcon, FileIcon, GitCommitIcon, MinusIcon, PlusIcon } from "lucide-react";
 import type { ComponentProps, HTMLAttributes } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useIntl } from "react-intl";
@@ -54,7 +62,7 @@ export type CommitHashProps = HTMLAttributes<HTMLSpanElement>;
 
 export const CommitHash = ({ className, children, ...props }: CommitHashProps) => (
   <span className={cn("font-mono text-xs", className)} {...props}>
-    <GitCommitIcon className="me-1 inline-block size-3" />
+    <HugeiconsIcon icon={GitCommitIcon} className="me-1 inline-block size-3" />
     {children}
   </span>
 );
@@ -207,7 +215,7 @@ export const CommitCopyButton = ({
     [],
   );
 
-  const Icon = isCopied ? CheckIcon : CopyIcon;
+  const Icon = isCopied ? Tick02Icon : Copy01Icon;
   const tooltipText = isCopied
     ? intl.formatMessage(commitMessages.copied)
     : intl.formatMessage(commitMessages.copyHash);
@@ -224,7 +232,7 @@ export const CommitCopyButton = ({
             variant="ghost"
             {...props}
           >
-            {children ?? <Icon size={14} />}
+            {children ?? <HugeiconsIcon icon={Icon} size={14} />}
           </Button>
         }
       />
@@ -303,10 +311,14 @@ export const CommitFileStatus = ({
   </span>
 );
 
-export type CommitFileIconProps = ComponentProps<typeof FileIcon>;
+export type CommitFileIconProps = Omit<HugeiconsProps, "icon">;
 
 export const CommitFileIcon = ({ className, ...props }: CommitFileIconProps) => (
-  <FileIcon className={cn("size-3.5 shrink-0 text-muted-foreground", className)} {...props} />
+  <HugeiconsIcon
+    icon={File01Icon}
+    className={cn("size-3.5 shrink-0 text-muted-foreground", className)}
+    {...props}
+  />
 );
 
 export type CommitFilePathProps = HTMLAttributes<HTMLSpanElement>;
@@ -343,7 +355,7 @@ export const CommitFileAdditions = ({
     <span className={cn("text-green-600 dark:text-green-400", className)} {...props}>
       {children ?? (
         <>
-          <PlusIcon className="inline-block size-3" />
+          <HugeiconsIcon icon={PlusSignIcon} className="inline-block size-3" />
           {count}
         </>
       )}
@@ -369,7 +381,7 @@ export const CommitFileDeletions = ({
     <span className={cn("text-red-600 dark:text-red-400", className)} {...props}>
       {children ?? (
         <>
-          <MinusIcon className="inline-block size-3" />
+          <HugeiconsIcon icon={MinusSignIcon} className="inline-block size-3" />
           {count}
         </>
       )}

--- a/apps/hyperlocalise-web/src/components/ai-elements/conversation.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/conversation.tsx
@@ -12,11 +12,12 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { ArrowDown01Icon, Download01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/primitives/cn";
 import type { UIMessage } from "ai";
-import { ArrowDownIcon, DownloadIcon } from "lucide-react";
 import type { ComponentProps } from "react";
 import { useCallback } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -117,7 +118,7 @@ export const ConversationScrollButton = ({
               variant="secondary"
               {...props}
             >
-              <ArrowDownIcon className="size-4" />
+              <HugeiconsIcon icon={ArrowDown01Icon} className="size-4" />
             </Button>
           }
         />
@@ -189,7 +190,7 @@ export const ConversationDownload = ({
             variant="outline"
             {...props}
           >
-            {children ?? <DownloadIcon className="size-4" />}
+            {children ?? <HugeiconsIcon icon={Download01Icon} className="size-4" />}
           </Button>
         }
       />

--- a/apps/hyperlocalise-web/src/components/ai-elements/environment-variables.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/environment-variables.tsx
@@ -12,12 +12,13 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { Copy01Icon, Tick02Icon, ViewIcon, ViewOffSlashIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/primitives/cn";
-import { CheckIcon, CopyIcon, EyeIcon, EyeOffIcon } from "lucide-react";
 import type { ComponentProps, HTMLAttributes } from "react";
 import {
   createContext,
@@ -123,7 +124,11 @@ export const EnvironmentVariablesToggle = ({
   return (
     <div className={cn("flex items-center gap-2", className)}>
       <span className="text-muted-foreground text-xs">
-        {showValues ? <EyeIcon size={14} /> : <EyeOffIcon size={14} />}
+        {showValues ? (
+          <HugeiconsIcon icon={ViewIcon} size={14} />
+        ) : (
+          <HugeiconsIcon icon={ViewOffSlashIcon} size={14} />
+        )}
       </span>
       <Switch
         aria-label={intl.formatMessage(environmentVariablesMessages.toggleVisibilityAria)}
@@ -297,7 +302,7 @@ export const EnvironmentVariableCopyButton = ({
     [],
   );
 
-  const Icon = isCopied ? CheckIcon : CopyIcon;
+  const Icon = isCopied ? Tick02Icon : Copy01Icon;
 
   const tooltipText = isCopied
     ? intl.formatMessage(environmentVariablesMessages.copied)
@@ -319,7 +324,7 @@ export const EnvironmentVariableCopyButton = ({
             variant="ghost"
             {...props}
           >
-            {children ?? <Icon size={12} />}
+            {children ?? <HugeiconsIcon icon={Icon} size={12} />}
           </Button>
         }
       />

--- a/apps/hyperlocalise-web/src/components/ai-elements/explore-tool-activity.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/explore-tool-activity.tsx
@@ -12,8 +12,9 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { ScrambleText } from "dot-anime-react";
-import { ChevronDownIcon } from "lucide-react";
 import { useReducedMotion } from "motion/react";
 import { useEffect, useState, type ReactNode } from "react";
 import { useIntl } from "react-intl";
@@ -144,7 +145,10 @@ export function ExploreToolActivity({
           }
         >
           <span className="min-w-0 truncate">{rollupLabel}</span>
-          <ChevronDownIcon className="size-3.5 shrink-0 opacity-0 transition-all group-hover:opacity-100 group-data-[state=open]:rotate-180 group-data-[state=open]:opacity-100" />
+          <HugeiconsIcon
+            icon={ArrowDown01Icon}
+            className="size-3.5 shrink-0 opacity-0 transition-all group-hover:opacity-100 group-data-[state=open]:rotate-180 group-data-[state=open]:opacity-100"
+          />
         </div>
       </TaskTrigger>
       <TaskContent className="text-sm [&_>div]:mt-2 [&_>div]:space-y-0">

--- a/apps/hyperlocalise-web/src/components/ai-elements/file-tree.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/file-tree.tsx
@@ -12,9 +12,15 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import {
+  ArrowRight01Icon,
+  File01Icon,
+  Folder01Icon,
+  FolderOpenIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { cn } from "@/lib/primitives/cn";
-import { ChevronRightIcon, FileIcon, FolderIcon, FolderOpenIcon } from "lucide-react";
 import type { HTMLAttributes, ReactNode } from "react";
 import { createContext, useCallback, useContext, useMemo, useState } from "react";
 
@@ -160,7 +166,8 @@ export const FileTreeFolder = ({
                 />
               }
             >
-              <ChevronRightIcon
+              <HugeiconsIcon
+                icon={ArrowRight01Icon}
                 className={cn(
                   "size-4 shrink-0 text-muted-foreground transition-transform",
                   isExpanded && "rotate-90",
@@ -174,9 +181,9 @@ export const FileTreeFolder = ({
             >
               <FileTreeIcon>
                 {isExpanded ? (
-                  <FolderOpenIcon className="size-4 text-blue-500" />
+                  <HugeiconsIcon icon={FolderOpenIcon} className="size-4 text-blue-500" />
                 ) : (
-                  <FolderIcon className="size-4 text-blue-500" />
+                  <HugeiconsIcon icon={Folder01Icon} className="size-4 text-blue-500" />
                 )}
               </FileTreeIcon>
               <FileTreeName>{name}</FileTreeName>
@@ -252,7 +259,7 @@ export const FileTreeFile = ({
             {/* Spacer for alignment */}
             <span className="size-4 shrink-0" />
             <FileTreeIcon>
-              {icon ?? <FileIcon className="size-4 text-muted-foreground" />}
+              {icon ?? <HugeiconsIcon icon={File01Icon} className="size-4 text-muted-foreground" />}
             </FileTreeIcon>
             <FileTreeName>{name}</FileTreeName>
           </>

--- a/apps/hyperlocalise-web/src/components/ai-elements/inline-citation.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/inline-citation.tsx
@@ -12,12 +12,13 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { ArrowLeft01Icon, ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { Badge } from "@/components/ui/badge";
 import type { CarouselApi } from "@/components/ui/carousel";
 import { Carousel, CarouselContent, CarouselItem } from "@/components/ui/carousel";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import { cn } from "@/lib/primitives/cn";
-import { ArrowLeftIcon, ArrowRightIcon } from "lucide-react";
 import type { ComponentProps } from "react";
 import { createContext, useCallback, useContext, useEffect, useState } from "react";
 import { useIntl } from "react-intl";
@@ -207,7 +208,7 @@ export const InlineCitationCarouselPrev = ({
       type="button"
       {...props}
     >
-      <ArrowLeftIcon className="size-4 text-muted-foreground" />
+      <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4 text-muted-foreground" />
     </button>
   );
 };
@@ -235,7 +236,7 @@ export const InlineCitationCarouselNext = ({
       type="button"
       {...props}
     >
-      <ArrowRightIcon className="size-4 text-muted-foreground" />
+      <HugeiconsIcon icon={ArrowRight01Icon} className="size-4 text-muted-foreground" />
     </button>
   );
 };

--- a/apps/hyperlocalise-web/src/components/ai-elements/jsx-preview.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/jsx-preview.tsx
@@ -12,8 +12,9 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { AlertCircleIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { cn } from "@/lib/primitives/cn";
-import { AlertCircle } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
 import {
   createContext,
@@ -290,7 +291,7 @@ export const JSXPreviewError = memo(({ className, children, ...props }: JSXPrevi
         renderChildren(children, error)
       ) : (
         <>
-          <AlertCircle className="size-4 shrink-0" />
+          <HugeiconsIcon icon={AlertCircleIcon} className="size-4 shrink-0" />
           <span>{error.message}</span>
         </>
       )}

--- a/apps/hyperlocalise-web/src/components/ai-elements/message.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/message.tsx
@@ -12,12 +12,13 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { ArrowLeft01Icon, ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup, ButtonGroupText } from "@/components/ui/button-group";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/primitives/cn";
 import type { UIMessage } from "ai";
-import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import type { ComponentProps, HTMLAttributes, ReactElement } from "react";
 import { createContext, memo, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -246,7 +247,7 @@ export const MessageBranchPrevious = ({ children, ...props }: MessageBranchPrevi
             variant="ghost"
             {...props}
           >
-            {children ?? <ChevronLeftIcon size={14} />}
+            {children ?? <HugeiconsIcon icon={ArrowLeft01Icon} size={14} />}
           </Button>
         }
       />
@@ -277,7 +278,7 @@ export const MessageBranchNext = ({ children, ...props }: MessageBranchNextProps
             variant="ghost"
             {...props}
           >
-            {children ?? <ChevronRightIcon size={14} />}
+            {children ?? <HugeiconsIcon icon={ArrowRight01Icon} size={14} />}
           </Button>
         }
       />

--- a/apps/hyperlocalise-web/src/components/ai-elements/mic-selector.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/mic-selector.tsx
@@ -12,6 +12,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { UnfoldMoreIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import { Button } from "@/components/ui/button";
 import {
@@ -23,7 +25,6 @@ import {
 } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/primitives/cn";
-import { ChevronsUpDownIcon } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
 import {
   createContext,
@@ -234,7 +235,7 @@ export const MicSelectorTrigger = ({ children, ...props }: MicSelectorTriggerPro
   return (
     <PopoverTrigger render={<Button variant="outline" {...props} ref={ref} />}>
       {children}
-      <ChevronsUpDownIcon className="shrink-0 text-muted-foreground" size={16} />
+      <HugeiconsIcon icon={UnfoldMoreIcon} className="shrink-0 text-muted-foreground" size={16} />
     </PopoverTrigger>
   );
 };

--- a/apps/hyperlocalise-web/src/components/ai-elements/open-in-chat.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/open-in-chat.tsx
@@ -12,6 +12,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { ArrowDown01Icon, ExternalLinkIcon, Message01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -22,7 +24,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/primitives/cn";
-import { ChevronDownIcon, ExternalLinkIcon, MessageCircleIcon } from "lucide-react";
 import type { ComponentProps } from "react";
 import { createContext, useContext, useMemo } from "react";
 import { useIntl } from "react-intl";
@@ -163,7 +164,7 @@ const providers = {
       `https://t3.chat/new?${new URLSearchParams({
         q,
       })}`,
-    icon: <MessageCircleIcon />,
+    icon: <HugeiconsIcon icon={Message01Icon} />,
   },
   v0: {
     createUrl: (q: string) =>
@@ -234,7 +235,7 @@ export const OpenInTrigger = ({ children, ...props }: OpenInTriggerProps) => {
       {children ?? (
         <Button type="button" variant="outline">
           {intl.formatMessage(openInChatMessages.openInChat)}
-          <ChevronDownIcon className="size-4" />
+          <HugeiconsIcon icon={ArrowDown01Icon} className="size-4" />
         </Button>
       )}
     </DropdownMenuTrigger>
@@ -261,7 +262,7 @@ export const OpenInChatGPT = (props: OpenInChatGPTProps) => {
     >
       <span className="shrink-0">{providers.chatgpt.icon}</span>
       <span className="flex-1">{intl.formatMessage(openInChatMessages.openInChatGpt)}</span>
-      <ExternalLinkIcon className="size-4 shrink-0" />
+      <HugeiconsIcon icon={ExternalLinkIcon} className="size-4 shrink-0" />
     </DropdownMenuItem>
   );
 };
@@ -286,7 +287,7 @@ export const OpenInClaude = (props: OpenInClaudeProps) => {
     >
       <span className="shrink-0">{providers.claude.icon}</span>
       <span className="flex-1">{intl.formatMessage(openInChatMessages.openInClaude)}</span>
-      <ExternalLinkIcon className="size-4 shrink-0" />
+      <HugeiconsIcon icon={ExternalLinkIcon} className="size-4 shrink-0" />
     </DropdownMenuItem>
   );
 };
@@ -311,7 +312,7 @@ export const OpenInT3 = (props: OpenInT3Props) => {
     >
       <span className="shrink-0">{providers.t3.icon}</span>
       <span className="flex-1">{intl.formatMessage(openInChatMessages.openInT3Chat)}</span>
-      <ExternalLinkIcon className="size-4 shrink-0" />
+      <HugeiconsIcon icon={ExternalLinkIcon} className="size-4 shrink-0" />
     </DropdownMenuItem>
   );
 };
@@ -336,7 +337,7 @@ export const OpenInScira = (props: OpenInSciraProps) => {
     >
       <span className="shrink-0">{providers.scira.icon}</span>
       <span className="flex-1">{intl.formatMessage(openInChatMessages.openInScira)}</span>
-      <ExternalLinkIcon className="size-4 shrink-0" />
+      <HugeiconsIcon icon={ExternalLinkIcon} className="size-4 shrink-0" />
     </DropdownMenuItem>
   );
 };
@@ -361,7 +362,7 @@ export const OpenInv0 = (props: OpenInv0Props) => {
     >
       <span className="shrink-0">{providers.v0.icon}</span>
       <span className="flex-1">{intl.formatMessage(openInChatMessages.openInV0)}</span>
-      <ExternalLinkIcon className="size-4 shrink-0" />
+      <HugeiconsIcon icon={ExternalLinkIcon} className="size-4 shrink-0" />
     </DropdownMenuItem>
   );
 };
@@ -386,7 +387,7 @@ export const OpenInCursor = (props: OpenInCursorProps) => {
     >
       <span className="shrink-0">{providers.cursor.icon}</span>
       <span className="flex-1">{intl.formatMessage(openInChatMessages.openInCursor)}</span>
-      <ExternalLinkIcon className="size-4 shrink-0" />
+      <HugeiconsIcon icon={ExternalLinkIcon} className="size-4 shrink-0" />
     </DropdownMenuItem>
   );
 };

--- a/apps/hyperlocalise-web/src/components/ai-elements/package-info.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/package-info.tsx
@@ -12,9 +12,15 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import {
+  ArrowRight01Icon,
+  MinusSignIcon,
+  PackageIcon,
+  PlusSignIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/primitives/cn";
-import { ArrowRightIcon, MinusIcon, PackageIcon, PlusIcon } from "lucide-react";
 import type { HTMLAttributes } from "react";
 import { createContext, useContext, useMemo } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -58,7 +64,7 @@ export const PackageInfoName = ({ className, children, ...props }: PackageInfoNa
 
   return (
     <div className={cn("flex items-center gap-2", className)} {...props}>
-      <PackageIcon className="size-4 text-muted-foreground" />
+      <HugeiconsIcon icon={PackageIcon} className="size-4 text-muted-foreground" />
       <span className="font-medium font-mono text-sm">{children ?? name}</span>
     </div>
   );
@@ -73,11 +79,11 @@ const changeTypeStyles: Record<ChangeType, string> = {
 };
 
 const changeTypeIcons: Record<ChangeType, React.ReactNode> = {
-  added: <PlusIcon className="size-3" />,
-  major: <ArrowRightIcon className="size-3" />,
-  minor: <ArrowRightIcon className="size-3" />,
-  patch: <ArrowRightIcon className="size-3" />,
-  removed: <MinusIcon className="size-3" />,
+  added: <HugeiconsIcon icon={PlusSignIcon} className="size-3" />,
+  major: <HugeiconsIcon icon={ArrowRight01Icon} className="size-3" />,
+  minor: <HugeiconsIcon icon={ArrowRight01Icon} className="size-3" />,
+  patch: <HugeiconsIcon icon={ArrowRight01Icon} className="size-3" />,
+  removed: <HugeiconsIcon icon={MinusSignIcon} className="size-3" />,
 };
 
 export type PackageInfoChangeTypeProps = HTMLAttributes<HTMLDivElement>;
@@ -126,7 +132,9 @@ export const PackageInfoVersion = ({ className, children, ...props }: PackageInf
       {children ?? (
         <>
           {currentVersion && <span>{currentVersion}</span>}
-          {currentVersion && newVersion && <ArrowRightIcon className="size-3" />}
+          {currentVersion && newVersion && (
+            <HugeiconsIcon icon={ArrowRight01Icon} className="size-3" />
+          )}
           {newVersion && <span className="font-medium text-foreground">{newVersion}</span>}
         </>
       )}

--- a/apps/hyperlocalise-web/src/components/ai-elements/plan.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/plan.tsx
@@ -12,6 +12,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { UnfoldMoreIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -24,7 +26,6 @@ import {
 } from "@/components/ui/card";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { cn } from "@/lib/primitives/cn";
-import { ChevronsUpDownIcon } from "lucide-react";
 import type { ComponentProps } from "react";
 import { createContext, useContext, useMemo } from "react";
 import { FormattedMessage } from "react-intl";
@@ -144,7 +145,7 @@ export const PlanTrigger = ({ className, children, ...props }: PlanTriggerProps)
   >
     {children ?? (
       <>
-        <ChevronsUpDownIcon className="size-4" />
+        <HugeiconsIcon icon={UnfoldMoreIcon} className="size-4" />
         <span className="sr-only">
           <FormattedMessage {...planMessages.togglePlanAria} />
         </span>

--- a/apps/hyperlocalise-web/src/components/ai-elements/prompt-input.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/prompt-input.tsx
@@ -13,6 +13,15 @@
  * Version 2.0 or later.
  */
 import {
+  Cancel01Icon,
+  ComputerIcon,
+  CornerDownLeftIcon,
+  Image01Icon,
+  PlusSignIcon,
+  SquareIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
   Command,
   CommandEmpty,
   CommandGroup,
@@ -46,7 +55,6 @@ import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/primitives/cn";
 import type { ChatStatus, FileUIPart, SourceDocumentUIPart } from "ai";
-import { CornerDownLeftIcon, ImageIcon, Monitor, PlusIcon, SquareIcon, XIcon } from "lucide-react";
 import { nanoid } from "nanoid";
 import type {
   ChangeEvent,
@@ -433,7 +441,7 @@ export const PromptInputActionAddAttachments = ({
 
   return (
     <DropdownMenuItem {...props} onSelect={handleSelect}>
-      <ImageIcon className="me-2 size-4" /> {resolvedLabel}
+      <HugeiconsIcon icon={Image01Icon} className="me-2 size-4" /> {resolvedLabel}
     </DropdownMenuItem>
   );
 };
@@ -478,7 +486,7 @@ export const PromptInputActionAddScreenshot = ({
 
   return (
     <DropdownMenuItem {...props} onSelect={handleSelect}>
-      <Monitor className="me-2 size-4" />
+      <HugeiconsIcon icon={ComputerIcon} className="me-2 size-4" />
       {resolvedLabel}
     </DropdownMenuItem>
   );
@@ -1133,7 +1141,7 @@ export const PromptInputActionMenuTrigger = ({
   ...props
 }: PromptInputActionMenuTriggerProps) => (
   <DropdownMenuTrigger render={<PromptInputButton className={className} {...props} />}>
-    {children ?? <PlusIcon className="size-4" />}
+    {children ?? <HugeiconsIcon icon={PlusSignIcon} className="size-4" />}
   </DropdownMenuTrigger>
 );
 
@@ -1174,14 +1182,14 @@ export const PromptInputSubmit = ({
   const isGenerating = status === "submitted" || status === "streaming";
   const intl = useIntl();
 
-  let Icon = <CornerDownLeftIcon className="size-4" />;
+  let Icon = <HugeiconsIcon icon={CornerDownLeftIcon} className="size-4" />;
 
   if (status === "submitted") {
     Icon = <Spinner />;
   } else if (status === "streaming") {
-    Icon = <SquareIcon className="size-4" />;
+    Icon = <HugeiconsIcon icon={SquareIcon} className="size-4" />;
   } else if (status === "error") {
-    Icon = <XIcon className="size-4" />;
+    Icon = <HugeiconsIcon icon={Cancel01Icon} className="size-4" />;
   }
 
   const handleClick = useCallback(

--- a/apps/hyperlocalise-web/src/components/ai-elements/queue.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/queue.tsx
@@ -12,11 +12,12 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { ArrowDown01Icon, AttachmentIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/primitives/cn";
-import { ChevronDownIcon, PaperclipIcon } from "lucide-react";
 import type { ComponentProps } from "react";
 import { useIntl } from "react-intl";
 
@@ -157,7 +158,7 @@ export const QueueItemFile = ({ children, className, ...props }: QueueItemFilePr
     className={cn("flex items-center gap-1 rounded border bg-muted px-2 py-1 text-xs", className)}
     {...props}
   >
-    <PaperclipIcon size={12} />
+    <HugeiconsIcon icon={AttachmentIcon} size={12} />
     <span className="max-w-[100px] truncate">{children}</span>
   </span>
 );
@@ -221,7 +222,10 @@ export const QueueSectionLabel = ({
 
   return (
     <span className={cn("flex items-center gap-2", className)} {...props}>
-      <ChevronDownIcon className="size-4 transition-transform group-data-[state=closed]:-rotate-90" />
+      <HugeiconsIcon
+        icon={ArrowDown01Icon}
+        className="size-4 transition-transform group-data-[state=closed]:-rotate-90"
+      />
       {icon}
       <span>
         {count === undefined

--- a/apps/hyperlocalise-web/src/components/ai-elements/reasoning.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/reasoning.tsx
@@ -12,10 +12,11 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { ArrowDown01Icon, BrainIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { cn } from "@/lib/primitives/cn";
-import { BrainIcon, ChevronDownIcon } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
 import {
   createContext,
@@ -188,9 +189,10 @@ export const ReasoningTrigger = memo(
       >
         {children ?? (
           <>
-            <BrainIcon className="size-4" />
+            <HugeiconsIcon icon={BrainIcon} className="size-4" />
             {resolveThinkingMessage(isStreaming, duration)}
-            <ChevronDownIcon
+            <HugeiconsIcon
+              icon={ArrowDown01Icon}
               className={cn("size-4 transition-transform", isOpen ? "rotate-180" : "rotate-0")}
             />
           </>

--- a/apps/hyperlocalise-web/src/components/ai-elements/sandbox.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/sandbox.tsx
@@ -12,11 +12,12 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { ArrowDown01Icon, SourceCodeIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/primitives/cn";
 import type { ToolUIPart } from "ai";
-import { ChevronDownIcon, Code } from "lucide-react";
 import type { ComponentProps } from "react";
 
 import { ToolStatusBadge } from "./tool";
@@ -43,11 +44,14 @@ export const SandboxHeader = ({ className, title, state, ...props }: SandboxHead
     {...props}
   >
     <div className="flex items-center gap-2">
-      <Code className="size-4 text-muted-foreground" />
+      <HugeiconsIcon icon={SourceCodeIcon} className="size-4 text-muted-foreground" />
       <span className="font-medium text-sm">{title}</span>
       <ToolStatusBadge status={state} />
     </div>
-    <ChevronDownIcon className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+    <HugeiconsIcon
+      icon={ArrowDown01Icon}
+      className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180"
+    />
   </CollapsibleTrigger>
 );
 

--- a/apps/hyperlocalise-web/src/components/ai-elements/schema-display.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/schema-display.tsx
@@ -12,10 +12,11 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { Badge } from "@/components/ui/badge";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { cn } from "@/lib/primitives/cn";
-import { ChevronRightIcon } from "lucide-react";
 import type { ComponentProps, HTMLAttributes } from "react";
 import { createContext, useContext, useMemo } from "react";
 import { FormattedMessage } from "react-intl";
@@ -208,7 +209,10 @@ export const SchemaDisplayParameters = ({
   return (
     <Collapsible className={cn(className)} defaultOpen {...props}>
       <CollapsibleTrigger className="group flex w-full items-center gap-2 px-4 py-3 text-start transition-colors hover:bg-muted/50">
-        <ChevronRightIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
+        <HugeiconsIcon
+          icon={ArrowRight01Icon}
+          className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90"
+        />
         <span className="font-medium text-sm">
           <FormattedMessage {...schemaDisplayMessages.parameters} />
         </span>
@@ -255,7 +259,10 @@ export const SchemaDisplayProperty = ({
           )}
           style={{ paddingLeft }}
         >
-          <ChevronRightIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
+          <HugeiconsIcon
+            icon={ArrowRight01Icon}
+            className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90"
+          />
           <span className="font-mono text-sm">{name}</span>
           <Badge className="text-xs" variant="outline">
             {type}
@@ -326,7 +333,10 @@ export const SchemaDisplayRequest = ({
   return (
     <Collapsible className={cn(className)} defaultOpen {...props}>
       <CollapsibleTrigger className="group flex w-full items-center gap-2 px-4 py-3 text-start transition-colors hover:bg-muted/50">
-        <ChevronRightIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
+        <HugeiconsIcon
+          icon={ArrowRight01Icon}
+          className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90"
+        />
         <span className="font-medium text-sm">
           <FormattedMessage {...schemaDisplayMessages.requestBody} />
         </span>
@@ -355,7 +365,10 @@ export const SchemaDisplayResponse = ({
   return (
     <Collapsible className={cn(className)} defaultOpen {...props}>
       <CollapsibleTrigger className="group flex w-full items-center gap-2 px-4 py-3 text-start transition-colors hover:bg-muted/50">
-        <ChevronRightIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
+        <HugeiconsIcon
+          icon={ArrowRight01Icon}
+          className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90"
+        />
         <span className="font-medium text-sm">
           <FormattedMessage {...schemaDisplayMessages.response} />
         </span>

--- a/apps/hyperlocalise-web/src/components/ai-elements/snippet.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/snippet.tsx
@@ -12,6 +12,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { Copy01Icon, Tick02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import {
   InputGroup,
   InputGroupAddon,
@@ -21,7 +23,6 @@ import {
 } from "@/components/ui/input-group";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/primitives/cn";
-import { CheckIcon, CopyIcon } from "lucide-react";
 import type { ComponentProps } from "react";
 import {
   createContext,
@@ -129,7 +130,7 @@ export const SnippetCopyButton = ({
     [],
   );
 
-  const Icon = isCopied ? CheckIcon : CopyIcon;
+  const Icon = isCopied ? Tick02Icon : Copy01Icon;
   const tooltipText = isCopied
     ? intl.formatMessage(snippetMessages.copied)
     : intl.formatMessage(snippetMessages.copy);
@@ -145,7 +146,7 @@ export const SnippetCopyButton = ({
             size="icon-sm"
             {...props}
           >
-            {children ?? <Icon className="size-3.5" size={14} />}
+            {children ?? <HugeiconsIcon icon={Icon} className="size-3.5" size={14} />}
           </InputGroupButton>
         }
       />

--- a/apps/hyperlocalise-web/src/components/ai-elements/sources.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/sources.tsx
@@ -12,9 +12,10 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { ArrowDown01Icon, BookOpen01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { cn } from "@/lib/primitives/cn";
-import { BookIcon, ChevronDownIcon } from "lucide-react";
 import type { ComponentProps } from "react";
 import { FormattedMessage } from "react-intl";
 import { TypographyP } from "@/components/ui/typography";
@@ -38,7 +39,7 @@ export const SourcesTrigger = ({ className, count, children, ...props }: Sources
         <TypographyP className="font-medium">
           <FormattedMessage {...sourcesMessages.usedSources} values={{ count }} />
         </TypographyP>
-        <ChevronDownIcon className="h-4 w-4" />
+        <HugeiconsIcon icon={ArrowDown01Icon} className="h-4 w-4" />
       </>
     )}
   </CollapsibleTrigger>
@@ -69,7 +70,7 @@ export const Source = ({ href, title, children, ...props }: SourceProps) => (
   >
     {children ?? (
       <>
-        <BookIcon className="h-4 w-4" />
+        <HugeiconsIcon icon={BookOpen01Icon} className="h-4 w-4" />
         <span className="block font-medium">{title}</span>
       </>
     )}

--- a/apps/hyperlocalise-web/src/components/ai-elements/speech-input.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/speech-input.tsx
@@ -12,10 +12,11 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { Mic01Icon, SquareIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/primitives/cn";
-import { MicIcon, SquareIcon } from "lucide-react";
 import type { ComponentProps } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useIntl } from "react-intl";
@@ -390,8 +391,8 @@ export const SpeechInput = ({
         aria-label={ariaLabel}
       >
         {isProcessing && <Spinner />}
-        {!isProcessing && isListening && <SquareIcon className="size-4" />}
-        {!(isProcessing || isListening) && <MicIcon className="size-4" />}
+        {!isProcessing && isListening && <HugeiconsIcon icon={SquareIcon} className="size-4" />}
+        {!(isProcessing || isListening) && <HugeiconsIcon icon={Mic01Icon} className="size-4" />}
       </Button>
     </div>
   );

--- a/apps/hyperlocalise-web/src/components/ai-elements/stack-trace.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/stack-trace.tsx
@@ -12,12 +12,13 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { Alert02Icon, ArrowDown01Icon, Copy01Icon, Tick02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/primitives/cn";
-import { AlertTriangleIcon, CheckIcon, ChevronDownIcon, CopyIcon } from "lucide-react";
 import type { ComponentProps } from "react";
 import {
   createContext,
@@ -244,7 +245,7 @@ export type StackTraceErrorProps = ComponentProps<"div">;
 
 export const StackTraceError = memo(({ className, children, ...props }: StackTraceErrorProps) => (
   <div className={cn("flex flex-1 items-center gap-2 overflow-hidden", className)} {...props}>
-    <AlertTriangleIcon className="size-4 shrink-0 text-destructive" />
+    <HugeiconsIcon icon={Alert02Icon} className="size-4 shrink-0 text-destructive" />
     {children}
   </div>
 ));
@@ -343,7 +344,7 @@ export const StackTraceCopyButton = memo(
       [],
     );
 
-    const Icon = isCopied ? CheckIcon : CopyIcon;
+    const Icon = isCopied ? Tick02Icon : Copy01Icon;
     const tooltipText = isCopied
       ? intl.formatMessage(stackTraceMessages.copied)
       : intl.formatMessage(stackTraceMessages.copyStackTrace);
@@ -360,7 +361,7 @@ export const StackTraceCopyButton = memo(
               variant="ghost"
               {...props}
             >
-              {children ?? <Icon size={14} />}
+              {children ?? <HugeiconsIcon icon={Icon} size={14} />}
             </Button>
           }
         />
@@ -378,7 +379,8 @@ export const StackTraceExpandButton = memo(
 
     return (
       <div className={cn("flex size-7 items-center justify-center", className)} {...props}>
-        <ChevronDownIcon
+        <HugeiconsIcon
+          icon={ArrowDown01Icon}
           className={cn(
             "size-4 text-muted-foreground transition-transform",
             isOpen ? "rotate-180" : "rotate-0",

--- a/apps/hyperlocalise-web/src/components/ai-elements/task.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/task.tsx
@@ -12,9 +12,10 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { ArrowDown01Icon, SearchIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { cn } from "@/lib/primitives/cn";
-import { ChevronDownIcon, SearchIcon } from "lucide-react";
 import type { ComponentProps } from "react";
 import { TypographyP } from "@/components/ui/typography";
 
@@ -54,9 +55,12 @@ export const TaskTrigger = ({ children, className, title, ...props }: TaskTrigge
   <CollapsibleTrigger className={cn("group", className)} {...props}>
     {children ?? (
       <div className="flex w-full cursor-pointer items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground">
-        <SearchIcon className="size-4" />
+        <HugeiconsIcon icon={SearchIcon} className="size-4" />
         <TypographyP className="text-sm">{title}</TypographyP>
-        <ChevronDownIcon className="size-4 transition-transform group-data-[state=open]:rotate-180" />
+        <HugeiconsIcon
+          icon={ArrowDown01Icon}
+          className="size-4 transition-transform group-data-[state=open]:rotate-180"
+        />
       </div>
     )}
   </CollapsibleTrigger>

--- a/apps/hyperlocalise-web/src/components/ai-elements/terminal.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/terminal.tsx
@@ -12,11 +12,12 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { Copy01Icon, Delete02Icon, TerminalIcon, Tick02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/primitives/cn";
 import Ansi from "ansi-to-react";
-import { CheckIcon, CopyIcon, TerminalIcon, Trash2Icon } from "lucide-react";
 import type { ComponentProps, HTMLAttributes } from "react";
 import {
   createContext,
@@ -65,7 +66,7 @@ export const TerminalTitle = ({ className, children, ...props }: TerminalTitlePr
 
   return (
     <div className={cn("flex items-center gap-2 text-sm text-zinc-400", className)} {...props}>
-      <TerminalIcon className="size-4" />
+      <HugeiconsIcon icon={TerminalIcon} className="size-4" />
       {children ?? intl.formatMessage(terminalMessages.title)}
     </div>
   );
@@ -137,7 +138,7 @@ export const TerminalCopyButton = ({
     [],
   );
 
-  const Icon = isCopied ? CheckIcon : CopyIcon;
+  const Icon = isCopied ? Tick02Icon : Copy01Icon;
   const tooltipText = isCopied
     ? intl.formatMessage(terminalMessages.copied)
     : intl.formatMessage(terminalMessages.copyOutput);
@@ -157,7 +158,7 @@ export const TerminalCopyButton = ({
             variant="ghost"
             {...props}
           >
-            {children ?? <Icon size={14} />}
+            {children ?? <HugeiconsIcon icon={Icon} size={14} />}
           </Button>
         }
       />
@@ -190,7 +191,7 @@ export const TerminalClearButton = ({
       variant="ghost"
       {...props}
     >
-      {children ?? <Trash2Icon size={14} />}
+      {children ?? <HugeiconsIcon icon={Delete02Icon} size={14} />}
     </Button>
   );
 };

--- a/apps/hyperlocalise-web/src/components/ai-elements/test-results.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/test-results.tsx
@@ -12,16 +12,17 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import {
+  ArrowRight01Icon,
+  CancelCircleIcon,
+  CheckmarkCircle02Icon,
+  CircleDotIcon,
+  CircleIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { Badge } from "@/components/ui/badge";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { cn } from "@/lib/primitives/cn";
-import {
-  CheckCircle2Icon,
-  ChevronRightIcon,
-  CircleDotIcon,
-  CircleIcon,
-  XCircleIcon,
-} from "lucide-react";
 import type { ComponentProps, HTMLAttributes } from "react";
 import { createContext, useContext, useMemo } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -97,7 +98,7 @@ export const TestResultsSummary = ({ className, children, ...props }: TestResult
             className="gap-1 bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
             variant="secondary"
           >
-            <CheckCircle2Icon className="size-3" />
+            <HugeiconsIcon icon={CheckmarkCircle02Icon} className="size-3" />
             <FormattedMessage
               {...testResultsMessages.passedCount}
               values={{ count: summary.passed }}
@@ -108,7 +109,7 @@ export const TestResultsSummary = ({ className, children, ...props }: TestResult
               className="gap-1 bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
               variant="secondary"
             >
-              <XCircleIcon className="size-3" />
+              <HugeiconsIcon icon={CancelCircleIcon} className="size-3" />
               <FormattedMessage
                 {...testResultsMessages.failedCount}
                 values={{ count: summary.failed }}
@@ -120,7 +121,7 @@ export const TestResultsSummary = ({ className, children, ...props }: TestResult
               className="gap-1 bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400"
               variant="secondary"
             >
-              <CircleIcon className="size-3" />
+              <HugeiconsIcon icon={CircleIcon} className="size-3" />
               <FormattedMessage
                 {...testResultsMessages.skippedCount}
                 values={{ count: summary.skipped }}
@@ -224,10 +225,10 @@ const statusStyles: Record<TestStatus, string> = {
 };
 
 const statusIcons: Record<TestStatus, React.ReactNode> = {
-  failed: <XCircleIcon className="size-4" />,
-  passed: <CheckCircle2Icon className="size-4" />,
-  running: <CircleDotIcon className="size-4 animate-pulse" />,
-  skipped: <CircleIcon className="size-4" />,
+  failed: <HugeiconsIcon icon={CancelCircleIcon} className="size-4" />,
+  passed: <HugeiconsIcon icon={CheckmarkCircle02Icon} className="size-4" />,
+  running: <HugeiconsIcon icon={CircleDotIcon} className="size-4 animate-pulse" />,
+  skipped: <HugeiconsIcon icon={CircleIcon} className="size-4" />,
 };
 
 const TestStatusIcon = ({ status }: { status: TestStatus }) => (
@@ -264,7 +265,10 @@ export const TestSuiteName = ({ className, children, ...props }: TestSuiteNamePr
       )}
       {...props}
     >
-      <ChevronRightIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
+      <HugeiconsIcon
+        icon={ArrowRight01Icon}
+        className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90"
+      />
       <TestStatusIcon status={status} />
       <span className="font-medium text-sm">{children ?? name}</span>
     </CollapsibleTrigger>

--- a/apps/hyperlocalise-web/src/components/ai-elements/tool.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/tool.tsx
@@ -18,13 +18,13 @@ import { ImageLightbox } from "@/components/ui/image-lightbox/image-lightbox";
 import { cn } from "@/lib/primitives/cn";
 import type { DynamicToolUIPart, ToolUIPart } from "ai";
 import {
+  ArrowRight01Icon,
   CheckmarkCircle02Icon,
   CircleIcon,
   Clock01Icon,
   MultiplicationSignCircleIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ChevronRightIcon } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
 import { isValidElement } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -261,7 +261,10 @@ function ToolJsonSection({
   return (
     <Collapsible defaultOpen={defaultOpen} className={cn("overflow-hidden", className)}>
       <CollapsibleTrigger className="group flex w-full cursor-pointer items-center gap-1.5 py-0.5 text-start">
-        <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
+        <HugeiconsIcon
+          icon={ArrowRight01Icon}
+          className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90"
+        />
         <span className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
           {label}
         </span>

--- a/apps/hyperlocalise-web/src/components/ai-elements/voice-selector.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/voice-selector.tsx
@@ -12,6 +12,18 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import {
+  CircleSmallIcon,
+  FemaleSymbolIcon,
+  Male02Icon,
+  MaleSymbolIcon,
+  PauseIcon,
+  PlayIcon,
+  UserIcon,
+  UserMultiple02Icon,
+  UserSwitchIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import { Button } from "@/components/ui/button";
 import {
@@ -28,17 +40,6 @@ import {
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/primitives/cn";
-import {
-  CircleSmallIcon,
-  MarsIcon,
-  MarsStrokeIcon,
-  NonBinaryIcon,
-  PauseIcon,
-  PlayIcon,
-  TransgenderIcon,
-  VenusAndMarsIcon,
-  VenusIcon,
-} from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
 import { createContext, useCallback, useContext, useMemo } from "react";
 import { useIntl } from "react-intl";
@@ -194,31 +195,31 @@ export const VoiceSelectorGender = ({
 
   switch (value) {
     case "male": {
-      icon = <MarsIcon className="size-4" />;
+      icon = <HugeiconsIcon icon={MaleSymbolIcon} className="size-4" />;
       break;
     }
     case "female": {
-      icon = <VenusIcon className="size-4" />;
+      icon = <HugeiconsIcon icon={FemaleSymbolIcon} className="size-4" />;
       break;
     }
     case "transgender": {
-      icon = <TransgenderIcon className="size-4" />;
+      icon = <HugeiconsIcon icon={UserSwitchIcon} className="size-4" />;
       break;
     }
     case "androgyne": {
-      icon = <MarsStrokeIcon className="size-4" />;
+      icon = <HugeiconsIcon icon={Male02Icon} className="size-4" />;
       break;
     }
     case "non-binary": {
-      icon = <NonBinaryIcon className="size-4" />;
+      icon = <HugeiconsIcon icon={UserIcon} className="size-4" />;
       break;
     }
     case "intersex": {
-      icon = <VenusAndMarsIcon className="size-4" />;
+      icon = <HugeiconsIcon icon={UserMultiple02Icon} className="size-4" />;
       break;
     }
     default: {
-      icon = <CircleSmallIcon className="size-4" />;
+      icon = <HugeiconsIcon icon={CircleSmallIcon} className="size-4" />;
     }
   }
 
@@ -442,12 +443,12 @@ export const VoiceSelectorPreview = ({
     [onClick, onPlay],
   );
 
-  let icon = <PlayIcon className="size-3" />;
+  let icon = <HugeiconsIcon icon={PlayIcon} className="size-3" />;
 
   if (loading) {
     icon = <Spinner className="size-3" />;
   } else if (playing) {
-    icon = <PauseIcon className="size-3" />;
+    icon = <HugeiconsIcon icon={PauseIcon} className="size-3" />;
   }
 
   return (

--- a/apps/hyperlocalise-web/src/components/ai-elements/web-preview.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/web-preview.tsx
@@ -12,12 +12,13 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/primitives/cn";
-import { ChevronDownIcon } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
 import { createContext, useCallback, useContext, useMemo, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -255,7 +256,8 @@ export const WebPreviewConsole = ({
         }
       >
         <FormattedMessage {...webPreviewMessages.console} />
-        <ChevronDownIcon
+        <HugeiconsIcon
+          icon={ArrowDown01Icon}
           className={cn("h-4 w-4 transition-transform duration-200", consoleOpen && "rotate-180")}
         />
       </CollapsibleTrigger>

--- a/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-error-boundary.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/chat-dock/chat-dock-error-boundary.tsx
@@ -12,7 +12,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { AlertCircleIcon } from "lucide-react";
+import { AlertCircleIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { type ErrorInfo, type ReactNode, useRef } from "react";
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 import { useQueryClient, type QueryClient } from "@tanstack/react-query";
@@ -60,7 +61,7 @@ function ChatDockErrorFallback({ resetErrorBoundary }: FallbackProps) {
   return (
     <div className="flex min-h-48 items-center justify-center border-b border-border p-4">
       <Alert variant="destructive" className="max-w-md">
-        <AlertCircleIcon />
+        <HugeiconsIcon icon={AlertCircleIcon} />
         <AlertTitle className="text-balance">
           <FormattedMessage {...chatDockMessages.panelErrorTitle} />
         </AlertTitle>

--- a/apps/hyperlocalise-web/src/components/app-shell/crowdin-user-pat-connect-dialog.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/crowdin-user-pat-connect-dialog.tsx
@@ -13,9 +13,8 @@
  * Version 2.0 or later.
  */
 import { useId, useState } from "react";
-import { Key01Icon } from "@hugeicons/core-free-icons";
+import { Key01Icon, ViewIcon, ViewOffSlashIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { EyeIcon, EyeOffIcon } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
@@ -172,7 +171,11 @@ export function CrowdinUserPatConnectDialog({
                   : crowdinUserPatConnectDialogMessages.showToken,
               )}
             >
-              {showToken ? <EyeOffIcon size={16} /> : <EyeIcon size={16} />}
+              {showToken ? (
+                <HugeiconsIcon icon={ViewOffSlashIcon} size={16} />
+              ) : (
+                <HugeiconsIcon icon={ViewIcon} size={16} />
+              )}
             </button>
           </div>
         </Field>

--- a/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-result.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/localisation-audit/localisation-audit-result.tsx
@@ -12,9 +12,10 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { ArrowDown01Icon, Cancel01Icon, Share08Icon, Tick02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
-import { CheckIcon, ChevronDownIcon, Share2Icon, XIcon } from "lucide-react";
 import { useEffect, useRef, useState, type FormEvent, type ReactNode } from "react";
 
 import { MeshStage, SAGE_MESH_GRADIENT_SRC } from "@/components/marketing/hero-frame-mesh-stage";
@@ -245,7 +246,7 @@ function CriterionStatusIcon({ status }: { status: LocalisationAuditCriterion["s
         )}
         aria-hidden
       >
-        <CheckIcon className="size-3.5" />
+        <HugeiconsIcon icon={Tick02Icon} className="size-3.5" />
       </span>
     );
   }
@@ -258,7 +259,7 @@ function CriterionStatusIcon({ status }: { status: LocalisationAuditCriterion["s
         )}
         aria-hidden
       >
-        <XIcon className="size-3.5" />
+        <HugeiconsIcon icon={Cancel01Icon} className="size-3.5" />
       </span>
     );
   }
@@ -380,7 +381,10 @@ function CriteriaGroup({
         <h3 className="text-lg font-medium">{heading}</h3>
         <CollapsibleTrigger className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground">
           {open ? collapseLabel : expandLabel}
-          <ChevronDownIcon className={cn("size-4 transition-transform", open && "rotate-180")} />
+          <HugeiconsIcon
+            icon={ArrowDown01Icon}
+            className={cn("size-4 transition-transform", open && "rotate-180")}
+          />
         </CollapsibleTrigger>
       </div>
       <CollapsibleContent>{list}</CollapsibleContent>
@@ -528,7 +532,7 @@ function AuditProgressTrack({
                   !done && !current && "border border-border bg-background",
                 )}
               >
-                {done ? <CheckIcon className="size-3.5" aria-hidden /> : null}
+                {done ? <HugeiconsIcon icon={Tick02Icon} className="size-3.5" aria-hidden /> : null}
                 {current ? (
                   <span className="size-2 rounded-full bg-foreground motion-safe:animate-pulse" />
                 ) : null}
@@ -918,7 +922,7 @@ export function LocalisationAuditResult({
               className="border-white/25 bg-white/10 text-white hover:bg-white/15 hover:text-white"
               onClick={copyShareLink}
             >
-              <Share2Icon className="size-3.5" aria-hidden />
+              <HugeiconsIcon icon={Share08Icon} className="size-3.5" aria-hidden />
               {copy.shareCopyLink}
             </Button>
           )}

--- a/apps/hyperlocalise-web/src/components/marketing/pricing/pricing-comparison-matrix.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/pricing/pricing-comparison-matrix.tsx
@@ -10,8 +10,9 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { CheckIcon, GaugeIcon, LayersIcon, ShieldCheckIcon, type LucideIcon } from "lucide-react";
 
+import { GaugeIcon, LayerIcon, Shield01Icon, Tick02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
 import { TypographyH2, TypographyH3, TypographyP } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
 
@@ -32,9 +33,9 @@ type PricingComparisonMatrixProps = {
   notIncludedAriaLabel: string;
 };
 
-const sectionIcons: Record<string, { icon: LucideIcon; className: string }> = {
+const sectionIcons: Record<string, { icon: IconSvgElement; className: string }> = {
   workspace: {
-    icon: LayersIcon,
+    icon: LayerIcon,
     className: "bg-blue-100 text-blue-900",
   },
   usage: {
@@ -42,7 +43,7 @@ const sectionIcons: Record<string, { icon: LucideIcon; className: string }> = {
     className: "bg-amber-100 text-amber-900",
   },
   enterprise: {
-    icon: ShieldCheckIcon,
+    icon: Shield01Icon,
     className: "bg-purple-100 text-purple-900",
   },
 };
@@ -57,7 +58,13 @@ function MatrixCellValue({
   notIncludedAriaLabel: string;
 }) {
   if (cell.kind === "check") {
-    return <CheckIcon className="size-4 text-foreground" aria-label={includedAriaLabel} />;
+    return (
+      <HugeiconsIcon
+        icon={Tick02Icon}
+        className="size-4 text-foreground"
+        aria-label={includedAriaLabel}
+      />
+    );
   }
 
   if (cell.kind === "dash") {
@@ -133,7 +140,7 @@ export function PricingComparisonMatrix({
                             sectionIcon.className,
                           )}
                         >
-                          <Icon className="size-4" strokeWidth={1.75} />
+                          <HugeiconsIcon icon={Icon} className="size-4" strokeWidth={1.75} />
                         </span>
                       ) : null}
                       <TypographyH3 className="text-lg md:text-lg">{section.title}</TypographyH3>

--- a/apps/hyperlocalise-web/src/components/marketing/pricing/pricing-plans-section.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/pricing/pricing-plans-section.tsx
@@ -10,8 +10,9 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { CheckIcon } from "lucide-react";
 
+import { Tick02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -85,7 +86,11 @@ export function PricingPlansSection({ plans, popularBadge }: PricingPlansSection
           <ul className="mb-8 flex flex-col gap-3">
             {plan.features.map((feature) => (
               <li key={feature} className="flex items-start gap-3 text-sm text-muted-foreground">
-                <CheckIcon className="mt-0.5 size-4 shrink-0 text-foreground" aria-hidden />
+                <HugeiconsIcon
+                  icon={Tick02Icon}
+                  className="mt-0.5 size-4 shrink-0 text-foreground"
+                  aria-hidden
+                />
                 <span>{feature}</span>
               </li>
             ))}

--- a/apps/hyperlocalise-web/src/components/marketing/product/product-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/product-page.tsx
@@ -12,8 +12,9 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import { ArrowRight01Icon, CheckmarkCircle02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
-import { ArrowRightIcon, CheckCircle2Icon } from "lucide-react";
 import { FormattedMessage } from "react-intl";
 
 import { HeroFrameMeshStage } from "@/components/marketing/hero-frame-mesh-stage";
@@ -60,7 +61,7 @@ function ProductHero({ content }: ProductPageProps) {
           render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
         >
           <ProductMessage messageKey="ctaJoinWaitlist" />
-          <ArrowRightIcon data-icon="inline-end" className="size-4" />
+          <HugeiconsIcon icon={ArrowRight01Icon} data-icon="inline-end" className="size-4" />
         </Button>
       </div>
     </div>
@@ -130,7 +131,7 @@ function AutomationPrimaryVisual() {
                 key={taskKey}
                 className="flex items-center gap-2 rounded-md bg-background/80 px-3 py-2 text-xs"
               >
-                <CheckCircle2Icon className="size-3.5 text-primary" />
+                <HugeiconsIcon icon={CheckmarkCircle02Icon} className="size-3.5 text-primary" />
                 <ProductMessage messageKey={taskKey} />
               </div>
             ))}
@@ -286,7 +287,11 @@ function ProductDetailsSection({ content }: ProductPageProps) {
                 render={<Link href={link.href} />}
               >
                 <ProductMessage messageKey={link.labelKey} />
-                <ArrowRightIcon data-icon="inline-end" className="size-3.5" />
+                <HugeiconsIcon
+                  icon={ArrowRight01Icon}
+                  data-icon="inline-end"
+                  className="size-3.5"
+                />
               </Button>
             ))}
           </div>


### PR DESCRIPTION
## What changed

Replace the remaining `lucide-react` icons in the web app with `@hugeicons/react` and `@hugeicons/core-free-icons`, then remove the Lucide dependency so the product uses one icon renderer.

## How to test

- [ ] Confirm no remaining `lucide-react` imports under `apps/hyperlocalise-web/src`
- [ ] In `apps/hyperlocalise-web`, run `vp check --fix`
- [ ] Spot-check icon-heavy screens: job detail, integrations credentials, pricing, chat AI elements, project dialog
- [ ] Confirm copy/eye-toggle/error-boundary icons still render

## Checklist

- [x] I ran relevant checks locally (`vp check --fix` in `apps/hyperlocalise-web`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)