### PR TITLE
feat(automations): activate localisation digest, review, and push blockers

### DIFF
--- a/apps/hyperlocalise-web/src/agents/_runtime/loader.test.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/loader.test.ts
@@ -62,6 +62,12 @@ Body content`);
     expect(loadSharedSkill("slack-notifications")).toContain("## Slack notifications");
   });
 
+  it("loads shared github-comment-notifications skill", () => {
+    expect(loadSharedSkill("github-comment-notifications")).toContain(
+      "## GitHub pull request comments",
+    );
+  });
+
   it("maps tool filenames to runtime names", () => {
     expect(toolNameFromFilename("translate_string.ts")).toBe("translate_string");
   });

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-skills/github-comment-notifications.md
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-skills/github-comment-notifications.md
@@ -1,0 +1,43 @@
+---
+id: github-comment-notifications
+name: GitHub comment notifications
+---
+
+## GitHub pull request comments
+
+When calling `notify_github_comment`, write `message` in **GitHub-flavored Markdown**. The tool posts a sticky pull request comment and updates that same comment on later runs. Do not mention HTML markers, comment IDs, or upsert mechanics.
+
+### Customer format first
+
+- If customer instructions, automation instructions, or recalled memory specify a comment shape, tone, template, sections, or wording — **follow that format**.
+- Use these defaults only when the customer did not define a format.
+- Keep Markdown readable (line breaks, lists when useful) even when following a custom format, unless the customer asked for a single line or plain text.
+
+### Default shape (when no customer format)
+
+1. **Headline** — bold line with the automation name and outcome (completed, blocked, no localisation findings).
+2. **Key facts** — short bullets for the facts that matter for this push.
+3. **Findings** — bullet blocking localisation defects first, then non-blocking follow-ups. Cite commit SHAs and file paths.
+4. **Next step** — one line on what the author should do. Omit if nothing useful.
+
+### Formatting defaults
+
+- Prefer names, titles, statuses, and counts over dumping opaque IDs into a sentence.
+- Put commit SHAs and file paths in backticks.
+- Keep it short: usually under ~20 lines.
+- Skip fluff and JSON dumps.
+- Do not invent links, names, or statuses that tools did not return.
+- If there are no localisation findings, say so clearly instead of inventing issues.
+
+### Example default
+
+```markdown
+**Notify on push blockers** completed
+
+- **Push:** `main` `abc1234..def5678`
+- **Blockers:**
+  - Hard-coded copy in `src/checkout.ts` (`def5678`)
+- **Follow-ups:**
+  - Missing context on `checkout.confirm`
+- **Next:** Fix the hard-coded string before merge
+```

--- a/apps/hyperlocalise-web/src/agents/automations/github-repository/agent/skills/github-repo-agent.md
+++ b/apps/hyperlocalise-web/src/agents/automations/github-repository/agent/skills/github-repo-agent.md
@@ -7,7 +7,7 @@ id: github-repo-agent
 - Read-only. Do not commit, push, upload sources, or modify files.
 - Start with `repoGitState` and `git log` for the requested lookback window and branch.
 - Use `read`, `grep`, or `glob` only when commit subjects or diffs need more context.
-- Follow the customer instructions. If they ask for a code review, prioritize defects, regressions, missing tests, and security over a changelog.
+- Follow the customer instructions. If they ask for a code review, prioritize the stated review focus over a changelog. If none is given, prioritize defects, regressions, missing tests, and security.
 - When summarizing, follow the customer digest focus. If none is given, group by features, fixes, refactors, docs, and dependencies.
 - Cite commit shas and file paths when making specific claims.
 - Call out follow-ups, risks, or missing tests when they matter to the customer task.

--- a/apps/hyperlocalise-web/src/agents/automations/github-repository/agent/skills/github-repo-agent.md
+++ b/apps/hyperlocalise-web/src/agents/automations/github-repository/agent/skills/github-repo-agent.md
@@ -8,7 +8,7 @@ id: github-repo-agent
 - Start with `repoGitState` and `git log` for the requested lookback window and branch.
 - Use `read`, `grep`, or `glob` only when commit subjects or diffs need more context.
 - Follow the customer instructions. If they ask for a code review, prioritize defects, regressions, missing tests, and security over a changelog.
-- Group changes by theme (features, fixes, refactors, docs, dependencies) when summarizing.
+- When summarizing, follow the customer digest focus. If none is given, group by features, fixes, refactors, docs, and dependencies.
 - Cite commit shas and file paths when making specific claims.
 - Call out follow-ups, risks, or missing tests when they matter to the customer task.
 - If there are no commits in the period, say so clearly.

--- a/apps/hyperlocalise-web/src/agents/automations/github-repository/agent/skills/github-repo-agent.md
+++ b/apps/hyperlocalise-web/src/agents/automations/github-repository/agent/skills/github-repo-agent.md
@@ -5,7 +5,7 @@ id: github-repo-agent
 ## GitHub repository agent procedure
 
 - Read-only. Do not commit, push, upload sources, or modify files.
-- Start with `repoGitState` and `git log` for the requested lookback window and branch.
+- Start with `repoGitState` and `git log` for the requested lookback window, push commit range, and branch.
 - Use `read`, `grep`, or `glob` only when commit subjects or diffs need more context.
 - Follow the customer instructions. If they ask for a code review, prioritize the stated review focus over a changelog. If none is given, prioritize defects, regressions, missing tests, and security.
 - When summarizing, follow the customer digest focus. If none is given, group by features, fixes, refactors, docs, and dependencies.

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/build-workspace-orchestrator-tools.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/build-workspace-orchestrator-tools.ts
@@ -19,6 +19,7 @@ import { createCreateIssueTool } from "./tools/create_issue";
 import { createNativeTmsJobTool } from "./tools/create_native_tms_job";
 import { createListIssuesTool } from "./tools/list_issues";
 import { createNotifyEmailTool } from "./tools/notify_email";
+import { createNotifyGithubCommentTool } from "./tools/notify_github_comment";
 import { createNotifySlackTool } from "./tools/notify_slack";
 import { createRecallMemoryTool } from "./tools/recall_memory";
 import { createRunContentfulTranslationTool } from "./tools/run_contentful_translation";
@@ -45,6 +46,7 @@ const TOOL_BUILDERS: Record<
   use_web_search: createUseWebSearchTool,
   notify_slack: createNotifySlackTool,
   notify_email: createNotifyEmailTool,
+  notify_github_comment: createNotifyGithubCommentTool,
   recall_memory: createRecallMemoryTool,
   save_memory: createSaveMemoryTool,
 };

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/compose-workspace-instructions.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/compose-workspace-instructions.test.ts
@@ -59,4 +59,16 @@ describe("composeWorkspaceAutomationInstructions", () => {
 
     expect(instructions).not.toContain("## Slack notifications");
   });
+
+  it("includes the GitHub comment skill when notify_github_comment is planned", () => {
+    const instructions = composeWorkspaceAutomationInstructions({
+      triggerMode: "github",
+      plan: { tools: ["use_github_repository", "notify_github_comment"] },
+      userOverride: "Comment on the pull request.",
+    });
+
+    expect(instructions).toContain("## GitHub pull request comments");
+    expect(instructions).toContain("sticky pull request comment");
+    expect(instructions).not.toContain("## Slack notifications");
+  });
 });

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/compose-workspace-instructions.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/compose-workspace-instructions.ts
@@ -45,7 +45,12 @@ export function composeWorkspaceAutomationInstructions(input: {
   const dynamicSections = [enabledToolsSection];
 
   const skills = input.templateSkillId ? [input.templateSkillId] : [];
-  const sharedSkills = input.plan.tools.includes("notify_slack") ? ["slack-notifications"] : [];
+  const sharedSkills = [
+    ...(input.plan.tools.includes("notify_slack") ? (["slack-notifications"] as const) : []),
+    ...(input.plan.tools.includes("notify_github_comment")
+      ? (["github-comment-notifications"] as const)
+      : []),
+  ];
 
   return composeInstructions({
     automationId: "workspace",

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.test.ts
@@ -192,6 +192,29 @@ describe("buildWorkspaceOrchestratorPlan", () => {
     expect(plan.tools).toEqual(["use_web_search", "notify_slack"]);
   });
 
+  it("includes notify_github_comment when GitHub comments are enabled", () => {
+    const plan = buildWorkspaceOrchestratorPlan(
+      automation({
+        repositoryTarget: {
+          kind: "github",
+          githubInstallationRepositoryId: "repo-1",
+        },
+        toolConfig: {
+          github: {
+            enabled: true,
+            mode: "agent",
+            pushSource: false,
+            pullTranslations: false,
+            validation: false,
+          },
+          githubComment: { enabled: true },
+        },
+      }),
+    );
+
+    expect(plan.tools).toEqual(["use_github_repository", "notify_github_comment"]);
+  });
+
   it("does not plan recall_memory when knowledge is enabled", () => {
     const plan = buildWorkspaceOrchestratorPlan(
       automation({

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.ts
@@ -40,6 +40,7 @@ export const WORKSPACE_ORCHESTRATOR_TOOL_NAMES = [
   "use_web_search",
   "notify_slack",
   "notify_email",
+  "notify_github_comment",
   "recall_memory",
   "save_memory",
 ] as const;
@@ -67,7 +68,11 @@ const WORKFLOW_TOOLS: WorkspaceOrchestratorToolName[] = [
   "use_web_search",
 ];
 
-const NOTIFICATION_TOOLS: WorkspaceOrchestratorToolName[] = ["notify_slack", "notify_email"];
+const NOTIFICATION_TOOLS: WorkspaceOrchestratorToolName[] = [
+  "notify_slack",
+  "notify_email",
+  "notify_github_comment",
+];
 
 // Memory tools remain in the tool-name union while the retrieval redesign is pending, but they
 // must not be added to execution plans. The orchestrator forces every planned tool, so planning
@@ -118,6 +123,8 @@ function notificationToolEnabled(
         toolConfig.email.recipients &&
         toolConfig.email.recipients.length > 0,
       );
+    case "notify_github_comment":
+      return Boolean(toolConfig.githubComment?.enabled);
     default:
       return false;
   }

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/run-workspace-orchestrator.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/run-workspace-orchestrator.test.ts
@@ -43,6 +43,23 @@ describe("buildWorkspaceOrchestratorUserMessage", () => {
     expect(message).not.toContain("Contentful entry ID");
   });
 
+  it("includes GitHub push context in the orchestrator prompt", () => {
+    const message = buildWorkspaceOrchestratorUserMessage({
+      automationName: "Notify on push blockers",
+      triggerSource: "github",
+      inputSnapshot: {
+        pushBranch: "main",
+        commitBefore: "aaa111",
+        commitAfter: "bbb222",
+      },
+    });
+
+    expect(message).toContain('Execute automation "Notify on push blockers"');
+    expect(message).toContain("Trigger source: github.");
+    expect(message).toContain("GitHub push branch: main.");
+    expect(message).toContain("GitHub push commits: aaa111..bbb222.");
+  });
+
   it("omits Contentful entry context when the snapshot has no entry ID", () => {
     const message = buildWorkspaceOrchestratorUserMessage({
       automationName: "Translate Contentful article",

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/run-workspace-orchestrator.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/run-workspace-orchestrator.ts
@@ -83,7 +83,9 @@ export function buildWorkspaceOrchestratorUserMessage(input: {
 
   if (input.triggerSource === "github") {
     const pushBranch =
-      typeof input.inputSnapshot.pushBranch === "string" ? input.inputSnapshot.pushBranch.trim() : "";
+      typeof input.inputSnapshot.pushBranch === "string"
+        ? input.inputSnapshot.pushBranch.trim()
+        : "";
     const commitBefore =
       typeof input.inputSnapshot.commitBefore === "string"
         ? input.inputSnapshot.commitBefore.trim()

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/run-workspace-orchestrator.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/run-workspace-orchestrator.ts
@@ -81,12 +81,37 @@ export function buildWorkspaceOrchestratorUserMessage(input: {
     }
   }
 
+  if (input.triggerSource === "github") {
+    const pushBranch =
+      typeof input.inputSnapshot.pushBranch === "string" ? input.inputSnapshot.pushBranch.trim() : "";
+    const commitBefore =
+      typeof input.inputSnapshot.commitBefore === "string"
+        ? input.inputSnapshot.commitBefore.trim()
+        : "";
+    const commitAfter =
+      typeof input.inputSnapshot.commitAfter === "string"
+        ? input.inputSnapshot.commitAfter.trim()
+        : "";
+    if (pushBranch) {
+      lines.push(`GitHub push branch: ${pushBranch}.`);
+    }
+    if (commitBefore && commitAfter) {
+      lines.push(`GitHub push commits: ${commitBefore}..${commitAfter}.`);
+    } else if (commitAfter) {
+      lines.push(`GitHub push commit: ${commitAfter}.`);
+    }
+  }
+
   lines.push("Apply customer instructions when running workflow tools.");
   return lines.join("\n");
 }
 
 function collectNotificationWarnings(session: WorkspaceOrchestratorSession) {
-  const warnings: Array<{ channel: "slack" | "email"; code: string; message: string }> = [];
+  const warnings: Array<{
+    channel: "slack" | "email" | "github_comment";
+    code: string;
+    message: string;
+  }> = [];
 
   const slackResult = session.stepResults.notify_slack;
   if (slackResult && slackResult.sent === false) {
@@ -109,6 +134,25 @@ function collectNotificationWarnings(session: WorkspaceOrchestratorSession) {
         typeof emailResult.message === "string"
           ? emailResult.message
           : "Email notification failed.",
+    });
+  }
+
+  const githubCommentResult = session.stepResults.notify_github_comment;
+  if (
+    githubCommentResult &&
+    githubCommentResult.posted === false &&
+    githubCommentResult.skipped !== true
+  ) {
+    warnings.push({
+      channel: "github_comment",
+      code:
+        typeof githubCommentResult.code === "string"
+          ? githubCommentResult.code
+          : "github_comment_send_failed",
+      message:
+        typeof githubCommentResult.message === "string"
+          ? githubCommentResult.message
+          : "GitHub comment failed.",
     });
   }
 

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/skills/notify-on-push-blockers.md
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/skills/notify-on-push-blockers.md
@@ -1,0 +1,29 @@
+---
+id: notify-on-push-blockers
+name: Notify on push blockers
+description: Review each GitHub push for localisation and translation risk, then comment on the pull request.
+category: popular
+activatable: true
+---
+
+You are a localisation-focused code reviewer for this repository.
+
+What you can do:
+
+- Read the pushed commits, diffs, and surrounding code
+- Judge localisation, translation, and locale-compliance risk in the changed code
+- Cite commit SHAs and file paths for each finding
+- Separate blocking localisation defects from non-blocking follow-ups
+- Ignore unrelated logic, security, and formatting issues unless they affect user-facing copy or locale behavior
+- Post findings as a sticky GitHub pull request comment and update it on later pushes
+
+Goal:
+
+- Surface localisation and translation risks from this push on the pull request before they merge.
+
+Review focus:
+
+- Hard-coded copy, missing keys, and source strings that cannot be translated
+- Broken ICU, placeholders, plurals, and locale-sensitive formatting
+- Translation coverage, fallback, and writeback regressions
+- Localisation compliance: locale, RTL, legal, and market-language constraints

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/skills/review-code-daily.md
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/skills/review-code-daily.md
@@ -1,28 +1,28 @@
 ---
 id: review-code-daily
 name: Review code daily
-description: Read recent repository changes each day, review them for defects, and post findings to Slack.
+description: Read recent repository changes each day, review them for localisation and translation risk, and post findings to Slack.
 category: popular
 activatable: true
 ---
 
-You are a staff code reviewer for this repository.
+You are a localisation-focused code reviewer for this repository.
 
 What you can do:
 
 - Read recent commits, diffs, and surrounding code in the lookback window
-- Judge correctness, regressions, missing tests, security, and rollout risk
+- Judge localisation, translation, and locale-compliance risk in the changed code
 - Cite commit SHAs and file paths for each finding
-- Separate blocking defects from non-blocking follow-ups
-- Ignore formatting-only churn unless it hides a real defect
+- Separate blocking localisation defects from non-blocking follow-ups
+- Ignore unrelated logic, security, and formatting issues unless they affect user-facing copy or locale behavior
 
 Goal:
 
-- Surface the highest-risk changes from the last day so the team can act before they ship further.
+- Surface localisation and translation risks from the last day so the team can act before they ship further.
 
 Review focus:
 
-- Logic bugs, broken contracts, and missing error handling
-- Security, auth, and data-exposure risks
-- Missing or weakened tests around the changed behavior
-- Rollout, migration, and backwards-compatibility risk
+- Hard-coded copy, missing keys, and source strings that cannot be translated
+- Broken ICU, placeholders, plurals, and locale-sensitive formatting
+- Translation coverage, fallback, and writeback regressions
+- Localisation compliance: locale, RTL, legal, and market-language constraints

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/skills/summarize-changes-daily.md
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/skills/summarize-changes-daily.md
@@ -1,0 +1,28 @@
+---
+id: summarize-changes-daily
+name: Summarize changes daily
+description: Read a GitHub repository each day and post a concise Slack digest of localisation-related changes.
+category: popular
+activatable: true
+---
+
+You are a daily localisation briefing agent.
+
+What you can do:
+
+- Read recent commits, diffs, and surrounding files in the lookback window
+- Keep the digest scoped to localisation, i18n, and translation work
+- Cite commit SHAs and file paths for specific claims
+- Call out coverage gaps, ICU or placeholder risk, and incomplete translation syncs
+- Ignore unrelated feature, infrastructure, and formatting work unless it changes user-facing copy or locale files
+
+Goal:
+
+- Post a concise digest of localisation-related changes so the team can stay aligned without reading every commit.
+
+Digest focus:
+
+- New or updated source strings and message catalogs
+- Translation file, locale resource, and coverage changes
+- ICU, placeholder, glossary, and i18n config updates
+- Localisation-related PRs, syncs, and release risks

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/summary-message.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/summary-message.ts
@@ -27,7 +27,7 @@ function asStringArray(value: unknown): string[] {
 }
 
 /**
- * `notify_slack` / `notify_email` run inside the tool loop, before
+ * `notify_slack` / `notify_email` / `notify_github_comment` run inside the tool loop, before
  * `deriveTerminalStatus` persists the final run status. Prefer explicit
  * terminal signals; treat still-queued/running as completed for the summary.
  */

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/notify_github_comment.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/notify_github_comment.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { defineAgentTool } from "@/agents/_runtime/define-agent-tool";
+import { upsertWorkspaceAutomationPullRequestComment } from "@/lib/agents/github/upsert-workspace-automation-pull-request-comment";
+import { db, schema } from "@/lib/database";
+
+import type { WorkspaceOrchestratorSession } from "../context";
+import { buildOrchestratorRunSummaryMessage } from "../summary-message";
+
+function readSnapshotString(snapshot: Record<string, unknown>, key: string): string | null {
+  const value = snapshot[key];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+export function createNotifyGithubCommentTool(session: WorkspaceOrchestratorSession) {
+  return defineAgentTool({
+    description:
+      "Post or update a sticky GitHub pull request comment summarizing this automation run. Pass `message` as GitHub-flavored Markdown. Follow any customer-specified comment format first; otherwise use a bold headline, short bullets, and a next step. If no pull request is associated with the push, the tool skips without failing the run.",
+    inputSchema: z.object({
+      message: z
+        .string()
+        .trim()
+        .min(1)
+        .optional()
+        .describe(
+          "Markdown summary for the pull request comment. Prefer the customer's requested format when provided; otherwise a bold headline, short bullets for key facts, and a one-line next step.",
+        ),
+    }),
+    execute: async ({ message }) => {
+      const githubComment = session.automation.toolConfig.githubComment;
+      if (!githubComment?.enabled) {
+        throw new Error("github_comment_not_configured");
+      }
+
+      if (!session.repository) {
+        throw new Error("github_repository_target_required");
+      }
+
+      const [repositoryRow] = await db
+        .select({
+          fullName: schema.githubInstallationRepositories.fullName,
+          githubInstallationId: schema.githubInstallationRepositories.githubInstallationId,
+        })
+        .from(schema.githubInstallationRepositories)
+        .where(
+          and(
+            eq(schema.githubInstallationRepositories.id, session.repository.id),
+            eq(schema.githubInstallationRepositories.organizationId, session.organizationId),
+          ),
+        )
+        .limit(1);
+
+      if (!repositoryRow) {
+        throw new Error("github_repository_not_found");
+      }
+
+      const commitSha = readSnapshotString(session.run.inputSnapshot, "commitAfter");
+      const text = message?.trim() || buildOrchestratorRunSummaryMessage(session);
+      const result = await upsertWorkspaceAutomationPullRequestComment({
+        installationId: repositoryRow.githubInstallationId,
+        repositoryFullName: repositoryRow.fullName,
+        automationId: session.automation.id,
+        commitSha: commitSha ?? "",
+        message: text,
+      });
+
+      const payload = result.ok
+        ? result.value.status === "skipped"
+          ? {
+              posted: false,
+              skipped: true,
+              code: result.value.code,
+            }
+          : {
+              posted: true,
+              skipped: false,
+              action: result.value.status,
+              pullRequestNumber: result.value.pullRequestNumber,
+              commentId: result.value.commentId,
+              url: result.value.url,
+            }
+        : {
+            posted: false,
+            skipped: false,
+            code: result.error.code,
+            message: result.error.message,
+          };
+
+      session.stepResults.notify_github_comment = payload;
+      return payload;
+    },
+  });
+}

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/resolve-github-repo-lookback.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/resolve-github-repo-lookback.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  formatGithubPushRangeLabel,
+  isGithubNullOid,
+  resolveGithubPushRange,
+  resolveGithubRepoLookbackHours,
+} from "./resolve-github-repo-lookback";
+
+describe("resolveGithubPushRange", () => {
+  it("reads the push commit range from the GitHub trigger snapshot", () => {
+    expect(
+      resolveGithubPushRange({
+        triggerSource: "github",
+        inputSnapshot: {
+          pushBranch: "main",
+          commitBefore: "aaa111",
+          commitAfter: "bbb222",
+        },
+      }),
+    ).toEqual({
+      branch: "main",
+      commitBefore: "aaa111",
+      commitAfter: "bbb222",
+    });
+  });
+
+  it("treats a GitHub null OID as a new-branch push", () => {
+    expect(isGithubNullOid("0000000000000000000000000000000000000000")).toBe(true);
+    expect(
+      resolveGithubPushRange({
+        triggerSource: "github",
+        inputSnapshot: {
+          pushBranch: "feature/x",
+          commitBefore: "0000000000000000000000000000000000000000",
+          commitAfter: "ccc333",
+        },
+      }),
+    ).toEqual({
+      branch: "feature/x",
+      commitBefore: null,
+      commitAfter: "ccc333",
+    });
+    expect(formatGithubPushRangeLabel({
+      branch: "feature/x",
+      commitBefore: null,
+      commitAfter: "ccc333",
+    })).toContain("new branch");
+  });
+
+  it("ignores non-GitHub triggers", () => {
+    expect(
+      resolveGithubPushRange({
+        triggerSource: "scheduled",
+        inputSnapshot: {
+          pushBranch: "main",
+          commitAfter: "bbb222",
+        },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("resolveGithubRepoLookbackHours", () => {
+  it("maps scheduled cadences onto lookback hours", () => {
+    expect(
+      resolveGithubRepoLookbackHours({
+        triggerSource: "scheduled",
+        automation: {
+          triggerConfig: {
+            mode: "scheduled",
+            schedule: { cadence: "hourly", hourUtc: 0, timezone: "UTC" },
+          },
+        } as Parameters<typeof resolveGithubRepoLookbackHours>[0]["automation"],
+      }),
+    ).toBe(1);
+    expect(
+      resolveGithubRepoLookbackHours({
+        triggerSource: "github",
+        automation: {
+          triggerConfig: { mode: "github", branches: ["main"] },
+        } as Parameters<typeof resolveGithubRepoLookbackHours>[0]["automation"],
+      }),
+    ).toBe(24);
+  });
+});

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/resolve-github-repo-lookback.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/resolve-github-repo-lookback.test.ts
@@ -53,11 +53,13 @@ describe("resolveGithubPushRange", () => {
       commitBefore: null,
       commitAfter: "ccc333",
     });
-    expect(formatGithubPushRangeLabel({
-      branch: "feature/x",
-      commitBefore: null,
-      commitAfter: "ccc333",
-    })).toContain("new branch");
+    expect(
+      formatGithubPushRangeLabel({
+        branch: "feature/x",
+        commitBefore: null,
+        commitAfter: "ccc333",
+      }),
+    ).toContain("new branch");
   });
 
   it("ignores non-GitHub triggers", () => {

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/resolve-github-repo-lookback.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/resolve-github-repo-lookback.ts
@@ -12,6 +12,51 @@
  */
 import type { WorkspaceAutomationRecord } from "@/lib/agents/workspace-automations";
 
+function readSnapshotString(snapshot: Record<string, unknown>, key: string): string | null {
+  const value = snapshot[key];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+export function isGithubNullOid(sha: string | null | undefined): boolean {
+  return !sha || /^0+$/.test(sha);
+}
+
+export type GithubPushInspectionRange = {
+  branch: string;
+  commitBefore: string | null;
+  commitAfter: string;
+};
+
+export function resolveGithubPushRange(input: {
+  triggerSource: string;
+  inputSnapshot: Record<string, unknown>;
+}): GithubPushInspectionRange | null {
+  if (input.triggerSource !== "github") {
+    return null;
+  }
+
+  const branch = readSnapshotString(input.inputSnapshot, "pushBranch");
+  const commitAfter = readSnapshotString(input.inputSnapshot, "commitAfter");
+  if (!branch || !commitAfter || isGithubNullOid(commitAfter)) {
+    return null;
+  }
+
+  const commitBeforeRaw = readSnapshotString(input.inputSnapshot, "commitBefore");
+  return {
+    branch,
+    commitBefore: commitBeforeRaw && !isGithubNullOid(commitBeforeRaw) ? commitBeforeRaw : null,
+    commitAfter,
+  };
+}
+
+export function formatGithubPushRangeLabel(range: GithubPushInspectionRange): string {
+  if (!range.commitBefore) {
+    return `new branch ${range.branch} at ${range.commitAfter}`;
+  }
+
+  return `${range.commitBefore}..${range.commitAfter} on ${range.branch}`;
+}
+
 export function resolveGithubRepoLookbackHours(input: {
   automation: WorkspaceAutomationRecord;
   triggerSource: string;

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_github_repository.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_github_repository.ts
@@ -37,7 +37,9 @@ import {
 
 import type { WorkspaceOrchestratorSession } from "../context";
 import {
+  formatGithubPushRangeLabel,
   formatGithubRepoLookbackLabel,
+  resolveGithubPushRange,
   resolveGithubRepoLookbackHours,
 } from "./resolve-github-repo-lookback";
 
@@ -72,12 +74,19 @@ export function createUseGithubRepositoryTool(session: WorkspaceOrchestratorSess
         throw new Error("github_repository_not_found");
       }
 
-      const branch = repositoryRow.defaultBranch?.trim() || "main";
+      const pushRange = resolveGithubPushRange({
+        triggerSource: session.run.triggerSource,
+        inputSnapshot: session.run.inputSnapshot,
+      });
+      const branch = pushRange?.branch || repositoryRow.defaultBranch?.trim() || "main";
+      const revision = pushRange?.commitAfter || branch;
       const lookbackHours = resolveGithubRepoLookbackHours({
         automation: session.automation,
         triggerSource: session.run.triggerSource,
       });
-      const lookbackLabel = formatGithubRepoLookbackLabel(lookbackHours);
+      const lookbackLabel = pushRange
+        ? formatGithubPushRangeLabel(pushRange)
+        : formatGithubRepoLookbackLabel(lookbackHours);
       const userInstructions =
         session.automation.instructions.trim() ||
         (typeof session.run.inputSnapshot.instructions === "string"
@@ -90,7 +99,7 @@ export function createUseGithubRepositoryTool(session: WorkspaceOrchestratorSess
         sandboxId = await createGithubRepositoryAutomationSandbox({
           installationId: repositoryRow.githubInstallationId,
           repositoryFullName: repositoryRow.fullName,
-          revision: branch,
+          revision,
           cloneDepth: 50,
         });
 
@@ -100,7 +109,9 @@ export function createUseGithubRepositoryTool(session: WorkspaceOrchestratorSess
             "This is an automated read-only GitHub repository task.",
             `Repository: ${repositoryRow.fullName}.`,
             `Branch: ${branch}.`,
-            `Lookback window: ${lookbackLabel}.`,
+            pushRange
+              ? `Inspect this push: ${lookbackLabel}.`
+              : `Lookback window: ${lookbackLabel}.`,
             `Sandbox id: ${sandboxId}.`,
           ],
         });
@@ -140,7 +151,9 @@ export function createUseGithubRepositoryTool(session: WorkspaceOrchestratorSess
 
         const prompt = [
           `Execute the customer task for ${repositoryRow.fullName} on branch ${branch}.`,
-          `Review changes from the last ${lookbackLabel}.`,
+          pushRange
+            ? `Review the localisation impact of this push (${lookbackLabel}).`
+            : `Review changes from the last ${lookbackLabel}.`,
           "Use repository tools to inspect git history and relevant files.",
           "Return the final digest as plain text for automation delivery.",
         ].join("\n");
@@ -169,7 +182,13 @@ export function createUseGithubRepositoryTool(session: WorkspaceOrchestratorSess
           digest,
           repositoryFullName: repositoryRow.fullName,
           branch,
-          lookbackHours,
+          lookbackHours: pushRange ? null : lookbackHours,
+          ...(pushRange
+            ? {
+                commitBefore: pushRange.commitBefore,
+                commitAfter: pushRange.commitAfter,
+              }
+            : {}),
         };
         session.stepResults.use_github_repository = payload;
 

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-orchestrator-output-summary.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-orchestrator-output-summary.test.ts
@@ -118,4 +118,35 @@ describe("buildWorkspaceOrchestratorOutputSummary", () => {
 
     expect(outputSummary.contentfulTranslationRunId).toBe("contentful-run-1");
   });
+
+  it("records GitHub comment notification warnings", () => {
+    const outputSummary = buildWorkspaceOrchestratorOutputSummary(
+      { orchestratorEnqueuedAt: "2026-06-24T00:00:00.000Z" },
+      {
+        notify_github_comment: {
+          posted: false,
+          skipped: false,
+          code: "github_comment_send_failed",
+          message: "GitHub comment failed.",
+        },
+      },
+      {
+        notificationWarnings: [
+          {
+            channel: "github_comment",
+            code: "github_comment_send_failed",
+            message: "GitHub comment failed.",
+          },
+        ],
+      },
+    );
+
+    expect(outputSummary.notificationWarnings).toEqual([
+      {
+        channel: "github_comment",
+        code: "github_comment_send_failed",
+        message: "GitHub comment failed.",
+      },
+    ]);
+  });
 });

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-orchestrator-output-summary.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-orchestrator-output-summary.ts
@@ -140,7 +140,11 @@ export function buildWorkspaceOrchestratorOutputSummary(
   base: Record<string, unknown>,
   stepResults: Partial<Record<WorkspaceOrchestratorToolName, Record<string, unknown>>>,
   options?: {
-    notificationWarnings?: Array<{ channel: "slack" | "email"; code: string; message: string }>;
+    notificationWarnings?: Array<{
+      channel: "slack" | "email" | "github_comment";
+      code: string;
+      message: string;
+    }>;
   },
 ): Record<string, unknown> {
   const contentfulTranslationRunId = readContentfulTranslationRunId(base, stepResults);

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-template-manifest.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-template-manifest.test.ts
@@ -104,6 +104,25 @@ describe("workspace template manifest", () => {
     expect(research?.instructions).toContain("You are a localisation research analyst");
   });
 
+  it("merges notify-on-push-blockers skill onto the gallery template", () => {
+    const [template] = mergeWorkspaceTemplateSkills(WORKSPACE_AUTOMATION_TEMPLATES_BASE).filter(
+      (entry) => entry.id === "notify-on-push-blockers",
+    );
+
+    expect(template).toMatchObject({
+      name: "Notify on push blockers",
+      category: "popular",
+      activatable: true,
+      defaultForm: expect.objectContaining({
+        githubMode: "agent",
+        triggerMode: "github",
+        githubCommentEnabled: true,
+      }),
+    });
+    expect(template?.description).toContain("comment on the pull request");
+    expect(template?.instructions).toContain("sticky GitHub pull request comment");
+  });
+
   it("keeps untested templates coming soon after skill merge", () => {
     const activatableIds = mergeWorkspaceTemplateSkills(WORKSPACE_AUTOMATION_TEMPLATES_BASE)
       .filter((template) => template.activatable)
@@ -115,6 +134,7 @@ describe("workspace template manifest", () => {
       "summarize-changes-daily",
       "review-code-daily",
       "daily-web-research",
+      "notify-on-push-blockers",
     ]);
   });
 });

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-template-manifest.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-template-manifest.test.ts
@@ -65,7 +65,7 @@ describe("workspace template manifest", () => {
     expect(getTemplateCategoryFromSkill("translate-on-source-upload")).toBe("popular");
   });
 
-  it("keeps summarize changes daily template content from base definition", () => {
+  it("merges summarize changes daily skill onto the gallery template", () => {
     const [template] = mergeWorkspaceTemplateSkills(WORKSPACE_AUTOMATION_TEMPLATES_BASE).filter(
       (entry) => entry.id === "summarize-changes-daily",
     );
@@ -73,15 +73,15 @@ describe("workspace template manifest", () => {
     expect(template).toMatchObject({
       name: "Summarize changes daily",
       category: "popular",
-      activatable: false,
+      activatable: true,
       defaultForm: expect.objectContaining({
         githubMode: "agent",
         triggerMode: "scheduled",
         scheduledCadence: "daily",
       }),
     });
-    expect(template?.description).toContain("GitHub repository");
-    expect(template?.instructions).toContain("You are a daily engineering briefing agent");
+    expect(template?.description).toContain("localisation-related changes");
+    expect(template?.instructions).toContain("You are a daily localisation briefing agent");
   });
 
   it("merges daily code-review and web-research skills onto gallery templates", () => {
@@ -111,6 +111,7 @@ describe("workspace template manifest", () => {
     expect(activatableIds).toEqual([
       "translate-on-source-upload",
       "translate-contentful-article",
+      "summarize-changes-daily",
       "review-code-daily",
       "daily-web-research",
     ]);

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-template-manifest.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-template-manifest.test.ts
@@ -94,7 +94,8 @@ describe("workspace template manifest", () => {
       category: "popular",
       activatable: true,
     });
-    expect(review?.instructions).toContain("You are a staff code reviewer");
+    expect(review?.description).toContain("localisation and translation risk");
+    expect(review?.instructions).toContain("You are a localisation-focused code reviewer");
     expect(research).toMatchObject({
       name: "Daily web research",
       category: "popular",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-template-flow.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-template-flow.stories.tsx
@@ -99,3 +99,12 @@ export const DailyWebResearch: Story = {
     await expect(canvas.getByLabelText("Daily → Slack → Web Search")).toBeInTheDocument();
   },
 };
+
+export const NotifyOnPushBlockers: Story = {
+  ...templateStory("notify-on-push-blockers"),
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByLabelText("GitHub push → GitHub → GitHub comment"),
+    ).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-template-flow.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-template-flow.tsx
@@ -32,6 +32,7 @@ function iconBucketForNode(node: WorkspaceAutomationTemplateFlowNode): IconBucke
   switch (node.id) {
     case "github-push":
     case "github":
+    case "github-comment":
     case "push-source":
     case "pull-translations":
     case "validation":

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.messages.ts
@@ -55,6 +55,11 @@ export const automationsPageViewModelMessages = defineMessages({
     id: "6QqDATp4yt",
     description: "Tool badge when an automation uses email",
   },
+  toolGithubComment: {
+    defaultMessage: "PR comment",
+    id: "pRc0mB4dge",
+    description: "Tool badge when an automation posts GitHub pull request comments",
+  },
   toolMcpServer: {
     defaultMessage: "MCP Server",
     id: "RLPdxshxAq",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.messages.ts
@@ -57,7 +57,7 @@ export const automationsPageViewModelMessages = defineMessages({
   },
   toolGithubComment: {
     defaultMessage: "PR comment",
-    id: "pRc0mB4dge",
+    id: "CvmC1QddwG",
     description: "Tool badge when an automation posts GitHub pull request comments",
   },
   toolMcpServer: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.ts
@@ -107,6 +107,9 @@ export function resolveAutomationTools(intl: IntlShape, automation: WorkspaceAut
   if (automation.toolConfig.email?.enabled) {
     tools.push(intl.formatMessage(automationsPageViewModelMessages.toolEmail));
   }
+  if (automation.toolConfig.githubComment?.enabled) {
+    tools.push(intl.formatMessage(automationsPageViewModelMessages.toolGithubComment));
+  }
   if (automation.toolConfig.mcp?.enabled) {
     tools.push(intl.formatMessage(automationsPageViewModelMessages.toolMcpServer));
   }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -195,11 +195,6 @@ export const workspaceAutomationFormMessages = defineMessages({
     id: "dYlXc1BTpY",
     description: "Shortcut hint when an integration must be connected first",
   },
-  syncOnlyShortcut: {
-    defaultMessage: "Sync only",
-    id: "Qr6HIhIqfm",
-    description: "Shortcut hint when GitHub push is unavailable because agent mode is enabled",
-  },
   enableFirstShortcut: {
     defaultMessage: "Enable first",
     id: "ZQbvwhJWXn",
@@ -356,6 +351,11 @@ export const workspaceAutomationFormMessages = defineMessages({
     defaultMessage: "GitHub sync workflows",
     id: "wewNVYT5+w",
     description: "Menu item and tool title for GitHub sync workflows",
+  },
+  commentOnPullRequest: {
+    defaultMessage: "Comment on pull request",
+    id: "nPrC0mM3nt",
+    description: "Menu item and tool title for GitHub pull request comments",
   },
   sendToSlack: {
     defaultMessage: "Send to Slack",
@@ -578,6 +578,22 @@ export const workspaceAutomationFormMessages = defineMessages({
     defaultMessage: "Connect Slack in <link>Integrations</link> to use this tool.",
     id: "so9cmZxAcw",
     description: "Description for Slack notifications when Slack is not connected",
+  },
+  githubCommentConnectedDescription: {
+    defaultMessage:
+      "Post a sticky review comment on the pull request for this push. Later runs update the same comment.",
+    id: "gHc0mD3sc1",
+    description: "Description for GitHub pull request comment notifications when GitHub is connected",
+  },
+  githubCommentDisconnectedDescription: {
+    defaultMessage: "Connect GitHub in <link>Integrations</link> to comment on pull requests.",
+    id: "gHc0mD3sc0",
+    description: "Description for GitHub comment notifications when GitHub is not connected",
+  },
+  removeGithubCommentNotifications: {
+    defaultMessage: "Remove GitHub comment notifications",
+    id: "gHc0mRm0v1",
+    description: "Accessible label to remove GitHub pull request comment notifications",
   },
   removeSlackNotifications: {
     defaultMessage: "Remove Slack notifications",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -354,7 +354,7 @@ export const workspaceAutomationFormMessages = defineMessages({
   },
   commentOnPullRequest: {
     defaultMessage: "Comment on pull request",
-    id: "nPrC0mM3nt",
+    id: "u6BhbzsvPa",
     description: "Menu item and tool title for GitHub pull request comments",
   },
   sendToSlack: {
@@ -582,17 +582,18 @@ export const workspaceAutomationFormMessages = defineMessages({
   githubCommentConnectedDescription: {
     defaultMessage:
       "Post a sticky review comment on the pull request for this push. Later runs update the same comment.",
-    id: "gHc0mD3sc1",
-    description: "Description for GitHub pull request comment notifications when GitHub is connected",
+    id: "AbZsOtFk+H",
+    description:
+      "Description for GitHub pull request comment notifications when GitHub is connected",
   },
   githubCommentDisconnectedDescription: {
     defaultMessage: "Connect GitHub in <link>Integrations</link> to comment on pull requests.",
-    id: "gHc0mD3sc0",
+    id: "Gsz+RNFKoM",
     description: "Description for GitHub comment notifications when GitHub is not connected",
   },
   removeGithubCommentNotifications: {
     defaultMessage: "Remove GitHub comment notifications",
-    id: "gHc0mRm0v1",
+    id: "jgR+WtYIxe",
     description: "Accessible label to remove GitHub pull request comment notifications",
   },
   removeSlackNotifications: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -19,6 +19,7 @@ import {
   ArrowDown01Icon,
   BrainCircuitIcon,
   Clock01Icon,
+  Comment01Icon,
   Delete02Icon,
   FolderLibraryIcon,
   GitBranchIcon,
@@ -338,6 +339,7 @@ function toolCount(form: WorkspaceAutomationFormState) {
     Number(form.githubEnabled) +
     Number(form.slackEnabled) +
     Number(form.emailEnabled) +
+    Number(form.githubCommentEnabled) +
     Number(form.contentfulEnabled) +
     Number(form.createNativeTmsJobEnabled) +
     Number(form.assignTranslateWithAgentEnabled) +
@@ -769,11 +771,7 @@ function AddTriggerMenu({
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuItem
-              disabled={
-                form.triggerMode === "github" ||
-                !githubConnected ||
-                (form.githubEnabled && form.githubMode === "agent")
-              }
+              disabled={form.triggerMode === "github" || !githubConnected}
               onClick={() => {
                 const defaultRepositoryId =
                   form.githubInstallationRepositoryId ||
@@ -788,9 +786,11 @@ function AddTriggerMenu({
                   repositoryTargetKind: "github",
                   githubInstallationRepositoryId: defaultRepositoryId,
                   validationEnabled:
-                    form.pushSourceEnabled || form.pullTranslationsEnabled
+                    form.githubMode === "agent"
                       ? form.validationEnabled
-                      : true,
+                      : form.pushSourceEnabled || form.pullTranslationsEnabled
+                        ? form.validationEnabled
+                        : true,
                 });
               }}
             >
@@ -803,10 +803,6 @@ function AddTriggerMenu({
               ) : !githubConnected ? (
                 <DropdownMenuShortcut>
                   <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
-                </DropdownMenuShortcut>
-              ) : form.githubEnabled && form.githubMode === "agent" ? (
-                <DropdownMenuShortcut>
-                  <FormattedMessage {...workspaceAutomationFormMessages.syncOnlyShortcut} />
                 </DropdownMenuShortcut>
               ) : null}
             </DropdownMenuItem>
@@ -1231,6 +1227,34 @@ function AddToolMenu({
                   <HugeiconsIcon icon={GitBranchIcon} strokeWidth={1.8} className="size-4" />
                   <FormattedMessage {...workspaceAutomationFormMessages.githubSyncWorkflows} />
                   {form.githubEnabled && form.githubMode === "sync" ? (
+                    <DropdownMenuShortcut>
+                      <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                    </DropdownMenuShortcut>
+                  ) : !githubConnected ? (
+                    <DropdownMenuShortcut>
+                      <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
+                    </DropdownMenuShortcut>
+                  ) : null}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  disabled={form.githubCommentEnabled || !githubConnected}
+                  onClick={() => {
+                    const defaultRepositoryId = resolveDefaultGithubRepositoryId(
+                      form,
+                      repositories,
+                    );
+
+                    onChange({
+                      ...form,
+                      githubCommentEnabled: true,
+                      repositoryTargetKind: "github",
+                      githubInstallationRepositoryId: defaultRepositoryId,
+                    });
+                  }}
+                >
+                  <HugeiconsIcon icon={Comment01Icon} strokeWidth={1.8} className="size-4" />
+                  <FormattedMessage {...workspaceAutomationFormMessages.commentOnPullRequest} />
+                  {form.githubCommentEnabled ? (
                     <DropdownMenuShortcut>
                       <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
                     </DropdownMenuShortcut>
@@ -1678,8 +1702,10 @@ function ToolsSettings({
                   onChange({
                     ...form,
                     githubEnabled: false,
-                    repositoryTargetKind: "none",
-                    githubInstallationRepositoryId: "",
+                    repositoryTargetKind: form.githubCommentEnabled ? "github" : "none",
+                    githubInstallationRepositoryId: form.githubCommentEnabled
+                      ? form.githubInstallationRepositoryId
+                      : "",
                   })
                 }
               />
@@ -1714,7 +1740,10 @@ function ToolsSettings({
                   onChange({
                     ...form,
                     githubEnabled: false,
-                    repositoryTargetKind: "none",
+                    repositoryTargetKind: form.githubCommentEnabled ? "github" : "none",
+                    githubInstallationRepositoryId: form.githubCommentEnabled
+                      ? form.githubInstallationRepositoryId
+                      : "",
                     pushSourceEnabled: false,
                     pullTranslationsEnabled: false,
                     validationEnabled: false,
@@ -1772,6 +1801,62 @@ function ToolsSettings({
                 </label>
               </div>
             </div>
+          </EditorRow>
+        ) : null}
+
+        {form.githubCommentEnabled ? (
+          <EditorRow
+            icon={<HugeiconsIcon icon={Comment01Icon} strokeWidth={1.8} className="size-4" />}
+            title={
+              <>
+                <span>
+                  <FormattedMessage {...workspaceAutomationFormMessages.commentOnPullRequest} />
+                </span>
+                {!githubConnected ? (
+                  <Badge variant="secondary">
+                    <FormattedMessage {...workspaceAutomationFormMessages.connectFirstBadge} />
+                  </Badge>
+                ) : null}
+              </>
+            }
+            description={
+              githubConnected
+                ? intl.formatMessage(
+                    workspaceAutomationFormMessages.githubCommentConnectedDescription,
+                  )
+                : intl.formatMessage(
+                    workspaceAutomationFormMessages.githubCommentDisconnectedDescription,
+                    {
+                      link: (chunks) => (
+                        <Link
+                          href={`/org/${organizationSlug}/integrations`}
+                          className="underline"
+                        >
+                          {chunks}
+                        </Link>
+                      ),
+                    },
+                  )
+            }
+            action={
+              <DeleteToolButton
+                disabled={disabled}
+                label={intl.formatMessage(
+                  workspaceAutomationFormMessages.removeGithubCommentNotifications,
+                )}
+                onClick={() => onChange({ ...form, githubCommentEnabled: false })}
+              />
+            }
+          >
+            {!form.githubEnabled ? (
+              <GithubRepositorySelect
+                disabled={disabled}
+                error={errors.githubRepository}
+                form={form}
+                onChange={onChange}
+                repositories={repositories}
+              />
+            ) : null}
           </EditorRow>
         ) : null}
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -1828,10 +1828,7 @@ function ToolsSettings({
                     workspaceAutomationFormMessages.githubCommentDisconnectedDescription,
                     {
                       link: (chunks) => (
-                        <Link
-                          href={`/org/${organizationSlug}/integrations`}
-                          className="underline"
-                        >
+                        <Link href={`/org/${organizationSlug}/integrations`} className="underline">
                           {chunks}
                         </Link>
                       ),

--- a/apps/hyperlocalise-web/src/lib/agents/github/upsert-workspace-automation-pull-request-comment.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/upsert-workspace-automation-pull-request-comment.test.ts
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { getInstallationOctokitMock } = vi.hoisted(() => ({
+  getInstallationOctokitMock: vi.fn(),
+}));
+
+vi.mock("@/lib/agents/github/app", () => ({
+  getInstallationOctokit: getInstallationOctokitMock,
+}));
+
+import {
+  buildWorkspaceAutomationGithubCommentMarker,
+  commentContainsWorkspaceAutomationMarker,
+  formatWorkspaceAutomationGithubCommentBody,
+  upsertWorkspaceAutomationPullRequestComment,
+} from "./upsert-workspace-automation-pull-request-comment";
+
+describe("workspace automation GitHub comment helpers", () => {
+  it("builds a stable HTML marker for sticky comments", () => {
+    expect(buildWorkspaceAutomationGithubCommentMarker("auto-1")).toBe(
+      "<!-- hyperlocalise-automation:auto-1 -->",
+    );
+    expect(
+      commentContainsWorkspaceAutomationMarker(
+        "<!-- hyperlocalise-automation:auto-1 -->\nHello",
+        "auto-1",
+      ),
+    ).toBe(true);
+    expect(
+      commentContainsWorkspaceAutomationMarker(
+        "<!-- hyperlocalise-automation:other -->\nHello",
+        "auto-1",
+      ),
+    ).toBe(false);
+  });
+
+  it("prefixes the message with the marker and truncates oversized bodies", () => {
+    const formatted = formatWorkspaceAutomationGithubCommentBody({
+      automationId: "auto-1",
+      message: "  Finding one.  ",
+    });
+    expect(formatted.startsWith("<!-- hyperlocalise-automation:auto-1 -->\n")).toBe(true);
+    expect(formatted).toContain("Finding one.");
+
+    const oversized = formatWorkspaceAutomationGithubCommentBody({
+      automationId: "auto-1",
+      message: "x".repeat(70_000),
+    });
+    expect(oversized.length).toBeLessThanOrEqual(65_536);
+    expect(oversized).toContain("_(Comment truncated.)_");
+  });
+});
+
+describe("upsertWorkspaceAutomationPullRequestComment", () => {
+  const listPullRequestsAssociatedWithCommit = vi.fn();
+  const listComments = vi.fn();
+  const createComment = vi.fn();
+  const updateComment = vi.fn();
+  const paginate = vi.fn();
+
+  beforeEach(() => {
+    listPullRequestsAssociatedWithCommit.mockReset();
+    listComments.mockReset();
+    createComment.mockReset();
+    updateComment.mockReset();
+    paginate.mockReset();
+    getInstallationOctokitMock.mockReset();
+    getInstallationOctokitMock.mockResolvedValue({
+      paginate,
+      rest: {
+        repos: { listPullRequestsAssociatedWithCommit },
+        issues: { listComments, createComment, updateComment },
+      },
+    });
+  });
+
+  it("skips when the commit SHA is missing or a GitHub null OID", async () => {
+    await expect(
+      upsertWorkspaceAutomationPullRequestComment({
+        installationId: "1",
+        repositoryFullName: "acme/app",
+        automationId: "auto-1",
+        commitSha: "0000000000000000000000000000000000000000",
+        message: "Review",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      value: { status: "skipped", code: "github_commit_not_found" },
+    });
+    expect(getInstallationOctokitMock).not.toHaveBeenCalled();
+  });
+
+  it("skips when no pull request is associated with the commit", async () => {
+    listPullRequestsAssociatedWithCommit.mockResolvedValue({ data: [] });
+
+    await expect(
+      upsertWorkspaceAutomationPullRequestComment({
+        installationId: "1",
+        repositoryFullName: "acme/app",
+        automationId: "auto-1",
+        commitSha: "abc123",
+        message: "Review",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      value: { status: "skipped", code: "github_pr_not_found" },
+    });
+    expect(createComment).not.toHaveBeenCalled();
+  });
+
+  it("creates a sticky comment on the preferred open pull request", async () => {
+    listPullRequestsAssociatedWithCommit.mockResolvedValue({
+      data: [
+        { number: 8, state: "closed", updated_at: "2026-08-18T12:00:00Z" },
+        { number: 12, state: "open", updated_at: "2026-08-18T10:00:00Z" },
+        { number: 9, state: "open", updated_at: "2026-08-18T11:00:00Z" },
+      ],
+    });
+    paginate.mockResolvedValue([]);
+    createComment.mockResolvedValue({
+      data: { id: 44, html_url: "https://github.com/acme/app/pull/9#issuecomment-44" },
+    });
+
+    const result = await upsertWorkspaceAutomationPullRequestComment({
+      installationId: "1",
+      repositoryFullName: "acme/app",
+      automationId: "auto-1",
+      commitSha: "abc123",
+      message: "**Blocker** found",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        status: "created",
+        pullRequestNumber: 9,
+        commentId: 44,
+        url: "https://github.com/acme/app/pull/9#issuecomment-44",
+      },
+    });
+    expect(createComment).toHaveBeenCalledWith({
+      owner: "acme",
+      repo: "app",
+      issue_number: 9,
+      body: "<!-- hyperlocalise-automation:auto-1 -->\n**Blocker** found",
+    });
+  });
+
+  it("updates the existing sticky comment instead of posting a new one", async () => {
+    listPullRequestsAssociatedWithCommit.mockResolvedValue({
+      data: [{ number: 3, state: "open", updated_at: "2026-08-18T11:00:00Z" }],
+    });
+    paginate.mockResolvedValue([
+      { id: 21, body: "unrelated" },
+      { id: 22, body: "<!-- hyperlocalise-automation:auto-1 -->\nOld review" },
+    ]);
+    updateComment.mockResolvedValue({
+      data: { id: 22, html_url: "https://github.com/acme/app/pull/3#issuecomment-22" },
+    });
+
+    const result = await upsertWorkspaceAutomationPullRequestComment({
+      installationId: "1",
+      repositoryFullName: "acme/app",
+      automationId: "auto-1",
+      commitSha: "abc123",
+      message: "Updated review",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        status: "updated",
+        pullRequestNumber: 3,
+        commentId: 22,
+        url: "https://github.com/acme/app/pull/3#issuecomment-22",
+      },
+    });
+    expect(createComment).not.toHaveBeenCalled();
+    expect(updateComment).toHaveBeenCalledWith({
+      owner: "acme",
+      repo: "app",
+      comment_id: 22,
+      body: "<!-- hyperlocalise-automation:auto-1 -->\nUpdated review",
+    });
+  });
+
+  it("returns a send failure when GitHub rejects the request", async () => {
+    listPullRequestsAssociatedWithCommit.mockRejectedValue(new Error("API rate limited"));
+
+    await expect(
+      upsertWorkspaceAutomationPullRequestComment({
+        installationId: "1",
+        repositoryFullName: "acme/app",
+        automationId: "auto-1",
+        commitSha: "abc123",
+        message: "Review",
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: {
+        code: "github_comment_send_failed",
+        message: "API rate limited",
+      },
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/github/upsert-workspace-automation-pull-request-comment.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/upsert-workspace-automation-pull-request-comment.ts
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { getInstallationOctokit } from "@/lib/agents/github/app";
+import { err, ok, type Result } from "@/lib/primitives/result/results";
+
+const GITHUB_ISSUE_COMMENT_MAX_LENGTH = 65_536;
+
+export type UpsertWorkspaceAutomationPullRequestCommentSkipCode =
+  | "github_pr_not_found"
+  | "github_commit_not_found";
+
+export type UpsertWorkspaceAutomationPullRequestCommentSuccess =
+  | {
+      status: "created" | "updated";
+      pullRequestNumber: number;
+      commentId: number;
+      url: string;
+    }
+  | {
+      status: "skipped";
+      code: UpsertWorkspaceAutomationPullRequestCommentSkipCode;
+    };
+
+export type UpsertWorkspaceAutomationPullRequestCommentError = {
+  code: "github_comment_send_failed" | "invalid_repository_full_name";
+  message: string;
+};
+
+export function buildWorkspaceAutomationGithubCommentMarker(automationId: string): string {
+  return `<!-- hyperlocalise-automation:${automationId} -->`;
+}
+
+export function commentContainsWorkspaceAutomationMarker(
+  body: string | null | undefined,
+  automationId: string,
+): boolean {
+  if (!body) {
+    return false;
+  }
+
+  return body.includes(buildWorkspaceAutomationGithubCommentMarker(automationId));
+}
+
+export function formatWorkspaceAutomationGithubCommentBody(input: {
+  automationId: string;
+  message: string;
+}): string {
+  const marker = buildWorkspaceAutomationGithubCommentMarker(input.automationId);
+  const message = input.message.trim();
+  const body = `${marker}\n${message}`;
+  if (body.length <= GITHUB_ISSUE_COMMENT_MAX_LENGTH) {
+    return body;
+  }
+
+  const suffix = "\n\n_(Comment truncated.)_";
+  const budget = GITHUB_ISSUE_COMMENT_MAX_LENGTH - marker.length - 1 - suffix.length;
+  return `${marker}\n${message.slice(0, Math.max(budget, 0)).trimEnd()}${suffix}`;
+}
+
+function parseRepositoryFullName(fullName: string): { owner: string; repo: string } | null {
+  const [owner, repo] = fullName.split("/");
+  if (!owner || !repo) {
+    return null;
+  }
+  return { owner, repo };
+}
+
+function isGithubNullOid(sha: string): boolean {
+  return sha.length === 0 || /^0+$/.test(sha);
+}
+
+function preferAssociatedPullRequest(
+  pullRequests: Array<{ number: number; state: string; updated_at: string }>,
+): { number: number; state: string; updated_at: string } | null {
+  if (pullRequests.length === 0) {
+    return null;
+  }
+
+  const ranked = [...pullRequests].toSorted((left, right) => {
+    const leftOpen = left.state === "open" ? 0 : 1;
+    const rightOpen = right.state === "open" ? 0 : 1;
+    if (leftOpen !== rightOpen) {
+      return leftOpen - rightOpen;
+    }
+    return right.updated_at.localeCompare(left.updated_at);
+  });
+
+  return ranked[0] ?? null;
+}
+
+export async function upsertWorkspaceAutomationPullRequestComment(input: {
+  installationId: string;
+  repositoryFullName: string;
+  automationId: string;
+  commitSha: string;
+  message: string;
+}): Promise<
+  Result<
+    UpsertWorkspaceAutomationPullRequestCommentSuccess,
+    UpsertWorkspaceAutomationPullRequestCommentError
+  >
+> {
+  const commitSha = input.commitSha.trim();
+  if (!commitSha || isGithubNullOid(commitSha)) {
+    return ok({ status: "skipped", code: "github_commit_not_found" });
+  }
+
+  const parsed = parseRepositoryFullName(input.repositoryFullName);
+  if (!parsed) {
+    return err({
+      code: "invalid_repository_full_name",
+      message: "GitHub repository full name is invalid.",
+    });
+  }
+
+  try {
+    const octokit = await getInstallationOctokit(input.installationId);
+    const associated = await octokit.rest.repos.listPullRequestsAssociatedWithCommit({
+      owner: parsed.owner,
+      repo: parsed.repo,
+      commit_sha: commitSha,
+    });
+    const pullRequest = preferAssociatedPullRequest(associated.data);
+    if (!pullRequest) {
+      return ok({ status: "skipped", code: "github_pr_not_found" });
+    }
+
+    const comments = await octokit.paginate(octokit.rest.issues.listComments, {
+      owner: parsed.owner,
+      repo: parsed.repo,
+      issue_number: pullRequest.number,
+      per_page: 100,
+    });
+    const existing = comments.find((comment) =>
+      commentContainsWorkspaceAutomationMarker(comment.body, input.automationId),
+    );
+    const body = formatWorkspaceAutomationGithubCommentBody({
+      automationId: input.automationId,
+      message: input.message,
+    });
+
+    if (existing) {
+      const updated = await octokit.rest.issues.updateComment({
+        owner: parsed.owner,
+        repo: parsed.repo,
+        comment_id: existing.id,
+        body,
+      });
+      return ok({
+        status: "updated",
+        pullRequestNumber: pullRequest.number,
+        commentId: updated.data.id,
+        url: updated.data.html_url,
+      });
+    }
+
+    const created = await octokit.rest.issues.createComment({
+      owner: parsed.owner,
+      repo: parsed.repo,
+      issue_number: pullRequest.number,
+      body,
+    });
+    return ok({
+      status: "created",
+      pullRequestNumber: pullRequest.number,
+      commentId: created.data.id,
+      url: created.data.html_url,
+    });
+  } catch (error) {
+    return err({
+      code: "github_comment_send_failed",
+      message: error instanceof Error ? error.message : "GitHub comment failed.",
+    });
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.test.ts
@@ -840,6 +840,67 @@ describe("workspace automation dispatcher", () => {
     });
   });
 
+  it("dispatches GitHub agent automations on matching pushes", async () => {
+    const scope = await seedDispatchScope();
+    const matching = expectOk(
+      await createWorkspaceAutomation({
+        organizationId: scope.organizationId,
+        authorUserId: scope.userId,
+        name: "Notify on push blockers",
+        instructions: "Review localisation risk on this push.",
+        triggerConfig: { mode: "github", branches: ["main"] },
+        repositoryTarget: {
+          kind: "github",
+          githubInstallationRepositoryId: scope.repository.id,
+        },
+        toolConfig: {
+          github: {
+            enabled: true,
+            mode: "agent",
+            pushSource: false,
+            pullTranslations: false,
+            validation: false,
+          },
+          githubComment: { enabled: true },
+        },
+      }),
+    );
+
+    const enqueued: Array<{ workspaceAutomationRunId: string; organizationId: string }> = [];
+    const queue = {
+      async enqueue(event: { workspaceAutomationRunId: string; organizationId: string }) {
+        enqueued.push(event);
+        return { ids: ["workflow-1"] };
+      },
+    };
+
+    const results = await dispatchWorkspaceAutomationsForGithubPush({
+      deliveryId: "delivery-github-agent-1",
+      organizationId: scope.organizationId,
+      githubInstallationRepositoryId: scope.repository.id,
+      branch: "main",
+      commitBefore: "aaa111",
+      commitAfter: "bbb222",
+      queue,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.outcome).toBe("enqueued");
+    expect(enqueued).toHaveLength(1);
+
+    const runs = await listWorkspaceAutomationRuns({
+      automationId: matching.id,
+      organizationId: scope.organizationId,
+    });
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.inputSnapshot).toMatchObject({
+      githubDeliveryId: "delivery-github-agent-1",
+      pushBranch: "main",
+      commitBefore: "aaa111",
+      commitAfter: "bbb222",
+    });
+  });
+
   it("dispatches source-upload automations scoped to the matching project", async () => {
     const scope = await seedDispatchScope();
     const otherProjectId = `project-other-${scope.organizationId.slice(0, 8)}`;

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.ts
@@ -28,7 +28,7 @@ import {
 } from "./workspace-automation-idempotency";
 import {
   hasWorkspaceAutomationGithubWorkflow,
-  workspaceAutomationMatchesPushBranch,
+  workspaceAutomationShouldDispatchOnGithubPush,
 } from "./workspace-automation-github-mapping";
 import {
   advanceWorkspaceAutomationNextRun,
@@ -384,9 +384,7 @@ export async function dispatchWorkspaceAutomationsForGithubPush(input: {
       automation.repositoryTarget.kind === "github" &&
       automation.repositoryTarget.githubInstallationRepositoryId ===
         input.githubInstallationRepositoryId &&
-      automation.triggerConfig.mode === "github" &&
-      workspaceAutomationMatchesPushBranch(automation, input.branch) &&
-      hasWorkspaceAutomationGithubWorkflow(automation.toolConfig),
+      workspaceAutomationShouldDispatchOnGithubPush(automation, input.branch),
   );
 
   const results: WorkspaceAutomationDispatchResult[] = [];

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-github-mapping.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-github-mapping.test.ts
@@ -23,6 +23,7 @@ import {
   hasWorkspaceAutomationGithubWorkflow,
   resolveWorkspaceAutomationGithubMode,
   workspaceAutomationMatchesPushBranch,
+  workspaceAutomationShouldDispatchOnGithubPush,
   workspaceAutomationToGithubSettings,
 } from "./workspace-automation-github-mapping";
 
@@ -215,6 +216,42 @@ describe("workspace automation GitHub mapping", () => {
         automation({
           triggerConfig: { mode: "manual" },
           toolConfig: toolConfig(syncWorkflow),
+        }),
+        "main",
+      ),
+    ).toBe(false);
+  });
+
+  it("dispatches GitHub agent and comment automations on matching pushes", () => {
+    const agentAutomation = automation({
+      triggerConfig: { mode: "github", branches: ["main"] },
+      toolConfig: {
+        github: {
+          enabled: true,
+          mode: "agent",
+          pushSource: false,
+          pullTranslations: false,
+          validation: false,
+        },
+        githubComment: { enabled: true },
+      },
+    });
+
+    expect(workspaceAutomationShouldDispatchOnGithubPush(agentAutomation, "main")).toBe(true);
+    expect(workspaceAutomationShouldDispatchOnGithubPush(agentAutomation, "feature/x")).toBe(false);
+    expect(
+      workspaceAutomationShouldDispatchOnGithubPush(
+        automation({
+          triggerConfig: { mode: "manual" },
+          toolConfig: {
+            github: {
+              enabled: true,
+              mode: "agent",
+              pushSource: false,
+              pullTranslations: false,
+              validation: false,
+            },
+          },
         }),
         "main",
       ),

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-github-mapping.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-github-mapping.ts
@@ -58,6 +58,31 @@ export function hasWorkspaceAutomationGithubTool(
   );
 }
 
+export function hasWorkspaceAutomationGithubCommentTool(
+  toolConfig: WorkspaceAutomationToolConfig,
+): boolean {
+  return Boolean(toolConfig.githubComment?.enabled);
+}
+
+export function workspaceAutomationShouldDispatchOnGithubPush(
+  automation: WorkspaceAutomationRecord,
+  branch: string,
+): boolean {
+  if (automation.repositoryTarget.kind !== "github") {
+    return false;
+  }
+
+  if (!workspaceAutomationMatchesPushBranch(automation, branch)) {
+    return false;
+  }
+
+  return (
+    hasWorkspaceAutomationGithubWorkflow(automation.toolConfig) ||
+    hasWorkspaceAutomationGithubAgentTool(automation.toolConfig) ||
+    hasWorkspaceAutomationGithubCommentTool(automation.toolConfig)
+  );
+}
+
 export function workspaceAutomationToGithubSettings(
   automation: WorkspaceAutomationRecord,
 ): GithubRepositoryAutomationSettings | null {

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.test.ts
@@ -67,6 +67,7 @@ describe("workspace automation templates", () => {
       "summarize-changes-daily",
       "review-code-daily",
       "daily-web-research",
+      "notify-on-push-blockers",
     ]);
   });
 
@@ -187,6 +188,38 @@ describe("workspace automation templates", () => {
       tools: [
         { id: "slack", label: "Slack" },
         { id: "web-search", label: "Web Search" },
+      ],
+    });
+  });
+
+  it("exposes an activatable push localisation-review template", () => {
+    const template = getWorkspaceAutomationTemplate(
+      "notify-on-push-blockers",
+      WORKSPACE_AUTOMATION_TEMPLATES_BASE,
+    );
+
+    expect(template).toMatchObject({
+      id: "notify-on-push-blockers",
+      category: "popular",
+      activatable: true,
+      defaultForm: {
+        triggerMode: "github",
+        pushBranches: ["main"],
+        githubEnabled: true,
+        githubMode: "agent",
+        githubCommentEnabled: true,
+        validationEnabled: false,
+      },
+    });
+    expect(template?.defaultForm.slackEnabled).toBeUndefined();
+    expect(template?.instructions).toContain("You are a localisation-focused code reviewer");
+    expect(template?.instructions).toContain("sticky GitHub pull request comment");
+    expect(template?.instructions).toContain("Review focus:");
+    expect(getWorkspaceAutomationTemplateFlow(template!)).toEqual({
+      trigger: { id: "github-push", label: "GitHub push" },
+      tools: [
+        { id: "github", label: "GitHub" },
+        { id: "github-comment", label: "GitHub comment" },
       ],
     });
   });

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.test.ts
@@ -152,6 +152,9 @@ describe("workspace automation templates", () => {
         slackEnabled: true,
       },
     });
+    expect(template?.instructions).toContain("You are a localisation-focused code reviewer");
+    expect(template?.instructions).toContain("Review focus:");
+    expect(template?.instructions).toContain("locale-compliance");
     expect(getWorkspaceAutomationTemplateFlow(template!)).toEqual({
       trigger: { id: "scheduled", label: "Daily" },
       tools: [

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.test.ts
@@ -64,6 +64,7 @@ describe("workspace automation templates", () => {
     ).toEqual([
       "translate-on-source-upload",
       "translate-contentful-article",
+      "summarize-changes-daily",
       "review-code-daily",
       "daily-web-research",
     ]);
@@ -100,6 +101,35 @@ describe("workspace automation templates", () => {
       tools: [
         { id: "create-job", label: "Create job" },
         { id: "translate-with-agent", label: "Translate with agent" },
+      ],
+    });
+  });
+
+  it("exposes an activatable daily localisation digest template", () => {
+    const template = getWorkspaceAutomationTemplate(
+      "summarize-changes-daily",
+      WORKSPACE_AUTOMATION_TEMPLATES_BASE,
+    );
+
+    expect(template).toMatchObject({
+      id: "summarize-changes-daily",
+      category: "popular",
+      activatable: true,
+      defaultForm: {
+        triggerMode: "scheduled",
+        scheduledCadence: "daily",
+        githubEnabled: true,
+        githubMode: "agent",
+        slackEnabled: true,
+      },
+    });
+    expect(template?.instructions).toContain("You are a daily localisation briefing agent");
+    expect(template?.instructions).toContain("Digest focus:");
+    expect(getWorkspaceAutomationTemplateFlow(template!)).toEqual({
+      trigger: { id: "scheduled", label: "Daily" },
+      tools: [
+        { id: "github", label: "GitHub" },
+        { id: "slack", label: "Slack" },
       ],
     });
   });

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
@@ -623,25 +623,43 @@ export const WORKSPACE_AUTOMATION_TEMPLATES_BASE: WorkspaceAutomationTemplate[] 
     id: "notify-on-push-blockers",
     category: "popular",
     name: "Notify on push blockers",
-    description: "Validate every push and ping Slack when localisation blockers are found.",
+    description:
+      "Review each GitHub push for localisation and translation risk, then comment on the pull request.",
     instructions: formatWorkspaceAutomationTemplateInstructions({
-      role: "a localisation incident notifier",
+      role: "a localisation-focused code reviewer for this repository",
       capabilities: [
-        "Validate localisation changes on every push",
-        "Notify Slack when required locales lose coverage",
-        "Notify Slack when placeholders, ICU syntax, or unsafe markup fail validation",
-        "Skip notifications for clean runs unless configured otherwise",
+        "Read the pushed commits, diffs, and surrounding code",
+        "Judge localisation, translation, and locale-compliance risk in the changed code",
+        "Cite commit SHAs and file paths for each finding",
+        "Separate blocking localisation defects from non-blocking follow-ups",
+        "Ignore unrelated logic, security, and formatting issues unless they affect user-facing copy or locale behavior",
+        "Post findings as a sticky GitHub pull request comment and update it on later pushes",
       ],
-      goal: "Alert the team only when a push introduces localisation blockers.",
+      goal: "Surface localisation and translation risks from this push on the pull request before they merge.",
+      extraSections: [
+        {
+          heading: "Review focus",
+          items: [
+            "Hard-coded copy, missing keys, and source strings that cannot be translated",
+            "Broken ICU, placeholders, plurals, and locale-sensitive formatting",
+            "Translation coverage, fallback, and writeback regressions",
+            "Localisation compliance: locale, RTL, legal, and market-language constraints",
+          ],
+        },
+      ],
     }),
-    activatable: false,
+    activatable: true,
     defaultForm: {
       name: "Notify on push blockers",
       triggerMode: "github",
       pushBranches: ["main"],
       githubEnabled: true,
-      validationEnabled: true,
-      slackEnabled: true,
+      githubMode: "agent",
+      repositoryTargetKind: "github",
+      pushSourceEnabled: false,
+      pullTranslationsEnabled: false,
+      validationEnabled: false,
+      githubCommentEnabled: true,
     },
   },
   {
@@ -910,6 +928,10 @@ export function getWorkspaceAutomationTemplateFlow(
 
   if (form.emailEnabled) {
     tools.push({ id: "email", label: "Email" });
+  }
+
+  if (form.githubCommentEnabled) {
+    tools.push({ id: "github-comment", label: "GitHub comment" });
   }
 
   if (form.contentfulEnabled) {

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
@@ -160,19 +160,30 @@ export const WORKSPACE_AUTOMATION_TEMPLATES_BASE: WorkspaceAutomationTemplate[] 
     category: "popular",
     name: "Summarize changes daily",
     description:
-      "Read a GitHub repository each day and post a concise digest of what changed to Slack.",
+      "Read a GitHub repository each day and post a concise Slack digest of localisation-related changes.",
     instructions: formatWorkspaceAutomationTemplateInstructions({
-      role: "a daily engineering briefing agent",
+      role: "a daily localisation briefing agent",
       capabilities: [
         "Read recent commits, diffs, and surrounding files in the lookback window",
-        "Group changes by theme: features, fixes, refactors, docs, and infrastructure",
+        "Keep the digest scoped to localisation, i18n, and translation work",
         "Cite commit SHAs and file paths for specific claims",
-        "Call out follow-ups such as missing tests, rollout risk, or incomplete migrations",
-        "Ignore dependency-only bumps and formatting-only churn unless they change runtime behavior",
+        "Call out coverage gaps, ICU or placeholder risk, and incomplete translation syncs",
+        "Ignore unrelated feature, infrastructure, and formatting work unless it changes user-facing copy or locale files",
       ],
-      goal: "Post a concise digest of what changed so the team can stay aligned without reading every commit.",
+      goal: "Post a concise digest of localisation-related changes so the team can stay aligned without reading every commit.",
+      extraSections: [
+        {
+          heading: "Digest focus",
+          items: [
+            "New or updated source strings and message catalogs",
+            "Translation file, locale resource, and coverage changes",
+            "ICU, placeholder, glossary, and i18n config updates",
+            "Localisation-related PRs, syncs, and release risks",
+          ],
+        },
+      ],
     }),
-    activatable: false,
+    activatable: true,
     defaultForm: {
       name: "Summarize changes daily",
       triggerMode: "scheduled",

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
@@ -204,25 +204,25 @@ export const WORKSPACE_AUTOMATION_TEMPLATES_BASE: WorkspaceAutomationTemplate[] 
     category: "popular",
     name: "Review code daily",
     description:
-      "Read recent repository changes each day, review them for defects, and post findings to Slack.",
+      "Read recent repository changes each day, review them for localisation and translation risk, and post findings to Slack.",
     instructions: formatWorkspaceAutomationTemplateInstructions({
-      role: "a staff code reviewer for this repository",
+      role: "a localisation-focused code reviewer for this repository",
       capabilities: [
         "Read recent commits, diffs, and surrounding code in the lookback window",
-        "Judge correctness, regressions, missing tests, security, and rollout risk",
+        "Judge localisation, translation, and locale-compliance risk in the changed code",
         "Cite commit SHAs and file paths for each finding",
-        "Separate blocking defects from non-blocking follow-ups",
-        "Ignore formatting-only churn unless it hides a real defect",
+        "Separate blocking localisation defects from non-blocking follow-ups",
+        "Ignore unrelated logic, security, and formatting issues unless they affect user-facing copy or locale behavior",
       ],
-      goal: "Surface the highest-risk changes from the last day so the team can act before they ship further.",
+      goal: "Surface localisation and translation risks from the last day so the team can act before they ship further.",
       extraSections: [
         {
           heading: "Review focus",
           items: [
-            "Logic bugs, broken contracts, and missing error handling",
-            "Security, auth, and data-exposure risks",
-            "Missing or weakened tests around the changed behavior",
-            "Rollout, migration, and backwards-compatibility risk",
+            "Hard-coded copy, missing keys, and source strings that cannot be translated",
+            "Broken ICU, placeholders, plurals, and locale-sensitive formatting",
+            "Translation coverage, fallback, and writeback regressions",
+            "Localisation compliance: locale, RTL, legal, and market-language constraints",
           ],
         },
       ],

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
@@ -229,7 +229,8 @@ describe("workspace automation view model", () => {
       slackEnabled: true,
       webSearchEnabled: false,
     });
-    expect(form?.instructions).toContain("You are a staff code reviewer");
+    expect(form?.instructions).toContain("You are a localisation-focused code reviewer");
+    expect(form?.instructions).toContain("Review focus:");
     expect(
       validateWorkspaceAutomationFormState({
         ...form!,

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
@@ -59,9 +59,6 @@ describe("workspace automation view model", () => {
       ),
     ).toBe(null);
     expect(
-      createWorkspaceAutomationFormStateFromTemplate("summarize-changes-daily", mergedTemplates),
-    ).toBe(null);
-    expect(
       createWorkspaceAutomationFormStateFromTemplate(
         "create-localisation-job-brief",
         mergedTemplates,
@@ -196,17 +193,25 @@ describe("workspace automation view model", () => {
     expect(form?.instructions).toContain("You are a Contentful localisation editor");
   });
 
-  it("keeps summarize changes daily as coming soon", () => {
-    const template = getWorkspaceAutomationTemplate("summarize-changes-daily", mergedTemplates);
-    expect(template).toMatchObject({
+  it("prefills the summarize changes daily template", () => {
+    const form = createWorkspaceAutomationFormStateFromTemplate(
+      "summarize-changes-daily",
+      mergedTemplates,
+    );
+
+    expect(form).toMatchObject({
       name: "Summarize changes daily",
-      activatable: false,
-      defaultForm: {
-        triggerMode: "scheduled",
-        githubMode: "agent",
-      },
+      triggerMode: "scheduled",
+      scheduledCadence: "daily",
+      githubEnabled: true,
+      githubMode: "agent",
+      slackEnabled: true,
+      pushSourceEnabled: false,
+      pullTranslationsEnabled: false,
+      validationEnabled: false,
     });
-    expect(template?.instructions).toContain("You are a daily engineering briefing agent");
+    expect(form?.instructions).toContain("You are a daily localisation briefing agent");
+    expect(form?.instructions).toContain("Digest focus:");
   });
 
   it("prefills the daily code-review template", () => {

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
@@ -262,6 +262,68 @@ describe("workspace automation view model", () => {
     });
   });
 
+  it("prefills the notify on push blockers template", () => {
+    const form = createWorkspaceAutomationFormStateFromTemplate(
+      "notify-on-push-blockers",
+      mergedTemplates,
+    );
+
+    expect(form).toMatchObject({
+      name: "Notify on push blockers",
+      triggerMode: "github",
+      pushBranches: ["main"],
+      githubEnabled: true,
+      githubMode: "agent",
+      githubCommentEnabled: true,
+      slackEnabled: false,
+      validationEnabled: false,
+    });
+    expect(form?.instructions).toContain("You are a localisation-focused code reviewer");
+    expect(form?.instructions).toContain("Review focus:");
+    expect(
+      validateWorkspaceAutomationFormState({
+        ...form!,
+        githubInstallationRepositoryId: "11111111-1111-4111-8111-111111111111",
+      }),
+    ).toEqual({});
+    expect(formStateToWorkspaceAutomationPayload(form!).toolConfig.githubComment).toEqual({
+      enabled: true,
+    });
+  });
+
+  it("allows GitHub agent mode with a GitHub push trigger", () => {
+    const form = {
+      ...createDefaultWorkspaceAutomationFormState(),
+      name: "Notify on push blockers",
+      instructions: "Review localisation risk on this push.",
+      triggerMode: "github" as const,
+      pushBranches: ["main"],
+      githubEnabled: true,
+      githubMode: "agent" as const,
+      githubInstallationRepositoryId: "11111111-1111-4111-8111-111111111111",
+      githubCommentEnabled: true,
+    };
+
+    expect(validateWorkspaceAutomationFormState(form)).toEqual({});
+    expect(formStateToWorkspaceAutomationPayload(form)).toMatchObject({
+      triggerConfig: { mode: "github", branches: ["main"] },
+      repositoryTarget: {
+        kind: "github",
+        githubInstallationRepositoryId: "11111111-1111-4111-8111-111111111111",
+      },
+      toolConfig: {
+        github: {
+          enabled: true,
+          mode: "agent",
+          pushSource: false,
+          pullTranslations: false,
+          validation: false,
+        },
+        githubComment: { enabled: true },
+      },
+    });
+  });
+
   it("validates GitHub agent mode without a Hyperlocalise project", () => {
     const form = {
       ...createDefaultWorkspaceAutomationFormState(),

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
@@ -52,6 +52,7 @@ export type WorkspaceAutomationFormState = {
   slackChannelId: string;
   emailEnabled: boolean;
   emailRecipients: string[];
+  githubCommentEnabled: boolean;
   contentfulEnabled: boolean;
   contentfulConnectionId: string;
   contentfulSourceLocale: string;
@@ -126,7 +127,7 @@ export const WORKSPACE_AUTOMATION_API_ERROR_MESSAGES: Record<string, string> = {
   translation_project_required: "Choose a Hyperlocalise project for this automation.",
   github_trigger_required: "Choose a schedule or GitHub push trigger for GitHub workflows.",
   github_agent_trigger_required:
-    "Use GitHub repo automations with a scheduled or manual trigger, not GitHub push.",
+    "Use GitHub repo automations with a scheduled, manual, or GitHub push trigger.",
   github_push_branches_required: "Add at least one branch pattern for GitHub push triggers.",
   scheduled_workflow_required:
     "Scheduled automations require at least one GitHub, Contentful, Issues, or Web Search workflow tool.",
@@ -181,6 +182,7 @@ export function createDefaultWorkspaceAutomationFormState(): WorkspaceAutomation
     slackChannelId: "",
     emailEnabled: false,
     emailRecipients: [],
+    githubCommentEnabled: false,
     contentfulEnabled: false,
     contentfulConnectionId: "",
     contentfulSourceLocale: "en",
@@ -265,6 +267,7 @@ export function createWorkspaceAutomationFormStateFromRecord(
     slackChannelId: slack?.channelId ?? "",
     emailEnabled: Boolean(email?.enabled),
     emailRecipients: email?.recipients ? [...email.recipients] : [],
+    githubCommentEnabled: Boolean(automation.toolConfig.githubComment?.enabled),
     contentfulEnabled: Boolean(contentful?.enabled),
     contentfulConnectionId: contentful?.connectionId ?? "",
     contentfulSourceLocale: contentful?.sourceLocale ?? "en",
@@ -382,7 +385,7 @@ export function formStateToWorkspaceAutomationPayload(form: WorkspaceAutomationF
             : { mode: "manual" };
 
   const repositoryTarget: WorkspaceAutomationRepositoryTarget =
-    form.githubEnabled && form.githubInstallationRepositoryId
+    (form.githubEnabled || form.githubCommentEnabled) && form.githubInstallationRepositoryId
       ? {
           kind: "github",
           githubInstallationRepositoryId: form.githubInstallationRepositoryId,
@@ -414,6 +417,13 @@ export function formStateToWorkspaceAutomationPayload(form: WorkspaceAutomationF
           email: {
             enabled: true,
             recipients: form.emailRecipients,
+          },
+        }
+      : {}),
+    ...(form.githubCommentEnabled
+      ? {
+          githubComment: {
+            enabled: true,
           },
         }
       : {}),
@@ -551,13 +561,13 @@ export function validateWorkspaceAutomationFormState(
       if (form.triggerMode === "manual") {
         errors.trigger = "Choose a schedule or GitHub push trigger.";
       }
-      if (form.triggerMode === "github" && form.pushBranches.length === 0) {
-        errors.pushBranches = "Add at least one branch pattern.";
-      }
-    } else if (form.triggerMode === "github") {
-      errors.trigger =
-        "Use GitHub repo automations with a scheduled or manual trigger, not GitHub push.";
     }
+  } else if (form.githubCommentEnabled && !form.githubInstallationRepositoryId) {
+    errors.githubRepository = "Choose a GitHub repository.";
+  }
+
+  if (form.triggerMode === "github" && form.pushBranches.length === 0) {
+    errors.pushBranches = "Add at least one branch pattern.";
   }
 
   if (form.slackEnabled && !form.slackChannelId.trim()) {
@@ -676,6 +686,7 @@ export function workspaceAutomationFormCanActivate(form: WorkspaceAutomationForm
     form.githubEnabled ||
     form.slackEnabled ||
     form.emailEnabled ||
+    form.githubCommentEnabled ||
     form.contentfulEnabled ||
     form.createNativeTmsJobEnabled ||
     form.assignTranslateWithAgentEnabled ||

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
@@ -341,6 +341,38 @@ describe("workspace automations", () => {
     expect(missingProject.error.code).toBe("project_required");
   });
 
+  it("creates GitHub agent automations with a push trigger and comment tool", async () => {
+    const scope = await seedWorkspaceAutomationScope();
+
+    const automation = expectOk(
+      await createWorkspaceAutomation({
+        organizationId: scope.organizationId,
+        authorUserId: scope.userId,
+        name: "Notify on push blockers",
+        instructions: "Review localisation risk on this push.",
+        triggerConfig: { mode: "github", branches: ["main"] },
+        repositoryTarget: {
+          kind: "github",
+          githubInstallationRepositoryId: scope.githubInstallationRepositoryId,
+        },
+        toolConfig: {
+          github: {
+            enabled: true,
+            mode: "agent",
+            pushSource: false,
+            pullTranslations: false,
+            validation: false,
+          },
+          githubComment: { enabled: true },
+        },
+      }),
+    );
+
+    expect(automation.triggerConfig).toEqual({ mode: "github", branches: ["main"] });
+    expect(automation.toolConfig.github).toMatchObject({ enabled: true, mode: "agent" });
+    expect(automation.toolConfig.githubComment).toEqual({ enabled: true });
+  });
+
   it("rejects scheduled automations without a GitHub or Contentful workflow", async () => {
     const scope = await seedWorkspaceAutomationScope();
     const triggerConfig = {

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -105,6 +105,12 @@ const emailToolConfigSchema = z
   })
   .default({ enabled: false });
 
+const githubCommentToolConfigSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+  })
+  .default({ enabled: false });
+
 const contentfulToolConfigSchema = z
   .object({
     enabled: z.boolean().default(false),
@@ -242,6 +248,7 @@ const toolConfigObjectSchema = z
     github: githubToolConfigSchema.optional(),
     slack: slackToolConfigSchema.optional(),
     email: emailToolConfigSchema.optional(),
+    githubComment: githubCommentToolConfigSchema.optional(),
     contentful: contentfulToolConfigSchema.optional(),
     createNativeTmsJob: createNativeTmsJobToolConfigSchema.optional(),
     assignTranslateWithAgent: assignTranslateWithAgentToolConfigSchema.optional(),
@@ -278,6 +285,9 @@ export type WorkspaceAutomationTriggerConfig = z.infer<typeof triggerConfigSchem
 export type WorkspaceAutomationRepositoryTarget = z.infer<typeof repositoryTargetSchema>;
 export type WorkspaceAutomationSlackToolConfig = z.infer<typeof slackToolConfigSchema>;
 export type WorkspaceAutomationEmailToolConfig = z.infer<typeof emailToolConfigSchema>;
+export type WorkspaceAutomationGithubCommentToolConfig = z.infer<
+  typeof githubCommentToolConfigSchema
+>;
 export type WorkspaceAutomationContentfulToolConfig = z.infer<typeof contentfulToolConfigSchema>;
 export type WorkspaceAutomationCreateNativeTmsJobToolConfig = z.infer<
   typeof createNativeTmsJobToolConfigSchema
@@ -587,7 +597,8 @@ function validateWorkspaceAutomationConfig(input: {
   }
 
   const githubTools = input.toolConfig.github;
-  if (githubTools?.enabled) {
+  const githubCommentEnabled = Boolean(input.toolConfig.githubComment?.enabled);
+  if (githubTools?.enabled || githubCommentEnabled) {
     if (
       input.repositoryTarget.kind !== "github" ||
       !input.repositoryTarget.githubInstallationRepositoryId
@@ -597,25 +608,16 @@ function validateWorkspaceAutomationConfig(input: {
         message: "Enabled GitHub tools require a GitHub repository target.",
       });
     }
+  }
 
-    const githubMode = githubTools.mode ?? "sync";
-
-    if (githubMode === "agent") {
-      if (input.triggerConfig.mode === "github") {
-        return err({
-          code: "github_agent_trigger_required",
-          message: "GitHub repo agent automations support scheduled or manual triggers only.",
-        });
-      }
-    } else if (
-      input.triggerConfig.mode === "github" &&
-      (!input.triggerConfig.branches || input.triggerConfig.branches.length === 0)
-    ) {
-      return err({
-        code: "github_push_branches_required",
-        message: "GitHub push triggers require at least one branch pattern.",
-      });
-    }
+  if (
+    input.triggerConfig.mode === "github" &&
+    (!input.triggerConfig.branches || input.triggerConfig.branches.length === 0)
+  ) {
+    return err({
+      code: "github_push_branches_required",
+      message: "GitHub push triggers require at least one branch pattern.",
+    });
   }
 
   if (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Activate localisation-focused workspace automations in Popular:

- **Summarize changes daily** posts a Slack digest of source strings, locale files, ICU/placeholder risk, i18n config, and translation syncs.
- **Review code daily** reviews localisation implications: untranslatable copy, ICU/placeholder defects, translation coverage regressions, and locale, RTL, legal, or market-language compliance.
- **Notify on push blockers** is now activatable too. It is the same localisation review as Review code daily, but it runs on GitHub push (default `main`) and upserts a sticky pull request comment instead of posting to Slack.

The GitHub repository agent inspects the pushed commit range on GitHub triggers, and GitHub agent automations may use a push trigger.

## How to test

- Open Automations → Popular.
- Confirm **Summarize changes daily** and **Review code daily** show **Use template** and prefill localisation Slack flows.
- Confirm **Notify on push blockers** shows **Use template** (not Coming soon), prefills GitHub push + GitHub agent + PR comment, and does not require Slack.
- From `apps/hyperlocalise-web`:
  - `vp test src/lib/agents/github/upsert-workspace-automation-pull-request-comment.test.ts src/lib/agents/workspace-automation-templates.test.ts src/lib/agents/workspace-automation-view-model.test.ts src/lib/agents/workspace-automation-github-mapping.test.ts src/lib/agents/workspace-automation-dispatcher.test.ts src/lib/agents/workspace-automations.test.ts src/agents/automations/workspace/agent/plan.test.ts src/agents/automations/workspace/agent/compose-workspace-instructions.test.ts src/agents/automations/workspace/agent/run-workspace-orchestrator.test.ts src/agents/automations/workspace/agent/tools/resolve-github-repo-lookback.test.ts src/agents/automations/workspace/agent/workspace-template-manifest.test.ts src/agents/automations/workspace/agent/workspace-orchestrator-output-summary.test.ts`
  - `vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`vp test` on changed automation files, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f5de270-111c-4cf8-8159-8a203b98317a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f5de270-111c-4cf8-8159-8a203b98317a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

