### PR TITLE
HL-597: Add target locale and spelling validation mode

### DIFF
--- a/apps/go-svc/BUILD.bazel
+++ b/apps/go-svc/BUILD.bazel
@@ -14,6 +14,7 @@ go_binary(
         "//internal/i18n/segmentvalidate",
         "//internal/i18n/spellcheck",
         "@com_github_workos_workos_go_v9//:workos-go",
+        "@org_golang_x_text//language",
     ],
 )
 

--- a/apps/go-svc/handler.go
+++ b/apps/go-svc/handler.go
@@ -5,23 +5,27 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/segmentvalidate"
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/spellcheck"
+	"golang.org/x/text/language"
 )
 
 const maxValidateSegmentBodyBytes = 512 << 10 // 512 KiB
 
 type validateSegmentRequest struct {
-	SourceText string   `json:"sourceText"`
-	TargetText string   `json:"targetText"`
-	SourcePath string   `json:"sourcePath"`
-	MaxLength  int      `json:"maxLength"`
-	Modes      []string `json:"modes,omitempty"`
+	SourceText   string   `json:"sourceText"`
+	TargetText   string   `json:"targetText"`
+	SourcePath   string   `json:"sourcePath"`
+	MaxLength    int      `json:"maxLength"`
+	Modes        []string `json:"modes,omitempty"`
+	TargetLocale string   `json:"targetLocale,omitempty"`
 }
 
 type validateSegmentResponse struct {
-	Checks []segmentvalidate.Check `json:"checks"`
+	Checks       []segmentvalidate.Check `json:"checks"`
+	SkippedModes []string                `json:"skippedModes,omitempty"`
 }
 
 type handler struct {
@@ -64,7 +68,24 @@ func (h *handler) validateSegment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, _ = h.checkSpelling(r.Context(), "", req.TargetText)
+	spellingRequested := requestsSpelling(req.Modes)
+
+	var skippedModes []string
+	if spellingRequested {
+		targetLocale, err := validateTargetLocale(req.TargetLocale)
+		if err != nil {
+			writeBadRequest(w, err.Error())
+			return
+		}
+
+		switch _, err := h.checkSpelling(r.Context(), targetLocale, req.TargetText); {
+		case errors.Is(err, ErrSpellCheckUnavailable):
+			skippedModes = append(skippedModes, QAModeSpelling)
+		case err != nil:
+			writeInternalError(w, "spell check failed")
+			return
+		}
+	}
 
 	checks := h.validate(segmentvalidate.Request{
 		SourceText: req.SourceText,
@@ -76,7 +97,27 @@ func (h *handler) validateSegment(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(validateSegmentResponse{Checks: checks})
+	_ = json.NewEncoder(w).Encode(validateSegmentResponse{Checks: checks, SkippedModes: skippedModes})
+}
+
+func requestsSpelling(modes []string) bool {
+	for _, mode := range modes {
+		if strings.TrimSpace(mode) == QAModeSpelling {
+			return true
+		}
+	}
+	return false
+}
+
+func validateTargetLocale(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", errors.New("targetLocale is required when requesting spelling checks")
+	}
+	if _, err := language.Parse(trimmed); err != nil {
+		return "", errors.New("targetLocale must be a valid BCP 47 language tag")
+	}
+	return trimmed, nil
 }
 
 func writeBadRequest(w http.ResponseWriter, message string) {
@@ -84,6 +125,15 @@ func writeBadRequest(w http.ResponseWriter, message string) {
 	w.WriteHeader(http.StatusBadRequest)
 	_ = json.NewEncoder(w).Encode(map[string]string{
 		"error":   "bad_request",
+		"message": message,
+	})
+}
+
+func writeInternalError(w http.ResponseWriter, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusInternalServerError)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"error":   "internal_error",
 		"message": message,
 	})
 }

