### PR TITLE
fix(issue-sheet): notify new mentions on comment edit and show email in @ picker (HL-496)

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/mentions/mention-suggestions.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mentions/mention-suggestions.route.test.ts
@@ -78,12 +78,14 @@ describe("Mention suggestions routes", () => {
     expect(response.status).toBe(200);
     const body = (await response.json()) as {
       mentionSuggestions: {
-        users: { userId: string; displayName: string }[];
+        users: { userId: string; displayName: string; email: string }[];
         issues: { issueId: string; displayKey: string; title: string }[];
       };
     };
 
-    expect(body.mentionSuggestions.users.some((member) => member.userId === user.id)).toBe(true);
+    const actorMember = body.mentionSuggestions.users.find((member) => member.userId === user.id);
+    expect(actorMember).toBeDefined();
+    expect(actorMember?.email).toBe(user.email);
     expect(body.mentionSuggestions.issues).toEqual([
       expect.objectContaining({
         issueId: created.issue.id,

--- a/apps/hyperlocalise-web/src/api/routes/mentions/mention-suggestions.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mentions/mention-suggestions.route.ts
@@ -128,6 +128,7 @@ export function createMentionSuggestionsRoutes() {
             users: userRows.map((row) => ({
               userId: row.userId,
               displayName: formatDisplayName(row),
+              email: row.email,
               avatarUrl: row.avatarUrl,
             })),
             issues: issueRows.map((row) => ({

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-comment-composer.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-comment-composer.tsx
@@ -123,6 +123,7 @@ export function IssueCommentComposer({
             users: {
               userId: string;
               displayName: string;
+              email: string;
               avatarUrl: string | null;
               isAgent?: boolean;
             }[];
@@ -141,6 +142,7 @@ export function IssueCommentComposer({
             id: `user:${entry.userId}`,
             userId: entry.userId,
             displayName: entry.displayName,
+            email: entry.email,
             avatarUrl: entry.avatarUrl,
             isAgent: entry.isAgent,
           })),

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-comment-thread.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/issue-detail/issue-comment-thread.tsx
@@ -610,6 +610,7 @@ export function IssueCommentThread({
           users: {
             userId: string;
             displayName: string;
+            email: string;
             avatarUrl: string | null;
             isAgent?: boolean;
           }[];
@@ -628,6 +629,7 @@ export function IssueCommentThread({
           id: `user:${user.userId}`,
           userId: user.userId,
           displayName: user.displayName,
+          email: user.email,
           avatarUrl: user.avatarUrl,
           isAgent: user.isAgent,
         })),

--- a/apps/hyperlocalise-web/src/components/markdown-editor/markdown-editor-mention-list.tsx
+++ b/apps/hyperlocalise-web/src/components/markdown-editor/markdown-editor-mention-list.tsx
@@ -140,8 +140,11 @@ export const MarkdownMentionList = forwardRef<MarkdownMentionListHandle, Markdow
                   {initials(item.displayName)}
                 </AvatarFallback>
               </Avatar>
-              <span className="min-w-0 flex-1 truncate font-medium leading-5">
-                {item.displayName}
+              <span className="min-w-0 flex-1 truncate">
+                <span className="block truncate font-medium leading-5">{item.displayName}</span>
+                {item.displayName.trim() !== item.email ? (
+                  <span className="block truncate text-xs text-muted-foreground">{item.email}</span>
+                ) : null}
               </span>
               {item.isAgent ? (
                 <Badge variant="secondary" className="shrink-0 text-[10px]">

--- a/apps/hyperlocalise-web/src/components/markdown-editor/markdown-editor-mention-types.ts
+++ b/apps/hyperlocalise-web/src/components/markdown-editor/markdown-editor-mention-types.ts
@@ -16,6 +16,7 @@ export type MarkdownMentionUserSuggestion = {
   id: string;
   userId: string;
   displayName: string;
+  email: string;
   avatarUrl: string | null;
   isAgent?: boolean;
 };

--- a/apps/hyperlocalise-web/src/e2e/flows/issue-comment-mentions.e2e.ts
+++ b/apps/hyperlocalise-web/src/e2e/flows/issue-comment-mentions.e2e.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { and, eq } from "drizzle-orm";
+import { describe, expect, it } from "vite-plus/test";
+
+import { db, schema } from "@/lib/database";
+
+import { E2E_BASE_URL, E2E_DEFAULT_LOCALE } from "../constants";
+import { getE2ePage, loginAsAdmin, useE2eBrowser } from "../fixtures/browser";
+import { provisionIssueCommentMentionFixture } from "../helpers/issue-sheet-fixture";
+
+function issueDetailUrl(input: { organizationSlug: string; projectId: string; issueId: string }) {
+  return new URL(
+    `/${E2E_DEFAULT_LOCALE}/org/${input.organizationSlug}/projects/${input.projectId}/issue-sheet/${input.issueId}`,
+    E2E_BASE_URL,
+  ).toString();
+}
+
+describe("issue comment mentions", () => {
+  useE2eBrowser();
+
+  it("shows member email in the mention picker", async () => {
+    const page = getE2ePage();
+    const identity = await loginAsAdmin(page);
+    const fixture = await provisionIssueCommentMentionFixture(identity);
+
+    await page.goto(
+      issueDetailUrl({
+        organizationSlug: fixture.organizationSlug,
+        projectId: fixture.projectId,
+        issueId: fixture.issueId,
+      }),
+      { waitUntil: "domcontentloaded" },
+    );
+
+    await page
+      .getByRole("textbox", { name: "Title" })
+      .waitFor({ state: "visible", timeout: 30_000 });
+    await page.getByText("Comments", { exact: true }).waitFor({ state: "visible" });
+    await page.locator(".ProseMirror").last().click();
+    await page.keyboard.type("@Ment");
+
+    const mentionMenu = page.getByRole("listbox");
+    await mentionMenu.waitFor({ state: "visible", timeout: 15_000 });
+    await mentionMenu.getByText(fixture.member.displayName).waitFor({ state: "visible" });
+    await mentionMenu.getByText(fixture.member.email).waitFor({ state: "visible" });
+  }, 120_000);
+
+  it("notifies a newly mentioned member when a comment is edited", async () => {
+    const page = getE2ePage();
+    const identity = await loginAsAdmin(page);
+    const fixture = await provisionIssueCommentMentionFixture(identity);
+
+    await page.goto(
+      issueDetailUrl({
+        organizationSlug: fixture.organizationSlug,
+        projectId: fixture.projectId,
+        issueId: fixture.issueId,
+      }),
+      { waitUntil: "domcontentloaded" },
+    );
+
+    await page
+      .getByRole("textbox", { name: "Title" })
+      .waitFor({ state: "visible", timeout: 30_000 });
+    await page
+      .getByText(fixture.initialCommentBody, { exact: true })
+      .waitFor({ state: "visible", timeout: 30_000 });
+
+    await page.getByRole("button", { name: "Edit" }).click();
+    const editEditor = page.locator(".ProseMirror").filter({ hasText: fixture.initialCommentBody });
+    await editEditor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.type(" @Target");
+
+    const mentionMenu = page.getByRole("listbox");
+    await mentionMenu.waitFor({ state: "visible", timeout: 15_000 });
+    await mentionMenu.getByRole("option", { name: /Mention Target/i }).click();
+
+    const updateResponsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes("/comments/") &&
+        response.request().method() === "PATCH" &&
+        response.ok(),
+    );
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await updateResponsePromise;
+
+    const [notification] = await db
+      .select()
+      .from(schema.issueNotifications)
+      .where(
+        and(
+          eq(schema.issueNotifications.issueId, fixture.issueId),
+          eq(schema.issueNotifications.recipientUserId, fixture.member.localUserId),
+          eq(schema.issueNotifications.type, "mentioned"),
+        ),
+      );
+
+    expect(notification).toBeDefined();
+    if (!notification) {
+      throw new Error("Expected a mention notification for the edited comment");
+    }
+    expect(notification.recipientUserId).toBe(fixture.member.localUserId);
+  }, 120_000);
+});

--- a/apps/hyperlocalise-web/src/e2e/helpers/issue-sheet-fixture.ts
+++ b/apps/hyperlocalise-web/src/e2e/helpers/issue-sheet-fixture.ts
@@ -14,10 +14,15 @@ import { randomUUID } from "node:crypto";
 
 import { eq } from "drizzle-orm";
 
+import { syncWorkosIdentity } from "@/api/auth/workos-sync";
+import { enrichAuthContextWithCapabilities } from "@/api/auth/policy";
 import { db, schema } from "@/lib/database";
+import { IssueSheetCommentService } from "@/lib/projects/issue-sheet/issue-sheet-comment-service";
 import { IssueSheetService } from "@/lib/projects/issue-sheet/issue-sheet-service";
 import { ensureDefaultWorkspaceTeam } from "@/lib/teams/default-workspace-team";
+import { toAuthOrganization, withMembershipAccessSource } from "@/test/auth-seed";
 
+import { createEmulatorWorkosClient, roleSlugForE2e } from "./emulator-client";
 import type { EmulatorIdentity } from "./emulator-identity";
 
 export type IssueSheetBulkFixture = {
@@ -80,5 +85,205 @@ export async function provisionIssueSheetBulkFixture(
     organizationSlug: organization.slug,
     projectId,
     issueTitles,
+  };
+}
+
+export type IssueCommentMentionFixtureMember = {
+  displayName: string;
+  email: string;
+  localUserId: string;
+  workosMembershipId: string;
+  workosUserId: string;
+};
+
+export type IssueCommentMentionFixture = {
+  organizationSlug: string;
+  projectId: string;
+  issueId: string;
+  issueTitle: string;
+  initialCommentBody: string;
+  member: IssueCommentMentionFixtureMember;
+};
+
+async function provisionEmulatorOrgMember(input: {
+  organizationName: string;
+  organizationSlug: string;
+  workosOrganizationId: string;
+}): Promise<IssueCommentMentionFixtureMember> {
+  const workos = createEmulatorWorkosClient();
+  const suffix = randomUUID().slice(0, 8);
+  const email = `e2e-member-${suffix}@example.test`;
+  const password = `e2e-password-${suffix}`;
+  const firstName = "Mention";
+  const lastName = "Target";
+
+  const user = await workos.userManagement.createUser({
+    email,
+    password,
+    emailVerified: true,
+    firstName,
+    lastName,
+  });
+
+  const membership = await workos.userManagement.createOrganizationMembership({
+    organizationId: input.workosOrganizationId,
+    userId: user.id,
+    roleSlug: roleSlugForE2e("member"),
+  });
+
+  const synced = await syncWorkosIdentity(db, {
+    user: {
+      workosUserId: user.id,
+      email,
+      firstName,
+      lastName,
+    },
+    organization: {
+      workosOrganizationId: input.workosOrganizationId,
+      name: input.organizationName,
+      slug: input.organizationSlug,
+    },
+    membership: {
+      workosMembershipId: membership.id,
+      role: "member",
+    },
+  });
+
+  return {
+    displayName: `${firstName} ${lastName}`,
+    email,
+    localUserId: synced.user.id,
+    workosMembershipId: membership.id,
+    workosUserId: user.id,
+  };
+}
+
+export async function provisionIssueCommentMentionFixture(
+  identity: EmulatorIdentity,
+): Promise<IssueCommentMentionFixture> {
+  const [organization] = await db
+    .select({
+      id: schema.organizations.id,
+      name: schema.organizations.name,
+      slug: schema.organizations.slug,
+      workosOrganizationId: schema.organizations.workosOrganizationId,
+    })
+    .from(schema.organizations)
+    .where(eq(schema.organizations.slug, identity.organizationSlug))
+    .limit(1);
+
+  if (!organization?.slug || !organization.workosOrganizationId) {
+    throw new Error(`E2E organization not found for slug ${identity.organizationSlug}`);
+  }
+
+  const [user] = await db
+    .select({ id: schema.users.id })
+    .from(schema.users)
+    .where(eq(schema.users.workosUserId, identity.workosUserId))
+    .limit(1);
+
+  if (!user) {
+    throw new Error(`E2E user not found for WorkOS user ${identity.workosUserId}`);
+  }
+
+  if (!identity.workosMembershipId) {
+    throw new Error("E2E admin identity is missing a WorkOS membership id");
+  }
+
+  const member = await provisionEmulatorOrgMember({
+    organizationName: organization.name,
+    organizationSlug: organization.slug,
+    workosOrganizationId: organization.workosOrganizationId,
+  });
+
+  const team = await ensureDefaultWorkspaceTeam(organization.id);
+  await db
+    .insert(schema.teamMemberships)
+    .values({
+      teamId: team.id,
+      userId: member.localUserId,
+      role: "member",
+    })
+    .onConflictDoNothing();
+
+  const projectId = `project_${randomUUID()}`;
+  const stamp = Date.now();
+  const issueTitle = `Mention issue ${stamp}`;
+  const initialCommentBody = "Initial comment without mention";
+
+  await db.insert(schema.projects).values({
+    id: projectId,
+    organizationId: organization.id,
+    teamId: team.id,
+    createdByUserId: user.id,
+    name: `Mention project ${stamp}`,
+    description: "",
+    translationContext: "",
+    sourceLocale: "en-US",
+    targetLocales: ["fr-FR"],
+  });
+
+  const issueSheetService = new IssueSheetService(db);
+  const issue = await issueSheetService.createIssue({
+    organizationId: organization.id,
+    projectId,
+    actorUserId: user.id,
+    body: { title: issueTitle },
+  });
+
+  const adminSynced = await syncWorkosIdentity(db, {
+    user: {
+      workosUserId: identity.workosUserId,
+      email: identity.email,
+    },
+    organization: {
+      workosOrganizationId: organization.workosOrganizationId,
+      name: organization.name,
+      slug: organization.slug,
+    },
+    membership: {
+      workosMembershipId: identity.workosMembershipId,
+      role: "admin",
+    },
+  });
+  const activeOrganization = toAuthOrganization(adminSynced.organization, adminSynced.membership);
+  const authContext = enrichAuthContextWithCapabilities({
+    user: {
+      workosUserId: adminSynced.user.workosUserId,
+      localUserId: adminSynced.user.id,
+      email: adminSynced.user.email,
+    },
+    organizations: [activeOrganization],
+    organization: activeOrganization,
+    activeOrganization,
+    membership: withMembershipAccessSource({
+      workosMembershipId: adminSynced.membership.workosMembershipId,
+      role: adminSynced.membership.role,
+    }),
+    activeTeam: null,
+  });
+
+  const commentService = new IssueSheetCommentService(db);
+  const created = await commentService.create({
+    organizationId: organization.id,
+    projectId,
+    issueId: issue.id,
+    actorUserId: user.id,
+    role: "admin",
+    auth: authContext,
+    body: { body: initialCommentBody },
+  });
+
+  if (!created.ok) {
+    throw new Error(`Failed to seed issue comment for E2E: ${created.error.code}`);
+  }
+
+  return {
+    organizationSlug: organization.slug,
+    projectId,
+    issueId: issue.id,
+    issueTitle,
+    initialCommentBody,
+    member,
   };
 }

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-notification-service.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-notification-service.test.ts
@@ -537,4 +537,212 @@ describe("IssueNotificationService", () => {
     ).toBe(true);
     expect(rows.some((row) => row.recipientUserId === outsiderUserId)).toBe(false);
   });
+
+  it("notifies newly added mentions when a comment is edited", async () => {
+    const { actor, assigneeUserId, organization, project } = await createProjectWithAssignee();
+    const issue = await issueSheetService.createIssue({
+      organizationId: organization.id,
+      projectId: project.id,
+      actorUserId: actor.id,
+      body: {
+        title: "Mention on edit",
+        assigneeUserId,
+      },
+    });
+
+    const auth = globalThis.__testApiAuthContext!;
+    const created = await commentService.create({
+      organizationId: organization.id,
+      projectId: project.id,
+      issueId: issue.id,
+      actorUserId: actor.id,
+      role: "admin",
+      auth,
+      body: { body: "Initial comment" },
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      return;
+    }
+
+    await db
+      .delete(schema.issueNotifications)
+      .where(eq(schema.issueNotifications.issueId, issue.id));
+
+    const updated = await commentService.update({
+      organizationId: organization.id,
+      projectId: project.id,
+      issueId: issue.id,
+      commentId: created.value.id,
+      actorUserId: actor.id,
+      role: "admin",
+      auth,
+      body: {
+        body: "Updated with mention",
+        mentionedUserIds: [assigneeUserId],
+      },
+    });
+    expect(updated.ok).toBe(true);
+
+    const rows = await db
+      .select()
+      .from(schema.issueNotifications)
+      .where(eq(schema.issueNotifications.issueId, issue.id));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      recipientUserId: assigneeUserId,
+      type: "mentioned",
+    });
+  });
+
+  it("does not bump mention notification readAt when mentions are unchanged on edit", async () => {
+    const { actor, assigneeUserId, organization, project } = await createProjectWithAssignee();
+    const issue = await issueSheetService.createIssue({
+      organizationId: organization.id,
+      projectId: project.id,
+      actorUserId: actor.id,
+      body: {
+        title: "Keep mention",
+        assigneeUserId,
+      },
+    });
+
+    const auth = globalThis.__testApiAuthContext!;
+    const created = await commentService.create({
+      organizationId: organization.id,
+      projectId: project.id,
+      issueId: issue.id,
+      actorUserId: actor.id,
+      role: "admin",
+      auth,
+      body: {
+        body: "Hello assignee",
+        mentionedUserIds: [assigneeUserId],
+      },
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      return;
+    }
+
+    const readAt = new Date("2026-01-01T00:00:00.000Z");
+    await db
+      .update(schema.issueNotifications)
+      .set({ readAt })
+      .where(
+        and(
+          eq(schema.issueNotifications.issueId, issue.id),
+          eq(schema.issueNotifications.recipientUserId, assigneeUserId),
+          eq(schema.issueNotifications.type, "mentioned"),
+        ),
+      );
+
+    const updated = await commentService.update({
+      organizationId: organization.id,
+      projectId: project.id,
+      issueId: issue.id,
+      commentId: created.value.id,
+      actorUserId: actor.id,
+      role: "admin",
+      auth,
+      body: {
+        body: "Hello assignee again",
+        mentionedUserIds: [assigneeUserId],
+      },
+    });
+    expect(updated.ok).toBe(true);
+
+    const [row] = await db
+      .select()
+      .from(schema.issueNotifications)
+      .where(
+        and(
+          eq(schema.issueNotifications.issueId, issue.id),
+          eq(schema.issueNotifications.recipientUserId, assigneeUserId),
+          eq(schema.issueNotifications.type, "mentioned"),
+        ),
+      );
+
+    expect(row?.readAt?.toISOString()).toBe(readAt.toISOString());
+  });
+
+  it("does not send comment notifications to watchers when a mention is added on edit", async () => {
+    const { actor, assigneeUserId, organization, project } = await createProjectWithAssignee();
+    const issue = await issueSheetService.createIssue({
+      organizationId: organization.id,
+      projectId: project.id,
+      actorUserId: actor.id,
+      body: {
+        title: "Watcher on edit",
+        assigneeUserId,
+      },
+    });
+
+    const auth = globalThis.__testApiAuthContext!;
+    const created = await commentService.create({
+      organizationId: organization.id,
+      projectId: project.id,
+      issueId: issue.id,
+      actorUserId: actor.id,
+      role: "admin",
+      auth,
+      body: { body: "No mention yet" },
+    });
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      return;
+    }
+
+    const commentRowsBefore = await db
+      .select()
+      .from(schema.issueNotifications)
+      .where(
+        and(
+          eq(schema.issueNotifications.issueId, issue.id),
+          eq(schema.issueNotifications.recipientUserId, assigneeUserId),
+          eq(schema.issueNotifications.type, "comment"),
+        ),
+      );
+    expect(commentRowsBefore).toHaveLength(1);
+
+    const updated = await commentService.update({
+      organizationId: organization.id,
+      projectId: project.id,
+      issueId: issue.id,
+      commentId: created.value.id,
+      actorUserId: actor.id,
+      role: "admin",
+      auth,
+      body: {
+        body: "Now with mention",
+        mentionedUserIds: [assigneeUserId],
+      },
+    });
+    expect(updated.ok).toBe(true);
+
+    const commentRowsAfter = await db
+      .select()
+      .from(schema.issueNotifications)
+      .where(
+        and(
+          eq(schema.issueNotifications.issueId, issue.id),
+          eq(schema.issueNotifications.recipientUserId, assigneeUserId),
+          eq(schema.issueNotifications.type, "comment"),
+        ),
+      );
+    expect(commentRowsAfter).toHaveLength(1);
+
+    const mentionedRows = await db
+      .select()
+      .from(schema.issueNotifications)
+      .where(
+        and(
+          eq(schema.issueNotifications.issueId, issue.id),
+          eq(schema.issueNotifications.recipientUserId, assigneeUserId),
+          eq(schema.issueNotifications.type, "mentioned"),
+        ),
+      );
+    expect(mentionedRows).toHaveLength(1);
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-notification-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-notification-service.ts
@@ -407,6 +407,46 @@ export class IssueNotificationService extends ProjectServiceBase {
     });
   }
 
+  async notifyMentions(input: {
+    organizationId: string;
+    projectId: string;
+    issueId: string;
+    actorUserId: string;
+    commentId: string;
+    commentBody: string;
+    mentionedUserIds: string[];
+    database?: DatabaseClient;
+  }): Promise<void> {
+    const database = input.database ?? this.database;
+    const issue = await this.loadIssueContext(input, database);
+    if (!issue) {
+      return;
+    }
+
+    const mentioned = [...new Set(input.mentionedUserIds)];
+    if (mentioned.length === 0) {
+      return;
+    }
+
+    const excerpt = commentExcerpt(input.commentBody);
+
+    await this.notifyRecipients({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      issueId: input.issueId,
+      actorUserId: input.actorUserId,
+      issueTitle: issue.title,
+      recipientUserIds: mentioned,
+      type: ISSUE_NOTIFICATION_MENTIONED,
+      dedupeKeyFor: (recipientUserId) => `mentioned:${input.commentId}:${recipientUserId}`,
+      payloadExtra: {
+        commentId: input.commentId,
+        commentExcerpt: excerpt,
+      },
+      database,
+    });
+  }
+
   async notifyCommentCreated(input: {
     organizationId: string;
     projectId: string;
@@ -426,19 +466,14 @@ export class IssueNotificationService extends ProjectServiceBase {
     const excerpt = commentExcerpt(input.commentBody);
     const mentioned = [...new Set(input.mentionedUserIds)];
 
-    await this.notifyRecipients({
+    await this.notifyMentions({
       organizationId: input.organizationId,
       projectId: input.projectId,
       issueId: input.issueId,
       actorUserId: input.actorUserId,
-      issueTitle: issue.title,
-      recipientUserIds: mentioned,
-      type: ISSUE_NOTIFICATION_MENTIONED,
-      dedupeKeyFor: (recipientUserId) => `mentioned:${input.commentId}:${recipientUserId}`,
-      payloadExtra: {
-        commentId: input.commentId,
-        commentExcerpt: excerpt,
-      },
+      commentId: input.commentId,
+      commentBody: input.commentBody,
+      mentionedUserIds: mentioned,
       database,
     });
 

--- a/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-comment-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/issue-sheet/issue-sheet-comment-service.ts
@@ -406,6 +406,7 @@ export class IssueSheetCommentService extends ProjectServiceBase {
       .select({
         id: schema.issueSheetComments.id,
         authorUserId: schema.issueSheetComments.authorUserId,
+        mentionedUserIds: schema.issueSheetComments.mentionedUserIds,
       })
       .from(schema.issueSheetComments)
       .where(
@@ -471,6 +472,23 @@ export class IssueSheetCommentService extends ProjectServiceBase {
       userIds: mentionedUserIds,
       requireProjectAccess: true,
     });
+
+    const previousMentionedUserIds = new Set(toStringArray(existing.mentionedUserIds));
+    const addedMentionedUserIds = mentionedUserIds.filter(
+      (userId) => !previousMentionedUserIds.has(userId),
+    );
+
+    await issueNotificationService.safeFanOut("comment_mentions_added", () =>
+      issueNotificationService.notifyMentions({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        issueId: input.issueId,
+        actorUserId: input.actorUserId,
+        commentId: existing.id,
+        commentBody: input.body.body,
+        mentionedUserIds: addedMentionedUserIds,
+      }),
+    );
 
     return {
       ok: true,


### PR DESCRIPTION
## What changed

Closes the remaining HL-496 gaps for comment mentions:

- **Edit path:** `IssueSheetCommentService.update()` notifies only **newly added** `mentionedUserIds` (delta vs previous jsonb), via extracted `notifyMentions()`. Does **not** call `notifyCommentCreated()` or fan out watcher `comment` notifications on edit.
- **Dedupe:** Reuses `mentioned:{commentId}:{recipientUserId}` — re-adding after remove upserts the same inbox row; unchanged mentions on edit do not bump `readAt`.
- **Picker:** `/mentions` returns `email`; @ picker shows name + muted email (assignee-picker pattern). Chip insertion still uses display name.
- **Tests:** Three notification-service cases + mentions route email assertion.
- **E2E:** `issue-comment-mentions.e2e.ts` (WorkOS emulator + Playwright) — picker email + mention-on-edit notification (local-only, not CI).

## How to test

```bash
cd apps/hyperlocalise-web
vp test src/lib/projects/issue-sheet/issue-notification-service.test.ts \
  src/lib/projects/issue-sheet/issue-sheet-comment-service.test.ts \
  src/api/routes/mentions/mention-suggestions.route.test.ts
vp check --fix <changed files>
```

Manual: open an issue → post a comment → Edit → add `@` mention → Save → mentioned member gets inbox `mentioned` notification (not a duplicate `comment` for watchers).

E2E (optional, local): Postgres + `vp run e2e:emulator` + app with `.env.e2e` → `vp test run --config vite.e2e.config.ts src/e2e/flows/issue-comment-mentions.e2e.ts`

## Checklist

- [x] I ran relevant checks locally (`vp check` on changed files; targeted `vp test`)
- [x] E2E exercised locally (not wired to CI)
- [ ] CI green on `hyperlocalise/hyperlocalise` (`Web Check` + `Web Test/Build`)
- [x] This PR is scoped and ready for review

Linear: HL-496
