### PR TITLE
feat(go-svc): add spell-check provider contract

### DIFF
--- a/apps/go-svc/BUILD.bazel
+++ b/apps/go-svc/BUILD.bazel
@@ -22,10 +22,12 @@ go_test(
     srcs = [
         "auth_test.go",
         "handler_test.go",
+        "spellcheck_test.go",
     ],
     embed = [":go_svc"],
     deps = [
         "//internal/i18n/segmentvalidate",
+        "//internal/i18n/spellcheck",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/apps/go-svc/BUILD.bazel
+++ b/apps/go-svc/BUILD.bazel
@@ -6,11 +6,13 @@ go_binary(
         "auth.go",
         "handler.go",
         "main.go",
+        "spellcheck.go",
     ],
     importpath = "github.com/hyperlocalise/hyperlocalise/apps/go-svc",
     visibility = ["//visibility:public"],
     deps = [
         "//internal/i18n/segmentvalidate",
+        "//internal/i18n/spellcheck",
         "@com_github_workos_workos_go_v9//:workos-go",
     ],
 )

--- a/apps/go-svc/handler.go
+++ b/apps/go-svc/handler.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
 
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/segmentvalidate"
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/spellcheck"
 )
 
 const maxValidateSegmentBodyBytes = 512 << 10 // 512 KiB
@@ -23,13 +25,19 @@ type validateSegmentResponse struct {
 }
 
 type handler struct {
-	validate func(segmentvalidate.Request) []segmentvalidate.Check
+	validate     func(segmentvalidate.Request) []segmentvalidate.Check
+	spellChecker SpellChecker
 }
 
 func newHandler() *handler {
 	return &handler{
-		validate: segmentvalidate.ValidateSegment,
+		validate:     segmentvalidate.ValidateSegment,
+		spellChecker: NoopSpellChecker{},
 	}
+}
+
+func (h *handler) checkSpelling(ctx context.Context, locale, text string) ([]SpellingIssue, error) {
+	return h.spellChecker.Check(ctx, locale, spellcheck.Tokenize(text))
 }
 
 func (h *handler) health(w http.ResponseWriter, _ *http.Request) {
@@ -55,6 +63,8 @@ func (h *handler) validateSegment(w http.ResponseWriter, r *http.Request) {
 		writeBadRequest(w, "invalid JSON body")
 		return
 	}
+
+	_, _ = h.checkSpelling(r.Context(), "", req.TargetText)
 
 	checks := h.validate(segmentvalidate.Request{
 		SourceText: req.SourceText,

--- a/apps/go-svc/handler_test.go
+++ b/apps/go-svc/handler_test.go
@@ -67,6 +67,7 @@ func TestValidateSegmentSuccess(t *testing.T) {
 				},
 			}
 		},
+		spellChecker: NoopSpellChecker{},
 	}
 
 	mux := http.NewServeMux()

--- a/apps/go-svc/spellcheck.go
+++ b/apps/go-svc/spellcheck.go
@@ -1,0 +1,18 @@
+package main
+
+import "context"
+
+type SpellingIssue struct {
+	Word        string
+	Suggestions []string
+}
+
+type SpellChecker interface {
+	Check(ctx context.Context, locale string, words []string) ([]SpellingIssue, error)
+}
+
+type NoopSpellChecker struct{}
+
+func (NoopSpellChecker) Check(_ context.Context, _ string, _ []string) ([]SpellingIssue, error) {
+	return nil, nil
+}

--- a/apps/go-svc/spellcheck_test.go
+++ b/apps/go-svc/spellcheck_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/spellcheck"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeSpellChecker struct {
+	receivedCtx    context.Context
+	receivedLocale string
+	receivedWords  []string
+
+	issues []SpellingIssue
+	err    error
+}
+
+func (f *fakeSpellChecker) Check(ctx context.Context, locale string, words []string) ([]SpellingIssue, error) {
+	f.receivedCtx = ctx
+	f.receivedLocale = locale
+	f.receivedWords = words
+	return f.issues, f.err
+}
+
+func TestCheckSpellingInjectsConfiguredProvider(t *testing.T) {
+	fake := &fakeSpellChecker{
+		issues: []SpellingIssue{{Word: "recieve", Suggestions: []string{"receive"}}},
+	}
+	h := &handler{spellChecker: fake}
+
+	text := "Please recieve the {name} update"
+	issues, err := h.checkSpelling(context.Background(), "fr-FR", text)
+
+	require.NoError(t, err)
+	require.Equal(t, fake.issues, issues)
+	require.Equal(t, "fr-FR", fake.receivedLocale)
+	require.Equal(t, spellcheck.Tokenize(text), fake.receivedWords)
+}
+
+func TestCheckSpellingPropagatesContextCancellation(t *testing.T) {
+	fake := &fakeSpellChecker{}
+	h := &handler{spellChecker: fake}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _ = h.checkSpelling(ctx, "", "Hello there")
+
+	require.NotNil(t, fake.receivedCtx)
+	require.ErrorIs(t, fake.receivedCtx.Err(), context.Canceled)
+}
+
+func TestCheckSpellingNoopWhenUnconfigured(t *testing.T) {
+	h := newHandler()
+
+	issues, err := h.checkSpelling(context.Background(), "", "Hello there")
+
+	require.NoError(t, err)
+	require.Nil(t, issues)
+}


### PR DESCRIPTION
## What changed

- Add service-owned `SpellChecker` and `SpellingIssue` types
- Inject spell checking into the validation handler while keeping `segmentvalidate` pure
- Propagate request context to the provider
- Add fake/no-op coverage for injection, cancellation, and unconfigured behavior

## How to test

- `go test ./apps/go-svc`
- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
