### PR TITLE
feat(cat): make editor panels horizontally resizable

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side-panel.tsx
@@ -36,6 +36,7 @@ import type {
   CatTranslationMemoryMatch,
 } from "@/components/cat/shared/types";
 import { useCatWorkspace } from "@/components/cat/workspace/cat-workspace-context";
+import { CatSideBySideResizableLayout } from "@/components/cat/workspace/cat-workspace-resizable-layout";
 
 import { CatSideBySideIntelligencePanel } from "./cat-side-by-side-intelligence-panel";
 import { CatSideBySideVirtualList } from "./cat-side-by-side-virtual-list";
@@ -208,112 +209,109 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
   const totalSegments = hasMoreQueue ? null : (pagination?.totalCount ?? segments.length);
 
   return (
-    <div
-      className={cn(
-        "grid h-full min-h-0 min-w-0 grid-cols-[minmax(0,1fr)_minmax(0,22rem)] overflow-hidden bg-background",
-        className,
-      )}
-    >
-      <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
-        <div className="shrink-0 border-b border-border px-4 py-3">
-          <div className="grid grid-cols-2 gap-0 text-xs font-medium tracking-wide text-muted-foreground uppercase">
-            <p className="border-r border-border pr-4">
-              <FormattedMessage {...catSideBySidePanelMessages.sourceColumn} />
-            </p>
-            <p className="pl-4">
-              <FormattedMessage {...catSideBySidePanelMessages.translationColumn} />
-            </p>
-          </div>
-        </div>
-
-        <div className="flex min-h-0 flex-1 flex-col">
-          {isQueueLoading && segments.length === 0 ? (
-            <CatQueueSkeletonList className="px-4 py-3" />
-          ) : segments.length === 0 ? (
-            <div className="flex flex-1 items-center justify-center px-4 py-8 text-sm text-muted-foreground">
-              <FormattedMessage {...emptyMessage} />
+    <CatSideBySideResizableLayout
+      className={cn("bg-background", className)}
+      editor={
+        <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
+          <div className="shrink-0 border-b border-border px-4 py-3">
+            <div className="grid grid-cols-2 gap-0 text-xs font-medium tracking-wide text-muted-foreground uppercase">
+              <p className="border-r border-border pr-4">
+                <FormattedMessage {...catSideBySidePanelMessages.sourceColumn} />
+              </p>
+              <p className="pl-4">
+                <FormattedMessage {...catSideBySidePanelMessages.translationColumn} />
+              </p>
             </div>
-          ) : (
-            <CatSideBySideVirtualList
-              segments={segments}
-              focusedSegmentId={focusedSegmentId}
-              hoveredSegmentId={hoveredSegmentId}
-              dirtySegmentIds={dirtySegmentIds}
-              canEdit={canEditTranslations}
-              loadingSegmentIds={loadingSegmentIds}
-              isApproving={isApproving}
-              isSavingDraft={isSavingDraft}
-              isPostingComment={isPostingComment}
-              isLookingUpContext={isLookingUpContext}
-              isAiSuggestionLoading={isAiSuggestionLoading}
-              isFormatChecksLoading={isFormatChecksLoading}
-              isImageBusy={isImageBusy}
-              canUseAiRecommendation={canUseAiRecommendation}
-              focusedIntelligence={focusedIntelligence}
-              aiRecommendationError={aiRecommendationError}
-              formatChecks={formatChecks}
-              segmentFormatChecks={segmentFormatChecks}
-              formatCheckLoadingSegmentIds={formatCheckLoadingSegmentIds}
-              primaryActionLabel={primaryActionLabel}
-              segmentShareUrl={segmentShareUrl}
-              onFocusSegment={onFocusSegment}
-              onHoverSegment={(segmentId) => store.ui.setHoveredSegment(segmentId)}
-              onLeaveSegment={() => store.ui.clearHoveredSegment()}
-              onVisibleSegmentIdsChange={handleVisibleSegmentIdsChange}
-              onTargetChange={onTargetChange}
-              onApprove={onApprove}
-              onSaveDraft={onSaveDraft}
-              onAddToIssueSheet={onAddToIssueSheet}
-              onUseAiSuggestion={onUseAiSuggestion}
-              onGenerateAiRecommendation={onGenerateAiRecommendation}
-              onTreatAsImage={onTreatAsImage}
-              onTreatAsVideo={onTreatAsVideo}
-              onRegenerateImage={onRegenerateImage}
-              onUploadImage={onUploadImage}
-              hasMore={hasMoreQueue}
-              isLoadingMore={isFetchingPage}
-              onNearEnd={onLoadMoreQueue}
-            />
-          )}
+          </div>
 
-          <div className="flex shrink-0 items-center justify-between border-t border-border px-4 py-2 text-xs text-muted-foreground">
-            <p>
-              <FormattedMessage
-                {...catQueuePanelMessages.paginationSummary}
-                values={{
-                  count: loadedCount,
-                  more: hasMoreQueue ? "+" : "",
-                }}
-              />
-            </p>
-            <p className="font-mono tabular-nums">
-              <FormattedMessage
-                {...catSideBySidePanelMessages.segmentPosition}
-                values={{
-                  position: segmentPosition,
-                  total: totalSegments ?? `${loadedCount}+`,
-                }}
-              />
-            </p>
-            {hasMoreQueue && onLoadMoreQueue ? (
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-7 px-2 text-xs"
-                onClick={onLoadMoreQueue}
-                disabled={isFetchingPage}
-              >
-                {isFetchingPage ? <Spinner className="size-3.5" /> : null}
-                <FormattedMessage {...catQueuePanelMessages.loadMore} />
-              </Button>
+          <div className="flex min-h-0 flex-1 flex-col">
+            {isQueueLoading && segments.length === 0 ? (
+              <CatQueueSkeletonList className="px-4 py-3" />
+            ) : segments.length === 0 ? (
+              <div className="flex flex-1 items-center justify-center px-4 py-8 text-sm text-muted-foreground">
+                <FormattedMessage {...emptyMessage} />
+              </div>
             ) : (
-              <span />
+              <CatSideBySideVirtualList
+                segments={segments}
+                focusedSegmentId={focusedSegmentId}
+                hoveredSegmentId={hoveredSegmentId}
+                dirtySegmentIds={dirtySegmentIds}
+                canEdit={canEditTranslations}
+                loadingSegmentIds={loadingSegmentIds}
+                isApproving={isApproving}
+                isSavingDraft={isSavingDraft}
+                isPostingComment={isPostingComment}
+                isLookingUpContext={isLookingUpContext}
+                isAiSuggestionLoading={isAiSuggestionLoading}
+                isFormatChecksLoading={isFormatChecksLoading}
+                isImageBusy={isImageBusy}
+                canUseAiRecommendation={canUseAiRecommendation}
+                focusedIntelligence={focusedIntelligence}
+                aiRecommendationError={aiRecommendationError}
+                formatChecks={formatChecks}
+                segmentFormatChecks={segmentFormatChecks}
+                formatCheckLoadingSegmentIds={formatCheckLoadingSegmentIds}
+                primaryActionLabel={primaryActionLabel}
+                segmentShareUrl={segmentShareUrl}
+                onFocusSegment={onFocusSegment}
+                onHoverSegment={(segmentId) => store.ui.setHoveredSegment(segmentId)}
+                onLeaveSegment={() => store.ui.clearHoveredSegment()}
+                onVisibleSegmentIdsChange={handleVisibleSegmentIdsChange}
+                onTargetChange={onTargetChange}
+                onApprove={onApprove}
+                onSaveDraft={onSaveDraft}
+                onAddToIssueSheet={onAddToIssueSheet}
+                onUseAiSuggestion={onUseAiSuggestion}
+                onGenerateAiRecommendation={onGenerateAiRecommendation}
+                onTreatAsImage={onTreatAsImage}
+                onTreatAsVideo={onTreatAsVideo}
+                onRegenerateImage={onRegenerateImage}
+                onUploadImage={onUploadImage}
+                hasMore={hasMoreQueue}
+                isLoadingMore={isFetchingPage}
+                onNearEnd={onLoadMoreQueue}
+              />
             )}
+
+            <div className="flex shrink-0 items-center justify-between border-t border-border px-4 py-2 text-xs text-muted-foreground">
+              <p>
+                <FormattedMessage
+                  {...catQueuePanelMessages.paginationSummary}
+                  values={{
+                    count: loadedCount,
+                    more: hasMoreQueue ? "+" : "",
+                  }}
+                />
+              </p>
+              <p className="font-mono tabular-nums">
+                <FormattedMessage
+                  {...catSideBySidePanelMessages.segmentPosition}
+                  values={{
+                    position: segmentPosition,
+                    total: totalSegments ?? `${loadedCount}+`,
+                  }}
+                />
+              </p>
+              {hasMoreQueue && onLoadMoreQueue ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2 text-xs"
+                  onClick={onLoadMoreQueue}
+                  disabled={isFetchingPage}
+                >
+                  {isFetchingPage ? <Spinner className="size-3.5" /> : null}
+                  <FormattedMessage {...catQueuePanelMessages.loadMore} />
+                </Button>
+              ) : (
+                <span />
+              )}
+            </div>
           </div>
         </div>
-      </div>
-
-      <div className="h-full min-h-0 min-w-0">
+      }
+      intelligence={
         <CatSideBySideIntelligencePanel
           segment={intelligenceSegment}
           intelligence={intelligence}
@@ -367,7 +365,7 @@ export const CatSideBySidePanel = observer(function CatSideBySidePanel({
           placement="right"
           className="h-full"
         />
-      </div>
-    </div>
+      }
+    />
   );
 });

--- a/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/side-by-side/cat-side-by-side.stories.tsx
@@ -136,6 +136,9 @@ export const Default: Story = {
 
     await expect(canvas.getByText("Source string")).toBeInTheDocument();
     await expect(canvas.getByText("Translation")).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("separator", { name: "Resize translation intelligence panel" }),
+    ).toBeInTheDocument();
     await expect(canvas.getByText("dashboard.reviews.pending.card")).toBeInTheDocument();
     await expect(canvas.getByRole("textbox", { name: "Target translation" })).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: /Copy source/i })).toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-container.test.tsx
