### PR TITLE
fix(web): keep pg out of public web chat client bundle

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(public-chat)/chat/[organizationSlug]/[automationId]/web-chat-page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(public-chat)/chat/[organizationSlug]/[automationId]/web-chat-page.tsx
@@ -26,7 +26,7 @@ import { isApiResponseErrorCode, readApiResponseError } from "@/lib/api-error";
 import {
   WEB_CHAT_IMAGE_CONTENT_TYPES,
   WEB_CHAT_MAX_IMAGE_FILES,
-} from "@/lib/agents/workspace-automation-web-chat";
+} from "@/lib/agents/workspace-automation-web-chat-constants";
 import { cn } from "@/lib/primitives/cn";
 
 import { webChatPageMessages } from "./web-chat-page.messages";

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-web-chat-constants.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-web-chat-constants.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildWebChatSourceThreadId,
+  isWebChatImageContentType,
+  WEB_CHAT_IMAGE_UPLOAD_MULTIPART_OVERHEAD_BYTES,
+  WEB_CHAT_MAX_IMAGE_BYTES,
+  WEB_CHAT_MAX_IMAGE_FILES,
+  WEB_CHAT_MAX_IMAGE_REQUEST_BYTES,
+} from "./workspace-automation-web-chat-constants";
+
+describe("workspace automation web chat constants", () => {
+  it("accepts allowed image content types case-insensitively", () => {
+    expect(isWebChatImageContentType("image/png")).toBe(true);
+    expect(isWebChatImageContentType("IMAGE/JPEG")).toBe(true);
+    expect(isWebChatImageContentType("application/pdf")).toBe(false);
+  });
+
+  it("builds a stable visitor thread id", () => {
+    expect(
+      buildWebChatSourceThreadId({
+        automationId: "auto-1",
+        visitorId: "visitor-1",
+      }),
+    ).toBe("web-chat:auto-1:visitor-1");
+  });
+
+  it("sizes the request body limit for every attached image plus multipart overhead", () => {
+    expect(WEB_CHAT_MAX_IMAGE_REQUEST_BYTES).toBe(
+      WEB_CHAT_MAX_IMAGE_FILES * WEB_CHAT_MAX_IMAGE_BYTES +
+        WEB_CHAT_IMAGE_UPLOAD_MULTIPART_OVERHEAD_BYTES,
+    );
+  });
+
+  it("does not import the drizzle web chat store from the public chat client page", () => {
+    const pageSource = readFileSync(
+      new URL(
+        "../../app/[lang]/(public-chat)/chat/[organizationSlug]/[automationId]/web-chat-page.tsx",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    expect(pageSource).not.toMatch(/from ["']@\/lib\/agents\/workspace-automation-web-chat["']/);
+    expect(pageSource).toMatch(
+      /from ["']@\/lib\/agents\/workspace-automation-web-chat-constants["']/,
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-web-chat-constants.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-web-chat-constants.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+export const WEB_CHAT_VISITOR_COOKIE_NAME = "hl_web_chat_visitor";
+export const WEB_CHAT_HISTORY_LIMIT = 40;
+export const WEB_CHAT_MAX_IMAGE_FILES = 4;
+export const WEB_CHAT_MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+/** Multipart framing + text-field headroom beyond the per-file byte cap. */
+export const WEB_CHAT_IMAGE_UPLOAD_MULTIPART_OVERHEAD_BYTES = 64 * 1024;
+/** Request body limit must cover every attached image plus multipart framing. */
+export const WEB_CHAT_MAX_IMAGE_REQUEST_BYTES =
+  WEB_CHAT_MAX_IMAGE_FILES * WEB_CHAT_MAX_IMAGE_BYTES +
+  WEB_CHAT_IMAGE_UPLOAD_MULTIPART_OVERHEAD_BYTES;
+export const WEB_CHAT_IMAGE_CONTENT_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/jpg",
+  "image/webp",
+  "image/gif",
+]);
+
+export function buildWebChatSourceThreadId(input: { automationId: string; visitorId: string }) {
+  return `web-chat:${input.automationId}:${input.visitorId}`;
+}
+
+export function isWebChatImageContentType(contentType: string) {
+  return WEB_CHAT_IMAGE_CONTENT_TYPES.has(contentType.toLowerCase());
+}

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-web-chat.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-web-chat.ts
@@ -10,10 +10,16 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import "server-only";
+
 import { and, desc, eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 
+import {
+  WEB_CHAT_HISTORY_LIMIT,
+  buildWebChatSourceThreadId,
+} from "./workspace-automation-web-chat-constants";
 import {
   buildWorkspaceAutomationWebChatHref,
   buildWorkspaceAutomationWebChatPath,
@@ -25,36 +31,22 @@ import {
 } from "./workspace-automations";
 
 export {
+  buildWebChatSourceThreadId,
+  isWebChatImageContentType,
+  WEB_CHAT_HISTORY_LIMIT,
+  WEB_CHAT_IMAGE_CONTENT_TYPES,
+  WEB_CHAT_IMAGE_UPLOAD_MULTIPART_OVERHEAD_BYTES,
+  WEB_CHAT_MAX_IMAGE_BYTES,
+  WEB_CHAT_MAX_IMAGE_FILES,
+  WEB_CHAT_MAX_IMAGE_REQUEST_BYTES,
+  WEB_CHAT_VISITOR_COOKIE_NAME,
+} from "./workspace-automation-web-chat-constants";
+
+export {
   buildWorkspaceAutomationWebChatHref,
   buildWorkspaceAutomationWebChatPath,
   buildWorkspaceAutomationWebChatUrl,
 };
-
-export const WEB_CHAT_VISITOR_COOKIE_NAME = "hl_web_chat_visitor";
-export const WEB_CHAT_HISTORY_LIMIT = 40;
-export const WEB_CHAT_MAX_IMAGE_FILES = 4;
-export const WEB_CHAT_MAX_IMAGE_BYTES = 10 * 1024 * 1024;
-/** Multipart framing + text-field headroom beyond the per-file byte cap. */
-export const WEB_CHAT_IMAGE_UPLOAD_MULTIPART_OVERHEAD_BYTES = 64 * 1024;
-/** Request body limit must cover every attached image plus multipart framing. */
-export const WEB_CHAT_MAX_IMAGE_REQUEST_BYTES =
-  WEB_CHAT_MAX_IMAGE_FILES * WEB_CHAT_MAX_IMAGE_BYTES +
-  WEB_CHAT_IMAGE_UPLOAD_MULTIPART_OVERHEAD_BYTES;
-export const WEB_CHAT_IMAGE_CONTENT_TYPES = new Set([
-  "image/png",
-  "image/jpeg",
-  "image/jpg",
-  "image/webp",
-  "image/gif",
-]);
-
-export function buildWebChatSourceThreadId(input: { automationId: string; visitorId: string }) {
-  return `web-chat:${input.automationId}:${input.visitorId}`;
-}
-
-export function isWebChatImageContentType(contentType: string) {
-  return WEB_CHAT_IMAGE_CONTENT_TYPES.has(contentType.toLowerCase());
-}
 
 export async function findOrganizationBySlug(slug: string) {
   const [organization] = await db


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The public web chat client page imported image upload limits from `@/lib/agents/workspace-automation-web-chat`. That module also loads Drizzle/`pg`, so Next tried to put `pg` in the Client Component Browser graph and failed compiling `.well-known/workflow/v1/step`.

This follows the same split as #1931:

- Move client-safe constants and helpers into `workspace-automation-web-chat-constants.ts`.
- Keep database lookups in `workspace-automation-web-chat.ts` behind `import "server-only"`.
- Point `web-chat-page.tsx` at the constants module.

Server routes can still import constants from the store; they are re-exported.

## How to test

- `vp test src/lib/agents/workspace-automation-web-chat-constants.test.ts` from `apps/hyperlocalise-web`
- `vp test src/api/routes/web-chat/web-chat.route.test.ts` from `apps/hyperlocalise-web`
- Confirm `web-chat-page.tsx` no longer imports `@/lib/agents/workspace-automation-web-chat`
- After Postgres is up, `vp run dev` and load `/en/chat/<org>/<automation>` without a `pg` / module-not-found overlay

## Checklist

- [x] I ran relevant checks locally (`vp test` on the web-chat units; `vp check --fix` on changed files)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-066d6f0e-5c71-4cbf-b2ec-e1cfe16a5864?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-066d6f0e-5c71-4cbf-b2ec-e1cfe16a5864&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

