### PR TITLE
fix(crowdin): add LabelIDs parity to BuildProjectFileTranslationRequest

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -1,5 +1,11 @@
 # Crowdin Steward's Journal
 
+## 2026-12-31 - Add LabelIDs parity to BuildProjectFileTranslationRequest
+
+**Learning:** In Crowdin API v2, the Build Project File Translation endpoint (`POST /api/v2/projects/{projectId}/translations/builds/files/{fileId}`) accepts an optional `labelIds` array in the request body to filter builds by label identifiers. While `BuildProjectRequest` and `BuildProjectDirectoryTranslationRequest` included `labelIds`, `BuildProjectFileTranslationRequest` was missing `LabelIDs`, and its custom `MarshalJSON()` method omitted `labelIds` from serialized JSON payloads.
+
+**Action:** Added `LabelIDs []int json:"labelIds,omitempty"` to `BuildProjectFileTranslationRequest` and updated its custom `MarshalJSON()` method in `crowdin/model/translations.go`. Updated unit and contract tests in `crowdin/model/translations_test.go` and `crowdin/translations_test.go` to assert `LabelIDs` JSON marshaling and API endpoint execution.
+
 ## 2026-12-30 - Add FileID/MaxLen parity and fix root upload validation in SourceStringsUploadRequest
 
 **Learning:** In Crowdin API v2, uploading source strings (`POST /api/v2/projects/{projectId}/strings/uploads`) accepts optional `fileId` and `maxLen` parameters in the request body. Furthermore, `branchId`, `directoryId`, and `fileId` are all optional (uploading without any targets the project root) but mutually exclusive. The SDK's `SourceStringsUploadRequest` previously lacked `FileID` and `MaxLen`, and its `Validate()` method incorrectly enforced that `branchId` or `directoryId` be non-zero, rejecting valid uploads targeting a `fileId` or uploading to the project root.

--- a/third_party/crowdin-api-client-go/crowdin/model/translations.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translations.go
@@ -272,6 +272,8 @@ type BuildProjectFileTranslationRequest struct {
 	SkipUntranslatedFiles *bool `json:"skipUntranslatedFiles,omitempty"`
 	// Defines whether to export only approved strings. Default: false.
 	ExportApprovedOnly *bool `json:"exportApprovedOnly,omitempty"`
+	// Label Identifiers.
+	LabelIDs []int `json:"labelIds,omitempty"`
 
 	// Defines whether to export only approved strings.
 	// Note: value greater than 0 can't be used with `exportStringsThatPassedWorkflow=true`
@@ -289,6 +291,7 @@ func (r *BuildProjectFileTranslationRequest) MarshalJSON() ([]byte, error) {
 		TargetLanguageID                string `json:"targetLanguageId"`
 		SkipUntranslatedStrings         *bool  `json:"skipUntranslatedStrings,omitempty"`
 		SkipUntranslatedFiles           *bool  `json:"skipUntranslatedFiles,omitempty"`
+		LabelIDs                        []int  `json:"labelIds,omitempty"`
 		ExportWithMinApprovalsCount     *int   `json:"exportWithMinApprovalsCount,omitempty"`
 		ExportStringsThatPassedWorkflow *bool  `json:"exportStringsThatPassedWorkflow,omitempty"`
 	}
@@ -303,6 +306,7 @@ func (r *BuildProjectFileTranslationRequest) MarshalJSON() ([]byte, error) {
 		TargetLanguageID:                r.TargetLanguageID,
 		SkipUntranslatedStrings:         r.SkipUntranslatedStrings,
 		SkipUntranslatedFiles:           r.SkipUntranslatedFiles,
+		LabelIDs:                        r.LabelIDs,
 		ExportWithMinApprovalsCount:     exportWithMinApprovalsCount,
 		ExportStringsThatPassedWorkflow: r.ExportStringsThatPassedWorkflow,
 	})

--- a/third_party/crowdin-api-client-go/crowdin/model/translations_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translations_test.go
@@ -98,6 +98,19 @@ func TestPreTranslationRequestValidate(t *testing.T) {
 	}
 }
 
+func TestBuildProjectFileTranslationRequestMarshalJSON(t *testing.T) {
+	req := &BuildProjectFileTranslationRequest{
+		TargetLanguageID:        "uk",
+		SkipUntranslatedStrings: toPtr(true),
+		ExportApprovedOnly:      toPtr(true),
+		LabelIDs:                []int{10, 20},
+	}
+
+	b, err := req.MarshalJSON()
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"targetLanguageId":"uk","skipUntranslatedStrings":true,"labelIds":[10,20],"exportWithMinApprovalsCount":1}`, string(b))
+}
+
 func TestBuildProjectDirectoryTranslationRequestValidate(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -190,7 +203,7 @@ func TestBuildProjectFileTranslationRequestValidate(t *testing.T) {
 			name: "valid request",
 			req: &BuildProjectFileTranslationRequest{
 				TargetLanguageID: "uk", SkipUntranslatedStrings: toPtr(true),
-				ExportApprovedOnly: toPtr(true),
+				ExportApprovedOnly: toPtr(true), LabelIDs: []int{1, 2},
 			},
 			valid: true,
 		},

--- a/third_party/crowdin-api-client-go/crowdin/translations_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/translations_test.go
@@ -540,6 +540,7 @@ func TestTranslationsService_BuildProjectFileTranslation(t *testing.T) {
 			"targetLanguageId": "uk",
 			"skipUntranslatedStrings": true,
 			"skipUntranslatedFiles": false,
+			"labelIds": [5],
 			"exportWithMinApprovalsCount": 0,
 			"exportStringsThatPassedWorkflow": true
 		}`
@@ -560,6 +561,7 @@ func TestTranslationsService_BuildProjectFileTranslation(t *testing.T) {
 		SkipUntranslatedStrings:         ToPtr(true),
 		SkipUntranslatedFiles:           ToPtr(false),
 		ExportApprovedOnly:              ToPtr(false),
+		LabelIDs:                        []int{5},
 		ExportWithMinApprovalsCount:     ToPtr(0),
 		ExportStringsThatPassedWorkflow: ToPtr(true),
 	}


### PR DESCRIPTION
This PR aligns `BuildProjectFileTranslationRequest` with official Crowdin API v2 specifications by adding support for `LabelIDs` ([]int) and updating its custom `MarshalJSON` method to serialize `labelIds` in JSON payloads.

Docs: https://developer.crowdin.com/api/v2/#operation/api.projects.translations.builds.files.post
Scope: `third_party/crowdin-api-client-go/crowdin/model/translations.go`, `third_party/crowdin-api-client-go/crowdin/model/translations_test.go`, `third_party/crowdin-api-client-go/crowdin/translations_test.go`
Verification: `make fmt`, `make lint`, and `make test` pass cleanly.
Confidence: Helps prevent missing label filters when triggering single file builds on Crowdin API v2.

---
*PR created automatically by Jules for task [7806101527673653074](https://jules.google.com/task/7806101527673653074) started by @cungminh2710*