### PR TITLE
fix(crowdin): add FileID, LabelIDs, and CroQL parity to StringTranslationsListOptions

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -1,5 +1,11 @@
 # Crowdin Steward's Journal
 
+## 2026-12-31 - Add FileID, LabelIDs, and CroQL parity to StringTranslationsListOptions
+
+**Learning:** In Crowdin API v2, the List String Translations endpoint (`GET /api/v2/projects/{projectId}/translations`) accepts filtering by `fileId`, `labelIds`, and `croql` in addition to `stringId` and `languageId`. Omission of these query parameters from `StringTranslationsListOptions` prevented callers from listing string translations for specific files, label filters, or CroQL query expressions.
+
+**Action:** Added `FileID int json:"fileId,omitempty"`, `LabelIDs []int json:"labelIds,omitempty"`, and `CroQL string json:"croql,omitempty"` fields to `StringTranslationsListOptions` in `third_party/crowdin-api-client-go/crowdin/model/string_translations.go` and updated its `Values()` query serialization logic. Added unit and contract tests in `string_translations_test.go` and `model/string_translations_test.go`.
+
 ## 2026-12-31 - Add LabelIDs parity to BuildProjectFileTranslationRequest
 
 **Learning:** In Crowdin API v2, the Build Project File Translation endpoint (`POST /api/v2/projects/{projectId}/translations/builds/files/{fileId}`) accepts an optional `labelIds` array in the request body to filter builds by label identifiers. While `BuildProjectRequest` and `BuildProjectDirectoryTranslationRequest` included `labelIds`, `BuildProjectFileTranslationRequest` was missing `LabelIDs`, and its custom `MarshalJSON()` method omitted `labelIds` from serialized JSON payloads.

--- a/third_party/crowdin-api-client-go/crowdin/model/string_translations.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/string_translations.go
@@ -425,8 +425,16 @@ type StringTranslationsListOptions struct {
 	// Note: Must be used together with `languageId`.
 	StringID int `json:"stringId,omitempty"`
 	// Language Identifier.
-	// Note: Must be used together with `stringId`.
+	// Note: Must be used together with `stringId`, `fileId` or `labelIds`.
 	LanguageID string `json:"languageId,omitempty"`
+	// File Identifier.
+	// Note: Must be used together with `languageId`.
+	FileID int `json:"fileId,omitempty"`
+	// Label Identifiers.
+	// Example: labelIds=1,2,3,4,5
+	LabelIDs []int `json:"labelIds,omitempty"`
+	// Filter translations by CroQL.
+	CroQL string `json:"croql,omitempty"`
 	// Denormalize Placeholders.
 	// Enum: 0, 1. Default: 0.
 	DenormalizePlaceholders *int `json:"denormalizePlaceholders,omitempty"`
@@ -451,6 +459,15 @@ func (o *StringTranslationsListOptions) Values() (url.Values, bool) {
 	}
 	if o.LanguageID != "" {
 		v.Add("languageId", o.LanguageID)
+	}
+	if o.FileID > 0 {
+		v.Add("fileId", strconv.Itoa(o.FileID))
+	}
+	if len(o.LabelIDs) > 0 {
+		v.Add("labelIds", JoinSlice(o.LabelIDs))
+	}
+	if o.CroQL != "" {
+		v.Add("croql", o.CroQL)
 	}
 	if o.DenormalizePlaceholders != nil &&
 		(*o.DenormalizePlaceholders == 0 || *o.DenormalizePlaceholders == 1) {

--- a/third_party/crowdin-api-client-go/crowdin/model/string_translations_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/string_translations_test.go
@@ -327,9 +327,11 @@ func TestStringTranslationsListOptionsValues(t *testing.T) {
 			name: "with all options",
 			opts: &StringTranslationsListOptions{
 				OrderBy: "createdAt desc,name", StringID: 1,
-				LanguageID: "en", DenormalizePlaceholders: toPtr(1),
+				LanguageID: "en", FileID: 42, LabelIDs: []int{10, 20},
+				CroQL: "croql_expr", DenormalizePlaceholders: toPtr(1),
+				ListOptions: ListOptions{Offset: 5, Limit: 15},
 			},
-			out: "denormalizePlaceholders=1&languageId=en&orderBy=createdAt+desc%2Cname&stringId=1",
+			out: "croql=croql_expr&denormalizePlaceholders=1&fileId=42&labelIds=10%2C20&languageId=en&limit=15&offset=5&orderBy=createdAt+desc%2Cname&stringId=1",
 		},
 	}
 

--- a/third_party/crowdin-api-client-go/crowdin/string_translations_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/string_translations_test.go
@@ -817,11 +817,14 @@ func TestStringTranslationsService_ListStringTranslations(t *testing.T) {
 			opts: &model.StringTranslationsListOptions{
 				StringID:                2345,
 				LanguageID:              "uk",
+				FileID:                  12,
+				LabelIDs:                []int{1, 2},
+				CroQL:                   "croql_test",
 				OrderBy:                 "createdAt desc,id",
 				DenormalizePlaceholders: ToPtr(1),
 				ListOptions:             model.ListOptions{Offset: 10, Limit: 25},
 			},
-			expect: "?denormalizePlaceholders=1&languageId=uk&limit=25&offset=10&orderBy=createdAt+desc%2Cid&stringId=2345",
+			expect: "?croql=croql_test&denormalizePlaceholders=1&fileId=12&labelIds=1%2C2&languageId=uk&limit=25&offset=10&orderBy=createdAt+desc%2Cid&stringId=2345",
 		},
 	}
 


### PR DESCRIPTION
Added missing FileID, LabelIDs, and CroQL fields to StringTranslationsListOptions in third_party/crowdin-api-client-go/crowdin/model/string_translations.go and updated its Values() method to encode them, bringing the List String Translations endpoint into full parity with Crowdin API v2 contract specifications. Updated unit and contract tests in crowdin/model/string_translations_test.go and crowdin/string_translations_test.go.

---
*PR created automatically by Jules for task [7832353895801335889](https://jules.google.com/task/7832353895801335889) started by @cungminh2710*