### PR TITLE
feat(automations): trigger notify blockers on pull requests to main

### DIFF
--- a/apps/hyperlocalise-web/lang/en-US.json
+++ b/apps/hyperlocalise-web/lang/en-US.json
@@ -287,6 +287,10 @@
     "defaultMessage": "Back to site",
     "description": "Button to return to the marketing site from the access denied page"
   },
+  "/2DsRIRpZu": {
+    "defaultMessage": "GitHub push and pull request · {repository} · {branches}",
+    "description": "Header summary for a GitHub trigger that runs on push and pull request"
+  },
   "/2wzw7IAoz": {
     "defaultMessage": "Unable to open Hyperlocalise",
     "description": "Title when Crowdin JWT bootstrap fails"
@@ -1206,6 +1210,10 @@
   "2BoI5eES6X": {
     "defaultMessage": "Validating…",
     "description": "Button label while validating a provider credential"
+  },
+  "2C7ykfN2tG": {
+    "defaultMessage": "Pull request opened",
+    "description": "Toggle label for GitHub pull request opened trigger events"
   },
   "2CcWvThdpB": {
     "defaultMessage": "Vendor and reviewer assignments happen manually across spreadsheets and Slack.",
@@ -3626,10 +3634,6 @@
   "Ab8vwYJKWj": {
     "defaultMessage": "Reviewers",
     "description": "Knowledge product visual memory node label"
-  },
-  "AbZsOtFk+H": {
-    "defaultMessage": "Post a sticky review comment on the pull request for this push. Later runs update the same comment.",
-    "description": "Description for GitHub pull request comment notifications when GitHub is connected"
   },
   "AcfkWiaJBh": {
     "defaultMessage": "Copied!",
@@ -13135,6 +13139,10 @@
     "defaultMessage": "Settings unavailable",
     "description": "Slack agent panel title when settings failed to load"
   },
+  "k2PKKnD3GN": {
+    "defaultMessage": "Push",
+    "description": "Toggle label for GitHub push trigger events"
+  },
   "k2mhvldg9T": {
     "defaultMessage": "Maya Chen",
     "description": "Marketing teammate name in the Slack launch intake mock"
@@ -15687,6 +15695,10 @@
     "defaultMessage": "Show token",
     "description": "Accessible label to reveal the personal access token value"
   },
+  "tp0Edn/npM": {
+    "defaultMessage": "Post a sticky review comment on the matching pull request. Later runs update the same comment.",
+    "description": "Description for GitHub pull request comment notifications when GitHub is connected"
+  },
   "tr/WtfszIz": {
     "defaultMessage": "Every",
     "description": "Prefix label before the schedule cadence select"
@@ -15794,6 +15806,10 @@
   "uHbVM9Pw9Y": {
     "defaultMessage": "Assignees updated",
     "description": "Toast when job assignees are saved"
+  },
+  "uI2rwqO19R": {
+    "defaultMessage": "GitHub pull request · {repository} · {branches}",
+    "description": "Header summary for a GitHub pull request trigger"
   },
   "uIj8uezhZ9": {
     "defaultMessage": "Earth from space",

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-skills/github-comment-notifications.md
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-skills/github-comment-notifications.md
@@ -16,7 +16,7 @@ When calling `notify_github_comment`, write `message` in **GitHub-flavored Markd
 ### Default shape (when no customer format)
 
 1. **Headline** — bold line with the automation name and outcome (completed, blocked, no localisation findings).
-2. **Key facts** — short bullets for the facts that matter for this push.
+2. **Key facts** — short bullets for the facts that matter for this review.
 3. **Findings** — bullet blocking localisation defects first, then non-blocking follow-ups. Cite commit SHAs and file paths.
 4. **Next step** — one line on what the author should do. Omit if nothing useful.
 
@@ -34,7 +34,7 @@ When calling `notify_github_comment`, write `message` in **GitHub-flavored Markd
 ```markdown
 **Notify on push blockers** completed
 
-- **Push:** `main` `abc1234..def5678`
+- **Pull request:** `#42` `feature/checkout` into `main` (`def5678`)
 - **Blockers:**
   - Hard-coded copy in `src/checkout.ts` (`def5678`)
 - **Follow-ups:**

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/run-workspace-orchestrator.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/run-workspace-orchestrator.test.ts
@@ -68,7 +68,7 @@ describe("buildWorkspaceOrchestratorUserMessage", () => {
         pullRequestNumber: 42,
         baseBranch: "main",
         headBranch: "feature/review",
-        pushBranch: "feature/review",
+        pushBranch: "main",
         commitBefore: "aaa111",
         commitAfter: "bbb222",
       },

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/run-workspace-orchestrator.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/run-workspace-orchestrator.test.ts
@@ -60,6 +60,26 @@ describe("buildWorkspaceOrchestratorUserMessage", () => {
     expect(message).toContain("GitHub push commits: aaa111..bbb222.");
   });
 
+  it("includes GitHub pull request context in the orchestrator prompt", () => {
+    const message = buildWorkspaceOrchestratorUserMessage({
+      automationName: "Notify on push blockers",
+      triggerSource: "github",
+      inputSnapshot: {
+        pullRequestNumber: 42,
+        baseBranch: "main",
+        headBranch: "feature/review",
+        pushBranch: "feature/review",
+        commitBefore: "aaa111",
+        commitAfter: "bbb222",
+      },
+    });
+
+    expect(message).toContain("GitHub pull request: #42.");
+    expect(message).toContain("GitHub pull request branches: feature/review into main.");
+    expect(message).toContain("GitHub pull request commits: aaa111..bbb222.");
+    expect(message).not.toContain("GitHub push branch");
+  });
+
   it("omits Contentful entry context when the snapshot has no entry ID", () => {
     const message = buildWorkspaceOrchestratorUserMessage({
       automationName: "Translate Contentful article",

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/run-workspace-orchestrator.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/run-workspace-orchestrator.ts
@@ -82,6 +82,18 @@ export function buildWorkspaceOrchestratorUserMessage(input: {
   }
 
   if (input.triggerSource === "github") {
+    const pullRequestNumber =
+      typeof input.inputSnapshot.pullRequestNumber === "number"
+        ? input.inputSnapshot.pullRequestNumber
+        : null;
+    const baseBranch =
+      typeof input.inputSnapshot.baseBranch === "string"
+        ? input.inputSnapshot.baseBranch.trim()
+        : "";
+    const headBranch =
+      typeof input.inputSnapshot.headBranch === "string"
+        ? input.inputSnapshot.headBranch.trim()
+        : "";
     const pushBranch =
       typeof input.inputSnapshot.pushBranch === "string"
         ? input.inputSnapshot.pushBranch.trim()
@@ -94,13 +106,26 @@ export function buildWorkspaceOrchestratorUserMessage(input: {
       typeof input.inputSnapshot.commitAfter === "string"
         ? input.inputSnapshot.commitAfter.trim()
         : "";
-    if (pushBranch) {
+    if (pullRequestNumber) {
+      lines.push(`GitHub pull request: #${pullRequestNumber}.`);
+      if (baseBranch && headBranch) {
+        lines.push(`GitHub pull request branches: ${headBranch} into ${baseBranch}.`);
+      }
+    } else if (pushBranch) {
       lines.push(`GitHub push branch: ${pushBranch}.`);
     }
     if (commitBefore && commitAfter) {
-      lines.push(`GitHub push commits: ${commitBefore}..${commitAfter}.`);
+      lines.push(
+        pullRequestNumber
+          ? `GitHub pull request commits: ${commitBefore}..${commitAfter}.`
+          : `GitHub push commits: ${commitBefore}..${commitAfter}.`,
+      );
     } else if (commitAfter) {
-      lines.push(`GitHub push commit: ${commitAfter}.`);
+      lines.push(
+        pullRequestNumber
+          ? `GitHub pull request commit: ${commitAfter}.`
+          : `GitHub push commit: ${commitAfter}.`,
+      );
     }
   }
 

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/skills/notify-on-push-blockers.md
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/skills/notify-on-push-blockers.md
@@ -1,7 +1,7 @@
 ---
 id: notify-on-push-blockers
 name: Notify on push blockers
-description: Review GitHub pushes and pull requests opened against main for localisation and translation risk, then comment on the pull request.
+description: Review pull requests opened against main for localisation and translation risk, then comment on the pull request.
 category: popular
 activatable: true
 sharedSkills: translation-review
@@ -11,17 +11,17 @@ You are a localisation-focused code reviewer for this repository.
 
 What you can do:
 
-- Read the pushed commits, pull request diffs, and surrounding code
+- Read the pull request diffs and surrounding code
 - If `i18n.yml` exists, run Hyperlocalise validation (`hl check`) against the translation files it maps
 - Follow the **Translation review** procedure for per-key findings and P0/P1/P2 output
 - Judge code-adjacent localisation risk: hard-coded copy, i18n APIs, locale routing, fallback, formatters, and writeback
 - Cite commit SHAs and file paths for each finding
 - Ignore unrelated logic, security, and formatting issues unless they affect user-facing copy or locale behavior
-- Post findings as a sticky GitHub pull request comment and update it on later pushes
+- Post findings as a sticky GitHub pull request comment and update it when the pull request changes
 
 Goal:
 
-- Surface localisation and translation risks from this push or pull request before they merge.
+- Surface localisation and translation risks on this pull request before it merges.
 
 Code-layer review focus (in addition to translation review):
 
@@ -32,5 +32,5 @@ Code-layer review focus (in addition to translation review):
 PR comment delivery:
 
 - Post the **Translation review** report sections as the sticky PR comment body.
-- Update the existing sticky comment in place on later pushes; do not spam new comments.
+- Update the existing sticky comment in place when the pull request changes; do not spam new comments.
 - When P0 blockers exist, lead with the **High Priority (P0)** section.

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/skills/notify-on-push-blockers.md
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/skills/notify-on-push-blockers.md
@@ -1,7 +1,7 @@
 ---
 id: notify-on-push-blockers
 name: Notify on push blockers
-description: Review each GitHub push for localisation and translation risk, then comment on the pull request.
+description: Review GitHub pushes and pull requests opened against main for localisation and translation risk, then comment on the pull request.
 category: popular
 activatable: true
 sharedSkills: translation-review
@@ -11,7 +11,7 @@ You are a localisation-focused code reviewer for this repository.
 
 What you can do:
 
-- Read the pushed commits, diffs, and surrounding code
+- Read the pushed commits, pull request diffs, and surrounding code
 - If `i18n.yml` exists, run Hyperlocalise validation (`hl check`) against the translation files it maps
 - Follow the **Translation review** procedure for per-key findings and P0/P1/P2 output
 - Judge code-adjacent localisation risk: hard-coded copy, i18n APIs, locale routing, fallback, formatters, and writeback
@@ -21,7 +21,7 @@ What you can do:
 
 Goal:
 
-- Surface localisation and translation risks from this push on the pull request before they merge.
+- Surface localisation and translation risks from this push or pull request before they merge.
 
 Code-layer review focus (in addition to translation review):
 

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/notify_github_comment.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/notify_github_comment.ts
@@ -68,12 +68,20 @@ export function createNotifyGithubCommentTool(session: WorkspaceOrchestratorSess
       }
 
       const commitSha = readSnapshotString(session.run.inputSnapshot, "commitAfter");
+      const pullRequestNumberRaw = session.run.inputSnapshot.pullRequestNumber;
+      const pullRequestNumber =
+        typeof pullRequestNumberRaw === "number" &&
+        Number.isInteger(pullRequestNumberRaw) &&
+        pullRequestNumberRaw > 0
+          ? pullRequestNumberRaw
+          : undefined;
       const text = message?.trim() || buildOrchestratorRunSummaryMessage(session);
       const result = await upsertWorkspaceAutomationPullRequestComment({
         installationId: repositoryRow.githubInstallationId,
         repositoryFullName: repositoryRow.fullName,
         automationId: session.automation.id,
         commitSha: commitSha ?? "",
+        pullRequestNumber,
         message: text,
       });
 

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/resolve-github-repo-lookback.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/resolve-github-repo-lookback.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   formatGithubPushRangeLabel,
   isGithubNullOid,
+  resolveGithubPullRequestNumber,
   resolveGithubPushRange,
   resolveGithubRepoLookbackHours,
 } from "./resolve-github-repo-lookback";
@@ -72,6 +73,12 @@ describe("resolveGithubPushRange", () => {
         },
       }),
     ).toBeNull();
+  });
+
+  it("reads a pull request number from the GitHub trigger snapshot", () => {
+    expect(resolveGithubPullRequestNumber({ pullRequestNumber: 42 })).toBe(42);
+    expect(resolveGithubPullRequestNumber({ pullRequestNumber: 0 })).toBeNull();
+    expect(resolveGithubPullRequestNumber({})).toBeNull();
   });
 });
 

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/resolve-github-repo-lookback.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/resolve-github-repo-lookback.test.ts
@@ -18,6 +18,7 @@ import {
   resolveGithubPullRequestNumber,
   resolveGithubPushRange,
   resolveGithubRepoLookbackHours,
+  resolveGithubWorkflowTriggerBranch,
 } from "./resolve-github-repo-lookback";
 
 describe("resolveGithubPushRange", () => {
@@ -75,10 +76,43 @@ describe("resolveGithubPushRange", () => {
     ).toBeNull();
   });
 
+  it("prefers the pull request head branch for inspection", () => {
+    expect(
+      resolveGithubPushRange({
+        triggerSource: "github",
+        inputSnapshot: {
+          pushBranch: "main",
+          headBranch: "feature/review",
+          commitBefore: "merge111",
+          commitAfter: "bbb222",
+        },
+      }),
+    ).toEqual({
+      branch: "feature/review",
+      commitBefore: "merge111",
+      commitAfter: "bbb222",
+    });
+  });
+
   it("reads a pull request number from the GitHub trigger snapshot", () => {
     expect(resolveGithubPullRequestNumber({ pullRequestNumber: 42 })).toBe(42);
     expect(resolveGithubPullRequestNumber({ pullRequestNumber: 0 })).toBeNull();
     expect(resolveGithubPullRequestNumber({})).toBeNull();
+  });
+
+  it("uses the pull request base branch for GitHub workflow dispatch", () => {
+    expect(
+      resolveGithubWorkflowTriggerBranch({
+        githubEvent: "pull_request",
+        baseBranch: "main",
+        pushBranch: "feature/review",
+      }),
+    ).toBe("main");
+    expect(
+      resolveGithubWorkflowTriggerBranch({
+        pushBranch: "main",
+      }),
+    ).toBe("main");
   });
 });
 

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/resolve-github-repo-lookback.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/resolve-github-repo-lookback.ts
@@ -57,6 +57,13 @@ export function formatGithubPushRangeLabel(range: GithubPushInspectionRange): st
   return `${range.commitBefore}..${range.commitAfter} on ${range.branch}`;
 }
 
+export function resolveGithubPullRequestNumber(
+  inputSnapshot: Record<string, unknown>,
+): number | null {
+  const value = inputSnapshot.pullRequestNumber;
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
+}
+
 export function resolveGithubRepoLookbackHours(input: {
   automation: WorkspaceAutomationRecord;
   triggerSource: string;

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/resolve-github-repo-lookback.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/resolve-github-repo-lookback.ts
@@ -35,7 +35,9 @@ export function resolveGithubPushRange(input: {
     return null;
   }
 
-  const branch = readSnapshotString(input.inputSnapshot, "pushBranch");
+  const branch =
+    readSnapshotString(input.inputSnapshot, "headBranch") ??
+    readSnapshotString(input.inputSnapshot, "pushBranch");
   const commitAfter = readSnapshotString(input.inputSnapshot, "commitAfter");
   if (!branch || !commitAfter || isGithubNullOid(commitAfter)) {
     return null;
@@ -55,6 +57,19 @@ export function formatGithubPushRangeLabel(range: GithubPushInspectionRange): st
   }
 
   return `${range.commitBefore}..${range.commitAfter} on ${range.branch}`;
+}
+
+export function resolveGithubWorkflowTriggerBranch(
+  inputSnapshot: Record<string, unknown>,
+): string | undefined {
+  const githubEvent = readSnapshotString(inputSnapshot, "githubEvent");
+  const baseBranch = readSnapshotString(inputSnapshot, "baseBranch");
+  const pushBranch = readSnapshotString(inputSnapshot, "pushBranch");
+  if (githubEvent === "pull_request" && baseBranch) {
+    return baseBranch;
+  }
+
+  return pushBranch ?? undefined;
 }
 
 export function resolveGithubPullRequestNumber(

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/run_github_workflows.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/run_github_workflows.ts
@@ -29,6 +29,7 @@ import {
 } from "@/lib/agent-runtime/subagents/constants";
 
 import type { WorkspaceOrchestratorSession } from "../context";
+import { resolveGithubWorkflowTriggerBranch } from "./resolve-github-repo-lookback";
 import { resolveGithubWorkflowsIdempotencyKey } from "./resolve-github-workflows-idempotency-key";
 
 function isTerminalGithubJobStatus(status: GithubRepositoryAutomationJobStatus) {
@@ -81,7 +82,7 @@ export function createRunGithubWorkflowsTool(session: WorkspaceOrchestratorSessi
       }
 
       const snapshot = session.run.inputSnapshot;
-      const pushBranch = typeof snapshot.pushBranch === "string" ? snapshot.pushBranch : undefined;
+      const pushBranch = resolveGithubWorkflowTriggerBranch(snapshot);
       const dispatchPayload = buildGithubRepoAutomationDispatchPayload({
         configVersion: session.automation.configVersion,
         githubInstallationRepositoryId: session.repository.id,

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_github_repository.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/use_github_repository.ts
@@ -39,6 +39,7 @@ import type { WorkspaceOrchestratorSession } from "../context";
 import {
   formatGithubPushRangeLabel,
   formatGithubRepoLookbackLabel,
+  resolveGithubPullRequestNumber,
   resolveGithubPushRange,
   resolveGithubRepoLookbackHours,
 } from "./resolve-github-repo-lookback";
@@ -78,6 +79,7 @@ export function createUseGithubRepositoryTool(session: WorkspaceOrchestratorSess
         triggerSource: session.run.triggerSource,
         inputSnapshot: session.run.inputSnapshot,
       });
+      const pullRequestNumber = resolveGithubPullRequestNumber(session.run.inputSnapshot);
       const branch = pushRange?.branch || repositoryRow.defaultBranch?.trim() || "main";
       const revision = pushRange?.commitAfter || branch;
       const lookbackHours = resolveGithubRepoLookbackHours({
@@ -87,6 +89,9 @@ export function createUseGithubRepositoryTool(session: WorkspaceOrchestratorSess
       const lookbackLabel = pushRange
         ? formatGithubPushRangeLabel(pushRange)
         : formatGithubRepoLookbackLabel(lookbackHours);
+      const inspectionLabel = pullRequestNumber
+        ? `pull request #${pullRequestNumber} (${lookbackLabel})`
+        : lookbackLabel;
       const userInstructions =
         session.automation.instructions.trim() ||
         (typeof session.run.inputSnapshot.instructions === "string"
@@ -115,7 +120,7 @@ export function createUseGithubRepositoryTool(session: WorkspaceOrchestratorSess
             `Repository: ${repositoryRow.fullName}.`,
             `Branch: ${branch}.`,
             pushRange
-              ? `Inspect this push: ${lookbackLabel}.`
+              ? `Inspect this ${pullRequestNumber ? "pull request" : "push"}: ${inspectionLabel}.`
               : `Lookback window: ${lookbackLabel}.`,
             `Sandbox id: ${sandboxId}.`,
           ],
@@ -157,7 +162,7 @@ export function createUseGithubRepositoryTool(session: WorkspaceOrchestratorSess
         const prompt = [
           `Execute the customer task for ${repositoryRow.fullName} on branch ${branch}.`,
           pushRange
-            ? `Review the localisation impact of this push (${lookbackLabel}).`
+            ? `Review the localisation impact of this ${pullRequestNumber ? "pull request" : "push"} (${inspectionLabel}).`
             : `Review changes from the last ${lookbackLabel}.`,
           "Use repository tools to inspect git history and relevant files.",
           "Follow the customer's required report sections exactly (including Translation Review Results, priority sections, and per-key entries when specified).",

--- a/apps/hyperlocalise-web/src/api/routes/github-webhook/github-webhook.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/github-webhook/github-webhook.route.test.ts
@@ -96,6 +96,42 @@ describe("githubWebhookRoutes", () => {
     await expect(response.json()).resolves.toEqual({ ok: true });
   });
 
+  it("handles pull request opened without delegating to the bot handler", async () => {
+    const installation = await createStoredGithubInstallation(true);
+    let called = false;
+    const app = createGithubWebhookRoutes({
+      githubWebhookHandler: async () => {
+        called = true;
+        return Response.json({ ok: true });
+      },
+    });
+
+    const response = await app.request("http://localhost/", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-github-event": "pull_request",
+        "x-github-delivery": "delivery-pr-open-1",
+      },
+      body: JSON.stringify({
+        action: "opened",
+        installation: { id: Number(installation.githubInstallationId) },
+        repository: { id: Number(installation.githubRepositoryId) },
+        pull_request: {
+          number: 42,
+          html_url: "https://github.com/hyperlocalise/hyperlocalise/pull/42",
+          draft: false,
+          base: { ref: "main", sha: "aaa111" },
+          head: { ref: "feature/review", sha: "bbb222" },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(called).toBe(false);
+    await expect(response.json()).resolves.toEqual({ ok: true, ignored: false });
+  });
+
   it("ignores unknown installations without delegating to the bot handler", async () => {
     let called = false;
     const app = createGithubWebhookRoutes({

--- a/apps/hyperlocalise-web/src/api/routes/github-webhook/github-webhook.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/github-webhook/github-webhook.route.ts
@@ -28,6 +28,10 @@ import {
   handleGithubPushWebhook,
   type GitHubPushWebhookPayload,
 } from "@/lib/agents/github/github-push-webhook";
+import {
+  handleGithubPullRequestWebhook,
+  type GitHubPullRequestWebhookPayload,
+} from "@/lib/agents/github/github-pull-request-webhook";
 import { safeJsonParse } from "@/lib/primitives/safeJsonParse/safeJsonParse";
 
 const logger = createLogger("github-webhook");
@@ -95,6 +99,26 @@ async function findStoredInstallation(githubInstallationId: string) {
     .limit(1);
 
   return installation ?? null;
+}
+
+async function findInstallationRepository(input: {
+  organizationId: string;
+  githubInstallationId: string;
+  githubRepositoryId: string;
+}) {
+  const [installationRepository] = await db
+    .select({ id: schema.githubInstallationRepositories.id })
+    .from(schema.githubInstallationRepositories)
+    .where(
+      and(
+        eq(schema.githubInstallationRepositories.organizationId, input.organizationId),
+        eq(schema.githubInstallationRepositories.githubInstallationId, input.githubInstallationId),
+        eq(schema.githubInstallationRepositories.githubRepositoryId, input.githubRepositoryId),
+      ),
+    )
+    .limit(1);
+
+  return installationRepository ?? null;
 }
 
 async function isRepositoryEnabled(input: {
@@ -273,23 +297,11 @@ export function createGithubWebhookRoutes(options: CreateGithubWebhookRoutesOpti
           return c.json({ error: "missing_github_delivery_id" }, 400);
         }
 
-        const [installationRepository] = await db
-          .select({ id: schema.githubInstallationRepositories.id })
-          .from(schema.githubInstallationRepositories)
-          .where(
-            and(
-              eq(schema.githubInstallationRepositories.organizationId, installation.organizationId),
-              eq(
-                schema.githubInstallationRepositories.githubInstallationId,
-                installation.githubInstallationId,
-              ),
-              eq(
-                schema.githubInstallationRepositories.githubRepositoryId,
-                String(payload.repository.id),
-              ),
-            ),
-          )
-          .limit(1);
+        const installationRepository = await findInstallationRepository({
+          organizationId: installation.organizationId,
+          githubInstallationId: installation.githubInstallationId,
+          githubRepositoryId: String(payload.repository.id),
+        });
 
         if (!installationRepository) {
           log.info(
@@ -323,6 +335,40 @@ export function createGithubWebhookRoutes(options: CreateGithubWebhookRoutesOpti
           },
           200,
         );
+      }
+
+      if (event === "pull_request") {
+        if (!delivery) {
+          log.warn("pull request webhook missing delivery id");
+          return c.json({ error: "missing_github_delivery_id" }, 400);
+        }
+
+        const installationRepository = await findInstallationRepository({
+          organizationId: installation.organizationId,
+          githubInstallationId: installation.githubInstallationId,
+          githubRepositoryId: String(payload.repository.id),
+        });
+
+        if (!installationRepository) {
+          log.info(
+            {
+              installationId: installation.githubInstallationId,
+              repositoryId: payload.repository.id,
+            },
+            "ignoring pull request webhook: installation repository not found",
+          );
+          return c.json({ ok: true, ignored: true }, 200);
+        }
+
+        const pullRequestResult = await handleGithubPullRequestWebhook({
+          deliveryId: delivery,
+          organizationId: installation.organizationId,
+          githubInstallationRepositoryId: installationRepository.id,
+          githubRepositoryId: String(payload.repository.id),
+          payload: payload as GitHubPullRequestWebhookPayload,
+        });
+
+        return c.json({ ok: true, ignored: pullRequestResult.ignored }, 200);
       }
 
       const handler = options.githubWebhookHandler ?? (await defaultGithubWebhookHandler());

--- a/apps/hyperlocalise-web/src/api/routes/github-webhook/github-webhook.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/github-webhook/github-webhook.route.ts
@@ -107,7 +107,10 @@ async function findInstallationRepository(input: {
   githubRepositoryId: string;
 }) {
   const [installationRepository] = await db
-    .select({ id: schema.githubInstallationRepositories.id })
+    .select({
+      id: schema.githubInstallationRepositories.id,
+      fullName: schema.githubInstallationRepositories.fullName,
+    })
     .from(schema.githubInstallationRepositories)
     .where(
       and(
@@ -363,8 +366,10 @@ export function createGithubWebhookRoutes(options: CreateGithubWebhookRoutesOpti
         const pullRequestResult = await handleGithubPullRequestWebhook({
           deliveryId: delivery,
           organizationId: installation.organizationId,
+          githubInstallationId: installation.githubInstallationId,
           githubInstallationRepositoryId: installationRepository.id,
           githubRepositoryId: String(payload.repository.id),
+          repositoryFullName: installationRepository.fullName,
           payload: payload as GitHubPullRequestWebhookPayload,
         });
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-template-flow.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-template-flow.tsx
@@ -31,6 +31,7 @@ type IconBucket = "schedule" | "github" | "slack" | "email" | "contentful" | "we
 function iconBucketForNode(node: WorkspaceAutomationTemplateFlowNode): IconBucket {
   switch (node.id) {
     case "github-push":
+    case "github-pull-request":
     case "github":
     case "github-comment":
     case "push-source":

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -35,6 +35,26 @@ export const workspaceAutomationFormMessages = defineMessages({
     id: "feBDOpIUbJ",
     description: "Header summary for a GitHub push trigger",
   },
+  githubPullRequestSummary: {
+    defaultMessage: "GitHub pull request · {repository} · {branches}",
+    id: "n7kQ2pLm9A",
+    description: "Header summary for a GitHub pull request trigger",
+  },
+  githubPushAndPullRequestSummary: {
+    defaultMessage: "GitHub push and pull request · {repository} · {branches}",
+    id: "r4Vw8sEt2C",
+    description: "Header summary for a GitHub trigger that runs on push and pull request",
+  },
+  githubEventPush: {
+    defaultMessage: "Push",
+    id: "p1Hx5dUq3B",
+    description: "Toggle label for GitHub push trigger events",
+  },
+  githubEventPullRequest: {
+    defaultMessage: "Pull request opened",
+    id: "w8Jm0cYv6D",
+    description: "Toggle label for GitHub pull request opened trigger events",
+  },
   repositoryRequired: {
     defaultMessage: "repository required",
     id: "+UD+5d3g3H",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages.ts
@@ -37,22 +37,22 @@ export const workspaceAutomationFormMessages = defineMessages({
   },
   githubPullRequestSummary: {
     defaultMessage: "GitHub pull request · {repository} · {branches}",
-    id: "n7kQ2pLm9A",
+    id: "uI2rwqO19R",
     description: "Header summary for a GitHub pull request trigger",
   },
   githubPushAndPullRequestSummary: {
     defaultMessage: "GitHub push and pull request · {repository} · {branches}",
-    id: "r4Vw8sEt2C",
+    id: "/2DsRIRpZu",
     description: "Header summary for a GitHub trigger that runs on push and pull request",
   },
   githubEventPush: {
     defaultMessage: "Push",
-    id: "p1Hx5dUq3B",
+    id: "k2PKKnD3GN",
     description: "Toggle label for GitHub push trigger events",
   },
   githubEventPullRequest: {
     defaultMessage: "Pull request opened",
-    id: "w8Jm0cYv6D",
+    id: "2C7ykfN2tG",
     description: "Toggle label for GitHub pull request opened trigger events",
   },
   repositoryRequired: {
@@ -627,8 +627,8 @@ export const workspaceAutomationFormMessages = defineMessages({
   },
   githubCommentConnectedDescription: {
     defaultMessage:
-      "Post a sticky review comment on the pull request for this push. Later runs update the same comment.",
-    id: "AbZsOtFk+H",
+      "Post a sticky review comment on the matching pull request. Later runs update the same comment.",
+    id: "tp0Edn/npM",
     description:
       "Description for GitHub pull request comment notifications when GitHub is connected",
   },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -242,12 +242,7 @@ function GithubEventSwitch({
 }) {
   return (
     <label className="flex items-center gap-2 text-xs text-foreground">
-      <Switch
-        size="sm"
-        checked={checked}
-        disabled={disabled}
-        onCheckedChange={onCheckedChange}
-      />
+      <Switch size="sm" checked={checked} disabled={disabled} onCheckedChange={onCheckedChange} />
       <span>{label}</span>
     </label>
   );
@@ -840,8 +835,7 @@ function AddTriggerMenu({
                   ...form,
                   triggerMode: "github",
                   githubEnabled: true,
-                  githubEvents:
-                    form.githubEvents.length > 0 ? form.githubEvents : ["push"],
+                  githubEvents: form.githubEvents.length > 0 ? form.githubEvents : ["push"],
                   repositoryTargetKind: "github",
                   githubInstallationRepositoryId: defaultRepositoryId,
                   validationEnabled:

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -99,6 +99,7 @@ import { SlackChannelSelect } from "@/app/[lang]/(authenticated)/org/[organizati
 import { workspaceAutomationFormMessages } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages";
 import { getLocaleLabel } from "@/lib/i18n/locales";
 import type { WorkspaceAutomationFormState } from "@/lib/agents/workspace-automation-view-model";
+import type { WorkspaceAutomationGithubTriggerEvent } from "@/lib/agents/workspace-automations";
 import {
   applyWorkspaceAutomationProjectSelection,
   selectableAutomationRepositories,
@@ -214,6 +215,42 @@ function FieldError({ message }: { message?: string }) {
   }
 
   return <p className="text-xs text-destructive">{message}</p>;
+}
+
+function toggleGithubEvent(
+  events: WorkspaceAutomationGithubTriggerEvent[],
+  event: WorkspaceAutomationGithubTriggerEvent,
+  enabled: boolean,
+): WorkspaceAutomationGithubTriggerEvent[] {
+  if (enabled) {
+    return events.includes(event) ? events : [...events, event];
+  }
+
+  return events.filter((value) => value !== event);
+}
+
+function GithubEventSwitch({
+  checked,
+  disabled,
+  label,
+  onCheckedChange,
+}: {
+  checked: boolean;
+  disabled?: boolean;
+  label: ReactNode;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <label className="flex items-center gap-2 text-xs text-foreground">
+      <Switch
+        size="sm"
+        checked={checked}
+        disabled={disabled}
+        onCheckedChange={onCheckedChange}
+      />
+      <span>{label}</span>
+    </label>
+  );
 }
 
 function EditorSection({ title, children }: { title: string; children: ReactNode }) {
@@ -346,7 +383,15 @@ function triggerSummary(
     const branchLabel =
       form.pushBranches.join(", ") ||
       intl.formatMessage(workspaceAutomationFormMessages.branchesRequired);
-    return intl.formatMessage(workspaceAutomationFormMessages.githubPushSummary, {
+    const listensToPush = form.githubEvents.includes("push");
+    const listensToPullRequest = form.githubEvents.includes("pull_request");
+    const summaryMessage =
+      listensToPush && listensToPullRequest
+        ? workspaceAutomationFormMessages.githubPushAndPullRequestSummary
+        : listensToPullRequest
+          ? workspaceAutomationFormMessages.githubPullRequestSummary
+          : workspaceAutomationFormMessages.githubPushSummary;
+    return intl.formatMessage(summaryMessage, {
       repository: repositoryLabel,
       branches: branchLabel,
     });
@@ -795,6 +840,8 @@ function AddTriggerMenu({
                   ...form,
                   triggerMode: "github",
                   githubEnabled: true,
+                  githubEvents:
+                    form.githubEvents.length > 0 ? form.githubEvents : ["push"],
                   repositoryTargetKind: "github",
                   githubInstallationRepositoryId: defaultRepositoryId,
                   validationEnabled:
@@ -1041,7 +1088,34 @@ function TriggerSettings({
                   onChange={(pushBranches) => onChange({ ...form, pushBranches })}
                 />
               </div>
+              <div className="flex flex-wrap items-center gap-3">
+                <GithubEventSwitch
+                  checked={form.githubEvents.includes("push")}
+                  disabled={disabled}
+                  label={<FormattedMessage {...workspaceAutomationFormMessages.githubEventPush} />}
+                  onCheckedChange={(checked) =>
+                    onChange({
+                      ...form,
+                      githubEvents: toggleGithubEvent(form.githubEvents, "push", checked),
+                    })
+                  }
+                />
+                <GithubEventSwitch
+                  checked={form.githubEvents.includes("pull_request")}
+                  disabled={disabled}
+                  label={
+                    <FormattedMessage {...workspaceAutomationFormMessages.githubEventPullRequest} />
+                  }
+                  onCheckedChange={(checked) =>
+                    onChange({
+                      ...form,
+                      githubEvents: toggleGithubEvent(form.githubEvents, "pull_request", checked),
+                    })
+                  }
+                />
+              </div>
               <FieldError message={errors.githubRepository} />
+              <FieldError message={errors.githubEvents} />
             </div>
           </EditorRow>
         ) : null}

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-pull-request-merge-base.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-pull-request-merge-base.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { getInstallationOctokitMock } = vi.hoisted(() => ({
+  getInstallationOctokitMock: vi.fn(),
+}));
+
+vi.mock("@/lib/agents/github/app", () => ({
+  getInstallationOctokit: getInstallationOctokitMock,
+}));
+
+import {
+  parseGithubRepositoryFullName,
+  resolveGithubPullRequestMergeBaseSha,
+} from "./github-pull-request-merge-base";
+
+describe("parseGithubRepositoryFullName", () => {
+  it("reads owner and repository from a full name", () => {
+    expect(parseGithubRepositoryFullName("acme/app")).toEqual({ owner: "acme", repo: "app" });
+    expect(parseGithubRepositoryFullName("acme")).toBeNull();
+  });
+});
+
+describe("resolveGithubPullRequestMergeBaseSha", () => {
+  beforeEach(() => {
+    getInstallationOctokitMock.mockReset();
+  });
+
+  it("returns the compare API merge base", async () => {
+    const compareCommits = vi.fn().mockResolvedValue({
+      data: { merge_base_commit: { sha: "merge111" } },
+    });
+    getInstallationOctokitMock.mockResolvedValue({
+      rest: { repos: { compareCommits } },
+    });
+
+    await expect(
+      resolveGithubPullRequestMergeBaseSha({
+        githubInstallationId: "123",
+        repositoryFullName: "acme/app",
+        base: "main",
+        head: "bbb222",
+      }),
+    ).resolves.toBe("merge111");
+
+    expect(compareCommits).toHaveBeenCalledWith({
+      owner: "acme",
+      repo: "app",
+      base: "main",
+      head: "bbb222",
+    });
+  });
+
+  it("returns null when compare fails", async () => {
+    getInstallationOctokitMock.mockResolvedValue({
+      rest: {
+        repos: {
+          compareCommits: vi.fn().mockRejectedValue(new Error("not found")),
+        },
+      },
+    });
+
+    await expect(
+      resolveGithubPullRequestMergeBaseSha({
+        githubInstallationId: "123",
+        repositoryFullName: "acme/app",
+        base: "main",
+        head: "bbb222",
+      }),
+    ).resolves.toBeNull();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-pull-request-merge-base.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-pull-request-merge-base.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { getInstallationOctokit } from "@/lib/agents/github/app";
+import { createLogger } from "@/lib/log";
+
+const logger = createLogger("github-pull-request-merge-base");
+
+export function parseGithubRepositoryFullName(
+  value: string | undefined,
+): { owner: string; repo: string } | null {
+  const [owner, repo] = value?.split("/") ?? [];
+  if (!owner?.trim() || !repo?.trim()) {
+    return null;
+  }
+
+  return { owner: owner.trim(), repo: repo.trim() };
+}
+
+export async function resolveGithubPullRequestMergeBaseSha(input: {
+  githubInstallationId: string;
+  repositoryFullName: string;
+  base: string;
+  head: string;
+}): Promise<string | null> {
+  const repository = parseGithubRepositoryFullName(input.repositoryFullName);
+  const base = input.base.trim();
+  const head = input.head.trim();
+  if (!repository || !base || !head) {
+    return null;
+  }
+
+  try {
+    const octokit = await getInstallationOctokit(input.githubInstallationId);
+    const { data } = await octokit.rest.repos.compareCommits({
+      owner: repository.owner,
+      repo: repository.repo,
+      base,
+      head,
+    });
+    const mergeBaseSha = data.merge_base_commit?.sha?.trim() ?? "";
+    return mergeBaseSha.length > 0 ? mergeBaseSha : null;
+  } catch (error) {
+    logger.warn(
+      {
+        githubInstallationId: input.githubInstallationId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "failed to resolve pull request merge base",
+    );
+    return null;
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-pull-request-webhook.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-pull-request-webhook.test.ts
@@ -12,15 +12,12 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-const {
-  dispatchWorkspaceAutomationsForGithubPullRequestMock,
-  loggerErrorMock,
-  loggerInfoMock,
-} = vi.hoisted(() => ({
-  dispatchWorkspaceAutomationsForGithubPullRequestMock: vi.fn(),
-  loggerErrorMock: vi.fn(),
-  loggerInfoMock: vi.fn(),
-}));
+const { dispatchWorkspaceAutomationsForGithubPullRequestMock, loggerErrorMock, loggerInfoMock } =
+  vi.hoisted(() => ({
+    dispatchWorkspaceAutomationsForGithubPullRequestMock: vi.fn(),
+    loggerErrorMock: vi.fn(),
+    loggerInfoMock: vi.fn(),
+  }));
 
 vi.mock("@/lib/log", () => ({
   createLogger: vi.fn(() => ({

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-pull-request-webhook.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-pull-request-webhook.test.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const {
+  dispatchWorkspaceAutomationsForGithubPullRequestMock,
+  loggerErrorMock,
+  loggerInfoMock,
+} = vi.hoisted(() => ({
+  dispatchWorkspaceAutomationsForGithubPullRequestMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
+  loggerInfoMock: vi.fn(),
+}));
+
+vi.mock("@/lib/log", () => ({
+  createLogger: vi.fn(() => ({
+    error: loggerErrorMock,
+    info: loggerInfoMock,
+  })),
+}));
+
+vi.mock("../workspace-automation-dispatcher", () => ({
+  dispatchWorkspaceAutomationsForGithubPullRequest:
+    dispatchWorkspaceAutomationsForGithubPullRequestMock,
+}));
+
+import {
+  handleGithubPullRequestWebhook,
+  shouldDispatchGithubPullRequestAction,
+} from "./github-pull-request-webhook";
+
+describe("shouldDispatchGithubPullRequestAction", () => {
+  it("dispatches opened, reopened, synchronize, and ready_for_review", () => {
+    expect(shouldDispatchGithubPullRequestAction("opened", { draft: false })).toBe(true);
+    expect(shouldDispatchGithubPullRequestAction("reopened", { draft: false })).toBe(true);
+    expect(shouldDispatchGithubPullRequestAction("synchronize", { draft: false })).toBe(true);
+    expect(shouldDispatchGithubPullRequestAction("ready_for_review", { draft: true })).toBe(true);
+  });
+
+  it("ignores drafts, merged PRs, and unrelated actions", () => {
+    expect(shouldDispatchGithubPullRequestAction("opened", { draft: true })).toBe(false);
+    expect(shouldDispatchGithubPullRequestAction("opened", { merged: true })).toBe(false);
+    expect(shouldDispatchGithubPullRequestAction("closed", { draft: false })).toBe(false);
+    expect(shouldDispatchGithubPullRequestAction("edited", { draft: false })).toBe(false);
+  });
+});
+
+describe("handleGithubPullRequestWebhook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dispatchWorkspaceAutomationsForGithubPullRequestMock.mockResolvedValue([]);
+  });
+
+  it("dispatches workspace automations for an opened pull request against main", async () => {
+    await expect(
+      handleGithubPullRequestWebhook({
+        deliveryId: "delivery-pr-1",
+        organizationId: "org_123",
+        githubInstallationRepositoryId: "installation-repo-123",
+        githubRepositoryId: "repo-123",
+        payload: {
+          action: "opened",
+          pull_request: {
+            number: 42,
+            html_url: "https://github.com/acme/app/pull/42",
+            draft: false,
+            base: { ref: "main", sha: "aaa111" },
+            head: { ref: "feature/review", sha: "bbb222" },
+          },
+        },
+      }),
+    ).resolves.toEqual({ ignored: false });
+
+    expect(dispatchWorkspaceAutomationsForGithubPullRequestMock).toHaveBeenCalledWith({
+      deliveryId: "delivery-pr-1",
+      organizationId: "org_123",
+      githubInstallationRepositoryId: "installation-repo-123",
+      action: "opened",
+      pullRequestNumber: 42,
+      pullRequestUrl: "https://github.com/acme/app/pull/42",
+      baseBranch: "main",
+      headBranch: "feature/review",
+      commitBefore: "aaa111",
+      commitAfter: "bbb222",
+    });
+  });
+
+  it("ignores draft pull requests without failing the webhook", async () => {
+    await expect(
+      handleGithubPullRequestWebhook({
+        deliveryId: "delivery-pr-draft",
+        organizationId: "org_123",
+        githubInstallationRepositoryId: "installation-repo-123",
+        githubRepositoryId: "repo-123",
+        payload: {
+          action: "opened",
+          pull_request: {
+            number: 7,
+            draft: true,
+            base: { ref: "main", sha: "aaa111" },
+            head: { ref: "feature/draft", sha: "bbb222" },
+          },
+        },
+      }),
+    ).resolves.toEqual({ ignored: true });
+
+    expect(dispatchWorkspaceAutomationsForGithubPullRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fail the webhook when workspace automation dispatch fails", async () => {
+    dispatchWorkspaceAutomationsForGithubPullRequestMock.mockRejectedValueOnce(
+      new Error("database unavailable"),
+    );
+
+    await expect(
+      handleGithubPullRequestWebhook({
+        deliveryId: "delivery-pr-2",
+        organizationId: "org_123",
+        githubInstallationRepositoryId: "installation-repo-123",
+        githubRepositoryId: "repo-123",
+        payload: {
+          action: "opened",
+          pull_request: {
+            number: 9,
+            draft: false,
+            base: { ref: "main", sha: "aaa111" },
+            head: { ref: "feature/x", sha: "bbb222" },
+          },
+        },
+      }),
+    ).resolves.toEqual({ ignored: false });
+
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      {
+        deliveryId: "delivery-pr-2",
+        error: "database unavailable",
+        repositoryId: "repo-123",
+      },
+      "workspace automations github pull request dispatch failed",
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-pull-request-webhook.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-pull-request-webhook.test.ts
@@ -12,12 +12,17 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-const { dispatchWorkspaceAutomationsForGithubPullRequestMock, loggerErrorMock, loggerInfoMock } =
-  vi.hoisted(() => ({
-    dispatchWorkspaceAutomationsForGithubPullRequestMock: vi.fn(),
-    loggerErrorMock: vi.fn(),
-    loggerInfoMock: vi.fn(),
-  }));
+const {
+  dispatchWorkspaceAutomationsForGithubPullRequestMock,
+  loggerErrorMock,
+  loggerInfoMock,
+  resolveGithubPullRequestMergeBaseShaMock,
+} = vi.hoisted(() => ({
+  dispatchWorkspaceAutomationsForGithubPullRequestMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
+  loggerInfoMock: vi.fn(),
+  resolveGithubPullRequestMergeBaseShaMock: vi.fn(),
+}));
 
 vi.mock("@/lib/log", () => ({
   createLogger: vi.fn(() => ({
@@ -29,6 +34,10 @@ vi.mock("@/lib/log", () => ({
 vi.mock("../workspace-automation-dispatcher", () => ({
   dispatchWorkspaceAutomationsForGithubPullRequest:
     dispatchWorkspaceAutomationsForGithubPullRequestMock,
+}));
+
+vi.mock("./github-pull-request-merge-base", () => ({
+  resolveGithubPullRequestMergeBaseSha: resolveGithubPullRequestMergeBaseShaMock,
 }));
 
 import {
@@ -56,6 +65,7 @@ describe("handleGithubPullRequestWebhook", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     dispatchWorkspaceAutomationsForGithubPullRequestMock.mockResolvedValue([]);
+    resolveGithubPullRequestMergeBaseShaMock.mockResolvedValue("merge111");
   });
 
   it("dispatches workspace automations for an opened pull request against main", async () => {
@@ -63,8 +73,10 @@ describe("handleGithubPullRequestWebhook", () => {
       handleGithubPullRequestWebhook({
         deliveryId: "delivery-pr-1",
         organizationId: "org_123",
+        githubInstallationId: "123",
         githubInstallationRepositoryId: "installation-repo-123",
         githubRepositoryId: "repo-123",
+        repositoryFullName: "acme/app",
         payload: {
           action: "opened",
           pull_request: {
@@ -78,6 +90,12 @@ describe("handleGithubPullRequestWebhook", () => {
       }),
     ).resolves.toEqual({ ignored: false });
 
+    expect(resolveGithubPullRequestMergeBaseShaMock).toHaveBeenCalledWith({
+      githubInstallationId: "123",
+      repositoryFullName: "acme/app",
+      base: "main",
+      head: "bbb222",
+    });
     expect(dispatchWorkspaceAutomationsForGithubPullRequestMock).toHaveBeenCalledWith({
       deliveryId: "delivery-pr-1",
       organizationId: "org_123",
@@ -87,9 +105,40 @@ describe("handleGithubPullRequestWebhook", () => {
       pullRequestUrl: "https://github.com/acme/app/pull/42",
       baseBranch: "main",
       headBranch: "feature/review",
-      commitBefore: "aaa111",
+      commitBefore: "merge111",
       commitAfter: "bbb222",
     });
+  });
+
+  it("falls back to the base tip when the merge base cannot be resolved", async () => {
+    resolveGithubPullRequestMergeBaseShaMock.mockResolvedValueOnce(null);
+
+    await expect(
+      handleGithubPullRequestWebhook({
+        deliveryId: "delivery-pr-fallback",
+        organizationId: "org_123",
+        githubInstallationId: "123",
+        githubInstallationRepositoryId: "installation-repo-123",
+        githubRepositoryId: "repo-123",
+        repositoryFullName: "acme/app",
+        payload: {
+          action: "opened",
+          pull_request: {
+            number: 8,
+            draft: false,
+            base: { ref: "main", sha: "aaa111" },
+            head: { ref: "feature/x", sha: "bbb222" },
+          },
+        },
+      }),
+    ).resolves.toEqual({ ignored: false });
+
+    expect(dispatchWorkspaceAutomationsForGithubPullRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commitBefore: "aaa111",
+        commitAfter: "bbb222",
+      }),
+    );
   });
 
   it("ignores draft pull requests without failing the webhook", async () => {
@@ -97,8 +146,10 @@ describe("handleGithubPullRequestWebhook", () => {
       handleGithubPullRequestWebhook({
         deliveryId: "delivery-pr-draft",
         organizationId: "org_123",
+        githubInstallationId: "123",
         githubInstallationRepositoryId: "installation-repo-123",
         githubRepositoryId: "repo-123",
+        repositoryFullName: "acme/app",
         payload: {
           action: "opened",
           pull_request: {
@@ -123,8 +174,10 @@ describe("handleGithubPullRequestWebhook", () => {
       handleGithubPullRequestWebhook({
         deliveryId: "delivery-pr-2",
         organizationId: "org_123",
+        githubInstallationId: "123",
         githubInstallationRepositoryId: "installation-repo-123",
         githubRepositoryId: "repo-123",
+        repositoryFullName: "acme/app",
         payload: {
           action: "opened",
           pull_request: {

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-pull-request-webhook.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-pull-request-webhook.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { createLogger } from "@/lib/log";
+
+const logger = createLogger("github-pull-request-webhook");
+
+const DISPATCH_ACTIONS = new Set(["opened", "reopened", "synchronize", "ready_for_review"]);
+
+export type GitHubPullRequestWebhookPayload = {
+  action?: string;
+  pull_request?: {
+    number?: number;
+    html_url?: string;
+    draft?: boolean;
+    merged?: boolean;
+    base?: { ref?: string; sha?: string };
+    head?: { ref?: string; sha?: string };
+  };
+};
+
+export type HandleGithubPullRequestWebhookInput = {
+  deliveryId: string;
+  organizationId: string;
+  githubInstallationRepositoryId: string;
+  githubRepositoryId: string;
+  payload: GitHubPullRequestWebhookPayload;
+};
+
+export type HandleGithubPullRequestWebhookResult = {
+  ignored: boolean;
+};
+
+function readBranchName(value: string | undefined): string | null {
+  const branch = value?.trim() ?? "";
+  return branch.length > 0 ? branch : null;
+}
+
+export function shouldDispatchGithubPullRequestAction(
+  action: string | undefined,
+  pullRequest: GitHubPullRequestWebhookPayload["pull_request"],
+): boolean {
+  if (!action || !DISPATCH_ACTIONS.has(action)) {
+    return false;
+  }
+
+  if (pullRequest?.merged) {
+    return false;
+  }
+
+  if (pullRequest?.draft && action !== "ready_for_review") {
+    return false;
+  }
+
+  return true;
+}
+
+export async function handleGithubPullRequestWebhook(
+  input: HandleGithubPullRequestWebhookInput,
+): Promise<HandleGithubPullRequestWebhookResult> {
+  const pullRequest = input.payload.pull_request;
+  if (!shouldDispatchGithubPullRequestAction(input.payload.action, pullRequest)) {
+    logger.info(
+      {
+        deliveryId: input.deliveryId,
+        repositoryId: input.githubRepositoryId,
+        action: input.payload.action,
+      },
+      "ignoring pull request event",
+    );
+    return { ignored: true };
+  }
+
+  const pullRequestNumber = pullRequest?.number;
+  const baseBranch = readBranchName(pullRequest?.base?.ref);
+  const headBranch = readBranchName(pullRequest?.head?.ref);
+  const commitAfter = pullRequest?.head?.sha?.trim() ?? "";
+  if (!pullRequestNumber || !baseBranch || !headBranch || !commitAfter) {
+    logger.info(
+      {
+        deliveryId: input.deliveryId,
+        repositoryId: input.githubRepositoryId,
+      },
+      "ignoring pull request event without review context",
+    );
+    return { ignored: true };
+  }
+
+  try {
+    const { dispatchWorkspaceAutomationsForGithubPullRequest } =
+      await import("../workspace-automation-dispatcher");
+    await dispatchWorkspaceAutomationsForGithubPullRequest({
+      deliveryId: input.deliveryId,
+      organizationId: input.organizationId,
+      githubInstallationRepositoryId: input.githubInstallationRepositoryId,
+      action: input.payload.action ?? "opened",
+      pullRequestNumber,
+      pullRequestUrl: pullRequest?.html_url,
+      baseBranch,
+      headBranch,
+      commitBefore: pullRequest?.base?.sha?.trim() ?? "",
+      commitAfter,
+    });
+  } catch (error) {
+    logger.error(
+      {
+        deliveryId: input.deliveryId,
+        repositoryId: input.githubRepositoryId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "workspace automations github pull request dispatch failed",
+    );
+  }
+
+  return { ignored: false };
+}

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-pull-request-webhook.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-pull-request-webhook.ts
@@ -11,6 +11,7 @@
  * Version 2.0 or later.
  */
 import { createLogger } from "@/lib/log";
+import { resolveGithubPullRequestMergeBaseSha } from "./github-pull-request-merge-base";
 
 const logger = createLogger("github-pull-request-webhook");
 
@@ -31,8 +32,10 @@ export type GitHubPullRequestWebhookPayload = {
 export type HandleGithubPullRequestWebhookInput = {
   deliveryId: string;
   organizationId: string;
+  githubInstallationId: string;
   githubInstallationRepositoryId: string;
   githubRepositoryId: string;
+  repositoryFullName?: string;
   payload: GitHubPullRequestWebhookPayload;
 };
 
@@ -84,6 +87,7 @@ export async function handleGithubPullRequestWebhook(
   const baseBranch = readBranchName(pullRequest?.base?.ref);
   const headBranch = readBranchName(pullRequest?.head?.ref);
   const commitAfter = pullRequest?.head?.sha?.trim() ?? "";
+  const baseTipSha = pullRequest?.base?.sha?.trim() ?? "";
   if (!pullRequestNumber || !baseBranch || !headBranch || !commitAfter) {
     logger.info(
       {
@@ -94,6 +98,16 @@ export async function handleGithubPullRequestWebhook(
     );
     return { ignored: true };
   }
+
+  const mergeBaseSha = input.repositoryFullName
+    ? await resolveGithubPullRequestMergeBaseSha({
+        githubInstallationId: input.githubInstallationId,
+        repositoryFullName: input.repositoryFullName,
+        base: baseBranch,
+        head: commitAfter,
+      })
+    : null;
+  const commitBefore = mergeBaseSha ?? baseTipSha;
 
   try {
     const { dispatchWorkspaceAutomationsForGithubPullRequest } =
@@ -107,7 +121,7 @@ export async function handleGithubPullRequestWebhook(
       pullRequestUrl: pullRequest?.html_url,
       baseBranch,
       headBranch,
-      commitBefore: pullRequest?.base?.sha?.trim() ?? "",
+      commitBefore,
       commitAfter,
     });
   } catch (error) {

--- a/apps/hyperlocalise-web/src/lib/agents/github/upsert-workspace-automation-pull-request-comment.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/upsert-workspace-automation-pull-request-comment.test.ts
@@ -120,6 +120,39 @@ describe("upsertWorkspaceAutomationPullRequestComment", () => {
     expect(createComment).not.toHaveBeenCalled();
   });
 
+  it("uses an explicit pull request number without looking up associated commits", async () => {
+    paginate.mockResolvedValue([]);
+    createComment.mockResolvedValue({
+      data: { id: 55, html_url: "https://github.com/acme/app/pull/42#issuecomment-55" },
+    });
+
+    const result = await upsertWorkspaceAutomationPullRequestComment({
+      installationId: "1",
+      repositoryFullName: "acme/app",
+      automationId: "auto-1",
+      commitSha: "abc123",
+      pullRequestNumber: 42,
+      message: "PR review",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        status: "created",
+        pullRequestNumber: 42,
+        commentId: 55,
+        url: "https://github.com/acme/app/pull/42#issuecomment-55",
+      },
+    });
+    expect(listPullRequestsAssociatedWithCommit).not.toHaveBeenCalled();
+    expect(createComment).toHaveBeenCalledWith({
+      owner: "acme",
+      repo: "app",
+      issue_number: 42,
+      body: "<!-- hyperlocalise-automation:auto-1 -->\nPR review",
+    });
+  });
+
   it("creates a sticky comment on the preferred open pull request", async () => {
     listPullRequestsAssociatedWithCommit.mockResolvedValue({
       data: [

--- a/apps/hyperlocalise-web/src/lib/agents/github/upsert-workspace-automation-pull-request-comment.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/upsert-workspace-automation-pull-request-comment.ts
@@ -103,6 +103,7 @@ export async function upsertWorkspaceAutomationPullRequestComment(input: {
   repositoryFullName: string;
   automationId: string;
   commitSha: string;
+  pullRequestNumber?: number;
   message: string;
 }): Promise<
   Result<
@@ -111,7 +112,13 @@ export async function upsertWorkspaceAutomationPullRequestComment(input: {
   >
 > {
   const commitSha = input.commitSha.trim();
-  if (!commitSha || isGithubNullOid(commitSha)) {
+  const explicitPullRequestNumber =
+    typeof input.pullRequestNumber === "number" &&
+    Number.isInteger(input.pullRequestNumber) &&
+    input.pullRequestNumber > 0
+      ? input.pullRequestNumber
+      : null;
+  if ((!commitSha || isGithubNullOid(commitSha)) && !explicitPullRequestNumber) {
     return ok({ status: "skipped", code: "github_commit_not_found" });
   }
 
@@ -125,20 +132,24 @@ export async function upsertWorkspaceAutomationPullRequestComment(input: {
 
   try {
     const octokit = await getInstallationOctokit(input.installationId);
-    const associated = await octokit.rest.repos.listPullRequestsAssociatedWithCommit({
-      owner: parsed.owner,
-      repo: parsed.repo,
-      commit_sha: commitSha,
-    });
-    const pullRequest = preferAssociatedPullRequest(associated.data);
-    if (!pullRequest) {
+    const pullRequestNumber =
+      explicitPullRequestNumber ??
+      (await (async () => {
+        const associated = await octokit.rest.repos.listPullRequestsAssociatedWithCommit({
+          owner: parsed.owner,
+          repo: parsed.repo,
+          commit_sha: commitSha,
+        });
+        return preferAssociatedPullRequest(associated.data)?.number ?? null;
+      })());
+    if (!pullRequestNumber) {
       return ok({ status: "skipped", code: "github_pr_not_found" });
     }
 
     const comments = await octokit.paginate(octokit.rest.issues.listComments, {
       owner: parsed.owner,
       repo: parsed.repo,
-      issue_number: pullRequest.number,
+      issue_number: pullRequestNumber,
       per_page: 100,
     });
     const existing = comments.find((comment) =>
@@ -158,7 +169,7 @@ export async function upsertWorkspaceAutomationPullRequestComment(input: {
       });
       return ok({
         status: "updated",
-        pullRequestNumber: pullRequest.number,
+        pullRequestNumber,
         commentId: updated.data.id,
         url: updated.data.html_url,
       });
@@ -167,12 +178,12 @@ export async function upsertWorkspaceAutomationPullRequestComment(input: {
     const created = await octokit.rest.issues.createComment({
       owner: parsed.owner,
       repo: parsed.repo,
-      issue_number: pullRequest.number,
+      issue_number: pullRequestNumber,
       body,
     });
     return ok({
       status: "created",
-      pullRequestNumber: pullRequest.number,
+      pullRequestNumber,
       commentId: created.data.id,
       url: created.data.html_url,
     });

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.test.ts
@@ -1035,6 +1035,7 @@ describe("workspace automation dispatcher", () => {
         authorUserId: scope.userId,
         name: "Push only GitHub automation",
         instructions: "Should not run for pull requests.",
+        projectId: scope.projectId,
         triggerConfig: { mode: "github", branches: ["main"] },
         repositoryTarget: {
           kind: "github",

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.test.ts
@@ -38,6 +38,7 @@ import {
   dispatchManualWorkspaceAutomationRun,
   dispatchWorkspaceAutomationForSchedule,
   dispatchWorkspaceAutomationsForContentfulWebhook,
+  dispatchWorkspaceAutomationsForGithubPullRequest,
   dispatchWorkspaceAutomationsForGithubPush,
   dispatchWorkspaceAutomationsForSourceUpload,
 } from "./workspace-automation-dispatcher";
@@ -998,6 +999,98 @@ describe("workspace automation dispatcher", () => {
     expect(runs[0]?.inputSnapshot).toMatchObject({
       githubDeliveryId: "delivery-github-agent-1",
       pushBranch: "main",
+      commitBefore: "aaa111",
+      commitAfter: "bbb222",
+    });
+  });
+
+  it("dispatches GitHub agent automations on matching pull requests", async () => {
+    const scope = await seedDispatchScope();
+    const matching = expectOk(
+      await createWorkspaceAutomation({
+        organizationId: scope.organizationId,
+        authorUserId: scope.userId,
+        name: "Notify on push blockers",
+        instructions: "Review localisation risk on this pull request.",
+        triggerConfig: { mode: "github", branches: ["main"], events: ["push", "pull_request"] },
+        repositoryTarget: {
+          kind: "github",
+          githubInstallationRepositoryId: scope.repository.id,
+        },
+        toolConfig: {
+          github: {
+            enabled: true,
+            mode: "agent",
+            pushSource: false,
+            pullTranslations: false,
+            validation: false,
+          },
+          githubComment: { enabled: true },
+        },
+      }),
+    );
+    expectOk(
+      await createWorkspaceAutomation({
+        organizationId: scope.organizationId,
+        authorUserId: scope.userId,
+        name: "Push only GitHub automation",
+        instructions: "Should not run for pull requests.",
+        triggerConfig: { mode: "github", branches: ["main"] },
+        repositoryTarget: {
+          kind: "github",
+          githubInstallationRepositoryId: scope.repository.id,
+        },
+        toolConfig: {
+          github: {
+            enabled: true,
+            mode: "sync",
+            pushSource: false,
+            pullTranslations: false,
+            validation: true,
+          },
+        },
+      }),
+    );
+
+    const enqueued: Array<{ workspaceAutomationRunId: string; organizationId: string }> = [];
+    const queue = {
+      async enqueue(event: { workspaceAutomationRunId: string; organizationId: string }) {
+        enqueued.push(event);
+        return { ids: ["workflow-1"] };
+      },
+    };
+
+    const results = await dispatchWorkspaceAutomationsForGithubPullRequest({
+      deliveryId: "delivery-github-pr-1",
+      organizationId: scope.organizationId,
+      githubInstallationRepositoryId: scope.repository.id,
+      action: "opened",
+      pullRequestNumber: 42,
+      pullRequestUrl: "https://github.com/acme/app/pull/42",
+      baseBranch: "main",
+      headBranch: "feature/review",
+      commitBefore: "aaa111",
+      commitAfter: "bbb222",
+      queue,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.outcome).toBe("enqueued");
+    expect(enqueued).toHaveLength(1);
+
+    const runs = await listWorkspaceAutomationRuns({
+      automationId: matching.id,
+      organizationId: scope.organizationId,
+    });
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.inputSnapshot).toMatchObject({
+      githubDeliveryId: "delivery-github-pr-1",
+      githubEvent: "pull_request",
+      githubAction: "opened",
+      pullRequestNumber: 42,
+      baseBranch: "main",
+      headBranch: "feature/review",
+      pushBranch: "feature/review",
       commitBefore: "aaa111",
       commitAfter: "bbb222",
     });

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.test.ts
@@ -1091,7 +1091,7 @@ describe("workspace automation dispatcher", () => {
       pullRequestNumber: 42,
       baseBranch: "main",
       headBranch: "feature/review",
-      pushBranch: "feature/review",
+      pushBranch: "main",
       commitBefore: "aaa111",
       commitAfter: "bbb222",
     });

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.test.ts
@@ -1012,7 +1012,7 @@ describe("workspace automation dispatcher", () => {
         authorUserId: scope.userId,
         name: "Notify on push blockers",
         instructions: "Review localisation risk on this pull request.",
-        triggerConfig: { mode: "github", branches: ["main"], events: ["push", "pull_request"] },
+        triggerConfig: { mode: "github", branches: ["main"], events: ["pull_request"] },
         repositoryTarget: {
           kind: "github",
           githubInstallationRepositoryId: scope.repository.id,

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.ts
@@ -476,7 +476,7 @@ export async function dispatchWorkspaceAutomationsForGithubPullRequest(input: {
           pullRequestUrl: input.pullRequestUrl,
           baseBranch: input.baseBranch,
           headBranch: input.headBranch,
-          pushBranch: input.headBranch,
+          pushBranch: input.baseBranch,
           commitBefore: input.commitBefore,
           commitAfter: input.commitAfter,
         },

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.ts
@@ -28,6 +28,7 @@ import {
 } from "./workspace-automation-idempotency";
 import {
   hasWorkspaceAutomationGithubWorkflow,
+  workspaceAutomationShouldDispatchOnGithubPullRequest,
   workspaceAutomationShouldDispatchOnGithubPush,
 } from "./workspace-automation-github-mapping";
 import {
@@ -420,6 +421,76 @@ export async function dispatchWorkspaceAutomationsForGithubPush(input: {
           error: error instanceof Error ? error.message : String(error),
         },
         "workspace automation github push dispatch failed",
+      );
+    }
+  }
+
+  return results;
+}
+
+export async function dispatchWorkspaceAutomationsForGithubPullRequest(input: {
+  deliveryId: string;
+  organizationId: string;
+  githubInstallationRepositoryId: string;
+  action: string;
+  pullRequestNumber: number;
+  pullRequestUrl?: string;
+  baseBranch: string;
+  headBranch: string;
+  commitBefore: string;
+  commitAfter: string;
+  queue?: WorkspaceAutomationExecutionQueue;
+}): Promise<WorkspaceAutomationDispatchResult[]> {
+  const automations = (
+    await listWorkspaceAutomations({
+      organizationId: input.organizationId,
+      status: "active",
+      limit: 100,
+    })
+  ).filter(
+    (automation) =>
+      automation.repositoryTarget.kind === "github" &&
+      automation.repositoryTarget.githubInstallationRepositoryId ===
+        input.githubInstallationRepositoryId &&
+      workspaceAutomationShouldDispatchOnGithubPullRequest(automation, input.baseBranch),
+  );
+
+  const results: WorkspaceAutomationDispatchResult[] = [];
+
+  for (const automation of automations) {
+    try {
+      const result = await dispatchWorkspaceAutomationViaOrchestrator({
+        organizationId: input.organizationId,
+        automation,
+        triggerSource: "github",
+        idempotencyKey: buildWorkspaceGithubPushAutomationIdempotencyKey({
+          automationId: automation.id,
+          configVersion: automation.configVersion,
+          githubDeliveryId: input.deliveryId,
+        }),
+        inputSnapshot: {
+          githubDeliveryId: input.deliveryId,
+          githubEvent: "pull_request",
+          githubAction: input.action,
+          pullRequestNumber: input.pullRequestNumber,
+          pullRequestUrl: input.pullRequestUrl,
+          baseBranch: input.baseBranch,
+          headBranch: input.headBranch,
+          pushBranch: input.headBranch,
+          commitBefore: input.commitBefore,
+          commitAfter: input.commitAfter,
+        },
+        queue: input.queue,
+      });
+      results.push(result);
+    } catch (error) {
+      logger.error(
+        {
+          automationId: automation.id,
+          deliveryId: input.deliveryId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "workspace automation github pull request dispatch failed",
       );
     }
   }

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-github-mapping.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-github-mapping.test.ts
@@ -280,9 +280,9 @@ describe("workspace automation GitHub mapping", () => {
     expect(workspaceAutomationShouldDispatchOnGithubPullRequest(agentAutomation, "main")).toBe(
       true,
     );
-    expect(
-      workspaceAutomationShouldDispatchOnGithubPullRequest(agentAutomation, "feature/x"),
-    ).toBe(false);
+    expect(workspaceAutomationShouldDispatchOnGithubPullRequest(agentAutomation, "feature/x")).toBe(
+      false,
+    );
     expect(
       workspaceAutomationShouldDispatchOnGithubPullRequest(
         automation({

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-github-mapping.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-github-mapping.test.ts
@@ -23,6 +23,7 @@ import {
   hasWorkspaceAutomationGithubWorkflow,
   resolveWorkspaceAutomationGithubMode,
   workspaceAutomationMatchesPushBranch,
+  workspaceAutomationShouldDispatchOnGithubPullRequest,
   workspaceAutomationShouldDispatchOnGithubPush,
   workspaceAutomationToGithubSettings,
 } from "./workspace-automation-github-mapping";
@@ -239,6 +240,9 @@ describe("workspace automation GitHub mapping", () => {
 
     expect(workspaceAutomationShouldDispatchOnGithubPush(agentAutomation, "main")).toBe(true);
     expect(workspaceAutomationShouldDispatchOnGithubPush(agentAutomation, "feature/x")).toBe(false);
+    expect(workspaceAutomationShouldDispatchOnGithubPullRequest(agentAutomation, "main")).toBe(
+      false,
+    );
     expect(
       workspaceAutomationShouldDispatchOnGithubPush(
         automation({
@@ -252,6 +256,38 @@ describe("workspace automation GitHub mapping", () => {
               validation: false,
             },
           },
+        }),
+        "main",
+      ),
+    ).toBe(false);
+  });
+
+  it("dispatches GitHub agent automations on matching pull request base branches", () => {
+    const agentAutomation = automation({
+      triggerConfig: { mode: "github", branches: ["main"], events: ["push", "pull_request"] },
+      toolConfig: {
+        github: {
+          enabled: true,
+          mode: "agent",
+          pushSource: false,
+          pullTranslations: false,
+          validation: false,
+        },
+        githubComment: { enabled: true },
+      },
+    });
+
+    expect(workspaceAutomationShouldDispatchOnGithubPullRequest(agentAutomation, "main")).toBe(
+      true,
+    );
+    expect(
+      workspaceAutomationShouldDispatchOnGithubPullRequest(agentAutomation, "feature/x"),
+    ).toBe(false);
+    expect(
+      workspaceAutomationShouldDispatchOnGithubPullRequest(
+        automation({
+          triggerConfig: { mode: "github", branches: ["main"], events: ["push"] },
+          toolConfig: agentAutomation.toolConfig,
         }),
         "main",
       ),

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-github-mapping.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-github-mapping.test.ts
@@ -264,7 +264,7 @@ describe("workspace automation GitHub mapping", () => {
 
   it("dispatches GitHub agent automations on matching pull request base branches", () => {
     const agentAutomation = automation({
-      triggerConfig: { mode: "github", branches: ["main"], events: ["push", "pull_request"] },
+      triggerConfig: { mode: "github", branches: ["main"], events: ["pull_request"] },
       toolConfig: {
         github: {
           enabled: true,
@@ -280,6 +280,7 @@ describe("workspace automation GitHub mapping", () => {
     expect(workspaceAutomationShouldDispatchOnGithubPullRequest(agentAutomation, "main")).toBe(
       true,
     );
+    expect(workspaceAutomationShouldDispatchOnGithubPush(agentAutomation, "main")).toBe(false);
     expect(workspaceAutomationShouldDispatchOnGithubPullRequest(agentAutomation, "feature/x")).toBe(
       false,
     );
@@ -292,5 +293,14 @@ describe("workspace automation GitHub mapping", () => {
         "main",
       ),
     ).toBe(false);
+    expect(
+      workspaceAutomationShouldDispatchOnGithubPullRequest(
+        automation({
+          triggerConfig: { mode: "github", branches: ["main"], events: ["push", "pull_request"] },
+          toolConfig: agentAutomation.toolConfig,
+        }),
+        "main",
+      ),
+    ).toBe(true);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-github-mapping.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-github-mapping.ts
@@ -65,9 +65,7 @@ export function hasWorkspaceAutomationGithubCommentTool(
   return Boolean(toolConfig.githubComment?.enabled);
 }
 
-function workspaceAutomationHasGithubDispatchTools(
-  automation: WorkspaceAutomationRecord,
-): boolean {
+function workspaceAutomationHasGithubDispatchTools(automation: WorkspaceAutomationRecord): boolean {
   return (
     hasWorkspaceAutomationGithubWorkflow(automation.toolConfig) ||
     hasWorkspaceAutomationGithubAgentTool(automation.toolConfig) ||

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-github-mapping.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-github-mapping.ts
@@ -15,10 +15,11 @@ import {
   type GithubRepositoryAutomationSettings,
 } from "@/lib/agents/github/github-repository-automation-settings";
 
-import type {
-  WorkspaceAutomationRecord,
-  WorkspaceAutomationToolConfig,
-  WorkspaceAutomationTriggerConfig,
+import {
+  workspaceAutomationGithubEventsInclude,
+  type WorkspaceAutomationRecord,
+  type WorkspaceAutomationToolConfig,
+  type WorkspaceAutomationTriggerConfig,
 } from "./workspace-automations";
 
 export function resolveWorkspaceAutomationGithubMode(
@@ -64,6 +65,16 @@ export function hasWorkspaceAutomationGithubCommentTool(
   return Boolean(toolConfig.githubComment?.enabled);
 }
 
+function workspaceAutomationHasGithubDispatchTools(
+  automation: WorkspaceAutomationRecord,
+): boolean {
+  return (
+    hasWorkspaceAutomationGithubWorkflow(automation.toolConfig) ||
+    hasWorkspaceAutomationGithubAgentTool(automation.toolConfig) ||
+    hasWorkspaceAutomationGithubCommentTool(automation.toolConfig)
+  );
+}
+
 export function workspaceAutomationShouldDispatchOnGithubPush(
   automation: WorkspaceAutomationRecord,
   branch: string,
@@ -72,15 +83,34 @@ export function workspaceAutomationShouldDispatchOnGithubPush(
     return false;
   }
 
+  if (!workspaceAutomationGithubEventsInclude(automation.triggerConfig.events, "push")) {
+    return false;
+  }
+
   if (!workspaceAutomationMatchesPushBranch(automation, branch)) {
     return false;
   }
 
-  return (
-    hasWorkspaceAutomationGithubWorkflow(automation.toolConfig) ||
-    hasWorkspaceAutomationGithubAgentTool(automation.toolConfig) ||
-    hasWorkspaceAutomationGithubCommentTool(automation.toolConfig)
-  );
+  return workspaceAutomationHasGithubDispatchTools(automation);
+}
+
+export function workspaceAutomationShouldDispatchOnGithubPullRequest(
+  automation: WorkspaceAutomationRecord,
+  baseBranch: string,
+): boolean {
+  if (automation.repositoryTarget.kind !== "github") {
+    return false;
+  }
+
+  if (!workspaceAutomationGithubEventsInclude(automation.triggerConfig.events, "pull_request")) {
+    return false;
+  }
+
+  if (!workspaceAutomationMatchesPushBranch(automation, baseBranch)) {
+    return false;
+  }
+
+  return workspaceAutomationHasGithubDispatchTools(automation);
 }
 
 export function workspaceAutomationToGithubSettings(

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.test.ts
@@ -210,7 +210,7 @@ describe("workspace automation templates", () => {
       defaultForm: {
         triggerMode: "github",
         pushBranches: ["main"],
-        githubEvents: ["push", "pull_request"],
+        githubEvents: ["pull_request"],
         githubEnabled: true,
         githubMode: "agent",
         githubCommentEnabled: true,
@@ -223,7 +223,7 @@ describe("workspace automation templates", () => {
     expect(template?.instructions).toContain("Review focus:");
     expect(template?.instructions).toContain("i18n.yml");
     expect(getWorkspaceAutomationTemplateFlow(template!)).toEqual({
-      trigger: { id: "github-push", label: "GitHub push and pull request" },
+      trigger: { id: "github-pull-request", label: "GitHub pull request" },
       tools: [
         { id: "github", label: "GitHub" },
         { id: "github-comment", label: "GitHub comment" },

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.test.ts
@@ -197,7 +197,7 @@ describe("workspace automation templates", () => {
     });
   });
 
-  it("exposes an activatable push localisation-review template", () => {
+  it("exposes an activatable pull request localisation-review template", () => {
     const template = getWorkspaceAutomationTemplate(
       "notify-on-push-blockers",
       WORKSPACE_AUTOMATION_TEMPLATES_BASE,

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.test.ts
@@ -210,6 +210,7 @@ describe("workspace automation templates", () => {
       defaultForm: {
         triggerMode: "github",
         pushBranches: ["main"],
+        githubEvents: ["push", "pull_request"],
         githubEnabled: true,
         githubMode: "agent",
         githubCommentEnabled: true,
@@ -222,7 +223,7 @@ describe("workspace automation templates", () => {
     expect(template?.instructions).toContain("Review focus:");
     expect(template?.instructions).toContain("i18n.yml");
     expect(getWorkspaceAutomationTemplateFlow(template!)).toEqual({
-      trigger: { id: "github-push", label: "GitHub push" },
+      trigger: { id: "github-push", label: "GitHub push and pull request" },
       tools: [
         { id: "github", label: "GitHub" },
         { id: "github-comment", label: "GitHub comment" },

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
@@ -633,19 +633,19 @@ export const WORKSPACE_AUTOMATION_TEMPLATES_BASE: WorkspaceAutomationTemplate[] 
     category: "popular",
     name: "Notify on push blockers",
     description:
-      "Review GitHub pushes and pull requests opened against main for localisation and translation risk, then comment on the pull request.",
+      "Review pull requests opened against main for localisation and translation risk, then comment on the pull request.",
     instructions: formatWorkspaceAutomationTemplateInstructions({
       role: "a localisation-focused code reviewer for this repository",
       capabilities: [
-        "Read the pushed commits, pull request diffs, and surrounding code",
+        "Read the pull request diffs and surrounding code",
         "If i18n.yml exists, run Hyperlocalise validation (hl check) against the translation files it maps",
         "Judge localisation, translation, and locale-compliance risk in the changed code",
         "Cite commit SHAs and file paths for each finding",
         "Separate blocking localisation defects from non-blocking follow-ups",
         "Ignore unrelated logic, security, and formatting issues unless they affect user-facing copy or locale behavior",
-        "Post findings as a sticky GitHub pull request comment and update it on later pushes",
+        "Post findings as a sticky GitHub pull request comment and update it when the pull request changes",
       ],
-      goal: "Surface localisation and translation risks from this push or pull request before they merge.",
+      goal: "Surface localisation and translation risks on this pull request before it merges.",
       extraSections: [
         {
           heading: "Review focus",
@@ -663,7 +663,7 @@ export const WORKSPACE_AUTOMATION_TEMPLATES_BASE: WorkspaceAutomationTemplate[] 
       name: "Notify on push blockers",
       triggerMode: "github",
       pushBranches: ["main"],
-      githubEvents: ["push", "pull_request"],
+      githubEvents: ["pull_request"],
       githubEnabled: true,
       githubMode: "agent",
       repositoryTargetKind: "github",

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
@@ -901,11 +901,12 @@ export function getWorkspaceAutomationTemplateFlow(
   const githubEvents = form.githubEvents ?? ["push"];
   const listensToPush = githubEvents.includes("push");
   const listensToPullRequest = githubEvents.includes("pull_request");
-  const githubTrigger: WorkspaceAutomationTemplateFlowNode = listensToPush && listensToPullRequest
-    ? { id: "github-push", label: "GitHub push and pull request" }
-    : listensToPullRequest
-      ? { id: "github-pull-request", label: "GitHub pull request" }
-      : { id: "github-push", label: "GitHub push" };
+  const githubTrigger: WorkspaceAutomationTemplateFlowNode =
+    listensToPush && listensToPullRequest
+      ? { id: "github-push", label: "GitHub push and pull request" }
+      : listensToPullRequest
+        ? { id: "github-pull-request", label: "GitHub pull request" }
+        : { id: "github-push", label: "GitHub push" };
 
   const trigger: WorkspaceAutomationTemplateFlowNode =
     triggerMode === "github"

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
@@ -633,11 +633,11 @@ export const WORKSPACE_AUTOMATION_TEMPLATES_BASE: WorkspaceAutomationTemplate[] 
     category: "popular",
     name: "Notify on push blockers",
     description:
-      "Review each GitHub push for localisation and translation risk, then comment on the pull request.",
+      "Review GitHub pushes and pull requests opened against main for localisation and translation risk, then comment on the pull request.",
     instructions: formatWorkspaceAutomationTemplateInstructions({
       role: "a localisation-focused code reviewer for this repository",
       capabilities: [
-        "Read the pushed commits, diffs, and surrounding code",
+        "Read the pushed commits, pull request diffs, and surrounding code",
         "If i18n.yml exists, run Hyperlocalise validation (hl check) against the translation files it maps",
         "Judge localisation, translation, and locale-compliance risk in the changed code",
         "Cite commit SHAs and file paths for each finding",
@@ -645,7 +645,7 @@ export const WORKSPACE_AUTOMATION_TEMPLATES_BASE: WorkspaceAutomationTemplate[] 
         "Ignore unrelated logic, security, and formatting issues unless they affect user-facing copy or locale behavior",
         "Post findings as a sticky GitHub pull request comment and update it on later pushes",
       ],
-      goal: "Surface localisation and translation risks from this push on the pull request before they merge.",
+      goal: "Surface localisation and translation risks from this push or pull request before they merge.",
       extraSections: [
         {
           heading: "Review focus",
@@ -663,6 +663,7 @@ export const WORKSPACE_AUTOMATION_TEMPLATES_BASE: WorkspaceAutomationTemplate[] 
       name: "Notify on push blockers",
       triggerMode: "github",
       pushBranches: ["main"],
+      githubEvents: ["push", "pull_request"],
       githubEnabled: true,
       githubMode: "agent",
       repositoryTargetKind: "github",
@@ -897,9 +898,18 @@ export function getWorkspaceAutomationTemplateFlow(
   const form = template.defaultForm;
   const triggerMode = form.triggerMode ?? "manual";
 
+  const githubEvents = form.githubEvents ?? ["push"];
+  const listensToPush = githubEvents.includes("push");
+  const listensToPullRequest = githubEvents.includes("pull_request");
+  const githubTrigger: WorkspaceAutomationTemplateFlowNode = listensToPush && listensToPullRequest
+    ? { id: "github-push", label: "GitHub push and pull request" }
+    : listensToPullRequest
+      ? { id: "github-pull-request", label: "GitHub pull request" }
+      : { id: "github-push", label: "GitHub push" };
+
   const trigger: WorkspaceAutomationTemplateFlowNode =
     triggerMode === "github"
-      ? { id: "github-push", label: "GitHub push" }
+      ? githubTrigger
       : triggerMode === "contentful"
         ? { id: "contentful-webhook", label: "Contentful webhook" }
         : triggerMode === "source_upload"

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
@@ -277,7 +277,7 @@ describe("workspace automation view model", () => {
       name: "Notify on push blockers",
       triggerMode: "github",
       pushBranches: ["main"],
-      githubEvents: ["push", "pull_request"],
+      githubEvents: ["pull_request"],
       githubEnabled: true,
       githubMode: "agent",
       githubCommentEnabled: true,
@@ -300,7 +300,7 @@ describe("workspace automation view model", () => {
     expect(formStateToWorkspaceAutomationPayload(form!).triggerConfig).toEqual({
       mode: "github",
       branches: ["main"],
-      events: ["push", "pull_request"],
+      events: ["pull_request"],
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
@@ -277,6 +277,7 @@ describe("workspace automation view model", () => {
       name: "Notify on push blockers",
       triggerMode: "github",
       pushBranches: ["main"],
+      githubEvents: ["push", "pull_request"],
       githubEnabled: true,
       githubMode: "agent",
       githubCommentEnabled: true,
@@ -296,6 +297,11 @@ describe("workspace automation view model", () => {
     expect(formStateToWorkspaceAutomationPayload(form!).toolConfig.githubComment).toEqual({
       enabled: true,
     });
+    expect(formStateToWorkspaceAutomationPayload(form!).triggerConfig).toEqual({
+      mode: "github",
+      branches: ["main"],
+      events: ["push", "pull_request"],
+    });
   });
 
   it("allows GitHub agent mode with a GitHub push trigger", () => {
@@ -313,7 +319,7 @@ describe("workspace automation view model", () => {
 
     expect(validateWorkspaceAutomationFormState(form)).toEqual({});
     expect(formStateToWorkspaceAutomationPayload(form)).toMatchObject({
-      triggerConfig: { mode: "github", branches: ["main"] },
+      triggerConfig: { mode: "github", branches: ["main"], events: ["push"] },
       repositoryTarget: {
         kind: "github",
         githubInstallationRepositoryId: "11111111-1111-4111-8111-111111111111",

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
@@ -10,13 +10,15 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import type {
-  WorkspaceAutomationGithubToolMode,
-  WorkspaceAutomationRecord,
-  WorkspaceAutomationRepositoryTarget,
-  WorkspaceAutomationToolConfig,
-  WorkspaceAutomationTriggerConfig,
-  WorkspaceAutomationWebSearchProvider,
+import {
+  resolveWorkspaceAutomationGithubEvents,
+  type WorkspaceAutomationGithubToolMode,
+  type WorkspaceAutomationGithubTriggerEvent,
+  type WorkspaceAutomationRecord,
+  type WorkspaceAutomationRepositoryTarget,
+  type WorkspaceAutomationToolConfig,
+  type WorkspaceAutomationTriggerConfig,
+  type WorkspaceAutomationWebSearchProvider,
 } from "./workspace-automations";
 import { parseSlackConversationId } from "./slack/channel-query";
 import {
@@ -38,6 +40,7 @@ export type WorkspaceAutomationFormState = {
   projectId: string;
   triggerMode: WorkspaceAutomationTriggerMode;
   pushBranches: string[];
+  githubEvents: WorkspaceAutomationGithubTriggerEvent[];
   scheduledCadence: "hourly" | "daily" | "weekly";
   scheduledHourUtc: number;
   scheduledDayOfWeek: number;
@@ -108,6 +111,7 @@ export type WorkspaceAutomationFieldErrors = Partial<
     | "githubRepository"
     | "trigger"
     | "pushBranches"
+    | "githubEvents"
     | "slackChannelId"
     | "emailRecipients"
     | "contentfulConnectionId"
@@ -132,7 +136,8 @@ export const WORKSPACE_AUTOMATION_API_ERROR_MESSAGES: Record<string, string> = {
   github_trigger_required: "Choose a schedule or GitHub push trigger for GitHub workflows.",
   github_agent_trigger_required:
     "Use GitHub repo automations with a scheduled, manual, or GitHub push trigger.",
-  github_push_branches_required: "Add at least one branch pattern for GitHub push triggers.",
+  github_push_branches_required: "Add at least one branch pattern for GitHub triggers.",
+  github_events_required: "Choose at least one GitHub event.",
   scheduled_workflow_required:
     "Scheduled automations require at least one GitHub, Contentful, Issues, Web Search, or Crowdin workflow tool.",
   slack_not_connected: "Connect Slack in Integrations before enabling Slack notifications.",
@@ -186,6 +191,7 @@ export function createDefaultWorkspaceAutomationFormState(): WorkspaceAutomation
     projectId: "",
     triggerMode: "manual",
     pushBranches: ["main"],
+    githubEvents: ["push"],
     scheduledCadence: "daily",
     scheduledHourUtc: 22,
     scheduledDayOfWeek: 1,
@@ -261,6 +267,9 @@ export function createWorkspaceAutomationFormStateFromRecord(
       automation.triggerConfig.mode === "github" && automation.triggerConfig.branches?.length
         ? [...automation.triggerConfig.branches]
         : ["main"],
+    githubEvents: resolveWorkspaceAutomationGithubEvents(
+      automation.triggerConfig.mode === "github" ? automation.triggerConfig.events : undefined,
+    ),
     scheduledCadence:
       automation.triggerConfig.mode === "scheduled" && automation.triggerConfig.schedule
         ? automation.triggerConfig.schedule.cadence
@@ -348,6 +357,7 @@ export function applyTemplateToWorkspaceAutomationFormState(
     name: template.defaultForm.name ?? template.name,
     instructions: template.defaultForm.instructions ?? template.instructions,
     pushBranches: template.defaultForm.pushBranches ?? base.pushBranches,
+    githubEvents: template.defaultForm.githubEvents ?? base.githubEvents,
     emailRecipients: template.defaultForm.emailRecipients ?? base.emailRecipients,
     contentfulContentTypeIds:
       template.defaultForm.contentfulContentTypeIds ?? base.contentfulContentTypeIds,
@@ -401,6 +411,7 @@ export function formStateToWorkspaceAutomationPayload(form: WorkspaceAutomationF
         ? {
             mode: "github",
             branches: form.pushBranches,
+            events: resolveWorkspaceAutomationGithubEvents(form.githubEvents),
           }
         : form.triggerMode === "contentful"
           ? { mode: "contentful" }
@@ -602,6 +613,10 @@ export function validateWorkspaceAutomationFormState(
     errors.pushBranches = "Add at least one branch pattern.";
   }
 
+  if (form.triggerMode === "github" && form.githubEvents.length === 0) {
+    errors.githubEvents = "Choose at least one GitHub event.";
+  }
+
   if (form.slackEnabled && !parseSlackConversationId(form.slackChannelId)) {
     errors.slackChannelId = "Enter a valid Slack channel ID.";
   }
@@ -684,6 +699,8 @@ export function mapWorkspaceAutomationApiErrorToFieldErrors(
       return { trigger: message };
     case "github_push_branches_required":
       return { pushBranches: message };
+    case "github_events_required":
+      return { githubEvents: message };
     case "slack_not_connected":
     case "slack_channel_required":
       return { slackChannelId: message };

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
@@ -410,6 +410,40 @@ describe("workspace automations", () => {
     expect(automation.toolConfig.githubComment).toEqual({ enabled: true });
   });
 
+  it("creates GitHub agent automations with push and pull request events", async () => {
+    const scope = await seedWorkspaceAutomationScope();
+
+    const automation = expectOk(
+      await createWorkspaceAutomation({
+        organizationId: scope.organizationId,
+        authorUserId: scope.userId,
+        name: "Notify on push blockers",
+        instructions: "Review localisation risk on this pull request.",
+        triggerConfig: { mode: "github", branches: ["main"], events: ["push", "pull_request"] },
+        repositoryTarget: {
+          kind: "github",
+          githubInstallationRepositoryId: scope.githubInstallationRepositoryId,
+        },
+        toolConfig: {
+          github: {
+            enabled: true,
+            mode: "agent",
+            pushSource: false,
+            pullTranslations: false,
+            validation: false,
+          },
+          githubComment: { enabled: true },
+        },
+      }),
+    );
+
+    expect(automation.triggerConfig).toEqual({
+      mode: "github",
+      branches: ["main"],
+      events: ["push", "pull_request"],
+    });
+  });
+
   it("rejects scheduled automations without a GitHub or Contentful workflow", async () => {
     const scope = await seedWorkspaceAutomationScope();
     const triggerConfig = {

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -51,6 +51,31 @@ const branchPatternSchema = z
   .max(255)
   .regex(/^[A-Za-z0-9._\-/*?]+$/, "invalid_branch_pattern");
 
+export const workspaceAutomationGithubTriggerEventSchema = z.enum(["push", "pull_request"]);
+export type WorkspaceAutomationGithubTriggerEvent = z.infer<
+  typeof workspaceAutomationGithubTriggerEventSchema
+>;
+export const DEFAULT_WORKSPACE_AUTOMATION_GITHUB_EVENTS: WorkspaceAutomationGithubTriggerEvent[] = [
+  "push",
+];
+
+export function resolveWorkspaceAutomationGithubEvents(
+  events?: readonly WorkspaceAutomationGithubTriggerEvent[] | null,
+): WorkspaceAutomationGithubTriggerEvent[] {
+  if (!events || events.length === 0) {
+    return [...DEFAULT_WORKSPACE_AUTOMATION_GITHUB_EVENTS];
+  }
+
+  return [...new Set(events)];
+}
+
+export function workspaceAutomationGithubEventsInclude(
+  events: readonly WorkspaceAutomationGithubTriggerEvent[] | undefined,
+  event: WorkspaceAutomationGithubTriggerEvent,
+): boolean {
+  return resolveWorkspaceAutomationGithubEvents(events).includes(event);
+}
+
 const triggerConfigSchema = z
   .object({
     mode: z
@@ -65,6 +90,7 @@ const triggerConfigSchema = z
       })
       .optional(),
     branches: z.array(branchPatternSchema).min(1).max(32).optional(),
+    events: z.array(workspaceAutomationGithubTriggerEventSchema).min(1).max(2).optional(),
   })
   .default({ mode: "manual" });
 
@@ -337,7 +363,11 @@ export type WorkspaceAutomationConfigValidationError =
     }
   | {
       code: "github_push_branches_required";
-      message: "GitHub push triggers require at least one branch pattern.";
+      message: "GitHub triggers require at least one branch pattern.";
+    }
+  | {
+      code: "github_events_required";
+      message: "GitHub triggers require at least one event.";
     }
   | {
       code: "scheduled_workflow_required";
@@ -670,7 +700,18 @@ function validateWorkspaceAutomationConfig(input: {
   ) {
     return err({
       code: "github_push_branches_required",
-      message: "GitHub push triggers require at least one branch pattern.",
+      message: "GitHub triggers require at least one branch pattern.",
+    });
+  }
+
+  if (
+    input.triggerConfig.mode === "github" &&
+    input.triggerConfig.events &&
+    input.triggerConfig.events.length === 0
+  ) {
+    return err({
+      code: "github_events_required",
+      message: "GitHub triggers require at least one event.",
     });
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Notify on push blockers now reviews **pull requests opened against `main`**. It no longer defaults to reviewing pushes to `main`.

- GitHub triggers accept an `events` array: `push` and/or `pull_request`. Omitted `events` stays push-only so existing automations do not change.
- The **Notify on push blockers** template defaults to `pull_request` only, with base branch `main`.
- PR matching uses the **base branch**.
- PR actions handled: `opened`, `reopened`, `synchronize`, `ready_for_review`. Drafts are skipped until `ready_for_review`.
- Runtime snapshot includes PR number, URL, base/head branches, and SHAs so the repo agent reviews the PR diff and the sticky comment posts on that PR.
- The automation editor still has **Push** and **Pull request opened** toggles if someone needs both.

Codex review fixes:

- Workflow dispatch matches the PR **base** branch, not the feature head, so validation still runs for `feature/*` into `main`.
- `commitBefore` is the compare-API **merge base**, not the current base tip, so the review range is only PR changes.

## How to test

- `vp test` focused merge-base, webhook, dispatcher, lookback, and route files — 42 tests passed
- `vp check --fix` — 0 errors (5 pre-existing warnings)

Existing saved automations stay on their stored events. Turn **Push** off on an existing notify blocker if it still listens to main.

The GitHub App must subscribe to `pull_request` webhooks, or these events never arrive.

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01be0-2e51-77ad-a385-61fafa82d198?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01be0-2e51-77ad-a385-61fafa82d198&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

