### PR TITLE
feat(automations): allow on-demand runs in scheduled mode

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/workspace-automation/workspace-automation.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/workspace-automation/workspace-automation.route.test.ts
@@ -484,4 +484,66 @@ describe("workspace automation routes", () => {
       automationRuns: [{ id: firstRun.automationRun.id, triggerSource: "manual" }],
     });
   });
+
+  it("queues on-demand runs for scheduled automations", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const organizationId = await getOrganizationId(identity.organization.workosOrganizationId);
+    const projectId = await seedProject({ organizationId });
+    const repository = await seedGithubRepository({ organizationId });
+    const organizationSlug = identity.organization.slug ?? "missing-slug";
+
+    const createdResponse = await client.api.orgs[":organizationSlug"].automations.$post(
+      {
+        param: { organizationSlug },
+        json: {
+          name: "Scheduled repository automation",
+          instructions: "Run scheduled automation.",
+          projectId,
+          triggerConfig: {
+            mode: "scheduled",
+            schedule: {
+              cadence: "daily",
+              hourUtc: 8,
+              timezone: "UTC",
+            },
+          },
+          repositoryTarget: {
+            kind: "github",
+            githubInstallationRepositoryId: repository.id,
+          },
+          toolConfig: {
+            github: {
+              enabled: true,
+              mode: "sync",
+              pushSource: true,
+              pullTranslations: false,
+              validation: false,
+            },
+          },
+        },
+      },
+      { headers },
+    );
+    expect(createdResponse.status).toBe(201);
+    const created = (await createdResponse.json()) as { automation: { id: string } };
+
+    const runResponse = await client.api.orgs[":organizationSlug"].automations[
+      ":automationId"
+    ].runs.$post(
+      {
+        param: { organizationSlug, automationId: created.automation.id },
+        json: {
+          idempotencyKey: `manual:${created.automation.id}:scheduled-run`,
+        },
+      },
+      { headers },
+    );
+
+    expect(runResponse.status).toBe(202);
+    await expect(runResponse.json()).resolves.toMatchObject({
+      dispatch: { outcome: "enqueued", inserted: true },
+      automationRun: { triggerSource: "manual" },
+    });
+  });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.stories.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect } from "storybook/test";
+
+import { createAutomationSummary } from "./automations.fixture";
+import { AutomationDetailPageContent } from "./automation-detail-page-content";
+import { createAutomationDetailMswHandlers } from "./automation-msw-handlers";
+
+const githubAutomation = createAutomationSummary();
+const scheduledAutomation = createAutomationSummary({
+  id: "33333333-3333-4333-8333-333333333333",
+  name: "Weekly translation sync",
+  triggerConfig: {
+    mode: "scheduled",
+    schedule: {
+      cadence: "weekly",
+      hourUtc: 9,
+      dayOfWeek: 1,
+      timezone: "UTC",
+    },
+  },
+});
+const manualAutomation = createAutomationSummary({
+  id: "44444444-4444-4444-8444-444444444444",
+  name: "Manual release checklist",
+  triggerConfig: { mode: "manual" },
+});
+
+const meta = {
+  title: "App/Automations/Detail",
+  component: AutomationDetailPageContent,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    organizationSlug: "acme",
+    automationId: githubAutomation.id,
+  },
+} satisfies Meta<typeof AutomationDetailPageContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const GithubTriggerHidesRun: Story = {
+  parameters: {
+    msw: {
+      handlers: createAutomationDetailMswHandlers(githubAutomation),
+    },
+    nextjs: {
+      navigation: {
+        pathname: `/org/acme/automations/${githubAutomation.id}`,
+      },
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(
+      await canvas.findByDisplayValue("Validate localisation on push"),
+    ).toBeInTheDocument();
+    await expect(canvas.queryByRole("button", { name: "Run now" })).not.toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Save changes" })).toBeDisabled();
+  },
+};
+
+export const ScheduledTriggerShowsRun: Story = {
+  args: {
+    automationId: scheduledAutomation.id,
+  },
+  parameters: {
+    msw: {
+      handlers: createAutomationDetailMswHandlers(scheduledAutomation),
+    },
+    nextjs: {
+      navigation: {
+        pathname: `/org/acme/automations/${scheduledAutomation.id}`,
+      },
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByDisplayValue("Weekly translation sync")).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Run now" })).toBeEnabled();
+    await expect(canvas.getByRole("button", { name: "Save changes" })).toBeDisabled();
+  },
+};
+
+export const ManualTriggerShowsRun: Story = {
+  args: {
+    automationId: manualAutomation.id,
+  },
+  parameters: {
+    msw: {
+      handlers: createAutomationDetailMswHandlers(manualAutomation),
+    },
+    nextjs: {
+      navigation: {
+        pathname: `/org/acme/automations/${manualAutomation.id}`,
+      },
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByDisplayValue("Manual release checklist")).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Run now" })).toBeEnabled();
+    await expect(canvas.getByRole("button", { name: "Save changes" })).toBeDisabled();
+  },
+};
+
+export const SaveEnablesAfterFormChange: Story = {
+  args: {
+    automationId: scheduledAutomation.id,
+  },
+  parameters: {
+    msw: {
+      handlers: createAutomationDetailMswHandlers(scheduledAutomation),
+    },
+    nextjs: {
+      navigation: {
+        pathname: `/org/acme/automations/${scheduledAutomation.id}`,
+      },
+    },
+  },
+  play: async ({ canvas, userEvent }) => {
+    const nameInput = await canvas.findByDisplayValue("Weekly translation sync");
+    await expect(canvas.getByRole("button", { name: "Save changes" })).toBeDisabled();
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, "Nightly translation sync");
+    await expect(canvas.getByRole("button", { name: "Save changes" })).toBeEnabled();
+    await expect(canvas.getByRole("button", { name: "Run now" })).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.tsx
@@ -161,7 +161,9 @@ export function AutomationDetailPageContent({
 
   const savedForm = createWorkspaceAutomationFormStateFromRecord(automation);
   const hasChanges = workspaceAutomationFormHasChanges(form, savedForm);
-  const showRunButton = workspaceAutomationFormSupportsOnDemandRun(form.triggerMode);
+  const showRunButton =
+    workspaceAutomationFormSupportsOnDemandRun(form.triggerMode) &&
+    workspaceAutomationFormSupportsOnDemandRun(savedForm.triggerMode);
 
   return (
     <WorkspacePageShell className="max-w-5xl">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.tsx
@@ -25,6 +25,8 @@ import {
   formStateToWorkspaceAutomationPayload,
   mapWorkspaceAutomationApiErrorToFieldErrors,
   validateWorkspaceAutomationFormState,
+  workspaceAutomationFormHasChanges,
+  workspaceAutomationFormSupportsOnDemandRun,
 } from "@/lib/agents/workspace-automation-view-model";
 import { WorkspacePageShell } from "../../_components/workspace-resource-shared";
 import { automationDetailPageContentMessages } from "./automation-detail-page-content.messages";
@@ -157,6 +159,10 @@ export function AutomationDetailPageContent({
     );
   }
 
+  const savedForm = createWorkspaceAutomationFormStateFromRecord(automation);
+  const hasChanges = workspaceAutomationFormHasChanges(form, savedForm);
+  const showRunButton = workspaceAutomationFormSupportsOnDemandRun(form.triggerMode);
+
   return (
     <WorkspacePageShell className="max-w-5xl">
       <WorkspaceAutomationEditor
@@ -170,14 +176,19 @@ export function AutomationDetailPageContent({
         runHistory={recentRuns}
         actions={
           <div className="flex gap-2">
+            {showRunButton ? (
+              <Button
+                variant="outline"
+                onClick={() => runMutation.mutate()}
+                disabled={runMutation.isPending || automation.status !== "active"}
+              >
+                <FormattedMessage {...automationDetailPageContentMessages.runNow} />
+              </Button>
+            ) : null}
             <Button
-              variant="outline"
-              onClick={() => runMutation.mutate()}
-              disabled={runMutation.isPending || automation.status !== "active"}
+              onClick={() => saveMutation.mutate()}
+              disabled={saveMutation.isPending || !hasChanges}
             >
-              <FormattedMessage {...automationDetailPageContentMessages.runNow} />
-            </Button>
-            <Button onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending}>
               {saveMutation.isPending ? (
                 <FormattedMessage {...automationDetailPageContentMessages.saving} />
               ) : (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.tsx
@@ -14,11 +14,14 @@
  */
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { PlayIcon, SaveIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import { apiClient } from "@/lib/api-client-instance";
 import {
   createWorkspaceAutomationFormStateFromRecord,
@@ -184,6 +187,11 @@ export function AutomationDetailPageContent({
                 onClick={() => runMutation.mutate()}
                 disabled={runMutation.isPending || automation.status !== "active"}
               >
+                {runMutation.isPending ? (
+                  <Spinner data-icon="inline-start" />
+                ) : (
+                  <HugeiconsIcon icon={PlayIcon} strokeWidth={1.8} data-icon="inline-start" />
+                )}
                 <FormattedMessage {...automationDetailPageContentMessages.runNow} />
               </Button>
             ) : null}
@@ -191,6 +199,11 @@ export function AutomationDetailPageContent({
               onClick={() => saveMutation.mutate()}
               disabled={saveMutation.isPending || !hasChanges}
             >
+              {saveMutation.isPending ? (
+                <Spinner data-icon="inline-start" />
+              ) : (
+                <HugeiconsIcon icon={SaveIcon} strokeWidth={1.8} data-icon="inline-start" />
+              )}
               {saveMutation.isPending ? (
                 <FormattedMessage {...automationDetailPageContentMessages.saving} />
               ) : (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-editor.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-editor.fixture.ts
@@ -154,6 +154,30 @@ export const createContentfulAutomationFormFixture = () => {
 export const createDetailAutomationFormFixture = () =>
   createWorkspaceAutomationFormStateFromRecord(createAutomationSummary());
 
+export const createScheduledAutomationFormFixture = () =>
+  createWorkspaceAutomationFormStateFromRecord(
+    createAutomationSummary({
+      name: "Weekly translation sync",
+      triggerConfig: {
+        mode: "scheduled",
+        schedule: {
+          cadence: "weekly",
+          hourUtc: 9,
+          dayOfWeek: 1,
+          timezone: "UTC",
+        },
+      },
+    }),
+  );
+
+export const createManualAutomationFormFixture = () =>
+  createWorkspaceAutomationFormStateFromRecord(
+    createAutomationSummary({
+      name: "Manual release checklist",
+      triggerConfig: { mode: "manual" },
+    }),
+  );
+
 export const createMemoriesAutomationFormFixture = () => ({
   ...createGithubAutomationFormFixture(),
   knowledgeEnabled: true,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-msw-handlers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-msw-handlers.ts
@@ -12,6 +12,8 @@
  */
 import { http, HttpResponse } from "msw";
 
+import type { WorkspaceAutomationRecord } from "@/lib/agents/workspace-automations";
+
 import {
   automationEditorContentfulConnectionsFixture,
   automationEditorProjectsFixture,
@@ -111,3 +113,36 @@ export const automationEditorDisconnectedMswHandlers = [
     HttpResponse.json({ contentfulConnections: [] }),
   ),
 ];
+
+export function createAutomationDetailMswHandlers(automation: WorkspaceAutomationRecord) {
+  return [
+    ...automationEditorMswHandlers,
+    http.get("/api/orgs/:organizationSlug/automations/:automationId", () =>
+      HttpResponse.json({ automation, recentRuns: [] }),
+    ),
+    http.patch("/api/orgs/:organizationSlug/automations/:automationId", async ({ request }) => {
+      const body = (await request.json()) as Record<string, unknown>;
+      return HttpResponse.json({
+        automation: {
+          ...automation,
+          ...body,
+        },
+        recentRuns: [],
+      });
+    }),
+    http.post("/api/orgs/:organizationSlug/automations/:automationId/runs", () =>
+      HttpResponse.json(
+        {
+          automationRun: {
+            id: "run_manual_001",
+            automationId: automation.id,
+            triggerSource: "manual",
+            status: "queued",
+          },
+          dispatch: { outcome: "enqueued", inserted: true },
+        },
+        { status: 202 },
+      ),
+    ),
+  ];
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-editor.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-editor.stories.tsx
@@ -24,7 +24,9 @@ import {
   createDetailAutomationFormFixture,
   createEmptyAutomationFormFixture,
   createGithubAutomationFormFixture,
+  createManualAutomationFormFixture,
   createMemoriesAutomationFormFixture,
+  createScheduledAutomationFormFixture,
 } from "./automation-editor.fixture";
 import { automationEditorMswHandlers } from "./automation-msw-handlers";
 import { WorkspaceAutomationEditor } from "./workspace-automation-form";
@@ -181,21 +183,60 @@ export const DetailDefault: Story = {
     mode: "detail",
     form: createDetailAutomationFormFixture(),
     actions: (
+      <Button type="button" disabled>
+        Save changes
+      </Button>
+    ),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByDisplayValue("Validate localisation on push")).toBeInTheDocument();
+    await expect(canvas.getByRole("tab", { name: "Run History" })).toBeInTheDocument();
+    await expect(canvas.queryByRole("button", { name: "Run now" })).not.toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Save changes" })).toBeDisabled();
+  },
+};
+
+export const DetailScheduled: Story = {
+  args: {
+    mode: "detail",
+    form: createScheduledAutomationFormFixture(),
+    actions: (
       <>
         <Button type="button" variant="outline" onClick={fn()}>
           Run now
         </Button>
-        <Button type="button" onClick={fn()}>
+        <Button type="button" disabled>
           Save changes
         </Button>
       </>
     ),
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByDisplayValue("Validate localisation on push")).toBeInTheDocument();
-    await expect(canvas.getByRole("tab", { name: "Run History" })).toBeInTheDocument();
+    await expect(canvas.getByDisplayValue("Weekly translation sync")).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Run now" })).toBeInTheDocument();
-    await expect(canvas.getByRole("button", { name: "Save changes" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Save changes" })).toBeDisabled();
+  },
+};
+
+export const DetailManual: Story = {
+  args: {
+    mode: "detail",
+    form: createManualAutomationFormFixture(),
+    actions: (
+      <>
+        <Button type="button" variant="outline" onClick={fn()}>
+          Run now
+        </Button>
+        <Button type="button" disabled>
+          Save changes
+        </Button>
+      </>
+    ),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByDisplayValue("Manual release checklist")).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Run now" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Save changes" })).toBeDisabled();
   },
 };
 
@@ -207,7 +248,7 @@ export const DetailPaused: Story = {
       status: "paused",
     },
     actions: (
-      <Button type="button" onClick={fn()}>
+      <Button type="button" disabled>
         Save changes
       </Button>
     ),
@@ -223,7 +264,7 @@ export const DetailRunHistory: Story = {
     form: createDetailAutomationFormFixture(),
     runHistory: automationRunsFixture,
     actions: (
-      <Button type="button" onClick={fn()}>
+      <Button type="button" disabled>
         Save changes
       </Button>
     ),
@@ -242,7 +283,7 @@ export const DetailRunHistoryEmpty: Story = {
     form: createDetailAutomationFormFixture(),
     runHistory: [],
     actions: (
-      <Button type="button" onClick={fn()}>
+      <Button type="button" disabled>
         Save changes
       </Button>
     ),

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-editor.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-editor.stories.tsx
@@ -11,6 +11,8 @@
  * Version 2.0 or later.
  */
 import { useState, type ReactNode } from "react";
+import { PlayIcon, SaveIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { expect, fn } from "storybook/test";
 
@@ -184,6 +186,7 @@ export const DetailDefault: Story = {
     form: createDetailAutomationFormFixture(),
     actions: (
       <Button type="button" disabled>
+        <HugeiconsIcon icon={SaveIcon} strokeWidth={1.8} data-icon="inline-start" />
         Save changes
       </Button>
     ),
@@ -203,9 +206,11 @@ export const DetailScheduled: Story = {
     actions: (
       <>
         <Button type="button" variant="outline" onClick={fn()}>
+          <HugeiconsIcon icon={PlayIcon} strokeWidth={1.8} data-icon="inline-start" />
           Run now
         </Button>
         <Button type="button" disabled>
+          <HugeiconsIcon icon={SaveIcon} strokeWidth={1.8} data-icon="inline-start" />
           Save changes
         </Button>
       </>
@@ -225,9 +230,11 @@ export const DetailManual: Story = {
     actions: (
       <>
         <Button type="button" variant="outline" onClick={fn()}>
+          <HugeiconsIcon icon={PlayIcon} strokeWidth={1.8} data-icon="inline-start" />
           Run now
         </Button>
         <Button type="button" disabled>
+          <HugeiconsIcon icon={SaveIcon} strokeWidth={1.8} data-icon="inline-start" />
           Save changes
         </Button>
       </>
@@ -249,6 +256,7 @@ export const DetailPaused: Story = {
     },
     actions: (
       <Button type="button" disabled>
+        <HugeiconsIcon icon={SaveIcon} strokeWidth={1.8} data-icon="inline-start" />
         Save changes
       </Button>
     ),
@@ -265,6 +273,7 @@ export const DetailRunHistory: Story = {
     runHistory: automationRunsFixture,
     actions: (
       <Button type="button" disabled>
+        <HugeiconsIcon icon={SaveIcon} strokeWidth={1.8} data-icon="inline-start" />
         Save changes
       </Button>
     ),
@@ -284,6 +293,7 @@ export const DetailRunHistoryEmpty: Story = {
     runHistory: [],
     actions: (
       <Button type="button" disabled>
+        <HugeiconsIcon icon={SaveIcon} strokeWidth={1.8} data-icon="inline-start" />
         Save changes
       </Button>
     ),
@@ -301,6 +311,7 @@ export const ReadOnly: Story = {
     disabled: true,
     actions: (
       <Button type="button" disabled>
+        <HugeiconsIcon icon={SaveIcon} strokeWidth={1.8} data-icon="inline-start" />
         Save changes
       </Button>
     ),

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.test.ts
@@ -35,6 +35,7 @@ function expectOk<T, E>(result: Result<T, E>): T {
 import {
   dispatchContentfulWorkspaceAutomationForManual,
   dispatchContentfulWorkspaceAutomationForSchedule,
+  dispatchManualWorkspaceAutomationRun,
   dispatchWorkspaceAutomationForSchedule,
   dispatchWorkspaceAutomationsForContentfulWebhook,
   dispatchWorkspaceAutomationsForGithubPush,
@@ -223,6 +224,107 @@ describe("workspace automation dispatcher", () => {
     });
     expect(runs).toHaveLength(1);
     expect(runs[0]?.outputSummary.orchestratorEnqueuedAt).toBeTruthy();
+  });
+
+  it("queues on-demand runs for scheduled automations", async () => {
+    const scope = await seedDispatchScope();
+    const automation = expectOk(
+      await createWorkspaceAutomation({
+        organizationId: scope.organizationId,
+        authorUserId: scope.userId,
+        name: "Scheduled validation",
+        instructions: "Run validation on a schedule.",
+        projectId: scope.projectId,
+        triggerConfig: {
+          mode: "scheduled",
+          schedule: {
+            cadence: "daily",
+            hourUtc: 8,
+            timezone: "UTC",
+          },
+        },
+        repositoryTarget: {
+          kind: "github",
+          githubInstallationRepositoryId: scope.repository.id,
+        },
+        toolConfig: {
+          github: {
+            enabled: true,
+            mode: "sync",
+            pushSource: false,
+            pullTranslations: false,
+            validation: true,
+          },
+        },
+      }),
+    );
+
+    const enqueued: Array<{ workspaceAutomationRunId: string; organizationId: string }> = [];
+    const result = await dispatchManualWorkspaceAutomationRun({
+      automation,
+      idempotencyKey: `manual:${automation.id}:operator-run`,
+      queue: {
+        async enqueue(event: { workspaceAutomationRunId: string; organizationId: string }) {
+          enqueued.push(event);
+          return { ids: ["workflow-1"] };
+        },
+      },
+    });
+
+    expect(result).toMatchObject({ outcome: "enqueued", inserted: true });
+    expect(enqueued).toHaveLength(1);
+
+    const runs = await listWorkspaceAutomationRuns({
+      automationId: automation.id,
+      organizationId: scope.organizationId,
+    });
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({
+      triggerSource: "manual",
+      status: "queued",
+    });
+  });
+
+  it("does not queue on-demand runs for GitHub push automations", async () => {
+    const scope = await seedDispatchScope();
+    const automation = expectOk(
+      await createWorkspaceAutomation({
+        organizationId: scope.organizationId,
+        authorUserId: scope.userId,
+        name: "Push validation",
+        instructions: "Run validation on GitHub push.",
+        projectId: scope.projectId,
+        triggerConfig: {
+          mode: "github",
+          branches: ["main"],
+        },
+        repositoryTarget: {
+          kind: "github",
+          githubInstallationRepositoryId: scope.repository.id,
+        },
+        toolConfig: {
+          github: {
+            enabled: true,
+            mode: "sync",
+            pushSource: false,
+            pullTranslations: false,
+            validation: true,
+          },
+        },
+      }),
+    );
+
+    const result = await dispatchManualWorkspaceAutomationRun({
+      automation,
+      idempotencyKey: `manual:${automation.id}:push-run`,
+    });
+
+    expect(result).toBeNull();
+    const runs = await listWorkspaceAutomationRuns({
+      automationId: automation.id,
+      organizationId: scope.organizationId,
+    });
+    expect(runs).toHaveLength(0);
   });
 
   it("dispatches Contentful webhook automation idempotently", async () => {

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.ts
@@ -280,7 +280,10 @@ export async function dispatchManualWorkspaceAutomationRun(input: {
     return null;
   }
 
-  if (input.automation.triggerConfig.mode !== "manual") {
+  if (
+    input.automation.triggerConfig.mode !== "manual" &&
+    input.automation.triggerConfig.mode !== "scheduled"
+  ) {
     return null;
   }
 

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
@@ -27,6 +27,8 @@ import {
   mapWorkspaceAutomationApiErrorToFieldErrors,
   selectableAutomationRepositories,
   validateWorkspaceAutomationFormState,
+  workspaceAutomationFormHasChanges,
+  workspaceAutomationFormSupportsOnDemandRun,
 } from "./workspace-automation-view-model";
 
 const mergedTemplates = mergeWorkspaceTemplateSkills(WORKSPACE_AUTOMATION_TEMPLATES_BASE);
@@ -606,5 +608,21 @@ describe("workspace automation view model", () => {
     expect(
       selectableAutomationRepositories(repositories, "disabled").map((repository) => repository.id),
     ).toEqual(["enabled", "disabled"]);
+  });
+
+  it("shows on-demand runs for scheduled and manual triggers only", () => {
+    expect(workspaceAutomationFormSupportsOnDemandRun("manual")).toBe(true);
+    expect(workspaceAutomationFormSupportsOnDemandRun("scheduled")).toBe(true);
+    expect(workspaceAutomationFormSupportsOnDemandRun("github")).toBe(false);
+    expect(workspaceAutomationFormSupportsOnDemandRun("contentful")).toBe(false);
+    expect(workspaceAutomationFormSupportsOnDemandRun("source_upload")).toBe(false);
+  });
+
+  it("detects unsaved automation form changes", () => {
+    const saved = createWorkspaceAutomationFormStateFromRecord(createAutomationSummary());
+    expect(workspaceAutomationFormHasChanges(saved, saved)).toBe(false);
+    expect(workspaceAutomationFormHasChanges({ ...saved, name: "Renamed automation" }, saved)).toBe(
+      true,
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
@@ -721,6 +721,19 @@ export function mapWorkspaceAutomationApiErrorToFieldErrors(
   }
 }
 
+export function workspaceAutomationFormSupportsOnDemandRun(
+  triggerMode: WorkspaceAutomationTriggerMode,
+) {
+  return triggerMode === "manual" || triggerMode === "scheduled";
+}
+
+export function workspaceAutomationFormHasChanges(
+  current: WorkspaceAutomationFormState,
+  saved: WorkspaceAutomationFormState,
+) {
+  return JSON.stringify(current) !== JSON.stringify(saved);
+}
+
 export function workspaceAutomationFormCanActivate(form: WorkspaceAutomationFormState) {
   return (
     form.githubEnabled ||


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Operators can queue a run from a scheduled automation, not only a manual one.

The detail page now shows **Run now** only when the trigger is scheduled or manual, both on the saved automation and on the form. GitHub push, Contentful webhook, and source-upload automations hide that button.

**Save changes** stays disabled until the form differs from the saved automation.

**Run now** and **Save changes** now include play and save icons. Each button shows a spinner while its request is pending.

## How to test

- Open a scheduled automation: **Run now** is visible with a play icon and queues a manual run.
- Open a manual automation: **Run now** remains visible with a play icon.
- Open a GitHub, Contentful, or source-upload automation: **Run now** is hidden.
- **Save changes** shows a save icon, stays disabled on load, and enables after editing a field such as the name.

```
cd apps/hyperlocalise-web
vp test
vp check --fix
```

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e58100a-9b28-43a6-8efc-6b9d427e1c64?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e58100a-9b28-43a6-8efc-6b9d427e1c64&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

