### PR TITLE
feat(web): add localized 404 not found page

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/not-found.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/not-found.tsx
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+export { generateNotFoundMetadata as generateMetadata } from "@/components/not-found/not-found-page";
+export { NotFoundPage as default } from "@/components/not-found/not-found-page";

--- a/apps/hyperlocalise-web/src/app/not-found.tsx
+++ b/apps/hyperlocalise-web/src/app/not-found.tsx
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+export { generateNotFoundMetadata as generateMetadata } from "@/components/not-found/not-found-page";
+export { NotFoundPage as default } from "@/components/not-found/not-found-page";

--- a/apps/hyperlocalise-web/src/components/not-found/not-found-copy.test.ts
+++ b/apps/hyperlocalise-web/src/components/not-found/not-found-copy.test.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { getNotFoundCopy, NOT_FOUND_STATUS_CODE } from "@/components/not-found/not-found-copy";
+import { getIntlShape } from "@/lib/app-i18n/intl";
+
+describe("getNotFoundCopy", () => {
+  it("returns English 404 copy for the default locale", () => {
+    const copy = getNotFoundCopy(getIntlShape("en"));
+
+    expect(copy.statusCode).toBe(NOT_FOUND_STATUS_CODE);
+    expect(copy.title).toBe("Page not found");
+    expect(copy.documentTitle).toBe("Page not found | Hyperlocalise");
+    expect(copy.homeLabel).toBe("Back to homepage");
+    expect(copy.dashboardLabel).toBe("Go to dashboard");
+    expect(copy.supportLabel).toBe("Contact support");
+  });
+});

--- a/apps/hyperlocalise-web/src/components/not-found/not-found-copy.ts
+++ b/apps/hyperlocalise-web/src/components/not-found/not-found-copy.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { IntlShape } from "@formatjs/intl";
+
+export const NOT_FOUND_STATUS_CODE = "404";
+
+export function getNotFoundCopy(intl: IntlShape) {
+  const title = intl.formatMessage({
+    defaultMessage: "Page not found",
+    id: "3rvYG+2rma",
+    description: "Heading on the application 404 page",
+  });
+
+  return {
+    statusCode: NOT_FOUND_STATUS_CODE,
+    title,
+    description: intl.formatMessage({
+      defaultMessage: "This address does not match a page. Return home, or open your dashboard.",
+      id: "zfBUiflpJx",
+      description: "Guidance on the application 404 page",
+    }),
+    homeLabel: intl.formatMessage({
+      defaultMessage: "Back to homepage",
+      id: "b/LOcyQLjC",
+      description: "Link from the 404 page to the marketing homepage",
+    }),
+    dashboardLabel: intl.formatMessage({
+      defaultMessage: "Go to dashboard",
+      id: "lmLPnsMyhs",
+      description: "Link from the 404 page to the workspace dashboard",
+    }),
+    supportLabel: intl.formatMessage({
+      defaultMessage: "Contact support",
+      id: "eOj0ETOfEV",
+      description: "Link from the 404 page to email customer support",
+    }),
+    documentTitle: intl.formatMessage(
+      {
+        defaultMessage: "{title} | Hyperlocalise",
+        id: "1XPTC/SDY9",
+        description: "Browser tab title for the application 404 page",
+      },
+      { title },
+    ),
+  };
+}

