### PR TITLE
fix(slack): fetch all channels and search them in the picker

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/slack-channel-select.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/slack-channel-select.test.tsx
@@ -67,16 +67,13 @@ describe("SlackChannelSelect", () => {
 
   it("filters the loaded channel list as the user types", async () => {
     const user = userEvent.setup();
-    apiMocks.searchChannels.mockImplementation(async (input: { query?: { q?: string } }) => {
-      if (input.query?.q) {
-        return jsonResponse([]);
-      }
-
-      return jsonResponse([
+    apiMocks.searchChannels.mockResolvedValue(
+      jsonResponse([
         { id: "slack:C1", name: "general", private: false },
         { id: "slack:C2", name: "release-notes", private: false },
-      ]);
-    });
+        { id: "slack:C3", name: "release-notes-eu", private: false },
+      ]),
+    );
 
     renderSelect(
       <SlackChannelSelect organizationSlug="acme" slackConnected value="" onChange={vi.fn()} />,
@@ -85,6 +82,7 @@ describe("SlackChannelSelect", () => {
     await user.click(await screen.findByRole("button", { name: /select channel/i }));
     expect(await screen.findByText("#general")).toBeInTheDocument();
     expect(screen.getByText("#release-notes")).toBeInTheDocument();
+    expect(screen.getByText("#release-notes-eu")).toBeInTheDocument();
 
     await user.type(
       screen.getByPlaceholderText("Search by name or paste a channel ID"),
@@ -93,31 +91,9 @@ describe("SlackChannelSelect", () => {
 
     expect(screen.queryByText("#general")).not.toBeInTheDocument();
     expect(screen.getByText("#release-notes")).toBeInTheDocument();
-  });
-
-  it("merges a remote match that is not in the loaded list", async () => {
-    const user = userEvent.setup();
-    apiMocks.searchChannels.mockImplementation(async (input: { query?: { q?: string } }) => {
-      if (input.query?.q) {
-        return jsonResponse([{ id: "slack:C9", name: "release-notes-eu", private: false }]);
-      }
-      return jsonResponse([{ id: "slack:C1", name: "general", private: false }]);
-    });
-
-    renderSelect(
-      <SlackChannelSelect organizationSlug="acme" slackConnected value="" onChange={vi.fn()} />,
-    );
-
-    await user.click(await screen.findByRole("button", { name: /select channel/i }));
-    expect(await screen.findByText("#general")).toBeInTheDocument();
-
-    await user.type(
-      screen.getByPlaceholderText("Search by name or paste a channel ID"),
-      "release-notes-eu",
-    );
-
-    expect(await screen.findByText("#release-notes-eu")).toBeInTheDocument();
-    expect(screen.queryByText("#general")).not.toBeInTheDocument();
+    expect(screen.getByText("#release-notes-eu")).toBeInTheDocument();
+    expect(apiMocks.searchChannels).toHaveBeenCalledTimes(1);
+    expect(apiMocks.searchChannels.mock.calls[0]?.[0].query?.q).toBeUndefined();
   });
 
   it("selects a filtered channel", async () => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/slack-channel-select.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/slack-channel-select.tsx
@@ -12,7 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useQuery } from "@tanstack/react-query";
@@ -31,26 +31,20 @@ import {
 import { Label } from "@/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
-  mergeVisibleSlackChannels,
+  filterVisibleSlackChannels,
   type SlackChannelQueryTarget,
 } from "@/lib/agents/slack/channel-query";
 import { createApiClient } from "@/lib/api-client";
 import { cn } from "@/lib/primitives/cn";
 
 const api = createApiClient();
-const SLACK_CHANNEL_SEARCH_DEBOUNCE_MS = 300;
 
 type SlackChannelOption = SlackChannelQueryTarget & { private: boolean };
 
-async function fetchSlackChannels(input: {
-  channelId?: string;
-  organizationSlug: string;
-  query?: string;
-}) {
+async function fetchSlackChannels(input: { channelId?: string; organizationSlug: string }) {
   const response = await api.api.orgs[":organizationSlug"]["agent-slack"].channels.$get({
     param: { organizationSlug: input.organizationSlug },
     query: {
-      q: input.query || undefined,
       channelId: input.channelId || undefined,
     },
   });
@@ -59,17 +53,6 @@ async function fetchSlackChannels(input: {
   }
   const body = await response.json();
   return body.channels as SlackChannelOption[];
-}
-
-function useDebouncedValue<T>(value: T, delayMs: number) {
-  const [debouncedValue, setDebouncedValue] = useState(value);
-
-  useEffect(() => {
-    const timeout = window.setTimeout(() => setDebouncedValue(value), delayMs);
-    return () => window.clearTimeout(timeout);
-  }, [delayMs, value]);
-
-  return debouncedValue;
 }
 
 function slackChannelLabel(
@@ -110,11 +93,9 @@ export function SlackChannelSelect({
   const intl = useIntl();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
-  const debouncedQuery = useDebouncedValue(query, SLACK_CHANNEL_SEARCH_DEBOUNCE_MS);
   const trimmedQuery = query.trim();
-  const trimmedDebouncedQuery = debouncedQuery.trim();
 
-  const browseQuery = useQuery({
+  const channelsQuery = useQuery({
     queryKey: ["slack-agent-channels", organizationSlug, value],
     queryFn: () =>
       fetchSlackChannels({
@@ -124,28 +105,11 @@ export function SlackChannelSelect({
     enabled: slackConnected,
   });
 
-  const searchQuery = useQuery({
-    queryKey: ["slack-agent-channels-search", organizationSlug, trimmedDebouncedQuery],
-    queryFn: () =>
-      fetchSlackChannels({
-        organizationSlug,
-        query: trimmedDebouncedQuery,
-      }),
-    enabled: slackConnected && open && Boolean(trimmedDebouncedQuery),
-  });
-
-  const browseChannels = browseQuery.data ?? [];
-  const remoteChannels = trimmedQuery ? (searchQuery.data ?? []) : [];
-  const visibleChannels = mergeVisibleSlackChannels(browseChannels, remoteChannels, query);
-  const selectedChannel =
-    browseChannels.find((channel) => channel.id === value) ??
-    remoteChannels.find((channel) => channel.id === value);
-  const isBrowseLoading = browseQuery.isLoading && browseQuery.data === undefined;
-  const isRemoteSearchPending =
-    Boolean(trimmedQuery) &&
-    visibleChannels.length === 0 &&
-    (searchQuery.isFetching || trimmedDebouncedQuery !== trimmedQuery);
-  const triggerDisabled = disabled || !slackConnected || (isBrowseLoading && !selectedChannel);
+  const channels = channelsQuery.data ?? [];
+  const visibleChannels = filterVisibleSlackChannels(channels, query);
+  const selectedChannel = channels.find((channel) => channel.id === value);
+  const isChannelsLoading = channelsQuery.isLoading && channelsQuery.data === undefined;
+  const triggerDisabled = disabled || !slackConnected || (isChannelsLoading && !selectedChannel);
 
   return (
     <div className="grid gap-1.5">
@@ -173,7 +137,7 @@ export function SlackChannelSelect({
           }
         >
           <span className="min-w-0 truncate">
-            {isBrowseLoading && !selectedChannel && !value
+            {isChannelsLoading && !selectedChannel && !value
               ? intl.formatMessage(workspaceAutomationFormMessages.loadingChannels)
               : slackChannelLabel(intl, selectedChannel, value)}
           </span>
@@ -195,7 +159,7 @@ export function SlackChannelSelect({
             />
             <CommandList>
               <CommandEmpty className="px-3 text-pretty">
-                {isBrowseLoading || isRemoteSearchPending
+                {isChannelsLoading
                   ? intl.formatMessage(workspaceAutomationFormMessages.loadingChannels)
                   : trimmedQuery
                     ? intl.formatMessage(workspaceAutomationFormMessages.noMatchingChannels)

--- a/apps/hyperlocalise-web/src/lib/agents/slack/channel-query.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/channel-query.test.ts
@@ -13,8 +13,8 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  filterVisibleSlackChannels,
   isExactSlackChannelMatch,
-  mergeVisibleSlackChannels,
   normalizeSlackChannelQuery,
   parseSlackConversationId,
   slackChannelMatchesQuery,
@@ -47,10 +47,9 @@ describe("channel-query", () => {
     expect(isExactSlackChannelMatch(releaseNotes, "rel")).toBe(false);
   });
 
-  it("keeps the loaded list and merges extra remote matches", () => {
-    const visible = mergeVisibleSlackChannels(
-      [general, releaseNotes],
-      [{ id: "slack:C99999999", name: "release-notes-eu" }],
+  it("filters the loaded list by typed query", () => {
+    const visible = filterVisibleSlackChannels(
+      [general, releaseNotes, { id: "slack:C99999999", name: "release-notes-eu" }],
       "release notes",
     );
 

--- a/apps/hyperlocalise-web/src/lib/agents/slack/channel-query.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/channel-query.ts
@@ -108,24 +108,15 @@ export function slackChannelMatchesQuery(channel: SlackChannelQueryTarget, query
   return slackChannelMatchKeys(query).some((key) => name.includes(key) || id.includes(key));
 }
 
-export function mergeVisibleSlackChannels<T extends SlackChannelQueryTarget>(
-  browse: T[],
-  remote: T[],
+export function filterVisibleSlackChannels<T extends SlackChannelQueryTarget>(
+  channels: T[],
   query: string,
 ): T[] {
-  const merged = new Map<string, T>();
-  for (const channel of browse) {
-    if (slackChannelMatchesQuery(channel, query)) {
-      merged.set(channel.id, channel);
-    }
-  }
-  for (const channel of remote) {
-    if (slackChannelMatchesQuery(channel, query)) {
-      merged.set(channel.id, channel);
-    }
-  }
+  const matched = query.trim()
+    ? channels.filter((channel) => slackChannelMatchesQuery(channel, query))
+    : [...channels];
 
-  return [...merged.values()].toSorted((left, right) => {
+  return matched.toSorted((left, right) => {
     if (query.trim()) {
       const leftExact = isExactSlackChannelMatch(left, query);
       const rightExact = isExactSlackChannelMatch(right, query);

--- a/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.test.ts
@@ -20,6 +20,7 @@ import {
   normalizeSlackChannelQuery,
   parseSlackConversationId,
   searchSlackChannels,
+  SLACK_CHANNEL_LIST_MAX_PAGES,
   SLACK_CHANNEL_LIST_PAGE_LIMIT,
   toCanonicalSlackChannelId,
 } from "./search-channels";
@@ -142,7 +143,7 @@ describe("searchSlackChannels", () => {
     expect(listPages).toBe(2);
   });
 
-  it("searches channel names without listing every page after an exact match", async () => {
+  it("keeps paging after an exact name match so later channels are still fetched", async () => {
     vi.stubGlobal("fetch", fetchMock);
     mockSlack((url) => {
       if (url.pathname.endsWith("/conversations.info")) {
@@ -153,6 +154,15 @@ describe("searchSlackChannels", () => {
 
       expect(url.searchParams.get("limit")).toBe(String(SLACK_CHANNEL_LIST_PAGE_LIMIT));
       expect(url.searchParams.get("exclude_archived")).toBe("true");
+      if (url.searchParams.get("cursor") === "page-2") {
+        return {
+          body: {
+            ok: true,
+            channels: [{ id: "C3", name: "alerts-eu" }],
+          },
+        };
+      }
+
       return {
         body: {
           ok: true,
@@ -176,15 +186,10 @@ describe("searchSlackChannels", () => {
     }
     expect(result.value).toEqual([{ id: "slack:C2", name: "l10n", private: false }]);
     expect(
-      fetchMock.mock.calls.some((call) =>
-        String(call[0]).includes("https://slack.com/api/conversations.info"),
-      ),
-    ).toBe(true);
-    expect(
       fetchMock.mock.calls.filter((call) =>
         String(call[0]).includes("https://slack.com/api/conversations.list"),
       ),
-    ).toHaveLength(1);
+    ).toHaveLength(2);
   });
 
   it("matches a typed display name to the hyphenated Slack channel name", async () => {
@@ -224,6 +229,15 @@ describe("searchSlackChannels", () => {
           body: {
             ok: true,
             channel: { id: "C_RELEASE", name: "release-notes", is_private: false },
+          },
+        };
+      }
+
+      if (url.searchParams.get("cursor") === "page-2") {
+        return {
+          body: {
+            ok: true,
+            channels: [{ id: "C_PUBLIC", name: "localization" }],
           },
         };
       }
@@ -366,19 +380,24 @@ describe("searchSlackChannels", () => {
 
   it("includes the selected channel even when it is outside the browse page", async () => {
     vi.stubGlobal("fetch", fetchMock);
-    fetchMock
-      .mockResolvedValueOnce(
-        jsonResponse({
-          ok: true,
-          channel: { id: "C_SELECTED", name: "release-updates", is_private: true },
-        }),
-      )
-      .mockResolvedValueOnce(
-        jsonResponse({
+    mockSlack((url) => {
+      if (url.pathname.endsWith("/conversations.info")) {
+        expect(url.searchParams.get("channel")).toBe("C_SELECTED");
+        return {
+          body: {
+            ok: true,
+            channel: { id: "C_SELECTED", name: "release-updates", is_private: true },
+          },
+        };
+      }
+
+      return {
+        body: {
           ok: true,
           channels: [{ id: "C_PUBLIC", name: "localization" }],
-        }),
-      );
+        },
+      };
+    });
 
     const result = await searchSlackChannels({
       botToken: "xoxb-token",
@@ -393,10 +412,15 @@ describe("searchSlackChannels", () => {
       { id: "slack:C_PUBLIC", name: "localization", private: false },
       { id: "slack:C_SELECTED", name: "release-updates", private: true },
     ]);
-    expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
-      "https://slack.com/api/conversations.info",
-    );
-    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("channel=C_SELECTED");
+    expect(
+      fetchMock.mock.calls.some((call) => {
+        const href = String(call[0]);
+        return (
+          href.includes("https://slack.com/api/conversations.info") &&
+          href.includes("channel=C_SELECTED")
+        );
+      }),
+    ).toBe(true);
   });
 
   it("retries Slack 429 responses and then succeeds", async () => {
@@ -534,5 +558,33 @@ describe("searchSlackChannels", () => {
     expect(second.value).toEqual([
       { id: "slack:C_RELEASE", name: "release-notes", private: false },
     ]);
+  });
+
+  it("stops listing after the max page budget", async () => {
+    vi.stubGlobal("fetch", fetchMock);
+    mockSlack((url) => {
+      const cursor = url.searchParams.get("cursor");
+      const page = cursor ? Number(cursor) : 0;
+      return {
+        body: {
+          ok: true,
+          channels: [{ id: `C${page}`, name: `channel-${page}` }],
+          response_metadata: { next_cursor: String(page + 1) },
+        },
+      };
+    });
+
+    const result = await searchSlackChannels({ botToken: "xoxb-token" });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw new Error("expected max-page browse to succeed");
+    }
+    expect(result.value).toHaveLength(SLACK_CHANNEL_LIST_MAX_PAGES);
+    expect(
+      fetchMock.mock.calls.filter((call) =>
+        String(call[0]).includes("https://slack.com/api/conversations.list"),
+      ),
+    ).toHaveLength(SLACK_CHANNEL_LIST_MAX_PAGES);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
@@ -480,16 +480,17 @@ export async function searchSlackChannels(input: {
   const options: SlackRequestOptions = { signal: input.signal, sleep };
   const query = input.query?.trim() ?? "";
 
-  const selectedPromise = input.selectedChannelId
-    ? loadSlackChannelByKey(
-        input.botToken,
-        fromCanonicalSlackChannelId(input.selectedChannelId),
-        options,
-      )
-    : Promise.resolve(ok(null));
-  const lookupPromise = query
+  const selectedPromise: Promise<Result<SlackChannelListItem | null, SlackChannelSearchError>> =
+    input.selectedChannelId
+      ? loadSlackChannelByKey(
+          input.botToken,
+          fromCanonicalSlackChannelId(input.selectedChannelId),
+          options,
+        )
+      : Promise.resolve(ok<SlackChannelListItem | null, SlackChannelSearchError>(null));
+  const lookupPromise: Promise<Result<SlackChannelListItem | null, SlackChannelSearchError>> = query
     ? lookupSlackChannelByQuery(input.botToken, query, options)
-    : Promise.resolve(ok(null));
+    : Promise.resolve(ok<SlackChannelListItem | null, SlackChannelSearchError>(null));
   const listPromise = loadCompleteSlackChannelList({
     botToken: input.botToken,
     cacheKey: input.cacheKey,

--- a/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
@@ -39,11 +39,7 @@ export {
 } from "./channel-query";
 
 export const SLACK_CHANNEL_LIST_PAGE_LIMIT = 200;
-export const SLACK_CHANNEL_BROWSE_LIMIT = SLACK_CHANNEL_LIST_PAGE_LIMIT;
-export const SLACK_CHANNEL_SEARCH_PAGE_LIMIT = SLACK_CHANNEL_LIST_PAGE_LIMIT;
-export const SLACK_CHANNEL_SEARCH_MAX_PAGES = 3;
-export const SLACK_CHANNEL_SEARCH_EXACT_MAX_PAGES = 10;
-export const SLACK_CHANNEL_SEARCH_MAX_RESULTS = 50;
+export const SLACK_CHANNEL_LIST_MAX_PAGES = 50;
 export const SLACK_CHANNEL_RATE_LIMIT_RETRIES = 3;
 export const SLACK_CHANNEL_RATE_LIMIT_MAX_WAIT_MS = 2000;
 export const SLACK_CHANNEL_LIST_CACHE_TTL_MS = 60_000;
@@ -308,7 +304,8 @@ type SlackChannelListSnapshot = {
 
 // In-memory conversations.list snapshot keyed by Slack team id. Do not store
 // this in Postgres: names and private membership change, and a DB row would
-// still miss the first fetch that 429s. A 60s TTL absorbs picker typing.
+// still miss the first fetch that 429s. A 60s TTL absorbs picker remounts
+// after the full list is fetched.
 const slackChannelListCache = new Map<string, SlackChannelListSnapshot>();
 
 export function clearSlackChannelListCache() {
@@ -407,30 +404,25 @@ function mergeSlackChannels(
   });
 }
 
-export async function searchSlackChannels(input: {
+async function loadCompleteSlackChannelList(input: {
   botToken: string;
   cacheKey?: string;
-  query?: string;
-  selectedChannelId?: string;
   signal?: AbortSignal;
-  sleep?: (ms: number) => Promise<void>;
-}): Promise<Result<SlackChannelListItem[], SlackChannelSearchError>> {
-  const sleep = input.sleep ?? defaultSleep;
-  const options: SlackRequestOptions = { signal: input.signal, sleep };
-  const query = input.query?.trim() ?? "";
+  sleep: (ms: number) => Promise<void>;
+}): Promise<Result<SlackChannelListSnapshot, SlackChannelSearchError>> {
   const now = Date.now();
   let snapshot = readSlackChannelListCache(input.cacheKey, now, false);
   let canPageFurther = true;
+  let pagesFetched = 0;
 
   const fetchListPage = async (
     cursor: string | undefined,
-    limit: number,
   ): Promise<Result<void, SlackChannelSearchError>> => {
     const pageResult = await listSlackChannelPage(input.botToken, {
       cursor,
-      limit,
+      limit: SLACK_CHANNEL_LIST_PAGE_LIMIT,
       signal: input.signal,
-      sleep,
+      sleep: input.sleep,
     });
     if (isErr(pageResult)) {
       if (pageResult.error.code === "slack_rate_limited") {
@@ -449,114 +441,88 @@ export async function searchSlackChannels(input: {
     }
     appendSlackChannelListPage(snapshot, pageResult.value, Date.now());
     writeSlackChannelListCache(input.cacheKey, snapshot);
+    pagesFetched += 1;
     return ok(undefined);
   };
 
-  let selectedChannel: SlackChannelListItem | null = null;
-  if (input.selectedChannelId) {
-    const selectedResult = await loadSlackChannelByKey(
-      input.botToken,
-      fromCanonicalSlackChannelId(input.selectedChannelId),
-      options,
-    );
-    if (isErr(selectedResult)) {
-      return selectedResult;
+  if (!snapshot) {
+    const firstPageResult = await fetchListPage(undefined);
+    if (isErr(firstPageResult)) {
+      return firstPageResult;
     }
-    selectedChannel = selectedResult.value;
   }
 
-  if (!query) {
-    if (!snapshot) {
-      const browseResult = await fetchListPage(undefined, SLACK_CHANNEL_LIST_PAGE_LIMIT);
-      if (isErr(browseResult)) {
-        return browseResult;
-      }
+  while (snapshot?.nextCursor && canPageFurther && pagesFetched < SLACK_CHANNEL_LIST_MAX_PAGES) {
+    const cursor = snapshot.nextCursor;
+    const pageResult = await fetchListPage(cursor);
+    if (isErr(pageResult)) {
+      return pageResult;
     }
-
-    for (let page = 1; page < SLACK_CHANNEL_SEARCH_EXACT_MAX_PAGES; page += 1) {
-      if (
-        (snapshot?.channels.length ?? 0) >= SLACK_CHANNEL_BROWSE_LIMIT ||
-        !snapshot?.nextCursor ||
-        !canPageFurther
-      ) {
-        break;
-      }
-
-      const moreResult = await fetchListPage(snapshot.nextCursor, SLACK_CHANNEL_LIST_PAGE_LIMIT);
-      if (isErr(moreResult)) {
-        return moreResult;
-      }
+    if (snapshot.nextCursor === cursor) {
+      snapshot.nextCursor = "";
+      writeSlackChannelListCache(input.cacheKey, snapshot);
+      break;
     }
-
-    return ok(
-      mergeSlackChannels(
-        selectedChannel,
-        (snapshot?.channels ?? []).slice(0, SLACK_CHANNEL_BROWSE_LIMIT),
-      ),
-    );
   }
 
-  const lookupPromise = lookupSlackChannelByQuery(input.botToken, query, options);
-  const firstPagePromise: Promise<Result<void, SlackChannelSearchError>> = snapshot
-    ? Promise.resolve(ok(undefined))
-    : fetchListPage(undefined, SLACK_CHANNEL_LIST_PAGE_LIMIT);
-  const [lookupResult, firstPageResult] = await Promise.all([lookupPromise, firstPagePromise]);
+  return ok(snapshot ?? { channels: [], nextCursor: "", fetchedAt: Date.now() });
+}
+
+export async function searchSlackChannels(input: {
+  botToken: string;
+  cacheKey?: string;
+  query?: string;
+  selectedChannelId?: string;
+  signal?: AbortSignal;
+  sleep?: (ms: number) => Promise<void>;
+}): Promise<Result<SlackChannelListItem[], SlackChannelSearchError>> {
+  const sleep = input.sleep ?? defaultSleep;
+  const options: SlackRequestOptions = { signal: input.signal, sleep };
+  const query = input.query?.trim() ?? "";
+
+  const selectedPromise = input.selectedChannelId
+    ? loadSlackChannelByKey(
+        input.botToken,
+        fromCanonicalSlackChannelId(input.selectedChannelId),
+        options,
+      )
+    : Promise.resolve(ok(null));
+  const lookupPromise = query
+    ? lookupSlackChannelByQuery(input.botToken, query, options)
+    : Promise.resolve(ok(null));
+  const listPromise = loadCompleteSlackChannelList({
+    botToken: input.botToken,
+    cacheKey: input.cacheKey,
+    signal: input.signal,
+    sleep,
+  });
+
+  const [selectedResult, lookupResult, listResult] = await Promise.all([
+    selectedPromise,
+    lookupPromise,
+    listPromise,
+  ]);
+  if (isErr(selectedResult)) {
+    return selectedResult;
+  }
+  if (isErr(listResult)) {
+    return listResult;
+  }
   if (isErr(lookupResult)) {
     if (
       lookupResult.error.code !== "slack_rate_limited" ||
-      !snapshot ||
-      snapshot.channels.length === 0
+      listResult.value.channels.length === 0
     ) {
       return lookupResult;
     }
   }
-  if (isErr(firstPageResult)) {
-    return firstPageResult;
-  }
 
-  const matches: SlackChannelListItem[] = [];
-  const seenIds = new Set<string>();
-  const pushMatch = (channel: SlackChannelListItem) => {
-    if (seenIds.has(channel.id)) {
-      return;
-    }
-    if (
-      !isExactSlackChannelMatch(channel, query) &&
-      matches.length >= SLACK_CHANNEL_SEARCH_MAX_RESULTS
-    ) {
-      return;
-    }
-    seenIds.add(channel.id);
-    matches.push(channel);
-  };
-
+  const matches = query
+    ? listResult.value.channels.filter((channel) => slackChannelMatchesQuery(channel, query))
+    : [...listResult.value.channels];
   if (isOk(lookupResult) && lookupResult.value) {
-    pushMatch(lookupResult.value);
-  }
-  for (const channel of snapshot?.channels ?? []) {
-    if (slackChannelMatchesQuery(channel, query)) {
-      pushMatch(channel);
-    }
+    matches.push(lookupResult.value);
   }
 
-  const hasExactMatch = () => matches.some((channel) => isExactSlackChannelMatch(channel, query));
-
-  for (let page = 1; page < SLACK_CHANNEL_SEARCH_EXACT_MAX_PAGES; page += 1) {
-    if (hasExactMatch() || !snapshot?.nextCursor || !canPageFurther) {
-      break;
-    }
-
-    const pageResult = await fetchListPage(snapshot.nextCursor, SLACK_CHANNEL_LIST_PAGE_LIMIT);
-    if (isErr(pageResult)) {
-      return pageResult;
-    }
-
-    for (const channel of snapshot?.channels ?? []) {
-      if (slackChannelMatchesQuery(channel, query)) {
-        pushMatch(channel);
-      }
-    }
-  }
-
-  return ok(mergeSlackChannels(selectedChannel, matches, query));
+  return ok(mergeSlackChannels(selectedResult.value, matches, query));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The Slack channel picker only loaded the first 200 `conversations.list` results and stopped paging once it found an exact name match. Typing in the search box therefore missed later channels.

The API now pages through Slack until the list is complete (capped at 50 pages as a safety budget) and caches that full snapshot. The automations picker fetches that list once and filters it on the client, so search sees every channel the bot can list.

## How to test

- Open an organization with Slack connected and a large channel list.
- Open an automation’s Slack channel picker and confirm channels beyond the first page appear.
- Type a name, spaced display name, or channel ID and confirm matches from later pages show immediately without a second network search.
- Select a filtered channel and confirm the form keeps that value.

Automated (passed):

```
cd apps/hyperlocalise-web
vp test src/lib/agents/slack/search-channels.test.ts src/lib/agents/slack/channel-query.test.ts src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/slack-channel-select.test.tsx
# 3 files, 20 tests passed
vp test src/api/routes/agent-slack/agent-slack.route.test.ts
# 1 file, 17 tests passed
vp check --fix
# 0 errors; remaining warnings are pre-existing
```

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73531fdb-62ef-4481-81f4-114e2249dc1c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73531fdb-62ef-4481-81f4-114e2249dc1c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

