### PR TITLE
fix(automations): raise workspace orchestrator step timeout to 10 minutes

### DIFF
--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/agent.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/agent.test.ts
@@ -33,7 +33,11 @@ vi.mock("@/lib/agent-runtime/loops/model", () => ({
   getHyperlocaliseAgentModel: vi.fn(() => "mock-model"),
 }));
 
-import { WORKSPACE_ORCHESTRATOR_STEP_LIMIT } from "@/lib/agent-runtime/subagents/constants";
+import {
+  WORKFLOW_AGENT_TIMEOUT,
+  WORKSPACE_ORCHESTRATOR_STEP_LIMIT,
+  WORKSPACE_ORCHESTRATOR_TIMEOUT,
+} from "@/lib/agent-runtime/subagents/constants";
 import type {
   WorkspaceAutomationRecord,
   WorkspaceAutomationRunRecord,
@@ -107,9 +111,12 @@ describe("workspace orchestrator agent", () => {
     // WORKSPACE_ORCHESTRATOR_STEP_LIMIT (6) is a floor, not a ceiling: a 2-tool plan still gets at
     // least that many steps even though plannedToolCount + 1 (3) is smaller.
     expect(isStepCountMock).toHaveBeenCalledWith(WORKSPACE_ORCHESTRATOR_STEP_LIMIT);
+    expect(WORKSPACE_ORCHESTRATOR_TIMEOUT.stepMs).toBe(WORKFLOW_AGENT_TIMEOUT.totalMs);
+    expect(WORKFLOW_AGENT_TIMEOUT.stepMs).toBe(WORKFLOW_AGENT_TIMEOUT.totalMs);
     expect(toolLoopAgentMock).toHaveBeenCalledWith(
       expect.objectContaining({
         activeTools: ["run_github_workflows", "notify_slack"],
+        timeout: WORKSPACE_ORCHESTRATOR_TIMEOUT,
         prepareStep: expect.any(Function),
       }),
     );

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/agent.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/agent.test.ts
@@ -112,7 +112,7 @@ describe("workspace orchestrator agent", () => {
     // least that many steps even though plannedToolCount + 1 (3) is smaller.
     expect(isStepCountMock).toHaveBeenCalledWith(WORKSPACE_ORCHESTRATOR_STEP_LIMIT);
     expect(WORKSPACE_ORCHESTRATOR_TIMEOUT.stepMs).toBe(WORKFLOW_AGENT_TIMEOUT.totalMs);
-    expect(WORKFLOW_AGENT_TIMEOUT.stepMs).toBe(WORKFLOW_AGENT_TIMEOUT.totalMs);
+    expect(WORKFLOW_AGENT_TIMEOUT.stepMs).toBeLessThan(WORKFLOW_AGENT_TIMEOUT.totalMs);
     expect(toolLoopAgentMock).toHaveBeenCalledWith(
       expect.objectContaining({
         activeTools: ["run_github_workflows", "notify_slack"],

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/agent.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/agent.test.ts
@@ -113,6 +113,9 @@ describe("workspace orchestrator agent", () => {
     expect(isStepCountMock).toHaveBeenCalledWith(WORKSPACE_ORCHESTRATOR_STEP_LIMIT);
     expect(WORKSPACE_ORCHESTRATOR_TIMEOUT.stepMs).toBe(WORKFLOW_AGENT_TIMEOUT.totalMs);
     expect(WORKFLOW_AGENT_TIMEOUT.stepMs).toBeLessThan(WORKFLOW_AGENT_TIMEOUT.totalMs);
+    expect(WORKSPACE_ORCHESTRATOR_TIMEOUT.stepMs).toBeLessThan(
+      WORKSPACE_ORCHESTRATOR_TIMEOUT.totalMs,
+    );
     expect(toolLoopAgentMock).toHaveBeenCalledWith(
       expect.objectContaining({
         activeTools: ["run_github_workflows", "notify_slack"],

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/constants.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/constants.ts
@@ -37,9 +37,11 @@ export const ORCHESTRATOR_AGENT_TIMEOUT = {
   stepMs: AGENT_STEP_TIMEOUT_MS,
 } as const;
 
+const WORKFLOW_AGENT_STEP_TIMEOUT_MS = 10 * 60 * 1000;
+
 export const WORKFLOW_AGENT_TIMEOUT = {
-  totalMs: 10 * 60 * 1000,
-  stepMs: 90 * 1000,
+  totalMs: WORKFLOW_AGENT_STEP_TIMEOUT_MS,
+  stepMs: WORKFLOW_AGENT_STEP_TIMEOUT_MS,
 } as const;
 
 /** Maximum tool steps for workspace automation orchestrator (workflows + notifications + summary). */
@@ -47,7 +49,10 @@ export const WORKSPACE_ORCHESTRATOR_STEP_LIMIT = 6;
 
 export const WORKSPACE_ORCHESTRATOR_TIMEOUT = {
   totalMs: 25 * 60 * 1000,
-  stepMs: 90 * 1000,
+  // One orchestrator step can be a nested GitHub/Semrush/Ahrefs agent. Those
+  // tools already budget 10 minutes, so the parent step has to match or it
+  // aborts them first.
+  stepMs: WORKFLOW_AGENT_STEP_TIMEOUT_MS,
 } as const;
 
 /** Poll interval while waiting for a GitHub repository automation job to finish. */

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/constants.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/constants.ts
@@ -42,8 +42,7 @@ const WORKFLOW_AGENT_STEP_TIMEOUT_MS = 5 * 60 * 1000;
 
 export const WORKFLOW_AGENT_TIMEOUT = {
   totalMs: WORKFLOW_AGENT_TOTAL_TIMEOUT_MS,
-  // Tighter than totalMs so a hung model/tool round aborts before the whole
-  // nested agent (GitHub, Semrush, Ahrefs, Crowdin) burns its 10-minute budget.
+  // Hung model/tool round aborts before the nested agent burns its whole budget.
   stepMs: WORKFLOW_AGENT_STEP_TIMEOUT_MS,
 } as const;
 
@@ -51,7 +50,8 @@ export const WORKFLOW_AGENT_TIMEOUT = {
 export const WORKSPACE_ORCHESTRATOR_STEP_LIMIT = 6;
 
 export const WORKSPACE_ORCHESTRATOR_TIMEOUT = {
-  totalMs: 25 * 60 * 1000,
+  // Two nested specialist runs (each up to totalMs) plus one parent model step.
+  totalMs: 2 * WORKFLOW_AGENT_TOTAL_TIMEOUT_MS + WORKFLOW_AGENT_STEP_TIMEOUT_MS,
   // One orchestrator step can be a nested agent. Match that agent's total
   // budget or the parent aborts it first.
   stepMs: WORKFLOW_AGENT_TOTAL_TIMEOUT_MS,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/constants.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/constants.ts
@@ -37,10 +37,13 @@ export const ORCHESTRATOR_AGENT_TIMEOUT = {
   stepMs: AGENT_STEP_TIMEOUT_MS,
 } as const;
 
-const WORKFLOW_AGENT_STEP_TIMEOUT_MS = 10 * 60 * 1000;
+const WORKFLOW_AGENT_TOTAL_TIMEOUT_MS = 10 * 60 * 1000;
+const WORKFLOW_AGENT_STEP_TIMEOUT_MS = 5 * 60 * 1000;
 
 export const WORKFLOW_AGENT_TIMEOUT = {
-  totalMs: WORKFLOW_AGENT_STEP_TIMEOUT_MS,
+  totalMs: WORKFLOW_AGENT_TOTAL_TIMEOUT_MS,
+  // Tighter than totalMs so a hung model/tool round aborts before the whole
+  // nested agent (GitHub, Semrush, Ahrefs, Crowdin) burns its 10-minute budget.
   stepMs: WORKFLOW_AGENT_STEP_TIMEOUT_MS,
 } as const;
 
@@ -49,10 +52,9 @@ export const WORKSPACE_ORCHESTRATOR_STEP_LIMIT = 6;
 
 export const WORKSPACE_ORCHESTRATOR_TIMEOUT = {
   totalMs: 25 * 60 * 1000,
-  // One orchestrator step can be a nested GitHub/Semrush/Ahrefs agent. Those
-  // tools already budget 10 minutes, so the parent step has to match or it
-  // aborts them first.
-  stepMs: WORKFLOW_AGENT_STEP_TIMEOUT_MS,
+  // One orchestrator step can be a nested agent. Match that agent's total
+  // budget or the parent aborts it first.
+  stepMs: WORKFLOW_AGENT_TOTAL_TIMEOUT_MS,
 } as const;
 
 /** Poll interval while waiting for a GitHub repository automation job to finish. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

`executeWorkspaceAutomationStep` runs the workspace automation orchestrator. That agent aborted each tool/model step after 90 seconds (`WORKSPACE_ORCHESTRATOR_TIMEOUT.stepMs`), even though nested GitHub, Semrush, and Ahrefs tools already budget 10 minutes (`WORKFLOW_AGENT_TIMEOUT.totalMs`).

Timeouts are now split so `stepMs` is always below `totalMs`:

- Nested workflow agents (GitHub, Semrush, Ahrefs, Crowdin): **5 minutes per step**, **10 minutes total**. A hung model/tool round aborts before it consumes the whole nested-agent budget.
- Workspace orchestrator: **10 minutes per step** (matches nested `totalMs`, so the parent does not abort a nested agent first), **25 minutes total** (two nested specialist runs plus one parent model step).

GitHub repository automation job polling still allows up to 20 minutes (`WORKSPACE_GITHUB_JOB_POLL_MAX_MS`). A poll longer than the 10-minute nested/orchestrator step budget can still time out.

## How to test

- `vp test src/agents/automations/workspace/agent/agent.test.ts src/workflows/steps/workspace-automation-execution.test.ts src/workflows/repository-agent.test.ts` — 19 passed
- `vp check --fix` — 0 errors

## Checklist

- [x] I ran relevant checks locally (`vp test` on the changed files, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83e15fe5-14ac-4c72-9891-5eeb5a3fa154?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83e15fe5-14ac-4c72-9891-5eeb5a3fa154&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