--- a/apps/hyperlocalise-web/src/components/not-found/not-found-page.tsx
+++ b/apps/hyperlocalise-web/src/components/not-found/not-found-page.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Metadata } from "next";
+
+import { getNotFoundCopy } from "@/components/not-found/not-found-copy";
+import { NotFoundRecovery } from "@/components/not-found/not-found-recovery";
+import { getIntlShape } from "@/lib/app-i18n/intl";
+import { getAppLocale } from "@/lib/app-i18n/server-locale";
+
+export async function generateNotFoundMetadata(): Promise<Metadata> {
+  const locale = await getAppLocale();
+  const copy = getNotFoundCopy(getIntlShape(locale));
+
+  return {
+    title: copy.documentTitle,
+    robots: {
+      index: false,
+      follow: false,
+    },
+  };
+}
+
+export async function NotFoundPage() {
+  const locale = await getAppLocale();
+  const copy = getNotFoundCopy(getIntlShape(locale));
+
+  return (
+    <NotFoundRecovery
+      statusCode={copy.statusCode}
+      title={copy.title}
+      description={copy.description}
+      homeLabel={copy.homeLabel}
+      dashboardLabel={copy.dashboardLabel}
+      supportLabel={copy.supportLabel}
+      homeHref="/"
+      dashboardHref="/dashboard"
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/components/not-found/not-found-recovery.test.tsx
+++ b/apps/hyperlocalise-web/src/components/not-found/not-found-recovery.test.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+
+import { NotFoundRecovery } from "@/components/not-found/not-found-recovery";
+import { SUPPORT_EMAIL } from "@/lib/support-contact";
+
+describe("NotFoundRecovery", () => {
+  it("offers homepage, dashboard, and support actions", () => {
+    render(
+      <NotFoundRecovery
+        statusCode="404"
+        title="Page not found"
+        description="This address does not match a page."
+        homeLabel="Back to homepage"
+        dashboardLabel="Go to dashboard"
+        supportLabel="Contact support"
+        homeHref="/"
+        dashboardHref="/dashboard"
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Page not found" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Back to homepage" })).toHaveAttribute("href", "/");
+    expect(screen.getByRole("button", { name: "Go to dashboard" })).toHaveAttribute(
+      "href",
+      "/dashboard",
+    );
+    expect(screen.getByRole("button", { name: "Contact support" })).toHaveAttribute(
+      "href",
+      `mailto:${SUPPORT_EMAIL}`,
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/components/not-found/not-found-recovery.tsx
+++ b/apps/hyperlocalise-web/src/components/not-found/not-found-recovery.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { CustomerSupportIcon, DashboardSquare01Icon, Home01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { Empty, EmptyContent, EmptyDescription, EmptyHeader } from "@/components/ui/empty";
+import { SUPPORT_EMAIL } from "@/lib/support-contact";
+
+type NotFoundRecoveryProps = {
+  statusCode: string;
+  title: string;
+  description: string;
+  homeLabel: string;
+  dashboardLabel: string;
+  supportLabel: string;
+  homeHref: string;
+  dashboardHref: string;
+};
+
+export function NotFoundRecovery({
+  statusCode,
+  title,
+  description,
+  homeLabel,
+  dashboardLabel,
+  supportLabel,
+  homeHref,
+  dashboardHref,
+}: NotFoundRecoveryProps) {
+  return (
+    <main className="flex min-h-dvh w-full items-center justify-center bg-background px-4 py-12 text-foreground">
+      <Empty className="max-w-xl border border-border bg-card px-6 py-12 shadow-sm sm:px-12">
+        <EmptyHeader className="max-w-md">
+          <p
+            aria-hidden="true"
+            className="font-heading text-7xl font-semibold tracking-[-0.04em] text-muted-foreground tabular-nums sm:text-8xl"
+          >
+            {statusCode}
+          </p>
+          <h1 className="font-heading text-2xl font-semibold text-balance">{title}</h1>
+          <EmptyDescription className="max-w-md text-pretty">{description}</EmptyDescription>
+        </EmptyHeader>
+
+        <EmptyContent className="max-w-md gap-3 sm:flex-row sm:justify-center">
+          <Button
+            className="w-full sm:w-auto"
+            nativeButton={false}
+            render={<Link href={homeHref} />}
+          >
+            <HugeiconsIcon data-icon="inline-start" icon={Home01Icon} strokeWidth={2} />
+            {homeLabel}
+          </Button>
+          <Button
+            className="w-full sm:w-auto"
+            variant="outline"
+            nativeButton={false}
+            render={<Link href={dashboardHref} />}
+          >
+            <HugeiconsIcon data-icon="inline-start" icon={DashboardSquare01Icon} strokeWidth={2} />
+            {dashboardLabel}
+          </Button>
+          <Button
+            className="w-full sm:w-auto"
+            variant="ghost"
+            nativeButton={false}
+            render={<a href={`mailto:${SUPPORT_EMAIL}`} />}
+          >
+            <HugeiconsIcon data-icon="inline-start" icon={CustomerSupportIcon} strokeWidth={2} />
+            {supportLabel}
+          </Button>
+        </EmptyContent>
+      </Empty>
+    </main>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds a branded 404 page for the web app.

Unmatched App Router URLs and `notFound()` calls (missing blog posts, product pages, unsupported locale segments, and similar) now render a localized empty state instead of the default Next.js 404. The page uses the same recovery layout as route errors: homepage, dashboard, and support actions.

Root `app/not-found.tsx` covers unmatched routes. `[lang]/not-found.tsx` covers `notFound()` thrown under locale routes. Copy is formatted on the server from the request locale.

## How to test

1. From `apps/hyperlocalise-web`, run `vp test src/components/not-found` and `vp check --fix`.
2. Open a missing locale route such as `/en/this-page-does-not-exist`.
3. Confirm the heading is "Page not found", the status reads 404, and the homepage / dashboard / support actions work.
4. Open a missing content route that calls `notFound()`, such as `/en/blog/not-a-real-post`.

Note: scanner-style paths without a locale prefix (for example `/wp-links.php`) still return an empty 404 from proxy so AuthKit is not invoked.

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test` for the new files)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac028e22-7340-4c62-a4ef-0cf19fa79b12?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac028e22-7340-4c62-a4ef-0cf19fa79b12&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

