### PR TITLE
fix(slack): omit exclude_archived on conversations.list

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.test.ts
@@ -230,6 +230,7 @@ describe("agentSlackRoutes", () => {
     await expect(response.json()).resolves.toEqual({
       channels: [
         { id: "slack:C_PUBLIC", name: "localization", private: false },
+        { id: "slack:C_ARCHIVED", name: "old", private: false },
         { id: "slack:C_PRIVATE", name: "team-l10n", private: true },
       ],
     });

--- a/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.test.ts
@@ -97,6 +97,7 @@ describe("searchSlackChannels", () => {
     }
     expect(result.value).toEqual([
       { id: "slack:C_PUBLIC", name: "localization", private: false },
+      { id: "slack:C_ARCHIVED", name: "old", private: false },
       { id: "slack:C_PRIVATE", name: "team-l10n", private: true },
     ]);
     expect(fetchMock).toHaveBeenCalledTimes(1);

--- a/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.test.ts
@@ -103,16 +103,16 @@ describe("searchSlackChannels", () => {
     const url = requestUrl(fetchMock.mock.calls[0]?.[0]);
     expect(url.origin + url.pathname).toBe("https://slack.com/api/conversations.list");
     expect(url.searchParams.get("limit")).toBe(String(SLACK_CHANNEL_LIST_PAGE_LIMIT));
-    expect(url.searchParams.get("exclude_archived")).toBe("true");
+    expect(url.searchParams.get("exclude_archived")).toBeNull();
     expect(url.searchParams.get("cursor")).toBeNull();
   });
 
-  it("keeps paging when exclude_archived shrinks a virtual page below limit", async () => {
+  it("keeps paging when a list page is shorter than limit", async () => {
     vi.stubGlobal("fetch", fetchMock);
     let listPages = 0;
     mockSlack((url) => {
       expect(url.searchParams.get("limit")).toBe(String(SLACK_CHANNEL_LIST_PAGE_LIMIT));
-      expect(url.searchParams.get("exclude_archived")).toBe("true");
+      expect(url.searchParams.get("exclude_archived")).toBeNull();
       listPages += 1;
       if (url.searchParams.get("cursor") === "page-2") {
         return {
@@ -152,7 +152,7 @@ describe("searchSlackChannels", () => {
       }
 
       expect(url.searchParams.get("limit")).toBe(String(SLACK_CHANNEL_LIST_PAGE_LIMIT));
-      expect(url.searchParams.get("exclude_archived")).toBe("true");
+      expect(url.searchParams.get("exclude_archived")).toBeNull();
       return {
         body: {
           ok: true,

--- a/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
@@ -113,7 +113,7 @@ function parseRetryAfterMs(response: Response) {
 
 function toChannelListItem(channel: SlackChannel): SlackChannelListItem | null {
   const name = channel.name || channel.name_normalized;
-  if (!channel.id || !name || channel.is_archived) {
+  if (!channel.id || !name) {
     return null;
   }
 
@@ -270,8 +270,7 @@ async function listSlackChannelPage(
 > {
   const url = new URL("https://slack.com/api/conversations.list");
   // Omit exclude_archived. Slack applies that filter after filling a virtual page
-  // of `limit`, which can shrink pages and skip later channels. Archived channels
-  // are dropped locally in toChannelListItem.
+  // of `limit`, which can shrink pages and skip later channels.
   url.searchParams.set("limit", String(input.limit));
   url.searchParams.set("types", "public_channel,private_channel");
   if (input.cursor) {

--- a/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
@@ -68,7 +68,6 @@ type SlackChannel = {
   name?: string;
   name_normalized?: string;
   is_private?: boolean;
-  is_archived?: boolean;
 };
 
 type SlackConversationsListResponse = {

--- a/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
@@ -269,9 +269,9 @@ async function listSlackChannelPage(
   Result<{ channels: SlackChannelListItem[]; nextCursor: string }, SlackChannelSearchError>
 > {
   const url = new URL("https://slack.com/api/conversations.list");
-  // Slack applies exclude_archived after filling a virtual page of `limit`, so a
-  // page can return fewer than `limit` channels while next_cursor still has more.
-  url.searchParams.set("exclude_archived", "true");
+  // Omit exclude_archived. Slack applies that filter after filling a virtual page
+  // of `limit`, which can shrink pages and skip later channels. Archived channels
+  // are dropped locally in toChannelListItem.
   url.searchParams.set("limit", String(input.limit));
   url.searchParams.set("types", "public_channel,private_channel");
   if (input.cursor) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

`conversations.list` no longer sends `exclude_archived=true`. Slack applies that filter after filling a virtual page of `limit`, which can return short pages and skip later channels.

Archived channels are no longer dropped locally either. `toChannelListItem` only skips channels missing an id or name, so picker results include archived channels Slack returns.

Merged latest `main` (`#1919` full-list paging). The test conflict was simple: keep omit-`exclude_archived` assertions and main’s extra page mock so search still pages after an exact match.

## How to test

- `vp test src/lib/agents/slack/search-channels.test.ts src/api/routes/agent-slack/agent-slack.route.test.ts` from `apps/hyperlocalise-web`
- Confirm list requests omit `exclude_archived` and archived channels still appear in search/browse results

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55218b1f-d6b9-4e68-a517-c6f9509594c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55218b1f-d6b9-4e68-a517-c6f9509594c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

