### PR TITLE
fix(automations): fire scheduled runs and replace timezone text input

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -96,6 +96,7 @@ import {
   isCrowdinAutomationConnected,
 } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-crowdin";
 import { SlackChannelSelect } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/slack-channel-select";
+import { AutomationTimeZoneSelect } from "@/components/automation/automation-time-zone-select";
 import { workspaceAutomationFormMessages } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.messages";
 import { getLocaleLabel } from "@/lib/i18n/locales";
 import {
@@ -1026,17 +1027,18 @@ function TriggerSettings({
                     </Select>
                   </>
                 ) : null}
-                <Input
+                <AutomationTimeZoneSelect
+                  size="sm"
                   aria-label={intl.formatMessage(
                     workspaceAutomationFormMessages.scheduleTimezoneAriaLabel,
                   )}
                   value={form.scheduledTimezone}
                   disabled={disabled}
-                  className="h-8 w-32 rounded-lg px-2 text-sm"
-                  onChange={(event) =>
+                  className="h-8 min-w-52"
+                  onValueChange={(value) =>
                     onChange({
                       ...form,
-                      scheduledTimezone: event.target.value,
+                      scheduledTimezone: value,
                     })
                   }
                 />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model.ts
@@ -19,6 +19,7 @@ import {
   hasEnabledGithubRepoAutomationWorkflow,
   validateGithubRepositoryAutomationSettings,
 } from "@/lib/agents/github/github-repository-automation-settings";
+import { isValidAutomationTimeZone } from "@/lib/agents/automation-time-zones";
 
 import { githubRepositoryAutomationViewModelMessages } from "./github-repository-automation-view-model.messages";
 
@@ -282,9 +283,7 @@ export function validateAutomationFormState(
     }
 
     const timezone = form.scheduledTimezone.trim() || "UTC";
-    try {
-      Intl.DateTimeFormat("en-US", { timeZone: timezone });
-    } catch {
+    if (!isValidAutomationTimeZone(timezone)) {
       errors.scheduledTimezone = intl.formatMessage(
         githubRepositoryAutomationViewModelMessages.invalidAutomationTimezone,
       );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-panel.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-panel.messages.ts
@@ -220,14 +220,14 @@ export const repositoryAutomationSettingsPanelMessages = defineMessages({
     description: "Scheduled cadence option for weekly runs",
   },
   scheduledHourLabel: {
-    defaultMessage: "Hour (UTC)",
-    id: "BrsVyR4Efb",
+    defaultMessage: "Hour",
+    id: "LcZxj/pk5J",
     description: "Label for scheduled automation hour select",
   },
   scheduledHourOption: {
-    defaultMessage: "{hour}:00 UTC",
-    id: "6xU6c/eKvO",
-    description: "Option label for a scheduled automation hour in UTC",
+    defaultMessage: "{hour}:00",
+    id: "ayQm+lJH/B",
+    description: "Option label for a scheduled automation hour",
   },
   scheduledDayLabel: {
     defaultMessage: "Day of week",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-panel.tsx
@@ -54,6 +54,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import { createApiClient } from "@/lib/api-client";
+import { AutomationTimeZoneSelect } from "@/components/automation/automation-time-zone-select";
 import type { GithubRepositoryAutomationSettings } from "@/lib/agents/github/github-repository-automation-settings";
 import { cn } from "@/lib/primitives/cn";
 
@@ -817,15 +818,12 @@ export function RepositoryAutomationSettingsPanel({
                     {...repositoryAutomationSettingsPanelMessages.scheduledTimezoneLabel}
                   />
                 </Label>
-                <input
+                <AutomationTimeZoneSelect
                   id="scheduled-timezone"
                   value={form.scheduledTimezone}
-                  onChange={(event) => updateForm({ scheduledTimezone: event.target.value })}
+                  onValueChange={(value) => updateForm({ scheduledTimezone: value })}
                   disabled={formDisabled}
-                  placeholder={intl.formatMessage(
-                    repositoryAutomationSettingsPanelMessages.scheduledTimezonePlaceholder,
-                  )}
-                  className="h-9 rounded-lg border border-border bg-background px-3 text-sm outline-none focus:border-primary/40 focus:ring-[3px] focus:ring-primary/20"
+                  className="w-full"
                 />
                 <FieldError message={fieldErrors.scheduledTimezone} />
               </div>

--- a/apps/hyperlocalise-web/src/components/automation/automation-time-zone-select.tsx
+++ b/apps/hyperlocalise-web/src/components/automation/automation-time-zone-select.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { useMemo } from "react";
+
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  formatAutomationTimeZoneLabel,
+  groupAutomationTimeZones,
+  listAutomationTimeZones,
+} from "@/lib/agents/automation-time-zones";
+import { cn } from "@/lib/primitives/cn";
+
+export function AutomationTimeZoneSelect({
+  value,
+  onValueChange,
+  disabled,
+  id,
+  size = "default",
+  className,
+  "aria-label": ariaLabel,
+}: {
+  value: string;
+  onValueChange: (value: string) => void;
+  disabled?: boolean;
+  id?: string;
+  size?: "sm" | "default";
+  className?: string;
+  "aria-label"?: string;
+}) {
+  const groups = useMemo(() => groupAutomationTimeZones(listAutomationTimeZones(value)), [value]);
+
+  return (
+    <Select
+      value={value}
+      onValueChange={(next) => {
+        if (!next) {
+          return;
+        }
+        onValueChange(next);
+      }}
+      disabled={disabled}
+    >
+      <SelectTrigger
+        id={id}
+        size={size}
+        aria-label={ariaLabel}
+        className={cn("min-w-52", className)}
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent className="max-h-72 min-w-72" alignItemWithTrigger={false}>
+        {groups.map((group) => (
+          <SelectGroup key={group.id}>
+            {group.id === "UTC" ? null : <SelectLabel>{group.id}</SelectLabel>}
+            {group.zones.map((zone) => (
+              <SelectItem key={zone} value={zone}>
+                {formatAutomationTimeZoneLabel(zone)}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/apps/hyperlocalise-web/src/lib/agents/automation-time-zones.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/automation-time-zones.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+    10| * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  formatAutomationTimeZoneLabel,
+  groupAutomationTimeZones,
+  isValidAutomationTimeZone,
+  listAutomationTimeZones,
+} from "./automation-time-zones";
+
+describe("automation time zones", () => {
+  it("accepts IANA time zones and rejects free-form labels", () => {
+    expect(isValidAutomationTimeZone("UTC")).toBe(true);
+    expect(isValidAutomationTimeZone("America/New_York")).toBe(true);
+    expect(isValidAutomationTimeZone("Not a zone")).toBe(false);
+  });
+
+  it("lists UTC first when grouped and keeps the current value", () => {
+    const zones = listAutomationTimeZones("Australia/Sydney");
+    expect(zones).toContain("UTC");
+    expect(zones).toContain("America/New_York");
+    expect(zones).toContain("Australia/Sydney");
+    expect(zones.some((zone) => zone.startsWith("Etc/"))).toBe(false);
+
+    const groups = groupAutomationTimeZones(zones);
+    expect(groups[0]).toEqual({ id: "UTC", zones: ["UTC"] });
+    expect(groups.some((group) => group.id === "Australia")).toBe(true);
+  });
+
+  it("formats IANA identifiers for the timezone select", () => {
+    expect(formatAutomationTimeZoneLabel("UTC")).toBe("UTC");
+    expect(formatAutomationTimeZoneLabel("America/New_York")).toBe("America/New York");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/automation-time-zones.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/automation-time-zones.test.ts
@@ -7,7 +7,7 @@
  * Change Date: Four years after publication of the applicable version.
  *
  * On the Change Date, in accordance with the Business Source License, use
-    10| * of this software will be governed by the GNU General Public License
+ * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
 import { describe, expect, it } from "vite-plus/test";

--- a/apps/hyperlocalise-web/src/lib/agents/automation-time-zones.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/automation-time-zones.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+    10| * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+const FALLBACK_AUTOMATION_TIME_ZONES = [
+  "UTC",
+  "Africa/Cairo",
+  "Africa/Johannesburg",
+  "Africa/Lagos",
+  "Africa/Nairobi",
+  "America/Argentina/Buenos_Aires",
+  "America/Bogota",
+  "America/Chicago",
+  "America/Denver",
+  "America/Los_Angeles",
+  "America/Mexico_City",
+  "America/New_York",
+  "America/Sao_Paulo",
+  "America/Toronto",
+  "America/Vancouver",
+  "Asia/Bangkok",
+  "Asia/Dubai",
+  "Asia/Hong_Kong",
+  "Asia/Jakarta",
+  "Asia/Kolkata",
+  "Asia/Seoul",
+  "Asia/Shanghai",
+  "Asia/Singapore",
+  "Asia/Tokyo",
+  "Australia/Melbourne",
+  "Australia/Perth",
+  "Australia/Sydney",
+  "Europe/Amsterdam",
+  "Europe/Berlin",
+  "Europe/London",
+  "Europe/Madrid",
+  "Europe/Paris",
+  "Europe/Stockholm",
+  "Pacific/Auckland",
+] as const;
+
+export type AutomationTimeZoneGroup = {
+  id: string;
+  zones: string[];
+};
+
+export function isValidAutomationTimeZone(timeZone: string) {
+  try {
+    Intl.DateTimeFormat("en-US", { timeZone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function supportedTimeZones() {
+  if (typeof Intl !== "undefined" && "supportedValuesOf" in Intl) {
+    return Intl.supportedValuesOf("timeZone");
+  }
+
+  return [...FALLBACK_AUTOMATION_TIME_ZONES];
+}
+
+export function listAutomationTimeZones(include?: string) {
+  const zones = new Set<string>(["UTC"]);
+
+  for (const zone of supportedTimeZones()) {
+    if (zone === "UTC" || zone.startsWith("Etc/")) {
+      continue;
+    }
+    zones.add(zone);
+  }
+
+  const extra = include?.trim();
+  if (extra) {
+    zones.add(extra);
+  }
+
+  return [...zones];
+}
+
+export function groupAutomationTimeZones(timeZones: string[]): AutomationTimeZoneGroup[] {
+  const groups = new Map<string, string[]>();
+  const utc: string[] = [];
+
+  for (const zone of timeZones.toSorted((left, right) => left.localeCompare(right))) {
+    if (zone === "UTC") {
+      utc.push(zone);
+      continue;
+    }
+
+    const separator = zone.indexOf("/");
+    const region = separator === -1 ? "Other" : zone.slice(0, separator);
+    const list = groups.get(region) ?? [];
+    list.push(zone);
+    groups.set(region, list);
+  }
+
+  const grouped = [...groups.entries()]
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(([id, zones]) => ({ id, zones }));
+
+  return utc.length > 0 ? [{ id: "UTC", zones: utc }, ...grouped] : grouped;
+}
+
+export function formatAutomationTimeZoneLabel(timeZone: string) {
+  if (timeZone === "UTC") {
+    return "UTC";
+  }
+
+  return timeZone.replaceAll("_", " ");
+}

--- a/apps/hyperlocalise-web/src/lib/agents/automation-time-zones.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/automation-time-zones.ts
@@ -7,7 +7,7 @@
  * Change Date: Four years after publication of the applicable version.
  *
  * On the Change Date, in accordance with the Business Source License, use
-    10| * of this software will be governed by the GNU General Public License
+ * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
 

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-settings.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-settings.test.ts
@@ -169,7 +169,7 @@ describe("github repository automation settings", () => {
     ).toBe("2026-05-30T11:00:00.000Z");
   });
 
-  it("schedules daily runs at hourUtc in UTC", () => {
+  it("schedules daily runs at the selected hour in the timezone", () => {
     const from = new Date("2026-05-30T14:00:00.000Z");
     const next = computeNextScheduledRunAt(
       {
@@ -181,10 +181,25 @@ describe("github repository automation settings", () => {
       from,
     );
 
+    expect(next.toISOString()).toBe("2026-05-31T13:00:00.000Z");
+  });
+
+  it("schedules daily UTC runs at hourUtc", () => {
+    const from = new Date("2026-05-30T14:00:00.000Z");
+    const next = computeNextScheduledRunAt(
+      {
+        mode: "scheduled",
+        cadence: "daily",
+        hourUtc: 9,
+        timezone: "UTC",
+      },
+      from,
+    );
+
     expect(next.toISOString()).toBe("2026-05-31T09:00:00.000Z");
   });
 
-  it("schedules weekly runs in the future when local weekday is behind UTC", () => {
+  it("schedules weekly runs at the local weekday and hour", () => {
     const from = new Date("2026-01-05T02:00:00.000Z");
     const next = computeNextScheduledRunAt(
       {
@@ -198,6 +213,6 @@ describe("github repository automation settings", () => {
     );
 
     expect(next.getTime()).toBeGreaterThan(from.getTime());
-    expect(next.toISOString()).toBe("2026-01-12T01:00:00.000Z");
+    expect(next.toISOString()).toBe("2026-01-05T06:00:00.000Z");
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-settings.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-settings.test.ts
@@ -199,6 +199,21 @@ describe("github repository automation settings", () => {
     expect(next.toISOString()).toBe("2026-05-31T09:00:00.000Z");
   });
 
+  it("schedules the first valid local hour when DST skips the selected time", () => {
+    const from = new Date("2026-03-08T06:30:00.000Z");
+    const next = computeNextScheduledRunAt(
+      {
+        mode: "scheduled",
+        cadence: "daily",
+        hourUtc: 2,
+        timezone: "America/New_York",
+      },
+      from,
+    );
+
+    expect(next.toISOString()).toBe("2026-03-08T07:00:00.000Z");
+  });
+
   it("schedules weekly runs at the local weekday and hour", () => {
     const from = new Date("2026-01-05T02:00:00.000Z");
     const next = computeNextScheduledRunAt(

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-settings.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-settings.ts
@@ -12,6 +12,7 @@
  */
 import { z } from "zod";
 
+import { isValidAutomationTimeZone } from "@/lib/agents/automation-time-zones";
 import { optionalProjectIdSchema } from "@/lib/projects/identity/project-id";
 
 const branchPatternSchema = z
@@ -226,15 +227,6 @@ export function validateGithubRepositoryAutomationSettings(
   return null;
 }
 
-function isValidAutomationTimeZone(timeZone: string) {
-  try {
-    Intl.DateTimeFormat("en-US", { timeZone });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 type ZonedDateTimeParts = {
   year: number;
   month: number;
@@ -302,18 +294,44 @@ function nextTopOfHourUtc(from: Date): Date {
   return next;
 }
 
-function nextDailyRunUtc(from: Date, hourUtc: number): Date {
-  const next = new Date(from);
-  next.setUTCHours(hourUtc, 0, 0, 0);
+function zonedWallTimeToUtc(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  timeZone: string,
+): Date {
+  const desiredAsUtcMs = Date.UTC(year, month - 1, day, hour, 0, 0, 0);
 
-  if (next.getTime() <= from.getTime()) {
-    next.setUTCDate(next.getUTCDate() + 1);
-  }
+  const shift = (instantMs: number) => {
+    const parts = getZonedDateTimeParts(new Date(instantMs), timeZone);
+    const mappedAsUtcMs = Date.UTC(
+      parts.year,
+      parts.month - 1,
+      parts.day,
+      parts.hour,
+      parts.minute,
+      parts.second,
+    );
+    return instantMs + (desiredAsUtcMs - mappedAsUtcMs);
+  };
 
-  return next;
+  return new Date(shift(shift(desiredAsUtcMs)));
 }
 
-function nextWeeklyRunUtc(from: Date, timeZone: string, hourUtc: number, dayOfWeek: number): Date {
+function nextDailyRun(from: Date, hour: number, timeZone: string): Date {
+  const zoned = getZonedDateTimeParts(from, timeZone);
+  let candidate = zonedWallTimeToUtc(zoned.year, zoned.month, zoned.day, hour, timeZone);
+
+  if (candidate.getTime() <= from.getTime()) {
+    const nextDay = addDaysToLocalDate(zoned.year, zoned.month, zoned.day, 1);
+    candidate = zonedWallTimeToUtc(nextDay.year, nextDay.month, nextDay.day, hour, timeZone);
+  }
+
+  return candidate;
+}
+
+function nextWeeklyRun(from: Date, timeZone: string, hour: number, dayOfWeek: number): Date {
   const zoned = getZonedDateTimeParts(from, timeZone);
   let { year, month, day } = zoned;
 
@@ -322,11 +340,11 @@ function nextWeeklyRunUtc(from: Date, timeZone: string, hourUtc: number, dayOfWe
     ({ year, month, day } = addDaysToLocalDate(year, month, day, daysUntil));
   }
 
-  let candidate = new Date(Date.UTC(year, month - 1, day, hourUtc, 0, 0));
+  let candidate = zonedWallTimeToUtc(year, month, day, hour, timeZone);
 
   if (candidate.getTime() <= from.getTime()) {
     ({ year, month, day } = addDaysToLocalDate(year, month, day, 7));
-    candidate = new Date(Date.UTC(year, month - 1, day, hourUtc, 0, 0));
+    candidate = zonedWallTimeToUtc(year, month, day, hour, timeZone);
   }
 
   return candidate;
@@ -340,12 +358,13 @@ export function computeNextScheduledRunAt(
     return nextTopOfHourUtc(from);
   }
 
-  const hourUtc = trigger.hourUtc;
+  const timeZone = isValidAutomationTimeZone(trigger.timezone) ? trigger.timezone : "UTC";
+  const hour = trigger.hourUtc;
   if (trigger.cadence === "daily") {
-    return nextDailyRunUtc(from, hourUtc);
+    return nextDailyRun(from, hour, timeZone);
   }
 
-  return nextWeeklyRunUtc(from, trigger.timezone, hourUtc, trigger.dayOfWeek ?? 1);
+  return nextWeeklyRun(from, timeZone, hour, trigger.dayOfWeek ?? 1);
 }
 
 export function resolveNextRunAtForSettings(

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-settings.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-settings.ts
@@ -294,7 +294,24 @@ function nextTopOfHourUtc(from: Date): Date {
   return next;
 }
 
-function zonedWallTimeToUtc(
+function isExactZonedWallHour(
+  parts: ZonedDateTimeParts,
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+) {
+  return (
+    parts.year === year &&
+    parts.month === month &&
+    parts.day === day &&
+    parts.hour === hour &&
+    parts.minute === 0 &&
+    parts.second === 0
+  );
+}
+
+function approximateZonedWallTimeToUtc(
   year: number,
   month: number,
   day: number,
@@ -317,6 +334,29 @@ function zonedWallTimeToUtc(
   };
 
   return new Date(shift(shift(desiredAsUtcMs)));
+}
+
+function zonedWallTimeToUtc(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  timeZone: string,
+): Date {
+  const candidate = approximateZonedWallTimeToUtc(year, month, day, hour, timeZone);
+  if (isExactZonedWallHour(getZonedDateTimeParts(candidate, timeZone), year, month, day, hour)) {
+    return candidate;
+  }
+
+  for (let nextHour = hour + 1; nextHour < 24; nextHour++) {
+    const later = approximateZonedWallTimeToUtc(year, month, day, nextHour, timeZone);
+    if (isExactZonedWallHour(getZonedDateTimeParts(later, timeZone), year, month, day, nextHour)) {
+      return later;
+    }
+  }
+
+  const nextDay = addDaysToLocalDate(year, month, day, 1);
+  return zonedWallTimeToUtc(nextDay.year, nextDay.month, nextDay.day, 0, timeZone);
 }
 
 function nextDailyRun(from: Date, hour: number, timeZone: string): Date {

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-schedule.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-schedule.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveNextRunAtForWorkspaceAutomation } from "./workspace-automation-schedule";
+import type { WorkspaceAutomationRecord } from "./workspace-automation-types";
+
+function automation(
+  overrides: Partial<WorkspaceAutomationRecord> &
+    Pick<WorkspaceAutomationRecord, "status" | "triggerConfig" | "toolConfig">,
+): WorkspaceAutomationRecord {
+  return {
+    id: "automation-1",
+    organizationId: "org-1",
+    authorUserId: null,
+    authorName: null,
+    name: "Nightly research",
+    instructions: "Search the web.",
+    model: "openai/gpt-5.6-luna",
+    projectId: null,
+    repositoryTarget: { kind: "none" },
+    configVersion: 1,
+    nextRunAt: null,
+    createdAt: "2026-06-01T00:00:00.000Z",
+    updatedAt: "2026-06-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("resolveNextRunAtForWorkspaceAutomation", () => {
+  it("schedules GitHub agent automations from the trigger, not sync workflows", () => {
+    const next = resolveNextRunAtForWorkspaceAutomation(
+      automation({
+        status: "active",
+        triggerConfig: {
+          mode: "scheduled",
+          schedule: {
+            cadence: "daily",
+            hourUtc: 1,
+            timezone: "UTC",
+          },
+        },
+        toolConfig: {
+          github: {
+            enabled: true,
+            mode: "agent",
+            pushSource: false,
+            pullTranslations: false,
+            validation: false,
+          },
+        },
+        repositoryTarget: {
+          kind: "github",
+          githubInstallationRepositoryId: "repo-1",
+        },
+      }),
+      new Date("2026-06-15T00:30:00.000Z"),
+    );
+
+    expect(next?.toISOString()).toBe("2026-06-15T01:00:00.000Z");
+  });
+
+  it("schedules Crowdin and web-search automations without a GitHub workflow", () => {
+    const next = resolveNextRunAtForWorkspaceAutomation(
+      automation({
+        status: "active",
+        triggerConfig: {
+          mode: "scheduled",
+          schedule: {
+            cadence: "daily",
+            hourUtc: 1,
+            timezone: "America/New_York",
+          },
+        },
+        toolConfig: {
+          webSearch: { enabled: true, provider: "auto" },
+        },
+      }),
+      new Date("2026-01-15T07:00:00.000Z"),
+    );
+
+    expect(next?.toISOString()).toBe("2026-01-16T06:00:00.000Z");
+  });
+
+  it("does not schedule paused automations", () => {
+    expect(
+      resolveNextRunAtForWorkspaceAutomation(
+        automation({
+          status: "paused",
+          triggerConfig: {
+            mode: "scheduled",
+            schedule: { cadence: "daily", hourUtc: 1, timezone: "UTC" },
+          },
+          toolConfig: { webSearch: { enabled: true, provider: "auto" } },
+        }),
+        new Date("2026-06-15T00:30:00.000Z"),
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-schedule.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-schedule.ts
@@ -7,7 +7,7 @@
  * Change Date: Four years after publication of the applicable version.
  *
  * On the Change Date, in accordance with the Business Source License, use
-    10| * of this software will be governed by the GNU General Public License
+ * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
 import { computeNextScheduledRunAt } from "@/lib/agents/github/github-repository-automation-settings";

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-schedule.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-schedule.ts
@@ -7,19 +7,12 @@
  * Change Date: Four years after publication of the applicable version.
  *
  * On the Change Date, in accordance with the Business Source License, use
- * of this software will be governed by the GNU General Public License
+    10| * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import {
-  computeNextScheduledRunAt,
-  resolveNextRunAtForSettings,
-} from "@/lib/agents/github/github-repository-automation-settings";
+import { computeNextScheduledRunAt } from "@/lib/agents/github/github-repository-automation-settings";
 
-import { workspaceAutomationToGithubSettings } from "./workspace-automation-github-mapping";
-import {
-  hasWorkspaceAutomationContentfulWorkflow,
-  type WorkspaceAutomationRecord,
-} from "./workspace-automation-types";
+import type { WorkspaceAutomationRecord } from "./workspace-automation-types";
 
 export function resolveNextRunAtForWorkspaceAutomation(
   automation: WorkspaceAutomationRecord,
@@ -29,25 +22,16 @@ export function resolveNextRunAtForWorkspaceAutomation(
     return null;
   }
 
-  const githubSettings = workspaceAutomationToGithubSettings(automation);
-  if (githubSettings) {
-    return resolveNextRunAtForSettings(githubSettings, from);
+  if (automation.triggerConfig.mode !== "scheduled" || !automation.triggerConfig.schedule) {
+    return null;
   }
 
-  if (
-    automation.triggerConfig.mode === "scheduled" &&
-    automation.triggerConfig.schedule &&
-    hasWorkspaceAutomationContentfulWorkflow(automation.toolConfig)
-  ) {
-    return computeNextScheduledRunAt(
-      {
-        mode: "scheduled",
-        ...automation.triggerConfig.schedule,
-        hourUtc: automation.triggerConfig.schedule.hourUtc ?? 0,
-      },
-      from,
-    );
-  }
-
-  return null;
+  return computeNextScheduledRunAt(
+    {
+      mode: "scheduled",
+      ...automation.triggerConfig.schedule,
+      hourUtc: automation.triggerConfig.schedule.hourUtc ?? 0,
+    },
+    from,
+  );
 }

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-scheduler.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-scheduler.test.ts
@@ -13,12 +13,15 @@
 import { describe, expect, it, vi, beforeEach } from "vite-plus/test";
 
 const listDueWorkspaceAutomations = vi.fn();
+const repairMissingScheduledWorkspaceAutomationNextRuns = vi.fn();
 const dispatchDueContentfulWorkspaceAutomations = vi.fn();
 const dispatchWorkspaceAutomationForScheduleAndAdvance = vi.fn();
 const buildWorkspaceOrchestratorPlan = vi.fn();
 
 vi.mock("./workspace-automations", () => ({
   listDueWorkspaceAutomations: (...args: unknown[]) => listDueWorkspaceAutomations(...args),
+  repairMissingScheduledWorkspaceAutomationNextRuns: (...args: unknown[]) =>
+    repairMissingScheduledWorkspaceAutomationNextRuns(...args),
 }));
 
 vi.mock("./workspace-automation-dispatcher", () => ({
@@ -44,6 +47,8 @@ import { runWorkspaceAutomationScheduler } from "./workspace-automation-schedule
 describe("runWorkspaceAutomationScheduler", () => {
   beforeEach(() => {
     listDueWorkspaceAutomations.mockReset();
+    repairMissingScheduledWorkspaceAutomationNextRuns.mockReset();
+    repairMissingScheduledWorkspaceAutomationNextRuns.mockResolvedValue(0);
     dispatchDueContentfulWorkspaceAutomations.mockReset();
     dispatchWorkspaceAutomationForScheduleAndAdvance.mockReset();
     buildWorkspaceOrchestratorPlan.mockReset();
@@ -98,26 +103,7 @@ describe("runWorkspaceAutomationScheduler", () => {
       updatedAt: scheduledRunAt.toISOString(),
     };
 
-    listDueWorkspaceAutomations.mockResolvedValue([
-      {
-        automation,
-        repository: {
-          id: "repo-1",
-          organizationId: "org-1",
-          githubInstallationId: "install-1",
-          githubRepositoryId: "12345",
-          owner: "hyperlocalise",
-          name: "web",
-          fullName: "hyperlocalise/web",
-          private: false,
-          archived: false,
-          defaultBranch: "main",
-          enabled: true,
-          createdAt: scheduledRunAt,
-          updatedAt: scheduledRunAt,
-        },
-      },
-    ]);
+    listDueWorkspaceAutomations.mockResolvedValue([automation]);
 
     dispatchWorkspaceAutomationForScheduleAndAdvance.mockResolvedValue({
       outcome: "enqueued",

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-scheduler.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-scheduler.ts
@@ -20,7 +20,10 @@ import {
   buildWorkspaceOrchestratorPlan,
   planHasActionableTool,
 } from "@/agents/automations/workspace/agent/plan";
-import { listDueWorkspaceAutomations } from "./workspace-automations";
+import {
+  listDueWorkspaceAutomations,
+  repairMissingScheduledWorkspaceAutomationNextRuns,
+} from "./workspace-automations";
 
 const logger = createLogger("workspace-automation-scheduler");
 
@@ -36,11 +39,15 @@ export async function runWorkspaceAutomationScheduler(input?: {
   limit?: number;
 }): Promise<WorkspaceAutomationSchedulerResult> {
   const now = input?.now ?? new Date();
+  await repairMissingScheduledWorkspaceAutomationNextRuns({
+    now,
+    limit: input?.limit,
+  });
   const dueAutomations = await listDueWorkspaceAutomations({
     now,
     limit: input?.limit,
   });
-  const githubDueAutomationIds = new Set(dueAutomations.map((entry) => entry.automation.id));
+  const githubDueAutomationIds = new Set(dueAutomations.map((automation) => automation.id));
   const contentfulResults = await dispatchDueContentfulWorkspaceAutomations({
     now,
     limit: input?.limit,
@@ -51,18 +58,16 @@ export async function runWorkspaceAutomationScheduler(input?: {
   let skipped = 0;
   let duplicates = 0;
 
-  for (const entry of dueAutomations) {
+  for (const automation of dueAutomations) {
     try {
-      const scheduledRunAt = entry.automation.nextRunAt
-        ? new Date(entry.automation.nextRunAt)
-        : null;
+      const scheduledRunAt = automation.nextRunAt ? new Date(automation.nextRunAt) : null;
       if (!scheduledRunAt) {
         logger.warn(
-          { automationId: entry.automation.id },
+          { automationId: automation.id },
           "workspace automation missing next_run_at; advancing",
         );
         await dispatchWorkspaceAutomationForScheduleAndAdvance({
-          automation: entry.automation,
+          automation,
           scheduledRunAt: now,
           completedAt: now,
         });
@@ -70,9 +75,9 @@ export async function runWorkspaceAutomationScheduler(input?: {
         continue;
       }
 
-      if (entry.automation.triggerConfig.mode !== "scheduled") {
+      if (automation.triggerConfig.mode !== "scheduled") {
         await dispatchWorkspaceAutomationForScheduleAndAdvance({
-          automation: entry.automation,
+          automation,
           scheduledRunAt,
           completedAt: now,
         });
@@ -80,10 +85,10 @@ export async function runWorkspaceAutomationScheduler(input?: {
         continue;
       }
 
-      const plan = buildWorkspaceOrchestratorPlan(entry.automation);
+      const plan = buildWorkspaceOrchestratorPlan(automation);
       if (!planHasActionableTool(plan)) {
         await dispatchWorkspaceAutomationForScheduleAndAdvance({
-          automation: entry.automation,
+          automation,
           scheduledRunAt,
           completedAt: now,
         });
@@ -92,7 +97,7 @@ export async function runWorkspaceAutomationScheduler(input?: {
       }
 
       const result = await dispatchWorkspaceAutomationForScheduleAndAdvance({
-        automation: entry.automation,
+        automation,
         scheduledRunAt,
         completedAt: now,
       });
@@ -113,7 +118,7 @@ export async function runWorkspaceAutomationScheduler(input?: {
     } catch (error) {
       logger.error(
         {
-          automationId: entry.automation.id,
+          automationId: automation.id,
           error: error instanceof Error ? error.message : String(error),
         },
         "workspace automation scheduler entry failed",

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-types.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-types.ts
@@ -381,6 +381,10 @@ export type WorkspaceAutomationConfigValidationError =
       message: "Scheduled automations require at least one GitHub, Contentful, Issues, Web Search, or Crowdin workflow tool.";
     }
   | {
+      code: "invalid_automation_timezone";
+      message: "Choose a valid timezone for the schedule.";
+    }
+  | {
       code: "contentful_connection_required";
       message: "Enabled Contentful tools require a Contentful connection.";
     }

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
@@ -24,6 +24,7 @@ import {
   type WorkspaceAutomationWebSearchProvider,
 } from "./workspace-automation-types";
 import { parseSlackConversationId } from "./slack/channel-query";
+import { isValidAutomationTimeZone } from "./automation-time-zones";
 import {
   getWorkspaceAutomationTemplate,
   type WorkspaceAutomationTemplate,
@@ -127,6 +128,7 @@ export type WorkspaceAutomationFieldErrors = Partial<
     | "semrushConnectionId"
     | "ahrefsConnectionId"
     | "crowdinProjectId"
+    | "scheduledTimezone"
     | "form",
     string
   >
@@ -145,6 +147,7 @@ export const WORKSPACE_AUTOMATION_API_ERROR_MESSAGES: Record<string, string> = {
   github_events_required: "Choose at least one GitHub event.",
   scheduled_workflow_required:
     "Scheduled automations require at least one GitHub, Contentful, Issues, Web Search, or Crowdin workflow tool.",
+  invalid_automation_timezone: "Choose a valid timezone for the schedule.",
   slack_not_connected: "Connect Slack in Integrations before enabling Slack notifications.",
   slack_channel_required: "Choose a Slack channel for notifications.",
   email_not_connected: "Enable the email agent in Integrations before using email notifications.",
@@ -626,6 +629,13 @@ export function validateWorkspaceAutomationFormState(
     errors.githubEvents = "Choose at least one GitHub event.";
   }
 
+  if (
+    form.triggerMode === "scheduled" &&
+    !isValidAutomationTimeZone(form.scheduledTimezone.trim() || "UTC")
+  ) {
+    errors.scheduledTimezone = "Choose a valid timezone.";
+  }
+
   if (form.slackEnabled && !parseSlackConversationId(form.slackChannelId)) {
     errors.slackChannelId = "Enter a valid Slack channel ID.";
   }
@@ -706,6 +716,8 @@ export function mapWorkspaceAutomationApiErrorToFieldErrors(
     case "scheduled_workflow_required":
     case "source_upload_workflow_required":
       return { trigger: message };
+    case "invalid_automation_timezone":
+      return { scheduledTimezone: message };
     case "github_push_branches_required":
       return { pushBranches: message };
     case "github_events_required":

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
@@ -33,6 +33,7 @@ import {
   getWorkspaceAutomationById,
   hoistLegacyWorkspaceAutomationProjectId,
   listDueContentfulWorkspaceAutomations,
+  listDueWorkspaceAutomations,
   listWorkspaceAutomations,
   listWorkspaceAutomationRuns,
   pauseWorkspaceAutomation,
@@ -1412,6 +1413,78 @@ describe("workspace automations", () => {
       }),
     );
     expect(created.toolConfig.crowdin?.enabled).toBe(true);
+    expect(created.nextRunAt).not.toBeNull();
+  });
+
+  it("computes nextRunAt for GitHub agent schedules and lists due automations without a repository join", async () => {
+    const scope = await seedWorkspaceAutomationScope();
+    const dueAt = new Date("2026-06-01T01:00:00.000Z");
+
+    const githubAgent = expectOk(
+      await createWorkspaceAutomation({
+        organizationId: scope.organizationId,
+        authorUserId: scope.userId,
+        name: "Nightly GitHub agent",
+        instructions: "Review localisation changes.",
+        repositoryTarget: {
+          kind: "github",
+          githubInstallationRepositoryId: scope.githubInstallationRepositoryId,
+        },
+        triggerConfig: {
+          mode: "scheduled",
+          schedule: {
+            cadence: "daily",
+            hourUtc: 1,
+            timezone: "UTC",
+          },
+        },
+        toolConfig: {
+          github: {
+            enabled: true,
+            mode: "agent",
+            pushSource: false,
+            pullTranslations: false,
+            validation: false,
+          },
+        },
+      }),
+    );
+    expect(githubAgent.nextRunAt).not.toBeNull();
+
+    const webSearch = expectOk(
+      await createWorkspaceAutomation({
+        organizationId: scope.organizationId,
+        authorUserId: scope.userId,
+        name: "Nightly web search",
+        instructions: "Search the live web.",
+        triggerConfig: {
+          mode: "scheduled",
+          schedule: {
+            cadence: "daily",
+            hourUtc: 1,
+            timezone: "UTC",
+          },
+        },
+        toolConfig: {
+          webSearch: { enabled: true, provider: "auto" },
+        },
+        nextRunAt: dueAt,
+      }),
+    );
+
+    await db
+      .update(schema.workspaceAutomations)
+      .set({ nextRunAt: dueAt })
+      .where(eq(schema.workspaceAutomations.id, githubAgent.id));
+
+    const due = await listDueWorkspaceAutomations({
+      now: new Date("2026-06-01T01:05:00.000Z"),
+      organizationId: scope.organizationId,
+    });
+
+    expect(due.map((automation) => automation.id).sort()).toEqual(
+      [githubAgent.id, webSearch.id].sort(),
+    );
   });
 
   it("hoists legacy nested project IDs from tool config", () => {

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -16,6 +16,7 @@ import { and, asc, desc, eq, isNotNull, isNull, lte, or, sql } from "drizzle-orm
 
 import { db, schema, type DatabaseClient } from "@/lib/database";
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
+import { isValidAutomationTimeZone } from "@/lib/agents/automation-time-zones";
 import { lockAhrefsConnectionForUpdate } from "@/lib/ahrefs/connections";
 import { lockSemrushConnectionForUpdate } from "@/lib/semrush/connections";
 import { crowdinAuth } from "@/lib/providers/adapters/crowdin/crowdin-auth";
@@ -159,6 +160,17 @@ function validateWorkspaceAutomationConfig(input: {
       code: "scheduled_workflow_required",
       message:
         "Scheduled automations require at least one GitHub, Contentful, Issues, Web Search, or Crowdin workflow tool.",
+    });
+  }
+
+  if (
+    input.triggerConfig.mode === "scheduled" &&
+    input.triggerConfig.schedule &&
+    !isValidAutomationTimeZone(input.triggerConfig.schedule.timezone)
+  ) {
+    return err({
+      code: "invalid_automation_timezone",
+      message: "Choose a valid timezone for the schedule.",
     });
   }
 
@@ -1028,25 +1040,20 @@ export async function listSourceUploadWorkspaceAutomations(input: {
   return rows.map((row) => serializeAutomation(row));
 }
 
-export type DueWorkspaceAutomation = {
-  automation: WorkspaceAutomationRecord;
-  repository: typeof schema.githubInstallationRepositories.$inferSelect;
-};
-
 export async function listDueWorkspaceAutomations(input: {
   now?: Date;
   limit?: number;
-}): Promise<DueWorkspaceAutomation[]> {
+  organizationId?: string;
+}): Promise<WorkspaceAutomationRecord[]> {
   const now = input.now ?? new Date();
   const limit = input.limit ?? 100;
 
   const rows = await db
     .select({
       automation: schema.workspaceAutomations,
-      repository: schema.githubInstallationRepositories,
     })
     .from(schema.workspaceAutomations)
-    .innerJoin(
+    .leftJoin(
       schema.githubInstallationRepositories,
       eq(
         schema.workspaceAutomations.githubInstallationRepositoryId,
@@ -1058,17 +1065,63 @@ export async function listDueWorkspaceAutomations(input: {
         eq(schema.workspaceAutomations.status, "active"),
         isNotNull(schema.workspaceAutomations.nextRunAt),
         lte(schema.workspaceAutomations.nextRunAt, now),
-        eq(schema.githubInstallationRepositories.enabled, true),
-        eq(schema.githubInstallationRepositories.archived, false),
+        sql`${schema.workspaceAutomations.triggerConfig}->>'mode' = 'scheduled'`,
+        or(
+          isNull(schema.workspaceAutomations.githubInstallationRepositoryId),
+          and(
+            eq(schema.githubInstallationRepositories.enabled, true),
+            eq(schema.githubInstallationRepositories.archived, false),
+          ),
+        ),
+        ...(input.organizationId
+          ? [eq(schema.workspaceAutomations.organizationId, input.organizationId)]
+          : []),
       ),
     )
     .orderBy(asc(schema.workspaceAutomations.nextRunAt), asc(schema.workspaceAutomations.id))
     .limit(limit);
 
-  return rows.map(({ automation, repository }) => ({
-    automation: serializeAutomation(automation),
-    repository,
-  }));
+  return rows.map(({ automation }) => serializeAutomation(automation));
+}
+
+export async function repairMissingScheduledWorkspaceAutomationNextRuns(input?: {
+  now?: Date;
+  limit?: number;
+}): Promise<number> {
+  const now = input?.now ?? new Date();
+  const limit = input?.limit ?? 100;
+
+  const rows = await db
+    .select()
+    .from(schema.workspaceAutomations)
+    .where(
+      and(
+        eq(schema.workspaceAutomations.status, "active"),
+        isNull(schema.workspaceAutomations.nextRunAt),
+        sql`${schema.workspaceAutomations.triggerConfig}->>'mode' = 'scheduled'`,
+      ),
+    )
+    .orderBy(asc(schema.workspaceAutomations.id))
+    .limit(limit);
+
+  let updated = 0;
+  for (const row of rows) {
+    const nextRunAt = resolveNextRunAtForWorkspaceAutomation(serializeAutomation(row), now);
+    if (!nextRunAt) {
+      continue;
+    }
+
+    await db
+      .update(schema.workspaceAutomations)
+      .set({
+        nextRunAt,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.workspaceAutomations.id, row.id));
+    updated += 1;
+  }
+
+  return updated;
 }
 
 export async function listDueContentfulWorkspaceAutomations(input: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Scheduled automations often never ran. The next-run time was only stored for GitHub sync workflows or Contentful, so the common GitHub agent templates (and Crowdin / web-search schedules) saved with an empty next-run timestamp. The due-job query also inner-joined GitHub repositories, so schedules without a repo were skipped.

The timezone field was a free-text IANA box, and daily hours were always treated as UTC even when another timezone was stored.

This change:

- Computes the next run from the trigger for every active scheduled automation
- Lists due jobs without requiring a GitHub repository
- Backfills missing next-run times on the cron tick
- Interprets the hour in the selected timezone
- Replaces the timezone text box with a searchable IANA select (Automations and GitHub repository automation settings)
- During DST spring-forward, skipped local hours (for example 02:00 in America/New_York) resolve to the next valid wall time instead of 01:00 or the following day
- Restores the standard BSL header on the new timezone files (removed a stray `10|` artifact)

Existing schedules with a blank next-run time start working after the next cron tick (every 15 minutes). They fire at the next matching hour, not as a catch-up run.

## How to test

- `vp test src/lib/agents/automation-time-zones.test.ts src/lib/agents/workspace-automation-schedule.test.ts src/lib/agents/github/github-repository-automation-settings.test.ts src/lib/agents/workspace-automation-scheduler.test.ts src/lib/agents/workspace-automations.test.ts src/lib/agents/workspace-automation-view-model.test.ts`
- `vp check --fix` (0 errors)
- In Automations, create a GitHub **agent** daily schedule at 1:00 UTC. Confirm the timezone control is a select (UTC, America, Europe, …). After save, the next run is stored and the 15-minute cron should enqueue it at 1:00 UTC.

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bcbd0ee-ae1e-4bea-a69b-1b9055bea4ca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bcbd0ee-ae1e-4bea-a69b-1b9055bea4ca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

