### PR TITLE
fix(crowdin): use spec-compliant JSON Patch for translation updates

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.messages.ts
@@ -60,4 +60,10 @@ export const useCatMutationsMessages = defineMessages({
     id: "1BOxhADmQk",
     description: "Fallback error when hiding or unhiding native CAT source strings fails",
   },
+  cannotEditHiddenStringTranslation: {
+    defaultMessage:
+      "Hidden strings can't be edited from the CAT. Unhide the string in Crowdin first.",
+    id: "sfQrLcactN",
+    description: "Error when saving a translation for a hidden string",
+  },
 });

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.test.tsx
@@ -20,6 +20,7 @@ import {
   createCatComment,
   createCatFileResponse,
   createCatProviderMeta,
+  createCatSegment,
   createCatTranslation,
   errorResponse,
   jsonResponse,
@@ -167,6 +168,22 @@ describe("useCatMutations", () => {
     ).rejects.toThrow("Provider rejected the update.");
     expect(onTranslationSaved).not.toHaveBeenCalled();
     expect(invalidateQueue).not.toHaveBeenCalled();
+  });
+
+  it("blocks saving translations for hidden segments", async () => {
+    const { result } = renderCatMutations({
+      ...createCatFileResponse().catFile,
+      segments: [createCatSegment({ isHidden: true })],
+    });
+
+    await expect(
+      result.current.saveTranslation({
+        externalStringId: "segment-1",
+        text: "Bonjour",
+      }),
+    ).rejects.toThrow("Hidden strings can't be edited from the CAT.");
+    expect(catTranslationsPostMock).not.toHaveBeenCalled();
+    expect(onTranslationSaved).not.toHaveBeenCalled();
   });
 
   it("throws when saving with a provider record missing an external resource id", async () => {

--- a/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file/use-cat-mutations.ts
@@ -92,6 +92,15 @@ export function useCatMutations(input: {
       text: string;
       approve?: boolean;
     }) => {
+      const segment = input.catFile?.segments.find(
+        (entry) => entry.externalStringId === mutationInput.externalStringId,
+      );
+      if (segment?.isHidden) {
+        throw new Error(
+          intl.formatMessage(useCatMutationsMessages.cannotEditHiddenStringTranslation),
+        );
+      }
+
       const { sourcePath, externalResourceId } = resolveCatMutationFileIdentity(
         input,
         mutationInput.externalStringId,

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -30,6 +30,7 @@ import {
   CrowdinApiClient,
   CrowdinApiError,
   CROWDIN_SOURCE_STRING_BATCH_PATCH_LIMIT,
+  extractCrowdinApiErrorSummary,
 } from "./crowdin-api";
 
 describe("CrowdinApiClient", () => {
@@ -1181,7 +1182,7 @@ describe("CrowdinApiClient", () => {
 
       if (path.endsWith("/projects/1/translations") && init?.method === "PATCH") {
         expect(JSON.parse(String(init.body))).toEqual([
-          { op: "replace", path: "/9001/text", value: "Salut" },
+          { op: "replace", path: "/9001", value: { text: "Salut" } },
         ]);
         return new Response(
           JSON.stringify({
@@ -1227,6 +1228,34 @@ describe("CrowdinApiClient", () => {
       status: 502,
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes translations with DELETE", async () => {
+    const fetchMock = vi.fn(
+      async () => new Response(null, { status: 204 }),
+    ) as unknown as typeof fetch;
+    const client = createClient(fetchMock);
+
+    await client.removeTranslation(1, 9001);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.crowdin.test/api/v2/projects/1/translations/9001",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("removes translation approvals with DELETE", async () => {
+    const fetchMock = vi.fn(
+      async () => new Response(null, { status: 204 }),
+    ) as unknown as typeof fetch;
+    const client = createClient(fetchMock);
+
+    await client.removeTranslationApproval(1, 7001);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.crowdin.test/api/v2/projects/1/approvals/7001",
+      expect.objectContaining({ method: "DELETE" }),
+    );
   });
 
   it("fails approved translation replacements when response text does not match", async () => {
@@ -1489,5 +1518,49 @@ describe("CrowdinApiClient", () => {
       "https://api.crowdin.test/api/v2/user",
       expect.objectContaining({ method: "GET", redirect: "error" }),
     );
+  });
+});
+
+describe("extractCrowdinApiErrorSummary", () => {
+  it("returns null for non-object bodies", () => {
+    expect(extractCrowdinApiErrorSummary(null)).toBeNull();
+    expect(extractCrowdinApiErrorSummary("oops")).toBeNull();
+    expect(extractCrowdinApiErrorSummary([1, 2])).toBeNull();
+  });
+
+  it("extracts top-level error code and message", () => {
+    expect(extractCrowdinApiErrorSummary({ error: { message: "Forbidden", code: 403 } })).toEqual({
+      code: 403,
+      message: "Forbidden",
+    });
+  });
+
+  it("extracts JSON Patch error entries with codes", () => {
+    expect(
+      extractCrowdinApiErrorSummary({
+        errors: [
+          {
+            index: 0,
+            errors: [
+              {
+                error: {
+                  key: "value",
+                  errors: [{ code: "validation_error", message: "Invalid request parameters" }],
+                },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toEqual({
+      errors: [{ index: 0, code: "validation_error", message: "Invalid request parameters" }],
+    });
+  });
+
+  it("truncates long messages and ignores non-string codes", () => {
+    const summary = extractCrowdinApiErrorSummary({
+      error: { message: "x".repeat(500), code: null },
+    });
+    expect(summary).toEqual({ message: "x".repeat(200) });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -655,6 +655,87 @@ export class CrowdinApiError extends Error {
   }
 }
 
+const MAX_CROWDIN_ERROR_SUMMARY_ENTRIES = 5;
+const MAX_CROWDIN_ERROR_SUMMARY_MESSAGE_LENGTH = 200;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readCrowdinErrorSummaryEntry(entry: unknown): {
+  index?: number;
+  code?: string;
+  message?: string;
+} | null {
+  if (!isRecord(entry)) {
+    return null;
+  }
+
+  const summary: { index?: number; code?: string; message?: string } = {};
+  if (typeof entry.index === "number") {
+    summary.index = entry.index;
+  }
+
+  const nestedErrors = entry.errors;
+  if (Array.isArray(nestedErrors)) {
+    const firstNested = nestedErrors.find(isRecord);
+    const error = firstNested?.error;
+    if (isRecord(error) && Array.isArray(error.errors)) {
+      const firstDetail = error.errors.find(isRecord);
+      if (firstDetail && typeof firstDetail.code === "string") {
+        summary.code = firstDetail.code;
+      }
+      if (firstDetail && typeof firstDetail.message === "string") {
+        summary.message = firstDetail.message.slice(0, MAX_CROWDIN_ERROR_SUMMARY_MESSAGE_LENGTH);
+      }
+    }
+  }
+
+  return Object.keys(summary).length > 0 ? summary : null;
+}
+
+/**
+ * Extracts a small, provider-generated error summary from a Crowdin error
+ * response body for logging. Never includes request or translation content.
+ */
+export function extractCrowdinApiErrorSummary(responseBody: unknown): {
+  code?: string | number;
+  message?: string;
+  errors?: Array<{ index?: number; code?: string; message?: string }>;
+} | null {
+  if (!isRecord(responseBody)) {
+    return null;
+  }
+
+  const summary: {
+    code?: string | number;
+    message?: string;
+    errors?: Array<{ index?: number; code?: string; message?: string }>;
+  } = {};
+
+  const error = responseBody.error;
+  if (isRecord(error)) {
+    if (typeof error.code === "string" || typeof error.code === "number") {
+      summary.code = error.code;
+    }
+    if (typeof error.message === "string") {
+      summary.message = error.message.slice(0, MAX_CROWDIN_ERROR_SUMMARY_MESSAGE_LENGTH);
+    }
+  }
+
+  if (Array.isArray(responseBody.errors)) {
+    const entries = responseBody.errors
+      .slice(0, MAX_CROWDIN_ERROR_SUMMARY_ENTRIES)
+      .map(readCrowdinErrorSummaryEntry)
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+    if (entries.length > 0) {
+      summary.errors = entries;
+    }
+  }
+
+  return Object.keys(summary).length > 0 ? summary : null;
+}
+
 export class CrowdinApiClient {
   private readonly token: string;
   private readonly baseUrl: string;
@@ -1529,7 +1610,7 @@ export class CrowdinApiClient {
   ): Promise<CrowdinStringTranslation> {
     const response = await this.patch<CrowdinListResponse<CrowdinStringTranslation>>(
       `/projects/${projectId}/translations`,
-      [{ op: "replace", path: `/${translationId}/text`, value: text }],
+      [{ op: "replace", path: `/${translationId}`, value: { text } }],
     );
     const updatedTranslation = response.data[0]?.data;
     if (!updatedTranslation) {
@@ -1537,6 +1618,14 @@ export class CrowdinApiClient {
     }
 
     return updatedTranslation;
+  }
+
+  async removeTranslation(projectId: number, translationId: number): Promise<void> {
+    await this.delete(`/projects/${projectId}/translations/${translationId}`);
+  }
+
+  async removeTranslationApproval(projectId: number, approvalId: number): Promise<void> {
+    await this.delete(`/projects/${projectId}/approvals/${approvalId}`);
   }
 
   async replaceApprovedTranslation(

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-cat.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-cat.test.ts
@@ -882,7 +882,7 @@ describe("getTmsProviderLiveCatFile", () => {
     );
     expect(patchCall).toBeDefined();
     expect(JSON.parse(String(patchCall?.[1]?.body))).toEqual([
-      { op: "replace", path: "/9002/text", value: "Bonjour amélioré" },
+      { op: "replace", path: "/9002", value: { text: "Bonjour amélioré" } },
     ]);
     expect(
       fetchMock.mock.calls.some(
@@ -890,6 +890,363 @@ describe("getTmsProviderLiveCatFile", () => {
           String(url).includes("/projects/42/translations") && init?.method === "POST",
       ),
     ).toBe(false);
+  });
+
+  function createCrowdinCatFileResolution(): (
+    url: unknown,
+    init?: RequestInit,
+  ) => Promise<Response> {
+    return async (url: unknown) => {
+      const path = String(url);
+
+      if (isCrowdinGetProjectRequest(path)) {
+        return mockCrowdinProject42Response();
+      }
+
+      if (path.includes("/projects/42/branches?")) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (path.includes("/projects/42/directories?")) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (path.includes("/projects/42/files?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 101,
+                  branchId: null,
+                  directoryId: null,
+                  name: "home.json",
+                  title: "home.json",
+                  type: "json",
+                  path: "/home.json",
+                  status: "active",
+                  revisionId: 7,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects/42/files/101/revisions?")) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    };
+  }
+
+  it("clears an existing unapproved Crowdin translation by deleting it", async () => {
+    const { organization, user } = await fixture.createLocalWorkosIdentity(
+      fixture.createWorkosIdentityWithRole("admin"),
+    );
+    await setupCrowdinPatCredential({
+      organizationId: organization.id,
+      userId: user.id,
+    });
+
+    const resolveFile = createCrowdinCatFileResolution();
+    const fetchMock = vi.fn(async (url: unknown, init?: RequestInit) => {
+      const path = String(url);
+
+      if (
+        path.includes("/projects/42/languages/fr/translations?") &&
+        path.includes("stringIds=1001")
+      ) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  stringId: 1001,
+                  contentType: "text",
+                  translationId: 9002,
+                  text: "Salut",
+                  createdAt: "2026-06-09T00:00:00Z",
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (
+        path.includes("/projects/42/approvals?") &&
+        path.includes("languageId=fr") &&
+        path.includes("fileId=101")
+      ) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (path.includes("/projects/42/translations/9002") && init?.method === "DELETE") {
+        return new Response(null, { status: 204 });
+      }
+
+      if (
+        path.includes("/projects/42/translations") &&
+        (init?.method === "PATCH" || init?.method === "POST")
+      ) {
+        throw new Error(`Unexpected translation write: ${init.method} ${path}`);
+      }
+
+      return resolveFile(url, init);
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const translation = await saveTmsProviderLiveCatTranslation(
+      organization.id,
+      "42",
+      "home.json",
+      {
+        targetLocale: "fr",
+        externalStringId: "1001",
+        text: "   ",
+      },
+      { actorUserId: user.id },
+    );
+
+    expect(translation).toEqual({ text: "", externalTranslationId: null, isApproved: false });
+    expect(
+      fetchMock.mock.calls.some(
+        ([url, init]) =>
+          String(url).includes("/projects/42/translations/9002") && init?.method === "DELETE",
+      ),
+    ).toBe(true);
+    expect(
+      fetchMock.mock.calls.some(
+        ([url, init]) =>
+          String(url).includes("/projects/42/translations") && init?.method === "PATCH",
+      ),
+    ).toBe(false);
+  });
+
+  it("removes the approval before clearing an approved Crowdin translation", async () => {
+    const { organization, user } = await fixture.createLocalWorkosIdentity(
+      fixture.createWorkosIdentityWithRole("admin"),
+    );
+    await setupCrowdinPatCredential({
+      organizationId: organization.id,
+      userId: user.id,
+    });
+
+    const resolveFile = createCrowdinCatFileResolution();
+    const fetchMock = vi.fn(async (url: unknown, init?: RequestInit) => {
+      const path = String(url);
+
+      if (
+        path.includes("/projects/42/languages/fr/translations?") &&
+        path.includes("stringIds=1001")
+      ) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  stringId: 1001,
+                  contentType: "text",
+                  translationId: 9002,
+                  text: "Salut",
+                  createdAt: "2026-06-09T00:00:00Z",
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (
+        path.includes("/projects/42/approvals?") &&
+        path.includes("languageId=fr") &&
+        path.includes("fileId=101")
+      ) {
+        return new Response(
+          JSON.stringify({
+            data: [{ data: { id: 7001, translationId: 9002, stringId: 1001, languageId: "fr" } }],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (init?.method === "DELETE") {
+        return new Response(null, { status: 204 });
+      }
+
+      return resolveFile(url, init);
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const translation = await saveTmsProviderLiveCatTranslation(
+      organization.id,
+      "42",
+      "home.json",
+      {
+        targetLocale: "fr",
+        externalStringId: "1001",
+        text: "",
+      },
+      { actorUserId: user.id },
+    );
+
+    expect(translation).toEqual({ text: "", externalTranslationId: null, isApproved: false });
+    const deleteCalls = fetchMock.mock.calls
+      .filter(([url, init]) => init?.method === "DELETE")
+      .map(([url]) => String(url));
+    expect(deleteCalls).toEqual([
+      expect.stringContaining("/projects/42/approvals/7001"),
+      expect.stringContaining("/projects/42/translations/9002"),
+    ]);
+  });
+
+  it("skips writes when clearing a translation that does not exist", async () => {
+    const { organization, user } = await fixture.createLocalWorkosIdentity(
+      fixture.createWorkosIdentityWithRole("admin"),
+    );
+    await setupCrowdinPatCredential({
+      organizationId: organization.id,
+      userId: user.id,
+    });
+
+    const resolveFile = createCrowdinCatFileResolution();
+    const fetchMock = vi.fn(async (url: unknown, init?: RequestInit) => {
+      const path = String(url);
+
+      if (
+        path.includes("/projects/42/languages/fr/translations?") &&
+        path.includes("stringIds=1001")
+      ) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (
+        path.includes("/projects/42/approvals?") &&
+        path.includes("languageId=fr") &&
+        path.includes("fileId=101")
+      ) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (path.includes("/projects/42/translations") && init?.method !== undefined) {
+        throw new Error(`Unexpected translation write: ${init.method} ${path}`);
+      }
+
+      return resolveFile(url, init);
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const translation = await saveTmsProviderLiveCatTranslation(
+      organization.id,
+      "42",
+      "home.json",
+      {
+        targetLocale: "fr",
+        externalStringId: "1001",
+        text: "",
+      },
+      { actorUserId: user.id },
+    );
+
+    expect(translation).toEqual({ text: "", externalTranslationId: null, isApproved: false });
+    expect(
+      fetchMock.mock.calls.some(
+        ([url, init]) =>
+          String(url).includes("/projects/42/translations") &&
+          (init?.method === "PATCH" || init?.method === "POST" || init?.method === "DELETE"),
+      ),
+    ).toBe(false);
+  });
+
+  it("maps Crowdin 400 translation update rejections to a client error", async () => {
+    const { organization, user } = await fixture.createLocalWorkosIdentity(
+      fixture.createWorkosIdentityWithRole("admin"),
+    );
+    await setupCrowdinPatCredential({
+      organizationId: organization.id,
+      userId: user.id,
+    });
+
+    const resolveFile = createCrowdinCatFileResolution();
+    const fetchMock = vi.fn(async (url: unknown, init?: RequestInit) => {
+      const path = String(url);
+
+      if (
+        path.includes("/projects/42/languages/fr/translations?") &&
+        path.includes("stringIds=1001")
+      ) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  stringId: 1001,
+                  contentType: "text",
+                  translationId: 9002,
+                  text: "Salut",
+                  createdAt: "2026-06-09T00:00:00Z",
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (
+        path.includes("/projects/42/approvals?") &&
+        path.includes("languageId=fr") &&
+        path.includes("fileId=101")
+      ) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (path.includes("/projects/42/translations") && init?.method === "PATCH") {
+        return new Response(
+          JSON.stringify({
+            errors: [
+              {
+                index: 0,
+                errors: [
+                  {
+                    error: {
+                      key: "text",
+                      errors: [{ code: "validation_error", message: "Invalid request parameters" }],
+                    },
+                  },
+                ],
+              },
+            ],
+          }),
+          { status: 400 },
+        );
+      }
+
+      return resolveFile(url, init);
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(
+      saveTmsProviderLiveCatTranslation(
+        organization.id,
+        "42",
+        "home.json",
+        {
+          targetLocale: "fr",
+          externalStringId: "1001",
+          text: "Bonjour amélioré",
+        },
+        { actorUserId: user.id },
+      ),
+    ).rejects.toMatchObject({
+      name: "TmsProviderLiveError",
+      code: "crowdin_translation_update_rejected",
+    });
   });
 
   it("loads paginated Crowdin queue pages without walking the full file for totals", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.test.ts
@@ -31,6 +31,7 @@ describe("getTmsProviderLiveErrorStatus", () => {
     ["invalid_crowdin_assignee_id", 400],
     ["crowdin_cat_all_files_query_too_large", 400],
     ["crowdin_hidden_strings_forbidden", 400],
+    ["crowdin_translation_update_rejected", 400],
     ["invalid_smartling_project_id", 400],
     ["invalid_smartling_string_id", 400],
     ["smartling_auth_invalid", 401],

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live-error-response.ts
@@ -52,6 +52,7 @@ export function getTmsProviderLiveErrorStatus(code: string): TmsProviderLiveErro
     case "invalid_crowdin_project_or_file_id":
     case "invalid_crowdin_project_or_string_id":
     case "crowdin_hidden_strings_forbidden":
+    case "crowdin_translation_update_rejected":
     case "crowdin_cat_all_files_query_too_large":
     case "invalid_phrase_project_id":
     case "invalid_smartling_project_id":

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -38,6 +38,7 @@ import {
   buildCrowdinFileQueueCroql,
   CrowdinApiClient,
   CrowdinApiError,
+  extractCrowdinApiErrorSummary,
   isCrowdinCroqlWithinLimit,
   type CrowdinProject,
   type CrowdinLanguageTranslation,
@@ -1308,6 +1309,20 @@ async function saveCrowdinLiveCatTranslation(input: {
     const approvedTranslationIds = new Set(approvals.map((approval) => approval.translationId));
     const existing = preferredLanguageTranslation(translations, approvedTranslationIds);
     const existingTranslationId = existing?.translationId;
+
+    if (input.text.trim().length === 0) {
+      if (existingTranslationId == null) {
+        return { text: "", externalTranslationId: null, isApproved: false };
+      }
+
+      const approval = approvals.find((item) => item.translationId === existingTranslationId);
+      if (approval) {
+        await client.removeTranslationApproval(projectId, approval.id);
+      }
+      await client.removeTranslation(projectId, existingTranslationId);
+      return { text: "", externalTranslationId: null, isApproved: false };
+    }
+
     const saved =
       existingTranslationId != null && approvedTranslationIds.has(existingTranslationId)
         ? await client.replaceApprovedTranslation(projectId, {
@@ -1333,6 +1348,22 @@ async function saveCrowdinLiveCatTranslation(input: {
   } catch (error) {
     if (error instanceof CrowdinApiError && error.status === 401) {
       throw new TmsProviderLiveError("crowdin_auth_invalid", "Crowdin credentials are invalid.");
+    }
+
+    if (error instanceof CrowdinApiError && (error.status === 400 || error.status === 403)) {
+      logger.warn(
+        {
+          providerProjectId: projectId,
+          providerStringId: stringId,
+          status: error.status,
+          providerError: extractCrowdinApiErrorSummary(error.responseBody),
+        },
+        "Crowdin rejected translation save",
+      );
+      throw new TmsProviderLiveError(
+        "crowdin_translation_update_rejected",
+        "Crowdin rejected the translation update. The string may be hidden or the connection may lack permission to edit it.",
+      );
     }
 
     throw error;


### PR DESCRIPTION
## Problem

Saving a translation in the CAT for a Crowdin project failed with HTTP 500 in production. The Crowdin API returned 400 for every `PATCH /projects/{projectId}/translations` request issued by `updateTranslation`.

## Root cause

The batch endpoint expects RFC 6902 operations where a replace uses path `/{translationId}` and an object value:

```json
[{ "op": "replace", "path": "/9002", "value": { "text": "..." } }]
```

We sent `path: "/9002/text"` with a bare string `value`, which Crowdin rejects with 400 "Invalid request parameters" regardless of content. `replaceApprovedTranslation` (remove + add ops) and `addTranslation` (POST) already matched the spec, which is why only unapproved-translation saves failed.

## Changes

- **crowdin-api**: spec-compliant replace payload; new `removeTranslation` and `removeTranslationApproval` client methods; `extractCrowdinApiErrorSummary` for safe provider error logging.
- **tms-provider-live**: saving empty text now clears the translation (removing its approval first when approved, no-op when none exists); Crowdin 400/403 now map to a clean `crowdin_translation_update_rejected` error (HTTP 400) with a sanitized warn log instead of an unhandled 500.
- **CAT UI**: translation saves for hidden segments are blocked with an explanatory message.

## Tests

- Updated payload assertions in crowdin-api and tms-provider-live-cat tests.
- New tests: DELETE-based clearing (unapproved/approved/no-op), 400 → client error mapping, hidden-segment UI guard, error summary extraction, and error status mapping.
- `vp test` targeted suites: 106/106 pass; `vp check --fix` clean.