### PR TITLE
feat(glossary): fetch Crowdin projects from live API

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.ts
@@ -10,11 +10,10 @@
  * of this software will be governed by the GNU General Public License
  * Version 2.0 or later.
  */
-import { and, count, desc, eq } from "drizzle-orm";
+import { count, desc } from "drizzle-orm";
 import { Hono } from "hono";
 import { validator } from "hono/validator";
 
-import { buildAccessibleProjectsWhere } from "@/api/auth/team-access";
 import { workosAuthMiddleware, type ApiAuthContext, type AuthVariables } from "@/api/auth/workos";
 import { badRequestResponse, conflictResponse } from "@/api/errors";
 import { PRODUCT_USAGE_ANALYTICS_EVENTS } from "@/lib/analytics/events";
@@ -68,14 +67,6 @@ type GlossaryListResult = {
   glossaries: NativeGlossary[];
   total: number;
   languagesByGlossaryId: Map<string, ReturnType<typeof toGlossaryRecord>["languages"]>;
-};
-
-type GlossaryProjectRecord = {
-  projectId: string;
-  projectName: string;
-  priority: number;
-  sourceLocale: string | null;
-  targetLocales: string[];
 };
 
 async function listGlossaries(
@@ -188,62 +179,6 @@ function parseGlossaryImport(payload: ImportGlossaryTermsBody): CreateGlossaryTe
         ]
       : [];
   });
