### PR TITLE
fix(agent-runtime): deny git --output writes in read-only bash

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.test.ts
@@ -96,6 +96,11 @@ describe("isAllowedBashCommand", () => {
     expect(isAllowedBashCommand("git log --oneline")).toBe(true);
   });
 
+  it("allows git revision ranges that use ..", () => {
+    expect(isAllowedBashCommand("git log HEAD..main")).toBe(true);
+    expect(isAllowedBashCommand("git diff main...HEAD")).toBe(true);
+  });
+
   it.each([
     "git log --output=package.json",
     "git log --output package.json",

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.test.ts
@@ -161,10 +161,7 @@ describe("createBashTool", () => {
         readFile: async () => "",
       },
     });
-    const result = await tool.execute!(
-      { command: "git log --output=package.json" },
-      toolCallInfo,
-    );
+    const result = await tool.execute!({ command: "git log --output=package.json" }, toolCallInfo);
     expect(result).toMatchObject({ success: false });
   });
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.test.ts
@@ -83,6 +83,44 @@ describe("isAllowedBashCommand", () => {
   ])("blocks hl write flag in %s", (command) => {
     expect(isAllowedBashCommand(command)).toBe(false);
   });
+
+  it("allows hl status --output as a format, not a write path", () => {
+    expect(isAllowedBashCommand("hl status --output csv")).toBe(true);
+  });
+
+  it("allows find -o as OR", () => {
+    expect(isAllowedBashCommand("find . -name '*.json' -o -name '*.yaml' -type f")).toBe(true);
+  });
+
+  it("allows git log --oneline", () => {
+    expect(isAllowedBashCommand("git log --oneline")).toBe(true);
+  });
+
+  it.each([
+    "git log --output=package.json",
+    "git log --output package.json",
+    "git show HEAD --output=src/index.ts",
+    "git diff --output=evil.js",
+    "git log -o package.json",
+    "git log -O orderfile",
+    "git log -opackage.json",
+    `git log "--output=package.json"`,
+    `git log "--output" pwned.txt`,
+  ])("blocks git output write flag in %s", (command) => {
+    expect(isAllowedBashCommand(command)).toBe(false);
+  });
+
+  it.each([
+    "git log --output=/tmp/x",
+    "git log --output=../../outside.txt",
+    "git diff --output=/tmp/evil.js",
+    `git show HEAD --output="/tmp/x"`,
+    "git log --output=../outside.txt",
+    "find . -path=/tmp/x -type f",
+    "find . -path=../../etc -type f",
+  ])("blocks attached absolute or parent path in %s", (command) => {
+    expect(isAllowedBashCommand(command)).toBe(false);
+  });
 });
 
 describe("createBashTool", () => {
@@ -110,6 +148,36 @@ describe("createBashTool", () => {
   it("rejects hl check --fix before execution", async () => {
     const tool = createBashTool(createTestContext());
     const result = await tool.execute!({ command: "hl check --fix" }, toolCallInfo);
+    expect(result).toMatchObject({ success: false });
+  });
+
+  it("rejects git log --output before execution", async () => {
+    const exec = async () => {
+      throw new Error("bash.exec must not run for git --output");
+    };
+    const tool = createBashTool({
+      bash: {
+        exec,
+        readFile: async () => "",
+      },
+    });
+    const result = await tool.execute!(
+      { command: "git log --output=package.json" },
+      toolCallInfo,
+    );
+    expect(result).toMatchObject({ success: false });
+  });
+
+  it("rejects git show -o before execution", async () => {
+    const tool = createBashTool({
+      bash: {
+        exec: async () => {
+          throw new Error("bash.exec must not run for git -o");
+        },
+        readFile: async () => "",
+      },
+    });
+    const result = await tool.execute!({ command: "git show HEAD -o src/index.ts" }, toolCallInfo);
     expect(result).toMatchObject({ success: false });
   });
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/bash.ts
@@ -43,6 +43,10 @@ const DISALLOWED_FLAG_NAMES = new Set([
   ...HL_WRITE_FLAG_NAMES,
 ]);
 
+// git log/diff/show `--output`/`-o` writes a file. Keep these git-only:
+// `find -o` is OR, and `hl status --output csv` is a format, not a path.
+const DISALLOWED_GIT_OUTPUT_FLAG_NAMES = new Set(["output", "o"]);
+
 const ALLOWED_COMMAND_PATTERNS = [
   /^git\s+(status|log|diff|rev-parse|show)\b/i,
   /^ls(\s+|$)/,
@@ -50,11 +54,47 @@ const ALLOWED_COMMAND_PATTERNS = [
   /^hl\s+(check|status|extract)\b/i,
 ];
 
-const ABSOLUTE_PATH_PATTERN = /(^|\s)\/(?!\.)(?!\s|$)/;
-const PARENT_TRAVERSAL_PATTERN = /(^|\s)\.\.(\/|\s|$)/;
+// Also match paths glued onto `--flag=` / `-o=` so `--output=/tmp/x` and
+// `--output=../../outside.txt` cannot skip the whitespace-bounded heuristics.
+const ABSOLUTE_PATH_PATTERN = /(^|[\s="'])\/(?!\.)(?!\s|$)/;
+const PARENT_TRAVERSAL_PATTERN = /(^|[\s="'])\.\.(\/|[\s"']|$)/;
 
-function isDisallowedFlagToken(token: string): boolean {
-  return token.startsWith("-") && DISALLOWED_FLAG_NAMES.has(flagBasename(token));
+function unquoteFlagValue(value: string): string {
+  return value.replace(/^['"]|['"]$/g, "");
+}
+
+function attachedFlagValueEscapesWorkspace(token: string): boolean {
+  const separator = token.indexOf("=");
+  if (separator === -1) {
+    return false;
+  }
+  const value = unquoteFlagValue(token.slice(separator + 1));
+  if (!value) {
+    return false;
+  }
+  return value.startsWith("/") || value.split("/").includes("..");
+}
+
+function isDisallowedGitOutputFlag(token: string): boolean {
+  if (!token.startsWith("-")) {
+    return false;
+  }
+  const name = flagBasename(token);
+  if (DISALLOWED_GIT_OUTPUT_FLAG_NAMES.has(name)) {
+    return true;
+  }
+  // git accepts `-ofile` as `-o` with an attached filename.
+  return /^-o./i.test(token) && !token.startsWith("--");
+}
+
+function isDisallowedFlagToken(token: string, bin: string): boolean {
+  if (!token.startsWith("-")) {
+    return false;
+  }
+  if (DISALLOWED_FLAG_NAMES.has(flagBasename(token))) {
+    return true;
+  }
+  return bin === "git" && isDisallowedGitOutputFlag(token);
 }
 
 export function isAllowedBashCommand(command: string): boolean {
@@ -80,8 +120,12 @@ export function isAllowedBashCommand(command: string): boolean {
     return false;
   }
 
-  const tokens = [splitResult.value.bin, ...splitResult.value.args];
-  if (tokens.some(isDisallowedFlagToken)) {
+  const { bin, args } = splitResult.value;
+  const tokens = [bin, ...args];
+  if (tokens.some((token) => isDisallowedFlagToken(token, bin))) {
+    return false;
+  }
+  if (tokens.some(attachedFlagValueEscapesWorkspace)) {
     return false;
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Read-only repository agents can still call allowlisted `bash`. `git log`, `git show`, and `git diff` accept `--output` / `-o` and write that path, so a steered agent could overwrite workspace files without `assertRepositoryWriteAllowed`.

This change:

- Denies git flag basenames `output` and `o`, including attached `-ofile`
- Treats `=`-attached absolute and `..` paths as workspace escapes (`--output=/tmp/x`, `--output=../../outside.txt`)
- Leaves `find -o` (OR) and `hl status --output csv` (format) allowed
- Still allows git revision ranges such as `HEAD..main`

Bash stays allowlist-enforced rather than write-gated, so genuine read-only git/ls/find/hl commands still run in `workMode: "read_only"`.

## How to test

- `cd apps/hyperlocalise-web && vp test src/lib/agent-runtime/tools/workspace/bash.test.ts` — 47 passed
- `cd apps/hyperlocalise-web && vp check --fix` — 0 errors (pre-existing warnings in unrelated files)

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ca8a747-8d0f-417d-b35d-43aeb96a0da3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ca8a747-8d0f-417d-b35d-43aeb96a0da3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

