### PR TITLE
fix(automations): run pull request triggers on draft PRs

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/github-webhook/github-webhook.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/github-webhook/github-webhook.route.test.ts
@@ -96,6 +96,42 @@ describe("githubWebhookRoutes", () => {
     await expect(response.json()).resolves.toEqual({ ok: true });
   });
 
+  it("handles draft pull request opened without ignoring the event", async () => {
+    const installation = await createStoredGithubInstallation(true);
+    let called = false;
+    const app = createGithubWebhookRoutes({
+      githubWebhookHandler: async () => {
+        called = true;
+        return Response.json({ ok: true });
+      },
+    });
+
+    const response = await app.request("http://localhost/", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-github-event": "pull_request",
+        "x-github-delivery": "delivery-pr-draft-open-1",
+      },
+      body: JSON.stringify({
+        action: "opened",
+        installation: { id: Number(installation.githubInstallationId) },
+        repository: { id: Number(installation.githubRepositoryId) },
+        pull_request: {
+          number: 7,
+          html_url: "https://github.com/hyperlocalise/hyperlocalise/pull/7",
+          draft: true,
+          base: { ref: "main", sha: "aaa111" },
+          head: { ref: "feature/draft", sha: "bbb222" },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(called).toBe(false);
+    await expect(response.json()).resolves.toEqual({ ok: true, ignored: false });
+  });
+
   it("handles pull request opened without delegating to the bot handler", async () => {
     const installation = await createStoredGithubInstallation(true);
     let called = false;

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-pull-request-webhook.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-pull-request-webhook.test.ts
@@ -53,8 +53,13 @@ describe("shouldDispatchGithubPullRequestAction", () => {
     expect(shouldDispatchGithubPullRequestAction("ready_for_review", { draft: true })).toBe(true);
   });
 
-  it("ignores drafts, merged PRs, and unrelated actions", () => {
-    expect(shouldDispatchGithubPullRequestAction("opened", { draft: true })).toBe(false);
+  it("dispatches draft pull requests so opened and updated drafts still run", () => {
+    expect(shouldDispatchGithubPullRequestAction("opened", { draft: true })).toBe(true);
+    expect(shouldDispatchGithubPullRequestAction("synchronize", { draft: true })).toBe(true);
+    expect(shouldDispatchGithubPullRequestAction("reopened", { draft: true })).toBe(true);
+  });
+
+  it("ignores merged PRs and unrelated actions", () => {
     expect(shouldDispatchGithubPullRequestAction("opened", { merged: true })).toBe(false);
     expect(shouldDispatchGithubPullRequestAction("closed", { draft: false })).toBe(false);
     expect(shouldDispatchGithubPullRequestAction("edited", { draft: false })).toBe(false);
@@ -141,7 +146,7 @@ describe("handleGithubPullRequestWebhook", () => {
     );
   });
 
-  it("ignores draft pull requests without failing the webhook", async () => {
+  it("dispatches draft pull requests opened against main", async () => {
     await expect(
       handleGithubPullRequestWebhook({
         deliveryId: "delivery-pr-draft",
@@ -154,15 +159,52 @@ describe("handleGithubPullRequestWebhook", () => {
           action: "opened",
           pull_request: {
             number: 7,
+            html_url: "https://github.com/acme/app/pull/7",
             draft: true,
             base: { ref: "main", sha: "aaa111" },
             head: { ref: "feature/draft", sha: "bbb222" },
           },
         },
       }),
-    ).resolves.toEqual({ ignored: true });
+    ).resolves.toEqual({ ignored: false });
 
-    expect(dispatchWorkspaceAutomationsForGithubPullRequestMock).not.toHaveBeenCalled();
+    expect(dispatchWorkspaceAutomationsForGithubPullRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "opened",
+        pullRequestNumber: 7,
+        baseBranch: "main",
+        headBranch: "feature/draft",
+      }),
+    );
+  });
+
+  it("strips refs/heads prefixes from pull request branch names", async () => {
+    await expect(
+      handleGithubPullRequestWebhook({
+        deliveryId: "delivery-pr-refs",
+        organizationId: "org_123",
+        githubInstallationId: "123",
+        githubInstallationRepositoryId: "installation-repo-123",
+        githubRepositoryId: "repo-123",
+        repositoryFullName: "acme/app",
+        payload: {
+          action: "opened",
+          pull_request: {
+            number: 11,
+            draft: false,
+            base: { ref: "refs/heads/main", sha: "aaa111" },
+            head: { ref: "refs/heads/feature/x", sha: "bbb222" },
+          },
+        },
+      }),
+    ).resolves.toEqual({ ignored: false });
+
+    expect(dispatchWorkspaceAutomationsForGithubPullRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseBranch: "main",
+        headBranch: "feature/x",
+      }),
+    );
   });
 
   it("does not fail the webhook when workspace automation dispatch fails", async () => {

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-pull-request-webhook.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-pull-request-webhook.ts
@@ -44,7 +44,12 @@ export type HandleGithubPullRequestWebhookResult = {
 };
 
 function readBranchName(value: string | undefined): string | null {
-  const branch = value?.trim() ?? "";
+  const raw = value?.trim() ?? "";
+  if (raw.length === 0) {
+    return null;
+  }
+
+  const branch = raw.startsWith("refs/heads/") ? raw.slice("refs/heads/".length).trim() : raw;
   return branch.length > 0 ? branch : null;
 }
 
@@ -57,10 +62,6 @@ export function shouldDispatchGithubPullRequestAction(
   }
 
   if (pullRequest?.merged) {
-    return false;
-  }
-
-  if (pullRequest?.draft && action !== "ready_for_review") {
     return false;
   }
 
@@ -77,6 +78,8 @@ export async function handleGithubPullRequestWebhook(
         deliveryId: input.deliveryId,
         repositoryId: input.githubRepositoryId,
         action: input.payload.action,
+        draft: Boolean(pullRequest?.draft),
+        merged: Boolean(pullRequest?.merged),
       },
       "ignoring pull request event",
     );

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.ts
@@ -455,6 +455,16 @@ export async function dispatchWorkspaceAutomationsForGithubPullRequest(input: {
       workspaceAutomationShouldDispatchOnGithubPullRequest(automation, input.baseBranch),
   );
 
+  logger.info(
+    {
+      deliveryId: input.deliveryId,
+      githubInstallationRepositoryId: input.githubInstallationRepositoryId,
+      action: input.action,
+      runnableAutomationCount: automations.length,
+    },
+    "workspace automation github pull request automations resolved",
+  );
+
   const results: WorkspaceAutomationDispatchResult[] = [];
 
   for (const automation of automations) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

`/api/webhooks/github` was receiving `pull_request` events, but **Notify on push blockers** still did not run.

The handler treated draft PRs as noise: `opened`, `reopened`, and `synchronize` were ignored until `ready_for_review`. Cursor and many teams open drafts first, so the automation never started even though GitHub delivered the webhook.

This change:

- Dispatches draft PRs on `opened`, `reopened`, `synchronize`, and `ready_for_review`
- Still ignores merged PRs and unrelated actions (`edited`, `labeled`, `closed`, …)
- Strips a `refs/heads/` prefix from base/head refs if GitHub sends one
- Logs how many automations matched a pull-request delivery

## How to test

- Open a **draft** PR against `main` on a repo with Notify on push blockers (Pull request opened on, Push off)
- Confirm a workspace automation run is queued and the sticky PR comment is posted
- Push another commit to the draft PR and confirm the comment updates
- `vp test` — 4724 passed
- `vp check --fix` — 0 errors (4 pre-existing warnings)

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a4a5b60-a8ec-4d76-8c4c-32a763285de6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a4a5b60-a8ec-4d76-8c4c-32a763285de6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

