### PR TITLE
fix(marketing): confine automations mock mesh to the left frame

### DIFF
--- a/apps/hyperlocalise-web/src/components/marketing/product/automations-mock-ui.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/automations-mock-ui.stories.tsx
@@ -13,19 +13,12 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { expect } from "storybook/test";
 
-import {
-  LAVENDER_MESH_GRADIENT_SRC,
-  MeshStage,
-} from "@/components/marketing/hero-frame-mesh-stage";
-
 import { AutomationsMockUI } from "./automations-mock-ui";
 
 function AutomationsMockShowcase() {
   return (
     <div className="mx-auto max-w-6xl p-6">
-      <MeshStage meshSrc={LAVENDER_MESH_GRADIENT_SRC}>
-        <AutomationsMockUI />
-      </MeshStage>
+      <AutomationsMockUI />
     </div>
   );
 }

--- a/apps/hyperlocalise-web/src/components/marketing/product/automations-mock-ui.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/automations-mock-ui.tsx
@@ -16,15 +16,15 @@ import { useEffect, useState } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { Clock01Icon, GitPullRequestIcon, Upload01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import Image from "next/image";
 import { FormattedMessage, useIntl } from "react-intl";
 
+import { LAVENDER_MESH_GRADIENT_SRC } from "@/components/marketing/hero-frame-mesh-stage";
+import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/primitives/cn";
-import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
 
 import { automationsMockMessages } from "./automations-mock-ui.messages";
-
-import Image from "next/image";
 
 type StepStatus = "pending" | "running" | "done" | "warning";
 
@@ -209,7 +209,7 @@ function UseCaseSelector({
   );
 }
 
-export function AutomationsMockUI() {
+export function AutomationsMockUI({ priority = false }: { priority?: boolean }) {
   const intl = useIntl();
   const shouldReduceMotion = useReducedMotion();
 
@@ -328,23 +328,40 @@ export function AutomationsMockUI() {
   }
 
   return (
-    <div className="overflow-hidden rounded-xl border border-border bg-card shadow-2xl shadow-gray-alpha-100">
+    <div className="overflow-hidden rounded-xl border border-border bg-background shadow-2xl shadow-gray-alpha-100">
       <div className="grid min-h-[22rem] md:grid-cols-[1fr_1.4fr]">
-        <div className="border-b border-border/60 md:border-b-0 md:border-r">
-          <AnimatePresence mode="wait">
-            <motion.div
-              key={activeUseCase.id}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.25 }}
-              className="h-full"
-            >
-              <TerminalPanel useCase={activeUseCase} visibleSteps={visibleSteps} />
-            </motion.div>
-          </AnimatePresence>
+        <div className="relative min-h-[20rem] overflow-hidden border-b border-border md:min-h-0 md:border-b-0">
+          <Image
+            src={LAVENDER_MESH_GRADIENT_SRC}
+            alt=""
+            aria-hidden
+            fill
+            priority={priority}
+            sizes="(min-width: 768px) 28rem, 100vw"
+            className="pointer-events-none object-cover object-center"
+          />
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-y-0 right-0 w-16 bg-gradient-to-r from-transparent to-background md:w-24"
+          />
+          <div className="relative flex h-full items-center p-5 sm:p-7 lg:p-8">
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={activeUseCase.id}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.25 }}
+                className="flex w-full flex-col overflow-hidden rounded-xl border border-border/80 bg-background/90 shadow-lg backdrop-blur-sm"
+              >
+                <TerminalPanel useCase={activeUseCase} visibleSteps={visibleSteps} />
+              </motion.div>
+            </AnimatePresence>
+          </div>
         </div>
-        <UseCaseSelector useCases={useCases} active={activeUseCase.id} onSelect={handleSelect} />
+        <div className="relative bg-background">
+          <UseCaseSelector useCases={useCases} active={activeUseCase.id} onSelect={handleSelect} />
+        </div>
       </div>
     </div>
   );

--- a/apps/hyperlocalise-web/src/components/marketing/product/product-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/product-page.tsx
@@ -17,11 +17,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 import { FormattedMessage } from "react-intl";
 
-import {
-  HeroFrameMeshStage,
-  LAVENDER_MESH_GRADIENT_SRC,
-  MeshStage,
-} from "@/components/marketing/hero-frame-mesh-stage";
+import { HeroFrameMeshStage } from "@/components/marketing/hero-frame-mesh-stage";
 import { MarketingFooter } from "@/components/marketing/marketing-footer";
 import { footerColumns } from "@/components/marketing/marketing-page-content";
 import { REQUEST_DEMO_URL } from "@/components/marketing/request-demo";
@@ -157,9 +153,7 @@ function ProductShowcase({ content }: ProductPageProps) {
   if (content.visualKind === "automation") {
     return (
       <div className="mx-auto max-w-6xl">
-        <MeshStage meshSrc={LAVENDER_MESH_GRADIENT_SRC} priority>
-          <AutomationsMockUI />
-        </MeshStage>
+        <AutomationsMockUI priority />
       </div>
     );
   }


### PR DESCRIPTION
## What changed

The product automations mock (Auto-review) no longer wraps the whole dialog in mesh. Mesh now fills only the left frame behind the run card; the right panel stays a clean background for the use-case list and CTA.

## How to test

- [ ] Open the Agents Automation product page and confirm mesh appears only on the left half of the mock, not around the full dialog.
- [ ] Confirm Auto-review is the first use case and the right-side copy stays readable on a solid background.
- [ ] Check Storybook `Marketing/Product/AutomationsMock` for the same split.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)