### PR TITLE
fix(web): return git diffs and review locale changelogs

### DIFF
--- a/apps/hyperlocalise-web/src/agents/_runtime/loader.test.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/loader.test.ts
@@ -68,6 +68,12 @@ Body content`);
     );
   });
 
+  it("loads shared recent-source-changes skill", () => {
+    expect(loadSharedSkill("recent-source-changes")).toContain("gitHistory");
+    expect(loadSharedSkill("recent-source-changes")).toContain("changedFiles");
+    expect(loadSharedSkill("recent-source-changes")).toContain("`git diff` exit code 1");
+  });
+
   it("maps tool filenames to runtime names", () => {
     expect(toolNameFromFilename("translate_string.ts")).toBe("translate_string");
   });

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-skills/recent-source-changes.md
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-skills/recent-source-changes.md
@@ -1,0 +1,23 @@
+---
+id: recent-source-changes
+name: Recent source changes
+---
+
+## Recent source-content changes (`gitHistory`)
+
+Use `gitHistory` for localisation review of recent repository changes. Prefer it over raw `git log` / `git diff` in bash.
+
+`gitHistory` runs git from the clone root. If the sandbox cwd is a parent of the clone, it uses `git -C <clone>`. If a path is prefixed with the repository directory name (for example `scribe-fe-v2/src/locales/en.json`), strip that prefix. `git diff` exit code 1 means differences were found — that is success and the patch is in the tool output.
+
+### Procedure
+
+1. Call `gitHistory` with `mode: "changedFiles"` and the requested `since`/`until` window (for a daily lookback use `"24 hours ago"`; for a push, use the push commit range).
+2. When no paths are provided, the tool discovers source files from **every tracked** `i18n.yml`, `i18n.jsonc`, `crowdin.yml`, `crowdin.yaml`, `.phrase.yml`, `phrase.yml`, or `phrase.yaml` in the repository (including nested paths), and merges their source `from`/`source` patterns.
+3. If discovery returns no files, an empty file list, or a "no localization config" / "no source files were resolved" diagnostic, **keep exploring the repository**:
+   - Use `detectRepoConfig` and/or `glob`/`grep` to find likely source locale files (for example `**/en*.json`, `**/en-US/**`, `**/locales/**`, `**/messages/**`, `**/i18n/**`, `**/*.messages.ts`, `**/lang/**`).
+   - Call `gitHistory` again with `mode: "changedFiles"` and those discovered `paths`.
+   - If still empty, broaden with common localization directories as `paths`, or use `mode: "fileDiff"` / `mode: "entryLog"` once you have candidate paths.
+4. For files that changed, use `mode: "fileDiff"` to inspect source entries. Collect added and updated keys/source strings from `+` lines together with the previous values from matching `-` lines. Also read localisation logic changes (i18n API usage, locale routing, fallback, formatters, writeback) — not only catalogs.
+5. Use `mode: "entryLog"` or `mode: "blame"` only when a specific currently present key/source string needs more provenance.
+
+Do **not** conclude that nothing changed, or that there are no localisation findings, solely because config-based path discovery was empty or a raw git command failed. Empty discovery means continue repo exploration. A failed `git diff` is not "no findings."

--- a/apps/hyperlocalise-web/src/agents/automations/github-repository/agent/skills/github-repo-agent.md
+++ b/apps/hyperlocalise-web/src/agents/automations/github-repository/agent/skills/github-repo-agent.md
@@ -1,14 +1,17 @@
 ---
 id: github-repo-agent
+sharedSkills: recent-source-changes
 ---
 
 ## GitHub repository agent procedure
 
 - Read-only. Do not commit, push, upload sources, or modify files.
-- Start with `repoGitState` and `git log` for the requested lookback window, push commit range, and branch.
-- Use `read`, `grep`, or `glob` only when commit subjects or diffs need more context.
-- Follow the customer instructions. If they ask for a code review, prioritize the stated review focus over a changelog. If none is given, prioritize defects, regressions, missing tests, and security.
+- For localisation, translation, or source-catalog work, follow the **Recent source-content changes** procedure: `gitHistory` `changedFiles` → `fileDiff` → extract keys and review diff values. Prefer `gitHistory` over raw `git log` / `git diff`.
+- Start with `repoGitState` only when you need the current branch/HEAD. Then use `gitHistory` for the requested lookback window, push commit range, and branch.
+- Use `read`, `grep`, or `glob` when commit subjects or diffs need more context, including localisation logic (i18n APIs, locale routing, fallback, formatters) as well as JSON/YAML catalogs.
+- Follow the customer instructions. If they ask for a code review, prioritize the stated review focus over a generic changelog, but still extract changed translation keys and values when locale files changed. If none is given, prioritize defects, regressions, missing tests, and security.
 - When summarizing, follow the customer digest focus. If none is given, group by features, fixes, refactors, docs, and dependencies.
 - Cite commit shas and file paths when making specific claims.
 - Call out follow-ups, risks, or missing tests when they matter to the customer task.
 - If there are no commits in the period, say so clearly.
+- Do not report "no localisation findings" when translation catalogs or source strings changed. That phrase means no defects, not "nothing changed."

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/skills/review-code-daily.md
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/skills/review-code-daily.md
@@ -11,6 +11,7 @@ You are a localisation-focused code reviewer for this repository.
 What you can do:
 
 - Read recent commits, diffs, and surrounding code in the lookback window
+- Extract changed translation keys and review old vs new values in locale catalogs
 - Judge localisation, translation, and locale-compliance risk in the changed code
 - Cite commit SHAs and file paths for each finding
 - Separate blocking localisation defects from non-blocking follow-ups
@@ -19,6 +20,13 @@ What you can do:
 Goal:
 
 - Surface localisation and translation risks from the last day so the team can act before they ship further.
+- When locale files change, the Slack report must include a key/value changelog even if there are no defects.
+
+Review procedure:
+
+- Follow `gitHistory` `changedFiles` → `fileDiff` → extract keys. Prefer `gitHistory` over raw git.
+- Collect added and updated keys from catalog diffs (`+`/`-` JSON/YAML lines) with old → new values.
+- Also review localisation logic changes: i18n API usage, locale routing, fallback, formatters, and writeback.
 
 Review focus:
 
@@ -26,3 +34,10 @@ Review focus:
 - Broken ICU, placeholders, plurals, and locale-sensitive formatting
 - Translation coverage, fallback, and writeback regressions
 - Localisation compliance: locale, RTL, legal, and market-language constraints
+- Changed catalog values that look wrong, truncated, or inconsistent with nearby keys
+
+Slack report:
+
+- If locale catalogs or source strings changed, lead with a key/value changelog (file, key, old → new or added/removed), then blocking defects, then follow-ups.
+- "No localisation findings" means no defects you could prove. Do **not** use it when translation JSON/YAML files changed.
+- If catalogs changed and there are no defects, say that source strings changed, include the changelog, and then "No blocking localisation defects."

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_github_repository.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_github_repository.ts
@@ -43,7 +43,7 @@ import {
   resolveGithubRepoLookbackHours,
 } from "./resolve-github-repo-lookback";
 
-const GITHUB_REPO_AGENT_STEP_LIMIT = 12;
+const GITHUB_REPO_AGENT_STEP_LIMIT = 16;
 
 export function createUseGithubRepositoryTool(session: WorkspaceOrchestratorSession) {
   return defineAgentTool({

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-template-manifest.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-template-manifest.test.ts
@@ -18,6 +18,7 @@ import {
   getTemplateCategoryFromSkill,
   getTemplateExecutorAgent,
   mergeWorkspaceTemplateSkills,
+  composeGithubRepoInstructions,
 } from "./workspace-template-manifest";
 
 describe("workspace template manifest", () => {
@@ -96,6 +97,10 @@ describe("workspace template manifest", () => {
     });
     expect(review?.description).toContain("localisation and translation risk");
     expect(review?.instructions).toContain("You are a localisation-focused code reviewer");
+    expect(review?.instructions).toContain("key/value changelog");
+    expect(review?.instructions).toContain(
+      "Do **not** use it when translation JSON/YAML files changed",
+    );
     expect(research).toMatchObject({
       name: "Daily web research",
       category: "popular",
@@ -136,5 +141,15 @@ describe("workspace template manifest", () => {
       "daily-web-research",
       "notify-on-push-blockers",
     ]);
+  });
+
+  it("composes github repo instructions with the recent source-change procedure", () => {
+    const instructions = composeGithubRepoInstructions({});
+
+    expect(instructions).toContain("gitHistory");
+    expect(instructions).toContain('mode: "changedFiles"');
+    expect(instructions).toContain("fileDiff");
+    expect(instructions).toContain("`git diff` exit code 1");
+    expect(instructions).toContain('Do not report "no localisation findings"');
   });
 });

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-template-manifest.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-template-manifest.ts
@@ -69,6 +69,7 @@ export function composeGithubRepoInstructions(input: {
 }) {
   return composeInstructions({
     automationId: "github-repository",
+    sharedSkills: ["recent-source-changes"],
     skills: ["github-repo-agent"],
     dynamicSections: input.dynamicSections,
     userOverride: input.userOverride,

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/repo-tools.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/repo-tools.md
@@ -21,7 +21,7 @@ Use these tools for read-only inspection of the connected GitHub repository.
 
 ## Recent source-content changes (`gitHistory`)
 
-Use `gitHistory` when the request asks what changed recently, asks for history/provenance, asks about "new translations" / new source copy in the repo, or asks for context for strings changed in a time window such as "last week".
+Use `gitHistory` when the request asks what changed recently, asks for history/provenance, asks about "new translations" / new source copy in the repo, or asks for context for strings changed in a time window such as "last week". Prefer `gitHistory` over raw `git log` / `git diff`. `gitHistory` runs git from the clone root and strips a repo-name path prefix such as `repo/src/locales/en.json`. `git diff` exit code 1 means differences were found — that is success and the patch is in the tool output.
 
 ### Procedure
 
@@ -31,7 +31,7 @@ Use `gitHistory` when the request asks what changed recently, asks for history/p
    - Use `detectRepoConfig` and/or `glob`/`grep` to find likely source locale files (for example `**/en*.json`, `**/en-US/**`, `**/locales/**`, `**/messages/**`, `**/i18n/**`, `**/*.messages.ts`, `**/lang/**`).
    - Call `gitHistory` again with `mode: "changedFiles"` and those discovered `paths`.
    - If still empty, broaden with common localization directories as `paths`, or use `mode: "fileDiff"` / `mode: "entryLog"` once you have candidate paths.
-4. For files that changed, use `mode: "fileDiff"` to inspect source entries. Collect only keys/source strings that **still exist now** (added or updated at HEAD). **Ignore deleted keys and deleted source content** from `-` diff lines.
+4. For files that changed, use `mode: "fileDiff"` to inspect source entries. Collect only keys/source strings that **still exist now** (added or updated at HEAD). **Ignore deleted keys and deleted source content** from `-` diff lines. Also read localisation logic changes (i18n API usage, locale routing, fallback, formatters, writeback) when those files changed — not only catalogs.
 5. Use `mode: "entryLog"` or `mode: "blame"` only when a specific currently present key/source string needs more provenance.
 
 ### After discovery

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
@@ -1102,7 +1102,7 @@ describe("createGitHistoryTool", () => {
       files: ["src/messages.json"],
       truncated: true,
     });
-    expect(gitCalls[0]).toContain("--max-count=3");
+    expect(gitCalls.find((args) => args[0] === "log")).toContain("--max-count=3");
   });
 
   it("reports unresolved Phrase placeholders as skipped diagnostics", async () => {
@@ -1168,6 +1168,9 @@ describe("createGitHistoryTool", () => {
     const ctx = createTestContext();
     ctx.bash.registerCommand(
       defineCommand("git", async (args) => {
+        if (args[0] === "rev-parse") {
+          return { stdout: "", stderr: "fatal: not a git repository", exitCode: 128 };
+        }
         expect(args).toEqual(["diff", "main..HEAD", "--", "lang/en.json"]);
         return { stdout: "A".repeat(200_000), stderr: "", exitCode: 0 };
       }),
@@ -1181,6 +1184,136 @@ describe("createGitHistoryTool", () => {
 
     expect(result).toMatchObject({ success: true, mode: "fileDiff", truncated: true });
     expect((result as { diff: string }).diff.length).toBeLessThan(200_000);
+  });
+
+  it("returns the patch when ranged git diff exits 1", async () => {
+    const patch =
+      'diff --git a/lang/en.json b/lang/en.json\n--- a/lang/en.json\n+++ b/lang/en.json\n@@ -1,3 +1,3 @@\n-  "save": "Save"\n+  "save": "Save changes"\n';
+    const ctx = createTestContext();
+    ctx.bash.registerCommand(
+      defineCommand("git", async (args) => {
+        if (args[0] === "rev-parse") {
+          return { stdout: "", stderr: "fatal: not a git repository", exitCode: 128 };
+        }
+        expect(args).toEqual(["diff", "abc^..abc", "--", "lang/en.json"]);
+        return { stdout: patch, stderr: "", exitCode: 1 };
+      }),
+    );
+
+    const t = createGitHistoryTool(ctx);
+    const result = await t.execute!(
+      { mode: "fileDiff", paths: ["lang/en.json"], range: "abc^..abc" },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({ success: true, mode: "fileDiff", diff: patch });
+  });
+
+  it("fails ranged git diff on exit 2+ and surfaces stdout when stderr is empty", async () => {
+    const ctx = createTestContext();
+    ctx.bash.registerCommand(
+      defineCommand("git", async (args) => {
+        if (args[0] === "rev-parse") {
+          return { stdout: "", stderr: "fatal: not a git repository", exitCode: 128 };
+        }
+        expect(args).toEqual(["diff", "abc^..abc", "--", "lang/en.json"]);
+        return { stdout: "usage: git diff [<options>]", stderr: "", exitCode: 129 };
+      }),
+    );
+
+    const t = createGitHistoryTool(ctx);
+    const result = await t.execute!(
+      { mode: "fileDiff", paths: ["lang/en.json"], range: "abc^..abc" },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "usage: git diff [<options>]",
+    });
+  });
+
+  it("runs git from a nested clone and strips a repo-name path prefix", async () => {
+    const patch =
+      'diff --git a/src/locales/en/messages.json b/src/locales/en/messages.json\n+  "save": "Save"\n';
+    const ctx = createTestContext({
+      "/home/user/project/scribe-fe-v2/src/locales/en/messages.json": '{"save":"Save"}\n',
+    });
+    const gitCalls: string[][] = [];
+    ctx.bash.registerCommand(
+      defineCommand("ls", async () => ({ stdout: "scribe-fe-v2\n", stderr: "", exitCode: 0 })),
+    );
+    ctx.bash.registerCommand(
+      defineCommand("test", async (args) => ({
+        stdout: "",
+        stderr: "",
+        exitCode: args[0] === "-d" && args[1] === "scribe-fe-v2" ? 0 : 1,
+      })),
+    );
+    ctx.bash.registerCommand(
+      defineCommand("git", async (args) => {
+        gitCalls.push(args);
+        if (args[0] === "rev-parse") {
+          return { stdout: "", stderr: "fatal: not a git repository", exitCode: 128 };
+        }
+        if (args[0] === "-C" && args[1] === "scribe-fe-v2" && args[2] === "rev-parse") {
+          return { stdout: "true\n", stderr: "", exitCode: 0 };
+        }
+        if (args[0] === "-C" && args[1] === "scribe-fe-v2" && args[2] === "log") {
+          expect(args).toEqual(expect.arrayContaining(["--", "src/locales/en/messages.json"]));
+          expect(args).not.toContain("scribe-fe-v2/src/locales/en/messages.json");
+          return {
+            stdout:
+              "abc\t2026-07-01T00:00:00Z\tMina\tUpdate strings\nsrc/locales/en/messages.json\n",
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        if (args[0] === "-C" && args[1] === "scribe-fe-v2" && args[2] === "diff") {
+          expect(args).toEqual([
+            "-C",
+            "scribe-fe-v2",
+            "diff",
+            "abc^..abc",
+            "--",
+            "src/locales/en/messages.json",
+          ]);
+          return { stdout: patch, stderr: "", exitCode: 1 };
+        }
+        return { stdout: "", stderr: "", exitCode: 1 };
+      }),
+    );
+
+    const t = createGitHistoryTool(ctx);
+    const changed = await t.execute!(
+      {
+        mode: "changedFiles",
+        paths: ["scribe-fe-v2/src/locales/en/messages.json"],
+        since: "24 hours ago",
+      },
+      toolCallInfo,
+    );
+    expect(changed).toMatchObject({
+      success: true,
+      mode: "changedFiles",
+      files: ["scribe-fe-v2/src/locales/en/messages.json"],
+    });
+
+    const diff = await t.execute!(
+      {
+        mode: "fileDiff",
+        paths: ["scribe-fe-v2/src/locales/en/messages.json"],
+        range: "abc^..abc",
+      },
+      toolCallInfo,
+    );
+    expect(diff).toMatchObject({
+      success: true,
+      mode: "fileDiff",
+      paths: ["scribe-fe-v2/src/locales/en/messages.json"],
+      diff: patch,
+    });
+    expect(gitCalls.some((args) => args[0] === "-C" && args[1] === "scribe-fe-v2")).toBe(true);
   });
 
   it("rejects option-like git revision ranges", async () => {
@@ -1201,6 +1334,9 @@ describe("createGitHistoryTool", () => {
     const ctx = createTestContext();
     ctx.bash.registerCommand(
       defineCommand("git", async (args) => {
+        if (args[0] === "rev-parse") {
+          return { stdout: "", stderr: "fatal: not a git repository", exitCode: 128 };
+        }
         expect(args).toEqual(
           expect.arrayContaining(["--patch", "--unified=3", "-SSave", "--", "lang/en.json"]),
         );
@@ -1256,6 +1392,9 @@ describe("createGitHistoryTool", () => {
     });
     ctx.bash.registerCommand(
       defineCommand("git", async (args) => {
+        if (args[0] === "rev-parse") {
+          return { stdout: "", stderr: "fatal: not a git repository", exitCode: 128 };
+        }
         expect(args).toEqual(["blame", "--line-porcelain", "-L2,2", "--", "lang/en.json"]);
         return {
           stdout:

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
@@ -1316,6 +1316,58 @@ describe("createGitHistoryTool", () => {
     expect(gitCalls.some((args) => args[0] === "-C" && args[1] === "scribe-fe-v2")).toBe(true);
   });
 
+  it("does not strip a nested clone prefix from an already git-relative path", async () => {
+    const patch =
+      'diff --git a/scribe-fe-v2/locales/en.json b/scribe-fe-v2/locales/en.json\n+  "save": "Save"\n';
+    const ctx = createTestContext({
+      "/home/user/project/scribe-fe-v2/scribe-fe-v2/locales/en.json": '{"save":"Save"}\n',
+    });
+    const gitCalls: string[][] = [];
+    ctx.bash.registerCommand(
+      defineCommand("git", async (args) => {
+        gitCalls.push(args);
+        if (args[0] === "rev-parse") {
+          return { stdout: "", stderr: "fatal: not a git repository", exitCode: 128 };
+        }
+        if (args[0] === "-C" && args[1] === "scribe-fe-v2" && args[2] === "rev-parse") {
+          return { stdout: "true\n", stderr: "", exitCode: 0 };
+        }
+        if (args[0] === "-C" && args[1] === "scribe-fe-v2" && args[2] === "diff") {
+          return { stdout: patch, stderr: "", exitCode: 1 };
+        }
+        return { stdout: "", stderr: "", exitCode: 1 };
+      }),
+    );
+
+    const t = createGitHistoryTool(ctx);
+    const result = await t.execute!(
+      {
+        mode: "fileDiff",
+        paths: ["scribe-fe-v2/scribe-fe-v2/locales/en.json"],
+        range: "abc^..abc",
+      },
+      toolCallInfo,
+    );
+
+    expect(gitCalls).toContainEqual([
+      "-C",
+      "scribe-fe-v2",
+      "diff",
+      "abc^..abc",
+      "--",
+      "scribe-fe-v2/locales/en.json",
+    ]);
+    expect(gitCalls.some((args) => args.includes("--") && args.at(-1) === "locales/en.json")).toBe(
+      false,
+    );
+    expect(result).toMatchObject({
+      success: true,
+      mode: "fileDiff",
+      paths: ["scribe-fe-v2/scribe-fe-v2/locales/en.json"],
+      diff: patch,
+    });
+  });
+
   it("rejects option-like git revision ranges", async () => {
     const ctx = createTestContext();
     const t = createGitHistoryTool(ctx);

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.ts
@@ -19,6 +19,14 @@ import { normalizeJsonc } from "@/lib/i18n/parse-jsonc-config";
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 
 import { DEFAULT_MAX_OUTPUT_BYTES, redact, truncate, type RepoToolContext } from "./workspace";
+import {
+  bindGitClone,
+  resolveGitCloneRoot,
+  toGitPath,
+  toWorkspacePath,
+  type GitCloneRoot,
+} from "./workspace/git-clone-root";
+import { isSuccessfulAllowlistedExit } from "./workspace/git-exit";
 import { normalizeWorkspacePath } from "./workspace/path";
 
 export type { RepoToolContext } from "./workspace";
@@ -222,7 +230,7 @@ type GitHistoryInput = {
 export function createGitHistoryTool(ctx: RepoToolContext) {
   return tool({
     description:
-      "Inspect read-only git history for repository localization source content. Use changedFiles for time-window discovery of changed source files, fileDiff for bounded patches of those files, entryLog for commits touching a key/source string, and blame only for current-line provenance. When paths are omitted, discover source files from every tracked i18n.yml/i18n.jsonc/crowdin/phrase config in the repository (not only the repo root). If discovery is empty, find likely source locale files and call again with explicit paths — do not stop at empty discovery.",
+      "Inspect read-only git history for repository localization source content. Runs git from the clone root (auto-detects a nested clone directory) and strips a repo-name path prefix such as `repo/src/locales/en.json`. Use changedFiles for time-window discovery of changed source files, fileDiff for bounded patches of those files, entryLog for commits touching a key/source string, and blame only for current-line provenance. git diff exit 1 is success and returns the patch. When paths are omitted, discover source files from every tracked i18n.yml/i18n.jsonc/crowdin/phrase config in the repository (not only the repo root). If discovery is empty, find likely source locale files and call again with explicit paths — do not stop at empty discovery.",
     inputSchema: z.object({
       mode: z.enum(GIT_HISTORY_MODES).describe("Git history lookup mode."),
       paths: z
@@ -251,6 +259,8 @@ async function executeGitHistory(ctx: RepoToolContext, input: GitHistoryInput) {
     };
   }
 
+  const clone = await resolveGitCloneRoot(ctx);
+  const bound = bindGitClone(ctx, clone);
   const normalizedInput = { ...input, range: rangeResult.value };
   const normalizedPathsResult = normalizeGitHistoryPaths(input.paths);
   if (isErr(normalizedPathsResult)) {
@@ -260,21 +270,18 @@ async function executeGitHistory(ctx: RepoToolContext, input: GitHistoryInput) {
     };
   }
 
+  const gitPaths = normalizedPathsResult.value?.map((path) => toGitPath(path, clone));
+
   try {
     switch (normalizedInput.mode) {
       case "changedFiles":
-        return await changedFilesHistory(
-          ctx,
-          normalizedInput,
-          normalizedPathsResult.value,
-          maxResults,
-        );
+        return await changedFilesHistory(bound, clone, normalizedInput, gitPaths, maxResults);
       case "fileDiff":
-        return await fileDiffHistory(ctx, normalizedInput, normalizedPathsResult.value, maxResults);
+        return await fileDiffHistory(bound, clone, normalizedInput, gitPaths, maxResults);
       case "entryLog":
-        return await entryLogHistory(ctx, normalizedInput, normalizedPathsResult.value, maxResults);
+        return await entryLogHistory(bound, clone, normalizedInput, gitPaths, maxResults);
       case "blame":
-        return await blameHistory(ctx, normalizedInput, normalizedPathsResult.value, maxResults);
+        return await blameHistory(bound, clone, normalizedInput, gitPaths, maxResults);
     }
   } catch (error) {
     return {
@@ -316,6 +323,7 @@ function normalizeGitRevisionRange(range: string | undefined): Result<string | u
 
 async function changedFilesHistory(
   ctx: RepoToolContext,
+  clone: GitCloneRoot,
   input: GitHistoryInput,
   providedPaths: string[] | undefined,
   maxResults: number,
@@ -329,13 +337,13 @@ async function changedFilesHistory(
     };
   }
 
-  const paths = providedPaths ?? discovery?.files ?? [];
+  const paths = (providedPaths ?? discovery?.files ?? []).map((path) => toGitPath(path, clone));
   if (paths.length === 0) {
     return {
       success: true as const,
       mode: "changedFiles" as const,
       files: [],
-      discovery,
+      discovery: remapDiscovery(discovery, clone),
       truncated: false,
       diagnostics: [
         "No source files were resolved from localization config.",
@@ -353,8 +361,8 @@ async function changedFilesHistory(
   if (result.exitCode !== 0) {
     return {
       success: false as const,
-      error: redact(result.stderr || "Failed to read git changed files."),
-      discovery,
+      error: redact(result.stderr || result.stdout || "Failed to read git changed files."),
+      discovery: remapDiscovery(discovery, clone),
     };
   }
 
@@ -368,20 +376,22 @@ async function changedFilesHistory(
   const changedFiles = uniqueLines(changedFileLines.join("\n"))
     .map((line) => normalizeSourcePath(line))
     .filter((line): line is string => Boolean(line))
+    .map((line) => toGitPath(line, clone))
     .filter((line) => pathSet.has(line));
-  const files = changedFiles.slice(0, maxResults);
+  const files = changedFiles.slice(0, maxResults).map((path) => toWorkspacePath(path, clone));
 
   return {
     success: true as const,
     mode: "changedFiles" as const,
     files,
-    discovery,
+    discovery: remapDiscovery(discovery, clone),
     truncated: commitLimited || files.length < changedFiles.length,
   };
 }
 
 async function fileDiffHistory(
   ctx: RepoToolContext,
+  clone: GitCloneRoot,
   input: GitHistoryInput,
   paths: string[] | undefined,
   maxResults: number,
@@ -390,23 +400,30 @@ async function fileDiffHistory(
     return { success: false as const, error: "fileDiff requires at least one path." };
   }
 
+  const gitPaths = paths.map((path) => toGitPath(path, clone));
   const args = input.range
-    ? ["diff", input.range, "--", ...paths]
+    ? ["diff", input.range, "--", ...gitPaths]
     : buildGitLogArgs(input, {
         patch: true,
         maxCount: maxResults,
-        paths,
+        paths: gitPaths,
       });
   const result = await ctx.bash.exec("git", { args });
-  if (result.exitCode !== 0) {
-    return { success: false as const, error: redact(result.stderr || "Failed to read git diff.") };
+  const diffSucceeded = input.range
+    ? isSuccessfulAllowlistedExit({ bin: "git", args, exitCode: result.exitCode })
+    : result.exitCode === 0;
+  if (!diffSucceeded) {
+    return {
+      success: false as const,
+      error: redact(result.stderr || result.stdout || "Failed to read git diff."),
+    };
   }
 
   const output = truncate(redact(result.stdout), DEFAULT_MAX_OUTPUT_BYTES);
   return {
     success: true as const,
     mode: "fileDiff" as const,
-    paths,
+    paths: gitPaths.map((path) => toWorkspacePath(path, clone)),
     diff: output.text,
     truncated: output.truncated,
   };
@@ -414,6 +431,7 @@ async function fileDiffHistory(
 
 async function entryLogHistory(
   ctx: RepoToolContext,
+  clone: GitCloneRoot,
   input: GitHistoryInput,
   paths: string[] | undefined,
   maxResults: number,
@@ -423,17 +441,18 @@ async function entryLogHistory(
     return { success: false as const, error: "entryLog requires query." };
   }
 
+  const gitPaths = paths?.map((path) => toGitPath(path, clone));
   const args = buildGitLogArgs(input, {
     patch: true,
     maxCount: maxResults,
     pickaxe: query,
-    paths,
+    paths: gitPaths,
   });
   const result = await ctx.bash.exec("git", { args });
   if (result.exitCode !== 0) {
     return {
       success: false as const,
-      error: redact(result.stderr || "Failed to read git entry log."),
+      error: redact(result.stderr || result.stdout || "Failed to read git entry log."),
     };
   }
 
@@ -442,7 +461,7 @@ async function entryLogHistory(
     success: true as const,
     mode: "entryLog" as const,
     query,
-    paths: paths ?? [],
+    paths: (gitPaths ?? []).map((path) => toWorkspacePath(path, clone)),
     log: output.text,
     truncated: output.truncated,
   };
@@ -450,6 +469,7 @@ async function entryLogHistory(
 
 async function blameHistory(
   ctx: RepoToolContext,
+  clone: GitCloneRoot,
   input: GitHistoryInput,
   paths: string[] | undefined,
   maxResults: number,
@@ -463,13 +483,14 @@ async function blameHistory(
     return { success: false as const, error: "blame requires a path." };
   }
 
+  const gitPath = toGitPath(path, clone);
   const query = input.query?.trim();
-  const lineRange = query ? await findLineRangeForQuery(ctx, path, query) : null;
+  const lineRange = query ? await findLineRangeForQuery(ctx, gitPath, query) : null;
   if (query && !lineRange) {
     return {
       success: true as const,
       mode: "blame" as const,
-      path,
+      path: toWorkspacePath(gitPath, clone),
       query,
       entries: [],
       truncated: false,
@@ -481,11 +502,14 @@ async function blameHistory(
   if (lineRange) {
     args.push(`-L${lineRange.start},${lineRange.end}`);
   }
-  args.push("--", path);
+  args.push("--", gitPath);
 
   const result = await ctx.bash.exec("git", { args });
   if (result.exitCode !== 0) {
-    return { success: false as const, error: redact(result.stderr || "Failed to read git blame.") };
+    return {
+      success: false as const,
+      error: redact(result.stderr || result.stdout || "Failed to read git blame."),
+    };
   }
 
   const allEntries = parseBlamePorcelain(result.stdout);
@@ -493,7 +517,7 @@ async function blameHistory(
   return {
     success: true as const,
     mode: "blame" as const,
-    path,
+    path: toWorkspacePath(gitPath, clone),
     query,
     entries,
     truncated: entries.length < allEntries.length,
@@ -887,6 +911,26 @@ function uniqueNullSeparatedLines(output: string): string[] {
 function normalizeSourcePath(path: string): string | null {
   const normalized = path.trim().replace(/\\/g, "/").replace(/^\.\//, "").replace(/^\/+/, "");
   return normalizeWorkspacePath(normalized);
+}
+
+function remapDiscovery(
+  discovery: SourceFileDiscovery | null,
+  clone: GitCloneRoot,
+): SourceFileDiscovery | null {
+  if (!discovery) {
+    return discovery;
+  }
+
+  return {
+    ...discovery,
+    configPath: discovery.configPath ? toWorkspacePath(discovery.configPath, clone) : null,
+    files: discovery.files.map((filePath) => toWorkspacePath(filePath, clone)),
+    configs: discovery.configs.map((config) => ({
+      ...config,
+      configPath: toWorkspacePath(config.configPath, clone),
+      files: config.files.map((filePath) => toWorkspacePath(filePath, clone)),
+    })),
+  };
 }
 
 function joinConfigPath(basePath: string | null, path: string): string {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.ts
@@ -270,6 +270,7 @@ async function executeGitHistory(ctx: RepoToolContext, input: GitHistoryInput) {
     };
   }
 
+  // Convert workspace paths once. History helpers must keep these git-relative.
   const gitPaths = normalizedPathsResult.value?.map((path) => toGitPath(path, clone));
 
   try {
@@ -337,7 +338,7 @@ async function changedFilesHistory(
     };
   }
 
-  const paths = (providedPaths ?? discovery?.files ?? []).map((path) => toGitPath(path, clone));
+  const paths = providedPaths ?? discovery?.files ?? [];
   if (paths.length === 0) {
     return {
       success: true as const,
@@ -376,7 +377,6 @@ async function changedFilesHistory(
   const changedFiles = uniqueLines(changedFileLines.join("\n"))
     .map((line) => normalizeSourcePath(line))
     .filter((line): line is string => Boolean(line))
-    .map((line) => toGitPath(line, clone))
     .filter((line) => pathSet.has(line));
   const files = changedFiles.slice(0, maxResults).map((path) => toWorkspacePath(path, clone));
 
@@ -400,13 +400,12 @@ async function fileDiffHistory(
     return { success: false as const, error: "fileDiff requires at least one path." };
   }
 
-  const gitPaths = paths.map((path) => toGitPath(path, clone));
   const args = input.range
-    ? ["diff", input.range, "--", ...gitPaths]
+    ? ["diff", input.range, "--", ...paths]
     : buildGitLogArgs(input, {
         patch: true,
         maxCount: maxResults,
-        paths: gitPaths,
+        paths,
       });
   const result = await ctx.bash.exec("git", { args });
   const diffSucceeded = input.range
@@ -423,7 +422,7 @@ async function fileDiffHistory(
   return {
     success: true as const,
     mode: "fileDiff" as const,
-    paths: gitPaths.map((path) => toWorkspacePath(path, clone)),
+    paths: paths.map((path) => toWorkspacePath(path, clone)),
     diff: output.text,
     truncated: output.truncated,
   };
@@ -441,12 +440,11 @@ async function entryLogHistory(
     return { success: false as const, error: "entryLog requires query." };
   }
 
-  const gitPaths = paths?.map((path) => toGitPath(path, clone));
   const args = buildGitLogArgs(input, {
     patch: true,
     maxCount: maxResults,
     pickaxe: query,
-    paths: gitPaths,
+    paths,
   });
   const result = await ctx.bash.exec("git", { args });
   if (result.exitCode !== 0) {
@@ -461,7 +459,7 @@ async function entryLogHistory(
     success: true as const,
     mode: "entryLog" as const,
     query,
-    paths: (gitPaths ?? []).map((path) => toWorkspacePath(path, clone)),
+    paths: (paths ?? []).map((path) => toWorkspacePath(path, clone)),
     log: output.text,
     truncated: output.truncated,
   };
@@ -483,14 +481,13 @@ async function blameHistory(
     return { success: false as const, error: "blame requires a path." };
   }
 
-  const gitPath = toGitPath(path, clone);
   const query = input.query?.trim();
-  const lineRange = query ? await findLineRangeForQuery(ctx, gitPath, query) : null;
+  const lineRange = query ? await findLineRangeForQuery(ctx, path, query) : null;
   if (query && !lineRange) {
     return {
       success: true as const,
       mode: "blame" as const,
-      path: toWorkspacePath(gitPath, clone),
+      path: toWorkspacePath(path, clone),
       query,
       entries: [],
       truncated: false,
@@ -502,7 +499,7 @@ async function blameHistory(
   if (lineRange) {
     args.push(`-L${lineRange.start},${lineRange.end}`);
   }
-  args.push("--", gitPath);
+  args.push("--", path);
 
   const result = await ctx.bash.exec("git", { args });
   if (result.exitCode !== 0) {
@@ -517,7 +514,7 @@ async function blameHistory(
   return {
     success: true as const,
     mode: "blame" as const,
-    path: toWorkspacePath(gitPath, clone),
+    path: toWorkspacePath(path, clone),
     query,
     entries,
     truncated: entries.length < allEntries.length,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.test.ts
@@ -112,4 +112,70 @@ describe("createBashTool", () => {
     const result = await tool.execute!({ command: "hl check --fix" }, toolCallInfo);
     expect(result).toMatchObject({ success: false });
   });
+
+  it("treats git diff exit 1 as success and returns the patch", async () => {
+    const patch =
+      'diff --git a/src/locales/en/messages.json b/src/locales/en/messages.json\n+  "save": "Save"\n';
+    const tool = createBashTool({
+      bash: {
+        exec: async (bin, options) => {
+          expect(bin).toBe("git");
+          expect(options?.args).toEqual(["diff", "HEAD^", "HEAD"]);
+          return { stdout: patch, stderr: "", exitCode: 1, env: {} };
+        },
+        readFile: async () => "",
+      },
+    });
+
+    const result = await tool.execute!({ command: "git diff HEAD^ HEAD" }, toolCallInfo);
+
+    expect(result).toMatchObject({
+      success: true,
+      exitCode: 1,
+      stdout: patch,
+    });
+  });
+
+  it("treats git diff exit 1 as success after injecting -C", async () => {
+    const patch = "diff --git a/messages.json b/messages.json\n";
+    const tool = createBashTool({
+      bash: {
+        exec: async (bin, options) => {
+          expect(bin).toBe("git");
+          expect(options?.args).toEqual(["-C", "scribe-fe-v2", "diff", "HEAD^", "HEAD"]);
+          return { stdout: patch, stderr: "", exitCode: 1, env: {} };
+        },
+        readFile: async () => "",
+      },
+    });
+
+    const result = await tool.execute!(
+      { command: "git diff HEAD^ HEAD", cwd: "scribe-fe-v2" },
+      toolCallInfo,
+    );
+
+    expect(result).toMatchObject({ success: true, exitCode: 1, stdout: patch });
+  });
+
+  it("fails git diff on exit codes of 2 or higher", async () => {
+    const tool = createBashTool({
+      bash: {
+        exec: async () => ({
+          stdout: "usage: git diff [<options>]",
+          stderr: "",
+          exitCode: 129,
+          env: {},
+        }),
+        readFile: async () => "",
+      },
+    });
+
+    const result = await tool.execute!({ command: "git diff HEAD^ HEAD" }, toolCallInfo);
+
+    expect(result).toMatchObject({
+      success: false,
+      exitCode: 129,
+      stdout: "usage: git diff [<options>]",
+    });
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.ts
@@ -16,6 +16,7 @@ import { z } from "zod";
 import { flagBasename, HL_WRITE_FLAG_NAMES } from "@/lib/agent-runtime/tools/hl-write-flags";
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 
+import { isSuccessfulAllowlistedExit } from "./git-exit";
 import { normalizeWorkspacePath } from "./path";
 import { DEFAULT_MAX_OUTPUT_BYTES, redact, truncate } from "./redact";
 import type { RepoToolContext } from "./types";
@@ -173,7 +174,11 @@ IMPORTANT:
         const stderr = truncate(redact(result.stderr), DEFAULT_MAX_OUTPUT_BYTES);
 
         return {
-          success: result.exitCode === 0,
+          success: isSuccessfulAllowlistedExit({
+            bin,
+            args: execArgs,
+            exitCode: result.exitCode,
+          }),
           exitCode: result.exitCode,
           stdout: stdout.text,
           stderr: stderr.text,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/git-clone-root.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/git-clone-root.test.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveGitCloneRoot, toGitPath, toWorkspacePath, withGitRootArgs } from "./git-clone-root";
+import type { RepoToolContext } from "./types";
+
+const nested = { gitRoot: "scribe-fe-v2", repoDirName: "scribe-fe-v2" };
+const cwdClone = { gitRoot: ".", repoDirName: "scribe-fe-v2" };
+
+function createExecContext(exec: RepoToolContext["bash"]["exec"]): RepoToolContext {
+  return {
+    bash: {
+      exec,
+      readFile: async () => "",
+    },
+  };
+}
+
+describe("git-clone-root path helpers", () => {
+  it("injects -C before git args when the clone is nested", () => {
+    expect(withGitRootArgs("scribe-fe-v2", ["log", "-1"])).toEqual([
+      "-C",
+      "scribe-fe-v2",
+      "log",
+      "-1",
+    ]);
+    expect(withGitRootArgs(".", ["log", "-1"])).toEqual(["log", "-1"]);
+  });
+
+  it("strips a repo-name or clone-root prefix from paths", () => {
+    expect(toGitPath("scribe-fe-v2/src/locales/en/messages.json", nested)).toBe(
+      "src/locales/en/messages.json",
+    );
+    expect(toGitPath("scribe-fe-v2/src/locales/en/messages.json", cwdClone)).toBe(
+      "src/locales/en/messages.json",
+    );
+    expect(toGitPath("src/locales/en/messages.json", nested)).toBe("src/locales/en/messages.json");
+  });
+
+  it("maps git paths back to workspace-relative paths", () => {
+    expect(toWorkspacePath("src/locales/en/common.json", nested)).toBe(
+      "scribe-fe-v2/src/locales/en/common.json",
+    );
+    expect(toWorkspacePath("src/locales/en/common.json", cwdClone)).toBe(
+      "src/locales/en/common.json",
+    );
+  });
+});
+
+describe("resolveGitCloneRoot", () => {
+  it("uses the sandbox cwd when it is already a git work tree", async () => {
+    const ctx = createExecContext(async (command, options) => {
+      const args = options?.args ?? [];
+      if (command === "git" && args[0] === "rev-parse" && args[1] === "--is-inside-work-tree") {
+        return { stdout: "true\n", stderr: "", exitCode: 0, env: {} };
+      }
+      if (command === "git" && args[0] === "rev-parse" && args[1] === "--show-toplevel") {
+        return {
+          stdout: "/home/user/project/scribe-fe-v2\n",
+          stderr: "",
+          exitCode: 0,
+          env: {},
+        };
+      }
+      return { stdout: "", stderr: "", exitCode: 1, env: {} };
+    });
+
+    await expect(resolveGitCloneRoot(ctx)).resolves.toEqual({
+      gitRoot: ".",
+      repoDirName: "scribe-fe-v2",
+    });
+  });
+
+  it("selects a nested clone when exactly one git directory exists", async () => {
+    const ctx = createExecContext(async (command, options) => {
+      const args = options?.args ?? [];
+      if (command === "git" && args[0] === "rev-parse") {
+        return { stdout: "", stderr: "fatal: not a git repository", exitCode: 128, env: {} };
+      }
+      if (command === "ls") {
+        return { stdout: "scribe-fe-v2\nREADME.md\n", stderr: "", exitCode: 0, env: {} };
+      }
+      if (command === "test" && args[0] === "-d" && args[1] === "scribe-fe-v2") {
+        return { stdout: "", stderr: "", exitCode: 0, env: {} };
+      }
+      if (
+        command === "git" &&
+        args[0] === "-C" &&
+        args[1] === "scribe-fe-v2" &&
+        args[2] === "rev-parse"
+      ) {
+        return { stdout: "true\n", stderr: "", exitCode: 0, env: {} };
+      }
+      return { stdout: "", stderr: "", exitCode: 1, env: {} };
+    });
+
+    await expect(resolveGitCloneRoot(ctx)).resolves.toEqual({
+      gitRoot: "scribe-fe-v2",
+      repoDirName: "scribe-fe-v2",
+    });
+  });
+
+  it("falls back to cwd when more than one nested git directory exists", async () => {
+    const ctx = createExecContext(async (command, options) => {
+      const args = options?.args ?? [];
+      if (command === "git" && args[0] === "rev-parse") {
+        return { stdout: "", stderr: "fatal: not a git repository", exitCode: 128, env: {} };
+      }
+      if (command === "ls") {
+        return { stdout: "repo-a\nrepo-b\n", stderr: "", exitCode: 0, env: {} };
+      }
+      if (command === "test") {
+        return { stdout: "", stderr: "", exitCode: 0, env: {} };
+      }
+      if (command === "git" && args[0] === "-C") {
+        return { stdout: "true\n", stderr: "", exitCode: 0, env: {} };
+      }
+      return { stdout: "", stderr: "", exitCode: 1, env: {} };
+    });
+
+    await expect(resolveGitCloneRoot(ctx)).resolves.toEqual({
+      gitRoot: ".",
+      repoDirName: null,
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/git-clone-root.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/git-clone-root.test.ts
@@ -46,6 +46,9 @@ describe("git-clone-root path helpers", () => {
       "src/locales/en/messages.json",
     );
     expect(toGitPath("src/locales/en/messages.json", nested)).toBe("src/locales/en/messages.json");
+    expect(toGitPath("scribe-fe-v2/scribe-fe-v2/locales/en.json", nested)).toBe(
+      "scribe-fe-v2/locales/en.json",
+    );
   });
 
   it("maps git paths back to workspace-relative paths", () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/git-clone-root.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/git-clone-root.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { normalizeWorkspacePath } from "./path";
+import type { RepoToolContext } from "./types";
+
+export type GitCloneRoot = {
+  /** Directory to pass to `git -C`. `.` means the sandbox cwd is already the clone. */
+  gitRoot: string;
+  /** Last path segment of the clone, used to strip `repo/src/...` prefixes. */
+  repoDirName: string | null;
+};
+
+function basenamePath(path: string): string | null {
+  const trimmed = path.replace(/\\/g, "/").replace(/\/+$/, "").trim();
+  if (!trimmed) {
+    return null;
+  }
+  const parts = trimmed.split("/").filter(Boolean);
+  return parts.at(-1) ?? null;
+}
+
+export function withGitRootArgs(gitRoot: string, args: string[]): string[] {
+  if (!gitRoot || gitRoot === "." || args[0] === "-C") {
+    return args;
+  }
+  return ["-C", gitRoot, ...args];
+}
+
+/**
+ * Convert a workspace path that may be prefixed with the clone directory name
+ * into a git-root-relative path.
+ */
+export function toGitPath(path: string, clone: GitCloneRoot): string {
+  const prefixes = new Set(
+    [clone.gitRoot, clone.repoDirName].filter(
+      (value): value is string => Boolean(value) && value !== ".",
+    ),
+  );
+  let current = path;
+  for (const prefix of prefixes) {
+    if (current === prefix) {
+      current = ".";
+      continue;
+    }
+    if (current.startsWith(`${prefix}/`)) {
+      current = current.slice(prefix.length + 1);
+    }
+  }
+  return current;
+}
+
+export function toWorkspacePath(gitPath: string, clone: GitCloneRoot): string {
+  if (!clone.gitRoot || clone.gitRoot === "." || gitPath === clone.gitRoot) {
+    return gitPath;
+  }
+  if (gitPath === ".") {
+    return clone.gitRoot;
+  }
+  return `${clone.gitRoot}/${gitPath}`;
+}
+
+export async function resolveGitCloneRoot(ctx: RepoToolContext): Promise<GitCloneRoot> {
+  const atCwd = await ctx.bash.exec("git", {
+    args: ["rev-parse", "--is-inside-work-tree"],
+  });
+  if (atCwd.exitCode === 0) {
+    const toplevel = await ctx.bash.exec("git", { args: ["rev-parse", "--show-toplevel"] });
+    const repoDirName =
+      toplevel.exitCode === 0 ? basenamePath(toplevel.stdout.split("\n")[0] ?? "") : null;
+    return { gitRoot: ".", repoDirName };
+  }
+
+  const listed = await ctx.bash.exec("ls", { args: ["-1"] });
+  if (listed.exitCode !== 0) {
+    return { gitRoot: ".", repoDirName: null };
+  }
+
+  const gitRoots: string[] = [];
+  for (const rawName of listed.stdout.split("\n")) {
+    const candidate = normalizeWorkspacePath(rawName.replace(/\/+$/, ""));
+    if (!candidate || candidate.includes("/")) {
+      continue;
+    }
+
+    const isDir = await ctx.bash.exec("test", { args: ["-d", candidate] });
+    if (isDir.exitCode !== 0) {
+      continue;
+    }
+
+    const probe = await ctx.bash.exec("git", {
+      args: ["-C", candidate, "rev-parse", "--is-inside-work-tree"],
+    });
+    if (probe.exitCode === 0) {
+      gitRoots.push(candidate);
+    }
+  }
+
+  if (gitRoots.length === 1) {
+    const gitRoot = gitRoots[0]!;
+    return { gitRoot, repoDirName: gitRoot };
+  }
+
+  return { gitRoot: ".", repoDirName: null };
+}
+
+export function bindGitClone(ctx: RepoToolContext, clone: GitCloneRoot): RepoToolContext {
+  const rewriteFsPath = (path: string) => toWorkspacePath(toGitPath(path, clone), clone);
+
+  return {
+    bash: {
+      exec: async (command, options) => {
+        if (command === "git") {
+          return ctx.bash.exec("git", {
+            ...options,
+            args: withGitRootArgs(clone.gitRoot, options?.args ?? []),
+          });
+        }
+        if (command === "yq") {
+          const args = [...(options?.args ?? [])];
+          const last = args.at(-1);
+          if (last && !last.startsWith("-")) {
+            args[args.length - 1] = rewriteFsPath(last);
+          }
+          return ctx.bash.exec("yq", { ...options, args });
+        }
+        return ctx.bash.exec(command, options);
+      },
+      readFile: async (path) => ctx.bash.readFile(rewriteFsPath(path)),
+      writeWorkspaceFile: ctx.bash.writeWorkspaceFile
+        ? (path, content) => ctx.bash.writeWorkspaceFile!(rewriteFsPath(path), content)
+        : undefined,
+    },
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/git-exit.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/git-exit.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { gitSubcommand, isGitDiffCommand, isSuccessfulAllowlistedExit } from "./git-exit";
+
+describe("git-exit", () => {
+  it("finds the subcommand after git -C flags", () => {
+    expect(gitSubcommand(["-C", "scribe-fe-v2", "diff", "HEAD^", "HEAD"])).toBe("diff");
+    expect(gitSubcommand(["diff", "HEAD^", "HEAD"])).toBe("diff");
+    expect(gitSubcommand(["-C", "repo", "--no-pager", "log"])).toBe("log");
+  });
+
+  it("treats git diff exit 0 and 1 as success", () => {
+    expect(
+      isSuccessfulAllowlistedExit({
+        bin: "git",
+        args: ["diff", "abc^..abc", "--", "file.json"],
+        exitCode: 0,
+      }),
+    ).toBe(true);
+    expect(
+      isSuccessfulAllowlistedExit({
+        bin: "git",
+        args: ["-C", "scribe-fe-v2", "diff", "abc^..abc"],
+        exitCode: 1,
+      }),
+    ).toBe(true);
+    expect(
+      isSuccessfulAllowlistedExit({
+        bin: "git",
+        args: ["diff", "abc^..abc"],
+        exitCode: 2,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not treat other git commands' exit 1 as success", () => {
+    expect(
+      isSuccessfulAllowlistedExit({
+        bin: "git",
+        args: ["log", "--oneline"],
+        exitCode: 1,
+      }),
+    ).toBe(false);
+    expect(isGitDiffCommand(["status"])).toBe(false);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/git-exit.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/git-exit.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+/**
+ * Git porcelain `diff` uses exit 1 to mean "differences found". That is success
+ * for a read-only reviewer that needs the patch.
+ */
+export function gitSubcommand(args: string[]): string | undefined {
+  for (let i = 0; i < args.length; i += 1) {
+    const token = args[i];
+    if (!token) {
+      continue;
+    }
+    if (token === "-C") {
+      i += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      continue;
+    }
+    return token;
+  }
+  return undefined;
+}
+
+export function isGitDiffCommand(args: string[]): boolean {
+  return gitSubcommand(args) === "diff";
+}
+
+export function isSuccessfulAllowlistedExit(input: {
+  bin: string;
+  args: string[];
+  exitCode: number;
+}): boolean {
+  if (input.exitCode === 0) {
+    return true;
+  }
+  return input.bin === "git" && isGitDiffCommand(input.args) && input.exitCode === 1;
+}

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/index.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/index.ts
@@ -19,15 +19,6 @@ export { createGrepTool } from "./grep";
 export { createFuzzySearchTool } from "./fuzzy-search";
 export { createGlobTool } from "./glob";
 export { createBashTool, isAllowedBashCommand } from "./bash";
-export { isGitDiffCommand, isSuccessfulAllowlistedExit, gitSubcommand } from "./git-exit";
-export {
-  bindGitClone,
-  resolveGitCloneRoot,
-  toGitPath,
-  toWorkspacePath,
-  withGitRootArgs,
-  type GitCloneRoot,
-} from "./git-clone-root";
 export { createWriteTool } from "./write";
 export { createApplyPatchTool } from "./apply-patch";
 export { createCaptureScreenshotTool } from "./capture-screenshot";

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/index.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/index.ts
@@ -19,6 +19,15 @@ export { createGrepTool } from "./grep";
 export { createFuzzySearchTool } from "./fuzzy-search";
 export { createGlobTool } from "./glob";
 export { createBashTool, isAllowedBashCommand } from "./bash";
+export { isGitDiffCommand, isSuccessfulAllowlistedExit, gitSubcommand } from "./git-exit";
+export {
+  bindGitClone,
+  resolveGitCloneRoot,
+  toGitPath,
+  toWorkspacePath,
+  withGitRootArgs,
+  type GitCloneRoot,
+} from "./git-clone-root";
 export { createWriteTool } from "./write";
 export { createApplyPatchTool } from "./apply-patch";
 export { createCaptureScreenshotTool } from "./capture-screenshot";

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.test.ts
@@ -156,6 +156,8 @@ describe("workspace automation templates", () => {
     expect(template?.instructions).toContain("You are a localisation-focused code reviewer");
     expect(template?.instructions).toContain("Review focus:");
     expect(template?.instructions).toContain("locale-compliance");
+    expect(template?.instructions).toContain("key/value changelog");
+    expect(template?.instructions).toContain("changedFiles");
     expect(getWorkspaceAutomationTemplateFlow(template!)).toEqual({
       trigger: { id: "scheduled", label: "Daily" },
       tools: [

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
@@ -209,6 +209,7 @@ export const WORKSPACE_AUTOMATION_TEMPLATES_BASE: WorkspaceAutomationTemplate[] 
       role: "a localisation-focused code reviewer for this repository",
       capabilities: [
         "Read recent commits, diffs, and surrounding code in the lookback window",
+        "Extract changed translation keys and review old vs new values in locale catalogs",
         "Judge localisation, translation, and locale-compliance risk in the changed code",
         "Cite commit SHAs and file paths for each finding",
         "Separate blocking localisation defects from non-blocking follow-ups",
@@ -217,12 +218,29 @@ export const WORKSPACE_AUTOMATION_TEMPLATES_BASE: WorkspaceAutomationTemplate[] 
       goal: "Surface localisation and translation risks from the last day so the team can act before they ship further.",
       extraSections: [
         {
+          heading: "Review procedure",
+          items: [
+            "Follow gitHistory changedFiles → fileDiff → extract keys. Prefer gitHistory over raw git",
+            "Collect added and updated keys from catalog diffs with old → new values",
+            "Also review localisation logic changes: i18n APIs, locale routing, fallback, formatters, and writeback",
+          ],
+        },
+        {
           heading: "Review focus",
           items: [
             "Hard-coded copy, missing keys, and source strings that cannot be translated",
             "Broken ICU, placeholders, plurals, and locale-sensitive formatting",
             "Translation coverage, fallback, and writeback regressions",
             "Localisation compliance: locale, RTL, legal, and market-language constraints",
+            "Changed catalog values that look wrong, truncated, or inconsistent with nearby keys",
+          ],
+        },
+        {
+          heading: "Slack report",
+          items: [
+            "If locale catalogs or source strings changed, lead with a key/value changelog, then defects",
+            "Do not post no localisation findings when translation JSON/YAML files changed",
+            "If catalogs changed and there are no defects, include the changelog and then No blocking localisation defects",
           ],
         },
       ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Review code daily was posting “no findings” even when translation JSON changed. Three tool/prompt bugs caused that:

- `fileDiff` and the bash tool treated `git diff` exit 1 as failure (exit 1 means “differences found”). The sandbox adapter also puts combined output in stdout, so the agent often only saw “Failed to read git diff.”
- `gitHistory` ran git from the sandbox cwd and passed paths prefixed with the clone directory name (`scribe-fe-v2/src/...`), which made `git log` exit 128.
- The GitHub repo agent started with `repoGitState` / raw `git log`, and Review code daily treated “no defects I could prove” as “nothing changed.” Slack copy did not require a key/value changelog.

This change:

- Treats `git diff` exit 0 and 1 as success in `fileDiff` and bash; only exit ≥2 fails. Exit 1 still returns the patch.
- Detects a nested clone, runs git with `-C`, and strips a repo-name path prefix once in `executeGitHistory`.
- Imports git helpers from `git-exit.ts` / `git-clone-root.ts` rather than `workspace/index.ts`.
- Shares a `recent-source-changes` procedure (`changedFiles` → `fileDiff` → extract keys, plus localisation logic) with `github-repo-agent` and Review code daily.
- Makes Slack lead with a key/value changelog when catalogs change. “No localisation findings” means no proven defects, not “no translation JSON changed.”

## How to test

From `apps/hyperlocalise-web`:

```
vp test src/lib/agent-runtime/tools/workspace/git-exit.test.ts src/lib/agent-runtime/tools/workspace/git-clone-root.test.ts src/lib/agent-runtime/tools/workspace/bash.test.ts src/lib/agent-runtime/tools/repo-read-tools.test.ts
vp test
vp check --fix
```

Covered cases: `git diff` exit 1 returns the patch; nested clone `git -C` plus a single prefix strip (including `repo/repo/...` paths); github-repo-agent instructions include the shared procedure.

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2a3f0c8-dadb-47aa-8e52-7de052462bcf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2a3f0c8-dadb-47aa-8e52-7de052462bcf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

