### PR TITLE
feat(glossary): add terms during concept creation

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
@@ -206,17 +206,30 @@ async function createConcept(
   sourceLocale: string,
   input: CreateGlossaryConceptBody,
 ) {
+  const { terms: additionalTerms = [], ...conceptInput } = input;
+  const submittedTermKeys = new Set<string>([
+    `${sourceLocale.toLowerCase()}\u0000${input.primaryTerm.toLowerCase()}`,
+  ]);
+
+  for (const term of additionalTerms) {
+    const termKey = `${term.locale.toLowerCase()}\u0000${term.term.toLowerCase()}`;
+    if (submittedTermKeys.has(termKey)) {
+      return null;
+    }
+    submittedTermKeys.add(termKey);
+  }
+
   return db.transaction(async (tx) => {
     const [concept] = await tx
       .insert(schema.glossaryConcepts)
       .values({
         glossaryId,
-        primaryTerm: input.primaryTerm,
-        subject: input.subject ?? "",
-        definition: input.definition ?? "",
-        translatable: input.translatable,
-        note: input.note ?? "",
-        url: input.url || null,
+        primaryTerm: conceptInput.primaryTerm,
+        subject: conceptInput.subject ?? "",
+        definition: conceptInput.definition ?? "",
+        translatable: conceptInput.translatable,
+        note: conceptInput.note ?? "",
+        url: conceptInput.url || null,
       })
       .returning();
 
@@ -225,13 +238,23 @@ async function createConcept(
       .values(
         nativeTermValues(glossaryId, concept.id, sourceLocale, {
           locale: sourceLocale,
-          term: input.primaryTerm,
+          term: conceptInput.primaryTerm,
           status: "preferred",
           caseSensitive: false,
           forbidden: false,
         }),
       )
       .returning();
+
+    if (additionalTerms.length > 0) {
+      await tx
+        .insert(schema.glossaryTerms)
+        .values(
+          additionalTerms.map((term) =>
+            nativeTermValues(glossaryId, concept.id, term.locale, term),
+          ),
+        );
+    }
 
     return { concept, term };
   });
@@ -510,7 +533,14 @@ export function createGlossaryConceptRoutes() {
         const glossary = await getOwnedGlossary(c.var.auth, glossaryId);
         if (!glossary) return glossaryNotFoundResponse(c);
         if (glossary.source !== "native") return externalTmsGlossaryImmutableResponse(c);
-        const { concept } = await createConcept(glossaryId, glossary.sourceLocale, payload);
+        const created = await createConcept(glossaryId, glossary.sourceLocale, payload);
+        if (!created)
+          return conflictResponse(
+            c,
+            "duplicate_glossary_concept_term",
+            "A term with this locale and text already exists",
+          );
+        const { concept } = created;
         serverAnalytics.track(PRODUCT_USAGE_ANALYTICS_EVENTS.glossaryTermCreated, {
           status: "created",
           source: "glossary_concept",

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.test.ts
@@ -153,6 +153,97 @@ describe("glossaryRoutes", () => {
     expect(importBody.glossaryTerms).toHaveLength(2);
   });
 
+  it("creates a concept with additional terms atomically", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const organizationSlug = identity.organization.slug ?? "missing-slug";
+    const glossaryResponse = await fixture.createGlossaryViaApi(identity, undefined, headers);
+    const glossaryId = ((await glossaryResponse.json()) as { glossary: { id: string } }).glossary
+      .id;
+
+    const response = await client.api.orgs[":organizationSlug"].glossaries[
+      ":glossaryId"
+    ].concepts.$post(
+      {
+        param: { organizationSlug, glossaryId },
+        json: {
+          primaryTerm: "Checkout",
+          subject: "Commerce",
+          translatable: true,
+          terms: [
+            {
+              locale: "vi-VN",
+              term: "Thanh toán",
+              status: "draft",
+              caseSensitive: false,
+              forbidden: false,
+            },
+            {
+              locale: "en-US",
+              term: "Check-out",
+              status: "draft",
+              caseSensitive: false,
+              forbidden: false,
+            },
+          ],
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as {
+      concept: {
+        primaryTerm: string;
+        terms: Array<{ locale: string; term: string; status: string }>;
+      };
+    };
+    expect(body.concept).toMatchObject({ primaryTerm: "Checkout" });
+    expect(body.concept.terms).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ locale: "en", term: "Checkout", status: "preferred" }),
+        expect.objectContaining({ locale: "vi-VN", term: "Thanh toán", status: "draft" }),
+        expect.objectContaining({ locale: "en-US", term: "Check-out", status: "draft" }),
+      ]),
+    );
+  });
+
+  it("rejects duplicate terms when creating a concept", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const organizationSlug = identity.organization.slug ?? "missing-slug";
+    const glossaryResponse = await fixture.createGlossaryViaApi(identity, undefined, headers);
+    const glossaryId = ((await glossaryResponse.json()) as { glossary: { id: string } }).glossary
+      .id;
+
+    const response = await client.api.orgs[":organizationSlug"].glossaries[
+      ":glossaryId"
+    ].concepts.$post(
+      {
+        param: { organizationSlug, glossaryId },
+        json: {
+          primaryTerm: "Checkout",
+          translatable: true,
+          terms: [
+            {
+              locale: "en",
+              term: "checkout",
+              status: "draft",
+              caseSensitive: false,
+              forbidden: false,
+            },
+          ],
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "duplicate_glossary_concept_term",
+    });
+  });
+
   it("rejects term mutations for externally managed glossaries", async () => {
     const { identity, organization, user, glossary } = await fixture.createStoredGlossaryFixture();
     const headers = await fixture.authHeadersFor(identity);

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.schema.ts
@@ -110,6 +110,18 @@ export const importGlossaryTermsBodySchema = z.object({
 
 const glossaryConceptTermStatusSchema = z.enum(["preferred", "draft", "not_recommended"]);
 
+export const createGlossaryConceptTermBodySchema = z.object({
+  locale: localeInputSchema,
+  term: z.string().trim().min(1).max(1_000),
+  partOfSpeech: z.string().max(200).optional(),
+  gender: z.string().max(100).nullable().optional(),
+  termType: z.string().max(100).nullable().optional(),
+  status: glossaryConceptTermStatusSchema.optional().default("draft"),
+  description: z.string().max(10_000).optional(),
+  caseSensitive: z.boolean().optional().default(false),
+  forbidden: z.boolean().optional().default(false),
+});
+
 export const createGlossaryConceptBodySchema = z.object({
   primaryTerm: z.string().trim().min(1).max(1_000),
   subject: z.string().max(200).optional(),
@@ -117,6 +129,7 @@ export const createGlossaryConceptBodySchema = z.object({
   translatable: z.boolean().optional().default(true),
   note: z.string().max(10_000).optional(),
   url: z.string().url().max(2_000).optional().or(z.literal("")),
+  terms: z.array(createGlossaryConceptTermBodySchema).max(1_000).optional(),
 });
 
 export const upsertGlossaryConceptTermBodySchema = z.object({
@@ -145,18 +158,6 @@ export const updateGlossaryConceptBodySchema = z
   .refine((value) => Object.keys(value).length > 0, {
     message: "at least one field must be provided",
   });
-
-export const createGlossaryConceptTermBodySchema = z.object({
-  locale: localeInputSchema,
-  term: z.string().trim().min(1).max(1_000),
-  partOfSpeech: z.string().max(200).optional(),
-  gender: z.string().max(100).nullable().optional(),
-  termType: z.string().max(100).nullable().optional(),
-  status: glossaryConceptTermStatusSchema.optional().default("draft"),
-  description: z.string().max(10_000).optional(),
-  caseSensitive: z.boolean().optional().default(false),
-  forbidden: z.boolean().optional().default(false),
-});
 
 export const updateGlossaryConceptTermBodySchema = z
   .object({

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.stories.tsx
@@ -189,6 +189,29 @@ export const ConceptDetail: Story = {
   },
 };
 
+export const ConceptCreationWithTerms: Story = {
+  args: {
+    conceptId: "new",
+  },
+  parameters: {
+    msw: { handlers: detailHandlers },
+    nextjs: {
+      navigation: {
+        pathname: `/org/acme/glossaries/${glossaryId}/concepts/new`,
+      },
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Add concept" })).toBeInTheDocument();
+    const addTermButton = canvas.getByRole("button", { name: "Add term" });
+    await expect(addTermButton).toBeEnabled();
+    await userEvent.click(addTermButton);
+    await userEvent.click(canvas.getByRole("button", { name: /French/ }));
+    await expect(canvas.getByText("French")).toBeInTheDocument();
+    await expect(canvas.getByPlaceholderText("Term")).toBeInTheDocument();
+  },
+};
+
 export const LoadingConceptList: Story = {
   parameters: {
     msw: {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
@@ -78,6 +78,8 @@ type TermDraft = {
   status: "preferred" | "draft" | "not_recommended";
 };
 
+type CreatingTermDraft = TermDraft & { id: string; locale: string };
+
 const emptyConceptDraft: ConceptDraft = {
   primaryTerm: "",
   subject: "",
@@ -306,6 +308,7 @@ export function GlossaryDetailPageContent({
   const [localePickerOpen, setLocalePickerOpen] = useState(false);
   const [newTermLocale, setNewTermLocale] = useState<string | null>(null);
   const [newTermDraft, setNewTermDraft] = useState<TermDraft>(emptyTermDraft);
+  const [creatingTermDrafts, setCreatingTermDrafts] = useState<CreatingTermDraft[]>([]);
   const [termDrafts, setTermDrafts] = useState<Record<string, TermDraft>>({});
   const [selectedProjectId, setSelectedProjectId] = useState("");
 
@@ -393,6 +396,7 @@ export function GlossaryDetailPageContent({
     if (conceptId === "new") {
       setConceptDraft(emptyConceptDraft);
       setTermDrafts({});
+      setCreatingTermDrafts([]);
       setNewTermLocale(null);
       setNewTermDraft(emptyTermDraft);
     }
@@ -408,6 +412,7 @@ export function GlossaryDetailPageContent({
       );
       setNewTermLocale(null);
       setNewTermDraft(emptyTermDraft);
+      setCreatingTermDrafts([]);
       setIsCreatingConcept(false);
     }
   }, [selectedConcept]);
@@ -442,7 +447,15 @@ export function GlossaryDetailPageContent({
           ":glossaryId"
         ].concepts.$post({
           param: { organizationSlug, glossaryId },
-          json: { ...draft, url: draft.url || undefined },
+          json: {
+            ...draft,
+            url: draft.url || undefined,
+            terms: creatingTermDrafts.map(({ id: _id, ...term }) => ({
+              ...term,
+              caseSensitive: false,
+              forbidden: false,
+            })),
+          },
         });
         if (!response.ok)
           throw new Error(
@@ -514,6 +527,7 @@ export function GlossaryDetailPageContent({
       }
       setNewTermLocale(null);
       setNewTermDraft(emptyTermDraft);
+      setCreatingTermDrafts([]);
       toast.success(intl.formatMessage(created ? messages.conceptAdded : messages.conceptSaved));
     },
     onError: (error) => toast.error(error.message),
@@ -654,9 +668,9 @@ export function GlossaryDetailPageContent({
     isSource: true,
   };
   const normalizedLanguageFilter = languageFilter.trim().toLowerCase();
-  const availableTermLocales = COMMON_LOCALES.filter(
-    (locale) => !selected?.terms.some((term) => term.locale === locale),
-  );
+  const availableTermLocales = isCreatingConcept
+    ? COMMON_LOCALES
+    : COMMON_LOCALES.filter((locale) => !selected?.terms.some((term) => term.locale === locale));
   const termGroups = (selected?.terms ?? [])
     .filter(
       (term) =>
@@ -691,7 +705,8 @@ export function GlossaryDetailPageContent({
     }),
   );
   const newTermIsDirty = Boolean(newTermLocale && newTermDraft.term.trim());
-  const isDirty = conceptIsDirty || termsAreDirty || newTermIsDirty;
+  const isDirty =
+    conceptIsDirty || termsAreDirty || newTermIsDirty || creatingTermDrafts.length > 0;
   if (conceptPageMode && !isCreatingConcept && conceptsQuery.isSuccess && !selected) {
     return (
       <TypographyP className="py-8 text-sm text-muted-foreground">
@@ -1043,7 +1058,7 @@ export function GlossaryDetailPageContent({
                       type="button"
                       variant="outline"
                       className="w-full sm:w-auto"
-                      disabled={!canEdit || !selected || availableTermLocales.length === 0}
+                      disabled={!canEdit || availableTermLocales.length === 0}
                       onClick={() => setLocalePickerOpen(true)}
                     >
                       <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
@@ -1068,8 +1083,19 @@ export function GlossaryDetailPageContent({
                             variant="outline"
                             className="justify-between"
                             onClick={() => {
-                              setNewTermLocale(locale);
-                              setNewTermDraft(emptyTermDraft);
+                              if (isCreatingConcept) {
+                                setCreatingTermDrafts((drafts) => [
+                                  ...drafts,
+                                  {
+                                    ...emptyTermDraft,
+                                    id: `new-${crypto.randomUUID()}`,
+                                    locale,
+                                  },
+                                ]);
+                              } else {
+                                setNewTermLocale(locale);
+                                setNewTermDraft(emptyTermDraft);
+                              }
                               setLocalePickerOpen(false);
                             }}
                           >
@@ -1082,6 +1108,214 @@ export function GlossaryDetailPageContent({
                   </Dialog>
                   <div className="max-h-[calc(100dvh-18rem)] overflow-y-auto pr-1">
                     <div className="grid gap-4">
+                      {isCreatingConcept && creatingTermDrafts.length > 0 ? (
+                        <div className="overflow-hidden rounded-lg border border-border">
+                          <div className="border-b border-border bg-muted/30 px-3 py-2 text-sm font-medium">
+                            <FormattedMessage {...messages.termsTitle} />
+                          </div>
+                          <div className="overflow-x-auto">
+                            <table className="min-w-[680px] w-full text-left text-xs">
+                              <thead className="text-muted-foreground">
+                                <tr>
+                                  <th className="px-3 py-2">Language</th>
+                                  <th className="px-3 py-2">
+                                    <FormattedMessage {...messages.termLabel} />
+                                  </th>
+                                  <th className="px-3 py-2">
+                                    <FormattedMessage {...messages.partOfSpeechLabel} />
+                                  </th>
+                                  <th className="px-3 py-2">
+                                    <FormattedMessage {...messages.genderLabel} />
+                                  </th>
+                                  <th className="px-3 py-2">
+                                    <FormattedMessage {...messages.typeLabel} />
+                                  </th>
+                                  <th className="px-3 py-2">
+                                    <FormattedMessage {...messages.statusLabel} />
+                                  </th>
+                                  <th className="w-10 px-3 py-2" />
+                                </tr>
+                              </thead>
+                              <tbody>
+                                {creatingTermDrafts.map((term) => (
+                                  <tr key={term.id} className="border-t border-border">
+                                    <td className="px-3 py-2">
+                                      <span className="font-medium">
+                                        {getLocaleLabel(term.locale)}
+                                      </span>
+                                      <span className="ml-1 text-muted-foreground">
+                                        {term.locale}
+                                      </span>
+                                    </td>
+                                    <td className="px-3 py-2">
+                                      <Input
+                                        autoFocus={creatingTermDrafts.at(-1)?.id === term.id}
+                                        className="h-7"
+                                        value={term.term}
+                                        onChange={(event) =>
+                                          setCreatingTermDrafts((drafts) =>
+                                            drafts.map((draft) =>
+                                              draft.id === term.id
+                                                ? { ...draft, term: event.target.value }
+                                                : draft,
+                                            ),
+                                          )
+                                        }
+                                      />
+                                    </td>
+                                    <td className="px-3 py-2">
+                                      <Select
+                                        value={term.partOfSpeech || "__none"}
+                                        onValueChange={(value) =>
+                                          setCreatingTermDrafts((drafts) =>
+                                            drafts.map((draft) =>
+                                              draft.id === term.id
+                                                ? {
+                                                    ...draft,
+                                                    partOfSpeech:
+                                                      value === "__none" ? "" : (value ?? ""),
+                                                  }
+                                                : draft,
+                                            ),
+                                          )
+                                        }
+                                      >
+                                        <SelectTrigger className="h-7">
+                                          <SelectValue>
+                                            {term.partOfSpeech
+                                              ? readableEnumLabel(term.partOfSpeech)
+                                              : "—"}
+                                          </SelectValue>
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                          <SelectItem value="__none">—</SelectItem>
+                                          {partOfSpeechOptionsFor(term.partOfSpeech).map(
+                                            (option) => (
+                                              <SelectItem key={option} value={option}>
+                                                {readableEnumLabel(option)}
+                                              </SelectItem>
+                                            ),
+                                          )}
+                                        </SelectContent>
+                                      </Select>
+                                    </td>
+                                    <td className="px-3 py-2">
+                                      <Select
+                                        value={term.gender ?? "__none"}
+                                        onValueChange={(value) =>
+                                          setCreatingTermDrafts((drafts) =>
+                                            drafts.map((draft) =>
+                                              draft.id === term.id
+                                                ? {
+                                                    ...draft,
+                                                    gender:
+                                                      value === "__none" ? null : (value ?? null),
+                                                  }
+                                                : draft,
+                                            ),
+                                          )
+                                        }
+                                      >
+                                        <SelectTrigger className="h-7">
+                                          <SelectValue>
+                                            {term.gender ? readableEnumLabel(term.gender) : "—"}
+                                          </SelectValue>
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                          <SelectItem value="__none">—</SelectItem>
+                                          {genderOptions.map((option) => (
+                                            <SelectItem key={option} value={option}>
+                                              {readableEnumLabel(option)}
+                                            </SelectItem>
+                                          ))}
+                                        </SelectContent>
+                                      </Select>
+                                    </td>
+                                    <td className="px-3 py-2">
+                                      <Select
+                                        value={term.termType ?? "__none"}
+                                        onValueChange={(value) =>
+                                          setCreatingTermDrafts((drafts) =>
+                                            drafts.map((draft) =>
+                                              draft.id === term.id
+                                                ? {
+                                                    ...draft,
+                                                    termType:
+                                                      value === "__none" ? null : (value ?? null),
+                                                  }
+                                                : draft,
+                                            ),
+                                          )
+                                        }
+                                      >
+                                        <SelectTrigger className="h-7">
+                                          <SelectValue>
+                                            {term.termType ? readableEnumLabel(term.termType) : "—"}
+                                          </SelectValue>
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                          <SelectItem value="__none">—</SelectItem>
+                                          {termTypeOptions.map((option) => (
+                                            <SelectItem key={option} value={option}>
+                                              {readableEnumLabel(option)}
+                                            </SelectItem>
+                                          ))}
+                                        </SelectContent>
+                                      </Select>
+                                    </td>
+                                    <td className="px-3 py-2">
+                                      <Select
+                                        value={term.status}
+                                        onValueChange={(value) =>
+                                          setCreatingTermDrafts((drafts) =>
+                                            drafts.map((draft) =>
+                                              draft.id === term.id
+                                                ? {
+                                                    ...draft,
+                                                    status: (value ??
+                                                      "draft") as TermDraft["status"],
+                                                  }
+                                                : draft,
+                                            ),
+                                          )
+                                        }
+                                      >
+                                        <SelectTrigger className="h-7">
+                                          <SelectValue>
+                                            {readableEnumLabel(term.status)}
+                                          </SelectValue>
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                          {statusOptions.map((option) => (
+                                            <SelectItem key={option} value={option}>
+                                              {readableEnumLabel(option)}
+                                            </SelectItem>
+                                          ))}
+                                        </SelectContent>
+                                      </Select>
+                                    </td>
+                                    <td className="px-3 py-2">
+                                      <Button
+                                        type="button"
+                                        size="icon-xs"
+                                        variant="ghost"
+                                        aria-label={intl.formatMessage(messages.deleteTerm)}
+                                        onClick={() =>
+                                          setCreatingTermDrafts((drafts) =>
+                                            drafts.filter((draft) => draft.id !== term.id),
+                                          )
+                                        }
+                                      >
+                                        <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
+                                      </Button>
+                                    </td>
+                                  </tr>
+                                ))}
+                              </tbody>
+                            </table>
+                          </div>
+                        </div>
+                      ) : null}
                       {termGroups.map((group) => {
                         const isSource = group.locale === glossary.sourceLocale;
                         return (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
@@ -450,11 +450,14 @@ export function GlossaryDetailPageContent({
           json: {
             ...draft,
             url: draft.url || undefined,
-            terms: creatingTermDrafts.map(({ id: _id, ...term }) => ({
-              ...term,
-              caseSensitive: false,
-              forbidden: false,
-            })),
+            terms: creatingTermDrafts
+              .filter(({ term }) => term.trim())
+              .map(({ id: _id, ...term }) => ({
+                ...term,
+                term: term.term.trim(),
+                caseSensitive: false,
+                forbidden: false,
+              })),
           },
         });
         if (!response.ok)
@@ -1151,6 +1154,7 @@ export function GlossaryDetailPageContent({
                                       <Input
                                         autoFocus={creatingTermDrafts.at(-1)?.id === term.id}
                                         className="h-7"
+                                        placeholder={intl.formatMessage(messages.termLabel)}
                                         value={term.term}
                                         onChange={(event) =>
                                           setCreatingTermDrafts((drafts) =>


### PR DESCRIPTION
## Summary
- allow adding multiple glossary terms while creating a concept
- persist the concept and additional terms atomically
- reject duplicate locale/text terms
- add route and Storybook coverage

## Validation
- `vp check --fix` passes with four pre-existing unrelated warnings
- `vp test` could not complete because PostgreSQL was unavailable at `localhost:5432`
