### PR TITLE
feat(glossary): improve concept editing parity

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
@@ -22,6 +22,7 @@ import { parseCsvRows } from "@/lib/csv/parse-csv-rows";
 import { getGlossaryProduct } from "@/lib/glossary/glossary-provider";
 import {
   GlossaryValidationError,
+  selectGlossaryPrimaryTerm,
   type NativeGlossary,
   type GlossaryConcept,
 } from "@/lib/glossary/glossary";
@@ -187,8 +188,7 @@ function toCrowdinConceptRecord(
   const conceptId = String(value.externalKey ?? value.id ?? value.conceptId);
   const createdAt = value.externalCreatedAt ?? new Date(0).toISOString();
   const updatedAt = value.externalUpdatedAt ?? new Date(0).toISOString();
-  const source =
-    value.terms.find((term) => term.languageId === glossary.sourceLocale) ?? value.terms[0];
+  const source = selectGlossaryPrimaryTerm(value.terms, glossary.sourceLocale) ?? value.terms[0];
   return {
     id: conceptId,
     glossaryId: glossary.id,

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-concept.route.ts
@@ -383,10 +383,6 @@ export function createGlossaryConceptRoutes() {
         const payload = c.req.valid("json");
         const glossary = await getOwnedGlossary(c.var.auth, glossaryId);
         if (!glossary) return glossaryNotFoundResponse(c);
-        const sourceTerm = payload.terms?.find((term) => term.locale === glossary.sourceLocale);
-        if (sourceTerm && sourceTerm.term.toLowerCase() === payload.primaryTerm.toLowerCase()) {
-          return conflictResponse(c, "duplicate_glossary_concept_term");
-        }
         const product = getGlossaryProduct({ auth: c.var.auth, glossary });
         if (!product) return externalTmsGlossaryImmutableResponse(c);
         let created;

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.test.ts
@@ -466,8 +466,8 @@ describe("glossaryRoutes", () => {
     expect(response.status).toBe(201);
     await expect(response.json()).resolves.toMatchObject({
       concept: {
-        primaryTerm: "checkout",
-        terms: [{ locale: "en", term: "checkout" }],
+        primaryTerm: "Checkout",
+        terms: [{ locale: "en", term: "Checkout" }],
       },
     });
   });

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.test.ts
@@ -418,7 +418,7 @@ describe("glossaryRoutes", () => {
     expect(storedTerm?.term).toBe("Thanh toán");
   });
 
-  it("rejects duplicate terms when creating a concept", async () => {
+  it("allows the primary source term when creating a concept", async () => {
     const identity = fixture.createWorkosIdentityWithRole("admin");
     const headers = await fixture.authHeadersFor(identity);
     const organizationSlug = identity.organization.slug ?? "missing-slug";
@@ -448,9 +448,12 @@ describe("glossaryRoutes", () => {
       { headers },
     );
 
-    expect(response.status).toBe(409);
+    expect(response.status).toBe(201);
     await expect(response.json()).resolves.toMatchObject({
-      error: "duplicate_glossary_concept_term",
+      concept: {
+        primaryTerm: "Checkout",
+        terms: [{ locale: "en", term: "checkout" }],
+      },
     });
   });
 

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.test.ts
@@ -172,6 +172,20 @@ describe("glossaryRoutes", () => {
           translatable: true,
           terms: [
             {
+              locale: "en",
+              term: "Check-out",
+              status: "draft",
+              caseSensitive: false,
+              forbidden: false,
+            },
+            {
+              locale: "en",
+              term: "Payment",
+              status: "draft",
+              caseSensitive: false,
+              forbidden: false,
+            },
+            {
               locale: "vi-VN",
               term: "Thanh toán",
               status: "draft",
@@ -202,6 +216,7 @@ describe("glossaryRoutes", () => {
     expect(body.concept.terms).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ locale: "en", term: "Checkout", status: "preferred" }),
+        expect.objectContaining({ locale: "en", term: "Payment", status: "draft" }),
         expect.objectContaining({ locale: "vi-VN", term: "Thanh toán", status: "draft" }),
         expect.objectContaining({ locale: "en-US", term: "Check-out", status: "draft" }),
       ]),
@@ -451,7 +466,7 @@ describe("glossaryRoutes", () => {
     expect(response.status).toBe(201);
     await expect(response.json()).resolves.toMatchObject({
       concept: {
-        primaryTerm: "Checkout",
+        primaryTerm: "checkout",
         terms: [{ locale: "en", term: "checkout" }],
       },
     });

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.ts
@@ -192,11 +192,39 @@ function parseGlossaryImport(payload: ImportGlossaryTermsBody): CreateGlossaryTe
 
 async function listGlossaryProjects(
   auth: ApiAuthContext,
-  glossaryId: string,
+  glossary: Awaited<ReturnType<typeof getOwnedGlossary>>,
 ): Promise<GlossaryProjectRecord[]> {
-  const accessibleProjectsWhere = await buildAccessibleProjectsWhere(auth);
+  if (!glossary) return [];
 
-  return db
+  const accessibleProjectsWhere = await buildAccessibleProjectsWhere(auth);
+  if (
+    glossary.source === "external_tms" &&
+    glossary.externalProviderKind === "crowdin" &&
+    glossary.externalProjectId
+  ) {
+    const [providerProject] = await db
+      .select({
+        projectId: schema.projects.id,
+        projectName: schema.projects.name,
+        sourceLocale: schema.projects.sourceLocale,
+        targetLocales: schema.projects.targetLocales,
+      })
+      .from(schema.projects)
+      .where(
+        and(
+          eq(schema.projects.organizationId, auth.organization.localOrganizationId),
+          eq(schema.projects.source, "external_tms"),
+          eq(schema.projects.externalProviderKind, "crowdin"),
+          eq(schema.projects.externalProjectId, glossary.externalProjectId),
+          accessibleProjectsWhere,
+        ),
+      )
+      .limit(1);
+
+    return providerProject ? [{ ...providerProject, priority: 0 }] : [];
+  }
+
+  const attachedProjects = await db
     .select({
       projectId: schema.projects.id,
       projectName: schema.projects.name,
@@ -209,11 +237,13 @@ async function listGlossaryProjects(
     .where(
       and(
         eq(schema.projectGlossaries.organizationId, auth.organization.localOrganizationId),
-        eq(schema.projectGlossaries.glossaryId, glossaryId),
+        eq(schema.projectGlossaries.glossaryId, glossary.id),
         accessibleProjectsWhere,
       ),
     )
     .orderBy(schema.projectGlossaries.priority, schema.projects.name);
+
+  return attachedProjects;
 }
 
 const validateGlossaryParams = validator("param", (value, c) => {
@@ -564,7 +594,7 @@ export function createGlossaryRoutes() {
         return glossaryNotFoundResponse(c);
       }
 
-      return c.json({ projects: await listGlossaryProjects(c.var.auth, params.glossaryId) }, 200);
+      return c.json({ projects: await listGlossaryProjects(c.var.auth, glossary) }, 200);
     })
     .post(
       "/:glossaryId/projects",
@@ -593,7 +623,7 @@ export function createGlossaryRoutes() {
         if (!product) return externalTmsGlossaryImmutableResponse(c);
         await product.attachProject(project.id, payload.priority);
 
-        return c.json({ projects: await listGlossaryProjects(c.var.auth, params.glossaryId) }, 200);
+        return c.json({ projects: await listGlossaryProjects(c.var.auth, glossary) }, 200);
       },
     )
     .delete("/:glossaryId/projects/:projectId", validateGlossaryProjectParams, async (c) => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content-msw-handlers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content-msw-handlers.ts
@@ -31,10 +31,19 @@ export function createGlossaryDetailMswHandlers({
   projects?: Array<{ id: string; name: string; sourceLocale: string }>;
   conceptsLoading?: boolean;
 }) {
+  let currentGlossary = glossary;
+
   return [
     http.get("/api/orgs/:organizationSlug/glossaries/:glossaryId", () =>
-      HttpResponse.json({ glossary }),
+      HttpResponse.json({ glossary: currentGlossary }),
     ),
+    http.patch("/api/orgs/:organizationSlug/glossaries/:glossaryId", async ({ request }) => {
+      const body = (await request.json()) as { name?: string };
+      currentGlossary = { ...currentGlossary, name: body.name ?? currentGlossary.name };
+      return HttpResponse.json({
+        glossary: currentGlossary,
+      });
+    }),
     http.get("/api/orgs/:organizationSlug/glossaries/:glossaryId/concepts", async () => {
       if (conceptsLoading) await delay("infinite");
       return HttpResponse.json({ concepts, total: concepts.length });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.messages.ts
@@ -15,6 +15,31 @@
 import { defineMessages } from "react-intl";
 
 export const glossaryDetailPageContentMessages = defineMessages({
+  editName: {
+    defaultMessage: "Edit glossary name",
+    id: "8Pm5sD+4i4",
+    description: "Accessible label for editing the glossary name",
+  },
+  saveName: {
+    defaultMessage: "Save glossary name",
+    id: "oHlz44sQOv",
+    description: "Accessible label for saving the glossary name",
+  },
+  cancelNameEdit: {
+    defaultMessage: "Cancel glossary name edit",
+    id: "fxdG0zsb5y",
+    description: "Accessible label for canceling the glossary name edit",
+  },
+  glossaryNameUpdated: {
+    defaultMessage: "Glossary name updated",
+    id: "wOWEjY5VIH",
+    description: "Toast after the glossary name is updated successfully",
+  },
+  updateGlossaryNameFailed: {
+    defaultMessage: "Unable to update glossary name",
+    id: "nIdUueH9Jz",
+    description: "Fallback error when updating the glossary name fails",
+  },
   loadGlossaryFailed: {
     defaultMessage: "Unable to load glossary",
     id: "zdN3ToHnj1",
@@ -204,6 +229,16 @@ export const glossaryDetailPageContentMessages = defineMessages({
     defaultMessage: "This glossary is used only by the projects listed here.",
     id: "LMGo1sN8VQ",
     description: "Section description for projects assigned to a glossary",
+  },
+  linkedProjectTitle: {
+    defaultMessage: "Linked project",
+    id: "kngndgvdvd",
+    description: "Section title for the project linked to a provider glossary",
+  },
+  linkedProjectDescription: {
+    defaultMessage: "This project is linked to the glossary in Crowdin.",
+    id: "wdTIdTeD/X",
+    description: "Section description for a provider-linked project",
   },
   selectProjectPlaceholder: {
     defaultMessage: "Select project",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.stories.tsx
@@ -136,6 +136,7 @@ export const ConceptList: Story = {
   parameters: {
     msw: { handlers: detailHandlers },
     nextjs: {
+      appDirectory: true,
       navigation: {
         pathname: `/org/acme/glossaries/${glossaryId}`,
       },
@@ -144,6 +145,13 @@ export const ConceptList: Story = {
   play: async ({ canvas }) => {
     await expect(
       await canvas.findByRole("heading", { name: "Product terminology" }),
+    ).toBeInTheDocument();
+    const nameInput = canvas.getByRole("textbox", { name: "Edit glossary name" });
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, "Updated terminology");
+    await userEvent.keyboard("{Enter}");
+    await expect(
+      await canvas.findByRole("heading", { name: "Updated terminology" }),
     ).toBeInTheDocument();
     await expect(await canvas.findByText("Agency")).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Add concept" })).toBeInTheDocument();
@@ -157,6 +165,7 @@ export const ConceptDetail: Story = {
   parameters: {
     msw: { handlers: detailHandlers },
     nextjs: {
+      appDirectory: true,
       navigation: {
         pathname: `/org/acme/glossaries/${glossaryId}/concepts/${conceptId}`,
       },
@@ -198,6 +207,7 @@ export const ConceptCreationWithTerms: Story = {
   parameters: {
     msw: { handlers: detailHandlers },
     nextjs: {
+      appDirectory: true,
       navigation: {
         pathname: `/org/acme/glossaries/${glossaryId}/concepts/new`,
       },
@@ -224,6 +234,7 @@ export const LoadingConceptList: Story = {
       }),
     },
     nextjs: {
+      appDirectory: true,
       navigation: {
         pathname: `/org/acme/glossaries/${glossaryId}`,
       },
@@ -252,6 +263,7 @@ export const LoadingConceptDetail: Story = {
       }),
     },
     nextjs: {
+      appDirectory: true,
       navigation: {
         pathname: `/org/acme/glossaries/${glossaryId}/concepts/${conceptId}`,
       },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.stories.tsx
@@ -148,6 +148,10 @@ export const ConceptList: Story = {
     ).toBeInTheDocument();
     const nameInput = canvas.getByRole("textbox", { name: "Edit glossary name" });
     await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, "Canceled terminology");
+    await userEvent.keyboard("{Escape}");
+    await expect(nameInput).toHaveValue("Product terminology");
+    await userEvent.clear(nameInput);
     await userEvent.type(nameInput, "Updated terminology");
     await userEvent.keyboard("{Enter}");
     await expect(

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
@@ -1039,7 +1039,11 @@ export function GlossaryDetailPageContent({
                           <td className="px-3 py-3">
                             <div className="flex flex-wrap items-center gap-2 font-medium">
                               {primary?.term ?? concept.primaryTerm}
-                              {primary ? <Badge variant="outline">{primary.status}</Badge> : null}
+                              {primary ? (
+                                <Badge variant="outline" className={statusClass(primary.status)}>
+                                  {primary.status}
+                                </Badge>
+                              ) : null}
                             </div>
                           </td>
                           <td className="max-w-xs truncate px-3 py-3 text-muted-foreground">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
@@ -12,7 +12,7 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { Fragment, useEffect, useMemo, useState, type ReactNode } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import {
@@ -79,6 +79,7 @@ import {
   glossaryPartOfSpeechValues,
   glossaryTermStatusValues,
   glossaryTermTypeValues,
+  selectGlossaryPrimaryTerm,
   type GlossaryPartOfSpeech,
   type GlossaryTermStatus,
 } from "@/lib/glossary/glossary";
@@ -356,6 +357,7 @@ export function GlossaryDetailPageContent({
   const [termToDeleteId, setTermToDeleteId] = useState<string | null>(null);
   const [selectedProjectId, setSelectedProjectId] = useState("");
   const [nameDraft, setNameDraft] = useState("");
+  const skipNameBlurSave = useRef(false);
 
   const glossaryQuery = useQuery({
     queryKey: ["glossary", organizationSlug, glossaryId],
@@ -892,29 +894,39 @@ export function GlossaryDetailPageContent({
               ))}
             </div>
             {canEdit ? (
-              <Textarea
-                value={nameDraft}
-                onChange={(event) => setNameDraft(event.currentTarget.value)}
-                onBlur={() => void saveGlossaryName()}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter" && !event.shiftKey) {
-                    event.preventDefault();
-                    event.currentTarget.blur();
-                  }
-                  if (event.key === "Escape") {
-                    event.preventDefault();
-                    setNameDraft(glossary.name);
-                    event.currentTarget.blur();
-                  }
-                }}
-                disabled={updateGlossaryName.isPending}
-                aria-label={intl.formatMessage(messages.editName)}
-                rows={1}
-                className={cn(
-                  "font-heading min-h-14 shrink-0 resize-none overflow-hidden rounded-none border-transparent bg-transparent px-0 py-1 text-3xl font-semibold text-balance text-foreground shadow-none md:text-5xl lg:text-6xl",
-                  "focus-visible:border-transparent focus-visible:ring-0",
-                )}
-              />
+              <>
+                <TypographyH1 className="sr-only">{glossary.name}</TypographyH1>
+                <Textarea
+                  value={nameDraft}
+                  onChange={(event) => setNameDraft(event.currentTarget.value)}
+                  onBlur={() => {
+                    if (skipNameBlurSave.current) {
+                      skipNameBlurSave.current = false;
+                      return;
+                    }
+                    void saveGlossaryName();
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" && !event.shiftKey) {
+                      event.preventDefault();
+                      event.currentTarget.blur();
+                    }
+                    if (event.key === "Escape") {
+                      event.preventDefault();
+                      skipNameBlurSave.current = true;
+                      setNameDraft(glossary.name);
+                      event.currentTarget.blur();
+                    }
+                  }}
+                  disabled={updateGlossaryName.isPending}
+                  aria-label={intl.formatMessage(messages.editName)}
+                  rows={1}
+                  className={cn(
+                    "font-heading min-h-14 shrink-0 resize-none overflow-hidden rounded-none border-transparent bg-transparent px-0 py-1 text-3xl font-semibold text-balance text-foreground shadow-none md:text-5xl lg:text-6xl",
+                    "focus-visible:border-transparent focus-visible:ring-0",
+                  )}
+                />
+              </>
             ) : (
               <TypographyH1 className="font-sans text-3xl font-semibold text-balance md:text-5xl lg:text-6xl">
                 {glossary.name}
@@ -1013,8 +1025,14 @@ export function GlossaryDetailPageContent({
                   </thead>
                   <tbody>
                     {filteredConcepts.map((concept) => {
-                      const primary = concept.terms.find(
-                        (term) => term.locale === glossary.sourceLocale,
+                      const primary = selectGlossaryPrimaryTerm(
+                        concept.terms.map((term) => ({
+                          id: term.id,
+                          languageId: term.locale,
+                          text: term.term,
+                          status: term.status,
+                        })),
+                        glossary.sourceLocale,
                       );
                       return (
                         <tr
@@ -1038,7 +1056,7 @@ export function GlossaryDetailPageContent({
                           </td>
                           <td className="px-3 py-3">
                             <div className="flex flex-wrap items-center gap-2 font-medium">
-                              {primary?.term ?? concept.primaryTerm}
+                              {primary?.text ?? concept.primaryTerm}
                               {primary ? (
                                 <Badge variant="outline" className={statusClass(primary.status)}>
                                   {primary.status}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
@@ -73,6 +73,7 @@ import { TypographyH1, TypographyP } from "@/components/ui/typography";
 import { readApiError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
 import { COMMON_LOCALES, getLocaleLabel } from "@/lib/i18n/locales";
+import { cn } from "@/lib/primitives/cn";
 import {
   glossaryGenderValues,
   glossaryPartOfSpeechValues,
@@ -198,11 +199,18 @@ function partOfSpeechOptionsFor(value: string) {
     : partOfSpeechOptions;
 }
 
+const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
 function formatDate(value: string) {
-  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(
-    new Date(value),
-  );
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : DATE_FORMATTER.format(date);
 }
+
+const termPropertyTriggerClassName =
+  "h-7 border-transparent bg-transparent px-2 text-xs font-normal shadow-none hover:bg-muted/60 focus-visible:bg-muted/60";
 
 function statusClass(status: TermDraft["status"]) {
   if (status === "preferred") return "border-emerald-500/30 text-emerald-700";
@@ -347,6 +355,7 @@ export function GlossaryDetailPageContent({
   const [expandedCreatingTermIds, setExpandedCreatingTermIds] = useState<Set<string>>(new Set());
   const [termToDeleteId, setTermToDeleteId] = useState<string | null>(null);
   const [selectedProjectId, setSelectedProjectId] = useState("");
+  const [nameDraft, setNameDraft] = useState("");
 
   const glossaryQuery = useQuery({
     queryKey: ["glossary", organizationSlug, glossaryId],
@@ -370,6 +379,10 @@ export function GlossaryDetailPageContent({
   const isConceptGlossary = isNative || isLiveCrowdin;
   const canEdit = canManageGlossaries && isConceptGlossary;
 
+  useEffect(() => {
+    if (glossary) setNameDraft(glossary.name);
+  }, [glossary?.name]);
+
   const conceptsQuery = useQuery({
     queryKey: ["glossary-concepts", organizationSlug, glossaryId],
     enabled: Boolean(isConceptGlossary),
@@ -388,7 +401,7 @@ export function GlossaryDetailPageContent({
   });
   const attachedProjectsQuery = useQuery({
     queryKey: ["glossary-projects", organizationSlug, glossaryId],
-    enabled: Boolean(isNative),
+    enabled: Boolean(isNative || isLiveCrowdin),
     queryFn: async () => {
       const response = await apiClient.api.orgs[":organizationSlug"].glossaries[
         ":glossaryId"
@@ -456,9 +469,7 @@ export function GlossaryDetailPageContent({
       setNewTermLocale(null);
       setNewTermDraft(emptyTermDraft);
       setCreatingTermDrafts([]);
-      setExpandedTermIds(
-        selectedConcept.terms[0] ? new Set([selectedConcept.terms[0].id]) : new Set(),
-      );
+      setExpandedTermIds(new Set());
       setExpandedCreatingTermIds(new Set());
       setIsCreatingConcept(false);
     }
@@ -665,6 +676,45 @@ export function GlossaryDetailPageContent({
     },
     onError: (error) => toast.error(error.message),
   });
+  const updateGlossaryName = useMutation({
+    mutationFn: async (name: string) => {
+      const response = await apiClient.api.orgs[":organizationSlug"].glossaries[
+        ":glossaryId"
+      ].$patch({
+        param: { organizationSlug, glossaryId },
+        json: { name },
+      });
+      if (!response.ok)
+        throw new Error(
+          await readApiError(response, intl.formatMessage(messages.updateGlossaryNameFailed)),
+        );
+      return (await response.json()).glossary as GlossaryRecord;
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["glossary", organizationSlug, glossaryId],
+      });
+      toast.success(intl.formatMessage(messages.glossaryNameUpdated));
+    },
+  });
+
+  const saveGlossaryName = async () => {
+    const name = nameDraft.trim();
+    if (!name || !glossary || name === glossary.name) {
+      setNameDraft(glossary?.name ?? nameDraft);
+      return;
+    }
+    try {
+      await updateGlossaryName.mutateAsync(name);
+    } catch (error) {
+      setNameDraft(glossary.name);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : intl.formatMessage(messages.updateGlossaryNameFailed),
+      );
+    }
+  };
   const attachProject = useMutation({
     mutationFn: async (projectId: string) => {
       const response = await apiClient.api.orgs[":organizationSlug"].glossaries[
@@ -841,7 +891,35 @@ export function GlossaryDetailPageContent({
                 </Badge>
               ))}
             </div>
-            <TypographyH1 className="font-sans text-2xl font-medium">{glossary.name}</TypographyH1>
+            {canEdit ? (
+              <Textarea
+                value={nameDraft}
+                onChange={(event) => setNameDraft(event.currentTarget.value)}
+                onBlur={() => void saveGlossaryName()}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" && !event.shiftKey) {
+                    event.preventDefault();
+                    event.currentTarget.blur();
+                  }
+                  if (event.key === "Escape") {
+                    event.preventDefault();
+                    setNameDraft(glossary.name);
+                    event.currentTarget.blur();
+                  }
+                }}
+                disabled={updateGlossaryName.isPending}
+                aria-label={intl.formatMessage(messages.editName)}
+                rows={1}
+                className={cn(
+                  "font-heading min-h-14 shrink-0 resize-none overflow-hidden rounded-none border-transparent bg-transparent px-0 py-1 text-3xl font-semibold text-balance text-foreground shadow-none md:text-5xl lg:text-6xl",
+                  "focus-visible:border-transparent focus-visible:ring-0",
+                )}
+              />
+            ) : (
+              <TypographyH1 className="font-sans text-3xl font-semibold text-balance md:text-5xl lg:text-6xl">
+                {glossary.name}
+              </TypographyH1>
+            )}
             <TypographyP className="max-w-3xl text-sm leading-6 text-muted-foreground">
               {glossary.description || intl.formatMessage(messages.descriptionFallback)}
             </TypographyP>
@@ -1258,7 +1336,10 @@ export function GlossaryDetailPageContent({
                                               )
                                             }
                                           >
-                                            <SelectTrigger className="h-7">
+                                            <SelectTrigger
+                                              showIcon={false}
+                                              className={termPropertyTriggerClassName}
+                                            >
                                               <SelectValue>
                                                 {term.partOfSpeech
                                                   ? readableEnumLabel(term.partOfSpeech)
@@ -1296,7 +1377,10 @@ export function GlossaryDetailPageContent({
                                               )
                                             }
                                           >
-                                            <SelectTrigger className="h-7">
+                                            <SelectTrigger
+                                              showIcon={false}
+                                              className={termPropertyTriggerClassName}
+                                            >
                                               <SelectValue>
                                                 {term.gender ? readableEnumLabel(term.gender) : "—"}
                                               </SelectValue>
@@ -1330,7 +1414,10 @@ export function GlossaryDetailPageContent({
                                               )
                                             }
                                           >
-                                            <SelectTrigger className="h-7">
+                                            <SelectTrigger
+                                              showIcon={false}
+                                              className={termPropertyTriggerClassName}
+                                            >
                                               <SelectValue>
                                                 {term.termType
                                                   ? readableEnumLabel(term.termType)
@@ -1364,7 +1451,10 @@ export function GlossaryDetailPageContent({
                                               )
                                             }
                                           >
-                                            <SelectTrigger className="h-7">
+                                            <SelectTrigger
+                                              showIcon={false}
+                                              className={termPropertyTriggerClassName}
+                                            >
                                               <SelectValue>
                                                 {readableEnumLabel(term.status)}
                                               </SelectValue>
@@ -1647,7 +1737,10 @@ export function GlossaryDetailPageContent({
                                                   })
                                                 }
                                               >
-                                                <SelectTrigger className="h-7">
+                                                <SelectTrigger
+                                                  showIcon={false}
+                                                  className={termPropertyTriggerClassName}
+                                                >
                                                   <SelectValue>
                                                     {draft.partOfSpeech
                                                       ? readableEnumLabel(draft.partOfSpeech)
@@ -1682,7 +1775,10 @@ export function GlossaryDetailPageContent({
                                                   })
                                                 }
                                               >
-                                                <SelectTrigger className="h-7">
+                                                <SelectTrigger
+                                                  showIcon={false}
+                                                  className={termPropertyTriggerClassName}
+                                                >
                                                   <SelectValue>
                                                     {draft.gender
                                                       ? readableEnumLabel(draft.gender)
@@ -1715,7 +1811,10 @@ export function GlossaryDetailPageContent({
                                                   })
                                                 }
                                               >
-                                                <SelectTrigger className="h-7">
+                                                <SelectTrigger
+                                                  showIcon={false}
+                                                  className={termPropertyTriggerClassName}
+                                                >
                                                   <SelectValue>
                                                     {draft.termType
                                                       ? readableEnumLabel(draft.termType)
@@ -1748,7 +1847,10 @@ export function GlossaryDetailPageContent({
                                                   })
                                                 }
                                               >
-                                                <SelectTrigger className="h-7">
+                                                <SelectTrigger
+                                                  showIcon={false}
+                                                  className={termPropertyTriggerClassName}
+                                                >
                                                   <SelectValue>
                                                     {readableEnumLabel(draft.status)}
                                                   </SelectValue>
@@ -1944,7 +2046,10 @@ export function GlossaryDetailPageContent({
                                               })
                                             }
                                           >
-                                            <SelectTrigger className="h-7">
+                                            <SelectTrigger
+                                              showIcon={false}
+                                              className={termPropertyTriggerClassName}
+                                            >
                                               <SelectValue>
                                                 {newTermDraft.partOfSpeech
                                                   ? readableEnumLabel(newTermDraft.partOfSpeech)
@@ -1973,7 +2078,10 @@ export function GlossaryDetailPageContent({
                                               })
                                             }
                                           >
-                                            <SelectTrigger className="h-7">
+                                            <SelectTrigger
+                                              showIcon={false}
+                                              className={termPropertyTriggerClassName}
+                                            >
                                               <SelectValue>
                                                 {newTermDraft.gender
                                                   ? readableEnumLabel(newTermDraft.gender)
@@ -2001,7 +2109,10 @@ export function GlossaryDetailPageContent({
                                               })
                                             }
                                           >
-                                            <SelectTrigger className="h-7">
+                                            <SelectTrigger
+                                              showIcon={false}
+                                              className={termPropertyTriggerClassName}
+                                            >
                                               <SelectValue>
                                                 {newTermDraft.termType
                                                   ? readableEnumLabel(newTermDraft.termType)
@@ -2028,7 +2139,10 @@ export function GlossaryDetailPageContent({
                                               })
                                             }
                                           >
-                                            <SelectTrigger className="h-7">
+                                            <SelectTrigger
+                                              showIcon={false}
+                                              className={termPropertyTriggerClassName}
+                                            >
                                               <SelectValue>
                                                 {readableEnumLabel(newTermDraft.status)}
                                               </SelectValue>
@@ -2190,17 +2304,23 @@ export function GlossaryDetailPageContent({
           )
         : null}
 
-      {!conceptPageMode && !isLiveCrowdin ? (
+      {!conceptPageMode && (isNative || isLiveCrowdin) ? (
         <section className="grid gap-4 rounded-lg border border-border p-4">
           <div>
             <TypographyP className="text-sm font-medium text-foreground">
-              <FormattedMessage {...messages.assignedProjectsTitle} />
+              <FormattedMessage
+                {...(isLiveCrowdin ? messages.linkedProjectTitle : messages.assignedProjectsTitle)}
+              />
             </TypographyP>
             <TypographyP className="text-xs text-muted-foreground">
-              <FormattedMessage {...messages.assignedProjectsDescription} />
+              <FormattedMessage
+                {...(isLiveCrowdin
+                  ? messages.linkedProjectDescription
+                  : messages.assignedProjectsDescription)}
+              />
             </TypographyP>
           </div>
-          {canEdit ? (
+          {canEdit && isNative ? (
             <div className="flex flex-col gap-2 sm:flex-row">
               <Select
                 value={selectedProjectId}
@@ -2245,7 +2365,7 @@ export function GlossaryDetailPageContent({
                 >
                   {project.projectName}
                 </Link>
-                {canEdit ? (
+                {canEdit && isNative ? (
                   <Button
                     type="button"
                     size="sm"

--- a/apps/hyperlocalise-web/src/lib/glossary/crowdin-glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/crowdin-glossary.ts
@@ -12,6 +12,7 @@
  */
 import {
   crowdinTmsProvider,
+  selectCrowdinPrimaryTerm,
   type CrowdinGlossaryConcept,
 } from "@/lib/providers/adapters/crowdin/crowdin-provider";
 import type { CrowdinGlossary as CrowdinGlossaryRecord } from "@/lib/providers/adapters/crowdin/crowdin-api";
@@ -87,17 +88,20 @@ function toGlossaryConceptInput(
   };
 }
 
-function toCrowdinConceptInput(concept: GlossaryConcept): CrowdinGlossaryConcept {
+export function toCrowdinConceptInput(concept: GlossaryConcept): CrowdinGlossaryConcept {
+  const primaryTerm = selectCrowdinPrimaryTerm(concept.terms, concept.sourceLocale);
   const terms = concept.terms.map((term) => ({
     id: term.id,
     languageId: term.languageId,
-    text:
-      term.languageId === concept.sourceLocale && concept.primaryTerm
-        ? concept.primaryTerm
-        : term.text,
+    text: term === primaryTerm && concept.primaryTerm ? concept.primaryTerm : term.text,
     description: term.description,
     partOfSpeech: normalizeGlossaryPartOfSpeech(term.partOfSpeech),
-    status: crowdinStatus(term.status),
+    status:
+      term !== primaryTerm &&
+      term.languageId === concept.sourceLocale &&
+      crowdinStatus(term.status) === "preferred"
+        ? "admitted"
+        : crowdinStatus(term.status),
     type: term.type,
     gender: term.gender,
     note: term.note,

--- a/apps/hyperlocalise-web/src/lib/glossary/crowdin-glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/crowdin-glossary.ts
@@ -12,7 +12,6 @@
  */
 import {
   crowdinTmsProvider,
-  selectCrowdinPrimaryTerm,
   type CrowdinGlossaryConcept,
 } from "@/lib/providers/adapters/crowdin/crowdin-provider";
 import type { CrowdinGlossary as CrowdinGlossaryRecord } from "@/lib/providers/adapters/crowdin/crowdin-api";
@@ -26,6 +25,7 @@ import {
   normalizeGlossaryPartOfSpeech,
   normalizeGlossaryTermStatus,
   normalizeGlossaryTermType,
+  selectGlossaryPrimaryTerm,
   type GlossaryConceptImportEntry,
   type GlossaryConcept,
   type GlossaryConceptTerm,
@@ -89,7 +89,12 @@ function toGlossaryConceptInput(
 }
 
 export function toCrowdinConceptInput(concept: GlossaryConcept): CrowdinGlossaryConcept {
-  const primaryTerm = selectCrowdinPrimaryTerm(concept.terms, concept.sourceLocale);
+  const primaryTerm = selectGlossaryPrimaryTerm(concept.terms, concept.sourceLocale);
+  const hasPreferredSourceTerm = concept.terms.some(
+    (term) =>
+      term.languageId === concept.sourceLocale &&
+      term.status?.trim().toLowerCase().replaceAll(" ", "_") === "preferred",
+  );
   const terms = concept.terms.map((term) => ({
     id: term.id,
     languageId: term.languageId,
@@ -97,11 +102,13 @@ export function toCrowdinConceptInput(concept: GlossaryConcept): CrowdinGlossary
     description: term.description,
     partOfSpeech: normalizeGlossaryPartOfSpeech(term.partOfSpeech),
     status:
-      term !== primaryTerm &&
-      term.languageId === concept.sourceLocale &&
-      crowdinStatus(term.status) === "preferred"
-        ? "admitted"
-        : crowdinStatus(term.status),
+      term === primaryTerm && term.languageId === concept.sourceLocale && !hasPreferredSourceTerm
+        ? "preferred"
+        : term !== primaryTerm &&
+            term.languageId === concept.sourceLocale &&
+            crowdinStatus(term.status) === "preferred"
+          ? "admitted"
+          : crowdinStatus(term.status),
     type: term.type,
     gender: term.gender,
     note: term.note,

--- a/apps/hyperlocalise-web/src/lib/glossary/glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/glossary.ts
@@ -150,6 +150,33 @@ export type GlossaryConcept = {
   terms: GlossaryConceptTerm[];
 };
 
+export type GlossaryPrimaryTermCandidate = {
+  id?: number | string;
+  languageId: string;
+  text: string;
+  status?: string | null;
+};
+
+export function selectGlossaryPrimaryTerm<T extends GlossaryPrimaryTermCandidate>(
+  terms: T[],
+  sourceLocale: string,
+): T | undefined {
+  const sourceTerms = terms.filter((term) => term.languageId === sourceLocale);
+  return (
+    sourceTerms.find(
+      (term) => term.status?.trim().toLowerCase().replaceAll(" ", "_") === "preferred",
+    ) ??
+    [...sourceTerms].sort((left, right) => {
+      const leftId = left.id == null ? Number.NaN : Number(left.id);
+      const rightId = right.id == null ? Number.NaN : Number(right.id);
+      if (Number.isFinite(leftId) && Number.isFinite(rightId)) return leftId - rightId;
+      if (Number.isFinite(leftId)) return -1;
+      if (Number.isFinite(rightId)) return 1;
+      return String(left.id ?? "").localeCompare(String(right.id ?? ""));
+    })[0]
+  );
+}
+
 export type GlossaryConceptRequestTerm = {
   id?: number | string;
   locale: string;

--- a/apps/hyperlocalise-web/src/lib/glossary/native-glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/native-glossary.ts
@@ -19,6 +19,7 @@ import {
   normalizeGlossaryPartOfSpeech,
   normalizeGlossaryTermStatus,
   normalizeGlossaryTermType,
+  selectGlossaryPrimaryTerm,
 } from "./glossary";
 import type {
   GlossaryTermCreateInput,
@@ -33,12 +34,18 @@ import type { GlossaryProviderContext } from "./glossary-provider";
 import { createGlossaryTermDuplicateTracker } from "./glossary-term-dedupe";
 
 function normalizeNativeConcept(input: GlossaryConcept): GlossaryConcept {
-  const terms = input.terms.map((term) => ({
+  let terms = input.terms.map((term) => ({
     ...term,
     partOfSpeech: normalizeGlossaryPartOfSpeech(term.partOfSpeech, { required: false }),
   }));
 
-  if (!terms.some((term) => term.languageId === input.sourceLocale) && input.primaryTerm) {
+  let primaryTerm = selectGlossaryPrimaryTerm(terms, input.sourceLocale);
+  const hasPreferredSourceTerm = terms.some(
+    (term) =>
+      term.languageId === input.sourceLocale &&
+      term.status?.trim().toLowerCase().replaceAll(" ", "_") === "preferred",
+  );
+  if (!primaryTerm && input.primaryTerm) {
     const sourcePartOfSpeech = terms.find((term) => term.partOfSpeech)?.partOfSpeech;
     terms.push({
       languageId: input.sourceLocale,
@@ -46,6 +53,21 @@ function normalizeNativeConcept(input: GlossaryConcept): GlossaryConcept {
       partOfSpeech: sourcePartOfSpeech,
       status: "preferred",
     });
+    primaryTerm = terms.at(-1);
+  }
+
+  if (primaryTerm && input.primaryTerm) {
+    terms = terms.map((term) =>
+      term === primaryTerm
+        ? {
+            ...term,
+            text: input.primaryTerm,
+            status: hasPreferredSourceTerm ? term.status : "preferred",
+          }
+        : term.languageId === input.sourceLocale && term.status === "preferred"
+          ? { ...term, status: "admitted" }
+          : term,
+    );
   }
 
   return {
@@ -164,7 +186,16 @@ export class NativeGlossary extends Glossary {
     loaded: NonNullable<Awaited<ReturnType<NativeGlossary["loadConcept"]>>>,
   ): GlossaryConcept {
     return {
-      primaryTerm: loaded.concept.primaryTerm,
+      primaryTerm:
+        selectGlossaryPrimaryTerm(
+          loaded.terms.map((term) => ({
+            id: term.id,
+            languageId: term.locale ?? "",
+            text: term.term ?? term.sourceTerm,
+            status: term.status,
+          })),
+          this.input.glossary.sourceLocale,
+        )?.text ?? loaded.concept.primaryTerm,
       sourceLocale: this.input.glossary.sourceLocale,
       subject: loaded.concept.subject,
       definition: loaded.concept.definition,

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider-glossary.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider-glossary.test.ts
@@ -46,7 +46,7 @@ describe("Crowdin live glossary concepts", () => {
 
     expect(concept.terms).toMatchObject([
       { id: 11, languageId: "en", text: "Payment", status: "admitted" },
-      { id: 10, languageId: "en", text: "Checkout updated", status: "draft" },
+      { id: 10, languageId: "en", text: "Checkout updated", status: "preferred" },
     ]);
   });
 

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider-glossary.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider-glossary.test.ts
@@ -13,8 +13,43 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import { crowdinTmsProvider } from "./crowdin-provider";
+import { toCrowdinConceptInput } from "@/lib/glossary/crowdin-glossary";
 
 describe("Crowdin live glossary concepts", () => {
+  it("preserves source-locale synonyms and updates only the canonical term", () => {
+    const concept = toCrowdinConceptInput({
+      primaryTerm: "Checkout updated",
+      sourceLocale: "en",
+      terms: [
+        { id: 10, languageId: "en", text: "Checkout", status: "preferred", partOfSpeech: "noun" },
+        { id: 11, languageId: "en", text: "Payment", status: "preferred", partOfSpeech: "noun" },
+        { id: 12, languageId: "de", text: "Bezahlen", status: "draft", partOfSpeech: "noun" },
+      ],
+    });
+
+    expect(concept.terms).toMatchObject([
+      { id: 10, languageId: "en", text: "Checkout updated", status: "preferred" },
+      { id: 11, languageId: "en", text: "Payment", status: "admitted" },
+      { id: 12, languageId: "de", text: "Bezahlen", status: "draft" },
+    ]);
+  });
+
+  it("uses the lowest source term ID when no preferred term exists", () => {
+    const concept = toCrowdinConceptInput({
+      primaryTerm: "Checkout updated",
+      sourceLocale: "en",
+      terms: [
+        { id: 11, languageId: "en", text: "Payment", status: "admitted", partOfSpeech: "noun" },
+        { id: 10, languageId: "en", text: "Checkout", status: "draft", partOfSpeech: "noun" },
+      ],
+    });
+
+    expect(concept.terms).toMatchObject([
+      { id: 11, languageId: "en", text: "Payment", status: "admitted" },
+      { id: 10, languageId: "en", text: "Checkout updated", status: "draft" },
+    ]);
+  });
+
   it("uses the glossary source locale to select the primary term", async () => {
     const fetchMock = vi.fn(async (url) => {
       const path = String(url).replace("https://api.crowdin.test/api/v2", "");

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
@@ -13,6 +13,7 @@
 import { createHash } from "node:crypto";
 
 import type { JobKind } from "@/lib/database/types";
+import { selectGlossaryPrimaryTerm } from "@/lib/glossary/glossary";
 import { createLogger } from "@/lib/log";
 import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-with-concurrency";
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
@@ -256,25 +257,6 @@ export type CrowdinGlossaryConcept = {
   externalUpdatedAt?: string | null;
   terms: CrowdinGlossaryConceptTerm[];
 };
-
-function isPreferredCrowdinTerm(term: CrowdinGlossaryTermInput) {
-  return term.status?.trim().toLowerCase().replaceAll(" ", "_") === "preferred";
-}
-
-export function selectCrowdinPrimaryTerm(terms: CrowdinGlossaryTermInput[], sourceLocale: string) {
-  const sourceTerms = terms.filter((term) => term.languageId === sourceLocale);
-  return (
-    sourceTerms.find(isPreferredCrowdinTerm) ??
-    [...sourceTerms].sort((left, right) => {
-      const leftId = "id" in left && left.id != null ? Number(left.id) : Number.NaN;
-      const rightId = "id" in right && right.id != null ? Number(right.id) : Number.NaN;
-      if (Number.isFinite(leftId) && Number.isFinite(rightId)) return leftId - rightId;
-      if (Number.isFinite(leftId)) return -1;
-      if (Number.isFinite(rightId)) return 1;
-      return 0;
-    })[0]
-  );
-}
 
 type CrowdinLiveGlossaryScope = Pick<
   TmsProviderProjectScope,
@@ -709,7 +691,7 @@ export class CrowdinTmsProvider extends TmsProvider {
     const mapped: CrowdinGlossaryConcept[] = concepts.map((concept) => ({
       conceptId: concept.id,
       primaryTerm:
-        selectCrowdinPrimaryTerm(termsByConcept.get(concept.id) ?? [], sourceLocale)?.text ?? "",
+        selectGlossaryPrimaryTerm(termsByConcept.get(concept.id) ?? [], sourceLocale)?.text ?? "",
       sourceLocale,
       subject: concept.subject,
       definition: concept.definition,
@@ -729,7 +711,7 @@ export class CrowdinTmsProvider extends TmsProvider {
       if (knownIds.has(conceptId)) continue;
       mapped.push({
         conceptId,
-        primaryTerm: selectCrowdinPrimaryTerm(conceptTerms, sourceLocale)?.text ?? "",
+        primaryTerm: selectGlossaryPrimaryTerm(conceptTerms, sourceLocale)?.text ?? "",
         sourceLocale,
         subject: "",
         definition: "",

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
@@ -257,6 +257,25 @@ export type CrowdinGlossaryConcept = {
   terms: CrowdinGlossaryConceptTerm[];
 };
 
+function isPreferredCrowdinTerm(term: CrowdinGlossaryTermInput) {
+  return term.status?.trim().toLowerCase().replaceAll(" ", "_") === "preferred";
+}
+
+export function selectCrowdinPrimaryTerm(terms: CrowdinGlossaryTermInput[], sourceLocale: string) {
+  const sourceTerms = terms.filter((term) => term.languageId === sourceLocale);
+  return (
+    sourceTerms.find(isPreferredCrowdinTerm) ??
+    [...sourceTerms].sort((left, right) => {
+      const leftId = "id" in left && left.id != null ? Number(left.id) : Number.NaN;
+      const rightId = "id" in right && right.id != null ? Number(right.id) : Number.NaN;
+      if (Number.isFinite(leftId) && Number.isFinite(rightId)) return leftId - rightId;
+      if (Number.isFinite(leftId)) return -1;
+      if (Number.isFinite(rightId)) return 1;
+      return 0;
+    })[0]
+  );
+}
+
 type CrowdinLiveGlossaryScope = Pick<
   TmsProviderProjectScope,
   "organizationId" | "credential" | "secretMaterial" | "signal"
@@ -690,8 +709,7 @@ export class CrowdinTmsProvider extends TmsProvider {
     const mapped: CrowdinGlossaryConcept[] = concepts.map((concept) => ({
       conceptId: concept.id,
       primaryTerm:
-        termsByConcept.get(concept.id)?.find((term) => term.languageId === sourceLocale)?.text ??
-        "",
+        selectCrowdinPrimaryTerm(termsByConcept.get(concept.id) ?? [], sourceLocale)?.text ?? "",
       sourceLocale,
       subject: concept.subject,
       definition: concept.definition,
@@ -711,7 +729,7 @@ export class CrowdinTmsProvider extends TmsProvider {
       if (knownIds.has(conceptId)) continue;
       mapped.push({
         conceptId,
-        primaryTerm: conceptTerms.find((term) => term.languageId === sourceLocale)?.text ?? "",
+        primaryTerm: selectCrowdinPrimaryTerm(conceptTerms, sourceLocale)?.text ?? "",
         sourceLocale,
         subject: "",
         definition: "",


### PR DESCRIPTION
## Summary

Improve glossary concept editing so Native and Crowdin glossaries handle source-locale synonyms consistently, while polishing the glossary detail experience.

## Changes

- Preserve multiple source-locale terms as independent synonyms for Native and Crowdin glossaries.
- Select a deterministic canonical source term, preferring the preferred term and otherwise using the stable lowest term ID.
- Apply the concept primary term only to the canonical source row.
- Demote additional preferred source terms to admitted during save.
- Return the canonical source term as the concept primary term in API responses.
- Allow a source term to match the concept primary term without treating it as a duplicate.
- Add regression coverage for multiple source-locale rows and canonical-term updates.
- Add semantic colors to glossary term-status badges.
- Retain the existing glossary detail-page inline editing and provider-context improvements.

## Verification

- `vp check --fix` passes with existing repository warnings only.
- Crowdin glossary regression tests pass: 4 tests.
- `git diff --check` passes.
- Glossary route integration tests require PostgreSQL on `localhost:5432`; the local database was unavailable during verification.
