### PR TITLE
feat(automations): add Crowdin review tool for agent automation

### DIFF
--- a/apps/hyperlocalise-web/src/agents/_runtime/define-agent-tool.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/define-agent-tool.ts
@@ -13,11 +13,15 @@
 import { tool, type Tool } from "ai";
 import type { z } from "zod";
 
+export type AgentToolExecuteOptions = {
+  abortSignal?: AbortSignal;
+};
+
 type DefineAgentToolInput<INPUT, OUTPUT> = {
   description: string;
   inputSchema: z.ZodType<INPUT>;
   outputSchema?: z.ZodType<OUTPUT>;
-  execute: (input: INPUT) => Promise<OUTPUT>;
+  execute: (input: INPUT, options?: AgentToolExecuteOptions) => Promise<OUTPUT>;
 };
 
 export function defineAgentTool<INPUT, OUTPUT = unknown>(

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/build-workspace-orchestrator-tools.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/build-workspace-orchestrator-tools.ts
@@ -25,6 +25,7 @@ import { createRunContentfulTranslationTool } from "./tools/run_contentful_trans
 import { createRunGithubWorkflowsTool } from "./tools/run_github_workflows";
 import { createSaveMemoryTool } from "./tools/save_memory";
 import { createUseAhrefsTool } from "./tools/use_ahrefs";
+import { createUseCrowdinTool } from "./tools/use_crowdin";
 import { createUseGithubRepositoryTool } from "./tools/use_github_repository";
 import { createUseSemrushTool } from "./tools/use_semrush";
 import { createUseWebSearchTool } from "./tools/use_web_search";
@@ -40,6 +41,7 @@ const TOOL_BUILDERS: Record<
   assign_translate_with_agent: createAssignTranslateWithAgentTool,
   list_issues: createListIssuesTool,
   create_issue: createCreateIssueTool,
+  use_crowdin: createUseCrowdinTool,
   use_semrush: createUseSemrushTool,
   use_ahrefs: createUseAhrefsTool,
   use_web_search: createUseWebSearchTool,

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/compose-workspace-instructions.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/compose-workspace-instructions.test.ts
@@ -50,6 +50,17 @@ describe("composeWorkspaceAutomationInstructions", () => {
     expect(instructions).not.toContain("save_memory tool");
   });
 
+  it("tells the orchestrator how to call use_crowdin when it is planned", () => {
+    const instructions = composeWorkspaceAutomationInstructions({
+      triggerMode: "scheduled",
+      plan: { tools: ["use_github_repository", "use_crowdin", "notify_slack"] },
+      userOverride: "Review user-facing strings.",
+    });
+
+    expect(instructions).toContain("When calling use_crowdin");
+    expect(instructions).toContain("search concordance");
+  });
+
   it("omits the Slack notifications skill when notify_slack is not planned", () => {
     const instructions = composeWorkspaceAutomationInstructions({
       triggerMode: "manual",

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/compose-workspace-instructions.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/compose-workspace-instructions.ts
@@ -37,6 +37,9 @@ export function composeWorkspaceAutomationInstructions(input: {
     hasSaveMemory
       ? "You have a save_memory tool. Use it only when this automation's own instructions say to remember something."
       : null,
+    input.plan.tools.includes("use_crowdin")
+      ? "When calling use_crowdin, pass source strings, source and target locales, and surrounding context from earlier steps (especially use_github_repository). Ask it to search concordance, load style guidance, and recommend translations that help the review."
+      : null,
     "Call each planned tool in order. Use customer instructions when invoking workflow tools.",
   ]
     .filter((line): line is string => Boolean(line))

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.test.ts
@@ -179,6 +179,45 @@ describe("buildWorkspaceOrchestratorPlan", () => {
     expect(plan.tools).toEqual(["use_ahrefs", "notify_slack"]);
   });
 
+  it("plans use_crowdin after GitHub tools when a Crowdin project is enabled", () => {
+    const plan = buildWorkspaceOrchestratorPlan(
+      automation({
+        toolConfig: {
+          github: {
+            enabled: true,
+            mode: "agent",
+            pushSource: false,
+            pullTranslations: false,
+            validation: false,
+          },
+          crowdin: {
+            enabled: true,
+            projectId: "ext:crowdin:42",
+          },
+          slack: { enabled: true, channelId: "C123" },
+        },
+      }),
+    );
+
+    expect(plan.tools).toEqual(["use_github_repository", "use_crowdin", "notify_slack"]);
+  });
+
+  it("includes use_crowdin when a Crowdin project is enabled", () => {
+    const plan = buildWorkspaceOrchestratorPlan(
+      automation({
+        toolConfig: {
+          crowdin: {
+            enabled: true,
+            projectId: "ext:crowdin:42",
+          },
+          slack: { enabled: true, channelId: "C123" },
+        },
+      }),
+    );
+
+    expect(plan.tools).toEqual(["use_crowdin", "notify_slack"]);
+  });
+
   it("includes use_web_search when Web Search is enabled", () => {
     const plan = buildWorkspaceOrchestratorPlan(
       automation({

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/plan.ts
@@ -35,6 +35,7 @@ export const WORKSPACE_ORCHESTRATOR_TOOL_NAMES = [
   "assign_translate_with_agent",
   "list_issues",
   "create_issue",
+  "use_crowdin",
   "use_semrush",
   "use_ahrefs",
   "use_web_search",
@@ -62,6 +63,7 @@ const WORKFLOW_TOOLS: WorkspaceOrchestratorToolName[] = [
   "assign_translate_with_agent",
   "list_issues",
   "create_issue",
+  "use_crowdin",
   "use_semrush",
   "use_ahrefs",
   "use_web_search",
@@ -94,6 +96,8 @@ function workflowToolEnabled(
       return hasWorkspaceAutomationListIssuesTool(toolConfig);
     case "create_issue":
       return hasWorkspaceAutomationCreateIssueTool(toolConfig);
+    case "use_crowdin":
+      return Boolean(toolConfig.crowdin?.enabled && toolConfig.crowdin.projectId?.trim());
     case "use_semrush":
       return Boolean(toolConfig.semrush?.enabled && toolConfig.semrush.connectionId);
     case "use_ahrefs":
@@ -145,6 +149,7 @@ function orderWorkflowTools(input: {
       ...enabled.filter((tool) => tool === "assign_translate_with_agent"),
       ...enabled.filter((tool) => tool === "list_issues"),
       ...enabled.filter((tool) => tool === "create_issue"),
+      ...enabled.filter((tool) => tool === "use_crowdin"),
       ...enabled.filter((tool) => tool === "use_semrush"),
       ...enabled.filter((tool) => tool === "use_ahrefs"),
       ...enabled.filter((tool) => tool === "use_web_search"),
@@ -159,6 +164,7 @@ function orderWorkflowTools(input: {
     ...enabled.filter((tool) => tool === "assign_translate_with_agent"),
     ...enabled.filter((tool) => tool === "list_issues"),
     ...enabled.filter((tool) => tool === "create_issue"),
+    ...enabled.filter((tool) => tool === "use_crowdin"),
     ...enabled.filter((tool) => tool === "use_semrush"),
     ...enabled.filter((tool) => tool === "use_ahrefs"),
     ...enabled.filter((tool) => tool === "use_web_search"),

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/summary-message.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/summary-message.test.ts
@@ -144,4 +144,43 @@ describe("buildOrchestratorRunSummaryMessage", () => {
 
     expect(message).toBe("Daily digest: 3 PRs merged.");
   });
+
+  it("appends Crowdin review under a GitHub digest when both exist", () => {
+    const message = buildOrchestratorRunSummaryMessage(
+      createSession({
+        stepResults: {
+          use_github_repository: {
+            digest: "Daily digest: 3 PRs merged.",
+          },
+          use_crowdin: {
+            summary: "Glossary prefers Speichern for Save.",
+          },
+        },
+      }),
+    );
+
+    expect(message).toBe(
+      [
+        "Daily digest: 3 PRs merged.",
+        "",
+        "## Crowdin review",
+        "",
+        "Glossary prefers Speichern for Save.",
+      ].join("\n"),
+    );
+  });
+
+  it("returns the Crowdin summary when there is no GitHub digest", () => {
+    const message = buildOrchestratorRunSummaryMessage(
+      createSession({
+        stepResults: {
+          use_crowdin: {
+            summary: "Glossary prefers Speichern for Save.",
+          },
+        },
+      }),
+    );
+
+    expect(message).toBe("Glossary prefers Speichern for Save.");
+  });
 });

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/summary-message.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/summary-message.ts
@@ -110,8 +110,21 @@ function buildNativeTmsSummary(session: WorkspaceOrchestratorSession): string | 
 
 export function buildOrchestratorRunSummaryMessage(session: WorkspaceOrchestratorSession) {
   const githubAgentResult = session.stepResults.use_github_repository;
-  if (githubAgentResult && typeof githubAgentResult.digest === "string") {
-    return githubAgentResult.digest.trim();
+  const githubDigest =
+    githubAgentResult && typeof githubAgentResult.digest === "string"
+      ? githubAgentResult.digest.trim()
+      : null;
+  const crowdinSummary = asString(session.stepResults.use_crowdin?.summary);
+
+  if (githubDigest) {
+    if (crowdinSummary) {
+      return `${githubDigest}\n\n## Crowdin review\n\n${crowdinSummary}`;
+    }
+    return githubDigest;
+  }
+
+  if (crowdinSummary) {
+    return crowdinSummary;
   }
 
   const nativeTmsSummary = buildNativeTmsSummary(session);

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/crowdin-review-tools.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/crowdin-review-tools.test.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { ok } from "@/lib/primitives/result/results";
+
+import { createCrowdinReviewTools } from "./crowdin-review-tools";
+
+const mocks = vi.hoisted(() => ({
+  searchConcordanceForAgent: vi.fn(),
+  loadStyleGuideForAgent: vi.fn(),
+  generateCatAiRecommendation: vi.fn(),
+  select: vi.fn(),
+  from: vi.fn(),
+  where: vi.fn(),
+  limit: vi.fn(),
+}));
+
+vi.mock("@/lib/providers/adapters/crowdin/crowdin-provider", () => ({
+  crowdinTmsProvider: {
+    searchConcordanceForAgent: (...args: unknown[]) => mocks.searchConcordanceForAgent(...args),
+    loadStyleGuideForAgent: (...args: unknown[]) => mocks.loadStyleGuideForAgent(...args),
+  },
+}));
+
+vi.mock("@/lib/translation/cat", () => ({
+  generateCatAiRecommendation: (...args: unknown[]) => mocks.generateCatAiRecommendation(...args),
+}));
+
+vi.mock("@/lib/database", () => ({
+  db: {
+    select: (...args: unknown[]) => mocks.select(...args),
+  },
+  schema: {
+    projects: {
+      name: "name",
+      translationContext: "translation_context",
+      organizationId: "organization_id",
+      id: "id",
+    },
+  },
+}));
+
+describe("createCrowdinReviewTools", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.select.mockReturnValue({ from: mocks.from });
+    mocks.from.mockReturnValue({ where: mocks.where });
+    mocks.where.mockReturnValue({ limit: mocks.limit });
+    mocks.limit.mockResolvedValue([
+      { name: "Marketing", translationContext: "Use sentence case." },
+    ]);
+  });
+
+  it("searches concordance through the Crowdin provider", async () => {
+    mocks.searchConcordanceForAgent.mockResolvedValue(
+      ok({
+        crowdinProjectId: 42,
+        glossaryMatches: [],
+        translationMemoryMatches: [],
+      }),
+    );
+    const tools = createCrowdinReviewTools({
+      organizationId: "org-1",
+      projectId: "ext:crowdin:42",
+      actorUserId: "user-1",
+    });
+
+    const result = await tools.search_concordance.execute!(
+      {
+        expressions: ["Save"],
+        sourceLocale: "en",
+        targetLocale: "de",
+      },
+      { toolCallId: "call-1", messages: [], context: {} },
+    );
+
+    expect(mocks.searchConcordanceForAgent).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      actorUserId: "user-1",
+      projectId: "ext:crowdin:42",
+      sourceLocale: "en",
+      targetLocale: "de",
+      expressions: ["Save"],
+    });
+    expect(result).toMatchObject({ success: true, crowdinProjectId: 42 });
+  });
+
+  it("loads project translation context with Crowdin style prompts", async () => {
+    mocks.loadStyleGuideForAgent.mockResolvedValue(
+      ok({
+        crowdinProjectId: 42,
+        prompts: [{ id: 1, name: "Brand voice", action: "assist", prompt: "Keep it short." }],
+      }),
+    );
+    const tools = createCrowdinReviewTools({
+      organizationId: "org-1",
+      projectId: "ext:crowdin:42",
+      actorUserId: "user-1",
+    });
+
+    const result = await tools.get_style_guide.execute!(
+      {},
+      { toolCallId: "call-2", messages: [], context: {} },
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      projectName: "Marketing",
+      translationContext: "Use sentence case.",
+      prompts: [{ id: 1, name: "Brand voice" }],
+    });
+  });
+
+  it("recommends a translation through the CAT engine", async () => {
+    mocks.generateCatAiRecommendation.mockResolvedValue(
+      ok({ aiSuggestion: "Speichern", aiReasoning: "Glossary prefers Speichern." }),
+    );
+    const tools = createCrowdinReviewTools({
+      organizationId: "org-1",
+      projectId: "ext:crowdin:42",
+      actorUserId: "user-1",
+    });
+
+    const result = await tools.recommend_translation.execute!(
+      {
+        sourceText: "Save",
+        sourceLocale: "en",
+        targetLocale: "de",
+      },
+      { toolCallId: "call-3", messages: [], context: {} },
+    );
+
+    expect(mocks.generateCatAiRecommendation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "ext:crowdin:42",
+        organizationId: "org-1",
+        sourceText: "Save",
+        sourceLocale: "en",
+        targetLocale: "de",
+      }),
+    );
+    expect(result).toEqual({
+      success: true,
+      suggestion: "Speichern",
+      reasoning: "Glossary prefers Speichern.",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/crowdin-review-tools.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/crowdin-review-tools.test.ts
@@ -12,7 +12,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-import { ok } from "@/lib/primitives/result/results";
+import { err, ok } from "@/lib/primitives/result/results";
 
 import { createCrowdinReviewTools } from "./crowdin-review-tools";
 
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   searchConcordanceForAgent: vi.fn(),
   loadStyleGuideForAgent: vi.fn(),
   generateCatAiRecommendation: vi.fn(),
+  ensureOrganizationProjectRecord: vi.fn(),
   select: vi.fn(),
   from: vi.fn(),
   where: vi.fn(),
@@ -35,6 +36,11 @@ vi.mock("@/lib/providers/adapters/crowdin/crowdin-provider", () => ({
 
 vi.mock("@/lib/translation/cat", () => ({
   generateCatAiRecommendation: (...args: unknown[]) => mocks.generateCatAiRecommendation(...args),
+}));
+
+vi.mock("@/lib/projects/organization/organization-project-service", () => ({
+  ensureOrganizationProjectRecord: (...args: unknown[]) =>
+    mocks.ensureOrganizationProjectRecord(...args),
 }));
 
 vi.mock("@/lib/database", () => ({
@@ -60,6 +66,7 @@ describe("createCrowdinReviewTools", () => {
     mocks.limit.mockResolvedValue([
       { name: "Marketing", translationContext: "Use sentence case." },
     ]);
+    mocks.ensureOrganizationProjectRecord.mockResolvedValue(ok("proj_materialized"));
   });
 
   it("searches concordance through the Crowdin provider", async () => {
@@ -76,13 +83,14 @@ describe("createCrowdinReviewTools", () => {
       actorUserId: "user-1",
     });
 
+    const abortSignal = new AbortController().signal;
     const result = await tools.search_concordance.execute!(
       {
         expressions: ["Save"],
         sourceLocale: "en",
         targetLocale: "de",
       },
-      { toolCallId: "call-1", messages: [], context: {} },
+      { toolCallId: "call-1", messages: [], context: {}, abortSignal },
     );
 
     expect(mocks.searchConcordanceForAgent).toHaveBeenCalledWith({
@@ -92,6 +100,7 @@ describe("createCrowdinReviewTools", () => {
       sourceLocale: "en",
       targetLocale: "de",
       expressions: ["Save"],
+      signal: abortSignal,
     });
     expect(result).toMatchObject({ success: true, crowdinProjectId: 42 });
   });
@@ -109,10 +118,18 @@ describe("createCrowdinReviewTools", () => {
       actorUserId: "user-1",
     });
 
+    const abortSignal = new AbortController().signal;
     const result = await tools.get_style_guide.execute!(
       {},
-      { toolCallId: "call-2", messages: [], context: {} },
+      { toolCallId: "call-2", messages: [], context: {}, abortSignal },
     );
+
+    expect(mocks.loadStyleGuideForAgent).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      actorUserId: "user-1",
+      projectId: "ext:crowdin:42",
+      signal: abortSignal,
+    });
 
     expect(result).toMatchObject({
       success: true,
@@ -132,28 +149,66 @@ describe("createCrowdinReviewTools", () => {
       actorUserId: "user-1",
     });
 
+    const abortSignal = new AbortController().signal;
     const result = await tools.recommend_translation.execute!(
       {
         sourceText: "Save",
         sourceLocale: "en",
         targetLocale: "de",
       },
-      { toolCallId: "call-3", messages: [], context: {} },
+      { toolCallId: "call-3", messages: [], context: {}, abortSignal },
     );
 
+    expect(mocks.ensureOrganizationProjectRecord).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      projectId: "ext:crowdin:42",
+      userId: "user-1",
+    });
     expect(mocks.generateCatAiRecommendation).toHaveBeenCalledWith(
       expect.objectContaining({
-        projectId: "ext:crowdin:42",
+        projectId: "proj_materialized",
         organizationId: "org-1",
         sourceText: "Save",
         sourceLocale: "en",
         targetLocale: "de",
       }),
+      { signal: abortSignal },
     );
     expect(result).toEqual({
       success: true,
       suggestion: "Speichern",
       reasoning: "Glossary prefers Speichern.",
+    });
+  });
+
+  it("returns a project error when an encoded Crowdin ID cannot be materialized", async () => {
+    mocks.ensureOrganizationProjectRecord.mockResolvedValue(
+      err({
+        code: "project_not_found",
+        reason: "external_project_unavailable",
+        organizationId: "org-1",
+        projectId: "ext:crowdin:42",
+      }),
+    );
+    const tools = createCrowdinReviewTools({
+      organizationId: "org-1",
+      projectId: "ext:crowdin:42",
+      actorUserId: "user-1",
+    });
+
+    const result = await tools.recommend_translation.execute!(
+      {
+        sourceText: "Save",
+        sourceLocale: "en",
+        targetLocale: "de",
+      },
+      { toolCallId: "call-4", messages: [], context: {} },
+    );
+
+    expect(mocks.generateCatAiRecommendation).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      success: false,
+      error: "The selected Crowdin project is not available for translation recommendations.",
     });
   });
 });

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/crowdin-review-tools.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/crowdin-review-tools.ts
@@ -190,11 +190,13 @@ export function createCrowdinReviewTools(input: {
               forbidden: term.status === "forbidden",
               description: term.description,
             })),
-            translationMemoryMatches: recommendationInput.translationMemoryMatches?.map((match) => ({
-              sourceText: match.sourceText,
-              targetText: match.targetText,
-              targetLocale: recommendationInput.targetLocale,
-            })),
+            translationMemoryMatches: recommendationInput.translationMemoryMatches?.map(
+              (match) => ({
+                sourceText: match.sourceText,
+                targetText: match.targetText,
+                targetLocale: recommendationInput.targetLocale,
+              }),
+            ),
           },
           { signal: abortSignal },
         );

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/crowdin-review-tools.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/crowdin-review-tools.ts
@@ -17,6 +17,7 @@ import type { ToolSet } from "ai";
 import { defineAgentTool } from "@/agents/_runtime/define-agent-tool";
 import { db, schema } from "@/lib/database";
 import { isErr } from "@/lib/primitives/result/results";
+import { ensureOrganizationProjectRecord } from "@/lib/projects/organization/organization-project-service";
 import { crowdinTmsProvider } from "@/lib/providers/adapters/crowdin/crowdin-provider";
 import { generateCatAiRecommendation } from "@/lib/translation/cat";
 
@@ -86,7 +87,7 @@ export function createCrowdinReviewTools(input: {
       description:
         "Search Crowdin glossary and translation memory for source expressions in a locale pair.",
       inputSchema: searchConcordanceInputSchema,
-      execute: async ({ expressions, sourceLocale, targetLocale }) => {
+      execute: async ({ expressions, sourceLocale, targetLocale }, { abortSignal } = {}) => {
         const result = await crowdinTmsProvider.searchConcordanceForAgent({
           organizationId: input.organizationId,
           actorUserId: input.actorUserId,
@@ -94,6 +95,7 @@ export function createCrowdinReviewTools(input: {
           sourceLocale,
           targetLocale,
           expressions,
+          signal: abortSignal,
         });
         if (isErr(result)) {
           return {
@@ -114,7 +116,7 @@ export function createCrowdinReviewTools(input: {
       description:
         "Load Hyperlocalise project translation context and Crowdin AI style prompts that apply to this project.",
       inputSchema: z.object({}),
-      execute: async () => {
+      execute: async (_input, { abortSignal } = {}) => {
         const [project] = await db
           .select({
             name: schema.projects.name,
@@ -133,6 +135,7 @@ export function createCrowdinReviewTools(input: {
           organizationId: input.organizationId,
           actorUserId: input.actorUserId,
           projectId: input.projectId,
+          signal: abortSignal,
         });
         if (isErr(styleResult)) {
           return {
@@ -156,30 +159,45 @@ export function createCrowdinReviewTools(input: {
       description:
         "Recommend a translation grounded in Crowdin concordance, project context, and style guidance. Read-only; does not write back to Crowdin.",
       inputSchema: recommendTranslationInputSchema,
-      execute: async (recommendationInput) => {
-        const result = await generateCatAiRecommendation({
-          projectId: input.projectId,
+      execute: async (recommendationInput, { abortSignal } = {}) => {
+        const ensured = await ensureOrganizationProjectRecord({
           organizationId: input.organizationId,
-          sourcePath: "automation-review",
-          filename: "review",
-          sourceLocale: recommendationInput.sourceLocale,
-          targetLocale: recommendationInput.targetLocale,
-          key: recommendationInput.key?.trim() || recommendationInput.sourceText.slice(0, 120),
-          sourceText: recommendationInput.sourceText,
-          context: recommendationInput.context ?? null,
-          glossaryTerms: recommendationInput.glossaryTerms?.map((term) => ({
-            sourceTerm: term.sourceTerm,
-            targetTerm: term.targetTerm,
-            targetLocale: recommendationInput.targetLocale,
-            forbidden: term.status === "forbidden",
-            description: term.description,
-          })),
-          translationMemoryMatches: recommendationInput.translationMemoryMatches?.map((match) => ({
-            sourceText: match.sourceText,
-            targetText: match.targetText,
-            targetLocale: recommendationInput.targetLocale,
-          })),
+          projectId: input.projectId,
+          userId: input.actorUserId,
         });
+        if (isErr(ensured)) {
+          return {
+            success: false,
+            error: "The selected Crowdin project is not available for translation recommendations.",
+          };
+        }
+
+        const result = await generateCatAiRecommendation(
+          {
+            projectId: ensured.value,
+            organizationId: input.organizationId,
+            sourcePath: "automation-review",
+            filename: "review",
+            sourceLocale: recommendationInput.sourceLocale,
+            targetLocale: recommendationInput.targetLocale,
+            key: recommendationInput.key?.trim() || recommendationInput.sourceText.slice(0, 120),
+            sourceText: recommendationInput.sourceText,
+            context: recommendationInput.context ?? null,
+            glossaryTerms: recommendationInput.glossaryTerms?.map((term) => ({
+              sourceTerm: term.sourceTerm,
+              targetTerm: term.targetTerm,
+              targetLocale: recommendationInput.targetLocale,
+              forbidden: term.status === "forbidden",
+              description: term.description,
+            })),
+            translationMemoryMatches: recommendationInput.translationMemoryMatches?.map((match) => ({
+              sourceText: match.sourceText,
+              targetText: match.targetText,
+              targetLocale: recommendationInput.targetLocale,
+            })),
+          },
+          { signal: abortSignal },
+        );
         if (isErr(result)) {
           return {
             success: false,

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/crowdin-review-tools.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/crowdin-review-tools.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import type { ToolSet } from "ai";
+
+import { defineAgentTool } from "@/agents/_runtime/define-agent-tool";
+import { db, schema } from "@/lib/database";
+import { isErr } from "@/lib/primitives/result/results";
+import { crowdinTmsProvider } from "@/lib/providers/adapters/crowdin/crowdin-provider";
+import { generateCatAiRecommendation } from "@/lib/translation/cat";
+
+const searchConcordanceInputSchema = z.object({
+  expressions: z
+    .array(z.string().trim().min(1))
+    .min(1)
+    .max(20)
+    .describe("Source strings or terms to look up in Crowdin glossary and translation memory."),
+  sourceLocale: z
+    .string()
+    .trim()
+    .min(1)
+    .describe("Crowdin source language ID, for example 'en' or 'en-US'."),
+  targetLocale: z
+    .string()
+    .trim()
+    .min(1)
+    .describe("Crowdin target language ID, for example 'de' or 'vi'."),
+});
+
+const recommendTranslationInputSchema = z.object({
+  sourceText: z
+    .string()
+    .trim()
+    .min(1)
+    .max(20_000)
+    .describe("Source string to recommend a translation for."),
+  sourceLocale: z.string().trim().min(1).describe("Source language ID."),
+  targetLocale: z.string().trim().min(1).describe("Target language ID."),
+  context: z
+    .string()
+    .trim()
+    .max(8000)
+    .optional()
+    .describe("Surrounding UI, code, or reviewer context for the string."),
+  key: z.string().trim().max(512).optional().describe("Optional string key or identifier."),
+  glossaryTerms: z
+    .array(
+      z.object({
+        sourceTerm: z.string(),
+        targetTerm: z.string(),
+        status: z.string().nullable().optional(),
+        description: z.string().nullable().optional(),
+      }),
+    )
+    .optional()
+    .describe("Optional glossary matches from search_concordance."),
+  translationMemoryMatches: z
+    .array(
+      z.object({
+        sourceText: z.string(),
+        targetText: z.string(),
+      }),
+    )
+    .optional()
+    .describe("Optional translation-memory matches from search_concordance."),
+});
+
+export function createCrowdinReviewTools(input: {
+  organizationId: string;
+  projectId: string;
+  actorUserId?: string | null;
+}): ToolSet {
+  return {
+    search_concordance: defineAgentTool({
+      description:
+        "Search Crowdin glossary and translation memory for source expressions in a locale pair.",
+      inputSchema: searchConcordanceInputSchema,
+      execute: async ({ expressions, sourceLocale, targetLocale }) => {
+        const result = await crowdinTmsProvider.searchConcordanceForAgent({
+          organizationId: input.organizationId,
+          actorUserId: input.actorUserId,
+          projectId: input.projectId,
+          sourceLocale,
+          targetLocale,
+          expressions,
+        });
+        if (isErr(result)) {
+          return {
+            success: false,
+            error: result.error.message,
+          };
+        }
+
+        return {
+          success: true,
+          crowdinProjectId: result.value.crowdinProjectId,
+          glossaryMatches: result.value.glossaryMatches,
+          translationMemoryMatches: result.value.translationMemoryMatches,
+        };
+      },
+    }),
+    get_style_guide: defineAgentTool({
+      description:
+        "Load Hyperlocalise project translation context and Crowdin AI style prompts that apply to this project.",
+      inputSchema: z.object({}),
+      execute: async () => {
+        const [project] = await db
+          .select({
+            name: schema.projects.name,
+            translationContext: schema.projects.translationContext,
+          })
+          .from(schema.projects)
+          .where(
+            and(
+              eq(schema.projects.organizationId, input.organizationId),
+              eq(schema.projects.id, input.projectId),
+            ),
+          )
+          .limit(1);
+
+        const styleResult = await crowdinTmsProvider.loadStyleGuideForAgent({
+          organizationId: input.organizationId,
+          actorUserId: input.actorUserId,
+          projectId: input.projectId,
+        });
+        if (isErr(styleResult)) {
+          return {
+            success: false,
+            error: styleResult.error.message,
+            projectName: project?.name ?? null,
+            translationContext: project?.translationContext?.trim() || null,
+          };
+        }
+
+        return {
+          success: true,
+          crowdinProjectId: styleResult.value.crowdinProjectId,
+          projectName: project?.name ?? null,
+          translationContext: project?.translationContext?.trim() || null,
+          prompts: styleResult.value.prompts,
+        };
+      },
+    }),
+    recommend_translation: defineAgentTool({
+      description:
+        "Recommend a translation grounded in Crowdin concordance, project context, and style guidance. Read-only; does not write back to Crowdin.",
+      inputSchema: recommendTranslationInputSchema,
+      execute: async (recommendationInput) => {
+        const result = await generateCatAiRecommendation({
+          projectId: input.projectId,
+          organizationId: input.organizationId,
+          sourcePath: "automation-review",
+          filename: "review",
+          sourceLocale: recommendationInput.sourceLocale,
+          targetLocale: recommendationInput.targetLocale,
+          key: recommendationInput.key?.trim() || recommendationInput.sourceText.slice(0, 120),
+          sourceText: recommendationInput.sourceText,
+          context: recommendationInput.context ?? null,
+          glossaryTerms: recommendationInput.glossaryTerms?.map((term) => ({
+            sourceTerm: term.sourceTerm,
+            targetTerm: term.targetTerm,
+            targetLocale: recommendationInput.targetLocale,
+            forbidden: term.status === "forbidden",
+            description: term.description,
+          })),
+          translationMemoryMatches: recommendationInput.translationMemoryMatches?.map((match) => ({
+            sourceText: match.sourceText,
+            targetText: match.targetText,
+            targetLocale: recommendationInput.targetLocale,
+          })),
+        });
+        if (isErr(result)) {
+          return {
+            success: false,
+            error: result.error.message,
+          };
+        }
+
+        return {
+          success: true,
+          suggestion: result.value.aiSuggestion,
+          reasoning: result.value.aiReasoning,
+        };
+      },
+    }),
+  };
+}

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_crowdin.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_crowdin.test.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import type {
+  WorkspaceAutomationRecord,
+  WorkspaceAutomationRunRecord,
+} from "@/lib/agents/workspace-automations";
+
+import type { WorkspaceOrchestratorSession } from "../context";
+import { createUseCrowdinTool } from "./use_crowdin";
+
+const mocks = vi.hoisted(() => ({
+  generate: vi.fn(),
+  createCrowdinReviewTools: vi.fn(),
+}));
+
+vi.mock("ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ai")>();
+  return {
+    ...actual,
+    isStepCount: vi.fn(),
+    ToolLoopAgent: class {
+      generate = mocks.generate;
+    },
+  };
+});
+
+vi.mock("@/lib/agent-runtime/loops/model", () => ({
+  getHyperlocaliseAgentModel: vi.fn(),
+}));
+
+vi.mock("@/lib/billing/agent-runtime-usage", () => ({
+  extractGenerateResultTokenUsage: vi.fn(),
+  withAgentRuntimeUsageMetering: vi.fn(async ({ run }: { run: () => Promise<unknown> }) => run()),
+}));
+
+vi.mock("./crowdin-review-tools", () => ({
+  createCrowdinReviewTools: (...args: unknown[]) => mocks.createCrowdinReviewTools(...args),
+}));
+
+function session(
+  toolConfig: WorkspaceAutomationRecord["toolConfig"] = {},
+): WorkspaceOrchestratorSession {
+  const automation = {
+    id: "automation-1",
+    organizationId: "org-1",
+    authorUserId: "user-1",
+    status: "active",
+    name: "Crowdin review",
+    instructions: "",
+    projectId: null,
+    triggerConfig: { mode: "manual" },
+    repositoryTarget: { kind: "none" },
+    toolConfig,
+    configVersion: 1,
+    nextRunAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  } satisfies WorkspaceAutomationRecord;
+
+  const run = {
+    id: "run-1",
+    automationId: automation.id,
+    organizationId: automation.organizationId,
+    triggerSource: "manual",
+    status: "running",
+    inputSnapshot: {},
+    outputSummary: {},
+    error: null,
+    githubRepositoryAutomationJobId: null,
+    idempotencyKey: null,
+    startedAt: null,
+    completedAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  } satisfies WorkspaceAutomationRunRecord;
+
+  return {
+    organizationId: automation.organizationId,
+    automation,
+    run,
+    plan: { tools: ["use_crowdin"] },
+    repository: null,
+    composedInstructions: "",
+    stepResults: {},
+    terminalStatus: null,
+    terminalError: null,
+  };
+}
+
+describe("createUseCrowdinTool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createCrowdinReviewTools.mockReturnValue({});
+    mocks.generate.mockResolvedValue({ text: "Glossary prefers Speichern." });
+  });
+
+  it("rejects when Crowdin is not configured on the automation", async () => {
+    await expect(
+      createUseCrowdinTool(session()).execute!(
+        { objective: "Review Save in German" },
+        { toolCallId: "call-1", messages: [], context: {} },
+      ),
+    ).rejects.toThrow("crowdin_not_configured");
+
+    await expect(
+      createUseCrowdinTool(
+        session({
+          crowdin: { enabled: true },
+        }),
+      ).execute!(
+        { objective: "Review Save in German" },
+        { toolCallId: "call-1", messages: [], context: {} },
+      ),
+    ).rejects.toThrow("crowdin_not_configured");
+
+    expect(mocks.createCrowdinReviewTools).not.toHaveBeenCalled();
+  });
+
+  it("runs a nested review agent with the selected project and author", async () => {
+    const current = session({
+      crowdin: {
+        enabled: true,
+        projectId: "ext:crowdin:42",
+      },
+    });
+
+    const payload = await createUseCrowdinTool(current).execute!(
+      { objective: "Review Save in German" },
+      { toolCallId: "call-1", messages: [], context: {} },
+    );
+
+    expect(mocks.createCrowdinReviewTools).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      projectId: "ext:crowdin:42",
+      actorUserId: "user-1",
+    });
+    expect(payload).toEqual({
+      summary: "Glossary prefers Speichern.",
+      projectId: "ext:crowdin:42",
+    });
+    expect(current.stepResults.use_crowdin).toEqual(payload);
+  });
+});

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_crowdin.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_crowdin.test.ts
@@ -136,9 +136,10 @@ describe("createUseCrowdinTool", () => {
       },
     });
 
+    const abortSignal = new AbortController().signal;
     const payload = await createUseCrowdinTool(current).execute!(
       { objective: "Review Save in German" },
-      { toolCallId: "call-1", messages: [], context: {} },
+      { toolCallId: "call-1", messages: [], context: {}, abortSignal },
     );
 
     expect(mocks.createCrowdinReviewTools).toHaveBeenCalledWith({
@@ -151,5 +152,10 @@ describe("createUseCrowdinTool", () => {
       projectId: "ext:crowdin:42",
     });
     expect(current.stepResults.use_crowdin).toEqual(payload);
+    expect(mocks.generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        abortSignal,
+      }),
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_crowdin.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_crowdin.ts
@@ -46,7 +46,7 @@ export function createUseCrowdinTool(session: WorkspaceOrchestratorSession) {
     description:
       "Look up Crowdin glossary, translation memory, style guidance, and translation recommendations for strings under review. Pass source strings, locales, and surrounding context from prior steps.",
     inputSchema: useCrowdinInputSchema,
-    execute: async ({ objective }) => {
+    execute: async ({ objective }, { abortSignal } = {}) => {
       const crowdin = session.automation.toolConfig.crowdin;
       const projectId = crowdin?.projectId?.trim();
       if (!crowdin?.enabled || !projectId) {
@@ -88,6 +88,7 @@ export function createUseCrowdinTool(session: WorkspaceOrchestratorSession) {
         extractTokenUsage: extractGenerateResultTokenUsage,
         run: () =>
           agent.generate({
+            abortSignal,
             messages: [
               {
                 role: "user",

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_crowdin.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_crowdin.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { isStepCount, ToolLoopAgent } from "ai";
+import { z } from "zod";
+
+import { defineAgentTool } from "@/agents/_runtime/define-agent-tool";
+import { getHyperlocaliseAgentModel } from "@/lib/agent-runtime/loops/model";
+import {
+  SUBAGENT_NO_QUESTIONS_RULES,
+  SUBAGENT_RESPONSE_FORMAT,
+  WORKFLOW_AGENT_TIMEOUT,
+} from "@/lib/agent-runtime/subagents/constants";
+import {
+  extractGenerateResultTokenUsage,
+  withAgentRuntimeUsageMetering,
+} from "@/lib/billing/agent-runtime-usage";
+
+import type { WorkspaceOrchestratorSession } from "../context";
+import { createCrowdinReviewTools } from "./crowdin-review-tools";
+
+const CROWDIN_TOOL_STEP_LIMIT = 10;
+
+const useCrowdinInputSchema = z.object({
+  objective: z
+    .string()
+    .trim()
+    .min(1)
+    .max(4000)
+    .describe(
+      "What Crowdin evidence to gather for translation review: source strings, locales, surrounding context, and the review question.",
+    ),
+});
+
+export function createUseCrowdinTool(session: WorkspaceOrchestratorSession) {
+  return defineAgentTool({
+    description:
+      "Look up Crowdin glossary, translation memory, style guidance, and translation recommendations for strings under review. Pass source strings, locales, and surrounding context from prior steps.",
+    inputSchema: useCrowdinInputSchema,
+    execute: async ({ objective }) => {
+      const crowdin = session.automation.toolConfig.crowdin;
+      const projectId = crowdin?.projectId?.trim();
+      if (!crowdin?.enabled || !projectId) {
+        throw new Error("crowdin_not_configured");
+      }
+
+      const tools = createCrowdinReviewTools({
+        organizationId: session.organizationId,
+        projectId,
+        actorUserId: session.automation.authorUserId,
+      });
+
+      const agent = new ToolLoopAgent({
+        model: getHyperlocaliseAgentModel(),
+        tools,
+        instructions: [
+          "You are gathering Crowdin evidence for a workspace automation translation review.",
+          "Use search_concordance for glossary and translation-memory matches.",
+          "Use get_style_guide for project translation context and Crowdin AI style prompts.",
+          "Use recommend_translation when the objective asks for suggested wording.",
+          "Stay read-only. Do not write translations back to Crowdin.",
+          "Return a concise factual summary: matches, style constraints, and any recommended translations with reasoning.",
+          SUBAGENT_NO_QUESTIONS_RULES,
+          SUBAGENT_RESPONSE_FORMAT,
+        ].join("\n"),
+        stopWhen: isStepCount(CROWDIN_TOOL_STEP_LIMIT),
+        timeout: WORKFLOW_AGENT_TIMEOUT,
+      });
+
+      const result = await withAgentRuntimeUsageMetering({
+        organizationId: session.organizationId,
+        operationKey: `workspace-crowdin:${session.run.id}:agent_runs`,
+        source: "workspace_crowdin_agent",
+        dimensions: {
+          surface: "automation",
+          agent_surface: "crowdin",
+          project_id: projectId,
+        },
+        extractTokenUsage: extractGenerateResultTokenUsage,
+        run: () =>
+          agent.generate({
+            messages: [
+              {
+                role: "user",
+                content: [
+                  `Objective: ${objective}`,
+                  `Crowdin project: ${projectId}`,
+                  session.automation.instructions.trim()
+                    ? `Automation instructions:\n${session.automation.instructions.trim()}`
+                    : null,
+                ]
+                  .filter((line): line is string => Boolean(line))
+                  .join("\n\n"),
+              },
+            ],
+          }),
+      });
+
+      const summary = result.text.trim() || "Completed Crowdin review with no textual summary.";
+      const payload = {
+        summary,
+        projectId,
+      };
+      session.stepResults.use_crowdin = payload;
+      return payload;
+    },
+  });
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-editor.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-editor.fixture.ts
@@ -36,6 +36,14 @@ export const automationEditorProjectsFixture = [
     sourceLocale: "en-US",
     targetLocales: ["es-ES", "pt-BR"],
   },
+  {
+    id: "ext:crowdin:42",
+    name: "Marketing Crowdin",
+    source: "external_tms",
+    externalProviderKind: "crowdin",
+    sourceLocale: "en",
+    targetLocales: ["de", "fr"],
+  },
 ];
 
 export const automationEditorRepositoriesFixture = [

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -454,23 +454,23 @@ export const workspaceAutomationFormMessages = defineMessages({
   },
   crowdin: {
     defaultMessage: "Crowdin",
-    id: "cR0wDinRv1",
+    id: "yQ7T8Cq+ij",
     description: "Menu item and tool title for Crowdin translation review",
   },
   crowdinDescription: {
     defaultMessage:
       "Search concordance, load style guidance, and recommend translations for strings under review.",
-    id: "cR0wDinDs2",
+    id: "a44831XqpD",
     description: "Description for the Crowdin automation tool when a linked project exists",
   },
   crowdinDisconnectedDescription: {
     defaultMessage: "Connect Crowdin and sync a project before using this review tool.",
-    id: "cR0wDinDc3",
+    id: "FZh9zX9beA",
     description: "Description when no Crowdin-linked project is available",
   },
   removeCrowdinTool: {
     defaultMessage: "Remove Crowdin tool",
-    id: "cR0wDinRm4",
+    id: "aQKVpqRw8t",
     description: "Accessible label to remove the Crowdin tool",
   },
   ahrefs: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -452,6 +452,27 @@ export const workspaceAutomationFormMessages = defineMessages({
     id: "s7935wKE28",
     description: "Accessible label to remove the Semrush tool",
   },
+  crowdin: {
+    defaultMessage: "Crowdin",
+    id: "cR0wDinRv1",
+    description: "Menu item and tool title for Crowdin translation review",
+  },
+  crowdinDescription: {
+    defaultMessage:
+      "Search concordance, load style guidance, and recommend translations for strings under review.",
+    id: "cR0wDinDs2",
+    description: "Description for the Crowdin automation tool when a linked project exists",
+  },
+  crowdinDisconnectedDescription: {
+    defaultMessage: "Connect Crowdin and sync a project before using this review tool.",
+    id: "cR0wDinDc3",
+    description: "Description when no Crowdin-linked project is available",
+  },
+  removeCrowdinTool: {
+    defaultMessage: "Remove Crowdin tool",
+    id: "cR0wDinRm4",
+    description: "Accessible label to remove the Crowdin tool",
+  },
   ahrefs: {
     defaultMessage: "Ahrefs",
     id: "l4moIhus0d",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -2176,8 +2176,8 @@ function ToolsSettings({
                   <SelectValue
                     placeholder={intl.formatMessage(workspaceAutomationFormMessages.selectProject)}
                   >
-                    {crowdinProjects.find((project) => project.id === form.crowdinProjectId)?.name ??
-                      intl.formatMessage(workspaceAutomationFormMessages.selectProject)}
+                    {crowdinProjects.find((project) => project.id === form.crowdinProjectId)
+                      ?.name ?? intl.formatMessage(workspaceAutomationFormMessages.selectProject)}
                   </SelectValue>
                 </SelectTrigger>
                 <SelectContent>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -41,6 +41,7 @@ import {
   siLinear,
   siMeta,
   siSemrush,
+  siCrowdin,
 } from "simple-icons";
 
 import { SimpleBrandIcon } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/simple-brand-icon";
@@ -95,6 +96,7 @@ import {
   workspaceAutomationFormCanActivate,
 } from "@/lib/agents/workspace-automation-view-model";
 import type { WorkspaceAutomationRunRecord } from "@/lib/agents/workspace-automations";
+import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 import { cn } from "@/lib/primitives/cn";
 
 const api = createApiClient();
@@ -103,6 +105,7 @@ type ProjectOption = {
   id: string;
   name: string;
   source?: string;
+  externalProviderKind?: string | null;
   sourceLocale: string | null;
   targetLocales: string[];
 };
@@ -171,6 +174,26 @@ function AutomationToolMenuIcon({ icon }: { icon?: SimpleIcon }) {
   }
 
   return <HugeiconsIcon icon={SearchIcon} className="size-4" />;
+}
+
+function isCrowdinLinkedProject(project: ProjectOption) {
+  if (project.externalProviderKind === "crowdin") {
+    return true;
+  }
+  return parseProviderProjectId(project.id)?.providerKind === "crowdin";
+}
+
+function defaultCrowdinProjectId(
+  form: WorkspaceAutomationFormState,
+  crowdinProjects: ProjectOption[],
+) {
+  if (crowdinProjects.some((project) => project.id === form.projectId)) {
+    return form.projectId;
+  }
+  if (crowdinProjects.some((project) => project.id === form.crowdinProjectId)) {
+    return form.crowdinProjectId;
+  }
+  return crowdinProjects[0]?.id ?? "";
 }
 
 function FieldError({ message }: { message?: string }) {
@@ -339,6 +362,7 @@ function toolCount(form: WorkspaceAutomationFormState) {
     Number(form.slackEnabled) +
     Number(form.emailEnabled) +
     Number(form.contentfulEnabled) +
+    Number(form.crowdinEnabled) +
     Number(form.createNativeTmsJobEnabled) +
     Number(form.assignTranslateWithAgentEnabled) +
     Number(form.listIssuesEnabled) +
@@ -1092,6 +1116,7 @@ function TriggerSettings({
 
 function AddToolMenu({
   contentfulConnected,
+  crowdinConnected,
   disabled,
   emailConnected,
   form,
@@ -1103,8 +1128,10 @@ function AddToolMenu({
   ahrefsConnected,
   semrushConnected,
   slackConnected,
+  crowdinProjects,
 }: {
   contentfulConnected: boolean;
+  crowdinConnected: boolean;
   disabled?: boolean;
   emailConnected: boolean;
   form: WorkspaceAutomationFormState;
@@ -1116,6 +1143,7 @@ function AddToolMenu({
   ahrefsConnected: boolean;
   semrushConnected: boolean;
   slackConnected: boolean;
+  crowdinProjects: ProjectOption[];
 }) {
   return (
     <div className="w-full">
@@ -1293,6 +1321,28 @@ function AddToolMenu({
                   <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
                 </DropdownMenuShortcut>
               ) : !contentfulConnected ? (
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
+                </DropdownMenuShortcut>
+              ) : null}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={form.crowdinEnabled || !crowdinConnected}
+              onClick={() =>
+                onChange({
+                  ...form,
+                  crowdinEnabled: true,
+                  crowdinProjectId: defaultCrowdinProjectId(form, crowdinProjects),
+                })
+              }
+            >
+              <AutomationToolMenuIcon icon={siCrowdin} />
+              <FormattedMessage {...workspaceAutomationFormMessages.crowdin} />
+              {form.crowdinEnabled ? (
+                <DropdownMenuShortcut>
+                  <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
+                </DropdownMenuShortcut>
+              ) : !crowdinConnected ? (
                 <DropdownMenuShortcut>
                   <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
                 </DropdownMenuShortcut>
@@ -1601,6 +1651,8 @@ function ToolsSettings({
     (connection) => connection.enabled && connection.validationStatus === "valid",
   );
   const ahrefsConnected = enabledAhrefsConnections.length > 0;
+  const crowdinProjects = projects.filter(isCrowdinLinkedProject);
+  const crowdinConnected = crowdinProjects.length > 0;
   const contentfulTargetLocalesFieldId = "contentful-target-locales";
   const selectedProject = projects.find((project) => project.id === form.projectId);
   const contentfulAvailableTargetLocales = selectedProject?.targetLocales ?? [];
@@ -2083,6 +2135,64 @@ function ToolsSettings({
           </EditorRow>
         ) : null}
 
+        {form.crowdinEnabled ? (
+          <EditorRow
+            icon={<AutomationToolMenuIcon icon={siCrowdin} />}
+            title={<FormattedMessage {...workspaceAutomationFormMessages.crowdin} />}
+            description={
+              crowdinConnected
+                ? intl.formatMessage(workspaceAutomationFormMessages.crowdinDescription)
+                : intl.formatMessage(workspaceAutomationFormMessages.crowdinDisconnectedDescription)
+            }
+            action={
+              <DeleteToolButton
+                disabled={disabled}
+                label={intl.formatMessage(workspaceAutomationFormMessages.removeCrowdinTool)}
+                onClick={() =>
+                  onChange({
+                    ...form,
+                    crowdinEnabled: false,
+                    crowdinProjectId: "",
+                  })
+                }
+              />
+            }
+          >
+            <div className="grid gap-1.5">
+              <Label className="text-xs text-muted-foreground">
+                <FormattedMessage {...workspaceAutomationFormMessages.selectProject} />
+              </Label>
+              <Select
+                value={form.crowdinProjectId || undefined}
+                disabled={disabled || !crowdinConnected}
+                onValueChange={(value) => {
+                  if (!value) {
+                    return;
+                  }
+                  onChange({ ...form, crowdinProjectId: value });
+                }}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue
+                    placeholder={intl.formatMessage(workspaceAutomationFormMessages.selectProject)}
+                  >
+                    {crowdinProjects.find((project) => project.id === form.crowdinProjectId)?.name ??
+                      intl.formatMessage(workspaceAutomationFormMessages.selectProject)}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  {crowdinProjects.map((project) => (
+                    <SelectItem key={project.id} value={project.id}>
+                      {project.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FieldError message={errors.crowdinProjectId} />
+            </div>
+          </EditorRow>
+        ) : null}
+
         {form.createNativeTmsJobEnabled ? (
           <EditorRow
             icon={<HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} className="size-4" />}
@@ -2466,6 +2576,8 @@ function ToolsSettings({
 
         <AddToolMenu
           contentfulConnected={contentfulConnected}
+          crowdinConnected={crowdinConnected}
+          crowdinProjects={crowdinProjects}
           disabled={disabled}
           emailConnected={emailConnected}
           form={form}

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
@@ -482,4 +482,45 @@ describe("workspace automation view model", () => {
       ahrefsConnectionId: "Enable the selected Ahrefs connection in Integrations before using it.",
     });
   });
+
+  it("requires a Crowdin project when the Crowdin tool is enabled", () => {
+    const form = {
+      ...createDefaultWorkspaceAutomationFormState(),
+      crowdinEnabled: true,
+    };
+
+    expect(validateWorkspaceAutomationFormState(form)).toMatchObject({
+      crowdinProjectId: "Choose a Crowdin-linked project.",
+    });
+  });
+
+  it("maps Crowdin API errors onto the Crowdin project field", () => {
+    expect(mapWorkspaceAutomationApiErrorToFieldErrors("crowdin_project_required")).toEqual({
+      crowdinProjectId: "Choose a Crowdin-linked project for Crowdin review.",
+    });
+    expect(mapWorkspaceAutomationApiErrorToFieldErrors("crowdin_project_not_found")).toEqual({
+      crowdinProjectId: "The selected Crowdin project was not found. Choose another project.",
+    });
+    expect(mapWorkspaceAutomationApiErrorToFieldErrors("crowdin_project_not_linked")).toEqual({
+      crowdinProjectId: "The selected project is not linked to Crowdin. Choose a Crowdin project.",
+    });
+    expect(mapWorkspaceAutomationApiErrorToFieldErrors("crowdin_not_connected")).toEqual({
+      crowdinProjectId: "Connect Crowdin in Integrations before using Crowdin review tools.",
+    });
+  });
+
+  it("maps Crowdin project into the API payload", () => {
+    const form = {
+      ...createDefaultWorkspaceAutomationFormState(),
+      name: "Code review",
+      instructions: "Review strings against Crowdin.",
+      crowdinEnabled: true,
+      crowdinProjectId: "ext:crowdin:42",
+    };
+
+    expect(validateWorkspaceAutomationFormState(form)).toEqual({});
+    expect(formStateToWorkspaceAutomationPayload(form).toolConfig).toEqual({
+      crowdin: { enabled: true, projectId: "ext:crowdin:42" },
+    });
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
@@ -76,6 +76,8 @@ export type WorkspaceAutomationFormState = {
   semrushConnectionId: string;
   ahrefsEnabled: boolean;
   ahrefsConnectionId: string;
+  crowdinEnabled: boolean;
+  crowdinProjectId: string;
   webSearchEnabled: boolean;
   webSearchProvider: WorkspaceAutomationWebSearchProvider;
 };
@@ -113,6 +115,7 @@ export type WorkspaceAutomationFieldErrors = Partial<
     | "mcpConnectionId"
     | "semrushConnectionId"
     | "ahrefsConnectionId"
+    | "crowdinProjectId"
     | "form",
     string
   >
@@ -129,7 +132,7 @@ export const WORKSPACE_AUTOMATION_API_ERROR_MESSAGES: Record<string, string> = {
     "Use GitHub repo automations with a scheduled or manual trigger, not GitHub push.",
   github_push_branches_required: "Add at least one branch pattern for GitHub push triggers.",
   scheduled_workflow_required:
-    "Scheduled automations require at least one GitHub, Contentful, Issues, or Web Search workflow tool.",
+    "Scheduled automations require at least one GitHub, Contentful, Issues, Web Search, or Crowdin workflow tool.",
   slack_not_connected: "Connect Slack in Integrations before enabling Slack notifications.",
   slack_channel_required: "Choose a Slack channel for notifications.",
   email_not_connected: "Enable the email agent in Integrations before using email notifications.",
@@ -153,6 +156,11 @@ export const WORKSPACE_AUTOMATION_API_ERROR_MESSAGES: Record<string, string> = {
   ahrefs_connection_not_found:
     "The selected Ahrefs connection was not found. Choose another connection.",
   ahrefs_not_connected: "Enable the selected Ahrefs connection in Integrations before using it.",
+  crowdin_project_required: "Choose a Crowdin-linked project for Crowdin review.",
+  crowdin_project_not_found: "The selected Crowdin project was not found. Choose another project.",
+  crowdin_project_not_linked:
+    "The selected project is not linked to Crowdin. Choose a Crowdin project.",
+  crowdin_not_connected: "Connect Crowdin in Integrations before using Crowdin review tools.",
   github_repository_not_enabled: "Enable this repository before configuring automation.",
   github_repository_archived: "Archived repositories cannot use automations.",
   project_not_found: "The selected project could not be found.",
@@ -205,6 +213,8 @@ export function createDefaultWorkspaceAutomationFormState(): WorkspaceAutomation
     semrushConnectionId: "",
     ahrefsEnabled: false,
     ahrefsConnectionId: "",
+    crowdinEnabled: false,
+    crowdinProjectId: "",
     webSearchEnabled: false,
     webSearchProvider: "auto",
   };
@@ -225,6 +235,7 @@ export function createWorkspaceAutomationFormStateFromRecord(
   const mcp = automation.toolConfig.mcp;
   const semrush = automation.toolConfig.semrush;
   const ahrefs = automation.toolConfig.ahrefs;
+  const crowdin = automation.toolConfig.crowdin;
   const webSearch = automation.toolConfig.webSearch;
 
   return {
@@ -291,6 +302,8 @@ export function createWorkspaceAutomationFormStateFromRecord(
     semrushConnectionId: semrush?.connectionId ?? "",
     ahrefsEnabled: Boolean(ahrefs?.enabled),
     ahrefsConnectionId: ahrefs?.connectionId ?? "",
+    crowdinEnabled: Boolean(crowdin?.enabled),
+    crowdinProjectId: crowdin?.projectId ?? "",
     webSearchEnabled: Boolean(webSearch?.enabled),
     webSearchProvider: webSearch?.provider ?? "auto",
   };
@@ -499,6 +512,14 @@ export function formStateToWorkspaceAutomationPayload(form: WorkspaceAutomationF
           },
         }
       : {}),
+    ...(form.crowdinEnabled
+      ? {
+          crowdin: {
+            enabled: true,
+            projectId: form.crowdinProjectId.trim() || undefined,
+          },
+        }
+      : {}),
     ...(form.webSearchEnabled
       ? {
           webSearch: {
@@ -609,6 +630,10 @@ export function validateWorkspaceAutomationFormState(
     errors.ahrefsConnectionId = "Choose an Ahrefs connection.";
   }
 
+  if (form.crowdinEnabled && !form.crowdinProjectId.trim()) {
+    errors.crowdinProjectId = "Choose a Crowdin-linked project.";
+  }
+
   return errors;
 }
 
@@ -666,6 +691,11 @@ export function mapWorkspaceAutomationApiErrorToFieldErrors(
     case "ahrefs_connection_not_found":
     case "ahrefs_not_connected":
       return { ahrefsConnectionId: message };
+    case "crowdin_project_required":
+    case "crowdin_project_not_found":
+    case "crowdin_project_not_linked":
+    case "crowdin_not_connected":
+      return { crowdinProjectId: message };
     default:
       return { form: message };
   }
@@ -684,6 +714,7 @@ export function workspaceAutomationFormCanActivate(form: WorkspaceAutomationForm
     form.mcpEnabled ||
     form.semrushEnabled ||
     form.ahrefsEnabled ||
+    form.crowdinEnabled ||
     form.webSearchEnabled
   );
 }

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
@@ -18,6 +18,11 @@ import { afterEach, beforeAll, describe, expect, it } from "vite-plus/test";
 import { createAhrefsConnection } from "@/lib/ahrefs/connections";
 import { db, schema } from "@/lib/database";
 import { type Result } from "@/lib/primitives/result/results";
+import { encodeProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
+import {
+  encryptProviderCredential,
+  unwrapProviderCredentialCrypto,
+} from "@/lib/security/provider-credential-crypto";
 import { createSemrushConnection } from "@/lib/semrush/connections";
 
 import { claimGithubRepositoryAutomationJob } from "./github/github-repository-automation-jobs";
@@ -378,7 +383,7 @@ describe("workspace automations", () => {
     expect(notificationOnlySchedule.error).toMatchObject({
       code: "scheduled_workflow_required",
       message:
-        "Scheduled automations require at least one GitHub, Contentful, Issues, or Web Search workflow tool.",
+        "Scheduled automations require at least one GitHub, Contentful, Issues, Web Search, or Crowdin workflow tool.",
     });
 
     const scheduledWebSearch = expectOk(
@@ -428,7 +433,7 @@ describe("workspace automations", () => {
     expect(scheduledUpdate.error).toMatchObject({
       code: "scheduled_workflow_required",
       message:
-        "Scheduled automations require at least one GitHub, Contentful, Issues, or Web Search workflow tool.",
+        "Scheduled automations require at least one GitHub, Contentful, Issues, Web Search, or Crowdin workflow tool.",
     });
   });
 
@@ -1106,6 +1111,134 @@ describe("workspace automations", () => {
       throw new Error("expected update-path semrush validation error");
     }
     expect(updateRejected.error.code).toBe("semrush_not_connected");
+  });
+
+  it("rejects Crowdin tools without a linked project or Crowdin connection", async () => {
+    const scope = await seedWorkspaceAutomationScope();
+    const base = {
+      organizationId: scope.organizationId,
+      authorUserId: scope.userId,
+      name: "Crowdin review automation",
+      instructions: "Review strings against Crowdin.",
+      triggerConfig: { mode: "manual" as const },
+      repositoryTarget: { kind: "none" as const },
+    };
+
+    const missingProject = await createWorkspaceAutomation({
+      ...base,
+      toolConfig: {
+        crowdin: { enabled: true },
+      },
+    });
+    expect(missingProject.ok).toBe(false);
+    if (missingProject.ok) {
+      throw new Error("expected crowdin project required error");
+    }
+    expect(missingProject.error.code).toBe("crowdin_project_required");
+
+    const notLinked = await createWorkspaceAutomation({
+      ...base,
+      toolConfig: {
+        crowdin: { enabled: true, projectId: scope.projectId },
+      },
+    });
+    expect(notLinked.ok).toBe(false);
+    if (notLinked.ok) {
+      throw new Error("expected crowdin project not linked error");
+    }
+    expect(notLinked.error.code).toBe("crowdin_project_not_linked");
+
+    const encodedWithoutCredential = await createWorkspaceAutomation({
+      ...base,
+      toolConfig: {
+        crowdin: { enabled: true, projectId: "ext:crowdin:42" },
+      },
+    });
+    expect(encodedWithoutCredential.ok).toBe(false);
+    if (encodedWithoutCredential.ok) {
+      throw new Error("expected crowdin not connected error");
+    }
+    expect(encodedWithoutCredential.error.code).toBe("crowdin_not_connected");
+
+    const encrypted = unwrapProviderCredentialCrypto(encryptProviderCredential("crowdin-token"));
+    await db.insert(schema.organizationExternalTmsProviderCredentials).values({
+      organizationId: scope.organizationId,
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      authMode: "api_token",
+      encryptionAlgorithm: encrypted.algorithm,
+      ciphertext: encrypted.ciphertext,
+      iv: encrypted.iv,
+      authTag: encrypted.authTag,
+      keyVersion: encrypted.keyVersion,
+      maskedSecretSuffix: "••••ken",
+      validationStatus: "valid",
+      createdByUserId: scope.userId,
+      updatedByUserId: scope.userId,
+    });
+
+    const created = expectOk(
+      await createWorkspaceAutomation({
+        ...base,
+        toolConfig: {
+          crowdin: {
+            enabled: true,
+            projectId: encodeProviderProjectId({
+              providerKind: "crowdin",
+              externalProjectId: "42",
+            }),
+          },
+        },
+      }),
+    );
+    expect(created.toolConfig.crowdin).toEqual({
+      enabled: true,
+      projectId: "ext:crowdin:42",
+    });
+  });
+
+  it("allows scheduled automations that only enable Crowdin review", async () => {
+    const scope = await seedWorkspaceAutomationScope();
+    const encrypted = unwrapProviderCredentialCrypto(encryptProviderCredential("crowdin-token"));
+    await db.insert(schema.organizationExternalTmsProviderCredentials).values({
+      organizationId: scope.organizationId,
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      authMode: "api_token",
+      encryptionAlgorithm: encrypted.algorithm,
+      ciphertext: encrypted.ciphertext,
+      iv: encrypted.iv,
+      authTag: encrypted.authTag,
+      keyVersion: encrypted.keyVersion,
+      maskedSecretSuffix: "••••ken",
+      validationStatus: "valid",
+      createdByUserId: scope.userId,
+      updatedByUserId: scope.userId,
+    });
+
+    const created = expectOk(
+      await createWorkspaceAutomation({
+        organizationId: scope.organizationId,
+        authorUserId: scope.userId,
+        name: "Daily Crowdin review",
+        instructions: "Review strings against Crowdin.",
+        triggerConfig: {
+          mode: "scheduled",
+          schedule: {
+            cadence: "daily",
+            hourUtc: 8,
+            timezone: "UTC",
+          },
+        },
+        toolConfig: {
+          crowdin: {
+            enabled: true,
+            projectId: "ext:crowdin:42",
+          },
+        },
+      }),
+    );
+    expect(created.toolConfig.crowdin?.enabled).toBe(true);
   });
 
   it("hoists legacy nested project IDs from tool config", () => {

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -331,8 +331,7 @@ export type WorkspaceAutomationConfigValidationError =
     }
   | {
       code: "scheduled_workflow_required";
-      message:
-        "Scheduled automations require at least one GitHub, Contentful, Issues, Web Search, or Crowdin workflow tool.";
+      message: "Scheduled automations require at least one GitHub, Contentful, Issues, Web Search, or Crowdin workflow tool.";
     }
   | {
       code: "contentful_connection_required";

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -18,6 +18,8 @@ import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 import { optionalProjectIdSchema } from "@/lib/projects/identity/project-id";
 import { lockAhrefsConnectionForUpdate } from "@/lib/ahrefs/connections";
 import { lockSemrushConnectionForUpdate } from "@/lib/semrush/connections";
+import { crowdinAuth } from "@/lib/providers/adapters/crowdin/crowdin-auth";
+import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 
 import {
   hasWorkspaceAutomationGithubAgentTool,
@@ -185,6 +187,13 @@ const ahrefsToolConfigSchema = z
   })
   .default({ enabled: false });
 
+const crowdinToolConfigSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+    projectId: z.string().trim().min(1).max(128).optional(),
+  })
+  .default({ enabled: false });
+
 export const workspaceAutomationWebSearchProviderSchema = z.enum(["auto", "perplexity", "exa"]);
 
 const webSearchToolConfigSchema = z
@@ -251,6 +260,7 @@ const toolConfigObjectSchema = z
     mcp: mcpToolConfigSchema.optional(),
     semrush: semrushToolConfigSchema.optional(),
     ahrefs: ahrefsToolConfigSchema.optional(),
+    crowdin: crowdinToolConfigSchema.optional(),
     webSearch: webSearchToolConfigSchema.optional(),
   })
   .default({});
@@ -291,6 +301,7 @@ export type WorkspaceAutomationKnowledgeToolConfig = z.infer<typeof knowledgeToo
 export type WorkspaceAutomationMcpToolConfig = z.infer<typeof mcpToolConfigSchema>;
 export type WorkspaceAutomationSemrushToolConfig = z.infer<typeof semrushToolConfigSchema>;
 export type WorkspaceAutomationAhrefsToolConfig = z.infer<typeof ahrefsToolConfigSchema>;
+export type WorkspaceAutomationCrowdinToolConfig = z.infer<typeof crowdinToolConfigSchema>;
 export type WorkspaceAutomationWebSearchProvider = z.infer<
   typeof workspaceAutomationWebSearchProviderSchema
 >;
@@ -320,7 +331,8 @@ export type WorkspaceAutomationConfigValidationError =
     }
   | {
       code: "scheduled_workflow_required";
-      message: "Scheduled automations require at least one GitHub, Contentful, Issues, or Web Search workflow tool.";
+      message:
+        "Scheduled automations require at least one GitHub, Contentful, Issues, Web Search, or Crowdin workflow tool.";
     }
   | {
       code: "contentful_connection_required";
@@ -397,6 +409,22 @@ export type WorkspaceAutomationConfigValidationError =
   | {
       code: "ahrefs_not_connected";
       message: "Enable the selected Ahrefs connection in Integrations before using it.";
+    }
+  | {
+      code: "crowdin_project_required";
+      message: "Enabled Crowdin tools require a Crowdin-linked project.";
+    }
+  | {
+      code: "crowdin_project_not_found";
+      message: "The selected Crowdin project was not found. Choose another project.";
+    }
+  | {
+      code: "crowdin_project_not_linked";
+      message: "The selected project is not linked to Crowdin. Choose a Crowdin project.";
+    }
+  | {
+      code: "crowdin_not_connected";
+      message: "Connect Crowdin in Integrations before using Crowdin review tools.";
     };
 
 type AutomationRow = typeof schema.workspaceAutomations.$inferSelect;
@@ -449,6 +477,10 @@ export function hasWorkspaceAutomationSemrushTool(toolConfig: WorkspaceAutomatio
 
 export function hasWorkspaceAutomationAhrefsTool(toolConfig: WorkspaceAutomationToolConfig) {
   return Boolean(toolConfig.ahrefs?.enabled);
+}
+
+export function hasWorkspaceAutomationCrowdinTool(toolConfig: WorkspaceAutomationToolConfig) {
+  return Boolean(toolConfig.crowdin?.enabled);
 }
 
 export function hasWorkspaceAutomationWebSearchTool(toolConfig: WorkspaceAutomationToolConfig) {
@@ -625,12 +657,13 @@ function validateWorkspaceAutomationConfig(input: {
     !hasWorkspaceAutomationContentfulWorkflow(input.toolConfig) &&
     !hasWorkspaceAutomationListIssuesTool(input.toolConfig) &&
     !hasWorkspaceAutomationCreateIssueTool(input.toolConfig) &&
-    !hasWorkspaceAutomationWebSearchTool(input.toolConfig)
+    !hasWorkspaceAutomationWebSearchTool(input.toolConfig) &&
+    !hasWorkspaceAutomationCrowdinTool(input.toolConfig)
   ) {
     return err({
       code: "scheduled_workflow_required",
       message:
-        "Scheduled automations require at least one GitHub, Contentful, Issues, or Web Search workflow tool.",
+        "Scheduled automations require at least one GitHub, Contentful, Issues, Web Search, or Crowdin workflow tool.",
     });
   }
 
@@ -726,6 +759,14 @@ function validateWorkspaceAutomationConfig(input: {
     return err({
       code: "ahrefs_connection_required",
       message: "Enabled Ahrefs tools require an Ahrefs connection.",
+    });
+  }
+
+  const crowdinTools = input.toolConfig.crowdin;
+  if (crowdinTools?.enabled && !readOptionalProjectId(crowdinTools.projectId)) {
+    return err({
+      code: "crowdin_project_required",
+      message: "Enabled Crowdin tools require a Crowdin-linked project.",
     });
   }
 
@@ -919,6 +960,63 @@ export async function validateWorkspaceAutomationIntegrations(input: {
       return err({
         code: "ahrefs_not_connected",
         message: "Enable the selected Ahrefs connection in Integrations before using it.",
+      });
+    }
+  }
+
+  if (input.toolConfig.crowdin?.enabled) {
+    const projectId = readOptionalProjectId(input.toolConfig.crowdin.projectId);
+    if (!projectId) {
+      return err({
+        code: "crowdin_project_required",
+        message: "Enabled Crowdin tools require a Crowdin-linked project.",
+      });
+    }
+
+    const encodedProject = parseProviderProjectId(projectId);
+    if (encodedProject) {
+      if (encodedProject.providerKind !== "crowdin") {
+        return err({
+          code: "crowdin_project_not_linked",
+          message: "The selected project is not linked to Crowdin. Choose a Crowdin project.",
+        });
+      }
+    } else {
+      const [project] = await database
+        .select({
+          id: schema.projects.id,
+          source: schema.projects.source,
+          externalProviderKind: schema.projects.externalProviderKind,
+        })
+        .from(schema.projects)
+        .where(
+          and(
+            eq(schema.projects.organizationId, input.organizationId),
+            eq(schema.projects.id, projectId),
+          ),
+        )
+        .limit(1);
+
+      if (!project) {
+        return err({
+          code: "crowdin_project_not_found",
+          message: "The selected Crowdin project was not found. Choose another project.",
+        });
+      }
+
+      if (project.source !== "external_tms" || project.externalProviderKind !== "crowdin") {
+        return err({
+          code: "crowdin_project_not_linked",
+          message: "The selected project is not linked to Crowdin. Choose a Crowdin project.",
+        });
+      }
+    }
+
+    const credential = await crowdinAuth.loadOrganizationCredential(input.organizationId);
+    if (!credential) {
+      return err({
+        code: "crowdin_not_connected",
+        message: "Connect Crowdin in Integrations before using Crowdin review tools.",
       });
     }
   }

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -1531,6 +1531,26 @@ describe("CrowdinApiClient", () => {
     );
   });
 
+  it("passes the client abort signal to fetches", async () => {
+    const abortSignal = new AbortController().signal;
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = new CrowdinApiClient({
+      token: "test-token",
+      baseUrl: "https://api.crowdin.test/api/v2",
+      fetchFn: fetchMock,
+      signal: abortSignal,
+    });
+    await client.listAiPrompts({ projectId: 42 });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.crowdin.test/api/v2/ai/prompts?projectId=42&limit=500&offset=0",
+      expect.objectContaining({ method: "GET", redirect: "error", signal: abortSignal }),
+    );
+  });
+
   it("lists AI prompts from /users/{id}/ai/prompts on Crowdin.com", async () => {
     const fetchMock = vi.fn(async (url) => {
       const href = String(url);

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -1490,4 +1490,82 @@ describe("CrowdinApiClient", () => {
       expect.objectContaining({ method: "GET", redirect: "error" }),
     );
   });
+
+  it("lists AI prompts from /ai/prompts on enterprise hosts", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          data: [
+            {
+              data: {
+                id: 7,
+                name: "Brand voice",
+                action: "assist",
+                isEnabled: true,
+                enabledProjectIds: [42],
+                config: { prompt: "Use sentence case." },
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const prompts = await client.listAiPrompts({ projectId: 42, action: "assist" });
+
+    expect(prompts).toEqual([
+      {
+        id: 7,
+        name: "Brand voice",
+        action: "assist",
+        isEnabled: true,
+        enabledProjectIds: [42],
+        config: { prompt: "Use sentence case." },
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.crowdin.test/api/v2/ai/prompts?projectId=42&action=assist&limit=500&offset=0",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("lists AI prompts from /users/{id}/ai/prompts on Crowdin.com", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const href = String(url);
+      if (href.endsWith("/user")) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 99,
+              username: "tester",
+              email: "tester@example.com",
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = new CrowdinApiClient({
+      token: "test-token",
+      baseUrl: "https://api.crowdin.com/api/v2",
+      fetchFn: fetchMock,
+    });
+    await client.listAiPrompts({ projectId: 42 });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.crowdin.com/api/v2/user",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.crowdin.com/api/v2/users/99/ai/prompts?projectId=42&limit=500&offset=0",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -197,6 +197,7 @@ export interface CrowdinApiClientOptions {
   token: string;
   baseUrl?: string;
   fetchFn?: typeof fetch;
+  signal?: AbortSignal;
 }
 
 export interface CrowdinProject {
@@ -678,11 +679,13 @@ export class CrowdinApiClient {
   private readonly token: string;
   private readonly baseUrl: string;
   private readonly fetchFn: typeof fetch;
+  private readonly signal?: AbortSignal;
 
   constructor(options: CrowdinApiClientOptions) {
     this.token = options.token;
     this.baseUrl = resolveCrowdinApiBaseUrl(options.baseUrl);
     this.fetchFn = options.fetchFn ?? defaultCrowdinFetch;
+    this.signal = options.signal;
   }
 
   /**
@@ -1692,16 +1695,18 @@ export class CrowdinApiClient {
   async addStorage(input: { fileName: string; content: Uint8Array; contentType?: string }) {
     const url = `${this.baseUrl}/storages`;
     this.logRequest("POST", url);
-    const response = await this.fetchFn(url, {
-      method: "POST",
-      redirect: "error",
-      headers: {
-        Authorization: `Bearer ${this.token}`,
-        "Content-Type": input.contentType ?? "application/octet-stream",
-        "Crowdin-API-FileName": encodeURIComponent(input.fileName),
-      },
-      body: input.content as BodyInit,
-    });
+    const response = await this.fetchFn(
+      url,
+      this.fetchInit({
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+          "Content-Type": input.contentType ?? "application/octet-stream",
+          "Crowdin-API-FileName": encodeURIComponent(input.fileName),
+        },
+        body: input.content as BodyInit,
+      }),
+    );
 
     if (!response.ok) {
       let body: unknown;
@@ -1803,15 +1808,17 @@ export class CrowdinApiClient {
   async exportTaskStrings(projectId: number, taskId: number): Promise<CrowdinDownloadLink | null> {
     const url = `${this.baseUrl}/projects/${projectId}/tasks/${taskId}/exports`;
     this.logRequest("POST", url);
-    const response = await this.fetchFn(url, {
-      method: "POST",
-      redirect: "error",
-      headers: {
-        Authorization: `Bearer ${this.token}`,
-        "Content-Type": "application/json",
-      },
-      body: "",
-    });
+    const response = await this.fetchFn(
+      url,
+      this.fetchInit({
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+          "Content-Type": "application/json",
+        },
+        body: "",
+      }),
+    );
 
     if (response.status === 204) {
       return null;
@@ -1846,7 +1853,7 @@ export class CrowdinApiClient {
     }
 
     this.logRequest("GET", safeUrl);
-    const response = await this.fetchFn(safeUrl, { method: "GET", redirect: "error" });
+    const response = await this.fetchFn(safeUrl, this.fetchInit({ method: "GET" }));
     if (!response.ok) {
       throw new CrowdinApiError(
         `Crowdin download returned HTTP ${response.status}`,
@@ -2131,10 +2138,18 @@ export class CrowdinApiClient {
     logger.info({ method, endpoint }, "Crowdin API request");
   }
 
+  private fetchInit(init: RequestInit): RequestInit {
+    return {
+      ...init,
+      redirect: "error",
+      ...(this.signal && !init.signal ? { signal: this.signal } : {}),
+    };
+  }
+
   private async request<T>(path: string, init: RequestInit): Promise<T> {
     const url = `${this.baseUrl}${path}`;
     this.logRequest(String(init.method ?? "GET"), url);
-    const response = await this.fetchFn(url, { ...init, redirect: "error" });
+    const response = await this.fetchFn(url, this.fetchInit(init));
 
     if (!response.ok) {
       let body: unknown;

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -599,6 +599,26 @@ export interface CrowdinTmConcordanceSearchResult {
   updatedAt: string;
 }
 
+export type CrowdinAiPromptAction = "pre_translate" | "assist";
+
+export interface CrowdinAiPromptConfig {
+  mode?: string | null;
+  companyDescription?: string | null;
+  projectDescription?: string | null;
+  audienceDescription?: string | null;
+  prompt?: string | null;
+}
+
+export interface CrowdinAiPrompt {
+  id: number;
+  name: string;
+  action: string;
+  isEnabled: boolean;
+  enabledProjectIds?: number[] | null;
+  config?: CrowdinAiPromptConfig | null;
+}
+}
+
 export interface CrowdinGlossaryConcordanceSearchRequest {
   sourceLanguageId: string;
   targetLanguageId: string;
@@ -1956,6 +1976,40 @@ export class CrowdinApiClient {
 
   async listGlossaries(): Promise<CrowdinGlossary[]> {
     return this.listPaginated<CrowdinGlossary>("/glossaries");
+  }
+
+  /**
+   * List Crowdin AI prompts. Enterprise uses `/ai/prompts`; Crowdin.com uses
+   * `/users/{userId}/ai/prompts`.
+   *
+   * @see https://developer.crowdin.com/api/v2/#operation/api.ai.prompts.getMany
+   */
+  async listAiPrompts(options?: {
+    projectId?: number;
+    action?: CrowdinAiPromptAction;
+  }): Promise<CrowdinAiPrompt[]> {
+    const params = new URLSearchParams();
+    if (options?.projectId !== undefined) {
+      params.set("projectId", String(options.projectId));
+    }
+    if (options?.action) {
+      params.set("action", options.action);
+    }
+
+    const collectionPath = await this.aiPromptsCollectionPath();
+    const query = params.toString();
+    return this.listPaginated<CrowdinAiPrompt>(
+      query ? `${collectionPath}?${query}` : collectionPath,
+    );
+  }
+
+  private async aiPromptsCollectionPath(): Promise<string> {
+    if (isCrowdinEnterpriseApiBaseUrl(this.baseUrl)) {
+      return "/ai/prompts";
+    }
+
+    const user = await this.getAuthenticatedUser();
+    return `/users/${user.id}/ai/prompts`;
   }
 
   async listGlossaryTerms(glossaryId: number): Promise<CrowdinGlossaryTerm[]> {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -617,7 +617,6 @@ export interface CrowdinAiPrompt {
   enabledProjectIds?: number[] | null;
   config?: CrowdinAiPromptConfig | null;
 }
-}
 
 export interface CrowdinGlossaryConcordanceSearchRequest {
   sourceLanguageId: string;

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-concordance-search.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-concordance-search.test.ts
@@ -65,7 +65,9 @@ describe("crowdinTmsProvider.searchConcordanceForAgent", () => {
                 data: {
                   glossary: { id: 9, name: "Product glossary" },
                   sourceTerms: [{ id: 1, languageId: "en", text: "Save", status: "preferred" }],
-                  targetTerms: [{ id: 2, languageId: "de", text: "Speichern", status: "preferred" }],
+                  targetTerms: [
+                    { id: 2, languageId: "de", text: "Speichern", status: "preferred" },
+                  ],
                 },
               },
             ],

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-concordance-search.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-concordance-search.test.ts
@@ -152,6 +152,53 @@ describe("crowdinTmsProvider.searchConcordanceForAgent", () => {
     }
     expect(result.error.code).toBe("crowdin_not_configured");
   });
+
+  it("passes the abort signal to Crowdin fetches", async () => {
+    const abortSignal = new AbortController().signal;
+    loadProjectCredentialMock.mockResolvedValue({
+      externalProjectId: "42",
+      credential: baseCredential,
+    });
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+
+    await crowdinTmsProvider.searchConcordanceForAgent({
+      organizationId: "org-1",
+      projectId: "ext:crowdin:42",
+      sourceLocale: "en",
+      targetLocale: "de",
+      expressions: ["Save"],
+      signal: abortSignal,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/glossaries/concordance"),
+      expect.objectContaining({ signal: abortSignal }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/tms/concordance"),
+      expect.objectContaining({ signal: abortSignal }),
+    );
+  });
+
+  it("rethrows abort errors instead of mapping them to API failures", async () => {
+    loadProjectCredentialMock.mockResolvedValue({
+      externalProjectId: "42",
+      credential: baseCredential,
+    });
+    const abortError = Object.assign(new Error("aborted"), { name: "AbortError" });
+    fetchMock.mockRejectedValue(abortError);
+
+    await expect(
+      crowdinTmsProvider.searchConcordanceForAgent({
+        organizationId: "org-1",
+        projectId: "ext:crowdin:42",
+        sourceLocale: "en",
+        targetLocale: "de",
+        expressions: ["Save"],
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
 });
 
 describe("crowdinTmsProvider.loadStyleGuideForAgent", () => {
@@ -237,5 +284,22 @@ describe("crowdinTmsProvider.loadStyleGuideForAgent", () => {
       return;
     }
     expect(result.value.prompts).toEqual([]);
+  });
+
+  it("rethrows abort errors instead of returning an empty prompt list", async () => {
+    loadProjectCredentialMock.mockResolvedValue({
+      externalProjectId: "42",
+      credential: baseCredential,
+    });
+    const abortError = Object.assign(new Error("aborted"), { name: "AbortError" });
+    fetchMock.mockRejectedValue(abortError);
+
+    await expect(
+      crowdinTmsProvider.loadStyleGuideForAgent({
+        organizationId: "org-1",
+        projectId: "ext:crowdin:42",
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-concordance-search.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-concordance-search.test.ts
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { isErr, isOk } from "@/lib/primitives/result/results";
+
+import { crowdinTmsProvider } from "./crowdin-provider";
+
+const { loadProjectCredentialMock, fetchMock } = vi.hoisted(() => ({
+  loadProjectCredentialMock: vi.fn(),
+  fetchMock: vi.fn(),
+}));
+
+const baseCredential = {
+  encryptionAlgorithm: "aes-256-gcm",
+  keyVersion: 1,
+  ciphertext: "cipher",
+  iv: "iv",
+  authTag: "tag",
+  baseUrl: "https://api.crowdin.test/api/v2",
+  providerKind: "crowdin" as const,
+  authMode: "api_token",
+};
+
+vi.mock("./crowdin-auth", () => ({
+  crowdinAuth: {
+    loadOrganizationCredential: vi.fn(),
+    loadProjectCredential: (...args: unknown[]) => loadProjectCredentialMock(...args),
+  },
+}));
+
+vi.mock("@/lib/providers/shared/tms-provider-content", () => ({
+  resolveExternalTmsSecretMaterialForActor: vi.fn(async () => "token"),
+}));
+
+describe("crowdinTmsProvider.searchConcordanceForAgent", () => {
+  beforeEach(() => {
+    loadProjectCredentialMock.mockReset();
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("returns glossary and translation-memory matches for a project", async () => {
+    loadProjectCredentialMock.mockResolvedValue({
+      externalProjectId: "42",
+      credential: baseCredential,
+    });
+    fetchMock.mockImplementation(async (url) => {
+      const href = String(url);
+      if (href.includes("/glossaries/concordance")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  glossary: { id: 9, name: "Product glossary" },
+                  sourceTerms: [{ id: 1, languageId: "en", text: "Save", status: "preferred" }],
+                  targetTerms: [{ id: 2, languageId: "de", text: "Speichern", status: "preferred" }],
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          data: [
+            {
+              data: {
+                tm: { id: 3, name: "Product TM" },
+                recordId: 88,
+                source: "Save changes",
+                target: "Änderungen speichern",
+                relevant: 92,
+                substituted: "Save changes",
+                updatedAt: "2026-08-01T00:00:00.000Z",
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    });
+
+    const result = await crowdinTmsProvider.searchConcordanceForAgent({
+      organizationId: "org-1",
+      actorUserId: "user-1",
+      projectId: "ext:crowdin:42",
+      sourceLocale: "en",
+      targetLocale: "de",
+      expressions: ["Save"],
+    });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      return;
+    }
+
+    expect(result.value).toEqual({
+      crowdinProjectId: 42,
+      glossaryMatches: [
+        {
+          glossaryId: 9,
+          glossaryName: "Product glossary",
+          sourceTerm: "Save",
+          targetTerm: "Speichern",
+          status: "preferred",
+          description: null,
+        },
+      ],
+      translationMemoryMatches: [
+        {
+          memoryId: 3,
+          memoryName: "Product TM",
+          recordId: 88,
+          sourceText: "Save changes",
+          targetText: "Änderungen speichern",
+          matchScore: 92,
+        },
+      ],
+    });
+  });
+
+  it("returns not configured when the project is not linked to Crowdin", async () => {
+    loadProjectCredentialMock.mockResolvedValue(null);
+
+    const result = await crowdinTmsProvider.searchConcordanceForAgent({
+      organizationId: "org-1",
+      projectId: "project-1",
+      sourceLocale: "en",
+      targetLocale: "de",
+      expressions: ["Save"],
+    });
+
+    expect(isErr(result)).toBe(true);
+    if (!isErr(result)) {
+      return;
+    }
+    expect(result.error.code).toBe("crowdin_not_configured");
+  });
+});
+
+describe("crowdinTmsProvider.loadStyleGuideForAgent", () => {
+  beforeEach(() => {
+    loadProjectCredentialMock.mockReset();
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("returns enabled prompts that apply to the project", async () => {
+    loadProjectCredentialMock.mockResolvedValue({
+      externalProjectId: "42",
+      credential: baseCredential,
+    });
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              data: {
+                id: 1,
+                name: "Brand voice",
+                action: "assist",
+                isEnabled: true,
+                enabledProjectIds: [42],
+                config: {
+                  companyDescription: "Acme",
+                  prompt: "Use sentence case.",
+                },
+              },
+            },
+            {
+              data: {
+                id: 2,
+                name: "Disabled",
+                action: "assist",
+                isEnabled: false,
+                config: { prompt: "Ignore" },
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const result = await crowdinTmsProvider.loadStyleGuideForAgent({
+      organizationId: "org-1",
+      projectId: "ext:crowdin:42",
+    });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      return;
+    }
+    expect(result.value.prompts).toEqual([
+      {
+        id: 1,
+        name: "Brand voice",
+        action: "assist",
+        companyDescription: "Acme",
+        projectDescription: null,
+        audienceDescription: null,
+        prompt: "Use sentence case.",
+      },
+    ]);
+  });
+
+  it("returns an empty prompt list when AI listing is unavailable", async () => {
+    loadProjectCredentialMock.mockResolvedValue({
+      externalProjectId: "42",
+      credential: baseCredential,
+    });
+    fetchMock.mockResolvedValue(new Response("not found", { status: 404 }));
+
+    const result = await crowdinTmsProvider.loadStyleGuideForAgent({
+      organizationId: "org-1",
+      projectId: "ext:crowdin:42",
+    });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      return;
+    }
+    expect(result.value.prompts).toEqual([]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
@@ -111,6 +111,11 @@ export {
 
 const implemented = { state: "implemented" } as const satisfies TmsProviderFeature;
 const logger = createLogger("crowdin-provider");
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
 const CROWDIN_GLOSSARY_FETCH_CONCURRENCY = 5;
 const CROWDIN_TM_FETCH_CONCURRENCY = 5;
 const MAX_SEGMENTS_PER_MEMORY = 2_000;
@@ -297,11 +302,13 @@ export class CrowdinTmsProvider extends TmsProvider {
     credential: { baseUrl?: string | null };
     secretMaterial: string;
     fetchFn?: typeof fetch;
+    signal?: AbortSignal;
   }) {
     return new CrowdinApiClient({
       token: input.secretMaterial,
       baseUrl: input.credential.baseUrl ?? undefined,
       fetchFn: input.fetchFn,
+      signal: input.signal,
     });
   }
 
@@ -1866,6 +1873,7 @@ export class CrowdinTmsProvider extends TmsProvider {
     expressions: string[];
     glossaryLimit?: number;
     translationMemoryLimit?: number;
+    signal?: AbortSignal;
   }): Promise<Result<SearchCrowdinConcordanceResult, CrowdinReviewLookupError>> {
     const expressions = [
       ...new Set(input.expressions.map((expression) => expression.trim()).filter(Boolean)),
@@ -1877,6 +1885,7 @@ export class CrowdinTmsProvider extends TmsProvider {
       organizationId: input.organizationId,
       projectId: input.projectId,
       actorUserId: input.actorUserId,
+      signal: input.signal,
     });
     if (isErr(clientResult)) {
       return err({
@@ -1962,6 +1971,10 @@ export class CrowdinTmsProvider extends TmsProvider {
         translationMemoryMatches,
       });
     } catch (error) {
+      if (isAbortError(error)) {
+        throw error;
+      }
+
       if (error instanceof CrowdinApiError && error.status === 401) {
         return err({
           code: "crowdin_api_error",
@@ -1984,11 +1997,13 @@ export class CrowdinTmsProvider extends TmsProvider {
     organizationId: string;
     actorUserId?: string | null;
     projectId: string;
+    signal?: AbortSignal;
   }): Promise<Result<LoadCrowdinStyleGuideResult, CrowdinReviewLookupError>> {
     const clientResult = await this.createProgressClient({
       organizationId: input.organizationId,
       projectId: input.projectId,
       actorUserId: input.actorUserId,
+      signal: input.signal,
     });
     if (isErr(clientResult)) {
       return err({
@@ -2008,6 +2023,10 @@ export class CrowdinTmsProvider extends TmsProvider {
         prompts: this.mapEnabledStylePrompts(prompts, crowdinProjectId),
       });
     } catch (error) {
+      if (isAbortError(error)) {
+        throw error;
+      }
+
       if (error instanceof CrowdinApiError && (error.status === 401 || error.status === 403)) {
         return err({
           code: "crowdin_api_error",
@@ -2301,6 +2320,7 @@ export class CrowdinTmsProvider extends TmsProvider {
     organizationId: string;
     projectId: string;
     actorUserId?: string | null;
+    signal?: AbortSignal;
   }): Promise<
     Result<
       { client: CrowdinApiClient; crowdinProjectId: number },
@@ -2348,6 +2368,7 @@ export class CrowdinTmsProvider extends TmsProvider {
     const client = this.createClient({
       credential: projectCredential.credential,
       secretMaterial: token,
+      signal: input.signal,
     });
     return ok({ client, crowdinProjectId });
   }

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
@@ -34,6 +34,7 @@ import {
   CrowdinApiClient,
   CrowdinApiError,
   escapeCrowdinCroqlString,
+  type CrowdinAiPrompt,
   type CrowdinBranch,
   type CrowdinCreateTaskRequest,
   type CrowdinDirectory,
@@ -197,6 +198,43 @@ export type SearchCrowdinGlossaryResult = {
 type CrowdinGlossarySearchError =
   | { code: "crowdin_not_configured"; message: string }
   | { code: "crowdin_api_error"; message: string };
+
+type CrowdinReviewLookupError =
+  | { code: "crowdin_not_configured"; message: string }
+  | { code: "crowdin_api_error"; message: string };
+
+/** Agent-facing Crowdin TM concordance match. */
+export type CrowdinAgentTranslationMemoryMatch = {
+  memoryId: number;
+  memoryName: string;
+  recordId: number;
+  sourceText: string;
+  targetText: string;
+  matchScore: number;
+};
+
+/** Combined glossary and TM concordance for workspace automation review. */
+export type SearchCrowdinConcordanceResult = {
+  crowdinProjectId: number;
+  glossaryMatches: CrowdinAgentGlossaryMatch[];
+  translationMemoryMatches: CrowdinAgentTranslationMemoryMatch[];
+};
+
+/** Crowdin AI prompt fields that act as a style guide for review. */
+export type CrowdinAgentStylePrompt = {
+  id: number;
+  name: string;
+  action: string;
+  companyDescription: string | null;
+  projectDescription: string | null;
+  audienceDescription: string | null;
+  prompt: string | null;
+};
+
+export type LoadCrowdinStyleGuideResult = {
+  crowdinProjectId: number;
+  prompts: CrowdinAgentStylePrompt[];
+};
 
 /**
  * Crowdin implementation of the shared TMS provider contract.
@@ -1814,6 +1852,205 @@ export class CrowdinTmsProvider extends TmsProvider {
         message: error instanceof Error ? error.message : "Crowdin glossary search failed.",
       });
     }
+  }
+
+  /**
+   * Agent concordance search: glossary plus translation memory for one or more expressions.
+   */
+  async searchConcordanceForAgent(input: {
+    organizationId: string;
+    actorUserId?: string | null;
+    projectId: string;
+    sourceLocale: string;
+    targetLocale: string;
+    expressions: string[];
+    glossaryLimit?: number;
+    translationMemoryLimit?: number;
+  }): Promise<Result<SearchCrowdinConcordanceResult, CrowdinReviewLookupError>> {
+    const expressions = [
+      ...new Set(input.expressions.map((expression) => expression.trim()).filter(Boolean)),
+    ].slice(0, 20);
+    const glossaryLimit = Math.min(Math.max(input.glossaryLimit ?? 20, 1), 50);
+    const translationMemoryLimit = Math.min(Math.max(input.translationMemoryLimit ?? 10, 1), 50);
+
+    const clientResult = await this.createProgressClient({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      actorUserId: input.actorUserId,
+    });
+    if (isErr(clientResult)) {
+      return err({
+        code:
+          clientResult.error.code === "crowdin_not_configured"
+            ? "crowdin_not_configured"
+            : "crowdin_api_error",
+        message: clientResult.error.message,
+      });
+    }
+
+    const { client, crowdinProjectId } = clientResult.value;
+    if (expressions.length === 0) {
+      return ok({
+        crowdinProjectId,
+        glossaryMatches: [],
+        translationMemoryMatches: [],
+      });
+    }
+
+    try {
+      const [glossaryResults, translationMemoryResults] = await Promise.all([
+        client.glossaryConcordanceSearch(crowdinProjectId, {
+          sourceLanguageId: input.sourceLocale,
+          targetLanguageId: input.targetLocale,
+          expressions,
+        }),
+        client.concordanceSearch(crowdinProjectId, {
+          sourceLanguageId: input.sourceLocale,
+          targetLanguageId: input.targetLocale,
+          expressions,
+          minRelevant: 50,
+          autoSubstitution: false,
+        }),
+      ]);
+
+      const glossaryMatches: CrowdinAgentGlossaryMatch[] = [];
+      resultsLoop: for (const result of glossaryResults) {
+        const sourceTerms = result.sourceTerms
+          .filter((term) => term.languageId === input.sourceLocale)
+          .map((term) => ({ ...term, text: term.text.trim() }))
+          .filter((term) => term.text);
+        const targetTerms = result.targetTerms
+          .filter((term) => term.languageId === input.targetLocale)
+          .map((term) => ({ ...term, text: term.text.trim() }))
+          .filter((term) => term.text);
+        if (sourceTerms.length === 0 || targetTerms.length === 0) {
+          continue;
+        }
+
+        for (const sourceTerm of sourceTerms) {
+          for (const targetTerm of targetTerms) {
+            const description = targetTerm.description ?? sourceTerm.description ?? null;
+            glossaryMatches.push({
+              glossaryId: result.glossary.id,
+              glossaryName: result.glossary.name,
+              sourceTerm: sourceTerm.text,
+              targetTerm: targetTerm.text,
+              status: targetTerm.status ?? sourceTerm.status ?? null,
+              description: description?.trim() ? description.trim() : null,
+            });
+            if (glossaryMatches.length >= glossaryLimit) {
+              break resultsLoop;
+            }
+          }
+        }
+      }
+
+      const translationMemoryMatches = translationMemoryResults
+        .slice(0, translationMemoryLimit)
+        .map((result) => ({
+          memoryId: result.tm.id,
+          memoryName: result.tm.name,
+          recordId: result.recordId,
+          sourceText: result.source,
+          targetText: result.target,
+          matchScore: result.relevant,
+        }));
+
+      return ok({
+        crowdinProjectId,
+        glossaryMatches,
+        translationMemoryMatches,
+      });
+    } catch (error) {
+      if (error instanceof CrowdinApiError && error.status === 401) {
+        return err({
+          code: "crowdin_api_error",
+          message: "Crowdin authentication failed. Reconnect Crowdin and try again.",
+        });
+      }
+
+      return err({
+        code: "crowdin_api_error",
+        message: error instanceof Error ? error.message : "Crowdin concordance search failed.",
+      });
+    }
+  }
+
+  /**
+   * Agent style-guide lookup: Crowdin AI prompts that apply to the linked project.
+   * Missing AI access returns an empty prompt list rather than failing the review.
+   */
+  async loadStyleGuideForAgent(input: {
+    organizationId: string;
+    actorUserId?: string | null;
+    projectId: string;
+  }): Promise<Result<LoadCrowdinStyleGuideResult, CrowdinReviewLookupError>> {
+    const clientResult = await this.createProgressClient({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      actorUserId: input.actorUserId,
+    });
+    if (isErr(clientResult)) {
+      return err({
+        code:
+          clientResult.error.code === "crowdin_not_configured"
+            ? "crowdin_not_configured"
+            : "crowdin_api_error",
+        message: clientResult.error.message,
+      });
+    }
+
+    const { client, crowdinProjectId } = clientResult.value;
+    try {
+      const prompts = await client.listAiPrompts({ projectId: crowdinProjectId });
+      return ok({
+        crowdinProjectId,
+        prompts: this.mapEnabledStylePrompts(prompts, crowdinProjectId),
+      });
+    } catch (error) {
+      if (error instanceof CrowdinApiError && (error.status === 401 || error.status === 403)) {
+        return err({
+          code: "crowdin_api_error",
+          message: "Crowdin authentication failed. Reconnect Crowdin and try again.",
+        });
+      }
+
+      logger.info(
+        {
+          organizationId: input.organizationId,
+          crowdinProjectId,
+          status: error instanceof CrowdinApiError ? error.status : null,
+        },
+        "crowdin ai prompt listing unavailable; returning empty style prompts",
+      );
+      return ok({
+        crowdinProjectId,
+        prompts: [],
+      });
+    }
+  }
+
+  private mapEnabledStylePrompts(
+    prompts: CrowdinAiPrompt[],
+    crowdinProjectId: number,
+  ): CrowdinAgentStylePrompt[] {
+    return prompts
+      .filter((prompt) => {
+        if (!prompt.isEnabled) {
+          return false;
+        }
+        const enabledProjectIds = prompt.enabledProjectIds ?? [];
+        return enabledProjectIds.length === 0 || enabledProjectIds.includes(crowdinProjectId);
+      })
+      .map((prompt) => ({
+        id: prompt.id,
+        name: prompt.name,
+        action: prompt.action,
+        companyDescription: prompt.config?.companyDescription?.trim() || null,
+        projectDescription: prompt.config?.projectDescription?.trim() || null,
+        audienceDescription: prompt.config?.audienceDescription?.trim() || null,
+        prompt: prompt.config?.prompt?.trim() || null,
+      }));
   }
 
   /**

--- a/apps/hyperlocalise-web/src/lib/translation/cat.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/cat.ts
@@ -417,6 +417,7 @@ export async function loadCatSegmentVisualContext(
 
 export async function generateCatAiRecommendation(
   input: CatAiRecommendationInput,
+  options?: { signal?: AbortSignal },
 ): Promise<Result<CatAiRecommendationResult, CatAiRecommendationError>> {
   const modelResult = await loadOrganizationTranslationModel(input.projectId);
   if (!modelResult.ok) {
@@ -456,17 +457,25 @@ export async function generateCatAiRecommendation(
   }
 
   try {
-    const recommendation = await new CatRecommendationEngine(modelResult.model).recommend(input, {
-      projectName: contextResult.snapshot.project.name,
-      projectTranslationContext: contextResult.snapshot.project.translationContext,
-      knowledgeMemory: contextResult.snapshot.knowledgeMemory ?? undefined,
-      glossaryTerms: input.glossaryTerms ?? contextResult.snapshot.glossaryTerms ?? [],
-      translationMemoryMatches:
-        input.translationMemoryMatches ?? contextResult.snapshot.translationMemoryMatches ?? [],
-    });
+    const recommendation = await new CatRecommendationEngine(modelResult.model).recommend(
+      input,
+      {
+        projectName: contextResult.snapshot.project.name,
+        projectTranslationContext: contextResult.snapshot.project.translationContext,
+        knowledgeMemory: contextResult.snapshot.knowledgeMemory ?? undefined,
+        glossaryTerms: input.glossaryTerms ?? contextResult.snapshot.glossaryTerms ?? [],
+        translationMemoryMatches:
+          input.translationMemoryMatches ?? contextResult.snapshot.translationMemoryMatches ?? [],
+      },
+      { signal: options?.signal },
+    );
 
     return ok(recommendation);
   } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw error;
+    }
+
     return err({
       code: "ai_recommendation_failed",
       message:

--- a/apps/hyperlocalise-web/src/lib/translation/generate-cat-ai-recommendation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/generate-cat-ai-recommendation.test.ts
@@ -192,4 +192,94 @@ describe("generateCatAiRecommendation", () => {
       },
     });
   });
+
+  it("passes an abort signal to generateText", async () => {
+    const abortSignal = new AbortController().signal;
+    loadOrganizationTranslationModelMock.mockResolvedValue({
+      ok: true,
+      project: {
+        name: "Hyperlocalise",
+        translationContext: "Use concise product UI language.",
+      },
+      model: {},
+    });
+    assembleStringTranslationContextSnapshotMock.mockResolvedValue({
+      ok: true,
+      snapshot: {
+        project: {
+          id: "proj_1",
+          name: "Hyperlocalise",
+          translationContext: "Use concise product UI language.",
+        },
+        glossaryTerms: [],
+        translationMemoryMatches: [],
+      },
+    });
+    generateTextMock.mockResolvedValue({
+      output: {
+        suggestion: "Bonjour",
+        reasoning: "Natural French greeting.",
+      },
+    });
+
+    await generateCatAiRecommendation(
+      {
+        projectId: "proj_1",
+        organizationId: "org_1",
+        sourcePath: "en-US.json",
+        filename: "en-US.json",
+        sourceLocale: "en-US",
+        targetLocale: "fr-FR",
+        key: "greeting",
+        sourceText: "Hello",
+      },
+      { signal: abortSignal },
+    );
+
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        abortSignal,
+      }),
+    );
+  });
+
+  it("rethrows abort errors from generateText", async () => {
+    loadOrganizationTranslationModelMock.mockResolvedValue({
+      ok: true,
+      project: {
+        name: "Hyperlocalise",
+        translationContext: "Use concise product UI language.",
+      },
+      model: {},
+    });
+    assembleStringTranslationContextSnapshotMock.mockResolvedValue({
+      ok: true,
+      snapshot: {
+        project: {
+          id: "proj_1",
+          name: "Hyperlocalise",
+          translationContext: "Use concise product UI language.",
+        },
+        glossaryTerms: [],
+        translationMemoryMatches: [],
+      },
+    });
+    generateTextMock.mockRejectedValue(Object.assign(new Error("aborted"), { name: "AbortError" }));
+
+    await expect(
+      generateCatAiRecommendation(
+        {
+          projectId: "proj_1",
+          organizationId: "org_1",
+          sourcePath: "en-US.json",
+          filename: "en-US.json",
+          sourceLocale: "en-US",
+          targetLocale: "fr-FR",
+          key: "greeting",
+          sourceText: "Hello",
+        },
+        { signal: new AbortController().signal },
+      ),
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/translation/generation.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/generation.ts
@@ -449,9 +449,11 @@ export class CatRecommendationEngine {
       glossaryTerms: PromptGlossaryTerm[];
       translationMemoryMatches: PromptTranslationMemoryMatch[];
     },
+    options?: { signal?: AbortSignal },
   ): Promise<CatAiRecommendationResult> {
     const { output } = await generateText({
       model: this.model,
+      abortSignal: options?.signal,
       output: Output.object({ schema: catAiRecommendationOutputSchema }),
       instructions: this.promptPolicy.buildSystemInstructions({
         mode: "cat-suggest",

--- a/docs/adr/2026-08-19-crowdin-workspace-automation-tool-design.md
+++ b/docs/adr/2026-08-19-crowdin-workspace-automation-tool-design.md
@@ -1,0 +1,45 @@
+# Crowdin Workspace Automation Tool Design
+
+## Date
+
+2026-08-19
+
+## Context
+
+Workspace Agent Automation already has first-class tools for GitHub review, Semrush, Ahrefs, and web search. Code review automations can inspect repository diffs, but they cannot look up Crowdin translation memory, glossary, or style guidance for the strings in those diffs.
+
+Crowdin already exposes the needed APIs in Hyperlocalise: TM concordance, glossary concordance, project translation context, and AI prompts that carry style-guide instructions. CAT already uses those sources to recommend translations. The missing piece is an automation tool that selects a Crowdin-linked project and queries that evidence during a run.
+
+## Decision
+
+Add a `use_crowdin` workspace orchestrator tool.
+
+### Configuration
+
+The automation stores:
+
+```
+toolConfig.crowdin = { enabled: true, projectId }
+```
+
+`projectId` is a Hyperlocalise project linked to Crowdin, or an encoded Crowdin project id (`ext:crowdin:{id}`). The editor shows a project picker on the tool card. GitHub-only review automations do not need the header project field.
+
+### Runtime
+
+The orchestrator calls `use_crowdin` with an objective. A nested read-only agent then uses three tools:
+
+1. `search_concordance` — Crowdin glossary and TM matches for source expressions and locales.
+2. `get_style_guide` — Hyperlocalise project translation context plus Crowdin AI prompt text that applies to the project.
+3. `recommend_translation` — the existing CAT recommendation engine, grounded in concordance and style context.
+
+Place `use_crowdin` after GitHub tools so a code-review digest can supply strings and locales. Combine the Crowdin summary with the GitHub digest when both exist.
+
+### Auth
+
+Reuse the existing Crowdin project credential path, including per-user OAuth when the workspace uses it. Automations pass the automation author as the actor.
+
+## Consequences
+
+- Daily code review can check user-facing strings against approved Crowdin terminology and style.
+- The tool stays search-only. It does not write translations back to Crowdin.
+- Accounts without Crowdin AI prompts still get project translation context and concordance.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Add a first-class Crowdin tool to workspace Agent Automation so code-review runs can look up translation evidence.

- Select a Crowdin-linked project on the tool card. GitHub-only review automations do not need the header project field.
- `use_crowdin` runs a nested read-only agent with `search_concordance`, `get_style_guide`, and `recommend_translation`.
- Concordance covers Crowdin glossary and translation memory. Style guidance combines Hyperlocalise project translation context with Crowdin AI prompts.
- Translation recommendations reuse the CAT recommendation engine and stay search-only (no Crowdin writeback).
- Planned after GitHub tools so a review digest can supply strings and locales. Slack/email summaries append a Crowdin review section when both exist.

Codex review follow-up:

- Nested Crowdin review tools honor the execution abort signal and pass it through `CrowdinApiClient` fetches and CAT `generateText`.
- Encoded `ext:crowdin:{id}` project IDs are materialized with `ensureOrganizationProjectRecord` before CAT recommendations.

## How to test

- `vp test` and `vp check --fix` in `apps/hyperlocalise-web`
- In Agent Automation, add the Crowdin tool, pick a Crowdin-linked project, and run a code-review automation that includes user-facing strings

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70d4bc9c-445e-44c0-817f-5e850afbc256?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70d4bc9c-445e-44c0-817f-5e850afbc256&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

