### PR TITLE
fix(slack): find typed channels and search inside the picker

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.test.ts
@@ -19,6 +19,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { app } from "@/api/app";
 import { createProjectTestFixture } from "@/api/routes/project/project.fixture";
 import { verifySlackState } from "@/lib/agents/slack/oauth-state";
+import { clearSlackChannelListCache } from "@/lib/agents/slack/search-channels";
 import { db, schema } from "@/lib/database";
 import { env } from "@/lib/env";
 
@@ -141,6 +142,7 @@ describe("agentSlackRoutes", () => {
   afterEach(async () => {
     vi.resetAllMocks();
     vi.unstubAllGlobals();
+    clearSlackChannelListCache();
     await fixture.cleanup();
   });
 

--- a/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.ts
@@ -126,6 +126,7 @@ async function loadSlackChannelsForTeam(
 
   return searchSlackChannels({
     botToken: installationResult.value.botToken,
+    cacheKey: teamId,
     query: input.query,
     selectedChannelId: input.selectedChannelId,
     signal: input.signal,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/slack-channel-select.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/slack-channel-select.test.tsx
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import type { ReactElement } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IntlProvider } from "react-intl";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { SlackChannelSelect } from "./slack-channel-select";
+
+const apiMocks = vi.hoisted(() => ({
+  searchChannels: vi.fn(),
+}));
+
+vi.mock("@/lib/api-client", () => ({
+  createApiClient: () => ({
+    api: {
+      orgs: {
+        ":organizationSlug": {
+          "agent-slack": {
+            channels: { $get: apiMocks.searchChannels },
+          },
+        },
+      },
+    },
+  }),
+}));
+
+function jsonResponse(channels: Array<{ id: string; name: string; private: boolean }>) {
+  return {
+    status: 200,
+    json: async () => ({ channels }),
+  };
+}
+
+function renderSelect(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return render(
+    <IntlProvider locale="en" messages={{}}>
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </IntlProvider>,
+  );
+}
+
+describe("SlackChannelSelect", () => {
+  afterEach(() => {
+    apiMocks.searchChannels.mockReset();
+  });
+
+  it("filters the loaded channel list as the user types", async () => {
+    const user = userEvent.setup();
+    apiMocks.searchChannels.mockImplementation(async (input: { query?: { q?: string } }) => {
+      if (input.query?.q) {
+        return jsonResponse([]);
+      }
+
+      return jsonResponse([
+        { id: "slack:C1", name: "general", private: false },
+        { id: "slack:C2", name: "release-notes", private: false },
+      ]);
+    });
+
+    renderSelect(
+      <SlackChannelSelect organizationSlug="acme" slackConnected value="" onChange={vi.fn()} />,
+    );
+
+    await user.click(await screen.findByRole("button", { name: /select channel/i }));
+    expect(await screen.findByText("#general")).toBeInTheDocument();
+    expect(screen.getByText("#release-notes")).toBeInTheDocument();
+
+    await user.type(
+      screen.getByPlaceholderText("Search by name or paste a channel ID"),
+      "Release Notes",
+    );
+
+    expect(screen.queryByText("#general")).not.toBeInTheDocument();
+    expect(screen.getByText("#release-notes")).toBeInTheDocument();
+  });
+
+  it("merges a remote match that is not in the loaded list", async () => {
+    const user = userEvent.setup();
+    apiMocks.searchChannels.mockImplementation(async (input: { query?: { q?: string } }) => {
+      if (input.query?.q) {
+        return jsonResponse([{ id: "slack:C9", name: "release-notes-eu", private: false }]);
+      }
+      return jsonResponse([{ id: "slack:C1", name: "general", private: false }]);
+    });
+
+    renderSelect(
+      <SlackChannelSelect organizationSlug="acme" slackConnected value="" onChange={vi.fn()} />,
+    );
+
+    await user.click(await screen.findByRole("button", { name: /select channel/i }));
+    expect(await screen.findByText("#general")).toBeInTheDocument();
+
+    await user.type(
+      screen.getByPlaceholderText("Search by name or paste a channel ID"),
+      "release-notes-eu",
+    );
+
+    expect(await screen.findByText("#release-notes-eu")).toBeInTheDocument();
+    expect(screen.queryByText("#general")).not.toBeInTheDocument();
+  });
+
+  it("selects a filtered channel", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    apiMocks.searchChannels.mockResolvedValue(
+      jsonResponse([
+        { id: "slack:C1", name: "general", private: false },
+        { id: "slack:C2", name: "release-notes", private: false },
+      ]),
+    );
+
+    renderSelect(
+      <SlackChannelSelect organizationSlug="acme" slackConnected value="" onChange={onChange} />,
+    );
+
+    await user.click(await screen.findByRole("button", { name: /select channel/i }));
+    await user.type(screen.getByPlaceholderText("Search by name or paste a channel ID"), "rel");
+    await user.click(await screen.findByText("#release-notes"));
+
+    expect(onChange).toHaveBeenCalledWith("slack:C2");
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/slack-channel-select.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/slack-channel-select.tsx
@@ -30,12 +30,36 @@ import {
 } from "@/components/ui/command";
 import { Label } from "@/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  mergeVisibleSlackChannels,
+  type SlackChannelQueryTarget,
+} from "@/lib/agents/slack/channel-query";
 import { createApiClient } from "@/lib/api-client";
 import { cn } from "@/lib/primitives/cn";
 
 const api = createApiClient();
+const SLACK_CHANNEL_SEARCH_DEBOUNCE_MS = 300;
 
-type SlackChannelOption = { id: string; name: string; private: boolean };
+type SlackChannelOption = SlackChannelQueryTarget & { private: boolean };
+
+async function fetchSlackChannels(input: {
+  channelId?: string;
+  organizationSlug: string;
+  query?: string;
+}) {
+  const response = await api.api.orgs[":organizationSlug"]["agent-slack"].channels.$get({
+    param: { organizationSlug: input.organizationSlug },
+    query: {
+      q: input.query || undefined,
+      channelId: input.channelId || undefined,
+    },
+  });
+  if (response.status !== 200) {
+    throw new Error("Failed to load Slack channels");
+  }
+  const body = await response.json();
+  return body.channels as SlackChannelOption[];
+}
 
 function useDebouncedValue<T>(value: T, delayMs: number) {
   const [debouncedValue, setDebouncedValue] = useState(value);
@@ -86,38 +110,57 @@ export function SlackChannelSelect({
   const intl = useIntl();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
-  const debouncedQuery = useDebouncedValue(query, 300);
+  const debouncedQuery = useDebouncedValue(query, SLACK_CHANNEL_SEARCH_DEBOUNCE_MS);
+  const trimmedQuery = query.trim();
+  const trimmedDebouncedQuery = debouncedQuery.trim();
 
-  const channelsQuery = useQuery({
-    queryKey: ["slack-agent-channels", organizationSlug, debouncedQuery, value],
-    queryFn: async () => {
-      const response = await api.api.orgs[":organizationSlug"]["agent-slack"].channels.$get({
-        param: { organizationSlug },
-        query: {
-          q: debouncedQuery || undefined,
-          channelId: value || undefined,
-        },
-      });
-      if (response.status !== 200) {
-        throw new Error("Failed to load Slack channels");
-      }
-      const body = await response.json();
-      return body.channels;
-    },
+  const browseQuery = useQuery({
+    queryKey: ["slack-agent-channels", organizationSlug, value],
+    queryFn: () =>
+      fetchSlackChannels({
+        organizationSlug,
+        channelId: value || undefined,
+      }),
     enabled: slackConnected,
   });
 
-  const channels = channelsQuery.data ?? [];
-  const selectedChannel = channels.find((channel) => channel.id === value);
-  const triggerDisabled =
-    disabled || !slackConnected || (channelsQuery.isLoading && !selectedChannel);
+  const searchQuery = useQuery({
+    queryKey: ["slack-agent-channels-search", organizationSlug, trimmedDebouncedQuery],
+    queryFn: () =>
+      fetchSlackChannels({
+        organizationSlug,
+        query: trimmedDebouncedQuery,
+      }),
+    enabled: slackConnected && open && Boolean(trimmedDebouncedQuery),
+  });
+
+  const browseChannels = browseQuery.data ?? [];
+  const remoteChannels = trimmedQuery ? (searchQuery.data ?? []) : [];
+  const visibleChannels = mergeVisibleSlackChannels(browseChannels, remoteChannels, query);
+  const selectedChannel =
+    browseChannels.find((channel) => channel.id === value) ??
+    remoteChannels.find((channel) => channel.id === value);
+  const isBrowseLoading = browseQuery.isLoading && browseQuery.data === undefined;
+  const isRemoteSearchPending =
+    Boolean(trimmedQuery) &&
+    visibleChannels.length === 0 &&
+    (searchQuery.isFetching || trimmedDebouncedQuery !== trimmedQuery);
+  const triggerDisabled = disabled || !slackConnected || (isBrowseLoading && !selectedChannel);
 
   return (
     <div className="grid gap-1.5">
       <Label className="text-xs text-muted-foreground">
         <FormattedMessage {...workspaceAutomationFormMessages.channelLabel} />
       </Label>
-      <Popover open={open} onOpenChange={setOpen}>
+      <Popover
+        open={open}
+        onOpenChange={(nextOpen) => {
+          setOpen(nextOpen);
+          if (!nextOpen) {
+            setQuery("");
+          }
+        }}
+      >
         <PopoverTrigger
           disabled={triggerDisabled}
           render={
@@ -130,7 +173,7 @@ export function SlackChannelSelect({
           }
         >
           <span className="min-w-0 truncate">
-            {channelsQuery.isLoading && !selectedChannel && !value
+            {isBrowseLoading && !selectedChannel && !value
               ? intl.formatMessage(workspaceAutomationFormMessages.loadingChannels)
               : slackChannelLabel(intl, selectedChannel, value)}
           </span>
@@ -143,6 +186,7 @@ export function SlackChannelSelect({
         <PopoverContent align="start" className="w-80 p-0" sideOffset={4}>
           <Command shouldFilter={false}>
             <CommandInput
+              autoFocus
               placeholder={intl.formatMessage(
                 workspaceAutomationFormMessages.searchChannelPlaceholder,
               )}
@@ -151,21 +195,22 @@ export function SlackChannelSelect({
             />
             <CommandList>
               <CommandEmpty className="px-3 text-pretty">
-                {channelsQuery.isFetching
+                {isBrowseLoading || isRemoteSearchPending
                   ? intl.formatMessage(workspaceAutomationFormMessages.loadingChannels)
-                  : query.trim()
+                  : trimmedQuery
                     ? intl.formatMessage(workspaceAutomationFormMessages.noMatchingChannels)
                     : intl.formatMessage(workspaceAutomationFormMessages.noChannelsFound)}
               </CommandEmpty>
               <CommandGroup>
-                {channels.map((channel) => (
+                {visibleChannels.map((channel) => (
                   <CommandItem
                     key={channel.id}
-                    value={channel.id}
+                    value={`${channel.name} ${channel.id}`}
                     data-checked={value === channel.id || undefined}
                     onSelect={() => {
                       onChange(channel.id);
                       setOpen(false);
+                      setQuery("");
                     }}
                   >
                     <span className={cn("min-w-0 flex-1 truncate")}>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/slack-channel-select.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/slack-channel-select.tsx
@@ -150,10 +150,12 @@ export function SlackChannelSelect({
               onValueChange={setQuery}
             />
             <CommandList>
-              <CommandEmpty>
+              <CommandEmpty className="px-3 text-pretty">
                 {channelsQuery.isFetching
                   ? intl.formatMessage(workspaceAutomationFormMessages.loadingChannels)
-                  : intl.formatMessage(workspaceAutomationFormMessages.noChannelsFound)}
+                  : query.trim()
+                    ? intl.formatMessage(workspaceAutomationFormMessages.noMatchingChannels)
+                    : intl.formatMessage(workspaceAutomationFormMessages.noChannelsFound)}
               </CommandEmpty>
               <CommandGroup>
                 {channels.map((channel) => (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -91,8 +91,8 @@ export const workspaceAutomationFormMessages = defineMessages({
     description: "Placeholder when no Slack channel is selected",
   },
   searchChannelPlaceholder: {
-    defaultMessage: "Search channels",
-    id: "ipTMc2bEYF",
+    defaultMessage: "Search by name or paste a channel ID",
+    id: "EnR+0v6FUm",
     description: "Placeholder for Slack channel search input",
   },
   selectConnection: {
@@ -641,6 +641,13 @@ export const workspaceAutomationFormMessages = defineMessages({
     defaultMessage: "No channels found",
     id: "AiZ8NmX54q",
     description: "Empty state when no Slack channels are available",
+  },
+  noMatchingChannels: {
+    defaultMessage:
+      "Can't find that channel. If it's private, invite the Hyperlocalise app, then search again. You can also paste the channel ID from Slack.",
+    id: "vLWybE+AOt",
+    description:
+      "Empty state when a typed Slack channel name or ID does not match visible channels",
   },
   privateChannelSuffix: {
     defaultMessage: "#{name} (private)",

--- a/apps/hyperlocalise-web/src/lib/agents/slack/channel-query.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/channel-query.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  isExactSlackChannelMatch,
+  mergeVisibleSlackChannels,
+  normalizeSlackChannelQuery,
+  parseSlackConversationId,
+  slackChannelMatchesQuery,
+  toCanonicalSlackChannelId,
+} from "./channel-query";
+
+const releaseNotes = { id: "slack:C01234567", name: "release-notes" };
+const general = { id: "slack:C07654321", name: "general" };
+
+describe("channel-query", () => {
+  it("normalizes names and parses Slack conversation ids", () => {
+    expect(toCanonicalSlackChannelId("C123")).toBe("slack:C123");
+    expect(normalizeSlackChannelQuery("#L10N")).toBe("l10n");
+    expect(parseSlackConversationId("slack:C01234567")).toBe("C01234567");
+    expect(parseSlackConversationId("https://acme.slack.com/archives/C01234567/p1")).toBe(
+      "C01234567",
+    );
+    expect(parseSlackConversationId("<#C01234567|release-notes>")).toBe("C01234567");
+    expect(parseSlackConversationId("release-notes")).toBeNull();
+  });
+
+  it("matches typed names against Slack slugs inside the selector", () => {
+    expect(slackChannelMatchesQuery(releaseNotes, "")).toBe(true);
+    expect(slackChannelMatchesQuery(releaseNotes, "rel")).toBe(true);
+    expect(slackChannelMatchesQuery(releaseNotes, "Release Notes")).toBe(true);
+    expect(slackChannelMatchesQuery(releaseNotes, "releasenotes")).toBe(true);
+    expect(slackChannelMatchesQuery(releaseNotes, "C01234567")).toBe(true);
+    expect(slackChannelMatchesQuery(releaseNotes, "general")).toBe(false);
+    expect(isExactSlackChannelMatch(releaseNotes, "release-notes")).toBe(true);
+    expect(isExactSlackChannelMatch(releaseNotes, "rel")).toBe(false);
+  });
+
+  it("keeps the loaded list and merges extra remote matches", () => {
+    const visible = mergeVisibleSlackChannels(
+      [general, releaseNotes],
+      [{ id: "slack:C99999999", name: "release-notes-eu" }],
+      "release notes",
+    );
+
+    expect(visible.map((channel) => channel.name)).toEqual(["release-notes", "release-notes-eu"]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/slack/channel-query.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/channel-query.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+const SLACK_CONVERSATION_ID_PATTERN = /^(?:slack:)?[CGD][A-Z0-9]{8,}$/i;
+const SLACK_ARCHIVE_CHANNEL_PATTERN = /\/archives\/([CGD][A-Z0-9]{8,})/i;
+const SLACK_MENTION_CHANNEL_PATTERN = /<#([CGD][A-Z0-9]{8,})(?:\|[^>]*)?>/i;
+export const SLACK_CHANNEL_NAME_PATTERN = /^[a-z0-9][a-z0-9_-]{0,79}$/;
+
+export type SlackChannelQueryTarget = { id: string; name: string };
+
+export function toCanonicalSlackChannelId(channelId: string) {
+  return channelId.startsWith("slack:") ? channelId : `slack:${channelId}`;
+}
+
+export function fromCanonicalSlackChannelId(channelId: string) {
+  return channelId.startsWith("slack:") ? channelId.slice("slack:".length) : channelId;
+}
+
+export function normalizeSlackChannelQuery(query: string) {
+  return query.trim().replace(/^#/, "").toLowerCase();
+}
+
+export function parseSlackConversationId(query: string) {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (SLACK_CONVERSATION_ID_PATTERN.test(trimmed)) {
+    return fromCanonicalSlackChannelId(trimmed);
+  }
+
+  const archiveMatch = trimmed.match(SLACK_ARCHIVE_CHANNEL_PATTERN);
+  if (archiveMatch?.[1]) {
+    return archiveMatch[1];
+  }
+
+  const mentionMatch = trimmed.match(SLACK_MENTION_CHANNEL_PATTERN);
+  if (mentionMatch?.[1]) {
+    return mentionMatch[1];
+  }
+
+  return null;
+}
+
+export function slackChannelMatchKeys(value: string) {
+  const normalized = normalizeSlackChannelQuery(value);
+  if (!normalized) {
+    return [];
+  }
+
+  const keys = [normalized];
+  if (/\s/u.test(normalized)) {
+    keys.push(normalized.replace(/\s+/g, "-"), normalized.replace(/\s+/g, "_"));
+  }
+  return keys;
+}
+
+function slackChannelCompactKey(value: string) {
+  return normalizeSlackChannelQuery(value).replace(/[\s_-]+/g, "");
+}
+
+export function isExactSlackChannelMatch(channel: SlackChannelQueryTarget, query: string) {
+  const queryKeys = slackChannelMatchKeys(query);
+  if (queryKeys.length === 0) {
+    return false;
+  }
+
+  const name = channel.name.toLowerCase();
+  const id = fromCanonicalSlackChannelId(channel.id).toLowerCase();
+  return queryKeys.includes(name) || queryKeys.includes(id);
+}
+
+export function slackChannelMatchesQuery(channel: SlackChannelQueryTarget, query: string) {
+  if (isExactSlackChannelMatch(channel, query)) {
+    return true;
+  }
+
+  const normalizedQuery = normalizeSlackChannelQuery(query);
+  if (!normalizedQuery) {
+    return true;
+  }
+
+  const conversationId = parseSlackConversationId(query);
+  if (conversationId) {
+    return fromCanonicalSlackChannelId(channel.id).toLowerCase() === conversationId.toLowerCase();
+  }
+
+  const name = channel.name.toLowerCase();
+  const id = fromCanonicalSlackChannelId(channel.id).toLowerCase();
+  const nameCompact = slackChannelCompactKey(channel.name);
+  const queryCompact = slackChannelCompactKey(normalizedQuery);
+
+  if (nameCompact.includes(queryCompact) || id.includes(normalizedQuery)) {
+    return true;
+  }
+
+  return slackChannelMatchKeys(query).some((key) => name.includes(key) || id.includes(key));
+}
+
+export function mergeVisibleSlackChannels<T extends SlackChannelQueryTarget>(
+  browse: T[],
+  remote: T[],
+  query: string,
+): T[] {
+  const merged = new Map<string, T>();
+  for (const channel of browse) {
+    if (slackChannelMatchesQuery(channel, query)) {
+      merged.set(channel.id, channel);
+    }
+  }
+  for (const channel of remote) {
+    if (slackChannelMatchesQuery(channel, query)) {
+      merged.set(channel.id, channel);
+    }
+  }
+
+  return [...merged.values()].toSorted((left, right) => {
+    if (query.trim()) {
+      const leftExact = isExactSlackChannelMatch(left, query);
+      const rightExact = isExactSlackChannelMatch(right, query);
+      if (leftExact !== rightExact) {
+        return leftExact ? -1 : 1;
+      }
+    }
+
+    return left.name.localeCompare(right.name);
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.test.ts
@@ -20,7 +20,7 @@ import {
   normalizeSlackChannelQuery,
   parseSlackConversationId,
   searchSlackChannels,
-  SLACK_CHANNEL_BROWSE_LIMIT,
+  SLACK_CHANNEL_LIST_PAGE_LIMIT,
   toCanonicalSlackChannelId,
 } from "./search-channels";
 
@@ -75,7 +75,7 @@ describe("searchSlackChannels", () => {
     expect(parseSlackConversationId("release-notes")).toBeNull();
   });
 
-  it("browses a single page and ignores further cursors", async () => {
+  it("browses a single page when Slack has no further cursor", async () => {
     vi.stubGlobal("fetch", fetchMock);
     fetchMock.mockResolvedValue(
       jsonResponse({
@@ -85,7 +85,7 @@ describe("searchSlackChannels", () => {
           { id: "C_PRIVATE", name: "team-l10n", is_private: true },
           { id: "C_ARCHIVED", name: "old", is_archived: true },
         ],
-        response_metadata: { next_cursor: "page-2" },
+        response_metadata: {},
       }),
     );
 
@@ -102,14 +102,57 @@ describe("searchSlackChannels", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const url = requestUrl(fetchMock.mock.calls[0]?.[0]);
     expect(url.origin + url.pathname).toBe("https://slack.com/api/conversations.list");
-    expect(url.searchParams.get("limit")).toBe(String(SLACK_CHANNEL_BROWSE_LIMIT));
+    expect(url.searchParams.get("limit")).toBe(String(SLACK_CHANNEL_LIST_PAGE_LIMIT));
+    expect(url.searchParams.get("exclude_archived")).toBe("true");
     expect(url.searchParams.get("cursor")).toBeNull();
+  });
+
+  it("keeps paging when exclude_archived shrinks a virtual page below limit", async () => {
+    vi.stubGlobal("fetch", fetchMock);
+    let listPages = 0;
+    mockSlack((url) => {
+      expect(url.searchParams.get("limit")).toBe(String(SLACK_CHANNEL_LIST_PAGE_LIMIT));
+      expect(url.searchParams.get("exclude_archived")).toBe("true");
+      listPages += 1;
+      if (url.searchParams.get("cursor") === "page-2") {
+        return {
+          body: {
+            ok: true,
+            channels: [{ id: "C_TARGET", name: "release-notes" }],
+          },
+        };
+      }
+
+      return {
+        body: {
+          ok: true,
+          channels: [{ id: "C_PUBLIC", name: "localization" }],
+          response_metadata: { next_cursor: "page-2" },
+        },
+      };
+    });
+
+    const result = await searchSlackChannels({ botToken: "xoxb-token" });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw new Error("expected browse to follow next_cursor after a short page");
+    }
+    expect(result.value.map((channel) => channel.id)).toEqual(["slack:C_PUBLIC", "slack:C_TARGET"]);
+    expect(listPages).toBe(2);
   });
 
   it("searches channel names without listing every page after an exact match", async () => {
     vi.stubGlobal("fetch", fetchMock);
     mockSlack((url) => {
-      expect(url.pathname.endsWith("/conversations.list")).toBe(true);
+      if (url.pathname.endsWith("/conversations.info")) {
+        return {
+          body: { ok: false, error: "channel_not_found" },
+        };
+      }
+
+      expect(url.searchParams.get("limit")).toBe(String(SLACK_CHANNEL_LIST_PAGE_LIMIT));
+      expect(url.searchParams.get("exclude_archived")).toBe("true");
       return {
         body: {
           ok: true,
@@ -136,7 +179,7 @@ describe("searchSlackChannels", () => {
       fetchMock.mock.calls.some((call) =>
         String(call[0]).includes("https://slack.com/api/conversations.info"),
       ),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       fetchMock.mock.calls.filter((call) =>
         String(call[0]).includes("https://slack.com/api/conversations.list"),
@@ -169,14 +212,20 @@ describe("searchSlackChannels", () => {
       fetchMock.mock.calls.some((call) =>
         String(call[0]).includes("https://slack.com/api/conversations.info"),
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 
-  it("does not resolve channel names through conversations.info", async () => {
+  it("resolves a typed channel name via conversations.info when list search would miss it", async () => {
     vi.stubGlobal("fetch", fetchMock);
     mockSlack((url) => {
       if (url.pathname.endsWith("/conversations.info")) {
-        throw new Error("conversations.info must not be called for channel names");
+        expect(url.searchParams.get("channel")).toBe("#release-notes");
+        return {
+          body: {
+            ok: true,
+            channel: { id: "C_RELEASE", name: "release-notes", is_private: false },
+          },
+        };
       }
 
       return {
@@ -190,21 +239,32 @@ describe("searchSlackChannels", () => {
 
     const result = await searchSlackChannels({
       botToken: "xoxb-token",
-      query: "release-notes",
+      query: "Release Notes",
     });
 
     expect(isOk(result)).toBe(true);
     if (!isOk(result)) {
-      throw new Error("expected named channel search to ignore conversations.info");
+      throw new Error("expected named channel lookup to succeed");
     }
-    expect(result.value).toEqual([]);
+    expect(result.value[0]).toEqual({
+      id: "slack:C_RELEASE",
+      name: "release-notes",
+      private: false,
+    });
+    expect(result.value.map((channel) => channel.id)).toContain("slack:C_RELEASE");
   });
 
   it("scans later list pages until an exact channel name matches", async () => {
     vi.stubGlobal("fetch", fetchMock);
     let listPages = 0;
     mockSlack((url) => {
-      expect(url.pathname.endsWith("/conversations.info")).toBe(false);
+      if (url.pathname.endsWith("/conversations.info")) {
+        return {
+          body: { ok: false, error: "channel_not_found" },
+        };
+      }
+
+      expect(url.pathname.endsWith("/conversations.list")).toBe(true);
       listPages += 1;
       if (url.searchParams.get("cursor") === "page-2") {
         return {
@@ -428,14 +488,29 @@ describe("searchSlackChannels", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-08-19T00:00:00.000Z"));
     vi.stubGlobal("fetch", fetchMock);
-    fetchMock
-      .mockResolvedValueOnce(
-        jsonResponse({
-          ok: true,
-          channels: [{ id: "C_RELEASE", name: "release-notes" }],
-        }),
-      )
-      .mockResolvedValue(jsonResponse({ ok: false, error: "ratelimited" }, { status: 429 }));
+    let listCalls = 0;
+    mockSlack((url) => {
+      if (url.pathname.endsWith("/conversations.info")) {
+        return {
+          body: { ok: false, error: "channel_not_found" },
+        };
+      }
+
+      listCalls += 1;
+      if (listCalls === 1) {
+        return {
+          body: {
+            ok: true,
+            channels: [{ id: "C_RELEASE", name: "release-notes" }],
+          },
+        };
+      }
+
+      return {
+        body: { ok: false, error: "ratelimited" },
+        init: { status: 429 },
+      };
+    });
 
     const first = await searchSlackChannels({
       botToken: "xoxb-token",

--- a/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.test.ts
@@ -15,8 +15,10 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { isErr, isOk } from "@/lib/primitives/result/results";
 
 import {
+  clearSlackChannelListCache,
   fromCanonicalSlackChannelId,
   normalizeSlackChannelQuery,
+  parseSlackConversationId,
   searchSlackChannels,
   SLACK_CHANNEL_BROWSE_LIMIT,
   toCanonicalSlackChannelId,
@@ -54,7 +56,9 @@ function mockSlack(
 describe("searchSlackChannels", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.useRealTimers();
     fetchMock.mockReset();
+    clearSlackChannelListCache();
   });
 
   it("canonicalizes Slack channel ids", () => {
@@ -63,6 +67,12 @@ describe("searchSlackChannels", () => {
     expect(fromCanonicalSlackChannelId("slack:C123")).toBe("C123");
     expect(fromCanonicalSlackChannelId("C123")).toBe("C123");
     expect(normalizeSlackChannelQuery("#L10N")).toBe("l10n");
+    expect(parseSlackConversationId("slack:C01234567")).toBe("C01234567");
+    expect(parseSlackConversationId("https://acme.slack.com/archives/C01234567/p1")).toBe(
+      "C01234567",
+    );
+    expect(parseSlackConversationId("<#C01234567|release-notes>")).toBe("C01234567");
+    expect(parseSlackConversationId("release-notes")).toBeNull();
   });
 
   it("browses a single page and ignores further cursors", async () => {
@@ -99,12 +109,7 @@ describe("searchSlackChannels", () => {
   it("searches channel names without listing every page after an exact match", async () => {
     vi.stubGlobal("fetch", fetchMock);
     mockSlack((url) => {
-      if (url.pathname.endsWith("/conversations.info")) {
-        return {
-          body: { ok: false, error: "channel_not_found" },
-        };
-      }
-
+      expect(url.pathname.endsWith("/conversations.list")).toBe(true);
       return {
         body: {
           ok: true,
@@ -129,9 +134,9 @@ describe("searchSlackChannels", () => {
     expect(result.value).toEqual([{ id: "slack:C2", name: "l10n", private: false }]);
     expect(
       fetchMock.mock.calls.some((call) =>
-        String(call[0]).includes("https://slack.com/api/conversations.list"),
+        String(call[0]).includes("https://slack.com/api/conversations.info"),
       ),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       fetchMock.mock.calls.filter((call) =>
         String(call[0]).includes("https://slack.com/api/conversations.list"),
@@ -139,17 +144,39 @@ describe("searchSlackChannels", () => {
     ).toHaveLength(1);
   });
 
-  it("resolves a typed channel name via conversations.info when list search would miss it", async () => {
+  it("matches a typed display name to the hyphenated Slack channel name", async () => {
+    vi.stubGlobal("fetch", fetchMock);
+    mockSlack(() => ({
+      body: {
+        ok: true,
+        channels: [{ id: "C_RELEASE", name: "release-notes", is_private: false }],
+      },
+    }));
+
+    const result = await searchSlackChannels({
+      botToken: "xoxb-token",
+      query: "Release Notes",
+    });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw new Error("expected spaced channel name to match");
+    }
+    expect(result.value).toEqual([
+      { id: "slack:C_RELEASE", name: "release-notes", private: false },
+    ]);
+    expect(
+      fetchMock.mock.calls.some((call) =>
+        String(call[0]).includes("https://slack.com/api/conversations.info"),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not resolve channel names through conversations.info", async () => {
     vi.stubGlobal("fetch", fetchMock);
     mockSlack((url) => {
       if (url.pathname.endsWith("/conversations.info")) {
-        expect(url.searchParams.get("channel")).toBe("#release-notes");
-        return {
-          body: {
-            ok: true,
-            channel: { id: "C_RELEASE", name: "release-notes", is_private: false },
-          },
-        };
+        throw new Error("conversations.info must not be called for channel names");
       }
 
       return {
@@ -168,26 +195,16 @@ describe("searchSlackChannels", () => {
 
     expect(isOk(result)).toBe(true);
     if (!isOk(result)) {
-      throw new Error("expected named channel lookup to succeed");
+      throw new Error("expected named channel search to ignore conversations.info");
     }
-    expect(result.value[0]).toEqual({
-      id: "slack:C_RELEASE",
-      name: "release-notes",
-      private: false,
-    });
-    expect(result.value.map((channel) => channel.id)).toContain("slack:C_RELEASE");
+    expect(result.value).toEqual([]);
   });
 
-  it("treats conversations.info channel_not_found as a miss and keeps scanning list pages", async () => {
+  it("scans later list pages until an exact channel name matches", async () => {
     vi.stubGlobal("fetch", fetchMock);
     let listPages = 0;
     mockSlack((url) => {
-      if (url.pathname.endsWith("/conversations.info")) {
-        return {
-          body: { ok: false, error: "channel_not_found" },
-        };
-      }
-
+      expect(url.pathname.endsWith("/conversations.info")).toBe(false);
       listPages += 1;
       if (url.searchParams.get("cursor") === "page-2") {
         return {
@@ -248,6 +265,43 @@ describe("searchSlackChannels", () => {
       throw new Error("expected id search to succeed after lookup miss");
     }
     expect(result.value).toEqual([{ id: "slack:C01234567", name: "eng-l10n", private: false }]);
+  });
+
+  it("looks up a Slack archive URL through conversations.info", async () => {
+    vi.stubGlobal("fetch", fetchMock);
+    mockSlack((url) => {
+      if (url.pathname.endsWith("/conversations.info")) {
+        expect(url.searchParams.get("channel")).toBe("C01234567");
+        return {
+          body: {
+            ok: true,
+            channel: { id: "C01234567", name: "eng-l10n", is_private: false },
+          },
+        };
+      }
+
+      return {
+        body: {
+          ok: true,
+          channels: [{ id: "C_PUBLIC", name: "localization" }],
+        },
+      };
+    });
+
+    const result = await searchSlackChannels({
+      botToken: "xoxb-token",
+      query: "https://acme.slack.com/archives/C01234567",
+    });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw new Error("expected archive URL lookup to succeed");
+    }
+    expect(result.value[0]).toEqual({
+      id: "slack:C01234567",
+      name: "eng-l10n",
+      private: false,
+    });
   });
 
   it("includes the selected channel even when it is outside the browse page", async () => {
@@ -330,5 +384,80 @@ describe("searchSlackChannels", () => {
       throw new Error("expected rate-limit exhaustion");
     }
     expect(result.error).toEqual({ code: "slack_rate_limited" });
+  });
+
+  it("reuses a cached channel list for later searches in the same workspace", async () => {
+    vi.stubGlobal("fetch", fetchMock);
+    mockSlack(() => ({
+      body: {
+        ok: true,
+        channels: [
+          { id: "C_PUBLIC", name: "localization" },
+          { id: "C_RELEASE", name: "release-notes" },
+        ],
+      },
+    }));
+
+    const first = await searchSlackChannels({
+      botToken: "xoxb-token",
+      cacheKey: "T123",
+      query: "localization",
+    });
+    const second = await searchSlackChannels({
+      botToken: "xoxb-token",
+      cacheKey: "T123",
+      query: "Release Notes",
+    });
+
+    expect(isOk(first)).toBe(true);
+    expect(isOk(second)).toBe(true);
+    if (!isOk(second)) {
+      throw new Error("expected cached name search to succeed");
+    }
+    expect(second.value).toEqual([
+      { id: "slack:C_RELEASE", name: "release-notes", private: false },
+    ]);
+    expect(
+      fetchMock.mock.calls.filter((call) =>
+        String(call[0]).includes("https://slack.com/api/conversations.list"),
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("serves a stale cached list when Slack rate-limits a later search", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-19T00:00:00.000Z"));
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          ok: true,
+          channels: [{ id: "C_RELEASE", name: "release-notes" }],
+        }),
+      )
+      .mockResolvedValue(jsonResponse({ ok: false, error: "ratelimited" }, { status: 429 }));
+
+    const first = await searchSlackChannels({
+      botToken: "xoxb-token",
+      cacheKey: "T123",
+      query: "release-notes",
+      sleep: async () => undefined,
+    });
+    vi.setSystemTime(new Date("2026-08-19T00:02:00.000Z"));
+    const second = await searchSlackChannels({
+      botToken: "xoxb-token",
+      cacheKey: "T123",
+      query: "release-notes",
+      sleep: async () => undefined,
+    });
+
+    expect(isOk(first)).toBe(true);
+    expect(isOk(second)).toBe(true);
+    if (!isOk(second)) {
+      throw new Error("expected stale cache fallback to succeed");
+    }
+    expect(second.value).toEqual([
+      { id: "slack:C_RELEASE", name: "release-notes", private: false },
+    ]);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
@@ -20,8 +20,9 @@ import {
   type Result,
 } from "@/lib/primitives/result/results";
 
-export const SLACK_CHANNEL_BROWSE_LIMIT = 200;
-export const SLACK_CHANNEL_SEARCH_PAGE_LIMIT = 1000;
+export const SLACK_CHANNEL_LIST_PAGE_LIMIT = 200;
+export const SLACK_CHANNEL_BROWSE_LIMIT = SLACK_CHANNEL_LIST_PAGE_LIMIT;
+export const SLACK_CHANNEL_SEARCH_PAGE_LIMIT = SLACK_CHANNEL_LIST_PAGE_LIMIT;
 export const SLACK_CHANNEL_SEARCH_MAX_PAGES = 3;
 export const SLACK_CHANNEL_SEARCH_EXACT_MAX_PAGES = 10;
 export const SLACK_CHANNEL_SEARCH_MAX_RESULTS = 50;
@@ -33,6 +34,7 @@ const SLACK_CHANNEL_LIST_CACHE_MAX_ENTRIES = 50;
 const SLACK_CONVERSATION_ID_PATTERN = /^(?:slack:)?[CGD][A-Z0-9]{8,}$/i;
 const SLACK_ARCHIVE_CHANNEL_PATTERN = /\/archives\/([CGD][A-Z0-9]{8,})/i;
 const SLACK_MENTION_CHANNEL_PATTERN = /<#([CGD][A-Z0-9]{8,})(?:\|[^>]*)?>/i;
+const SLACK_CHANNEL_NAME_PATTERN = /^[a-z0-9][a-z0-9_-]{0,79}$/;
 const SLACK_CHANNEL_LOOKUP_MISS_ERRORS = new Set([
   "channel_not_found",
   "invalid_arguments",
@@ -184,7 +186,20 @@ function channelMatchesQuery(channel: SlackChannelListItem, query: string) {
 
 function slackChannelLookupKeys(query: string) {
   const channelId = parseSlackConversationId(query);
-  return channelId ? [channelId] : [];
+  if (channelId) {
+    return [channelId];
+  }
+
+  const keys: string[] = [];
+  const seen = new Set<string>();
+  for (const name of slackChannelMatchKeys(query)) {
+    if (!SLACK_CHANNEL_NAME_PATTERN.test(name) || seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+    keys.push(`#${name}`);
+  }
+  return keys;
 }
 
 function isSlackChannelLookupMiss(error: SlackChannelSearchError) {
@@ -258,8 +273,6 @@ async function loadSlackChannelByKey(
     return ok(null);
   }
 
-  // conversations.info only accepts a conversation ID (C…, G…, D…). A channel
-  // name always returns channel_not_found, even when that channel exists.
   const url = new URL("https://slack.com/api/conversations.info");
   url.searchParams.set("channel", channelKey);
 
@@ -287,7 +300,7 @@ async function lookupSlackChannelByQuery(
   for (const key of keys) {
     const lookupResult = await loadSlackChannelByKey(botToken, key, options);
     if (isErr(lookupResult)) {
-      // Speculative id lookup must not fail the search; list scan can still match.
+      // Speculative name/id lookup must not fail the search; list scan can still match.
       if (
         lookupResult.error.code === "slack_rate_limited" ||
         lookupResult.error.code === "bot_unavailable"
@@ -316,6 +329,8 @@ async function listSlackChannelPage(
   Result<{ channels: SlackChannelListItem[]; nextCursor: string }, SlackChannelSearchError>
 > {
   const url = new URL("https://slack.com/api/conversations.list");
+  // Slack applies exclude_archived after filling a virtual page of `limit`, so a
+  // page can return fewer than `limit` channels while next_cursor still has more.
   url.searchParams.set("exclude_archived", "true");
   url.searchParams.set("limit", String(input.limit));
   url.searchParams.set("types", "public_channel,private_channel");
@@ -512,9 +527,24 @@ export async function searchSlackChannels(input: {
 
   if (!query) {
     if (!snapshot) {
-      const browseResult = await fetchListPage(undefined, SLACK_CHANNEL_BROWSE_LIMIT);
+      const browseResult = await fetchListPage(undefined, SLACK_CHANNEL_LIST_PAGE_LIMIT);
       if (isErr(browseResult)) {
         return browseResult;
+      }
+    }
+
+    for (let page = 1; page < SLACK_CHANNEL_SEARCH_EXACT_MAX_PAGES; page += 1) {
+      if (
+        (snapshot?.channels.length ?? 0) >= SLACK_CHANNEL_BROWSE_LIMIT ||
+        !snapshot?.nextCursor ||
+        !canPageFurther
+      ) {
+        break;
+      }
+
+      const moreResult = await fetchListPage(snapshot.nextCursor, SLACK_CHANNEL_LIST_PAGE_LIMIT);
+      if (isErr(moreResult)) {
+        return moreResult;
       }
     }
 
@@ -529,7 +559,7 @@ export async function searchSlackChannels(input: {
   const lookupPromise = lookupSlackChannelByQuery(input.botToken, query, options);
   const firstPagePromise: Promise<Result<void, SlackChannelSearchError>> = snapshot
     ? Promise.resolve(ok(undefined))
-    : fetchListPage(undefined, SLACK_CHANNEL_SEARCH_PAGE_LIMIT);
+    : fetchListPage(undefined, SLACK_CHANNEL_LIST_PAGE_LIMIT);
   const [lookupResult, firstPageResult] = await Promise.all([lookupPromise, firstPagePromise]);
   if (isErr(lookupResult)) {
     if (
@@ -576,7 +606,7 @@ export async function searchSlackChannels(input: {
       break;
     }
 
-    const pageResult = await fetchListPage(snapshot.nextCursor, SLACK_CHANNEL_SEARCH_PAGE_LIMIT);
+    const pageResult = await fetchListPage(snapshot.nextCursor, SLACK_CHANNEL_LIST_PAGE_LIMIT);
     if (isErr(pageResult)) {
       return pageResult;
     }

--- a/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
@@ -20,6 +20,24 @@ import {
   type Result,
 } from "@/lib/primitives/result/results";
 
+import {
+  fromCanonicalSlackChannelId,
+  isExactSlackChannelMatch,
+  normalizeSlackChannelQuery,
+  parseSlackConversationId,
+  SLACK_CHANNEL_NAME_PATTERN,
+  slackChannelMatchKeys,
+  slackChannelMatchesQuery,
+  toCanonicalSlackChannelId,
+} from "./channel-query";
+
+export {
+  fromCanonicalSlackChannelId,
+  normalizeSlackChannelQuery,
+  parseSlackConversationId,
+  toCanonicalSlackChannelId,
+} from "./channel-query";
+
 export const SLACK_CHANNEL_LIST_PAGE_LIMIT = 200;
 export const SLACK_CHANNEL_BROWSE_LIMIT = SLACK_CHANNEL_LIST_PAGE_LIMIT;
 export const SLACK_CHANNEL_SEARCH_PAGE_LIMIT = SLACK_CHANNEL_LIST_PAGE_LIMIT;
@@ -31,10 +49,6 @@ export const SLACK_CHANNEL_RATE_LIMIT_MAX_WAIT_MS = 2000;
 export const SLACK_CHANNEL_LIST_CACHE_TTL_MS = 60_000;
 const SLACK_CHANNEL_LIST_CACHE_MAX_ENTRIES = 50;
 
-const SLACK_CONVERSATION_ID_PATTERN = /^(?:slack:)?[CGD][A-Z0-9]{8,}$/i;
-const SLACK_ARCHIVE_CHANNEL_PATTERN = /\/archives\/([CGD][A-Z0-9]{8,})/i;
-const SLACK_MENTION_CHANNEL_PATTERN = /<#([CGD][A-Z0-9]{8,})(?:\|[^>]*)?>/i;
-const SLACK_CHANNEL_NAME_PATTERN = /^[a-z0-9][a-z0-9_-]{0,79}$/;
 const SLACK_CHANNEL_LOOKUP_MISS_ERRORS = new Set([
   "channel_not_found",
   "invalid_arguments",
@@ -77,54 +91,6 @@ type SlackRequestOptions = {
   sleep: (ms: number) => Promise<void>;
 };
 
-export function toCanonicalSlackChannelId(channelId: string) {
-  return channelId.startsWith("slack:") ? channelId : `slack:${channelId}`;
-}
-
-export function fromCanonicalSlackChannelId(channelId: string) {
-  return channelId.startsWith("slack:") ? channelId.slice("slack:".length) : channelId;
-}
-
-export function normalizeSlackChannelQuery(query: string) {
-  return query.trim().replace(/^#/, "").toLowerCase();
-}
-
-export function parseSlackConversationId(query: string) {
-  const trimmed = query.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  if (SLACK_CONVERSATION_ID_PATTERN.test(trimmed)) {
-    return fromCanonicalSlackChannelId(trimmed);
-  }
-
-  const archiveMatch = trimmed.match(SLACK_ARCHIVE_CHANNEL_PATTERN);
-  if (archiveMatch?.[1]) {
-    return archiveMatch[1];
-  }
-
-  const mentionMatch = trimmed.match(SLACK_MENTION_CHANNEL_PATTERN);
-  if (mentionMatch?.[1]) {
-    return mentionMatch[1];
-  }
-
-  return null;
-}
-
-function slackChannelMatchKeys(value: string) {
-  const normalized = normalizeSlackChannelQuery(value);
-  if (!normalized) {
-    return [];
-  }
-
-  const keys = [normalized];
-  if (/\s/u.test(normalized)) {
-    keys.push(normalized.replace(/\s+/g, "-"), normalized.replace(/\s+/g, "_"));
-  }
-  return keys;
-}
-
 function defaultSleep(ms: number) {
   return new Promise<void>((resolve) => {
     setTimeout(resolve, ms);
@@ -156,32 +122,6 @@ function toChannelListItem(channel: SlackChannel): SlackChannelListItem | null {
     name,
     private: Boolean(channel.is_private),
   };
-}
-
-function isExactChannelMatch(channel: SlackChannelListItem, query: string) {
-  const queryKeys = slackChannelMatchKeys(query);
-  if (queryKeys.length === 0) {
-    return false;
-  }
-
-  const name = channel.name.toLowerCase();
-  const id = fromCanonicalSlackChannelId(channel.id).toLowerCase();
-  return queryKeys.includes(name) || queryKeys.includes(id);
-}
-
-function channelMatchesQuery(channel: SlackChannelListItem, query: string) {
-  if (isExactChannelMatch(channel, query)) {
-    return true;
-  }
-
-  const normalizedQuery = normalizeSlackChannelQuery(query);
-  if (!normalizedQuery) {
-    return true;
-  }
-
-  const name = channel.name.toLowerCase();
-  const id = fromCanonicalSlackChannelId(channel.id).toLowerCase();
-  return slackChannelMatchKeys(query).some((key) => name.includes(key) || id.includes(key));
 }
 
 function slackChannelLookupKeys(query: string) {
@@ -456,8 +396,8 @@ function mergeSlackChannels(
   const normalizedQuery = normalizeSlackChannelQuery(query);
   return [...merged.values()].sort((left, right) => {
     if (normalizedQuery) {
-      const leftExact = isExactChannelMatch(left, normalizedQuery);
-      const rightExact = isExactChannelMatch(right, normalizedQuery);
+      const leftExact = isExactSlackChannelMatch(left, normalizedQuery);
+      const rightExact = isExactSlackChannelMatch(right, normalizedQuery);
       if (leftExact !== rightExact) {
         return leftExact ? -1 : 1;
       }
@@ -581,7 +521,7 @@ export async function searchSlackChannels(input: {
       return;
     }
     if (
-      !isExactChannelMatch(channel, query) &&
+      !isExactSlackChannelMatch(channel, query) &&
       matches.length >= SLACK_CHANNEL_SEARCH_MAX_RESULTS
     ) {
       return;
@@ -594,12 +534,12 @@ export async function searchSlackChannels(input: {
     pushMatch(lookupResult.value);
   }
   for (const channel of snapshot?.channels ?? []) {
-    if (channelMatchesQuery(channel, query)) {
+    if (slackChannelMatchesQuery(channel, query)) {
       pushMatch(channel);
     }
   }
 
-  const hasExactMatch = () => matches.some((channel) => isExactChannelMatch(channel, query));
+  const hasExactMatch = () => matches.some((channel) => isExactSlackChannelMatch(channel, query));
 
   for (let page = 1; page < SLACK_CHANNEL_SEARCH_EXACT_MAX_PAGES; page += 1) {
     if (hasExactMatch() || !snapshot?.nextCursor || !canPageFurther) {
@@ -612,7 +552,7 @@ export async function searchSlackChannels(input: {
     }
 
     for (const channel of snapshot?.channels ?? []) {
-      if (channelMatchesQuery(channel, query)) {
+      if (slackChannelMatchesQuery(channel, query)) {
         pushMatch(channel);
       }
     }

--- a/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
@@ -11,7 +11,14 @@
  * Version 2.0 or later.
  */
 
-import { err, fromThrowableAsync, isErr, ok, type Result } from "@/lib/primitives/result/results";
+import {
+  err,
+  fromThrowableAsync,
+  isErr,
+  isOk,
+  ok,
+  type Result,
+} from "@/lib/primitives/result/results";
 
 export const SLACK_CHANNEL_BROWSE_LIMIT = 200;
 export const SLACK_CHANNEL_SEARCH_PAGE_LIMIT = 1000;
@@ -20,9 +27,12 @@ export const SLACK_CHANNEL_SEARCH_EXACT_MAX_PAGES = 10;
 export const SLACK_CHANNEL_SEARCH_MAX_RESULTS = 50;
 export const SLACK_CHANNEL_RATE_LIMIT_RETRIES = 3;
 export const SLACK_CHANNEL_RATE_LIMIT_MAX_WAIT_MS = 2000;
+export const SLACK_CHANNEL_LIST_CACHE_TTL_MS = 60_000;
+const SLACK_CHANNEL_LIST_CACHE_MAX_ENTRIES = 50;
 
 const SLACK_CONVERSATION_ID_PATTERN = /^(?:slack:)?[CGD][A-Z0-9]{8,}$/i;
-const SLACK_CHANNEL_NAME_PATTERN = /^[a-z0-9][a-z0-9_-]{0,79}$/;
+const SLACK_ARCHIVE_CHANNEL_PATTERN = /\/archives\/([CGD][A-Z0-9]{8,})/i;
+const SLACK_MENTION_CHANNEL_PATTERN = /<#([CGD][A-Z0-9]{8,})(?:\|[^>]*)?>/i;
 const SLACK_CHANNEL_LOOKUP_MISS_ERRORS = new Set([
   "channel_not_found",
   "invalid_arguments",
@@ -77,6 +87,42 @@ export function normalizeSlackChannelQuery(query: string) {
   return query.trim().replace(/^#/, "").toLowerCase();
 }
 
+export function parseSlackConversationId(query: string) {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (SLACK_CONVERSATION_ID_PATTERN.test(trimmed)) {
+    return fromCanonicalSlackChannelId(trimmed);
+  }
+
+  const archiveMatch = trimmed.match(SLACK_ARCHIVE_CHANNEL_PATTERN);
+  if (archiveMatch?.[1]) {
+    return archiveMatch[1];
+  }
+
+  const mentionMatch = trimmed.match(SLACK_MENTION_CHANNEL_PATTERN);
+  if (mentionMatch?.[1]) {
+    return mentionMatch[1];
+  }
+
+  return null;
+}
+
+function slackChannelMatchKeys(value: string) {
+  const normalized = normalizeSlackChannelQuery(value);
+  if (!normalized) {
+    return [];
+  }
+
+  const keys = [normalized];
+  if (/\s/u.test(normalized)) {
+    keys.push(normalized.replace(/\s+/g, "-"), normalized.replace(/\s+/g, "_"));
+  }
+  return keys;
+}
+
 function defaultSleep(ms: number) {
   return new Promise<void>((resolve) => {
     setTimeout(resolve, ms);
@@ -111,45 +157,34 @@ function toChannelListItem(channel: SlackChannel): SlackChannelListItem | null {
 }
 
 function isExactChannelMatch(channel: SlackChannelListItem, query: string) {
-  const normalizedQuery = normalizeSlackChannelQuery(query);
-  if (!normalizedQuery) {
+  const queryKeys = slackChannelMatchKeys(query);
+  if (queryKeys.length === 0) {
     return false;
   }
 
-  return (
-    channel.name.toLowerCase() === normalizedQuery ||
-    fromCanonicalSlackChannelId(channel.id).toLowerCase() === normalizedQuery
-  );
+  const name = channel.name.toLowerCase();
+  const id = fromCanonicalSlackChannelId(channel.id).toLowerCase();
+  return queryKeys.includes(name) || queryKeys.includes(id);
 }
 
 function channelMatchesQuery(channel: SlackChannelListItem, query: string) {
+  if (isExactChannelMatch(channel, query)) {
+    return true;
+  }
+
   const normalizedQuery = normalizeSlackChannelQuery(query);
   if (!normalizedQuery) {
     return true;
   }
 
-  return (
-    channel.name.toLowerCase().includes(normalizedQuery) ||
-    fromCanonicalSlackChannelId(channel.id).toLowerCase().includes(normalizedQuery)
-  );
+  const name = channel.name.toLowerCase();
+  const id = fromCanonicalSlackChannelId(channel.id).toLowerCase();
+  return slackChannelMatchKeys(query).some((key) => name.includes(key) || id.includes(key));
 }
 
 function slackChannelLookupKeys(query: string) {
-  const trimmed = query.trim();
-  if (!trimmed) {
-    return [];
-  }
-
-  if (SLACK_CONVERSATION_ID_PATTERN.test(trimmed)) {
-    return [fromCanonicalSlackChannelId(trimmed)];
-  }
-
-  const name = normalizeSlackChannelQuery(trimmed);
-  if (SLACK_CHANNEL_NAME_PATTERN.test(name)) {
-    return [`#${name}`];
-  }
-
-  return [];
+  const channelId = parseSlackConversationId(query);
+  return channelId ? [channelId] : [];
 }
 
 function isSlackChannelLookupMiss(error: SlackChannelSearchError) {
@@ -223,6 +258,8 @@ async function loadSlackChannelByKey(
     return ok(null);
   }
 
+  // conversations.info only accepts a conversation ID (C…, G…, D…). A channel
+  // name always returns channel_not_found, even when that channel exists.
   const url = new URL("https://slack.com/api/conversations.info");
   url.searchParams.set("channel", channelKey);
 
@@ -242,10 +279,15 @@ async function lookupSlackChannelByQuery(
   query: string,
   options: SlackRequestOptions,
 ): Promise<Result<SlackChannelListItem | null, SlackChannelSearchError>> {
-  for (const key of slackChannelLookupKeys(query)) {
+  const keys = slackChannelLookupKeys(query);
+  if (keys.length === 0) {
+    return ok(null);
+  }
+
+  for (const key of keys) {
     const lookupResult = await loadSlackChannelByKey(botToken, key, options);
     if (isErr(lookupResult)) {
-      // Speculative name/id lookup must not fail the search; list scan can still match.
+      // Speculative id lookup must not fail the search; list scan can still match.
       if (
         lookupResult.error.code === "slack_rate_limited" ||
         lookupResult.error.code === "bot_unavailable"
@@ -303,6 +345,86 @@ async function listSlackChannelPage(
   });
 }
 
+type SlackChannelListSnapshot = {
+  channels: SlackChannelListItem[];
+  nextCursor: string;
+  fetchedAt: number;
+};
+
+// In-memory conversations.list snapshot keyed by Slack team id. Do not store
+// this in Postgres: names and private membership change, and a DB row would
+// still miss the first fetch that 429s. A 60s TTL absorbs picker typing.
+const slackChannelListCache = new Map<string, SlackChannelListSnapshot>();
+
+export function clearSlackChannelListCache() {
+  slackChannelListCache.clear();
+}
+
+function cloneSlackChannelListSnapshot(
+  snapshot: SlackChannelListSnapshot,
+): SlackChannelListSnapshot {
+  return {
+    channels: [...snapshot.channels],
+    nextCursor: snapshot.nextCursor,
+    fetchedAt: snapshot.fetchedAt,
+  };
+}
+
+function readSlackChannelListCache(cacheKey: string | undefined, now: number, allowStale: boolean) {
+  if (!cacheKey) {
+    return null;
+  }
+
+  const entry = slackChannelListCache.get(cacheKey);
+  if (!entry) {
+    return null;
+  }
+
+  const isFresh = now - entry.fetchedAt <= SLACK_CHANNEL_LIST_CACHE_TTL_MS;
+  if (!isFresh && !allowStale) {
+    return null;
+  }
+
+  return cloneSlackChannelListSnapshot(entry);
+}
+
+function writeSlackChannelListCache(
+  cacheKey: string | undefined,
+  snapshot: SlackChannelListSnapshot,
+) {
+  if (!cacheKey) {
+    return;
+  }
+
+  if (
+    !slackChannelListCache.has(cacheKey) &&
+    slackChannelListCache.size >= SLACK_CHANNEL_LIST_CACHE_MAX_ENTRIES
+  ) {
+    const oldestKey = slackChannelListCache.keys().next().value;
+    if (oldestKey) {
+      slackChannelListCache.delete(oldestKey);
+    }
+  }
+
+  slackChannelListCache.set(cacheKey, cloneSlackChannelListSnapshot(snapshot));
+}
+
+function appendSlackChannelListPage(
+  snapshot: SlackChannelListSnapshot,
+  page: { channels: SlackChannelListItem[]; nextCursor: string },
+  now: number,
+) {
+  const seenIds = new Set(snapshot.channels.map((channel) => channel.id));
+  for (const channel of page.channels) {
+    if (!seenIds.has(channel.id)) {
+      snapshot.channels.push(channel);
+      seenIds.add(channel.id);
+    }
+  }
+  snapshot.nextCursor = page.nextCursor;
+  snapshot.fetchedAt = now;
+}
+
 function mergeSlackChannels(
   selected: SlackChannelListItem | null,
   channels: SlackChannelListItem[],
@@ -332,6 +454,7 @@ function mergeSlackChannels(
 
 export async function searchSlackChannels(input: {
   botToken: string;
+  cacheKey?: string;
   query?: string;
   selectedChannelId?: string;
   signal?: AbortSignal;
@@ -340,6 +463,39 @@ export async function searchSlackChannels(input: {
   const sleep = input.sleep ?? defaultSleep;
   const options: SlackRequestOptions = { signal: input.signal, sleep };
   const query = input.query?.trim() ?? "";
+  const now = Date.now();
+  let snapshot = readSlackChannelListCache(input.cacheKey, now, false);
+  let canPageFurther = true;
+
+  const fetchListPage = async (
+    cursor: string | undefined,
+    limit: number,
+  ): Promise<Result<void, SlackChannelSearchError>> => {
+    const pageResult = await listSlackChannelPage(input.botToken, {
+      cursor,
+      limit,
+      signal: input.signal,
+      sleep,
+    });
+    if (isErr(pageResult)) {
+      if (pageResult.error.code === "slack_rate_limited") {
+        const stale = snapshot ?? readSlackChannelListCache(input.cacheKey, Date.now(), true);
+        if (stale && stale.channels.length > 0) {
+          snapshot = stale;
+          canPageFurther = false;
+          return ok(undefined);
+        }
+      }
+      return pageResult;
+    }
+
+    if (!snapshot) {
+      snapshot = { channels: [], nextCursor: "", fetchedAt: Date.now() };
+    }
+    appendSlackChannelListPage(snapshot, pageResult.value, Date.now());
+    writeSlackChannelListCache(input.cacheKey, snapshot);
+    return ok(undefined);
+  };
 
   let selectedChannel: SlackChannelListItem | null = null;
   if (input.selectedChannelId) {
@@ -355,72 +511,80 @@ export async function searchSlackChannels(input: {
   }
 
   if (!query) {
-    const pageResult = await listSlackChannelPage(input.botToken, {
-      limit: SLACK_CHANNEL_BROWSE_LIMIT,
-      signal: input.signal,
-      sleep,
-    });
-    if (isErr(pageResult)) {
-      return pageResult;
+    if (!snapshot) {
+      const browseResult = await fetchListPage(undefined, SLACK_CHANNEL_BROWSE_LIMIT);
+      if (isErr(browseResult)) {
+        return browseResult;
+      }
     }
 
-    return ok(mergeSlackChannels(selectedChannel, pageResult.value.channels));
+    return ok(
+      mergeSlackChannels(
+        selectedChannel,
+        (snapshot?.channels ?? []).slice(0, SLACK_CHANNEL_BROWSE_LIMIT),
+      ),
+    );
   }
 
   const lookupPromise = lookupSlackChannelByQuery(input.botToken, query, options);
-  const firstPagePromise = listSlackChannelPage(input.botToken, {
-    limit: SLACK_CHANNEL_SEARCH_PAGE_LIMIT,
-    signal: input.signal,
-    sleep,
-  });
+  const firstPagePromise: Promise<Result<void, SlackChannelSearchError>> = snapshot
+    ? Promise.resolve(ok(undefined))
+    : fetchListPage(undefined, SLACK_CHANNEL_SEARCH_PAGE_LIMIT);
   const [lookupResult, firstPageResult] = await Promise.all([lookupPromise, firstPagePromise]);
   if (isErr(lookupResult)) {
-    return lookupResult;
+    if (
+      lookupResult.error.code !== "slack_rate_limited" ||
+      !snapshot ||
+      snapshot.channels.length === 0
+    ) {
+      return lookupResult;
+    }
   }
   if (isErr(firstPageResult)) {
     return firstPageResult;
   }
 
   const matches: SlackChannelListItem[] = [];
-  if (lookupResult.value && channelMatchesQuery(lookupResult.value, query)) {
-    matches.push(lookupResult.value);
+  const seenIds = new Set<string>();
+  const pushMatch = (channel: SlackChannelListItem) => {
+    if (seenIds.has(channel.id)) {
+      return;
+    }
+    if (
+      !isExactChannelMatch(channel, query) &&
+      matches.length >= SLACK_CHANNEL_SEARCH_MAX_RESULTS
+    ) {
+      return;
+    }
+    seenIds.add(channel.id);
+    matches.push(channel);
+  };
+
+  if (isOk(lookupResult) && lookupResult.value) {
+    pushMatch(lookupResult.value);
   }
-  for (const channel of firstPageResult.value.channels) {
+  for (const channel of snapshot?.channels ?? []) {
     if (channelMatchesQuery(channel, query)) {
-      matches.push(channel);
+      pushMatch(channel);
     }
   }
 
-  let cursor = firstPageResult.value.nextCursor;
   const hasExactMatch = () => matches.some((channel) => isExactChannelMatch(channel, query));
 
-  if (matches.length >= SLACK_CHANNEL_SEARCH_MAX_RESULTS || hasExactMatch() || !cursor) {
-    return ok(mergeSlackChannels(selectedChannel, matches, query));
-  }
-
   for (let page = 1; page < SLACK_CHANNEL_SEARCH_EXACT_MAX_PAGES; page += 1) {
-    const pageResult = await listSlackChannelPage(input.botToken, {
-      cursor,
-      limit: SLACK_CHANNEL_SEARCH_PAGE_LIMIT,
-      signal: input.signal,
-      sleep,
-    });
+    if (hasExactMatch() || !snapshot?.nextCursor || !canPageFurther) {
+      break;
+    }
+
+    const pageResult = await fetchListPage(snapshot.nextCursor, SLACK_CHANNEL_SEARCH_PAGE_LIMIT);
     if (isErr(pageResult)) {
       return pageResult;
     }
 
-    for (const channel of pageResult.value.channels) {
+    for (const channel of snapshot?.channels ?? []) {
       if (channelMatchesQuery(channel, query)) {
-        matches.push(channel);
-        if (matches.length >= SLACK_CHANNEL_SEARCH_MAX_RESULTS) {
-          return ok(mergeSlackChannels(selectedChannel, matches, query));
-        }
+        pushMatch(channel);
       }
-    }
-
-    cursor = pageResult.value.nextCursor;
-    if (!cursor || hasExactMatch()) {
-      break;
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Typing in the Slack channel picker used to replace the loaded list with a server search. If Slack missed, the browse list vanished and the picker showed “Can’t find that channel.”

The picker now keeps the loaded list and searches inside it:

- Filters the first page immediately as you type, including spaced names such as `Release Notes` → `release-notes`
- Debounced server search only merges in channels that are not already on that page
- Closing the picker clears the search
- Empty-state copy still explains private channels the bot has not joined

Slack lookup behind this is unchanged from the earlier commits on this branch:

- `conversations.info` for IDs and `#name`
- `conversations.list` with `exclude_archived=true` and `limit=200`, following `next_cursor` when a virtual page shrinks
- In-memory list cache for 60s per workspace (not Postgres), with stale fallback on 429

## How to test

- Open an automation Slack channel picker and type part of a name already in the list; the list should filter in place instead of going empty
- Type a public channel that is not on the first page, or a spaced display name such as `Release Notes`
- Confirm a private channel the bot has not joined still shows the empty-state copy about inviting the app
- Automated: `vp test src/lib/agents/slack/channel-query.test.ts src/lib/agents/slack/search-channels.test.ts src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/slack-channel-select.test.tsx src/api/routes/agent-slack/agent-slack.route.test.ts` (37 passed) and `vp check --fix` in `apps/hyperlocalise-web`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-996ad1c4-4d1d-4ef3-a339-a7c258aafc2f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-996ad1c4-4d1d-4ef3-a339-a7c258aafc2f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

