### PR TITLE
fix(automations): stop showing Connect first after Crowdin is linked

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-editor.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-editor.fixture.ts
@@ -21,7 +21,7 @@ import type { WorkspaceAutomationRunRecord } from "@/lib/agents/workspace-automa
 
 import { createAutomationSummary } from "./automations.fixture";
 
-export const automationEditorProjectsFixture = [
+export const automationEditorNativeProjectsFixture = [
   {
     id: "project_website",
     name: "Website",
@@ -36,6 +36,9 @@ export const automationEditorProjectsFixture = [
     sourceLocale: "en-US",
     targetLocales: ["es-ES", "pt-BR"],
   },
+];
+
+export const automationEditorCrowdinProjectsFixture = [
   {
     id: "ext:crowdin:42",
     name: "Marketing Crowdin",
@@ -44,6 +47,11 @@ export const automationEditorProjectsFixture = [
     sourceLocale: "en",
     targetLocales: ["de", "fr"],
   },
+];
+
+export const automationEditorProjectsFixture = [
+  ...automationEditorNativeProjectsFixture,
+  ...automationEditorCrowdinProjectsFixture,
 ];
 
 export const automationEditorRepositoriesFixture = [

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-msw-handlers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-msw-handlers.ts
@@ -14,14 +14,28 @@ import { http, HttpResponse } from "msw";
 
 import {
   automationEditorContentfulConnectionsFixture,
-  automationEditorProjectsFixture,
+  automationEditorCrowdinProjectsFixture,
+  automationEditorNativeProjectsFixture,
   automationEditorRepositoriesFixture,
   automationEditorSlackChannelsFixture,
 } from "./automation-editor.fixture";
 
 export const automationEditorMswHandlers = [
   http.get("/api/orgs/:organizationSlug/projects", () =>
-    HttpResponse.json({ projects: automationEditorProjectsFixture }),
+    HttpResponse.json({ projects: automationEditorNativeProjectsFixture }),
+  ),
+  http.get("/api/orgs/:organizationSlug/tms-provider/connection", () =>
+    HttpResponse.json({
+      connection: {
+        providerKind: "crowdin",
+        displayName: "Crowdin",
+        validationStatus: "valid",
+        validationMessage: null,
+      },
+    }),
+  ),
+  http.get("/api/orgs/:organizationSlug/tms-provider/projects", () =>
+    HttpResponse.json({ projects: automationEditorCrowdinProjectsFixture }),
   ),
   http.get("/api/orgs/:organizationSlug/github-installation", () =>
     HttpResponse.json({
@@ -79,7 +93,13 @@ export const automationEditorMswHandlers = [
 
 export const automationEditorDisconnectedMswHandlers = [
   http.get("/api/orgs/:organizationSlug/projects", () =>
-    HttpResponse.json({ projects: automationEditorProjectsFixture }),
+    HttpResponse.json({ projects: automationEditorNativeProjectsFixture }),
+  ),
+  http.get("/api/orgs/:organizationSlug/tms-provider/connection", () =>
+    HttpResponse.json({ error: "no_active_tms_provider" }, { status: 404 }),
+  ),
+  http.get("/api/orgs/:organizationSlug/tms-provider/projects", () =>
+    HttpResponse.json({ projects: [] }),
   ),
   http.get("/api/orgs/:organizationSlug/github-installation", () =>
     HttpResponse.json({ installation: null }),

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-crowdin.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-crowdin.test.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  collectCrowdinProjects,
+  isCrowdinAutomationConnected,
+  isCrowdinLinkedProject,
+} from "./workspace-automation-crowdin";
+
+describe("workspace automation Crowdin connection", () => {
+  it("treats Crowdin as connected from the active TMS provider, not native projects", () => {
+    expect(isCrowdinAutomationConnected("crowdin")).toBe(true);
+    expect(isCrowdinAutomationConnected("phrase")).toBe(false);
+    expect(isCrowdinAutomationConnected(null)).toBe(false);
+    expect(isCrowdinAutomationConnected(undefined)).toBe(false);
+  });
+
+  it("recognizes Crowdin-linked projects by provider kind or encoded id", () => {
+    expect(
+      isCrowdinLinkedProject({
+        id: "project_website",
+        externalProviderKind: "crowdin",
+      }),
+    ).toBe(true);
+    expect(
+      isCrowdinLinkedProject({
+        id: "ext:crowdin:42",
+        externalProviderKind: null,
+      }),
+    ).toBe(true);
+    expect(
+      isCrowdinLinkedProject({
+        id: "project_website",
+        externalProviderKind: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("collects Crowdin projects from live TMS results when native lists omit them", () => {
+    expect(
+      collectCrowdinProjects(
+        [{ id: "project_website", externalProviderKind: null }],
+        [
+          {
+            id: "ext:crowdin:42",
+            externalProviderKind: "crowdin",
+          },
+        ],
+      ),
+    ).toEqual([
+      {
+        id: "ext:crowdin:42",
+        externalProviderKind: "crowdin",
+      },
+    ]);
+  });
+
+  it("dedupes native and live Crowdin projects by id", () => {
+    expect(
+      collectCrowdinProjects(
+        [{ id: "ext:crowdin:42", externalProviderKind: "crowdin" }],
+        [{ id: "ext:crowdin:42", externalProviderKind: "crowdin" }],
+      ),
+    ).toEqual([{ id: "ext:crowdin:42", externalProviderKind: "crowdin" }]);
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-crowdin.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-crowdin.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
+
+export type CrowdinProjectRef = {
+  id: string;
+  externalProviderKind?: string | null;
+};
+
+export function isCrowdinAutomationConnected(
+  activeProviderKind: string | null | undefined,
+): boolean {
+  return activeProviderKind === "crowdin";
+}
+
+export function isCrowdinLinkedProject(project: CrowdinProjectRef) {
+  if (project.externalProviderKind === "crowdin") {
+    return true;
+  }
+  return parseProviderProjectId(project.id)?.providerKind === "crowdin";
+}
+
+export function collectCrowdinProjects<T extends CrowdinProjectRef>(
+  nativeProjects: T[],
+  liveProjects: T[],
+): T[] {
+  const byId = new Map<string, T>();
+  for (const project of [...nativeProjects, ...liveProjects]) {
+    if (!isCrowdinLinkedProject(project)) {
+      continue;
+    }
+    byId.set(project.id, project);
+  }
+  return [...byId.values()];
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-editor.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-editor.stories.tsx
@@ -12,7 +12,7 @@
  */
 import { useState, type ReactNode } from "react";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { expect, fn } from "storybook/test";
+import { expect, fn, within } from "storybook/test";
 
 import { Button } from "@/components/ui/button";
 import type { WorkspaceAutomationFormState } from "@/lib/agents/workspace-automation-view-model";
@@ -26,7 +26,10 @@ import {
   createGithubAutomationFormFixture,
   createMemoriesAutomationFormFixture,
 } from "./automation-editor.fixture";
-import { automationEditorMswHandlers } from "./automation-msw-handlers";
+import {
+  automationEditorDisconnectedMswHandlers,
+  automationEditorMswHandlers,
+} from "./automation-msw-handlers";
 import { WorkspaceAutomationEditor } from "./workspace-automation-form";
 
 function WorkspaceAutomationEditorStory({
@@ -112,6 +115,40 @@ export const CreateEmpty: Story = {
     await expect(
       canvas.getByText("Add at least one supported tool to activate this automation."),
     ).toBeInTheDocument();
+  },
+};
+
+export const CreateCrowdinToolConnected: Story = {
+  play: async ({ canvas, canvasElement, userEvent }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(canvas.getByRole("button", { name: "Add tool" }));
+    const crowdinItem = await body.findByRole("menuitem", { name: /^Crowdin$/ });
+    await expect(crowdinItem).toBeEnabled();
+    await userEvent.click(crowdinItem);
+    await expect(
+      canvas.getByText(
+        "Search concordance, load style guidance, and recommend translations for strings under review.",
+      ),
+    ).toBeInTheDocument();
+    await userEvent.click(canvas.getByRole("combobox"));
+    await expect(
+      await body.findByRole("option", { name: "Marketing Crowdin" }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const CreateCrowdinToolDisconnected: Story = {
+  parameters: {
+    msw: {
+      handlers: automationEditorDisconnectedMswHandlers,
+    },
+  },
+  play: async ({ canvas, canvasElement, userEvent }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(canvas.getByRole("button", { name: "Add tool" }));
+    const crowdinItem = await body.findByRole("menuitem", { name: /Crowdin Connect first/i });
+    await expect(crowdinItem).toHaveAttribute("data-disabled");
+    await expect(crowdinItem).toHaveTextContent("Connect first");
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -460,13 +460,13 @@ export const workspaceAutomationFormMessages = defineMessages({
   crowdinDescription: {
     defaultMessage:
       "Search concordance, load style guidance, and recommend translations for strings under review.",
-    id: "a44831XqpD",
-    description: "Description for the Crowdin automation tool when a linked project exists",
+    id: "0udJ5Zg8a7",
+    description: "Description for the Crowdin automation tool when Crowdin is connected",
   },
   crowdinDisconnectedDescription: {
-    defaultMessage: "Connect Crowdin and sync a project before using this review tool.",
-    id: "FZh9zX9beA",
-    description: "Description when no Crowdin-linked project is available",
+    defaultMessage: "Connect Crowdin in <link>Integrations</link> to use this tool.",
+    id: "Ka+KmK/Z9+",
+    description: "Description when Crowdin is not connected",
   },
   removeCrowdinTool: {
     defaultMessage: "Remove Crowdin tool",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -57,7 +57,7 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
-  DropdownMenuShortcut,
+  DropdownMenuHint,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
@@ -89,6 +89,12 @@ import {
   addBranchPattern,
 } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model";
 import { AUTOMATION_WEEKDAY_MESSAGE_BY_VALUE } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model.messages";
+import { useActiveTmsProvider } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/_hooks/use-active-tms-provider";
+import { useTmsLiveProjects } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/_hooks/use-tms-live-projects";
+import {
+  collectCrowdinProjects,
+  isCrowdinAutomationConnected,
+} from "@/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-crowdin";
 import { workspaceAutomationFormMessages } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages";
 import { getLocaleLabel } from "@/lib/i18n/locales";
 import type { WorkspaceAutomationFormState } from "@/lib/agents/workspace-automation-view-model";
@@ -97,8 +103,8 @@ import {
   workspaceAutomationFormCanActivate,
 } from "@/lib/agents/workspace-automation-view-model";
 import type { WorkspaceAutomationRunRecord } from "@/lib/agents/workspace-automations";
-import { parseProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 import { cn } from "@/lib/primitives/cn";
+import type { ApiProject } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/project-list";
 
 const api = createApiClient();
 
@@ -177,11 +183,15 @@ function AutomationToolMenuIcon({ icon }: { icon?: SimpleIcon }) {
   return <HugeiconsIcon icon={SearchIcon} className="size-4" />;
 }
 
-function isCrowdinLinkedProject(project: ProjectOption) {
-  if (project.externalProviderKind === "crowdin") {
-    return true;
-  }
-  return parseProviderProjectId(project.id)?.providerKind === "crowdin";
+function toCrowdinProjectOption(project: ApiProject): ProjectOption {
+  return {
+    id: project.id,
+    name: project.name,
+    source: project.source,
+    externalProviderKind: project.externalProviderKind,
+    sourceLocale: project.sourceLocale ?? null,
+    targetLocales: project.targetLocales ?? [],
+  };
 }
 
 function defaultCrowdinProjectId(
@@ -591,9 +601,9 @@ function HeaderProjectSelector({
               <HugeiconsIcon icon={FolderLibraryIcon} strokeWidth={1.8} className="size-4" />
               {project.name}
               {activeProjectId === project.id ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.selectedShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : null}
             </DropdownMenuItem>
           ))}
@@ -682,9 +692,9 @@ function BranchPatternSelector({
                   onClick={() => onChange(branches.filter((value) => value !== branch))}
                 >
                   <span className="min-w-0 flex-1 truncate">{branch}</span>
-                  <DropdownMenuShortcut>
+                  <DropdownMenuHint>
                     <FormattedMessage {...workspaceAutomationFormMessages.removeShortcut} />
-                  </DropdownMenuShortcut>
+                  </DropdownMenuHint>
                 </DropdownMenuItem>
               ))
             )}
@@ -777,9 +787,9 @@ function AddTriggerMenu({
               <HugeiconsIcon icon={Clock01Icon} className="size-4" />
               <FormattedMessage {...workspaceAutomationFormMessages.manualRun} />
               {form.triggerMode === "manual" ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -789,9 +799,9 @@ function AddTriggerMenu({
               <HugeiconsIcon icon={Clock01Icon} className="size-4" />
               <FormattedMessage {...workspaceAutomationFormMessages.scheduled} />
               {form.triggerMode === "scheduled" ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -821,13 +831,13 @@ function AddTriggerMenu({
               <HugeiconsIcon icon={GitBranchIcon} strokeWidth={1.8} className="size-4" />
               <FormattedMessage {...workspaceAutomationFormMessages.githubPush} />
               {form.triggerMode === "github" ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : !githubConnected ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -843,13 +853,13 @@ function AddTriggerMenu({
               <HugeiconsIcon icon={SearchIcon} className="size-4" />
               <FormattedMessage {...workspaceAutomationFormMessages.contentfulWebhook} />
               {form.triggerMode === "contentful" ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : !contentfulConnected ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -867,9 +877,9 @@ function AddTriggerMenu({
               <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} className="size-4" />
               <FormattedMessage {...workspaceAutomationFormMessages.sourceUpload} />
               {form.triggerMode === "source_upload" ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : null}
             </DropdownMenuItem>
           </DropdownMenuGroup>
@@ -1174,15 +1184,15 @@ function AddToolMenu({
               <HugeiconsIcon icon={BrainCircuitIcon} strokeWidth={1.8} className="size-4" />
               <FormattedMessage {...workspaceAutomationFormMessages.memories} />
               {form.knowledgeEnabled ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : !knowledgeAvailable ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage
                     {...workspaceAutomationFormMessages.enableKnowledgeFirstShortcut}
                   />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : null}
             </DropdownMenuItem>
           </DropdownMenuGroup>
@@ -1222,13 +1232,13 @@ function AddToolMenu({
                   <HugeiconsIcon icon={GitBranchIcon} strokeWidth={1.8} className="size-4" />
                   <FormattedMessage {...workspaceAutomationFormMessages.useGithubRepo} />
                   {form.githubEnabled && form.githubMode === "agent" ? (
-                    <DropdownMenuShortcut>
+                    <DropdownMenuHint>
                       <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                    </DropdownMenuShortcut>
+                    </DropdownMenuHint>
                   ) : !githubConnected ? (
-                    <DropdownMenuShortcut>
+                    <DropdownMenuHint>
                       <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
-                    </DropdownMenuShortcut>
+                    </DropdownMenuHint>
                   ) : null}
                 </DropdownMenuItem>
                 <DropdownMenuItem
@@ -1255,13 +1265,13 @@ function AddToolMenu({
                   <HugeiconsIcon icon={GitBranchIcon} strokeWidth={1.8} className="size-4" />
                   <FormattedMessage {...workspaceAutomationFormMessages.githubSyncWorkflows} />
                   {form.githubEnabled && form.githubMode === "sync" ? (
-                    <DropdownMenuShortcut>
+                    <DropdownMenuHint>
                       <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                    </DropdownMenuShortcut>
+                    </DropdownMenuHint>
                   ) : !githubConnected ? (
-                    <DropdownMenuShortcut>
+                    <DropdownMenuHint>
                       <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
-                    </DropdownMenuShortcut>
+                    </DropdownMenuHint>
                   ) : null}
                 </DropdownMenuItem>
                 <DropdownMenuItem
@@ -1283,13 +1293,13 @@ function AddToolMenu({
                   <HugeiconsIcon icon={Comment01Icon} strokeWidth={1.8} className="size-4" />
                   <FormattedMessage {...workspaceAutomationFormMessages.commentOnPullRequest} />
                   {form.githubCommentEnabled ? (
-                    <DropdownMenuShortcut>
+                    <DropdownMenuHint>
                       <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                    </DropdownMenuShortcut>
+                    </DropdownMenuHint>
                   ) : !githubConnected ? (
-                    <DropdownMenuShortcut>
+                    <DropdownMenuHint>
                       <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
-                    </DropdownMenuShortcut>
+                    </DropdownMenuHint>
                   ) : null}
                 </DropdownMenuItem>
               </DropdownMenuSubContent>
@@ -1301,13 +1311,13 @@ function AddToolMenu({
               <HugeiconsIcon icon={SlackIcon} strokeWidth={1.8} className="size-4" />
               <FormattedMessage {...workspaceAutomationFormMessages.sendToSlack} />
               {form.slackEnabled ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : !slackConnected ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -1317,13 +1327,13 @@ function AddToolMenu({
               <HugeiconsIcon icon={Mail01Icon} className="size-4" />
               <FormattedMessage {...workspaceAutomationFormMessages.sendEmail} />
               {form.emailEnabled ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : !emailConnected ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.enableFirstShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -1341,13 +1351,13 @@ function AddToolMenu({
               <HugeiconsIcon icon={SearchIcon} className="size-4" />
               <FormattedMessage {...workspaceAutomationFormMessages.contentfulTranslate} />
               {form.contentfulEnabled ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : !contentfulConnected ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -1363,13 +1373,13 @@ function AddToolMenu({
               <AutomationToolMenuIcon icon={siCrowdin} />
               <FormattedMessage {...workspaceAutomationFormMessages.crowdin} />
               {form.crowdinEnabled ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : !crowdinConnected ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuSub>
@@ -1395,9 +1405,9 @@ function AddToolMenu({
                   <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} className="size-4" />
                   <FormattedMessage {...workspaceAutomationFormMessages.createJob} />
                   {form.createNativeTmsJobEnabled ? (
-                    <DropdownMenuShortcut>
+                    <DropdownMenuHint>
                       <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                    </DropdownMenuShortcut>
+                    </DropdownMenuHint>
                   ) : null}
                 </DropdownMenuItem>
                 <DropdownMenuItem
@@ -1418,9 +1428,9 @@ function AddToolMenu({
                   <HugeiconsIcon icon={BrainCircuitIcon} strokeWidth={1.8} className="size-4" />
                   <FormattedMessage {...workspaceAutomationFormMessages.translateWithAgent} />
                   {form.assignTranslateWithAgentEnabled ? (
-                    <DropdownMenuShortcut>
+                    <DropdownMenuHint>
                       <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                    </DropdownMenuShortcut>
+                    </DropdownMenuHint>
                   ) : null}
                 </DropdownMenuItem>
               </DropdownMenuSubContent>
@@ -1440,9 +1450,9 @@ function AddToolMenu({
                   <HugeiconsIcon icon={Task01Icon} strokeWidth={1.8} className="size-4" />
                   <FormattedMessage {...workspaceAutomationFormMessages.listIssues} />
                   {form.listIssuesEnabled ? (
-                    <DropdownMenuShortcut>
+                    <DropdownMenuHint>
                       <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                    </DropdownMenuShortcut>
+                    </DropdownMenuHint>
                   ) : null}
                 </DropdownMenuItem>
                 <DropdownMenuItem
@@ -1452,9 +1462,9 @@ function AddToolMenu({
                   <HugeiconsIcon icon={Task01Icon} strokeWidth={1.8} className="size-4" />
                   <FormattedMessage {...workspaceAutomationFormMessages.createIssue} />
                   {form.createIssueEnabled ? (
-                    <DropdownMenuShortcut>
+                    <DropdownMenuHint>
                       <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                    </DropdownMenuShortcut>
+                    </DropdownMenuHint>
                   ) : null}
                 </DropdownMenuItem>
               </DropdownMenuSubContent>
@@ -1466,13 +1476,13 @@ function AddToolMenu({
               <HugeiconsIcon icon={FolderLibraryIcon} strokeWidth={1.8} className="size-4" />
               <FormattedMessage {...workspaceAutomationFormMessages.mcpServer} />
               {form.mcpEnabled ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : !mcpConnected ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -1482,13 +1492,13 @@ function AddToolMenu({
               <AutomationToolMenuIcon icon={siSemrush} />
               <FormattedMessage {...workspaceAutomationFormMessages.semrush} />
               {form.semrushEnabled ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : !semrushConnected ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -1498,13 +1508,13 @@ function AddToolMenu({
               <AutomationToolMenuIcon />
               <FormattedMessage {...workspaceAutomationFormMessages.ahrefs} />
               {form.ahrefsEnabled ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : !ahrefsConnected ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.connectFirstShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : null}
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -1514,9 +1524,9 @@ function AddToolMenu({
               <HugeiconsIcon icon={Globe02Icon} className="size-4" />
               <FormattedMessage {...workspaceAutomationFormMessages.webSearch} />
               {form.webSearchEnabled ? (
-                <DropdownMenuShortcut>
+                <DropdownMenuHint>
                   <FormattedMessage {...workspaceAutomationFormMessages.addedShortcut} />
-                </DropdownMenuShortcut>
+                </DropdownMenuHint>
               ) : null}
             </DropdownMenuItem>
           </DropdownMenuGroup>
@@ -1626,6 +1636,8 @@ function ContentfulTargetLocalesPicker({
 function ToolsSettings({
   canUpdateKnowledgeMemory,
   contentfulConnections,
+  crowdinConnected,
+  crowdinLiveProjects,
   disabled,
   emailConnected,
   errors,
@@ -1645,6 +1657,8 @@ function ToolsSettings({
 }: {
   canUpdateKnowledgeMemory: boolean;
   contentfulConnections: ContentfulConnectionOption[];
+  crowdinConnected: boolean;
+  crowdinLiveProjects: ProjectOption[];
   disabled?: boolean;
   emailConnected: boolean;
   errors: Record<string, string | undefined>;
@@ -1675,8 +1689,7 @@ function ToolsSettings({
     (connection) => connection.enabled && connection.validationStatus === "valid",
   );
   const ahrefsConnected = enabledAhrefsConnections.length > 0;
-  const crowdinProjects = projects.filter(isCrowdinLinkedProject);
-  const crowdinConnected = crowdinProjects.length > 0;
+  const crowdinProjects = collectCrowdinProjects(projects, crowdinLiveProjects);
   const contentfulTargetLocalesFieldId = "contentful-target-locales";
   const selectedProject = projects.find((project) => project.id === form.projectId);
   const contentfulAvailableTargetLocales = selectedProject?.targetLocales ?? [];
@@ -2220,11 +2233,31 @@ function ToolsSettings({
         {form.crowdinEnabled ? (
           <EditorRow
             icon={<AutomationToolMenuIcon icon={siCrowdin} />}
-            title={<FormattedMessage {...workspaceAutomationFormMessages.crowdin} />}
+            title={
+              <>
+                <span>
+                  <FormattedMessage {...workspaceAutomationFormMessages.crowdin} />
+                </span>
+                {!crowdinConnected ? (
+                  <Badge variant="secondary">
+                    <FormattedMessage {...workspaceAutomationFormMessages.connectFirstBadge} />
+                  </Badge>
+                ) : null}
+              </>
+            }
             description={
               crowdinConnected
                 ? intl.formatMessage(workspaceAutomationFormMessages.crowdinDescription)
-                : intl.formatMessage(workspaceAutomationFormMessages.crowdinDisconnectedDescription)
+                : intl.formatMessage(
+                    workspaceAutomationFormMessages.crowdinDisconnectedDescription,
+                    {
+                      link: (chunks) => (
+                        <Link href={`/org/${organizationSlug}/integrations`} className="underline">
+                          {chunks}
+                        </Link>
+                      ),
+                    },
+                  )
             }
             action={
               <DeleteToolButton
@@ -2830,6 +2863,11 @@ export function WorkspaceAutomationEditor({
   });
 
   const githubConnected = Boolean(githubInstallationQuery.data);
+  const tmsProviderQuery = useActiveTmsProvider(organizationSlug);
+  const crowdinConnected = isCrowdinAutomationConnected(tmsProviderQuery.data?.providerKind);
+  const tmsLiveProjectsQuery = useTmsLiveProjects(organizationSlug, {
+    enabled: crowdinConnected,
+  });
 
   const repositoriesQuery = useQuery({
     queryKey: ["github-installation-repositories", organizationSlug],
@@ -2960,6 +2998,7 @@ export function WorkspaceAutomationEditor({
   const mcpServerConnections = mcpServerConnectionsQuery.data ?? [];
   const semrushConnections = semrushConnectionsQuery.data ?? [];
   const ahrefsConnections = ahrefsConnectionsQuery.data ?? [];
+  const crowdinLiveProjects = (tmsLiveProjectsQuery.data ?? []).map(toCrowdinProjectOption);
   const hasHistory = mode === "detail";
 
   return (
@@ -3094,6 +3133,8 @@ export function WorkspaceAutomationEditor({
           <ToolsSettings
             canUpdateKnowledgeMemory={canUpdateKnowledgeMemory}
             contentfulConnections={contentfulConnections}
+            crowdinConnected={crowdinConnected}
+            crowdinLiveProjects={crowdinLiveProjects}
             disabled={disabled}
             emailConnected={emailConnected}
             errors={errors}

--- a/apps/hyperlocalise-web/src/components/ui/dropdown-menu.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/dropdown-menu.tsx
@@ -265,6 +265,19 @@ function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<"spa
   );
 }
 
+function DropdownMenuHint({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-hint"
+      className={cn(
+        "ms-auto text-xs text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
 export {
   ComingSoonBadge,
   DropdownMenu,
@@ -279,6 +292,7 @@ export {
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
+  DropdownMenuHint,
   DropdownMenuSub,
   DropdownMenuSubTrigger,
   DropdownMenuSubContent,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Crowdin in the automation tool menu showed **Connect first** after the org had already connected Crowdin.

The editor inferred Crowdin from `GET /orgs/:slug/projects`, which only returns native workspace projects. Crowdin projects live on the TMS provider APIs, so the menu always looked disconnected.

The editor now:

- Treats Crowdin as connected when the active TMS provider is Crowdin
- Loads the tool's project picker from live Crowdin projects
- Renders **Connect first** / **Added** as a status hint, not a keyboard shortcut (`tracking-widest`)

## How to test

1. Connect Crowdin in Integrations (no native Hyperlocalise project required).
2. Open Automations → new automation → **Add tool**.
3. Crowdin should be enabled, without **Connect first**.
4. Adding Crowdin should show live Crowdin projects in the picker.
5. Disconnect Crowdin and confirm **Connect first** still appears, with normal letter-spacing.

```
cd apps/hyperlocalise-web
vp check --fix
vp test src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-crowdin.test.ts
```

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, targeted `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4b62762-c15e-41ba-a22d-64fc8ce9353f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4b62762-c15e-41ba-a22d-64fc8ce9353f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