-}
-
-async function listGlossaryProjects(
-  auth: ApiAuthContext,
-  glossary: Awaited<ReturnType<typeof getOwnedGlossary>>,
-): Promise<GlossaryProjectRecord[]> {
-  if (!glossary) return [];
-
-  const accessibleProjectsWhere = await buildAccessibleProjectsWhere(auth);
-  if (
-    glossary.source === "external_tms" &&
-    glossary.externalProviderKind === "crowdin" &&
-    glossary.externalProjectId
-  ) {
-    const [providerProject] = await db
-      .select({
-        projectId: schema.projects.id,
-        projectName: schema.projects.name,
-        sourceLocale: schema.projects.sourceLocale,
-        targetLocales: schema.projects.targetLocales,
-      })
-      .from(schema.projects)
-      .where(
-        and(
-          eq(schema.projects.organizationId, auth.organization.localOrganizationId),
-          eq(schema.projects.source, "external_tms"),
-          eq(schema.projects.externalProviderKind, "crowdin"),
-          eq(schema.projects.externalProjectId, glossary.externalProjectId),
-          accessibleProjectsWhere,
-        ),
-      )
-      .limit(1);
-
-    return providerProject ? [{ ...providerProject, priority: 0 }] : [];
-  }
-
-  const attachedProjects = await db
-    .select({
-      projectId: schema.projects.id,
-      projectName: schema.projects.name,
-      priority: schema.projectGlossaries.priority,
-      sourceLocale: schema.projects.sourceLocale,
-      targetLocales: schema.projects.targetLocales,
-    })
-    .from(schema.projectGlossaries)
-    .innerJoin(schema.projects, eq(schema.projectGlossaries.projectId, schema.projects.id))
-    .where(
-      and(
-        eq(schema.projectGlossaries.organizationId, auth.organization.localOrganizationId),
-        eq(schema.projectGlossaries.glossaryId, glossary.id),
-        accessibleProjectsWhere,
-      ),
-    )
-    .orderBy(schema.projectGlossaries.priority, schema.projects.name);
-
-  return attachedProjects;
 }
 
 const validateGlossaryParams = validator("param", (value, c) => {
@@ -594,7 +529,8 @@ export function createGlossaryRoutes() {
         return glossaryNotFoundResponse(c);
       }
 
-      return c.json({ projects: await listGlossaryProjects(c.var.auth, glossary) }, 200);
+      const product = getGlossaryProduct({ auth: c.var.auth, glossary });
+      return c.json({ projects: product ? await product.listProjects() : [] }, 200);
     })
     .post(
       "/:glossaryId/projects",
@@ -623,7 +559,7 @@ export function createGlossaryRoutes() {
         if (!product) return externalTmsGlossaryImmutableResponse(c);
         await product.attachProject(project.id, payload.priority);
 
-        return c.json({ projects: await listGlossaryProjects(c.var.auth, glossary) }, 200);
+        return c.json({ projects: await product.listProjects() }, 200);
       },
     )
     .delete("/:glossaryId/projects/:projectId", validateGlossaryProjectParams, async (c) => {

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.schema.ts
@@ -321,6 +321,7 @@ export const glossaryProjectRecordSchema = z.object({
   priority: z.number().int(),
   sourceLocale: z.string().nullable(),
   targetLocales: z.array(z.string()),
+  externalUrl: z.string().url().nullable(),
 });
 
 export const glossaryResponseSchema = z.object({

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
@@ -50,7 +50,7 @@ import {
   updateTmsProviderLiveJobFields,
   getTmsProviderLiveProject,
   listTmsProviderLiveFilesForProject,
-  listTmsProviderLiveGlossaries,
+  listTmsProviderLiveGlossariesPage,
   listTmsProviderLiveJobs,
   listTmsProviderLiveJobsForProject,
   listTmsProviderLiveProjectMembers,
@@ -70,6 +70,14 @@ const mineQuerySchema = z.object({
 
 const externalProjectIdQuerySchema = z.object({
   externalProjectId: z.string().min(1).optional(),
+});
+
+const liveGlossaryQuerySchema = z.object({
+  externalProjectId: z.string().min(1).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional().default(25),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+  orderBy: z.string().trim().min(1).max(100).optional().default("createdAt desc,name"),
+  filter: z.string().trim().max(200).optional(),
 });
 
 const projectFilesQuerySchema = z.object({
@@ -137,6 +145,15 @@ const validateMineQuery = validator("query", (value, c) => {
 
 const validateExternalProjectIdQuery = validator("query", (value, c) => {
   const parsed = externalProjectIdQuerySchema.safeParse(value);
+  if (!parsed.success) {
+    return c.json({ error: "invalid_query" }, 400);
+  }
+
+  return parsed.data;
+});
+
+const validateLiveGlossaryQuery = validator("query", (value, c) => {
+  const parsed = liveGlossaryQuerySchema.safeParse(value);
   if (!parsed.success) {
     return c.json({ error: "invalid_query" }, 400);
   }
@@ -723,7 +740,7 @@ export function createTmsProviderRoutes(options: CreateTmsProviderRoutesOptions 
 
       return c.json({ agentRun: serializeAgentRun(agentRun) }, 201);
     })
-    .get("/glossaries", validateExternalProjectIdQuery, async (c) => {
+    .get("/glossaries", validateLiveGlossaryQuery, async (c) => {
       if (!hasCapability(c.var.auth.membership.role, "glossaries:read")) {
         return c.json({ error: "forbidden" }, 403);
       }
@@ -731,14 +748,28 @@ export function createTmsProviderRoutes(options: CreateTmsProviderRoutesOptions 
       const query = c.req.valid("query");
 
       try {
-        const glossaries = await listTmsProviderLiveGlossaries(
+        const glossaryPage = await listTmsProviderLiveGlossariesPage(
           c.var.auth.organization.localOrganizationId,
           {
             externalProjectId: query.externalProjectId,
             actorUserId: c.var.auth.user.localUserId,
+            limit: query.limit,
+            offset: query.offset,
+            orderBy: query.orderBy,
+            filter: query.filter,
           },
         );
-        return c.json({ glossaries }, 200);
+        return c.json(
+          {
+            glossaries: glossaryPage.glossaries,
+            pagination: {
+              offset: glossaryPage.offset,
+              limit: glossaryPage.limit,
+              hasMore: glossaryPage.hasMore,
+            },
+          },
+          200,
+        );
       } catch (error) {
         return tmsProviderLiveErrorResponse(c, error);
       }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/tms-live-project-picker.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/tms-live-project-picker.messages.ts
@@ -30,4 +30,9 @@ export const tmsLiveProjectPickerMessages = defineMessages({
     id: "RtU7kH2epq",
     description: "Placeholder prompting the user to choose a TMS project",
   },
+  allProjects: {
+    defaultMessage: "All projects",
+    id: "TXSZ3cXaZk",
+    description: "Placeholder for browsing live TMS resources across all projects",
+  },
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/tms-live-project-picker.test.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/tms-live-project-picker.test.tsx
@@ -55,4 +55,24 @@ describe("TmsLiveProjectPicker", () => {
     expect(screen.getByText("Marketing website")).toBeInTheDocument();
     expect(screen.queryByText("902807")).not.toBeInTheDocument();
   });
+
+  it("uses all projects as the empty selection when enabled", () => {
+    useTmsLiveProjectsMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+
+    render(
+      <IntlProvider locale="en" messages={{}}>
+        <TmsLiveProjectPicker
+          organizationSlug="acme"
+          value=""
+          allowAll
+          onValueChange={() => undefined}
+        />
+      </IntlProvider>,
+    );
+
+    expect(screen.getByText("All projects")).toBeInTheDocument();
+  });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/tms-live-project-picker.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/tms-live-project-picker.tsx
@@ -31,11 +31,13 @@ export function TmsLiveProjectPicker({
   value,
   onValueChange,
   disabled = false,
+  allowAll = false,
 }: {
   organizationSlug: string;
   value: string;
   onValueChange: (externalProjectId: string) => void;
   disabled?: boolean;
+  allowAll?: boolean;
 }) {
   const intl = useIntl();
   const tmsProjectsQuery = useTmsLiveProjects(organizationSlug);
@@ -55,7 +57,9 @@ export function TmsLiveProjectPicker({
       <Select
         value={value || null}
         items={projectItems}
-        onValueChange={(nextValue) => onValueChange(nextValue ?? "")}
+        onValueChange={(nextValue) =>
+          onValueChange(nextValue === "__all__" || !nextValue ? "" : nextValue)
+        }
         disabled={disabled || tmsProjectsQuery.isLoading}
       >
         <SelectTrigger className={workspaceFilterTriggerClassName}>
@@ -63,11 +67,16 @@ export function TmsLiveProjectPicker({
             placeholder={
               tmsProjectsQuery.isLoading
                 ? intl.formatMessage(messages.loadingProjects)
-                : intl.formatMessage(messages.selectProject)
+                : intl.formatMessage(allowAll ? messages.allProjects : messages.selectProject)
             }
           />
         </SelectTrigger>
         <SelectContent>
+          {allowAll ? (
+            <SelectItem value="__all__" label={intl.formatMessage(messages.allProjects)}>
+              {intl.formatMessage(messages.allProjects)}
+            </SelectItem>
+          ) : null}
           {projects.map((project) => (
             <SelectItem
               key={project.externalProjectId!}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.messages.ts
@@ -185,15 +185,35 @@ export const glossaryDetailPageContentMessages = defineMessages({
     id: "CCHRUS19n3",
     description: "Empty search result in the part of speech picker",
   },
-  partOfSpeechNotSpecified: {
-    defaultMessage: "Not specified",
-    id: "bR1JlDPT+J",
-    description: "Empty value in the part of speech picker",
+  termTypeFullFormDescription: {
+    defaultMessage: "Complete form of a term",
+    id: 'F+qlLuaEi6',
+    description: "Description for the full form term type",
   },
-  partOfSpeechViewAllCategories: {
-    defaultMessage: "View all categories",
-    id: "NSKwDatzIu",
-    description: "Action to reveal all part of speech categories",
+  termTypeAcronymDescription: {
+    defaultMessage: "Initials pronounced as a word",
+    id: 'OMHukdK6Wt',
+    description: "Description for the acronym term type",
+  },
+  termTypeAbbreviationDescription: {
+    defaultMessage: "Shortened written form",
+    id: 'r7qqla56RV',
+    description: "Description for the abbreviation term type",
+  },
+  termTypeShortFormDescription: {
+    defaultMessage: "Informal shortened name",
+    id: '04/aNgNk5U',
+    description: "Description for the short form term type",
+  },
+  termTypePhraseDescription: {
+    defaultMessage: "Multi-word expression",
+    id: 'kDMX9jypDk',
+    description: "Description for the phrase term type",
+  },
+  termTypeVariantDescription: {
+    defaultMessage: "Alternative form",
+    id: '3s0Ll5QBJY',
+    description: "Description for the variant term type",
   },
   descriptionLabel: {
     defaultMessage: "Description",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.messages.ts
@@ -175,6 +175,26 @@ export const glossaryDetailPageContentMessages = defineMessages({
     id: "r1aEK84u1V",
     description: "Label for the part of speech field on a glossary term form",
   },
+  partOfSpeechSearchPlaceholder: {
+    defaultMessage: "Search part of speech...",
+    id: "wsUFAfa8Hd",
+    description: "Search placeholder for the part of speech picker",
+  },
+  partOfSpeechNoMatches: {
+    defaultMessage: "No categories found.",
+    id: "CCHRUS19n3",
+    description: "Empty search result in the part of speech picker",
+  },
+  partOfSpeechNotSpecified: {
+    defaultMessage: "Not specified",
+    id: "bR1JlDPT+J",
+    description: "Empty value in the part of speech picker",
+  },
+  partOfSpeechViewAllCategories: {
+    defaultMessage: "View all categories",
+    id: "NSKwDatzIu",
+    description: "Action to reveal all part of speech categories",
+  },
   descriptionLabel: {
     defaultMessage: "Description",
     id: "zXcAMcp/DE",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
@@ -26,7 +26,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { FormattedMessage, useIntl } from "react-intl";
+import { FormattedMessage, useIntl, type MessageDescriptor } from "react-intl";
 import { toast } from "sonner";
 
 import type {
@@ -47,7 +47,6 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
-  CommandSeparator,
 } from "@/components/ui/command";
 import {
   AlertDialog,
@@ -91,6 +90,7 @@ import {
   glossaryTermTypeValues,
   selectGlossaryPrimaryTerm,
   type GlossaryPartOfSpeech,
+  type GlossaryTermType,
   type GlossaryTermStatus,
 } from "@/lib/glossary/glossary";
 
@@ -227,29 +227,39 @@ const partOfSpeechMarks: Record<string, string> = {
   other: "Other",
 };
 
-const commonPartOfSpeechOptions = [
-  "noun",
-  "verb",
-  "adjective",
-  "adverb",
-  "pronoun",
-  "proper noun",
-] as const;
-
 function partOfSpeechMark(value: string) {
   return partOfSpeechMarks[value.trim().toLowerCase()] ?? "Other";
 }
 
-function PartOfSpeechMark({ value }: { value: string }) {
+const genderMarks: Record<string, string> = {
+  masculine: "M",
+  feminine: "F",
+  neuter: "N",
+  other: "O",
+};
+
+function TermMark({ mark }: { mark: string }) {
   return (
     <Badge
       variant="outline"
-      className="h-6 min-w-7 justify-center rounded-md border-border/70 bg-muted/35 px-1.5 py-0 text-xs font-medium leading-5 text-foreground"
+      className="h-5 min-w-7 justify-center rounded-md border-border/70 bg-muted/35 px-1 py-0 text-[11px] font-medium leading-4 text-foreground"
       aria-hidden="true"
     >
-      {partOfSpeechMark(value)}
+      {mark}
     </Badge>
   );
+}
+
+function PartOfSpeechMark({ value }: { value: string }) {
+  return <TermMark mark={partOfSpeechMark(value)} />;
+}
+
+function genderMark(value: string) {
+  return genderMarks[value.trim().toLowerCase()] ?? "O";
+}
+
+function GenderMark({ value }: { value: string }) {
+  return <TermMark mark={genderMark(value)} />;
 }
 
 function PartOfSpeechDisplay({ value }: { value: string | null | undefined }) {
@@ -257,14 +267,14 @@ function PartOfSpeechDisplay({ value }: { value: string | null | undefined }) {
   if (!value) {
     return (
       <span className="truncate text-muted-foreground">
-        {intl.formatMessage(messages.partOfSpeechNotSpecified)}
+        —
       </span>
     );
   }
 
   return (
     <span className="flex min-w-0 items-center gap-2">
-      <span className="flex w-14 shrink-0 items-center">
+      <span className="flex w-10 shrink-0 items-center">
         <PartOfSpeechMark value={value} />
       </span>
       <span className="truncate">{readableEnumLabel(value)}</span>
@@ -286,22 +296,13 @@ function PartOfSpeechPicker({
   const intl = useIntl();
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
-  const [showAllCategories, setShowAllCategories] = useState(false);
 
   const options = useMemo(() => partOfSpeechOptionsFor(value), [value]);
-  const visibleOptions = useMemo(() => {
-    const common = commonPartOfSpeechOptions.filter((option) => options.includes(option));
-    const selected = value && !common.some((option) => option === value) ? [value] : [];
-
-    if (showAllCategories || search.trim()) return options;
-    return [...common, ...selected];
-  }, [options, search, showAllCategories, value]);
 
   const handleOpenChange = (nextOpen: boolean) => {
     setOpen(nextOpen);
     if (!nextOpen) {
       setSearch("");
-      setShowAllCategories(false);
     }
   };
 
@@ -321,17 +322,23 @@ function PartOfSpeechPicker({
             aria-label={`${intl.formatMessage(messages.partOfSpeechLabel)}: ${
               value
                 ? readableEnumLabel(value)
-                : intl.formatMessage(messages.partOfSpeechNotSpecified)
+                : "—"
             }`}
             className={cn(
               termPropertyTriggerClassName,
-              "w-full max-w-[280px] justify-start gap-2 text-left",
+              "w-[80px] max-w-[80px] shrink-0 justify-start gap-2 text-left",
               className,
             )}
           />
         }
       >
-        <PartOfSpeechDisplay value={value} />
+        {value ? (
+          <PartOfSpeechMark value={value} />
+        ) : (
+          <span className="truncate text-muted-foreground">
+            —
+          </span>
+        )}
         <HugeiconsIcon
           icon={ArrowDown01Icon}
           strokeWidth={2}
@@ -353,15 +360,7 @@ function PartOfSpeechPicker({
           <CommandList className="max-h-64" label={intl.formatMessage(messages.partOfSpeechLabel)}>
             <CommandEmpty>{intl.formatMessage(messages.partOfSpeechNoMatches)}</CommandEmpty>
             <CommandGroup>
-              <CommandItem
-                value={`__none__ ${intl.formatMessage(messages.partOfSpeechNotSpecified)}`}
-                data-checked={value === "" || undefined}
-                aria-label={intl.formatMessage(messages.partOfSpeechNotSpecified)}
-                onSelect={() => selectValue("")}
-              >
-                {intl.formatMessage(messages.partOfSpeechNotSpecified)}
-              </CommandItem>
-              {visibleOptions.map((option) => (
+              {options.map((option) => (
                 <CommandItem
                   key={option}
                   value={`${option} ${readableEnumLabel(option)} ${partOfSpeechMark(option)}`}
@@ -373,20 +372,6 @@ function PartOfSpeechPicker({
                 </CommandItem>
               ))}
             </CommandGroup>
-            {!showAllCategories && !search.trim() ? (
-              <>
-                <CommandSeparator />
-                <CommandGroup>
-                  <CommandItem
-                    value="__view_all_categories__"
-                    onSelect={() => setShowAllCategories(true)}
-                    className="justify-center text-muted-foreground"
-                  >
-                    {intl.formatMessage(messages.partOfSpeechViewAllCategories)}
-                  </CommandItem>
-                </CommandGroup>
-              </>
-            ) : null}
           </CommandList>
         </Command>
       </PopoverContent>
@@ -394,19 +379,224 @@ function PartOfSpeechPicker({
   );
 }
 
-function TermPropertyBadge({ value }: { value: string | null | undefined }) {
-  if (!value) return <span className="text-muted-foreground">—</span>;
+function GenderDisplay({ value }: { value: string | null | undefined }) {
+  const intl = useIntl();
+  if (!value) {
+    return (
+      <span className="truncate text-muted-foreground">
+        —
+      </span>
+    );
+  }
 
-  const label = readableEnumLabel(value);
   return (
-    <Badge
-      variant="outline"
-      className="h-6 min-w-8 justify-center border-border/70 bg-muted/35 px-2 py-0 text-xs font-semibold leading-5 text-foreground"
-      title={label}
-      aria-label={label}
-    >
-      {label}
-    </Badge>
+    <span className="flex min-w-0 items-center gap-2">
+      <span className="flex w-10 shrink-0 items-center">
+        <GenderMark value={value} />
+      </span>
+      <span className="truncate">{readableEnumLabel(value)}</span>
+    </span>
+  );
+}
+
+function GenderPicker({
+  value,
+  onValueChange,
+  disabled = false,
+}: {
+  value: string;
+  onValueChange: (value: string | null) => void;
+  disabled?: boolean;
+}) {
+  const intl = useIntl();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={disabled}
+            aria-label={`${intl.formatMessage(messages.genderLabel)}: ${
+              value
+                ? readableEnumLabel(value)
+                : "—"
+            }`}
+            className={cn(termPropertyTriggerClassName, "justify-start gap-2 text-left")}
+          />
+        }
+      >
+        {value ? (
+          <GenderMark value={value} />
+        ) : (
+          <span className="truncate text-muted-foreground">
+            —
+          </span>
+        )}
+        <HugeiconsIcon
+          icon={ArrowDown01Icon}
+          strokeWidth={2}
+          className="size-4 shrink-0 text-muted-foreground"
+          aria-hidden="true"
+        />
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        sideOffset={4}
+        className="w-[280px] max-w-[calc(100vw-2rem)] p-0"
+      >
+        <Command>
+          <CommandList className="max-h-64" label={intl.formatMessage(messages.genderLabel)}>
+            <CommandEmpty>{intl.formatMessage(messages.partOfSpeechNoMatches)}</CommandEmpty>
+            <CommandGroup>
+              {genderOptions.map((option) => (
+                <CommandItem
+                  key={option}
+                  value={`${option} ${readableEnumLabel(option)} ${genderMark(option)}`}
+                  data-checked={value === option || undefined}
+                  aria-label={readableEnumLabel(option)}
+                  onSelect={() => {
+                    onValueChange(option);
+                    setOpen(false);
+                  }}
+                >
+                  <GenderDisplay value={option} />
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+const termTypeMarks: Record<GlossaryTermType, string> = {
+  "full form": "FF",
+  acronym: "AC",
+  abbreviation: "AB",
+  "short form": "SF",
+  phrase: "PH",
+  variant: "VAR",
+};
+
+const termTypeDescriptionMessages: Record<GlossaryTermType, MessageDescriptor> = {
+  "full form": messages.termTypeFullFormDescription,
+  acronym: messages.termTypeAcronymDescription,
+  abbreviation: messages.termTypeAbbreviationDescription,
+  "short form": messages.termTypeShortFormDescription,
+  phrase: messages.termTypePhraseDescription,
+  variant: messages.termTypeVariantDescription,
+};
+
+function termTypeMark(value: string) {
+  return termTypeMarks[value.trim().toLowerCase() as GlossaryTermType] ?? "VAR";
+}
+
+function TermTypeDisplay({ value }: { value: string | null | undefined }) {
+  const intl = useIntl();
+  if (!value) {
+    return (
+      <span className="truncate text-muted-foreground">
+        —
+      </span>
+    );
+  }
+
+  return (
+    <span className="flex min-w-0 items-center gap-2">
+      <span className="flex w-10 shrink-0 items-center">
+        <TermMark mark={termTypeMark(value)} />
+      </span>
+      <span className="truncate">{readableEnumLabel(value)}</span>
+    </span>
+  );
+}
+
+function TermTypePicker({
+  value,
+  onValueChange,
+  disabled = false,
+}: {
+  value: string;
+  onValueChange: (value: string | null) => void;
+  disabled?: boolean;
+}) {
+  const intl = useIntl();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={disabled}
+            aria-label={`${intl.formatMessage(messages.typeLabel)}: ${
+              value
+                ? readableEnumLabel(value)
+                : "—"
+            }`}
+            className={cn(termPropertyTriggerClassName, "justify-start gap-2 text-left")}
+          />
+        }
+      >
+        {value ? (
+          <TermMark mark={termTypeMark(value)} />
+        ) : (
+          <span className="truncate text-muted-foreground">
+            —
+          </span>
+        )}
+        <HugeiconsIcon
+          icon={ArrowDown01Icon}
+          strokeWidth={2}
+          className="size-4 shrink-0 text-muted-foreground"
+          aria-hidden="true"
+        />
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        sideOffset={4}
+        className="w-[280px] max-w-[calc(100vw-2rem)] p-0"
+      >
+        <Command>
+          <CommandList className="max-h-64" label={intl.formatMessage(messages.typeLabel)}>
+            <CommandEmpty>{intl.formatMessage(messages.partOfSpeechNoMatches)}</CommandEmpty>
+            <CommandGroup>
+              {termTypeOptions.map((option) => (
+                <CommandItem
+                  key={option}
+                  value={`${option} ${readableEnumLabel(option)} ${termTypeMark(option)}`}
+                  data-checked={value === option || undefined}
+                  aria-label={readableEnumLabel(option)}
+                  onSelect={() => {
+                    onValueChange(option);
+                    setOpen(false);
+                  }}
+                  className="items-start py-2.5"
+                >
+                  <span className="flex min-w-0 items-start gap-2">
+                    <span className="flex w-10 shrink-0 pt-0.5">
+                      <TermMark mark={termTypeMark(option)} />
+                    </span>
+                    <span className="min-w-0">
+                      <span className="block truncate">{readableEnumLabel(option)}</span>
+                      <span className="block truncate text-xs text-muted-foreground">
+                        {intl.formatMessage(termTypeDescriptionMessages[option])}
+                      </span>
+                    </span>
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -427,7 +617,7 @@ function formatDate(value: string) {
 }
 
 const termPropertyTriggerClassName =
-  "h-8 border-transparent bg-transparent px-2.5 text-sm font-normal shadow-none hover:bg-muted/60 focus-visible:bg-muted/60";
+  "h-8 w-[100px] shrink-0 border-transparent bg-transparent px-2.5 text-sm font-normal shadow-none hover:bg-muted/60 focus-visible:bg-muted/60";
 
 function statusClass(status: TermDraft["status"]) {
   if (status === "preferred") {
@@ -450,7 +640,7 @@ function statusBadgeClass(status: TermDraft["status"]) {
 }
 
 function statusPickerTriggerClass() {
-  return "h-8 max-w-full justify-end rounded-md border-transparent bg-transparent px-1.5 shadow-none hover:bg-muted/60 focus-visible:border-ring";
+  return "h-8 w-[140px] shrink-0 justify-end rounded-md border-transparent bg-transparent px-1.5 shadow-none hover:bg-muted/60 focus-visible:border-ring";
 }
 
 function statusPickerItemClass(_status: TermDraft["status"]) {
@@ -1656,7 +1846,7 @@ export function GlossaryDetailPageContent({
                                         <td className="px-3 py-2">
                                           <Textarea
                                             autoFocus={creatingTermDrafts.at(-1)?.id === term.id}
-                                            className="w-64 max-w-full min-h-8 resize-y px-2 py-1.5 text-sm leading-5"
+                                            className="w-48 max-w-full min-h-8 resize-y px-2 py-1.5 text-sm leading-5"
                                             placeholder={intl.formatMessage(messages.termLabel)}
                                             value={term.term}
                                             onChange={(event) =>
@@ -1685,78 +1875,32 @@ export function GlossaryDetailPageContent({
                                           />
                                         </td>
                                         <td className="px-3 py-2">
-                                          <Select
-                                            value={term.gender ?? "__none"}
+                                          <GenderPicker
+                                            value={term.gender ?? ""}
                                             onValueChange={(value) =>
                                               setCreatingTermDrafts((drafts) =>
                                                 drafts.map((draft) =>
                                                   draft.id === term.id
-                                                    ? {
-                                                        ...draft,
-                                                        gender:
-                                                          value === "__none"
-                                                            ? null
-                                                            : (value ?? null),
-                                                      }
+                                                    ? { ...draft, gender: value }
                                                     : draft,
                                                 ),
                                               )
                                             }
-                                          >
-                                            <SelectTrigger
-                                              showIcon={false}
-                                              className={termPropertyTriggerClassName}
-                                            >
-                                              <SelectValue>
-                                                {term.gender ? readableEnumLabel(term.gender) : "—"}
-                                              </SelectValue>
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                              <SelectItem value="__none">—</SelectItem>
-                                              {genderOptions.map((option) => (
-                                                <SelectItem key={option} value={option}>
-                                                  {readableEnumLabel(option)}
-                                                </SelectItem>
-                                              ))}
-                                            </SelectContent>
-                                          </Select>
+                                          />
                                         </td>
                                         <td className="px-3 py-2">
-                                          <Select
-                                            value={term.termType ?? "__none"}
+                                          <TermTypePicker
+                                            value={term.termType ?? ""}
                                             onValueChange={(value) =>
                                               setCreatingTermDrafts((drafts) =>
                                                 drafts.map((draft) =>
                                                   draft.id === term.id
-                                                    ? {
-                                                        ...draft,
-                                                        termType:
-                                                          value === "__none"
-                                                            ? null
-                                                            : (value ?? null),
-                                                      }
+                                                    ? { ...draft, termType: value }
                                                     : draft,
                                                 ),
                                               )
                                             }
-                                          >
-                                            <SelectTrigger
-                                              showIcon={false}
-                                              className={termPropertyTriggerClassName}
-                                            >
-                                              <SelectValue>
-                                                <TermPropertyBadge value={term.termType} />
-                                              </SelectValue>
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                              <SelectItem value="__none">—</SelectItem>
-                                              {termTypeOptions.map((option) => (
-                                                <SelectItem key={option} value={option}>
-                                                  {readableEnumLabel(option)}
-                                                </SelectItem>
-                                              ))}
-                                            </SelectContent>
-                                          </Select>
+                                          />
                                         </td>
                                         <td className="px-3 py-2">
                                           <Select
@@ -2033,15 +2177,9 @@ export function GlossaryDetailPageContent({
                                         <tr className="border-t border-border">
                                           <td className="px-3 py-2">
                                             <div className="flex items-center gap-2">
-                                              {isTermDirty ? (
-                                                <span
-                                                  className="size-2 rounded-full bg-emerald-500"
-                                                  aria-hidden="true"
-                                                />
-                                              ) : null}
                                               {canEdit ? (
                                                 <Textarea
-                                                  className="w-64 max-w-full min-h-8 resize-y px-2 py-1.5 text-sm leading-5"
+                                                  className="w-48 max-w-full min-h-8 resize-y px-2 py-1.5 text-sm leading-5"
                                                   value={draft.term}
                                                   onChange={(event) =>
                                                     updateTermDraft(term.id, {
@@ -2070,70 +2208,26 @@ export function GlossaryDetailPageContent({
                                           </td>
                                           <td className="px-3 py-2">
                                             {canEdit ? (
-                                              <Select
-                                                value={draft.gender ?? "__none"}
+                                              <GenderPicker
+                                                value={draft.gender ?? ""}
                                                 onValueChange={(value) =>
-                                                  updateTermDraft(term.id, {
-                                                    gender:
-                                                      value === "__none" ? null : (value ?? null),
-                                                  })
+                                                  updateTermDraft(term.id, { gender: value })
                                                 }
-                                              >
-                                                <SelectTrigger
-                                                  showIcon={false}
-                                                  className={termPropertyTriggerClassName}
-                                                >
-                                                  <SelectValue>
-                                                    {draft.gender
-                                                      ? readableEnumLabel(draft.gender)
-                                                      : "—"}
-                                                  </SelectValue>
-                                                </SelectTrigger>
-                                                <SelectContent>
-                                                  <SelectItem value="__none">—</SelectItem>
-                                                  {genderOptions.map((option) => (
-                                                    <SelectItem key={option} value={option}>
-                                                      {readableEnumLabel(option)}
-                                                    </SelectItem>
-                                                  ))}
-                                                </SelectContent>
-                                              </Select>
-                                            ) : term.gender ? (
-                                              readableEnumLabel(term.gender)
+                                              />
                                             ) : (
-                                              "—"
+                                              <GenderDisplay value={term.gender} />
                                             )}
                                           </td>
                                           <td className="px-3 py-2">
                                             {canEdit ? (
-                                              <Select
-                                                value={draft.termType ?? "__none"}
+                                              <TermTypePicker
+                                                value={draft.termType ?? ""}
                                                 onValueChange={(value) =>
-                                                  updateTermDraft(term.id, {
-                                                    termType:
-                                                      value === "__none" ? null : (value ?? null),
-                                                  })
+                                                  updateTermDraft(term.id, { termType: value })
                                                 }
-                                              >
-                                                <SelectTrigger
-                                                  showIcon={false}
-                                                  className={termPropertyTriggerClassName}
-                                                >
-                                                  <SelectValue>
-                                                    <TermPropertyBadge value={draft.termType} />
-                                                  </SelectValue>
-                                                </SelectTrigger>
-                                                <SelectContent>
-                                                  <SelectItem value="__none">—</SelectItem>
-                                                  {termTypeOptions.map((option) => (
-                                                    <SelectItem key={option} value={option}>
-                                                      {readableEnumLabel(option)}
-                                                    </SelectItem>
-                                                  ))}
-                                                </SelectContent>
-                                              </Select>
+                                              />
                                             ) : (
-                                              <TermPropertyBadge value={term.termType} />
+                                              <TermTypeDisplay value={term.termType} />
                                             )}
                                           </td>
                                           <td className="px-3 py-2">
@@ -2179,31 +2273,40 @@ export function GlossaryDetailPageContent({
                                             )}
                                           </td>
                                           <td className="px-3 py-2 text-right">
-                                            <Button
-                                              type="button"
-                                              size="icon-xs"
-                                              variant="outline"
-                                              aria-expanded={isExpanded}
-                                              aria-label={intl.formatMessage(
-                                                isExpanded
-                                                  ? messages.collapseTerm
-                                                  : messages.expandTerm,
-                                              )}
-                                              onClick={() =>
-                                                setExpandedTermIds((current) => {
-                                                  const next = new Set(current);
-                                                  if (next.has(term.id)) next.delete(term.id);
-                                                  else next.add(term.id);
-                                                  return next;
-                                                })
-                                              }
-                                            >
-                                              <HugeiconsIcon
-                                                icon={ArrowDown01Icon}
-                                                strokeWidth={1.8}
-                                                className={isExpanded ? "" : "-rotate-90"}
+                                            <div className="flex items-center justify-end gap-2">
+                                              <span
+                                                className={cn(
+                                                  "size-2 shrink-0 rounded-full",
+                                                  isTermDirty ? "bg-emerald-500" : "bg-transparent",
+                                                )}
+                                                aria-hidden="true"
                                               />
-                                            </Button>
+                                              <Button
+                                                type="button"
+                                                size="icon-xs"
+                                                variant="outline"
+                                                aria-expanded={isExpanded}
+                                                aria-label={intl.formatMessage(
+                                                  isExpanded
+                                                    ? messages.collapseTerm
+                                                    : messages.expandTerm,
+                                                )}
+                                                onClick={() =>
+                                                  setExpandedTermIds((current) => {
+                                                    const next = new Set(current);
+                                                    if (next.has(term.id)) next.delete(term.id);
+                                                    else next.add(term.id);
+                                                    return next;
+                                                  })
+                                                }
+                                              >
+                                                <HugeiconsIcon
+                                                  icon={ArrowDown01Icon}
+                                                  strokeWidth={1.8}
+                                                  className={isExpanded ? "" : "-rotate-90"}
+                                                />
+                                              </Button>
+                                            </div>
                                           </td>
                                         </tr>
                                         {isExpanded ? (
@@ -2321,15 +2424,9 @@ export function GlossaryDetailPageContent({
                                       <tr className="border-t border-emerald-500/30 bg-emerald-500/5">
                                         <td className="px-3 py-2">
                                           <div className="flex items-center gap-2">
-                                            {newTermIsDirty ? (
-                                              <span
-                                                className="size-2 rounded-full bg-emerald-500"
-                                                aria-hidden="true"
-                                              />
-                                            ) : null}
                                             <Textarea
                                               autoFocus
-                                              className="w-64 max-w-full min-h-8 resize-y px-2 py-1.5 text-sm leading-5"
+                                              className="w-48 max-w-full min-h-8 resize-y px-2 py-1.5 text-sm leading-5"
                                               placeholder={intl.formatMessage(messages.termLabel)}
                                               value={newTermDraft.term}
                                               onChange={(event) =>
@@ -2353,63 +2450,26 @@ export function GlossaryDetailPageContent({
                                           />
                                         </td>
                                         <td className="px-3 py-2">
-                                          <Select
-                                            value={newTermDraft.gender ?? "__none"}
+                                          <GenderPicker
+                                            value={newTermDraft.gender ?? ""}
                                             onValueChange={(value) =>
                                               setNewTermDraft({
                                                 ...newTermDraft,
-                                                gender: value === "__none" ? null : (value ?? null),
+                                                gender: value,
                                               })
                                             }
-                                          >
-                                            <SelectTrigger
-                                              showIcon={false}
-                                              className={termPropertyTriggerClassName}
-                                            >
-                                              <SelectValue>
-                                                {newTermDraft.gender
-                                                  ? readableEnumLabel(newTermDraft.gender)
-                                                  : "—"}
-                                              </SelectValue>
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                              <SelectItem value="__none">—</SelectItem>
-                                              {genderOptions.map((option) => (
-                                                <SelectItem key={option} value={option}>
-                                                  {readableEnumLabel(option)}
-                                                </SelectItem>
-                                              ))}
-                                            </SelectContent>
-                                          </Select>
+                                          />
                                         </td>
                                         <td className="px-3 py-2">
-                                          <Select
-                                            value={newTermDraft.termType ?? "__none"}
+                                          <TermTypePicker
+                                            value={newTermDraft.termType ?? ""}
                                             onValueChange={(value) =>
                                               setNewTermDraft({
                                                 ...newTermDraft,
-                                                termType:
-                                                  value === "__none" ? null : (value ?? null),
+                                                termType: value,
                                               })
                                             }
-                                          >
-                                            <SelectTrigger
-                                              showIcon={false}
-                                              className={termPropertyTriggerClassName}
-                                            >
-                                              <SelectValue>
-                                                <TermPropertyBadge value={newTermDraft.termType} />
-                                              </SelectValue>
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                              <SelectItem value="__none">—</SelectItem>
-                                              {termTypeOptions.map((option) => (
-                                                <SelectItem key={option} value={option}>
-                                                  {readableEnumLabel(option)}
-                                                </SelectItem>
-                                              ))}
-                                            </SelectContent>
-                                          </Select>
+                                          />
                                         </td>
                                         <td className="px-3 py-2">
                                           <Select
@@ -2443,18 +2503,32 @@ export function GlossaryDetailPageContent({
                                           </Select>
                                         </td>
                                         <td className="px-3 py-2">
-                                          <Button
-                                            type="button"
-                                            size="icon-xs"
-                                            variant="ghost"
-                                            aria-label={intl.formatMessage(messages.cancelEdit)}
-                                            onClick={() => {
-                                              setNewTermLocale(null);
-                                              setNewTermDraft(emptyTermDraft);
-                                            }}
-                                          >
-                                            <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
-                                          </Button>
+                                          <div className="flex items-center justify-end gap-2">
+                                            <span
+                                              className={cn(
+                                                "size-2 shrink-0 rounded-full",
+                                                newTermIsDirty
+                                                  ? "bg-emerald-500"
+                                                  : "bg-transparent",
+                                              )}
+                                              aria-hidden="true"
+                                            />
+                                            <Button
+                                              type="button"
+                                              size="icon-xs"
+                                              variant="ghost"
+                                              aria-label={intl.formatMessage(messages.cancelEdit)}
+                                              onClick={() => {
+                                                setNewTermLocale(null);
+                                                setNewTermDraft(emptyTermDraft);
+                                              }}
+                                            >
+                                              <HugeiconsIcon
+                                                icon={Delete02Icon}
+                                                strokeWidth={1.8}
+                                              />
+                                            </Button>
+                                          </div>
                                         </td>
                                       </tr>
                                       <tr className="border-t border-emerald-500/30 bg-emerald-500/5">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
@@ -19,9 +19,14 @@ import {
   Add01Icon,
   ArrowDown01Icon,
   ArrowLeft01Icon,
+  AlertCircleIcon,
   BookOpenTextIcon,
+  CancelCircleIcon,
+  CheckmarkCircle02Icon,
+  Clock01Icon,
   Delete02Icon,
   FilterIcon,
+  InformationCircleIcon,
   Link01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -214,9 +219,56 @@ const termPropertyTriggerClassName =
   "h-7 border-transparent bg-transparent px-2 text-xs font-normal shadow-none hover:bg-muted/60 focus-visible:bg-muted/60";
 
 function statusClass(status: TermDraft["status"]) {
-  if (status === "preferred") return "border-emerald-500/30 text-emerald-700";
-  if (status === "not_recommended") return "border-destructive/30 text-destructive";
-  return "border-amber-500/30 text-amber-700";
+  if (status === "preferred") {
+    return "!border-emerald-500/30 !bg-emerald-500/10 !text-emerald-700 dark:!text-emerald-300";
+  }
+  if (status === "admitted") {
+    return "!border-sky-500/30 !bg-sky-500/10 !text-sky-700 dark:!text-sky-300";
+  }
+  if (status === "draft") {
+    return "!border-amber-500/30 !bg-amber-500/10 !text-amber-700 dark:!text-amber-300";
+  }
+  if (status === "not_recommended") {
+    return "!border-rose-500/30 !bg-rose-500/10 !text-rose-700 dark:!text-rose-300";
+  }
+  return "!border-slate-500/30 !bg-slate-500/10 !text-slate-700 dark:!text-slate-300";
+}
+
+function statusIcon(status: TermDraft["status"]) {
+  if (status === "preferred") return CheckmarkCircle02Icon;
+  if (status === "admitted") return InformationCircleIcon;
+  if (status === "draft") return Clock01Icon;
+  if (status === "not_recommended") return AlertCircleIcon;
+  return CancelCircleIcon;
+}
+
+function StatusLabel({ status, className }: { status: TermDraft["status"]; className?: string }) {
+  return (
+    <span className={cn("inline-flex items-center gap-1.5", className)}>
+      <HugeiconsIcon
+        icon={statusIcon(status)}
+        strokeWidth={1.8}
+        className="size-3.5"
+        aria-hidden="true"
+      />
+      <span>{readableEnumLabel(status)}</span>
+    </span>
+  );
+}
+
+function TermStatusSkeleton({ compact = false }: { compact?: boolean }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-md border border-border/70 bg-muted/40 px-2",
+        compact ? "h-5" : "h-7 w-full",
+      )}
+      aria-hidden="true"
+    >
+      <Skeleton className={cn("rounded-full", compact ? "size-2.5" : "size-3")} />
+      <Skeleton className={cn("h-2.5", compact ? "w-14" : "w-20")} />
+    </span>
+  );
 }
 
 function ConceptListSkeleton() {
@@ -253,7 +305,10 @@ function ConceptListSkeleton() {
               className="grid min-w-[760px] grid-cols-[2.5rem_1.4fr_2fr_1fr_1fr_1fr] gap-4 border-b border-border px-3 py-4 last:border-b-0"
             >
               <Skeleton className="size-4 rounded-md" />
-              <Skeleton className="h-4 w-36 max-w-full" />
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-4 w-36 max-w-full" />
+                <TermStatusSkeleton compact />
+              </div>
               <Skeleton className="h-4 w-full max-w-xs" />
               <Skeleton className="h-4 w-24 max-w-full" />
               <Skeleton className="h-4 w-28 max-w-full" />
@@ -304,7 +359,7 @@ function ConceptDetailSkeleton() {
                       <Skeleton className="h-7 w-full" />
                       <Skeleton className="h-7 w-full" />
                       <Skeleton className="h-7 w-full" />
-                      <Skeleton className="h-7 w-full" />
+                      <TermStatusSkeleton />
                     </div>
                   ))}
                 </div>
@@ -1059,7 +1114,7 @@ export function GlossaryDetailPageContent({
                               {primary?.text ?? concept.primaryTerm}
                               {primary ? (
                                 <Badge variant="outline" className={statusClass(primary.status)}>
-                                  {primary.status}
+                                  <StatusLabel status={primary.status} />
                                 </Badge>
                               ) : null}
                             </div>
@@ -1475,16 +1530,23 @@ export function GlossaryDetailPageContent({
                                           >
                                             <SelectTrigger
                                               showIcon={false}
-                                              className={termPropertyTriggerClassName}
+                                              className={cn(
+                                                termPropertyTriggerClassName,
+                                                statusClass(term.status),
+                                              )}
                                             >
                                               <SelectValue>
-                                                {readableEnumLabel(term.status)}
+                                                <StatusLabel status={term.status} />
                                               </SelectValue>
                                             </SelectTrigger>
                                             <SelectContent>
                                               {statusOptions.map((option) => (
-                                                <SelectItem key={option} value={option}>
-                                                  {readableEnumLabel(option)}
+                                                <SelectItem
+                                                  key={option}
+                                                  value={option}
+                                                  className={statusClass(option)}
+                                                >
+                                                  <StatusLabel status={option} />
                                                 </SelectItem>
                                               ))}
                                             </SelectContent>
@@ -1890,7 +1952,7 @@ export function GlossaryDetailPageContent({
                                                 variant="outline"
                                                 className={statusClass(term.status)}
                                               >
-                                                {readableEnumLabel(term.status)}
+                                                <StatusLabel status={term.status} />
                                               </Badge>
                                             )}
                                           </td>
@@ -2163,16 +2225,23 @@ export function GlossaryDetailPageContent({
                                           >
                                             <SelectTrigger
                                               showIcon={false}
-                                              className={termPropertyTriggerClassName}
+                                              className={cn(
+                                                termPropertyTriggerClassName,
+                                                statusClass(newTermDraft.status),
+                                              )}
                                             >
                                               <SelectValue>
-                                                {readableEnumLabel(newTermDraft.status)}
+                                                <StatusLabel status={newTermDraft.status} />
                                               </SelectValue>
                                             </SelectTrigger>
                                             <SelectContent>
                                               {statusOptions.map((option) => (
-                                                <SelectItem key={option} value={option}>
-                                                  {readableEnumLabel(option)}
+                                                <SelectItem
+                                                  key={option}
+                                                  value={option}
+                                                  className={statusClass(option)}
+                                                >
+                                                  <StatusLabel status={option} />
                                                 </SelectItem>
                                               ))}
                                             </SelectContent>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
@@ -2381,12 +2381,23 @@ export function GlossaryDetailPageContent({
                 key={project.projectId}
                 className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-border px-3 py-2"
               >
-                <Link
-                  href={`/org/${organizationSlug}/projects/${project.projectId}`}
-                  className="text-sm font-medium text-foreground hover:underline"
-                >
-                  {project.projectName}
-                </Link>
+                {project.externalUrl ? (
+                  <a
+                    href={project.externalUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-sm font-medium text-foreground hover:underline"
+                  >
+                    {project.projectName}
+                  </a>
+                ) : (
+                  <Link
+                    href={`/org/${organizationSlug}/projects/${project.projectId}`}
+                    className="text-sm font-medium text-foreground hover:underline"
+                  >
+                    {project.projectName}
+                  </Link>
+                )}
                 {canEdit && isNative ? (
                   <Button
                     type="button"

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
@@ -41,6 +41,15 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -70,6 +79,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
 import { TypographyH1, TypographyP } from "@/components/ui/typography";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { readApiError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
 import { COMMON_LOCALES, getLocaleLabel } from "@/lib/i18n/locales";
@@ -194,7 +204,197 @@ function readableEnumLabel(value: string) {
   return label ? `${label.charAt(0).toUpperCase()}${label.slice(1)}` : label;
 }
 
-function PartOfSpeechBadge({ value }: { value: string | null | undefined }) {
+const partOfSpeechMarks: Record<string, string> = {
+  noun: "N",
+  "proper noun": "PN",
+  verb: "V",
+  auxiliary: "Aux",
+  adjective: "Adj",
+  adverb: "Adv",
+  pronoun: "Pro",
+  adposition: "Adp",
+  preposition: "Prep",
+  conjunction: "Conj",
+  "coordinating conjunction": "CConj",
+  "subordinating conjunction": "SConj",
+  determiner: "Det",
+  interjection: "Int",
+  numeral: "Num",
+  particle: "Part",
+  article: "Art",
+  abbreviation: "Abbr",
+  phrase: "Phr",
+  other: "Other",
+};
+
+const commonPartOfSpeechOptions = [
+  "noun",
+  "verb",
+  "adjective",
+  "adverb",
+  "pronoun",
+  "proper noun",
+] as const;
+
+function partOfSpeechMark(value: string) {
+  return partOfSpeechMarks[value.trim().toLowerCase()] ?? "Other";
+}
+
+function PartOfSpeechMark({ value }: { value: string }) {
+  return (
+    <Badge
+      variant="outline"
+      className="h-6 min-w-7 justify-center rounded-md border-border/70 bg-muted/35 px-1.5 py-0 text-xs font-medium leading-5 text-foreground"
+      aria-hidden="true"
+    >
+      {partOfSpeechMark(value)}
+    </Badge>
+  );
+}
+
+function PartOfSpeechDisplay({ value }: { value: string | null | undefined }) {
+  const intl = useIntl();
+  if (!value) {
+    return (
+      <span className="truncate text-muted-foreground">
+        {intl.formatMessage(messages.partOfSpeechNotSpecified)}
+      </span>
+    );
+  }
+
+  return (
+    <span className="flex min-w-0 items-center gap-2">
+      <span className="flex w-14 shrink-0 items-center">
+        <PartOfSpeechMark value={value} />
+      </span>
+      <span className="truncate">{readableEnumLabel(value)}</span>
+    </span>
+  );
+}
+
+function PartOfSpeechPicker({
+  value,
+  onValueChange,
+  disabled = false,
+  className,
+}: {
+  value: string;
+  onValueChange: (value: string) => void;
+  disabled?: boolean;
+  className?: string;
+}) {
+  const intl = useIntl();
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [showAllCategories, setShowAllCategories] = useState(false);
+
+  const options = useMemo(() => partOfSpeechOptionsFor(value), [value]);
+  const visibleOptions = useMemo(() => {
+    const common = commonPartOfSpeechOptions.filter((option) => options.includes(option));
+    const selected = value && !common.some((option) => option === value) ? [value] : [];
+
+    if (showAllCategories || search.trim()) return options;
+    return [...common, ...selected];
+  }, [options, search, showAllCategories, value]);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setSearch("");
+      setShowAllCategories(false);
+    }
+  };
+
+  const selectValue = (nextValue: string) => {
+    onValueChange(nextValue);
+    handleOpenChange(false);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger
+        render={
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={disabled}
+            aria-label={`${intl.formatMessage(messages.partOfSpeechLabel)}: ${
+              value
+                ? readableEnumLabel(value)
+                : intl.formatMessage(messages.partOfSpeechNotSpecified)
+            }`}
+            className={cn(
+              termPropertyTriggerClassName,
+              "w-full max-w-[280px] justify-start gap-2 text-left",
+              className,
+            )}
+          />
+        }
+      >
+        <PartOfSpeechDisplay value={value} />
+        <HugeiconsIcon
+          icon={ArrowDown01Icon}
+          strokeWidth={2}
+          className="size-4 shrink-0 text-muted-foreground"
+          aria-hidden="true"
+        />
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        sideOffset={4}
+        className="w-[280px] max-w-[calc(100vw-2rem)] p-0"
+      >
+        <Command>
+          <CommandInput
+            placeholder={intl.formatMessage(messages.partOfSpeechSearchPlaceholder)}
+            value={search}
+            onValueChange={setSearch}
+          />
+          <CommandList className="max-h-64" label={intl.formatMessage(messages.partOfSpeechLabel)}>
+            <CommandEmpty>{intl.formatMessage(messages.partOfSpeechNoMatches)}</CommandEmpty>
+            <CommandGroup>
+              <CommandItem
+                value={`__none__ ${intl.formatMessage(messages.partOfSpeechNotSpecified)}`}
+                data-checked={value === "" || undefined}
+                aria-label={intl.formatMessage(messages.partOfSpeechNotSpecified)}
+                onSelect={() => selectValue("")}
+              >
+                {intl.formatMessage(messages.partOfSpeechNotSpecified)}
+              </CommandItem>
+              {visibleOptions.map((option) => (
+                <CommandItem
+                  key={option}
+                  value={`${option} ${readableEnumLabel(option)} ${partOfSpeechMark(option)}`}
+                  data-checked={value === option || undefined}
+                  aria-label={readableEnumLabel(option)}
+                  onSelect={() => selectValue(option)}
+                >
+                  <PartOfSpeechDisplay value={option} />
+                </CommandItem>
+              ))}
+            </CommandGroup>
+            {!showAllCategories && !search.trim() ? (
+              <>
+                <CommandSeparator />
+                <CommandGroup>
+                  <CommandItem
+                    value="__view_all_categories__"
+                    onSelect={() => setShowAllCategories(true)}
+                    className="justify-center text-muted-foreground"
+                  >
+                    {intl.formatMessage(messages.partOfSpeechViewAllCategories)}
+                  </CommandItem>
+                </CommandGroup>
+              </>
+            ) : null}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function TermPropertyBadge({ value }: { value: string | null | undefined }) {
   if (!value) return <span className="text-muted-foreground">—</span>;
 
   const label = readableEnumLabel(value);
@@ -1454,9 +1654,9 @@ export function GlossaryDetailPageContent({
                                           </span>
                                         </td>
                                         <td className="px-3 py-2">
-                                          <Input
+                                          <Textarea
                                             autoFocus={creatingTermDrafts.at(-1)?.id === term.id}
-                                            className="h-7"
+                                            className="w-64 max-w-full min-h-8 resize-y px-2 py-1.5 text-sm leading-5"
                                             placeholder={intl.formatMessage(messages.termLabel)}
                                             value={term.term}
                                             onChange={(event) =>
@@ -1471,41 +1671,18 @@ export function GlossaryDetailPageContent({
                                           />
                                         </td>
                                         <td className="px-3 py-2">
-                                          <Select
-                                            value={term.partOfSpeech || "__none"}
+                                          <PartOfSpeechPicker
+                                            value={term.partOfSpeech}
                                             onValueChange={(value) =>
                                               setCreatingTermDrafts((drafts) =>
                                                 drafts.map((draft) =>
                                                   draft.id === term.id
-                                                    ? {
-                                                        ...draft,
-                                                        partOfSpeech:
-                                                          value === "__none" ? "" : (value ?? ""),
-                                                      }
+                                                    ? { ...draft, partOfSpeech: value }
                                                     : draft,
                                                 ),
                                               )
                                             }
-                                          >
-                                            <SelectTrigger
-                                              showIcon={false}
-                                              className={termPropertyTriggerClassName}
-                                            >
-                                              <SelectValue>
-                                                <PartOfSpeechBadge value={term.partOfSpeech} />
-                                              </SelectValue>
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                              <SelectItem value="__none">—</SelectItem>
-                                              {partOfSpeechOptionsFor(term.partOfSpeech).map(
-                                                (option) => (
-                                                  <SelectItem key={option} value={option}>
-                                                    {readableEnumLabel(option)}
-                                                  </SelectItem>
-                                                ),
-                                              )}
-                                            </SelectContent>
-                                          </Select>
+                                          />
                                         </td>
                                         <td className="px-3 py-2">
                                           <Select
@@ -1568,9 +1745,7 @@ export function GlossaryDetailPageContent({
                                               className={termPropertyTriggerClassName}
                                             >
                                               <SelectValue>
-                                                {term.termType
-                                                  ? readableEnumLabel(term.termType)
-                                                  : "—"}
+                                                <TermPropertyBadge value={term.termType} />
                                               </SelectValue>
                                             </SelectTrigger>
                                             <SelectContent>
@@ -1865,8 +2040,8 @@ export function GlossaryDetailPageContent({
                                                 />
                                               ) : null}
                                               {canEdit ? (
-                                                <Input
-                                                  className="h-7"
+                                                <Textarea
+                                                  className="w-64 max-w-full min-h-8 resize-y px-2 py-1.5 text-sm leading-5"
                                                   value={draft.term}
                                                   onChange={(event) =>
                                                     updateTermDraft(term.id, {
@@ -1881,36 +2056,16 @@ export function GlossaryDetailPageContent({
                                           </td>
                                           <td className="px-3 py-2">
                                             {canEdit ? (
-                                              <Select
-                                                value={draft.partOfSpeech || "__none"}
+                                              <PartOfSpeechPicker
+                                                value={draft.partOfSpeech}
                                                 onValueChange={(value) =>
                                                   updateTermDraft(term.id, {
-                                                    partOfSpeech:
-                                                      value === "__none" ? "" : (value ?? ""),
+                                                    partOfSpeech: value,
                                                   })
                                                 }
-                                              >
-                                                <SelectTrigger
-                                                  showIcon={false}
-                                                  className={termPropertyTriggerClassName}
-                                                >
-                                                  <SelectValue>
-                                                    <PartOfSpeechBadge value={draft.partOfSpeech} />
-                                                  </SelectValue>
-                                                </SelectTrigger>
-                                                <SelectContent>
-                                                  <SelectItem value="__none">—</SelectItem>
-                                                  {partOfSpeechOptionsFor(draft.partOfSpeech).map(
-                                                    (option) => (
-                                                      <SelectItem key={option} value={option}>
-                                                        {readableEnumLabel(option)}
-                                                      </SelectItem>
-                                                    ),
-                                                  )}
-                                                </SelectContent>
-                                              </Select>
+                                              />
                                             ) : (
-                                              <PartOfSpeechBadge value={term.partOfSpeech} />
+                                              <PartOfSpeechDisplay value={term.partOfSpeech} />
                                             )}
                                           </td>
                                           <td className="px-3 py-2">
@@ -1965,9 +2120,7 @@ export function GlossaryDetailPageContent({
                                                   className={termPropertyTriggerClassName}
                                                 >
                                                   <SelectValue>
-                                                    {draft.termType
-                                                      ? readableEnumLabel(draft.termType)
-                                                      : "—"}
+                                                    <TermPropertyBadge value={draft.termType} />
                                                   </SelectValue>
                                                 </SelectTrigger>
                                                 <SelectContent>
@@ -1979,10 +2132,8 @@ export function GlossaryDetailPageContent({
                                                   ))}
                                                 </SelectContent>
                                               </Select>
-                                            ) : term.termType ? (
-                                              readableEnumLabel(term.termType)
                                             ) : (
-                                              "—"
+                                              <TermPropertyBadge value={term.termType} />
                                             )}
                                           </td>
                                           <td className="px-3 py-2">
@@ -2176,9 +2327,9 @@ export function GlossaryDetailPageContent({
                                                 aria-hidden="true"
                                               />
                                             ) : null}
-                                            <Input
+                                            <Textarea
                                               autoFocus
-                                              className="h-7"
+                                              className="w-64 max-w-full min-h-8 resize-y px-2 py-1.5 text-sm leading-5"
                                               placeholder={intl.formatMessage(messages.termLabel)}
                                               value={newTermDraft.term}
                                               onChange={(event) =>
@@ -2191,37 +2342,15 @@ export function GlossaryDetailPageContent({
                                           </div>
                                         </td>
                                         <td className="px-3 py-2">
-                                          <Select
-                                            value={newTermDraft.partOfSpeech || "__none"}
+                                          <PartOfSpeechPicker
+                                            value={newTermDraft.partOfSpeech}
                                             onValueChange={(value) =>
                                               setNewTermDraft({
                                                 ...newTermDraft,
-                                                partOfSpeech:
-                                                  value === "__none" ? "" : (value ?? ""),
+                                                partOfSpeech: value,
                                               })
                                             }
-                                          >
-                                            <SelectTrigger
-                                              showIcon={false}
-                                              className={termPropertyTriggerClassName}
-                                            >
-                                              <SelectValue>
-                                                <PartOfSpeechBadge
-                                                  value={newTermDraft.partOfSpeech}
-                                                />
-                                              </SelectValue>
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                              <SelectItem value="__none">—</SelectItem>
-                                              {partOfSpeechOptionsFor(
-                                                newTermDraft.partOfSpeech,
-                                              ).map((option) => (
-                                                <SelectItem key={option} value={option}>
-                                                  {readableEnumLabel(option)}
-                                                </SelectItem>
-                                              ))}
-                                            </SelectContent>
-                                          </Select>
+                                          />
                                         </td>
                                         <td className="px-3 py-2">
                                           <Select
@@ -2269,9 +2398,7 @@ export function GlossaryDetailPageContent({
                                               className={termPropertyTriggerClassName}
                                             >
                                               <SelectValue>
-                                                {newTermDraft.termType
-                                                  ? readableEnumLabel(newTermDraft.termType)
-                                                  : "—"}
+                                                <TermPropertyBadge value={newTermDraft.termType} />
                                               </SelectValue>
                                             </SelectTrigger>
                                             <SelectContent>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
@@ -19,14 +19,9 @@ import {
   Add01Icon,
   ArrowDown01Icon,
   ArrowLeft01Icon,
-  AlertCircleIcon,
   BookOpenTextIcon,
-  CancelCircleIcon,
-  CheckmarkCircle02Icon,
-  Clock01Icon,
   Delete02Icon,
   FilterIcon,
-  InformationCircleIcon,
   Link01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -199,6 +194,45 @@ function readableEnumLabel(value: string) {
   return label ? `${label.charAt(0).toUpperCase()}${label.slice(1)}` : label;
 }
 
+const partOfSpeechShortLabels: Record<GlossaryPartOfSpeech, string> = {
+  adjective: "adj",
+  adposition: "adp",
+  adverb: "adv",
+  auxiliary: "aux",
+  "coordinating conjunction": "cc",
+  determiner: "det",
+  interjection: "intj",
+  noun: "n",
+  numeral: "num",
+  particle: "part",
+  pronoun: "pron",
+  "proper noun": "propn",
+  "subordinating conjunction": "sc",
+  verb: "v",
+  other: "other",
+};
+
+function partOfSpeechShortLabel(value: string) {
+  const normalized = normalizePartOfSpeech(value) ?? value;
+  return partOfSpeechShortLabels[normalized as GlossaryPartOfSpeech] ?? normalized;
+}
+
+function PartOfSpeechBadge({ value }: { value: string | null | undefined }) {
+  if (!value) return <span className="text-muted-foreground">—</span>;
+
+  const label = readableEnumLabel(value);
+  return (
+    <Badge
+      variant="outline"
+      className="h-6 min-w-8 justify-center border-border/70 bg-muted/35 px-2 py-0 text-xs font-semibold leading-5 text-foreground"
+      title={label}
+      aria-label={label}
+    >
+      {partOfSpeechShortLabel(value)}
+    </Badge>
+  );
+}
+
 function partOfSpeechOptionsFor(value: string) {
   return value && !partOfSpeechOptions.includes(value as GlossaryPartOfSpeech)
     ? [value, ...partOfSpeechOptions]
@@ -234,23 +268,83 @@ function statusClass(status: TermDraft["status"]) {
   return "!border-slate-500/30 !bg-slate-500/10 !text-slate-700 dark:!text-slate-300";
 }
 
-function statusIcon(status: TermDraft["status"]) {
-  if (status === "preferred") return CheckmarkCircle02Icon;
-  if (status === "admitted") return InformationCircleIcon;
-  if (status === "draft") return Clock01Icon;
-  if (status === "not_recommended") return AlertCircleIcon;
-  return CancelCircleIcon;
+function statusBadgeClass(status: TermDraft["status"]) {
+  return cn(statusClass(status), "px-1.5 py-0 text-[11px] leading-5");
+}
+
+function statusPickerTriggerClass() {
+  return "h-8 max-w-full justify-end rounded-md border-transparent bg-transparent px-1.5 shadow-none hover:bg-muted/60 focus-visible:border-ring";
+}
+
+function statusPickerItemClass(_status: TermDraft["status"]) {
+  return "rounded-lg px-2 py-1.5 hover:bg-muted! focus:bg-muted! focus:text-foreground! data-highlighted:bg-muted! data-highlighted:text-foreground!";
+}
+
+const statusPickerContentClassName = "min-w-44 p-1.5";
+
+function TermStatusIcon({
+  status,
+  className,
+}: {
+  status: TermDraft["status"];
+  className?: string;
+}) {
+  const iconClassName = cn("size-4 shrink-0", className);
+
+  if (status === "preferred") {
+    return (
+      <svg viewBox="0 0 16 16" fill="none" className={iconClassName} aria-hidden="true">
+        <circle cx="8" cy="8" r="7" className="fill-emerald-500" />
+        <path
+          d="m5 8.2 2 2 4-4"
+          stroke="white"
+          strokeWidth="1.75"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    );
+  }
+
+  if (status === "admitted") {
+    return (
+      <svg viewBox="0 0 16 16" fill="none" className={iconClassName} aria-hidden="true">
+        <circle cx="8" cy="8" r="6" className="stroke-sky-500" strokeWidth="1.75" />
+        <circle cx="8" cy="8" r="2.25" className="fill-sky-500" />
+      </svg>
+    );
+  }
+
+  if (status === "draft") {
+    return (
+      <svg viewBox="0 0 16 16" fill="none" className={iconClassName} aria-hidden="true">
+        <circle cx="8" cy="8" r="6" className="stroke-amber-500" strokeWidth="1.75" />
+        <path d="M8 2a6 6 0 0 1 0 12Z" className="fill-amber-500" />
+      </svg>
+    );
+  }
+
+  if (status === "not_recommended") {
+    return (
+      <svg viewBox="0 0 16 16" fill="none" className={iconClassName} aria-hidden="true">
+        <circle cx="8" cy="8" r="6" className="stroke-rose-500" strokeWidth="1.75" />
+        <path d="M5.5 8h5" className="stroke-rose-500" strokeWidth="1.75" strokeLinecap="round" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg viewBox="0 0 16 16" fill="none" className={iconClassName} aria-hidden="true">
+      <circle cx="8" cy="8" r="7" className="fill-slate-500" />
+      <path d="m5.5 5.5 5 5m0-5-5 5" stroke="white" strokeWidth="1.75" strokeLinecap="round" />
+    </svg>
+  );
 }
 
 function StatusLabel({ status, className }: { status: TermDraft["status"]; className?: string }) {
   return (
     <span className={cn("inline-flex items-center gap-1.5", className)}>
-      <HugeiconsIcon
-        icon={statusIcon(status)}
-        strokeWidth={1.8}
-        className="size-3.5"
-        aria-hidden="true"
-      />
+      <TermStatusIcon status={status} />
       <span>{readableEnumLabel(status)}</span>
     </span>
   );
@@ -1113,7 +1207,10 @@ export function GlossaryDetailPageContent({
                             <div className="flex flex-wrap items-center gap-2 font-medium">
                               {primary?.text ?? concept.primaryTerm}
                               {primary ? (
-                                <Badge variant="outline" className={statusClass(primary.status)}>
+                                <Badge
+                                  variant="outline"
+                                  className={statusBadgeClass(primary.status)}
+                                >
                                   <StatusLabel status={primary.status} />
                                 </Badge>
                               ) : null}
@@ -1418,9 +1515,7 @@ export function GlossaryDetailPageContent({
                                               className={termPropertyTriggerClassName}
                                             >
                                               <SelectValue>
-                                                {term.partOfSpeech
-                                                  ? readableEnumLabel(term.partOfSpeech)
-                                                  : "—"}
+                                                <PartOfSpeechBadge value={term.partOfSpeech} />
                                               </SelectValue>
                                             </SelectTrigger>
                                             <SelectContent>
@@ -1530,21 +1625,18 @@ export function GlossaryDetailPageContent({
                                           >
                                             <SelectTrigger
                                               showIcon={false}
-                                              className={cn(
-                                                termPropertyTriggerClassName,
-                                                statusClass(term.status),
-                                              )}
+                                              className={statusPickerTriggerClass()}
                                             >
                                               <SelectValue>
                                                 <StatusLabel status={term.status} />
                                               </SelectValue>
                                             </SelectTrigger>
-                                            <SelectContent>
+                                            <SelectContent className={statusPickerContentClassName}>
                                               {statusOptions.map((option) => (
                                                 <SelectItem
                                                   key={option}
                                                   value={option}
-                                                  className={statusClass(option)}
+                                                  className={statusPickerItemClass(option)}
                                                 >
                                                   <StatusLabel status={option} />
                                                 </SelectItem>
@@ -1826,9 +1918,7 @@ export function GlossaryDetailPageContent({
                                                   className={termPropertyTriggerClassName}
                                                 >
                                                   <SelectValue>
-                                                    {draft.partOfSpeech
-                                                      ? readableEnumLabel(draft.partOfSpeech)
-                                                      : "—"}
+                                                    <PartOfSpeechBadge value={draft.partOfSpeech} />
                                                   </SelectValue>
                                                 </SelectTrigger>
                                                 <SelectContent>
@@ -1842,10 +1932,8 @@ export function GlossaryDetailPageContent({
                                                   )}
                                                 </SelectContent>
                                               </Select>
-                                            ) : term.partOfSpeech ? (
-                                              readableEnumLabel(term.partOfSpeech)
                                             ) : (
-                                              "—"
+                                              <PartOfSpeechBadge value={term.partOfSpeech} />
                                             )}
                                           </td>
                                           <td className="px-3 py-2">
@@ -1933,16 +2021,22 @@ export function GlossaryDetailPageContent({
                                               >
                                                 <SelectTrigger
                                                   showIcon={false}
-                                                  className={termPropertyTriggerClassName}
+                                                  className={statusPickerTriggerClass()}
                                                 >
                                                   <SelectValue>
-                                                    {readableEnumLabel(draft.status)}
+                                                    <StatusLabel status={draft.status} />
                                                   </SelectValue>
                                                 </SelectTrigger>
-                                                <SelectContent>
+                                                <SelectContent
+                                                  className={statusPickerContentClassName}
+                                                >
                                                   {statusOptions.map((option) => (
-                                                    <SelectItem key={option} value={option}>
-                                                      {readableEnumLabel(option)}
+                                                    <SelectItem
+                                                      key={option}
+                                                      value={option}
+                                                      className={statusPickerItemClass(option)}
+                                                    >
+                                                      <StatusLabel status={option} />
                                                     </SelectItem>
                                                   ))}
                                                 </SelectContent>
@@ -1950,7 +2044,7 @@ export function GlossaryDetailPageContent({
                                             ) : (
                                               <Badge
                                                 variant="outline"
-                                                className={statusClass(term.status)}
+                                                className={statusBadgeClass(term.status)}
                                               >
                                                 <StatusLabel status={term.status} />
                                               </Badge>
@@ -2135,9 +2229,9 @@ export function GlossaryDetailPageContent({
                                               className={termPropertyTriggerClassName}
                                             >
                                               <SelectValue>
-                                                {newTermDraft.partOfSpeech
-                                                  ? readableEnumLabel(newTermDraft.partOfSpeech)
-                                                  : "—"}
+                                                <PartOfSpeechBadge
+                                                  value={newTermDraft.partOfSpeech}
+                                                />
                                               </SelectValue>
                                             </SelectTrigger>
                                             <SelectContent>
@@ -2225,21 +2319,18 @@ export function GlossaryDetailPageContent({
                                           >
                                             <SelectTrigger
                                               showIcon={false}
-                                              className={cn(
-                                                termPropertyTriggerClassName,
-                                                statusClass(newTermDraft.status),
-                                              )}
+                                              className={statusPickerTriggerClass()}
                                             >
                                               <SelectValue>
                                                 <StatusLabel status={newTermDraft.status} />
                                               </SelectValue>
                                             </SelectTrigger>
-                                            <SelectContent>
+                                            <SelectContent className={statusPickerContentClassName}>
                                               {statusOptions.map((option) => (
                                                 <SelectItem
                                                   key={option}
                                                   value={option}
-                                                  className={statusClass(option)}
+                                                  className={statusPickerItemClass(option)}
                                                 >
                                                   <StatusLabel status={option} />
                                                 </SelectItem>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
@@ -194,29 +194,6 @@ function readableEnumLabel(value: string) {
   return label ? `${label.charAt(0).toUpperCase()}${label.slice(1)}` : label;
 }
 
-const partOfSpeechShortLabels: Record<GlossaryPartOfSpeech, string> = {
-  adjective: "adj",
-  adposition: "adp",
-  adverb: "adv",
-  auxiliary: "aux",
-  "coordinating conjunction": "cc",
-  determiner: "det",
-  interjection: "intj",
-  noun: "n",
-  numeral: "num",
-  particle: "part",
-  pronoun: "pron",
-  "proper noun": "propn",
-  "subordinating conjunction": "sc",
-  verb: "v",
-  other: "other",
-};
-
-function partOfSpeechShortLabel(value: string) {
-  const normalized = normalizePartOfSpeech(value) ?? value;
-  return partOfSpeechShortLabels[normalized as GlossaryPartOfSpeech] ?? normalized;
-}
-
 function PartOfSpeechBadge({ value }: { value: string | null | undefined }) {
   if (!value) return <span className="text-muted-foreground">—</span>;
 
@@ -228,7 +205,7 @@ function PartOfSpeechBadge({ value }: { value: string | null | undefined }) {
       title={label}
       aria-label={label}
     >
-      {partOfSpeechShortLabel(value)}
+      {label}
     </Badge>
   );
 }
@@ -250,7 +227,7 @@ function formatDate(value: string) {
 }
 
 const termPropertyTriggerClassName =
-  "h-7 border-transparent bg-transparent px-2 text-xs font-normal shadow-none hover:bg-muted/60 focus-visible:bg-muted/60";
+  "h-8 border-transparent bg-transparent px-2.5 text-sm font-normal shadow-none hover:bg-muted/60 focus-visible:bg-muted/60";
 
 function statusClass(status: TermDraft["status"]) {
   if (status === "preferred") {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-content.tsx
@@ -55,6 +55,32 @@ type GlossaryListFilters = {
   syncFilter: string;
 };
 
+type WorkspaceGlossariesResult = {
+  glossaries: ApiGlossary[];
+  total: number;
+};
+
+type LiveGlossariesResult = {
+  liveRows: GlossaryListRow[];
+  total: number;
+  hasMore: boolean;
+};
+
+const CROWDIN_GLOSSARIES_PAGE_SIZE = 25;
+const CROWDIN_GLOSSARIES_DEFAULT_ORDER = "createdAt desc,name";
+
+function isWorkspaceGlossariesResult(
+  result: WorkspaceGlossariesResult | LiveGlossariesResult | undefined,
+): result is WorkspaceGlossariesResult {
+  return Boolean(result && "glossaries" in result);
+}
+
+function isLiveGlossariesResult(
+  result: WorkspaceGlossariesResult | LiveGlossariesResult | undefined,
+): result is LiveGlossariesResult {
+  return Boolean(result && "liveRows" in result);
+}
+
 const glossariesQueryKey = (
   organizationSlug: string,
   page: number,
@@ -103,6 +129,42 @@ function buildGlossaryListQuery(page: number, filters: GlossaryListFilters) {
   }
 
   return query;
+}
+
+function nativeGlossaryFilters(filters: GlossaryListFilters): GlossaryListFilters {
+  return {
+    ...filters,
+    sourceFilter: "native",
+    providerFilter: "all",
+    resourceTypeFilter: "all",
+    syncFilter: "all",
+  };
+}
+
+async function fetchWorkspaceGlossaries(
+  organizationSlug: string,
+  intl: ReturnType<typeof useIntl>,
+  page: number,
+  filters: GlossaryListFilters,
+): Promise<WorkspaceGlossariesResult> {
+  const response = await apiClient.api.orgs[":organizationSlug"].glossaries.$get({
+    param: { organizationSlug },
+    query: buildGlossaryListQuery(page, filters),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      intl.formatMessage(glossariesPageContentMessages.loadGlossariesFailed, {
+        status: response.status,
+      }),
+    );
+  }
+
+  const body = await response.json();
+  return {
+    glossaries: body.glossaries as ApiGlossary[],
+    total: body.total as number,
+  };
 }
 const projectsQueryKey = (organizationSlug: string) => ["glossary-projects", organizationSlug];
 const credentialsQueryKey = (organizationSlug: string) => [
@@ -200,12 +262,15 @@ export function GlossariesPageContent({
   const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const [page, setPage] = useState(1);
+  const [crowdinPage, setCrowdinPage] = useState(1);
+  const [crowdinOrderBy, setCrowdinOrderBy] = useState(CROWDIN_GLOSSARIES_DEFAULT_ORDER);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [createForm, setCreateForm] = useState<GlossaryCreateForm>(() => createEmptyGlossaryForm());
   const [createErrors, setCreateErrors] = useState<{ name?: string }>({});
   const [selectedExternalProjectId, setSelectedExternalProjectId] = useState("");
   const { data: activeTmsProvider } = useActiveTmsProvider(organizationSlug);
   const useLiveProviderGlossaries = Boolean(activeTmsProvider);
+  const useLiveCrowdinGlossaries = activeTmsProvider?.providerKind === "crowdin";
   const allowCreateGlossaries = canCreateGlossaries && !useLiveProviderGlossaries;
   const {
     filters,
@@ -269,13 +334,15 @@ export function GlossariesPageContent({
     },
   });
 
-  const glossariesQuery = useQuery({
+  const glossariesQuery = useQuery<WorkspaceGlossariesResult | LiveGlossariesResult>({
     queryKey: [
       ...glossariesQueryKey(organizationSlug, page, filters),
       useLiveProviderGlossaries ? "live" : "native",
       selectedExternalProjectId,
     ],
-    enabled: !useLiveProviderGlossaries || Boolean(selectedExternalProjectId),
+    enabled:
+      !useLiveCrowdinGlossaries &&
+      (!useLiveProviderGlossaries || Boolean(selectedExternalProjectId)),
     queryFn: async () => {
       if (useLiveProviderGlossaries && activeTmsProvider) {
         const response = await apiClient.api.orgs[":organizationSlug"][
@@ -284,6 +351,9 @@ export function GlossariesPageContent({
           param: { organizationSlug },
           query: {
             externalProjectId: selectedExternalProjectId,
+            limit: String(CROWDIN_GLOSSARIES_PAGE_SIZE),
+            offset: "0",
+            orderBy: CROWDIN_GLOSSARIES_DEFAULT_ORDER,
           },
         });
 
@@ -321,26 +391,83 @@ export function GlossariesPageContent({
           glossaries: [] as ApiGlossary[],
           liveRows: filtered,
           total: filtered.length,
+          hasMore: false,
         };
       }
 
-      const response = await apiClient.api.orgs[":organizationSlug"].glossaries.$get({
+      return fetchWorkspaceGlossaries(organizationSlug, intl, page, filters);
+    },
+  });
+
+  const nativeGlossariesQuery = useQuery<WorkspaceGlossariesResult>({
+    queryKey: ["native-glossaries", organizationSlug, page, nativeGlossaryFilters(filters)],
+    enabled: useLiveCrowdinGlossaries,
+    queryFn: () =>
+      fetchWorkspaceGlossaries(organizationSlug, intl, page, nativeGlossaryFilters(filters)),
+  });
+
+  const liveCrowdinGlossariesQuery = useQuery<LiveGlossariesResult>({
+    queryKey: [
+      "live-crowdin-glossaries",
+      organizationSlug,
+      crowdinPage,
+      crowdinOrderBy,
+      selectedExternalProjectId,
+      filters.searchQuery,
+      filters.sourceFilter,
+      filters.providerFilter,
+      filters.resourceTypeFilter,
+    ],
+    enabled: useLiveCrowdinGlossaries,
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"][
+        "tms-provider"
+      ].glossaries.$get({
         param: { organizationSlug },
-        query: buildGlossaryListQuery(page, filters),
+        query: {
+          limit: String(CROWDIN_GLOSSARIES_PAGE_SIZE),
+          offset: String((crowdinPage - 1) * CROWDIN_GLOSSARIES_PAGE_SIZE),
+          orderBy: crowdinOrderBy,
+          ...(filters.searchQuery.trim() ? { filter: filters.searchQuery.trim() } : {}),
+          ...(selectedExternalProjectId ? { externalProjectId: selectedExternalProjectId } : {}),
+        },
       });
 
       if (!response.ok) {
         throw new Error(
-          intl.formatMessage(glossariesPageContentMessages.loadGlossariesFailed, {
+          intl.formatMessage(glossariesPageContentMessages.loadProviderGlossariesFailed, {
             status: response.status,
           }),
         );
       }
 
-      const body = await response.json();
+      const body = (await response.json()) as {
+        glossaries: TmsProviderLiveGlossary[];
+        pagination?: { hasMore?: boolean };
+      };
+      const rows = body.glossaries.map((glossary) =>
+        mapLiveTmsProviderGlossaryToListRow(glossary, "crowdin", intl),
+      );
+      const filtered = rows.filter((row) => {
+        if (filters.sourceFilter !== "all" && row.source !== filters.sourceFilter) {
+          return false;
+        }
+        if (
+          filters.providerFilter !== "all" &&
+          row.externalProviderKind !== filters.providerFilter
+        ) {
+          return false;
+        }
+        if (filters.resourceTypeFilter !== "all" && row.externalResourceType !== "glossary") {
+          return false;
+        }
+        return true;
+      });
+
       return {
-        glossaries: body.glossaries as ApiGlossary[],
-        total: body.total as number,
+        liveRows: filtered,
+        total: filtered.length,
+        hasMore: body.pagination?.hasMore ?? rows.length === CROWDIN_GLOSSARIES_PAGE_SIZE,
       };
     },
   });
@@ -384,60 +511,144 @@ export function GlossariesPageContent({
     [projectsQuery.data],
   );
 
-  const glossaries = useMemo(() => {
-    if (useLiveProviderGlossaries) {
-      return glossariesQuery.data?.liveRows ?? [];
-    }
+  const persistedRows = useMemo(() => {
+    if (useLiveProviderGlossaries) return [];
 
-    return (glossariesQuery.data?.glossaries ?? []).map((glossary) =>
+    const result = isWorkspaceGlossariesResult(glossariesQuery.data)
+      ? glossariesQuery.data
+      : undefined;
+    return (result?.glossaries ?? []).map((glossary) =>
       mapGlossaryToListRow(glossary, projectIdByExternalKey, intl),
     );
+  }, [glossariesQuery.data, intl, projectIdByExternalKey, useLiveProviderGlossaries]);
+
+  const legacyLiveRows = useMemo(
+    () => (isLiveGlossariesResult(glossariesQuery.data) ? glossariesQuery.data.liveRows : []),
+    [glossariesQuery.data],
+  );
+
+  const nativeGlossaries = useMemo(() => {
+    if (useLiveCrowdinGlossaries) {
+      if (
+        filters.sourceFilter === "external_tms" ||
+        filters.providerFilter !== "all" ||
+        filters.resourceTypeFilter !== "all"
+      ) {
+        return [];
+      }
+
+      return (nativeGlossariesQuery.data?.glossaries ?? []).map((glossary) =>
+        mapGlossaryToListRow(glossary, projectIdByExternalKey, intl),
+      );
+    }
+
+    return persistedRows.filter((glossary) => glossary.source === "native");
   }, [
-    glossariesQuery.data?.glossaries,
-    glossariesQuery.data?.liveRows,
+    filters.providerFilter,
+    filters.resourceTypeFilter,
+    filters.sourceFilter,
     intl,
+    nativeGlossariesQuery.data?.glossaries,
+    persistedRows,
     projectIdByExternalKey,
-    useLiveProviderGlossaries,
+    useLiveCrowdinGlossaries,
   ]);
 
-  const glossaryTotal = glossariesQuery.data?.total ?? 0;
-  const totalPages = Math.max(1, Math.ceil(glossaryTotal / GLOSSARIES_PAGE_SIZE));
-  const pageStart = glossaryTotal === 0 ? 0 : (page - 1) * GLOSSARIES_PAGE_SIZE + 1;
-  const pageEnd = Math.min(page * GLOSSARIES_PAGE_SIZE, glossaryTotal);
+  const externalGlossaries = useMemo(
+    () =>
+      useLiveCrowdinGlossaries
+        ? (liveCrowdinGlossariesQuery.data?.liveRows ?? [])
+        : useLiveProviderGlossaries
+          ? legacyLiveRows
+          : persistedRows.filter((glossary) => glossary.source === "external_tms"),
+    [
+      legacyLiveRows,
+      liveCrowdinGlossariesQuery.data?.liveRows,
+      persistedRows,
+      useLiveCrowdinGlossaries,
+      useLiveProviderGlossaries,
+    ],
+  );
+
+  const nativeTotal = useLiveCrowdinGlossaries
+    ? nativeGlossaries.length > 0 ||
+      (filters.sourceFilter === "all" &&
+        filters.providerFilter === "all" &&
+        filters.resourceTypeFilter === "all")
+      ? (nativeGlossariesQuery.data?.total ?? 0)
+      : 0
+    : nativeGlossaries.length;
+  const externalTotal = useLiveCrowdinGlossaries
+    ? (liveCrowdinGlossariesQuery.data?.total ?? 0)
+    : externalGlossaries.length;
+  const glossaryTotal = useLiveCrowdinGlossaries
+    ? nativeTotal + externalTotal
+    : isWorkspaceGlossariesResult(glossariesQuery.data)
+      ? glossariesQuery.data.total
+      : externalTotal;
+  const totalPages = Math.max(
+    1,
+    Math.ceil((useLiveCrowdinGlossaries ? nativeTotal : glossaryTotal) / GLOSSARIES_PAGE_SIZE),
+  );
+  const paginationTotal = useLiveCrowdinGlossaries ? nativeTotal : glossaryTotal;
+  const pageStart = paginationTotal === 0 ? 0 : (page - 1) * GLOSSARIES_PAGE_SIZE + 1;
+  const pageEnd = Math.min(page * GLOSSARIES_PAGE_SIZE, paginationTotal);
 
   const providerKinds = useMemo(() => {
     const kinds = new Set<string>();
-    for (const glossary of glossaries) {
+    for (const glossary of externalGlossaries) {
       if (glossary.externalProviderKind) {
         kinds.add(glossary.externalProviderKind);
       }
     }
+    if (useLiveCrowdinGlossaries) kinds.add("crowdin");
     return [...kinds].sort((a, b) => providerLabel(a).localeCompare(providerLabel(b)));
-  }, [glossaries]);
+  }, [externalGlossaries, useLiveCrowdinGlossaries]);
 
-  const hasResourceTypes = glossaries.some((glossary) => glossary.externalResourceType);
+  const hasResourceTypes = externalGlossaries.some((glossary) => glossary.externalResourceType);
 
   useEffect(() => {
     setPage(1);
-  }, [organizationSlug, filters, selectedExternalProjectId]);
+    setCrowdinPage(1);
+  }, [organizationSlug, filters, selectedExternalProjectId, useLiveCrowdinGlossaries]);
+
+  useEffect(() => {
+    setCrowdinPage(1);
+  }, [crowdinOrderBy]);
 
   useEffect(() => {
     setSelectedExternalProjectId("");
-  }, [organizationSlug, useLiveProviderGlossaries]);
+  }, [organizationSlug, useLiveProviderGlossaries, useLiveCrowdinGlossaries]);
 
   useEffect(() => {
-    if (glossariesQuery.isSuccess && page > totalPages) {
+    const paginationQuery = useLiveCrowdinGlossaries ? nativeGlossariesQuery : glossariesQuery;
+    if (paginationQuery.isSuccess && page > totalPages) {
       setPage(totalPages);
     }
-  }, [glossariesQuery.isSuccess, page, totalPages]);
+  }, [glossariesQuery, nativeGlossariesQuery, page, totalPages, useLiveCrowdinGlossaries]);
 
-  const hasExternalGlossaries = glossaries.some((glossary) => glossary.source === "external_tms");
+  const hasExternalGlossaries = externalGlossaries.length > 0 || useLiveCrowdinGlossaries;
   const connectedCredentials = (credentialsQuery.data ?? []).filter(
     (credential) => credential.validationStatus === "connected",
   );
   const hasConnectedProvider = useLiveProviderGlossaries
     ? Boolean(activeTmsProvider)
     : credentialsQuery.isSuccess && connectedCredentials.length > 0;
+
+  const idleQueryState = {
+    isLoading: false,
+    isError: false,
+    isSuccess: true,
+    error: null,
+  } as const;
+  const nativeQueryState = useLiveCrowdinGlossaries
+    ? nativeGlossariesQuery
+    : useLiveProviderGlossaries
+      ? idleQueryState
+      : glossariesQuery;
+  const externalQueryState = useLiveCrowdinGlossaries
+    ? liveCrowdinGlossariesQuery
+    : glossariesQuery;
 
   function submitCreateGlossary() {
     const errors: { name?: string } = {};
@@ -454,15 +665,17 @@ export function GlossariesPageContent({
   return (
     <GlossariesPageView
       organizationSlug={organizationSlug}
-      glossaries={glossaries}
+      nativeGlossaries={nativeGlossaries}
+      externalGlossaries={externalGlossaries}
       glossaryTotal={glossaryTotal}
-      isLoading={glossariesQuery.isLoading}
-      isError={glossariesQuery.isError}
-      isSuccess={glossariesQuery.isSuccess}
-      error={glossariesQuery.error}
+      nativeTotal={nativeTotal}
+      externalTotal={externalTotal}
+      nativeQuery={nativeQueryState}
+      externalQuery={externalQueryState}
       allowCreateGlossaries={allowCreateGlossaries}
       hasConnectedProvider={hasConnectedProvider}
       useLiveProviderGlossaries={useLiveProviderGlossaries}
+      useLiveCrowdinGlossaries={useLiveCrowdinGlossaries}
       selectedExternalProjectId={selectedExternalProjectId}
       onSelectedExternalProjectIdChange={setSelectedExternalProjectId}
       searchQuery={searchQuery}
@@ -486,6 +699,11 @@ export function GlossariesPageContent({
       pageStart={pageStart}
       pageEnd={pageEnd}
       onPageChange={setPage}
+      crowdinPage={crowdinPage}
+      crowdinHasMore={liveCrowdinGlossariesQuery.data?.hasMore ?? false}
+      onCrowdinPageChange={setCrowdinPage}
+      crowdinOrderBy={crowdinOrderBy}
+      onCrowdinOrderByChange={setCrowdinOrderBy}
       createDialogOpen={createDialogOpen}
       onCreateDialogOpenChange={setCreateDialogOpen}
       createForm={createForm}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-view.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-view.messages.ts
@@ -141,6 +141,36 @@ export const glossariesPageViewMessages = defineMessages({
     id: "HwI92QKVOs",
     description: "Empty filter state for glossaries, with a clear-filters action",
   },
+  nativeSectionTitle: {
+    defaultMessage: "Native glossaries",
+    id: "tR49yNVFBv",
+    description: "Heading for workspace-native glossaries",
+  },
+  externalSectionTitle: {
+    defaultMessage: "Provider glossaries",
+    id: "iTLkbt2liA",
+    description: "Heading for persisted provider glossaries",
+  },
+  crowdinSectionTitle: {
+    defaultMessage: "Crowdin glossaries",
+    id: "CckeviPE6F",
+    description: "Heading for live Crowdin glossaries",
+  },
+  nativeEmptyTitle: {
+    defaultMessage: "No native glossaries",
+    id: "EN/XL+26FR",
+    description: "Empty state title for the native glossary section when creation is unavailable",
+  },
+  nativeEmptyDescription: {
+    defaultMessage: "Native glossaries created in this workspace will appear here.",
+    id: "cH3TG4pXPd",
+    description: "Empty state description for native glossaries",
+  },
+  externalEmptyTitle: {
+    defaultMessage: "No provider glossaries",
+    id: "ZiWVuGHeQL",
+    description: "Empty state title for a connected provider with no glossaries",
+  },
   chooseTmsProjectTitle: {
     defaultMessage: "Choose a TMS project",
     id: "VTNiq0wxG3",
@@ -199,6 +229,31 @@ export const glossariesPageViewMessages = defineMessages({
     defaultMessage: "Next",
     id: "pUTlRV1r0u",
     description: "Button to go to the next page of glossaries",
+  },
+  sortLabel: {
+    defaultMessage: "Sort",
+    id: "9DtnBnymqw",
+    description: "Label for the Crowdin glossary ordering control",
+  },
+  sortNewest: {
+    defaultMessage: "Newest first",
+    id: "Xo2+rtWc3U",
+    description: "Crowdin glossary ordering option for newest glossaries",
+  },
+  sortNameAsc: {
+    defaultMessage: "Name A–Z",
+    id: "lNH8JueKxa",
+    description: "Crowdin glossary ordering option for ascending names",
+  },
+  sortNameDesc: {
+    defaultMessage: "Name Z–A",
+    id: "BBn+JiQbC1",
+    description: "Crowdin glossary ordering option for descending names",
+  },
+  crowdinPaginationSummary: {
+    defaultMessage: "Crowdin page {page}",
+    id: "8mLorWvZHa",
+    description: "Pagination summary for the live Crowdin glossary list",
   },
   createDialogTitle: {
     defaultMessage: "Create glossary",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-view.stories.tsx
@@ -28,15 +28,17 @@ const meta = {
   },
   args: {
     organizationSlug: "acme",
-    glossaries: glossariesFixture,
+    nativeGlossaries: glossariesFixture.filter((glossary) => glossary.source === "native"),
+    externalGlossaries: glossariesFixture.filter((glossary) => glossary.source === "external_tms"),
     glossaryTotal: glossariesFixture.length,
-    isLoading: false,
-    isError: false,
-    isSuccess: true,
-    error: null,
+    nativeTotal: 1,
+    externalTotal: 2,
+    nativeQuery: { isLoading: false, isError: false, isSuccess: true, error: null },
+    externalQuery: { isLoading: false, isError: false, isSuccess: true, error: null },
     allowCreateGlossaries: true,
     hasConnectedProvider: true,
     useLiveProviderGlossaries: false,
+    useLiveCrowdinGlossaries: false,
     selectedExternalProjectId: "",
     onSelectedExternalProjectIdChange: fn(),
     searchQuery: "",
@@ -60,6 +62,11 @@ const meta = {
     pageStart: 1,
     pageEnd: glossariesFixture.length,
     onPageChange: fn(),
+    crowdinPage: 1,
+    crowdinHasMore: false,
+    onCrowdinPageChange: fn(),
+    crowdinOrderBy: "createdAt desc,name",
+    onCrowdinOrderByChange: fn(),
     createDialogOpen: false,
     onCreateDialogOpenChange: fn(),
     createForm: createEmptyGlossaryFormFixture(),
@@ -96,7 +103,8 @@ export const Default: Story = {
 
 export const LiveProviderGlossary: Story = {
   args: {
-    glossaries: [
+    nativeGlossaries: [],
+    externalGlossaries: [
       createGlossaryListRow({
         id: "crowdin:glossary:99",
         detailId: "crowdin:glossary:99",
@@ -108,7 +116,13 @@ export const LiveProviderGlossary: Story = {
       }),
     ],
     glossaryTotal: 1,
+    nativeTotal: 0,
+    externalTotal: 1,
+    nativeQuery: { isLoading: false, isError: false, isSuccess: true, error: null },
+    externalQuery: { isLoading: false, isError: false, isSuccess: true, error: null },
     allowCreateGlossaries: false,
+    useLiveProviderGlossaries: false,
+    useLiveCrowdinGlossaries: true,
     pageEnd: 1,
   },
   play: async ({ canvas }) => {
@@ -122,10 +136,13 @@ export const LiveProviderGlossary: Story = {
 
 export const Loading: Story = {
   args: {
-    glossaries: [],
+    nativeGlossaries: [],
+    externalGlossaries: [],
     glossaryTotal: 0,
-    isLoading: true,
-    isSuccess: false,
+    nativeTotal: 0,
+    externalTotal: 0,
+    nativeQuery: { isLoading: true, isError: false, isSuccess: false, error: null },
+    externalQuery: { isLoading: true, isError: false, isSuccess: false, error: null },
     pageStart: 0,
     pageEnd: 0,
     providerKinds: [],
@@ -139,8 +156,13 @@ export const Loading: Story = {
 
 export const Empty: Story = {
   args: {
-    glossaries: [],
+    nativeGlossaries: [],
+    externalGlossaries: [],
     glossaryTotal: 0,
+    nativeTotal: 0,
+    externalTotal: 0,
+    nativeQuery: { isLoading: false, isError: false, isSuccess: true, error: null },
+    externalQuery: { isLoading: false, isError: false, isSuccess: true, error: null },
     pageStart: 0,
     pageEnd: 0,
     providerKinds: [],
@@ -159,8 +181,13 @@ export const Empty: Story = {
 
 export const NoProviderConnected: Story = {
   args: {
-    glossaries: [],
+    nativeGlossaries: [],
+    externalGlossaries: [],
     glossaryTotal: 0,
+    nativeTotal: 0,
+    externalTotal: 0,
+    nativeQuery: { isLoading: false, isError: false, isSuccess: true, error: null },
+    externalQuery: { isLoading: false, isError: false, isSuccess: true, error: null },
     allowCreateGlossaries: false,
     hasConnectedProvider: false,
     pageStart: 0,
@@ -207,11 +234,18 @@ export const CreateDialogOpen: Story = {
 
 export const LoadError: Story = {
   args: {
-    glossaries: [],
+    nativeGlossaries: [],
+    externalGlossaries: [],
     glossaryTotal: 0,
-    isError: true,
-    isSuccess: false,
-    error: new Error("The glossaries API returned a 500."),
+    nativeTotal: 0,
+    externalTotal: 0,
+    nativeQuery: {
+      isLoading: false,
+      isError: true,
+      isSuccess: false,
+      error: new Error("The native glossaries API returned a 500."),
+    },
+    externalQuery: { isLoading: false, isError: false, isSuccess: true, error: null },
     pageStart: 0,
     pageEnd: 0,
     providerKinds: [],
@@ -223,11 +257,17 @@ export const LoadError: Story = {
   },
 };
 
-export const LiveProjectSelectionRequired: Story = {
+export const LiveAllProjects: Story = {
   args: {
-    glossaries: [],
+    nativeGlossaries: [],
+    externalGlossaries: [],
     glossaryTotal: 0,
-    useLiveProviderGlossaries: true,
+    nativeTotal: 0,
+    externalTotal: 0,
+    nativeQuery: { isLoading: false, isError: false, isSuccess: true, error: null },
+    externalQuery: { isLoading: false, isError: false, isSuccess: true, error: null },
+    useLiveProviderGlossaries: false,
+    useLiveCrowdinGlossaries: true,
     allowCreateGlossaries: false,
     pageStart: 0,
     pageEnd: 0,
@@ -236,14 +276,20 @@ export const LiveProjectSelectionRequired: Story = {
     hasResourceTypes: false,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText("Choose a TMS project")).toBeInTheDocument();
+    await expect(canvas.getByText("Native glossaries")).toBeInTheDocument();
+    await expect(canvas.getByText("Crowdin glossaries")).toBeInTheDocument();
   },
 };
 
 export const NoFilterMatches: Story = {
   args: {
-    glossaries: [],
+    nativeGlossaries: [],
+    externalGlossaries: [],
     glossaryTotal: 0,
+    nativeTotal: 0,
+    externalTotal: 0,
+    nativeQuery: { isLoading: false, isError: false, isSuccess: true, error: null },
+    externalQuery: { isLoading: false, isError: false, isSuccess: true, error: null },
     hasActiveFilters: true,
     activeFilterCount: 1,
     sourceFilter: "native",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-view.tsx
@@ -56,7 +56,11 @@ import {
 } from "../../_components/workspace-resource-shared";
 import type { GlossaryListRow } from "./glossary-list";
 import { providerLabel } from "./glossary-list";
-import { GlossariesEmptyAction, GlossariesTable } from "./glossaries-table";
+import {
+  GlossariesEmptyAction,
+  GlossariesTable,
+  type GlossariesTableQuery,
+} from "./glossaries-table";
 import { glossariesPageViewMessages } from "./glossaries-page-view.messages";
 import { ProjectSourceLocalePicker } from "../../projects/_components/project-locale-picker";
 
@@ -71,15 +75,17 @@ export type GlossaryCreateForm = {
 
 export function GlossariesPageView({
   organizationSlug,
-  glossaries,
+  nativeGlossaries,
+  externalGlossaries,
   glossaryTotal,
-  isLoading,
-  isError,
-  isSuccess,
-  error,
+  nativeTotal,
+  externalTotal,
+  nativeQuery,
+  externalQuery,
   allowCreateGlossaries,
   hasConnectedProvider,
   useLiveProviderGlossaries,
+  useLiveCrowdinGlossaries,
   selectedExternalProjectId,
   onSelectedExternalProjectIdChange,
   searchQuery,
@@ -103,6 +109,11 @@ export function GlossariesPageView({
   pageStart,
   pageEnd,
   onPageChange,
+  crowdinPage,
+  crowdinHasMore,
+  onCrowdinPageChange,
+  crowdinOrderBy,
+  onCrowdinOrderByChange,
   createDialogOpen,
   onCreateDialogOpenChange,
   createForm,
@@ -113,15 +124,17 @@ export function GlossariesPageView({
   onSubmitCreateGlossary,
 }: {
   organizationSlug: string;
-  glossaries: GlossaryListRow[];
+  nativeGlossaries: GlossaryListRow[];
+  externalGlossaries: GlossaryListRow[];
   glossaryTotal: number;
-  isLoading: boolean;
-  isError: boolean;
-  isSuccess: boolean;
-  error: Error | null;
+  nativeTotal: number;
+  externalTotal: number;
+  nativeQuery: GlossariesTableQuery;
+  externalQuery: GlossariesTableQuery;
   allowCreateGlossaries: boolean;
   hasConnectedProvider: boolean;
   useLiveProviderGlossaries: boolean;
+  useLiveCrowdinGlossaries: boolean;
   selectedExternalProjectId: string;
   onSelectedExternalProjectIdChange: (value: string) => void;
   searchQuery: string;
@@ -145,6 +158,11 @@ export function GlossariesPageView({
   pageStart: number;
   pageEnd: number;
   onPageChange: (page: number) => void;
+  crowdinPage: number;
+  crowdinHasMore: boolean;
+  onCrowdinPageChange: (page: number) => void;
+  crowdinOrderBy: string;
+  onCrowdinOrderByChange: (orderBy: string) => void;
   createDialogOpen: boolean;
   onCreateDialogOpenChange: (open: boolean) => void;
   createForm: GlossaryCreateForm;
@@ -156,7 +174,8 @@ export function GlossariesPageView({
 }) {
   const intl = useIntl();
   const [projectPickerOpen, setProjectPickerOpen] = useState(false);
-  const liveProjectSelectionRequired = useLiveProviderGlossaries && !selectedExternalProjectId;
+  const liveProjectSelectionRequired =
+    useLiveProviderGlossaries && !useLiveCrowdinGlossaries && !selectedExternalProjectId;
   const selectableProjects = useMemo(
     () => projects.filter((project) => project.sourceLocale === createForm.sourceLocale),
     [createForm.sourceLocale, projects],
@@ -189,21 +208,30 @@ export function GlossariesPageView({
     error: intl.formatMessage(glossariesPageViewMessages.syncError),
   } as const;
 
-  const emptyTitle = hasConnectedProvider
+  const nativeEmptyTitle = allowCreateGlossaries
     ? intl.formatMessage(glossariesPageViewMessages.emptyTitle)
+    : intl.formatMessage(glossariesPageViewMessages.nativeEmptyTitle);
+  const nativeEmptyDescription = allowCreateGlossaries
+    ? intl.formatMessage(glossariesPageViewMessages.emptyDescriptionCreate)
+    : intl.formatMessage(glossariesPageViewMessages.nativeEmptyDescription);
+  const externalEmptyTitle = hasConnectedProvider
+    ? intl.formatMessage(glossariesPageViewMessages.externalEmptyTitle)
     : intl.formatMessage(glossariesPageViewMessages.emptyTitleConnectProvider);
-  const emptyDescription = hasConnectedProvider
+  const externalEmptyDescription = hasConnectedProvider
     ? intl.formatMessage(glossariesPageViewMessages.emptyDescriptionWithProvider)
     : intl.formatMessage(glossariesPageViewMessages.emptyDescriptionWithoutProvider);
-
+  const nativeSectionTitle = intl.formatMessage(glossariesPageViewMessages.nativeSectionTitle);
+  const externalSectionTitle = useLiveCrowdinGlossaries
+    ? intl.formatMessage(glossariesPageViewMessages.crowdinSectionTitle)
+    : intl.formatMessage(glossariesPageViewMessages.externalSectionTitle);
   const glossaryCountLabel =
-    isSuccess && glossaryTotal > 0
+    glossaryTotal > 0
       ? intl.formatMessage(glossariesPageViewMessages.glossaryCount, {
           count: glossaryTotal,
         })
       : undefined;
-
-  const glossariesQuery = { isLoading, isError, isSuccess, error };
+  const hasAnyResults = nativeTotal > 0 || externalTotal > 0;
+  const queriesHaveNoResults = nativeQuery.isSuccess && externalQuery.isSuccess && !hasAnyResults;
   const allProvidersLabel = intl.formatMessage(glossariesPageViewMessages.providerAll);
 
   return (
@@ -234,11 +262,55 @@ export function GlossariesPageView({
             organizationSlug={organizationSlug}
             value={selectedExternalProjectId}
             onValueChange={onSelectedExternalProjectIdChange}
+            allowAll={useLiveCrowdinGlossaries}
           />
+          {useLiveCrowdinGlossaries ? (
+            <WorkspaceFilterField
+              label={intl.formatMessage(glossariesPageViewMessages.sortLabel)}
+              className="w-full sm:w-44"
+            >
+              <Select
+                value={crowdinOrderBy}
+                onValueChange={(value) => {
+                  if (value) onCrowdinOrderByChange(value);
+                }}
+              >
+                <SelectTrigger className={workspaceFilterTriggerClassName}>
+                  <SelectValue>
+                    {crowdinOrderBy === "name asc"
+                      ? intl.formatMessage(glossariesPageViewMessages.sortNameAsc)
+                      : crowdinOrderBy === "name desc"
+                        ? intl.formatMessage(glossariesPageViewMessages.sortNameDesc)
+                        : intl.formatMessage(glossariesPageViewMessages.sortNewest)}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem
+                    value="createdAt desc,name"
+                    label={intl.formatMessage(glossariesPageViewMessages.sortNewest)}
+                  >
+                    <FormattedMessage {...glossariesPageViewMessages.sortNewest} />
+                  </SelectItem>
+                  <SelectItem
+                    value="name asc"
+                    label={intl.formatMessage(glossariesPageViewMessages.sortNameAsc)}
+                  >
+                    <FormattedMessage {...glossariesPageViewMessages.sortNameAsc} />
+                  </SelectItem>
+                  <SelectItem
+                    value="name desc"
+                    label={intl.formatMessage(glossariesPageViewMessages.sortNameDesc)}
+                  >
+                    <FormattedMessage {...glossariesPageViewMessages.sortNameDesc} />
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </WorkspaceFilterField>
+          ) : null}
         </div>
       ) : null}
 
-      {isSuccess && (glossaryTotal > 0 || hasActiveFilters) ? (
+      {hasAnyResults || hasActiveFilters || nativeQuery.isLoading || externalQuery.isLoading ? (
         <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:gap-2">
           <WorkspaceFilterField
             label={intl.formatMessage(glossariesPageViewMessages.searchLabel)}
@@ -388,7 +460,7 @@ export function GlossariesPageView({
         </div>
       ) : null}
 
-      {isSuccess && hasActiveFilters && glossaryTotal === 0 ? (
+      {queriesHaveNoResults && hasActiveFilters ? (
         <div className="text-sm text-muted-foreground">
           <FormattedMessage
             {...glossariesPageViewMessages.noFilterMatches}
@@ -407,43 +479,130 @@ export function GlossariesPageView({
         </div>
       ) : null}
 
-      {liveProjectSelectionRequired ? (
-        <div className="space-y-3 py-10">
-          <TypographyP className="text-sm font-medium text-foreground">
-            <FormattedMessage {...glossariesPageViewMessages.chooseTmsProjectTitle} />
-          </TypographyP>
-          <TypographyP className="max-w-xl text-sm leading-6 text-muted-foreground">
-            <FormattedMessage {...glossariesPageViewMessages.chooseTmsProjectDescription} />
-          </TypographyP>
-        </div>
-      ) : (
+      <div className="grid gap-8">
         <GlossariesTable
-          glossaries={glossaries}
-          glossariesQuery={glossariesQuery}
+          glossaries={nativeGlossaries}
+          glossariesQuery={nativeQuery}
           organizationSlug={organizationSlug}
-          emptyTitle={
-            allowCreateGlossaries
-              ? intl.formatMessage(glossariesPageViewMessages.emptyTitle)
-              : emptyTitle
-          }
-          emptyDescription={
-            allowCreateGlossaries
-              ? intl.formatMessage(glossariesPageViewMessages.emptyDescriptionCreate)
-              : emptyDescription
-          }
+          title={nativeSectionTitle}
+          count={nativeTotal}
+          emptyTitle={nativeEmptyTitle}
+          emptyDescription={nativeEmptyDescription}
           emptyAction={
             allowCreateGlossaries ? (
               <Button type="button" size="sm" onClick={() => onCreateDialogOpenChange(true)}>
                 <FormattedMessage {...glossariesPageViewMessages.createGlossary} />
               </Button>
-            ) : (
-              <GlossariesEmptyAction organizationSlug={organizationSlug} />
-            )
+            ) : undefined
           }
         />
-      )}
+        {liveProjectSelectionRequired ? (
+          <section aria-label={externalSectionTitle} className="min-w-0">
+            <div className="mb-3 flex items-baseline justify-between gap-3">
+              <h2 className="text-sm font-semibold tracking-[-0.01em] text-foreground">
+                {externalSectionTitle}
+              </h2>
+            </div>
+            <div className="space-y-3 rounded-lg border border-border px-5 py-8">
+              <TypographyP className="text-sm font-medium text-foreground">
+                <FormattedMessage {...glossariesPageViewMessages.chooseTmsProjectTitle} />
+              </TypographyP>
+              <TypographyP className="max-w-xl text-sm leading-6 text-muted-foreground">
+                <FormattedMessage {...glossariesPageViewMessages.chooseTmsProjectDescription} />
+              </TypographyP>
+            </div>
+          </section>
+        ) : (
+          <GlossariesTable
+            glossaries={externalGlossaries}
+            glossariesQuery={externalQuery}
+            organizationSlug={organizationSlug}
+            title={externalSectionTitle}
+            count={externalTotal}
+            emptyTitle={externalEmptyTitle}
+            emptyDescription={externalEmptyDescription}
+            emptyAction={
+              !hasConnectedProvider ? (
+                <GlossariesEmptyAction organizationSlug={organizationSlug} />
+              ) : undefined
+            }
+          />
+        )}
+      </div>
 
-      {!liveProjectSelectionRequired && isSuccess && glossaryTotal > GLOSSARIES_PAGE_SIZE ? (
+      {useLiveCrowdinGlossaries && nativeQuery.isSuccess && nativeTotal > GLOSSARIES_PAGE_SIZE ? (
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <p className="text-sm text-muted-foreground">
+            <FormattedMessage
+              {...glossariesPageViewMessages.paginationSummary}
+              values={{ pageStart, pageEnd, glossaryTotal: nativeTotal }}
+            />
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={page <= 1}
+              onClick={() => onPageChange(Math.max(1, page - 1))}
+            >
+              <FormattedMessage {...glossariesPageViewMessages.previousPage} />
+            </Button>
+            <p className="text-sm text-muted-foreground">
+              <FormattedMessage
+                {...glossariesPageViewMessages.paginationPage}
+                values={{ page, totalPages }}
+              />
+            </p>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={page >= totalPages}
+              onClick={() => onPageChange(page + 1)}
+            >
+              <FormattedMessage {...glossariesPageViewMessages.nextPage} />
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {useLiveCrowdinGlossaries &&
+      externalQuery.isSuccess &&
+      (crowdinPage > 1 || crowdinHasMore) ? (
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <p className="text-sm text-muted-foreground">
+            <FormattedMessage
+              {...glossariesPageViewMessages.crowdinPaginationSummary}
+              values={{ page: crowdinPage }}
+            />
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={crowdinPage <= 1}
+              onClick={() => onCrowdinPageChange(Math.max(1, crowdinPage - 1))}
+            >
+              <FormattedMessage {...glossariesPageViewMessages.previousPage} />
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={!crowdinHasMore}
+              onClick={() => onCrowdinPageChange(crowdinPage + 1)}
+            >
+              <FormattedMessage {...glossariesPageViewMessages.nextPage} />
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {!useLiveCrowdinGlossaries &&
+      !useLiveProviderGlossaries &&
+      glossaryTotal > GLOSSARIES_PAGE_SIZE ? (
         <div className="flex flex-wrap items-center justify-between gap-2">
           <p className="text-sm text-muted-foreground">
             <FormattedMessage

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.messages.ts
@@ -35,6 +35,11 @@ export const glossariesTableMessages = defineMessages({
     id: "VyUTnEU0ZM",
     description: "Fallback error when glossaries fail to load without a message",
   },
+  retry: {
+    defaultMessage: "Retry",
+    id: "IOmySBLwfP",
+    description: "Button to retry loading one glossary source",
+  },
   sourceWorkspace: {
     defaultMessage: "Workspace",
     id: "XXixo4/l3k",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.tsx
@@ -30,6 +30,13 @@ import type { GlossaryListRow } from "./glossary-list";
 import { providerLabel } from "./glossary-list";
 import { glossariesTableMessages } from "./glossaries-table.messages";
 
+export type GlossariesTableQuery = Pick<
+  UseQueryResult<unknown, Error>,
+  "isLoading" | "isError" | "isSuccess" | "error"
+> & {
+  refetch?: () => void;
+};
+
 function SourceLabel({ glossary }: { glossary: GlossaryListRow }) {
   if (glossary.source === "native") {
     return (
@@ -182,16 +189,17 @@ export function GlossariesTable({
   glossaries,
   glossariesQuery,
   organizationSlug,
+  title,
+  count,
   emptyTitle,
   emptyDescription,
   emptyAction,
 }: {
   glossaries: GlossaryListRow[];
-  glossariesQuery: Pick<
-    UseQueryResult<unknown, Error>,
-    "isLoading" | "isError" | "isSuccess" | "error"
-  >;
+  glossariesQuery: GlossariesTableQuery;
   organizationSlug: string;
+  title?: string;
+  count?: number;
   emptyTitle: string;
   emptyDescription: string;
   emptyAction?: ReactNode;
@@ -200,13 +208,30 @@ export function GlossariesTable({
 
   return (
     <section
-      aria-label={intl.formatMessage(glossariesTableMessages.sectionLabel)}
+      aria-label={title ?? intl.formatMessage(glossariesTableMessages.sectionLabel)}
       className="min-w-0"
     >
+      {title ? (
+        <div className="mb-3 flex items-baseline justify-between gap-3">
+          <h2 className="text-sm font-semibold tracking-[-0.01em] text-foreground">{title}</h2>
+          {count !== undefined ? (
+            <span className="text-xs tabular-nums text-muted-foreground">{count}</span>
+          ) : null}
+        </div>
+      ) : null}
+
       {glossariesQuery.isLoading ? (
-        <TypographyP className="py-8 text-sm text-muted-foreground">
-          <FormattedMessage {...glossariesTableMessages.loading} />
-        </TypographyP>
+        <div
+          className="space-y-3 rounded-lg border border-border px-5 py-8"
+          aria-busy="true"
+          aria-label={intl.formatMessage(glossariesTableMessages.loading)}
+        >
+          <TypographyP className="text-sm text-muted-foreground">
+            <FormattedMessage {...glossariesTableMessages.loading} />
+          </TypographyP>
+          <div className="h-2 w-2/3 animate-pulse rounded-full bg-skeleton" />
+          <div className="h-2 w-1/3 animate-pulse rounded-full bg-skeleton" />
+        </div>
       ) : null}
 
       {glossariesQuery.isError ? (
@@ -219,6 +244,17 @@ export function GlossariesTable({
               ? glossariesQuery.error.message
               : intl.formatMessage(glossariesTableMessages.loadFailedFallback)}
           </TypographyP>
+          {glossariesQuery.refetch ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="mt-4"
+              onClick={glossariesQuery.refetch}
+            >
+              <FormattedMessage {...glossariesTableMessages.retry} />
+            </Button>
+          ) : null}
         </div>
       ) : null}
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.tsx
@@ -22,6 +22,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
 import { TypographyP } from "@/components/ui/typography";
 
 import { ProviderKindBadge } from "../../_components/workspace-files-shared";
@@ -72,6 +73,32 @@ function TermCapabilityBadge({ glossary }: { glossary: GlossaryListRow }) {
     <Badge variant="outline" className={toneClass(glossary.termCapabilityTone)}>
       {glossary.termCapabilityLabel}
     </Badge>
+  );
+}
+
+function GlossaryRowSkeleton() {
+  return (
+    <div className="grid gap-3 px-5 py-4 md:grid-cols-[1.35fr_0.95fr_0.75fr_1fr] md:items-center">
+      <div className="min-w-0 space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <Skeleton className="size-4 rounded-md" />
+          <Skeleton className="h-4 w-36" />
+          <Skeleton className="h-5 w-20 rounded-full" />
+          <Skeleton className="h-5 w-16 rounded-full" />
+        </div>
+        <Skeleton className="h-3 w-48 max-w-full" />
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-3 w-24" />
+          <Skeleton className="h-3 w-16" />
+        </div>
+      </div>
+      <div className="flex items-center gap-1">
+        <Skeleton className="h-4 w-16" />
+        <Skeleton className="h-4 w-20" />
+      </div>
+      <Skeleton className="h-4 w-20" />
+      <Skeleton className="h-6 w-24 rounded-full" />
+    </div>
   );
 }
 
@@ -222,15 +249,19 @@ export function GlossariesTable({
 
       {glossariesQuery.isLoading ? (
         <div
-          className="space-y-3 rounded-lg border border-border px-5 py-8"
+          className="overflow-hidden rounded-lg border border-border"
           aria-busy="true"
           aria-label={intl.formatMessage(glossariesTableMessages.loading)}
         >
-          <TypographyP className="text-sm text-muted-foreground">
+          <TypographyP className="border-b border-border px-5 py-3 text-sm text-muted-foreground">
             <FormattedMessage {...glossariesTableMessages.loading} />
           </TypographyP>
-          <div className="h-2 w-2/3 animate-pulse rounded-full bg-skeleton" />
-          <div className="h-2 w-1/3 animate-pulse rounded-full bg-skeleton" />
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={index}>
+              <GlossaryRowSkeleton />
+              {index < 2 ? <Separator className="bg-skeleton" /> : null}
+            </div>
+          ))}
         </div>
       ) : null}
 

--- a/apps/hyperlocalise-web/src/lib/glossary/crowdin-glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/crowdin-glossary.ts
@@ -31,6 +31,7 @@ import {
   type GlossaryConcept,
   type GlossaryConceptTerm,
   type GlossaryConceptInput,
+  type GlossaryProjectRecord,
   type GlossaryTermCreateInput,
   type GlossaryTermRecord,
   type GlossaryTermUpdateInput,
@@ -45,6 +46,7 @@ import {
 
 import { parseId, resolveCrowdinContext, toCrowdinContext } from "./glossary-provider";
 import type { GlossaryProviderContext } from "./glossary-provider";
+import { sanitizeExternalUrl } from "@/lib/security/safe-external-url";
 
 function crowdinStatus(status: string | undefined) {
   switch (status) {
@@ -299,6 +301,23 @@ export class CrowdinGlossary extends Glossary {
       parseId(this.input.glossary.externalGlossaryId!, "glossary_id"),
     );
     return toNativeGlossary(glossary, this.input.glossary);
+  }
+
+  async listProjects(): Promise<GlossaryProjectRecord[]> {
+    const context = await this.context();
+    const projects = await crowdinTmsProvider.listLiveGlossaryProjects(
+      toCrowdinContext(context),
+      parseId(this.input.glossary.externalGlossaryId!, "glossary_id"),
+    );
+
+    return projects.map((project) => ({
+      projectId: String(project.id),
+      projectName: project.name,
+      priority: 0,
+      sourceLocale: project.sourceLanguageId,
+      targetLocales: project.targetLanguageIds,
+      externalUrl: sanitizeExternalUrl(project.webUrl),
+    }));
   }
 
   async update(payload: { name?: string; description?: string }) {

--- a/apps/hyperlocalise-web/src/lib/glossary/glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/glossary.ts
@@ -74,6 +74,15 @@ export type GlossaryTermRecord = {
   reviewStatus: string;
 };
 
+export type GlossaryProjectRecord = {
+  projectId: string;
+  projectName: string;
+  priority: number;
+  sourceLocale: string | null;
+  targetLocales: string[];
+  externalUrl: string | null;
+};
+
 export type GlossaryTermCreateInput = {
   sourceTerm: string;
   targetTerm: string;
@@ -265,6 +274,7 @@ export function normalizeGlossaryTermStatus(value: string | null | undefined): G
 export abstract class Glossary {
   abstract readonly kind: "native" | "crowdin";
   abstract get(): Promise<NativeGlossary | null>;
+  abstract listProjects(): Promise<GlossaryProjectRecord[]>;
   abstract update(payload: { name?: string; description?: string }): Promise<NativeGlossary | null>;
   abstract delete(): Promise<boolean>;
   abstract listConcepts(): Promise<GlossaryConcept[]>;

--- a/apps/hyperlocalise-web/src/lib/glossary/native-glossary.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/native-glossary.ts
@@ -12,6 +12,7 @@
  */
 import { and, eq, inArray, isNull, ne, sql } from "drizzle-orm";
 
+import { buildAccessibleProjectsWhere } from "@/api/auth/team-access";
 import { db, schema, type DatabaseClient } from "@/lib/database";
 import {
   Glossary,
@@ -29,6 +30,7 @@ import type {
   GlossaryConcept,
   GlossaryConceptInput,
   NativeGlossaryTermInput,
+  GlossaryProjectRecord,
 } from "./glossary";
 import type { GlossaryProviderContext } from "./glossary-provider";
 import { createGlossaryTermDuplicateTracker } from "./glossary-term-dedupe";
@@ -133,6 +135,33 @@ export class NativeGlossary extends Glossary {
       )
       .limit(1);
     return glossary ?? null;
+  }
+
+  async listProjects(): Promise<GlossaryProjectRecord[]> {
+    const accessibleProjectsWhere = await buildAccessibleProjectsWhere(this.input.auth);
+    const attachedProjects = await db
+      .select({
+        projectId: schema.projects.id,
+        projectName: schema.projects.name,
+        priority: schema.projectGlossaries.priority,
+        sourceLocale: schema.projects.sourceLocale,
+        targetLocales: schema.projects.targetLocales,
+      })
+      .from(schema.projectGlossaries)
+      .innerJoin(schema.projects, eq(schema.projectGlossaries.projectId, schema.projects.id))
+      .where(
+        and(
+          eq(
+            schema.projectGlossaries.organizationId,
+            this.input.auth.organization.localOrganizationId,
+          ),
+          eq(schema.projectGlossaries.glossaryId, this.input.glossary.id),
+          accessibleProjectsWhere,
+        ),
+      )
+      .orderBy(schema.projectGlossaries.priority, schema.projects.name);
+
+    return attachedProjects.map((project) => ({ ...project, externalUrl: null }));
   }
 
   async update(payload: { name?: string; description?: string }) {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -1516,6 +1516,31 @@ describe("CrowdinApiClient", () => {
     expect(memories[0]?.segmentsCount).toBe(100);
   });
 
+  it("passes glossary pagination, ordering, user, and filter parameters", async () => {
+    let requestedUrl = "";
+    const fetchMock = vi.fn(async (url) => {
+      requestedUrl = String(url);
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const page = await client.listGlossariesPage({
+      limit: 25,
+      offset: 50,
+      orderBy: "createdAt desc,name",
+      userId: 9920,
+      filter: "string",
+    });
+
+    const query = new URL(requestedUrl).searchParams;
+    expect(query.get("limit")).toBe("25");
+    expect(query.get("offset")).toBe("50");
+    expect(query.get("orderBy")).toBe("createdAt desc,name");
+    expect(query.get("userId")).toBe("9920");
+    expect(query.get("filter")).toBe("string");
+    expect(page).toMatchObject({ offset: 50, limit: 25, hasMore: false, glossaries: [] });
+  });
+
   it("lists project language progress", async () => {
     const fetchMock = vi.fn(async () => {
       return new Response(

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -180,6 +180,8 @@ export const CROWDIN_SOURCE_STRING_BATCH_PATCH_LIMIT = 500;
 export const CROWDIN_LIVE_TASK_LIST_LIMIT = 50;
 export const CROWDIN_LIVE_TASK_LIST_ORDER_BY = "createdAt desc";
 export const CROWDIN_PROJECT_LIST_ORDER_BY = "lastActivity desc";
+export const CROWDIN_GLOSSARY_LIST_LIMIT = 25;
+export const CROWDIN_GLOSSARY_LIST_ORDER_BY = "createdAt desc,name";
 export const CROWDIN_SYNC_TASK_PAGE_LIMIT = 500;
 
 export type ListCrowdinTasksOptions = {
@@ -187,6 +189,14 @@ export type ListCrowdinTasksOptions = {
   offset?: number;
   orderBy?: string;
   fetchAll?: boolean;
+};
+
+export type ListCrowdinGlossariesOptions = {
+  limit?: number;
+  offset?: number;
+  orderBy?: string;
+  filter?: string;
+  userId?: number;
 };
 
 function defaultCrowdinFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
@@ -722,6 +732,13 @@ export type CrowdinSourceStringsPage = {
   limit: number;
   hasMore: boolean;
   totalCount: number;
+};
+
+export type CrowdinGlossariesPage = {
+  glossaries: CrowdinGlossary[];
+  offset: number;
+  limit: number;
+  hasMore: boolean;
 };
 
 interface CrowdinGetResponse<T> {
@@ -2135,6 +2152,37 @@ export class CrowdinApiClient {
 
   async listGlossaries(): Promise<CrowdinGlossary[]> {
     return this.listPaginated<CrowdinGlossary>("/glossaries");
+  }
+
+  async listGlossariesPage(
+    options: ListCrowdinGlossariesOptions = {},
+  ): Promise<CrowdinGlossariesPage> {
+    const limit = options.limit ?? CROWDIN_GLOSSARY_LIST_LIMIT;
+    const offset = options.offset ?? 0;
+    const params = new URLSearchParams({
+      limit: String(limit),
+      offset: String(offset),
+      orderBy: options.orderBy ?? CROWDIN_GLOSSARY_LIST_ORDER_BY,
+    });
+
+    if (options.userId !== undefined) {
+      params.set("userId", String(options.userId));
+    }
+    if (options.filter?.trim()) {
+      params.set("filter", options.filter.trim());
+    }
+
+    const response = await this.get<CrowdinListResponse<CrowdinGlossary>>(
+      `/glossaries?${params.toString()}`,
+    );
+    const glossaries = response.data.map((item) => item.data);
+
+    return {
+      glossaries,
+      offset,
+      limit,
+      hasMore: glossaries.length === limit,
+    };
   }
 
   /**

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider-glossary.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider-glossary.test.ts
@@ -16,6 +16,94 @@ import { crowdinTmsProvider } from "./crowdin-provider";
 import { toCrowdinConceptInput } from "@/lib/glossary/crowdin-glossary";
 
 describe("Crowdin live glossary concepts", () => {
+  it("lists projects associated with a glossary from the live Crowdin API", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url).replace("https://api.crowdin.test/api/v2", "");
+
+      if (path === "/glossaries/7") {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 7,
+              name: "Product glossary",
+              description: null,
+              languageId: "en",
+              languageIds: ["en", "fr"],
+              terms: 12,
+              projectIds: [43, 42],
+              defaultProjectIds: [42, 44],
+              webUrl: "https://crowdin.test/glossary/7",
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.startsWith("/projects?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 44,
+                  name: "Zeta project",
+                  identifier: "zeta",
+                  sourceLanguageId: "en",
+                  targetLanguageIds: ["de"],
+                  webUrl: "https://crowdin.test/project/zeta",
+                  isSuspended: false,
+                },
+              },
+              {
+                data: {
+                  id: 42,
+                  name: "Alpha project",
+                  identifier: "alpha",
+                  sourceLanguageId: "en",
+                  targetLanguageIds: ["fr"],
+                  webUrl: "https://crowdin.test/project/alpha",
+                  isSuspended: false,
+                },
+              },
+              {
+                data: {
+                  id: 99,
+                  name: "Unrelated project",
+                  identifier: "unrelated",
+                  sourceLanguageId: "en",
+                  targetLanguageIds: ["es"],
+                  webUrl: "https://crowdin.test/project/unrelated",
+                  isSuspended: false,
+                },
+              },
+            ],
+            pagination: { offset: 0, limit: 500 },
+          }),
+          { status: 200 },
+        );
+      }
+
+      throw new Error(`Unexpected Crowdin request: ${path}`);
+    }) as unknown as typeof fetch;
+
+    const projects = await crowdinTmsProvider.listLiveGlossaryProjects(
+      {
+        organizationId: "organization-1",
+        credential: { baseUrl: "https://api.crowdin.test/api/v2" } as never,
+        secretMaterial: "test-token",
+        projectId: "42",
+        externalProjectId: "42",
+        sourceLocale: "en",
+        fetchFn: fetchMock,
+      },
+      7,
+    );
+
+    expect(projects.map((project) => project.id)).toEqual([42, 44]);
+    expect(projects.map((project) => project.name)).toEqual(["Alpha project", "Zeta project"]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("maps native locales before creating a glossary term", async () => {
     let requestBody: Record<string, unknown> | undefined;
     const fetchMock = vi.fn(async (_url, init) => {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
@@ -40,6 +40,7 @@ import {
   type CrowdinCreateTaskRequest,
   type CrowdinDirectory,
   type CrowdinFile,
+  type CrowdinGlossary,
   type CrowdinProject,
   type CrowdinShortUser,
   type CrowdinSourceString,
@@ -271,6 +272,23 @@ type CrowdinLiveGlossaryScope = Pick<
   sourceLocale: string;
   targetLocales?: string[];
   fetchFn?: typeof fetch;
+};
+
+export type CrowdinLiveGlossaryPage = {
+  glossaries: Array<{
+    externalGlossaryId: string;
+    name: string;
+    description: string | null;
+    sourceLocale: string;
+    targetLocale: string;
+    localeCoverage: string[];
+    termCount: number;
+    externalUrl: string | null;
+    externalProjectIds: string[];
+  }>;
+  offset: number;
+  limit: number;
+  hasMore: boolean;
 };
 
 type CrowdinGlossarySearchError =
@@ -679,6 +697,58 @@ export class CrowdinTmsProvider extends TmsProvider {
     );
 
     return results.flat();
+  }
+
+  /** Lists the account's glossaries using Crowdin's native pagination and filtering. */
+  async fetchGlossariesPage(
+    scope: Pick<
+      CrowdinLiveGlossaryScope,
+      "organizationId" | "credential" | "secretMaterial" | "signal"
+    > & {
+      fetchFn?: typeof fetch;
+      limit?: number;
+      offset?: number;
+      orderBy?: string;
+      filter?: string;
+    },
+  ): Promise<CrowdinLiveGlossaryPage> {
+    const client = this.createClient(scope);
+    const authenticatedUser = await client.getAuthenticatedUser();
+    const page = await client.listGlossariesPage({
+      limit: scope.limit,
+      offset: scope.offset,
+      orderBy: scope.orderBy,
+      filter: scope.filter,
+      userId: authenticatedUser.id,
+    });
+
+    return {
+      ...page,
+      glossaries: page.glossaries.map((glossary: CrowdinGlossary) => {
+        const sourceLocale = toNativeGlossaryLocale(glossary.languageId, ["en"]);
+        const preferredLocales = [sourceLocale, ...glossary.languageIds];
+        const localeCoverage = this.uniqueLocales([
+          sourceLocale,
+          ...glossary.languageIds.map((languageId) =>
+            toNativeGlossaryLocale(languageId, preferredLocales),
+          ),
+        ]);
+        const targetLocale =
+          localeCoverage.find((locale) => locale !== sourceLocale) ?? sourceLocale;
+
+        return {
+          externalGlossaryId: String(glossary.id),
+          name: glossary.name,
+          description: glossary.description ?? null,
+          sourceLocale,
+          targetLocale,
+          localeCoverage,
+          termCount: glossary.terms,
+          externalUrl: glossary.webUrl ?? null,
+          externalProjectIds: [...glossary.projectIds, ...glossary.defaultProjectIds].map(String),
+        };
+      }),
+    };
   }
 
   async fetchLiveGlossary(scope: CrowdinLiveGlossaryScope, glossaryId: number) {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-provider.ts
@@ -693,6 +693,19 @@ export class CrowdinTmsProvider extends TmsProvider {
     };
   }
 
+  async listLiveGlossaryProjects(scope: CrowdinLiveGlossaryScope, glossaryId: number) {
+    const client = this.createClient(scope);
+    const glossary = await client.getGlossary(glossaryId);
+    const associatedProjectIds = new Set([...glossary.projectIds, ...glossary.defaultProjectIds]);
+
+    if (associatedProjectIds.size === 0) return [];
+
+    const projects = await client.listProjects();
+    return projects
+      .filter((project) => associatedProjectIds.has(project.id))
+      .sort((left, right) => left.name.localeCompare(right.name));
+  }
+
   async updateLiveGlossary(
     scope: CrowdinLiveGlossaryScope,
     glossaryId: number,

--- a/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/jobs/tms-provider-live.ts
@@ -4068,7 +4068,7 @@ function dedupeGlossaries(items: TmsProviderLiveGlossary[]) {
 function mapLiveGlossary(input: {
   glossary: ExternalTmsGlossaryMetadata;
   externalProjectId: string;
-  projectName: string;
+  projectName: string | null;
   providerKind: ExternalTmsProviderKind;
 }): TmsProviderLiveGlossary {
   return {
@@ -4086,10 +4086,32 @@ function mapLiveGlossary(input: {
   };
 }
 
+export type TmsProviderLiveGlossariesPage = {
+  glossaries: TmsProviderLiveGlossary[];
+  offset: number;
+  limit: number;
+  hasMore: boolean;
+};
+
 export async function listTmsProviderLiveGlossaries(
   organizationId: string,
   options?: { externalProjectId?: string; actorUserId?: string | null },
 ): Promise<TmsProviderLiveGlossary[]> {
+  const page = await listTmsProviderLiveGlossariesPage(organizationId, options);
+  return page.glossaries;
+}
+
+export async function listTmsProviderLiveGlossariesPage(
+  organizationId: string,
+  options?: {
+    externalProjectId?: string;
+    actorUserId?: string | null;
+    limit?: number;
+    offset?: number;
+    orderBy?: string;
+    filter?: string;
+  },
+): Promise<TmsProviderLiveGlossariesPage> {
   const context = await loadActiveTmsProviderContext(organizationId, {
     actorUserId: options?.actorUserId,
   });
@@ -4102,6 +4124,58 @@ export async function listTmsProviderLiveGlossaries(
   }
 
   const projects = await fetchLiveProjectsCached(context, options);
+
+  if (context.providerKind === "crowdin") {
+    const projectById = new Map(projects.map((project) => [project.externalProjectId, project]));
+    const crowdinPage = await crowdinTmsProvider.fetchGlossariesPage({
+      organizationId: context.organizationId,
+      credential: context.credential,
+      secretMaterial: context.secretMaterial,
+      limit: options?.limit,
+      offset: options?.offset,
+      orderBy: options?.orderBy,
+      filter: options?.filter,
+    });
+
+    const glossaries = crowdinPage.glossaries.flatMap((glossary) => {
+      const linkedProjectIds = glossary.externalProjectIds.filter((projectId) =>
+        projectById.has(projectId),
+      );
+      if (options?.externalProjectId && !linkedProjectIds.includes(options.externalProjectId)) {
+        return [];
+      }
+
+      const externalProjectId =
+        options?.externalProjectId ?? linkedProjectIds[0] ?? glossary.externalProjectIds[0] ?? "";
+      const project = projectById.get(externalProjectId);
+
+      return [
+        mapLiveGlossary({
+          glossary: {
+            externalGlossaryId: glossary.externalGlossaryId,
+            name: glossary.name,
+            description: glossary.description ?? undefined,
+            sourceLocale: glossary.sourceLocale,
+            targetLocale: glossary.targetLocale,
+            localeCoverage: glossary.localeCoverage,
+            termCount: glossary.termCount,
+            externalUrl: glossary.externalUrl,
+          },
+          externalProjectId,
+          projectName: project?.name ?? null,
+          providerKind: context.providerKind,
+        }),
+      ];
+    });
+
+    return {
+      glossaries,
+      offset: crowdinPage.offset,
+      limit: crowdinPage.limit,
+      hasMore: crowdinPage.hasMore,
+    };
+  }
+
   const scopedProjects = options?.externalProjectId
     ? projects.filter((project) => project.externalProjectId === options.externalProjectId)
     : projects.filter((project) => project.isActive !== false);
@@ -4153,7 +4227,13 @@ export async function listTmsProviderLiveGlossaries(
     },
   );
 
-  return dedupeGlossaries(glossariesByProject.flat());
+  const glossaries = dedupeGlossaries(glossariesByProject.flat());
+  return {
+    glossaries,
+    offset: 0,
+    limit: glossaries.length,
+    hasMore: false,
+  };
 }
 
 function mapLiveTranslationMemory(input: {


### PR DESCRIPTION
## Summary
- Fetch Crowdin glossary-associated projects from the live API.
- Delegate project listing through the glossary product abstraction.
- Preserve native project access filtering and external project links.

## Validation
- Focused Crowdin and glossary provider tests pass (11/11).
- vp check --fix passes with 0 errors.
- Route tests require PostgreSQL, which was unavailable locally.