### PR TITLE
fix(crowdin): align SourceStringsUploadRequest with Crowdin API v2 contract

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -1,5 +1,11 @@
 # Crowdin Steward's Journal
 
+## 2026-12-30 - Add FileID/MaxLen parity and fix root upload validation in SourceStringsUploadRequest
+
+**Learning:** In Crowdin API v2, uploading source strings (`POST /api/v2/projects/{projectId}/strings/uploads`) accepts optional `fileId` and `maxLen` parameters in the request body. Furthermore, `branchId`, `directoryId`, and `fileId` are all optional (uploading without any targets the project root) but mutually exclusive. The SDK's `SourceStringsUploadRequest` previously lacked `FileID` and `MaxLen`, and its `Validate()` method incorrectly enforced that `branchId` or `directoryId` be non-zero, rejecting valid uploads targeting a `fileId` or uploading to the project root.
+
+**Action:** Added `FileID int json:"fileId,omitempty"` and `MaxLen int json:"maxLen,omitempty"` to `SourceStringsUploadRequest` in `crowdin/model/source_strings.go`. Updated `Validate()` to make target identifiers optional while enforcing mutual exclusivity (at most one of `branchId`, `directoryId`, or `fileId` set). Added comprehensive unit and contract tests in `crowdin/model/source_strings_test.go` and `crowdin/source_strings_test.go`.
+
 ## 2026-12-29 - Add Force option to InstallApplicationRequest
 
 **Learning:** In Crowdin API v2, installing applications (`POST /api/v2/applications/installations`) supports an optional `force` boolean flag (`force: true`) to force re-installing an application if it is already installed. The SDK previously omitted `Force` from `InstallApplicationRequest`, preventing callers from specifying force installation behavior.

