### PR TITLE
fix(web): set 404 document title when notFound() is thrown

### DIFF
--- a/apps/hyperlocalise-web/src/components/not-found/not-found-page.tsx
+++ b/apps/hyperlocalise-web/src/components/not-found/not-found-page.tsx
@@ -35,15 +35,18 @@ export async function NotFoundPage() {
   const copy = getNotFoundCopy(getIntlShape(locale));
 
   return (
-    <NotFoundRecovery
-      statusCode={copy.statusCode}
-      title={copy.title}
-      description={copy.description}
-      homeLabel={copy.homeLabel}
-      dashboardLabel={copy.dashboardLabel}
-      supportLabel={copy.supportLabel}
-      homeHref="/"
-      dashboardHref="/dashboard"
-    />
+    <>
+      <title>{copy.documentTitle}</title>
+      <NotFoundRecovery
+        statusCode={copy.statusCode}
+        title={copy.title}
+        description={copy.description}
+        homeLabel={copy.homeLabel}
+        dashboardLabel={copy.dashboardLabel}
+        supportLabel={copy.supportLabel}
+        homeHref="/"
+        dashboardHref="/dashboard"
+      />
+    </>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Follow-up to #1905. Nested `notFound()` calls (for example a missing blog post) kept the default layout document title. This renders a `<title>` in the 404 page tree so those routes show `Page not found | Hyperlocalise`.

`generateMetadata` still sets `robots: noindex` for unmatched routes.

## How to test

1. Open `/en/blog/not-a-real-post`.
2. Confirm the tab title is `Page not found | Hyperlocalise`.
3. Open `/en/this-page-does-not-exist` and confirm the same title.

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test` for not-found files; full `vp test` was green before this follow-up)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac028e22-7340-4c62-a4ef-0cf19fa79b12?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac028e22-7340-4c62-a4ef-0cf19fa79b12&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

