### PR TITLE
feat(automations): show creator on the automation list

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/workspace-automation/workspace-automation.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/workspace-automation/workspace-automation.route.test.ts
@@ -164,7 +164,12 @@ describe("workspace automation routes", () => {
     );
     expect(listedResponse.status).toBe(200);
     await expect(listedResponse.json()).resolves.toMatchObject({
-      automations: [{ id: createdBody.automation.id }],
+      automations: [
+        {
+          id: createdBody.automation.id,
+          authorName: identity.user.email,
+        },
+      ],
     });
 
     const updatedResponse = await client.api.orgs[":organizationSlug"].automations[

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.messages.ts
@@ -67,7 +67,7 @@ export const automationsPageViewModelMessages = defineMessages({
   },
   unknownCreator: {
     defaultMessage: "Unknown",
-    id: "pQ3mN7vK2s",
+    id: "O+ldw8Aj3z",
     description: "Fallback label when an automation has no creator name",
   },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.messages.ts
@@ -65,4 +65,9 @@ export const automationsPageViewModelMessages = defineMessages({
     id: "RLPdxshxAq",
     description: "Tool badge when an automation uses an MCP server",
   },
+  unknownCreator: {
+    defaultMessage: "Unknown",
+    id: "pQ3mN7vK2s",
+    description: "Fallback label when an automation has no creator name",
+  },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { createIntl } from "@formatjs/intl";
+import { describe, expect, it } from "vite-plus/test";
+
+import { createAutomationSummary } from "./automations.fixture";
+import { resolveAutomationCreatorName } from "./automations-page-view-model";
+
+const intl = createIntl({ locale: "en", messages: {} });
+
+describe("resolveAutomationCreatorName", () => {
+  it("uses the author display name when present", () => {
+    expect(
+      resolveAutomationCreatorName(
+        intl,
+        createAutomationSummary({ authorName: "Ada Lovelace" }),
+      ),
+    ).toBe("Ada Lovelace");
+  });
+
+  it("falls back to Unknown when the author is missing", () => {
+    expect(
+      resolveAutomationCreatorName(intl, createAutomationSummary({ authorName: null })),
+    ).toBe("Unknown");
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.test.ts
@@ -21,16 +21,13 @@ const intl = createIntl({ locale: "en", messages: {} });
 describe("resolveAutomationCreatorName", () => {
   it("uses the author display name when present", () => {
     expect(
-      resolveAutomationCreatorName(
-        intl,
-        createAutomationSummary({ authorName: "Ada Lovelace" }),
-      ),
+      resolveAutomationCreatorName(intl, createAutomationSummary({ authorName: "Ada Lovelace" })),
     ).toBe("Ada Lovelace");
   });
 
   it("falls back to Unknown when the author is missing", () => {
-    expect(
-      resolveAutomationCreatorName(intl, createAutomationSummary({ authorName: null })),
-    ).toBe("Unknown");
+    expect(resolveAutomationCreatorName(intl, createAutomationSummary({ authorName: null }))).toBe(
+      "Unknown",
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.ts
@@ -83,6 +83,18 @@ export function formatAutomationRelativeTimestamp(
   });
 }
 
+export function resolveAutomationCreatorName(
+  intl: Pick<IntlShape, "formatMessage">,
+  automation: WorkspaceAutomationRecord,
+) {
+  const name = automation.authorName?.trim();
+  if (name) {
+    return name;
+  }
+
+  return intl.formatMessage(automationsPageViewModelMessages.unknownCreator);
+}
+
 export function resolveAutomationTriggerLabel(
   intl: IntlShape,
   triggerConfig: WorkspaceAutomationTriggerConfig,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.messages.ts
@@ -71,6 +71,11 @@ export const automationsPageViewMessages = defineMessages({
     id: "g/SyG0phTI",
     description: "Automations list column header for status",
   },
+  columnCreator: {
+    defaultMessage: "Creator",
+    id: "n4qR8kLm2P",
+    description: "Automations list column header for creator",
+  },
   columnCreated: {
     defaultMessage: "Created",
     id: "z5k8iKEIXN",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.messages.ts
@@ -73,7 +73,7 @@ export const automationsPageViewMessages = defineMessages({
   },
   columnCreator: {
     defaultMessage: "Creator",
-    id: "n4qR8kLm2P",
+    id: "Zs0OvEkqcZ",
     description: "Automations list column header for creator",
   },
   columnCreated: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.stories.tsx
@@ -41,6 +41,9 @@ export const Default: Story = {
     await expect(canvas.getByRole("heading", { name: "Automations" })).toBeInTheDocument();
     await expect(canvas.getByText("Validate localisation on push")).toBeInTheDocument();
     await expect(canvas.getByText("Weekly translation sync")).toBeInTheDocument();
+    await expect(canvas.getByText("Ada Lovelace")).toBeInTheDocument();
+    await expect(canvas.getByText("Grace Hopper")).toBeInTheDocument();
+    await expect(canvas.getByText("Unknown")).toBeInTheDocument();
     await expect(canvas.getByText("Translate Contentful article")).toBeInTheDocument();
   },
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
@@ -35,6 +35,7 @@ import { AutomationTemplateFlow } from "./automation-template-flow";
 import { automationsPageViewMessages } from "./automations-page-view.messages";
 import {
   formatAutomationRelativeTimestamp,
+  resolveAutomationCreatorName,
   resolveAutomationPageStats,
   resolveAutomationTools,
   resolveAutomationTriggerLabel,
@@ -47,7 +48,7 @@ const TEMPLATE_FILTER_TABS_CLASS =
   "h-auto flex-none rounded-full border-transparent px-3 py-1.5 text-muted-foreground shadow-none after:hidden hover:text-foreground data-active:bg-accent data-active:text-foreground dark:data-active:border-transparent dark:data-active:bg-accent";
 
 const AUTOMATION_LIST_GRID_CLASS =
-  "grid grid-cols-[minmax(0,1.6fr)_minmax(0,0.8fr)_minmax(0,0.8fr)_minmax(0,0.5fr)] gap-4";
+  "grid min-w-[52rem] grid-cols-[minmax(0,1.5fr)_minmax(0,0.8fr)_minmax(0,0.55fr)_minmax(0,0.8fr)_minmax(0,0.45fr)] gap-4";
 
 const TEMPLATE_CATEGORY_MESSAGES = {
   popular: automationsPageViewMessages.categoryPopular,
@@ -80,6 +81,7 @@ function AutomationListSkeleton() {
             <Skeleton className="h-5 w-12 rounded-full bg-muted" />
           </div>
           <Skeleton className="h-5 w-16 rounded-full bg-muted" />
+          <Skeleton className="h-4 w-24 rounded-full bg-muted" />
           <Skeleton className="h-4 w-8 rounded-full bg-muted" />
         </div>
       ))}
@@ -224,7 +226,7 @@ export function AutomationsPageView({
       </section>
 
       <section className="flex flex-col gap-4">
-        <div className="overflow-hidden rounded-xl border border-border">
+        <div className="overflow-x-auto rounded-xl border border-border">
           <div
             className={`${AUTOMATION_LIST_GRID_CLASS} border-b border-border px-4 py-3 text-xs font-medium text-muted-foreground`}
           >
@@ -236,6 +238,9 @@ export function AutomationsPageView({
             </span>
             <span>
               <FormattedMessage {...automationsPageViewMessages.columnStatus} />
+            </span>
+            <span>
+              <FormattedMessage {...automationsPageViewMessages.columnCreator} />
             </span>
             <span>
               <FormattedMessage {...automationsPageViewMessages.columnCreated} />
@@ -280,6 +285,9 @@ export function AutomationsPageView({
                           <FormattedMessage {...automationsPageViewMessages.statusPaused} />
                         )}
                       </Badge>
+                      <span className="truncate text-sm text-muted-foreground">
+                        {resolveAutomationCreatorName(intl, automation)}
+                      </span>
                       <span className="text-sm text-muted-foreground">
                         {formatAutomationRelativeTimestamp(intl, automation.createdAt, now)}
                       </span>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations.fixture.ts
@@ -40,6 +40,7 @@ export function createAutomationSummary(
     id: "11111111-1111-4111-8111-111111111111",
     organizationId: "org_001",
     authorUserId: "user_001",
+    authorName: "Ada Lovelace",
     status: "active",
     name: "Validate localisation on push",
     instructions: "Validate source and translation changes on every push.",
@@ -110,6 +111,7 @@ export const automationsFixture: WorkspaceAutomationRecord[] = [
       contentful: disabledContentfulToolConfig,
     },
     createdAt: "2026-06-01T08:00:00.000Z",
+    authorName: "Grace Hopper",
   }),
   createAutomationSummary({
     id: "44444444-4444-4444-8444-444444444444",
@@ -133,6 +135,7 @@ export const automationsFixture: WorkspaceAutomationRecord[] = [
       },
       contentful: disabledContentfulToolConfig,
     },
+    authorName: null,
     createdAt: "2026-05-20T14:30:00.000Z",
   }),
 ];

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
@@ -24,6 +24,7 @@ import { claimGithubRepositoryAutomationJob } from "./github/github-repository-a
 import {
   createWorkspaceAutomation,
   createWorkspaceAutomationRun,
+  formatWorkspaceAutomationAuthorName,
   getWorkspaceAutomationById,
   hoistLegacyWorkspaceAutomationProjectId,
   listDueContentfulWorkspaceAutomations,
@@ -67,6 +68,8 @@ async function seedWorkspaceAutomationScope() {
     id: userId,
     workosUserId: `user_${userId}`,
     email: `${userId}@example.test`,
+    firstName: "Ada",
+    lastName: "Lovelace",
   });
 
   await db.insert(schema.projects).values({
@@ -195,6 +198,33 @@ describe("hoistLegacyWorkspaceAutomationProjectId", () => {
   });
 });
 
+describe("formatWorkspaceAutomationAuthorName", () => {
+  it("prefers a full name, then email, then null", () => {
+    expect(
+      formatWorkspaceAutomationAuthorName({
+        firstName: "Ada",
+        lastName: "Lovelace",
+        email: "ada@example.test",
+      }),
+    ).toBe("Ada Lovelace");
+    expect(
+      formatWorkspaceAutomationAuthorName({
+        firstName: null,
+        lastName: null,
+        email: "hopper@example.test",
+      }),
+    ).toBe("hopper@example.test");
+    expect(
+      formatWorkspaceAutomationAuthorName({
+        firstName: "  ",
+        lastName: "",
+        email: "  ",
+      }),
+    ).toBeNull();
+    expect(formatWorkspaceAutomationAuthorName(null)).toBeNull();
+  });
+});
+
 describe("workspace automations", () => {
   beforeAll(async () => {
     await db.$client.query("select 1");
@@ -277,6 +307,7 @@ describe("workspace automations", () => {
     expect(automation).toMatchObject({
       organizationId: scope.organizationId,
       authorUserId: scope.userId,
+      authorName: "Ada Lovelace",
       status: "active",
       name: "Refresh repository translations",
       triggerConfig: { mode: "manual" },
@@ -288,6 +319,7 @@ describe("workspace automations", () => {
 
     const [listed] = await listWorkspaceAutomations({ organizationId: scope.organizationId });
     expect(listed?.id).toBe(automation.id);
+    expect(listed?.authorName).toBe("Ada Lovelace");
   });
 
   it("rejects enabled GitHub tools without project and repository config", async () => {
@@ -738,6 +770,54 @@ describe("workspace automations", () => {
 
     expect(firstPage.map((item) => item.name)).toEqual(["Automation 3", "Automation 2"]);
     expect(secondPage.map((item) => item.name)).toEqual(["Automation 1"]);
+  });
+
+  it("falls back to email for author names and omits deleted authors", async () => {
+    const scope = await seedWorkspaceAutomationScope();
+    const emailOnlyUserId = crypto.randomUUID();
+    await db.insert(schema.users).values({
+      id: emailOnlyUserId,
+      workosUserId: `user_${emailOnlyUserId}`,
+      email: "hopper@example.test",
+    });
+
+    const namedAutomation = expectOk(
+      await createWorkspaceAutomation({
+        organizationId: scope.organizationId,
+        authorUserId: scope.userId,
+        name: "Named author automation",
+        instructions: "Created by a named user.",
+      }),
+    );
+    const emailAutomation = expectOk(
+      await createWorkspaceAutomation({
+        organizationId: scope.organizationId,
+        authorUserId: emailOnlyUserId,
+        name: "Email author automation",
+        instructions: "Created by an email-only user.",
+      }),
+    );
+    const anonymousAutomation = expectOk(
+      await createWorkspaceAutomation({
+        organizationId: scope.organizationId,
+        authorUserId: null,
+        name: "Anonymous automation",
+        instructions: "Created without an author.",
+      }),
+    );
+
+    const listed = await listWorkspaceAutomations({ organizationId: scope.organizationId });
+    const listedById = new Map(listed.map((item) => [item.id, item]));
+
+    expect(listedById.get(namedAutomation.id)?.authorName).toBe("Ada Lovelace");
+    expect(listedById.get(emailAutomation.id)?.authorName).toBe("hopper@example.test");
+    expect(listedById.get(anonymousAutomation.id)?.authorName).toBeNull();
+
+    const loadedEmail = await getWorkspaceAutomationById({
+      automationId: emailAutomation.id,
+      organizationId: scope.organizationId,
+    });
+    expect(loadedEmail?.authorName).toBe("hopper@example.test");
   });
 
   it("creates and serializes run history with optional GitHub job links", async () => {

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
@@ -772,13 +772,13 @@ describe("workspace automations", () => {
     expect(secondPage.map((item) => item.name)).toEqual(["Automation 1"]);
   });
 
-  it("falls back to email for author names and omits deleted authors", async () => {
+  it("falls back to email for author names and omits missing authors", async () => {
     const scope = await seedWorkspaceAutomationScope();
     const emailOnlyUserId = crypto.randomUUID();
     await db.insert(schema.users).values({
       id: emailOnlyUserId,
       workosUserId: `user_${emailOnlyUserId}`,
-      email: "hopper@example.test",
+      email: `${emailOnlyUserId}@example.test`,
     });
 
     const namedAutomation = expectOk(
@@ -810,14 +810,14 @@ describe("workspace automations", () => {
     const listedById = new Map(listed.map((item) => [item.id, item]));
 
     expect(listedById.get(namedAutomation.id)?.authorName).toBe("Ada Lovelace");
-    expect(listedById.get(emailAutomation.id)?.authorName).toBe("hopper@example.test");
+    expect(listedById.get(emailAutomation.id)?.authorName).toBe(`${emailOnlyUserId}@example.test`);
     expect(listedById.get(anonymousAutomation.id)?.authorName).toBeNull();
 
     const loadedEmail = await getWorkspaceAutomationById({
       automationId: emailAutomation.id,
       organizationId: scope.organizationId,
     });
-    expect(loadedEmail?.authorName).toBe("hopper@example.test");
+    expect(loadedEmail?.authorName).toBe(`${emailOnlyUserId}@example.test`);
   });
 
   it("creates and serializes run history with optional GitHub job links", async () => {

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -1447,7 +1447,7 @@ export async function listSourceUploadWorkspaceAutomations(input: {
     .orderBy(desc(schema.workspaceAutomations.createdAt))
     .limit(input.limit ?? 20);
 
-  return rows.map(serializeAutomation);
+  return rows.map((row) => serializeAutomation(row));
 }
 
 export type DueWorkspaceAutomation = {
@@ -1520,7 +1520,7 @@ export async function listDueContentfulWorkspaceAutomations(input: {
     .limit(limit);
 
   return rows
-    .map(serializeAutomation)
+    .map((row) => serializeAutomation(row))
     .filter(
       (automation) =>
         automation.triggerConfig.mode === "scheduled" &&

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -469,6 +469,7 @@ export type WorkspaceAutomationRecord = {
   id: string;
   organizationId: string;
   authorUserId: string | null;
+  authorName?: string | null;
   status: WorkspaceAutomationStatus;
   name: string;
   instructions: string;
@@ -481,6 +482,28 @@ export type WorkspaceAutomationRecord = {
   createdAt: string;
   updatedAt: string;
 };
+
+type AutomationAuthor = {
+  firstName: string | null;
+  lastName: string | null;
+  email: string | null;
+};
+
+export function formatWorkspaceAutomationAuthorName(
+  author: AutomationAuthor | null | undefined,
+): string | null {
+  if (!author) {
+    return null;
+  }
+
+  const name = [author.firstName, author.lastName].filter(Boolean).join(" ").trim();
+  if (name.length > 0) {
+    return name;
+  }
+
+  const email = author.email?.trim();
+  return email && email.length > 0 ? email : null;
+}
 
 function readOptionalProjectId(value: unknown): string | null {
   if (typeof value !== "string") {
@@ -928,12 +951,16 @@ export async function validateWorkspaceAutomationIntegrations(input: {
   return ok(undefined);
 }
 
-function serializeAutomation(row: AutomationRow): WorkspaceAutomationRecord {
+function serializeAutomation(
+  row: AutomationRow,
+  author?: AutomationAuthor | null,
+): WorkspaceAutomationRecord {
   const rawToolConfig = (row.toolConfig ?? {}) as Record<string, unknown>;
   return {
     id: row.id,
     organizationId: row.organizationId,
     authorUserId: row.authorUserId,
+    authorName: formatWorkspaceAutomationAuthorName(author),
     status: row.status,
     name: row.name,
     instructions: row.instructions,
@@ -948,6 +975,47 @@ function serializeAutomation(row: AutomationRow): WorkspaceAutomationRecord {
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
   };
+}
+
+function serializeAutomationWithAuthor(row: {
+  automation: AutomationRow;
+  authorFirstName: string | null;
+  authorLastName: string | null;
+  authorEmail: string | null;
+}): WorkspaceAutomationRecord {
+  return serializeAutomation(row.automation, {
+    firstName: row.authorFirstName,
+    lastName: row.authorLastName,
+    email: row.authorEmail,
+  });
+}
+
+const automationAuthorSelect = {
+  automation: schema.workspaceAutomations,
+  authorFirstName: schema.users.firstName,
+  authorLastName: schema.users.lastName,
+  authorEmail: schema.users.email,
+};
+
+async function loadAutomationAuthor(
+  userId: string | null,
+  database: DatabaseClient = db,
+): Promise<AutomationAuthor | null> {
+  if (!userId) {
+    return null;
+  }
+
+  const [user] = await database
+    .select({
+      firstName: schema.users.firstName,
+      lastName: schema.users.lastName,
+      email: schema.users.email,
+    })
+    .from(schema.users)
+    .where(eq(schema.users.id, userId))
+    .limit(1);
+
+  return user ?? null;
 }
 
 function serializeAutomationRun(row: AutomationRunRow): WorkspaceAutomationRunRecord {
@@ -1015,6 +1083,7 @@ export async function createWorkspaceAutomation(input: {
     id: crypto.randomUUID(),
     organizationId: input.organizationId,
     authorUserId: input.authorUserId ?? null,
+    authorName: null,
     status: input.status ?? "active",
     name: input.name,
     instructions: input.instructions,
@@ -1074,7 +1143,7 @@ export async function createWorkspaceAutomation(input: {
       throw new Error("failed_to_create_workspace_automation");
     }
 
-    return ok(serializeAutomation(row));
+    return ok(serializeAutomation(row, await loadAutomationAuthor(row.authorUserId, database)));
   };
 
   if (input.db) {
@@ -1233,7 +1302,9 @@ export async function updateWorkspaceAutomation(input: {
       .where(and(...updateConditions))
       .returning();
 
-    return ok(row ? serializeAutomation(row) : null);
+    return ok(
+      row ? serializeAutomation(row, await loadAutomationAuthor(row.authorUserId, database)) : null,
+    );
   };
 
   if (input.db) {
@@ -1273,8 +1344,9 @@ export async function getWorkspaceAutomationById(input: {
   organizationId: string;
 }): Promise<WorkspaceAutomationRecord | null> {
   const [row] = await db
-    .select()
+    .select(automationAuthorSelect)
     .from(schema.workspaceAutomations)
+    .leftJoin(schema.users, eq(schema.workspaceAutomations.authorUserId, schema.users.id))
     .where(
       and(
         eq(schema.workspaceAutomations.id, input.automationId),
@@ -1283,7 +1355,7 @@ export async function getWorkspaceAutomationById(input: {
     )
     .limit(1);
 
-  return row ? serializeAutomation(row) : null;
+  return row ? serializeAutomationWithAuthor(row) : null;
 }
 
 export async function listWorkspaceAutomations(input: {
@@ -1332,14 +1404,15 @@ export async function listWorkspaceAutomations(input: {
   ];
 
   const rows = await db
-    .select()
+    .select(automationAuthorSelect)
     .from(schema.workspaceAutomations)
+    .leftJoin(schema.users, eq(schema.workspaceAutomations.authorUserId, schema.users.id))
     .where(and(...conditions))
     .orderBy(desc(schema.workspaceAutomations.createdAt))
     .limit(input.limit ?? 50)
     .offset(input.offset ?? 0);
 
-  return rows.map(serializeAutomation);
+  return rows.map(serializeAutomationWithAuthor);
 }
 
 export async function listSourceUploadWorkspaceAutomations(input: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Workspace Agent Automations are organization-scoped. Any workspace operator (admin or localization manager) can see every automation in the org, not only ones they created. Developers, reviewers, translators, and other non-operator roles still cannot access the automations API.

This change adds a **Creator** column to the automations list. The API now joins the author user and returns `authorName` (full name, or email if no name is stored). Automations without an author show **Unknown**.

[Automations list with Creator column](https://cursor.com/agents/bc-693d41b4-f91d-47a5-b205-350e30264712/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fautomations_list_creator_column.png)

## How to test

- Open `/org/<slug>/automations` as an admin or localization manager.
- Confirm you can see automations created by other operators in the same workspace.
- Confirm the Creator column shows the author's name (or email / Unknown).
- In `apps/hyperlocalise-web`: `vp test` and `vp check --fix`.

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693d41b4-f91d-47a5-b205-350e30264712?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693d41b4-f91d-47a5-b205-350e30264712&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

