### PR TITLE
feat(automations): show Auto-review mock and open settings from Configure

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.stories.tsx
@@ -11,7 +11,7 @@
  * Version 2.0 or later.
  */
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { expect } from "storybook/test";
+import { expect, within } from "storybook/test";
 
 import { automationTemplatesFixture, automationsFixture } from "./automations.fixture";
 import { AutomationsPageView } from "./automations-page-view";
@@ -51,18 +51,27 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  play: async ({ canvas }) => {
+  play: async ({ canvas, canvasElement, userEvent }) => {
     await expect(canvas.getByRole("heading", { name: "Automations" })).toBeInTheDocument();
     await expect(canvas.getByRole("heading", { name: "From Hyperlocalise" })).toBeInTheDocument();
-    await expect(canvas.getByText("Auto-review")).toBeInTheDocument();
-    await expect(canvas.getByText("acme/app")).toBeInTheDocument();
-    await expect(canvas.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("heading", { name: "Review localisation before it merges" }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: /Auto-review/ })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Configure" })).toBeInTheDocument();
+    await expect(canvas.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
     await expect(canvas.getByText("Validate localisation on push")).toBeInTheDocument();
     await expect(canvas.getByText("Weekly translation sync")).toBeInTheDocument();
     await expect(canvas.getByText("Ada Lovelace")).toBeInTheDocument();
     await expect(canvas.getByText("Grace Hopper")).toBeInTheDocument();
     await expect(canvas.getByText("Unknown")).toBeInTheDocument();
     await expect(canvas.getByText("Translate Contentful article")).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole("button", { name: "Configure" }));
+    const body = within(canvasElement.ownerDocument.body);
+    await expect(await body.findByRole("button", { name: "Save" })).toBeInTheDocument();
+    await expect(body.getByText("acme/app")).toBeInTheDocument();
+    await expect(body.getByLabelText("Enable Auto-review")).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/github-auto-review-card.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/github-auto-review-card.messages.ts
@@ -94,7 +94,7 @@ export const githubAutoReviewCardMessages = defineMessages({
   },
   configure: {
     defaultMessage: "Configure",
-    id: 'zlI6VpVvWz',
+    id: "zlI6VpVvWz",
     description: "Button that opens Auto-review configuration",
   },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/github-auto-review-card.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/github-auto-review-card.messages.ts
@@ -92,4 +92,9 @@ export const githubAutoReviewCardMessages = defineMessages({
     id: "BObFUJ/lEj",
     description: "Error title when Auto-review settings fail to load",
   },
+  configure: {
+    defaultMessage: "Configure",
+    id: 'zlI6VpVvWz',
+    description: "Button that opens Auto-review configuration",
+  },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/github-auto-review-card.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/github-auto-review-card.tsx
@@ -16,21 +16,33 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
+import {
+  AUTOMATIONS_MOCK_AUTO_REVIEW_ID,
+  AutomationsMockUI,
+} from "@/components/marketing/product/automations-mock-ui";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { TypographyP } from "@/components/ui/typography";
 
 import type { GithubAutoReviewSettingsDto, GithubAutoReviewSettingsWrite } from "./automations-api";
+import { automationsPageViewMessages } from "./automations-page-view.messages";
 import { githubAutoReviewCardMessages as messages } from "./github-auto-review-card.messages";
 
 const ADDITIONAL_PROMPT_MAX_LENGTH = 8_000;
+const MOCK_CTA_BUTTON_CLASS = "cursor-pointer rounded-sm";
 
-export function GithubAutoReviewCard({
+function GithubAutoReviewSettingsForm({
   organizationSlug,
   settings,
   isLoading,
@@ -90,6 +102,134 @@ export function GithubAutoReviewCard({
     });
   }
 
+  if (isLoading) {
+    return (
+      <div className="space-y-3" aria-busy="true">
+        <Skeleton className="h-4 w-2/5 rounded-full bg-muted" />
+        <Skeleton className="h-16 w-full rounded-xl bg-muted" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <TypographyP className="text-sm font-medium text-flame-100">
+        <FormattedMessage {...messages.loadError} />
+      </TypographyP>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center justify-between gap-4">
+        <Label htmlFor="github-auto-review-enabled" className="text-sm font-medium">
+          <FormattedMessage {...messages.enabledLabel} />
+        </Label>
+        <Switch
+          id="github-auto-review-enabled"
+          checked={enabled}
+          disabled={isSaving || !settings}
+          onCheckedChange={setEnabled}
+          aria-label={intl.formatMessage(messages.enabledLabel)}
+        />
+      </div>
+
+      <TypographyP className="text-sm text-muted-foreground">
+        <FormattedMessage {...messages.mentionNote} />
+      </TypographyP>
+
+      <div className="space-y-2">
+        <Label className="text-sm font-medium">
+          <FormattedMessage {...messages.repositoriesLabel} />
+        </Label>
+        {!hasAnyRepositories ? (
+          <TypographyP className="text-sm text-muted-foreground">
+            <FormattedMessage {...messages.noGithub} />{" "}
+            <Link
+              href={`/org/${organizationSlug}/integrations`}
+              className="text-foreground underline underline-offset-4"
+            >
+              <FormattedMessage {...messages.integrationsLink} />
+            </Link>
+          </TypographyP>
+        ) : selectableRepositories.length === 0 ? (
+          <TypographyP className="text-sm text-muted-foreground">
+            <FormattedMessage {...messages.noEnabledRepos} />{" "}
+            <Link
+              href={`/org/${organizationSlug}/integrations`}
+              className="text-foreground underline underline-offset-4"
+            >
+              <FormattedMessage {...messages.integrationsLink} />
+            </Link>
+          </TypographyP>
+        ) : (
+          <ul className="space-y-2">
+            {selectableRepositories.map((repository) => {
+              const checkboxId = `github-auto-review-repo-${repository.id}`;
+              return (
+                <li key={repository.id} className="flex items-center gap-2">
+                  <Checkbox
+                    id={checkboxId}
+                    checked={selectedIds.includes(repository.id)}
+                    disabled={isSaving}
+                    onCheckedChange={(checked) => toggleRepository(repository.id, checked === true)}
+                  />
+                  <Label htmlFor={checkboxId} className="text-sm font-normal">
+                    {repository.fullName}
+                  </Label>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="github-auto-review-prompt" className="text-sm font-medium">
+          <FormattedMessage {...messages.additionalPromptLabel} />
+        </Label>
+        <Textarea
+          id="github-auto-review-prompt"
+          value={additionalPrompt}
+          maxLength={ADDITIONAL_PROMPT_MAX_LENGTH}
+          disabled={isSaving}
+          placeholder={intl.formatMessage(messages.additionalPromptPlaceholder)}
+          onChange={(event) => setAdditionalPrompt(event.target.value)}
+        />
+      </div>
+
+      {onSave ? (
+        <Button
+          type="button"
+          disabled={isSaving || !hasChanges}
+          onClick={() => {
+            void handleSave();
+          }}
+        >
+          <FormattedMessage {...messages.save} />
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+export function GithubAutoReviewCard({
+  organizationSlug,
+  settings,
+  isLoading,
+  error,
+  isSaving = false,
+  onSave,
+}: {
+  organizationSlug: string;
+  settings?: GithubAutoReviewSettingsDto | null;
+  isLoading: boolean;
+  error?: unknown;
+  isSaving?: boolean;
+  onSave?: (input: GithubAutoReviewSettingsWrite) => Promise<void>;
+}) {
+  const [configOpen, setConfigOpen] = useState(false);
+
   return (
     <section className="flex flex-col gap-4">
       <div>
@@ -97,117 +237,49 @@ export function GithubAutoReviewCard({
           <FormattedMessage {...messages.sectionTitle} />
         </h2>
       </div>
-      <Card>
-        <CardHeader className="flex flex-row items-start justify-between gap-4">
-          <div className="space-y-1.5">
-            <CardTitle>
-              <FormattedMessage {...messages.title} />
-            </CardTitle>
-            <CardDescription>
-              <FormattedMessage {...messages.description} />
-            </CardDescription>
-          </div>
-          <Switch
-            id="github-auto-review-enabled"
-            checked={enabled}
-            disabled={isLoading || isSaving || !settings}
-            onCheckedChange={setEnabled}
-            aria-label={intl.formatMessage(messages.enabledLabel)}
-          />
-        </CardHeader>
-        <CardContent className="space-y-5">
-          {isLoading ? (
-            <div className="space-y-3" aria-busy="true">
-              <Skeleton className="h-4 w-2/5 rounded-full bg-muted" />
-              <Skeleton className="h-16 w-full rounded-xl bg-muted" />
-            </div>
-          ) : error ? (
-            <TypographyP className="text-sm font-medium text-flame-100">
-              <FormattedMessage {...messages.loadError} />
-            </TypographyP>
+      <AutomationsMockUI
+        pauseAutoplay
+        renderCta={(useCaseId) =>
+          useCaseId === AUTOMATIONS_MOCK_AUTO_REVIEW_ID ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              className={MOCK_CTA_BUTTON_CLASS}
+              onClick={() => setConfigOpen(true)}
+            >
+              <FormattedMessage {...messages.configure} />
+            </Button>
           ) : (
-            <>
-              <TypographyP className="text-sm text-muted-foreground">
-                <FormattedMessage {...messages.mentionNote} />
-              </TypographyP>
-
-              <div className="space-y-2">
-                <Label className="text-sm font-medium">
-                  <FormattedMessage {...messages.repositoriesLabel} />
-                </Label>
-                {!hasAnyRepositories ? (
-                  <TypographyP className="text-sm text-muted-foreground">
-                    <FormattedMessage {...messages.noGithub} />{" "}
-                    <Link
-                      href={`/org/${organizationSlug}/integrations`}
-                      className="text-foreground underline underline-offset-4"
-                    >
-                      <FormattedMessage {...messages.integrationsLink} />
-                    </Link>
-                  </TypographyP>
-                ) : selectableRepositories.length === 0 ? (
-                  <TypographyP className="text-sm text-muted-foreground">
-                    <FormattedMessage {...messages.noEnabledRepos} />{" "}
-                    <Link
-                      href={`/org/${organizationSlug}/integrations`}
-                      className="text-foreground underline underline-offset-4"
-                    >
-                      <FormattedMessage {...messages.integrationsLink} />
-                    </Link>
-                  </TypographyP>
-                ) : (
-                  <ul className="space-y-2">
-                    {selectableRepositories.map((repository) => {
-                      const checkboxId = `github-auto-review-repo-${repository.id}`;
-                      return (
-                        <li key={repository.id} className="flex items-center gap-2">
-                          <Checkbox
-                            id={checkboxId}
-                            checked={selectedIds.includes(repository.id)}
-                            disabled={isSaving}
-                            onCheckedChange={(checked) =>
-                              toggleRepository(repository.id, checked === true)
-                            }
-                          />
-                          <Label htmlFor={checkboxId} className="text-sm font-normal">
-                            {repository.fullName}
-                          </Label>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                )}
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="github-auto-review-prompt" className="text-sm font-medium">
-                  <FormattedMessage {...messages.additionalPromptLabel} />
-                </Label>
-                <Textarea
-                  id="github-auto-review-prompt"
-                  value={additionalPrompt}
-                  maxLength={ADDITIONAL_PROMPT_MAX_LENGTH}
-                  disabled={isSaving}
-                  placeholder={intl.formatMessage(messages.additionalPromptPlaceholder)}
-                  onChange={(event) => setAdditionalPrompt(event.target.value)}
-                />
-              </div>
-
-              {onSave ? (
-                <Button
-                  type="button"
-                  disabled={isSaving || !hasChanges}
-                  onClick={() => {
-                    void handleSave();
-                  }}
-                >
-                  <FormattedMessage {...messages.save} />
-                </Button>
-              ) : null}
-            </>
-          )}
-        </CardContent>
-      </Card>
+            <Button type="button" variant="outline" size="lg" className="rounded-sm" disabled>
+              <FormattedMessage {...automationsPageViewMessages.comingSoon} />
+            </Button>
+          )
+        }
+      />
+      <Sheet open={configOpen} onOpenChange={setConfigOpen}>
+        <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-xl md:max-w-2xl">
+          <SheetHeader>
+            <SheetTitle>
+              <FormattedMessage {...messages.title} />
+            </SheetTitle>
+            <SheetDescription>
+              <FormattedMessage {...messages.description} />
+            </SheetDescription>
+          </SheetHeader>
+          <div className="px-6 pb-6">
+            <GithubAutoReviewSettingsForm
+              key={configOpen ? "open" : "closed"}
+              organizationSlug={organizationSlug}
+              settings={settings}
+              isLoading={isLoading}
+              error={error}
+              isSaving={isSaving}
+              onSave={onSave}
+            />
+          </div>
+        </SheetContent>
+      </Sheet>
     </section>
   );
 }

--- a/apps/hyperlocalise-web/src/components/marketing/product/automations-mock-ui.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/product/automations-mock-ui.tsx
@@ -12,7 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { Clock01Icon, GitPullRequestIcon, Upload01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -32,6 +32,8 @@ type Step = {
   label: string;
   status: StepStatus;
 };
+
+export const AUTOMATIONS_MOCK_AUTO_REVIEW_ID = "auto-review";
 
 type UseCase = {
   id: string;
@@ -139,10 +141,12 @@ function UseCaseSelector({
   useCases,
   active,
   onSelect,
+  cta,
 }: {
   useCases: UseCase[];
   active: string;
   onSelect: (id: string) => void;
+  cta: ReactNode;
 }) {
   return (
     <div className="flex h-full flex-col justify-between px-6 py-5">
@@ -194,28 +198,26 @@ function UseCaseSelector({
         </div>
       </div>
 
-      <div className="mt-4 flex items-center">
-        <Button
-          variant="outline"
-          size="lg"
-          nativeButton={false}
-          render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
-          className="cursor-pointer rounded-sm"
-        >
-          <FormattedMessage {...automationsMockMessages.requestDemo} />
-        </Button>
-      </div>
+      <div className="mt-4 flex items-center">{cta}</div>
     </div>
   );
 }
 
-export function AutomationsMockUI({ priority = false }: { priority?: boolean }) {
+export function AutomationsMockUI({
+  priority = false,
+  pauseAutoplay = false,
+  renderCta,
+}: {
+  priority?: boolean;
+  pauseAutoplay?: boolean;
+  renderCta?: (useCaseId: string) => ReactNode;
+}) {
   const intl = useIntl();
   const shouldReduceMotion = useReducedMotion();
 
   const useCases: UseCase[] = [
     {
-      id: "auto-review",
+      id: AUTOMATIONS_MOCK_AUTO_REVIEW_ID,
       title: intl.formatMessage(automationsMockMessages.useCaseAutoReviewTitle),
       description: intl.formatMessage(automationsMockMessages.useCaseAutoReviewDescription),
       triggerIcon: <HugeiconsIcon icon={GitPullRequestIcon} strokeWidth={1.8} className="size-3" />,
@@ -294,7 +296,7 @@ export function AutomationsMockUI({ priority = false }: { priority?: boolean }) 
   });
 
   useEffect(() => {
-    if (isPaused || shouldReduceMotion) return;
+    if (isPaused || pauseAutoplay || shouldReduceMotion) return;
 
     const totalSteps = activeUseCase.steps.length;
 
@@ -313,6 +315,7 @@ export function AutomationsMockUI({ priority = false }: { priority?: boolean }) 
     visibleStepCount,
     activeIndex,
     isPaused,
+    pauseAutoplay,
     activeUseCase.steps.length,
     useCases.length,
     shouldReduceMotion,
@@ -360,7 +363,26 @@ export function AutomationsMockUI({ priority = false }: { priority?: boolean }) 
           </div>
         </div>
         <div className="relative bg-background">
-          <UseCaseSelector useCases={useCases} active={activeUseCase.id} onSelect={handleSelect} />
+          <UseCaseSelector
+            useCases={useCases}
+            active={activeUseCase.id}
+            onSelect={handleSelect}
+            cta={
+              renderCta ? (
+                renderCta(activeUseCase.id)
+              ) : (
+                <Button
+                  variant="outline"
+                  size="lg"
+                  nativeButton={false}
+                  render={<a href={REQUEST_DEMO_URL} target="_blank" rel="noopener noreferrer" />}
+                  className="cursor-pointer rounded-sm"
+                >
+                  <FormattedMessage {...automationsMockMessages.requestDemo} />
+                </Button>
+              )
+            }
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What changed

The Automations **From Hyperlocalise** section now reuses the product automations mock instead of showing the settings form inline. **Configure** opens Auto-review (repos, additional prompt, enable toggle) in a sheet. Auto Translation and Localisation audit stay **Coming soon**. The marketing page still uses Request a Demo.

## How to test

- Open workspace Automations and confirm the Auto-review mock appears under From Hyperlocalise.
- Click **Configure** on Auto-review and confirm the sheet has the enable toggle, repository checkboxes, additional prompt, and Save.
- Select Auto Translation or Localisation audit and confirm the CTA is **Coming soon**.
- Confirm the product automations page still shows Request a Demo.
- `vp check --fix` in `apps/hyperlocalise-web` (pre-existing type/lint issues remain elsewhere).

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)