--- a/apps/go-svc/handler.go
+++ b/apps/go-svc/handler.go
@@ -80,7 +80,7 @@ func (h *handler) validateSegment(w http.ResponseWriter, r *http.Request) {
 
 		switch _, err := h.checkSpelling(r.Context(), targetLocale, req.TargetText); {
 		case errors.Is(err, ErrSpellCheckUnavailable):
-			skippedModes = append(skippedModes, QAModeSpelling)
+			skippedModes = append(skippedModes, QA_MODE_SPELLING)
 		case err != nil:
 			writeInternalError(w, "spell check failed")
 			return
@@ -102,7 +102,7 @@ func (h *handler) validateSegment(w http.ResponseWriter, r *http.Request) {
 
 func requestsSpelling(modes []string) bool {
 	for _, mode := range modes {
-		if strings.TrimSpace(mode) == QAModeSpelling {
+		if strings.TrimSpace(mode) == QA_MODE_SPELLING {
 			return true
 		}
 	}

--- a/apps/go-svc/handler_test.go
+++ b/apps/go-svc/handler_test.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/segmentvalidate"
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/spellcheck"
 	"github.com/stretchr/testify/require"
 )
 
@@ -150,4 +152,138 @@ func TestValidateSegmentBodyTooLarge(t *testing.T) {
 	var body map[string]string
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 	require.Equal(t, "payload_too_large", body["error"])
+}
+
+func newAuthedValidateSegmentMux(h *handler) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.Handle(
+		"POST /v1/validate/segment",
+		authMiddleware(mockSessionVerifier{claims: AuthClaims{UserID: "user_123"}})(http.HandlerFunc(h.validateSegment)),
+	)
+	return mux
+}
+
+func postValidateSegment(mux *http.ServeMux, payload string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/validate/segment", bytes.NewBufferString(payload))
+	req.AddCookie(&http.Cookie{Name: workOSSessionCookieName, Value: "test-session"})
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestValidateSegmentResponseOmitsSkippedModesWithoutSpelling(t *testing.T) {
+	mux := newAuthedValidateSegmentMux(newHandler())
+
+	payload := `{"sourceText":"Hello","targetText":"Bonjour","sourcePath":"/messages/en.json"}`
+	rec := postValidateSegment(mux, payload)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+	_, present := raw["skippedModes"]
+	require.False(t, present, "skippedModes must be omitted from the wire format when spelling is not requested")
+}
+
+func TestValidateSegmentIgnoresTargetLocaleWithoutSpelling(t *testing.T) {
+	mux := newAuthedValidateSegmentMux(newHandler())
+
+	payload := `{"sourceText":"Hello","targetText":"Bonjour","sourcePath":"/messages/en.json","targetLocale":"???"}`
+	rec := postValidateSegment(mux, payload)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestValidateSegmentSpellingRequiresTargetLocale(t *testing.T) {
+	mux := newAuthedValidateSegmentMux(newHandler())
+
+	payload := `{"sourceText":"Hello","targetText":"Bonjour","sourcePath":"/messages/en.json","modes":["spelling"]}`
+	rec := postValidateSegment(mux, payload)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, "bad_request", body["error"])
+}
+
+func TestValidateSegmentSpellingRejectsMalformedTargetLocale(t *testing.T) {
+	mux := newAuthedValidateSegmentMux(newHandler())
+
+	payload := `{"sourceText":"Hello","targetText":"Bonjour","sourcePath":"/messages/en.json","modes":["spelling"],"targetLocale":"???"}`
+	rec := postValidateSegment(mux, payload)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, "bad_request", body["error"])
+}
+
+func TestValidateSegmentSpellingSkippedWhenProviderUnavailable(t *testing.T) {
+	mux := newAuthedValidateSegmentMux(newHandler())
+
+	payload := `{"sourceText":"Hello","targetText":"Bonjour","sourcePath":"/messages/en.json","modes":["spelling"],"targetLocale":"fr-FR"}`
+	rec := postValidateSegment(mux, payload)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp validateSegmentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Checks, 1)
+	require.Equal(t, "format-parity", resp.Checks[0].ID)
+	require.Equal(t, []string{"spelling"}, resp.SkippedModes)
+}
+
+func TestValidateSegmentSpellingSucceedsWithoutSkip(t *testing.T) {
+	fake := &fakeSpellChecker{}
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: fake}
+	mux := newAuthedValidateSegmentMux(h)
+
+	payload := `{"sourceText":"Hello","targetText":"Bonjour","sourcePath":"/messages/en.json","modes":["spelling"],"targetLocale":"fr-FR"}`
+	rec := postValidateSegment(mux, payload)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp validateSegmentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Checks, 1)
+	require.Empty(t, resp.SkippedModes)
+	require.Equal(t, "fr-FR", fake.receivedLocale)
+}
+
+func TestValidateSegmentSpellingDiscardsIssuesOnSuccess(t *testing.T) {
+	fake := &fakeSpellChecker{
+		issues: []SpellingIssue{{Word: "recieve", Suggestions: []string{"receive"}}},
+	}
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: fake}
+	mux := newAuthedValidateSegmentMux(h)
+
+	targetText := "Please recieve the update"
+	payload := `{"sourceText":"Hello","targetText":"Please recieve the update","sourcePath":"/messages/en.json","modes":["spelling"],"targetLocale":"fr-FR"}`
+	rec := postValidateSegment(mux, payload)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp validateSegmentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Checks, 1, "spelling issues must not be surfaced as checks in this contract")
+	require.Empty(t, resp.SkippedModes, "a successful check must not be reported as skipped, even with issues found")
+	require.Equal(t, "fr-FR", fake.receivedLocale)
+	require.Equal(t, spellcheck.Tokenize(targetText), fake.receivedWords)
+}
+
+func TestValidateSegmentSpellingUnexpectedProviderErrorReturns500(t *testing.T) {
+	fake := &fakeSpellChecker{err: errors.New("provider exploded")}
+	h := &handler{validate: segmentvalidate.ValidateSegment, spellChecker: fake}
+	mux := newAuthedValidateSegmentMux(h)
+
+	payload := `{"sourceText":"Hello","targetText":"Bonjour","sourcePath":"/messages/en.json","modes":["spelling"],"targetLocale":"fr-FR"}`
+	rec := postValidateSegment(mux, payload)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, "internal_error", body["error"])
 }