--- a/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
@@ -282,6 +282,9 @@ type SourceStringsUploadRequest struct {
 	// Directory Identifier.
 	// Defines directory to which file will be added.
 	DirectoryID int `json:"directoryId,omitempty"`
+	// File Identifier.
+	// Defines file to which strings will be added.
+	FileID int `json:"fileId,omitempty"`
 	// Default: auto
 	// Enum: auto, android, macosx, arb, csv, json, xlsx, xliff, xliff_two
 	// - empty value or `auto` — Try to detect file type by extension or MIME type
@@ -310,6 +313,8 @@ type SourceStringsUploadRequest struct {
 	// Enum: "clear_translations_and_approvals" "keep_translations" "keep_translations_and_approvals"
 	// Must be used together with updateStrings = true
 	UpdateOption UpdateOption `json:"updateOption,omitempty"`
+	// Max. length of translated text (0 – unlimited).
+	MaxLen int `json:"maxLen,omitempty"`
 }
 
 // SourceStringsImportOptions defines the options for importing strings.
@@ -333,11 +338,18 @@ func (o *SourceStringsUploadRequest) Validate() error {
 	if o.StorageID == 0 {
 		return errors.New("storageId is required")
 	}
-	if o.BranchID == 0 && o.DirectoryID == 0 {
-		return errors.New("branchId or directoryId is required")
+	count := 0
+	if o.BranchID > 0 {
+		count++
 	}
-	if o.BranchID != 0 && o.DirectoryID != 0 {
-		return errors.New("only one of branchId or directoryId may be set")
+	if o.DirectoryID > 0 {
+		count++
+	}
+	if o.FileID > 0 {
+		count++
+	}
+	if count > 1 {
+		return errors.New("only one of branchId, directoryId or fileId may be set")
 	}
 	if o.UpdateOption != "" && (o.UpdateStrings == nil || !(*o.UpdateStrings)) {
 		return errors.New("updateStrings must be set to true to use updateOption")

--- a/third_party/crowdin-api-client-go/crowdin/model/source_strings_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_strings_test.go
@@ -224,9 +224,9 @@ func TestSourceStringsUploadRequestValidate(t *testing.T) {
 			err:  "storageId is required",
 		},
 		{
-			name: "missing identifiers",
-			req:  &SourceStringsUploadRequest{StorageID: 1},
-			err:  "branchId or directoryId is required",
+			name:  "valid request targeting project root",
+			req:   &SourceStringsUploadRequest{StorageID: 1},
+			valid: true,
 		},
 		{
 			name: "invalid request",
@@ -253,9 +253,19 @@ func TestSourceStringsUploadRequestValidate(t *testing.T) {
 			valid: true,
 		},
 		{
-			name: "multi-set identifiers",
+			name: "multi-set identifiers branch and directory",
 			req:  &SourceStringsUploadRequest{StorageID: 1, BranchID: 1, DirectoryID: 1},
-			err:  "only one of branchId or directoryId may be set",
+			err:  "only one of branchId, directoryId or fileId may be set",
+		},
+		{
+			name: "multi-set identifiers branch and file",
+			req:  &SourceStringsUploadRequest{StorageID: 1, BranchID: 1, FileID: 1},
+			err:  "only one of branchId, directoryId or fileId may be set",
+		},
+		{
+			name: "multi-set identifiers directory and file",
+			req:  &SourceStringsUploadRequest{StorageID: 1, DirectoryID: 1, FileID: 1},
+			err:  "only one of branchId, directoryId or fileId may be set",
 		},
 		{
 			name: "valid request with directoryId",
@@ -266,6 +276,14 @@ func TestSourceStringsUploadRequestValidate(t *testing.T) {
 					FirstLineContainsHeader: toPtr(true),
 					ImportTranslations:      toPtr(true), Scheme: map[string]int{"key": 0},
 				},
+			},
+			valid: true,
+		},
+		{
+			name: "valid request with fileId and maxLen",
+			req: &SourceStringsUploadRequest{
+				StorageID: 1, FileID: 48, Type: "xlsx", ParserVersion: 1, MaxLen: 50,
+				LabelIDs: []int{1, 2, 3}, UpdateStrings: toPtr(false), CleanupMode: toPtr(false),
 			},
 			valid: true,
 		},

--- a/third_party/crowdin-api-client-go/crowdin/source_strings_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/source_strings_test.go
@@ -979,14 +979,15 @@ func TestSourceStringsService_UploadWithRequiredFields(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/api/v2/projects/2/strings/uploads", func(w http.ResponseWriter, r *http.Request) {
-		testBody(t, r, `{"storageId":61,"branchId":34}`+"\n")
+		testBody(t, r, `{"storageId":61,"fileId":48,"maxLen":100}`+"\n")
 
 		fmt.Fprint(w, `{}`)
 	})
 
 	_, _, err := client.SourceStrings.Upload(context.Background(), 2, &model.SourceStringsUploadRequest{
 		StorageID: 61,
-		BranchID:  34,
+		FileID:    48,
+		MaxLen:    100,
 	})
 	if err != nil {
 		t.Errorf("SourceStrings.Upload returned error: %v", err)
@@ -1004,8 +1005,8 @@ func TestSourceStringsService_UploadWithValidationError(t *testing.T) {
 	}{
 		{"nil request", nil, "request cannot be nil"},
 		{"empty storageId", &model.SourceStringsUploadRequest{BranchID: 34}, "storageId is required"},
-		{"empty branchId and directoryId", &model.SourceStringsUploadRequest{StorageID: 61}, "branchId or directoryId is required"},
-		{"both branchId and directoryId", &model.SourceStringsUploadRequest{StorageID: 61, BranchID: 34, DirectoryID: 12}, "only one of branchId or directoryId may be set"},
+		{"both branchId and directoryId", &model.SourceStringsUploadRequest{StorageID: 61, BranchID: 34, DirectoryID: 12}, "only one of branchId, directoryId or fileId may be set"},
+		{"both branchId and fileId", &model.SourceStringsUploadRequest{StorageID: 61, BranchID: 34, FileID: 48}, "only one of branchId, directoryId or fileId may be set"},
 		{"misconfigured updateStrings for non-empty updateOption", &model.SourceStringsUploadRequest{BranchID: 34, StorageID: 61, UpdateStrings: ToPtr(false), UpdateOption: model.UpdateOptionClearTranslationsAndApprovals}, "updateStrings must be set to true to use updateOption"},
 		{"nil updateStrings for non-empty updateOption", &model.SourceStringsUploadRequest{BranchID: 34, StorageID: 61, UpdateStrings: nil, UpdateOption: model.UpdateOptionClearTranslationsAndApprovals}, "updateStrings must be set to true to use updateOption"},
 	}


### PR DESCRIPTION
This PR aligns `SourceStringsUploadRequest` in the Crowdin fork with official Crowdin API v2 specifications for Upload Source Strings (`POST /api/v2/projects/{projectId}/strings/uploads`).

### What:
- Added `FileID int json:"fileId,omitempty"` and `MaxLen int json:"maxLen,omitempty"` to `SourceStringsUploadRequest` in `crowdin/model/source_strings.go`.
- Updated `SourceStringsUploadRequest.Validate()` to make target identifiers optional (permitting uploads to project root or specific files) while enforcing mutual exclusivity among `BranchID`, `DirectoryID`, and `FileID`.
- Updated unit and contract tests in `crowdin/model/source_strings_test.go` and `crowdin/source_strings_test.go`.
- Recorded learning in `.jules/crowdin-steward.md`.

### Why:
Previously, `SourceStringsUploadRequest` lacked `FileID` and `MaxLen` fields and its `Validate()` method required `BranchID` or `DirectoryID` to be set, erroneously rejecting valid uploads targeting `FileID` or uploading to the project root.

### Scope:
- `third_party/crowdin-api-client-go/crowdin/model/source_strings.go`
- `third_party/crowdin-api-client-go/crowdin/model/source_strings_test.go`
- `third_party/crowdin-api-client-go/crowdin/source_strings_test.go`
- `.jules/crowdin-steward.md`

### Verification:
- All unit and contract tests in `third_party/crowdin-api-client-go` passed.
- Workspace unit tests passed.

---
*PR created automatically by Jules for task [14523979562806089066](https://jules.google.com/task/14523979562806089066) started by @cungminh2710*