### PR TITLE
fix(web): keep pg out of automation knowledge client bundle

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-knowledge-files-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-knowledge-files-panel.tsx
@@ -23,11 +23,11 @@ import { Button } from "@/components/ui/button";
 import { createApiClient } from "@/lib/api-client";
 import { isApiResponseErrorCode, readApiResponseError } from "@/lib/api-error";
 import {
+  WORKSPACE_AUTOMATION_KNOWLEDGE_ACCEPT_EXTENSIONS,
   WORKSPACE_AUTOMATION_KNOWLEDGE_MAX_BYTES,
   WORKSPACE_AUTOMATION_KNOWLEDGE_MAX_FILES,
   type WorkspaceAutomationKnowledgeFileSummary,
-} from "@/lib/agents/workspace-automation-knowledge-files";
-import { WORKSPACE_AUTOMATION_KNOWLEDGE_ACCEPT_EXTENSIONS } from "@/lib/agents/workspace-automation-knowledge-text";
+} from "@/lib/agents/workspace-automation-knowledge-constants";
 
 import { workspaceAutomationFormMessages } from "./workspace-automation-form.messages";
 

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-knowledge-constants.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-knowledge-constants.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  isSupportedWorkspaceAutomationKnowledgeFilename,
+  WORKSPACE_AUTOMATION_KNOWLEDGE_ACCEPT_EXTENSIONS,
+  WORKSPACE_AUTOMATION_KNOWLEDGE_MAX_BYTES,
+  WORKSPACE_AUTOMATION_KNOWLEDGE_MAX_FILES,
+} from "./workspace-automation-knowledge-constants";
+
+describe("workspace automation knowledge constants", () => {
+  it("accepts document filenames used for agent knowledge", () => {
+    expect(isSupportedWorkspaceAutomationKnowledgeFilename("policy.pdf")).toBe(true);
+    expect(isSupportedWorkspaceAutomationKnowledgeFilename("notes.MD")).toBe(true);
+    expect(isSupportedWorkspaceAutomationKnowledgeFilename("guide.docx")).toBe(true);
+    expect(isSupportedWorkspaceAutomationKnowledgeFilename("photo.png")).toBe(false);
+    expect(WORKSPACE_AUTOMATION_KNOWLEDGE_ACCEPT_EXTENSIONS).toEqual([
+      ".pdf",
+      ".txt",
+      ".md",
+      ".markdown",
+      ".csv",
+      ".json",
+      ".docx",
+    ]);
+    expect(WORKSPACE_AUTOMATION_KNOWLEDGE_MAX_FILES).toBe(20);
+    expect(WORKSPACE_AUTOMATION_KNOWLEDGE_MAX_BYTES).toBe(25 * 1024 * 1024);
+  });
+
+  it("does not import drizzle or unpdf from the knowledge files client panel", () => {
+    const panelSource = readFileSync(
+      new URL(
+        "../../app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-knowledge-files-panel.tsx",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    expect(panelSource).not.toMatch(
+      /from ["']@\/lib\/agents\/workspace-automation-knowledge-files["']/,
+    );
+    expect(panelSource).not.toMatch(
+      /from ["']@\/lib\/agents\/workspace-automation-knowledge-text["']/,
+    );
+    expect(panelSource).toMatch(
+      /from ["']@\/lib\/agents\/workspace-automation-knowledge-constants["']/,
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-knowledge-constants.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-knowledge-constants.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Hyperlocalise Pty Ltd
+ *
+ * Use of this software is governed by the Business Source License 1.1
+ * included in this application's LICENSE file.
+ *
+ * Change Date: Four years after publication of the applicable version.
+ *
+ * On the Change Date, in accordance with the Business Source License, use
+ * of this software will be governed by the GNU General Public License
+ * Version 2.0 or later.
+ */
+
+export const WORKSPACE_AUTOMATION_KNOWLEDGE_MAX_FILES = 20;
+export const WORKSPACE_AUTOMATION_KNOWLEDGE_MAX_BYTES = 25 * 1024 * 1024;
+export const WORKSPACE_AUTOMATION_KNOWLEDGE_MAX_EXTRACTED_CHARS = 100_000;
+
+export const WORKSPACE_AUTOMATION_KNOWLEDGE_ACCEPT_EXTENSIONS = [
+  ".pdf",
+  ".txt",
+  ".md",
+  ".markdown",
+  ".csv",
+  ".json",
+  ".docx",
+] as const;
+
+const ACCEPT_EXTENSIONS = new Set<string>(WORKSPACE_AUTOMATION_KNOWLEDGE_ACCEPT_EXTENSIONS);
+
+export type WorkspaceAutomationKnowledgeFileRecord = {
+  id: string;
+  organizationId: string;
+  automationId: string;
+  storedFileId: string;
+  filename: string;
+  contentType: string;
+  byteSize: number;
+  extractedText: string;
+  createdByUserId: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type WorkspaceAutomationKnowledgeFileSummary = Omit<
+  WorkspaceAutomationKnowledgeFileRecord,
+  "extractedText"
+> & {
+  extractedCharacterCount: number;
+};
+
+export function isSupportedWorkspaceAutomationKnowledgeFilename(filename: string) {
+  const index = filename.lastIndexOf(".");
+  if (index < 0) {
+    return false;
+  }
+  return ACCEPT_EXTENSIONS.has(filename.slice(index).toLowerCase());
+}

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-knowledge-files.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-knowledge-files.ts
@@ -10,6 +10,8 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import "server-only";
+
 import { and, desc, eq } from "drizzle-orm";
 
 import { db, schema, type DatabaseClient } from "@/lib/database";
@@ -19,33 +21,21 @@ import { createStoredFile } from "@/lib/file-storage/records";
 import { err, ok, type Result } from "@/lib/primitives/result/results";
 
 import {
-  extractWorkspaceAutomationKnowledgeText,
   isSupportedWorkspaceAutomationKnowledgeFilename,
-} from "./workspace-automation-knowledge-text";
+  WORKSPACE_AUTOMATION_KNOWLEDGE_MAX_BYTES,
+  WORKSPACE_AUTOMATION_KNOWLEDGE_MAX_FILES,
+  type WorkspaceAutomationKnowledgeFileRecord,
+  type WorkspaceAutomationKnowledgeFileSummary,
+} from "./workspace-automation-knowledge-constants";
+import { extractWorkspaceAutomationKnowledgeText } from "./workspace-automation-knowledge-text";
 
-export const WORKSPACE_AUTOMATION_KNOWLEDGE_MAX_FILES = 20;
-export const WORKSPACE_AUTOMATION_KNOWLEDGE_MAX_BYTES = 25 * 1024 * 1024;
-
-export type WorkspaceAutomationKnowledgeFileRecord = {
-  id: string;
-  organizationId: string;
-  automationId: string;
-  storedFileId: string;
-  filename: string;
-  contentType: string;
-  byteSize: number;
-  extractedText: string;
-  createdByUserId: string | null;
-  createdAt: string;
-  updatedAt: string;
-};
-
-export type WorkspaceAutomationKnowledgeFileSummary = Omit<
-  WorkspaceAutomationKnowledgeFileRecord,
-  "extractedText"
-> & {
-  extractedCharacterCount: number;
-};
+export {
+  isSupportedWorkspaceAutomationKnowledgeFilename,
+  WORKSPACE_AUTOMATION_KNOWLEDGE_MAX_BYTES,
+  WORKSPACE_AUTOMATION_KNOWLEDGE_MAX_FILES,
+  type WorkspaceAutomationKnowledgeFileRecord,
+  type WorkspaceAutomationKnowledgeFileSummary,
+} from "./workspace-automation-knowledge-constants";
 
 type KnowledgeFileRow = typeof schema.workspaceAutomationKnowledgeFiles.$inferSelect;
 

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-knowledge-text.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-knowledge-text.test.ts
@@ -12,19 +12,9 @@
  */
 import { describe, expect, it } from "vite-plus/test";
 
-import {
-  extractWorkspaceAutomationKnowledgeText,
-  isSupportedWorkspaceAutomationKnowledgeFilename,
-} from "./workspace-automation-knowledge-text";
+import { extractWorkspaceAutomationKnowledgeText } from "./workspace-automation-knowledge-text";
 
 describe("workspace automation knowledge text", () => {
-  it("accepts document filenames used for agent knowledge", () => {
-    expect(isSupportedWorkspaceAutomationKnowledgeFilename("policy.pdf")).toBe(true);
-    expect(isSupportedWorkspaceAutomationKnowledgeFilename("notes.MD")).toBe(true);
-    expect(isSupportedWorkspaceAutomationKnowledgeFilename("guide.docx")).toBe(true);
-    expect(isSupportedWorkspaceAutomationKnowledgeFilename("photo.png")).toBe(false);
-  });
-
   it("extracts and truncates plain text files", async () => {
     const extracted = await extractWorkspaceAutomationKnowledgeText({
       filename: "faq.md",

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-knowledge-text.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-knowledge-text.ts
@@ -10,23 +10,21 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
+import "server-only";
+
 import mammoth from "mammoth";
 
-export const WORKSPACE_AUTOMATION_KNOWLEDGE_MAX_EXTRACTED_CHARS = 100_000;
+import { WORKSPACE_AUTOMATION_KNOWLEDGE_MAX_EXTRACTED_CHARS } from "./workspace-automation-knowledge-constants";
+
+export {
+  isSupportedWorkspaceAutomationKnowledgeFilename,
+  WORKSPACE_AUTOMATION_KNOWLEDGE_ACCEPT_EXTENSIONS,
+  WORKSPACE_AUTOMATION_KNOWLEDGE_MAX_EXTRACTED_CHARS,
+} from "./workspace-automation-knowledge-constants";
 
 const TEXT_EXTENSIONS = new Set([".txt", ".md", ".markdown", ".csv", ".json"]);
 const DOCX_EXTENSIONS = new Set([".docx"]);
 const PDF_EXTENSIONS = new Set([".pdf"]);
-
-export const WORKSPACE_AUTOMATION_KNOWLEDGE_ACCEPT_EXTENSIONS = [
-  ".pdf",
-  ".txt",
-  ".md",
-  ".markdown",
-  ".csv",
-  ".json",
-  ".docx",
-] as const;
 
 export type KnowledgeTextExtractResult = {
   text: string;
@@ -40,15 +38,6 @@ function filenameExtension(filename: string) {
     return "";
   }
   return filename.slice(index).toLowerCase();
-}
-
-export function isSupportedWorkspaceAutomationKnowledgeFilename(filename: string) {
-  const extension = filenameExtension(filename);
-  return (
-    TEXT_EXTENSIONS.has(extension) ||
-    DOCX_EXTENSIONS.has(extension) ||
-    PDF_EXTENSIONS.has(extension)
-  );
 }
 
 function truncateExtractedText(text: string): { text: string; truncated: boolean } {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

#1946 stopped the public web chat page from bundling `pg`. Next still failed compiling `.well-known/workflow/v1/step` because the automations knowledge files panel imported:

- upload limits from `@/lib/agents/workspace-automation-knowledge-files` (Drizzle/`pg`)
- accept extensions from `@/lib/agents/workspace-automation-knowledge-text` (`unpdf` / mammoth)

This follows the same split as #1931 and #1946:

- Move client-safe limits, extensions, filename checks, and summary types into `workspace-automation-knowledge-constants.ts`.
- Keep database lookups and PDF/DOCX extraction behind `import "server-only"`.
- Point `workspace-automation-knowledge-files-panel.tsx` at the constants module.

Server routes can still import constants from the store; they are re-exported.

## How to test

From `apps/hyperlocalise-web`:

- `vp test src/lib/agents/workspace-automation-knowledge-constants.test.ts src/lib/agents/workspace-automation-knowledge-text.test.ts src/api/routes/workspace-automation/workspace-automation-knowledge-files.route.test.ts`
- Confirm `workspace-automation-knowledge-files-panel.tsx` does not import the drizzle store or extractor
- `vp run build` should compile `/.well-known/workflow/v1/step` and `/[lang]/org/[organizationSlug]/automations/new` without `pg` in Client Component Browser

## Checklist

- [x] I ran relevant checks locally (`vp test` on the knowledge units; `vp lint` on changed files; `vp run build`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-066d6f0e-5c71-4cbf-b2ec-e1cfe16a5864?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-066d6f0e-5c71-4cbf-b2ec-e1cfe16a5864&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