@@ -60,6 +60,10 @@ describe("CatWorkspaceContainer UI", () => {
 
     expect(screen.getByText("Queue")).toBeInTheDocument();
     expect(screen.getByText("Translation Intelligence")).toBeInTheDocument();
+    expect(screen.getByRole("separator", { name: "Resize queue panel" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("separator", { name: "Resize translation intelligence panel" }),
+    ).toBeInTheDocument();
     await waitFor(() =>
       expect(screen.getByRole("button", { name: /Approve/i })).toBeInTheDocument(),
     );
@@ -195,6 +199,9 @@ describe("CatWorkspaceContainer UI", () => {
 
       await user.click(screen.getByRole("tab", { name: "Queue" }));
       expect(screen.getByRole("tab", { name: "Queue" })).toHaveAttribute("data-active");
+      expect(
+        screen.queryByRole("separator", { name: "Resize queue panel" }),
+      ).not.toBeInTheDocument();
     } finally {
       window.matchMedia = originalMatchMedia;
     }

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-resizable-layout.test.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-resizable-layout.test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+// @vitest-environment happy-dom
+
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+
+import { renderWithCatProviders } from "@/components/cat/shared/cat-test-utils";
+
+import {
+  CatComfortableResizableLayout,
+  CatSideBySideResizableLayout,
+} from "./cat-workspace-resizable-layout";
+
+describe("CatComfortableResizableLayout", () => {
+  it("exposes horizontal resize handles for the queue and intelligence panels", () => {
+    renderWithCatProviders(
+      <div style={{ width: 1280, height: 900 }}>
+        <CatComfortableResizableLayout
+          queue={<div>Queue pane</div>}
+          editor={<div>Editor pane</div>}
+          intelligence={<div>Intelligence pane</div>}
+        />
+      </div>,
+    );
+
+    expect(screen.getByRole("separator", { name: "Resize queue panel" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("separator", { name: "Resize translation intelligence panel" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Queue pane")).toBeInTheDocument();
+    expect(screen.getByText("Editor pane")).toBeInTheDocument();
+    expect(screen.getByText("Intelligence pane")).toBeInTheDocument();
+  });
+});
+
+describe("CatSideBySideResizableLayout", () => {
+  it("exposes a horizontal resize handle for the intelligence panel", () => {
+    renderWithCatProviders(
+      <div style={{ width: 1280, height: 900 }}>
+        <CatSideBySideResizableLayout
+          editor={<div>Source and translation</div>}
+          intelligence={<div>Intelligence pane</div>}
+        />
+      </div>,
+    );
+
+    expect(
+      screen.getByRole("separator", { name: "Resize translation intelligence panel" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Source and translation")).toBeInTheDocument();
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-resizable-layout.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace-resizable-layout.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import type { ReactNode } from "react";
+import { useDefaultLayout } from "react-resizable-panels";
+import { useIntl } from "react-intl";
+
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
+import { cn } from "@/lib/primitives/cn";
+
+import { catWorkspaceViewMessages } from "./cat-workspace.messages";
+
+export const CAT_COMFORTABLE_LAYOUT_ID = "cat-workspace-comfortable";
+export const CAT_SIDE_BY_SIDE_LAYOUT_ID = "cat-workspace-side-by-side";
+
+const COMFORTABLE_PANEL_IDS = ["queue", "editor", "intelligence"] as const;
+const SIDE_BY_SIDE_PANEL_IDS = ["editor", "intelligence"] as const;
+
+const QUEUE_DEFAULT_SIZE = "20rem";
+const QUEUE_MIN_SIZE = "14rem";
+const QUEUE_MAX_SIZE = "36rem";
+const EDITOR_MIN_SIZE = "24rem";
+const INTELLIGENCE_DEFAULT_SIZE = "22rem";
+const INTELLIGENCE_MIN_SIZE = "16rem";
+const INTELLIGENCE_MAX_SIZE = "40rem";
+
+function CatResizablePane({ children }: { children: ReactNode }) {
+  return <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">{children}</div>;
+}
+
+export function CatComfortableResizableLayout({
+  queue,
+  editor,
+  intelligence,
+  className,
+}: {
+  queue: ReactNode;
+  editor: ReactNode;
+  intelligence: ReactNode;
+  className?: string;
+}) {
+  const intl = useIntl();
+  const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+    id: CAT_COMFORTABLE_LAYOUT_ID,
+    panelIds: [...COMFORTABLE_PANEL_IDS],
+    onlySaveAfterUserInteractions: true,
+  });
+
+  return (
+    <ResizablePanelGroup
+      id={CAT_COMFORTABLE_LAYOUT_ID}
+      orientation="horizontal"
+      className={cn("h-full min-h-0 min-w-0 flex-1 overflow-hidden", className)}
+      defaultLayout={defaultLayout}
+      onLayoutChanged={onLayoutChanged}
+    >
+      <ResizablePanel
+        id="queue"
+        defaultSize={QUEUE_DEFAULT_SIZE}
+        minSize={QUEUE_MIN_SIZE}
+        maxSize={QUEUE_MAX_SIZE}
+        className="min-h-0 min-w-0 overflow-hidden"
+      >
+        <CatResizablePane>{queue}</CatResizablePane>
+      </ResizablePanel>
+      <ResizableHandle
+        withHandle
+        aria-label={intl.formatMessage(catWorkspaceViewMessages.resizeQueuePanel)}
+      />
+      <ResizablePanel
+        id="editor"
+        minSize={EDITOR_MIN_SIZE}
+        className="min-h-0 min-w-0 overflow-hidden"
+      >
+        <CatResizablePane>{editor}</CatResizablePane>
+      </ResizablePanel>
+      <ResizableHandle
+        withHandle
+        aria-label={intl.formatMessage(catWorkspaceViewMessages.resizeIntelligencePanel)}
+      />
+      <ResizablePanel
+        id="intelligence"
+        defaultSize={INTELLIGENCE_DEFAULT_SIZE}
+        minSize={INTELLIGENCE_MIN_SIZE}
+        maxSize={INTELLIGENCE_MAX_SIZE}
+        className="min-h-0 min-w-0 overflow-hidden"
+      >
+        <CatResizablePane>{intelligence}</CatResizablePane>
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  );
+}
+
+export function CatSideBySideResizableLayout({
+  editor,
+  intelligence,
+  className,
+}: {
+  editor: ReactNode;
+  intelligence: ReactNode;
+  className?: string;
+}) {
+  const intl = useIntl();
+  const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+    id: CAT_SIDE_BY_SIDE_LAYOUT_ID,
+    panelIds: [...SIDE_BY_SIDE_PANEL_IDS],
+    onlySaveAfterUserInteractions: true,
+  });
+
+  return (
+    <ResizablePanelGroup
+      id={CAT_SIDE_BY_SIDE_LAYOUT_ID}
+      orientation="horizontal"
+      className={cn("h-full min-h-0 min-w-0 overflow-hidden", className)}
+      defaultLayout={defaultLayout}
+      onLayoutChanged={onLayoutChanged}
+    >
+      <ResizablePanel
+        id="editor"
+        minSize={EDITOR_MIN_SIZE}
+        className="min-h-0 min-w-0 overflow-hidden"
+      >
+        <CatResizablePane>{editor}</CatResizablePane>
+      </ResizablePanel>
+      <ResizableHandle
+        withHandle
+        aria-label={intl.formatMessage(catWorkspaceViewMessages.resizeIntelligencePanel)}
+      />
+      <ResizablePanel
+        id="intelligence"
+        defaultSize={INTELLIGENCE_DEFAULT_SIZE}
+        minSize={INTELLIGENCE_MIN_SIZE}
+        maxSize={INTELLIGENCE_MAX_SIZE}
+        className="min-h-0 min-w-0 overflow-hidden"
+      >
+        <CatResizablePane>{intelligence}</CatResizablePane>
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.messages.ts
@@ -25,4 +25,15 @@ export const catWorkspaceViewMessages = defineMessages({
     id: "0x11s5ha3b",
     description: "Current segment index when more queue pages may exist and total count is unknown",
   },
+  resizeQueuePanel: {
+    defaultMessage: "Resize queue panel",
+    id: "e/sLamxaMH",
+    description: "Accessible name for the horizontal handle that resizes the CAT queue panel",
+  },
+  resizeIntelligencePanel: {
+    defaultMessage: "Resize translation intelligence panel",
+    id: "ml60MI46D3",
+    description:
+      "Accessible name for the horizontal handle that resizes the CAT translation intelligence panel",
+  },
 });

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.stories.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.stories.tsx
@@ -79,6 +79,10 @@ export const Default: Story = {
 
     await expect(canvas.getByText("Queue")).toBeInTheDocument();
     await expect(canvas.getByText("Translation Intelligence")).toBeInTheDocument();
+    await expect(canvas.getByRole("separator", { name: "Resize queue panel" })).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("separator", { name: "Resize translation intelligence panel" }),
+    ).toBeInTheDocument();
     await expect(canvas.getByText("Translation memory")).toBeInTheDocument();
     await expect(
       canvas.getByText("Dashboard card showing how many reviews still need approval."),

--- a/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/workspace/cat-workspace.tsx
@@ -33,6 +33,7 @@ import { resolveCatFileViewCapabilities } from "./cat-file-view-capabilities";
 import { CatPanelErrorBoundary } from "./cat-panel-error-boundary";
 import { useCatWorkspace } from "./cat-workspace-context";
 import { catWorkspaceViewMessages } from "./cat-workspace.messages";
+import { CatComfortableResizableLayout } from "./cat-workspace-resizable-layout";
 import { resolveSegmentIntelligenceForDisplay } from "./store/cat-workspace-store-utils";
 
 const COMPACT_WORKSPACE_QUERY = "(max-width: 1023px)";
@@ -701,19 +702,11 @@ export const CatWorkspaceView = observer(function CatWorkspaceView({
       ) : isSideBySideDesktop ? (
         renderSideBySidePanel()
       ) : (
-        <div className="grid h-full min-h-0 min-w-0 flex-1 grid-cols-[minmax(0,20rem)_minmax(0,1fr)_minmax(0,22rem)] overflow-hidden">
-          <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
-            {renderQueuePanel()}
-          </div>
-
-          <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
-            {renderEditorPanel()}
-          </div>
-
-          <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
-            {renderIntelligencePanel()}
-          </div>
-        </div>
+        <CatComfortableResizableLayout
+          queue={renderQueuePanel()}
+          editor={renderEditorPanel()}
+          intelligence={renderIntelligencePanel()}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Comfortable CAT editor view used a fixed three-column grid (`20rem` queue, flexible editor, `22rem` intelligence). Those columns are now shadcn `Resizable` panels, so translators can drag the vertical handles and grow or shrink the queue and intelligence panes.

Side by side gets the same treatment for its intelligence pane.

Chosen widths persist in `localStorage` (`cat-workspace-comfortable` and `cat-workspace-side-by-side`) after a user drag, with min/max clamps so the editor stays usable. Compact tab layout is unchanged.

## How to test

- Open a CAT file in Comfortable view on a wide viewport.
- Drag the handle between queue and editor, then the handle between editor and intelligence.
- Reload: the widths should stay.
- Switch to Side by side and resize the intelligence pane the same way.
- Narrow the viewport until the tabbed layout appears: resize handles should not show.

Automated:

```bash
cd apps/hyperlocalise-web
vp test src/components/cat/workspace/cat-workspace-resizable-layout.test.tsx src/components/cat/workspace/cat-workspace-container.test.tsx
vp check --fix
```

## Checklist

- [x] I ran relevant checks locally (`vp test` on CAT workspace tests, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d7df17b-b3c6-4122-a58b-174ac319bf40?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d7df17b-b3c6-4122-a58b-174ac319bf40&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

