### PR TITLE
fix(slack): find typed channels when Slack returns not found

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.test.ts
@@ -16,6 +16,7 @@ import { isErr, isOk } from "@/lib/primitives/result/results";
 
 import {
   fromCanonicalSlackChannelId,
+  normalizeSlackChannelQuery,
   searchSlackChannels,
   SLACK_CHANNEL_BROWSE_LIMIT,
   toCanonicalSlackChannelId,
@@ -34,10 +35,20 @@ function jsonResponse(body: unknown, init?: { status?: number; headers?: Record<
   } as unknown as Response;
 }
 
-function conversationsListUrl(href: string) {
-  const url = new URL(href);
-  expect(url.origin + url.pathname).toBe("https://slack.com/api/conversations.list");
-  return url;
+function requestUrl(input: unknown) {
+  return new URL(String(input));
+}
+
+function mockSlack(
+  handler: (url: URL) => {
+    body: unknown;
+    init?: { status?: number; headers?: Record<string, string> };
+  },
+) {
+  fetchMock.mockImplementation(async (input: unknown) => {
+    const response = handler(requestUrl(input));
+    return jsonResponse(response.body, response.init);
+  });
 }
 
 describe("searchSlackChannels", () => {
@@ -51,6 +62,7 @@ describe("searchSlackChannels", () => {
     expect(toCanonicalSlackChannelId("slack:C123")).toBe("slack:C123");
     expect(fromCanonicalSlackChannelId("slack:C123")).toBe("C123");
     expect(fromCanonicalSlackChannelId("C123")).toBe("C123");
+    expect(normalizeSlackChannelQuery("#L10N")).toBe("l10n");
   });
 
   it("browses a single page and ignores further cursors", async () => {
@@ -78,23 +90,32 @@ describe("searchSlackChannels", () => {
       { id: "slack:C_PRIVATE", name: "team-l10n", private: true },
     ]);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const url = conversationsListUrl(String(fetchMock.mock.calls[0]?.[0]));
+    const url = requestUrl(fetchMock.mock.calls[0]?.[0]);
+    expect(url.origin + url.pathname).toBe("https://slack.com/api/conversations.list");
     expect(url.searchParams.get("limit")).toBe(String(SLACK_CHANNEL_BROWSE_LIMIT));
     expect(url.searchParams.get("cursor")).toBeNull();
   });
 
-  it("searches channel names without listing every page after enough matches", async () => {
+  it("searches channel names without listing every page after an exact match", async () => {
     vi.stubGlobal("fetch", fetchMock);
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse({
-        ok: true,
-        channels: [
-          { id: "C1", name: "alerts" },
-          { id: "C2", name: "l10n-reviews" },
-        ],
-        response_metadata: {},
-      }),
-    );
+    mockSlack((url) => {
+      if (url.pathname.endsWith("/conversations.info")) {
+        return {
+          body: { ok: false, error: "channel_not_found" },
+        };
+      }
+
+      return {
+        body: {
+          ok: true,
+          channels: [
+            { id: "C1", name: "alerts" },
+            { id: "C2", name: "l10n" },
+          ],
+          response_metadata: { next_cursor: "page-2" },
+        },
+      };
+    });
 
     const result = await searchSlackChannels({
       botToken: "xoxb-token",
@@ -105,10 +126,128 @@ describe("searchSlackChannels", () => {
     if (!isOk(result)) {
       throw new Error("expected channel search to succeed");
     }
-    expect(result.value).toEqual([{ id: "slack:C2", name: "l10n-reviews", private: false }]);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const url = conversationsListUrl(String(fetchMock.mock.calls[0]?.[0]));
-    expect(url.searchParams.get("limit")).toBe("1000");
+    expect(result.value).toEqual([{ id: "slack:C2", name: "l10n", private: false }]);
+    expect(
+      fetchMock.mock.calls.some((call) =>
+        String(call[0]).includes("https://slack.com/api/conversations.list"),
+      ),
+    ).toBe(true);
+    expect(
+      fetchMock.mock.calls.filter((call) =>
+        String(call[0]).includes("https://slack.com/api/conversations.list"),
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("resolves a typed channel name via conversations.info when list search would miss it", async () => {
+    vi.stubGlobal("fetch", fetchMock);
+    mockSlack((url) => {
+      if (url.pathname.endsWith("/conversations.info")) {
+        expect(url.searchParams.get("channel")).toBe("#release-notes");
+        return {
+          body: {
+            ok: true,
+            channel: { id: "C_RELEASE", name: "release-notes", is_private: false },
+          },
+        };
+      }
+
+      return {
+        body: {
+          ok: true,
+          channels: [{ id: "C_PUBLIC", name: "localization" }],
+          response_metadata: { next_cursor: "page-2" },
+        },
+      };
+    });
+
+    const result = await searchSlackChannels({
+      botToken: "xoxb-token",
+      query: "release-notes",
+    });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw new Error("expected named channel lookup to succeed");
+    }
+    expect(result.value[0]).toEqual({
+      id: "slack:C_RELEASE",
+      name: "release-notes",
+      private: false,
+    });
+    expect(result.value.map((channel) => channel.id)).toContain("slack:C_RELEASE");
+  });
+
+  it("treats conversations.info channel_not_found as a miss and keeps scanning list pages", async () => {
+    vi.stubGlobal("fetch", fetchMock);
+    let listPages = 0;
+    mockSlack((url) => {
+      if (url.pathname.endsWith("/conversations.info")) {
+        return {
+          body: { ok: false, error: "channel_not_found" },
+        };
+      }
+
+      listPages += 1;
+      if (url.searchParams.get("cursor") === "page-2") {
+        return {
+          body: {
+            ok: true,
+            channels: [{ id: "C_TARGET", name: "release-notes" }],
+          },
+        };
+      }
+
+      return {
+        body: {
+          ok: true,
+          channels: [{ id: "C_PUBLIC", name: "localization" }],
+          response_metadata: { next_cursor: "page-2" },
+        },
+      };
+    });
+
+    const result = await searchSlackChannels({
+      botToken: "xoxb-token",
+      query: "release-notes",
+    });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw new Error("expected list scan after lookup miss to succeed");
+    }
+    expect(result.value).toEqual([{ id: "slack:C_TARGET", name: "release-notes", private: false }]);
+    expect(listPages).toBe(2);
+  });
+
+  it("looks up a typed Slack channel id without treating channel_not_found as a hard error", async () => {
+    vi.stubGlobal("fetch", fetchMock);
+    mockSlack((url) => {
+      if (url.pathname.endsWith("/conversations.info")) {
+        expect(url.searchParams.get("channel")).toBe("C01234567");
+        return {
+          body: { ok: false, error: "channel_not_found" },
+        };
+      }
+
+      return {
+        body: {
+          ok: true,
+          channels: [{ id: "C01234567", name: "eng-l10n" }],
+        },
+      };
+    });
+
+    const result = await searchSlackChannels({
+      botToken: "xoxb-token",
+      query: "C01234567",
+    });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw new Error("expected id search to succeed after lookup miss");
+    }
+    expect(result.value).toEqual([{ id: "slack:C01234567", name: "eng-l10n", private: false }]);
   });
 
   it("includes the selected channel even when it is outside the browse page", async () => {

--- a/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
@@ -16,9 +16,18 @@ import { err, fromThrowableAsync, isErr, ok, type Result } from "@/lib/primitive
 export const SLACK_CHANNEL_BROWSE_LIMIT = 200;
 export const SLACK_CHANNEL_SEARCH_PAGE_LIMIT = 1000;
 export const SLACK_CHANNEL_SEARCH_MAX_PAGES = 3;
+export const SLACK_CHANNEL_SEARCH_EXACT_MAX_PAGES = 10;
 export const SLACK_CHANNEL_SEARCH_MAX_RESULTS = 50;
 export const SLACK_CHANNEL_RATE_LIMIT_RETRIES = 3;
 export const SLACK_CHANNEL_RATE_LIMIT_MAX_WAIT_MS = 2000;
+
+const SLACK_CONVERSATION_ID_PATTERN = /^(?:slack:)?[CGD][A-Z0-9]{8,}$/i;
+const SLACK_CHANNEL_NAME_PATTERN = /^[a-z0-9][a-z0-9_-]{0,79}$/;
+const SLACK_CHANNEL_LOOKUP_MISS_ERRORS = new Set([
+  "channel_not_found",
+  "invalid_arguments",
+  "invalid_name",
+]);
 
 export type SlackChannelListItem = { id: string; name: string; private: boolean };
 
@@ -28,7 +37,13 @@ export type SlackChannelSearchError =
   | { code: "slack_rate_limited" }
   | { code: "bot_unavailable"; cause: unknown };
 
-type SlackChannel = { id?: string; name?: string; is_private?: boolean; is_archived?: boolean };
+type SlackChannel = {
+  id?: string;
+  name?: string;
+  name_normalized?: string;
+  is_private?: boolean;
+  is_archived?: boolean;
+};
 
 type SlackConversationsListResponse = {
   ok?: boolean;
@@ -45,12 +60,21 @@ type SlackConversationsInfoResponse = {
 
 type SlackJsonResponse = SlackConversationsListResponse & SlackConversationsInfoResponse;
 
+type SlackRequestOptions = {
+  signal?: AbortSignal;
+  sleep: (ms: number) => Promise<void>;
+};
+
 export function toCanonicalSlackChannelId(channelId: string) {
   return channelId.startsWith("slack:") ? channelId : `slack:${channelId}`;
 }
 
 export function fromCanonicalSlackChannelId(channelId: string) {
   return channelId.startsWith("slack:") ? channelId.slice("slack:".length) : channelId;
+}
+
+export function normalizeSlackChannelQuery(query: string) {
+  return query.trim().replace(/^#/, "").toLowerCase();
 }
 
 function defaultSleep(ms: number) {
@@ -74,33 +98,72 @@ function parseRetryAfterMs(response: Response) {
 }
 
 function toChannelListItem(channel: SlackChannel): SlackChannelListItem | null {
-  if (!channel.id || !channel.name || channel.is_archived) {
+  const name = channel.name || channel.name_normalized;
+  if (!channel.id || !name || channel.is_archived) {
     return null;
   }
 
   return {
     id: toCanonicalSlackChannelId(channel.id),
-    name: channel.name,
+    name,
     private: Boolean(channel.is_private),
   };
 }
 
+function isExactChannelMatch(channel: SlackChannelListItem, query: string) {
+  const normalizedQuery = normalizeSlackChannelQuery(query);
+  if (!normalizedQuery) {
+    return false;
+  }
+
+  return (
+    channel.name.toLowerCase() === normalizedQuery ||
+    fromCanonicalSlackChannelId(channel.id).toLowerCase() === normalizedQuery
+  );
+}
+
 function channelMatchesQuery(channel: SlackChannelListItem, query: string) {
-  const normalizedQuery = query.trim().replace(/^#/, "").toLowerCase();
+  const normalizedQuery = normalizeSlackChannelQuery(query);
   if (!normalizedQuery) {
     return true;
   }
 
-  return channel.name.toLowerCase().includes(normalizedQuery);
+  return (
+    channel.name.toLowerCase().includes(normalizedQuery) ||
+    fromCanonicalSlackChannelId(channel.id).toLowerCase().includes(normalizedQuery)
+  );
+}
+
+function slackChannelLookupKeys(query: string) {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  if (SLACK_CONVERSATION_ID_PATTERN.test(trimmed)) {
+    return [fromCanonicalSlackChannelId(trimmed)];
+  }
+
+  const name = normalizeSlackChannelQuery(trimmed);
+  if (SLACK_CHANNEL_NAME_PATTERN.test(name)) {
+    return [`#${name}`];
+  }
+
+  return [];
+}
+
+function isSlackChannelLookupMiss(error: SlackChannelSearchError) {
+  if (error.code === "slack_http_error" && error.status === 404) {
+    return true;
+  }
+
+  return error.code === "slack_api_error" && SLACK_CHANNEL_LOOKUP_MISS_ERRORS.has(error.slackError);
 }
 
 async function fetchSlackJson(
   url: URL,
   botToken: string,
-  options: {
-    signal?: AbortSignal;
-    sleep: (ms: number) => Promise<void>;
-  },
+  options: SlackRequestOptions,
 ): Promise<Result<SlackJsonResponse, SlackChannelSearchError>> {
   for (let attempt = 0; attempt <= SLACK_CHANNEL_RATE_LIMIT_RETRIES; attempt += 1) {
     const responseResult = await fromThrowableAsync(
@@ -151,34 +214,52 @@ async function fetchSlackJson(
   return err({ code: "slack_rate_limited" });
 }
 
-async function loadSelectedSlackChannel(
+async function loadSlackChannelByKey(
   botToken: string,
-  channelId: string,
-  options: {
-    signal?: AbortSignal;
-    sleep: (ms: number) => Promise<void>;
-  },
+  channelKey: string,
+  options: SlackRequestOptions,
 ): Promise<Result<SlackChannelListItem | null, SlackChannelSearchError>> {
-  const slackChannelId = fromCanonicalSlackChannelId(channelId);
-  if (!slackChannelId) {
+  if (!channelKey) {
     return ok(null);
   }
 
   const url = new URL("https://slack.com/api/conversations.info");
-  url.searchParams.set("channel", slackChannelId);
+  url.searchParams.set("channel", channelKey);
 
   const bodyResult = await fetchSlackJson(url, botToken, options);
   if (isErr(bodyResult)) {
-    if (
-      bodyResult.error.code === "slack_api_error" &&
-      bodyResult.error.slackError === "channel_not_found"
-    ) {
+    if (isSlackChannelLookupMiss(bodyResult.error)) {
       return ok(null);
     }
     return bodyResult;
   }
 
   return ok(toChannelListItem(bodyResult.value.channel ?? {}));
+}
+
+async function lookupSlackChannelByQuery(
+  botToken: string,
+  query: string,
+  options: SlackRequestOptions,
+): Promise<Result<SlackChannelListItem | null, SlackChannelSearchError>> {
+  for (const key of slackChannelLookupKeys(query)) {
+    const lookupResult = await loadSlackChannelByKey(botToken, key, options);
+    if (isErr(lookupResult)) {
+      // Speculative name/id lookup must not fail the search; list scan can still match.
+      if (
+        lookupResult.error.code === "slack_rate_limited" ||
+        lookupResult.error.code === "bot_unavailable"
+      ) {
+        return lookupResult;
+      }
+      continue;
+    }
+    if (lookupResult.value) {
+      return lookupResult;
+    }
+  }
+
+  return ok(null);
 }
 
 async function listSlackChannelPage(
@@ -225,16 +306,28 @@ async function listSlackChannelPage(
 function mergeSlackChannels(
   selected: SlackChannelListItem | null,
   channels: SlackChannelListItem[],
+  query = "",
 ) {
   const merged = new Map<string, SlackChannelListItem>();
-  if (selected) {
-    merged.set(selected.id, selected);
-  }
   for (const channel of channels) {
     merged.set(channel.id, channel);
   }
+  if (selected) {
+    merged.set(selected.id, selected);
+  }
 
-  return [...merged.values()].sort((left, right) => left.name.localeCompare(right.name));
+  const normalizedQuery = normalizeSlackChannelQuery(query);
+  return [...merged.values()].sort((left, right) => {
+    if (normalizedQuery) {
+      const leftExact = isExactChannelMatch(left, normalizedQuery);
+      const rightExact = isExactChannelMatch(right, normalizedQuery);
+      if (leftExact !== rightExact) {
+        return leftExact ? -1 : 1;
+      }
+    }
+
+    return left.name.localeCompare(right.name);
+  });
 }
 
 export async function searchSlackChannels(input: {
@@ -245,14 +338,16 @@ export async function searchSlackChannels(input: {
   sleep?: (ms: number) => Promise<void>;
 }): Promise<Result<SlackChannelListItem[], SlackChannelSearchError>> {
   const sleep = input.sleep ?? defaultSleep;
+  const options: SlackRequestOptions = { signal: input.signal, sleep };
   const query = input.query?.trim() ?? "";
 
   let selectedChannel: SlackChannelListItem | null = null;
   if (input.selectedChannelId) {
-    const selectedResult = await loadSelectedSlackChannel(input.botToken, input.selectedChannelId, {
-      signal: input.signal,
-      sleep,
-    });
+    const selectedResult = await loadSlackChannelByKey(
+      input.botToken,
+      fromCanonicalSlackChannelId(input.selectedChannelId),
+      options,
+    );
     if (isErr(selectedResult)) {
       return selectedResult;
     }
@@ -272,10 +367,38 @@ export async function searchSlackChannels(input: {
     return ok(mergeSlackChannels(selectedChannel, pageResult.value.channels));
   }
 
-  const matches: SlackChannelListItem[] = [];
-  let cursor = "";
+  const lookupPromise = lookupSlackChannelByQuery(input.botToken, query, options);
+  const firstPagePromise = listSlackChannelPage(input.botToken, {
+    limit: SLACK_CHANNEL_SEARCH_PAGE_LIMIT,
+    signal: input.signal,
+    sleep,
+  });
+  const [lookupResult, firstPageResult] = await Promise.all([lookupPromise, firstPagePromise]);
+  if (isErr(lookupResult)) {
+    return lookupResult;
+  }
+  if (isErr(firstPageResult)) {
+    return firstPageResult;
+  }
 
-  for (let page = 0; page < SLACK_CHANNEL_SEARCH_MAX_PAGES; page += 1) {
+  const matches: SlackChannelListItem[] = [];
+  if (lookupResult.value && channelMatchesQuery(lookupResult.value, query)) {
+    matches.push(lookupResult.value);
+  }
+  for (const channel of firstPageResult.value.channels) {
+    if (channelMatchesQuery(channel, query)) {
+      matches.push(channel);
+    }
+  }
+
+  let cursor = firstPageResult.value.nextCursor;
+  const hasExactMatch = () => matches.some((channel) => isExactChannelMatch(channel, query));
+
+  if (matches.length >= SLACK_CHANNEL_SEARCH_MAX_RESULTS || hasExactMatch() || !cursor) {
+    return ok(mergeSlackChannels(selectedChannel, matches, query));
+  }
+
+  for (let page = 1; page < SLACK_CHANNEL_SEARCH_EXACT_MAX_PAGES; page += 1) {
     const pageResult = await listSlackChannelPage(input.botToken, {
       cursor,
       limit: SLACK_CHANNEL_SEARCH_PAGE_LIMIT,
@@ -290,16 +413,16 @@ export async function searchSlackChannels(input: {
       if (channelMatchesQuery(channel, query)) {
         matches.push(channel);
         if (matches.length >= SLACK_CHANNEL_SEARCH_MAX_RESULTS) {
-          return ok(mergeSlackChannels(selectedChannel, matches));
+          return ok(mergeSlackChannels(selectedChannel, matches, query));
         }
       }
     }
 
     cursor = pageResult.value.nextCursor;
-    if (!cursor) {
+    if (!cursor || hasExactMatch()) {
       break;
     }
   }
 
-  return ok(mergeSlackChannels(selectedChannel, matches));
+  return ok(mergeSlackChannels(selectedChannel, matches, query));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Typing an existing Slack channel in the automation picker could still return no results. Search only scanned a few `conversations.list` pages, and Slack's `conversations.info` reports `channel_not_found` when the query is a name (or an ID the bot cannot see).

The picker now:

- Looks up a typed channel ID or `#name` with `conversations.info`
- Treats `channel_not_found` as a miss instead of failing the search
- Keeps scanning list pages until the exact name is found (or the page cap is hit)

Exact matches are sorted first.

## How to test

- Open an automation with Slack notifications and type a channel name that exists but is not on the first list page
- Confirm the channel appears instead of "No channels found"
- Type a channel ID and confirm it resolves when the bot can see it
- Automated: `vp test src/lib/agents/slack/search-channels.test.ts src/api/routes/agent-slack/agent-slack.route.test.ts` (26 passed) and `vp check --fix` in `apps/hyperlocalise-web`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d3280a2-8e59-429c-8bc1-cad7fd794db4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d3280a2-8e59-429c-8bc1-cad7fd794db4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