--- a/apps/go-svc/spellcheck.go
+++ b/apps/go-svc/spellcheck.go
@@ -1,11 +1,18 @@
 package main
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
 type SpellingIssue struct {
 	Word        string
 	Suggestions []string
 }
+
+var ErrSpellCheckUnavailable = errors.New("spell checking is not available")
+
+const QAModeSpelling = "spelling"
 
 type SpellChecker interface {
 	Check(ctx context.Context, locale string, words []string) ([]SpellingIssue, error)
@@ -14,5 +21,5 @@ type SpellChecker interface {
 type NoopSpellChecker struct{}
 
 func (NoopSpellChecker) Check(_ context.Context, _ string, _ []string) ([]SpellingIssue, error) {
-	return nil, nil
+	return nil, ErrSpellCheckUnavailable
 }

--- a/apps/go-svc/spellcheck.go
+++ b/apps/go-svc/spellcheck.go
@@ -12,7 +12,7 @@ type SpellingIssue struct {
 
 var ErrSpellCheckUnavailable = errors.New("spell checking is not available")
 
-const QAModeSpelling = "spelling"
+const QA_MODE_SPELLING = "spelling"
 
 type SpellChecker interface {
 	Check(ctx context.Context, locale string, words []string) ([]SpellingIssue, error)

--- a/apps/go-svc/spellcheck_test.go
+++ b/apps/go-svc/spellcheck_test.go
@@ -57,6 +57,6 @@ func TestCheckSpellingNoopWhenUnconfigured(t *testing.T) {
 
 	issues, err := h.checkSpelling(context.Background(), "", "Hello there")
 
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrSpellCheckUnavailable)
 	require.Nil(t, issues)
 }


### PR DESCRIPTION
## What changed

- Add optional `targetLocale` and `spelling` QA mode support to segment validation.
- Validate BCP 47 locale tags when spelling is requested.
- Report unavailable spelling via `skippedModes` while preserving existing validation checks.
- Preserve existing behavior for requests that do not request spelling.

## How to test

```bash
go test ./apps/go-svc ./internal/i18n/segmentvalidate
make fmt
make lint
make test
```

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
