### PR TITLE
fix(slack): replace channel picker with ID verification via conversations.info

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.test.ts
@@ -19,7 +19,6 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { app } from "@/api/app";
 import { createProjectTestFixture } from "@/api/routes/project/project.fixture";
 import { verifySlackState } from "@/lib/agents/slack/oauth-state";
-import { clearSlackChannelListCache } from "@/lib/agents/slack/search-channels";
 import { db, schema } from "@/lib/database";
 import { env } from "@/lib/env";
 
@@ -142,7 +141,6 @@ describe("agentSlackRoutes", () => {
   afterEach(async () => {
     vi.resetAllMocks();
     vi.unstubAllGlobals();
-    clearSlackChannelListCache();
     await fixture.cleanup();
   });
 
@@ -202,89 +200,85 @@ describe("agentSlackRoutes", () => {
     });
   });
 
-  it("lists Slack channels for an enabled connector", async () => {
+  it("verifies a Slack channel for an enabled connector", async () => {
     const { organizationSlug, headers } = await setupEnabledSlackConnector();
 
     mocks.fetchMock.mockResolvedValue({
       ok: true,
       json: vi.fn().mockResolvedValue({
         ok: true,
-        channels: [
-          { id: "C_PRIVATE", name: "team-l10n", is_private: true },
-          { id: "C_PUBLIC", name: "localization", is_private: false },
-          { id: "C_ARCHIVED", name: "old", is_archived: true },
-        ],
-        response_metadata: {},
+        channel: { id: "C01234567", name: "localization", is_private: false },
       }),
     } as unknown as Response);
 
-    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.$get(
+    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.verify.$get(
       {
         param: { organizationSlug },
-        query: {},
+        query: { channelId: "C01234567" },
       },
       { headers },
     );
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
-      channels: [
-        { id: "slack:C_PUBLIC", name: "localization", private: false },
-        { id: "slack:C_ARCHIVED", name: "old", private: false },
-        { id: "slack:C_PRIVATE", name: "team-l10n", private: true },
-      ],
+      channel: { id: "slack:C01234567", name: "localization", private: false },
     });
     expect(mocks.getInstallationMock).toHaveBeenCalledWith("T123");
     expect(mocks.fetchMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        href: expect.stringContaining("https://slack.com/api/conversations.list"),
+        href: expect.stringContaining("https://slack.com/api/conversations.info"),
       }),
       expect.objectContaining({
         headers: { authorization: "Bearer xoxb-token" },
       }),
     );
-    const listUrl = mocks.fetchMock.mock.calls[0]?.[0] as URL;
-    expect(listUrl.searchParams.get("limit")).toBe("200");
-    expect(listUrl.searchParams.get("cursor")).toBeNull();
+    const infoUrl = mocks.fetchMock.mock.calls[0]?.[0] as URL;
+    expect(infoUrl.searchParams.get("channel")).toBe("C01234567");
   });
 
-  it("searches Slack channels by name", async () => {
+  it("returns 404 when the channel cannot be verified", async () => {
     const { organizationSlug, headers } = await setupEnabledSlackConnector();
 
     mocks.fetchMock.mockResolvedValue({
       ok: true,
-      headers: { get: () => null },
-      json: vi.fn().mockResolvedValue({
-        ok: true,
-        channels: [
-          { id: "C_PUBLIC", name: "localization", is_private: false },
-          { id: "C_PRIVATE", name: "team-l10n", is_private: true },
-        ],
-        response_metadata: {},
-      }),
+      json: vi.fn().mockResolvedValue({ ok: false, error: "channel_not_found" }),
     } as unknown as Response);
 
-    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.$get(
+    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.verify.$get(
       {
         param: { organizationSlug },
-        query: { q: "l10n" },
+        query: { channelId: "C01234567" },
       },
       { headers },
     );
 
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
-      channels: [{ id: "slack:C_PRIVATE", name: "team-l10n", private: true }],
-    });
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "slack_channel_not_found" });
   });
 
