### PR TITLE
ci: run web and Go workflows only on feature-branch PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,6 @@ on:
     paths-ignore:
       - apps/hyperlocalise-web/**
       - .github/workflows/web.yml
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - apps/hyperlocalise-web/**
-      - .github/workflows/web.yml
 
 permissions:
   contents: read
@@ -44,7 +38,7 @@ jobs:
 
   action-self-test:
     name: Action Self Test
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
@@ -84,7 +78,7 @@ jobs:
 
   web-sync-cli-smoke-test:
     name: Web Sync CLI Smoke Test
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false
     runs-on: blacksmith-4vcpu-ubuntu-2404
     defaults:
       run:
@@ -113,7 +107,7 @@ jobs:
 
   bazel-build-test:
     name: Bazel Build/Test
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
@@ -133,7 +127,7 @@ jobs:
 
   go-quality:
     name: Go Quality
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -67,7 +67,7 @@ jobs:
 
   web-test-build:
     name: Hyperlocalise Web Test/Build
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     runs-on: blacksmith-4vcpu-ubuntu-2404
     services:
       postgres:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -6,12 +6,6 @@ on:
     paths:
       - apps/hyperlocalise-web/**
       - .github/workflows/web.yml
-  push:
-    branches:
-      - main
-    paths:
-      - apps/hyperlocalise-web/**
-      - .github/workflows/web.yml
 
 permissions:
   contents: read
@@ -67,7 +61,7 @@ jobs:
 
   web-test-build:
     name: Hyperlocalise Web Test/Build
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false
     runs-on: blacksmith-4vcpu-ubuntu-2404
     services:
       postgres:

--- a/docs/adr/2026-07-26-draft-pr-ci-gating-design.md
+++ b/docs/adr/2026-07-26-draft-pr-ci-gating-design.md
@@ -9,7 +9,8 @@ PR is ready for review.
 ## Design
 
 On draft PRs, run only cheap checks for fast feedback. Skip expensive jobs
-until the PR is non-draft or the push is to `main`.
+until the PR is non-draft or the push is to `main` (for Go CI). Web test/build
+already gates merges on feature-branch PRs, so skip that job on `main` pushes.
 
 Trigger `pull_request` with `opened`, `synchronize`, `reopened`, and
 `ready_for_review` so converting a draft to ready re-runs the full suite.
@@ -19,12 +20,18 @@ Gate expensive jobs with:
 if: github.event_name == 'push' || github.event.pull_request.draft == false
 ```
 
+Gate web test/build with:
+
+```yaml
+if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+```
+
 Cheap jobs have no draft gate and always run when the workflow triggers.
 
-| Workflow | Cheap (draft + non-draft + main) | Expensive (non-draft + main) |
-|---|---|---|
-| `web.yml` | install, migration checks, `vp check` | Postgres, migrate, `vp test`, `vp run build` |
-| `ci.yml` | `make fmt`, `make lint` | Bazel, workspace tests, check-build, action self-test, sync smoke |
+| Workflow | Cheap (draft + non-draft + main) | Expensive (non-draft + main) | Expensive (non-draft PR only) |
+|---|---|---|---|
+| `web.yml` | install, migration checks, `vp check` | — | Postgres, migrate, `vp test`, `vp run build` |
+| `ci.yml` | `make fmt`, `make lint` | Bazel, workspace tests, check-build, action self-test, sync smoke | — |
 
 Keep existing path filters and concurrency groups. Do not require a `run-ci`
 label; that remains an optional escape hatch later if drafts need forced
@@ -35,4 +42,4 @@ expensive runs.
 - Push to a draft PR: cheap jobs run; expensive jobs skip.
 - Mark the PR ready for review: cheap and expensive jobs run.
 - Further non-draft pushes: both job groups run again.
-- Push to `main`: both job groups run (subject to path filters).
+- Push to `main`: Go expensive jobs run; web test/build skips (subject to path filters).

--- a/docs/adr/2026-07-26-draft-pr-ci-gating-design.md
+++ b/docs/adr/2026-07-26-draft-pr-ci-gating-design.md
@@ -4,34 +4,29 @@
 
 Draft PRs get many small pushes while iterating. Running full CI on every push
 burns Blacksmith minutes on Postgres, Bazel, tests, and Next builds before the
-PR is ready for review.
+PR is ready for review. Feature-branch PRs already gate merges, so re-running
+the same jobs on `main` pushes duplicates work.
 
 ## Design
 
-On draft PRs, run only cheap checks for fast feedback. Skip expensive jobs
-until the PR is non-draft or the push is to `main` (for Go CI). Web test/build
-already gates merges on feature-branch PRs, so skip that job on `main` pushes.
+Run `web.yml` and `ci.yml` only on `pull_request` events (no `push` to
+`main`). On draft PRs, run only cheap checks for fast feedback. Skip expensive
+jobs until the PR is non-draft.
 
 Trigger `pull_request` with `opened`, `synchronize`, `reopened`, and
 `ready_for_review` so converting a draft to ready re-runs the full suite.
 Gate expensive jobs with:
 
 ```yaml
-if: github.event_name == 'push' || github.event.pull_request.draft == false
-```
-
-Gate web test/build with:
-
-```yaml
-if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+if: github.event.pull_request.draft == false
 ```
 
 Cheap jobs have no draft gate and always run when the workflow triggers.
 
-| Workflow | Cheap (draft + non-draft + main) | Expensive (non-draft + main) | Expensive (non-draft PR only) |
-|---|---|---|---|
-| `web.yml` | install, migration checks, `vp check` | — | Postgres, migrate, `vp test`, `vp run build` |
-| `ci.yml` | `make fmt`, `make lint` | Bazel, workspace tests, check-build, action self-test, sync smoke | — |
+| Workflow | Cheap (draft + non-draft PR) | Expensive (non-draft PR only) |
+|---|---|---|
+| `web.yml` | install, migration checks, `vp check` | Postgres, migrate, `vp test`, `vp run build` |
+| `ci.yml` | `make fmt`, `make lint` | Bazel, workspace tests, check-build, action self-test, sync smoke |
 
 Keep existing path filters and concurrency groups. Do not require a `run-ci`
 label; that remains an optional escape hatch later if drafts need forced
@@ -42,4 +37,4 @@ expensive runs.
 - Push to a draft PR: cheap jobs run; expensive jobs skip.
 - Mark the PR ready for review: cheap and expensive jobs run.
 - Further non-draft pushes: both job groups run again.
-- Push to `main`: Go expensive jobs run; web test/build skips (subject to path filters).
+- Push to `main`: neither workflow runs (subject to path filters).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Both `web.yml` and `ci.yml` now trigger **only on pull requests** — the `push` to `main` triggers are removed.

| Job group | Draft PR | Ready PR | Push to `main` |
|---|---|---|---|
| Cheap (`web-check`, `go-lint`) | Runs | Runs | Skipped (workflow does not trigger) |
| Expensive (test/build, Bazel, etc.) | Skipped | Runs | Skipped |

## Why

Feature-branch PRs already gate merges. Re-running lint, check, test, and build on every `main` push duplicates work and burns CI minutes without adding coverage.

## How to test

- Open or update a draft PR: cheap jobs run; expensive jobs skip.
- Mark the PR ready for review: all jobs run.
- Merge to `main`: neither workflow triggers for its path filters.

## Checklist

- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0190e-12c5-7144-a02e-10a4629382a0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0190e-12c5-7144-a02e-10a4629382a0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

