### PR TITLE
fix(automations): search Slack channels and show enabled GitHub repos

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.test.ts
@@ -219,6 +219,7 @@ describe("agentSlackRoutes", () => {
     const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.$get(
       {
         param: { organizationSlug },
+        query: {},
       },
       { headers },
     );
@@ -297,6 +298,7 @@ describe("agentSlackRoutes", () => {
     const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.$get(
       {
         param: { organizationSlug },
+        query: {},
       },
       { headers },
     );
@@ -316,6 +318,7 @@ describe("agentSlackRoutes", () => {
     const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.$get(
       {
         param: { organizationSlug },
+        query: {},
       },
       { headers },
     );
@@ -343,6 +346,7 @@ describe("agentSlackRoutes", () => {
     const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.$get(
       {
         param: { organizationSlug },
+        query: {},
       },
       { headers },
     );
@@ -367,6 +371,7 @@ describe("agentSlackRoutes", () => {
     const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.$get(
       {
         param: { organizationSlug },
+        query: {},
       },
       { headers },
     );
@@ -391,6 +396,7 @@ describe("agentSlackRoutes", () => {
     const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.$get(
       {
         param: { organizationSlug },
+        query: {},
       },
       {
         headers: await fixture.authHeadersFor(identity),

--- a/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.test.ts
@@ -239,6 +239,55 @@ describe("agentSlackRoutes", () => {
         headers: { authorization: "Bearer xoxb-token" },
       }),
     );
+    const listUrl = mocks.fetchMock.mock.calls[0]?.[0] as URL;
+    expect(listUrl.searchParams.get("limit")).toBe("200");
+    expect(listUrl.searchParams.get("cursor")).toBeNull();
+  });
+
+  it("searches Slack channels by name", async () => {
+    const { organizationSlug, headers } = await setupEnabledSlackConnector();
+
+    mocks.fetchMock.mockResolvedValue({
+      ok: true,
+      headers: { get: () => null },
+      json: vi.fn().mockResolvedValue({
+        ok: true,
+        channels: [
+          { id: "C_PUBLIC", name: "localization", is_private: false },
+          { id: "C_PRIVATE", name: "team-l10n", is_private: true },
+        ],
+        response_metadata: {},
+      }),
+    } as unknown as Response);
+
+    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.$get(
+      {
+        param: { organizationSlug },
+        query: { q: "l10n" },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      channels: [{ id: "slack:C_PRIVATE", name: "team-l10n", private: true }],
+    });
+  });
+
+  it("rejects an oversized Slack channel search query", async () => {
+    const { organizationSlug, headers } = await setupEnabledSlackConnector();
+
+    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.$get(
+      {
+        param: { organizationSlug },
+        query: { q: "a".repeat(513) },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "invalid_slack_channel_query" });
+    expect(mocks.fetchMock).not.toHaveBeenCalled();
   });
 
   it("returns 404 when the Slack installation is missing", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.ts
@@ -42,24 +42,19 @@ import { createLogger, serializeErrorForLog } from "@/lib/log";
 import { err, fromThrowableAsync, isErr, ok, type Result } from "@/lib/primitives/result/results";
 import { assertProviderCredentialAdmin } from "@/lib/providers/credentials/organization-provider-credentials";
 
-import { updateSlackAgentBodySchema } from "./agent-slack.schema";
+import {
+  searchSlackChannels,
+  type SlackChannelListItem,
+  type SlackChannelSearchError,
+} from "@/lib/agents/slack/search-channels";
+
+import { searchSlackChannelsQuerySchema, updateSlackAgentBodySchema } from "./agent-slack.schema";
 
 type SlackConnectorConfig = { teamId?: string; teamName?: string };
 type SlackInstallation = { botToken: string };
-type SlackChannel = { id?: string; name?: string; is_private?: boolean; is_archived?: boolean };
-type SlackConversationsListResponse = {
-  ok?: boolean;
-  error?: string;
-  channels?: SlackChannel[];
-  response_metadata?: { next_cursor?: string };
-};
-
-type SlackChannelListItem = { id: string; name: string; private: boolean };
 type SlackChannelListError =
   | { code: "installation_not_found" }
-  | { code: "bot_unavailable"; cause: unknown }
-  | { code: "slack_http_error"; status: number }
-  | { code: "slack_api_error"; slackError: string };
+  | SlackChannelSearchError;
 
 const logger = createLogger("agent-slack");
 
@@ -72,9 +67,14 @@ const validateUpdateSlackAgentBody = validator("json", (value, c) => {
   return parsed.data;
 });
 
-function toCanonicalSlackChannelId(channelId: string) {
-  return channelId.startsWith("slack:") ? channelId : `slack:${channelId}`;
-}
+const validateSearchSlackChannelsQuery = validator("query", (value, c) => {
+  const parsed = searchSlackChannelsQuerySchema.safeParse(value);
+  if (!parsed.success) {
+    return c.json({ error: "invalid_slack_channel_query" as const }, 400);
+  }
+
+  return parsed.data;
+});
 
 async function getSlackConnector(organizationId: string) {
   const [connector] = await db
@@ -117,79 +117,27 @@ async function getSlackInstallation(
   return ok(installationResult.value);
 }
 
-async function listSlackChannels(
-  botToken: string,
-): Promise<Result<SlackChannelListItem[], SlackChannelListError>> {
-  const channels: SlackChannelListItem[] = [];
-  let cursor = "";
-
-  do {
-    const url = new URL("https://slack.com/api/conversations.list");
-    url.searchParams.set("exclude_archived", "true");
-    url.searchParams.set("limit", "1000");
-    url.searchParams.set("types", "public_channel,private_channel");
-    if (cursor) {
-      url.searchParams.set("cursor", cursor);
-    }
-
-    const responseResult = await fromThrowableAsync(
-      fetch(url, {
-        headers: { authorization: `Bearer ${botToken}` },
-        redirect: "error",
-      }),
-    );
-    if (isErr(responseResult)) {
-      return err({ code: "bot_unavailable", cause: responseResult.error });
-    }
-
-    const response = responseResult.value;
-    if (!response.ok) {
-      return err({ code: "slack_http_error", status: response.status });
-    }
-
-    const bodyResult = await fromThrowableAsync(
-      response.json() as Promise<SlackConversationsListResponse>,
-    );
-    if (isErr(bodyResult)) {
-      return err({ code: "bot_unavailable", cause: bodyResult.error });
-    }
-
-    const body = bodyResult.value;
-    if (!body.ok) {
-      return err({ code: "slack_api_error", slackError: body.error ?? "unknown" });
-    }
-
-    for (const channel of body.channels ?? []) {
-      if (!channel.id || !channel.name || channel.is_archived) {
-        continue;
-      }
-      channels.push({
-        id: toCanonicalSlackChannelId(channel.id),
-        name: channel.name,
-        private: Boolean(channel.is_private),
-      });
-    }
-
-    cursor = body.response_metadata?.next_cursor ?? "";
-  } while (cursor);
-
-  return ok(channels.sort((left, right) => left.name.localeCompare(right.name)));
-}
-
 async function loadSlackChannelsForTeam(
   teamId: string,
+  input: { query?: string; selectedChannelId?: string; signal?: AbortSignal },
 ): Promise<Result<SlackChannelListItem[], SlackChannelListError>> {
   const installationResult = await getSlackInstallation(teamId);
   if (isErr(installationResult)) {
     return installationResult;
   }
 
-  return listSlackChannels(installationResult.value.botToken);
+  return searchSlackChannels({
+    botToken: installationResult.value.botToken,
+    query: input.query,
+    selectedChannelId: input.selectedChannelId,
+    signal: input.signal,
+  });
 }
 
 function slackChannelListErrorLogFields(error: SlackChannelListError) {
   switch (error.code) {
     case "installation_not_found":
+    case "slack_rate_limited":
       return {};
     case "slack_api_error":
       return { slackError: error.slackError };
@@ -224,7 +172,7 @@ export function createAgentSlackRoutes() {
         200,
       );
     })
-    .get("/channels", async (c) => {
+    .get("/channels", validateSearchSlackChannelsQuery, async (c) => {
       if (!isIntegrationsReadAllowed(c.var.auth.membership.role)) {
         return forbiddenResponse(c);
       }
@@ -235,7 +183,12 @@ export function createAgentSlackRoutes() {
         return c.json({ channels: [] }, 200);
       }
 
-      const channelsResult = await loadSlackChannelsForTeam(config.teamId);
+      const query = c.req.valid("query");
+      const channelsResult = await loadSlackChannelsForTeam(config.teamId, {
+        query: query.q,
+        selectedChannelId: query.channelId,
+        signal: c.req.raw.signal,
+      });
       if (isErr(channelsResult)) {
         if (channelsResult.error.code === "installation_not_found") {
           return c.json({ error: "slack_installation_not_found" as const }, 404);

--- a/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.ts
@@ -52,9 +52,7 @@ import { searchSlackChannelsQuerySchema, updateSlackAgentBodySchema } from "./ag
 
 type SlackConnectorConfig = { teamId?: string; teamName?: string };
 type SlackInstallation = { botToken: string };
-type SlackChannelListError =
-  | { code: "installation_not_found" }
-  | SlackChannelSearchError;
+type SlackChannelListError = { code: "installation_not_found" } | SlackChannelSearchError;
 
 const logger = createLogger("agent-slack");
 

--- a/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.schema.ts
@@ -15,3 +15,8 @@ import { z } from "zod";
 export const updateSlackAgentBodySchema = z.object({
   enabled: z.boolean(),
 });
+
+export const searchSlackChannelsQuerySchema = z.object({
+  q: z.string().max(512).optional(),
+  channelId: z.string().max(128).optional(),
+});

--- a/apps/hyperlocalise-web/src/api/routes/security-limits-identifiers.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/security-limits-identifiers.test.ts
@@ -32,6 +32,7 @@ import {
   uploadBodySchema,
   fileParamsSchema as publicFileParamsSchema,
 } from "./public-files/public-files.schema";
+import { searchSlackChannelsQuerySchema } from "./agent-slack/agent-slack.schema";
 import { searchRepositoriesSchema } from "./github-installation/github-installation.schema";
 import { apiKeyIdParamsSchema } from "./api-key/api-key.schema";
 import { fileParamsSchema } from "./file/file.schema";
@@ -99,6 +100,10 @@ describe("Identifier Schema length limits", () => {
 
   it("should enforce max length on search query q in github-installation.schema", () => {
     expect(searchRepositoriesSchema.safeParse({ q: longSearch }).success).toBe(false);
+  });
+
+  it("should enforce max length on search query q in agent-slack.schema", () => {
+    expect(searchSlackChannelsQuerySchema.safeParse({ q: longSearch }).success).toBe(false);
   });
 
   it("should enforce max length on apiKeyId", () => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/slack-channel-select.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/slack-channel-select.tsx
@@ -109,7 +109,8 @@ export function SlackChannelSelect({
 
   const channels = channelsQuery.data ?? [];
   const selectedChannel = channels.find((channel) => channel.id === value);
-  const triggerDisabled = disabled || !slackConnected || (channelsQuery.isLoading && !selectedChannel);
+  const triggerDisabled =
+    disabled || !slackConnected || (channelsQuery.isLoading && !selectedChannel);
 
   return (
     <div className="grid gap-1.5">
@@ -142,7 +143,9 @@ export function SlackChannelSelect({
         <PopoverContent align="start" className="w-80 p-0" sideOffset={4}>
           <Command shouldFilter={false}>
             <CommandInput
-              placeholder={intl.formatMessage(workspaceAutomationFormMessages.searchChannelPlaceholder)}
+              placeholder={intl.formatMessage(
+                workspaceAutomationFormMessages.searchChannelPlaceholder,
+              )}
               value={query}
               onValueChange={setQuery}
             />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/slack-channel-select.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/slack-channel-select.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useEffect, useState } from "react";
+import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useQuery } from "@tanstack/react-query";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { workspaceAutomationFormMessages } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Label } from "@/components/ui/label";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { createApiClient } from "@/lib/api-client";
+import { cn } from "@/lib/primitives/cn";
+
+const api = createApiClient();
+
+type SlackChannelOption = { id: string; name: string; private: boolean };
+
+function useDebouncedValue<T>(value: T, delayMs: number) {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => setDebouncedValue(value), delayMs);
+    return () => window.clearTimeout(timeout);
+  }, [delayMs, value]);
+
+  return debouncedValue;
+}
+
+function slackChannelLabel(
+  intl: ReturnType<typeof useIntl>,
+  channel: SlackChannelOption | undefined,
+  fallbackId: string,
+) {
+  if (!channel) {
+    return fallbackId
+      ? fallbackId
+      : intl.formatMessage(workspaceAutomationFormMessages.selectChannel);
+  }
+
+  return channel.private
+    ? intl.formatMessage(workspaceAutomationFormMessages.privateChannelSuffix, {
+        name: channel.name,
+      })
+    : intl.formatMessage(workspaceAutomationFormMessages.publicChannelLabel, {
+        name: channel.name,
+      });
+}
+
+export function SlackChannelSelect({
+  disabled,
+  error,
+  onChange,
+  organizationSlug,
+  slackConnected,
+  value,
+}: {
+  disabled?: boolean;
+  error?: string;
+  onChange: (channelId: string) => void;
+  organizationSlug: string;
+  slackConnected: boolean;
+  value: string;
+}) {
+  const intl = useIntl();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const debouncedQuery = useDebouncedValue(query, 300);
+
+  const channelsQuery = useQuery({
+    queryKey: ["slack-agent-channels", organizationSlug, debouncedQuery, value],
+    queryFn: async () => {
+      const response = await api.api.orgs[":organizationSlug"]["agent-slack"].channels.$get({
+        param: { organizationSlug },
+        query: {
+          q: debouncedQuery || undefined,
+          channelId: value || undefined,
+        },
+      });
+      if (response.status !== 200) {
+        throw new Error("Failed to load Slack channels");
+      }
+      const body = await response.json();
+      return body.channels;
+    },
+    enabled: slackConnected,
+  });
+
+  const channels = channelsQuery.data ?? [];
+  const selectedChannel = channels.find((channel) => channel.id === value);
+  const triggerDisabled = disabled || !slackConnected || (channelsQuery.isLoading && !selectedChannel);
+
+  return (
+    <div className="grid gap-1.5">
+      <Label className="text-xs text-muted-foreground">
+        <FormattedMessage {...workspaceAutomationFormMessages.channelLabel} />
+      </Label>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger
+          disabled={triggerDisabled}
+          render={
+            <Button
+              type="button"
+              variant="outline"
+              disabled={triggerDisabled}
+              className="h-8 w-full justify-between rounded-lg px-2.5 font-normal"
+            />
+          }
+        >
+          <span className="min-w-0 truncate">
+            {channelsQuery.isLoading && !selectedChannel && !value
+              ? intl.formatMessage(workspaceAutomationFormMessages.loadingChannels)
+              : slackChannelLabel(intl, selectedChannel, value)}
+          </span>
+          <HugeiconsIcon
+            icon={ArrowDown01Icon}
+            strokeWidth={2}
+            className="size-4 shrink-0 text-muted-foreground"
+          />
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-80 p-0" sideOffset={4}>
+          <Command shouldFilter={false}>
+            <CommandInput
+              placeholder={intl.formatMessage(workspaceAutomationFormMessages.searchChannelPlaceholder)}
+              value={query}
+              onValueChange={setQuery}
+            />
+            <CommandList>
+              <CommandEmpty>
+                {channelsQuery.isFetching
+                  ? intl.formatMessage(workspaceAutomationFormMessages.loadingChannels)
+                  : intl.formatMessage(workspaceAutomationFormMessages.noChannelsFound)}
+              </CommandEmpty>
+              <CommandGroup>
+                {channels.map((channel) => (
+                  <CommandItem
+                    key={channel.id}
+                    value={channel.id}
+                    data-checked={value === channel.id || undefined}
+                    onSelect={() => {
+                      onChange(channel.id);
+                      setOpen(false);
+                    }}
+                  >
+                    <span className={cn("min-w-0 flex-1 truncate")}>
+                      {slackChannelLabel(intl, channel, channel.id)}
+                    </span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -90,6 +90,11 @@ export const workspaceAutomationFormMessages = defineMessages({
     id: "J7Yta0PrqK",
     description: "Placeholder when no Slack channel is selected",
   },
+  searchChannelPlaceholder: {
+    defaultMessage: "Search channels",
+    id: "n4Q2kL8mVx",
+    description: "Placeholder for Slack channel search input",
+  },
   selectConnection: {
     defaultMessage: "Select connection",
     id: "x6H592pqcv",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -92,7 +92,7 @@ export const workspaceAutomationFormMessages = defineMessages({
   },
   searchChannelPlaceholder: {
     defaultMessage: "Search channels",
-    id: "n4Q2kL8mVx",
+    id: "ipTMc2bEYF",
     description: "Placeholder for Slack channel search input",
   },
   selectConnection: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -89,11 +89,13 @@ import {
   addBranchPattern,
 } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model";
 import { AUTOMATION_WEEKDAY_MESSAGE_BY_VALUE } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model.messages";
+import { SlackChannelSelect } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/slack-channel-select";
 import { workspaceAutomationFormMessages } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages";
 import { getLocaleLabel } from "@/lib/i18n/locales";
 import type { WorkspaceAutomationFormState } from "@/lib/agents/workspace-automation-view-model";
 import {
   applyWorkspaceAutomationProjectSelection,
+  selectableAutomationRepositories,
   workspaceAutomationFormCanActivate,
 } from "@/lib/agents/workspace-automation-view-model";
 import type { WorkspaceAutomationRunRecord } from "@/lib/agents/workspace-automations";
@@ -117,7 +119,6 @@ type GithubRepositoryOption = {
   archived: boolean;
   defaultBranch: string | null;
 };
-type SlackChannelOption = { id: string; name: string; private: boolean };
 type McpServerConnectionOption = {
   id: string;
   displayName: string;
@@ -414,7 +415,7 @@ function resolveDefaultGithubRepositoryId(
     return form.githubInstallationRepositoryId;
   }
 
-  return repositories.find((repository) => repository.enabled)?.id ?? repositories[0]?.id ?? "";
+  return repositories.find((repository) => repository.enabled && !repository.archived)?.id ?? "";
 }
 
 function GithubRepositorySelect({
@@ -469,29 +470,6 @@ function GithubRepositorySelect({
       <FieldError message={error} />
     </div>
   );
-}
-
-function selectedSlackChannelLabel(
-  intl: IntlShape,
-  channelId: string,
-  channels: SlackChannelOption[],
-) {
-  if (!channelId) {
-    return intl.formatMessage(workspaceAutomationFormMessages.selectChannel);
-  }
-
-  const channel = channels.find((entry) => entry.id === channelId);
-  if (!channel) {
-    return channelId;
-  }
-
-  return channel.private
-    ? intl.formatMessage(workspaceAutomationFormMessages.privateChannelSuffix, {
-        name: channel.name,
-      })
-    : intl.formatMessage(workspaceAutomationFormMessages.publicChannelLabel, {
-        name: channel.name,
-      });
 }
 
 function selectedContentfulConnectionLabel(
@@ -1639,8 +1617,6 @@ function ToolsSettings({
   repositories,
   ahrefsConnections,
   semrushConnections,
-  slackChannels,
-  slackChannelsLoading,
   slackConnected,
 }: {
   canUpdateKnowledgeMemory: boolean;
@@ -1658,8 +1634,6 @@ function ToolsSettings({
   repositories: GithubRepositoryOption[];
   ahrefsConnections: AhrefsConnectionOption[];
   semrushConnections: SemrushConnectionOption[];
-  slackChannels: SlackChannelOption[];
-  slackChannelsLoading: boolean;
   slackConnected: boolean;
 }) {
   const contentfulConnected = contentfulConnections.length > 0;
@@ -1943,48 +1917,14 @@ function ToolsSettings({
               />
             }
           >
-            <div className="grid gap-1.5">
-              <Label className="text-xs text-muted-foreground">
-                <FormattedMessage {...workspaceAutomationFormMessages.channelLabel} />
-              </Label>
-              <Select
-                value={form.slackChannelId || undefined}
-                onValueChange={(value) => {
-                  if (!value) {
-                    return;
-                  }
-                  onChange({ ...form, slackChannelId: value });
-                }}
-                disabled={disabled || !slackConnected || slackChannelsLoading}
-              >
-                <SelectTrigger className="h-8 w-full rounded-lg">
-                  <span className="truncate">
-                    {slackChannelsLoading
-                      ? intl.formatMessage(workspaceAutomationFormMessages.loadingChannels)
-                      : selectedSlackChannelLabel(intl, form.slackChannelId, slackChannels)}
-                  </span>
-                </SelectTrigger>
-                <SelectContent>
-                  {!slackChannelsLoading && slackChannels.length === 0 ? (
-                    <SelectItem value="__no_slack_channels" disabled>
-                      {intl.formatMessage(workspaceAutomationFormMessages.noChannelsFound)}
-                    </SelectItem>
-                  ) : null}
-                  {slackChannels.map((channel) => (
-                    <SelectItem key={channel.id} value={channel.id}>
-                      {channel.private
-                        ? intl.formatMessage(workspaceAutomationFormMessages.privateChannelSuffix, {
-                            name: channel.name,
-                          })
-                        : intl.formatMessage(workspaceAutomationFormMessages.publicChannelLabel, {
-                            name: channel.name,
-                          })}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <FieldError message={errors.slackChannelId} />
-            </div>
+            <SlackChannelSelect
+              disabled={disabled}
+              error={errors.slackChannelId}
+              organizationSlug={organizationSlug}
+              slackConnected={slackConnected}
+              value={form.slackChannelId}
+              onChange={(slackChannelId) => onChange({ ...form, slackChannelId })}
+            />
           </EditorRow>
         ) : null}
 
@@ -2863,21 +2803,6 @@ export function WorkspaceAutomationEditor({
     },
   });
 
-  const slackChannelsQuery = useQuery({
-    queryKey: ["slack-agent-channels", organizationSlug],
-    queryFn: async () => {
-      const response = await api.api.orgs[":organizationSlug"]["agent-slack"].channels.$get({
-        param: { organizationSlug },
-      });
-      if (!response.ok) {
-        throw new Error("Failed to load Slack channels");
-      }
-      const body = await response.json();
-      return body.channels as SlackChannelOption[];
-    },
-    enabled: Boolean(slackQuery.data?.enabled),
-  });
-
   const emailQuery = useQuery({
     queryKey: ["email-agent", organizationSlug],
     queryFn: async () => {
@@ -2949,8 +2874,12 @@ export function WorkspaceAutomationEditor({
   });
 
   const repositories = useMemo(
-    () => (repositoriesQuery.data ?? []).filter((repository) => !repository.archived),
-    [repositoriesQuery.data],
+    () =>
+      selectableAutomationRepositories(
+        repositoriesQuery.data ?? [],
+        form.githubInstallationRepositoryId,
+      ),
+    [form.githubInstallationRepositoryId, repositoriesQuery.data],
   );
   const canActivate = workspaceAutomationFormCanActivate(form);
   const slackConnected = Boolean(slackQuery.data?.enabled);
@@ -3107,8 +3036,6 @@ export function WorkspaceAutomationEditor({
             repositories={repositories}
             ahrefsConnections={ahrefsConnections}
             semrushConnections={semrushConnections}
-            slackChannels={slackChannelsQuery.data ?? []}
-            slackChannelsLoading={slackChannelsQuery.isLoading}
             slackConnected={slackConnected}
           />
         </TabsContent>

--- a/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.test.ts
@@ -92,7 +92,7 @@ describe("searchSlackChannels", () => {
           { id: "C1", name: "alerts" },
           { id: "C2", name: "l10n-reviews" },
         ],
-        response_metadata: { next_cursor: "page-2" },
+        response_metadata: {},
       }),
     );
 
@@ -140,7 +140,9 @@ describe("searchSlackChannels", () => {
       { id: "slack:C_PUBLIC", name: "localization", private: false },
       { id: "slack:C_SELECTED", name: "release-updates", private: true },
     ]);
-    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("https://slack.com/api/conversations.info");
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+      "https://slack.com/api/conversations.info",
+    );
     expect(String(fetchMock.mock.calls[0]?.[0])).toContain("channel=C_SELECTED");
   });
 
@@ -149,7 +151,10 @@ describe("searchSlackChannels", () => {
     const sleep = vi.fn().mockResolvedValue(undefined);
     fetchMock
       .mockResolvedValueOnce(
-        jsonResponse({ ok: false, error: "ratelimited" }, { status: 429, headers: { "retry-after": "1" } }),
+        jsonResponse(
+          { ok: false, error: "ratelimited" },
+          { status: 429, headers: { "retry-after": "1" } },
+        ),
       )
       .mockResolvedValueOnce(
         jsonResponse({

--- a/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.test.ts
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { isErr, isOk } from "@/lib/primitives/result/results";
+
+import {
+  fromCanonicalSlackChannelId,
+  searchSlackChannels,
+  SLACK_CHANNEL_BROWSE_LIMIT,
+  toCanonicalSlackChannelId,
+} from "./search-channels";
+
+const fetchMock = vi.fn();
+
+function jsonResponse(body: unknown, init?: { status?: number; headers?: Record<string, string> }) {
+  return {
+    ok: (init?.status ?? 200) >= 200 && (init?.status ?? 200) < 300,
+    status: init?.status ?? 200,
+    headers: {
+      get: (name: string) => init?.headers?.[name.toLowerCase()] ?? null,
+    },
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+function conversationsListUrl(href: string) {
+  const url = new URL(href);
+  expect(url.origin + url.pathname).toBe("https://slack.com/api/conversations.list");
+  return url;
+}
+
+describe("searchSlackChannels", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    fetchMock.mockReset();
+  });
+
+  it("canonicalizes Slack channel ids", () => {
+    expect(toCanonicalSlackChannelId("C123")).toBe("slack:C123");
+    expect(toCanonicalSlackChannelId("slack:C123")).toBe("slack:C123");
+    expect(fromCanonicalSlackChannelId("slack:C123")).toBe("C123");
+    expect(fromCanonicalSlackChannelId("C123")).toBe("C123");
+  });
+
+  it("browses a single page and ignores further cursors", async () => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        ok: true,
+        channels: [
+          { id: "C_PUBLIC", name: "localization", is_private: false },
+          { id: "C_PRIVATE", name: "team-l10n", is_private: true },
+          { id: "C_ARCHIVED", name: "old", is_archived: true },
+        ],
+        response_metadata: { next_cursor: "page-2" },
+      }),
+    );
+
+    const result = await searchSlackChannels({ botToken: "xoxb-token" });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw new Error("expected channel browse to succeed");
+    }
+    expect(result.value).toEqual([
+      { id: "slack:C_PUBLIC", name: "localization", private: false },
+      { id: "slack:C_PRIVATE", name: "team-l10n", private: true },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const url = conversationsListUrl(String(fetchMock.mock.calls[0]?.[0]));
+    expect(url.searchParams.get("limit")).toBe(String(SLACK_CHANNEL_BROWSE_LIMIT));
+    expect(url.searchParams.get("cursor")).toBeNull();
+  });
+
+  it("searches channel names without listing every page after enough matches", async () => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        ok: true,
+        channels: [
+          { id: "C1", name: "alerts" },
+          { id: "C2", name: "l10n-reviews" },
+        ],
+        response_metadata: { next_cursor: "page-2" },
+      }),
+    );
+
+    const result = await searchSlackChannels({
+      botToken: "xoxb-token",
+      query: "#L10N",
+    });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw new Error("expected channel search to succeed");
+    }
+    expect(result.value).toEqual([{ id: "slack:C2", name: "l10n-reviews", private: false }]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const url = conversationsListUrl(String(fetchMock.mock.calls[0]?.[0]));
+    expect(url.searchParams.get("limit")).toBe("1000");
+  });
+
+  it("includes the selected channel even when it is outside the browse page", async () => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          ok: true,
+          channel: { id: "C_SELECTED", name: "release-updates", is_private: true },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          ok: true,
+          channels: [{ id: "C_PUBLIC", name: "localization" }],
+        }),
+      );
+
+    const result = await searchSlackChannels({
+      botToken: "xoxb-token",
+      selectedChannelId: "slack:C_SELECTED",
+    });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw new Error("expected selected channel merge to succeed");
+    }
+    expect(result.value).toEqual([
+      { id: "slack:C_PUBLIC", name: "localization", private: false },
+      { id: "slack:C_SELECTED", name: "release-updates", private: true },
+    ]);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("https://slack.com/api/conversations.info");
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("channel=C_SELECTED");
+  });
+
+  it("retries Slack 429 responses and then succeeds", async () => {
+    vi.stubGlobal("fetch", fetchMock);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({ ok: false, error: "ratelimited" }, { status: 429, headers: { "retry-after": "1" } }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          ok: true,
+          channels: [{ id: "C1", name: "general" }],
+        }),
+      );
+
+    const result = await searchSlackChannels({
+      botToken: "xoxb-token",
+      sleep,
+    });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw new Error("expected rate-limit retry to succeed");
+    }
+    expect(result.value).toEqual([{ id: "slack:C1", name: "general", private: false }]);
+    expect(sleep).toHaveBeenCalledWith(1000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns slack_rate_limited after retries are exhausted", async () => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockResolvedValue(jsonResponse({ ok: false, error: "ratelimited" }, { status: 429 }));
+
+    const result = await searchSlackChannels({
+      botToken: "xoxb-token",
+      sleep: async () => undefined,
+    });
+
+    expect(isErr(result)).toBe(true);
+    if (!isErr(result)) {
+      throw new Error("expected rate-limit exhaustion");
+    }
+    expect(result.error).toEqual({ code: "slack_rate_limited" });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
@@ -247,14 +247,16 @@ export async function searchSlackChannels(input: {
   const sleep = input.sleep ?? defaultSleep;
   const query = input.query?.trim() ?? "";
 
-  const selectedResult = input.selectedChannelId
-    ? await loadSelectedSlackChannel(input.botToken, input.selectedChannelId, {
-        signal: input.signal,
-        sleep,
-      })
-    : ok(null);
-  if (isErr(selectedResult)) {
-    return selectedResult;
+  let selectedChannel: SlackChannelListItem | null = null;
+  if (input.selectedChannelId) {
+    const selectedResult = await loadSelectedSlackChannel(input.botToken, input.selectedChannelId, {
+      signal: input.signal,
+      sleep,
+    });
+    if (isErr(selectedResult)) {
+      return selectedResult;
+    }
+    selectedChannel = selectedResult.value;
   }
 
   if (!query) {
@@ -267,7 +269,7 @@ export async function searchSlackChannels(input: {
       return pageResult;
     }
 
-    return ok(mergeSlackChannels(selectedResult.value, pageResult.value.channels));
+    return ok(mergeSlackChannels(selectedChannel, pageResult.value.channels));
   }
 
   const matches: SlackChannelListItem[] = [];
@@ -288,7 +290,7 @@ export async function searchSlackChannels(input: {
       if (channelMatchesQuery(channel, query)) {
         matches.push(channel);
         if (matches.length >= SLACK_CHANNEL_SEARCH_MAX_RESULTS) {
-          return ok(mergeSlackChannels(selectedResult.value, matches));
+          return ok(mergeSlackChannels(selectedChannel, matches));
         }
       }
     }
@@ -299,5 +301,5 @@ export async function searchSlackChannels(input: {
     }
   }
 
-  return ok(mergeSlackChannels(selectedResult.value, matches));
+  return ok(mergeSlackChannels(selectedChannel, matches));
 }

--- a/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+import { err, fromThrowableAsync, isErr, ok, type Result } from "@/lib/primitives/result/results";
+
+export const SLACK_CHANNEL_BROWSE_LIMIT = 200;
+export const SLACK_CHANNEL_SEARCH_PAGE_LIMIT = 1000;
+export const SLACK_CHANNEL_SEARCH_MAX_PAGES = 3;
+export const SLACK_CHANNEL_SEARCH_MAX_RESULTS = 50;
+export const SLACK_CHANNEL_RATE_LIMIT_RETRIES = 3;
+export const SLACK_CHANNEL_RATE_LIMIT_MAX_WAIT_MS = 2000;
+
+export type SlackChannelListItem = { id: string; name: string; private: boolean };
+
+export type SlackChannelSearchError =
+  | { code: "slack_http_error"; status: number }
+  | { code: "slack_api_error"; slackError: string }
+  | { code: "slack_rate_limited" }
+  | { code: "bot_unavailable"; cause: unknown };
+
+type SlackChannel = { id?: string; name?: string; is_private?: boolean; is_archived?: boolean };
+
+type SlackConversationsListResponse = {
+  ok?: boolean;
+  error?: string;
+  channels?: SlackChannel[];
+  response_metadata?: { next_cursor?: string };
+};
+
+type SlackConversationsInfoResponse = {
+  ok?: boolean;
+  error?: string;
+  channel?: SlackChannel;
+};
+
+type SlackJsonResponse = SlackConversationsListResponse & SlackConversationsInfoResponse;
+
+export function toCanonicalSlackChannelId(channelId: string) {
+  return channelId.startsWith("slack:") ? channelId : `slack:${channelId}`;
+}
+
+export function fromCanonicalSlackChannelId(channelId: string) {
+  return channelId.startsWith("slack:") ? channelId.slice("slack:".length) : channelId;
+}
+
+function defaultSleep(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function parseRetryAfterMs(response: Response) {
+  const retryAfter = response.headers.get("retry-after");
+  if (!retryAfter) {
+    return 1000;
+  }
+
+  const seconds = Number(retryAfter);
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return 1000;
+  }
+
+  return Math.min(Math.ceil(seconds * 1000), SLACK_CHANNEL_RATE_LIMIT_MAX_WAIT_MS);
+}
+
+function toChannelListItem(channel: SlackChannel): SlackChannelListItem | null {
+  if (!channel.id || !channel.name || channel.is_archived) {
+    return null;
+  }
+
+  return {
+    id: toCanonicalSlackChannelId(channel.id),
+    name: channel.name,
+    private: Boolean(channel.is_private),
+  };
+}
+
+function channelMatchesQuery(channel: SlackChannelListItem, query: string) {
+  const normalizedQuery = query.trim().replace(/^#/, "").toLowerCase();
+  if (!normalizedQuery) {
+    return true;
+  }
+
+  return channel.name.toLowerCase().includes(normalizedQuery);
+}
+
+async function fetchSlackJson(
+  url: URL,
+  botToken: string,
+  options: {
+    signal?: AbortSignal;
+    sleep: (ms: number) => Promise<void>;
+  },
+): Promise<Result<SlackJsonResponse, SlackChannelSearchError>> {
+  for (let attempt = 0; attempt <= SLACK_CHANNEL_RATE_LIMIT_RETRIES; attempt += 1) {
+    const responseResult = await fromThrowableAsync(
+      fetch(url, {
+        headers: { authorization: `Bearer ${botToken}` },
+        redirect: "error",
+        signal: options.signal,
+      }),
+    );
+    if (isErr(responseResult)) {
+      return err({ code: "bot_unavailable", cause: responseResult.error });
+    }
+
+    const response = responseResult.value;
+    if (response.status === 429) {
+      if (attempt === SLACK_CHANNEL_RATE_LIMIT_RETRIES) {
+        return err({ code: "slack_rate_limited" });
+      }
+      await options.sleep(parseRetryAfterMs(response));
+      continue;
+    }
+
+    if (!response.ok) {
+      return err({ code: "slack_http_error", status: response.status });
+    }
+
+    const bodyResult = await fromThrowableAsync(response.json() as Promise<SlackJsonResponse>);
+    if (isErr(bodyResult)) {
+      return err({ code: "bot_unavailable", cause: bodyResult.error });
+    }
+
+    const body = bodyResult.value;
+    if (!body.ok) {
+      if (body.error === "ratelimited") {
+        if (attempt === SLACK_CHANNEL_RATE_LIMIT_RETRIES) {
+          return err({ code: "slack_rate_limited" });
+        }
+        await options.sleep(parseRetryAfterMs(response));
+        continue;
+      }
+
+      return err({ code: "slack_api_error", slackError: body.error ?? "unknown" });
+    }
+
+    return ok(body);
+  }
+
+  return err({ code: "slack_rate_limited" });
+}
+
+async function loadSelectedSlackChannel(
+  botToken: string,
+  channelId: string,
+  options: {
+    signal?: AbortSignal;
+    sleep: (ms: number) => Promise<void>;
+  },
+): Promise<Result<SlackChannelListItem | null, SlackChannelSearchError>> {
+  const slackChannelId = fromCanonicalSlackChannelId(channelId);
+  if (!slackChannelId) {
+    return ok(null);
+  }
+
+  const url = new URL("https://slack.com/api/conversations.info");
+  url.searchParams.set("channel", slackChannelId);
+
+  const bodyResult = await fetchSlackJson(url, botToken, options);
+  if (isErr(bodyResult)) {
+    if (
+      bodyResult.error.code === "slack_api_error" &&
+      bodyResult.error.slackError === "channel_not_found"
+    ) {
+      return ok(null);
+    }
+    return bodyResult;
+  }
+
+  return ok(toChannelListItem(bodyResult.value.channel ?? {}));
+}
+
+async function listSlackChannelPage(
+  botToken: string,
+  input: {
+    cursor?: string;
+    limit: number;
+    signal?: AbortSignal;
+    sleep: (ms: number) => Promise<void>;
+  },
+): Promise<
+  Result<{ channels: SlackChannelListItem[]; nextCursor: string }, SlackChannelSearchError>
+> {
+  const url = new URL("https://slack.com/api/conversations.list");
+  url.searchParams.set("exclude_archived", "true");
+  url.searchParams.set("limit", String(input.limit));
+  url.searchParams.set("types", "public_channel,private_channel");
+  if (input.cursor) {
+    url.searchParams.set("cursor", input.cursor);
+  }
+
+  const bodyResult = await fetchSlackJson(url, botToken, {
+    signal: input.signal,
+    sleep: input.sleep,
+  });
+  if (isErr(bodyResult)) {
+    return bodyResult;
+  }
+
+  const channels: SlackChannelListItem[] = [];
+  for (const channel of bodyResult.value.channels ?? []) {
+    const item = toChannelListItem(channel);
+    if (item) {
+      channels.push(item);
+    }
+  }
+
+  return ok({
+    channels,
+    nextCursor: bodyResult.value.response_metadata?.next_cursor ?? "",
+  });
+}
+
+function mergeSlackChannels(
+  selected: SlackChannelListItem | null,
+  channels: SlackChannelListItem[],
+) {
+  const merged = new Map<string, SlackChannelListItem>();
+  if (selected) {
+    merged.set(selected.id, selected);
+  }
+  for (const channel of channels) {
+    merged.set(channel.id, channel);
+  }
+
+  return [...merged.values()].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export async function searchSlackChannels(input: {
+  botToken: string;
+  query?: string;
+  selectedChannelId?: string;
+  signal?: AbortSignal;
+  sleep?: (ms: number) => Promise<void>;
+}): Promise<Result<SlackChannelListItem[], SlackChannelSearchError>> {
+  const sleep = input.sleep ?? defaultSleep;
+  const query = input.query?.trim() ?? "";
+
+  const selectedResult = input.selectedChannelId
+    ? await loadSelectedSlackChannel(input.botToken, input.selectedChannelId, {
+        signal: input.signal,
+        sleep,
+      })
+    : ok(null);
+  if (isErr(selectedResult)) {
+    return selectedResult;
+  }
+
+  if (!query) {
+    const pageResult = await listSlackChannelPage(input.botToken, {
+      limit: SLACK_CHANNEL_BROWSE_LIMIT,
+      signal: input.signal,
+      sleep,
+    });
+    if (isErr(pageResult)) {
+      return pageResult;
+    }
+
+    return ok(mergeSlackChannels(selectedResult.value, pageResult.value.channels));
+  }
+
+  const matches: SlackChannelListItem[] = [];
+  let cursor = "";
+
+  for (let page = 0; page < SLACK_CHANNEL_SEARCH_MAX_PAGES; page += 1) {
+    const pageResult = await listSlackChannelPage(input.botToken, {
+      cursor,
+      limit: SLACK_CHANNEL_SEARCH_PAGE_LIMIT,
+      signal: input.signal,
+      sleep,
+    });
+    if (isErr(pageResult)) {
+      return pageResult;
+    }
+
+    for (const channel of pageResult.value.channels) {
+      if (channelMatchesQuery(channel, query)) {
+        matches.push(channel);
+        if (matches.length >= SLACK_CHANNEL_SEARCH_MAX_RESULTS) {
+          return ok(mergeSlackChannels(selectedResult.value, matches));
+        }
+      }
+    }
+
+    cursor = pageResult.value.nextCursor;
+    if (!cursor) {
+      break;
+    }
+  }
+
+  return ok(mergeSlackChannels(selectedResult.value, matches));
+}

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
@@ -600,9 +600,9 @@ describe("workspace automation view model", () => {
       { id: "archived", fullName: "acme/archive", enabled: true, archived: true },
     ];
 
-    expect(selectableAutomationRepositories(repositories).map((repository) => repository.id)).toEqual(
-      ["enabled"],
-    );
+    expect(
+      selectableAutomationRepositories(repositories).map((repository) => repository.id),
+    ).toEqual(["enabled"]);
     expect(
       selectableAutomationRepositories(repositories, "disabled").map((repository) => repository.id),
     ).toEqual(["enabled", "disabled"]);

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
@@ -25,6 +25,7 @@ import {
   createWorkspaceAutomationFormStateFromTemplate,
   formStateToWorkspaceAutomationPayload,
   mapWorkspaceAutomationApiErrorToFieldErrors,
+  selectableAutomationRepositories,
   validateWorkspaceAutomationFormState,
 } from "./workspace-automation-view-model";
 
@@ -590,5 +591,20 @@ describe("workspace automation view model", () => {
     expect(formStateToWorkspaceAutomationPayload(form).toolConfig).toEqual({
       crowdin: { enabled: true, projectId: "ext:crowdin:42" },
     });
+  });
+
+  it("offers only enabled repositories, keeping a selected disabled repository visible", () => {
+    const repositories = [
+      { id: "enabled", fullName: "acme/web", enabled: true, archived: false },
+      { id: "disabled", fullName: "acme/old", enabled: false, archived: false },
+      { id: "archived", fullName: "acme/archive", enabled: true, archived: true },
+    ];
+
+    expect(selectableAutomationRepositories(repositories).map((repository) => repository.id)).toEqual(
+      ["enabled"],
+    );
+    expect(
+      selectableAutomationRepositories(repositories, "disabled").map((repository) => repository.id),
+    ).toEqual(["enabled", "disabled"]);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
@@ -167,6 +167,16 @@ export const WORKSPACE_AUTOMATION_API_ERROR_MESSAGES: Record<string, string> = {
   project_not_found: "The selected project could not be found.",
 };
 
+export function selectableAutomationRepositories<
+  T extends { id: string; enabled: boolean; archived: boolean },
+>(repositories: T[], selectedId = ""): T[] {
+  return repositories.filter(
+    (repository) =>
+      (repository.enabled && !repository.archived) ||
+      (selectedId.length > 0 && repository.id === selectedId),
+  );
+}
+
 export function createDefaultWorkspaceAutomationFormState(): WorkspaceAutomationFormState {
   return {
     name: "",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Automation Slack channel selection no longer pages through every workspace channel with `conversations.list`. That path 429s when a workspace has a large channel set.

The picker now searches as the user types:

- Empty query browses the first page only
- A search query scans a bounded number of pages, filters by name, and retries Slack 429s
- A selected channel is resolved with `conversations.info` so the current value still displays

GitHub repository selectors in Automation only offer enabled, non-archived repositories. A currently selected disabled repository stays visible so existing automations do not lose their label.

## How to test

- Open an automation with Slack notifications enabled and search for a channel instead of scrolling a full list
- Confirm a saved Slack channel still shows its name after reload
- Open the GitHub repo tool and confirm disabled or archived repositories are not selectable
- Automated: `vp test` and `vp check --fix` in `apps/hyperlocalise-web`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01865-a905-76d6-bea4-fd1e2469d26e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01865-a905-76d6-bea4-fd1e2469d26e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

