### PR TITLE
Make automation lookback 24 hours and run hl check on i18n.yml

### DIFF
--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-skills/translation-review.md
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-skills/translation-review.md
@@ -7,6 +7,8 @@ name: Translation review
 
 Use this procedure when reviewing localisation or translation changes in a repository. Pair with **Recent source-content changes** to gather diffs, then review **every changed key** individually.
 
+If `i18n.yml` exists, run Hyperlocalise validation with `runHyperlocaliseCli` (`hl check`) against the translation files it maps. Skip that step when no `i18n.yml` is present. Do not look for `i18n.jsonc`.
+
 Keep output **scannable**. One entry per key. Do not repeat the same key in multiple sections.
 
 ### Per-key review
@@ -73,7 +75,7 @@ If every changed key has a finding: `None.` If no catalog changes: `No locale ca
 
 One line each:
 
-- **Hyperlocalise validation:** ran | skipped | failed — config path and reason when not run
+- **Hyperlocalise validation:** ran | skipped | failed — `i18n.yml` path and reason when not run
 - **Crowdin concordance:** ran (N keys) | skipped | not configured
 - **Coverage:** N keys · N locales · N commits
 

--- a/apps/hyperlocalise-web/src/agents/automations/github-repository/agent/skills/github-repo-agent.md
+++ b/apps/hyperlocalise-web/src/agents/automations/github-repository/agent/skills/github-repo-agent.md
@@ -7,7 +7,8 @@ sharedSkills: recent-source-changes
 
 - Read-only. Do not commit, push, upload sources, or modify files.
 - For localisation or translation review, follow **Recent source-content changes** to gather diffs, then **Translation review** for per-key findings and P0/P1/P2 output.
-- Start with `repoGitState` only when you need the current branch/HEAD. Then use `gitHistory` for the requested lookback window, push commit range, and branch.
+- Start with `repoGitState` only when you need the current branch/HEAD. Then use `gitHistory` for the requested window: last 24 hours for a daily lookback, or the push commit range for a push.
+- If `i18n.yml` exists (including nested paths), run `hl check` via `runHyperlocaliseCli` against the translation files it maps. Skip Hyperlocalise validation when no `i18n.yml` is present. Do not look for `i18n.jsonc`.
 - Use `read`, `grep`, or `glob` when commit subjects or diffs need more context, including localisation logic (i18n APIs, locale routing, fallback, formatters) as well as JSON/YAML catalogs.
 - Follow the customer instructions exactly, including delivery channel (Slack, PR comment) and any code-layer review focus.
 - If the task is not a localisation review, group by features, fixes, refactors, docs, and dependencies.

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/skills/notify-on-push-blockers.md
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/skills/notify-on-push-blockers.md
@@ -12,6 +12,7 @@ You are a localisation-focused code reviewer for this repository.
 What you can do:
 
 - Read the pushed commits, diffs, and surrounding code
+- If `i18n.yml` exists, run Hyperlocalise validation (`hl check`) against the translation files it maps
 - Follow the **Translation review** procedure for per-key findings and P0/P1/P2 output
 - Judge code-adjacent localisation risk: hard-coded copy, i18n APIs, locale routing, fallback, formatters, and writeback
 - Cite commit SHAs and file paths for each finding

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/skills/review-code-daily.md
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/skills/review-code-daily.md
@@ -11,7 +11,8 @@ You are a localisation-focused code reviewer for this repository.
 
 What you can do:
 
-- Read recent commits, diffs, and surrounding code in the lookback window
+- Read recent commits, diffs, and surrounding code from the last 24 hours
+- If `i18n.yml` exists, run Hyperlocalise validation (`hl check`) against the translation files it maps
 - Follow the **Translation review** procedure for per-key findings and P0/P1/P2 output
 - Judge code-adjacent localisation risk: hard-coded copy, i18n APIs, locale routing, fallback, formatters, and writeback
 - Cite commit SHAs and file paths for each finding

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/skills/summarize-changes-daily.md
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/skills/summarize-changes-daily.md
@@ -10,7 +10,8 @@ You are a daily localisation briefing agent.
 
 What you can do:
 
-- Read recent commits, diffs, and surrounding files in the lookback window
+- Read recent commits, diffs, and surrounding files from the last 24 hours
+- If `i18n.yml` exists, run Hyperlocalise validation (`hl check`) against the translation files it maps
 - Keep the digest scoped to localisation, i18n, and translation work
 - Cite commit SHAs and file paths for specific claims
 - Call out coverage gaps, ICU or placeholder risk, and incomplete translation syncs

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/skills/validate-localisation-on-push.md
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/skills/validate-localisation-on-push.md
@@ -12,6 +12,7 @@ You are a localisation quality reviewer.
 What you can do:
 
 - Inspect changed source strings and translations on protected-branch pushes
+- If `i18n.yml` exists, run Hyperlocalise validation (`hl check`) against the translation files it maps
 - Flag missing context, unstable copy, and accidental key churn
 - Flag missing translations, broken ICU syntax, mismatched placeholders, and unsafe HTML
 - Treat locale coverage regressions as blocking findings

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-template-manifest.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/workspace-template-manifest.test.ts
@@ -85,6 +85,8 @@ describe("workspace template manifest", () => {
     });
     expect(template?.description).toContain("localisation-related changes");
     expect(template?.instructions).toContain("You are a daily localisation briefing agent");
+    expect(template?.instructions).toContain("last 24 hours");
+    expect(template?.instructions).toContain("i18n.yml");
   });
 
   it("merges daily code-review and web-research skills onto gallery templates", () => {
@@ -101,6 +103,8 @@ describe("workspace template manifest", () => {
     expect(review?.instructions).toContain("You are a localisation-focused code reviewer");
     expect(review?.instructions).toContain("Translation review");
     expect(review?.instructions).toContain("Slack delivery");
+    expect(review?.instructions).toContain("last 24 hours");
+    expect(review?.instructions).toContain("i18n.yml");
     expect(
       listWorkspaceTemplateSkills().find((skill) => skill.id === "review-code-daily")?.frontmatter
         .sharedSkills,
@@ -131,6 +135,7 @@ describe("workspace template manifest", () => {
     expect(template?.description).toContain("comment on the pull request");
     expect(template?.instructions).toContain("sticky GitHub pull request comment");
     expect(template?.instructions).toContain("Translation review");
+    expect(template?.instructions).toContain("i18n.yml");
   });
 
   it("keeps untested templates coming soon after skill merge", () => {
@@ -155,6 +160,8 @@ describe("workspace template manifest", () => {
     expect(instructions).toContain('mode: "changedFiles"');
     expect(instructions).toContain("fileDiff");
     expect(instructions).toContain("`git diff` exit code 1");
+    expect(instructions).toContain("last 24 hours");
+    expect(instructions).toContain("i18n.yml");
     expect(instructions).not.toContain("Translation Review Results");
   });
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
@@ -1576,10 +1576,7 @@ describe("createRunHyperlocaliseCliTool", () => {
     );
 
     const t = createRunHyperlocaliseCliTool(ctx);
-    await t.execute!(
-      { subcommand: "check", flags: { config: "custom/i18n.yml" } },
-      toolCallInfo,
-    );
+    await t.execute!({ subcommand: "check", flags: { config: "custom/i18n.yml" } }, toolCallInfo);
 
     expect(hlArgs).toEqual(["check", "--config=custom/i18n.yml"]);
   });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.test.ts
@@ -1506,6 +1506,84 @@ describe("createRunHyperlocaliseCliTool", () => {
     expect((result as { stdout: string }).stdout).toContain("subcommand=check");
   });
 
+  it("passes a tracked i18n.yml as --config when the agent omits config", async () => {
+    const ctx = createTestContext({
+      "/home/user/project/apps/web/i18n.yml": "locales:\n  source: en-US\n",
+    });
+    let hlArgs: string[] = [];
+    ctx.bash.registerCommand(
+      defineCommand("git", async (args) => {
+        if (args[0] === "rev-parse") {
+          return { stdout: "true\n", stderr: "", exitCode: 0 };
+        }
+        if (args[0] === "ls-files") {
+          return { stdout: "apps/web/i18n.yml\0", stderr: "", exitCode: 0 };
+        }
+        return { stdout: "", stderr: "", exitCode: 0 };
+      }),
+    );
+    ctx.bash.registerCommand(
+      defineCommand("hl", async (args) => {
+        hlArgs = args;
+        return { stdout: "", stderr: "", exitCode: 0 };
+      }),
+    );
+
+    const t = createRunHyperlocaliseCliTool(ctx);
+    await t.execute!({ subcommand: "check", boolFlags: ["quiet"] }, toolCallInfo);
+
+    expect(hlArgs).toEqual(["check", "--quiet", "--config=apps/web/i18n.yml"]);
+  });
+
+  it("does not fall back to i18n.jsonc when no i18n.yml exists", async () => {
+    const ctx = createTestContext({
+      "/home/user/project/i18n.jsonc": '{"locales":{"source":"en-US"}}',
+    });
+    let hlArgs: string[] = [];
+    ctx.bash.registerCommand(
+      defineCommand("git", async (args) => {
+        if (args[0] === "rev-parse") {
+          return { stdout: "true\n", stderr: "", exitCode: 0 };
+        }
+        if (args[0] === "ls-files") {
+          return { stdout: "i18n.jsonc\0", stderr: "", exitCode: 0 };
+        }
+        return { stdout: "", stderr: "", exitCode: 0 };
+      }),
+    );
+    ctx.bash.registerCommand(
+      defineCommand("hl", async (args) => {
+        hlArgs = args;
+        return { stdout: "", stderr: "", exitCode: 0 };
+      }),
+    );
+
+    const t = createRunHyperlocaliseCliTool(ctx);
+    await t.execute!({ subcommand: "check" }, toolCallInfo);
+
+    expect(hlArgs).toEqual(["check"]);
+    expect(hlArgs.join(" ")).not.toContain("i18n.jsonc");
+  });
+
+  it("keeps an explicit --config path", async () => {
+    const ctx = createTestContext();
+    let hlArgs: string[] = [];
+    ctx.bash.registerCommand(
+      defineCommand("hl", async (args) => {
+        hlArgs = args;
+        return { stdout: "", stderr: "", exitCode: 0 };
+      }),
+    );
+
+    const t = createRunHyperlocaliseCliTool(ctx);
+    await t.execute!(
+      { subcommand: "check", flags: { config: "custom/i18n.yml" } },
+      toolCallInfo,
+    );
+
+    expect(hlArgs).toEqual(["check", "--config=custom/i18n.yml"]);
+  });
+
   it.each(["phrase", "crowdin", "lokalise"] as const)(
     "rejects provider/TMS actions for %s for now",
     async (provider) => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-read-tools.ts
@@ -55,7 +55,7 @@ export type I18NConfigSummary = {
 export function createDetectRepoConfigTool(ctx: RepoToolContext) {
   return tool({
     description:
-      "Detect whether a Hyperlocalise i18n configuration file (i18n.yml or i18n.jsonc) exists in the repository and return a secret-free summary.",
+      "Detect whether a Hyperlocalise i18n.yml configuration file exists in the repository and return a secret-free summary. Falls back to i18n.jsonc only for legacy configs.",
     inputSchema: z.object({
       path: z.string().optional().describe("Directory to check. Defaults to repo root."),
     }),
@@ -1040,11 +1040,43 @@ export type RunHyperlocaliseCliOutput = {
 };
 
 const HL_SUBCOMMANDS = ["check", "status", "extract"] as const;
+const HL_YAML_CONFIG_NAME = "i18n.yml";
+
+function hasConfigFlag(flags?: Record<string, string>): boolean {
+  if (!flags) {
+    return false;
+  }
+  return Object.keys(flags).some((key) => key.replace(/^-+/, "").toLowerCase() === "config");
+}
+
+async function resolveDefaultHlYamlConfigPath(ctx: RepoToolContext): Promise<string | null> {
+  const clone = await resolveGitCloneRoot(ctx);
+  const bound = bindGitClone(ctx, clone);
+  const listed = await bound.bash.exec("git", {
+    args: ["ls-files", "-z", "--", HL_YAML_CONFIG_NAME, `**/${HL_YAML_CONFIG_NAME}`],
+  });
+
+  if (listed.exitCode === 0) {
+    const paths = uniqueNullSeparatedLines(listed.stdout)
+      .map((line) => normalizeSourcePath(line))
+      .filter((line): line is string => Boolean(line))
+      .filter((line) => basenameMatches(line, HL_YAML_CONFIG_NAME))
+      .sort(compareConfigPaths);
+    const first = paths[0];
+    if (first) {
+      return toWorkspacePath(first, clone);
+    }
+  }
+
+  const fallbackPath = toWorkspacePath(HL_YAML_CONFIG_NAME, clone);
+  const exists = await ctx.bash.exec("test", { args: ["-f", fallbackPath] });
+  return exists.exitCode === 0 ? fallbackPath : null;
+}
 
 export function createRunHyperlocaliseCliTool(ctx: RepoToolContext) {
   return tool({
     description:
-      "Run an allowlisted hyperlocalise CLI subcommand for read-only repository checks. Does not expose arbitrary shell execution.",
+      "Run an allowlisted hyperlocalise CLI subcommand for read-only repository checks. When --config is omitted, uses a tracked i18n.yml (including nested paths). Does not expose arbitrary shell execution.",
     inputSchema: z.object({
       subcommand: z.enum(HL_SUBCOMMANDS).describe("The subcommand to run."),
       args: z.array(z.string()).optional().describe("Positional arguments."),
@@ -1052,7 +1084,20 @@ export function createRunHyperlocaliseCliTool(ctx: RepoToolContext) {
       boolFlags: z.array(z.string()).optional().describe("Boolean flags (--flag)."),
     }),
     execute: async ({ subcommand, args, flags, boolFlags }) => {
-      const commandArgsResult = buildHlArgs({ subcommand, args, flags, boolFlags });
+      const resolvedFlags = { ...flags };
+      if (!hasConfigFlag(resolvedFlags)) {
+        const configPath = await resolveDefaultHlYamlConfigPath(ctx);
+        if (configPath) {
+          resolvedFlags.config = configPath;
+        }
+      }
+
+      const commandArgsResult = buildHlArgs({
+        subcommand,
+        args,
+        flags: Object.keys(resolvedFlags).length > 0 ? resolvedFlags : undefined,
+        boolFlags,
+      });
       if (isErr(commandArgsResult)) {
         return {
           success: false,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.ts
@@ -119,7 +119,7 @@ export function createBashTool(ctx: RepoToolContext) {
 WHEN TO USE:
 - git status, git log, git diff
 - ls or find for directory discovery when glob is insufficient
-- hl check/status/extract for Hyperlocalise CLI read-only checks
+- hl check/status/extract for Hyperlocalise CLI read-only checks against i18n.yml
 
 WHEN NOT TO USE:
 - Reading files (use read)

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.test.ts
@@ -126,6 +126,8 @@ describe("workspace automation templates", () => {
     });
     expect(template?.instructions).toContain("You are a daily localisation briefing agent");
     expect(template?.instructions).toContain("Digest focus:");
+    expect(template?.instructions).toContain("last 24 hours");
+    expect(template?.instructions).toContain("i18n.yml");
     expect(getWorkspaceAutomationTemplateFlow(template!)).toEqual({
       trigger: { id: "scheduled", label: "Daily" },
       tools: [
@@ -157,6 +159,8 @@ describe("workspace automation templates", () => {
     expect(template?.instructions).toContain("Review scope");
     expect(template?.instructions).toContain("Translation review");
     expect(template?.instructions).toContain("Slack delivery");
+    expect(template?.instructions).toContain("last 24 hours");
+    expect(template?.instructions).toContain("i18n.yml");
     expect(getWorkspaceAutomationTemplateFlow(template!)).toEqual({
       trigger: { id: "scheduled", label: "Daily" },
       tools: [
@@ -216,6 +220,7 @@ describe("workspace automation templates", () => {
     expect(template?.instructions).toContain("You are a localisation-focused code reviewer");
     expect(template?.instructions).toContain("sticky GitHub pull request comment");
     expect(template?.instructions).toContain("Review focus:");
+    expect(template?.instructions).toContain("i18n.yml");
     expect(getWorkspaceAutomationTemplateFlow(template!)).toEqual({
       trigger: { id: "github-push", label: "GitHub push" },
       tools: [

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
@@ -136,6 +136,7 @@ export const WORKSPACE_AUTOMATION_TEMPLATES_BASE: WorkspaceAutomationTemplate[] 
       role: "a localisation quality reviewer",
       capabilities: [
         "Inspect changed source strings and translations on protected-branch pushes",
+        "If i18n.yml exists, run Hyperlocalise validation (hl check) against the translation files it maps",
         "Flag missing context, unstable copy, and accidental key churn",
         "Flag missing translations, broken ICU syntax, mismatched placeholders, and unsafe HTML",
         "Treat locale coverage regressions as blocking findings",
@@ -164,7 +165,8 @@ export const WORKSPACE_AUTOMATION_TEMPLATES_BASE: WorkspaceAutomationTemplate[] 
     instructions: formatWorkspaceAutomationTemplateInstructions({
       role: "a daily localisation briefing agent",
       capabilities: [
-        "Read recent commits, diffs, and surrounding files in the lookback window",
+        "Read recent commits, diffs, and surrounding files from the last 24 hours",
+        "If i18n.yml exists, run Hyperlocalise validation (hl check) against the translation files it maps",
         "Keep the digest scoped to localisation, i18n, and translation work",
         "Cite commit SHAs and file paths for specific claims",
         "Call out coverage gaps, ICU or placeholder risk, and incomplete translation syncs",
@@ -208,7 +210,8 @@ export const WORKSPACE_AUTOMATION_TEMPLATES_BASE: WorkspaceAutomationTemplate[] 
     instructions: formatWorkspaceAutomationTemplateInstructions({
       role: "a localisation-focused code reviewer for this repository",
       capabilities: [
-        "Read recent commits, diffs, and surrounding code in the lookback window",
+        "Read recent commits, diffs, and surrounding code from the last 24 hours",
+        "If i18n.yml exists, run Hyperlocalise validation (hl check) against the translation files it maps",
         "Extract changed translation keys and review old vs new values in locale catalogs",
         "Judge localisation, translation, and locale-compliance risk in the changed code",
         "Cite commit SHAs and file paths for each finding",
@@ -635,6 +638,7 @@ export const WORKSPACE_AUTOMATION_TEMPLATES_BASE: WorkspaceAutomationTemplate[] 
       role: "a localisation-focused code reviewer for this repository",
       capabilities: [
         "Read the pushed commits, diffs, and surrounding code",
+        "If i18n.yml exists, run Hyperlocalise validation (hl check) against the translation files it maps",
         "Judge localisation, translation, and locale-compliance risk in the changed code",
         "Cite commit SHAs and file paths for each finding",
         "Separate blocking localisation defects from non-blocking follow-ups",

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/materialize-hl-check-workspace.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/materialize-hl-check-workspace.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+    10| * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { hyperlocaliseAgentModelId } from "@/lib/agent-runtime/loops/model-id";
+
+import { buildHlCheckWorkspaceBundle } from "./materialize-hl-check-workspace";
+
+describe("buildHlCheckWorkspaceBundle", () => {
+    20|  it("writes i18n.yml instead of i18n.jsonc", () => {
+    const bundle = buildHlCheckWorkspaceBundle(
+      {
+        externalJobId: "job-1",
+        sourceLocale: "en",
+        targetLocales: ["fr"],
+        units: [
+          {
+            externalStringId: "1",
+            key: "greeting",
+            sourceText: "Hello",
+            translations: [{ locale: "fr", text: "Bonjour" }],
+          },
+        ],
+      },
+      ["fr"],
+    );
+
+    expect(bundle.configPath).toBe("/tmp/hl-provider-qa/i18n.yml");
+    const configFile = bundle.files.find((file) => file.path === bundle.configPath);
+    expect(configFile?.content).toContain("locales:");
+    expect(configFile?.content).toContain("source: en");
+    expect(configFile?.content).toContain("- fr");
+    expect(configFile?.content).toContain("from:");
+    expect(configFile?.content).toContain(`model: ${hyperlocaliseAgentModelId}`);
+    expect(bundle.files.some((file) => file.path.endsWith("i18n.jsonc"))).toBe(false);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/materialize-hl-check-workspace.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/materialize-hl-check-workspace.test.ts
@@ -17,7 +17,7 @@ import { hyperlocaliseAgentModelId } from "@/lib/agent-runtime/loops/model-id";
 import { buildHlCheckWorkspaceBundle } from "./materialize-hl-check-workspace";
 
 describe("buildHlCheckWorkspaceBundle", () => {
-    20|  it("writes i18n.yml instead of i18n.jsonc", () => {
+  it("writes an i18n.yml workspace config", () => {
     const bundle = buildHlCheckWorkspaceBundle(
       {
         externalJobId: "job-1",

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/materialize-hl-check-workspace.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/materialize-hl-check-workspace.ts
@@ -88,10 +88,7 @@ function buildJsonMap(
 }
 
 function yamlScalar(value: string): string {
-  if (
-    /^[A-Za-z0-9_./-]+$/.test(value) &&
-    !/^(?:true|false|null|yes|no|on|off)$/i.test(value)
-  ) {
+  if (/^[A-Za-z0-9_./-]+$/.test(value) && !/^(?:true|false|null|yes|no|on|off)$/i.test(value)) {
     return value;
   }
   return JSON.stringify(value);

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/materialize-hl-check-workspace.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/materialize-hl-check-workspace.ts
@@ -87,19 +87,49 @@ function buildJsonMap(
   return { payload, manifest };
 }
 
+function yamlScalar(value: string): string {
+  if (
+    /^[A-Za-z0-9_./-]+$/.test(value) &&
+    !/^(?:true|false|null|yes|no|on|off)$/i.test(value)
+  ) {
+    return value;
+  }
+  return JSON.stringify(value);
+}
+
+function yamlList(values: string[], indent: string): string {
+  return values.map((value) => `${indent}- ${yamlScalar(value)}`).join("\n");
+}
+
 function buildCheckConfigContent(
   sourcePath: string,
   targetPathTemplate: string,
   sourceLocale: string,
   targetLocales: string[],
 ) {
-  const quotedLocales = targetLocales.map((locale) => JSON.stringify(locale));
-  return `{
-  "locales": {"source":${JSON.stringify(sourceLocale)},"targets":[${quotedLocales.join(",")}]},
-  "buckets": {"provider":{"files":[{"from":${JSON.stringify(sourcePath)},"to":${JSON.stringify(targetPathTemplate)}}]}},
-  "groups": {"default":{"targets":[${quotedLocales.join(",")}],"buckets":["provider"]}},
-  "llm": {"profiles":{"default":{"provider":"openai","model":${JSON.stringify(hyperlocaliseAgentModelId)},"prompt":"Translate {{input}}"}}}
-}`;
+  const targets = yamlList(targetLocales, "    ");
+  return `locales:
+  source: ${yamlScalar(sourceLocale)}
+  targets:
+${targets}
+buckets:
+  provider:
+    files:
+      - from: ${yamlScalar(sourcePath)}
+        to: ${yamlScalar(targetPathTemplate)}
+groups:
+  default:
+    targets:
+${targets}
+    buckets:
+      - provider
+llm:
+  profiles:
+    default:
+      provider: openai
+      model: ${yamlScalar(hyperlocaliseAgentModelId)}
+      prompt: ${yamlScalar("Translate {{input}}")}
+`;
 }
 
 export function buildHlCheckWorkspaceBundle(
@@ -110,7 +140,7 @@ export function buildHlCheckWorkspaceBundle(
   const sourceLocale = content.sourceLocale?.trim() || "en";
   const sourceRelative = path.join("content", sourceLocale, STRINGS_FILE).replaceAll("\\", "/");
   const targetTemplate = path.join("content", "{{target}}", STRINGS_FILE).replaceAll("\\", "/");
-  const configPath = path.join(workspaceRoot, "i18n.jsonc").replaceAll("\\", "/");
+  const configPath = path.join(workspaceRoot, "i18n.yml").replaceAll("\\", "/");
   const reportPath = path.join(workspaceRoot, "report.json").replaceAll("\\", "/");
 
   const sourceBundle = buildJsonMap(content.units, (unit) => unit.sourceText ?? "");

--- a/pkg/i18nconfig/i18n.go
+++ b/pkg/i18nconfig/i18n.go
@@ -125,7 +125,7 @@ type CacheConfig struct {
 }
 
 // Load parses and validates i18n configuration from path.
-// When path is empty, it prefers i18n.yml and falls back to i18n.jsonc in the current working directory.
+// When path is empty, it prefers i18n.yml and falls back to i18n.jsonc only when that file exists.
 func Load(path string) (*I18NConfig, error) {
 	if strings.TrimSpace(path) == "" {
 		path = resolveDefaultPath()
@@ -185,8 +185,11 @@ func resolveDefaultPath() string {
 	if _, err := os.Stat(defaultConfigYAMLPath); err == nil {
 		return defaultConfigYAMLPath
 	}
+	if _, err := os.Stat(defaultConfigJSONCPath); err == nil {
+		return defaultConfigJSONCPath
+	}
 
-	return defaultConfigJSONCPath
+	return defaultConfigYAMLPath
 }
 
 func normalizeConfigContent(path string, content []byte) ([]byte, error) {

--- a/pkg/i18nconfig/i18n_test.go
+++ b/pkg/i18nconfig/i18n_test.go
@@ -755,6 +755,12 @@ func TestLoadIgnoresHiddenJSONCPathWhenDefaultMissing(t *testing.T) {
 	if !strings.Contains(err.Error(), "open i18n config") {
 		t.Fatalf("unexpected error: got %q", err.Error())
 	}
+	if !strings.Contains(err.Error(), "i18n.yml") {
+		t.Fatalf("expected missing-config error to mention i18n.yml, got %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "i18n.jsonc") {
+		t.Fatalf("expected missing-config error not to mention i18n.jsonc, got %q", err.Error())
+	}
 }
 
 func TestLoadParsesJSONCFile(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Daily GitHub automation templates named an unspecified lookback window. They now say **the last 24 hours**, and they tell the agent to run Hyperlocalise validation (`hl check`) against translation files mapped by `i18n.yml` when that config exists.

Sandbox `hl check` no longer treats `i18n.jsonc` as the default:

- The CLI reports a missing default config as `i18n.yml` (JSONC is used only when that file still exists).
- `runHyperlocaliseCli` discovers a tracked `i18n.yml` (including nested paths) when `--config` is omitted.
- Provider QA sandbox workspaces are generated with `i18n.yml` instead of `i18n.jsonc`.

## How to test

- `go test ./pkg/i18nconfig` (passed)
- `go test ./...` (passed; `make test` still warns about missing `covdata`)
- `make lint` (0 issues)
- In `apps/hyperlocalise-web`:
  - `CI=true vp test src/lib/agents/workspace-automation-templates.test.ts src/agents/automations/workspace/agent/workspace-template-manifest.test.ts src/lib/agent-runtime/tools/repo-read-tools.test.ts src/lib/providers/provider-job-qa/materialize-hl-check-workspace.test.ts` — 4 files, 104 tests passed
  - `vp check --fix` — 0 errors (pre-existing warnings in unrelated files)

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e857e89-0718-48bc-93d6-c63f43928b75?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e857e89-0718-48bc-93d6-c63f43928b75&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