-  it("rejects an oversized Slack channel search query", async () => {
+  it("rejects a missing channelId query parameter", async () => {
     const { organizationSlug, headers } = await setupEnabledSlackConnector();
 
-    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.$get(
+    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.verify.$get(
       {
         param: { organizationSlug },
-        query: { q: "a".repeat(513) },
+        query: { channelId: "" },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "invalid_slack_channel_query" });
+    expect(mocks.fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an oversized Slack channel id query", async () => {
+    const { organizationSlug, headers } = await setupEnabledSlackConnector();
+
+    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.verify.$get(
+      {
+        param: { organizationSlug },
+        query: { channelId: "C".repeat(129) },
       },
       { headers },
     );
@@ -298,10 +292,10 @@ describe("agentSlackRoutes", () => {
     const { organizationSlug, headers } = await setupEnabledSlackConnector();
     mocks.getInstallationMock.mockResolvedValue(null);
 
-    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.$get(
+    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.verify.$get(
       {
         param: { organizationSlug },
-        query: {},
+        query: { channelId: "C01234567" },
       },
       { headers },
     );
@@ -318,16 +312,16 @@ describe("agentSlackRoutes", () => {
       status: 503,
     } as Response);
 
-    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.$get(
+    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.verify.$get(
       {
         param: { organizationSlug },
-        query: {},
+        query: { channelId: "C01234567" },
       },
       { headers },
     );
 
     expect(response.status).toBe(502);
-    await expect(response.json()).resolves.toEqual({ error: "slack_channels_unavailable" });
+    await expect(response.json()).resolves.toEqual({ error: "slack_channel_unavailable" });
     expect(mocks.loggerErrorMock).toHaveBeenCalledWith(
       expect.objectContaining({
         errorCode: "slack_http_error",
@@ -335,7 +329,7 @@ describe("agentSlackRoutes", () => {
         organizationId: auth.organization.localOrganizationId,
         teamId: "T123",
       }),
-      "slack channel list failed",
+      "slack channel verify failed",
     );
   });
 
@@ -346,16 +340,16 @@ describe("agentSlackRoutes", () => {
       json: vi.fn().mockResolvedValue({ ok: false, error: "invalid_auth" }),
     } as unknown as Response);
 
-    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.$get(
+    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.verify.$get(
       {
         param: { organizationSlug },
-        query: {},
+        query: { channelId: "C01234567" },
       },
       { headers },
     );
 
     expect(response.status).toBe(502);
-    await expect(response.json()).resolves.toEqual({ error: "slack_channels_unavailable" });
+    await expect(response.json()).resolves.toEqual({ error: "slack_channel_unavailable" });
     expect(mocks.loggerErrorMock).toHaveBeenCalledWith(
       expect.objectContaining({
         errorCode: "slack_api_error",
@@ -363,7 +357,7 @@ describe("agentSlackRoutes", () => {
         organizationId: auth.organization.localOrganizationId,
         teamId: "T123",
       }),
-      "slack channel list failed",
+      "slack channel verify failed",
     );
   });
 
@@ -371,16 +365,16 @@ describe("agentSlackRoutes", () => {
     const { organizationSlug, headers, auth } = await setupEnabledSlackConnector();
     mocks.fetchMock.mockRejectedValue(new Error("network unavailable"));
 
-    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.$get(
+    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.verify.$get(
       {
         param: { organizationSlug },
-        query: {},
+        query: { channelId: "C01234567" },
       },
       { headers },
     );
 
     expect(response.status).toBe(502);
-    await expect(response.json()).resolves.toEqual({ error: "slack_channels_unavailable" });
+    await expect(response.json()).resolves.toEqual({ error: "slack_channel_unavailable" });
     expect(mocks.loggerErrorMock).toHaveBeenCalledWith(
       expect.objectContaining({
         errorCode: "bot_unavailable",
@@ -388,26 +382,26 @@ describe("agentSlackRoutes", () => {
         organizationId: auth.organization.localOrganizationId,
         teamId: "T123",
       }),
-      "slack channel list failed",
+      "slack channel verify failed",
     );
   });
 
-  it("returns an empty channel list when Slack is disconnected", async () => {
+  it("returns 404 when Slack is disconnected", async () => {
     const identity = fixture.createWorkosIdentityWithRole("admin");
     const organizationSlug = identity.organization.slug ?? "missing-slug";
 
-    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.$get(
+    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.verify.$get(
       {
         param: { organizationSlug },
-        query: {},
+        query: { channelId: "C01234567" },
       },
       {
         headers: await fixture.authHeadersFor(identity),
       },
     );
 
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ channels: [] });
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "slack_not_connected" });
   });
 
   it("returns an org-scoped slack install url for admins", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.ts
@@ -43,12 +43,12 @@ import { err, fromThrowableAsync, isErr, ok, type Result } from "@/lib/primitive
 import { assertProviderCredentialAdmin } from "@/lib/providers/credentials/organization-provider-credentials";
 
 import {
-  searchSlackChannels,
+  verifySlackChannel,
   type SlackChannelListItem,
   type SlackChannelSearchError,
 } from "@/lib/agents/slack/search-channels";
 
-import { searchSlackChannelsQuerySchema, updateSlackAgentBodySchema } from "./agent-slack.schema";
+import { updateSlackAgentBodySchema, verifySlackChannelQuerySchema } from "./agent-slack.schema";
 
 type SlackConnectorConfig = { teamId?: string; teamName?: string };
 type SlackInstallation = { botToken: string };
@@ -65,8 +65,8 @@ const validateUpdateSlackAgentBody = validator("json", (value, c) => {
   return parsed.data;
 });
 
-const validateSearchSlackChannelsQuery = validator("query", (value, c) => {
-  const parsed = searchSlackChannelsQuerySchema.safeParse(value);
+const validateVerifySlackChannelQuery = validator("query", (value, c) => {
+  const parsed = verifySlackChannelQuerySchema.safeParse(value);
   if (!parsed.success) {
     return c.json({ error: "invalid_slack_channel_query" as const }, 400);
   }
@@ -115,20 +115,18 @@ async function getSlackInstallation(
   return ok(installationResult.value);
 }
 
-async function loadSlackChannelsForTeam(
+async function verifySlackChannelForTeam(
   teamId: string,
-  input: { query?: string; selectedChannelId?: string; signal?: AbortSignal },
-): Promise<Result<SlackChannelListItem[], SlackChannelListError>> {
+  input: { channelId: string; signal?: AbortSignal },
+): Promise<Result<SlackChannelListItem | null, SlackChannelListError>> {
   const installationResult = await getSlackInstallation(teamId);
   if (isErr(installationResult)) {
     return installationResult;
   }
 
-  return searchSlackChannels({
+  return verifySlackChannel({
     botToken: installationResult.value.botToken,
-    cacheKey: teamId,
-    query: input.query,
-    selectedChannelId: input.selectedChannelId,
+    channelId: input.channelId,
     signal: input.signal,
   });
 }
@@ -171,7 +169,7 @@ export function createAgentSlackRoutes() {
         200,
       );
     })
-    .get("/channels", validateSearchSlackChannelsQuery, async (c) => {
+    .get("/channels/verify", validateVerifySlackChannelQuery, async (c) => {
       if (!isIntegrationsReadAllowed(c.var.auth.membership.role)) {
         return forbiddenResponse(c);
       }
@@ -179,33 +177,36 @@ export function createAgentSlackRoutes() {
       const connector = await getSlackConnector(c.var.auth.organization.localOrganizationId);
       const config = (connector?.config ?? {}) as SlackConnectorConfig;
       if (!connector?.enabled || !config.teamId) {
-        return c.json({ channels: [] }, 200);
+        return c.json({ error: "slack_not_connected" as const }, 404);
       }
 
       const query = c.req.valid("query");
-      const channelsResult = await loadSlackChannelsForTeam(config.teamId, {
-        query: query.q,
-        selectedChannelId: query.channelId,
+      const channelResult = await verifySlackChannelForTeam(config.teamId, {
+        channelId: query.channelId,
         signal: c.req.raw.signal,
       });
-      if (isErr(channelsResult)) {
-        if (channelsResult.error.code === "installation_not_found") {
+      if (isErr(channelResult)) {
+        if (channelResult.error.code === "installation_not_found") {
           return c.json({ error: "slack_installation_not_found" as const }, 404);
         }
 
         logger.error(
           {
-            ...slackChannelListErrorLogFields(channelsResult.error),
+            ...slackChannelListErrorLogFields(channelResult.error),
             organizationId: c.var.auth.organization.localOrganizationId,
             teamId: config.teamId,
-            errorCode: channelsResult.error.code,
+            errorCode: channelResult.error.code,
           },
-          "slack channel list failed",
+          "slack channel verify failed",
         );
-        return c.json({ error: "slack_channels_unavailable" as const }, 502);
+        return c.json({ error: "slack_channel_unavailable" as const }, 502);
       }
 
-      return c.json({ channels: channelsResult.value }, 200);
+      if (!channelResult.value) {
+        return c.json({ error: "slack_channel_not_found" as const }, 404);
+      }
+
+      return c.json({ channel: channelResult.value }, 200);
     })
     .get("/install-url", async (c) => {
       try {

--- a/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.schema.ts
@@ -16,7 +16,6 @@ export const updateSlackAgentBodySchema = z.object({
   enabled: z.boolean(),
 });
 
-export const searchSlackChannelsQuerySchema = z.object({
-  q: z.string().max(512).optional(),
-  channelId: z.string().max(128).optional(),
+export const verifySlackChannelQuerySchema = z.object({
+  channelId: z.string().trim().min(1).max(128),
 });

--- a/apps/hyperlocalise-web/src/api/routes/security-limits-identifiers.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/security-limits-identifiers.test.ts
@@ -32,7 +32,7 @@ import {
   uploadBodySchema,
   fileParamsSchema as publicFileParamsSchema,
 } from "./public-files/public-files.schema";
-import { searchSlackChannelsQuerySchema } from "./agent-slack/agent-slack.schema";
+import { verifySlackChannelQuerySchema } from "./agent-slack/agent-slack.schema";
 import { searchRepositoriesSchema } from "./github-installation/github-installation.schema";
 import { apiKeyIdParamsSchema } from "./api-key/api-key.schema";
 import { fileParamsSchema } from "./file/file.schema";
@@ -102,8 +102,8 @@ describe("Identifier Schema length limits", () => {
     expect(searchRepositoriesSchema.safeParse({ q: longSearch }).success).toBe(false);
   });
 
-  it("should enforce max length on search query q in agent-slack.schema", () => {
-    expect(searchSlackChannelsQuerySchema.safeParse({ q: longSearch }).success).toBe(false);
+  it("should enforce max length on channelId in agent-slack.schema", () => {
+    expect(verifySlackChannelQuerySchema.safeParse({ channelId: longSearch }).success).toBe(false);
   });
 
   it("should enforce max length on apiKeyId", () => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-msw-handlers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-msw-handlers.ts
@@ -58,9 +58,17 @@ export const automationEditorMswHandlers = [
       },
     }),
   ),
-  http.get("/api/orgs/:organizationSlug/agent-slack/channels", () =>
-    HttpResponse.json({ channels: automationEditorSlackChannelsFixture }),
-  ),
+  http.get("/api/orgs/:organizationSlug/agent-slack/channels/verify", ({ request }) => {
+    const url = new URL(request.url);
+    const channelId = url.searchParams.get("channelId");
+    const channel = automationEditorSlackChannelsFixture.find(
+      (entry) => entry.id === `slack:${channelId}` || entry.id === channelId,
+    );
+    if (!channel) {
+      return HttpResponse.json({ error: "slack_channel_not_found" }, { status: 404 });
+    }
+    return HttpResponse.json({ channel });
+  }),
   http.get("/api/orgs/:organizationSlug/agent-email", () =>
     HttpResponse.json({
       emailAgent: {
@@ -118,8 +126,8 @@ export const automationEditorDisconnectedMswHandlers = [
       },
     }),
   ),
-  http.get("/api/orgs/:organizationSlug/agent-slack/channels", () =>
-    HttpResponse.json({ channels: [] }),
+  http.get("/api/orgs/:organizationSlug/agent-slack/channels/verify", () =>
+    HttpResponse.json({ error: "slack_not_connected" }, { status: 404 }),
   ),
   http.get("/api/orgs/:organizationSlug/agent-email", () =>
     HttpResponse.json({

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/slack-channel-select.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/slack-channel-select.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 /*
  * Copyright (c) 2026 Hyperlocalise Pty Ltd
  *
@@ -10,11 +12,9 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-// @vitest-environment happy-dom
-
 import type { ReactElement } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { IntlProvider } from "react-intl";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
@@ -22,7 +22,7 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { SlackChannelSelect } from "./slack-channel-select";
 
 const apiMocks = vi.hoisted(() => ({
-  searchChannels: vi.fn(),
+  verifyChannel: vi.fn(),
 }));
 
 vi.mock("@/lib/api-client", () => ({
@@ -31,20 +31,15 @@ vi.mock("@/lib/api-client", () => ({
       orgs: {
         ":organizationSlug": {
           "agent-slack": {
-            channels: { $get: apiMocks.searchChannels },
+            channels: {
+              verify: { $get: apiMocks.verifyChannel },
+            },
           },
         },
       },
     },
   }),
 }));
-
-function jsonResponse(channels: Array<{ id: string; name: string; private: boolean }>) {
-  return {
-    status: 200,
-    json: async () => ({ channels }),
-  };
-}
 
 function renderSelect(ui: ReactElement) {
   const queryClient = new QueryClient({
@@ -62,58 +57,67 @@ function renderSelect(ui: ReactElement) {
 
 describe("SlackChannelSelect", () => {
   afterEach(() => {
-    apiMocks.searchChannels.mockReset();
+    apiMocks.verifyChannel.mockReset();
+    vi.useRealTimers();
   });
 
-  it("filters the loaded channel list as the user types", async () => {
-    const user = userEvent.setup();
-    apiMocks.searchChannels.mockResolvedValue(
-      jsonResponse([
-        { id: "slack:C1", name: "general", private: false },
-        { id: "slack:C2", name: "release-notes", private: false },
-        { id: "slack:C3", name: "release-notes-eu", private: false },
-      ]),
-    );
+  it("verifies a channel ID and shows the resolved channel name", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    apiMocks.verifyChannel.mockResolvedValue({
+      status: 200,
+      json: async () => ({
+        channel: { id: "slack:C01234567", name: "release-notes", private: false },
+      }),
+    });
 
     renderSelect(
       <SlackChannelSelect organizationSlug="acme" slackConnected value="" onChange={vi.fn()} />,
     );
 
-    await user.click(await screen.findByRole("button", { name: /select channel/i }));
-    expect(await screen.findByText("#general")).toBeInTheDocument();
-    expect(screen.getByText("#release-notes")).toBeInTheDocument();
-    expect(screen.getByText("#release-notes-eu")).toBeInTheDocument();
+    await user.type(screen.getByPlaceholderText("C0123456789"), "C01234567");
+    await vi.advanceTimersByTimeAsync(400);
 
-    await user.type(
-      screen.getByPlaceholderText("Search by name or paste a channel ID"),
-      "Release Notes",
-    );
+    await waitFor(() => {
+      expect(apiMocks.verifyChannel).toHaveBeenCalled();
+    });
 
-    expect(screen.queryByText("#general")).not.toBeInTheDocument();
-    expect(screen.getByText("#release-notes")).toBeInTheDocument();
-    expect(screen.getByText("#release-notes-eu")).toBeInTheDocument();
-    expect(apiMocks.searchChannels).toHaveBeenCalledTimes(1);
-    expect(apiMocks.searchChannels.mock.calls[0]?.[0].query?.q).toBeUndefined();
+    expect(await screen.findByText("#release-notes")).toBeInTheDocument();
   });
 
-  it("selects a filtered channel", async () => {
-    const user = userEvent.setup();
-    const onChange = vi.fn();
-    apiMocks.searchChannels.mockResolvedValue(
-      jsonResponse([
-        { id: "slack:C1", name: "general", private: false },
-        { id: "slack:C2", name: "release-notes", private: false },
-      ]),
+  it("shows an error when the channel cannot be verified", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    apiMocks.verifyChannel.mockResolvedValue({
+      status: 404,
+      json: async () => ({ error: "slack_channel_not_found" }),
+    });
+
+    renderSelect(
+      <SlackChannelSelect organizationSlug="acme" slackConnected value="" onChange={vi.fn()} />,
     );
+
+    await user.type(screen.getByPlaceholderText("C0123456789"), "C01234567");
+    await vi.advanceTimersByTimeAsync(400);
+
+    await waitFor(() => {
+      expect(apiMocks.verifyChannel).toHaveBeenCalled();
+    });
+
+    expect(
+      await screen.findByText(/Channel not found or the app is not a member/i),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onChange with the typed channel ID", async () => {
+    const onChange = vi.fn();
 
     renderSelect(
       <SlackChannelSelect organizationSlug="acme" slackConnected value="" onChange={onChange} />,
     );
 
-    await user.click(await screen.findByRole("button", { name: /select channel/i }));
-    await user.type(screen.getByPlaceholderText("Search by name or paste a channel ID"), "rel");
-    await user.click(await screen.findByText("#release-notes"));
+    await userEvent.type(screen.getByPlaceholderText("C0123456789"), "C01234567");
 
-    expect(onChange).toHaveBeenCalledWith("slack:C2");
+    expect(onChange).toHaveBeenLastCalledWith("C01234567");
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/slack-channel-select.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/slack-channel-select.tsx
@@ -12,58 +12,46 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useState } from "react";
-import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
+import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { workspaceAutomationFormMessages } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages";
-import { Button } from "@/components/ui/button";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import {
-  filterVisibleSlackChannels,
-  type SlackChannelQueryTarget,
-} from "@/lib/agents/slack/channel-query";
+import { parseSlackConversationId } from "@/lib/agents/slack/channel-query";
 import { createApiClient } from "@/lib/api-client";
 import { cn } from "@/lib/primitives/cn";
 
 const api = createApiClient();
+const SLACK_CHANNEL_VERIFY_DEBOUNCE_MS = 400;
 
-type SlackChannelOption = SlackChannelQueryTarget & { private: boolean };
+type VerifiedSlackChannel = { id: string; name: string; private: boolean };
 
-async function fetchSlackChannels(input: { channelId?: string; organizationSlug: string }) {
-  const response = await api.api.orgs[":organizationSlug"]["agent-slack"].channels.$get({
+async function fetchVerifiedSlackChannel(input: {
+  channelId: string;
+  organizationSlug: string;
+}): Promise<VerifiedSlackChannel | null> {
+  const response = await api.api.orgs[":organizationSlug"]["agent-slack"].channels.verify.$get({
     param: { organizationSlug: input.organizationSlug },
-    query: {
-      channelId: input.channelId || undefined,
-    },
+    query: { channelId: input.channelId },
   });
+  if (response.status === 404) {
+    return null;
+  }
   if (response.status !== 200) {
-    throw new Error("Failed to load Slack channels");
+    throw new Error("Failed to verify Slack channel");
   }
   const body = await response.json();
-  return body.channels as SlackChannelOption[];
+  return body.channel as VerifiedSlackChannel;
 }
 
 function slackChannelLabel(
   intl: ReturnType<typeof useIntl>,
-  channel: SlackChannelOption | undefined,
-  fallbackId: string,
+  channel: VerifiedSlackChannel | undefined,
 ) {
   if (!channel) {
-    return fallbackId
-      ? fallbackId
-      : intl.formatMessage(workspaceAutomationFormMessages.selectChannel);
+    return null;
   }
 
   return channel.private
@@ -91,103 +79,89 @@ export function SlackChannelSelect({
   value: string;
 }) {
   const intl = useIntl();
-  const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState("");
-  const trimmedQuery = query.trim();
+  const [draft, setDraft] = useState(value);
+  const [debouncedDraft, setDebouncedDraft] = useState(value);
 
-  const channelsQuery = useQuery({
-    queryKey: ["slack-agent-channels", organizationSlug, value],
+  useEffect(() => {
+    setDraft(value);
+    setDebouncedDraft(value);
+  }, [value]);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setDebouncedDraft(draft);
+    }, SLACK_CHANNEL_VERIFY_DEBOUNCE_MS);
+    return () => clearTimeout(timeout);
+  }, [draft]);
+
+  const parsedChannelId = parseSlackConversationId(debouncedDraft.trim());
+  const verifyQuery = useQuery({
+    queryKey: ["slack-channel-verify", organizationSlug, parsedChannelId],
     queryFn: () =>
-      fetchSlackChannels({
+      fetchVerifiedSlackChannel({
+        channelId: parsedChannelId!,
         organizationSlug,
-        channelId: value || undefined,
       }),
-    enabled: slackConnected,
+    enabled: slackConnected && Boolean(parsedChannelId),
   });
 
-  const channels = channelsQuery.data ?? [];
-  const visibleChannels = filterVisibleSlackChannels(channels, query);
-  const selectedChannel = channels.find((channel) => channel.id === value);
-  const isChannelsLoading = channelsQuery.isLoading && channelsQuery.data === undefined;
-  const triggerDisabled = disabled || !slackConnected || (isChannelsLoading && !selectedChannel);
+  const verifiedChannel = verifyQuery.isSuccess ? verifyQuery.data : undefined;
+  const showInvalidFormat = slackConnected && debouncedDraft.trim().length > 0 && !parsedChannelId;
+  const showNotFound =
+    slackConnected &&
+    Boolean(parsedChannelId) &&
+    !verifyQuery.isLoading &&
+    verifyQuery.isSuccess &&
+    verifyQuery.data === null;
+  const verificationError = verifyQuery.isError
+    ? intl.formatMessage(workspaceAutomationFormMessages.slackChannelVerifyFailed)
+    : undefined;
+  const helperError = error ?? verificationError;
+  const verifiedLabel = verifiedChannel === null ? null : slackChannelLabel(intl, verifiedChannel);
 
   return (
     <div className="grid gap-1.5">
       <Label className="text-xs text-muted-foreground">
         <FormattedMessage {...workspaceAutomationFormMessages.channelLabel} />
       </Label>
-      <Popover
-        open={open}
-        onOpenChange={(nextOpen) => {
-          setOpen(nextOpen);
-          if (!nextOpen) {
-            setQuery("");
-          }
+      <Input
+        aria-invalid={Boolean(helperError || showInvalidFormat || showNotFound) || undefined}
+        disabled={disabled || !slackConnected}
+        placeholder={intl.formatMessage(workspaceAutomationFormMessages.channelIdPlaceholder)}
+        value={draft}
+        onChange={(event) => {
+          const nextValue = event.currentTarget.value;
+          setDraft(nextValue);
+          onChange(nextValue.trim());
         }}
-      >
-        <PopoverTrigger
-          disabled={triggerDisabled}
-          render={
-            <Button
-              type="button"
-              variant="outline"
-              disabled={triggerDisabled}
-              className="h-8 w-full justify-between rounded-lg px-2.5 font-normal"
-            />
-          }
-        >
-          <span className="min-w-0 truncate">
-            {isChannelsLoading && !selectedChannel && !value
-              ? intl.formatMessage(workspaceAutomationFormMessages.loadingChannels)
-              : slackChannelLabel(intl, selectedChannel, value)}
-          </span>
-          <HugeiconsIcon
-            icon={ArrowDown01Icon}
-            strokeWidth={2}
-            className="size-4 shrink-0 text-muted-foreground"
-          />
-        </PopoverTrigger>
-        <PopoverContent align="start" className="w-80 p-0" sideOffset={4}>
-          <Command shouldFilter={false}>
-            <CommandInput
-              autoFocus
-              placeholder={intl.formatMessage(
-                workspaceAutomationFormMessages.searchChannelPlaceholder,
-              )}
-              value={query}
-              onValueChange={setQuery}
-            />
-            <CommandList>
-              <CommandEmpty className="px-3 text-pretty">
-                {isChannelsLoading
-                  ? intl.formatMessage(workspaceAutomationFormMessages.loadingChannels)
-                  : trimmedQuery
-                    ? intl.formatMessage(workspaceAutomationFormMessages.noMatchingChannels)
-                    : intl.formatMessage(workspaceAutomationFormMessages.noChannelsFound)}
-              </CommandEmpty>
-              <CommandGroup>
-                {visibleChannels.map((channel) => (
-                  <CommandItem
-                    key={channel.id}
-                    value={`${channel.name} ${channel.id}`}
-                    data-checked={value === channel.id || undefined}
-                    onSelect={() => {
-                      onChange(channel.id);
-                      setOpen(false);
-                      setQuery("");
-                    }}
-                  >
-                    <span className={cn("min-w-0 flex-1 truncate")}>
-                      {slackChannelLabel(intl, channel, channel.id)}
-                    </span>
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            </CommandList>
-          </Command>
-        </PopoverContent>
-      </Popover>
-      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+        spellCheck={false}
+        autoComplete="off"
+        className="h-8 font-mono text-sm"
+      />
+      {verifyQuery.isLoading && parsedChannelId ? (
+        <p className="text-xs text-muted-foreground">
+          <FormattedMessage {...workspaceAutomationFormMessages.verifyingChannel} />
+        </p>
+      ) : null}
+      {verifiedLabel ? (
+        <p className={cn("text-xs text-muted-foreground")}>{verifiedLabel}</p>
+      ) : null}
+      {showInvalidFormat ? (
+        <p className="text-xs text-destructive">
+          <FormattedMessage {...workspaceAutomationFormMessages.invalidChannelId} />
+        </p>
+      ) : null}
+      {showNotFound ? (
+        <p className="text-xs text-destructive">
+          <FormattedMessage {...workspaceAutomationFormMessages.channelNotFound} />
+        </p>
+      ) : null}
+      {helperError ? <p className="text-xs text-destructive">{helperError}</p> : null}
+      {!helperError && !showInvalidFormat && !showNotFound && !verifiedLabel ? (
+        <p className="text-xs text-muted-foreground">
+          <FormattedMessage {...workspaceAutomationFormMessages.channelIdHelp} />
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -628,26 +628,41 @@ export const workspaceAutomationFormMessages = defineMessages({
     description: "Accessible label to remove Slack notifications",
   },
   channelLabel: {
-    defaultMessage: "Channel",
-    id: "T8F8lD+KK1",
-    description: "Label for the Slack channel select",
+    defaultMessage: "Channel ID",
+    id: "FxNFbqpNBI",
+    description: "Label for the Slack channel ID input",
   },
-  loadingChannels: {
-    defaultMessage: "Loading channels...",
-    id: "D0mCtflyKZ",
-    description: "Placeholder while Slack channels are loading",
+  channelIdPlaceholder: {
+    defaultMessage: "C0123456789",
+    id: "/69jKTmJ4I",
+    description: "Placeholder for the Slack channel ID input",
   },
-  noChannelsFound: {
-    defaultMessage: "No channels found",
-    id: "AiZ8NmX54q",
-    description: "Empty state when no Slack channels are available",
-  },
-  noMatchingChannels: {
+  channelIdHelp: {
     defaultMessage:
-      "Can't find that channel. If it's private, invite the Hyperlocalise app, then search again. You can also paste the channel ID from Slack.",
-    id: "vLWybE+AOt",
-    description:
-      "Empty state when a typed Slack channel name or ID does not match visible channels",
+      "Paste the channel ID from Slack. Open the channel, click the channel name, then copy the ID at the bottom of the About tab. The app must be invited to private channels.",
+    id: "7w0EIy2MLW",
+    description: "Help text for entering a Slack channel ID",
+  },
+  verifyingChannel: {
+    defaultMessage: "Verifying channel...",
+    id: "0AwFQKS1li",
+    description: "Status while a Slack channel ID is being verified",
+  },
+  invalidChannelId: {
+    defaultMessage: "Enter a valid Slack channel ID, such as C0123456789.",
+    id: "Jsu6BbXJ5w",
+    description: "Error when the Slack channel ID format is invalid",
+  },
+  channelNotFound: {
+    defaultMessage:
+      "Channel not found or the app is not a member. For private channels, invite the Hyperlocalise app first.",
+    id: "WAbDlyKYQP",
+    description: "Error when conversations.info does not resolve the channel ID",
+  },
+  slackChannelVerifyFailed: {
+    defaultMessage: "Unable to verify this channel right now. Try again.",
+    id: "ZM4eC/SiqK",
+    description: "Error when Slack channel verification fails unexpectedly",
   },
   privateChannelSuffix: {
     defaultMessage: "#{name} (private)",

--- a/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.test.ts
@@ -15,14 +15,11 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { isErr, isOk } from "@/lib/primitives/result/results";
 
 import {
-  clearSlackChannelListCache,
   fromCanonicalSlackChannelId,
   normalizeSlackChannelQuery,
   parseSlackConversationId,
-  searchSlackChannels,
-  SLACK_CHANNEL_LIST_MAX_PAGES,
-  SLACK_CHANNEL_LIST_PAGE_LIMIT,
   toCanonicalSlackChannelId,
+  verifySlackChannel,
 } from "./search-channels";
 
 const fetchMock = vi.fn();
@@ -42,24 +39,11 @@ function requestUrl(input: unknown) {
   return new URL(String(input));
 }
 
-function mockSlack(
-  handler: (url: URL) => {
-    body: unknown;
-    init?: { status?: number; headers?: Record<string, string> };
-  },
-) {
-  fetchMock.mockImplementation(async (input: unknown) => {
-    const response = handler(requestUrl(input));
-    return jsonResponse(response.body, response.init);
-  });
-}
-
-describe("searchSlackChannels", () => {
+describe("verifySlackChannel", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.useRealTimers();
     fetchMock.mockReset();
-    clearSlackChannelListCache();
   });
 
   it("canonicalizes Slack channel ids", () => {
@@ -76,373 +60,108 @@ describe("searchSlackChannels", () => {
     expect(parseSlackConversationId("release-notes")).toBeNull();
   });
 
-  it("browses a single page when Slack has no further cursor", async () => {
+  it("verifies a channel through conversations.info", async () => {
     vi.stubGlobal("fetch", fetchMock);
     fetchMock.mockResolvedValue(
       jsonResponse({
         ok: true,
-        channels: [
-          { id: "C_PUBLIC", name: "localization", is_private: false },
-          { id: "C_PRIVATE", name: "team-l10n", is_private: true },
-          { id: "C_ARCHIVED", name: "old", is_archived: true },
-        ],
-        response_metadata: {},
+        channel: { id: "C01234567", name: "localization", is_private: false },
       }),
     );
 
-    const result = await searchSlackChannels({ botToken: "xoxb-token" });
+    const result = await verifySlackChannel({
+      botToken: "xoxb-token",
+      channelId: "C01234567",
+    });
 
     expect(isOk(result)).toBe(true);
     if (!isOk(result)) {
-      throw new Error("expected channel browse to succeed");
+      throw new Error("expected channel verify to succeed");
     }
-    expect(result.value).toEqual([
-      { id: "slack:C_PUBLIC", name: "localization", private: false },
-      { id: "slack:C_ARCHIVED", name: "old", private: false },
-      { id: "slack:C_PRIVATE", name: "team-l10n", private: true },
-    ]);
+    expect(result.value).toEqual({
+      id: "slack:C01234567",
+      name: "localization",
+      private: false,
+    });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const url = requestUrl(fetchMock.mock.calls[0]?.[0]);
-    expect(url.origin + url.pathname).toBe("https://slack.com/api/conversations.list");
-    expect(url.searchParams.get("limit")).toBe(String(SLACK_CHANNEL_LIST_PAGE_LIMIT));
-    expect(url.searchParams.get("exclude_archived")).toBeNull();
-    expect(url.searchParams.get("cursor")).toBeNull();
+    expect(url.origin + url.pathname).toBe("https://slack.com/api/conversations.info");
+    expect(url.searchParams.get("channel")).toBe("C01234567");
   });
 
-  it("keeps paging when a list page is shorter than limit", async () => {
+  it("returns null for archived channels", async () => {
     vi.stubGlobal("fetch", fetchMock);
-    let listPages = 0;
-    mockSlack((url) => {
-      expect(url.searchParams.get("limit")).toBe(String(SLACK_CHANNEL_LIST_PAGE_LIMIT));
-      expect(url.searchParams.get("exclude_archived")).toBeNull();
-      listPages += 1;
-      if (url.searchParams.get("cursor") === "page-2") {
-        return {
-          body: {
-            ok: true,
-            channels: [{ id: "C_TARGET", name: "release-notes" }],
-          },
-        };
-      }
-
-      return {
-        body: {
-          ok: true,
-          channels: [{ id: "C_PUBLIC", name: "localization" }],
-          response_metadata: { next_cursor: "page-2" },
-        },
-      };
-    });
-
-    const result = await searchSlackChannels({ botToken: "xoxb-token" });
-
-    expect(isOk(result)).toBe(true);
-    if (!isOk(result)) {
-      throw new Error("expected browse to follow next_cursor after a short page");
-    }
-    expect(result.value.map((channel) => channel.id)).toEqual(["slack:C_PUBLIC", "slack:C_TARGET"]);
-    expect(listPages).toBe(2);
-  });
-
-  it("keeps paging after an exact name match so later channels are still fetched", async () => {
-    vi.stubGlobal("fetch", fetchMock);
-    mockSlack((url) => {
-      if (url.pathname.endsWith("/conversations.info")) {
-        return {
-          body: { ok: false, error: "channel_not_found" },
-        };
-      }
-
-      expect(url.searchParams.get("limit")).toBe(String(SLACK_CHANNEL_LIST_PAGE_LIMIT));
-      expect(url.searchParams.get("exclude_archived")).toBeNull();
-      if (url.searchParams.get("cursor") === "page-2") {
-        return {
-          body: {
-            ok: true,
-            channels: [{ id: "C3", name: "alerts-eu" }],
-          },
-        };
-      }
-
-      return {
-        body: {
-          ok: true,
-          channels: [
-            { id: "C1", name: "alerts" },
-            { id: "C2", name: "l10n" },
-          ],
-          response_metadata: { next_cursor: "page-2" },
-        },
-      };
-    });
-
-    const result = await searchSlackChannels({
-      botToken: "xoxb-token",
-      query: "#L10N",
-    });
-
-    expect(isOk(result)).toBe(true);
-    if (!isOk(result)) {
-      throw new Error("expected channel search to succeed");
-    }
-    expect(result.value).toEqual([{ id: "slack:C2", name: "l10n", private: false }]);
-    expect(
-      fetchMock.mock.calls.filter((call) =>
-        String(call[0]).includes("https://slack.com/api/conversations.list"),
-      ),
-    ).toHaveLength(2);
-  });
-
-  it("matches a typed display name to the hyphenated Slack channel name", async () => {
-    vi.stubGlobal("fetch", fetchMock);
-    mockSlack(() => ({
-      body: {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
         ok: true,
-        channels: [{ id: "C_RELEASE", name: "release-notes", is_private: false }],
-      },
-    }));
-
-    const result = await searchSlackChannels({
-      botToken: "xoxb-token",
-      query: "Release Notes",
-    });
-
-    expect(isOk(result)).toBe(true);
-    if (!isOk(result)) {
-      throw new Error("expected spaced channel name to match");
-    }
-    expect(result.value).toEqual([
-      { id: "slack:C_RELEASE", name: "release-notes", private: false },
-    ]);
-    expect(
-      fetchMock.mock.calls.some((call) =>
-        String(call[0]).includes("https://slack.com/api/conversations.info"),
-      ),
-    ).toBe(true);
-  });
-
-  it("resolves a typed channel name via conversations.info when list search would miss it", async () => {
-    vi.stubGlobal("fetch", fetchMock);
-    mockSlack((url) => {
-      if (url.pathname.endsWith("/conversations.info")) {
-        expect(url.searchParams.get("channel")).toBe("#release-notes");
-        return {
-          body: {
-            ok: true,
-            channel: { id: "C_RELEASE", name: "release-notes", is_private: false },
-          },
-        };
-      }
-
-      if (url.searchParams.get("cursor") === "page-2") {
-        return {
-          body: {
-            ok: true,
-            channels: [{ id: "C_PUBLIC", name: "localization" }],
-          },
-        };
-      }
-
-      return {
-        body: {
-          ok: true,
-          channels: [{ id: "C_PUBLIC", name: "localization" }],
-          response_metadata: { next_cursor: "page-2" },
-        },
-      };
-    });
-
-    const result = await searchSlackChannels({
-      botToken: "xoxb-token",
-      query: "Release Notes",
-    });
-
-    expect(isOk(result)).toBe(true);
-    if (!isOk(result)) {
-      throw new Error("expected named channel lookup to succeed");
-    }
-    expect(result.value[0]).toEqual({
-      id: "slack:C_RELEASE",
-      name: "release-notes",
-      private: false,
-    });
-    expect(result.value.map((channel) => channel.id)).toContain("slack:C_RELEASE");
-  });
-
-  it("scans later list pages until an exact channel name matches", async () => {
-    vi.stubGlobal("fetch", fetchMock);
-    let listPages = 0;
-    mockSlack((url) => {
-      if (url.pathname.endsWith("/conversations.info")) {
-        return {
-          body: { ok: false, error: "channel_not_found" },
-        };
-      }
-
-      expect(url.pathname.endsWith("/conversations.list")).toBe(true);
-      listPages += 1;
-      if (url.searchParams.get("cursor") === "page-2") {
-        return {
-          body: {
-            ok: true,
-            channels: [{ id: "C_TARGET", name: "release-notes" }],
-          },
-        };
-      }
-
-      return {
-        body: {
-          ok: true,
-          channels: [{ id: "C_PUBLIC", name: "localization" }],
-          response_metadata: { next_cursor: "page-2" },
-        },
-      };
-    });
-
-    const result = await searchSlackChannels({
-      botToken: "xoxb-token",
-      query: "release-notes",
-    });
-
-    expect(isOk(result)).toBe(true);
-    if (!isOk(result)) {
-      throw new Error("expected list scan after lookup miss to succeed");
-    }
-    expect(result.value).toEqual([{ id: "slack:C_TARGET", name: "release-notes", private: false }]);
-    expect(listPages).toBe(2);
-  });
-
-  it("looks up a typed Slack channel id without treating channel_not_found as a hard error", async () => {
-    vi.stubGlobal("fetch", fetchMock);
-    mockSlack((url) => {
-      if (url.pathname.endsWith("/conversations.info")) {
-        expect(url.searchParams.get("channel")).toBe("C01234567");
-        return {
-          body: { ok: false, error: "channel_not_found" },
-        };
-      }
-
-      return {
-        body: {
-          ok: true,
-          channels: [{ id: "C01234567", name: "eng-l10n" }],
-        },
-      };
-    });
-
-    const result = await searchSlackChannels({
-      botToken: "xoxb-token",
-      query: "C01234567",
-    });
-
-    expect(isOk(result)).toBe(true);
-    if (!isOk(result)) {
-      throw new Error("expected id search to succeed after lookup miss");
-    }
-    expect(result.value).toEqual([{ id: "slack:C01234567", name: "eng-l10n", private: false }]);
-  });
-
-  it("looks up a Slack archive URL through conversations.info", async () => {
-    vi.stubGlobal("fetch", fetchMock);
-    mockSlack((url) => {
-      if (url.pathname.endsWith("/conversations.info")) {
-        expect(url.searchParams.get("channel")).toBe("C01234567");
-        return {
-          body: {
-            ok: true,
-            channel: { id: "C01234567", name: "eng-l10n", is_private: false },
-          },
-        };
-      }
-
-      return {
-        body: {
-          ok: true,
-          channels: [{ id: "C_PUBLIC", name: "localization" }],
-        },
-      };
-    });
-
-    const result = await searchSlackChannels({
-      botToken: "xoxb-token",
-      query: "https://acme.slack.com/archives/C01234567",
-    });
-
-    expect(isOk(result)).toBe(true);
-    if (!isOk(result)) {
-      throw new Error("expected archive URL lookup to succeed");
-    }
-    expect(result.value[0]).toEqual({
-      id: "slack:C01234567",
-      name: "eng-l10n",
-      private: false,
-    });
-  });
-
-  it("includes the selected channel even when it is outside the browse page", async () => {
-    vi.stubGlobal("fetch", fetchMock);
-    mockSlack((url) => {
-      if (url.pathname.endsWith("/conversations.info")) {
-        expect(url.searchParams.get("channel")).toBe("C_SELECTED");
-        return {
-          body: {
-            ok: true,
-            channel: { id: "C_SELECTED", name: "release-updates", is_private: true },
-          },
-        };
-      }
-
-      return {
-        body: {
-          ok: true,
-          channels: [{ id: "C_PUBLIC", name: "localization" }],
-        },
-      };
-    });
-
-    const result = await searchSlackChannels({
-      botToken: "xoxb-token",
-      selectedChannelId: "slack:C_SELECTED",
-    });
-
-    expect(isOk(result)).toBe(true);
-    if (!isOk(result)) {
-      throw new Error("expected selected channel merge to succeed");
-    }
-    expect(result.value).toEqual([
-      { id: "slack:C_PUBLIC", name: "localization", private: false },
-      { id: "slack:C_SELECTED", name: "release-updates", private: true },
-    ]);
-    expect(
-      fetchMock.mock.calls.some((call) => {
-        const href = String(call[0]);
-        return (
-          href.includes("https://slack.com/api/conversations.info") &&
-          href.includes("channel=C_SELECTED")
-        );
+        channel: { id: "C01234568", name: "old", is_archived: true },
       }),
-    ).toBe(true);
+    );
+
+    const result = await verifySlackChannel({
+      botToken: "xoxb-token",
+      channelId: "C01234568",
+    });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw new Error("expected archived channel verify to succeed with null");
+    }
+    expect(result.value).toBeNull();
   });
 
-  it("retries Slack 429 responses and then succeeds", async () => {
+  it("returns null when Slack cannot find the channel", async () => {
     vi.stubGlobal("fetch", fetchMock);
-    const sleep = vi.fn().mockResolvedValue(undefined);
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        ok: false,
+        error: "channel_not_found",
+      }),
+    );
+
+    const result = await verifySlackChannel({
+      botToken: "xoxb-token",
+      channelId: "C01234569",
+    });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw new Error("expected missing channel verify to succeed with null");
+    }
+    expect(result.value).toBeNull();
+  });
+
+  it("returns null for invalid channel id input without calling Slack", async () => {
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await verifySlackChannel({
+      botToken: "xoxb-token",
+      channelId: "not-a-channel",
+    });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) {
+      throw new Error("expected invalid channel id to return null");
+    }
+    expect(result.value).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("retries Slack rate limits before succeeding", async () => {
+    vi.stubGlobal("fetch", fetchMock);
     fetchMock
-      .mockResolvedValueOnce(
-        jsonResponse(
-          { ok: false, error: "ratelimited" },
-          { status: 429, headers: { "retry-after": "1" } },
-        ),
-      )
+      .mockResolvedValueOnce(jsonResponse({ ok: false, error: "ratelimited" }, { status: 429 }))
       .mockResolvedValueOnce(
         jsonResponse({
           ok: true,
-          channels: [{ id: "C1", name: "general" }],
+          channel: { id: "C01234570", name: "general", is_private: false },
         }),
       );
 
-    const result = await searchSlackChannels({
+    const sleep = vi.fn(async () => undefined);
+    const result = await verifySlackChannel({
       botToken: "xoxb-token",
+      channelId: "C01234570",
       sleep,
     });
 
@@ -450,7 +169,7 @@ describe("searchSlackChannels", () => {
     if (!isOk(result)) {
       throw new Error("expected rate-limit retry to succeed");
     }
-    expect(result.value).toEqual([{ id: "slack:C1", name: "general", private: false }]);
+    expect(result.value).toEqual({ id: "slack:C01234570", name: "general", private: false });
     expect(sleep).toHaveBeenCalledWith(1000);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
@@ -459,8 +178,9 @@ describe("searchSlackChannels", () => {
     vi.stubGlobal("fetch", fetchMock);
     fetchMock.mockResolvedValue(jsonResponse({ ok: false, error: "ratelimited" }, { status: 429 }));
 
-    const result = await searchSlackChannels({
+    const result = await verifySlackChannel({
       botToken: "xoxb-token",
+      channelId: "C01234571",
       sleep: async () => undefined,
     });
 
@@ -469,123 +189,5 @@ describe("searchSlackChannels", () => {
       throw new Error("expected rate-limit exhaustion");
     }
     expect(result.error).toEqual({ code: "slack_rate_limited" });
-  });
-
-  it("reuses a cached channel list for later searches in the same workspace", async () => {
-    vi.stubGlobal("fetch", fetchMock);
-    mockSlack(() => ({
-      body: {
-        ok: true,
-        channels: [
-          { id: "C_PUBLIC", name: "localization" },
-          { id: "C_RELEASE", name: "release-notes" },
-        ],
-      },
-    }));
-
-    const first = await searchSlackChannels({
-      botToken: "xoxb-token",
-      cacheKey: "T123",
-      query: "localization",
-    });
-    const second = await searchSlackChannels({
-      botToken: "xoxb-token",
-      cacheKey: "T123",
-      query: "Release Notes",
-    });
-
-    expect(isOk(first)).toBe(true);
-    expect(isOk(second)).toBe(true);
-    if (!isOk(second)) {
-      throw new Error("expected cached name search to succeed");
-    }
-    expect(second.value).toEqual([
-      { id: "slack:C_RELEASE", name: "release-notes", private: false },
-    ]);
-    expect(
-      fetchMock.mock.calls.filter((call) =>
-        String(call[0]).includes("https://slack.com/api/conversations.list"),
-      ),
-    ).toHaveLength(1);
-  });
-
-  it("serves a stale cached list when Slack rate-limits a later search", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-08-19T00:00:00.000Z"));
-    vi.stubGlobal("fetch", fetchMock);
-    let listCalls = 0;
-    mockSlack((url) => {
-      if (url.pathname.endsWith("/conversations.info")) {
-        return {
-          body: { ok: false, error: "channel_not_found" },
-        };
-      }
-
-      listCalls += 1;
-      if (listCalls === 1) {
-        return {
-          body: {
-            ok: true,
-            channels: [{ id: "C_RELEASE", name: "release-notes" }],
-          },
-        };
-      }
-
-      return {
-        body: { ok: false, error: "ratelimited" },
-        init: { status: 429 },
-      };
-    });
-
-    const first = await searchSlackChannels({
-      botToken: "xoxb-token",
-      cacheKey: "T123",
-      query: "release-notes",
-      sleep: async () => undefined,
-    });
-    vi.setSystemTime(new Date("2026-08-19T00:02:00.000Z"));
-    const second = await searchSlackChannels({
-      botToken: "xoxb-token",
-      cacheKey: "T123",
-      query: "release-notes",
-      sleep: async () => undefined,
-    });
-
-    expect(isOk(first)).toBe(true);
-    expect(isOk(second)).toBe(true);
-    if (!isOk(second)) {
-      throw new Error("expected stale cache fallback to succeed");
-    }
-    expect(second.value).toEqual([
-      { id: "slack:C_RELEASE", name: "release-notes", private: false },
-    ]);
-  });
-
-  it("stops listing after the max page budget", async () => {
-    vi.stubGlobal("fetch", fetchMock);
-    mockSlack((url) => {
-      const cursor = url.searchParams.get("cursor");
-      const page = cursor ? Number(cursor) : 0;
-      return {
-        body: {
-          ok: true,
-          channels: [{ id: `C${page}`, name: `channel-${page}` }],
-          response_metadata: { next_cursor: String(page + 1) },
-        },
-      };
-    });
-
-    const result = await searchSlackChannels({ botToken: "xoxb-token" });
-
-    expect(isOk(result)).toBe(true);
-    if (!isOk(result)) {
-      throw new Error("expected max-page browse to succeed");
-    }
-    expect(result.value).toHaveLength(SLACK_CHANNEL_LIST_MAX_PAGES);
-    expect(
-      fetchMock.mock.calls.filter((call) =>
-        String(call[0]).includes("https://slack.com/api/conversations.list"),
-      ),
-    ).toHaveLength(SLACK_CHANNEL_LIST_MAX_PAGES);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/search-channels.ts
@@ -11,23 +11,11 @@
  * Version 2.0 or later.
  */
 
-import {
-  err,
-  fromThrowableAsync,
-  isErr,
-  isOk,
-  ok,
-  type Result,
-} from "@/lib/primitives/result/results";
+import { err, fromThrowableAsync, isErr, ok, type Result } from "@/lib/primitives/result/results";
 
 import {
   fromCanonicalSlackChannelId,
-  isExactSlackChannelMatch,
-  normalizeSlackChannelQuery,
   parseSlackConversationId,
-  SLACK_CHANNEL_NAME_PATTERN,
-  slackChannelMatchKeys,
-  slackChannelMatchesQuery,
   toCanonicalSlackChannelId,
 } from "./channel-query";
 
@@ -38,12 +26,8 @@ export {
   toCanonicalSlackChannelId,
 } from "./channel-query";
 
-export const SLACK_CHANNEL_LIST_PAGE_LIMIT = 200;
-export const SLACK_CHANNEL_LIST_MAX_PAGES = 50;
 export const SLACK_CHANNEL_RATE_LIMIT_RETRIES = 3;
 export const SLACK_CHANNEL_RATE_LIMIT_MAX_WAIT_MS = 2000;
-export const SLACK_CHANNEL_LIST_CACHE_TTL_MS = 60_000;
-const SLACK_CHANNEL_LIST_CACHE_MAX_ENTRIES = 50;
 
 const SLACK_CHANNEL_LOOKUP_MISS_ERRORS = new Set([
   "channel_not_found",
@@ -64,13 +48,7 @@ type SlackChannel = {
   name?: string;
   name_normalized?: string;
   is_private?: boolean;
-};
-
-type SlackConversationsListResponse = {
-  ok?: boolean;
-  error?: string;
-  channels?: SlackChannel[];
-  response_metadata?: { next_cursor?: string };
+  is_archived?: boolean;
 };
 
 type SlackConversationsInfoResponse = {
@@ -78,8 +56,6 @@ type SlackConversationsInfoResponse = {
   error?: string;
   channel?: SlackChannel;
 };
-
-type SlackJsonResponse = SlackConversationsListResponse & SlackConversationsInfoResponse;
 
 type SlackRequestOptions = {
   signal?: AbortSignal;
@@ -107,6 +83,10 @@ function parseRetryAfterMs(response: Response) {
 }
 
 function toChannelListItem(channel: SlackChannel): SlackChannelListItem | null {
+  if (channel.is_archived) {
+    return null;
+  }
+
   const name = channel.name || channel.name_normalized;
   if (!channel.id || !name) {
     return null;
@@ -117,24 +97,6 @@ function toChannelListItem(channel: SlackChannel): SlackChannelListItem | null {
     name,
     private: Boolean(channel.is_private),
   };
-}
-
-function slackChannelLookupKeys(query: string) {
-  const channelId = parseSlackConversationId(query);
-  if (channelId) {
-    return [channelId];
-  }
-
-  const keys: string[] = [];
-  const seen = new Set<string>();
-  for (const name of slackChannelMatchKeys(query)) {
-    if (!SLACK_CHANNEL_NAME_PATTERN.test(name) || seen.has(name)) {
-      continue;
-    }
-    seen.add(name);
-    keys.push(`#${name}`);
-  }
-  return keys;
 }
 
 function isSlackChannelLookupMiss(error: SlackChannelSearchError) {
@@ -149,7 +111,7 @@ async function fetchSlackJson(
   url: URL,
   botToken: string,
   options: SlackRequestOptions,
-): Promise<Result<SlackJsonResponse, SlackChannelSearchError>> {
+): Promise<Result<SlackConversationsInfoResponse, SlackChannelSearchError>> {
   for (let attempt = 0; attempt <= SLACK_CHANNEL_RATE_LIMIT_RETRIES; attempt += 1) {
     const responseResult = await fromThrowableAsync(
       fetch(url, {
@@ -175,7 +137,9 @@ async function fetchSlackJson(
       return err({ code: "slack_http_error", status: response.status });
     }
 
-    const bodyResult = await fromThrowableAsync(response.json() as Promise<SlackJsonResponse>);
+    const bodyResult = await fromThrowableAsync(
+      response.json() as Promise<SlackConversationsInfoResponse>,
+    );
     if (isErr(bodyResult)) {
       return err({ code: "bot_unavailable", cause: bodyResult.error });
     }
@@ -199,19 +163,24 @@ async function fetchSlackJson(
   return err({ code: "slack_rate_limited" });
 }
 
-async function loadSlackChannelByKey(
-  botToken: string,
-  channelKey: string,
-  options: SlackRequestOptions,
-): Promise<Result<SlackChannelListItem | null, SlackChannelSearchError>> {
-  if (!channelKey) {
+export async function verifySlackChannel(input: {
+  botToken: string;
+  channelId: string;
+  signal?: AbortSignal;
+  sleep?: (ms: number) => Promise<void>;
+}): Promise<Result<SlackChannelListItem | null, SlackChannelSearchError>> {
+  const parsedChannelId = parseSlackConversationId(input.channelId);
+  if (!parsedChannelId) {
     return ok(null);
   }
 
   const url = new URL("https://slack.com/api/conversations.info");
-  url.searchParams.set("channel", channelKey);
+  url.searchParams.set("channel", fromCanonicalSlackChannelId(parsedChannelId));
 
-  const bodyResult = await fetchSlackJson(url, botToken, options);
+  const bodyResult = await fetchSlackJson(url, input.botToken, {
+    signal: input.signal,
+    sleep: input.sleep ?? defaultSleep,
+  });
   if (isErr(bodyResult)) {
     if (isSlackChannelLookupMiss(bodyResult.error)) {
       return ok(null);
@@ -220,308 +189,4 @@ async function loadSlackChannelByKey(
   }
 
   return ok(toChannelListItem(bodyResult.value.channel ?? {}));
-}
-
-async function lookupSlackChannelByQuery(
-  botToken: string,
-  query: string,
-  options: SlackRequestOptions,
-): Promise<Result<SlackChannelListItem | null, SlackChannelSearchError>> {
-  const keys = slackChannelLookupKeys(query);
-  if (keys.length === 0) {
-    return ok(null);
-  }
-
-  for (const key of keys) {
-    const lookupResult = await loadSlackChannelByKey(botToken, key, options);
-    if (isErr(lookupResult)) {
-      // Speculative name/id lookup must not fail the search; list scan can still match.
-      if (
-        lookupResult.error.code === "slack_rate_limited" ||
-        lookupResult.error.code === "bot_unavailable"
-      ) {
-        return lookupResult;
-      }
-      continue;
-    }
-    if (lookupResult.value) {
-      return lookupResult;
-    }
-  }
-
-  return ok(null);
-}
-
-async function listSlackChannelPage(
-  botToken: string,
-  input: {
-    cursor?: string;
-    limit: number;
-    signal?: AbortSignal;
-    sleep: (ms: number) => Promise<void>;
-  },
-): Promise<
-  Result<{ channels: SlackChannelListItem[]; nextCursor: string }, SlackChannelSearchError>
-> {
-  const url = new URL("https://slack.com/api/conversations.list");
-  // Omit exclude_archived. Slack applies that filter after filling a virtual page
-  // of `limit`, which can shrink pages and skip later channels.
-  url.searchParams.set("limit", String(input.limit));
-  url.searchParams.set("types", "public_channel,private_channel");
-  if (input.cursor) {
-    url.searchParams.set("cursor", input.cursor);
-  }
-
-  const bodyResult = await fetchSlackJson(url, botToken, {
-    signal: input.signal,
-    sleep: input.sleep,
-  });
-  if (isErr(bodyResult)) {
-    return bodyResult;
-  }
-
-  const channels: SlackChannelListItem[] = [];
-  for (const channel of bodyResult.value.channels ?? []) {
-    const item = toChannelListItem(channel);
-    if (item) {
-      channels.push(item);
-    }
-  }
-
-  return ok({
-    channels,
-    nextCursor: bodyResult.value.response_metadata?.next_cursor ?? "",
-  });
-}
-
-type SlackChannelListSnapshot = {
-  channels: SlackChannelListItem[];
-  nextCursor: string;
-  fetchedAt: number;
-};
-
-// In-memory conversations.list snapshot keyed by Slack team id. Do not store
-// this in Postgres: names and private membership change, and a DB row would
-// still miss the first fetch that 429s. A 60s TTL absorbs picker remounts
-// after the full list is fetched.
-const slackChannelListCache = new Map<string, SlackChannelListSnapshot>();
-
-export function clearSlackChannelListCache() {
-  slackChannelListCache.clear();
-}
-
-function cloneSlackChannelListSnapshot(
-  snapshot: SlackChannelListSnapshot,
-): SlackChannelListSnapshot {
-  return {
-    channels: [...snapshot.channels],
-    nextCursor: snapshot.nextCursor,
-    fetchedAt: snapshot.fetchedAt,
-  };
-}
-
-function readSlackChannelListCache(cacheKey: string | undefined, now: number, allowStale: boolean) {
-  if (!cacheKey) {
-    return null;
-  }
-
-  const entry = slackChannelListCache.get(cacheKey);
-  if (!entry) {
-    return null;
-  }
-
-  const isFresh = now - entry.fetchedAt <= SLACK_CHANNEL_LIST_CACHE_TTL_MS;
-  if (!isFresh && !allowStale) {
-    return null;
-  }
-
-  return cloneSlackChannelListSnapshot(entry);
-}
-
-function writeSlackChannelListCache(
-  cacheKey: string | undefined,
-  snapshot: SlackChannelListSnapshot,
-) {
-  if (!cacheKey) {
-    return;
-  }
-
-  if (
-    !slackChannelListCache.has(cacheKey) &&
-    slackChannelListCache.size >= SLACK_CHANNEL_LIST_CACHE_MAX_ENTRIES
-  ) {
-    const oldestKey = slackChannelListCache.keys().next().value;
-    if (oldestKey) {
-      slackChannelListCache.delete(oldestKey);
-    }
-  }
-
-  slackChannelListCache.set(cacheKey, cloneSlackChannelListSnapshot(snapshot));
-}
-
-function appendSlackChannelListPage(
-  snapshot: SlackChannelListSnapshot,
-  page: { channels: SlackChannelListItem[]; nextCursor: string },
-  now: number,
-) {
-  const seenIds = new Set(snapshot.channels.map((channel) => channel.id));
-  for (const channel of page.channels) {
-    if (!seenIds.has(channel.id)) {
-      snapshot.channels.push(channel);
-      seenIds.add(channel.id);
-    }
-  }
-  snapshot.nextCursor = page.nextCursor;
-  snapshot.fetchedAt = now;
-}
-
-function mergeSlackChannels(
-  selected: SlackChannelListItem | null,
-  channels: SlackChannelListItem[],
-  query = "",
-) {
-  const merged = new Map<string, SlackChannelListItem>();
-  for (const channel of channels) {
-    merged.set(channel.id, channel);
-  }
-  if (selected) {
-    merged.set(selected.id, selected);
-  }
-
-  const normalizedQuery = normalizeSlackChannelQuery(query);
-  return [...merged.values()].sort((left, right) => {
-    if (normalizedQuery) {
-      const leftExact = isExactSlackChannelMatch(left, normalizedQuery);
-      const rightExact = isExactSlackChannelMatch(right, normalizedQuery);
-      if (leftExact !== rightExact) {
-        return leftExact ? -1 : 1;
-      }
-    }
-
-    return left.name.localeCompare(right.name);
-  });
-}
-
-async function loadCompleteSlackChannelList(input: {
-  botToken: string;
-  cacheKey?: string;
-  signal?: AbortSignal;
-  sleep: (ms: number) => Promise<void>;
-}): Promise<Result<SlackChannelListSnapshot, SlackChannelSearchError>> {
-  const now = Date.now();
-  let snapshot = readSlackChannelListCache(input.cacheKey, now, false);
-  let canPageFurther = true;
-  let pagesFetched = 0;
-
-  const fetchListPage = async (
-    cursor: string | undefined,
-  ): Promise<Result<void, SlackChannelSearchError>> => {
-    const pageResult = await listSlackChannelPage(input.botToken, {
-      cursor,
-      limit: SLACK_CHANNEL_LIST_PAGE_LIMIT,
-      signal: input.signal,
-      sleep: input.sleep,
-    });
-    if (isErr(pageResult)) {
-      if (pageResult.error.code === "slack_rate_limited") {
-        const stale = snapshot ?? readSlackChannelListCache(input.cacheKey, Date.now(), true);
-        if (stale && stale.channels.length > 0) {
-          snapshot = stale;
-          canPageFurther = false;
-          return ok(undefined);
-        }
-      }
-      return pageResult;
-    }
-
-    if (!snapshot) {
-      snapshot = { channels: [], nextCursor: "", fetchedAt: Date.now() };
-    }
-    appendSlackChannelListPage(snapshot, pageResult.value, Date.now());
-    writeSlackChannelListCache(input.cacheKey, snapshot);
-    pagesFetched += 1;
-    return ok(undefined);
-  };
-
-  if (!snapshot) {
-    const firstPageResult = await fetchListPage(undefined);
-    if (isErr(firstPageResult)) {
-      return firstPageResult;
-    }
-  }
-
-  while (snapshot?.nextCursor && canPageFurther && pagesFetched < SLACK_CHANNEL_LIST_MAX_PAGES) {
-    const cursor = snapshot.nextCursor;
-    const pageResult = await fetchListPage(cursor);
-    if (isErr(pageResult)) {
-      return pageResult;
-    }
-    if (snapshot.nextCursor === cursor) {
-      snapshot.nextCursor = "";
-      writeSlackChannelListCache(input.cacheKey, snapshot);
-      break;
-    }
-  }
-
-  return ok(snapshot ?? { channels: [], nextCursor: "", fetchedAt: Date.now() });
-}
-
-export async function searchSlackChannels(input: {
-  botToken: string;
-  cacheKey?: string;
-  query?: string;
-  selectedChannelId?: string;
-  signal?: AbortSignal;
-  sleep?: (ms: number) => Promise<void>;
-}): Promise<Result<SlackChannelListItem[], SlackChannelSearchError>> {
-  const sleep = input.sleep ?? defaultSleep;
-  const options: SlackRequestOptions = { signal: input.signal, sleep };
-  const query = input.query?.trim() ?? "";
-
-  const selectedPromise: Promise<Result<SlackChannelListItem | null, SlackChannelSearchError>> =
-    input.selectedChannelId
-      ? loadSlackChannelByKey(
-          input.botToken,
-          fromCanonicalSlackChannelId(input.selectedChannelId),
-          options,
-        )
-      : Promise.resolve(ok<SlackChannelListItem | null, SlackChannelSearchError>(null));
-  const lookupPromise: Promise<Result<SlackChannelListItem | null, SlackChannelSearchError>> = query
-    ? lookupSlackChannelByQuery(input.botToken, query, options)
-    : Promise.resolve(ok<SlackChannelListItem | null, SlackChannelSearchError>(null));
-  const listPromise = loadCompleteSlackChannelList({
-    botToken: input.botToken,
-    cacheKey: input.cacheKey,
-    signal: input.signal,
-    sleep,
-  });
-
-  const [selectedResult, lookupResult, listResult] = await Promise.all([
-    selectedPromise,
-    lookupPromise,
-    listPromise,
-  ]);
-  if (isErr(selectedResult)) {
-    return selectedResult;
-  }
-  if (isErr(listResult)) {
-    return listResult;
-  }
-  if (isErr(lookupResult)) {
-    if (
-      lookupResult.error.code !== "slack_rate_limited" ||
-      listResult.value.channels.length === 0
-    ) {
-      return lookupResult;
-    }
-  }
-
-  const matches = query
-    ? listResult.value.channels.filter((channel) => slackChannelMatchesQuery(channel, query))
-    : [...listResult.value.channels];
-  if (isOk(lookupResult) && lookupResult.value) {
-    matches.push(lookupResult.value);
-  }
-
-  return ok(mergeSlackChannels(selectedResult.value, matches, query));
 }

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
@@ -80,7 +80,7 @@ describe("workspace automation view model", () => {
       githubInstallationRepositoryId: "11111111-1111-4111-8111-111111111111",
       validationEnabled: true,
       slackEnabled: true,
-      slackChannelId: "C123",
+      slackChannelId: "C01234567",
       emailEnabled: true,
       emailRecipients: ["ops@example.com"],
     };
@@ -100,7 +100,7 @@ describe("workspace automation view model", () => {
     expect(payload.toolConfig.github).not.toHaveProperty("projectId");
     expect(payload.toolConfig.slack).toEqual({
       enabled: true,
-      channelId: "C123",
+      channelId: "C01234567",
     });
     expect(payload.toolConfig.email).toEqual({
       enabled: true,
@@ -240,7 +240,7 @@ describe("workspace automation view model", () => {
       validateWorkspaceAutomationFormState({
         ...form!,
         githubInstallationRepositoryId: "11111111-1111-4111-8111-111111111111",
-        slackChannelId: "C123",
+        slackChannelId: "C01234567",
       }),
     ).toEqual({});
   });

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
@@ -18,6 +18,7 @@ import type {
   WorkspaceAutomationTriggerConfig,
   WorkspaceAutomationWebSearchProvider,
 } from "./workspace-automations";
+import { parseSlackConversationId } from "./slack/channel-query";
 import {
   getWorkspaceAutomationTemplate,
   type WorkspaceAutomationTemplate,
@@ -601,8 +602,8 @@ export function validateWorkspaceAutomationFormState(
     errors.pushBranches = "Add at least one branch pattern.";
   }
 
-  if (form.slackEnabled && !form.slackChannelId.trim()) {
-    errors.slackChannelId = "Choose a Slack channel.";
+  if (form.slackEnabled && !parseSlackConversationId(form.slackChannelId)) {
+    errors.slackChannelId = "Enter a valid Slack channel ID.";
   }
 
   if (form.emailEnabled && form.emailRecipients.length === 0) {


### PR DESCRIPTION
## What changed

Replaces the Slack channel browse/search flow with channel ID entry verified through `conversations.info`.

- **Removed** `conversations.list` usage, pagination (50-page cap), and the 60s in-memory channel list cache
- **Added** `GET /agent-slack/channels/verify?channelId=…` to verify a channel via `conversations.info`
- **Updated** the automation Slack settings UI from a searchable dropdown to a channel ID input with debounced verification and resolved channel name feedback
- **Rejected** archived channels during verification
- **Tightened** form validation to require a valid Slack channel ID format (`C…` / `G…` / `D…`)

This avoids incomplete channel lists from pagination/rate limits and matches Slack’s recommended approach for standard bot apps, where there is no reliable lookup-by-name API outside Enterprise admin scopes.

## How to test

1. Connect Slack for an org in **Integrations**
2. Open an automation with Slack notifications enabled
3. Paste a valid channel ID (from Slack → channel name → About) and confirm the resolved `#channel-name` appears
4. Paste an invalid ID and confirm format/error messaging
5. Paste a channel ID the app is not in (or an archived channel) and confirm the not-found error
6. Save the automation and confirm the channel ID persists

```bash
cd apps/hyperlocalise-web
vp test src/lib/agents/slack/search-channels.test.ts \
  src/app/[lang]/\(authenticated\)/org/[organizationSlug]/automations/_components/slack-channel-select.test.tsx \
  src/lib/agents/workspace-automation-view-model.test.ts \
  src/api/routes/agent-slack/agent-slack.route.test.ts
vp check --fix
```

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review