### PR TITLE
Add project Automations tab and show project picker for every trigger

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/workspace-automation/workspace-automation.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/workspace-automation/workspace-automation.route.test.ts
@@ -362,6 +362,64 @@ describe("workspace automation routes", () => {
     });
   });
 
+  it("lists automations filtered by projectId", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const organizationId = await getOrganizationId(identity.organization.workosOrganizationId);
+    const organizationSlug = identity.organization.slug ?? "missing-slug";
+    const projectId = await seedProject({ organizationId });
+    const otherProjectId = await seedProject({ organizationId });
+
+    const matchingResponse = await client.api.orgs[":organizationSlug"].automations.$post(
+      {
+        param: { organizationSlug },
+        json: {
+          name: "Website automation",
+          instructions: "Run for the website project.",
+          projectId,
+          triggerConfig: { mode: "manual" },
+          repositoryTarget: { kind: "none" },
+          toolConfig: {},
+        },
+      },
+      { headers },
+    );
+    expect(matchingResponse.status).toBe(201);
+    const matchingBody = (await matchingResponse.json()) as { automation: { id: string } };
+
+    const otherResponse = await client.api.orgs[":organizationSlug"].automations.$post(
+      {
+        param: { organizationSlug },
+        json: {
+          name: "Mobile automation",
+          instructions: "Run for the mobile project.",
+          projectId: otherProjectId,
+          triggerConfig: { mode: "manual" },
+          repositoryTarget: { kind: "none" },
+          toolConfig: {},
+        },
+      },
+      { headers },
+    );
+    expect(otherResponse.status).toBe(201);
+
+    const listedResponse = await client.api.orgs[":organizationSlug"].automations.$get(
+      {
+        param: { organizationSlug },
+        query: { projectId, limit: "50", offset: "0" },
+      },
+      { headers },
+    );
+    expect(listedResponse.status).toBe(200);
+    const listedBody = (await listedResponse.json()) as {
+      automations: Array<{ id: string; name: string }>;
+    };
+    expect(listedBody.automations.map((automation) => automation.id)).toEqual([
+      matchingBody.automation.id,
+    ]);
+    expect(listedBody.automations[0]?.name).toBe("Website automation");
+  });
+
   it("returns stable errors for invalid tool and trigger configuration", async () => {
     const identity = fixture.createWorkosIdentityWithRole("admin");
     const headers = await fixture.authHeadersFor(identity);

--- a/apps/hyperlocalise-web/src/api/routes/workspace-automation/workspace-automation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/workspace-automation/workspace-automation.route.ts
@@ -367,6 +367,7 @@ export function createWorkspaceAutomationRoutes() {
       const query = c.req.valid("query");
       const automations = await listWorkspaceAutomations({
         organizationId: c.var.auth.organization.localOrganizationId,
+        projectId: query.projectId,
         status: query.status,
         limit: query.limit,
         offset: query.offset,

--- a/apps/hyperlocalise-web/src/api/routes/workspace-automation/workspace-automation.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/workspace-automation/workspace-automation.schema.ts
@@ -17,6 +17,7 @@ import {
   workspaceAutomationModelSchema,
   workspaceAutomationStatusSchema,
 } from "@/lib/agents/workspace-automations";
+import { optionalProjectIdSchema } from "@/lib/projects/identity/project-id";
 
 export const workspaceAutomationIdParamSchema = z.object({
   automationId: z.string().uuid(),
@@ -24,6 +25,7 @@ export const workspaceAutomationIdParamSchema = z.object({
 
 export const listWorkspaceAutomationsQuerySchema = z.object({
   status: workspaceAutomationStatusSchema.optional(),
+  projectId: optionalProjectIdSchema,
   limit: z.coerce.number().int().min(1).max(100).default(50),
   offset: z.coerce.number().int().min(0).default(0),
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
+import { buildAutomationsPath } from "@/components/app-shell/navigation-config";
 import { apiClient } from "@/lib/api-client-instance";
 import {
   createWorkspaceAutomationFormStateFromRecord,
@@ -47,11 +48,13 @@ import { WorkspaceAutomationEditor } from "./workspace-automation-form";
 
 export function AutomationDetailPageContent({
   organizationSlug,
+  projectId,
   automationId,
   knowledgeAvailable = false,
   canUpdateKnowledgeMemory = false,
 }: {
   organizationSlug: string;
+  projectId?: string;
   automationId: string;
   knowledgeAvailable?: boolean;
   canUpdateKnowledgeMemory?: boolean;
@@ -59,6 +62,7 @@ export function AutomationDetailPageContent({
   const intl = useIntl();
   const router = useRouter();
   const queryClient = useQueryClient();
+  const automationsBasePath = buildAutomationsPath(organizationSlug, { projectId });
 
   const automationQuery = useQuery({
     queryKey: ["workspace-automation", organizationSlug, automationId],
@@ -202,7 +206,7 @@ export function AutomationDetailPageContent({
         queryKey: ["workspace-automations", organizationSlug],
       });
       setDeleteDialogOpen(false);
-      router.push(`/org/${organizationSlug}/automations`);
+      router.push(automationsBasePath);
     },
     onError: (error) => {
       if (error.message === "save_in_progress") {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-api.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-api.ts
@@ -37,7 +37,10 @@ export type GithubAutoReviewSettingsWrite = {
 };
 
 export type AutomationsApi = {
-  listAutomations(organizationSlug: string): Promise<AutomationSummaryRow[]>;
+  listAutomations(
+    organizationSlug: string,
+    options?: { projectId?: string },
+  ): Promise<AutomationSummaryRow[]>;
   getGithubAutoReviewSettings(organizationSlug: string): Promise<GithubAutoReviewSettingsDto>;
   updateGithubAutoReviewSettings(
     organizationSlug: string,
@@ -51,10 +54,14 @@ export function createAutomationsApi(client: ApiClient): AutomationsApi {
   const automations = client.api.orgs[":organizationSlug"].automations;
 
   return {
-    async listAutomations(organizationSlug) {
+    async listAutomations(organizationSlug, options) {
       const response = await automations.$get({
         param: { organizationSlug },
-        query: { limit: "100", offset: "0" },
+        query: {
+          limit: "100",
+          offset: "0",
+          ...(options?.projectId ? { projectId: options.projectId } : {}),
+        },
       });
       if (!response.ok) {
         throw await readApiResponseError(response, "Failed to load automations");

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-new-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-new-page-content.tsx
@@ -20,6 +20,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
+import { buildAutomationsPath } from "@/components/app-shell/navigation-config";
 import { apiClient } from "@/lib/api-client-instance";
 import {
   createDefaultWorkspaceAutomationFormState,
@@ -34,11 +35,13 @@ import { WorkspaceAutomationEditor } from "./workspace-automation-form";
 
 export function AutomationsNewPageContent({
   organizationSlug,
+  projectId,
   initialForm = createDefaultWorkspaceAutomationFormState(),
   knowledgeAvailable = false,
   canUpdateKnowledgeMemory = false,
 }: {
   organizationSlug: string;
+  projectId?: string;
   initialForm?: WorkspaceAutomationFormState;
   knowledgeAvailable?: boolean;
   canUpdateKnowledgeMemory?: boolean;
@@ -47,6 +50,7 @@ export function AutomationsNewPageContent({
   const router = useRouter();
   const [form, setForm] = useState(initialForm);
   const [errors, setErrors] = useState<Record<string, string | undefined>>({});
+  const automationsBasePath = buildAutomationsPath(organizationSlug, { projectId });
 
   const createMutation = useMutation({
     mutationFn: async () => {
@@ -79,7 +83,7 @@ export function AutomationsNewPageContent({
     },
     onSuccess: (body) => {
       toast.success(intl.formatMessage(automationsNewPageContentMessages.createSuccess));
-      router.push(`/org/${organizationSlug}/automations/${body.automation.id}`);
+      router.push(`${automationsBasePath}/${body.automation.id}`);
     },
     onError: (error) => {
       if (error.message === "validation_failed") {
@@ -104,7 +108,7 @@ export function AutomationsNewPageContent({
             <Button
               variant="outline"
               nativeButton={false}
-              render={<Link href={`/org/${organizationSlug}/automations`} />}
+              render={<Link href={automationsBasePath} />}
             >
               <FormattedMessage {...automationsNewPageContentMessages.cancel} />
             </Button>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-content.tsx
@@ -28,8 +28,8 @@ import { githubAutoReviewCardMessages } from "./github-auto-review-card.messages
 
 const automationsApi = createAutomationsApi(apiClient);
 
-function automationsQueryKey(organizationSlug: string) {
-  return ["workspace-automations", organizationSlug] as const;
+function automationsQueryKey(organizationSlug: string, projectId?: string) {
+  return ["workspace-automations", organizationSlug, projectId ?? "all"] as const;
 }
 
 function githubAutoReviewQueryKey(organizationSlug: string) {
@@ -66,21 +66,24 @@ function renderProductionActionLink({
 
 export function AutomationsPageContent({
   organizationSlug,
+  projectId,
   templates,
   automationsApi: injectedAutomationsApi = automationsApi,
 }: {
   organizationSlug: string;
+  projectId?: string;
   templates: WorkspaceAutomationTemplate[];
   automationsApi?: typeof automationsApi;
 }) {
   const intl = useIntl();
   const queryClient = useQueryClient();
   const automationsQuery = useQuery({
-    queryKey: automationsQueryKey(organizationSlug),
-    queryFn: () => injectedAutomationsApi.listAutomations(organizationSlug),
+    queryKey: automationsQueryKey(organizationSlug, projectId),
+    queryFn: () => injectedAutomationsApi.listAutomations(organizationSlug, { projectId }),
   });
   const autoReviewQuery = useQuery({
     queryKey: githubAutoReviewQueryKey(organizationSlug),
+    enabled: !projectId,
     queryFn: () => injectedAutomationsApi.getGithubAutoReviewSettings(organizationSlug),
   });
   const saveAutoReview = useMutation({
@@ -103,6 +106,7 @@ export function AutomationsPageContent({
   return (
     <AutomationsPageView
       organizationSlug={organizationSlug}
+      projectId={projectId}
       automations={automationsQuery.data ?? []}
       templates={templates}
       isLoading={automationsQuery.isLoading}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.test.ts
@@ -14,7 +14,7 @@ import { createIntl } from "@formatjs/intl";
 import { describe, expect, it } from "vite-plus/test";
 
 import { createAutomationSummary } from "./automations.fixture";
-import { resolveAutomationCreatorName } from "./automations-page-view-model";
+import { resolveAutomationCreatorName, resolveVisibleAutomations } from "./automations-page-view-model";
 
 const intl = createIntl({ locale: "en", messages: {} });
 
@@ -29,5 +29,26 @@ describe("resolveAutomationCreatorName", () => {
     expect(resolveAutomationCreatorName(intl, createAutomationSummary({ authorName: null }))).toBe(
       "Unknown",
     );
+  });
+});
+
+describe("resolveVisibleAutomations", () => {
+  it("hides archived automations", () => {
+    const visible = createAutomationSummary({ id: "visible", status: "active" });
+    const archived = createAutomationSummary({ id: "archived", status: "archived" });
+
+    expect(resolveVisibleAutomations([visible, archived]).map((item) => item.id)).toEqual([
+      "visible",
+    ]);
+  });
+
+  it("keeps automations for the selected project", () => {
+    const matching = createAutomationSummary({ id: "matching", projectId: "project-1" });
+    const other = createAutomationSummary({ id: "other", projectId: "project-2" });
+    const unscoped = createAutomationSummary({ id: "unscoped", projectId: null });
+
+    expect(
+      resolveVisibleAutomations([matching, other, unscoped], "project-1").map((item) => item.id),
+    ).toEqual(["matching"]);
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.test.ts
@@ -14,7 +14,10 @@ import { createIntl } from "@formatjs/intl";
 import { describe, expect, it } from "vite-plus/test";
 
 import { createAutomationSummary } from "./automations.fixture";
-import { resolveAutomationCreatorName, resolveVisibleAutomations } from "./automations-page-view-model";
+import {
+  resolveAutomationCreatorName,
+  resolveVisibleAutomations,
+} from "./automations-page-view-model";
 
 const intl = createIntl({ locale: "en", messages: {} });
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view-model.ts
@@ -25,8 +25,19 @@ import type {
 
 import { automationsPageViewModelMessages } from "./automations-page-view-model.messages";
 
-export function resolveVisibleAutomations(automations: WorkspaceAutomationRecord[]) {
-  return automations.filter((automation) => automation.status !== "archived");
+export function resolveVisibleAutomations(
+  automations: WorkspaceAutomationRecord[],
+  projectId?: string,
+) {
+  return automations.filter((automation) => {
+    if (automation.status === "archived") {
+      return false;
+    }
+    if (!projectId) {
+      return true;
+    }
+    return automation.projectId === projectId;
+  });
 }
 
 export function resolveAutomationPageStats(automations: WorkspaceAutomationRecord[]) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.messages.ts
@@ -20,6 +20,11 @@ export const automationsPageViewMessages = defineMessages({
     id: "22cLivfsp0",
     description: "Automations page header eyebrow label",
   },
+  pageLabelProject: {
+    defaultMessage: "Project",
+    id: "+WMW4vljPC",
+    description: "Project automations page header eyebrow label",
+  },
   pageTitle: {
     defaultMessage: "Automations",
     id: "hScQeR54rc",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.stories.tsx
@@ -137,3 +137,23 @@ export const ActivatableTemplate: Story = {
     await expect(canvas.getAllByRole("button", { name: "Add" })).not.toHaveLength(0);
   },
 };
+
+export const ProjectScoped: Story = {
+  args: {
+    projectId: "project-1",
+    automations: automationsFixture.filter((automation) => automation.projectId === "project-1"),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Automations" })).toBeInTheDocument();
+    await expect(canvas.queryByRole("heading", { name: "From Hyperlocalise" })).not.toBeInTheDocument();
+    await expect(canvas.queryByText("Auto-review")).not.toBeInTheDocument();
+    await expect(canvas.getByText("Validate localisation on push")).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("link", { name: /Validate localisation on push/i }),
+    ).toHaveAttribute("href", "/org/acme/projects/project-1/automations/11111111-1111-4111-8111-111111111111");
+    await expect(canvas.getByRole("link", { name: /New Automation/i })).toHaveAttribute(
+      "href",
+      "/org/acme/projects/project-1/automations/new",
+    );
+  },
+};

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.stories.tsx
@@ -145,6 +145,7 @@ export const ProjectScoped: Story = {
   },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("heading", { name: "Automations" })).toBeInTheDocument();
+    await expect(canvas.getByText("Project")).toBeInTheDocument();
     await expect(
       canvas.queryByRole("heading", { name: "From Hyperlocalise" }),
     ).not.toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.stories.tsx
@@ -145,12 +145,17 @@ export const ProjectScoped: Story = {
   },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole("heading", { name: "Automations" })).toBeInTheDocument();
-    await expect(canvas.queryByRole("heading", { name: "From Hyperlocalise" })).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole("heading", { name: "From Hyperlocalise" }),
+    ).not.toBeInTheDocument();
     await expect(canvas.queryByText("Auto-review")).not.toBeInTheDocument();
     await expect(canvas.getByText("Validate localisation on push")).toBeInTheDocument();
     await expect(
       canvas.getByRole("link", { name: /Validate localisation on push/i }),
-    ).toHaveAttribute("href", "/org/acme/projects/project-1/automations/11111111-1111-4111-8111-111111111111");
+    ).toHaveAttribute(
+      "href",
+      "/org/acme/projects/project-1/automations/11111111-1111-4111-8111-111111111111",
+    );
     await expect(canvas.getByRole("link", { name: /New Automation/i })).toHaveAttribute(
       "href",
       "/org/acme/projects/project-1/automations/new",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
@@ -18,6 +18,7 @@ import { Add01Icon, SparklesIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
 
+import { buildAutomationsPath } from "@/components/app-shell/navigation-config";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -148,6 +149,7 @@ function AutomationToolsSummary({ automation }: { automation: WorkspaceAutomatio
 
 export function AutomationsPageView({
   organizationSlug,
+  projectId,
   automations,
   templates,
   isLoading,
@@ -162,6 +164,7 @@ export function AutomationsPageView({
   renderActionLink = defaultRenderActionLink,
 }: {
   organizationSlug: string;
+  projectId?: string;
   automations: WorkspaceAutomationRecord[];
   templates: WorkspaceAutomationTemplate[];
   isLoading: boolean;
@@ -178,8 +181,12 @@ export function AutomationsPageView({
   const intl = useIntl();
   const [templateCategoryFilter, setTemplateCategoryFilter] =
     useState<WorkspaceAutomationTemplateCategory>("popular");
+  const automationsBasePath = buildAutomationsPath(organizationSlug, { projectId });
 
-  const visibleAutomations = useMemo(() => resolveVisibleAutomations(automations), [automations]);
+  const visibleAutomations = useMemo(
+    () => resolveVisibleAutomations(automations, projectId),
+    [automations, projectId],
+  );
   const stats = useMemo(() => resolveAutomationPageStats(visibleAutomations), [visibleAutomations]);
   const sortedTemplates = useMemo(() => resolveSortedAutomationTemplates(templates), [templates]);
   const templateCategoryTabs = useMemo(
@@ -199,7 +206,7 @@ export function AutomationsPageView({
         title={intl.formatMessage(automationsPageViewMessages.pageTitle)}
         description={intl.formatMessage(automationsPageViewMessages.pageDescription)}
         actions={renderActionLink({
-          href: `/org/${organizationSlug}/automations/new`,
+          href: `${automationsBasePath}/new`,
           kind: "header",
           children: (
             <>
@@ -237,14 +244,16 @@ export function AutomationsPageView({
         </Card>
       </section>
 
-      <GithubAutoReviewCard
-        organizationSlug={organizationSlug}
-        settings={autoReview}
-        isLoading={autoReviewLoading}
-        error={autoReviewError}
-        isSaving={autoReviewSaving}
-        onSave={onSaveAutoReview}
-      />
+      {projectId ? null : (
+        <GithubAutoReviewCard
+          organizationSlug={organizationSlug}
+          settings={autoReview}
+          isLoading={autoReviewLoading}
+          error={autoReviewError}
+          isSaving={autoReviewSaving}
+          onSave={onSaveAutoReview}
+        />
+      )}
 
       <section className="flex flex-col gap-4">
         <div className="overflow-x-auto rounded-xl border border-border">
@@ -288,7 +297,7 @@ export function AutomationsPageView({
             visibleAutomations.map((automation) => (
               <Fragment key={automation.id}>
                 {renderAutomationLink({
-                  href: `/org/${organizationSlug}/automations/${automation.id}`,
+                  href: `${automationsBasePath}/${automation.id}`,
                   className: `${AUTOMATION_LIST_GRID_CLASS} border-b border-border px-4 py-4 transition-colors last:border-b-0 hover:bg-muted`,
                   children: (
                     <>
@@ -364,7 +373,7 @@ export function AutomationsPageView({
                 <div className="mt-auto flex items-center gap-2">
                   {template.activatable ? (
                     renderActionLink({
-                      href: `/org/${organizationSlug}/automations/new?template=${template.id}`,
+                      href: `${automationsBasePath}/new?template=${template.id}`,
                       kind: "template",
                       children: <FormattedMessage {...automationsPageViewMessages.addTemplate} />,
                     })

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
@@ -202,7 +202,11 @@ export function AutomationsPageView({
     <WorkspacePageShell>
       <PageHeader
         icon={SparklesIcon}
-        label={intl.formatMessage(automationsPageViewMessages.pageLabel)}
+        label={intl.formatMessage(
+          projectId
+            ? automationsPageViewMessages.pageLabelProject
+            : automationsPageViewMessages.pageLabel,
+        )}
         title={intl.formatMessage(automationsPageViewMessages.pageTitle)}
         description={intl.formatMessage(automationsPageViewMessages.pageDescription)}
         actions={renderActionLink({

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-editor.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-editor.stories.tsx
@@ -127,7 +127,9 @@ export const CreateEmpty: Story = {
 export const ProjectSelectorForScheduledTrigger: Story = {
   play: async ({ canvas, canvasElement, userEvent }) => {
     const body = within(canvasElement.ownerDocument.body);
-    await expect(await canvas.findByRole("button", { name: /Select project/i })).toBeInTheDocument();
+    await expect(
+      await canvas.findByRole("button", { name: /Select project/i }),
+    ).toBeInTheDocument();
     await userEvent.click(canvas.getByRole("button", { name: "Add Trigger" }));
     await userEvent.click(await body.findByRole("menuitem", { name: /^Scheduled/ }));
     await expect(canvas.getByRole("button", { name: /Select project/i })).toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-editor.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-editor.stories.tsx
@@ -124,6 +124,16 @@ export const CreateEmpty: Story = {
   },
 };
 
+export const ProjectSelectorForScheduledTrigger: Story = {
+  play: async ({ canvas, canvasElement, userEvent }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await expect(await canvas.findByRole("button", { name: /Select project/i })).toBeInTheDocument();
+    await userEvent.click(canvas.getByRole("button", { name: "Add Trigger" }));
+    await userEvent.click(await body.findByRole("menuitem", { name: /^Scheduled/ }));
+    await expect(canvas.getByRole("button", { name: /Select project/i })).toBeInTheDocument();
+  },
+};
+
 export const CreateModelOptions: Story = {
   play: async ({ canvas, canvasElement, userEvent }) => {
     const body = within(canvasElement.ownerDocument.body);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -3057,23 +3057,15 @@ export function WorkspaceAutomationEditor({
               )}
             </span>
           </label>
-          {form.createNativeTmsJobEnabled ||
-          form.assignTranslateWithAgentEnabled ||
-          form.contentfulEnabled ||
-          (form.githubEnabled && form.githubMode === "sync") ||
-          form.triggerMode === "source_upload" ? (
-            <>
-              <span className="text-border">{METADATA_SEPARATOR}</span>
-              <HeaderProjectSelector
-                disabled={disabled}
-                form={form}
-                isError={projectsQuery.isError}
-                isLoading={projectsQuery.isLoading}
-                onChange={onChange}
-                projects={projectsQuery.data ?? []}
-              />
-            </>
-          ) : null}
+          <span className="text-border">{METADATA_SEPARATOR}</span>
+          <HeaderProjectSelector
+            disabled={disabled}
+            form={form}
+            isError={projectsQuery.isError}
+            isLoading={projectsQuery.isLoading}
+            onChange={onChange}
+            projects={projectsQuery.data ?? []}
+          />
           {form.triggerMode !== "manual" ? (
             <>
               <span className="text-border">{METADATA_SEPARATOR}</span>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/automations/[automationId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/automations/[automationId]/page.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { Suspense } from "react";
+
+import { hasCapability } from "@/api/auth/policy";
+import {
+  evaluateWorkspaceFeatureFlags,
+  requireWorkspaceFeatureFlag,
+  workspaceAutomationsFlag,
+} from "@/lib/flags/workspace-flags";
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
+
+import { AutomationDetailPageContent } from "../../../../automations/_components/automation-detail-page-content";
+
+export default async function ProjectAutomationDetailPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; projectId: string; automationId: string }>;
+}) {
+  const { organizationSlug, projectId, automationId } = await params;
+  const auth = await requireAppAuthContext({ organizationSlug });
+  await requireWorkspaceFeatureFlag(workspaceAutomationsFlag, auth);
+  const flags = await evaluateWorkspaceFeatureFlags(auth);
+
+  return (
+    <Suspense fallback={null}>
+      <AutomationDetailPageContent
+        organizationSlug={organizationSlug}
+        projectId={projectId}
+        automationId={automationId}
+        knowledgeAvailable={flags.knowledge}
+        canUpdateKnowledgeMemory={hasCapability(auth.membership.role, "workspace:update")}
+      />
+    </Suspense>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/automations/new/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/automations/new/page.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { Suspense } from "react";
+
+import { hasCapability } from "@/api/auth/policy";
+import {
+  createDefaultWorkspaceAutomationFormState,
+  createWorkspaceAutomationFormStateFromTemplate,
+} from "@/lib/agents/workspace-automation-view-model";
+import { getMergedWorkspaceAutomationTemplates } from "@/lib/agents/workspace-automation-templates.server";
+import {
+  evaluateWorkspaceFeatureFlags,
+  requireWorkspaceFeatureFlag,
+  workspaceAutomationsFlag,
+} from "@/lib/flags/workspace-flags";
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
+
+import { AutomationsNewPageContent } from "../../../../automations/_components/automations-new-page-content";
+
+export default async function ProjectNewAutomationPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ organizationSlug: string; projectId: string }>;
+  searchParams: Promise<{ template?: string }>;
+}) {
+  const { organizationSlug, projectId } = await params;
+  const { template } = await searchParams;
+  const auth = await requireAppAuthContext({ organizationSlug });
+  await requireWorkspaceFeatureFlag(workspaceAutomationsFlag, auth);
+  const flags = await evaluateWorkspaceFeatureFlags(auth);
+  const templates = getMergedWorkspaceAutomationTemplates();
+  const templateForm = template
+    ? createWorkspaceAutomationFormStateFromTemplate(template, templates)
+    : null;
+  const initialForm = {
+    ...(templateForm ?? createDefaultWorkspaceAutomationFormState()),
+    projectId,
+  };
+
+  return (
+    <Suspense fallback={null}>
+      <AutomationsNewPageContent
+        organizationSlug={organizationSlug}
+        projectId={projectId}
+        initialForm={initialForm}
+        knowledgeAvailable={flags.knowledge}
+        canUpdateKnowledgeMemory={hasCapability(auth.membership.role, "workspace:update")}
+      />
+    </Suspense>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/automations/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/automations/page.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { Suspense } from "react";
+
+import { getMergedWorkspaceAutomationTemplates } from "@/lib/agents/workspace-automation-templates.server";
+import { requireWorkspaceFeatureFlag, workspaceAutomationsFlag } from "@/lib/flags/workspace-flags";
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
+
+import { AutomationsPageContent } from "../../../automations/_components/automations-page-content";
+
+export default async function ProjectAutomationsPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; projectId: string }>;
+}) {
+  const { organizationSlug, projectId } = await params;
+  const auth = await requireAppAuthContext({ organizationSlug });
+  await requireWorkspaceFeatureFlag(workspaceAutomationsFlag, auth);
+  const templates = getMergedWorkspaceAutomationTemplates();
+
+  return (
+    <Suspense fallback={null}>
+      <AutomationsPageContent
+        organizationSlug={organizationSlug}
+        projectId={projectId}
+        templates={templates}
+      />
+    </Suspense>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -24,6 +24,7 @@ import { RELEASE_CAT_ALL_FILES_FLAG } from "@/lib/flags/release-flag-keys";
 import { encodeProviderProjectId } from "@/lib/providers/jobs/tms-provider-resource-id";
 
 import {
+  buildAutomationsPath,
   buildGlobalNavigationGroups,
   buildOrganizationPath,
   buildProjectNavigationItems,
@@ -159,6 +160,23 @@ describe("path builders", () => {
     expect(buildProjectPath("acme", "proj_1", "files")).toBe("/org/acme/projects/proj_1/files");
   });
 
+  it("builds workspace and project automations paths", () => {
+    expect(buildAutomationsPath("acme")).toBe("/org/acme/automations");
+    expect(buildAutomationsPath("acme", { section: "new" })).toBe("/org/acme/automations/new");
+    expect(buildAutomationsPath("acme", { automationId: "auto_1" })).toBe(
+      "/org/acme/automations/auto_1",
+    );
+    expect(buildAutomationsPath("acme", { projectId: "proj_1" })).toBe(
+      "/org/acme/projects/proj_1/automations",
+    );
+    expect(buildAutomationsPath("acme", { projectId: "proj_1", section: "new" })).toBe(
+      "/org/acme/projects/proj_1/automations/new",
+    );
+    expect(
+      buildAutomationsPath("acme", { projectId: "ext:crowdin:1", automationId: "auto_1" }),
+    ).toBe("/org/acme/projects/ext%3Acrowdin%3A1/automations/auto_1");
+  });
+
   it("encodes reserved characters in the project id segment", () => {
     expect(buildProjectPath("acme", "ext:crowdin:1", "jobs")).toBe(
       "/org/acme/projects/ext%3Acrowdin%3A1/jobs",
@@ -191,9 +209,13 @@ describe("path builders", () => {
       ["Strings", "/org/acme/projects/proj_1/strings"],
       ["Jobs", "/org/acme/projects/proj_1/jobs"],
       ["Issues", "/org/acme/projects/proj_1/issue-sheet"],
+      ["Automations", "/org/acme/projects/proj_1/automations"],
       ["Settings", "/org/acme/projects/proj_1/settings"],
     ]);
     expect(items.find((item) => item.label === "Issues")?.featureFlagKey).toBeUndefined();
+    expect(items.find((item) => item.label === "Automations")?.featureFlagKey).toBe(
+      WORKSPACE_AUTOMATIONS_FLAG,
+    );
   });
 });
 
@@ -273,6 +295,13 @@ describe("buildProjectNavigationItems", () => {
     });
     const items = buildProjectNavigationItems("acme", projectId, intl);
     expect(items.find((item) => item.label === "Strings")).toBeUndefined();
+  });
+
+  it("includes an Automations item gated by the workspace automations flag", () => {
+    const items = buildProjectNavigationItems("acme", "proj_1", intl);
+    const automationsItem = items.find((item) => item.label === "Automations");
+    expect(automationsItem?.href).toBe("/org/acme/projects/proj_1/automations");
+    expect(automationsItem?.featureFlagKey).toBe(WORKSPACE_AUTOMATIONS_FLAG);
   });
 });
 

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -73,6 +73,26 @@ export function buildProjectPath(organizationSlug: string, projectId: string, se
   return section ? `${base}/${section}` : base;
 }
 
+export function buildAutomationsPath(
+  organizationSlug: string,
+  options?: {
+    automationId?: string;
+    projectId?: string;
+    section?: "new";
+  },
+) {
+  const suffix = options?.section === "new" ? "new" : options?.automationId;
+  if (options?.projectId) {
+    return suffix
+      ? buildProjectPath(organizationSlug, options.projectId, `automations/${suffix}`)
+      : buildProjectPath(organizationSlug, options.projectId, "automations");
+  }
+
+  return suffix
+    ? buildOrganizationPath(organizationSlug, `automations/${suffix}`)
+    : buildOrganizationPath(organizationSlug, "automations");
+}
+
 export function buildGlobalNavigationGroups(
   organizationSlug: string,
   intl: IntlShape,
@@ -317,6 +337,16 @@ export function buildProjectNavigationItems(
       }),
       href: project("issue-sheet"),
       icon: ClipboardListIcon,
+    },
+    {
+      label: intl.formatMessage({
+        defaultMessage: "Automations",
+        id: "kQ8mN4pR2s",
+        description: "Project sidebar navigation item for project automations",
+      }),
+      href: project("automations"),
+      icon: Task01Icon,
+      featureFlagKey: WORKSPACE_AUTOMATIONS_FLAG,
     },
     {
       label: intl.formatMessage({

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -341,7 +341,7 @@ export function buildProjectNavigationItems(
     {
       label: intl.formatMessage({
         defaultMessage: "Automations",
-        id: "kQ8mN4pR2s",
+        id: "Weqt7PXrnL",
         description: "Project sidebar navigation item for project automations",
       }),
       href: project("automations"),

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
@@ -839,6 +839,75 @@ describe("workspace automations", () => {
     expect(secondPage.map((item) => item.name)).toEqual(["Automation 1"]);
   });
 
+  it("lists automations for a single project including legacy tool project ids", async () => {
+    const scope = await seedWorkspaceAutomationScope();
+    const otherProjectId = `project-${crypto.randomUUID().slice(0, 8)}`;
+    await db.insert(schema.projects).values({
+      id: otherProjectId,
+      organizationId: scope.organizationId,
+      createdByUserId: scope.userId,
+      name: "Mobile",
+    });
+
+    const matching = expectOk(
+      await createWorkspaceAutomation({
+        organizationId: scope.organizationId,
+        authorUserId: scope.userId,
+        name: "Matching project automation",
+        instructions: "Run for the website project.",
+        projectId: scope.projectId,
+      }),
+    );
+    expectOk(
+      await createWorkspaceAutomation({
+        organizationId: scope.organizationId,
+        authorUserId: scope.userId,
+        name: "Other project automation",
+        instructions: "Run for the mobile project.",
+        projectId: otherProjectId,
+      }),
+    );
+    expectOk(
+      await createWorkspaceAutomation({
+        organizationId: scope.organizationId,
+        authorUserId: scope.userId,
+        name: "Unscoped automation",
+        instructions: "Run without a project.",
+      }),
+    );
+
+    const [legacy] = await db
+      .insert(schema.workspaceAutomations)
+      .values({
+        organizationId: scope.organizationId,
+        authorUserId: scope.userId,
+        status: "active",
+        name: "Legacy translation project automation",
+        instructions: "Run from a legacy tool project id.",
+        model: "openai/gpt-5.6-luna",
+        projectId: null,
+        triggerConfig: { mode: "manual" },
+        repositoryTarget: { kind: "none" },
+        toolConfig: {
+          translation: { enabled: true, projectId: scope.projectId },
+        },
+        configVersion: 1,
+      })
+      .returning();
+
+    const listed = await listWorkspaceAutomations({
+      organizationId: scope.organizationId,
+      projectId: scope.projectId,
+    });
+
+    expect(listed.map((item) => item.name).toSorted()).toEqual([
+      "Legacy translation project automation",
+      "Matching project automation",
+    ]);
+    expect(listed.some((item) => item.id === matching.id)).toBe(true);
+    expect(listed.some((item) => item.id === legacy?.id)).toBe(true);
+  });
+
   it("falls back to email for author names and omits missing authors", async () => {
     const scope = await seedWorkspaceAutomationScope();
     const emailOnlyUserId = crypto.randomUUID();

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -948,8 +948,24 @@ export async function getWorkspaceAutomationById(input: {
   return row ? serializeAutomationWithAuthor(row) : null;
 }
 
+function workspaceAutomationMatchesProjectId(projectId: string) {
+  return or(
+    eq(schema.workspaceAutomations.projectId, projectId),
+    and(
+      isNull(schema.workspaceAutomations.projectId),
+      sql`(
+        ${schema.workspaceAutomations.toolConfig}->'contentful'->>'projectId' = ${projectId}
+        OR ${schema.workspaceAutomations.toolConfig}->'translation'->>'projectId' = ${projectId}
+        OR ${schema.workspaceAutomations.toolConfig}->'github'->>'projectId' = ${projectId}
+        OR ${schema.workspaceAutomations.toolConfig}->'createNativeTmsJob'->>'projectId' = ${projectId}
+      )`,
+    ),
+  );
+}
+
 export async function listWorkspaceAutomations(input: {
   organizationId: string;
+  projectId?: string;
   status?: WorkspaceAutomationStatus;
   contentfulWebhookConnectionId?: string;
   contentfulWebhookContentTypeId?: string | null;
@@ -963,6 +979,7 @@ export async function listWorkspaceAutomations(input: {
 
   const conditions = [
     eq(schema.workspaceAutomations.organizationId, input.organizationId),
+    ...(input.projectId ? [workspaceAutomationMatchesProjectId(input.projectId)] : []),
     ...(input.status ? [eq(schema.workspaceAutomations.status, input.status)] : []),
     ...(input.contentfulWebhookConnectionId
       ? [
@@ -1022,16 +1039,7 @@ export async function listSourceUploadWorkspaceAutomations(input: {
           ${schema.workspaceAutomations.toolConfig}->'createNativeTmsJob'->>'enabled' = 'true'
           OR ${schema.workspaceAutomations.toolConfig}->'translation'->>'enabled' = 'true'
         )`,
-        or(
-          eq(schema.workspaceAutomations.projectId, input.projectId),
-          and(
-            isNull(schema.workspaceAutomations.projectId),
-            sql`(
-              ${schema.workspaceAutomations.toolConfig}->'createNativeTmsJob'->>'projectId' = ${input.projectId}
-              OR ${schema.workspaceAutomations.toolConfig}->'translation'->>'projectId' = ${input.projectId}
-            )`,
-          ),
-        ),
+        workspaceAutomationMatchesProjectId(input.projectId),
       ),
     )
     .orderBy(desc(schema.workspaceAutomations.createdAt))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds an Automations item to the project sidebar that opens a project-scoped automations list (`/org/:slug/projects/:id/automations`). Create and detail stay under that project path. The page uses a Project eyebrow and hides the org-level GitHub Auto-review card.

The list API accepts an optional `projectId` query and matches both `workspace_automations.project_id` and legacy tool JSON (`contentful`, `translation`, `github`, `createNativeTmsJob`).

The automation editor header now always shows the project picker, including Scheduled triggers. Project remains required only for the same tool/trigger combinations as before.

## How to test

- Open a project with the workspace automations flag. The sidebar should include Automations after Issues.
- The page should list only that project's automations; New Automation should stay under the project path.
- Create a scheduled automation: the header project selector should remain visible after adding a Scheduled trigger.
- `vp test` and `vp check --fix` in `apps/hyperlocalise-web`.

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix` in `apps/hyperlocalise-web`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a6777aa-26ab-46e1-9702-c415ff46c5f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a6777aa-26ab-46e1-9702-c415ff46c5f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

