### PR TITLE
feat(spellcheck): add pure-Go tokenizer for translated segment text (HL-598)

### DIFF
--- a/internal/i18n/segmentvalidate/extra_placeholders.go
+++ b/internal/i18n/segmentvalidate/extra_placeholders.go
@@ -7,10 +7,15 @@ import (
 	"strings"
 )
 
+// ExtraPlaceholderPattern matches printf-style (%s, %d, %1$s, %(name)s, %@,
+// %{name}) and shell/template-style (${name}, $name$) placeholders. It is
+// exported so other packages (e.g. spellcheck) can recognize the same
+// placeholder syntax without duplicating the regex.
+//
 // BOLT OPTIMIZATION: Combine individual placeholder patterns into a single
 // regex to reduce the number of passes over the input string. The order of
 // alternations is preserved from the original set to maintain priority.
-var combinedPlaceholderPattern = regexp.MustCompile(
+var ExtraPlaceholderPattern = regexp.MustCompile(
 	`%[0-9]+\$[-+ #0]*[0-9]*(?:\.[0-9]*)?(?:ll|l|hh|h)?[diuXxfsSFeEgGcC]|` +
 		`%\([A-Za-z_][\w]*\)[-+ #0]*[0-9]*(?:\.[0-9]*)?(?:ll|l|hh|h)?[diuXxfsSFeEgGcC]|` +
 		`%[-+ #0]*[0-9]*(?:\.[0-9]*)?(?:ll|l|hh|h)?[diuXxfsSFeEgGcC]\b|` +
@@ -29,7 +34,7 @@ func extractExtraPlaceholders(text string) []string {
 
 	// BOLT OPTIMIZATION: Iterate using strings.IndexAny to fast-skip plain text and
 	// FindStringIndex to match regex incrementally, avoiding [][]int slice allocations
-	// from FindAllStringIndex. All alternations in combinedPlaceholderPattern start with
+	// from FindAllStringIndex. All alternations in ExtraPlaceholderPattern start with
 	// '%' or '$'. Slice capacity is lazily allocated on first match.
 	var out []string
 
@@ -40,7 +45,7 @@ func extractExtraPlaceholders(text string) []string {
 			break
 		}
 		curr := pos + idx
-		loc := combinedPlaceholderPattern.FindStringIndex(text[curr:])
+		loc := ExtraPlaceholderPattern.FindStringIndex(text[curr:])
 		if loc == nil {
 			break
 		}
@@ -51,7 +56,7 @@ func extractExtraPlaceholders(text string) []string {
 
 		// Printf-style %% escapes a literal percent. Skip matches whose
 		// leading '%' is the second half of an escape pair (e.g. %%@).
-		if match[0] != '%' || !isEscapedPercentAt(text, matchStart) {
+		if match[0] != '%' || !IsEscapedPercentAt(text, matchStart) {
 			if out == nil {
 				out = make([]string, 0, 4)
 			}
@@ -77,10 +82,10 @@ func extractExtraPlaceholders(text string) []string {
 	return out
 }
 
-// isEscapedPercentAt reports whether text[index] is '%' that belongs to a
+// IsEscapedPercentAt reports whether text[index] is '%' that belongs to a
 // %% escape rather than starting a format placeholder. An odd run of '%'
 // ending at index is a real placeholder; an even run is escaped.
-func isEscapedPercentAt(text string, index int) bool {
+func IsEscapedPercentAt(text string, index int) bool {
 	if index < 0 || index >= len(text) || text[index] != '%' {
 		return false
 	}

--- a/internal/i18n/spellcheck/BUILD.bazel
+++ b/internal/i18n/spellcheck/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "icu.go",
         "markup.go",
+        "tokenizer.go",
         "words.go",
     ],
     importpath = "github.com/hyperlocalise/hyperlocalise/internal/i18n/spellcheck",
@@ -20,6 +21,7 @@ go_test(
     srcs = [
         "icu_test.go",
         "markup_test.go",
+        "tokenizer_test.go",
         "words_test.go",
     ],
     embed = [":spellcheck"],

--- a/internal/i18n/spellcheck/BUILD.bazel
+++ b/internal/i18n/spellcheck/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "spellcheck",
     srcs = [
+        "entities.go",
         "icu.go",
         "markup.go",
         "tokenizer.go",
@@ -19,6 +20,7 @@ go_library(
 go_test(
     name = "spellcheck_test",
     srcs = [
+        "entities_test.go",
         "icu_test.go",
         "markup_test.go",
         "tokenizer_test.go",

--- a/internal/i18n/spellcheck/BUILD.bazel
+++ b/internal/i18n/spellcheck/BUILD.bazel
@@ -2,13 +2,20 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "spellcheck",
-    srcs = ["markup.go"],
+    srcs = [
+        "icu.go",
+        "markup.go",
+    ],
     importpath = "github.com/hyperlocalise/hyperlocalise/internal/i18n/spellcheck",
     visibility = ["//visibility:public"],
+    deps = ["//internal/i18n/icuparser"],
 )
 
 go_test(
     name = "spellcheck_test",
-    srcs = ["markup_test.go"],
+    srcs = [
+        "icu_test.go",
+        "markup_test.go",
+    ],
     embed = [":spellcheck"],
 )

--- a/internal/i18n/spellcheck/BUILD.bazel
+++ b/internal/i18n/spellcheck/BUILD.bazel
@@ -5,10 +5,14 @@ go_library(
     srcs = [
         "icu.go",
         "markup.go",
+        "words.go",
     ],
     importpath = "github.com/hyperlocalise/hyperlocalise/internal/i18n/spellcheck",
     visibility = ["//visibility:public"],
-    deps = ["//internal/i18n/icuparser"],
+    deps = [
+        "//internal/i18n/icuparser",
+        "//internal/i18n/segmentvalidate",
+    ],
 )
 
 go_test(
@@ -16,6 +20,7 @@ go_test(
     srcs = [
         "icu_test.go",
         "markup_test.go",
+        "words_test.go",
     ],
     embed = [":spellcheck"],
 )

--- a/internal/i18n/spellcheck/BUILD.bazel
+++ b/internal/i18n/spellcheck/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "spellcheck",
+    srcs = ["markup.go"],
+    importpath = "github.com/hyperlocalise/hyperlocalise/internal/i18n/spellcheck",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "spellcheck_test",
+    srcs = ["markup_test.go"],
+    embed = [":spellcheck"],
+)

--- a/internal/i18n/spellcheck/entities.go
+++ b/internal/i18n/spellcheck/entities.go
@@ -1,0 +1,58 @@
+package spellcheck
+
+import (
+	"html"
+	"regexp"
+	"unicode/utf8"
+)
+
+var namedEntityPattern = regexp.MustCompile(`^&[A-Za-z][A-Za-z0-9]{0,31};`)
+var numericEntityPattern = regexp.MustCompile(`(?i)^&#(?:[0-9]{1,7}|x[0-9a-f]{1,6});`)
+
+func scanEntity(fragment string, start int) (decoded string, end int, ok bool) {
+	if candidate := namedEntityPattern.FindString(fragment[start:]); candidate != "" {
+		if decoded, ok := decodeWholeNamedEntity(candidate); ok {
+			return decoded, start + len(candidate), true
+		}
+		return "", 0, false
+	}
+	if candidate := numericEntityPattern.FindString(fragment[start:]); candidate != "" {
+		decoded := html.UnescapeString(candidate)
+		if decoded == candidate {
+			return "", 0, false
+		}
+		return decoded, start + len(candidate), true
+	}
+	return "", 0, false
+}
+
+// html.UnescapeString can decode legacy entity prefixes without a semicolon,
+// so verify that the full named entity was consumed.
+func decodeWholeNamedEntity(candidate string) (string, bool) {
+	fullDecode := html.UnescapeString(candidate)
+	prefixDecode := html.UnescapeString(candidate[:len(candidate)-1]) + ";"
+	if fullDecode == prefixDecode {
+		return "", false
+	}
+	return fullDecode, true
+}
+
+func isAllWordChars(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if !isWordChar(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func decodedSingleRune(s string) (rune, bool) {
+	r, size := utf8.DecodeRuneInString(s)
+	if size == 0 || size != len(s) {
+		return 0, false
+	}
+	return r, true
+}

--- a/internal/i18n/spellcheck/entities.go
+++ b/internal/i18n/spellcheck/entities.go
@@ -6,8 +6,10 @@ import (
 	"unicode/utf8"
 )
 
-var namedEntityPattern = regexp.MustCompile(`^&[A-Za-z][A-Za-z0-9]{0,31};`)
-var numericEntityPattern = regexp.MustCompile(`(?i)^&#(?:[0-9]{1,7}|x[0-9a-f]{1,6});`)
+var (
+	namedEntityPattern   = regexp.MustCompile(`^&[A-Za-z][A-Za-z0-9]{0,31};`)
+	numericEntityPattern = regexp.MustCompile(`(?i)^&#(?:[0-9]{1,7}|x[0-9a-f]{1,6});`)
+)
 
 func scanEntity(fragment string, start int) (decoded string, end int, ok bool) {
 	if candidate := namedEntityPattern.FindString(fragment[start:]); candidate != "" {

--- a/internal/i18n/spellcheck/entities_test.go
+++ b/internal/i18n/spellcheck/entities_test.go
@@ -1,0 +1,99 @@
+package spellcheck
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestScanWordsEntities(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "named entity between two real words is decoded away, not tokenized",
+			in:   "Tom &amp; Jerry",
+			want: []string{"Tom", "Jerry"},
+		},
+		{
+			name: "named entity mid-word is decoded and merged into a single token",
+			in:   "caf&eacute;",
+			want: []string{"café"},
+		},
+		{
+			name: "named entity mid-word, multiple entities in one word",
+			in:   "Fran&ccedil;ais",
+			want: []string{"Français"},
+		},
+		{
+			name: "named entity at the very start of a word seeds the run",
+			in:   "&eacute;cole",
+			want: []string{"école"},
+		},
+		{
+			name: "non-breaking space entity between words is a silent boundary",
+			in:   "hello&nbsp;world",
+			want: []string{"hello", "world"},
+		},
+		{
+			name: "standalone non-breaking space entity yields no tokens",
+			in:   "&nbsp;",
+			want: nil,
+		},
+		{
+			name: "standalone hex numeric non-breaking space entity yields no tokens",
+			in:   "&#xA0;",
+			want: nil,
+		},
+		{
+			name: "escaped literal angle brackets decode and are silent boundaries, inner text survives",
+			in:   "&lt;tag&gt;",
+			want: []string{"tag"},
+		},
+		{
+			name: "bare ampersand with no entity shape is unaffected",
+			in:   "Fish & Chips",
+			want: []string{"Fish", "Chips"},
+		},
+		{
+			name: "unrecognized entity name retains current (pre-fix) behavior",
+			in:   "&notarealentity;",
+			want: []string{"notarealentity"},
+		},
+		{
+			name: "decimal numeric apostrophe entity flanked by letters merges as a contraction",
+			in:   "don&#39;t",
+			want: []string{"don't"},
+		},
+		{
+			name: "named curly-apostrophe entity flanked by letters merges as a contraction",
+			in:   "don&rsquo;t",
+			want: []string{"don\u2019t"},
+		},
+		{
+			name: "hex numeric HYPHEN entity flanked by letters is word-internal",
+			in:   "co&#x2010;operate",
+			want: []string{"co\u2010operate"},
+		},
+		{
+			name: "hex numeric HYPHEN entity surrounded by spaces is not word-internal",
+			in:   "well&#x2010;known &#x2010; really",
+			want: []string{"well\u2010known", "really"},
+		},
+		{
+			name: "leading apostrophe entity has no left flank and is a silent boundary",
+			in:   "&#39;tis",
+			want: []string{"tis"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := scanWords(tt.in, nil)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("scanWords(%q) = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/i18n/spellcheck/icu.go
+++ b/internal/i18n/spellcheck/icu.go
@@ -1,0 +1,43 @@
+package spellcheck
+
+import (
+	"strings"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/icuparser"
+)
+
+// splitICULiterals returns user-visible literal text from ICU messages.
+// Placeholder values are skipped, while plural/select branch text is retained.
+func splitICULiterals(s string) []string {
+	if !strings.Contains(s, "{") {
+		return []string{s}
+	}
+
+	elems, err := icuparser.Parse(s, nil)
+	if err != nil {
+		// Malformed ICU is treated as opaque fragment.
+		return []string{s}
+	}
+
+	return appendICULiterals(nil, elems)
+}
+
+func appendICULiterals(out []string, elems []icuparser.Element) []string {
+	for _, elem := range elems {
+		switch e := elem.(type) {
+		case icuparser.LiteralElement:
+			if e.Value != "" {
+				out = append(out, e.Value)
+			}
+		case icuparser.SelectElement:
+			for _, opt := range e.Options {
+				out = appendICULiterals(out, opt.Value)
+			}
+		case icuparser.PluralElement:
+			for _, opt := range e.Options {
+				out = appendICULiterals(out, opt.Value)
+			}
+		}
+	}
+	return out
+}

--- a/internal/i18n/spellcheck/icu_test.go
+++ b/internal/i18n/spellcheck/icu_test.go
@@ -1,0 +1,80 @@
+package spellcheck
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestSplitICULiterals(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "no braces returns the whole string as one fragment",
+			in:   "Hello world",
+			want: []string{"Hello world"},
+		},
+		{
+			name: "empty string",
+			in:   "",
+			want: []string{""},
+		},
+		{
+			name: "pure argument placeholder produces no fragments",
+			in:   "{name}",
+			want: nil,
+		},
+		{
+			name: "plural branches produce a fragment each, argument itself does not",
+			in:   "{count, plural, one {item} other {items}}",
+			want: []string{"item", "items"},
+		},
+		{
+			name: "literal text and argument interleaved with a plural, order preserved",
+			in:   "Hello {name}, you have {count, plural, one {item} other {items}}",
+			want: []string{"Hello ", ", you have ", "item", "items"},
+		},
+		{
+			name: "nested plural inside select branches, order preserved",
+			in:   "{gender, select, male {{count, plural, one {one item} other {# items}}} other {{count, plural, one {one item} other {# items}}}}",
+			want: []string{"one item", " items", "one item", " items"},
+		},
+		{
+			name: "empty branch contributes no fragment",
+			in:   "{count, plural, one {} other {items}}",
+			want: []string{"items"},
+		},
+
+		{
+			name: "unbalanced braces fall back to one opaque fragment",
+			in:   "Hello {name, you have {count, plural, one {item} other {items}}",
+			want: []string{"Hello {name, you have {count, plural, one {item} other {items}}"},
+		},
+		{
+			name: "unclosed plural options fall back to one opaque fragment",
+			in:   "{count, plural",
+			want: []string{"{count, plural"},
+		},
+		{
+			name: "non-ICU curly template syntax falls back to one opaque fragment",
+			in:   "This has {{mustache}} style",
+			want: []string{"This has {{mustache}} style"},
+		},
+		{
+			name: "an incomplete tag-shaped span that survived stripMarkup triggers fallback",
+			in:   "before <b unclosed {count}",
+			want: []string{"before <b unclosed {count}"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitICULiterals(tt.in)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("splitICULiterals(%q) = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/i18n/spellcheck/markup.go
+++ b/internal/i18n/spellcheck/markup.go
@@ -2,15 +2,9 @@ package spellcheck
 
 import "strings"
 
-// stripMarkup replaces Hyperlocalise/Liquid internal placeholder sentinels,
-// HTML tags and attributes, and Markdown code spans with a single space
-// each, leaving everything else (including the text inside HTML elements)
-// untouched. Replacing a matched span with exactly one space, regardless of
-// its length, prevents words on either side of the removed span from being
-// glued together.
+// stripMarkup replaces internal placeholder sentinels, HTML tags, and
+// Markdown code spans with spaces so adjacent words remain separated.
 func stripMarkup(s string) string {
-	// BOLT OPTIMIZATION: Fast-path strings that contain none of the
-	// trigger bytes to avoid allocating a builder for plain text.
 	if !strings.ContainsAny(s, "\x1e<`") {
 		return s
 	}
@@ -45,12 +39,8 @@ func stripMarkup(s string) string {
 	return b.String()
 }
 
-// scanSentinel reports whether s[start:] begins a Hyperlocalise/Liquid
-// internal placeholder sentinel, delimited by ASCII RS (\x1e) and US (\x1f)
-// control bytes. It matches any \x1e...\x1f span generically (covering
-// HLMDPH_, HLLQPH_, HLHTPH_, and any future HL*PH_ prefix) since these
-// control bytes don't otherwise appear in translation content. On success it
-// returns the index immediately after the closing \x1f.
+// scanSentinel matches an internal placeholder delimited by ASCII
+// record separator (\x1e) and unit separator (\x1f).
 func scanSentinel(s string, start int) (int, bool) {
 	end := strings.IndexByte(s[start+1:], '\x1f')
 	if end < 0 {
@@ -59,18 +49,9 @@ func scanSentinel(s string, start int) (int, bool) {
 	return start + 1 + end + 1, true
 }
 
-// scanHTMLTag reports whether s[start:] begins an HTML-tag-shaped span:
-// '<' followed by a letter (opening tag), '/' then a letter (closing tag),
-// '!' (comment/doctype), or '?' (processing instruction). It scans to the
-// matching unquoted '>', respecting quoted attribute values the same way
-// htmltagparity.collectMarkupTags does, so a '>' inside a quoted attribute
-// value does not terminate the tag early. On success it returns the index
-// immediately after the matching '>'.
-//
-// This incidentally also matches Markdown autolinks (<https://example.com>)
-// since they share the same "< followed by a letter" shape, and it removes
-// any ICU-look-alike placeholder embedded inside an attribute value (e.g.
-// href="/{lang}/page") since the whole tag span is dropped.
+// scanHTMLTag matches an HTML-tag-shaped span through its unquoted closing
+// '>', so '>' inside quoted attribute values does not terminate the tag.
+// This also strips Markdown autolinks such as <https://example.com>.
 func scanHTMLTag(s string, start int) (int, bool) {
 	i := start + 1
 	if i >= len(s) {
@@ -111,12 +92,8 @@ func isHTMLTagLead(ch byte) bool {
 	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '!' || ch == '?'
 }
 
-// scanCodeSpan reports whether s[start:] begins a Markdown code span: a run
-// of one or more backticks with a later run of exactly the same length
-// (the CommonMark code-span rule — a longer or shorter run of backticks
-// does not close the span). On success it returns the index immediately
-// after the closing backtick run. If no matching closing run exists, the
-// opening backticks are left in place as ordinary, non-word punctuation.
+// scanCodeSpan matches a Markdown code span whose closing backtick run has
+// the same length as its opening run.
 func scanCodeSpan(s string, start int) (int, bool) {
 	i := start
 	for i < len(s) && s[i] == '`' {

--- a/internal/i18n/spellcheck/markup.go
+++ b/internal/i18n/spellcheck/markup.go
@@ -1,0 +1,142 @@
+package spellcheck
+
+import "strings"
+
+// stripMarkup replaces Hyperlocalise/Liquid internal placeholder sentinels,
+// HTML tags and attributes, and Markdown code spans with a single space
+// each, leaving everything else (including the text inside HTML elements)
+// untouched. Replacing a matched span with exactly one space, regardless of
+// its length, prevents words on either side of the removed span from being
+// glued together.
+func stripMarkup(s string) string {
+	// BOLT OPTIMIZATION: Fast-path strings that contain none of the
+	// trigger bytes to avoid allocating a builder for plain text.
+	if !strings.ContainsAny(s, "\x1e<`") {
+		return s
+	}
+
+	var b strings.Builder
+	b.Grow(len(s))
+
+	for i := 0; i < len(s); {
+		switch s[i] {
+		case '\x1e':
+			if end, ok := scanSentinel(s, i); ok {
+				b.WriteByte(' ')
+				i = end
+				continue
+			}
+		case '<':
+			if end, ok := scanHTMLTag(s, i); ok {
+				b.WriteByte(' ')
+				i = end
+				continue
+			}
+		case '`':
+			if end, ok := scanCodeSpan(s, i); ok {
+				b.WriteByte(' ')
+				i = end
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}
+
+// scanSentinel reports whether s[start:] begins a Hyperlocalise/Liquid
+// internal placeholder sentinel, delimited by ASCII RS (\x1e) and US (\x1f)
+// control bytes. It matches any \x1e...\x1f span generically (covering
+// HLMDPH_, HLLQPH_, HLHTPH_, and any future HL*PH_ prefix) since these
+// control bytes don't otherwise appear in translation content. On success it
+// returns the index immediately after the closing \x1f.
+func scanSentinel(s string, start int) (int, bool) {
+	end := strings.IndexByte(s[start+1:], '\x1f')
+	if end < 0 {
+		return 0, false
+	}
+	return start + 1 + end + 1, true
+}
+
+// scanHTMLTag reports whether s[start:] begins an HTML-tag-shaped span:
+// '<' followed by a letter (opening tag), '/' then a letter (closing tag),
+// '!' (comment/doctype), or '?' (processing instruction). It scans to the
+// matching unquoted '>', respecting quoted attribute values the same way
+// htmltagparity.collectMarkupTags does, so a '>' inside a quoted attribute
+// value does not terminate the tag early. On success it returns the index
+// immediately after the matching '>'.
+//
+// This incidentally also matches Markdown autolinks (<https://example.com>)
+// since they share the same "< followed by a letter" shape, and it removes
+// any ICU-look-alike placeholder embedded inside an attribute value (e.g.
+// href="/{lang}/page") since the whole tag span is dropped.
+func scanHTMLTag(s string, start int) (int, bool) {
+	i := start + 1
+	if i >= len(s) {
+		return 0, false
+	}
+	next := s[i]
+	if next == '/' {
+		i++
+		if i >= len(s) {
+			return 0, false
+		}
+		next = s[i]
+	}
+	if !isHTMLTagLead(next) {
+		return 0, false
+	}
+
+	var quote byte
+	for j := i; j < len(s); j++ {
+		ch := s[j]
+		if quote != 0 {
+			if ch == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch ch {
+		case '"', '\'':
+			quote = ch
+		case '>':
+			return j + 1, true
+		}
+	}
+	return 0, false
+}
+
+func isHTMLTagLead(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '!' || ch == '?'
+}
+
+// scanCodeSpan reports whether s[start:] begins a Markdown code span: a run
+// of one or more backticks with a later run of exactly the same length
+// (the CommonMark code-span rule — a longer or shorter run of backticks
+// does not close the span). On success it returns the index immediately
+// after the closing backtick run. If no matching closing run exists, the
+// opening backticks are left in place as ordinary, non-word punctuation.
+func scanCodeSpan(s string, start int) (int, bool) {
+	i := start
+	for i < len(s) && s[i] == '`' {
+		i++
+	}
+	fenceLen := i - start
+
+	for i < len(s) {
+		if s[i] != '`' {
+			i++
+			continue
+		}
+		j := i
+		for j < len(s) && s[j] == '`' {
+			j++
+		}
+		if j-i == fenceLen {
+			return j, true
+		}
+		i = j
+	}
+	return 0, false
+}

--- a/internal/i18n/spellcheck/markup_test.go
+++ b/internal/i18n/spellcheck/markup_test.go
@@ -1,0 +1,116 @@
+package spellcheck
+
+import "testing"
+
+func TestStripMarkup(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "plain text is untouched",
+			in:   "Hello world",
+			want: "Hello world",
+		},
+		{
+			name: "empty string",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "HL sentinel is replaced with a single space",
+			in:   "\x1eHLHTPH_ABCDEF012345_0\x1f Hello \x1eHLLQPH_ABCDEF012345_1\x1f",
+			want: "  Hello  ",
+		},
+		{
+			name: "unterminated sentinel is left in place",
+			in:   "before \x1eHLHTPH_ABCDEF012345_0 after",
+			want: "before \x1eHLHTPH_ABCDEF012345_0 after",
+		},
+		{
+			name: "simple opening and closing tags",
+			in:   "<b>Hello</b> <a href=\"/x\">world</a>",
+			want: " Hello   world ",
+		},
+		{
+			name: "self-closing tag",
+			in:   "Line one<br/>Line two",
+			want: "Line one Line two",
+		},
+		{
+			name: "tag with quoted attribute containing angle bracket",
+			in:   "<a title=\"a > b\">text</a>",
+			want: " text ",
+		},
+		{
+			name: "tag with single-quoted attribute containing angle bracket",
+			in:   "<a title='a > b'>text</a>",
+			want: " text ",
+		},
+		{
+			name: "ICU placeholder inside an attribute is removed with the tag",
+			in:   "<a href=\"/{lang}/page\">Click here</a>",
+			want: " Click here ",
+		},
+		{
+			name: "doctype declaration",
+			in:   "<!DOCTYPE html>Hello",
+			want: " Hello",
+		},
+		{
+			name: "processing instruction",
+			in:   "<?php echo 1; ?>Hello",
+			want: " Hello",
+		},
+		{
+			name: "markdown autolink matches the HTML tag shape",
+			in:   "See <https://example.com> for more",
+			want: "See   for more",
+		},
+		{
+			name: "closing tag without a following letter is not a tag",
+			in:   "aw </3 sad face",
+			want: "aw </3 sad face",
+		},
+		{
+			name: "unclosed tag is left in place",
+			in:   "before <b unclosed",
+			want: "before <b unclosed",
+		},
+		{
+			name: "single backtick code span",
+			in:   "Use `git commit` now",
+			want: "Use   now",
+		},
+		{
+			name: "double backtick code span with inner single backtick",
+			in:   "Use ``git ` commit`` now",
+			want: "Use   now",
+		},
+		{
+			name: "unmatched backtick run is left as punctuation",
+			in:   "This has a stray ` backtick",
+			want: "This has a stray ` backtick",
+		},
+		{
+			name: "shorter inner backtick run does not close a longer fence",
+			in:   "``one` two``",
+			want: " ",
+		},
+		{
+			name: "combination of sentinel, tag, and code span",
+			in:   "\x1eHLHTPH_ABCDEF012345_0\x1f <b>bold</b> and `code`",
+			want: "   bold  and  ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripMarkup(tt.in)
+			if got != tt.want {
+				t.Errorf("stripMarkup(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/i18n/spellcheck/tokenizer.go
+++ b/internal/i18n/spellcheck/tokenizer.go
@@ -1,0 +1,15 @@
+// Package spellcheck extracts user-visible words from translated segments.
+package spellcheck
+
+// Tokenize returns user-visible words in source order, preserving their
+// original spelling. Callers are responsible for deduplication.
+func Tokenize(s string) []string {
+	cleaned := stripMarkup(s)
+	fragments := splitICULiterals(cleaned)
+
+	var out []string
+	for _, fragment := range fragments {
+		out = scanWords(fragment, out)
+	}
+	return out
+}

--- a/internal/i18n/spellcheck/tokenizer.go
+++ b/internal/i18n/spellcheck/tokenizer.go
@@ -2,7 +2,8 @@
 package spellcheck
 
 // Tokenize returns user-visible words in source order, preserving their
-// original spelling. Callers are responsible for deduplication.
+// rendered spelling. Recognized escapes and entities are decoded.
+// Callers are responsible for deduplication.
 func Tokenize(s string) []string {
 	cleaned := stripMarkup(s)
 	fragments := splitICULiterals(cleaned)

--- a/internal/i18n/spellcheck/tokenizer_test.go
+++ b/internal/i18n/spellcheck/tokenizer_test.go
@@ -205,6 +205,12 @@ func TestTokenize(t *testing.T) {
 		},
 
 		{
+			name: "HTML entity decoded inside an ICU plural literal, alongside real markup",
+			in:   "<p>caf&eacute; {count, plural, one{cup} other{cups}}</p>",
+			want: []string{"café", "cup", "cups"},
+		},
+
+		{
 			name: "empty string",
 			in:   "",
 			want: nil,

--- a/internal/i18n/spellcheck/tokenizer_test.go
+++ b/internal/i18n/spellcheck/tokenizer_test.go
@@ -1,0 +1,242 @@
+package spellcheck
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestTokenize(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "plain text",
+			in:   "Hello world",
+			want: []string{"Hello", "world"},
+		},
+
+		{
+			name: "punctuation-adjacent words",
+			in:   "Hello, world!",
+			want: []string{"Hello", "world"},
+		},
+
+		{
+			name: "precomposed accented letters",
+			in:   "café naïve",
+			want: []string{"café", "naïve"},
+		},
+		{
+			name: "decomposed combining marks stay grouped with their base letters",
+			in:   "tie\u0302ng Vie\u0323\u0302t",
+			want: []string{"tie\u0302ng", "Vie\u0323\u0302t"},
+		},
+		{
+			name: "straight and curly apostrophes are word-internal",
+			in:   "don't and O\u2019Brien",
+			want: []string{"don't", "and", "O\u2019Brien"},
+		},
+		{
+			name: "lowercase elision apostrophe",
+			in:   "l'\u00e9cole",
+			want: []string{"l'\u00e9cole"},
+		},
+		{
+			name: "polynesian okina is word-internal",
+			in:   "\u02BBokina",
+			want: []string{"\u02BBokina"},
+		},
+		{
+			name: "leading and trailing quotes are stripped as boundaries",
+			in:   "'quoted'",
+			want: []string{"quoted"},
+		},
+
+		{
+			name: "hyphen word-internal",
+			in:   "mother-in-law and co-operate",
+			want: []string{"mother-in-law", "and", "co-operate"},
+		},
+		{
+			name: "hyphen surrounded by spaces is not word-internal",
+			in:   "well-known - really",
+			want: []string{"well-known", "really"},
+		},
+		{
+			name: "soft hyphen is a boundary, not word-internal",
+			in:   "wor\u00ADd",
+			want: []string{"wor", "d"},
+		},
+
+		{
+			name: "pure argument placeholder produces no words",
+			in:   "{name}",
+			want: nil,
+		},
+		{
+			name: "plural branches are extracted, the argument itself is not",
+			in:   "{count, plural, one {item} other {items}}",
+			want: []string{"item", "items"},
+		},
+		{
+			name: "nested select and plural branches, order preserved",
+			in:   "{gender, select, male {He} female {She} other {They}} liked {count, plural, one {one item} other {# items}}",
+			want: []string{"He", "She", "They", "liked", "one", "item", "items"},
+		},
+
+		{
+			name: "ICU-quoted literal braces are real text, not a placeholder to skip",
+			in:   "Use '{literal brace}' here",
+			want: []string{"Use", "literal", "brace", "here"},
+		},
+
+		{
+			name: "malformed ICU falls back to opaque scanning of the whole string",
+			in:   "Hello {name, you have {count, plural, one {item} other {items}}",
+			want: []string{"Hello", "name", "you", "have", "count", "plural", "one", "item", "other", "items"},
+		},
+
+		{
+			name: "basic printf specifiers",
+			in:   "Hello %s, you have %d messages",
+			want: []string{"Hello", "you", "have", "messages"},
+		},
+		{
+			name: "positional, named, objc, and shell-style placeholders",
+			in:   "%1$s and %(name)s and %@ and ${name}",
+			want: []string{"and", "and", "and"},
+		},
+		{
+			name: "escaped percent is not a placeholder",
+			in:   "100%% discount",
+			want: []string{"discount"},
+		},
+
+		{
+			name: "simple tags and a link",
+			in:   `<b>Hello</b> <a href="/x">world</a>`,
+			want: []string{"Hello", "world"},
+		},
+		{
+			name: "self-closing tag",
+			in:   "Line<br/>break",
+			want: []string{"Line", "break"},
+		},
+		{
+			name: "ICU placeholder embedded in an attribute is removed with the tag",
+			in:   `<a href="/{lang}/page">Click here</a>`,
+			want: []string{"Click", "here"},
+		},
+
+		{
+			name: "code span",
+			in:   "Use `git commit` now",
+			want: []string{"Use", "now"},
+		},
+		{
+			name: "inline link with destination and title",
+			in:   `[Click here](https://example.com "title")`,
+			want: []string{"Click", "here"},
+		},
+		{
+			name: "reference-style link",
+			in:   "[Click here][ref]",
+			want: []string{"Click", "here"},
+		},
+		{
+			name: "bare URL in prose",
+			in:   "See https://example.com/path for more",
+			want: []string{"See", "for", "more"},
+		},
+		{
+			name: "documented limitation: adjacent bracket groups misread as a reference link",
+			in:   "See sections [3][see also] for details",
+			want: []string{"See", "sections", "for", "details"},
+		},
+		{
+			name: "contrast: non-adjacent bracket groups are unaffected",
+			in:   "See sections [3] and [see also] for details",
+			want: []string{"See", "sections", "and", "see", "also", "for", "details"},
+		},
+
+		{
+			name: "HL sentinels are removed, surrounding text is kept",
+			in:   "\x1eHLHTPH_ABCDEF012345_0\x1f Hello \x1eHLLQPH_ABCDEF012345_1\x1f",
+			want: []string{"Hello"},
+		},
+
+		{
+			name: "pure numbers and currency amounts never enter a word run",
+			in:   "Order 12345 costs $10.50",
+			want: []string{"Order", "costs"},
+		},
+		{
+			name: "digit-adjacent product names keep their letter prefix",
+			in:   "Web3 and GPT4 are popular, iPhone15 too",
+			want: []string{"Web", "and", "GPT", "are", "popular", "iPhone", "too"},
+		},
+		{
+			name: "hyphenated disease name keeps its letter prefix",
+			in:   "the disease is called COVID-19",
+			want: []string{"the", "disease", "is", "called", "COVID"},
+		},
+		{
+			name: "hyphenated SKU identifier keeps its letter prefix",
+			in:   "the SKU-12345 is out of stock",
+			want: []string{"the", "SKU", "is", "out", "of", "stock"},
+		},
+		{
+			name: "underscore is never word-forming",
+			in:   "user_id2 and user_id",
+			want: []string{"user", "id", "and", "user", "id"},
+		},
+		{
+			name: "canonical UUID is skipped wholesale, not fragmented",
+			in:   "id 550e8400-e29b-41d4-a716-446655440000 done",
+			want: []string{"id", "done"},
+		},
+
+		{
+			name: "mixed HTML, Markdown, ICU, and bare URL in one segment",
+			in:   "<b>Hello</b>, you have {count, plural, one {one message} other {# messages}}. See `code` or https://example.com for details.",
+			want: []string{"Hello", "you", "have", "one", "message", "messages", "See", "or", "for", "details"},
+		},
+
+		{
+			name: "empty string",
+			in:   "",
+			want: nil,
+		},
+		{
+			name: "whitespace only",
+			in:   "   ",
+			want: nil,
+		},
+		{
+			name: "placeholder-only ICU argument",
+			in:   "{name}",
+			want: nil,
+		},
+		{
+			name: "placeholder-only printf specifier",
+			in:   "%s",
+			want: nil,
+		},
+		{
+			name: "sentinel-only internal placeholder",
+			in:   "\x1eHLMDPH_ABCDEF012345_0\x1f",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Tokenize(tt.in)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("Tokenize(%q) = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/i18n/spellcheck/words.go
+++ b/internal/i18n/spellcheck/words.go
@@ -1,0 +1,185 @@
+package spellcheck
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/segmentvalidate"
+)
+
+// UUIDs are skipped explicitly to avoid fragmenting them into meaningless single-letter tokens.
+var uuidPattern = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b`)
+
+var bareURLPattern = regexp.MustCompile(`(?i)^(?:https?://|www\.)\S+`)
+
+const urlTrailingCutset = ".,;:!?\"')]"
+
+// scanWords appends spell-checkable words in source order, preserving their exact spelling.
+func scanWords(fragment string, out []string) []string {
+	for i := 0; i < len(fragment); {
+		ch := fragment[i]
+
+		switch ch {
+		case '%', '$':
+			if end, ok := scanPrintfPlaceholder(fragment, i); ok {
+				i = end
+				continue
+			}
+		case '{':
+			if end, ok := scanStrayBraces(fragment, i); ok {
+				i = end
+				continue
+			}
+		case ']':
+			if end, ok := scanMarkdownLinkTail(fragment, i+1); ok {
+				i = end
+				continue
+			}
+		}
+
+		if isHexDigitByte(ch) {
+			if end, ok := scanUUID(fragment, i); ok {
+				i = end
+				continue
+			}
+		}
+		if ch == 'h' || ch == 'H' || ch == 'w' || ch == 'W' {
+			if end, ok := scanBareURL(fragment, i); ok {
+				i = end
+				continue
+			}
+		}
+
+		r, size := utf8.DecodeRuneInString(fragment[i:])
+		if isWordChar(r) {
+			end := scanWordRun(fragment, i)
+			out = append(out, fragment[i:end])
+			i = end
+			continue
+		}
+		i += size
+	}
+	return out
+}
+
+func scanPrintfPlaceholder(fragment string, start int) (int, bool) {
+	loc := segmentvalidate.ExtraPlaceholderPattern.FindStringIndex(fragment[start:])
+	if loc == nil || loc[0] != 0 {
+		return 0, false
+	}
+	if fragment[start] == '%' && segmentvalidate.IsEscapedPercentAt(fragment, start) {
+		return 0, false
+	}
+	return start + loc[1], true
+}
+
+// scanStrayBraces skips a balanced {...} span.
+func scanStrayBraces(fragment string, start int) (int, bool) {
+	depth := 0
+	for i := start; i < len(fragment); i++ {
+		switch fragment[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i + 1, true
+			}
+		}
+	}
+	return 0, false
+}
+
+func scanUUID(fragment string, start int) (int, bool) {
+	loc := uuidPattern.FindStringIndex(fragment[start:])
+	if loc == nil || loc[0] != 0 {
+		return 0, false
+	}
+	return start + loc[1], true
+}
+
+func scanBareURL(fragment string, start int) (int, bool) {
+	match := bareURLPattern.FindString(fragment[start:])
+	if match == "" {
+		return 0, false
+	}
+	trimmed := strings.TrimRight(match, urlTrailingCutset)
+	if trimmed == "" {
+		return 0, false
+	}
+	return start + len(trimmed), true
+}
+
+// scanMarkdownLinkTail skips a Markdown link destination or reference label
+// immediately following ']'.
+func scanMarkdownLinkTail(fragment string, start int) (int, bool) {
+	if start >= len(fragment) {
+		return 0, false
+	}
+	switch fragment[start] {
+	case '(':
+		return scanBalancedTail(fragment, start, ')')
+	case '[':
+		return scanBalancedTail(fragment, start, ']')
+	default:
+		return 0, false
+	}
+}
+
+func scanBalancedTail(fragment string, start int, close byte) (int, bool) {
+	idx := strings.IndexByte(fragment[start+1:], close)
+	if idx < 0 {
+		return 0, false
+	}
+	return start + 1 + idx + 1, true
+}
+
+func isWordChar(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsMark(r)
+}
+
+func isApostrophe(r rune) bool {
+	switch r {
+	case '\'', '\u2019', '\u02BC', '\u02BB':
+		return true
+	default:
+		return false
+	}
+}
+
+func isHyphen(r rune) bool {
+	switch r {
+	case '-', '\u2011':
+		return true
+	default:
+		return false
+	}
+}
+
+func isHexDigitByte(ch byte) bool {
+	return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F')
+}
+
+// scanWordRun includes apostrophes and hyphens only when they occur
+// between word characters.
+func scanWordRun(fragment string, start int) int {
+	i := start
+	for i < len(fragment) {
+		r, size := utf8.DecodeRuneInString(fragment[i:])
+		if isWordChar(r) {
+			i += size
+			continue
+		}
+		if isApostrophe(r) || isHyphen(r) {
+			nr, nsize := utf8.DecodeRuneInString(fragment[i+size:])
+			if nsize > 0 && isWordChar(nr) {
+				i += size
+				continue
+			}
+		}
+		break
+	}
+	return i
+}

--- a/internal/i18n/spellcheck/words.go
+++ b/internal/i18n/spellcheck/words.go
@@ -27,11 +27,6 @@ func scanWords(fragment string, out []string) []string {
 				i = end
 				continue
 			}
-		case '{':
-			if end, ok := scanStrayBraces(fragment, i); ok {
-				i = end
-				continue
-			}
 		case ']':
 			if end, ok := scanMarkdownLinkTail(fragment, i+1); ok {
 				i = end
@@ -73,23 +68,6 @@ func scanPrintfPlaceholder(fragment string, start int) (int, bool) {
 		return 0, false
 	}
 	return start + loc[1], true
-}
-
-// scanStrayBraces skips a balanced {...} span.
-func scanStrayBraces(fragment string, start int) (int, bool) {
-	depth := 0
-	for i := start; i < len(fragment); i++ {
-		switch fragment[i] {
-		case '{':
-			depth++
-		case '}':
-			depth--
-			if depth == 0 {
-				return i + 1, true
-			}
-		}
-	}
-	return 0, false
 }
 
 func scanUUID(fragment string, start int) (int, bool) {

--- a/internal/i18n/spellcheck/words.go
+++ b/internal/i18n/spellcheck/words.go
@@ -16,7 +16,8 @@ var bareURLPattern = regexp.MustCompile(`(?i)^(?:https?://|www\.)\S+`)
 
 const urlTrailingCutset = ".,;:!?\"')]"
 
-// scanWords appends spell-checkable words in source order, preserving their exact spelling.
+// scanWords appends user-visible words in source order, using rendered
+// spelling for decoded entities.
 func scanWords(fragment string, out []string) []string {
 	for i := 0; i < len(fragment); {
 		ch := fragment[i]
@@ -29,6 +30,17 @@ func scanWords(fragment string, out []string) []string {
 			}
 		case ']':
 			if end, ok := scanMarkdownLinkTail(fragment, i+1); ok {
+				i = end
+				continue
+			}
+		case '&':
+			if decoded, end, ok := scanEntity(fragment, i); ok {
+				if isAllWordChars(decoded) {
+					token, runEnd := scanWordRun(fragment, i)
+					out = append(out, token)
+					i = runEnd
+					continue
+				}
 				i = end
 				continue
 			}
@@ -49,8 +61,8 @@ func scanWords(fragment string, out []string) []string {
 
 		r, size := utf8.DecodeRuneInString(fragment[i:])
 		if isWordChar(r) {
-			end := scanWordRun(fragment, i)
-			out = append(out, fragment[i:end])
+			token, end := scanWordRun(fragment, i)
+			out = append(out, token)
 			i = end
 			continue
 		}
@@ -90,8 +102,6 @@ func scanBareURL(fragment string, start int) (int, bool) {
 	return start + len(trimmed), true
 }
 
-// scanMarkdownLinkTail skips a Markdown link destination or reference label
-// immediately following ']'.
 func scanMarkdownLinkTail(fragment string, start int) (int, bool) {
 	if start >= len(fragment) {
 		return 0, false
@@ -152,11 +162,41 @@ func isHexDigitByte(ch byte) bool {
 	return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F')
 }
 
-// scanWordRun includes apostrophes and hyphens only when they occur
-// between word characters.
-func scanWordRun(fragment string, start int) int {
+// scanWordRun returns one maximal word token, decoding recognized entities
+// that form part of the word.
+func scanWordRun(fragment string, start int) (string, int) {
 	i := start
+	litStart := start
+	var b strings.Builder
+
 	for i < len(fragment) {
+		if fragment[i] == '&' {
+			decoded, end, ok := scanEntity(fragment, i)
+			if !ok {
+				break
+			}
+			if isAllWordChars(decoded) {
+				b.WriteString(fragment[litStart:i])
+				b.WriteString(decoded)
+				i = end
+				litStart = i
+				continue
+			}
+			if i > start {
+				if r, single := decodedSingleRune(decoded); single && (isApostrophe(r) || isHyphen(r)) {
+					nr, nsize := utf8.DecodeRuneInString(fragment[end:])
+					if nsize > 0 && isWordChar(nr) {
+						b.WriteString(fragment[litStart:i])
+						b.WriteRune(r)
+						i = end
+						litStart = i
+						continue
+					}
+				}
+			}
+			break
+		}
+
 		r, size := utf8.DecodeRuneInString(fragment[i:])
 		if isWordChar(r) {
 			i += size
@@ -171,5 +211,10 @@ func scanWordRun(fragment string, start int) int {
 		}
 		break
 	}
-	return i
+
+	if litStart == start {
+		return fragment[start:i], i
+	}
+	b.WriteString(fragment[litStart:i])
+	return b.String(), i
 }

--- a/internal/i18n/spellcheck/words.go
+++ b/internal/i18n/spellcheck/words.go
@@ -98,20 +98,32 @@ func scanMarkdownLinkTail(fragment string, start int) (int, bool) {
 	}
 	switch fragment[start] {
 	case '(':
-		return scanBalancedTail(fragment, start, ')')
+		return scanBalancedTail(fragment, start, '(', ')')
 	case '[':
-		return scanBalancedTail(fragment, start, ']')
+		return scanBalancedTail(fragment, start, '[', ']')
 	default:
 		return 0, false
 	}
 }
 
-func scanBalancedTail(fragment string, start int, close byte) (int, bool) {
-	idx := strings.IndexByte(fragment[start+1:], close)
-	if idx < 0 {
-		return 0, false
+func scanBalancedTail(fragment string, start int, open, close byte) (int, bool) {
+	depth := 1
+	for i := start + 1; i < len(fragment); i++ {
+		switch fragment[i] {
+		case '\\':
+			if i+1 < len(fragment) {
+				i++
+			}
+		case open:
+			depth++
+		case close:
+			depth--
+			if depth == 0 {
+				return i + 1, true
+			}
+		}
 	}
-	return start + 1 + idx + 1, true
+	return 0, false
 }
 
 func isWordChar(r rune) bool {
@@ -129,7 +141,7 @@ func isApostrophe(r rune) bool {
 
 func isHyphen(r rune) bool {
 	switch r {
-	case '-', '\u2011':
+	case '-', '\u2010', '\u2011':
 		return true
 	default:
 		return false

--- a/internal/i18n/spellcheck/words_test.go
+++ b/internal/i18n/spellcheck/words_test.go
@@ -82,6 +82,16 @@ func TestScanWords(t *testing.T) {
 			want: []string{"well-known", "really"},
 		},
 		{
+			name: "unicode HYPHEN (U+2010) is word-internal, same as ASCII hyphen",
+			in:   "co\u2010operate",
+			want: []string{"co\u2010operate"},
+		},
+		{
+			name: "unicode HYPHEN (U+2010) surrounded by spaces is not word-internal",
+			in:   "well\u2010known \u2010 really",
+			want: []string{"well\u2010known", "really"},
+		},
+		{
 			name: "soft hyphen is excluded from the hyphen class and splits the word",
 			in:   "wor\u00ADd",
 			want: []string{"wor", "d"},
@@ -155,6 +165,21 @@ func TestScanWords(t *testing.T) {
 			name: "reference-style link",
 			in:   "[Click here][ref]",
 			want: []string{"Click", "here"},
+		},
+		{
+			name: "link destination with a nested balanced parenthetical is skipped in full",
+			in:   "[docs](https://example.com/a_(b)tail)",
+			want: []string{"docs"},
+		},
+		{
+			name: "reference label with a nested balanced bracket is skipped in full",
+			in:   "[docs][a[nested]tail]",
+			want: []string{"docs"},
+		},
+		{
+			name: "link destination with an escaped close paren is skipped past it",
+			in:   `[docs](url\)stillurl) after`,
+			want: []string{"docs", "after"},
 		},
 		{
 			name: "documented limitation: adjacent bracket groups misread as a reference link",

--- a/internal/i18n/spellcheck/words_test.go
+++ b/internal/i18n/spellcheck/words_test.go
@@ -1,0 +1,204 @@
+package spellcheck
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestScanWords(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "empty string",
+			in:   "",
+			want: nil,
+		},
+		{
+			name: "whitespace only",
+			in:   "   ",
+			want: nil,
+		},
+		{
+			name: "plain text",
+			in:   "Hello world",
+			want: []string{"Hello", "world"},
+		},
+		{
+			name: "punctuation-adjacent words",
+			in:   "Hello, world!",
+			want: []string{"Hello", "world"},
+		},
+		{
+			name: "precomposed accented letters kept as single tokens",
+			in:   "café naïve",
+			want: []string{"café", "naïve"},
+		},
+		{
+			name: "decomposed combining marks grouped with their base letters",
+			in:   "tie\u0302ng Vie\u0323\u0302t",
+			want: []string{"tie\u0302ng", "Vie\u0323\u0302t"},
+		},
+		{
+			name: "straight apostrophe word-internal",
+			in:   "don't",
+			want: []string{"don't"},
+		},
+		{
+			name: "curly apostrophe word-internal",
+			in:   "O\u2019Brien",
+			want: []string{"O\u2019Brien"},
+		},
+		{
+			name: "apostrophe in a lowercase contraction",
+			in:   "l'\u00e9cole",
+			want: []string{"l'\u00e9cole"},
+		},
+		{
+			name: "polynesian okina is word-internal",
+			in:   "\u02BBokina word",
+			want: []string{"\u02BBokina", "word"},
+		},
+		{
+			name: "leading and trailing quotes are boundaries, not word-internal",
+			in:   "'quoted'",
+			want: []string{"quoted"},
+		},
+		{
+			name: "hyphen word-internal, multiple hyphens",
+			in:   "mother-in-law",
+			want: []string{"mother-in-law"},
+		},
+		{
+			name: "hyphen word-internal",
+			in:   "co-operate",
+			want: []string{"co-operate"},
+		},
+		{
+			name: "hyphen surrounded by spaces is not word-internal",
+			in:   "well-known - really",
+			want: []string{"well-known", "really"},
+		},
+		{
+			name: "soft hyphen is excluded from the hyphen class and splits the word",
+			in:   "wor\u00ADd",
+			want: []string{"wor", "d"},
+		},
+		{
+			name: "basic printf specifiers",
+			in:   "Hello %s, you have %d messages",
+			want: []string{"Hello", "you", "have", "messages"},
+		},
+		{
+			name: "positional, named, objc, and shell-style placeholders",
+			in:   "%1$s and %(name)s and %@ and ${name}",
+			want: []string{"and", "and", "and"},
+		},
+		{
+			name: "fully escaped percent placeholder yields no placeholder",
+			in:   "Literal %%@",
+			want: []string{"Literal"},
+		},
+		{
+			name: "escaped pair followed by a real placeholder",
+			in:   "Escaped then real %%%@",
+			want: []string{"Escaped", "then", "real"},
+		},
+		{
+			name: "escaped percent leaves the following letter as an ordinary word",
+			in:   "Save %%s today",
+			want: []string{"Save", "s", "today"},
+		},
+		{
+			name: "escaped percent with no adjacent specifier",
+			in:   "100%% discount",
+			want: []string{"discount"},
+		},
+		{
+			name: "balanced non-ICU curly content is skipped wholesale",
+			in:   "{{mustache}} style",
+			want: []string{"style"},
+		},
+		{
+			name: "canonical UUID is skipped wholesale, not fragmented",
+			in:   "id 550e8400-e29b-41d4-a716-446655440000 done",
+			want: []string{"id", "done"},
+		},
+		{
+			name: "letters immediately before a UUID are extracted as their own word",
+			in:   "abc550e8400-e29b-41d4-a716-446655440000",
+			want: []string{"abc"},
+		},
+		{
+			name: "bare https URL",
+			in:   "See https://example.com/path for more",
+			want: []string{"See", "for", "more"},
+		},
+		{
+			name: "trailing sentence punctuation is trimmed off the URL",
+			in:   "See https://example.com/path. Then stop",
+			want: []string{"See", "Then", "stop"},
+		},
+		{
+			name: "bare www URL without scheme",
+			in:   "Visit www.example.com now",
+			want: []string{"Visit", "now"},
+		},
+		{
+			name: "inline link with destination and title",
+			in:   `[Click here](https://example.com "title")`,
+			want: []string{"Click", "here"},
+		},
+		{
+			name: "reference-style link",
+			in:   "[Click here][ref]",
+			want: []string{"Click", "here"},
+		},
+		{
+			name: "documented limitation: adjacent bracket groups misread as a reference link",
+			in:   "See sections [3][see also] for details",
+			want: []string{"See", "sections", "for", "details"},
+		},
+		{
+			name: "contrast: non-adjacent bracket groups are unaffected",
+			in:   "See sections [3] and [see also] for details",
+			want: []string{"See", "sections", "and", "see", "also", "for", "details"},
+		},
+		{
+			name: "pure numbers never enter a word run",
+			in:   "Order 12345 costs $10.50",
+			want: []string{"Order", "costs"},
+		},
+		{
+			name: "digit-adjacent product names keep their letter prefix",
+			in:   "Web3 and GPT4 are popular, iPhone15 too",
+			want: []string{"Web", "and", "GPT", "are", "popular", "iPhone", "too"},
+		},
+		{
+			name: "hyphenated disease/SKU-style identifiers keep their letter prefix",
+			in:   "the disease is called COVID-19",
+			want: []string{"the", "disease", "is", "called", "COVID"},
+		},
+		{
+			name: "hyphenated SKU identifier keeps its letter prefix",
+			in:   "the SKU-12345 is out of stock",
+			want: []string{"the", "SKU", "is", "out", "of", "stock"},
+		},
+		{
+			name: "underscore is never word-forming",
+			in:   "user_id2 and user_id",
+			want: []string{"user", "id", "and", "user", "id"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := scanWords(tt.in, nil)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("scanWords(%q) = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/i18n/spellcheck/words_test.go
+++ b/internal/i18n/spellcheck/words_test.go
@@ -117,9 +117,9 @@ func TestScanWords(t *testing.T) {
 			want: []string{"discount"},
 		},
 		{
-			name: "balanced non-ICU curly content is skipped wholesale",
+			name: "braces are ordinary punctuation, not a placeholder skip",
 			in:   "{{mustache}} style",
-			want: []string{"style"},
+			want: []string{"mustache", "style"},
 		},
 		{
 			name: "canonical UUID is skipped wholesale, not fragmented",


### PR DESCRIPTION
## What changed

Adds the tokenizer for HL-598 to extract spell-checkable words from translated segments:

- **Tokenization:** Adds `internal/i18n/spellcheck` with `Tokenize()`, preserving exact token spelling and source order across Unicode letters and combining marks.
- **Markup/placeholders:** Skips ICU/printf placeholders, internal placeholder sentinels, HTML tags/attributes, Markdown code spans/link destinations, bare URLs, and canonical UUIDs.
- **Word boundaries:** Supports word-internal apostrophes and language-appropriate hyphens; digits remain boundaries (`Web3` → `Web`, `COVID-19` → `COVID`). Deduplication remains caller-owned.
- **Identifiers:** Skips canonical UUIDs wholesale; broader alphanumeric identifier classification (`Web3`, `SKU-12345`, `user_id`) is deferred to the dictionary/glossary layer.
- **Shared printf parsing:** Reuses `segmentvalidate`'s existing placeholder detection rather than duplicating its grammar.
- **Tests:** Adds table-driven coverage for plain/accented text, combining marks, apostrophes/hyphens, ICU, printf, HTML, Markdown, internal placeholders, URLs, and identifiers.

## How to test

```bash
go test ./internal/i18n/spellcheck/... ./internal/i18n/segmentvalidate/...
make fmt
make lint
make test
CGO_ENABLED=0 go build ./internal/i18n/spellcheck/...
```

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
